### PR TITLE
[iOS] Fixes Fabric related podspec

### DIFF
--- a/React-Core.podspec
+++ b/React-Core.podspec
@@ -65,8 +65,7 @@ Pod::Spec.new do |s|
                                 "React/Views/RCTPicker*",
                                 "React/Views/RCTRefreshControl*",
                                 "React/Views/RCTSlider*",
-                                "React/Views/RCTSwitch*",
-    ss.private_header_files   = "React/Cxx*/*.h"
+                                "React/Views/RCTSwitch*"
   end
 
   s.subspec "DevSupport" do |ss|

--- a/ReactCommon/React-Fabric.podspec
+++ b/ReactCommon/React-Fabric.podspec
@@ -160,6 +160,24 @@ Pod::Spec.new do |s|
       sss.header_dir           = "react/components/view"
       sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\"" }
     end
+
+    ss.subspec "safeareaview" do |sss|
+      sss.dependency             folly_dep_name, folly_version
+      sss.compiler_flags       = folly_compiler_flags
+      sss.source_files         = "fabric/components/safeareaview/**/*.{m,mm,cpp,h}"
+      sss.exclude_files        = "**/tests/*"
+      sss.header_dir           = "react/components/safeareaview"
+      sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\"" }
+    end
+
+    ss.subspec "legacyviewmanagerinterop" do |sss|
+      sss.dependency             folly_dep_name, folly_version
+      sss.compiler_flags       = folly_compiler_flags
+      sss.source_files         = "fabric/components/legacyviewmanagerinterop/**/*.{m,mm,cpp,h}"
+      sss.exclude_files        = "**/tests/*"
+      sss.header_dir           = "react/components/legacyviewmanagerinterop"
+      sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\"" }
+    end
   end
 
   s.subspec "debug" do |ss|

--- a/ReactCommon/yoga/Yoga.podspec
+++ b/ReactCommon/yoga/Yoga.podspec
@@ -38,9 +38,12 @@ Pod::Spec.new do |spec|
       '-fexceptions',
       '-Wall',
       '-Werror',
-      '-std=c++1y',
       '-fPIC'
   ]
+
+  spec.pod_target_xcconfig    = {
+    "CLANG_CXX_LANGUAGE_STANDARD" => "c++14" 
+  }
 
   # Pinning to the same version as React.podspec.
   spec.platforms = { :ios => "9.0", :tvos => "9.2" }
@@ -51,7 +54,7 @@ Pod::Spec.new do |spec|
   source_files = File.join('ReactCommon/yoga', source_files) if ENV['INSTALL_YOGA_WITHOUT_PATH_OPTION']
   spec.source_files = source_files
 
-  header_files = 'yoga/{Yoga,YGEnums,YGMacros,YGValue}.h'
+  header_files = 'yoga/{Yoga,YGEnums,YGMacros,YGValue,YGNode,YGStyle}.h'
   header_files = File.join('ReactCommon/yoga', header_files) if ENV['INSTALL_YOGA_WITHOUT_PATH_OPTION']
   spec.public_header_files = header_files
 end


### PR DESCRIPTION
## Summary

1. Add missing podspec like `safeareaview` and `legacyviewmanagerinterop`.
2. Expose `YGNode,YGStyle.h` to public, fabric uses it, ex. `YogaStylableProps.h`.
3. Make `React-Core`'s Cxx header public, because `RCTLegacyViewManagerInteropCoordinator.m` uses it.

## Changelog

[iOS] [Fixed] - Fixes Fabric related podspec

## Test Plan

Fabric RNTester can run.
