### PR TITLE
fix typo in comment about package

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/ModuleHolder.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/ModuleHolder.java
@@ -99,7 +99,7 @@ public class ModuleHolder {
     }
   }
 
-  /* pacakge */ synchronized boolean hasInstance() {
+  /* package */ synchronized boolean hasInstance() {
     return mModule != null;
   }
 


### PR DESCRIPTION
## Summary

This PR only fixes a typo in `ModuleHolder.java`.

## Changelog

[Internal] [Fixed] - Fix typo in comment about package
