### PR TITLE
Make android modal to appear underneath translucent StatusBar

### DIFF
--- a/Libraries/Modal/Modal.js
+++ b/Libraries/Modal/Modal.js
@@ -70,6 +70,14 @@ export type Props = $ReadOnly<{|
   transparent?: ?boolean,
 
   /**
+   * The `statusBarTranslucent` prop determines whether your modal should go under
+   * the system statusbar.
+   *
+   * See https://facebook.github.io/react-native/docs/modal.html#transparent
+   */
+  statusBarTranslucent?: ?boolean,
+
+  /**
    * The `hardwareAccelerated` prop controls whether to force hardware
    * acceleration for the underlying window.
    *
@@ -235,6 +243,7 @@ class Modal extends React.Component<Props> {
         hardwareAccelerated={this.props.hardwareAccelerated}
         onRequestClose={this.props.onRequestClose}
         onShow={this.props.onShow}
+        statusBarTranslucent={this.props.statusBarTranslucent}
         identifier={this._identifier}
         style={styles.modal}
         onStartShouldSetResponder={this._shouldSetResponder}

--- a/Libraries/Modal/Modal.js
+++ b/Libraries/Modal/Modal.js
@@ -81,6 +81,8 @@ export type Props = $ReadOnly<{|
    * The `hardwareAccelerated` prop controls whether to force hardware
    * acceleration for the underlying window.
    *
+   * This prop works inly on Android.
+   *
    * See https://facebook.github.io/react-native/docs/modal.html#hardwareaccelerated
    */
   hardwareAccelerated?: ?boolean,

--- a/Libraries/Modal/RCTModalHostViewNativeComponent.js
+++ b/Libraries/Modal/RCTModalHostViewNativeComponent.js
@@ -53,6 +53,14 @@ type NativeProps = $ReadOnly<{|
   transparent?: WithDefault<boolean, false>,
 
   /**
+   * The `statusBarTranslucent` prop determines whether your modal should go under
+   * the system statusbar.
+   *
+   * See https://facebook.github.io/react-native/docs/modal.html#statusBarTranslucent
+   */
+  statusBarTranslucent?: WithDefault<boolean, false>,
+
+  /**
    * The `hardwareAccelerated` prop controls whether to force hardware
    * acceleration for the underlying window.
    *

--- a/ReactAndroid/src/main/java/com/facebook/react/viewmanagers/ModalHostViewManagerDelegate.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/viewmanagers/ModalHostViewManagerDelegate.java
@@ -32,6 +32,9 @@ public class ModalHostViewManagerDelegate<T extends View, U extends BaseViewMana
       case "transparent":
         mViewManager.setTransparent(view, value == null ? false : (boolean) value);
         break;
+      case "statusBarTranslucent":
+        mViewManager.setStatusBarTranslucent(view, value == null ? false : (boolean) value);
+        break;
       case "hardwareAccelerated":
         mViewManager.setHardwareAccelerated(view, value == null ? false : (boolean) value);
         break;

--- a/ReactAndroid/src/main/java/com/facebook/react/viewmanagers/ModalHostViewManagerInterface.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/viewmanagers/ModalHostViewManagerInterface.java
@@ -17,6 +17,7 @@ public interface ModalHostViewManagerInterface<T extends View> {
   void setAnimationType(T view, @Nullable String value);
   void setPresentationStyle(T view, @Nullable String value);
   void setTransparent(T view, boolean value);
+  void setStatusBarTranslucent(T view, boolean value);
   void setHardwareAccelerated(T view, boolean value);
   void setAnimated(T view, boolean value);
   void setSupportedOrientations(T view, @Nullable ReadableArray value);

--- a/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostManager.java
@@ -79,6 +79,13 @@ public class ReactModalHostManager extends ViewGroupManager<ReactModalHostView>
   }
 
   @Override
+  @ReactProp(name = "statusBarTranslucent")
+  public void setStatusBarTranslucent(ReactModalHostView view, boolean statusBarTranslucent) {
+    view.setStatusBarTranslucent(statusBarTranslucent);
+  }
+
+
+  @Override
   @ReactProp(name = "hardwareAccelerated")
   public void setHardwareAccelerated(ReactModalHostView view, boolean hardwareAccelerated) {
     view.setHardwareAccelerated(hardwareAccelerated);

--- a/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
@@ -306,7 +306,7 @@ public class ReactModalHostView extends ViewGroup implements LifecycleEventListe
   private View getContentView() {
     FrameLayout frameLayout = new FrameLayout(getContext());
     frameLayout.addView(mHostView);
-    frameLayout.setFitsSystemWindows(true);
+    frameLayout.setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN);
     return frameLayout;
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
@@ -314,7 +314,6 @@ public class ReactModalHostView extends ViewGroup implements LifecycleEventListe
   private View getContentView() {
     FrameLayout frameLayout = new FrameLayout(getContext());
     frameLayout.addView(mHostView);
-    frameLayout.setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN);
     if (mStatusBarTranslucent) {
       frameLayout.setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN);
     } else {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
@@ -5,6 +5,7 @@
  * directory of this source tree.
  */
 package com.facebook.react.views.modal;
+import android.util.Log;
 
 import android.annotation.TargetApi;
 import android.app.Activity;
@@ -66,6 +67,7 @@ public class ReactModalHostView extends ViewGroup implements LifecycleEventListe
   private DialogRootViewGroup mHostView;
   private @Nullable Dialog mDialog;
   private boolean mTransparent;
+  private boolean mStatusBarTranslucent;
   private String mAnimationType;
   private boolean mHardwareAccelerated;
   // Set this flag to true if changing a particular property on the view requires a new Dialog to
@@ -165,6 +167,12 @@ public class ReactModalHostView extends ViewGroup implements LifecycleEventListe
 
   protected void setTransparent(boolean transparent) {
     mTransparent = transparent;
+  }
+
+  protected void setStatusBarTranslucent(boolean statusBarTranslucent) {
+    Log.v("asd", statusBarTranslucent+"");
+    mStatusBarTranslucent = statusBarTranslucent;
+    mPropertyRequiresNewDialog = true;
   }
 
   protected void setAnimationType(String animationType) {
@@ -306,7 +314,12 @@ public class ReactModalHostView extends ViewGroup implements LifecycleEventListe
   private View getContentView() {
     FrameLayout frameLayout = new FrameLayout(getContext());
     frameLayout.addView(mHostView);
-    frameLayout.setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN);
+    frameLayout.setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN);
+    if (mStatusBarTranslucent) {
+      frameLayout.setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN);
+    } else {
+      frameLayout.setFitsSystemWindows(true);
+    }
     return frameLayout;
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
@@ -5,7 +5,6 @@
  * directory of this source tree.
  */
 package com.facebook.react.views.modal;
-import android.util.Log;
 
 import android.annotation.TargetApi;
 import android.app.Activity;
@@ -170,7 +169,6 @@ public class ReactModalHostView extends ViewGroup implements LifecycleEventListe
   }
 
   protected void setStatusBarTranslucent(boolean statusBarTranslucent) {
-    Log.v("asd", statusBarTranslucent+"");
     mStatusBarTranslucent = statusBarTranslucent;
     mPropertyRequiresNewDialog = true;
   }


### PR DESCRIPTION
## Summary

As described in #26559 , the modal is not appearing underneath translucent StatusBar so you can see previous view underneath the StatusBar instead. As a solution you can now provide prop to set the modal to have translucent StatusBar and therefore the content will appear underneath. I tried to reuse layout flags that are possibly set if you use StatusBar component but sadly values in them do not reflect the props set by StatusBar component.

## Changelog

[Android] [added] - Added statusBarTranslucent prop to Modal component, to indicate if StatusBar should appear translucent.

## Test Plan

### With StatusBar translucent

![image](https://user-images.githubusercontent.com/3984319/66131336-8bfdf200-e5f3-11e9-940e-c6bb3f67ea6f.png)

``` <Modal statusBarTranslucent>```
### Without

![image](https://user-images.githubusercontent.com/3984319/66131403-a768fd00-e5f3-11e9-9814-ff7592b4ceac.png)

``` <Modal>```

