### PR TITLE
Add AnimatedInterpolation as possible type for toValue

### DIFF
--- a/Libraries/Animated/src/animations/SpringAnimation.js
+++ b/Libraries/Animated/src/animations/SpringAnimation.js
@@ -12,6 +12,7 @@
 
 const AnimatedValue = require('../nodes/AnimatedValue');
 const AnimatedValueXY = require('../nodes/AnimatedValueXY');
+const AnimatedInterpolation = require('../nodes/AnimatedInterpolation');
 const Animation = require('./Animation');
 const SpringConfig = require('../SpringConfig');
 
@@ -30,7 +31,8 @@ export type SpringAnimationConfig = AnimationConfig & {
         y: number,
         ...
       }
-    | AnimatedValueXY,
+    | AnimatedValueXY
+    | AnimatedInterpolation,
   overshootClamping?: boolean,
   restDisplacementThreshold?: number,
   restSpeedThreshold?: number,
@@ -53,7 +55,7 @@ export type SpringAnimationConfig = AnimationConfig & {
 };
 
 export type SpringAnimationConfigSingle = AnimationConfig & {
-  toValue: number | AnimatedValue,
+  toValue: number | AnimatedValue | AnimatedInterpolation,
   overshootClamping?: boolean,
   restDisplacementThreshold?: number,
   restSpeedThreshold?: number,

--- a/Libraries/Animated/src/animations/TimingAnimation.js
+++ b/Libraries/Animated/src/animations/TimingAnimation.js
@@ -12,6 +12,7 @@
 
 const AnimatedValue = require('../nodes/AnimatedValue');
 const AnimatedValueXY = require('../nodes/AnimatedValueXY');
+const AnimatedInterpolation = require('../nodes/AnimatedInterpolation');
 const Animation = require('./Animation');
 
 const {shouldUseNativeDriver} = require('../NativeAnimatedHelper');
@@ -27,7 +28,8 @@ export type TimingAnimationConfig = AnimationConfig & {
         y: number,
         ...
       }
-    | AnimatedValueXY,
+    | AnimatedValueXY
+    | AnimatedInterpolation,
   easing?: (value: number) => number,
   duration?: number,
   delay?: number,
@@ -35,7 +37,7 @@ export type TimingAnimationConfig = AnimationConfig & {
 };
 
 export type TimingAnimationConfigSingle = AnimationConfig & {
-  toValue: number | AnimatedValue,
+  toValue: number | AnimatedValue | AnimatedInterpolation,
   easing?: (value: number) => number,
   duration?: number,
   delay?: number,


### PR DESCRIPTION
## Summary

AnimatedInterpolation should be a valid type to pass to `toValue` according to the documentation. 

https://facebook.github.io/react-native/docs/animations#tracking-dynamic-values

## Changelog

[General] [Fixed] - Add AnimationInterpolation as possible type for toValue

## Test Plan

`yarn flow` works without errors.