### PR TITLE
[Android][Websockets] - Origin header check shouldn't be case sensitive

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java
@@ -101,7 +101,9 @@ public final class WebSocketModule extends NativeWebSocketModuleSpec {
     if (cookie != null) {
       builder.addHeader("Cookie", cookie);
     }
-
+    
+    boolean hasOriginHeader = false;
+    
     if (options != null
         && options.hasKey("headers")
         && options.getType("headers").equals(ReadableType.Map)) {
@@ -109,19 +111,20 @@ public final class WebSocketModule extends NativeWebSocketModuleSpec {
       ReadableMap headers = options.getMap("headers");
       ReadableMapKeySetIterator iterator = headers.keySetIterator();
 
-      if (!headers.hasKey("origin") && !headers.hasKey("Origin" ) {
-        builder.addHeader("origin", getDefaultOrigin(url));
-      }
-
       while (iterator.hasNextKey()) {
         String key = iterator.nextKey();
         if (ReadableType.String.equals(headers.getType(key))) {
+          if(key.equalsIgnoreCase("origin")){ 
+            hasOriginHeader = true;
+          }
           builder.addHeader(key, headers.getString(key));
         } else {
           FLog.w(ReactConstants.TAG, "Ignoring: requested " + key + ", value not a string");
         }
       }
-    } else {
+    }
+    
+    if (!hasOriginHeader) {
       builder.addHeader("origin", getDefaultOrigin(url));
     }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java
@@ -114,7 +114,7 @@ public final class WebSocketModule extends NativeWebSocketModuleSpec {
       while (iterator.hasNextKey()) {
         String key = iterator.nextKey();
         if (ReadableType.String.equals(headers.getType(key))) {
-          if(key.equalsIgnoreCase("origin")){ 
+          if (key.equalsIgnoreCase("origin")){ 
             hasOriginHeader = true;
           }
           builder.addHeader(key, headers.getString(key));

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java
@@ -109,7 +109,7 @@ public final class WebSocketModule extends NativeWebSocketModuleSpec {
       ReadableMap headers = options.getMap("headers");
       ReadableMapKeySetIterator iterator = headers.keySetIterator();
 
-      if (!headers.hasKey("origin")) {
+      if (!headers.hasKey("origin") && !headers.hasKey("Origin" ) {
         builder.addHeader("origin", getDefaultOrigin(url));
       }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Based on [this](https://stackoverflow.com/a/5259004), header names are not case sensitive.
That means that it's valid to pass a header `Origin` or `origin`.

With the current implementation. on Android only, if you pass `Origin`, it will get overwritten by the default origin.

This made me waste a lot of time debugging a problem while trying to connect to a websockets server that required an `origin` header and my implementation was working fine in iOS but not on Android, so I'm suggest changing the logic a little bit to take that into account.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[Android] [Fixed] - Support for case insensitive "Origin" headers for Websockets

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Here's a screenshot of that shows the issue before the fix (`Origin` header set, but getting overridden)

![Screen Shot 2020-01-21 at 11 41 33 AM](https://user-images.githubusercontent.com/1247834/72824606-86302900-3c43-11ea-92c2-3d39881495f0.png)

The fix is not that easy to test since it requires a public websocket server that checks for a custom Origin header, but I think the code changes are very small and clear.