### PR TITLE
Fix Unable to find module for UIManager issue

### DIFF
--- a/React/CxxBridge/RCTCxxBridge.mm
+++ b/React/CxxBridge/RCTCxxBridge.mm
@@ -463,6 +463,9 @@ struct RCTInstanceCallback : public InstanceCallback {
 
 - (id)moduleForName:(NSString *)moduleName lazilyLoadIfNecessary:(BOOL)lazilyLoad
 {
+  if (!_moduleDataByName) {
+    return nil;
+  }
   if (RCTTurboModuleEnabled() && _turboModuleLookupDelegate) {
     const char* moduleNameCStr = [moduleName UTF8String];
     if (lazilyLoad || [_turboModuleLookupDelegate moduleIsInitialized:moduleNameCStr]) {


### PR DESCRIPTION
## Summary
A race condition sometimes causes redbox errors when reloading the app after previously opening the Chrome debugger. In the project I was working on, we were regularly getting `Unable to find module for UIManager` and I was able to track it down to `_moduleDataByName` sometimes being empty or nil. This change safely early-exits when that is the case and the app loads successfully. Related issues:
#24549
#23235

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[iOS] [Fixed] - Race condition causing redbox errors when reloading app after using Chrome debugger

## Test Plan
As this is a difficult-to-reproduce race condition, I'm not entirely certain what the test plan should be. I created this change as a patch to React Native in the closed-source project I've been working on and it works flawlessly, however I haven't been able to reproduce the issue in a clean project. This is a fairly safe change as the early exit only ever occurs if the variable is empty and it seems to be resilient enough to load the module again after the race condition has been defeated, but I'm open to suggestions on potential options to test this.
