### PR TITLE
MainActivity launchMode is singleTask

### DIFF
--- a/RNTester/android/app/src/main/AndroidManifest.xml
+++ b/RNTester/android/app/src/main/AndroidManifest.xml
@@ -35,6 +35,7 @@
         android:name=".RNTesterActivity"
         android:label="@string/app_name"
         android:screenOrientation="fullSensor"
+        android:launchMode="singleTask"
         android:configChanges="orientation|screenSize|uiMode" >
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />

--- a/template/android/app/src/main/AndroidManifest.xml
+++ b/template/android/app/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:name=".MainActivity"
         android:label="@string/app_name"
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
+        android:launchMode="singleTask"
         android:windowSoftInputMode="adjustResize">
         <intent-filter>
             <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
## Summary

Most RN apps have single activity, and developers expect to resume application from background when app icon pressed. But Android default configuration creates a new activity instance, which confuses developers, see https://github.com/facebook/react-native/issues/27370 and https://github.com/facebook/react-native/issues/27368.

This PR changes template manifest so that when app icon pressed, background app will resume instead of creating a new activity, therefore match developers expectations. Also it's required to make Linking work.

## Changelog

[Android] [Changed] - MainActivity launchMode is singleTask

## Test Plan

RNTester will resume background app, instead of creating a new instance when app icon pressed