### PR TITLE
Allow again for injecting custom root view via ReactActivityDelegate

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
@@ -47,7 +47,7 @@ public class ReactActivityDelegate {
   }
 
   protected ReactRootView createRootView() {
-    return mReactDelegate.createRootView();
+    return new ReactRootView(getContext());
   }
 
   /**
@@ -73,7 +73,12 @@ public class ReactActivityDelegate {
     String mainComponentName = getMainComponentName();
     mReactDelegate =
         new ReactDelegate(
-            getPlainActivity(), getReactNativeHost(), mainComponentName, getLaunchOptions());
+            getPlainActivity(), getReactNativeHost(), mainComponentName, getLaunchOptions()) {
+          @Override
+          protected ReactRootView createRootView() {
+            return ReactActivityDelegate.this.createRootView();
+          }
+        };
     if (mMainComponentName != null) {
       loadApp(mainComponentName);
     }


### PR DESCRIPTION
## Summary

This change restores the possibility of injecting custom root views via ReactAcitivtyDelegate. It has been used by react-native-gesture-handler library in order to replace default root view with a one that'd route touch events to gesture-handler internal pipeline.

The regression happened in d0792d4b8ac42711dfd9fccb782f16e72ce3e335 where new `ReactDelegate` was introduced to provide support for rendering react native views in both Android fragments and activities. As a part of that change the logic responsible for creating root view has been moved from `ReactActivityDelegate` to `ReactDelegate` rendering `ReactActivityDelegate.createRootView` unused – that is there is no code path that leads to this method being called. Instead `ReactDelegate.createRootView` method has been added which now plays the same role. The custom root view injection was relying on overwriting that method and hence the method is no longer referenced overwriting it has no effect. Following the logic migration out of `ReactActivityDelegate` into `ReactDelegate` we could potentially now start overwriting methods of `ReactDelegate`. However when working with Android's activities in React Native we can only provide an instance of `ReactActivityDelegate` and in my opinion it does not make too much sense to expose also a way to provide own instance of `ReactDelegate`.

The proposed fix was to route `ReactDelegate.createRootView` to call `ReactActivityDelegate.createRootView` and this way regaining control over root view creation to `ReactActivityDelgate`. The change of the behavior has been implemented by subclassing `ReactDelegate` directly from `ReactActivityDelegate` and hooking the aforementioned methods together. Thanks to this approach, the change has no effect on `ReactDelegate` being used directly from fragments or in other scenarios where it is not being instantiated from `ReactActivityDelegate`.

This fixes an issue reported in https://github.com/kmagiera/react-native-gesture-handler/issues/745 and discussed on 0.61 release thread: https://github.com/react-native-community/releases/issues/140#issuecomment-532235945

## Changelog

[Internal] [Fixed] - Allow for custom root view to be injected via ReactActivityDelegate

## Test Plan

1. Run RNTester, take layout snapshot, see the react root view being on the top of view hierarchy. 
2. Run gesture-handler Example app (or some other app that overwrites ReactActivityDelegate.createRootView method), on layout snapshot see custom root view being used.
