### PR TITLE
Summary: Added accessibility label prop to Picker component 

### DIFF
--- a/Libraries/Components/Picker/PickerIOS.ios.js
+++ b/Libraries/Components/Picker/PickerIOS.ios.js
@@ -48,6 +48,7 @@ type Props = $ReadOnly<{|
   onChange?: ?(event: PickerIOSChangeEvent) => mixed,
   onValueChange?: ?(itemValue: string | number, itemIndex: number) => mixed,
   selectedValue: ?(number | string),
+  accessibilityLabel: ?string,
 |}>;
 
 type State = {|
@@ -106,6 +107,7 @@ class PickerIOS extends React.Component<Props, State> {
           items={this.state.items}
           selectedIndex={this.state.selectedIndex}
           onChange={this._onChange}
+          accessibilityLabel={this.props.accessibilityLabel}
         />
       </View>
     );

--- a/RNTester/js/examples/Picker/PickerExample.js
+++ b/RNTester/js/examples/Picker/PickerExample.js
@@ -129,6 +129,24 @@ class ColorPickerExample extends React.Component<{}, ColorState> {
     );
   }
 }
+class AccessibilityLabelPickerExample extends React.Component<{}, State> {
+  state: State = {
+    value: 'key1',
+  };
+
+  render(): React.Node {
+    return (
+      <Picker
+        accessibilityLabel="This is the accessibility label"
+        style={styles.picker}
+        selectedValue={this.state.value}
+        onValueChange={v => this.setState({value: v})}>
+        <Item label="hello" value="key0" />
+        <Item label="world" value="key1" />
+      </Picker>
+    );
+  }
+}
 
 const styles = StyleSheet.create({
   picker: {
@@ -188,6 +206,12 @@ exports.examples = [
     title: 'Colorful pickers',
     render: function(): React.Element<typeof ColorPickerExample> {
       return <ColorPickerExample />;
+    },
+  },
+  {
+    title: 'AccessibilityLabel pickers',
+    render: function(): React.Element<typeof AccessibilityLabelPickerExample> {
+      return <AccessibilityLabelPickerExample />;
     },
   },
 ];

--- a/React/Views/RCTPicker.m
+++ b/React/Views/RCTPicker.m
@@ -10,7 +10,7 @@
 #import "RCTConvert.h"
 #import "RCTUtils.h"
 
-@interface RCTPicker() <UIPickerViewDataSource, UIPickerViewDelegate>
+@interface RCTPicker() <UIPickerViewDataSource, UIPickerViewDelegate, UIPickerViewAccessibilityDelegate>
 @end
 
 @implementation RCTPicker
@@ -107,6 +107,12 @@ numberOfRowsInComponent:(__unused NSInteger)component
       @"newValue": RCTNullIfNil(_items[row][@"value"]),
     });
   }
+}
+
+#pragma mark - UIPickerViewAccessibilityDelegate protocol
+
+- (NSString *)pickerView:(UIPickerView *)pickerView accessibilityLabelForComponent:(NSInteger)component{
+    return super.accessibilityLabel;
 }
 
 @end

--- a/React/Views/RCTPickerManager.m
+++ b/React/Views/RCTPickerManager.m
@@ -23,6 +23,7 @@ RCT_EXPORT_MODULE()
 
 RCT_EXPORT_VIEW_PROPERTY(items, NSArray<NSDictionary *>)
 RCT_EXPORT_VIEW_PROPERTY(selectedIndex, NSInteger)
+RCT_REMAP_VIEW_PROPERTY(accessibilityLabel, reactAccessibilityElement.accessibilityLabel, NSString)
 RCT_EXPORT_VIEW_PROPERTY(onChange, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(color, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(textAlign, NSTextAlignment)
@@ -43,7 +44,7 @@ RCT_CUSTOM_VIEW_PROPERTY(fontFamily, NSString, RCTPicker)
   view.font = [RCTFont updateFont:view.font withFamily:json ?: defaultView.font.familyName];
 }
 
-RCT_EXPORT_METHOD(setNativeSelectedIndex : (nonnull NSNumber *)viewTag toIndex : (NSNumber *)index)
+RCT_EXPORT_METHOD(setNativeSelectedIndex : (nonnull NSNumber *)viewTag toIndex : (nonnull NSNumber *)index)
 {
   [self.bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
     UIView *view = viewRegistry[viewTag];

--- a/ReactAndroid/src/main/java/com/facebook/react/views/picker/ReactPickerManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/picker/ReactPickerManager.java
@@ -43,6 +43,11 @@ public abstract class ReactPickerManager extends SimpleViewManager<ReactPicker> 
     view.setPrompt(prompt);
   }
 
+  @ReactProp(name = "accessibilityLabel")
+  public void setAccessibilityLabel(ReactPicker view, @Nullable String accessibilityLabel) {
+    view.setContentDescription(accessibilityLabel);
+  }
+
   @ReactProp(name = ViewProps.ENABLED, defaultBoolean = true)
   public void setEnabled(ReactPicker view, boolean enabled) {
     view.setEnabled(enabled);


### PR DESCRIPTION

## Summary

With a Picker we would like to allow accessibility labels to be passed as a prop for situations where we want go give more detail. For example if we have a number picker that will be used as a timer instead of just saying 3, we might want to say 3 hours.


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

[General] [Added] - Picker test with an accessibility label prop
[General] [Added] - Support for accessibility Label prop to the Picker component


## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Test plan is testing in RNTester making sure the examples work
