### PR TITLE
Add support for calling .start() multiple times on animated sequence

### DIFF
--- a/Libraries/Animated/src/AnimatedImplementation.js
+++ b/Libraries/Animated/src/AnimatedImplementation.js
@@ -280,6 +280,10 @@ const sequence = function(
   let current = 0;
   return {
     start: function(callback?: ?EndCallback) {
+      if (current > 0) {
+        throw new Error("Can't start a new iteration until previous one ends");
+      }
+
       const onComplete = function(result) {
         if (!result.finished) {
           current = 0;

--- a/Libraries/Animated/src/AnimatedImplementation.js
+++ b/Libraries/Animated/src/AnimatedImplementation.js
@@ -282,6 +282,7 @@ const sequence = function(
     start: function(callback?: ?EndCallback) {
       const onComplete = function(result) {
         if (!result.finished) {
+          current = 0;
           callback && callback(result);
           return;
         }
@@ -289,6 +290,7 @@ const sequence = function(
         current++;
 
         if (current === animations.length) {
+          current = 0;
           callback && callback(result);
           return;
         }

--- a/Libraries/Animated/src/__tests__/Animated-test.js
+++ b/Libraries/Animated/src/__tests__/Animated-test.js
@@ -230,6 +230,22 @@ describe('Animated tests', () => {
       expect(cb).toBeCalledTimes(2);
     });
 
+    it('throws when user tries to start while already running', () => {
+      const anim1 = {start: jest.fn()};
+      const anim2 = {start: jest.fn()};
+      const cb = jest.fn();
+
+      const seq = Animated.sequence([anim1, anim2]);
+
+      seq.start(cb);
+      anim1.start.mock.calls[0][0]({finished: true});
+      expect(() => seq.start(cb)).toThrowError();
+      anim2.start.mock.calls[0][0]({finished: true});
+      expect(() => seq.start(cb)).not.toThrowError();
+      expect(cb).toBeCalledTimes(1);
+      expect(() => seq.start(cb)).not.toThrowError();
+    });
+
     it('supports interrupting sequence', () => {
       const anim1 = {start: jest.fn()};
       const anim2 = {start: jest.fn()};

--- a/Libraries/Animated/src/__tests__/Animated-test.js
+++ b/Libraries/Animated/src/__tests__/Animated-test.js
@@ -212,6 +212,24 @@ describe('Animated tests', () => {
       expect(cb).toBeCalledWith({finished: true});
     });
 
+    it('supports starting the same sequence multiple times', () => {
+      const anim1 = {start: jest.fn()};
+      const anim2 = {start: jest.fn()};
+      const cb = jest.fn();
+
+      const seq = Animated.sequence([anim1, anim2]);
+
+      seq.start(cb);
+      anim1.start.mock.calls[0][0]({finished: true});
+      anim2.start.mock.calls[0][0]({finished: true});
+      expect(cb).toBeCalledTimes(1);
+
+      seq.start(cb);
+      anim1.start.mock.calls[0][0]({finished: true});
+      anim2.start.mock.calls[0][0]({finished: true});
+      expect(cb).toBeCalledTimes(2);
+    });
+
     it('supports interrupting sequence', () => {
       const anim1 = {start: jest.fn()};
       const anim2 = {start: jest.fn()};


### PR DESCRIPTION
## Summary

This PR solves #26790 

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[General] [Fixed] - Fix error thrown when sequence animation was started for the second time

## Test Plan

I've added a test to cover this case
