### PR TITLE
[RCTImageLoader] Make C++ requirement opt-in

### DIFF
--- a/Libraries/Image/RCTImageLoaderWithAttributionProtocol.h
+++ b/Libraries/Image/RCTImageLoaderWithAttributionProtocol.h
@@ -17,6 +17,7 @@ RCT_EXTERN void RCTEnableImageLoadingPerfInstrumentation(BOOL enabled);
 
 @protocol RCTImageLoaderWithAttributionProtocol<RCTImageLoaderProtocol>
 
+#ifdef __cplusplus
 /**
  * Same as the variant in RCTImageURLLoaderProtocol, but allows passing attribution
  * information that each image URL loader can process.
@@ -30,6 +31,8 @@ RCT_EXTERN void RCTEnableImageLoadingPerfInstrumentation(BOOL enabled);
                                         progressBlock:(RCTImageLoaderProgressBlock)progressBlock
                                      partialLoadBlock:(RCTImageLoaderPartialLoadBlock)partialLoadBlock
                                       completionBlock:(RCTImageLoaderCompletionBlock)completionBlock;
+#endif
+
 /**
  * Image instrumentation - notify that the image content (UIImage) has been set on the native view.
  */

--- a/Libraries/Image/RCTImageURLLoaderWithAttribution.h
+++ b/Libraries/Image/RCTImageURLLoaderWithAttribution.h
@@ -7,6 +7,7 @@
 
 #import <React/RCTImageURLLoader.h>
 
+#ifdef __cplusplus
 namespace facebook {
 namespace react {
 
@@ -17,6 +18,7 @@ struct ImageURLLoaderAttribution {
 
 } // namespace react
 } // namespace facebook
+#endif
 
 @interface RCTImageURLLoaderRequest : NSObject
 
@@ -35,6 +37,7 @@ struct ImageURLLoaderAttribution {
  */
 @protocol RCTImageURLLoaderWithAttribution <RCTImageURLLoader>
 
+#ifdef __cplusplus
 /**
  * Same as the RCTImageURLLoader variant above, but allows optional `attribution` information.
  * Caller may also specify a preferred requestId for tracking purpose.
@@ -48,6 +51,7 @@ struct ImageURLLoaderAttribution {
                               progressHandler:(RCTImageLoaderProgressBlock)progressHandler
                            partialLoadHandler:(RCTImageLoaderPartialLoadBlock)partialLoadHandler
                             completionHandler:(RCTImageLoaderCompletionBlock)completionHandler;
+#endif
 
 /**
  * Image instrumentation - notify that the image content (UIImage) has been set on the native view.


### PR DESCRIPTION
## Summary

When building as a framework these headers get automatically added to the framework umbrella header for React-Core. Instead of converting all the React sources to ObjC++ files and still forcing external users that build native source (and link against a framework build) to also compile as ObjC++, this makes the attribution related methods that were added in https://github.com/facebook/react-native/commit/fdcdca4 opt-in to ObjC++ builds.

This is also the reason for the current failure of the CI `test_ios_frameworks` run.

## Changelog

I’m unsure if this change really warrants an entry in the CHANGELOG, as it’s more of an amendment of the (afaik) unreleased [change](https://github.com/facebook/react-native/commit/fdcdca4).

[iOS] [Fixed] - Make framework builds work again by making `RCTImageLoader` C++ requirement opt-in

## Test Plan

I tested static and dynamic (framework) builds and ran the test suite.

This change should make the `test_ios_frameworks` CI run _build_ again, ~~but it may still fail overall as in my local testing one of the tests leads to a segfault (which I will try to address separately)~~.