### PR TITLE
fix(eslint-config): Clashes with prettier

### DIFF
--- a/packages/eslint-config-react-native-community/index.js
+++ b/packages/eslint-config-react-native-community/index.js
@@ -112,7 +112,7 @@ module.exports = {
 
   rules: {
     // General
-    'comma-dangle': [1, 'always-multiline'], // allow or disallow trailing commas
+    'comma-dangle': 0, // allow or disallow trailing commas (off by default)
     'no-cond-assign': 1, // disallow assignment in conditional expressions
     'no-console': 0, // disallow use of console (off by default in the node environment)
     'no-const-assign': 2, // disallow assignment to const-declared variables
@@ -250,9 +250,9 @@ module.exports = {
     'no-trailing-spaces': 1, // disallow trailing whitespace at the end of lines
     'no-underscore-dangle': 0, // disallow dangling underscores in identifiers
     'no-mixed-spaces-and-tabs': 1, // disallow mixed spaces and tabs for indentation
-    quotes: [1, 'single', 'avoid-escape'], // specify whether double or single quotes should be used
+    quotes: 0, // specify whether double or single quotes should be used (off by default)
     'quote-props': 0, // require quotes around object literal property names (off by default)
-    semi: 1, // require or disallow use of semicolons instead of ASI
+    semi: 0, // require or disallow use of semicolons instead of ASI (off by default)
     'sort-vars': 0, // sort variables within the same declaration block (off by default)
     'space-in-brackets': 0, // require or disallow spaces inside brackets (off by default)
     'space-in-parens': 0, // require or disallow spaces inside parentheses (off by default)
@@ -309,5 +309,11 @@ module.exports = {
     'jest/no-focused-tests': 1,
     'jest/no-identical-title': 1,
     'jest/valid-expect': 1,
+
+    // Prettier Plugin
+    'prettier/prettier': [
+      1,
+      {singleQuote: true, trailingComma: 'es5', semi: true},
+    ],
   },
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Currently, @react-native-community config package extends from prettier/recommended which comes with default settings from prettier. However there are still some eslint rules in the config that either clash or duplicate the settings from prettier.

This results in eslint fixing the formatting and then prettier undoing it. This PR removes the style specific rules from eslint and place them in the prettier section.
## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[General] [Fixed] - Remove style rules from eslint config for prettier options

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

I created a repo for you to test with https://github.com/iRoachie/eslint-bug-replicate. You can see that running `yarn lint --fix` will never fix the issue. Eslint will complain about double quotes and subsequently after fixing it will complain about single quotes. 

Here's a gif of the behaviour (vscode eslint plugin `"eslint.autoFixOnSave": true`):

![Kapture 2019-10-13 at 23 34 15](https://user-images.githubusercontent.com/5962998/66728290-ff80da00-ee11-11e9-8993-4d1b679c270b.gif)
