### PR TITLE
Update RNTester CocoaPods to 1.8.4

### DIFF
--- a/RNTester/Gemfile
+++ b/RNTester/Gemfile
@@ -1,4 +1,4 @@
 # Gemfile
 source 'https://rubygems.org'
 
-gem 'cocoapods', '= 1.7.1'
+gem 'cocoapods', '= 1.8.4'


### PR DESCRIPTION
## Summary

This is the second half of #26976 (the CocoaPods update did not make it to `master`).

@RSNara @hramos @fkgozali @PeteTheHeat - Please take a quick look and comment if there are any known issues with using the latest stable version of CocoaPods. Thanks! 🙏

It seems like the older version of CocoaPods has a bug that _lowercases_ the spec repo url, even in the unfortunate case that the repo maintainers use upper case characters. This would essentially revert what was fixed in #26976.

## Changelog

[General] [Changed] - Update RNTester CocoaPods to 1.8.4

## Test Plan

```
cd RNTester
bundle install
bundle exec pod install
```
