### PR TITLE
AndroidTextInputNativeComponent: Make event properties ReadOnly

### DIFF
--- a/Libraries/Components/TextInput/AndroidTextInputNativeComponent.js
+++ b/Libraries/Components/TextInput/AndroidTextInputNativeComponent.js
@@ -324,8 +324,7 @@ export type NativeProps = $ReadOnly<{|
   onContentSizeChange?: ?DirectEventHandler<
     $ReadOnly<{|
       target: Int32,
-      //      contentSize: $ReadOnly<{|width: Double, height: Double|}>,
-      contentSize: {|width: Double, height: Double|},
+      contentSize: $ReadOnly<{|width: Double, height: Double|}>,
     |}>,
   >,
 
@@ -334,8 +333,7 @@ export type NativeProps = $ReadOnly<{|
       target: Int32,
       text: string,
       previousText: string,
-      //      range: $ReadOnly<{|start: Double, end: Double|}>,
-      range: {|start: Double, end: Double|},
+      range: $ReadOnly<{|start: Double, end: Double|}>,
     |}>,
   >,
 
@@ -354,8 +352,7 @@ export type NativeProps = $ReadOnly<{|
   onSelectionChange?: ?DirectEventHandler<
     $ReadOnly<{|
       target: Int32,
-      //selection: $ReadOnly<{|start: Double, end: Double|}>,
-      selection: {|start: Double, end: Double|},
+      selection: $ReadOnly<{|start: Double, end: Double|}>,
     |}>,
   >,
 
@@ -385,33 +382,28 @@ export type NativeProps = $ReadOnly<{|
     $ReadOnly<{|
       target: Int32,
       responderIgnoreScroll: boolean,
-      contentInset: {|
-        //$ReadOnly<{|
+      contentInset: $ReadOnly<{|
         top: Double, // always 0 on Android
         bottom: Double, // always 0 on Android
         left: Double, // always 0 on Android
         right: Double, // always 0 on Android
-      |},
-      contentOffset: {|
-        //$ReadOnly<{|
+      |}>,
+      contentOffset: $ReadOnly<{|
         x: Double,
         y: Double,
-      |},
-      contentSize: {|
-        // $ReadOnly<{|
+      |}>,
+      contentSize: $ReadOnly<{|
         width: Double, // always 0 on Android
         height: Double, // always 0 on Android
-      |},
-      layoutMeasurement: {|
-        // $ReadOnly<{|
+      |}>,
+      layoutMeasurement: $ReadOnly<{|
         width: Double,
         height: Double,
-      |},
-      velocity: {|
-        // $ReadOnly<{|
+      |}>,
+      velocity: $ReadOnly<{|
         x: Double, // always 0 on Android
         y: Double, // always 0 on Android
-      |},
+      |}>,
     |}>,
   >,
 


### PR DESCRIPTION
## Summary

This pull request makes properties of events' Flow types in `AndroidTextInputNativeComponent` be `$ReadOnly`.

This will make them more compatible with the callback types in `TextInput`.

## Changelog

[Internal] [Changed] - Made properties of events' Flow types in `AndroidTextInputNativeComponent` readonly

## Test Plan

`yarn flow-check-ios` and `yarn flow-check-android` both pass.

No regressions to running `scripts/generate-rncore.sh` have been noted.