### PR TITLE
Issue Template: Add Needs Triage label to new issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,39 +2,36 @@
 name: "🐛 Bug Report"
 about: Report a reproducible bug or regression in React Native.
 title: ''
-labels: 'Bug'
+labels: 'Needs: Triage :mag:'
 
 ---
 
-<!--
-  Please provide a clear and concise description of what the bug is.
-  Include screenshots if needed.
-  Please test using the latest React Native release to make sure your issue has not already been fixed: http://facebook.github.io/react-native/docs/upgrading.html
--->
+Description:
+
+    Please provide a clear and concise description of what the bug is. Include screenshots if needed.
+    Please test using the latest React Native release to make sure your issue has not already been fixed: http://facebook.github.io/react-native/docs/upgrading.html
+
 
 React Native version:
-<!--
-  Run `react-native info` in your terminal and copy the results here.
--->
+
+    Run `react-native info` in your terminal and copy the results here.
+
 
 ## Steps To Reproduce
+
+    Provide a detailed list of steps that reproduce the issue.
+    Issues without reproduction steps or code are likely to stall.
 
 1.
 2.
 
-<!--
- Issues without reproduction steps or code are likely to stall.
--->
 
-Describe what you expected to happen:
+## Expected Results
 
+    Describe what you expected to happen.
 
-Snack, code example, screenshot, or link to a repository:
+## Snack, code example, screenshot, or link to a repository:
 
-<!--
-  Please provide a Snack (https://snack.expo.io/), a link to a repository on GitHub, or
-  provide a minimal code example that reproduces the problem.
-  You may provide a screenshot of the application if you think it is relevant to your bug report. 
-  Here are some tips for providing a minimal example: https://stackoverflow.com/help/mcve.	  --	
--->
-
+    Please provide a Snack (https://snack.expo.io/), a link to a repository on GitHub, or provide a minimal code example that reproduces the problem.
+    You may provide a screenshot of the application if you think it is relevant to your bug report.
+    Here are some tips for providing a minimal example: https://stackoverflow.com/help/mcve

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,6 +1,6 @@
 ---
 name: "🤔 Questions and Help"
-about: The issue tracker is not for questions. Please ask questions on https://stackoverflow.com/questions/tagged/react-native.
+about: Please ask questions at https://stackoverflow.com/questions/tagged/react-native.
 title: 'Question: '
 labels: 'Type: Question'
 


### PR DESCRIPTION
## Summary

A new triage group is being set up. As part of the triage process, all new issues will be tagged as "Needs: Triage :mag:". We can achieve this by baking the label into the default issue template.

The `react-native-bot` has been updated so it does not auto-close issues tagged with this label. Previously, it would look for the presence of the "Bug" label to determine if someone used the default issue template. 

I've removed HTML comments from the template to minimize confusion. Folks that may not be familiar with HTML or Markdown and how they handle comments. 

## Changelog

[Internal] - Modify GitHub issue template

## Test Plan

N/A