### PR TITLE
Make JSStringToSTLString 23x faster

### DIFF
--- a/ReactCommon/jsi/JSCRuntime.cpp
+++ b/ReactCommon/jsi/JSCRuntime.cpp
@@ -286,9 +286,11 @@ class JSCRuntime : public jsi::Runtime {
 namespace {
 std::string JSStringToSTLString(JSStringRef str) {
   size_t maxBytes = JSStringGetMaximumUTF8CStringSize(str);
-  std::vector<char> buffer(maxBytes);
-  JSStringGetUTF8CString(str, buffer.data(), maxBytes);
-  return std::string(buffer.data());
+  char* buffer = new char[maxBytes];
+  size_t actualBytes = JSStringGetUTF8CString(str, buffer, maxBytes);
+  std::string stlString = std::string(buffer, actualBytes -1);
+  delete [] buffer;
+  return stlString;
 }
 
 JSStringRef getLengthString() {

--- a/ReactCommon/jsi/JSCRuntime.cpp
+++ b/ReactCommon/jsi/JSCRuntime.cpp
@@ -286,11 +286,16 @@ class JSCRuntime : public jsi::Runtime {
 namespace {
 std::string JSStringToSTLString(JSStringRef str) {
   size_t maxBytes = JSStringGetMaximumUTF8CStringSize(str);
-  char* buffer = new char[maxBytes];
-  size_t actualBytes = JSStringGetUTF8CString(str, buffer, maxBytes);
-  std::string stlString = std::string(buffer, actualBytes -1);
-  delete [] buffer;
-  return stlString;
+
+  if (maxBytes < 21) {
+    char buffer[20];
+    size_t actualBytes = JSStringGetUTF8CString(str, buffer, maxBytes);
+    return std::string(buffer, actualBytes - 1);
+  }
+
+  auto buffer = std::make_unique<char[]>(maxBytes);
+  size_t actualBytes = JSStringGetUTF8CString(str, buffer.get(), maxBytes);
+  return std::string(buffer.get(), actualBytes - 1);
 }
 
 JSStringRef getLengthString() {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

In my app I have a case where I need to pass a very large string (45MB) between JS and native. This is obviously suboptimal, but… this is where I'm at.

The main bottleneck to doing this turned out to be `jsi`'s `JSStringToSTLString()`, which was extremely slow. In my case, 4.7s to execute. After this change, 204ms.

I don't really know C++, so I'm not sure this code is 100% correct and safe, and I bet it could be done even better by avoiding the extra memory allocation (would shave off another 70ms).

## Changelog

[General] [Changed] - Make JSStringToSTLString 23x faster 

## Test Plan

