### PR TITLE
Fix onPress prop for Touchable Components being called twice on Android Tv

### DIFF
--- a/Libraries/Components/Touchable/Touchable.js
+++ b/Libraries/Components/Touchable/Touchable.js
@@ -380,7 +380,7 @@ const TouchableMixin = {
           cmp.touchableHandleFocus(evt);
         } else if (evt.eventType === 'blur') {
           cmp.touchableHandleBlur(evt);
-        } else if (evt.eventType === 'select') {
+        } else if (evt.eventType === 'select' && Platform.OS !== 'android') {
           cmp.touchableHandlePress &&
             !cmp.props.disabled &&
             cmp.touchableHandlePress(evt);


### PR DESCRIPTION
## Summary

Due to an update to react-native on the  android tv platform tapping the select button on a remote calls the onPress prop twice for `TouchableHighlight`, `TouchableOpacity`, and `TouchableWithoutFeedback`. This is happening because touchableHandlePress gets called from two places. First from the onClick prop in the touchable component and second from the TVEventHandler in the TouchableMixin.

## Changelog

[Android] [Fixed] - Adds a not android check to the select case of the TVEventHandler callback in the TouchableMixin.

## Test Plan
Confirmed on Android Tv and Apple Tv

1) Add a TouchableOpacity to a screen with an onPress callback
2) Run app
3) Focus the TouchableOpacity
4) Press the Select Button on the Remote

**Expected Results**
onPress is called once

