### PR TITLE
Fix hermes cannot pick up on custom variants

### DIFF
--- a/RNTester/android/app/build.gradle
+++ b/RNTester/android/app/build.gradle
@@ -167,8 +167,12 @@ dependencies {
     implementation project(':ReactAndroid')
 
     def hermesPath = '$projectDir/../../../../node_modules/hermes-engine/android/'
-    debugImplementation files(hermesPath + "hermes-debug.aar")
-    releaseImplementation files(hermesPath + "hermes-release.aar")
+
+    if(gradle.startParameter.taskNames.contains("Release")) {
+        implementation files(hermesPath + "hermes-release.aar")
+    } else {
+        implementation files(hermesPath + "hermes-debug.aar")
+    }
 
     debugImplementation("com.facebook.flipper:flipper:0.23.4") {
         exclude group:'com.facebook.yoga'

--- a/template/android/app/build.gradle
+++ b/template/android/app/build.gradle
@@ -200,8 +200,11 @@ dependencies {
 
     if (enableHermes) {
         def hermesPath = "../../node_modules/hermes-engine/android/";
-        debugImplementation files(hermesPath + "hermes-debug.aar")
-        releaseImplementation files(hermesPath + "hermes-release.aar")
+        if(gradle.startParameter.taskNames.contains("Release")) {
+            implementation files(hermesPath + "hermes-release.aar")
+        } else {
+            implementation files(hermesPath + "hermes-debug.aar")
+        }
     } else {
         implementation jscFlavor
     }


### PR DESCRIPTION
## Summary

To fix issue of Hermes not being pick up correctly on custom variants

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[Android] [Fixed] - Pick up Hermes correctly with custom build variants

## Test Plan

- Add a custom release type, e.g: stagingRelease
- Generate APK with stagingRelease
- `releaseImplementation` will not be successfully pickup hermes
