### PR TITLE
Fix LAN instead of Wi-Fi device bundle config

### DIFF
--- a/scripts/react-native-xcode.sh
+++ b/scripts/react-native-xcode.sh
@@ -15,7 +15,7 @@ DEST=$CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH
 # Enables iOS devices to get the IP address of the machine running Metro
 if [[ "$CONFIGURATION" = *Debug* && ! "$PLATFORM_NAME" == *simulator ]]; then
   IP=$(ipconfig getifaddr en0)
-  if [ -z "$IP" ]; then
+  if [[ -z "$IP" || -n "`ifconfig $value | grep 'baseT'`" ]]; then
     IP=$(ipconfig getifaddr en1)
   fi
   if [ -z "$IP" ]; then


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
React-native server-device connection must be via Wi-Fi. But if the OS-X server has LAN & Wi-Fi interfaces, then device bundle can be incorrectly configured to  use LAN interface instead of Wi-Fi. This patch fix this issue. It greps for "baseT" (e.g. media: autoselect (1000baseT <full-duplex>)) and skip interface if it is.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[iOS] [Fixed] - Fix LAN instead of Wi-Fi device bundle configuration

## Test Plan

To reproduce an issue setup Mac OS 10.15.1 with LAN and Wi-Fi active interfaces. And connect
real device (not simulator).

And "ifconfig en0" in console should display LAN interface e.g.:
```
en0: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500
	options=50b<RXCSUM,TXCSUM,VLAN_HWTAGGING,AV,CHANNEL_IO>
	ether 78:7b:8a:d8:61:42
	inet 10.15.61.16 netmask 0xffffff00 broadcast 10.15.61.255
	nd6 options=201<PERFORMNUD,DAD>
	media: autoselect (1000baseT <full-duplex>)
	status: active

```
"ifconfig eg1" in console should display WiFi interface e.g.:
```
en1: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500
	options=400<CHANNEL_IO>
	ether 14:20:5e:03:5b:2a
	inet6 fe80::10e6:1cb6:54ec:1b41%en1 prefixlen 64 secured scopeid 0x5
	inet 10.15.91.27 netmask 0xffffff00 broadcast 10.15.91.255
	nd6 options=201<PERFORMNUD,DAD>
	media: autoselect
	status: active
```

In this case device bundle in react-native-xcode.sh script wood be incorrectly configured to use en0 (LAN interface) instead of en1(Wi-Fi) interface.

My patch fixes this issue.

fragment of script output before patch:
```
...
++ ipconfig getifaddr en0
+ IP=10.15.61.16
+ '[' -z 10.15.61.16 ']
+ '[' -z 10.15.61.16 ']'
+ echo 10.15.61.16
+ [[ -n '' ]]
...
```
After start project ob device we have time lag about 20s then debug out:
`
2019-12-20 16:58:57.530538+0300 AwesomeProject[4590:1923358] Task <164D9AB0-8473-4BA3-BD1A-EC0E92887C17>.<1> finished with error [-1001] Error Domain=NSURLErrorDomain Code=-1001 "The request timed out." UserInfo={NSUnderlyingError=0x2838dc2d0 {Error Domain=kCFErrorDomainCFNetwork Code=-1001 "(null)" UserInfo={_kCFStreamErrorCodeKey=-2102, _kCFStreamErrorDomainKey=4}}, NSErrorFailingURLStringKey=http://10.15.61.16:8081/status, NSErrorFailingURLKey=http://10.15.61.16:8081/status, _kCFStreamErrorDomainKey=4, _kCFStreamErrorCodeKey=-2102, NSLocalizedDescription=The request timed out.}
`

fragment of script output after apply patch:
```
...
++ ipconfig getifaddr en0
+ IP=10.15.61.16
+ [[ -z 10.15.61.16 ]]
++ ifconfig
++ grep baseT
+ [[ -n 	media: autoselect (1000baseT <full-duplex>)
	media: autoselect (100baseTX <full-duplex>) ]]
++ ipconfig getifaddr en1
+ IP=10.15.91.27
+ '[' -z 10.15.91.27 ']'
+ echo 10.15.91.27
+ [[ -n '' ]]
...
```

App start OK.

On iPhone /iPad simulator works too.