### PR TITLE
Add Expo dot folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,6 @@ RNTester/Pods/*
 # Visual studio
 .vscode
 .vs
+
+# Expo
+.expo/


### PR DESCRIPTION
Hello,

## Summary

When using expo for React native instant verification, I saw that the configuration folder wasn't in actual .gitignore.

## Changelog

[GENERAL] [CHANGED] - Adding .expo folder to .gitignore

## Test Plan

Now .expo folder is ignored by tracking.
<img width="81" alt="Capture d’écran 2020-01-19 à 22 08 44" src="https://user-images.githubusercontent.com/8058096/72688508-444e9800-3b08-11ea-9cdd-f6babbb1e8f3.png">

Thanks.