### PR TITLE
Support for accessibility Label prop to the Picker component

### DIFF
--- a/Libraries/Components/Picker/Picker.js
+++ b/Libraries/Components/Picker/Picker.js
@@ -106,6 +106,10 @@ type PickerProps = $ReadOnly<{|
    * Used to locate this view in end-to-end tests.
    */
   testID?: ?string,
+  /**
+   * The string used for the accessibility label. Will be read once focused on the picker but not on change.
+   */
+  accessibilityLabel?: ?string,
 |}>;
 
 /**

--- a/Libraries/Components/Picker/PickerIOS.ios.js
+++ b/Libraries/Components/Picker/PickerIOS.ios.js
@@ -48,6 +48,7 @@ type Props = $ReadOnly<{|
   onChange?: ?(event: PickerIOSChangeEvent) => mixed,
   onValueChange?: ?(itemValue: string | number, itemIndex: number) => mixed,
   selectedValue: ?(number | string),
+  accessibilityLabel?: ?string,
 |}>;
 
 type State = {|
@@ -106,6 +107,7 @@ class PickerIOS extends React.Component<Props, State> {
           items={this.state.items}
           selectedIndex={this.state.selectedIndex}
           onChange={this._onChange}
+          accessibilityLabel={this.props.accessibilityLabel}
         />
       </View>
     );

--- a/Libraries/Components/Picker/RCTPickerNativeComponent.js
+++ b/Libraries/Components/Picker/RCTPickerNativeComponent.js
@@ -39,6 +39,7 @@ type NativeProps = $ReadOnly<{|
   selectedIndex: number,
   style?: ?TextStyleProp,
   testID?: ?string,
+  accessibilityLabel?: ?string,
 |}>;
 
 type ComponentType = HostComponent<NativeProps>;

--- a/RNTester/js/examples/Picker/PickerExample.js
+++ b/RNTester/js/examples/Picker/PickerExample.js
@@ -125,6 +125,25 @@ class ColorPickerExample extends React.Component<{...}, ColorState> {
     );
   }
 }
+class AccessibilityLabelPickerExample extends React.Component<{}, State> {
+  state: State = {
+    value: '3',
+  };
+
+  render(): React.Node {
+    return (
+      <Picker
+        accessibilityLabel={this.state.value + 'Hours'}
+        style={styles.picker}
+        selectedValue={this.state.value}
+        onValueChange={v => this.setState({value: v})}>
+        <Item label="1" value="1" />
+        <Item label="2" value="2" />
+        <Item label="3" value="3" />
+      </Picker>
+    );
+  }
+}
 
 const styles = StyleSheet.create({
   picker: {
@@ -161,6 +180,12 @@ exports.examples = [
     },
   },
   {
+    title: 'Accessibility Label pickers',
+    render: function(): React.Element<typeof AccessibilityLabelPickerExample> {
+      return <AccessibilityLabelPickerExample />;
+    },
+  },
+  {
     title: 'Picker with no listener',
     render: function(): React.Element<typeof PromptPickerExample> {
       return (
@@ -184,6 +209,12 @@ exports.examples = [
     title: 'Colorful pickers',
     render: function(): React.Element<typeof ColorPickerExample> {
       return <ColorPickerExample />;
+    },
+  },
+  {
+    title: 'AccessibilityLabel pickers',
+    render: function(): React.Element<typeof AccessibilityLabelPickerExample> {
+      return <AccessibilityLabelPickerExample />;
     },
   },
 ];

--- a/React/Views/RCTPicker.m
+++ b/React/Views/RCTPicker.m
@@ -10,7 +10,7 @@
 #import "RCTConvert.h"
 #import "RCTUtils.h"
 
-@interface RCTPicker() <UIPickerViewDataSource, UIPickerViewDelegate>
+@interface RCTPicker() <UIPickerViewDataSource, UIPickerViewDelegate, UIPickerViewAccessibilityDelegate>
 @end
 
 @implementation RCTPicker
@@ -107,6 +107,12 @@ numberOfRowsInComponent:(__unused NSInteger)component
       @"newValue": RCTNullIfNil(_items[row][@"value"]),
     });
   }
+}
+
+#pragma mark - UIPickerViewAccessibilityDelegate protocol
+
+- (NSString *)pickerView:(UIPickerView *)pickerView accessibilityLabelForComponent:(NSInteger)component{
+    return super.accessibilityLabel;
 }
 
 @end

--- a/React/Views/RCTPickerManager.m
+++ b/React/Views/RCTPickerManager.m
@@ -23,6 +23,7 @@ RCT_EXPORT_MODULE()
 
 RCT_EXPORT_VIEW_PROPERTY(items, NSArray<NSDictionary *>)
 RCT_EXPORT_VIEW_PROPERTY(selectedIndex, NSInteger)
+RCT_REMAP_VIEW_PROPERTY(accessibilityLabel, reactAccessibilityElement.accessibilityLabel, NSString)
 RCT_EXPORT_VIEW_PROPERTY(onChange, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(color, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(textAlign, NSTextAlignment)

--- a/docs/generatedComponentApiDocs.js
+++ b/docs/generatedComponentApiDocs.js
@@ -14,182 +14,182 @@
 
 module.exports = [
   {
-    "description": "A visual toggle between two mutually exclusive states.\n\nThis is a controlled component that requires an `onValueChange` callback that\nupdates the `value` prop in order for the component to reflect user actions.\nIf the `value` prop is not updated, the component will continue to render the\nsupplied `value` prop instead of the expected result of any user actions.",
-    "displayName": "Switch",
-    "methods": [],
-    "props": {
-      "disabled": {
-        "required": false,
-        "flowType": {
-          "name": "boolean",
-          "nullable": true
+    'description': 'A visual toggle between two mutually exclusive states.\n\nThis is a controlled component that requires an `onValueChange` callback that\nupdates the `value` prop in order for the component to reflect user actions.\nIf the `value` prop is not updated, the component will continue to render the\nsupplied `value` prop instead of the expected result of any user actions.',
+    'displayName': 'Switch',
+    'methods': [],
+    'props': {
+      'disabled': {
+        'required': false,
+        'flowType': {
+          'name': 'boolean',
+          'nullable': true,
         },
-        "description": "Whether the switch is disabled. Defaults to false."
+        'description': 'Whether the switch is disabled. Defaults to false.',
       },
-      "value": {
-        "required": false,
-        "flowType": {
-          "name": "boolean",
-          "nullable": true
+      'value': {
+        'required': false,
+        'flowType': {
+          'name': 'boolean',
+          'nullable': true,
         },
-        "description": "Boolean value of the switch. Defaults to false."
+        'description': 'Boolean value of the switch. Defaults to false.',
       },
-      "thumbColor": {
-        "required": false,
-        "flowType": {
-          "name": "ColorValue",
-          "nullable": true
+      'thumbColor': {
+        'required': false,
+        'flowType': {
+          'name': 'ColorValue',
+          'nullable': true,
         },
-        "description": "Custom color for the switch thumb."
+        'description': 'Custom color for the switch thumb.',
       },
-      "trackColor": {
-        "required": false,
-        "flowType": {
-          "name": "$ReadOnly",
-          "elements": [
+      'trackColor': {
+        'required': false,
+        'flowType': {
+          'name': '$ReadOnly',
+          'elements': [
             {
-              "name": "signature",
-              "type": "object",
-              "raw": "{|\n  false?: ?ColorValue,\n  true?: ?ColorValue,\n|}",
-              "signature": {
-                "properties": [
+              'name': 'signature',
+              'type': 'object',
+              'raw': '{|\n  false?: ?ColorValue,\n  true?: ?ColorValue,\n|}',
+              'signature': {
+                'properties': [
                   {
-                    "key": "false",
-                    "value": {
-                      "name": "ColorValue",
-                      "nullable": true,
-                      "required": false
-                    }
+                    'key': 'false',
+                    'value': {
+                      'name': 'ColorValue',
+                      'nullable': true,
+                      'required': false,
+                    },
                   },
                   {
-                    "key": "true",
-                    "value": {
-                      "name": "ColorValue",
-                      "nullable": true,
-                      "required": false
-                    }
-                  }
-                ]
-              }
-            }
+                    'key': 'true',
+                    'value': {
+                      'name': 'ColorValue',
+                      'nullable': true,
+                      'required': false,
+                    },
+                  },
+                ],
+              },
+            },
           ],
-          "raw": "$ReadOnly<{|\n  false?: ?ColorValue,\n  true?: ?ColorValue,\n|}>",
-          "nullable": true
+          'raw': '$ReadOnly<{|\n  false?: ?ColorValue,\n  true?: ?ColorValue,\n|}>',
+          'nullable': true,
         },
-        "description": "Custom colors for the switch track.\n\nNOTE: On iOS when the switch value is false, the track shrinks into the\nborder. If you want to change the color of the background exposed by the\nshrunken track, use `ios_backgroundColor`."
+        'description': 'Custom colors for the switch track.\n\nNOTE: On iOS when the switch value is false, the track shrinks into the\nborder. If you want to change the color of the background exposed by the\nshrunken track, use `ios_backgroundColor`.',
       },
-      "ios_backgroundColor": {
-        "required": false,
-        "flowType": {
-          "name": "ColorValue",
-          "nullable": true
+      'ios_backgroundColor': {
+        'required': false,
+        'flowType': {
+          'name': 'ColorValue',
+          'nullable': true,
         },
-        "description": "On iOS, custom color for the background. This background color can be seen\neither when the switch value is false or when the switch is disabled (and\nthe switch is translucent)."
+        'description': 'On iOS, custom color for the background. This background color can be seen\neither when the switch value is false or when the switch is disabled (and\nthe switch is translucent).',
       },
-      "onChange": {
-        "required": false,
-        "flowType": {
-          "name": "signature",
-          "type": "function",
-          "raw": "(event: SwitchChangeEvent) => Promise<void> | void",
-          "signature": {
-            "arguments": [
+      'onChange': {
+        'required': false,
+        'flowType': {
+          'name': 'signature',
+          'type': 'function',
+          'raw': '(event: SwitchChangeEvent) => Promise<void> | void',
+          'signature': {
+            'arguments': [
               {
-                "name": "event",
-                "type": {
-                  "name": "SyntheticEvent",
-                  "elements": [
+                'name': 'event',
+                'type': {
+                  'name': 'SyntheticEvent',
+                  'elements': [
                     {
-                      "name": "$ReadOnly",
-                      "elements": [
+                      'name': '$ReadOnly',
+                      'elements': [
                         {
-                          "name": "signature",
-                          "type": "object",
-                          "raw": "{|\n  value: boolean,\n|}",
-                          "signature": {
-                            "properties": [
+                          'name': 'signature',
+                          'type': 'object',
+                          'raw': '{|\n  value: boolean,\n|}',
+                          'signature': {
+                            'properties': [
                               {
-                                "key": "value",
-                                "value": {
-                                  "name": "boolean",
-                                  "required": true
-                                }
-                              }
-                            ]
-                          }
-                        }
+                                'key': 'value',
+                                'value': {
+                                  'name': 'boolean',
+                                  'required': true,
+                                },
+                              },
+                            ],
+                          },
+                        },
                       ],
-                      "raw": "$ReadOnly<{|\n  value: boolean,\n|}>"
-                    }
+                      'raw': '$ReadOnly<{|\n  value: boolean,\n|}>',
+                    },
                   ],
-                  "raw": "SyntheticEvent<\n  $ReadOnly<{|\n    value: boolean,\n  |}>,\n>"
-                }
-              }
+                  'raw': 'SyntheticEvent<\n  $ReadOnly<{|\n    value: boolean,\n  |}>,\n>',
+                },
+              },
             ],
-            "return": {
-              "name": "union",
-              "raw": "Promise<void> | void",
-              "elements": [
+            'return': {
+              'name': 'union',
+              'raw': 'Promise<void> | void',
+              'elements': [
                 {
-                  "name": "Promise",
-                  "elements": [
+                  'name': 'Promise',
+                  'elements': [
                     {
-                      "name": "void"
-                    }
+                      'name': 'void',
+                    },
                   ],
-                  "raw": "Promise<void>"
+                  'raw': 'Promise<void>',
                 },
                 {
-                  "name": "void"
-                }
-              ]
-            }
+                  'name': 'void',
+                },
+              ],
+            },
           },
-          "nullable": true
+          'nullable': true,
         },
-        "description": "Called when the user tries to change the value of the switch.\n\nReceives the change event as an argument. If you want to only receive the\nnew value, use `onValueChange` instead."
+        'description': 'Called when the user tries to change the value of the switch.\n\nReceives the change event as an argument. If you want to only receive the\nnew value, use `onValueChange` instead.',
       },
-      "onValueChange": {
-        "required": false,
-        "flowType": {
-          "name": "signature",
-          "type": "function",
-          "raw": "(value: boolean) => Promise<void> | void",
-          "signature": {
-            "arguments": [
+      'onValueChange': {
+        'required': false,
+        'flowType': {
+          'name': 'signature',
+          'type': 'function',
+          'raw': '(value: boolean) => Promise<void> | void',
+          'signature': {
+            'arguments': [
               {
-                "name": "value",
-                "type": {
-                  "name": "boolean"
-                }
-              }
+                'name': 'value',
+                'type': {
+                  'name': 'boolean',
+                },
+              },
             ],
-            "return": {
-              "name": "union",
-              "raw": "Promise<void> | void",
-              "elements": [
+            'return': {
+              'name': 'union',
+              'raw': 'Promise<void> | void',
+              'elements': [
                 {
-                  "name": "Promise",
-                  "elements": [
+                  'name': 'Promise',
+                  'elements': [
                     {
-                      "name": "void"
-                    }
+                      'name': 'void',
+                    },
                   ],
-                  "raw": "Promise<void>"
+                  'raw': 'Promise<void>',
                 },
                 {
-                  "name": "void"
-                }
-              ]
-            }
+                  'name': 'void',
+                },
+              ],
+            },
           },
-          "nullable": true
+          'nullable': true,
         },
-        "description": "Called when the user tries to change the value of the switch.\n\nReceives the new value as an argument. If you want to instead receive an\nevent, use `onChange`."
-      }
+        'description': 'Called when the user tries to change the value of the switch.\n\nReceives the new value as an argument. If you want to instead receive an\nevent, use `onChange`.',
+      },
     },
-    "composes": [
-      "ViewProps"
-    ]
-  }
-]
+    'composes': [
+      'ViewProps',
+    ],
+  },
+];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
With a Picker we would like to allow accessibility labels to be passed as a prop for situations where we want go give more detail. For example if we have a number picker that will be used for a timer instead of just saying 3, we might want to say 3 hours.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog
[General] [Added] - Picker test with an accessibility label prop
[General] [Added] - Support for accessibility Label prop to the Picker component
<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

## Test Plan
Test plan is testing in RNTester making sure the examples work

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
