### PR TITLE
Update Android Gradle plugin to 3.5.3

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:3.5.2")
+        classpath("com.android.tools.build:gradle:3.5.3")
         classpath("de.undercouch:gradle-download-task:4.0.2")
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/template/android/build.gradle
+++ b/template/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:3.5.2")
+        classpath("com.android.tools.build:gradle:3.5.3")
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
## Summary
Android Studio 3.5.3 is now available in the stable channel

https://androidstudio.googleblog.com/2019/12/android-studio-353-available.html

## Changelog

[Android] [Changed] - Update Android Gradle plugin to 3.5.3

## Test Plan

Build project
