### PR TITLE
Use new provider api for images in RNTester

### DIFF
--- a/RNTester/RNTester/AppDelegate.mm
+++ b/RNTester/RNTester/AppDelegate.mm
@@ -13,6 +13,9 @@
 #import <React/RCTCxxBridgeDelegate.h>
 #import <React/RCTJavaScriptLoader.h>
 #import <React/RCTLinkingManager.h>
+#import <React/RCTImageLoader.h>
+#import <React/RCTLocalAssetImageLoader.h>
+#import <React/RCTGIFImageDecoder.h>
 #import <React/RCTRootView.h>
 
 #import <cxxreact/JSExecutor.h>
@@ -142,6 +145,13 @@
 
 - (id<RCTTurboModule>)getModuleInstanceFromClass:(Class)moduleClass
 {
+  if (moduleClass == RCTImageLoader.class) {
+    return [[moduleClass alloc] initWithRedirectDelegate:nil loadersProvider:^NSArray<id<RCTImageURLLoader>> *{
+      return @[[RCTLocalAssetImageLoader new]];
+    } decodersProvider:^NSArray<id<RCTImageDataDecoder>> *{
+      return @[[RCTGIFImageDecoder new]];
+    }];
+  }
   // No custom initializer here.
   return [moduleClass new];
 }


### PR DESCRIPTION
## Summary

Local assets do not work in release mode since they rely on `RCTLocalAssetImageLoader`. Since converting image native modules to turbo modules the old loading method no longer works. This uses the new api in RNTester.

## Changelog

[Internal] [Fixed] - Use new provider api for images in RNTester

## Test Plan

Tested that local images work in RNTester images example in release mode