### PR TITLE
Update eslint-plugin-react-native to 3.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "eslint-plugin-prettier": "2.6.2",
     "eslint-plugin-react": "7.12.4",
     "eslint-plugin-react-hooks": "^2.0.1",
-    "eslint-plugin-react-native": "3.6.0",
+    "eslint-plugin-react-native": "3.8.1",
     "eslint-plugin-relay": "1.3.12",
     "flow-bin": "^0.110.1",
     "flow-remove-types": "1.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2729,10 +2729,10 @@ eslint-plugin-react-native-globals@^0.1.1:
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-native-globals/-/eslint-plugin-react-native-globals-0.1.2.tgz#ee1348bc2ceb912303ce6bdbd22e2f045ea86ea2"
   integrity sha512-9aEPf1JEpiTjcFAmmyw8eiIXmcNZOqaZyHO77wgm0/dWfT/oxC1SrIq8ET38pMxHYrcB6Uew+TzUVsBeczF88g==
 
-eslint-plugin-react-native@3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react-native/-/eslint-plugin-react-native-3.6.0.tgz#7cad3b7c6159df6d26fe3252c6c5417a17f27b4b"
-  integrity sha512-BEQcHZ06hZSBYWFVuNEq0xuui5VEsWpHDsZGBtfadHfCRqRMUrkYPgdDb3bpc60qShHE83kqIv59uKdinEg91Q==
+eslint-plugin-react-native@3.8.1:
+  version "3.8.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-native/-/eslint-plugin-react-native-3.8.1.tgz#92811e37191ecb0d29c0f0a0c9e5c943ee573821"
+  integrity sha512-6Z4s4nvgFRdda/1s1+uu4a6EMZwEjjJ9Bk/1yBImv0fd9U2CsGu2cUakAtV83cZKhizbWhSouXoaK4JtlScdFg==
   dependencies:
     eslint-plugin-react-native-globals "^0.1.1"
 


### PR DESCRIPTION
## Summary

This updates [`eslint-plugin-react-native`](https://github.com/intellicode/eslint-plugin-react-native) to `3.8.1`.

Includes some minor updates and fixes, and avoids errors related to incorrect peer dependencies when using ESLint 6+

```
error "react-native#eslint-plugin-react-native#eslint@^3.17.0 || ^4 || ^5" doesn't satisfy found match of "eslint@6.6.0"
```

## Changelog

[Internal] [Changed] - Update eslint-plugin-react-native to 3.8.1

## Test Plan

Check that ESlint and CI passes.