### PR TITLE
RNTester: Add missing key attribute in NewAppScreen example

### DIFF
--- a/RNTester/js/examples/NewAppScreen/NewAppScreenExample.js
+++ b/RNTester/js/examples/NewAppScreen/NewAppScreenExample.js
@@ -50,6 +50,7 @@ exports.examples = [
         <View style={{flexDirection: 'row'}}>
           {Object.keys(Colors).map(key => (
             <View
+              key={`color-${key}`}
               style={{width: 50, height: 50, backgroundColor: Colors[key]}}
             />
           ))}


### PR DESCRIPTION
## Summary

This pull request adds a missing key attribute to an array of elements in the example for `NewAppScreen`. This results in the "missing key" warning no longer appearing when viewing this example.

## Changelog

[General] [Fixed] - RNTester: Add missing key attribute in NewAppScreen example

## Test Plan

When viewing this example in RNTester, this warning is no longer printed.