### PR TITLE
Add Visual Studio and VSCode files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,7 @@ RNTester/Pods/*
 # react-native-codegen
 /ReactCommon/fabric/components/rncore/
 /schema-rncore.json
+
+# Visual studio
+.vscode
+.vs


### PR DESCRIPTION
## Summary
These files are currently seen by Git if opening the project in Visual Studio or VSCode.

## Changelog
[Internal] [Fixed] - Add Visual Studio files to .gitignore