### PR TITLE
Remove code that would cause accessibility header role to be spoken twice

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAccessibilityDelegate.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAccessibilityDelegate.java
@@ -367,9 +367,8 @@ public class ReactAccessibilityDelegate extends AccessibilityDelegateCompat {
     } else if (role.equals(AccessibilityRole.SUMMARY)) {
       nodeInfo.setRoleDescription(context.getString(R.string.summary_description));
     } else if (role.equals(AccessibilityRole.HEADER)) {
-      nodeInfo.setRoleDescription(context.getString(R.string.header_description));
       final AccessibilityNodeInfoCompat.CollectionItemInfoCompat itemInfo =
-          AccessibilityNodeInfoCompat.CollectionItemInfoCompat.obtain(0, 1, 0, 1, true);
+        AccessibilityNodeInfoCompat.CollectionItemInfoCompat.obtain(0, 1, 0, 1, true);
       nodeInfo.setCollectionItemInfo(itemInfo);
     } else if (role.equals(AccessibilityRole.ALERT)) {
       nodeInfo.setRoleDescription(context.getString(R.string.alert_description));

--- a/docs/generatedComponentApiDocs.js
+++ b/docs/generatedComponentApiDocs.js
@@ -14,182 +14,182 @@
 
 module.exports = [
   {
-    "description": "A visual toggle between two mutually exclusive states.\n\nThis is a controlled component that requires an `onValueChange` callback that\nupdates the `value` prop in order for the component to reflect user actions.\nIf the `value` prop is not updated, the component will continue to render the\nsupplied `value` prop instead of the expected result of any user actions.",
-    "displayName": "Switch",
-    "methods": [],
-    "props": {
-      "disabled": {
-        "required": false,
-        "flowType": {
-          "name": "boolean",
-          "nullable": true
+    'description': 'A visual toggle between two mutually exclusive states.\n\nThis is a controlled component that requires an `onValueChange` callback that\nupdates the `value` prop in order for the component to reflect user actions.\nIf the `value` prop is not updated, the component will continue to render the\nsupplied `value` prop instead of the expected result of any user actions.',
+    'displayName': 'Switch',
+    'methods': [],
+    'props': {
+      'disabled': {
+        'required': false,
+        'flowType': {
+          'name': 'boolean',
+          'nullable': true,
         },
-        "description": "Whether the switch is disabled. Defaults to false."
+        'description': 'Whether the switch is disabled. Defaults to false.',
       },
-      "value": {
-        "required": false,
-        "flowType": {
-          "name": "boolean",
-          "nullable": true
+      'value': {
+        'required': false,
+        'flowType': {
+          'name': 'boolean',
+          'nullable': true,
         },
-        "description": "Boolean value of the switch. Defaults to false."
+        'description': 'Boolean value of the switch. Defaults to false.',
       },
-      "thumbColor": {
-        "required": false,
-        "flowType": {
-          "name": "ColorValue",
-          "nullable": true
+      'thumbColor': {
+        'required': false,
+        'flowType': {
+          'name': 'ColorValue',
+          'nullable': true,
         },
-        "description": "Custom color for the switch thumb."
+        'description': 'Custom color for the switch thumb.',
       },
-      "trackColor": {
-        "required": false,
-        "flowType": {
-          "name": "$ReadOnly",
-          "elements": [
+      'trackColor': {
+        'required': false,
+        'flowType': {
+          'name': '$ReadOnly',
+          'elements': [
             {
-              "name": "signature",
-              "type": "object",
-              "raw": "{|\n  false?: ?ColorValue,\n  true?: ?ColorValue,\n|}",
-              "signature": {
-                "properties": [
+              'name': 'signature',
+              'type': 'object',
+              'raw': '{|\n  false?: ?ColorValue,\n  true?: ?ColorValue,\n|}',
+              'signature': {
+                'properties': [
                   {
-                    "key": "false",
-                    "value": {
-                      "name": "ColorValue",
-                      "nullable": true,
-                      "required": false
-                    }
+                    'key': 'false',
+                    'value': {
+                      'name': 'ColorValue',
+                      'nullable': true,
+                      'required': false,
+                    },
                   },
                   {
-                    "key": "true",
-                    "value": {
-                      "name": "ColorValue",
-                      "nullable": true,
-                      "required": false
-                    }
-                  }
-                ]
-              }
-            }
+                    'key': 'true',
+                    'value': {
+                      'name': 'ColorValue',
+                      'nullable': true,
+                      'required': false,
+                    },
+                  },
+                ],
+              },
+            },
           ],
-          "raw": "$ReadOnly<{|\n  false?: ?ColorValue,\n  true?: ?ColorValue,\n|}>",
-          "nullable": true
+          'raw': '$ReadOnly<{|\n  false?: ?ColorValue,\n  true?: ?ColorValue,\n|}>',
+          'nullable': true,
         },
-        "description": "Custom colors for the switch track.\n\nNOTE: On iOS when the switch value is false, the track shrinks into the\nborder. If you want to change the color of the background exposed by the\nshrunken track, use `ios_backgroundColor`."
+        'description': 'Custom colors for the switch track.\n\nNOTE: On iOS when the switch value is false, the track shrinks into the\nborder. If you want to change the color of the background exposed by the\nshrunken track, use `ios_backgroundColor`.',
       },
-      "ios_backgroundColor": {
-        "required": false,
-        "flowType": {
-          "name": "ColorValue",
-          "nullable": true
+      'ios_backgroundColor': {
+        'required': false,
+        'flowType': {
+          'name': 'ColorValue',
+          'nullable': true,
         },
-        "description": "On iOS, custom color for the background. This background color can be seen\neither when the switch value is false or when the switch is disabled (and\nthe switch is translucent)."
+        'description': 'On iOS, custom color for the background. This background color can be seen\neither when the switch value is false or when the switch is disabled (and\nthe switch is translucent).',
       },
-      "onChange": {
-        "required": false,
-        "flowType": {
-          "name": "signature",
-          "type": "function",
-          "raw": "(event: SwitchChangeEvent) => Promise<void> | void",
-          "signature": {
-            "arguments": [
+      'onChange': {
+        'required': false,
+        'flowType': {
+          'name': 'signature',
+          'type': 'function',
+          'raw': '(event: SwitchChangeEvent) => Promise<void> | void',
+          'signature': {
+            'arguments': [
               {
-                "name": "event",
-                "type": {
-                  "name": "SyntheticEvent",
-                  "elements": [
+                'name': 'event',
+                'type': {
+                  'name': 'SyntheticEvent',
+                  'elements': [
                     {
-                      "name": "$ReadOnly",
-                      "elements": [
+                      'name': '$ReadOnly',
+                      'elements': [
                         {
-                          "name": "signature",
-                          "type": "object",
-                          "raw": "{|\n  value: boolean,\n|}",
-                          "signature": {
-                            "properties": [
+                          'name': 'signature',
+                          'type': 'object',
+                          'raw': '{|\n  value: boolean,\n|}',
+                          'signature': {
+                            'properties': [
                               {
-                                "key": "value",
-                                "value": {
-                                  "name": "boolean",
-                                  "required": true
-                                }
-                              }
-                            ]
-                          }
-                        }
+                                'key': 'value',
+                                'value': {
+                                  'name': 'boolean',
+                                  'required': true,
+                                },
+                              },
+                            ],
+                          },
+                        },
                       ],
-                      "raw": "$ReadOnly<{|\n  value: boolean,\n|}>"
-                    }
+                      'raw': '$ReadOnly<{|\n  value: boolean,\n|}>',
+                    },
                   ],
-                  "raw": "SyntheticEvent<\n  $ReadOnly<{|\n    value: boolean,\n  |}>,\n>"
-                }
-              }
+                  'raw': 'SyntheticEvent<\n  $ReadOnly<{|\n    value: boolean,\n  |}>,\n>',
+                },
+              },
             ],
-            "return": {
-              "name": "union",
-              "raw": "Promise<void> | void",
-              "elements": [
+            'return': {
+              'name': 'union',
+              'raw': 'Promise<void> | void',
+              'elements': [
                 {
-                  "name": "Promise",
-                  "elements": [
+                  'name': 'Promise',
+                  'elements': [
                     {
-                      "name": "void"
-                    }
+                      'name': 'void',
+                    },
                   ],
-                  "raw": "Promise<void>"
+                  'raw': 'Promise<void>',
                 },
                 {
-                  "name": "void"
-                }
-              ]
-            }
+                  'name': 'void',
+                },
+              ],
+            },
           },
-          "nullable": true
+          'nullable': true,
         },
-        "description": "Called when the user tries to change the value of the switch.\n\nReceives the change event as an argument. If you want to only receive the\nnew value, use `onValueChange` instead."
+        'description': 'Called when the user tries to change the value of the switch.\n\nReceives the change event as an argument. If you want to only receive the\nnew value, use `onValueChange` instead.',
       },
-      "onValueChange": {
-        "required": false,
-        "flowType": {
-          "name": "signature",
-          "type": "function",
-          "raw": "(value: boolean) => Promise<void> | void",
-          "signature": {
-            "arguments": [
+      'onValueChange': {
+        'required': false,
+        'flowType': {
+          'name': 'signature',
+          'type': 'function',
+          'raw': '(value: boolean) => Promise<void> | void',
+          'signature': {
+            'arguments': [
               {
-                "name": "value",
-                "type": {
-                  "name": "boolean"
-                }
-              }
+                'name': 'value',
+                'type': {
+                  'name': 'boolean',
+                },
+              },
             ],
-            "return": {
-              "name": "union",
-              "raw": "Promise<void> | void",
-              "elements": [
+            'return': {
+              'name': 'union',
+              'raw': 'Promise<void> | void',
+              'elements': [
                 {
-                  "name": "Promise",
-                  "elements": [
+                  'name': 'Promise',
+                  'elements': [
                     {
-                      "name": "void"
-                    }
+                      'name': 'void',
+                    },
                   ],
-                  "raw": "Promise<void>"
+                  'raw': 'Promise<void>',
                 },
                 {
-                  "name": "void"
-                }
-              ]
-            }
+                  'name': 'void',
+                },
+              ],
+            },
           },
-          "nullable": true
+          'nullable': true,
         },
-        "description": "Called when the user tries to change the value of the switch.\n\nReceives the new value as an argument. If you want to instead receive an\nevent, use `onChange`."
-      }
+        'description': 'Called when the user tries to change the value of the switch.\n\nReceives the new value as an argument. If you want to instead receive an\nevent, use `onChange`.',
+      },
     },
-    "composes": [
-      "ViewProps"
-    ]
-  }
-]
+    'composes': [
+      'ViewProps',
+    ],
+  },
+];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
The header role is being said twice in android. Stopped that from happening.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog
[General] [Added] - removed code that would cause accessibility header role to be spoken twice


## Test Plan
Test plan is testing in RNTester making sure the examples work

## Note:
generatedComponentApiDocs.js was modified by lint commands. I can submit a PR without it if preferred.  

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
