### PR TITLE
Added AccessibilityLabel support to Picker

### DIFF
--- a/Libraries/Components/Picker/Picker.js
+++ b/Libraries/Components/Picker/Picker.js
@@ -106,6 +106,11 @@ type PickerProps = $ReadOnly<{|
    * Used to locate this view in end-to-end tests.
    */
   testID?: ?string,
+
+  /**
+   * Screen reader will read this string when a user selects the Picker.
+   */
+  accessibilityLabel?: ?string,
 |}>;
 
 /**

--- a/Libraries/Components/Picker/PickerIOS.ios.js
+++ b/Libraries/Components/Picker/PickerIOS.ios.js
@@ -48,6 +48,7 @@ type Props = $ReadOnly<{|
   onChange?: ?(event: PickerIOSChangeEvent) => mixed,
   onValueChange?: ?(itemValue: string | number, itemIndex: number) => mixed,
   selectedValue: ?(number | string),
+  accessibilityLabel: ?string,
 |}>;
 
 type State = {|
@@ -106,6 +107,7 @@ class PickerIOS extends React.Component<Props, State> {
           items={this.state.items}
           selectedIndex={this.state.selectedIndex}
           onChange={this._onChange}
+          accessibilityLabel={this.props.accessibilityLabel}
         />
       </View>
     );

--- a/Libraries/Components/Picker/RCTPickerNativeComponent.js
+++ b/Libraries/Components/Picker/RCTPickerNativeComponent.js
@@ -39,6 +39,7 @@ type NativeProps = $ReadOnly<{|
   selectedIndex: number,
   style?: ?TextStyleProp,
   testID?: ?string,
+  accessibilityLabel?: ?string,
 |}>;
 
 type ComponentType = HostComponent<NativeProps>;

--- a/RNTester/js/examples/Picker/PickerExample.js
+++ b/RNTester/js/examples/Picker/PickerExample.js
@@ -129,6 +129,24 @@ class ColorPickerExample extends React.Component<{}, ColorState> {
     );
   }
 }
+class AccessibilityLabelPickerExample extends React.Component<{}, State> {
+  state: State = {
+    value: 'key1',
+  };
+
+  render(): React.Node {
+    return (
+      <Picker
+        accessibilityLabel="This is the accessibility label"
+        style={styles.picker}
+        selectedValue={this.state.value}
+        onValueChange={v => this.setState({value: v})}>
+        <Item label="hello" value="key0" />
+        <Item label="world" value="key1" />
+      </Picker>
+    );
+  }
+}
 
 const styles = StyleSheet.create({
   picker: {
@@ -188,6 +206,12 @@ exports.examples = [
     title: 'Colorful pickers',
     render: function(): React.Element<typeof ColorPickerExample> {
       return <ColorPickerExample />;
+    },
+  },
+  {
+    title: 'AccessibilityLabel pickers',
+    render: function(): React.Element<typeof AccessibilityLabelPickerExample> {
+      return <AccessibilityLabelPickerExample />;
     },
   },
 ];

--- a/React/Views/RCTPicker.h
+++ b/React/Views/RCTPicker.h
@@ -17,6 +17,7 @@
 @property (nonatomic, strong) UIColor *color;
 @property (nonatomic, strong) UIFont *font;
 @property (nonatomic, assign) NSTextAlignment textAlign;
+@property (nonatomic, copy, nullable) NSString* accessibilityLabel;
 
 @property (nonatomic, copy) RCTBubblingEventBlock onChange;
 

--- a/React/Views/RCTPicker.m
+++ b/React/Views/RCTPicker.m
@@ -94,6 +94,7 @@ numberOfRowsInComponent:(__unused NSInteger)component
 
   label.textAlignment = _textAlign;
   label.text = [self pickerView:pickerView titleForRow:row forComponent:component];
+  label.accessibilityLabel = _accessibilityLabel;
   return label;
 }
 

--- a/React/Views/RCTPickerManager.m
+++ b/React/Views/RCTPickerManager.m
@@ -23,6 +23,7 @@ RCT_EXPORT_MODULE()
 
 RCT_EXPORT_VIEW_PROPERTY(items, NSArray<NSDictionary *>)
 RCT_EXPORT_VIEW_PROPERTY(selectedIndex, NSInteger)
+RCT_EXPORT_VIEW_PROPERTY(accessibilityLabel, NSString)
 RCT_EXPORT_VIEW_PROPERTY(onChange, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(color, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(textAlign, NSTextAlignment)

--- a/ReactAndroid/src/main/java/com/facebook/react/views/picker/ReactPickerManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/picker/ReactPickerManager.java
@@ -43,6 +43,11 @@ public abstract class ReactPickerManager extends SimpleViewManager<ReactPicker> 
     view.setPrompt(prompt);
   }
 
+  @ReactProp(name = "accessibilityLabel")
+  public void setAccessibilityLabel(ReactPicker view, @Nullable String accessibilityLabel) {
+    view.setContentDescription(accessibilityLabel);
+  }
+
   @ReactProp(name = ViewProps.ENABLED, defaultBoolean = true)
   public void setEnabled(ReactPicker view, boolean enabled) {
     view.setEnabled(enabled);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

With a Picker we would like to allow accessibility labels to be passed as a prop for situations where we want go give more detail. For example if we have a number picker that will be used for a timer instead of just saying 3, we might want to say 3 hours.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog
[General] [Added] - Picker test with an accessibility label prop
[General] [Added] - Support for accessibility Label prop to the Picker component
<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[CATEGORY] [TYPE] - Message

## Test Plan

Test plan is testing in RNTester making sure the examples work
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
