### PR TITLE
Fix `onEndReached` bugs for FlatList

### DIFF
--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -1134,7 +1134,6 @@ class VirtualizedList extends React.PureComponent<Props, State> {
   _totalCellsMeasured = 0;
   _updateCellsToRenderBatcher: Batchinator;
   _viewabilityTuples: Array<ViewabilityHelperCallbackTuple> = [];
-  _nextExpectedOnEndReachedOffset = 0;
 
   _captureScrollRef = ref => {
     this._scrollRef = ref;
@@ -1376,6 +1375,7 @@ class VirtualizedList extends React.PureComponent<Props, State> {
     }
 
     const {contentLength, visibleLength, offset, dOffset} = this._scrollMetrics;
+
     // Scrolled in a direction that doesn't require a check,
     // such as scrolling up in the vertical list
     if (offset <= 0 || dOffset <= 0) {
@@ -1389,22 +1389,18 @@ class VirtualizedList extends React.PureComponent<Props, State> {
 
     const distanceFromEnd = contentLength - visibleLength - offset;
 
+    // If the distance is farther than can be seen on the screen
+    if (distanceFromEnd >= visibleLength) {
+      return;
+    }
+
     // $FlowFixMe
     const minimumDistanceFromEnd = onEndReachedThreshold * visibleLength;
     if (distanceFromEnd >= minimumDistanceFromEnd) {
       return;
     }
 
-    // Not as scrolling as expected after the last `onEndReached` call
-    if (
-      this._nextExpectedOnEndReachedOffset > 0 &&
-      offset < this._nextExpectedOnEndReachedOffset
-    ) {
-      return;
-    }
-
-    this._sentEndForContentLength = this._scrollMetrics.contentLength;
-    this._nextExpectedOnEndReachedOffset = offset + minimumDistanceFromEnd / 2;
+    this._sentEndForContentLength = contentLength;
     onEndReached({distanceFromEnd});
   }
 

--- a/Libraries/Lists/__tests__/VirtualizedList-test.js
+++ b/Libraries/Lists/__tests__/VirtualizedList-test.js
@@ -273,4 +273,149 @@ describe('VirtualizedList', () => {
       }),
     );
   });
+
+  it('OnEndReached should not be called after initial rendering', () => {
+    const ITEM_HEIGHT = 100;
+    const APPENDED_ITEM_COUNT = 10;
+    const data = appendNewItems([], 10);
+    const onEndReached = jest.fn(function() {
+      appendNewItems(data, APPENDED_ITEM_COUNT);
+    });
+
+    const props = createPropsWithonEndReached(data, ITEM_HEIGHT, onEndReached);
+
+    const component = ReactTestRenderer.create(<VirtualizedList {...props} />);
+    const instance = component.getInstance();
+
+    const scroll = createScrollMethod(instance, ITEM_HEIGHT);
+    scroll(data, 0);
+
+    expect(onEndReached).not.toHaveBeenCalled();
+    expect(data.length).toBe(10);
+  });
+
+  it('OnEndReached should be called once after scrolling by 200', () => {
+    const ITEM_HEIGHT = 100;
+    const APPENDED_ITEM_COUNT = 10;
+    const data = appendNewItems([], 10);
+    const onEndReached = jest.fn(function() {
+      appendNewItems(data, APPENDED_ITEM_COUNT);
+    });
+
+    const props = createPropsWithonEndReached(data, ITEM_HEIGHT, onEndReached);
+
+    const component = ReactTestRenderer.create(<VirtualizedList {...props} />);
+    const instance = component.getInstance();
+
+    const scroll = createScrollMethod(instance, ITEM_HEIGHT);
+    scroll(data, 200);
+
+    expect(onEndReached).toHaveBeenCalledTimes(1);
+    expect(onEndReached).toHaveBeenLastCalledWith({
+      distanceFromEnd: 200,
+    });
+    expect(data.length).toBe(20);
+  });
+
+  it('OnEndReached should not be called twice in a short period while scrolling fast', () => {
+    const ITEM_HEIGHT = 100;
+    const APPENDED_ITEM_COUNT = 10;
+    const data = appendNewItems([], 10);
+    const onEndReached = jest.fn(function() {
+      appendNewItems(data, APPENDED_ITEM_COUNT);
+    });
+
+    const props = createPropsWithonEndReached(data, ITEM_HEIGHT, onEndReached);
+
+    const component = ReactTestRenderer.create(<VirtualizedList {...props} />);
+    const instance = component.getInstance();
+
+    const scroll = createScrollMethod(instance, ITEM_HEIGHT);
+    scroll(data, 200);
+    scroll(data, 300, 50);
+
+    expect(onEndReached).toHaveBeenCalledTimes(1);
+    expect(onEndReached).toHaveBeenLastCalledWith({
+      distanceFromEnd: 200,
+    });
+    expect(data.length).toBe(20);
+  });
+
+  it('OnEndReached should be called when required to load more items', () => {
+    const ITEM_HEIGHT = 100;
+    const APPENDED_ITEM_COUNT = 10;
+    const data = appendNewItems([], 10);
+    const onEndReached = jest.fn(function() {
+      appendNewItems(data, APPENDED_ITEM_COUNT);
+    });
+
+    const props = createPropsWithonEndReached(data, ITEM_HEIGHT, onEndReached);
+
+    const component = ReactTestRenderer.create(<VirtualizedList {...props} />);
+    const instance = component.getInstance();
+
+    const scroll = createScrollMethod(instance, ITEM_HEIGHT);
+    scroll(data, 200);
+    expect(onEndReached).toHaveBeenCalledTimes(1);
+    expect(data.length).toBe(20);
+
+    scroll(data, 1000);
+    expect(onEndReached).toHaveBeenCalledTimes(2);
+    expect(onEndReached).toHaveBeenLastCalledWith({
+      distanceFromEnd: 400,
+    });
+    expect(data.length).toBe(30);
+  });
 });
