### PR TITLE
Resolve signature issue causing crashes on iOS 13 under RN version 0.56.1

### DIFF
--- a/React/Base/RCTModuleMethod.mm
+++ b/React/Base/RCTModuleMethod.mm
@@ -91,6 +91,7 @@ static BOOL RCTParseSelectorPart(const char **input, NSMutableString *selector)
 static BOOL RCTParseUnused(const char **input)
 {
   return RCTReadString(input, "__unused") ||
+         RCTReadString(input, "__attribute__((__unused__))") ||
          RCTReadString(input, "__attribute__((unused))");
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native",
-  "version": "0.56.1",
+  "version": "0.56.2",
   "description": "A framework for building native apps using React",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

Tried to build an app under RN 0.56.1 but it crashed immediately. A fix was provided on recent version with https://github.com/facebook/react-native/pull/25146, I'm just bringing this fix to 0.56.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[iOS] [Fixed] - Resolve signature issue causing crashes on iOS 13 under RN version 0.56.1.

## Test Plan

Just built an app and it worked. No more crashes!