### PR TITLE
[Android][RNTester] Use new Flipper SDK

### DIFF
--- a/RNTester/android/app/build.gradle
+++ b/RNTester/android/app/build.gradle
@@ -170,10 +170,16 @@ dependencies {
     debugImplementation files(hermesPath + "hermes-debug.aar")
     releaseImplementation files(hermesPath + "hermes-release.aar")
 
-    debugImplementation("com.facebook.flipper:flipper:0.23.4") {
-        exclude group:'com.facebook.yoga'
-        exclude group:'com.facebook.flipper', module: 'fbjni'
-        exclude group:'com.facebook.litho', module: 'litho-annotations'
+    debugImplementation("com.facebook.flipper:flipper:0.30.2") {
+        exclude group:'com.facebook.fbjni'
+    }
+
+    debugImplementation("com.facebook.flipper:flipper-network-plugin:0.30.2") {
+        exclude group:'com.facebook.flipper'
+    }
+
+    debugImplementation("com.facebook.flipper:flipper-fresco-plugin:0.30.2") {
+        exclude group:'com.facebook.flipper'
     }
 
     if (useIntlJsc) {


### PR DESCRIPTION
# Summary

The FBJNI compat issue is gone so this is working now. 🥳

Still a bit ugly to set up, but that's on our ToDo. Next: Template.

## Changelog

[Android] [Fixed] - Use modern Flipper SDK version for RNTester

## Test Plan

```
./gradlew :RNTester:android:app:installHermesDebug
```

![Screenshot 2020-01-22 at 09 30 22](https://user-images.githubusercontent.com/9906/72883088-9c012500-3cfb-11ea-9997-b38831196259.png)
