### PR TITLE
Include transform in OUTER_PROPS

### DIFF
--- a/Libraries/StyleSheet/__tests__/splitLayoutProps-test.js
+++ b/Libraries/StyleSheet/__tests__/splitLayoutProps-test.js
@@ -13,11 +13,14 @@
 const splitLayoutProps = require('../splitLayoutProps');
 
 test('splits style objects', () => {
-  const style = {width: 10, margin: 20, padding: 30};
+  const style = {width: 10, margin: 20, padding: 30, transform: {scaleY: -1}};
   const {outer, inner} = splitLayoutProps(style);
   expect(outer).toMatchInlineSnapshot(`
     Object {
       "margin": 20,
+      "transform": Object {
+        "scaleY": -1,
+      },
       "width": 10,
     }
   `);

--- a/Libraries/StyleSheet/splitLayoutProps.js
+++ b/Libraries/StyleSheet/splitLayoutProps.js
@@ -36,6 +36,7 @@ const OUTER_PROPS = Object.assign(Object.create(null), {
   right: true,
   bottom: true,
   top: true,
+  transform: true,
 });
 
 function splitLayoutProps(


### PR DESCRIPTION
## Summary
Without `transform` in `OUTER_PROPS`, the refresh control component would not include `transform: {scaleY: -1}` in its style and so pulling down, rather than up, on a scroll view would trigger a refresh.

Fixes https://github.com/facebook/react-native/issues/26181

## Changelog
[Android] [Fixed] - Fixed issue with refresh control not working properly on an inverted ScrollView

## Test Plan
Updated unit test in splitLayoutProps-test.js.

