### PR TITLE
Linking to the ReactJS code of conduct.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,9 +8,9 @@ The [Open Source Guides](https://opensource.guide/) website has a collection of 
 * [Building Welcoming Communities](https://opensource.guide/building-community/)
 
 
-### [Code of Conduct](https://code.fb.com/codeofconduct/)
+### [Code of Conduct](https://github.com/facebook/react/blob/master/CODE_OF_CONDUCT.md)
 
-As a reminder, all contributors are expected to adhere to the [Code of Conduct](https://code.facebook.com/codeofconduct).
+As a reminder, all contributors are expected to adhere to the [Code of Conduct](https://github.com/facebook/react/blob/master/CODE_OF_CONDUCT.md).
 
 ## Ways to Contribute
 


### PR DESCRIPTION
## Overview

Recently, React Native switched over to a new code of conduct based on the contributors' covenant [here](https://github.com/facebook/react-native/blob/master/CODE_OF_CONDUCT.md). This PR updates CONTRIBUTING.md to link to this updated CoC.