### PR TITLE
fix R8 warning

### DIFF
--- a/ReactAndroid/proguard-rules.pro
+++ b/ReactAndroid/proguard-rules.pro
@@ -39,8 +39,8 @@
   *** get*();
 }
 
--keep class * extends com.facebook.react.bridge.JavaScriptModule { *; }
--keep class * extends com.facebook.react.bridge.NativeModule { *; }
+-keep class * implements com.facebook.react.bridge.JavaScriptModule { *; }
+-keep class * implements com.facebook.react.bridge.NativeModule { *; }
 -keepclassmembers,includedescriptorclasses class * { native <methods>; }
 -keepclassmembers class *  { @com.facebook.react.uimanager.annotations.ReactProp <methods>; }
 -keepclassmembers class *  { @com.facebook.react.uimanager.annotations.ReactPropGroup <methods>; }


### PR DESCRIPTION
## Summary

R8 shows warning that **com.facebook.react.bridge.JavaScriptModule**, **com.facebook.react.bridge.NativeModule** are interfaces so proguard rules must use implements instead of extends. This PR changes proguard rules to fix the warnings.

## Changelog

[Android] [Changed] - Fix R8 warning

## Test Plan

RNTester builds and runs as expected.