### PR TITLE
fix build failure due to duplicate libc++_shared.so

### DIFF
--- a/template/android/app/build.gradle
+++ b/template/android/app/build.gradle
@@ -165,7 +165,10 @@ android {
     }
 
     packagingOptions {
-        pickFirst "**/libc++_shared.so"
+        pickFirst "lib/armeabi-v7a/libc++_shared.so"
+        pickFirst "lib/arm64-v8a/libc++_shared.so"
+        pickFirst "lib/x86/libc++_shared.so"
+        pickFirst "lib/x86_64/libc++_shared.so"
     }
 
     // applicationVariants are e.g. debug, release

--- a/template/android/app/build.gradle
+++ b/template/android/app/build.gradle
@@ -163,6 +163,11 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }
     }
+
+    packagingOptions {
+        pickFirst "**/libc++_shared.so"
+    }
+
     // applicationVariants are e.g. debug, release
     applicationVariants.all { variant ->
         variant.outputs.each { output ->


### PR DESCRIPTION
## Summary

This PR fixes build failure caused by duplicate libc++_shared.so, because dependencies (like Flipper) might include one in addition to RN.

## Changelog

[Android] [Changed] - fix build failure due to duplicate libc++_shared.so

## Test Plan

Create a project from master, then build and run. Build will fail without the patch, and succeed with the patch.