### PR TITLE
Update generate-rncore.sh for more recent versions of codgen

### DIFF
--- a/scripts/generate-rncore.sh
+++ b/scripts/generate-rncore.sh
@@ -11,4 +11,4 @@
 # shellcheck disable=SC2038
 
 find "$PWD/../Libraries" -name "*NativeComponent.js" -print | xargs yarn flow-node packages/react-native-codegen/src/cli/combine/combine-js-to-schema-cli.js schema-rncore.json
-yarn flow-node packages/react-native-codegen/buck_tests/generate-tests.js schema-rncore.json rncore ReactCommon/fabric/components/rncore
+yarn flow-node packages/react-native-codegen/buck_tests/generate-tests.js schema-rncore.json rncore ReactCommon/fabric/components/rncore rncore


### PR DESCRIPTION
## Summary

This pull request makes the following changes to the script `scripts/generate-rncore.js`:

 * Adds a missing argument to the call of `generate-tests.js`
 * Ran `chmod +x generate-rncore.sh` so the script is executable

## Changelog

[Internal] [Fixed] - Updated `generate-rncore.sh` for recent versions of codegen

## Test Plan

`(cd scripts && ./generate-rncore.sh)` works perfectly now.