### PR TITLE
Fix modals not being dismissed properly

### DIFF
--- a/React/Views/RCTModalHostViewManager.m
+++ b/React/Views/RCTModalHostViewManager.m
@@ -74,7 +74,19 @@ RCT_EXPORT_MODULE()
   if (_presentationBlock) {
     _presentationBlock([modalHostView reactViewController], viewController, animated, completionBlock);
   } else {
-    [[modalHostView reactViewController] presentViewController:viewController animated:animated completion:completionBlock];
+    UIViewController *topViewController = [modalHostView reactViewController];
+    while (topViewController.presentedViewController != nil) {
+      if ([topViewController.presentedViewController isKindOfClass:UIAlertController.class]) {
+        // Don't present on top of UIAlertController, this will mess it up:
+        // https://stackoverflow.com/questions/27028983/uialertcontroller-is-moved-to-buggy-position-at-top-of-screen-when-it-calls-pre
+        [topViewController dismissViewControllerAnimated:animated completion:^{
+          [topViewController presentViewController:viewController animated:animated completion:completionBlock];
+        }];
+        return;
+      }
+      topViewController = topViewController.presentedViewController;
+    }
+    [topViewController presentViewController:viewController animated:animated completion:completionBlock];
   }
 }
 


### PR DESCRIPTION
## Summary

Improve the algorithm for determining the view controller for presentation of `RCTModalHostViewController`.

The problem was that `RCTModalHostViewManager` always used the first responder view controller (`[modalHostView reactViewController]`), whereas it is possible that such controller also had presented another view controller on top of itself (and that one could present yet another VC, and so on). So we walk through the presentedViewController chain to find the top-most presented VC.

These changes fix a bug where if you present 2 modals on top of each other, you would not be able to click on anything on the screen after they go away because there is a `RCTModalHostView` hanging around in the view hierarchy on top of everything else.

My previous pull request related to this issue: #22666 (closed).

## Changelog

[iOS] [Fixed]  - Fixed a bug with modals blocking user input after they are hidden

## Test Plan

I have a [test project](https://github.com/sryze/react-native-modal-bugs) that demonstrates the bug and allows one to verify this fix (bugs no. 2 and 3 in the bug list). The project is made with React 0.61.2.
