### PR TITLE
Fix ActionSheet completion callback not called when dialog is dismissed

### DIFF
--- a/React/CoreModules/RCTActionSheetManager.mm
+++ b/React/CoreModules/RCTActionSheetManager.mm
@@ -183,7 +183,7 @@ RCT_EXPORT_METHOD(showShareActionSheetWithOptions:(JS::NativeActionSheetManager:
   shareController.completionWithItemsHandler = ^(NSString *activityType, BOOL completed, __unused NSArray *returnedItems, NSError *activityError) {
     if (activityError) {
       failureCallback(@[RCTJSErrorFromNSError(activityError)]);
-    } else if (completed) {
+    } else if (completed || !activityType) {
       successCallback(@[@(completed), RCTNullIfNil(activityType)]);
     }
   };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

https://github.com/facebook/react-native/pull/26429 introduced this problem: when the action sheet is dismissed without having selected and then canceled an action, neither of the success or failure callbacks is called.  This causes the Promise that opens the action sheet in the Javascript code to remain unfulfilled.  This fix checks that if no activity was chosen, in other words the dismiss button on the share dialog was pressed and the dialog was closed, then the success callback will still be called.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[iOS] [Fixed] - Fix ActionSheet completion callback not called when dialog is dismissed

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

I'm using the react-native-share component to invoke the action sheet.  Add these lines to the Javascript code:
`import Share from 'react-native-share';`
`Share.open({`
`    url: 'http://www.facebook.com'`
`}).finally(() => {`
`    console.log('finally called');`
`});`

In the ActionSheet dialog, press the dismiss button without having selected an action.  Without this fix, the finally function is not called.  With the fix, it is called.  All other behavior is the same as before.
