### PR TITLE
Fix Android RNTester debug build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -506,7 +506,9 @@ jobs:
 
       - run:
           name: Build Android RNTester App
-          command: ./gradlew RNTester:android:app:assembleRelease
+          command: |
+            ./gradlew RNTester:android:app:assembleDebug
+            ./gradlew RNTester:android:app:assembleRelease
 
       # Collect Results
       - run:

--- a/RNTester/android/app/build.gradle
+++ b/RNTester/android/app/build.gradle
@@ -151,6 +151,14 @@ android {
             signingConfig signingConfigs.release
         }
     }
+
+    // The Flipper dependency pulls in a second runtime library
+    packagingOptions {
+        pickFirst '**/armeabi-v7a/libc++_shared.so'
+        pickFirst '**/x86/libc++_shared.so'
+        pickFirst '**/arm64-v8a/libc++_shared.so'
+        pickFirst '**/x86_64/libc++_shared.so'
+    }
 }
 
 dependencies {


### PR DESCRIPTION
## Summary

The Flipper dependency draws in a second C++ runtime library, so it
needs a `pickFirst`. This was not caught by CI because it only tests the
release build.

## Changelog

[ANDROID] [Fixed] - RNTester now successfully builds in debug mode

## Test Plan

Before:
```
willholen@willholen-mbp ~/extern/react-native $ ./gradlew RNTester:android:app:assembleDebug
> Task :RNTester:android:app:mergeHermesDebugNativeLibs FAILED
> Task :RNTester:android:app:mergeJscDebugNativeLibs FAILED

FAILURE: Build completed with 2 failures.

1: Task failed with an exception.
-----------
* What went wrong:
Execution failed for task ':RNTester:android:app:mergeHermesDebugNativeLibs'.
> A failure occurred while executing com.android.build.gradle.internal.tasks.Workers$ActionFacade
   > More than one file was found with OS independent path 'lib/x86/libc++_shared.so'
```

After:
```
willholen@willholen-mbp ~/extern/react-native $ ./gradlew RNTester:android:app:assembleDebug

BUILD SUCCESSFUL in 2s
81 actionable tasks: 1 executed, 80 up-to-date
willholen@willholen-mbp ~/extern/react-native $
```