### PR TITLE
[TextInput]: Fixed duplicated letters being added when changing text through onChangeText

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -503,7 +503,8 @@ public class ReactEditText extends AppCompatEditText {
       // When we update text, we trigger onChangeText code that will
       // try to update state if the wrapper is available. Temporarily disable
       // to prevent an infinite loop.
-      getText().replace(0, length(), spannableStringBuilder);
+      getText().clear();
+      append(spannableStringBuilder);
     }
     mDisableTextDiffing = false;
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
Fix for https://github.com/facebook/react-native/issues/11068.
` getText().replace` caused a bug where letters would be duplicated when the text was being set through onChangeText:

```
<TextInput ref={(el) => this.input = el} onChangeText={(val) => { this.input.setNativeProps({text: val.toUpperCase()}); }}/>
```

Debugged and tried a bunch of different ways to solve it explained here: https://github.com/facebook/react-native/issues/11068#issuecomment-574013816

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[Android] [Fixed] - Fixed duplicated letters being added when changing text through onChangeText

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Added this to RNTester:
```
<TextInput ref={(el) => this.input = el} onChangeText={(val) => { this.input.setNativeProps({text: val.toUpperCase()}); }}/>
```
Verified it works properly and there were no regressions in the other examples.

Note: There is some performance issues when typing for a long time, probably a lag between clearing and appending. Would love to see if someone has suggestions in handling that.

**Edit**: Seems like the perf is a known issue https://github.com/facebook/react-native/issues/20119