### PR TITLE
Add Flipper to default template on Android and iOS

### DIFF
--- a/template/android/app/src/main/java/com/helloworld/MainApplication.java
+++ b/template/android/app/src/main/java/com/helloworld/MainApplication.java
@@ -44,6 +44,7 @@ public class MainApplication extends Application implements ReactApplication {
   public void onCreate() {
     super.onCreate();
     SoLoader.init(this, /* native exopackage */ false);
+    initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
   }
 
   /**

--- a/template/ios/HelloWorld/AppDelegate.m
+++ b/template/ios/HelloWorld/AppDelegate.m
@@ -26,7 +26,7 @@
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
-  [self initializeFlipper:application];
+  [AppDelegate initializeFlipper:application];
   RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
   RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge
                                                    moduleName:@"HelloWorld"
@@ -51,7 +51,7 @@
 #endif
 }
 
-- (void) initializeFlipper:(UIApplication *)application
++ (void) initializeFlipper:(UIApplication *)application
 {
 #if DEBUG
 #ifdef FB_SONARKIT_ENABLED

--- a/template/ios/HelloWorld/AppDelegate.m
+++ b/template/ios/HelloWorld/AppDelegate.m
@@ -26,6 +26,7 @@
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
+  [self initializeFlipper:application];
   RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
   RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge
                                                    moduleName:@"HelloWorld"
@@ -50,7 +51,7 @@
 #endif
 }
 
-+ (void) initializeFlipper:(UIApplication *)application
+- (void) initializeFlipper:(UIApplication *)application
 {
 #if DEBUG
 #ifdef FB_SONARKIT_ENABLED


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
Issue: https://github.com/facebook/react-native/issues/27565

initalizeFlipper should be set in template app by default.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[iOS] [Changed] - Added Flipper to template app
[Android] [Changed] - Added Flipper to template app

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
Connect Flipper to the iOS application
Connect Flipper to the Android application
