### PR TITLE
Adjust HelloWorld-tvOSTests/Info.plist `CFBundleIdentifier` to use PR ODUCT_BUNDLE_IDENTIFIER

### DIFF
--- a/template/ios/HelloWorld-tvOSTests/Info.plist
+++ b/template/ios/HelloWorld-tvOSTests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>


### PR DESCRIPTION
## Summary

In other part of the hello world, this replacement has been made already. The only place left this way (which make sense) is in `HelloWorld.xcodeproj/project.pbxproj`.

## Changelog

[General] [Fixed] - Adjust HelloWorld-tvOSTests/Info.plist `CFBundleIdentifier` to use PRODUCT_BUNDLE_IDENTIFIER

## Test Plan

I made this change locally on a project. No big deal as this is a test piece, not going to go on any kind of real world environment.