### PR TITLE
Fix setting keyboardType from breaking autoCapitalize

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -67,6 +67,7 @@ import com.facebook.yoga.YogaConstants;
 import java.lang.reflect.Field;
 import java.util.LinkedList;
 import java.util.Map;
+import java.util.Arrays;
 
 /** Manages instances of TextInput. */
 @ReactModule(name = ReactTextInputManager.REACT_CLASS)
@@ -104,6 +105,15 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
   private static final String KEYBOARD_TYPE_NUMBER_PAD = "number-pad";
   private static final String KEYBOARD_TYPE_PHONE_PAD = "phone-pad";
   private static final String KEYBOARD_TYPE_VISIBLE_PASSWORD = "visible-password";
+  private static final String[] KEYBOARD_TYPES = new String[]{ 
+    KEYBOARD_TYPE_DEFAULT,
+    KEYBOARD_TYPE_EMAIL_ADDRESS,
+    KEYBOARD_TYPE_NUMERIC,
+    KEYBOARD_TYPE_DECIMAL_PAD,
+    KEYBOARD_TYPE_NUMBER_PAD,
+    KEYBOARD_TYPE_PHONE_PAD,
+    KEYBOARD_TYPE_VISIBLE_PASSWORD
+  };
   private static final InputFilter[] EMPTY_FILTERS = new InputFilter[0];
   private static final int UNSET = -1;
 
