### PR TITLE
[iOS] Remove max depth parameter while measuring layout of shadow view

### DIFF
--- a/React/Views/RCTShadowView.m
+++ b/React/Views/RCTShadowView.m
@@ -156,13 +156,11 @@ static void RCTProcessMetaPropsBorder(const YGValue metaProps[META_PROP_COUNT], 
 - (CGRect)measureLayoutRelativeToAncestor:(RCTShadowView *)ancestor
 {
   CGPoint offset = CGPointZero;
-  NSInteger depth = 30; // max depth to search
   RCTShadowView *shadowView = self;
-  while (depth && shadowView && shadowView != ancestor) {
+  while (shadowView && shadowView != ancestor) {
     offset.x += shadowView.layoutMetrics.frame.origin.x;
     offset.y += shadowView.layoutMetrics.frame.origin.y;
     shadowView = shadowView->_superview;
-    depth--;
   }
   if (ancestor != shadowView) {
     return CGRectNull;
@@ -172,11 +170,9 @@ static void RCTProcessMetaPropsBorder(const YGValue metaProps[META_PROP_COUNT], 
 
 - (BOOL)viewIsDescendantOf:(RCTShadowView *)ancestor
 {
-  NSInteger depth = 30; // max depth to search
   RCTShadowView *shadowView = self;
-  while (depth && shadowView && shadowView != ancestor) {
+  while (shadowView && shadowView != ancestor) {
     shadowView = shadowView->_superview;
-    depth--;
   }
   return ancestor == shadowView;
 }


### PR DESCRIPTION
## Summary
Searching for the ancestor view while measuring a shadow view layout relative to the ancestor is limited to `30`. I couldn't find the reason nor commit where it was introduced (because I have no access to internal facebook commits).
I think we should keep looking for an ancestor view until the shadow view has the superview property.

## Changelog

[iOS] [Fixed] - Remove maximum searching depth while measuring layout.

## Test Plan
- Tested if RNTester works as expected.
- Tested in app with a lot of nested flatlists where sometimes I was facing this redbox because of the max depth limit.
<img width="297" alt="Screenshot 2019-10-24 at 14 40 11" src="https://user-images.githubusercontent.com/16336501/67486474-6309d380-f66c-11e9-9eab-15e8fb8372a5.png">
