### PR TITLE
Cap selection indices when text changes

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputShadowNode.java
@@ -156,6 +156,18 @@ public class ReactTextInputShadowNode extends ReactBaseTextShadowNode
   @ReactProp(name = PROP_TEXT)
   public void setText(@Nullable String text) {
     mText = text;
+    if (text != null) {
+      // The selection shouldn't be bigger than the length of the text
+      if (mSelectionStart > text.length()) {
+        mSelectionStart = text.length();
+      }
+      if (mSelectionEnd > text.length()) {
+        mSelectionEnd = text.length();
+      }
+    } else {
+      mSelectionStart = UNSET;
+      mSelectionEnd = UNSET;
+    }
     markUpdated();
   }
 


### PR DESCRIPTION
## Summary
This PR https://github.com/facebook/react-native/pull/22723 cached selections, so if you had a cached selection indicies, but updated the text to be an empty string, then this would crash.

As reported in https://github.com/facebook/react-native/issues/25265 and other issues of `setSpan(4 ... 4) ends beyond length`

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[Android] [fixed] - Crash in TextInput

## Test Plan
```
input.setNativeProps({ text: "xxx", selection: {"begin": 0, "end": 3}});
input.setNativeProps({ text: ""});
```
