### PR TITLE
Add `scripts/generate-rncore.sh` to npm module

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "README.md",
     "rn-get-polyfills.js",
     "scripts/compose-source-maps.js",
+    "scripts/generate-rncore.sh",
     "scripts/ios-configure-glog.sh",
     "scripts/ios-install-third-party.sh",
     "scripts/launchPackager.bat",


### PR DESCRIPTION
the `react-native/ReactCommon/React-Fabric.podspec` references this file
https://github.com/facebook/react-native/blob/master/ReactCommon/React-Fabric.podspec#L33
which causes various cocoapods commands to crash when trying to read the `podspec`

```
[!] Invalid `React-Fabric.podspec` file: No such file or directory @ rb_sysopen - ../scripts/generate-rncore.sh.
```

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[CATEGORY] [TYPE] - Message

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
