### PR TITLE
JSBigString: Fix building on Windows

### DIFF
--- a/ReactCommon/cxxreact/JSBigString.h
+++ b/ReactCommon/cxxreact/JSBigString.h
@@ -5,9 +5,6 @@
 
 #pragma once
 
-#include <fcntl.h>
-#include <sys/mman.h>
-
 #include <folly/Exception.h>
 
 #ifndef RN_EXPORT


### PR DESCRIPTION
## Summary

This pull request replaces the last remaining Unix headers in `JSBigString` with their equivalent Folly Portability headers, and replaces the calls to `getpagesize()` with `sysconf(_SC_PAGESIZE)` since Folly Portability is missing that function.

The work to get this building on windows was mostly done by @acoates-ms, this pull request just adds the finishing touches.

## Changelog

[General] [Fixed] - Fixed `JSBigString` not compiling on Windows due to Unix-specific headers

## Test Plan

Compiled with Clang and with MSVC (2017)