### PR TITLE
use iPhone X instead of iPhone 6s

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,13 +164,13 @@
         "binaryPath": "RNTester/build/Build/Products/Release-iphonesimulator/RNTester.app/",
         "build": "xcodebuild -workspace RNTester/RNTesterPods.xcworkspace -scheme RNTester -configuration Release -sdk iphonesimulator -derivedDataPath RNTester/build -UseModernBuildSystem=NO -quiet",
         "type": "ios.simulator",
-        "name": "iPhone 6s"
+        "name": "iPhone X"
       },
       "ios.sim.debug": {
         "binaryPath": "RNTester/build/Build/Products/Debug-iphonesimulator/RNTester.app/",
         "build": "xcodebuild -workspace RNTester/RNTesterPods.xcworkspace -scheme RNTester -configuration Debug -sdk iphonesimulator -derivedDataPath RNTester/build -UseModernBuildSystem=NO -quiet",
         "type": "ios.simulator",
-        "name": "iPhone 6s"
+        "name": "iPhone X"
       }
     }
   }

--- a/scripts/.tests.env
+++ b/scripts/.tests.env
@@ -18,7 +18,7 @@ export AVD_ABI=x86
 
 ## IOS ##
 export IOS_TARGET_OS="12.4"
-export IOS_DEVICE="iPhone 6s"
+export IOS_DEVICE="iPhone X"
 export TVOS_DEVICE="Apple TV"
 
 ## CI OVERRIDES ##


### PR DESCRIPTION
Summary: Changelog: [Testing] [iOS] Use iPhone X in end to end tests since newer versions of iOS do not run on iPhone 6s

Reviewed By: TheSavior

Differential Revision: D18645860

