### PR TITLE
Added React-RCTWrapper.podspec to use RCTWrapper in cocoapods-based projects

### DIFF
--- a/Libraries/Wrapper/React-RCTWrapper.podspec
+++ b/Libraries/Wrapper/React-RCTWrapper.podspec
@@ -1,0 +1,34 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+require "json"
+
+package = JSON.parse(File.read(File.join(__dir__, "..", "..", "package.json")))
+version = package['version']
+
+source = { :git => 'https://github.com/facebook/react-native.git' }
+if version == '1000.0.0'
+  # This is an unpublished version, use the latest commit hash of the react-native repo, which we’re presumably in.
+  source[:commit] = `git rev-parse HEAD`.strip
+else
+  source[:tag] = "v#{version}"
+end
+
+Pod::Spec.new do |s|
+  s.name                   = "React-RCTWrapper"
+  s.version                = version
+  s.summary                = "A library that allows turn any UIView/UIViewController-based widget into React Native component"
+  s.homepage               = "http://facebook.github.io/react-native/"
+  s.documentation_url      = "https://github.com/facebook/react-native/commit/c0e9936d8e43e949567012eab77ad8f6005397a8"
+  s.license                = package["license"]
+  s.author                 = "Facebook, Inc. and its affiliates"
+  s.platforms              = { :ios => "9.0", :tvos => "9.2" }
+  s.source                 = source
+  s.source_files           = "*.{m}"
+  s.preserve_paths         = "package.json", "LICENSE", "LICENSE-docs"
+  s.header_dir             = "RCTWrapper"
+
+  s.dependency "React-Core/RCTWrapperHeaders", version  
+end

--- a/React-Core.podspec
+++ b/React-Core.podspec
@@ -33,6 +33,7 @@ header_subspecs = {
   'RCTSettingsHeaders'          => 'Libraries/Settings/*.h',
   'RCTTextHeaders'              => 'Libraries/Text/**/*.h',
   'RCTVibrationHeaders'         => 'Libraries/Vibration/*.h',
+  'RCTWrapperHeaders'           => 'Libraries/Wrapper/*.h',
 }
 
 Pod::Spec.new do |s|


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

I found that there is a Library/Wrapper exist in the project but it is not accessible through cocoa-pods, and either needs to be copied and pasted or forgotten. May be it is not used much but I found it handy in some situation building native UI Components. 

To use this library with this MR it needs to add this into apps Podfile:
```
pod 'React-RCTWrapper', :path => '../node_modules/react-native/Libraries/Wrapper'
```
Than follow Similar instructions as described in example: https://github.com/facebook/react-native/commit/c0e9936d8e43e949567012eab77ad8f6005397a8

Basically this module provides size calculation logic for native modules that need to be wrapped quickly. 

**Side note and learning:** : it is not possible to use RCT_EXPORT_VIEW_PROPERTY as it will than be mapped to RCTWrapperView which we return from view.

to workaround this it is advised to use RCT_CUSTOM_VIEW_PROPERTY, like that:
```
RCT_CUSTOM_VIEW_PROPERTY(yourCustomProperty, YourCustomPropertyType, RCTWrapperView) {
  [(YourCustomView*)[view contentView]setYourCustomProperty:
[RCTConvert YourCustomPropertyType:json]];
}
```

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[iOS] [Added] - Library/Wrapper/React-RCTWrapper.podspec to describe code in Library/Wrapper
[iOS] [Changed] - React-Core.podspec to have RCTWrapperHeaders in subspec

## Test Plan

Not sure how to automate testing of it, but open for suggestions....

What I did:

I added this podspec changes to my own project, included changes into Podfile that described in the beginning and run pod install:
```
Analyzing dependencies
Downloading dependencies
Installing React-Core 0.61.1
Installing React-RCTWrapper 0.61.1
Generating Pods project
Integrating client project
Pod installation complete! There are 50 dependencies from the Podfile and 65 total pods installed.
```

Also now able to reference <React/RCTWrapperViewManager.h> and use RCTWrapperView in my project.
