### PR TITLE
Add Intl to eslint globals.

### DIFF
--- a/packages/eslint-config-react-native-community/index.js
+++ b/packages/eslint-config-react-native-community/index.js
@@ -94,6 +94,7 @@ module.exports = {
     fetch: false,
     FormData: false,
     global: false,
+    Intl: false,
     Map: true,
     module: false,
     navigator: false,


### PR DESCRIPTION
Fix `'Intl' is not defined. eslint(no-undef)` warning by eslint: see https://github.com/facebook/react-native/issues/27076
