### PR TITLE
Reverts "Timing: Fixes timer when app get into background (#24649)"

### DIFF
--- a/React/Modules/RCTTiming.m
+++ b/React/Modules/RCTTiming.m
@@ -97,7 +97,6 @@ static const NSTimeInterval kIdleCallbackFrameDeadline = 0.001;
   NSTimer *_sleepTimer;
   BOOL _sendIdleEvents;
   BOOL _inBackground;
-  UIBackgroundTaskIdentifier _backgroundTaskIdentifier;
 }
 
 @synthesize bridge = _bridge;
@@ -113,7 +112,6 @@ RCT_EXPORT_MODULE()
   _paused = YES;
   _timers = [NSMutableDictionary new];
   _inBackground = NO;
-  _backgroundTaskIdentifier = UIBackgroundTaskInvalid;
 
   for (NSString *name in @[UIApplicationWillResignActiveNotification,
                            UIApplicationDidEnterBackgroundNotification,
@@ -137,33 +135,8 @@ RCT_EXPORT_MODULE()
 
 - (void)dealloc
 {
-  [self markEndOfBackgroundTaskIfNeeded];
   [_sleepTimer invalidate];
   [[NSNotificationCenter defaultCenter] removeObserver:self];
-}
-
-- (void)markStartOfBackgroundTaskIfNeeded
-{
-  if (_backgroundTaskIdentifier == UIBackgroundTaskInvalid) {
-    __weak typeof(self) weakSelf = self;
-    // Marks the beginning of a new long-running background task. We can run the timer in the background.
-    _backgroundTaskIdentifier = [[UIApplication sharedApplication] beginBackgroundTaskWithName:@"rct.timing.gb.task" expirationHandler:^{
-      typeof(self) strongSelf = weakSelf;
-      if (!strongSelf) {
-        return;
-      }
-      // Mark the end of background task
-      [strongSelf markEndOfBackgroundTaskIfNeeded];
-    }];
-  }
-}
-
-- (void)markEndOfBackgroundTaskIfNeeded
-{
-  if (_backgroundTaskIdentifier != UIBackgroundTaskInvalid) {
-    [[UIApplication sharedApplication] endBackgroundTask:_backgroundTaskIdentifier];
-    _backgroundTaskIdentifier = UIBackgroundTaskInvalid;
-  }
 }
 
 - (dispatch_queue_t)methodQueue
@@ -190,7 +163,6 @@ RCT_EXPORT_MODULE()
 
 - (void)appDidMoveToForeground
 {
-  [self markEndOfBackgroundTaskIfNeeded];
   _inBackground = NO;
   [self startTimers];
 }
@@ -288,7 +260,6 @@ RCT_EXPORT_MODULE()
   }
   if (_inBackground) {
     if (timerCount) {
-      [self markStartOfBackgroundTaskIfNeeded];
       [self scheduleSleepTimer:nextScheduledTarget];
     }
   } else if (!_sendIdleEvents && timersToCall.count == 0) {
@@ -367,7 +338,6 @@ RCT_EXPORT_METHOD(createTimer:(nonnull NSNumber *)callbackID
   }
 
   if (_inBackground) {
-    [self markStartOfBackgroundTaskIfNeeded];
     [self scheduleSleepTimer:timer.target];
   } else if (_paused) {
     if ([timer.target timeIntervalSinceNow] > kMinimumSleepInterval) {


### PR DESCRIPTION
This reverts commit 338298417f8077dee177057c57b38671b4ec8c75

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
This is related #26696 - an issue where the app would be closed immediately after going to background on iOS 13.1/13.2 and was investigated by @minhtc https://github.com/facebook/react-native/issues/26696#issuecomment-548056694. The commit that is being reverted is apparently causing the app to be closed immediately. This has to be reverted in master separately as the file differs there.


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[iOS] [Fixed] - Reverts commit causing a crash in the background

## Test Plan

Create an empty app on 0.61.x with a timer, put it in the background.

