### PR TITLE
update NativePermissionsAndroid.js to include ACCESS_BACKGROUND_LOCATION

### DIFF
--- a/Libraries/PermissionsAndroid/NativePermissionsAndroid.js
+++ b/Libraries/PermissionsAndroid/NativePermissionsAndroid.js
@@ -25,6 +25,7 @@ export type PermissionType =
   | 'android.permission.READ_CONTACTS'
   | 'android.permission.WRITE_CONTACTS'
   | 'android.permission.GET_ACCOUNTS'
+  | 'android.permission.ACCESS_BACKGROUND_LOCATION'
   | 'android.permission.ACCESS_FINE_LOCATION'
   | 'android.permission.ACCESS_COARSE_LOCATION'
   | 'android.permission.RECORD_AUDIO'


### PR DESCRIPTION
## Summary

https://github.com/facebook/react-native/pull/26562 added support for ACCESS_BACKGROUND_LOCATION permission, and @thymikee requested to update NativePermissionsAndroid.js too. This PR updates NativePermissionsAndroid.js to include ACCESS_BACKGROUND_LOCATION

## Changelog

[Android] [Changed] - update NativePermissionsAndroid.js to include ACCESS_BACKGROUND_LOCATION

## Test Plan

Everything builds and runs as expected
