### PR TITLE
cleanup DrawerLayoutAndroid

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/drawer/ReactDrawerLayoutManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/drawer/ReactDrawerLayoutManager.java
@@ -6,18 +6,17 @@
  */
 package com.facebook.react.views.drawer;
 
-import android.os.Build;
 import android.view.Gravity;
 import android.view.View;
+
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.drawerlayout.widget.DrawerLayout;
-import com.facebook.common.logging.FLog;
 import com.facebook.react.bridge.Dynamic;
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableType;
 import com.facebook.react.common.MapBuilder;
-import com.facebook.react.common.ReactConstants;
 import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.ThemedReactContext;
@@ -29,7 +28,6 @@ import com.facebook.react.views.drawer.events.DrawerClosedEvent;
 import com.facebook.react.views.drawer.events.DrawerOpenedEvent;
 import com.facebook.react.views.drawer.events.DrawerSlideEvent;
 import com.facebook.react.views.drawer.events.DrawerStateChangedEvent;
-import java.lang.reflect.Method;
 import java.util.Map;
 
 /** View Manager for {@link ReactDrawerLayout} components. */
@@ -42,19 +40,20 @@ public class ReactDrawerLayoutManager extends ViewGroupManager<ReactDrawerLayout
   public static final int CLOSE_DRAWER = 2;
 
   @Override
-  public String getName() {
+  public @NonNull String getName() {
     return REACT_CLASS;
   }
 
   @Override
   protected void addEventEmitters(ThemedReactContext reactContext, ReactDrawerLayout view) {
-    view.setDrawerListener(
-        new DrawerEventEmitter(
-            view, reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher()));
+    view.addDrawerListener(
+      new DrawerEventEmitter(
+        view, reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher())
+    );
   }
 
   @Override
-  protected ReactDrawerLayout createViewInstance(ThemedReactContext context) {
+  protected @NonNull ReactDrawerLayout createViewInstance(@NonNull ThemedReactContext context) {
     return new ReactDrawerLayout(context);
   }
 
@@ -110,21 +109,8 @@ public class ReactDrawerLayoutManager extends ViewGroupManager<ReactDrawerLayout
   }
 
   @Override
-  public void setElevation(ReactDrawerLayout view, float elevation) {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-      // Facebook is using an older version of the support lib internally that doesn't support
-      // setDrawerElevation so we invoke it using reflection.
-      // TODO: Call the method directly when this is no longer needed.
-      try {
-        Method method = ReactDrawerLayout.class.getMethod("setDrawerElevation", float.class);
-        method.invoke(view, PixelUtil.toPixelFromDIP(elevation));
-      } catch (Exception ex) {
-        FLog.w(
-            ReactConstants.TAG,
-            "setDrawerElevation is not available in this version of the support lib.",
-            ex);
-      }
-    }
+  public void setElevation(@NonNull ReactDrawerLayout view, float elevation) {
+    view.setDrawerElevation(PixelUtil.toPixelFromDIP(elevation));
   }
 
   @Override
@@ -152,7 +138,7 @@ public class ReactDrawerLayoutManager extends ViewGroupManager<ReactDrawerLayout
 
   @Override
   public void receiveCommand(
-      ReactDrawerLayout root, String commandId, @Nullable ReadableArray args) {
+      @NonNull ReactDrawerLayout root, String commandId, @Nullable ReadableArray args) {
     switch (commandId) {
       case "openDrawer":
         root.openDrawer();
@@ -208,17 +194,17 @@ public class ReactDrawerLayoutManager extends ViewGroupManager<ReactDrawerLayout
     }
 
     @Override
-    public void onDrawerSlide(View view, float v) {
+    public void onDrawerSlide(@NonNull View view, float v) {
       mEventDispatcher.dispatchEvent(new DrawerSlideEvent(mDrawerLayout.getId(), v));
     }
 
     @Override
-    public void onDrawerOpened(View view) {
+    public void onDrawerOpened(@NonNull View view) {
       mEventDispatcher.dispatchEvent(new DrawerOpenedEvent(mDrawerLayout.getId()));
     }
 
     @Override
-    public void onDrawerClosed(View view) {
+    public void onDrawerClosed(@NonNull View view) {
       mEventDispatcher.dispatchEvent(new DrawerClosedEvent(mDrawerLayout.getId()));
     }
 


### PR DESCRIPTION
## Summary

This PR removes Java reflection use in ReactDrawerLayoutManager.java because we all use AndroidX and setDrawerElevation is available. Also adds NonNull annotations

## Changelog

[Android] [Changed] - cleanup DrawerLayoutAndroid

## Test Plan

RNTester is working as expected.
