### PR TITLE
iOS: Possible fix for #26577

### DIFF
--- a/Libraries/Text/Text/RCTTextShadowView.m
+++ b/Libraries/Text/Text/RCTTextShadowView.m
@@ -175,6 +175,17 @@
                          range:NSMakeRange(0, attributedText.length)];
 }
 
+static UIImage *emptyImg = NULL;
+- (UIImage*)getEmptyImg
+{
+  if (emptyImg == NULL) {
+    UIGraphicsBeginImageContextWithOptions(CGSizeMake(1, 1), NO, 0);
+    emptyImg = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+  }
+  return emptyImg;
+}
+
 - (NSAttributedString *)attributedTextWithMeasuredAttachmentsThatFitSize:(CGSize)size
 {
   NSMutableAttributedString *attributedText =
@@ -195,6 +206,7 @@
                                                    maximumSize:size];
       NSTextAttachment *attachment = [NSTextAttachment new];
       attachment.bounds = (CGRect){CGPointZero, fittingSize};
+      [attachment setImage:[self getEmptyImg]];
       [attributedText addAttribute:NSAttachmentAttributeName value:attachment range:range];
     }
   ];


### PR DESCRIPTION
See https://github.com/facebook/react-native/issues/26577 for the idea behind this change

## Summary

When rendering a view nested inside a text on iOS 13 there will be a document icon behind this view. That's because RN uses attachments to make the text flow around the child-views.

This code replaces the attachment image with an empty image so that the rendered output looks like expected.

## Changelog

[iOS] [Fixed] - Remove the document-icon behind childviews of text

## Test Plan

See https://github.com/facebook/react-native/issues/26577 for an example where the old code would render incorrectly. The new code renders just like it's expected.

I also added many of childviews to different texts and added NSLog-statements to verify that only one empty placeholder-image gets created.

Since I'm not normally developing in Objective-C it might be a good idea for someone else to have a look at it and see if this is a good way to do it.
