### PR TITLE
bump Android build-tools to 29.0.2, compileSdk to 29

### DIFF
--- a/.appveyor/config.yml
+++ b/.appveyor/config.yml
@@ -2,7 +2,7 @@ environment:
   ANDROID_HOME: "C:\\android-sdk-windows"
   ANDROID_NDK: "C:\\android-sdk-windows\\android-ndk-r19c"
   ANDROID_BUILD_VERSION: 28
-  ANDROID_TOOLS_VERSION: 28.0.3
+  ANDROID_TOOLS_VERSION: 29.0.2
 
   GRADLE_OPTS: -Dorg.gradle.daemon=false
 

--- a/.circleci/Dockerfiles/Dockerfile.android
+++ b/.circleci/Dockerfiles/Dockerfile.android
@@ -14,7 +14,7 @@
 # and build a Android application that can be used to run the
 # tests specified in the scripts/ directory.
 #
-FROM reactnativecommunity/react-native-android:2019-9-4
+FROM reactnativecommunity/react-native-android:2019-10-18
 
 LABEL Description="React Native Android Test Image"
 LABEL maintainer="Héctor Ramos <hector@fb.com>"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ executors:
   reactnativeandroid:
     <<: *defaults
     docker:
-      - image: reactnativecommunity/react-native-android:2019-9-4
+      - image: reactnativecommunity/react-native-android:2019-10-18
     resource_class: "large"
     environment:
       - TERM: "dumb"

--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -345,7 +345,7 @@ def packageReactNdkLibsForBuck = tasks.register("packageReactNdkLibsForBuck", Co
 }
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     compileOptions {
         sourceCompatibility(JavaVersion.VERSION_1_8)

--- a/scripts/.tests.env
+++ b/scripts/.tests.env
@@ -4,7 +4,7 @@
 
 ## ANDROID ##
 # Android SDK Build Tools revision
-export ANDROID_SDK_BUILD_TOOLS_REVISION=28.0.3
+export ANDROID_SDK_BUILD_TOOLS_REVISION=29.0.2
 # Android API Level we build with
 export ANDROID_SDK_BUILD_API_LEVEL="28"
 # Google APIs for Android level

--- a/template/android/build.gradle
+++ b/template/android/build.gradle
@@ -2,9 +2,9 @@
 
 buildscript {
     ext {
-        buildToolsVersion = "28.0.3"
+        buildToolsVersion = "29.0.2"
         minSdkVersion = 16
-        compileSdkVersion = 28
+        compileSdkVersion = 29
         targetSdkVersion = 28
     }
     repositories {


### PR DESCRIPTION
## Summary

Bump bump Android build-tools to 29.0.2, compileSdk to 29, Buck to 2019.10.17.01.

## Changelog

[Android] [Changed] - bump Android build-tools to 29.0.2, compileSdk to 29

## Test Plan

CI is green