### PR TITLE
Allow overriding EditText construction in ReactTextInputShadowNode

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputShadowNode.java
@@ -37,7 +37,7 @@ public class ReactTextInputShadowNode extends ReactBaseTextShadowNode
     implements YogaMeasureFunction {
 
   private int mMostRecentEventCount = UNSET;
-  private @Nullable EditText mDummyEditText;
+  private @Nullable EditText mInternalEditText;
   private @Nullable ReactTextInputLocalData mLocalData;
 
   @VisibleForTesting public static final String PROP_TEXT = "text";
@@ -75,20 +75,20 @@ public class ReactTextInputShadowNode extends ReactBaseTextShadowNode
     // of Android), and it cannot be changed.
     // So, we have to enforce it as a default padding.
     // TODO #7120264: Cache this stuff better.
-    EditText editText = createDummyEditText();
+    EditText editText = createInternalEditText();
     setDefaultPadding(Spacing.START, ViewCompat.getPaddingStart(editText));
     setDefaultPadding(Spacing.TOP, editText.getPaddingTop());
     setDefaultPadding(Spacing.END, ViewCompat.getPaddingEnd(editText));
     setDefaultPadding(Spacing.BOTTOM, editText.getPaddingBottom());
 
-    mDummyEditText = editText;
+    mInternalEditText = editText;
 
     // We must measure the EditText without paddings, so we have to reset them.
-    mDummyEditText.setPadding(0, 0, 0, 0);
+    mInternalEditText.setPadding(0, 0, 0, 0);
 
     // This is needed to fix an android bug since 4.4.3 which will throw an NPE in measure,
     // setting the layoutParams fixes it: https://code.google.com/p/android/issues/detail?id=75877
-    mDummyEditText.setLayoutParams(
+    mInternalEditText.setLayoutParams(
         new ViewGroup.LayoutParams(
             ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT));
   }
@@ -101,7 +101,7 @@ public class ReactTextInputShadowNode extends ReactBaseTextShadowNode
       float height,
       YogaMeasureMode heightMode) {
     // measure() should never be called before setThemedContext()
-    EditText editText = Assertions.assertNotNull(mDummyEditText);
+    EditText editText = Assertions.assertNotNull(mInternalEditText);
 
     if (mLocalData != null) {
       mLocalData.apply(editText);
@@ -254,7 +254,7 @@ public class ReactTextInputShadowNode extends ReactBaseTextShadowNode
    * May be overriden by subclasses that would like to provide their own instance of the internal
    * {@code EditText} this class uses to determine the expected size of the view.
    */
-  protected EditText createDummyEditText() {
+  protected EditText createInternalEditText() {
     return new EditText(getThemedContext());
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputShadowNode.java
@@ -75,7 +75,7 @@ public class ReactTextInputShadowNode extends ReactBaseTextShadowNode
     // of Android), and it cannot be changed.
     // So, we have to enforce it as a default padding.
     // TODO #7120264: Cache this stuff better.
-    EditText editText = new EditText(getThemedContext());
+    EditText editText = createDummyEditText();
     setDefaultPadding(Spacing.START, ViewCompat.getPaddingStart(editText));
     setDefaultPadding(Spacing.TOP, editText.getPaddingTop());
     setDefaultPadding(Spacing.END, ViewCompat.getPaddingEnd(editText));
@@ -248,5 +248,13 @@ public class ReactTextInputShadowNode extends ReactBaseTextShadowNode
   public void setPadding(int spacingType, float padding) {
     super.setPadding(spacingType, padding);
     markUpdated();
+  }
+
+  /**
+   * May be overriden by subclasses that would like to provide their own instance of the internal
+   * {@code EditText} this class uses to determine the expected size of the view.
+   */
+  protected EditText createDummyEditText() {
+    return new EditText(getThemedContext());
   }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

This PR makes it possible for subclasses of `ReactTextInputShadowNode` to control the construction of the "dummy" `EditText` instance that `ReactTextInputShadowNode` internally uses to determine the expected height of the view. This PR does not change the default behavior, it just opens up that default to being overriden.

This is useful in the case of custom views that have different behavior from a "default" `EditText` instance (`new EditText(context)`). For example, it might have a different style applied.

As a side benefit, this change also makes it easy to have subclasses not apply the default theme, which can allow the custom view to avoid a longstanding crash issue (#17530).

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[Android] [Added] - Allow overriding `EditText` construction in `ReactTextInputShadowNode`

## Test Plan

All tests pass.
