### PR TITLE
Avoid throwing exceptions when the host activity is not FragmentActivity

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/datepicker/DatePickerDialogModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/datepicker/DatePickerDialogModule.java
@@ -7,6 +7,7 @@
 
 package com.facebook.react.modules.datepicker;
 
+import android.app.Activity;
 import android.app.DatePickerDialog.OnDateSetListener;
 import android.content.DialogInterface;
 import android.content.DialogInterface.OnDismissListener;
@@ -101,12 +102,15 @@ public class DatePickerDialogModule extends ReactContextBaseJavaModule {
    */
   @ReactMethod
   public void open(@Nullable final ReadableMap options, Promise promise) {
-    FragmentActivity activity = (FragmentActivity) getCurrentActivity();
-    if (activity == null) {
+    Activity raw_activity = getCurrentActivity();
+    if (raw_activity == null || !(raw_activity instanceof FragmentActivity)) {
       promise.reject(
-          ERROR_NO_ACTIVITY, "Tried to open a DatePicker dialog while not attached to an Activity");
+          ERROR_NO_ACTIVITY,
+          "Tried to open a DatePicker dialog while not attached to a FragmentActivity");
       return;
     }
+
+    FragmentActivity activity = (FragmentActivity) raw_activity;
 
     FragmentManager fragmentManager = activity.getSupportFragmentManager();
     DialogFragment oldFragment = (DialogFragment) fragmentManager.findFragmentByTag(FRAGMENT_TAG);

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/DialogModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/DialogModule.java
@@ -234,7 +234,7 @@ public class DialogModule extends ReactContextBaseJavaModule implements Lifecycl
    */
   private @Nullable FragmentManagerHelper getFragmentManagerHelper() {
     Activity activity = getCurrentActivity();
-    if (activity == null) {
+    if (activity == null || !(activity instanceof FragmentActivity)) {
       return null;
     }
     return new FragmentManagerHelper(((FragmentActivity) activity).getSupportFragmentManager());

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/timepicker/TimePickerDialogModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/timepicker/TimePickerDialogModule.java
@@ -7,6 +7,7 @@
 
 package com.facebook.react.modules.timepicker;
 
+import android.app.Activity;
 import android.app.TimePickerDialog.OnTimeSetListener;
 import android.content.DialogInterface;
 import android.content.DialogInterface.OnDismissListener;
@@ -89,12 +90,16 @@ public class TimePickerDialogModule extends ReactContextBaseJavaModule {
   @ReactMethod
   public void open(@Nullable final ReadableMap options, Promise promise) {
 
-    FragmentActivity activity = (FragmentActivity) getCurrentActivity();
-    if (activity == null) {
+    Activity raw_activity = getCurrentActivity();
+    if (raw_activity == null || !(raw_activity instanceof FragmentActivity)) {
       promise.reject(
-          ERROR_NO_ACTIVITY, "Tried to open a TimePicker dialog while not attached to an Activity");
+        ERROR_NO_ACTIVITY,
+        "Tried to open a DatePicker dialog while not attached to a FragmentActivity");
       return;
     }
+
+    FragmentActivity activity = (FragmentActivity) raw_activity;
+
     // We want to support both android.app.Activity and the pre-Honeycomb FragmentActivity
     // (for apps that use it for legacy reasons). This unfortunately leads to some code duplication.
     FragmentManager fragmentManager = activity.getSupportFragmentManager();


### PR DESCRIPTION
## Summary

There are some code in native modules which currently throws exception when the host activity is not a FragmentActivity, even if the native module is not used. This change avoids the throw and fail the promise instead.

## Changelog

There are some code in native modules which currently throws exception when the host activity is not a FragmentActivity, even if the native module is not used. This change avoids the throw and fail the promise instead.

[CATEGORY] [TYPE] - Message

## Test Plan

We've tested the change on MS Office applications, which currently don't use FragmentActivity.