### PR TITLE
improve error message in NativeModuleRegistryBuilder.java

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/NativeModuleRegistryBuilder.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/NativeModuleRegistryBuilder.java
@@ -52,7 +52,8 @@ public class NativeModuleRegistryBuilder {
                   + name
                   + " tried to override "
                   + existingNativeModule.getClassName()
-                  + ". Check the getPackages() method in MainApplication.java, it might be that module is being created twice. If this was your intention, set canOverrideExistingModule=true");
+                  + ". Check the getPackages() method in MainApplication.java, it might be that module is being created twice. If this was your intention, set canOverrideExistingModule=true. "
+                  + "This error may also be present if the package is present only once in getPackages() but is also automatically added later during build time by autolinking. Try removing the existing entry and rebuild.");
         }
         mModules.remove(existingNativeModule);
       }


### PR DESCRIPTION
## Motivation

I have seen a spike in users reporting this error. Unfortunately I did not receive any repros that would confirm this, but my hypothesis is that they ran into situation when `new XYZPackage()` was present in `getPackages()` method and then the CLI kicked in with autolinking and they were left with this incomplete error. 

someone more knowledgeable of autolinking should review this.