### PR TITLE
Added Warning message Linking API with Phones in iOS Simulator

### DIFF
--- a/Libraries/LinkingIOS/RCTLinkingManager.m
+++ b/Libraries/LinkingIOS/RCTLinkingManager.m
@@ -10,6 +10,7 @@
 #import <React/RCTBridge.h>
 #import <React/RCTEventDispatcher.h>
 #import <React/RCTUtils.h>
+#import <React/RCTLog.h>
 
 static NSString *const kOpenURLNotification = @"RCTOpenURLNotification";
 
@@ -97,7 +98,18 @@ RCT_EXPORT_METHOD(openURL:(NSURL *)URL
       if (success) {
         resolve(@YES);
       } else {
-        reject(RCTErrorUnspecified, [NSString stringWithFormat:@"Unable to open URL: %@", URL], nil);
+        #if TARGET_OS_SIMULATOR
+          // Simulator-specific code
+          if([URL.absoluteString hasPrefix:@"tel:"]){
+            RCTLogWarn(@"Unable to open phone dialer app in the simulator for Telephone URLs. URL:  %@", URL);
+            resolve(@NO);
+          } else {
+            reject(RCTErrorUnspecified, [NSString stringWithFormat:@"Unable to open URL: %@", URL], nil);
+          }
+        #else
+          // Device-specific code
+          reject(RCTErrorUnspecified, [NSString stringWithFormat:@"Unable to open URL: %@", URL], nil);
+        #endif
       }
     }];
   } else {
@@ -107,7 +119,18 @@ RCT_EXPORT_METHOD(openURL:(NSURL *)URL
     if (opened) {
       resolve(@YES);
     } else {
-      reject(RCTErrorUnspecified, [NSString stringWithFormat:@"Unable to open URL: %@", URL], nil);
+      #if TARGET_OS_SIMULATOR
+        // Simulator-specific code
+        if([URL.absoluteString hasPrefix:@"tel:"]){
+          RCTLogWarn(@"Unable to open phone dialer app in the simulator for Telephone URLs. URL:  %@", URL);
+          resolve(@NO);
+        } else {
+          reject(RCTErrorUnspecified, [NSString stringWithFormat:@"Unable to open URL: %@", URL], nil);
+        }
+      #else
+        // Device-specific code
+        reject(RCTErrorUnspecified, [NSString stringWithFormat:@"Unable to open URL: %@", URL], nil);
+      #endif
     }
 #endif
   }

--- a/Libraries/LinkingIOS/RCTLinkingManager.m
+++ b/Libraries/LinkingIOS/RCTLinkingManager.m
@@ -101,7 +101,7 @@ RCT_EXPORT_METHOD(openURL:(NSURL *)URL
         #if TARGET_OS_SIMULATOR
           // Simulator-specific code
           if([URL.absoluteString hasPrefix:@"tel:"]){
-            RCTLogWarn(@"Unable to open phone dialer app in the simulator for Telephone URLs. URL:  %@", URL);
+            RCTLogWarn(@"Unable to open the Phone app in the simulator for telephone URLs. URL:  %@", URL);
             resolve(@NO);
           } else {
             reject(RCTErrorUnspecified, [NSString stringWithFormat:@"Unable to open URL: %@", URL], nil);
@@ -122,7 +122,7 @@ RCT_EXPORT_METHOD(openURL:(NSURL *)URL
       #if TARGET_OS_SIMULATOR
         // Simulator-specific code
         if([URL.absoluteString hasPrefix:@"tel:"]){
-          RCTLogWarn(@"Unable to open phone dialer app in the simulator for Telephone URLs. URL:  %@", URL);
+          RCTLogWarn(@"Unable to open the Phone app in the simulator for telephone URLs. URL:  %@", URL);
           resolve(@NO);
         } else {
           reject(RCTErrorUnspecified, [NSString stringWithFormat:@"Unable to open URL: %@", URL], nil);


### PR DESCRIPTION
## Summary
This PR, tries to fix the problem at #26554 

## Changelog
iOS Fixed - Now it will show a warning when trying to use it inside a simulator, instead of throwing a red screen error.

## Notes
Docs PR opened as well at: https://github.com/facebook/react-native-website/pull/1295
<img width="418" alt="image" src="https://user-images.githubusercontent.com/12865914/65734976-532ebc00-e0cd-11e9-8e8c-2b4a5a7b8aea.png">

