### PR TITLE
gitignore ReactAndroid prebuilt libs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,8 +32,7 @@ project.xcworkspace
 # Buck
 .buckd
 buck-out
-/ReactAndroid/src/main/jni/prebuilt/lib/armeabi-v7a/
-/ReactAndroid/src/main/jni/prebuilt/lib/x86/
+/ReactAndroid/src/main/jni/prebuilt/lib/
 /ReactAndroid/src/main/gen
 
 # Watchman


### PR DESCRIPTION
## Summary

This PR changes gitignore to ignore prebuilt libs in ReactAndroid as a whole, because we added 64 bit platforms and their files are showing up as changes.

## Changelog

[GENERAL] [Changed] - gitignore ReactAndroid prebuilt libs

## Test Plan

After ReactAndroid build, you won't see prebuilt lib changes in git.