### PR TITLE
Do not handle JSI host object in deepFreezeAndThrowOnMutationInDev

### DIFF
--- a/Libraries/Utilities/deepFreezeAndThrowOnMutationInDev.js
+++ b/Libraries/Utilities/deepFreezeAndThrowOnMutationInDev.js
@@ -23,6 +23,8 @@
  *     will unfortunately fail silently :(
  *   - If the object is already frozen or sealed, it will not continue the
  *     deep traversal and will leave leaf nodes unfrozen.
+ *   - If the object is JSI host object, it will not continue the
+ *     deep traversal as JSI host object may be changed from C++ native side.
  *
  * Freezing the object and adding the throw mechanism is expensive and will
  * only be used in DEV.
@@ -33,7 +35,8 @@ function deepFreezeAndThrowOnMutationInDev<T: Object>(object: T): T {
       typeof object !== 'object' ||
       object === null ||
       Object.isFrozen(object) ||
-      Object.isSealed(object)
+      Object.isSealed(object) ||
+      (global.__jsiUtils && global.__jsiUtils.isHostObject(object))
     ) {
       return object;
     }

--- a/ReactCommon/jsiexecutor/jsireact/JSIExecutor.h
+++ b/ReactCommon/jsiexecutor/jsireact/JSIExecutor.h
@@ -114,6 +114,7 @@ class JSIExecutor : public JSExecutor {
   void callNativeModules(const jsi::Value &queue, bool isEndOfBatch);
   jsi::Value nativeCallSyncHook(const jsi::Value *args, size_t count);
   jsi::Value nativeRequire(const jsi::Value *args, size_t count);
+  jsi::Value createJSIUtils();
 #ifdef DEBUG
   jsi::Value globalEvalWithSourceUrl(const jsi::Value *args, size_t count);
 #endif


### PR DESCRIPTION
## Summary

That is specific for react-native-v8 issue https://github.com/Kudo/react-native-v8/issues/27, but I do think that V8 is semantic right and to introduce the change for RN upstream.

JSI host object is a JavaScript Object that C++ side could control getter or setter.
In react-native-v8, I use V8 object interceptor to implement JSI host object.
V8 does not allow `Object.freeze()` for objects with interceptor and will throw exception.
https://chromium.googlesource.com/v8/v8.git/+/lkgr/src/objects/js-objects.cc#3845
That is, you cannot truly freeze the JavaScript object because C++ side may add new properties in interceptor.

In this CL, I introduced some JSI helper functions to determine if the target object is JSI host object and skip the freezing.

```typescript
function global.__jsiUtils.isHostObject(target: Object): boolean
function global.__jsiUtils.isHostFunction(target: Function): boolean
```

## Changelog

[General] [Changed] - Do not handle JSI host object in deepFreezeAndThrowOnMutationInDev

## Test Plan

1. Test react-native-v8 + [BlobCollector JSI object change](https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/modules/blob/jni/BlobCollector.cpp) and the test case:
```js
const TestCase = async () => {
  const resp = await fetch('http://www.africau.edu/images/default/sample.pdf', {
    method: 'GET',
  });
  const respBlob = await resp.blob();
  await AsyncStorage.setItem('foo', respBlob);
};
```
And see if there is JS exception.

2. Verify the JSI helper function by
```js
global.__jsiUtils.isHostObject(global.nativeModuleProxy);
```
That the returned value should be true.
