### PR TITLE
Remove requestAnimationFrame when focusing input on mount

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -702,14 +702,25 @@ function useFocusOnMount(
     // Since initialAutoFocusValue and inputRef will never change
     // this should match the expected behavior
     if (initialAutoFocusValue.current) {
-      const rafId = requestAnimationFrame(() => {
+      const focus = () => {
         if (inputRef.current != null) {
           inputRef.current.focus();
         }
-      });
+      };
+
+      let rafId;
+      if (Platform.OS === 'android') {
+        // On Android this needs to be executed in a rAF callback
+        // otherwise the keyboard opens then closes immediately.
+        rafId = requestAnimationFrame(focus);
+      } else {
+        focus();
+      }
 
       return () => {
-        cancelAnimationFrame(rafId);
+        if (rafId != null) {
+          cancelAnimationFrame(rafId);
+        }
       };
     }
   }, [initialAutoFocusValue, inputRef]);


### PR DESCRIPTION
## Summary

When using `react-native-screen` which uses native view controller animations for navigation `TextInput` with `autoFocus` causes a weird animation glitch.

Removing the requestAnimationFrame will cause the focus command to be sent in the same batch as starting screen transitions which fixes the issue.

It is unclear why the rAF was added in the first place as it was part of the initial RN open source commit. If someone at facebook has more context that would be great to make sure it doesn't cause unintended side effects.

Credits to @kmagiera for figuring out this

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[General] [Fixed] - Remove requestAnimationFrame when focusing input on mount

## Test Plan

- Tested in an app using react-native-screen to make sure the animation glitch is fixed
- Tested in RNTester to make sure it doesn't cause other issues when not using react-native-screens

Before:

![1](https://user-images.githubusercontent.com/2677334/68799447-2ce5c100-0626-11ea-8310-a9ac9e9419b6.gif)

After:

![2](https://user-images.githubusercontent.com/2677334/68799450-2fe0b180-0626-11ea-865f-ef88f7307831.gif)

