### PR TITLE
Fix error with bundling task eval. when no gradle config is provided

### DIFF
--- a/react.gradle
+++ b/react.gradle
@@ -7,7 +7,7 @@
 
 import org.apache.tools.ant.taskdefs.condition.Os
 
-def config = project.hasProperty("react") ? project.react : [];
+def config = project.hasProperty("react") ? project.react : [:];
 
 def detectEntryFile(config) {
     if (System.getenv('ENTRY_FILE')) {


### PR DESCRIPTION
## Summary

Fix `react.gradle`'s handling of the case where a configuration isn't explicitly specified by the parent project - e.g. before importing to `build.gradle` files:

```groovy
apply plugin: 'com.android.application'

// Nothing to define:
// project.ext.react = [
// ]
apply from: "../../node_modules/react-native/react.gradle"
```

This is a _ridiculously_ subtle change but it is nevertheless important, as, combined with other groovy quirks, it can result in an overall misbehaviour of the build script.

### Source of the bug

Currently, when a react build config _isn't_ specified by the user, RN's `react.gradle` falls back to `[]` (i.e. in [this line](https://github.com/facebook/react-native/blob/81a6b6ed3c54498f6f2148c106846352405949bf/react.gradle#L8)). In groovy, `[]` stands for an empty _array_ (actually, an empty `ArrayList` instance). The config, however, is expected to have the nature of a `Map`.

### Effects of the bug

As a bottom line, whenever a configuration isn't specified, the evaluation of [the condition](https://github.com/facebook/react-native/blob/81a6b6ed3c54498f6f2148c106846352405949bf/react.gradle#L184) as to whether the bundling task in question should be enabled, results in the following build-time exception:

```
FAILURE: Build failed with an exception.

* Where:
Script '/Users/...../node_modules/react-native/react.gradle' line: 179

* What went wrong:
A problem occurred configuring project ':app'.
> Could not create task ':app:bundleDebugJsAndAssets'.
   > Could not find method enabled() for arguments [[]] on task ':app:bundleDebugJsAndAssets' of type org.gradle.api.tasks.Exec.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 9s
```

I'm not much of a Groovy person, but while digging in, I've learned that it has the following odd attribute to it:
When accessing a non-existing property of an empty `ArrayList` in a bean-like fashion (i.e. as `array.property1` rather than `array.getProperty('property1')`), a new empty array is returned. This only holds true for _empty_ arrays, as illustrated by the following snippet:

```groovy
def emptyArr = []
def arr = [40, 2]

def result1 = (emptyArr.uninitializedProp == null)
println "$result1, ${emptyArr.uninitializedProp}" // ==> false, []"

def result2 = (arr.uninitializedProp == null) // ==> MissingPropertyException
println result2 // Never reached
```

While this whole scheme could be a bug, it's nonetheless effective in both the latest 2.x.x groovy version and in 2.1.0 (which is the oldest one that seems to be available for download nowadays). The point being is that its a behavior that's sticked.

Note that other evaluations of `config` properties (e.g. [lines 10-19](https://github.com/facebook/react-native/blob/81a6b6ed3c54498f6f2148c106846352405949bf/react.gradle#L10))  in the script are not effected by this as they are initially only examined in a boolean form, rather than using a null comparison; "Lucky" for us, empty arrays evaluate to `false`.

### Fix

Simply fallback to a groovy map rather than an array whenever `config` hasn't been specified. Namely, initialize it to `[:]`, which results in a new `HashMap` instance, rather than `[]`.

### Workaround

Until effectively fixed, can be worked-around by explicitly setting config to an empty map before the react gradle script is imported by the user:
```groovy
apply plugin: 'com.android.application'
project.ext.react = [:]
apply from: "../../node_modules/react-native/react.gradle"
```


## Changelog

[Android] [Fixed] - Fix 'Could not create task ':app:bundleDebugJsAndAssets'.' error in project with no react config

## Test Plan

Mostly regression is required here. I've myself ran this over a project with an empty config and the app has launched successfully in both `release` and `debug` flavors.
