### PR TITLE
[android][gradle] Use Node's module resolution algo to find JSC & Hermes

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -94,23 +94,16 @@ task prepareFolly(dependsOn: dependenciesPath ? [] : [downloadFolly], type: Copy
 }
 
 task prepareHermes() {
-    def hermesAAR = null
     def hermesPackagePath = findNodeModulePath(projectDir, "hermes-engine")
-    if (hermesPackagePath) {
-        hermesAAR = file("$hermesPackagePath/android/hermes-debug.aar")
-        if (!hermesAAR.exists()) {
-            throw new GradleScriptException("The hermes-engine npm package is missing \"android/hermes-debug.aar\"")
-        }
-    } else {
-        // For an app to build from RN source, hermes-engine is located at /path/to/app/node_modules
-        // and $projectDir is located at /path/to/app/node_modules/react-native/ReactAndroid
-        hermesAAR = file("$projectDir/../../hermes-engine/android/hermes-debug.aar")
-
-        if (!hermesAAR.exists()) {
-            // At Facebook, this file is in a different folder
-            hermesAAR = file("$projectDir/../../node_modules/hermes-engine/android/hermes-debug.aar")
-        }
+    if (!hermesPackagePath) {
+        throw new GradleScriptException("Could not find the hermes-engine npm package")
     }
+
+    def hermesAAR = file("$hermesPackagePath/android/hermes-debug.aar")
+    if (!hermesAAR.exists()) {
+        throw new GradleScriptException("The hermes-engine npm package is missing \"android/hermes-debug.aar\"")
+    }
+
     def soFiles = zipTree(hermesAAR).matching({ it.include "**/*.so" })
 
     copy {
@@ -168,18 +161,16 @@ task prepareGlog(dependsOn: dependenciesPath ? [] : [downloadGlog], type: Copy) 
 // Create Android.mk library module based on jsc from npm
 task prepareJSC {
     doLast {
-        def jscDist = null
         def jscPackagePath = findNodeModulePath(projectDir, "jsc-android")
-        if (jscPackagePath) {
-            jscDist = file("$jscPackagePath/dist")
-            if (!jscDist.exists()) {
-                throw new GradleScriptException("The jsc-android npm package is missing its \"dist\" directory")
-            }
-        } else {
-            // For an app to build from RN source, the jsc-android is located at /path/to/app/node_modules
-            // and $projectDir may located at /path/to/app/node_modules/react-native/ReactAndroid
-            jscDist = file("$projectDir/../../jsc-android/dist")
+        if (!jscPackagePath) {
+            throw new GradleScriptException("Could not find the jsc-android npm package")
+        } 
+
+        def jscDist = file("$jscPackagePath/dist")
+        if (!jscDist.exists()) {
+            throw new GradleScriptException("The jsc-android npm package is missing its \"dist\" directory")
         }
+
         def jscAAR = fileTree(jscDist).matching({ it.include "**/android-jsc/**/*.aar" }).singleFile
         def soFiles = zipTree(jscAAR).matching({ it.include "**/*.so" })
 
@@ -206,6 +197,27 @@ task downloadNdkBuildDependencies {
     dependsOn(downloadGlog)
 }
 
+/**
+ * Finds the path of the installed npm package with the given name using Node's
+ * module resolution algorithm, which searches "node_modules" directories up to
+ * the file system root. This handles various cases, including:
+ *
+ *   - Working in the open-source RN repo:
+ *       Gradle: /path/to/react-native/ReactAndroid
+ *       Node module: /path/to/react-native/node_modules/[package]
+ *
+ *   - Installing RN as a dependency of an app and searching for hoisted
+ *     dependencies:
+ *       Gradle: /path/to/app/node_modules/react-native/ReactAndroid
+ *       Node module: /path/to/app/node_modules/[package]
+ *
+ *   - Working in a larger repo (e.g., Facebook) that contains RN:
+ *       Gradle: /path/to/repo/path/to/react-native/ReactAndroid
+ *       Node module: /path/to/repo/node_modules/[package]
+ *
+ * The search begins at the given base directory (a File object). The returned
+ * path is a string.
+ */
 def findNodeModulePath(baseDir, packageName) {
     def basePath = baseDir.toPath().normalize()
     // Node's module resolution algorithm searches up to the root directory,

--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -9,6 +9,8 @@ plugins {
     id("de.undercouch.download")
 }
 
+import java.nio.file.Paths
+
 import de.undercouch.gradle.tasks.download.Download
 import org.apache.tools.ant.taskdefs.condition.Os
 import org.apache.tools.ant.filters.ReplaceTokens
@@ -92,8 +94,14 @@ task prepareFolly(dependsOn: dependenciesPath ? [] : [downloadFolly], type: Copy
 }
 
 task prepareHermes() {
-    def hermesAAR = file("$projectDir/../node_modules/hermes-engine/android/hermes-debug.aar")
-    if (!hermesAAR.exists()) {
+    def hermesAAR = null
+    def hermesPackagePath = findNodeModulePath(projectDir, "hermes-engine")
+    if (hermesPackagePath) {
+        hermesAAR = file("$hermesPackagePath/android/hermes-debug.aar")
+        if (!hermesAAR.exists()) {
+            throw new GradleScriptException("The hermes-engine npm package is missing \"android/hermes-debug.aar\"")
+        }
+    } else {
         // For an app to build from RN source, hermes-engine is located at /path/to/app/node_modules
         // and $projectDir is located at /path/to/app/node_modules/react-native/ReactAndroid
         hermesAAR = file("$projectDir/../../hermes-engine/android/hermes-debug.aar")
@@ -160,16 +168,22 @@ task prepareGlog(dependsOn: dependenciesPath ? [] : [downloadGlog], type: Copy) 
 // Create Android.mk library module based on jsc from npm
 task prepareJSC {
     doLast {
-        def jscPackageRoot = file("$projectDir/../node_modules/jsc-android/dist")
-        if (!jscPackageRoot.exists()) {
+        def jscDist = null
+        def jscPackagePath = findNodeModulePath(projectDir, "jsc-android")
+        if (jscPackagePath) {
+            jscDist = file("$jscPackagePath/dist")
+            if (!jscDist.exists()) {
+                throw new GradleScriptException("The jsc-android npm package is missing its \"dist\" directory")
+            }
+        } else {
             // For an app to build from RN source, the jsc-android is located at /path/to/app/node_modules
             // and $projectDir may located at /path/to/app/node_modules/react-native/ReactAndroid
-            jscPackageRoot = file("$projectDir/../../jsc-android/dist")
+            jscDist = file("$projectDir/../../jsc-android/dist")
         }
-        def jscAAR = fileTree(jscPackageRoot).matching({ it.include "**/android-jsc/**/*.aar" }).singleFile
+        def jscAAR = fileTree(jscDist).matching({ it.include "**/android-jsc/**/*.aar" }).singleFile
         def soFiles = zipTree(jscAAR).matching({ it.include "**/*.so" })
 
-        def headerFiles = fileTree(jscPackageRoot).matching({ it.include "**/include/*.h" })
+        def headerFiles = fileTree(jscDist).matching({ it.include "**/include/*.h" })
 
         copy {
             from(soFiles)
@@ -190,6 +204,20 @@ task downloadNdkBuildDependencies {
     dependsOn(downloadDoubleConversion)
     dependsOn(downloadFolly)
     dependsOn(downloadGlog)
+}
+
+def findNodeModulePath(baseDir, packageName) {
+    def basePath = baseDir.toPath().normalize()
+    // Node's module resolution algorithm searches up to the root directory,
+    // after which the base path will be null 
+    while (basePath) {
+        def candidatePath = Paths.get(basePath.toString(), "node_modules", packageName)
+        if (candidatePath.toFile().exists()) {
+            return candidatePath.toString()
+        }
+        basePath = basePath.getParent()
+    }
+    return null
 }
 
 def getNdkBuildName() {


### PR DESCRIPTION
## Summary

The Gradle build file looks up jsc-android and hermes-engine using hard-coded paths. Rather than assuming the location of these packages, which are distributed and installed as npm packages, this commit makes the Gradle file use Node's standard module resolution algorithm. It looks up the file hierarchy until it finds a matching npm package or reaches the root directory.

## Changelog

[Android] [Changed] - ReactAndroid's Gradle file uses Node's module resolution algorithm to find JSC & Hermes

## Test Plan

Ensure that CI tests pass, and that `./gradlew :ReactAndroid:installArchives` works. Printed out the paths that the Gradle script found for jsc-android and hermes-engine (both were `<my stuff>/react-native/node_modules/jsc-android|hermes-engine`).
