### PR TITLE
Share - title is not a valid attribute in iOS

### DIFF
--- a/Libraries/Share/Share.js
+++ b/Libraries/Share/Share.js
@@ -50,13 +50,16 @@ class Share {
    * ### Content
    *
    *  - `message` - a message to share
-   *  - `title` - title of the message
    *
    * #### iOS
    *
    *  - `url` - an URL to share
    *
    * At least one of URL and message is required.
+   * 
+   * #### Android
+   * 
+   * - `title` - title of the message
    *
    * ### Options
    *

--- a/Libraries/Share/Share.js
+++ b/Libraries/Share/Share.js
@@ -56,9 +56,9 @@ class Share {
    *  - `url` - an URL to share
    *
    * At least one of URL and message is required.
-   * 
+   *
    * #### Android
-   * 
+   *
    * - `title` - title of the message
    *
    * ### Options


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Code document incorrectly indicates that the `title` property is supported in both iOS and Android.
https://github.com/facebook/react-native/issues/27306 

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[iOS] [Changed] - Changed doc.

## Test Plan

NA - Only code comments have been changed.