### PR TITLE
Fix scrollIndicatorInsets on iOS 13

### DIFF
--- a/RNTester/js/examples/ScrollView/ScrollViewExample.js
+++ b/RNTester/js/examples/ScrollView/ScrollViewExample.js
@@ -43,6 +43,7 @@ exports.examples = [
               _scrollView = scrollView;
             }}
             automaticallyAdjustContentInsets={false}
+            scrollIndicatorInsets={{top: 50, bottom: 50}}
             onScroll={() => {
               console.log('onScroll!');
             }}
@@ -89,6 +90,7 @@ exports.examples = [
               ref={scrollView => {
                 _scrollView = scrollView;
               }}
+              scrollIndicatorInsets={{left: 50, right: 50}}
               automaticallyAdjustContentInsets={false}
               horizontal={true}
               style={[styles.scrollView, styles.horizontalScrollView]}>

--- a/RNTester/js/examples/ScrollView/ScrollViewSimpleExample.js
+++ b/RNTester/js/examples/ScrollView/ScrollViewSimpleExample.js
@@ -91,7 +91,7 @@ const styles = StyleSheet.create({
   },
 });
 
-exports.title = '<ScrollView>';
+exports.title = '<ScrollView> - Simple';
 exports.description =
   'Component that enables scrolling through child components.';
 

--- a/React/Views/ScrollView/RCTScrollView.m
+++ b/React/Views/ScrollView/RCTScrollView.m
@@ -299,6 +299,12 @@
     }
 #endif
 
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000 /* __IPHONE_13_0 */
+    if (@available(iOS 13.0, *)) {
+      _scrollView.automaticallyAdjustsScrollIndicatorInsets = NO;
+    }
+#endif
+
     _automaticallyAdjustContentInsets = YES;
     _DEPRECATED_sendUpdatedChildFrames = NO;
     _contentInset = UIEdgeInsetsZero;
@@ -1027,7 +1033,32 @@ RCT_SET_AND_PRESERVE_OFFSET(setScrollsToTop, scrollsToTop, BOOL)
 RCT_SET_AND_PRESERVE_OFFSET(setShowsHorizontalScrollIndicator, showsHorizontalScrollIndicator, BOOL)
 RCT_SET_AND_PRESERVE_OFFSET(setShowsVerticalScrollIndicator, showsVerticalScrollIndicator, BOOL)
 RCT_SET_AND_PRESERVE_OFFSET(setZoomScale, zoomScale, CGFloat);
-RCT_SET_AND_PRESERVE_OFFSET(setScrollIndicatorInsets, scrollIndicatorInsets, UIEdgeInsets);
+
+- (UIEdgeInsets)scrollIndicatorInsets
+{
+  return [_scrollView scrollIndicatorInsets];
+}
+
+- (void)setScrollIndicatorInsets:(UIEdgeInsets)value
+{
+  CGPoint contentOffset = _scrollView.contentOffset;
+
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000 /* __IPHONE_13_0 */
+  if (@available(iOS 13.0, *)) {
+    UIEdgeInsets verticalInsets = UIEdgeInsetsMake(value.top, 0, value.bottom, 0);
+    UIEdgeInsets horizontalInsets = UIEdgeInsetsMake(0, value.left, 0, value.right);
+    _scrollView.verticalScrollIndicatorInsets = verticalInsets;
+    _scrollView.horizontalScrollIndicatorInsets = horizontalInsets;
+  } else {
+    _scrollView.scrollIndicatorInsets = value;
+  }
+#else
+  _scrollView.scrollIndicatorInsets = value;
+#endif
+
+
+  _scrollView.contentOffset = contentOffset;
+}
 
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000 /* __IPHONE_11_0 */
 - (void)setContentInsetAdjustmentBehavior:(UIScrollViewContentInsetAdjustmentBehavior)behavior


### PR DESCRIPTION

## Summary

`scrollIndicatorInsets` seems to be broken on iOS 13. I think this might be an iOS bug? Or maybe a behavior change. Either way, it's a regression for React Native users. Setting `automaticallyAdjustsScrollIndicatorInsets = NO` fixes the behavior + we stop using deprecated `scrollIndicatorInsets` if possible

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[iOS] [Fixed] - Fixed `ScrollView`'s `scrollIndicatorInsets` prop on iOS 13

## Test Plan

- RNTester → scrollView - both horizontal and vertical examples have insets set to 50px on both sides