### PR TITLE
Expose [RCTBundleURLProvider isPackagerRunning] publicly

### DIFF
--- a/React/Base/RCTBundleURLProvider.h
+++ b/React/Base/RCTBundleURLProvider.h
@@ -31,6 +31,10 @@ extern const NSUInteger kRCTBundleURLProviderDefaultPort;
  */
 - (void)resetToDefaults;
 
+#if RCT_DEV
+- (BOOL)isPackagerRunning:(NSString *)host;
+#endif
+
 /**
  * Returns the jsBundleURL for a given bundle entrypoint and
  * the fallback offline JS bundle if the packager is not running.


### PR DESCRIPTION
## Summary

The private API isPackagerRunning is useful. Rather than duplicating it, I am exposing it here so that I can make use of it in future PRs, and so others can do the same.

## Changelog

[iOS] [Changed] - Expose the isPackagerRunning methods on RCTBundleURLProvider

## Test Plan

This change doesn't impact any runtime code, though it does impact build. I used a vanilla test app (react-native init) and built it using xcode as well as react-native run-ios.
