### PR TITLE
use androidx annotations in fbreact/specs

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/fbreact/specs/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/fbreact/specs/BUCK
@@ -5,7 +5,7 @@ rn_android_library(
     srcs = glob(["*.java"]),
     visibility = ["PUBLIC"],
     deps = [
-        react_native_dep("third-party/java/jsr-305:jsr-305"),
+        react_native_dep("third-party/android/androidx:annotation"),
         react_native_dep("third-party/java/jsr-330:jsr-330"),
         react_native_target("java/com/facebook/react/bridge:bridge"),
         react_native_target("java/com/facebook/react/common:common"),

--- a/ReactAndroid/src/main/java/com/facebook/fbreact/specs/NativeAppStateSpec.java
+++ b/ReactAndroid/src/main/java/com/facebook/fbreact/specs/NativeAppStateSpec.java
@@ -12,6 +12,7 @@
 
 package com.facebook.fbreact.specs;
 
+import androidx.annotation.Nullable;
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
@@ -23,7 +24,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nullable;
 
 public abstract class NativeAppStateSpec extends ReactContextBaseJavaModule implements ReactModuleWithSpec, TurboModule {
   public NativeAppStateSpec(ReactApplicationContext reactContext) {

--- a/ReactAndroid/src/main/java/com/facebook/fbreact/specs/NativeAppearanceSpec.java
+++ b/ReactAndroid/src/main/java/com/facebook/fbreact/specs/NativeAppearanceSpec.java
@@ -12,12 +12,12 @@
 
 package com.facebook.fbreact.specs;
 
+import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReactModuleWithSpec;
 import com.facebook.react.turbomodule.core.interfaces.TurboModule;
-import javax.annotation.Nullable;
 
 public abstract class NativeAppearanceSpec extends ReactContextBaseJavaModule implements ReactModuleWithSpec, TurboModule {
   public NativeAppearanceSpec(ReactApplicationContext reactContext) {

--- a/ReactAndroid/src/main/java/com/facebook/fbreact/specs/NativeBlobModuleSpec.java
+++ b/ReactAndroid/src/main/java/com/facebook/fbreact/specs/NativeBlobModuleSpec.java
@@ -12,6 +12,7 @@
 
 package com.facebook.fbreact.specs;
 
+import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
@@ -24,7 +25,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nullable;
 
 public abstract class NativeBlobModuleSpec extends ReactContextBaseJavaModule implements ReactModuleWithSpec, TurboModule {
   public NativeBlobModuleSpec(ReactApplicationContext reactContext) {

--- a/ReactAndroid/src/main/java/com/facebook/fbreact/specs/NativeDeviceInfoSpec.java
+++ b/ReactAndroid/src/main/java/com/facebook/fbreact/specs/NativeDeviceInfoSpec.java
@@ -12,6 +12,7 @@
 
 package com.facebook.fbreact.specs;
 
+import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactModuleWithSpec;
@@ -21,7 +22,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nullable;
 
 public abstract class NativeDeviceInfoSpec extends ReactContextBaseJavaModule implements ReactModuleWithSpec, TurboModule {
   public NativeDeviceInfoSpec(ReactApplicationContext reactContext) {

--- a/ReactAndroid/src/main/java/com/facebook/fbreact/specs/NativeDialogManagerAndroidSpec.java
+++ b/ReactAndroid/src/main/java/com/facebook/fbreact/specs/NativeDialogManagerAndroidSpec.java
@@ -12,6 +12,7 @@
 
 package com.facebook.fbreact.specs;
 
+import androidx.annotation.Nullable;
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
@@ -24,7 +25,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nullable;
 
 public abstract class NativeDialogManagerAndroidSpec extends ReactContextBaseJavaModule implements ReactModuleWithSpec, TurboModule {
   public NativeDialogManagerAndroidSpec(ReactApplicationContext reactContext) {

--- a/ReactAndroid/src/main/java/com/facebook/fbreact/specs/NativeHeapCaptureSpec.java
+++ b/ReactAndroid/src/main/java/com/facebook/fbreact/specs/NativeHeapCaptureSpec.java
@@ -12,12 +12,12 @@
 
 package com.facebook.fbreact.specs;
 
+import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReactModuleWithSpec;
 import com.facebook.react.turbomodule.core.interfaces.TurboModule;
-import javax.annotation.Nullable;
 
 public abstract class NativeHeapCaptureSpec extends ReactContextBaseJavaModule implements ReactModuleWithSpec, TurboModule {
   public NativeHeapCaptureSpec(ReactApplicationContext reactContext) {

--- a/ReactAndroid/src/main/java/com/facebook/fbreact/specs/NativeI18nManagerSpec.java
+++ b/ReactAndroid/src/main/java/com/facebook/fbreact/specs/NativeI18nManagerSpec.java
@@ -12,6 +12,7 @@
 
 package com.facebook.fbreact.specs;
 
+import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
@@ -22,7 +23,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nullable;
 
 public abstract class NativeI18nManagerSpec extends ReactContextBaseJavaModule implements ReactModuleWithSpec, TurboModule {
   public NativeI18nManagerSpec(ReactApplicationContext reactContext) {

--- a/ReactAndroid/src/main/java/com/facebook/fbreact/specs/NativeJSCSamplingProfilerSpec.java
+++ b/ReactAndroid/src/main/java/com/facebook/fbreact/specs/NativeJSCSamplingProfilerSpec.java
@@ -12,12 +12,12 @@
 
 package com.facebook.fbreact.specs;
 
+import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReactModuleWithSpec;
 import com.facebook.react.turbomodule.core.interfaces.TurboModule;
-import javax.annotation.Nullable;
 
 public abstract class NativeJSCSamplingProfilerSpec extends ReactContextBaseJavaModule implements ReactModuleWithSpec, TurboModule {
   public NativeJSCSamplingProfilerSpec(ReactApplicationContext reactContext) {

--- a/ReactAndroid/src/main/java/com/facebook/fbreact/specs/NativeJSDevSupportSpec.java
+++ b/ReactAndroid/src/main/java/com/facebook/fbreact/specs/NativeJSDevSupportSpec.java
@@ -12,6 +12,7 @@
 
 package com.facebook.fbreact.specs;
 
+import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
@@ -22,7 +23,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nullable;
 
 public abstract class NativeJSDevSupportSpec extends ReactContextBaseJavaModule implements ReactModuleWithSpec, TurboModule {
   public NativeJSDevSupportSpec(ReactApplicationContext reactContext) {

--- a/ReactAndroid/src/main/java/com/facebook/fbreact/specs/NativePlatformConstantsAndroidSpec.java
+++ b/ReactAndroid/src/main/java/com/facebook/fbreact/specs/NativePlatformConstantsAndroidSpec.java
@@ -12,6 +12,7 @@
 
 package com.facebook.fbreact.specs;
 
+import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
@@ -22,7 +23,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nullable;
 
 public abstract class NativePlatformConstantsAndroidSpec extends ReactContextBaseJavaModule implements ReactModuleWithSpec, TurboModule {
   public NativePlatformConstantsAndroidSpec(ReactApplicationContext reactContext) {

--- a/ReactAndroid/src/main/java/com/facebook/fbreact/specs/NativePlatformConstantsIOSSpec.java
+++ b/ReactAndroid/src/main/java/com/facebook/fbreact/specs/NativePlatformConstantsIOSSpec.java
@@ -12,6 +12,7 @@
 
 package com.facebook.fbreact.specs;
 
+import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactModuleWithSpec;
@@ -21,7 +22,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nullable;
 
 public abstract class NativePlatformConstantsIOSSpec extends ReactContextBaseJavaModule implements ReactModuleWithSpec, TurboModule {
   public NativePlatformConstantsIOSSpec(ReactApplicationContext reactContext) {

--- a/ReactAndroid/src/main/java/com/facebook/fbreact/specs/NativeSettingsManagerSpec.java
+++ b/ReactAndroid/src/main/java/com/facebook/fbreact/specs/NativeSettingsManagerSpec.java
@@ -12,6 +12,7 @@
 
 package com.facebook.fbreact.specs;
 
+import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
@@ -24,7 +25,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nullable;
 
 public abstract class NativeSettingsManagerSpec extends ReactContextBaseJavaModule implements ReactModuleWithSpec, TurboModule {
   public NativeSettingsManagerSpec(ReactApplicationContext reactContext) {

--- a/ReactAndroid/src/main/java/com/facebook/fbreact/specs/NativeSourceCodeSpec.java
+++ b/ReactAndroid/src/main/java/com/facebook/fbreact/specs/NativeSourceCodeSpec.java
@@ -12,6 +12,7 @@
 
 package com.facebook.fbreact.specs;
 
+import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactModuleWithSpec;
@@ -21,7 +22,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nullable;
 
 public abstract class NativeSourceCodeSpec extends ReactContextBaseJavaModule implements ReactModuleWithSpec, TurboModule {
   public NativeSourceCodeSpec(ReactApplicationContext reactContext) {

--- a/ReactAndroid/src/main/java/com/facebook/fbreact/specs/NativeStatusBarManagerAndroidSpec.java
+++ b/ReactAndroid/src/main/java/com/facebook/fbreact/specs/NativeStatusBarManagerAndroidSpec.java
@@ -12,6 +12,7 @@
 
 package com.facebook.fbreact.specs;
 
+import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
@@ -22,7 +23,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nullable;
 
 public abstract class NativeStatusBarManagerAndroidSpec extends ReactContextBaseJavaModule implements ReactModuleWithSpec, TurboModule {
   public NativeStatusBarManagerAndroidSpec(ReactApplicationContext reactContext) {

--- a/ReactAndroid/src/main/java/com/facebook/fbreact/specs/NativeStatusBarManagerIOSSpec.java
+++ b/ReactAndroid/src/main/java/com/facebook/fbreact/specs/NativeStatusBarManagerIOSSpec.java
@@ -12,6 +12,7 @@
 
 package com.facebook.fbreact.specs;
 
+import androidx.annotation.Nullable;
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
@@ -23,7 +24,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nullable;
 
 public abstract class NativeStatusBarManagerIOSSpec extends ReactContextBaseJavaModule implements ReactModuleWithSpec, TurboModule {
   public NativeStatusBarManagerIOSSpec(ReactApplicationContext reactContext) {

--- a/ReactAndroid/src/main/java/com/facebook/fbreact/specs/NativeStatusBarManagerSpec.java
+++ b/ReactAndroid/src/main/java/com/facebook/fbreact/specs/NativeStatusBarManagerSpec.java
@@ -12,6 +12,7 @@
 
 package com.facebook.fbreact.specs;
 
+import androidx.annotation.Nullable;
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
@@ -23,7 +24,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nullable;
 
 public abstract class NativeStatusBarManagerSpec extends ReactContextBaseJavaModule implements ReactModuleWithSpec, TurboModule {
   public NativeStatusBarManagerSpec(ReactApplicationContext reactContext) {

--- a/ReactAndroid/src/main/java/com/facebook/fbreact/specs/NativeToastAndroidSpec.java
+++ b/ReactAndroid/src/main/java/com/facebook/fbreact/specs/NativeToastAndroidSpec.java
@@ -12,6 +12,7 @@
 
 package com.facebook.fbreact.specs;
 
+import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
@@ -22,7 +23,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nullable;
 
 public abstract class NativeToastAndroidSpec extends ReactContextBaseJavaModule implements ReactModuleWithSpec, TurboModule {
   public NativeToastAndroidSpec(ReactApplicationContext reactContext) {

--- a/ReactAndroid/src/main/java/com/facebook/fbreact/specs/NativeUIManagerSpec.java
+++ b/ReactAndroid/src/main/java/com/facebook/fbreact/specs/NativeUIManagerSpec.java
@@ -12,6 +12,7 @@
 
 package com.facebook.fbreact.specs;
 
+import androidx.annotation.Nullable;
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
@@ -23,7 +24,6 @@ import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.turbomodule.core.interfaces.TurboModule;
 import java.util.Map;
-import javax.annotation.Nullable;
 
 public abstract class NativeUIManagerSpec extends ReactContextBaseJavaModule implements ReactModuleWithSpec, TurboModule {
   public NativeUIManagerSpec(ReactApplicationContext reactContext) {


### PR DESCRIPTION
## Summary

This PR replaces jsr-305 nullable annotations with AndroidX annotations.

## Changelog

[Android] [Changed] - use androidx annotations in fbreact/specs

## Test Plan

ReactAndroid and RNTester builds as expected