### PR TITLE
bump gradle-download-task to 4.0.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ buildscript {
     }
     dependencies {
         classpath("com.android.tools.build:gradle:3.5.2")
-        classpath("de.undercouch:gradle-download-task:4.0.0")
+        classpath("de.undercouch:gradle-download-task:4.0.2")
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
## Summary

Recently, we bumped Gradle to 6.0.1, and it seems that gradle-download-task has a compatibility issue, thus 4.0.2 fixed and added 6.0.1 in their CI.

## Changelog

[Android] [Changed] - Bump gradle-download-task to 4.0.2

## Test Plan

RNTester builds and runs as expected.