### PR TITLE
[CI] Generate test results in a discoverable location

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ commands:
     steps:
       - run:
           name: Initial Setup
-          command: mkdir -p ~/reports/{buck,build,junit,outputs}
+          command: mkdir -p ./reports/{buck,build,junit,outputs,results}
 
   run_yarn:
     steps:
@@ -249,7 +249,7 @@ jobs:
 
       - run:
           name: Lint code
-          command: scripts/circleci/exec_swallow_error.sh yarn lint --format junit -o ~/reports/junit/eslint/results.xml
+          command: scripts/circleci/exec_swallow_error.sh yarn lint --format junit -o ./reports/junit/eslint/results.xml
           when: always
 
       - run:
@@ -275,7 +275,7 @@ jobs:
           when: always
 
       - store_test_results:
-          path: ~/reports/junit
+          path: ./reports/junit
 
   # -------------------------
   #   JOBS: Test JavaScript
@@ -298,7 +298,7 @@ jobs:
           command: node ./scripts/run-ci-javascript-tests.js --maxWorkers 2
 
       - store_test_results:
-          path: ~/reports/junit
+          path: ./reports/junit
   # -------------------------
   #     JOBS: Test iOS
   # -------------------------
@@ -310,7 +310,7 @@ jobs:
         type: boolean
         default: false
     environment:
-      - REPORTS_DIR: "./reports"
+      - REPORTS_DIR: "./reports/junit"
     steps:
       - restore_cache_checkout:
           checkout_type: ios
@@ -350,7 +350,7 @@ jobs:
 
       - run: yarn test-ios
       - store_test_results:
-          path: ~/reports/junit
+          path: ./reports/junit
 
   # Runs iOS end-to-end tests
   test_ios_e2e:
@@ -429,7 +429,7 @@ jobs:
           command: node ./scripts/run-ci-e2e-tests.js --js --retries 3
 
       - store_test_results:
-          path: ~/reports/junit
+          path: ./reports/junit
 
   # -------------------------
   #    JOBS: Test Android
@@ -494,7 +494,7 @@ jobs:
       # Test Suite
       - run:
           name: Run Unit Tests
-          command: buck test ReactAndroid/src/test/... --config build.threads=$BUILD_THREADS --xml ~/reports/buck/all-results-raw.xml
+          command: buck test ReactAndroid/src/test/... --config build.threads=$BUILD_THREADS --xml ./reports/buck/all-results-raw.xml
 
       - run:
           name: Run Instrumentation Tests
@@ -512,16 +512,16 @@ jobs:
       - run:
           name: Collect Test Results
           command: |
-            find . -type f -regex ".*/build/test-results/debug/.*xml" -exec cp {} ~/reports/build/ \;
-            find . -type f -regex ".*/outputs/androidTest-results/connected/.*xml" -exec cp {} ~/reports/outputs/ \;
-            find . -type f -regex ".*/buck-out/gen/ReactAndroid/src/test/.*/.*xml" -exec cp {} ~/reports/buck/ \;
+            find . -type f -regex ".*/build/test-results/debug/.*xml" -exec cp {} ./reports/build/ \;
+            find . -type f -regex ".*/outputs/androidTest-results/connected/.*xml" -exec cp {} ./reports/outputs/ \;
+            find . -type f -regex ".*/buck-out/gen/ReactAndroid/src/test/.*/.*xml" -exec cp {} ./reports/buck/ \;
             if [ -f ~/react-native/reports/buck/all-results-raw.xml ]; then
-              ./tooling/junit/buck_to_junit.sh ~/react-native/reports/buck/all-results-raw.xml ~/react-native/reports/junit/all-results-junit.xml
+              ./tooling/junit/buck_to_junit.sh ~/react-native/reports/buck/all-results-raw.xml ~/react-native/reports/results/all-results-junit.xml
             fi
           when: always
 
       - store_test_results:
-          path: ~/reports/junit
+          path: ./reports/junit
 
   # -------------------------
   #    JOBS: Test Docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -415,6 +415,9 @@ jobs:
             - ~/.cocoapods/repos
           key: v1-cocoapods-{{ checksum "template/ios/Podfile" }}
 
+      - store_test_results:
+          path: ./reports/junit
+
   test_js_e2e:
     executor: node8
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ commands:
     steps:
       - run:
           name: Initial Setup
-          command: mkdir -p ./reports/{buck,build,junit,outputs,results}
+          command: mkdir -p ./reports/{buck,build,junit,outputs}
 
   run_yarn:
     steps:
@@ -519,7 +519,7 @@ jobs:
             find . -type f -regex ".*/outputs/androidTest-results/connected/.*xml" -exec cp {} ./reports/outputs/ \;
             find . -type f -regex ".*/buck-out/gen/ReactAndroid/src/test/.*/.*xml" -exec cp {} ./reports/buck/ \;
             if [ -f ~/react-native/reports/buck/all-results-raw.xml ]; then
-              ./tooling/junit/buck_to_junit.sh ~/react-native/reports/buck/all-results-raw.xml ~/react-native/reports/results/all-results-junit.xml
+              ./tooling/junit/buck_to_junit.sh ~/react-native/reports/buck/all-results-raw.xml ~/react-native/reports/junit/results.xml
             fi
           when: always
 

--- a/scripts/objc-test.sh
+++ b/scripts/objc-test.sh
@@ -69,7 +69,7 @@ buildProject() {
 xcprettyFormat() {
   if [ "$CI" ]; then
     # Circle CI expects JUnit reports to be available here
-    REPORTS_DIR="$HOME/react-native/reports"
+    REPORTS_DIR="$HOME/react-native/reports/junit"
   else
     THIS_DIR=$(cd -P "$(dirname "$(readlink "${BASH_SOURCE[0]}" || echo "${BASH_SOURCE[0]}")")" && pwd)
 
@@ -77,7 +77,7 @@ xcprettyFormat() {
     REPORTS_DIR="$THIS_DIR/../build/reports"
   fi
 
-  xcpretty --report junit --output "$REPORTS_DIR/junit/$TEST_NAME/results.xml"
+  xcpretty --report junit --output "$REPORTS_DIR/$TEST_NAME/results.xml"
 }
 
 preloadBundles() {

--- a/scripts/objc-test.sh
+++ b/scripts/objc-test.sh
@@ -77,7 +77,7 @@ xcprettyFormat() {
     REPORTS_DIR="$THIS_DIR/../build/reports"
   fi
 
-  xcpretty --report junit --output "$REPORTS_DIR/$TEST_NAME/results.xml"
+  xcpretty --report junit --output "$REPORTS_DIR/ios/results.xml"
 }
 
 preloadBundles() {

--- a/scripts/run-ci-e2e-tests.js
+++ b/scripts/run-ci-e2e-tests.js
@@ -242,7 +242,7 @@ try {
                 '--report',
                 'junit',
                 '--output',
-                `"~/reports/junit/${iosTestType}-e2e/results.xml"`,
+                `"~/react-native/reports/junit/${iosTestType}-e2e/results.xml"`,
               ].join(' ') +
               ' && exit ${PIPESTATUS[0]}',
           ).code;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Test results were being written to ~/reports/, while Circle CI was configured to look for these in ~/react-native/reports/.

This simple fix makes it so that Circle CI's test result tab can now display line-by-line results without the need to dig through log spew to understand which tests failed.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[Internal] [Fixed] - Generate test results in discoverable location (CI)

## Test Plan

See https://app.circleci.com/jobs/github/hramos/react-native/7112/tests
Compare with any other run, where this tab would show an error message due to lack of test results.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->