### PR TITLE
Add in the optimization to check the first/least timer in the queue before iterating

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/core/JavaTimerManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/core/JavaTimerManager.java
@@ -384,12 +384,26 @@ public class JavaTimerManager {
    */
   /* package */ boolean hasActiveTimersInRange(long rangeMs) {
     synchronized (mTimerGuard) {
+      Timer nextTimer = mTimers.peek();
+      if (nextTimer == null) {
+        // Timers queue is empty
+        return false;
+      }
+      if (isTimerInRange(nextTimer, rangeMs)) {
+        // First check the next timer, so we can avoid iterating over the entire queue if it's
+        // already within range.
+        return true;
+      }
       for (Timer timer : mTimers) {
-        if (!timer.mRepeat && timer.mInterval < rangeMs) {
+        if (isTimerInRange(timer, rangeMs)) {
           return true;
         }
       }
     }
     return false;
+  }
+
+  private static boolean isTimerInRange(Timer timer, long rangeMs) {
+    return !timer.mRepeat && timer.mInterval < rangeMs;
   }
 }


### PR DESCRIPTION
## Summary
Follow up from https://github.com/facebook/react-native/pull/27539 - adding back in the optimization that Detox has in TimersIdlingResource to avoid iterating over the entire timers queue if the next timer is already within the specified range.

## Changelog
[Internal]

## Test Plan
TimingModuleTest

Differential Revision: D19522346

