### PR TITLE
Use EXPECT instead of ASSERT (repeat 582738b)

### DIFF
--- a/ReactCommon/cxxreact/tests/jsbigstring.cpp
+++ b/ReactCommon/cxxreact/tests/jsbigstring.cpp
@@ -58,9 +58,9 @@ TEST(JSBigFileString, MapPartTest) {
   JSBigFileString bigStr {fd, needle.size(), offset};
 
   // Test
-  ASSERT_EQ(needle.length(), bigStr.size());
+  EXPECT_EQ(needle.length(), bigStr.size());
   for (unsigned int i = 0; i < needle.length(); ++i) {
-    ASSERT_EQ(needle[i], bigStr.c_str()[i]);
+    EXPECT_EQ(needle[i], bigStr.c_str()[i]);
   }
 }
 
@@ -96,13 +96,13 @@ TEST(JSBigFileString, RemapTest) {
   int fd = tempFileFromString(data);
   JSBigFileString bigStr {fd, data.size()};
 
-  ASSERT_EQ(pageSize * 2, bigStr.size());
+  EXPECT_EQ(pageSize * 2, bigStr.size());
   auto remapped = bigStr.c_str();
   size_t i = 0;
   for (; i < pageSize; ++i) {
-    ASSERT_EQ(0x22, remapped[i]);
+    EXPECT_EQ(0x22, remapped[i]);
   }
   for (; i < pageSize * 2; ++i) {
-    ASSERT_EQ(0x11, remapped[i]);
+    EXPECT_EQ(0x11, remapped[i]);
   }
 }

