### PR TITLE
Add codegen script generated files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,7 @@ RNTester/build
 /template/ios/Podfile.lock
 /RNTester/Pods/
 /RNTester/Gemfile.lock
+
+# react-native-codegen
+/ReactCommon/fabric/components/rncore/
+/schema-rncore.json


### PR DESCRIPTION
## Summary

The files autogenerated by `scripts/generate-rncore.sh` aren't to be committed. This pull request adds them to the repo's `.gitignore`

## Changelog

[Internal] [Changed] - Add codegen generated files to gitignore

## Test Plan

The files generated by `generate-rncore.sh` are no longer added when you run `git add .`