### PR TITLE
[NativeAnimated] Don't restore default values when components unmount

### DIFF
--- a/Libraries/Animated/src/NativeAnimatedHelper.js
+++ b/Libraries/Animated/src/NativeAnimatedHelper.js
@@ -116,6 +116,13 @@ const API = {
     invariant(NativeAnimatedModule, 'Native animated module is not available');
     NativeAnimatedModule.disconnectAnimatedNodeFromView(nodeTag, viewTag);
   },
+  restoreDefaultValues: function(nodeTag: number): void {
+    invariant(NativeAnimatedModule, 'Native animated module is not available');
+    // Backwards compat with older native runtimes, can be removed later.
+    if (NativeAnimatedModule.restoreDefaultValues != null) {
+      NativeAnimatedModule.restoreDefaultValues(nodeTag);
+    }
+  },
   dropAnimatedNode: function(tag: number): void {
     invariant(NativeAnimatedModule, 'Native animated module is not available');
     NativeAnimatedModule.dropAnimatedNode(tag);

--- a/Libraries/Animated/src/NativeAnimatedModule.js
+++ b/Libraries/Animated/src/NativeAnimatedModule.js
@@ -45,6 +45,7 @@ export interface Spec extends TurboModule {
   +extractAnimatedNodeOffset: (nodeTag: number) => void;
   +connectAnimatedNodeToView: (nodeTag: number, viewTag: number) => void;
   +disconnectAnimatedNodeFromView: (nodeTag: number, viewTag: number) => void;
+  +restoreDefaultValues: (nodeTag: number) => void;
   +dropAnimatedNode: (tag: number) => void;
   +addAnimatedEventToView: (
     viewTag: number,

--- a/Libraries/Animated/src/__tests__/AnimatedNative-test.js
+++ b/Libraries/Animated/src/__tests__/AnimatedNative-test.js
@@ -46,6 +46,7 @@ describe('Native Animated', () => {
       extractAnimatedNodeOffset: jest.fn(),
       flattenAnimatedNodeOffset: jest.fn(),
       removeAnimatedEventFromView: jest.fn(),
+      restoreDefaultValues: jest.fn(),
       setAnimatedNodeOffset: jest.fn(),
       setAnimatedNodeValue: jest.fn(),
       startAnimatingNode: jest.fn(),
@@ -835,6 +836,27 @@ describe('Native Animated', () => {
 
       animation.stop();
       expect(NativeAnimatedModule.stopAnimation).toBeCalledWith(animationId);
+    });
+  });
+
+  describe('Animated Components', () => {
+    it('Should restore default values on prop updates only', () => {
+      const opacity = new Animated.Value(0);
+      opacity.__makeNative();
+
+      const root = TestRenderer.create(<Animated.View style={{opacity}} />);
+      expect(NativeAnimatedModule.restoreDefaultValues).not.toHaveBeenCalled();
+
+      root.update(<Animated.View style={{opacity}} />);
+      expect(NativeAnimatedModule.restoreDefaultValues).toHaveBeenCalledWith(
+        expect.any(Number),
+      );
+
+      root.unmount();
+      // Make sure it doesn't get called on unmount.
+      expect(NativeAnimatedModule.restoreDefaultValues).toHaveBeenCalledTimes(
+        1,
+      );
     });
   });
 });

--- a/Libraries/Animated/src/createAnimatedComponent.js
+++ b/Libraries/Animated/src/createAnimatedComponent.js
@@ -111,7 +111,10 @@ function createAnimatedComponent<Props: {+[string]: mixed}, Instance>(
       // This way the intermediate state isn't to go to 0 and trigger
       // this expensive recursive detaching to then re-attach everything on
       // the very next operation.
-      oldPropsAnimated && oldPropsAnimated.__detach();
+      if (oldPropsAnimated) {
+        oldPropsAnimated.__restoreDefaultValues();
+        oldPropsAnimated.__detach();
+      }
     }
 
     _setComponentRef = setAndForwardRef({

--- a/Libraries/Animated/src/nodes/AnimatedProps.js
+++ b/Libraries/Animated/src/nodes/AnimatedProps.js
@@ -147,6 +147,16 @@ class AnimatedProps extends AnimatedNode {
     );
   }
 
+  __restoreDefaultValues(): void {
+    // When using the native driver, view properties need to be restored to
+    // their default values manually since react no longer tracks them. This
+    // is needed to handle cases where a prop driven by native animated is removed
+    // after having been changed natively by an animation.
+    if (this.__isNative) {
+      NativeAnimatedHelper.API.restoreDefaultValues(this.__getNativeTag());
+    }
+  }
+
   __getNativeConfig(): Object {
     const propsConfig = {};
     for (const propKey in this._props) {

--- a/Libraries/NativeAnimation/RCTNativeAnimatedModule.mm
+++ b/Libraries/NativeAnimation/RCTNativeAnimatedModule.mm
@@ -160,11 +160,15 @@ RCT_EXPORT_METHOD(connectAnimatedNodeToView:(double)nodeTag
 RCT_EXPORT_METHOD(disconnectAnimatedNodeFromView:(double)nodeTag
                   viewTag:(double)viewTag)
 {
-  [self addPreOperationBlock:^(RCTNativeAnimatedNodesManager *nodesManager) {
-    [nodesManager restoreDefaultValues:[NSNumber numberWithDouble:nodeTag]];
-  }];
   [self addOperationBlock:^(RCTNativeAnimatedNodesManager *nodesManager) {
     [nodesManager disconnectAnimatedNodeFromView:[NSNumber numberWithDouble:nodeTag] viewTag:[NSNumber numberWithDouble:viewTag]];
+  }];
+}
+
+RCT_EXPORT_METHOD(restoreDefaultValues:(double)nodeTag)
+{
+  [self addPreOperationBlock:^(RCTNativeAnimatedNodesManager *nodesManager) {
+    [nodesManager restoreDefaultValues:[NSNumber numberWithDouble:nodeTag]];
   }];
 }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedModule.java
@@ -373,18 +373,22 @@ public class NativeAnimatedModule extends ReactContextBaseJavaModule
 
   @ReactMethod
   public void disconnectAnimatedNodeFromView(final int animatedNodeTag, final int viewTag) {
-    mPreOperations.add(
-        new UIThreadOperation() {
-          @Override
-          public void execute(NativeAnimatedNodesManager animatedNodesManager) {
-            animatedNodesManager.restoreDefaultValues(animatedNodeTag, viewTag);
-          }
-        });
     mOperations.add(
         new UIThreadOperation() {
           @Override
           public void execute(NativeAnimatedNodesManager animatedNodesManager) {
             animatedNodesManager.disconnectAnimatedNodeFromView(animatedNodeTag, viewTag);
+          }
+        });
+  }
+
+  @ReactMethod
+  public void restoreDefaultValues(final int animatedNodeTag) {
+    mPreOperations.add(
+        new UIThreadOperation() {
+          @Override
+          public void execute(NativeAnimatedNodesManager animatedNodesManager) {
+            animatedNodesManager.restoreDefaultValues(animatedNodeTag);
           }
         });
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedNodesManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedNodesManager.java
@@ -318,7 +318,7 @@ import java.util.Queue;
     propsAnimatedNode.disconnectFromView(viewTag);
   }
 
-  public void restoreDefaultValues(int animatedNodeTag, int viewTag) {
+  public void restoreDefaultValues(int animatedNodeTag) {
     AnimatedNode node = mAnimatedNodes.get(animatedNodeTag);
     // Restoring default values needs to happen before UIManager operations so it is
     // possible the node hasn't been created yet if it is being connected and

--- a/ReactAndroid/src/test/java/com/facebook/react/animated/NativeAnimatedNodeTraversalTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/animated/NativeAnimatedNodeTraversalTest.java
@@ -981,7 +981,7 @@ public class NativeAnimatedNodeTraversalTest {
     assertThat(stylesCaptor.getValue().getDouble("opacity")).isEqualTo(0);
 
     reset(mUIManagerMock);
-    mNativeAnimatedNodesManager.restoreDefaultValues(propsNodeTag, viewTag);
+    mNativeAnimatedNodesManager.restoreDefaultValues(propsNodeTag);
     verify(mUIManagerMock).synchronouslyUpdateViewOnUIThread(eq(viewTag), stylesCaptor.capture());
     assertThat(stylesCaptor.getValue().isNull("opacity"));
   }


### PR DESCRIPTION
## Summary

There are some cases where restoring default values on component unmount is not desirable. For example in react-native-screens we want to keep the native view displayed after react has unmounted them. Restoring default values causes an issue there because it will change props controlled my native animated back to their default value instead of keeping whatever value they had been animated to.

Restoring default values is only needed for updates anyway, where removing a prop controlled by native animated need to be reset to its default value since react no longer tracks its value.

This splits restoring default values and disconnecting from views in 2 separate native methods, this way we can restore default values only on component update and not on unmount. This takes care of being backwards compatible for OTA JS updates.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[General] [Fixed] - NativeAnimated - Don't restore default values when components unmount

## Test Plan

- Tested in an app using react-native-screens to make sure native views that are kept after their underlying component has been unmount don't change. Also tested in RNTester animated example.

- Tested that new JS works with old native code
