### PR TITLE
Don't wrap console methods for metro logging in Chrome debugger

### DIFF
--- a/Libraries/Core/setUpDeveloperTools.js
+++ b/Libraries/Core/setUpDeveloperTools.js
@@ -59,7 +59,9 @@ if (__DEV__) {
       JSInspector.registerAgent(require('../JSInspector/NetworkAgent'));
     }
 
-    if (!Platform.isTesting) {
+    // Only attach metro logging if we're in a native app environment,
+    // otherwise continue to use the native logging for the envionment we're in.
+    if (!Platform.isTesting && global.nativeLoggingHook) {
       const HMRClient = require('../Utilities/HMRClient');
       [
         'trace',


### PR DESCRIPTION
Summary:
This diff fixes an issue reported in https://github.com/facebook/react-native/issues/26788 where logs in the Chrome console were showing a different location than previous versions.

In the change here, we stop wrapping the console functions to attach the metro websocket in any environment that isn't a native app environment. We do this by checking `global.nativeLoggingHook` which is bound only by native apps and not environments like the Chrome DevTools.

Differential Revision: D17951707

