### PR TITLE
setting this.state.bottom to 0 when keyboard is hidden in the Keyboar…

### DIFF
--- a/Libraries/Components/Keyboard/KeyboardAvoidingView.js
+++ b/Libraries/Components/Keyboard/KeyboardAvoidingView.js
@@ -90,14 +90,14 @@ class KeyboardAvoidingView extends React.Component<Props, State> {
     return Math.max(frame.y + frame.height - keyboardY, 0);
   }
 
-  _onKeyboardChange = (event: ?KeyboardEvent) => {
+  _onKeyboardChange = (event: ?KeyboardEvent, hidden = false) => {
     if (event == null) {
       this.setState({bottom: 0});
       return;
     }
 
     const {duration, easing, endCoordinates} = event;
-    const height = this._relativeKeyboardHeight(endCoordinates);
+    const height = hidden ? 0 : this._relativeKeyboardHeight(endCoordinates);
 
     if (this.state.bottom === height) {
       return;
@@ -131,7 +131,9 @@ class KeyboardAvoidingView extends React.Component<Props, State> {
       ];
     } else {
       this._subscriptions = [
-        Keyboard.addListener('keyboardDidHide', this._onKeyboardChange),
+        Keyboard.addListener('keyboardDidHide', e =>
+          this._onKeyboardChange(e, true),
+        ),
         Keyboard.addListener('keyboardDidShow', this._onKeyboardChange),
       ];
     }


### PR DESCRIPTION
## Summary
In the KeyboardAvoidingView, `this._relativeKeyboardHeight` returns the height of the keyboard on keyboard change events. This method seems to return a non-zero value while the keyboard is hidden. This PR ensures that if the keyboard is hidden, the returned value of `this._relativeKeyboardHeight` is dismissed to instead apply `0`. 

## Changelog

[General] [Fixed] - setting this.state.bottom to 0 when keyboard is hidden in the KeyboardAvoindingView

## Test Plan

All tests pass when running `npm test`. This does not affect native components. 