+
+function createPropsWithonEndReached(data, itemHeight, onEndReached) {
+  const props = {
+    data,
+    renderItem: ({item}) => <item value={item.key} />,
+    getItem: (items, index) => items[index],
+    getItemCount: items => items.length,
+    getItemLayout: (items, index) => ({
+      length: itemHeight,
+      offset: itemHeight * index,
+      index,
+    }),
+    onEndReached,
+  };
+
+  return props;
+}
+
+function appendNewItems(items, count) {
+  const nextId = (items.length > 0 ? items[items.length - 1].id : 0) + 1;
+
+  for (let loop = 1; loop <= count; loop++) {
+    const id = nextId + loop;
+    items.push({
+      id: id,
+      key: `k${id}`,
+    });
+  }
+
+  return items;
+}
+
+function createScrollMethod(instance, itemHeight) {
+  let scrollTimeStamp = 0;
+
+  return function scroll(items, y, delay = 1000) {
+    scrollTimeStamp += delay;
+
+    const nativeEvent = {
+      contentOffset: {y, x: 0},
+      layoutMeasurement: {width: 300, height: 600},
+      contentSize: {width: 300, height: items.length * itemHeight},
+      zoomScale: 1,
+      contentInset: {right: 0, top: 0, left: 0, bottom: 0},
+    };
+
+    instance._onScroll({
+      timeStamp: scrollTimeStamp,
+      nativeEvent,
+    });
+  };
+}

--- a/Libraries/Lists/__tests__/VirtualizedList-test.js
+++ b/Libraries/Lists/__tests__/VirtualizedList-test.js
@@ -273,149 +273,119 @@ describe('VirtualizedList', () => {
       }),
     );
   });
+});
 
