### PR TITLE
Add missing NativeEventListener methods to NativeDevSettings

### DIFF
--- a/Libraries/NativeModules/specs/NativeDevSettings.js
+++ b/Libraries/NativeModules/specs/NativeDevSettings.js
@@ -23,6 +23,10 @@ export interface Spec extends TurboModule {
   +toggleElementInspector: () => void;
   +addMenuItem: (title: string) => void;
 
+  // Events
+  +addListener: (eventName: string) => void;
+  +removeListeners: (count: number) => void;
+
   // iOS only.
   +setIsShakeToShowDevMenuEnabled: (enabled: boolean) => void;
 }


### PR DESCRIPTION
## Summary

Since migrating to Turbomodules (8fe04cf) the addMenuItem method crashes because the NativeEventListener methods are missing from the codegen flow type. Added the same methods based on what we do in AppState which is another native module that extends NativeEventListener.

## Changelog

[Internal] [Fixed] - Add missing NativeEventListener methods to NativeDevSettings

## Test Plan

TODO: Need someone at fb to run codegen and run the RNTester DevSettings example