### PR TITLE
fix(modal): fix onDismiss logic for the modal component on iOS

### DIFF
--- a/Libraries/Modal/Modal.js
+++ b/Libraries/Modal/Modal.js
@@ -169,13 +169,10 @@ class Modal extends React.Component<Props> {
     };
   }
 
-  componentWillUnmount() {
-    if (this.props.onDismiss != null) {
+  UNSAFE_componentWillReceiveProps(nextProps: Props) {
+    if (!nextProps.visible && this.props.visible && this.props.onDismiss) {
       this.props.onDismiss();
     }
-  }
-
-  UNSAFE_componentWillReceiveProps(nextProps: Props) {
     Modal._confirmProps(nextProps);
   }
 


### PR DESCRIPTION
## Summary

This PR fixes https://github.com/facebook/react-native/issues/26473 which was introduced by https://github.com/facebook/react-native/commit/bd2b7d6c0366b5f19de56b71cb706a0af4b0be43

Basically ```componentWillUnmount``` for a modal is never called because it internally returns 'null' and remains mounted on iOS. For Android, this may have worked because of empty nodes being removed by the OS from the view hierarchy, but I'm not sure.

## Changelog

[iOS] [Fixed] - fix onDismiss logic for the modal component on iOS

## Test Plan

Before this change onDismiss is never called. After the change it is called on prop change `visible`  from true to false.

```
const App = () => {
  const [isOpen, setOpen] = useState(true);

  function onDismiss() {
    console.log('dismissed');
  }

  return (
    <>
      <StatusBar barStyle="dark-content" />
      <SafeAreaView>
        <Modal visible={isOpen} animationType="slide" onDismiss={onDismiss}>
          <TouchableOpacity onPress={() => setOpen(false)}>
            <View style={{height: 500, backgroundColor: 'blue'}}>
              <Text>1</Text>
            </View>
          </TouchableOpacity>
        </Modal>
      </SafeAreaView>
    </>
  );
};
```
