### PR TITLE
Add support for native pseudo-OS to Platform.select

### DIFF
--- a/Libraries/Utilities/Platform.android.js
+++ b/Libraries/Utilities/Platform.android.js
@@ -55,7 +55,11 @@ const Platform = {
     return this.constants.uiMode === 'tv';
   },
   select: <A, N, D>(spec: PlatformSelectSpec<A, N, D>): A | N | D =>
-    'android' in spec ? spec.android : 'native' in spec ? spec.native : spec.default,
+    'android' in spec
+      ? spec.android
+      : 'native' in spec
+      ? spec.native
+      : spec.default,
 };
 
 module.exports = Platform;

--- a/Libraries/Utilities/Platform.android.js
+++ b/Libraries/Utilities/Platform.android.js
@@ -12,8 +12,9 @@
 
 import NativePlatformConstantsAndroid from './NativePlatformConstantsAndroid';
 
-export type PlatformSelectSpec<A, D> = {
+export type PlatformSelectSpec<A, N, D> = {
   android?: A,
+  native?: N,
   default?: D,
 };
 
@@ -53,8 +54,8 @@ const Platform = {
   get isTV(): boolean {
     return this.constants.uiMode === 'tv';
   },
-  select: <A, D>(spec: PlatformSelectSpec<A, D>): A | D =>
-    'android' in spec ? spec.android : spec.default,
+  select: <A, N, D>(spec: PlatformSelectSpec<A, N, D>): A | N | D =>
+    'android' in spec ? spec.android : 'native' in spec ? spec.native : spec.default,
 };
 
 module.exports = Platform;

--- a/Libraries/Utilities/Platform.ios.js
+++ b/Libraries/Utilities/Platform.ios.js
@@ -12,8 +12,9 @@
 
 import NativePlatformConstantsIOS from './NativePlatformConstantsIOS';
 
-export type PlatformSelectSpec<D, I> = {
+export type PlatformSelectSpec<D, N, I> = {
   default?: D,
+  native?: N,
   ios?: I,
 };
 
@@ -59,8 +60,8 @@ const Platform = {
     }
     return false;
   },
-  select: <D, I>(spec: PlatformSelectSpec<D, I>): D | I =>
-    'ios' in spec ? spec.ios : spec.default,
+  select: <D, N, I>(spec: PlatformSelectSpec<D, N, I>): D | N | I =>
+    'ios' in spec ? spec.ios : 'native' in spec ? spec.native : spec.default,
 };
 
 module.exports = Platform;

--- a/Libraries/Utilities/__tests__/Platform-test.js
+++ b/Libraries/Utilities/__tests__/Platform-test.js
@@ -27,5 +27,17 @@ describe('Platform', () => {
       expect(PlatformIOS.select(obj)).toEqual(obj.ios);
       expect(PlatformAndroid.select(obj)).toEqual(obj.android);
     });
+
+    it('should return native value if no specific value was found', () => {
+      const obj = {native: 'native', default: 'default'};
+      expect(PlatformIOS.select(obj)).toEqual(obj.native);
+      expect(PlatformAndroid.select(obj)).toEqual(obj.native);
+    });
+
+    it('should return default value if no specific value was found', () => {
+      const obj = {default: 'default'};
+      expect(PlatformIOS.select(obj)).toEqual(obj.default);
+      expect(PlatformAndroid.select(obj)).toEqual(obj.default);
+    });
   });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

When you write platform-specific code using [file extensions](https://facebook.github.io/react-native/docs/platform-specific-code#platform-specific-extensions), you can specify `.ios.js`, `.android.js`, or the catch-all `.native.js` when you are sharing code with a web project.

This `native` shortcut is missing for the `Platform.select` method, and this PR is adding support for that.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[General] [Added] - Platform.select now supports native as an option.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Added relevant passing unit tests for Platform module.
