### PR TITLE
macOS: Implement Platform.isMac

### DIFF
--- a/Libraries/FBReactNativeSpec/FBReactNativeSpec/FBReactNativeSpec.h
+++ b/Libraries/FBReactNativeSpec/FBReactNativeSpec/FBReactNativeSpec.h
@@ -2062,6 +2062,7 @@ namespace JS {
           RCTRequired<NSString *> osVersion;
           RCTRequired<NSString *> systemName;
           RCTRequired<NSString *> interfaceIdiom;
+          RCTRequired<bool> isMac;
         };
 
         /** Initialize with a set of values */
@@ -3671,6 +3672,8 @@ inline JS::NativePlatformConstantsIOS::Constants::Builder::Builder(const Input i
   d[@"systemName"] = systemName;
   auto interfaceIdiom = i.interfaceIdiom.get();
   d[@"interfaceIdiom"] = interfaceIdiom;
+  auto isMac = i.isMac.get();
+  d[@"isMac"] = @(isMac);
   return d;
 }) {}
 inline JS::NativePlatformConstantsIOS::Constants::Builder::Builder(Constants i) : _factory(^{

--- a/Libraries/Utilities/NativePlatformConstantsIOS.js
+++ b/Libraries/Utilities/NativePlatformConstantsIOS.js
@@ -26,6 +26,7 @@ export interface Spec extends TurboModule {
     osVersion: string,
     systemName: string,
     interfaceIdiom: string,
+    isMac: boolean,
   |};
 }
 

--- a/Libraries/Utilities/Platform.android.js
+++ b/Libraries/Utilities/Platform.android.js
@@ -55,6 +55,9 @@ const Platform = {
   get isTV(): boolean {
     return this.constants.uiMode === 'tv';
   },
+  get isMac(): boolean {
+    return false;
+  },
   select: <A, N, D>(spec: PlatformSelectSpec<A, N, D>): A | N | D =>
     'android' in spec
       ? spec.android

--- a/Libraries/Utilities/Platform.ios.js
+++ b/Libraries/Utilities/Platform.ios.js
@@ -37,6 +37,7 @@ const Platform = {
       prerelease: ?number,
     |},
     systemName: string,
+    isMac: boolean,
   |} {
     if (this.__constants == null) {
       this.__constants = NativePlatformConstantsIOS.getConstants();
@@ -60,6 +61,9 @@ const Platform = {
       return this.constants.isTesting;
     }
     return false;
+  },
+  get isMac(): boolean {
+    return this.constants.isMac;
   },
   select: <D, N, I>(spec: PlatformSelectSpec<D, N, I>): D | N | I =>
     'ios' in spec ? spec.ios : 'native' in spec ? spec.native : spec.default,

--- a/Libraries/Utilities/__tests__/Platform-test.js
+++ b/Libraries/Utilities/__tests__/Platform-test.js
@@ -40,4 +40,10 @@ describe('Platform', () => {
       expect(PlatformAndroid.select(obj)).toEqual(obj.default);
     });
   });
+
+  describe('isMac', () => {
+    it('should return false for android', () => {
+      expect(PlatformAndroid.isMac).toBe(false);
+    });
+  });
 });

--- a/React/CoreModules/RCTPlatform.mm
+++ b/React/CoreModules/RCTPlatform.mm
@@ -32,6 +32,14 @@ static NSString *interfaceIdiom(UIUserInterfaceIdiom idiom) {
   }
 }
 
+static BOOL isMac() {
+#if TARGET_OS_MACCATALYST
+  return YES;
+#else
+  return NO;
+#endif
+}
+
 @interface RCTPlatform () <NativePlatformConstantsIOSSpec>
 @end
 
@@ -65,6 +73,7 @@ RCT_EXPORT_MODULE(PlatformConstants)
     .systemName = [device systemName],
     .interfaceIdiom = interfaceIdiom([device userInterfaceIdiom]),
     .isTesting = RCTRunningInTestEnvironment() ? true : false,
+    .isMac = isMac() ? true : false,
     .reactNativeVersion = JS::NativePlatformConstantsIOS::ConstantsReactNativeVersion::Builder({
       .minor = [versions[@"minor"] doubleValue],
       .major = [versions[@"major"] doubleValue],


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Implementing `Platform.isMac` to know if we're running on macOS with Catalyst.

⚠️ Note that `Platform.OS` is still returning `ios`, even on macOS.

We'll be able to use `Platform.isMac` to target macOS.

```javascript
import { Platform } from 'react-native';

if (Platform.isMac) {
  // Do something specific to macOS
} else {
 // Do something else for other platforms.
}
```

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[iOS] [Added] - Implement Platform.isMac to know if we're running on macOS with Catalyst.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

```javascript
// On iOS
Platform.isMac // false

// On macOS
Platform.isMac // true
```
