### PR TITLE
Add typescript entry file auto detection to the xcode script

### DIFF
--- a/scripts/react-native-xcode.sh
+++ b/scripts/react-native-xcode.sh
@@ -71,6 +71,10 @@ if [[ "$ENTRY_FILE" ]]; then
   :
 elif [[ -s "index.ios.js" ]]; then
    ENTRY_FILE=${1:-index.ios.js}
+elif [[ -s "index.ios.ts" ]]; then
+   ENTRY_FILE=${1:-index.ios.ts}
+elif [[ -s "index.ts" ]]; then
+   ENTRY_FILE=${1:-index.ts}
  else
    ENTRY_FILE=${1:-index.js}
 fi


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
Archiving a project with a `.ts` entry file on Xcode crashes because the `react-native-xcode.sh` script does not auto-detect entry files with the `.ts` extension. 
![Screenshot 2019-11-29 at 05 33 51](https://user-images.githubusercontent.com/18237132/69845985-70693d80-126a-11ea-813c-1a621ccd85a0.png)
This PR adds support for `.ts` and `.ios.ts` entry file auto-detection
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[General] [Fixed] - Auto detect entry file for projects with a `.ts` index file when Archiving iOS projects

## Test Plan
Archive an iOS project with a `.ts` entry file
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
