### PR TITLE
Fixed scrollview inset when RN view is embedded in another view

### DIFF
--- a/Libraries/Components/Keyboard/KeyboardAvoidingView.js
+++ b/Libraries/Components/Keyboard/KeyboardAvoidingView.js
@@ -118,7 +118,28 @@ class KeyboardAvoidingView extends React.Component<Props, State> {
 
   _onLayout = (event: ViewLayoutEvent) => {
     this._frame = event.nativeEvent.layout;
-    if (!this._initialFrameHeight) {
+
+    let isInitial = !this._initialFrameHeight;
+
+    if (this.viewRef.current !== null) {
+      // Try to measure inside the window, not the view controller
+      this.viewRef.current.measureInWindow((x, y, width, height) => {
+        const frame: ViewLayout = {
+          x: x,
+          y: y,
+          width: width,
+          height: height,
+        };
+        this._frame = frame;
+
+        if (isInitial) {
+          // save the initial frame height, before the keyboard is visible
+          this._initialFrameHeight = frame.height;
+        }
+      });
+    }
+
+    if (isInitial) {
       // save the initial frame height, before the keyboard is visible
       this._initialFrameHeight = this._frame.height;
     }


### PR DESCRIPTION
## Summary

I'm using RNN, which embeds RN view inside native view controllers.

On iOS 13, a modal view controller is "floating" and is offset from the top of the screen.

This causes the calculation of inset in `KeyboardAvoidingView` incorrect as it mixes local view controller coordinate space, with keyboard's screen coordinate space.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[iOS] [Fixed] - Fixed `KeyboardAvoidingView` inset in embedded views (i.e modal view controllers on iOS 13)

## Test Plan

1. Tested before and after in a simple view controller (should stay the same)
2. Tested before and after in a modal view controller (should be offset before, and fixed after)
3. Repeated no. 2 with each device rotation (upsideDown, landscapeLeft, landscapeRight)