### PR TITLE
menual-e2e use npx and installs cocoapods dependencies

### DIFF
--- a/scripts/test-manual-e2e.sh
+++ b/scripts/test-manual-e2e.sh
@@ -61,6 +61,8 @@ adb shell am start -n com.facebook.react.uiapp/.RNTesterActivity
 info "Press any key to open the workspace in Xcode, then build and test manually."
 info ""
 read -n 1
+success "Installing CocoaPods dependencies"
+rm -rf RNTester/Pods && cd RNTester && pod install
 open "RNTester/RNTesterPods.xcworkspace"
 
 info "When done testing RNTester app on iOS and Android press any key to continue."
@@ -98,7 +100,7 @@ info ""
 info "Press any key to run the sample in Android emulator/device"
 info ""
 read -n 1
-cd "/tmp/${project_name}" && react-native run-android
+cd "/tmp/${project_name}" && npx react-native run-android
 
 info "Test the following on iOS:"
 info "   - Disable Fast Refresh. It might be enabled from last time (the setting is stored on the device)"


### PR DESCRIPTION
## Summary

This PR tries to improve manual-e2e experience by installing RNTester cocoapods dependencies automatically, and using npx to run react-native command. Removing RNTester/Pods because pod specs might change while RN version still the same or 1000.0.0, and this might cause unexpected issues.

## Changelog

[General] [Changed] - test-manual-e2e.sh script uses npx and installs cocoapods dependencies

## Test Plan

run ./scripts/test-manual-e2e.sh, and it'll install cocoapods dependencies and run npx react-native run-android.