-  it('OnEndReached should not be called after initial rendering', () => {
-    const ITEM_HEIGHT = 100;
-    const APPENDED_ITEM_COUNT = 10;
-    const data = appendNewItems([], 10);
-    const onEndReached = jest.fn(function() {
-      appendNewItems(data, APPENDED_ITEM_COUNT);
+describe('VirtualizedList > OnEndReached', () => {
+  const ITEM_HEIGHT = 100;
+  const APPENDED_ITEM_COUNT = 10;
+
+  let listItems, onEndReached, instance;
+
+  beforeEach(() => {
+    listItems = appendNewItems([], 10);
+
+    onEndReached = jest.fn(function() {
+      appendNewItems(listItems, APPENDED_ITEM_COUNT);
     });
 
-    const props = createPropsWithonEndReached(data, ITEM_HEIGHT, onEndReached);
+    instance = createComponentInstance();
+  });
 
-    const component = ReactTestRenderer.create(<VirtualizedList {...props} />);
-    const instance = component.getInstance();
-
-    const scroll = createScrollMethod(instance, ITEM_HEIGHT);
-    scroll(data, 0);
+  it('should not be called after initial rendering', () => {
+    const scroll = createScrollMethod();
+    scroll(0);
 
     expect(onEndReached).not.toHaveBeenCalled();
-    expect(data.length).toBe(10);
+    expect(listItems.length).toBe(10);
   });
 
-  it('OnEndReached should be called once after scrolling by 200', () => {
-    const ITEM_HEIGHT = 100;
-    const APPENDED_ITEM_COUNT = 10;
-    const data = appendNewItems([], 10);
-    const onEndReached = jest.fn(function() {
-      appendNewItems(data, APPENDED_ITEM_COUNT);
-    });
-
-    const props = createPropsWithonEndReached(data, ITEM_HEIGHT, onEndReached);
-
-    const component = ReactTestRenderer.create(<VirtualizedList {...props} />);
-    const instance = component.getInstance();
-
-    const scroll = createScrollMethod(instance, ITEM_HEIGHT);
-    scroll(data, 200);
+  it('should be called once after scrolling by 200', () => {
+    const scroll = createScrollMethod();
+    scroll(200);
 
     expect(onEndReached).toHaveBeenCalledTimes(1);
     expect(onEndReached).toHaveBeenLastCalledWith({
       distanceFromEnd: 200,
     });
-    expect(data.length).toBe(20);
+    expect(listItems.length).toBe(20);
   });
 
-  it('OnEndReached should not be called twice in a short period while scrolling fast', () => {
-    const ITEM_HEIGHT = 100;
-    const APPENDED_ITEM_COUNT = 10;
-    const data = appendNewItems([], 10);
-    const onEndReached = jest.fn(function() {
-      appendNewItems(data, APPENDED_ITEM_COUNT);
-    });
-
-    const props = createPropsWithonEndReached(data, ITEM_HEIGHT, onEndReached);
-
-    const component = ReactTestRenderer.create(<VirtualizedList {...props} />);
-    const instance = component.getInstance();
-
-    const scroll = createScrollMethod(instance, ITEM_HEIGHT);
-    scroll(data, 200);
-    scroll(data, 300, 50);
+  it('should not be called twice in a short period while scrolling fast', () => {
+    const scroll = createScrollMethod();
+    scroll(200);
+    scroll(300, 50);
 
     expect(onEndReached).toHaveBeenCalledTimes(1);
     expect(onEndReached).toHaveBeenLastCalledWith({
       distanceFromEnd: 200,
     });
-    expect(data.length).toBe(20);
+    expect(listItems.length).toBe(20);
   });
 
-  it('OnEndReached should be called when required to load more items', () => {
-    const ITEM_HEIGHT = 100;
-    const APPENDED_ITEM_COUNT = 10;
-    const data = appendNewItems([], 10);
-    const onEndReached = jest.fn(function() {
-      appendNewItems(data, APPENDED_ITEM_COUNT);
-    });
-
-    const props = createPropsWithonEndReached(data, ITEM_HEIGHT, onEndReached);
-
-    const component = ReactTestRenderer.create(<VirtualizedList {...props} />);
-    const instance = component.getInstance();
-
-    const scroll = createScrollMethod(instance, ITEM_HEIGHT);
-    scroll(data, 200);
+  it('should be called when required to load more items', () => {
+    const scroll = createScrollMethod();
+    scroll(200);
     expect(onEndReached).toHaveBeenCalledTimes(1);
-    expect(data.length).toBe(20);
+    expect(listItems.length).toBe(20);
 
-    scroll(data, 1000);
+    scroll(1000);
     expect(onEndReached).toHaveBeenCalledTimes(2);
     expect(onEndReached).toHaveBeenLastCalledWith({
       distanceFromEnd: 400,
     });
-    expect(data.length).toBe(30);
+    expect(listItems.length).toBe(30);
   });
-});
 
-function createPropsWithonEndReached(data, itemHeight, onEndReached) {
-  const props = {
-    data,
-    renderItem: ({item}) => <item value={item.key} />,
-    getItem: (items, index) => items[index],
-    getItemCount: items => items.length,
-    getItemLayout: (items, index) => ({
-      length: itemHeight,
-      offset: itemHeight * index,
-      index,
-    }),
-    onEndReached,
-  };
-
-  return props;
-}
-
-function appendNewItems(items, count) {
-  const nextId = (items.length > 0 ? items[items.length - 1].id : 0) + 1;
-
-  for (let loop = 1; loop <= count; loop++) {
-    const id = nextId + loop;
-    items.push({
-      id: id,
-      key: `k${id}`,
-    });
-  }
-
-  return items;
-}
-
-function createScrollMethod(instance, itemHeight) {
-  let scrollTimeStamp = 0;
-
-  return function scroll(items, y, delay = 1000) {
-    scrollTimeStamp += delay;
-
-    const nativeEvent = {
-      contentOffset: {y, x: 0},
-      layoutMeasurement: {width: 300, height: 600},
-      contentSize: {width: 300, height: items.length * itemHeight},
-      zoomScale: 1,
-      contentInset: {right: 0, top: 0, left: 0, bottom: 0},
+  function createComponentInstance() {
+    const props = {
+      data: listItems,
+      renderItem: ({item}) => <item value={item.key} />,
+      getItem: (items, index) => items[index],
+      getItemCount: items => items.length,
+      getItemLayout: (items, index) => ({
+        length: ITEM_HEIGHT,
+        offset: ITEM_HEIGHT * index,
+        index,
+      }),
+      onEndReached,
     };
 
-    instance._onScroll({
-      timeStamp: scrollTimeStamp,
-      nativeEvent,
-    });
-  };
-}
+    const component = ReactTestRenderer.create(<VirtualizedList {...props} />);
+    return component.getInstance();
+  }
+
+  function appendNewItems(items, count) {
+    const nextId = (items.length > 0 ? items[items.length - 1].id : 0) + 1;
+
+    for (let loop = 1; loop <= count; loop++) {
+      const id = nextId + loop;
+      items.push({
+        id: id,
+        key: `k${id}`,
+      });
+    }
+
+    return items;
+  }
+
+  function createScrollMethod() {
+    let scrollTimeStamp = 0;
+
+    return function scroll(y, delay = 1000) {
+      scrollTimeStamp += delay;
+
+      const nativeEvent = {
+        contentOffset: {y, x: 0},
+        layoutMeasurement: {width: 300, height: 600},
+        contentSize: {width: 300, height: listItems.length * ITEM_HEIGHT},
+        zoomScale: 1,
+        contentInset: {right: 0, top: 0, left: 0, bottom: 0},
+      };
+
+      instance._onScroll({
+        timeStamp: scrollTimeStamp,
+        nativeEvent,
+      });
+    };
+  }
+});


### PR DESCRIPTION
## Summary

Related to : #18887 #16067 #25656 #14015 (There're more issues.)

I'm sure FlatList's `onEndReached` doesn't work as expected. It's one of the headaches that hasn't been solved for quite some time. We had to make it work by modifying `onEndReachedThreshold` several times, but eventually it doesn't work efficiently.

### Problems
1. Unnecessary calls on first render
In most cases, `onEndReached` is called one or more times after the initial rendering.
2. Inefficient calls during scrolling
If scrolling is fast, it will be called again after the `onEndReached` call.
3. Inefficient logic to check
There're some logic implementations that are not needed.

### Solutions
1. Removed unnecessary calls on first render
2. Removed inefficient calls during scrolling
3. Improved and clarified logic to check

## Changelog

[General] [Fixed] - Fix `onEndReached` bugs for FlatList

## Test Plan

[Test App : https://github.com/ifsnow/FlatListImprovementTest](https://github.com/ifsnow/FlatListImprovementTest.git)

- The list has 10 items at the beginning.
- When `onEndReached` is called, 10 items are added.

### 1. After the initial rendering
- Current FlatList

![old_flatlist_initial_renering](https://user-images.githubusercontent.com/3139234/64923103-aa9d7400-d811-11e9-9cc0-33a505179ca2.png)

`OnEndReached` is called twice in a short period and has 30 items.

- Patched FlatList

![patched_flatlist_initial_renering](https://user-images.githubusercontent.com/3139234/64923109-b9842680-d811-11e9-97f5-406794f70256.png)

`OnEndReached` is not called and has 10 items.

### 2. After scrolling to the 11th item
- Current FlatList

![old_flatlist_scrolling](https://user-images.githubusercontent.com/3139234/64923114-c56fe880-d811-11e9-894b-15819d00dbfc.png)

`OnEndReached` is called twice in a short period, having 50 items.

- Patched FlatList

![patched_flatlist_scrolling](https://user-images.githubusercontent.com/3139234/64923116-cbfe6000-d811-11e9-9b1b-36836a7383ce.png)

`OnEndReached` is called twice when required, having 30 items.
