### PR TITLE
Enable dev keyboard shortcuts on Mac Catalyst

### DIFF
--- a/React/CoreModules/RCTDevMenu.mm
+++ b/React/CoreModules/RCTDevMenu.mm
@@ -122,7 +122,7 @@ RCT_EXPORT_MODULE()
                                                object:nil];
     _extraMenuItems = [NSMutableArray new];
 
-#if TARGET_OS_SIMULATOR
+#if TARGET_OS_SIMULATOR || TARGET_OS_MACCATALYST
     RCTKeyCommands *commands = [RCTKeyCommands sharedInstance];
     __weak __typeof(self) weakSelf = self;
 

--- a/React/CoreModules/RCTRedBox.mm
+++ b/React/CoreModules/RCTRedBox.mm
@@ -116,7 +116,7 @@
         _stackTraceTableView.indicatorStyle = UIScrollViewIndicatorStyleWhite;
         [rootView addSubview:_stackTraceTableView];
 
-#if TARGET_OS_SIMULATOR
+#if TARGET_OS_SIMULATOR || TARGET_OS_MACCATALYST
         NSString *reloadText = @"Reload\n(\u2318R)";
         NSString *dismissText = @"Dismiss\n(ESC)";
         NSString *copyText = @"Copy\n(\u2325\u2318C)";

--- a/React/Modules/RCTRedBoxExtraDataViewController.m
+++ b/React/Modules/RCTRedBoxExtraDataViewController.m
@@ -106,7 +106,7 @@
         _tableView.rowHeight = UITableViewAutomaticDimension;
         _tableView.allowsSelection = NO;
 
-#if TARGET_OS_SIMULATOR
+#if TARGET_OS_SIMULATOR || TARGET_OS_MACCATALYST
         NSString *reloadText = @"Reload JS (\u2318R)";
         NSString *dismissText = @"Dismiss (ESC)";
 #else


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This enables the dev menu to bo opened from keyboard shortcuts in dev from a Mac Catalyst app.

cc @TheSavior @andymatuschak @radex 

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[iOS] [Fixed] - Enable dev keyboard shortcuts on Mac Catalyst

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

It depends on #27469 (to have working WebSocket in debug).

![image](https://user-images.githubusercontent.com/7189823/70629346-d3a68880-1bf7-11ea-8949-7553157a2f9c.png)
