### PR TITLE
Revert "Set rounded rectangle mask on TouchableNativeFeedback's rippl…

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactDrawableHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactDrawableHelper.java
@@ -9,6 +9,8 @@ package com.facebook.react.views.view;
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.res.ColorStateList;
+import android.graphics.Color;
+import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.RippleDrawable;
 import android.os.Build;
@@ -28,8 +30,7 @@ public class ReactDrawableHelper {
 
   @TargetApi(Build.VERSION_CODES.LOLLIPOP)
   public static Drawable createDrawableFromJSDescription(
-      ReactViewGroup view, ReadableMap drawableDescriptionDict) {
-    Context context = view.getContext();
+      Context context, ReadableMap drawableDescriptionDict) {
     String type = drawableDescriptionDict.getString("type");
     if ("ThemeAttrAndroid".equals(type)) {
       String attr = drawableDescriptionDict.getString("attribute");
@@ -74,7 +75,7 @@ public class ReactDrawableHelper {
       if (!drawableDescriptionDict.hasKey("borderless")
           || drawableDescriptionDict.isNull("borderless")
           || !drawableDescriptionDict.getBoolean("borderless")) {
-        mask = view.getBorderRadiusMask();
+        mask = new ColorDrawable(Color.WHITE);
       }
       ColorStateList colorStateList =
           new ColorStateList(new int[][] {new int[] {}}, new int[] {color});

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -18,15 +18,12 @@ import android.graphics.Rect;
 import android.graphics.RectF;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.LayerDrawable;
-import android.graphics.drawable.ShapeDrawable;
-import android.graphics.drawable.shapes.RoundRectShape;
 import android.os.Build;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewStructure;
 import android.view.animation.Animation;
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.facebook.common.logging.FLog;
 import com.facebook.infer.annotation.Assertions;
@@ -287,31 +284,6 @@ public class ReactViewGroup extends ViewGroup
 
   public void setBorderStyle(@Nullable String style) {
     getOrCreateReactViewBackground().setBorderStyle(style);
-  }
-
-  @NonNull
-  public Drawable getBorderRadiusMask() {
-    final float[] outerRadii;
-    if (mReactBackgroundDrawable == null) {
-      outerRadii = null;
-    } else {
-      final float[] borderRadii = getBorderRadii(mReactBackgroundDrawable);
-      outerRadii =
-          new float[] {
-            borderRadii[0],
-            borderRadii[0],
-            borderRadii[1],
-            borderRadii[1],
-            borderRadii[2],
-            borderRadii[2],
-            borderRadii[3],
-            borderRadii[3]
-          };
-    }
-    final ShapeDrawable shapeDrawable =
-        new ShapeDrawable(new RoundRectShape(outerRadii, null, null));
-    shapeDrawable.getPaint().setColor(Color.WHITE);
-    return shapeDrawable;
   }
 
   @Override
@@ -760,11 +732,92 @@ public class ReactViewGroup extends ViewGroup
               bottom -= borderWidth.bottom;
             }
 
-            final float borderRadii[] = getBorderRadii(mReactBackgroundDrawable);
-            final float topLeftBorderRadius = borderRadii[0];
-            final float topRightBorderRadius = borderRadii[1];
-            final float bottomRightBorderRadius = borderRadii[2];
-            final float bottomLeftBorderRadius = borderRadii[3];
+            final float borderRadius = mReactBackgroundDrawable.getFullBorderRadius();
+            float topLeftBorderRadius =
+                mReactBackgroundDrawable.getBorderRadiusOrDefaultTo(
+                    borderRadius, ReactViewBackgroundDrawable.BorderRadiusLocation.TOP_LEFT);
+            float topRightBorderRadius =
+                mReactBackgroundDrawable.getBorderRadiusOrDefaultTo(
+                    borderRadius, ReactViewBackgroundDrawable.BorderRadiusLocation.TOP_RIGHT);
+            float bottomLeftBorderRadius =
+                mReactBackgroundDrawable.getBorderRadiusOrDefaultTo(
+                    borderRadius, ReactViewBackgroundDrawable.BorderRadiusLocation.BOTTOM_LEFT);
+            float bottomRightBorderRadius =
+                mReactBackgroundDrawable.getBorderRadiusOrDefaultTo(
+                    borderRadius, ReactViewBackgroundDrawable.BorderRadiusLocation.BOTTOM_RIGHT);
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+              final boolean isRTL = mLayoutDirection == View.LAYOUT_DIRECTION_RTL;
+              float topStartBorderRadius =
+                  mReactBackgroundDrawable.getBorderRadius(
+                      ReactViewBackgroundDrawable.BorderRadiusLocation.TOP_START);
+              float topEndBorderRadius =
+                  mReactBackgroundDrawable.getBorderRadius(
+                      ReactViewBackgroundDrawable.BorderRadiusLocation.TOP_END);
+              float bottomStartBorderRadius =
+                  mReactBackgroundDrawable.getBorderRadius(
+                      ReactViewBackgroundDrawable.BorderRadiusLocation.BOTTOM_START);
+              float bottomEndBorderRadius =
+                  mReactBackgroundDrawable.getBorderRadius(
+                      ReactViewBackgroundDrawable.BorderRadiusLocation.BOTTOM_END);
+
+              if (I18nUtil.getInstance().doLeftAndRightSwapInRTL(getContext())) {
+                if (YogaConstants.isUndefined(topStartBorderRadius)) {
+                  topStartBorderRadius = topLeftBorderRadius;
+                }
+
+                if (YogaConstants.isUndefined(topEndBorderRadius)) {
+                  topEndBorderRadius = topRightBorderRadius;
+                }
+
+                if (YogaConstants.isUndefined(bottomStartBorderRadius)) {
+                  bottomStartBorderRadius = bottomLeftBorderRadius;
+                }
+
+                if (YogaConstants.isUndefined(bottomEndBorderRadius)) {
+                  bottomEndBorderRadius = bottomRightBorderRadius;
+                }
+
+                final float directionAwareTopLeftRadius =
+                    isRTL ? topEndBorderRadius : topStartBorderRadius;
+                final float directionAwareTopRightRadius =
+                    isRTL ? topStartBorderRadius : topEndBorderRadius;
+                final float directionAwareBottomLeftRadius =
+                    isRTL ? bottomEndBorderRadius : bottomStartBorderRadius;
+                final float directionAwareBottomRightRadius =
+                    isRTL ? bottomStartBorderRadius : bottomEndBorderRadius;
+
+                topLeftBorderRadius = directionAwareTopLeftRadius;
+                topRightBorderRadius = directionAwareTopRightRadius;
+                bottomLeftBorderRadius = directionAwareBottomLeftRadius;
+                bottomRightBorderRadius = directionAwareBottomRightRadius;
+              } else {
+                final float directionAwareTopLeftRadius =
+                    isRTL ? topEndBorderRadius : topStartBorderRadius;
+                final float directionAwareTopRightRadius =
+                    isRTL ? topStartBorderRadius : topEndBorderRadius;
+                final float directionAwareBottomLeftRadius =
+                    isRTL ? bottomEndBorderRadius : bottomStartBorderRadius;
+                final float directionAwareBottomRightRadius =
+                    isRTL ? bottomStartBorderRadius : bottomEndBorderRadius;
+
+                if (!YogaConstants.isUndefined(directionAwareTopLeftRadius)) {
+                  topLeftBorderRadius = directionAwareTopLeftRadius;
+                }
+
+                if (!YogaConstants.isUndefined(directionAwareTopRightRadius)) {
+                  topRightBorderRadius = directionAwareTopRightRadius;
+                }
+
+                if (!YogaConstants.isUndefined(directionAwareBottomLeftRadius)) {
+                  bottomLeftBorderRadius = directionAwareBottomLeftRadius;
+                }
+
+                if (!YogaConstants.isUndefined(directionAwareBottomRightRadius)) {
+                  bottomRightBorderRadius = directionAwareBottomRightRadius;
+                }
+              }
+            }
 
             if (topLeftBorderRadius > 0
                 || topRightBorderRadius > 0
@@ -801,97 +854,6 @@ public class ReactViewGroup extends ViewGroup
           break;
       }
     }
-  }
-
-  @NonNull
-  private float[] getBorderRadii(@NonNull ReactViewBackgroundDrawable backgroundDrawable) {
-    final float borderRadius = backgroundDrawable.getFullBorderRadius();
-    float topLeftBorderRadius =
-        backgroundDrawable.getBorderRadiusOrDefaultTo(
-            borderRadius, ReactViewBackgroundDrawable.BorderRadiusLocation.TOP_LEFT);
-    float topRightBorderRadius =
-        backgroundDrawable.getBorderRadiusOrDefaultTo(
-            borderRadius, ReactViewBackgroundDrawable.BorderRadiusLocation.TOP_RIGHT);
-    float bottomLeftBorderRadius =
-        backgroundDrawable.getBorderRadiusOrDefaultTo(
-            borderRadius, ReactViewBackgroundDrawable.BorderRadiusLocation.BOTTOM_LEFT);
-    float bottomRightBorderRadius =
-        backgroundDrawable.getBorderRadiusOrDefaultTo(
-            borderRadius, ReactViewBackgroundDrawable.BorderRadiusLocation.BOTTOM_RIGHT);
-
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-      final boolean isRTL = mLayoutDirection == View.LAYOUT_DIRECTION_RTL;
-      float topStartBorderRadius =
-          backgroundDrawable.getBorderRadius(
-              ReactViewBackgroundDrawable.BorderRadiusLocation.TOP_START);
-      float topEndBorderRadius =
-          backgroundDrawable.getBorderRadius(
-              ReactViewBackgroundDrawable.BorderRadiusLocation.TOP_END);
-      float bottomStartBorderRadius =
-          backgroundDrawable.getBorderRadius(
-              ReactViewBackgroundDrawable.BorderRadiusLocation.BOTTOM_START);
-      float bottomEndBorderRadius =
-          backgroundDrawable.getBorderRadius(
-              ReactViewBackgroundDrawable.BorderRadiusLocation.BOTTOM_END);
-
-      if (I18nUtil.getInstance().doLeftAndRightSwapInRTL(getContext())) {
-        if (YogaConstants.isUndefined(topStartBorderRadius)) {
-          topStartBorderRadius = topLeftBorderRadius;
-        }
-
-        if (YogaConstants.isUndefined(topEndBorderRadius)) {
-          topEndBorderRadius = topRightBorderRadius;
-        }
-
-        if (YogaConstants.isUndefined(bottomStartBorderRadius)) {
-          bottomStartBorderRadius = bottomLeftBorderRadius;
-        }
-
-        if (YogaConstants.isUndefined(bottomEndBorderRadius)) {
-          bottomEndBorderRadius = bottomRightBorderRadius;
-        }
-
-        final float directionAwareTopLeftRadius = isRTL ? topEndBorderRadius : topStartBorderRadius;
-        final float directionAwareTopRightRadius =
-            isRTL ? topStartBorderRadius : topEndBorderRadius;
-        final float directionAwareBottomLeftRadius =
-            isRTL ? bottomEndBorderRadius : bottomStartBorderRadius;
-        final float directionAwareBottomRightRadius =
-            isRTL ? bottomStartBorderRadius : bottomEndBorderRadius;
-
-        topLeftBorderRadius = directionAwareTopLeftRadius;
-        topRightBorderRadius = directionAwareTopRightRadius;
-        bottomLeftBorderRadius = directionAwareBottomLeftRadius;
-        bottomRightBorderRadius = directionAwareBottomRightRadius;
-      } else {
-        final float directionAwareTopLeftRadius = isRTL ? topEndBorderRadius : topStartBorderRadius;
-        final float directionAwareTopRightRadius =
-            isRTL ? topStartBorderRadius : topEndBorderRadius;
-        final float directionAwareBottomLeftRadius =
-            isRTL ? bottomEndBorderRadius : bottomStartBorderRadius;
-        final float directionAwareBottomRightRadius =
-            isRTL ? bottomStartBorderRadius : bottomEndBorderRadius;
-
-        if (!YogaConstants.isUndefined(directionAwareTopLeftRadius)) {
-          topLeftBorderRadius = directionAwareTopLeftRadius;
-        }
-
-        if (!YogaConstants.isUndefined(directionAwareTopRightRadius)) {
-          topRightBorderRadius = directionAwareTopRightRadius;
-        }
-
-        if (!YogaConstants.isUndefined(directionAwareBottomLeftRadius)) {
-          bottomLeftBorderRadius = directionAwareBottomLeftRadius;
-        }
-
-        if (!YogaConstants.isUndefined(directionAwareBottomRightRadius)) {
-          bottomRightBorderRadius = directionAwareBottomRightRadius;
-        }
-      }
-    }
-    return new float[] {
-      topLeftBorderRadius, topRightBorderRadius, bottomRightBorderRadius, bottomLeftBorderRadius
-    };
   }
 
   public void setOpacityIfPossible(float opacity) {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
@@ -52,9 +52,6 @@ public class ReactViewManager extends ViewGroupManager<ReactViewGroup> {
   private static final int CMD_SET_PRESSED = 2;
   private static final String HOTSPOT_UPDATE_KEY = "hotspotUpdate";
 
-  private @Nullable ReadableMap mNativeBackground;
-  private @Nullable ReadableMap mNativeForeground;
-
   @ReactProp(name = "accessible")
   public void setAccessible(ReactViewGroup view, boolean accessible) {
     view.setFocusable(accessible);
@@ -121,14 +118,6 @@ public class ReactViewManager extends ViewGroupManager<ReactViewGroup> {
     } else {
       view.setBorderRadius(borderRadius, index - 1);
     }
-
-    if (mNativeBackground != null) {
-      setNativeBackground(view, mNativeBackground);
-    }
-
-    if (mNativeForeground != null) {
-      setNativeForeground(view, mNativeForeground);
-    }
   }
 
   @ReactProp(name = "borderStyle")
@@ -169,17 +158,19 @@ public class ReactViewManager extends ViewGroupManager<ReactViewGroup> {
 
   @ReactProp(name = "nativeBackgroundAndroid")
   public void setNativeBackground(ReactViewGroup view, @Nullable ReadableMap bg) {
-    mNativeBackground = bg;
     view.setTranslucentBackgroundDrawable(
-        bg == null ? null : ReactDrawableHelper.createDrawableFromJSDescription(view, bg));
+        bg == null
+            ? null
+            : ReactDrawableHelper.createDrawableFromJSDescription(view.getContext(), bg));
   }
 
   @TargetApi(Build.VERSION_CODES.M)
   @ReactProp(name = "nativeForegroundAndroid")
   public void setNativeForeground(ReactViewGroup view, @Nullable ReadableMap fg) {
-    mNativeForeground = fg;
     view.setForeground(
-        fg == null ? null : ReactDrawableHelper.createDrawableFromJSDescription(view, fg));
+        fg == null
+            ? null
+            : ReactDrawableHelper.createDrawableFromJSDescription(view.getContext(), fg));
   }
 
   @ReactProp(


### PR DESCRIPTION
This reverts commit 14b455f69a30d128db384749347f41b03b9a6000. Fixes #26544. Reopens #6480

## Summary

The commit introduced regression https://github.com/facebook/react-native/issues/26544. Rolling it back fixes the issue.

## Test Plan

Test plan is in the #26544, I have confirmed it to be working. You can render `borderRadius` with `elevation` and observe the glitch (on latest Android API).
