### PR TITLE
iOS - include safe area insets as part of window dimensions

### DIFF
--- a/Libraries/Utilities/Dimensions.js
+++ b/Libraries/Utilities/Dimensions.js
@@ -65,6 +65,14 @@ class Dimensions {
         height: windowPhysicalPixels.height / windowPhysicalPixels.scale,
         scale: windowPhysicalPixels.scale,
         fontScale: windowPhysicalPixels.fontScale,
+        topSafeAreaInset:
+          windowPhysicalPixels.topSafeAreaInset / windowPhysicalPixels.scale,
+        bottomSafeAreaInset:
+          windowPhysicalPixels.bottomSafeAreaInset / windowPhysicalPixels.scale,
+        leftSafeAreaInset:
+          windowPhysicalPixels.leftSafeAreaInset / windowPhysicalPixels.scale,
+        rightSafeAreaInset:
+          windowPhysicalPixels.rightSafeAreaInset / windowPhysicalPixels.scale,
       };
     }
     const {screenPhysicalPixels} = dims;
@@ -74,6 +82,14 @@ class Dimensions {
         height: screenPhysicalPixels.height / screenPhysicalPixels.scale,
         scale: screenPhysicalPixels.scale,
         fontScale: screenPhysicalPixels.fontScale,
+        topSafeAreaInset:
+          screenPhysicalPixels.topSafeAreaInset / screenPhysicalPixels.scale,
+        bottomSafeAreaInset:
+          screenPhysicalPixels.bottomSafeAreaInset / screenPhysicalPixels.scale,
+        leftSafeAreaInset:
+          screenPhysicalPixels.leftSafeAreaInset / screenPhysicalPixels.scale,
+        rightSafeAreaInset:
+          screenPhysicalPixels.rightSafeAreaInset / screenPhysicalPixels.scale,
       };
     } else if (screen == null) {
       screen = window;

--- a/Libraries/Utilities/NativeDeviceInfo.js
+++ b/Libraries/Utilities/NativeDeviceInfo.js
@@ -19,6 +19,10 @@ type DisplayMetricsAndroid = {|
   scale: number,
   fontScale: number,
   densityDpi: number,
+  topSafeAreaInset: number,
+  bottomSafeAreaInset: number,
+  leftSafeAreaInset: number,
+  rightSafeAreaInset: number,
 |};
 
 export type DisplayMetrics = {|
@@ -26,6 +30,10 @@ export type DisplayMetrics = {|
   height: number,
   scale: number,
   fontScale: number,
+  topSafeAreaInset: number,
+  bottomSafeAreaInset: number,
+  leftSafeAreaInset: number,
+  rightSafeAreaInset: number,
 |};
 
 export type DimensionsPayload = {|

--- a/React/CoreModules/RCTDeviceInfo.mm
+++ b/React/CoreModules/RCTDeviceInfo.mm
@@ -97,14 +97,22 @@ static NSDictionary *RCTExportedDimensions(RCTBridge *bridge)
       @"width": @(window.width),
       @"height": @(window.height),
       @"scale": @(window.scale),
-      @"fontScale": @(window.fontScale)
+      @"fontScale": @(window.fontScale),
+      @"topSafeAreaInset": @(window.topSafeAreaInset),
+      @"bottomSafeAreaInset": @(window.bottomSafeAreaInset),
+      @"leftSafeAreaInset": @(window.leftSafeAreaInset),
+      @"rightSafeAreaInset": @(window.rightSafeAreaInset),
   };
   __typeof(dimensions.screen) screen = dimensions.screen;
   NSDictionary<NSString *, NSNumber *> *dimsScreen = @{
       @"width": @(screen.width),
       @"height": @(screen.height),
       @"scale": @(screen.scale),
-      @"fontScale": @(screen.fontScale)
+      @"fontScale": @(screen.fontScale),
+      @"topSafeAreaInset": @(screen.topSafeAreaInset),
+      @"bottomSafeAreaInset": @(screen.bottomSafeAreaInset),
+      @"leftSafeAreaInset": @(screen.leftSafeAreaInset),
+      @"rightSafeAreaInset": @(screen.rightSafeAreaInset),
   };
   return @{
       @"window": dimsWindow,

--- a/React/UIUtils/RCTUIUtils.h
+++ b/React/UIUtils/RCTUIUtils.h
@@ -18,7 +18,7 @@ extern "C" {
 // Get window and screen dimensions
 typedef struct {
   struct {
-    CGFloat width, height, scale, fontScale;
+    CGFloat width, height, scale, fontScale, topSafeAreaInset, leftSafeAreaInset, rightSafeAreaInset, bottomSafeAreaInset;
   } window, screen;
 } RCTDimensions;
 extern __attribute__((visibility("default")))

--- a/React/UIUtils/RCTUIUtils.m
+++ b/React/UIUtils/RCTUIUtils.m
@@ -17,20 +17,36 @@ RCTDimensions RCTGetDimensions(CGFloat fontScale)
   UIView *mainWindow;
   mainWindow = RCTKeyWindow();
   CGSize windowSize = mainWindow.bounds.size;
-
+    
   RCTDimensions result;
   typeof (result.screen) dimsScreen = {
     .width = screenSize.width,
     .height = screenSize.height,
     .scale = mainScreen.scale,
-    .fontScale = fontScale
+    .fontScale = fontScale,
+    .topSafeAreaInset = 0.0,
+    .bottomSafeAreaInset = 0.0,
+    .leftSafeAreaInset = 0.0,
+    .rightSafeAreaInset = 0.0,
   };
   typeof (result.window) dimsWindow = {
     .width = windowSize.width,
     .height = windowSize.height,
     .scale = mainScreen.scale,
-    .fontScale = fontScale
+    .fontScale = fontScale,
+    .topSafeAreaInset = 0.0,
+    .bottomSafeAreaInset = 0.0,
+    .leftSafeAreaInset = 0.0,
+    .rightSafeAreaInset = 0.0,
   };
+    
+  if (@available(iOS 11.0, *)) {
+    dimsWindow.topSafeAreaInset = mainWindow.safeAreaInsets.top;
+    dimsWindow.bottomSafeAreaInset = mainWindow.safeAreaInsets.bottom;
+    dimsWindow.leftSafeAreaInset = mainWindow.safeAreaInsets.left;
+    dimsWindow.rightSafeAreaInset = mainWindow.safeAreaInsets.right;
+  }
+
   result.screen = dimsScreen;
   result.window = dimsWindow;
 

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -707,7 +707,7 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
 
     private void checkForDeviceDimensionsChanges() {
       // Get current display metrics.
-      DisplayMetricsHolder.initDisplayMetrics(getContext());
+      DisplayMetricsHolder.initDisplayMetricsIfNotInitialized(getContext());
       // Check changes to both window and screen display metrics since they may not update at the
       // same time.
       if (!areMetricsEqual(mWindowMetrics, DisplayMetricsHolder.getWindowDisplayMetrics())

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/DisplayMetricsHolder.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/DisplayMetricsHolder.java
@@ -48,7 +48,7 @@ public class DisplayMetricsHolder {
     initDisplayMetrics(context);
   }
 
-  public static void initDisplayMetrics(Context context) {
+  private static void initDisplayMetrics(Context context) {
     DisplayMetrics displayMetrics = context.getResources().getDisplayMetrics();
     DisplayMetricsHolder.setWindowDisplayMetrics(displayMetrics);
 
@@ -57,6 +57,8 @@ public class DisplayMetricsHolder {
     WindowManager wm = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
     Assertions.assertNotNull(wm, "WindowManager is null!");
     Display display = wm.getDefaultDisplay();
+
+    // Todo figure out how to call getWindow().getDecorView().getRootWindowInsets()
 
     // Get the real display metrics if we are using API level 17 or higher.
     // The real metrics include system decor elements (e.g. soft menu bar).
@@ -133,6 +135,10 @@ public class DisplayMetricsHolder {
     result.put("scale", displayMetrics.density);
     result.put("fontScale", fontScale);
     result.put("densityDpi", displayMetrics.densityDpi);
+    result.put("topSafeAreaInset", 0);
+    result.put("bottomSafeAreaInset", 0);
+    result.put("leftSafeAreaInset", 0);
+    result.put("rightSafeAreaInset", 0);
     return result;
   }
 
@@ -144,6 +150,10 @@ public class DisplayMetricsHolder {
     result.putDouble("scale", displayMetrics.density);
     result.putDouble("fontScale", fontScale);
     result.putDouble("densityDpi", displayMetrics.densityDpi);
+    result.putInt("topSafeAreaInset", 0);
+    result.putInt("bottomSafeAreaInset", 0);
+    result.putInt("leftSafeAreaInset", 0);
+    result.putInt("rightSafeAreaInset", 0);
     return result;
   }
 }


### PR DESCRIPTION
## Summary

It'd be great to have the safe area insets available as part of the window dimensions.

```{javascript}
import { Dimensions } from 'react-native';

const {
  height,
  width,
  fontScale,
  scale,
  topSafeAreaInset,
  BottomSafeAreaInset,
  leftSafeAreaInset,
  rightSafeAreaInset
} = Dimensions.get('window');

```

I'm stuck on the android side at the moment. If anyone has any ideas or suggestions that'd be awesome. For the time being android returns 0 for the safe area inset params.

## Changelog

[iOS] [Added] - Safe Area insets included with Dimensions

## Test Plan

RNTester app

iOS Simulator
![Simulator Screen Shot - iPhone 11 - 2019-10-15 at 19 51 09](https://user-images.githubusercontent.com/4999026/66884858-5360ff80-ef87-11e9-91b7-cf42d5bff52b.png)
