### PR TITLE
Fix android modal not disappear when reload

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
@@ -97,6 +97,12 @@ public class ReactModalHostView extends ViewGroup implements LifecycleEventListe
   }
 
   @Override
+  protected void onDetachedFromWindow() {
+    super.onDetachedFromWindow();
+    dismiss();
+  }
+
+  @Override
   public void addView(View child, int index) {
     UiThreadUtil.assertOnUiThread();
 


### PR DESCRIPTION
Fixes https://github.com/facebook/react-native/issues/17986

## Summary

See above issue

After apply this change:
![ezgif-4-45d9add85b74](https://user-images.githubusercontent.com/615282/70987576-2520ad00-20fb-11ea-9b90-c9a7839824a5.gif)


## Changelog

[Android] [Fixed] - Fix android modal not disappear when reload

## Test Plan

Open a modal and do a refresh to see whether it disappears
