### PR TITLE
[CI] Skip testNotUTF8Convertible (correct path)

### DIFF
--- a/scripts/objc-test.sh
+++ b/scripts/objc-test.sh
@@ -17,7 +17,7 @@ ROOT=$(dirname "$SCRIPTS")
 SKIPPED_TESTS=()
 # TODO: T60408036 This test crashes iOS 13 for bad access, please investigate
 # and re-enable. See https://gist.github.com/0xced/56035d2f57254cf518b5.
-SKIPPED_TESTS+=("-skip-testing:RNTesterUnitTests/testNotUTF8Convertible")
+SKIPPED_TESTS+=("-skip-testing:RNTesterUnitTests/RCTJSONTests/testNotUTF8Convertible")
 
 # Create cleanup handler
 cleanup() {


### PR DESCRIPTION
## Summary

Use correct path to testNotUTF8Convertible which is being skipped.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[Internal] - Use correct path to testNotUTF8Convertible which is being skipped.

## Test Plan

Circle CI
