### PR TITLE
[iOS] Add autorelease pool for each run loop for JS Thread

### DIFF
--- a/React/CxxBridge/RCTMessageThread.mm
+++ b/React/CxxBridge/RCTMessageThread.mm
@@ -36,7 +36,12 @@ RCTMessageThread::~RCTMessageThread() {
 
 // This is analogous to dispatch_async
 void RCTMessageThread::runAsync(std::function<void()> func) {
-  CFRunLoopPerformBlock(m_cfRunLoop, kCFRunLoopCommonModes, ^{ func(); });
+  CFRunLoopPerformBlock(m_cfRunLoop, kCFRunLoopCommonModes, ^{
+    // Create an autorelease pool each run loop to prevent memory footprint from growing too large, which can lead to performance problems.
+    @autoreleasepool {
+      func();
+    }
+  });
   CFRunLoopWakeUp(m_cfRunLoop);
 }
 


### PR DESCRIPTION
## Summary

Fixes #27327 , we need to create autorelease pool for each run loop in secondary thread, otherwise application may have memory issues. More details can refer to [CreatingThreads](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/Multithreading/CreatingThreads/CreatingThreads.html)
![image](https://user-images.githubusercontent.com/5061845/70033738-05fa2980-15eb-11ea-9adb-f01bee937766.png)


## Changelog

[iOS] [Fixed] - Add autorelease pool for each run loop for JS Thread

## Test Plan

Example can be found in https://github.com/facebook/react-native/issues/27327. No memory spikes any more.
