### PR TITLE
Add onSlidingComplete callbacks when sliders adjusted via a11y

### DIFF
--- a/React/Views/RCTSlider.m
+++ b/React/Views/RCTSlider.m
@@ -84,4 +84,24 @@
   return [self thumbImageForState:UIControlStateNormal];
 }
 
+- (void)accessibilityIncrement
+{
+  [super accessibilityIncrement];
+  if (_onSlidingComplete) {
+    _onSlidingComplete(@{
+        @"value": @(self.value),
+    });
+  }
+}
+
+- (void)accessibilityDecrement
+{
+  [super accessibilityDecrement];
+  if (_onSlidingComplete) {
+    _onSlidingComplete(@{
+        @"value": @(self.value),
+    });
+  }
+}
+
 @end

--- a/ReactAndroid/src/main/java/com/facebook/react/views/slider/ReactSliderManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/slider/ReactSliderManager.java
@@ -10,10 +10,14 @@ import android.content.Context;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.LayerDrawable;
+import android.os.Bundle;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.SeekBar;
 import androidx.annotation.Nullable;
+import androidx.core.view.accessibility.AccessibilityNodeInfoCompat.AccessibilityActionCompat;
+import androidx.core.view.AccessibilityDelegateCompat;
+import androidx.core.view.ViewCompat;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.common.MapBuilder;
@@ -132,7 +136,9 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider>
 
   @Override
   protected ReactSlider createViewInstance(ThemedReactContext context) {
-    return new ReactSlider(context, null, STYLE);
+    final ReactSlider slider = new ReactSlider(context, null, STYLE);
+    ViewCompat.setAccessibilityDelegate(slider, sAccessibilityDelegate);
+    return slider;
   }
 
   @Override
@@ -256,4 +262,25 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider>
   protected ViewManagerDelegate<ReactSlider> getDelegate() {
     return mDelegate;
   }
+ 
+  protected static class ReactSliderAccessibilityDelegate extends AccessibilityDelegateCompat {
+    private static boolean isSliderAction(int action) {
+      return (action == AccessibilityActionCompat.ACTION_SCROLL_FORWARD.getId()) ||
+        (action == AccessibilityActionCompat.ACTION_SCROLL_BACKWARD.getId()) ||
+        (action == AccessibilityActionCompat.ACTION_SET_PROGRESS.getId());
+    }
+
+    @Override
+    public boolean performAccessibilityAction(View host, int action, Bundle args) {
+      if (isSliderAction(action)) {
+        ON_CHANGE_LISTENER.onStartTrackingTouch((SeekBar)host);        
+      }
+      final boolean rv = super.performAccessibilityAction(host, action, args);
+      if (isSliderAction(action)) {
+        ON_CHANGE_LISTENER.onStopTrackingTouch((SeekBar)host);        
+      }
+      return rv;
+    }
+  };
+  protected static ReactSliderAccessibilityDelegate sAccessibilityDelegate = new ReactSliderAccessibilityDelegate();
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
When sliders are adjusted via accessibility, no onSlidingComplete callback is
generated. This causes problems for components which perform behavior in this
callback, and means that such components don't behave properly when adjusted via
accessibility. For example, if an app hosting a volume control slider only commits the volume change to the hardware on onSlidingComplete, it is impossible for a screen reader user to ever actually adjust the volume.

Ensure that sliders call the onSlidingComplete callback after adjusted via
accessibility.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

[General] [Fix] - Add onSlidingComplete callbacks when sliders adjusted via a11y.

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[CATEGORY] [TYPE] - Message

## Test Plan

Prior to this change, using the RNTester slider example with a screen reader, the onSlidingComplete callback tests never shows any callbacks when the slider is adjusted. With this change applied, the callback test will show a number of callbacks corresponding to the number of times the slider was adjusted via the screen reader.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
