### PR TITLE
[iOS] [CI] Fix test-ios by bumping Xcode version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ executors:
   reactnativeios:
     <<: *defaults
     macos:
-      xcode: "10.2.1"
+      xcode: "10.3.0"
 
 # -------------------------
 #        COMMANDS
@@ -109,13 +109,13 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - v1-brew
+            - v2-brew
       - steps: << parameters.steps >>
       - save_cache:
           paths:
             - /usr/local/Homebrew
             - ~/Library/Caches/Homebrew
-          key: v1-brew
+          key: v2-brew
 
   with_pods_cache_span:
     parameters:

--- a/RNTester/RNTesterIntegrationTests/RNTesterSnapshotTests.m
+++ b/RNTester/RNTesterIntegrationTests/RNTesterSnapshotTests.m
@@ -38,9 +38,8 @@ RCT_TEST(LayoutExample)
 RCT_TEST(ScrollViewExample)
 RCT_TEST(TextExample)
 #if !TARGET_OS_TV
-// No switch or slider available on tvOS
+// No switch available on tvOS
 RCT_TEST(SwitchExample)
-RCT_TEST(SliderExample)
 #endif
 
 - (void)testZZZNotInRecordMode

--- a/scripts/run-ci-e2e-tests.js
+++ b/scripts/run-ci-e2e-tests.js
@@ -212,12 +212,12 @@ try {
     if (
       tryExecNTimes(
         () => {
-          let destination = 'platform=iOS Simulator,name=iPhone 6s,OS=12.2';
+          let destination = 'platform=iOS Simulator,name=iPhone 6s,OS=12.4';
           let sdk = 'iphonesimulator';
           let scheme = 'HelloWorld';
 
           if (argv.tvos) {
-            destination = 'platform=tvOS Simulator,name=Apple TV,OS=11.4';
+            destination = 'platform=tvOS Simulator,name=Apple TV,OS=12.4';
             sdk = 'appletvsimulator';
             scheme = 'HelloWorld-tvOS';
           }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

iOS tests have been failing due to iOS 12.4 not being supported by Xcode 10.2.1. Bumping to 10.3 solves it.

Ideally, we'd bump to Xcode 11.2.1 and iOS 13.2.2. We can do this once all of our internal CI machines have Xcode 11.2.1 available.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[iOS] [Fixed] - Fix CI iOS tests by bumping Xcode version used in Circle CI

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Circle