### PR TITLE
Fix spinner is not shown on beginRefreshingProgrammatically on IOS

### DIFF
--- a/React/Views/RCTRefreshControl.m
+++ b/React/Views/RCTRefreshControl.m
@@ -57,6 +57,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
   _refreshingProgrammatically = YES;
   // When using begin refreshing we need to adjust the ScrollView content offset manually.
   UIScrollView *scrollView = (UIScrollView *)self.superview;
+  [self sizeToFit];
   CGPoint offset = {scrollView.contentOffset.x, scrollView.contentOffset.y - self.frame.size.height};
 
   // `beginRefreshing` must be called after the animation is done. This is why it is impossible


### PR DESCRIPTION
## Summary
It closes https://github.com/facebook/react-native/issues/24855 
In the endRefreshProgrammatically of RCTRefreshControl.m there is calculation for content offset when spinner is shown `CGPoint offset = {scrollView.contentOffset.x, scrollView.contentOffset.y - self.frame.size.height};`
However `self.frame.size.height` is always 0 and therefore spinner is not visible
This change should fix that

## Changelog

[iOS] [Fixed] - Fix spinner visibility on `beginRefreshingProgrammatically`

## Test Plan
IOS tests passed
Check whether this issue is reproduced or not for the repro which is described inside the issue.
https://github.com/facebook/react-native/issues/24855 
