### PR TITLE
fix: save connection url as class variable

### DIFF
--- a/Libraries/WebSocket/WebSocket.js
+++ b/Libraries/WebSocket/WebSocket.js
@@ -88,6 +88,7 @@ class WebSocket extends (EventTarget(...WEBSOCKET_EVENTS): any) {
     options: ?{headers?: {origin?: string, ...}, ...},
   ) {
     super();
+    this.url = url;
     if (typeof protocols === 'string') {
       protocols = [protocols];
     }


### PR DESCRIPTION
## Changelog
[General] [Fixed] - WebSocket now exposes url on instance

## Test Plan
Simply console.log connection.url it should equal the original url used to make the websockets connection

## Summary
Conform with Websocket javascript api.
related to web3js issues: https://github.com/ethereum/web3.js/issues/2864 https://github.com/ethereum/web3.js/issues/2602
