### PR TITLE
Fix Share dialog not resolving promise when dismissed on iOS

### DIFF
--- a/React/CoreModules/RCTActionSheetManager.mm
+++ b/React/CoreModules/RCTActionSheetManager.mm
@@ -183,7 +183,7 @@ RCT_EXPORT_METHOD(showShareActionSheetWithOptions:(JS::NativeActionSheetManager:
   shareController.completionWithItemsHandler = ^(NSString *activityType, BOOL completed, __unused NSArray *returnedItems, NSError *activityError) {
     if (activityError) {
       failureCallback(@[RCTJSErrorFromNSError(activityError)]);
-    } else if (completed) {
+    } else if (completed || activityType == nil) {
       successCallback(@[@(completed), RCTNullIfNil(activityType)]);
     }
   };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
On iOS the promised returned by `Share.share(content, options)` isn't resolved if the user dismisses the dialog by either pressing "Cancel" or pressing outside the shared dialog. This PR fixes this issue. 

This fixes #26809.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[iOS] [Fixed] - Fix promised returned by `Share.share(content, options)` not resolving if share dialog dismissed

## Test Plan
1. on iOS, open a share dialog with: 

```typescript
const onShare = async () => {
  const result = await Share.share({ message: 'example message' });
}
```

2. Dismiss the opened share dialog and the returned promised should resolve.


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