--- a/ReactCommon/cxxreact/tests/methodcall.cpp
+++ b/ReactCommon/cxxreact/tests/methodcall.cpp
@@ -20,11 +20,11 @@ using namespace folly;
 TEST(parseMethodCalls, SingleReturnCallNoArgs) {
   auto jsText = "[[7],[3],[[]]]";
   auto returnedCalls = parseMethodCalls(folly::parseJson(jsText));
-  ASSERT_EQ(1, returnedCalls.size());
+  EXPECT_EQ(1, returnedCalls.size());
   auto returnedCall = returnedCalls[0];
-  ASSERT_EQ(0, returnedCall.arguments.size());
-  ASSERT_EQ(7, returnedCall.moduleId);
-  ASSERT_EQ(3, returnedCall.methodId);
+  EXPECT_EQ(0, returnedCall.arguments.size());
+  EXPECT_EQ(7, returnedCall.moduleId);
+  EXPECT_EQ(3, returnedCall.methodId);
 }
 
 TEST(parseMethodCalls, InvalidReturnFormat) {
@@ -72,49 +72,49 @@ TEST(parseMethodCalls, InvalidReturnFormat) {
 TEST(parseMethodCalls, NumberReturn) {
   auto jsText = "[[0],[0],[[\"foobar\"]]]";
   auto returnedCalls = parseMethodCalls(folly::parseJson(jsText));
-  ASSERT_EQ(1, returnedCalls.size());
+  EXPECT_EQ(1, returnedCalls.size());
   auto returnedCall = returnedCalls[0];
-  ASSERT_EQ(1, returnedCall.arguments.size());
-  ASSERT_EQ(folly::dynamic::STRING, returnedCall.arguments[0].type());
-  ASSERT_EQ("foobar", returnedCall.arguments[0].asString());
+  EXPECT_EQ(1, returnedCall.arguments.size());
+  EXPECT_EQ(folly::dynamic::STRING, returnedCall.arguments[0].type());
+  EXPECT_EQ("foobar", returnedCall.arguments[0].asString());
 }
 
 TEST(parseMethodCalls, StringReturn) {
   auto jsText = "[[0],[0],[[42.16]]]";
   auto returnedCalls = parseMethodCalls(folly::parseJson(jsText));
-  ASSERT_EQ(1, returnedCalls.size());
+  EXPECT_EQ(1, returnedCalls.size());
   auto returnedCall = returnedCalls[0];
-  ASSERT_EQ(1, returnedCall.arguments.size());
-  ASSERT_EQ(folly::dynamic::DOUBLE, returnedCall.arguments[0].type());
-  ASSERT_EQ(42.16, returnedCall.arguments[0].asDouble());
+  EXPECT_EQ(1, returnedCall.arguments.size());
+  EXPECT_EQ(folly::dynamic::DOUBLE, returnedCall.arguments[0].type());
+  EXPECT_EQ(42.16, returnedCall.arguments[0].asDouble());
 }
 
 TEST(parseMethodCalls, BooleanReturn) {
   auto jsText = "[[0],[0],[[false]]]";
   auto returnedCalls = parseMethodCalls(folly::parseJson(jsText));
-  ASSERT_EQ(1, returnedCalls.size());
+  EXPECT_EQ(1, returnedCalls.size());
   auto returnedCall = returnedCalls[0];
-  ASSERT_EQ(1, returnedCall.arguments.size());
-  ASSERT_EQ(folly::dynamic::BOOL, returnedCall.arguments[0].type());
+  EXPECT_EQ(1, returnedCall.arguments.size());
+  EXPECT_EQ(folly::dynamic::BOOL, returnedCall.arguments[0].type());
   ASSERT_FALSE(returnedCall.arguments[0].asBool());
 }
 
 TEST(parseMethodCalls, NullReturn) {
   auto jsText = "[[0],[0],[[null]]]";
   auto returnedCalls = parseMethodCalls(folly::parseJson(jsText));
-  ASSERT_EQ(1, returnedCalls.size());
+  EXPECT_EQ(1, returnedCalls.size());
   auto returnedCall = returnedCalls[0];
-  ASSERT_EQ(1, returnedCall.arguments.size());
-  ASSERT_EQ(folly::dynamic::NULLT, returnedCall.arguments[0].type());
+  EXPECT_EQ(1, returnedCall.arguments.size());
+  EXPECT_EQ(folly::dynamic::NULLT, returnedCall.arguments[0].type());
 }
 
 TEST(parseMethodCalls, MapReturn) {
   auto jsText = "[[0],[0],[[{\"foo\": \"hello\", \"bar\": 4.0, \"baz\": true}]]]";
   auto returnedCalls = parseMethodCalls(folly::parseJson(jsText));
-  ASSERT_EQ(1, returnedCalls.size());
+  EXPECT_EQ(1, returnedCalls.size());
   auto returnedCall = returnedCalls[0];
-  ASSERT_EQ(1, returnedCall.arguments.size());
-  ASSERT_EQ(folly::dynamic::OBJECT, returnedCall.arguments[0].type());
+  EXPECT_EQ(1, returnedCall.arguments.size());
+  EXPECT_EQ(folly::dynamic::OBJECT, returnedCall.arguments[0].type());
   auto& returnedMap = returnedCall.arguments[0];
   auto foo = returnedMap.at("foo");
   EXPECT_EQ(folly::dynamic("hello"), foo);
@@ -127,31 +127,31 @@ TEST(parseMethodCalls, MapReturn) {
 TEST(parseMethodCalls, ArrayReturn) {
   auto jsText = "[[0],[0],[[[\"foo\", 42.0, false]]]]";
   auto returnedCalls = parseMethodCalls(folly::parseJson(jsText));
-  ASSERT_EQ(1, returnedCalls.size());
+  EXPECT_EQ(1, returnedCalls.size());
   auto returnedCall = returnedCalls[0];
-  ASSERT_EQ(1, returnedCall.arguments.size());
-  ASSERT_EQ(folly::dynamic::ARRAY, returnedCall.arguments[0].type());
+  EXPECT_EQ(1, returnedCall.arguments.size());
+  EXPECT_EQ(folly::dynamic::ARRAY, returnedCall.arguments[0].type());
   auto& returnedArray = returnedCall.arguments[0];
-  ASSERT_EQ(3, returnedArray.size());
-  ASSERT_EQ(folly::dynamic("foo"), returnedArray[0]);
-  ASSERT_EQ(folly::dynamic(42.0), returnedArray[1]);
-  ASSERT_EQ(folly::dynamic(false), returnedArray[2]);
+  EXPECT_EQ(3, returnedArray.size());
+  EXPECT_EQ(folly::dynamic("foo"), returnedArray[0]);
+  EXPECT_EQ(folly::dynamic(42.0), returnedArray[1]);
+  EXPECT_EQ(folly::dynamic(false), returnedArray[2]);
 }
 
 TEST(parseMethodCalls, ReturnMultipleParams) {
   auto jsText = "[[0],[0],[[\"foo\", 14, null, false]]]";
   auto returnedCalls = parseMethodCalls(folly::parseJson(jsText));
-  ASSERT_EQ(1, returnedCalls.size());
+  EXPECT_EQ(1, returnedCalls.size());
   auto returnedCall = returnedCalls[0];
-  ASSERT_EQ(4, returnedCall.arguments.size());
-  ASSERT_EQ(folly::dynamic::STRING, returnedCall.arguments[0].type());
-  ASSERT_EQ(folly::dynamic::INT64, returnedCall.arguments[1].type());
-  ASSERT_EQ(folly::dynamic::NULLT, returnedCall.arguments[2].type());
-  ASSERT_EQ(folly::dynamic::BOOL, returnedCall.arguments[3].type());
+  EXPECT_EQ(4, returnedCall.arguments.size());
+  EXPECT_EQ(folly::dynamic::STRING, returnedCall.arguments[0].type());
+  EXPECT_EQ(folly::dynamic::INT64, returnedCall.arguments[1].type());
+  EXPECT_EQ(folly::dynamic::NULLT, returnedCall.arguments[2].type());
+  EXPECT_EQ(folly::dynamic::BOOL, returnedCall.arguments[3].type());
 }
 
 TEST(parseMethodCalls, ParseTwoCalls) {
   auto jsText = "[[0,0],[1,1],[[],[]]]";
   auto returnedCalls = parseMethodCalls(folly::parseJson(jsText));
-  ASSERT_EQ(2, returnedCalls.size());
+  EXPECT_EQ(2, returnedCalls.size());
 }

--- a/ReactCommon/fabric/uimanager/tests/UITemplateProcessorTest.cpp
+++ b/ReactCommon/fabric/uimanager/tests/UITemplateProcessorTest.cpp
@@ -150,7 +150,7 @@ TEST(UITemplateProcessorTest, testConditionalBytecode) {
   auto children1 = root1->getChildren();
   EXPECT_EQ(children1.size(), 1);
   auto child_props1 =
-      std::dynamic_pointer_cast<const ViewProps>(children1.at(0)->getPros());
+      std::dynamic_pointer_cast<const ViewProps>(children1.at(0)->getProps());
   ASSERT_STREQ(child_props1->testId.c_str(), "cond_true");
 
   mockSimpleTestValue_ = false;

--- a/ReactCommon/fabric/uimanager/tests/UITemplateProcessorTest.cpp
+++ b/ReactCommon/fabric/uimanager/tests/UITemplateProcessorTest.cpp
@@ -107,10 +107,10 @@ TEST(UITemplateProcessorTest, testSimpleBytecode) {
   LOG(INFO) << std::endl << root1->getDebugDescription();
 #endif
   auto props1 = std::dynamic_pointer_cast<const ViewProps>(root1->getProps());
-  ASSERT_NEAR(props1->opacity, 0.5, 0.001);
+  EXPECT_NEAR(props1->opacity, 0.5, 0.001);
   ASSERT_STREQ(props1->testId.c_str(), "root");
   auto children1 = root1->getChildren();
-  ASSERT_EQ(children1.size(), 1);
+  EXPECT_EQ(children1.size(), 1);
   auto child_props1 =
       std::dynamic_pointer_cast<const ViewProps>(children1.at(0)->getProps());
   ASSERT_STREQ(child_props1->testId.c_str(), "child");
@@ -148,9 +148,9 @@ TEST(UITemplateProcessorTest, testConditionalBytecode) {
   auto props1 = std::dynamic_pointer_cast<const ViewProps>(root1->getProps());
   ASSERT_STREQ(props1->testId.c_str(), "root");
   auto children1 = root1->getChildren();
-  ASSERT_EQ(children1.size(), 1);
+  EXPECT_EQ(children1.size(), 1);
   auto child_props1 =
-      std::dynamic_pointer_cast<const ViewProps>(children1.at(0)->getProps());
+      std::dynamic_pointer_cast<const ViewProps>(children1.at(0)->getPros());
   ASSERT_STREQ(child_props1->testId.c_str(), "cond_true");
 
   mockSimpleTestValue_ = false;

--- a/ReactCommon/jsi/jsi/test/testlib.cpp
+++ b/ReactCommon/jsi/jsi/test/testlib.cpp
@@ -559,11 +559,11 @@ TEST_P(JSITest, FunctionConstructorTest) {
       .getObject(rt)
       .setProperty(rt, "pika", "chu");
   auto empty = ctor.callAsConstructor(rt);
-  ASSERT_TRUE(empty.isObject());
+  EXPECT_TRUE(empty.isObject());
   auto emptyObj = std::move(empty).getObject(rt);
   EXPECT_EQ(emptyObj.getProperty(rt, "pika").getString(rt).utf8(rt), "chu");
   auto who = ctor.callAsConstructor(rt, "who");
-  ASSERT_TRUE(who.isObject());
+  EXPECT_TRUE(who.isObject());
   auto whoObj = std::move(who).getObject(rt);
   EXPECT_EQ(whoObj.getProperty(rt, "pika").getString(rt).utf8(rt), "who");
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This change will keep project consistency.
This change repeat the previous commit 582738bdc8ffd391362faf8b75ff17c1b024e2c3.
That was created by @sammy-SC and reviewed by @shergin

That changed 
* `ASSERT_TRUE` -> `EXPECT_TRUE`
* `ASSERT_NEAR` -> `EXPECT_NEAR`
* `ASSERT_EQ` -> `EXPECT_EQ`

That said
> 1. Replace ASSERT_* with EXPECT_*. Assert is a fatal assertion. Expect is non-fatal assertion. So if assert fails, tests do not continue and therefore provide less information.
>
> 2. Rename tests in `RawPropsTest.cpp` from `ShadowNodeTest` to `RawPropsTest`.
>
> Source: https://github.com/google/googletest/blob/master/googletest/docs/primer.md#basic-assertions


## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[CATEGORY] [TYPE] - Message

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
