### PR TITLE
[CI] Use correct location for buck_to_junit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -519,6 +519,7 @@ jobs:
             find . -type f -regex ".*/outputs/androidTest-results/connected/.*xml" -exec cp {} ./reports/outputs/ \;
             find . -type f -regex ".*/buck-out/gen/ReactAndroid/src/test/.*/.*xml" -exec cp {} ./reports/buck/ \;
             if [ -f ~/react-native/reports/buck/all-results-raw.xml ]; then
+              cd ~/okbuck
               ./tooling/junit/buck_to_junit.sh ~/react-native/reports/buck/all-results-raw.xml ~/react-native/reports/junit/results.xml
             fi
           when: always


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

`test_android`'s Test Collection step fails when it attempts to convert buck's output to the junit-compatible format that Circle CI expects. Executing the script from the `okbuck` location should help here.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[Internal] - Use correct location for buck_to_junit in test_android CI step

## Test Plan

Circle CI