### PR TITLE
Fix Switch component accessibility role

### DIFF
--- a/Libraries/Components/Switch/Switch.js
+++ b/Libraries/Components/Switch/Switch.js
@@ -156,7 +156,7 @@ class Switch extends React.Component<Props> {
         <AndroidSwitchNativeComponent
           {...props}
           {...platformProps}
-          accessibilityRole={props.accessibilityRole ?? 'button'}
+          accessibilityRole={props.accessibilityRole ?? 'switch'}
           onChange={this._handleChange}
           onResponderTerminationRequest={returnsFalse}
           onStartShouldSetResponder={returnsTrue}
@@ -189,7 +189,7 @@ class Switch extends React.Component<Props> {
       <SwitchNativeComponent
         {...props}
         {...platformProps}
-        accessibilityRole={props.accessibilityRole ?? 'button'}
+        accessibilityRole={props.accessibilityRole ?? 'switch'}
         onChange={this._handleChange}
         onResponderTerminationRequest={returnsFalse}
         onStartShouldSetResponder={returnsTrue}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
`accessibilityRole` communicates the purpose of a component to the user of assistive technology. It needs to have the correct value for it to be fully utilized.

Switch component has `accessibilityRole` of a `button` instead of `switch` on default. Change the component default role to `switch`.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[General] [Fixed] - Change default `accessibilityRole` of Switch component from `button` to `switch`

## Test Plan

- All unit test passed
- On Switch component, it's supposed to have `switch` like element type on both platform. (`XCUIElementTypeSwitch` on iOS)
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

fix [#26873](https://github.com/facebook/react-native/issues/26873)
