### PR TITLE
Fix template whitespace error

### DIFF
--- a/template/ios/HelloWorldTests/HelloWorldTests.m
+++ b/template/ios/HelloWorldTests/HelloWorldTests.m
@@ -59,7 +59,7 @@
       return NO;
     }];
   }
-  
+
 #ifdef DEBUG
   RCTSetLogFunction(RCTDefaultLogFunction);
 #endif


### PR DESCRIPTION
## Summary

Very small update here. 0fcaca8e26223e47cc101c76bb7a7b02e0fc7101 accidentally introduced a whitespace error (trailing whitespace) in an iOS test file - This whitespace error is now propagated into all new projects generated by `react-native init`. This fixes it.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

[iOS] [Fixed] - Template whitespace error

## Test Plan

N/A