### PR TITLE
Add an API for Detox to check if there are any timers expiring in a certain range

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/core/JavaTimerManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/core/JavaTimerManager.java
@@ -373,4 +373,23 @@ public class JavaTimerManager {
           }
         });
   }
+
+  /**
+   * Returns a bool representing whether there are any active timers that will be fired within a
+   * certain period of time. Disregards repeating timers (setInterval). Used for testing to
+   * determine if RN is idle.
+   *
+   * @param rangeMs The time range, in ms, to check
+   * @return True if there are pending timers within the given range; false otherwise
+   */
+  /* package */ boolean hasActiveTimersInRange(long rangeMs) {
+    synchronized (mTimerGuard) {
+      for (Timer timer : mTimers) {
+        if (!timer.mRepeat && timer.mInterval < rangeMs) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/core/TimingModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/core/TimingModule.java
@@ -11,6 +11,7 @@ import com.facebook.fbreact.specs.NativeTimingSpec;
 import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.WritableArray;
+import com.facebook.react.common.annotations.VisibleForTesting;
 import com.facebook.react.devsupport.interfaces.DevSupportManager;
 import com.facebook.react.jstasks.HeadlessJsTaskContext;
 import com.facebook.react.jstasks.HeadlessJsTaskEventListener;
@@ -133,5 +134,10 @@ public final class TimingModule extends NativeTimingSpec
         HeadlessJsTaskContext.getInstance(getReactApplicationContext());
     headlessJsTaskContext.removeTaskEventListener(this);
     mJavaTimerManager.onInstanceDestroy();
+  }
+
+  @VisibleForTesting
+  public boolean hasActiveTimersInRange(long rangeMs) {
+    return mJavaTimerManager.hasActiveTimersInRange(rangeMs);
   }
 }

--- a/ReactAndroid/src/test/java/com/facebook/react/modules/BUCK
+++ b/ReactAndroid/src/test/java/com/facebook/react/modules/BUCK
@@ -28,6 +28,7 @@ rn_robolectric_test(
         react_native_target("java/com/facebook/react/common/network:network"),
         react_native_target("java/com/facebook/react/devsupport:interfaces"),
         react_native_target("java/com/facebook/react/jstasks:jstasks"),
+        react_native_target("java/com/facebook/react/module/annotations:annotations"),
         react_native_target("java/com/facebook/react/modules/blob:blob"),
         react_native_target("java/com/facebook/react/modules/camera:camera"),
         react_native_target("java/com/facebook/react/modules/clipboard:clipboard"),

--- a/ReactAndroid/src/test/java/com/facebook/react/modules/timing/TimingModuleTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/modules/timing/TimingModuleTest.java
@@ -7,6 +7,7 @@
 
 package com.facebook.react.modules.timing;
 
+import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 import com.facebook.react.bridge.Arguments;
@@ -252,6 +253,19 @@ public class TimingModuleTest {
 
     stepChoreographerFrame();
     verify(mJSTimersMock).callIdleCallbacks(SystemClock.currentTimeMillis());
+  }
+
+  @Test
+  public void testActiveTimersInRange() {
+    mTimingModule.onHostResume();
+    assertThat(mTimingModule.hasActiveTimersInRange(100)).isFalse();
+
+    mTimingModule.createTimer(41, 1, 0, true);
+    assertThat(mTimingModule.hasActiveTimersInRange(100)).isFalse(); // Repeating
+
+    mTimingModule.createTimer(42, 150, 0, false);
+    assertThat(mTimingModule.hasActiveTimersInRange(100)).isFalse(); // Out of range
+    assertThat(mTimingModule.hasActiveTimersInRange(200)).isTrue(); // In range
   }
 
   private static class PostFrameIdleCallbackHandler implements Answer<Void> {


### PR DESCRIPTION
## Summary
Detox currently relies on reflection to inspect the private timers queue in the Timing module to check if React Native is idle or not. This broke when I renamed TimingModule and moved the queue to JavaTimerManager in D17260848 and D17282187. A better solution to this problem is for us to expose a public API for checking the timers queue from TimingModule, so that Detox doesn't need to access private fields.

Using similar logic to Detox's TimersIdlingResource: https://github.com/wix/Detox/blob/4f81a77baee4e4542a693922bcbde621d9d8c1a5/detox/android/detox/src/main/java/com/wix/detox/reactnative/idlingresources/TimersIdlingResource.kt#L95
based on discussion here: https://github.com/wix/detox/issues/907

## Changelog
[Android] [Added] Added an API for checking if there are busy timers to TimingModule

## Test Plan
Added tests to TimingModuleTest.java

Differential Revision: D19128786

