### PR TITLE
Fix disappearing alert bug on iOS

### DIFF
--- a/React/Modules/RCTAlertManager.m
+++ b/React/Modules/RCTAlertManager.m
@@ -91,16 +91,10 @@ RCT_EXPORT_METHOD(alertWithArgs:(NSDictionary *)args
     }
   }
 
-  CGSize screenSize = [UIScreen mainScreen].bounds.size;
-  self->_window = [[UIWindow alloc] initWithFrame:CGRectMake(0, 0, screenSize.width, screenSize.height)];
-#if TARGET_OS_TV
-  self->_window.windowLevel = UIWindowLevelNormal + 1;
-#else
-  self->_window.windowLevel = UIWindowLevelStatusBar + 1;
-#endif
+  _window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+  _window.windowLevel = UIWindowLevelStatusBar + 1;
   UIViewController *presentingController = [UIViewController new];
-  self->_window.rootViewController = presentingController;
-  self->_window.hidden = NO;
+  _window.rootViewController = presentingController;
 
   UIAlertController *alertController = [UIAlertController
                                         alertControllerWithTitle:title

--- a/React/Modules/RCTAlertManager.m
+++ b/React/Modules/RCTAlertManager.m
@@ -30,7 +30,6 @@ RCT_ENUM_CONVERTER(RCTAlertViewStyle, (@{
 @implementation RCTAlertManager
 {
   NSHashTable *_alertControllers;
-  UIWindow *_window;
 }
 
 RCT_EXPORT_MODULE()
@@ -91,10 +90,11 @@ RCT_EXPORT_METHOD(alertWithArgs:(NSDictionary *)args
     }
   }
 
-  _window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
-  _window.windowLevel = UIWindowLevelStatusBar + 1;
+  __block UIWindow *window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+  window.windowLevel = UIWindowLevelStatusBar + 1;
   UIViewController *presentingController = [UIViewController new];
-  _window.rootViewController = presentingController;
+  window.rootViewController = presentingController;
+  window.hidden = NO;
 
   UIAlertController *alertController = [UIAlertController
                                         alertControllerWithTitle:title
@@ -152,7 +152,7 @@ RCT_EXPORT_METHOD(alertWithArgs:(NSDictionary *)args
     [alertController addAction:[UIAlertAction actionWithTitle:buttonTitle
                                                         style:buttonStyle
                                                       handler:^(__unused UIAlertAction *action) {
-      self->_window = nil;
+      window = nil;
       switch (type) {
         case RCTAlertViewStylePlainTextInput:
         case RCTAlertViewStyleSecureTextInput:


### PR DESCRIPTION
## Summary

Present each alert (UIAlertController) in a separate window so that they are not affected by modals or other presented view controlelrs. This also allows one to display mulitple alerts on top of each other (it is sometimes useful).

I basically copied a bunch of code from RCTDevLoadingView to achieve this.

This patch fixes issue #22237.

My previous pull request related to this issue: #22666 (closed).

## Changelog

[iOS] [Fixed] - Fixed a bug with alerts disappearing when a modal gets hidden

## Test Plan

I have a [test project](https://github.com/sryze/react-native-modal-bugs) that demonstrates the bug and allows one to verify this fix (bug no. 1 in the bug list). The project is made with React 0.61.2.


