### PR TITLE
Updated Jitpack URL in android template to fix gradle errors

### DIFF
--- a/template/android/build.gradle
+++ b/template/android/build.gradle
@@ -33,6 +33,6 @@ allprojects {
 
         google()
         jcenter()
-        maven { url 'https://jitpack.io' }
+        maven { url 'https://www.jitpack.io' }
     }
 }


### PR DESCRIPTION
## Summary
Running `react-native run-android` fails for me with the error saying connection timed out for fetching a library from jitpack. This seems to be a well known issue mentioned around. The issue is resolved by updating the url from `https://jitpack.io` to `https://www.jitpack.io` .

## Changelog

[Android] [Fixed] - Updated template/android/build.gradle with a modified jitpack URL

## Test Plan

1. Create a new react-native app with `react-native init <app-name>`
2. Run `react-native run-android`
3. App runs without modifications!