### PR TITLE
fix build with hermes on windows

### DIFF
--- a/react.gradle
+++ b/react.gradle
@@ -149,7 +149,12 @@ afterEvaluate {
                             hermesFlags = config.hermesFlagsDebug
                             if (hermesFlags == null) hermesFlags = []
                         }
-                        commandLine(getHermesCommand(), "-emit-binary", "-out", hbcTempFile, jsBundleFile, *hermesFlags)
+                        
+                        if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                            commandLine("cmd", "/c", getHermesCommand(), "-emit-binary", "-out", hbcTempFile, jsBundleFile, *hermesFlags)
+                        } else {
+                            commandLine(getHermesCommand(), "-emit-binary", "-out", hbcTempFile, jsBundleFile, *hermesFlags)
+                        }
                     }
                     ant.move(
                         file: hbcTempFile,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
On the Windows platform, with hermes-engine enabled, the assembly crashes with an error:
![image](https://user-images.githubusercontent.com/8634793/65568495-ab11d980-df8c-11e9-83a0-2a2d26447860.png)
The problem lies in calling hermes command without the leading arguments `"cmd", "/c"` ([react.gradle, line: 152](https://github.com/facebook/react-native/blob/e028ac7af2d5b48860f01055f3bbacf91f6b6956/react.gradle#L152) )

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[General] [Fixed] - Added a platform check and running commandLine with the corresponding arguments

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
Under Windows, enable hermes-engine in _build.gradle_ and run the `gradlew assembleRelease` or `gradlew bundleRelease` command
Also check assembly on other available platforms