### PR TITLE
Android template: Allow overriding default "index.js" entry file

### DIFF
--- a/react.gradle
+++ b/react.gradle
@@ -7,10 +7,22 @@ import org.apache.tools.ant.taskdefs.condition.Os
 
 def config = project.hasProperty("react") ? project.react : [];
 
+def detectEntryFile(config) {
+    if (System.getenv('ENTRY_FILE')) {
+        return System.getenv('ENTRY_FILE')
+    } else if (config.entryFile) {
+        return config.entryFile
+    } else if ((new File("${projectDir}/../../index.android.js")).exists()) {
+        return "index.android.js"
+    }
+
+    return "index.js";
+}
+
 def cliPath = config.cliPath ?: "node_modules/react-native/cli.js"
 def composeSourceMapsPath = config.composeSourceMapsPath ?: "node_modules/react-native/scripts/compose-source-maps.js"
 def bundleAssetName = config.bundleAssetName ?: "index.android.bundle"
-def entryFile = config.entryFile ?: "index.android.js"
+def entryFile = detectEntryFile(config)
 def bundleCommand = config.bundleCommand ?: "bundle"
 def reactRoot = file(config.root ?: "../../")
 def inputExcludes = config.inputExcludes ?: ["android/**", "ios/**"]
@@ -149,7 +161,7 @@ afterEvaluate {
                             hermesFlags = config.hermesFlagsDebug
                             if (hermesFlags == null) hermesFlags = []
                         }
-                        
+
                         if (Os.isFamily(Os.FAMILY_WINDOWS)) {
                             commandLine("cmd", "/c", getHermesCommand(), "-emit-binary", "-out", hbcTempFile, jsBundleFile, *hermesFlags)
                         } else {

--- a/template/android/app/build.gradle
+++ b/template/android/app/build.gradle
@@ -15,7 +15,9 @@ import com.android.build.OutputFile
  *   // the name of the generated asset file containing your JS bundle
  *   bundleAssetName: "index.android.bundle",
  *
- *   // the entry file for bundle generation
+ *   // the entry file for bundle generation. If none specified and
+ *   // "index.android.js" exists, it will be used. Otherwise "index.js" is
+ *   // default. Can be overridden with ENTRY_FILE environment variable.
  *   entryFile: "index.android.js",
  *
  *   // https://facebook.github.io/react-native/docs/performance#enable-the-ram-format
@@ -76,7 +78,6 @@ import com.android.build.OutputFile
  */
 
 project.ext.react = [
-    entryFile: "index.js",
     enableHermes: false,  // clean and rebuild if changing
 ]
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

- Using "System.getenv" allows to specify any entry file using environment variables and without modifying gradle file. Example:

    export ENTRY_FILE="another_entry_file.js"
    ./gradlew assembleDebug

- This functionality is also more align with iOS implementation that uses 'if [[ "$ENTRY_FILE" ]]; then'. See https://github.com/facebook/react-native/pull/23667 for more details.

- Possibility to define entry file on CI without modifying sources (Example: project like [pixels-catcher](https://www.npmjs.com/package/pixels-catcher) requires different entry file)

## Changelog

[Android] [Added]  - Custom entry file on android using `ENTRY_FILE` environment variable

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

- Create a project from template

- Define `ENTRY_FILE` environment variable

```
export ENTRY_FILE="anotherIndexFile.js"
```

- Build android 

```
./gradlew assembleDebug
```

Expected result: App contains bundle file that starts from `anotherIndexFile.js` file.