@@ -718,7 +728,7 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
   @ReactProp(name = "keyboardType")
   public void setKeyboardType(ReactEditText view, @Nullable String keyboardType) {
     int flagsToSet = InputType.TYPE_CLASS_TEXT;
-    if (keyboardType == null || KEYBOARD_TYPE_DEFAULT.equalsIgnoreCase(keyboardType)) {
+    if (keyboardType == null || !Arrays.asList(KEYBOARD_TYPES).contains(keyboardType) || KEYBOARD_TYPE_DEFAULT.equalsIgnoreCase(keyboardType)) {
       return;
     } else if (KEYBOARD_TYPE_NUMERIC.equalsIgnoreCase(keyboardType)) {
       flagsToSet = INPUT_TYPE_KEYBOARD_NUMBERED;

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -97,6 +97,7 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
           | InputType.TYPE_CLASS_PHONE
           | PASSWORD_VISIBILITY_FLAG;
 
+  private static final String KEYBOARD_TYPE_DEFAULT = "default";
   private static final String KEYBOARD_TYPE_EMAIL_ADDRESS = "email-address";
   private static final String KEYBOARD_TYPE_NUMERIC = "numeric";
   private static final String KEYBOARD_TYPE_DECIMAL_PAD = "decimal-pad";
@@ -717,7 +718,9 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
   @ReactProp(name = "keyboardType")
   public void setKeyboardType(ReactEditText view, @Nullable String keyboardType) {
     int flagsToSet = InputType.TYPE_CLASS_TEXT;
-    if (KEYBOARD_TYPE_NUMERIC.equalsIgnoreCase(keyboardType)) {
+    if (keyboardType == null || KEYBOARD_TYPE_DEFAULT.equalsIgnoreCase(keyboardType)) {
+      return;
+    } else if (KEYBOARD_TYPE_NUMERIC.equalsIgnoreCase(keyboardType)) {
       flagsToSet = INPUT_TYPE_KEYBOARD_NUMBERED;
     } else if (KEYBOARD_TYPE_NUMBER_PAD.equalsIgnoreCase(keyboardType)) {
       flagsToSet = INPUT_TYPE_KEYBOARD_NUMBER_PAD;

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -67,9 +67,6 @@ import com.facebook.yoga.YogaConstants;
 import java.lang.reflect.Field;
 import java.util.LinkedList;
 import java.util.Map;
-import java.util.Arrays;
-import java.util.ArrayList;
-import java.util.List;
 
 /** Manages instances of TextInput. */
 @ReactModule(name = ReactTextInputManager.REACT_CLASS)
@@ -106,14 +103,6 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
   private static final String KEYBOARD_TYPE_NUMBER_PAD = "number-pad";
   private static final String KEYBOARD_TYPE_PHONE_PAD = "phone-pad";
   private static final String KEYBOARD_TYPE_VISIBLE_PASSWORD = "visible-password";
-  private static final List<String> KEYBOARD_TYPES = new ArrayList<>(Arrays.asList(
-    KEYBOARD_TYPE_EMAIL_ADDRESS,
-    KEYBOARD_TYPE_NUMERIC,
-    KEYBOARD_TYPE_DECIMAL_PAD,
-    KEYBOARD_TYPE_NUMBER_PAD,
-    KEYBOARD_TYPE_PHONE_PAD,
-    KEYBOARD_TYPE_VISIBLE_PASSWORD
-  ));
   private static final InputFilter[] EMPTY_FILTERS = new InputFilter[0];
   private static final int UNSET = -1;
 
@@ -728,9 +717,7 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
   @ReactProp(name = "keyboardType")
   public void setKeyboardType(ReactEditText view, @Nullable String keyboardType) {
     int flagsToSet = InputType.TYPE_CLASS_TEXT;
-    if (keyboardType == null || !KEYBOARD_TYPES.contains(keyboardType)) {
-      return;
-    } else if (KEYBOARD_TYPE_NUMERIC.equalsIgnoreCase(keyboardType)) {
+    if (KEYBOARD_TYPE_NUMERIC.equalsIgnoreCase(keyboardType)) {
       flagsToSet = INPUT_TYPE_KEYBOARD_NUMBERED;
     } else if (KEYBOARD_TYPE_NUMBER_PAD.equalsIgnoreCase(keyboardType)) {
       flagsToSet = INPUT_TYPE_KEYBOARD_NUMBER_PAD;
@@ -744,6 +731,10 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
       // This will supercede secureTextEntry={false}. If it doesn't, due to the way
       //  the flags work out, the underlying field will end up a URI-type field.
       flagsToSet = InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD;
+    } else {
+      // This prevents KEYBOARD_TYPE_FLAGS from being set when the keyboardType is
+      //  default or null. Setting of this flag breaks autoCapitalize prop.
+      return;
     }
     updateStagedInputTypeFlag(view, KEYBOARD_TYPE_FLAGS, flagsToSet);
     checkPasswordType(view);

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -100,7 +100,6 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
           | InputType.TYPE_CLASS_PHONE
           | PASSWORD_VISIBILITY_FLAG;
 
-  private static final String KEYBOARD_TYPE_DEFAULT = "default";
   private static final String KEYBOARD_TYPE_EMAIL_ADDRESS = "email-address";
   private static final String KEYBOARD_TYPE_NUMERIC = "numeric";
   private static final String KEYBOARD_TYPE_DECIMAL_PAD = "decimal-pad";
@@ -108,7 +107,6 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
   private static final String KEYBOARD_TYPE_PHONE_PAD = "phone-pad";
   private static final String KEYBOARD_TYPE_VISIBLE_PASSWORD = "visible-password";
   private static final List<String> KEYBOARD_TYPES = new ArrayList<>(Arrays.asList(
-    KEYBOARD_TYPE_DEFAULT,
     KEYBOARD_TYPE_EMAIL_ADDRESS,
     KEYBOARD_TYPE_NUMERIC,
     KEYBOARD_TYPE_DECIMAL_PAD,
@@ -730,7 +728,7 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
   @ReactProp(name = "keyboardType")
   public void setKeyboardType(ReactEditText view, @Nullable String keyboardType) {
     int flagsToSet = InputType.TYPE_CLASS_TEXT;
-    if (keyboardType == null || !KEYBOARD_TYPES.contains(keyboardType) || KEYBOARD_TYPE_DEFAULT.equalsIgnoreCase(keyboardType)) {
+    if (keyboardType == null || !KEYBOARD_TYPES.contains(keyboardType)) {
       return;
     } else if (KEYBOARD_TYPE_NUMERIC.equalsIgnoreCase(keyboardType)) {
       flagsToSet = INPUT_TYPE_KEYBOARD_NUMBERED;

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -733,7 +733,7 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
       flagsToSet = InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD;
     } else {
       // This prevents KEYBOARD_TYPE_FLAGS from being set when the keyboardType is
-      //  default or null. Setting of this flag breaks autoCapitalize prop.
+      // default, unsupported or null. Setting of this flag breaks the autoCapitalize functionality.
       return;
     }
     updateStagedInputTypeFlag(view, KEYBOARD_TYPE_FLAGS, flagsToSet);

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -68,6 +68,8 @@ import java.lang.reflect.Field;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
 
 /** Manages instances of TextInput. */
 @ReactModule(name = ReactTextInputManager.REACT_CLASS)
@@ -105,7 +107,7 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
   private static final String KEYBOARD_TYPE_NUMBER_PAD = "number-pad";
   private static final String KEYBOARD_TYPE_PHONE_PAD = "phone-pad";
   private static final String KEYBOARD_TYPE_VISIBLE_PASSWORD = "visible-password";
-  private static final String[] KEYBOARD_TYPES = new String[]{ 
+  private static final List<String> KEYBOARD_TYPES = new ArrayList<>(Arrays.asList(
     KEYBOARD_TYPE_DEFAULT,
     KEYBOARD_TYPE_EMAIL_ADDRESS,
     KEYBOARD_TYPE_NUMERIC,
@@ -113,7 +115,7 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
     KEYBOARD_TYPE_NUMBER_PAD,
     KEYBOARD_TYPE_PHONE_PAD,
     KEYBOARD_TYPE_VISIBLE_PASSWORD
-  };
+  ));
   private static final InputFilter[] EMPTY_FILTERS = new InputFilter[0];
   private static final int UNSET = -1;
 
@@ -728,7 +730,7 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
   @ReactProp(name = "keyboardType")
   public void setKeyboardType(ReactEditText view, @Nullable String keyboardType) {
     int flagsToSet = InputType.TYPE_CLASS_TEXT;
-    if (keyboardType == null || !Arrays.asList(KEYBOARD_TYPES).contains(keyboardType) || KEYBOARD_TYPE_DEFAULT.equalsIgnoreCase(keyboardType)) {
+    if (keyboardType == null || !KEYBOARD_TYPES.contains(keyboardType) || KEYBOARD_TYPE_DEFAULT.equalsIgnoreCase(keyboardType)) {
       return;
     } else if (KEYBOARD_TYPE_NUMERIC.equalsIgnoreCase(keyboardType)) {
       flagsToSet = INPUT_TYPE_KEYBOARD_NUMBERED;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
Fix for https://github.com/facebook/react-native/issues/27510.

Setting the `InputType.TYPE_CLASS_TEXT` flag when `keyboardType` is null or default breaks autoCapitalize. Handle the case when `keyboardType` is null, default, or invalid type.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[Android] [Fixed] - Fix setting keyboardType from breaking autoCapitalize

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Added keyboardType prop to RNTester as so
```
<TextInput autoCapitalize="words" keyboardType="default" style={styles.default} />
```
![fixedKeyboardType](https://user-images.githubusercontent.com/8675043/70872892-c96dec80-1f5f-11ea-8e33-714a67eff581.gif)
