### PR TITLE
Export props type for TextInput component

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -410,7 +410,7 @@ type AndroidProps = $ReadOnly<{|
   showSoftInputOnFocus?: ?boolean,
 |}>;
 
-type Props = $ReadOnly<{|
+export type Props = $ReadOnly<{|
   ...$Diff<ViewProps, $ReadOnly<{|style: ?ViewStyleProp|}>>,
   ...IOSProps,
   ...AndroidProps,


### PR DESCRIPTION
## Summary

Fix for issue #26263

## Changelog

[JavaScript] [Fixed] - Added an export for TextInput props type

## Test Plan

This PR does not change user interface