### PR TITLE
Add accessibilityValue prop on Touchables

### DIFF
--- a/Libraries/Components/Touchable/TouchableBounce.js
+++ b/Libraries/Components/Touchable/TouchableBounce.js
@@ -183,6 +183,7 @@ const TouchableBounce = ((createReactClass({
         accessibilityState={this.props.accessibilityState}
         accessibilityActions={this.props.accessibilityActions}
         onAccessibilityAction={this.props.onAccessibilityAction}
+        accessibilityValue={this.props.accessibilityValue}
         nativeID={this.props.nativeID}
         testID={this.props.testID}
         hitSlop={this.props.hitSlop}

--- a/Libraries/Components/Touchable/TouchableHighlight.js
+++ b/Libraries/Components/Touchable/TouchableHighlight.js
@@ -408,6 +408,7 @@ const TouchableHighlight = ((createReactClass({
         accessibilityHint={this.props.accessibilityHint}
         accessibilityRole={this.props.accessibilityRole}
         accessibilityState={this.props.accessibilityState}
+        accessibilityValue={this.props.accessibilityValue}
         accessibilityActions={this.props.accessibilityActions}
         onAccessibilityAction={this.props.onAccessibilityAction}
         style={StyleSheet.compose(

--- a/Libraries/Components/Touchable/TouchableNativeFeedback.android.js
+++ b/Libraries/Components/Touchable/TouchableNativeFeedback.android.js
@@ -316,6 +316,7 @@ const TouchableNativeFeedback = createReactClass({
       accessibilityState: this.props.accessibilityState,
       accessibilityActions: this.props.accessibilityActions,
       onAccessibilityAction: this.props.onAccessibilityAction,
+      accessibilityValue: this.props.accessibilityValue,
       children,
       testID: this.props.testID,
       onLayout: this.props.onLayout,

--- a/Libraries/Components/Touchable/TouchableOpacity.js
+++ b/Libraries/Components/Touchable/TouchableOpacity.js
@@ -313,6 +313,7 @@ const TouchableOpacity = ((createReactClass({
         accessibilityState={this.props.accessibilityState}
         accessibilityActions={this.props.accessibilityActions}
         onAccessibilityAction={this.props.onAccessibilityAction}
+        accessibilityValue={this.props.accessibilityValue}
         style={[this.props.style, {opacity: this.state.anim}]}
         nativeID={this.props.nativeID}
         testID={this.props.testID}

--- a/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+++ b/Libraries/Components/Touchable/TouchableWithoutFeedback.js
@@ -34,6 +34,7 @@ import type {
   AccessibilityState,
   AccessibilityActionInfo,
   AccessibilityActionEvent,
+  AccessibilityValue,
 } from '../View/ViewAccessibility';
 
 type TargetEvent = SyntheticEvent<
@@ -55,6 +56,7 @@ const OVERRIDE_PROPS = [
   'accessibilityState',
   'accessibilityActions',
   'onAccessibilityAction',
+  'accessibilityValue',
   'hitSlop',
   'nativeID',
   'onBlur',
@@ -71,6 +73,7 @@ export type Props = $ReadOnly<{|
   accessibilityRole?: ?AccessibilityRole,
   accessibilityState?: ?AccessibilityState,
   accessibilityActions?: ?$ReadOnlyArray<AccessibilityActionInfo>,
+  accessibilityValue?: ?AccessibilityValue,
   children?: ?React.Node,
   delayLongPress?: ?number,
   delayPressIn?: ?number,
@@ -112,6 +115,7 @@ const TouchableWithoutFeedback = ((createReactClass({
     accessibilityState: PropTypes.object,
     accessibilityActions: PropTypes.array,
     onAccessibilityAction: PropTypes.func,
+    accessibilityValue: PropTypes.object,
     /**
      * When `accessible` is true (which is the default) this may be called when
      * the OS-specific concept of "focus" occurs. Some platforms may not have

--- a/RNTester/js/examples/Accessibility/AccessibilityExample.js
+++ b/RNTester/js/examples/Accessibility/AccessibilityExample.js
@@ -564,7 +564,7 @@ class FakeSliderExample extends React.Component {
           }}>
           <Text>Fake Slider</Text>
         </View>
-        <View
+        <TouchableWithoutFeedback
           accessible={true}
           accessibilityLabel="Equalizer"
           accessibilityRole="adjustable"
@@ -588,8 +588,10 @@ class FakeSliderExample extends React.Component {
             }
           }}
           accessibilityValue={{text: this.state.textualValue}}>
-          <Text>Equalizer</Text>
-        </View>
+          <View>
+            <Text>Equalizer</Text>
+          </View>
+        </TouchableWithoutFeedback>
       </View>
     );
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

AccessibilityValue support was added for view in PR[#26169](https://github.com/facebook/react-native/pull/26169). This patch is to extend the support for all touchables.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[General] [Added] - Add accessibilityValue prop on Touchables

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
Modify one accessibility value example to use Touchable in AccessibilityExample.js.
