### PR TITLE
Update bottom padding calculation

### DIFF
--- a/Libraries/Components/Keyboard/KeyboardAvoidingView.js
+++ b/Libraries/Components/Keyboard/KeyboardAvoidingView.js
@@ -191,7 +191,7 @@ class KeyboardAvoidingView extends React.Component<Props, State> {
               style={StyleSheet.compose(
                 contentContainerStyle,
                 {
-                  bottom: bottomHeight,
+                  bottom: bottomHeight + contentContainerStyle.bottom,
                 },
               )}>
               {children}


### PR DESCRIPTION
## Summary

This is a fix for issue **KeyboardAvoidingView styles don't compose nicely** #26755.

## Changelog

[General] [Fixed] - Updated calculation of `bottom` style when the behaviour is `position`.

## Test Plan

The expected behaviour as per #26755 is obtained.