### PR TITLE
[CI] Ignore js_coverage failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -557,11 +557,12 @@ jobs:
       - setup_artifacts
       - run_yarn
       - run:
-          name: Test coverage
+          name: Collect test coverage information
           command: |
-            yarn test --coverage --maxWorkers=2
-            cat ./coverage/lcov.info | ./node_modules/.bin/coveralls
-          when: always
+            scripts/circleci/exec_swallow_error.sh yarn test --coverage --maxWorkers=2
+            if [[ -e ./coverage/lcov.info ]]; then
+              cat ./coverage/lcov.info | scripts/circleci/exec_swallow_error.sh ./node_modules/.bin/coveralls
+            fi
       - store_artifacts:
           path: ~/react-native/coverage/
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

The js_coverage step has failed on some recent PRs. While we want to continue collecting coverage data, we are not rejecting PRs that decrease coverage at the moment. Failing a PR in this step sends the wrong message, therefore, we should ignore whenever js_coverage fails.

> The actual coverage failures appear to be issues related to coveralls (the coverage service) failing to map the coverage data to a specific repository, not necessarily due to a decrease in coverage.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->
[Internal]


## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
CircleCI.