### PR TITLE
Replace folly::make_unique with std::make_unique

### DIFF
--- a/React/CxxBridge/JSCExecutorFactory.mm
+++ b/React/CxxBridge/JSCExecutorFactory.mm
@@ -10,6 +10,8 @@
 #import <React/RCTLog.h>
 #import <jsi/JSCRuntime.h>
 
+#import<memory>
+
 namespace facebook {
 namespace react {
 
@@ -28,7 +30,7 @@ std::unique_ptr<JSExecutor> JSCExecutorFactory::createJSExecutor(
       runtimeInstaller(runtime);
     }
   };
-  return folly::make_unique<JSIExecutor>(
+  return std::make_unique<JSIExecutor>(
       facebook::jsc::makeJSCRuntime(),
       delegate,
       JSIExecutor::defaultTimeoutInvoker,

--- a/React/CxxModule/RCTCxxMethod.mm
+++ b/React/CxxModule/RCTCxxMethod.mm
@@ -12,9 +12,10 @@
 #import <React/RCTConvert.h>
 #import <React/RCTFollyConvert.h>
 #import <cxxreact/JsArgumentHelpers.h>
-#import <folly/Memory.h>
 
 #import "RCTCxxUtils.h"
+
+#import <memory>
 
 using facebook::xplat::module::CxxModule;
 using namespace facebook::react;
@@ -27,7 +28,7 @@ using namespace facebook::react;
 - (instancetype)initWithCxxMethod:(const CxxModule::Method &)method
 {
   if ((self = [super init])) {
-    _method = folly::make_unique<CxxModule::Method>(method);
+    _method = std::make_unique<CxxModule::Method>(method);
   }
   return self;
 }

--- a/ReactAndroid/src/main/java/com/facebook/hermes/reactexecutor/OnLoad.cpp
+++ b/ReactAndroid/src/main/java/com/facebook/hermes/reactexecutor/OnLoad.cpp
@@ -7,13 +7,14 @@
 #include <../instrumentation/HermesMemoryDumper.h>
 #include <HermesExecutorFactory.h>
 #include <fb/fbjni.h>
-#include <folly/Memory.h>
 #include <hermes/Public/GCConfig.h>
 #include <hermes/Public/RuntimeConfig.h>
 #include <jni.h>
 #include <react/jni/JReactMarker.h>
 #include <react/jni/JSLogging.h>
 #include <react/jni/JavaScriptExecutorHolder.h>
+
+#include <memory>
 
 namespace facebook {
 namespace react {
@@ -102,7 +103,7 @@ class HermesExecutorHolder
     JReactMarker::setLogPerfMarkerIfNeeded();
 
     return makeCxxInstance(
-        folly::make_unique<HermesExecutorFactory>(installBindings));
+        std::make_unique<HermesExecutorFactory>(installBindings));
   }
 
   static jni::local_ref<jhybriddata> initHybrid(
@@ -123,7 +124,7 @@ class HermesExecutorHolder
         heapDumper,
         tripWireCooldownMS,
         tripWireLimitBytes);
-    return makeCxxInstance(folly::make_unique<HermesExecutorFactory>(
+    return makeCxxInstance(std::make_unique<HermesExecutorFactory>(
         installBindings, JSIExecutor::defaultTimeoutInvoker, runtimeConfig));
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/jscexecutor/OnLoad.cpp
+++ b/ReactAndroid/src/main/java/com/facebook/react/jscexecutor/OnLoad.cpp
@@ -4,13 +4,14 @@
 // LICENSE file in the root directory of this source tree.
 
 #include <fb/fbjni.h>
-#include <folly/Memory.h>
 #include <jsi/JSCRuntime.h>
 #include <jsireact/JSIExecutor.h>
 #include <react/jni/JReactMarker.h>
 #include <react/jni/JSLogging.h>
 #include <react/jni/JavaScriptExecutorHolder.h>
 #include <react/jni/ReadableNativeMap.h>
+
+#include <memory>
 
 namespace facebook {
 namespace react {
@@ -28,7 +29,7 @@ class JSCExecutorFactory : public JSExecutorFactory {
               &reactAndroidLoggingHook);
       react::bindNativeLogger(runtime, androidLogger);
     };
-    return folly::make_unique<JSIExecutor>(
+    return std::make_unique<JSIExecutor>(
         jsc::makeJSCRuntime(),
         delegate,
         JSIExecutor::defaultTimeoutInvoker,
@@ -54,7 +55,7 @@ class JSCExecutorHolder
     // Android.
     JReactMarker::setLogPerfMarkerIfNeeded();
     // TODO mhorowitz T28461666 fill in some missing nice to have glue
-    return makeCxxInstance(folly::make_unique<JSCExecutorFactory>());
+    return makeCxxInstance(std::make_unique<JSCExecutorFactory>());
   }
 
   static void registerNatives() {

--- a/ReactAndroid/src/main/jni/react/jni/CatalystInstanceImpl.cpp
+++ b/ReactAndroid/src/main/jni/react/jni/CatalystInstanceImpl.cpp
@@ -6,6 +6,7 @@
 #include "CatalystInstanceImpl.h"
 
 #include <condition_variable>
+#include <memory>
 #include <mutex>
 #include <sstream>
 #include <vector>
@@ -23,7 +24,6 @@
 #include <cxxreact/RecoverableError.h>
 #include <fb/fbjni/ByteBuffer.h>
 #include <fb/log.h>
-#include <folly/Memory.h>
 #include <folly/dynamic.h>
 #include <jni/Countable.h>
 #include <jni/LocalReference.h>
@@ -91,7 +91,7 @@ CatalystInstanceImpl::initHybrid(jni::alias_ref<jclass>) {
 }
 
 CatalystInstanceImpl::CatalystInstanceImpl()
-    : instance_(folly::make_unique<Instance>()) {}
+    : instance_(std::make_unique<Instance>()) {}
 
 CatalystInstanceImpl::~CatalystInstanceImpl() {
   if (moduleMessageQueue_ != NULL) {
@@ -179,7 +179,7 @@ void CatalystInstanceImpl::initializeBridge(
   instance_->initializeBridge(
       std::make_unique<JInstanceCallback>(callback, moduleMessageQueue_),
       jseh->getExecutorFactory(),
-      folly::make_unique<JMessageQueueThread>(jsQueue),
+      std::make_unique<JMessageQueueThread>(jsQueue),
       moduleRegistry_);
 }
 
@@ -274,7 +274,7 @@ void CatalystInstanceImpl::setGlobalVariable(
 
   instance_->setGlobalVariable(
       std::move(propName),
-      folly::make_unique<JSBigStdString>(std::move(jsonValue)));
+      std::make_unique<JSBigStdString>(std::move(jsonValue)));
 }
 
 jlong CatalystInstanceImpl::getJavaScriptContext() {

--- a/ReactAndroid/src/main/jni/react/jni/CatalystInstanceImpl.h
+++ b/ReactAndroid/src/main/jni/react/jni/CatalystInstanceImpl.h
@@ -3,12 +3,12 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+#include <memory>
 #include <string>
 
 #include <ReactCommon/BridgeJSCallInvoker.h>
 #include <ReactCommon/CallInvokerHolder.h>
 #include <fb/fbjni.h>
-#include <folly/Memory.h>
 
 #include "CxxModuleWrapper.h"
 #include "JMessageQueueThread.h"

--- a/ReactAndroid/src/main/jni/react/jni/JInspector.cpp
+++ b/ReactAndroid/src/main/jni/react/jni/JInspector.cpp
@@ -5,6 +5,8 @@
 
 #include "JInspector.h"
 
+#include <memory>
+
 #ifdef WITH_INSPECTOR
 
 namespace facebook {
@@ -78,7 +80,7 @@ jni::local_ref<jni::JArrayClass<JPage::javaobject>> JInspector::getPages() {
 }
 
 jni::local_ref<JLocalConnection::javaobject> JInspector::connect(int pageId, jni::alias_ref<JRemoteConnection::javaobject> remote) {
-  auto localConnection = inspector_->connect(pageId, folly::make_unique<RemoteConnection>(std::move(remote)));
+  auto localConnection = inspector_->connect(pageId, std::make_unique<RemoteConnection>(std::move(remote)));
   return JLocalConnection::newObjectCxxArgs(std::move(localConnection));
 }
 

--- a/ReactAndroid/src/main/jni/react/jni/JInspector.h
+++ b/ReactAndroid/src/main/jni/react/jni/JInspector.h
@@ -10,7 +10,8 @@
 #include <jsinspector/InspectorInterfaces.h>
 
 #include <fb/fbjni.h>
-#include <folly/Memory.h>
+
+#include <memory>
 
 namespace facebook {
 namespace react {

--- a/ReactAndroid/src/main/jni/react/jni/JMessageQueueThread.cpp
+++ b/ReactAndroid/src/main/jni/react/jni/JMessageQueueThread.cpp
@@ -10,7 +10,6 @@
 
 #include <fb/fbjni.h>
 #include <fb/log.h>
-#include <folly/Memory.h>
 #include <jsi/jsi.h>
 
 #include "JNativeRunnable.h"

--- a/ReactAndroid/src/main/jni/react/jni/JSLoader.cpp
+++ b/ReactAndroid/src/main/jni/react/jni/JSLoader.cpp
@@ -10,8 +10,8 @@
 #include <fb/fbjni.h>
 #include <fb/log.h>
 #include <folly/Conv.h>
-#include <folly/Memory.h>
 #include <fstream>
+#include <memory>
 #include <sstream>
 #include <streambuf>
 #include <string>
@@ -46,7 +46,7 @@ std::unique_ptr<const JSBigString> loadScriptFromAssets(
       assetName.c_str(),
       AASSET_MODE_STREAMING); // Optimized for sequential read: see AssetManager.java for docs
     if (asset) {
-      auto buf = folly::make_unique<JSBigBufferString>(AAsset_getLength(asset));
+      auto buf = std::make_unique<JSBigBufferString>(AAsset_getLength(asset));
       size_t offset = 0;
       int readbytes;
       while ((readbytes = AAsset_read(asset, buf->data() + offset, buf->size() - offset)) > 0) {

--- a/ReactAndroid/src/main/jni/react/jni/JniJSModulesUnbundle.cpp
+++ b/ReactAndroid/src/main/jni/react/jni/JniJSModulesUnbundle.cpp
@@ -13,8 +13,6 @@
 #include <sys/endian.h>
 #include <utility>
 
-#include <folly/Memory.h>
-
 using magic_number_t = uint32_t;
 const magic_number_t MAGIC_FILE_HEADER = 0xFB0BD1E5;
 const char* MAGIC_FILE_NAME = "UNBUNDLE";
@@ -44,7 +42,7 @@ static asset_ptr openAsset(
 std::unique_ptr<JniJSModulesUnbundle> JniJSModulesUnbundle::fromEntryFile(
   AAssetManager *assetManager,
   const std::string& entryFile) {
-    return folly::make_unique<JniJSModulesUnbundle>(assetManager, jsModulesDir(entryFile));
+    return std::make_unique<JniJSModulesUnbundle>(assetManager, jsModulesDir(entryFile));
   }
 
 JniJSModulesUnbundle::JniJSModulesUnbundle(AAssetManager *assetManager, const std::string& moduleDirectory) :

--- a/ReactAndroid/src/main/jni/react/jni/ModuleRegistryBuilder.cpp
+++ b/ReactAndroid/src/main/jni/react/jni/ModuleRegistryBuilder.cpp
@@ -5,11 +5,11 @@
 
 #include "ModuleRegistryBuilder.h"
 
+#include <memory>
 #include <string>
 #include <glog/logging.h>
 
 #include <cxxreact/CxxNativeModule.h>
-#include <folly/Memory.h>
 
 namespace facebook {
 namespace react {
@@ -45,14 +45,14 @@ std::vector<std::unique_ptr<NativeModule>> buildNativeModuleList(
   std::vector<std::unique_ptr<NativeModule>> modules;
   if (javaModules) {
     for (const auto& jm : *javaModules) {
-      modules.emplace_back(folly::make_unique<JavaNativeModule>(
+      modules.emplace_back(std::make_unique<JavaNativeModule>(
                      winstance, jm, moduleMessageQueue));
     }
   }
   if (cxxModules) {
     for (const auto& cm : *cxxModules) {
       std::string moduleName = cm->getName();
-      modules.emplace_back(folly::make_unique<CxxNativeModule>(
+      modules.emplace_back(std::make_unique<CxxNativeModule>(
                              winstance, moduleName, cm->getProvider(moduleName), moduleMessageQueue));
     }
   }

--- a/ReactAndroid/src/main/jni/react/jni/ProxyExecutor.cpp
+++ b/ReactAndroid/src/main/jni/react/jni/ProxyExecutor.cpp
@@ -11,9 +11,10 @@
 #include <fb/assert.h>
 #include <fb/Environment.h>
 #include <folly/json.h>
-#include <folly/Memory.h>
 #include <jni/LocalReference.h>
 #include <jni/LocalString.h>
+
+#include <memory>
 
 namespace facebook {
 namespace react {
@@ -36,7 +37,7 @@ static std::string executeJSCallWithProxy(
 
 std::unique_ptr<JSExecutor> ProxyExecutorOneTimeFactory::createJSExecutor(
     std::shared_ptr<ExecutorDelegate> delegate, std::shared_ptr<MessageQueueThread>) {
-  return folly::make_unique<ProxyExecutor>(std::move(m_executor), delegate);
+  return std::make_unique<ProxyExecutor>(std::move(m_executor), delegate);
 }
 
 ProxyExecutor::ProxyExecutor(jni::global_ref<jobject>&& executorInstance,
@@ -72,7 +73,7 @@ void ProxyExecutor::loadApplicationScript(
     SystraceSection t("setGlobalVariable");
     setGlobalVariable(
       "__fbBatchedBridgeConfig",
-      folly::make_unique<JSBigStdString>(folly::toJson(config)));
+      std::make_unique<JSBigStdString>(folly::toJson(config)));
   }
 
   static auto loadApplicationScript =

--- a/ReactCommon/cxxreact/JSBigString.cpp
+++ b/ReactCommon/cxxreact/JSBigString.cpp
@@ -11,9 +11,10 @@
 
 #include <glog/logging.h>
 
-#include <folly/Memory.h>
 #include <folly/portability/SysMman.h>
 #include <folly/ScopeGuard.h>
+
+#include <memory>
 
 namespace facebook {
 namespace react {
@@ -149,7 +150,7 @@ std::unique_ptr<const JSBigFileString> JSBigFileString::fromPath(const std::stri
   struct stat fileInfo;
   folly::checkUnixError(::fstat(fd, &fileInfo), "fstat on bundle failed.");
 
-  return folly::make_unique<const JSBigFileString>(fd, fileInfo.st_size);
+  return std::make_unique<const JSBigFileString>(fd, fileInfo.st_size);
 }
 
 }  // namespace react

--- a/ReactCommon/cxxreact/JSDeltaBundleClient.cpp
+++ b/ReactCommon/cxxreact/JSDeltaBundleClient.cpp
@@ -5,9 +5,8 @@
 
 #include "JSDeltaBundleClient.h"
 
+#include <memory>
 #include <sstream>
-
-#include <folly/Memory.h>
 
 namespace facebook {
 namespace react {
@@ -87,7 +86,7 @@ JSModulesUnbundle::Module JSDeltaBundleClient::getModule(uint32_t moduleId) cons
 }
 
 std::unique_ptr<const JSBigString> JSDeltaBundleClient::getStartupCode() const {
-  return folly::make_unique<JSBigStdString>(startupCode_);
+  return std::make_unique<JSBigStdString>(startupCode_);
 }
 
 void JSDeltaBundleClient::clear() {

--- a/ReactCommon/cxxreact/JSIndexedRAMBundle.cpp
+++ b/ReactCommon/cxxreact/JSIndexedRAMBundle.cpp
@@ -6,16 +6,16 @@
 #include "JSIndexedRAMBundle.h"
 
 #include <glog/logging.h>
+#include <memory>
 #include <fstream>
 #include <sstream>
-#include <folly/Memory.h>
 
 namespace facebook {
 namespace react {
 
 std::function<std::unique_ptr<JSModulesUnbundle>(std::string)> JSIndexedRAMBundle::buildFactory() {
   return [](const std::string& bundlePath){
-    return folly::make_unique<JSIndexedRAMBundle>(bundlePath.c_str());
+    return std::make_unique<JSIndexedRAMBundle>(bundlePath.c_str());
   };
 }
 

--- a/ReactCommon/cxxreact/NativeToJsBridge.cpp
+++ b/ReactCommon/cxxreact/NativeToJsBridge.cpp
@@ -6,7 +6,6 @@
 #include "NativeToJsBridge.h"
 
 #include <folly/json.h>
-#include <folly/Memory.h>
 #include <folly/MoveWrapper.h>
 #include <glog/logging.h>
 
@@ -17,6 +16,8 @@
 #include "MessageQueueThread.h"
 #include "ModuleRegistry.h"
 #include "RAMBundleRegistry.h"
+
+#include <memory>
 
 #ifdef WITH_FBSYSTRACE
 #include <fbsystrace.h>
@@ -37,7 +38,7 @@ public:
   std::shared_ptr<ModuleRegistry> getModuleRegistry() override {
     return m_registry;
   }
-  
+
   bool isBatchActive() {
     return m_batchHadNativeModuleCalls;
   }
@@ -228,7 +229,7 @@ void* NativeToJsBridge::getJavaScriptContext() {
 bool NativeToJsBridge::isInspectable() {
   return m_inspectable;
 }
-  
+
 bool NativeToJsBridge::isBatchActive() {
   return m_delegate->isBatchActive();
 }

--- a/ReactCommon/cxxreact/RAMBundleRegistry.cpp
+++ b/ReactCommon/cxxreact/RAMBundleRegistry.cpp
@@ -5,8 +5,9 @@
 
 #include "RAMBundleRegistry.h"
 
-#include <folly/Memory.h>
 #include <folly/String.h>
+
+#include <memory>
 
 namespace facebook {
 namespace react {
@@ -15,13 +16,13 @@ constexpr uint32_t RAMBundleRegistry::MAIN_BUNDLE_ID;
 
 std::unique_ptr<RAMBundleRegistry> RAMBundleRegistry::singleBundleRegistry(
     std::unique_ptr<JSModulesUnbundle> mainBundle) {
-  return folly::make_unique<RAMBundleRegistry>(std::move(mainBundle));
+  return std::make_unique<RAMBundleRegistry>(std::move(mainBundle));
 }
 
 std::unique_ptr<RAMBundleRegistry> RAMBundleRegistry::multipleBundlesRegistry(
     std::unique_ptr<JSModulesUnbundle> mainBundle,
     std::function<std::unique_ptr<JSModulesUnbundle>(std::string)> factory) {
-  return folly::make_unique<RAMBundleRegistry>(
+  return std::make_unique<RAMBundleRegistry>(
       std::move(mainBundle), std::move(factory));
 }
 

--- a/ReactCommon/cxxreact/SampleCxxModule.cpp
+++ b/ReactCommon/cxxreact/SampleCxxModule.cpp
@@ -6,9 +6,9 @@
 #include "SampleCxxModule.h"
 #include <cxxreact/JsArgumentHelpers.h>
 
-#include <folly/Memory.h>
 #include <glog/logging.h>
 
+#include <memory>
 #include <thread>
 
 using namespace folly;
@@ -158,5 +158,5 @@ void SampleCxxModule::load(__unused folly::dynamic args, Callback cb) {
 // By convention, the function name should be the same as the class name.
 facebook::xplat::module::CxxModule *SampleCxxModule() {
   return new facebook::xplat::samples::SampleCxxModule(
-    folly::make_unique<facebook::xplat::samples::Sample>());
+    std::make_unique<facebook::xplat::samples::Sample>());
 }


### PR DESCRIPTION
## Summary

There is a mixed usage of `folly::make_unique` and `std::make_unique`. Soon, `folly::make_unique` may be removed (see [this PR](https://github.com/facebook/folly/pull/1150)). Since `react-native` only supports C++14-compilers and later, switch to always using `std::make_unique`.

## Changelog

[Internal] [Removed] - Replace folly::make_unique with std::make_unique

## Test Plan

Running the existing test suite. No change in behavior is expected.
