### PR TITLE
fix: Bundle assets in monorepo

### DIFF
--- a/RNTester/android/app/build.gradle
+++ b/RNTester/android/app/build.gradle
@@ -65,7 +65,6 @@ plugins {
  */
 
 project.ext.react = [
-    cliPath: "$rootDir/cli.js",
     bundleAssetName: "RNTesterApp.android.bundle",
     entryFile: file("../../js/RNTesterApp.android.js"),
     root: "$rootDir",
@@ -107,6 +106,16 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+
+    packagingOptions {
+        pickFirst 'lib/x86/libc++_shared.so'
+        pickFirst 'lib/arm64-v8a/libc++_shared.so'
+        pickFirst 'lib/x86_64/libc++_shared.so'
+        pickFirst 'lib/armeabi-v7a/libc++_shared.so'
+        pickFirst 'lib/x86_64/libjsc.so'
+        pickFirst 'lib/arm64-v8a/libjsc.so'
     }
 
     flavorDimensions "vm"

--- a/RNTester/android/app/build.gradle
+++ b/RNTester/android/app/build.gradle
@@ -108,15 +108,6 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    packagingOptions {
-        pickFirst 'lib/x86/libc++_shared.so'
-        pickFirst 'lib/arm64-v8a/libc++_shared.so'
-        pickFirst 'lib/x86_64/libc++_shared.so'
-        pickFirst 'lib/armeabi-v7a/libc++_shared.so'
-        pickFirst 'lib/x86_64/libjsc.so'
-        pickFirst 'lib/arm64-v8a/libjsc.so'
-    }
-
     flavorDimensions "vm"
     productFlavors {
         hermes {

--- a/RNTester/android/app/build.gradle
+++ b/RNTester/android/app/build.gradle
@@ -108,7 +108,6 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-
     packagingOptions {
         pickFirst 'lib/x86/libc++_shared.so'
         pickFirst 'lib/arm64-v8a/libc++_shared.so'

--- a/react.gradle
+++ b/react.gradle
@@ -99,6 +99,7 @@ afterEvaluate {
         // Additional node and packager commandline arguments
         def nodeExecutableAndArgs = config.nodeExecutableAndArgs ?: ["node"]
         def extraPackagerArgs = config.extraPackagerArgs ?: []
+        def npx = Os.isFamily(Os.FAMILY_WINDOWS) ? "npx.cmd" : "npx"
 
         def execCommand = []
 
@@ -109,7 +110,7 @@ afterEvaluate {
                 execCommand.addAll([*nodeExecutableAndArgs, cliPath])
             }
         } else {
-            execCommand.addAll(["npx", "react-native"])
+            execCommand.addAll([npx, "react-native"])
         }
 
         def enableHermes = enableHermesForVariant(variant)

--- a/react.gradle
+++ b/react.gradle
@@ -100,6 +100,18 @@ afterEvaluate {
         def nodeExecutableAndArgs = config.nodeExecutableAndArgs ?: ["node"]
         def extraPackagerArgs = config.extraPackagerArgs ?: []
 
+        def execCommand = []
+
+        if (config.cliPath || config.nodeExecutableAndArgs) {
+            if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                execCommand.addAll(["cmd", "/c", *nodeExecutableAndArgs, cliPath])
+            } else {
+                execCommand.addAll([*nodeExecutableAndArgs, cliPath])
+            }
+        } else {
+            execCommand.addAll(["npx", "react-native"])
+        }
+
         def enableHermes = enableHermesForVariant(variant)
 
         def currentBundleTask = tasks.create(
@@ -140,15 +152,10 @@ afterEvaluate {
                 extraArgs.add(bundleConfig);
             }
 
-            if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                commandLine("cmd", "/c", *nodeExecutableAndArgs, cliPath, bundleCommand, "--platform", "android", "--dev", "${devEnabled}",
-                    "--reset-cache", "--entry-file", entryFile, "--bundle-output", jsBundleFile, "--assets-dest", resourcesDir,
-                    "--sourcemap-output", enableHermes ? jsPackagerSourceMapFile : jsOutputSourceMapFile, *extraArgs)
-            } else {
-                commandLine(*nodeExecutableAndArgs, cliPath, bundleCommand, "--platform", "android", "--dev", "${devEnabled}",
-                    "--reset-cache", "--entry-file", entryFile, "--bundle-output", jsBundleFile, "--assets-dest", resourcesDir,
-                    "--sourcemap-output", enableHermes ? jsPackagerSourceMapFile : jsOutputSourceMapFile, *extraArgs)
-            }
+            commandLine(*execCommand, bundleCommand, "--platform", "android", "--dev", "${devEnabled}",
+                "--reset-cache", "--entry-file", entryFile, "--bundle-output", jsBundleFile, "--assets-dest", resourcesDir,
+                "--sourcemap-output", enableHermes ? jsPackagerSourceMapFile : jsOutputSourceMapFile, *extraArgs)
+
 
             if (enableHermes) {
                 doLast {


### PR DESCRIPTION
## Summary

In monorepo environment, `metro` isn't able to resolve `react-native` because the path to it is hardcoded.

I've also added `packagingOptions` to RNTester to make Android builds work for me. Let me know if this is something that is only specific to my setup, and shouldn't be added.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[Android] [Fixed] - Fix `bundleReleaseJsAndAssets` in monorepo env

## Test Plan

- [x] - Works in monorepo setup on MacOS
- [x] - Works with RNTester app



