### PR TITLE
fix conflict with google gms services

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/WritableArray.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/WritableArray.java
@@ -24,5 +24,5 @@ public interface WritableArray extends ReadableArray {
 
   void pushArray(@Nullable ReadableArray array);
 
-  void pushMap(@Nullable ReadableMap map);
+  void pushIntoMap(@Nullable ReadableMap map);
 }


### PR DESCRIPTION
The method name "pushMap" is used in com.google.android.gms.internal.zzbfm 
and this causes a conflict.
I would like to suggest to rename this method to "pushIntoMap" or any other name.

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

In com.facebook.react.bridge.WritableArray the method "pushMap" has the same name with a method from google gms services and this cause a conflict when they are used in one project so I would like to suggest to rename this method to "pushIntoMap" or any other name.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[General] [Fixed] - In com.facebook.react.bridge.WritableArray the method "pushMap" has the same name with a method from google gms services and this cause a conflict when they are used in one project so I would like to suggest to rename this method to "pushIntoMap" or any other name.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
