### PR TITLE
remove `xcshareddata` from gitignore

### DIFF
--- a/template/_gitignore
+++ b/template/_gitignore
@@ -20,7 +20,6 @@ DerivedData
 *.hmap
 *.ipa
 *.xcuserstate
-xcshareddata
 
 # Android/IntelliJ
 #


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Files that are inside `xcshareddata` are meant to be "shared", and that means committed to git. These files are for example `ios/RnDiffApp.xcodeproj/xcshareddata/xcschemes/RnDiffApp.xcscheme`, and if ignored that means they are removed from the repo or are missing when cloning. These should be present. They are the shared schemes so Xcode knows what and how to build, on everyone's machine.

I noticed it being there in a new project on 0.62.0-rc.0.

## Changelog



<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[iOS] [Changed] - Remove the xcshareddata from .gitignore

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
