### PR TITLE
Bump detox simulator version to work with latest xcode

### DIFF
--- a/RNTester/e2e/__tests__/DatePickerIOS-test.js
+++ b/RNTester/e2e/__tests__/DatePickerIOS-test.js
@@ -44,7 +44,7 @@ describe('DatePickerIOS', () => {
     await testElement.setColumnToValue(3, 'AM');
 
     await expect(dateIndicator).toHaveText('12/4/2006');
-    await expect(timeIndicator).toHaveText('4:10 AM');
+    await expect(timeIndicator).toHaveText('04:10 AM');
   });
 
   it('Should change indicator with date-only picker', async () => {

--- a/RNTester/js/examples/Touchable/TouchableExample.js
+++ b/RNTester/js/examples/Touchable/TouchableExample.js
@@ -582,7 +582,7 @@ exports.examples = [
   {
     title: '3D Touch / Force Touch',
     description:
-      'iPhone 6s and 6s plus support 3D touch, which adds a force property to touches',
+      'iPhone 8 and 8 plus support 3D touch, which adds a force property to touches',
     render: function(): React.Element<any> {
       return <ForceTouchExample />;
     },

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "babel-eslint": "10.0.1",
     "clang-format": "^1.2.4",
     "coveralls": "^3.0.2",
-    "detox": "14.5.1",
+    "detox": "^15.1.0",
     "eslint": "5.1.0",
     "eslint-config-fb-strict": "24.3.0",
     "eslint-config-fbjs": "2.1.0",
@@ -164,13 +164,13 @@
         "binaryPath": "RNTester/build/Build/Products/Release-iphonesimulator/RNTester.app/",
         "build": "xcodebuild -workspace RNTester/RNTesterPods.xcworkspace -scheme RNTester -configuration Release -sdk iphonesimulator -derivedDataPath RNTester/build -UseModernBuildSystem=NO -quiet",
         "type": "ios.simulator",
-        "name": "iPhone 6s"
+        "name": "iPhone 8"
       },
       "ios.sim.debug": {
         "binaryPath": "RNTester/build/Build/Products/Debug-iphonesimulator/RNTester.app/",
         "build": "xcodebuild -workspace RNTester/RNTesterPods.xcworkspace -scheme RNTester -configuration Debug -sdk iphonesimulator -derivedDataPath RNTester/build -UseModernBuildSystem=NO -quiet",
         "type": "ios.simulator",
-        "name": "iPhone 6s"
+        "name": "iPhone 8"
       }
     }
   }

--- a/scripts/.tests.env
+++ b/scripts/.tests.env
@@ -18,7 +18,7 @@ export AVD_ABI=x86
 
 ## IOS ##
 export IOS_TARGET_OS="12.4"
-export IOS_DEVICE="iPhone 6s"
+export IOS_DEVICE="iPhone 8"
 export TVOS_DEVICE="Apple TV"
 
 ## CI OVERRIDES ##

--- a/scripts/run-ci-e2e-tests.js
+++ b/scripts/run-ci-e2e-tests.js
@@ -212,7 +212,7 @@ try {
     if (
       tryExecNTimes(
         () => {
-          let destination = 'platform=iOS Simulator,name=iPhone 6s,OS=12.4';
+          let destination = 'platform=iOS Simulator,name=iPhone 8,OS=12.4';
           let sdk = 'iphonesimulator';
           let scheme = 'HelloWorld';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2644,10 +2644,10 @@ detect-newline@^2.1.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
   integrity sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=
 
-detox@14.5.1:
-  version "14.5.1"
-  resolved "https://registry.yarnpkg.com/detox/-/detox-14.5.1.tgz#dd3cbdb4f26aaf461774303eb825f2f0fc8e8260"
-  integrity sha512-ZFt9LOHRXTxX1HVefysCnF5tLQQRQvr+w4KSXxkdJUa+9afr9/avZyz5kR0elasC2aU6/pnuzUiOJmCCyy7f6w==
+detox@^15.1.0:
+  version "15.1.0"
+  resolved "https://registry.yarnpkg.com/detox/-/detox-15.1.0.tgz#6dc0a2214f20f6811cc7d769790e549f3206a070"
+  integrity sha512-7tXuK1zePmYyVHZomugkaCsxOIk7rVTNtfPNVnE3TdAOSiQ7p5Jo6Qcrt3CV7d20uX9z0slcHYKd6x9CoiQ9Zw==
   dependencies:
     "@babel/core" "^7.4.5"
     bunyan "^1.8.12"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

The latest xcode version removed iPhone 6s, so we need to bump to the latest simulator listed that has 3d touch.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[General] [Fixed] - Bump e2e simulator version

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

- `yarn build-ios-e2e && yarn test-ios-e2e `