### PR TITLE
fix: resolve Require Cycle warning

### DIFF
--- a/Libraries/Components/ScrollResponder.js
+++ b/Libraries/Components/ScrollResponder.js
@@ -18,14 +18,13 @@ const ReactNative = require('../Renderer/shims/ReactNative');
 const TextInputState = require('./TextInput/TextInputState');
 const UIManager = require('../ReactNative/UIManager');
 const Platform = require('../Utilities/Platform');
-const ScrollView = require('./ScrollView/ScrollView');
 import Commands from './ScrollView/ScrollViewCommands';
 
 const invariant = require('invariant');
 const performanceNow = require('fbjs/lib/performanceNow');
 
 import type {PressEvent, ScrollEvent} from '../Types/CoreEventTypes';
-import type {Props as ScrollViewProps} from './ScrollView/ScrollView';
+import type {Props as ScrollViewProps, ScrollViewType} from './ScrollView/ScrollView';
 import type {KeyboardEvent} from './Keyboard/Keyboard';
 import type EmitterSubscription from '../vendor/emitter/EmitterSubscription';
 import type {HostComponent} from '../Renderer/shims/ReactNativeTypes';
@@ -468,7 +467,7 @@ const ScrollResponderMixin = {
       ({x, y, animated} = x || {});
     }
 
-    const that: React.ElementRef<typeof ScrollView> = (this: any);
+    const that: React.ElementRef<ScrollViewType> = (this: any);
     invariant(
       that.getNativeScrollRef != null,
       'Expected scrollTo to be called on a scrollViewRef. If this exception occurs it is likely a bug in React Native',
@@ -492,7 +491,7 @@ const ScrollResponderMixin = {
     // Default to true
     const animated = (options && options.animated) !== false;
 
-    const that: React.ElementRef<typeof ScrollView> = (this: any);
+    const that: React.ElementRef<ScrollViewType> = (this: any);
     invariant(
       that.getNativeScrollRef != null,
       'Expected scrollToEnd to be called on a scrollViewRef. If this exception occurs it is likely a bug in React Native',
@@ -531,7 +530,7 @@ const ScrollResponderMixin = {
       );
     }
 
-    const that: React.ElementRef<typeof ScrollView> = this;
+    const that: React.ElementRef<ScrollViewType> = this;
     invariant(
       that.getNativeScrollRef != null,
       'Expected zoomToRect to be called on a scrollViewRef. If this exception occurs it is likely a bug in React Native',
@@ -547,7 +546,7 @@ const ScrollResponderMixin = {
    * Displays the scroll indicators momentarily.
    */
   scrollResponderFlashScrollIndicators: function() {
-    const that: React.ElementRef<typeof ScrollView> = (this: any);
+    const that: React.ElementRef<ScrollViewType> = (this: any);
     invariant(
       that.getNativeScrollRef != null,
       'Expected flashScrollIndicators to be called on a scrollViewRef. If this exception occurs it is likely a bug in React Native',

--- a/Libraries/Components/ScrollResponder.js
+++ b/Libraries/Components/ScrollResponder.js
@@ -24,7 +24,10 @@ const invariant = require('invariant');
 const performanceNow = require('fbjs/lib/performanceNow');
 
 import type {PressEvent, ScrollEvent} from '../Types/CoreEventTypes';
-import type {Props as ScrollViewProps, ScrollViewType} from './ScrollView/ScrollView';
+import type {
+  Props as ScrollViewProps,
+  ScrollViewType,
+} from './ScrollView/ScrollView';
 import type {KeyboardEvent} from './Keyboard/Keyboard';
 import type EmitterSubscription from '../vendor/emitter/EmitterSubscription';
 import type {HostComponent} from '../Renderer/shims/ReactNativeTypes';

--- a/Libraries/Components/ScrollResponder.js
+++ b/Libraries/Components/ScrollResponder.js
@@ -24,9 +24,8 @@ const invariant = require('invariant');
 const performanceNow = require('fbjs/lib/performanceNow');
 
 import type {PressEvent, ScrollEvent} from '../Types/CoreEventTypes';
-import type ScrollView, {
-  Props as ScrollViewProps,
-} from './ScrollView/ScrollView';
+import typeof ScrollView from './ScrollView/ScrollView';
+import type {Props as ScrollViewProps} from './ScrollView/ScrollView';
 import type {KeyboardEvent} from './Keyboard/Keyboard';
 import type EmitterSubscription from '../vendor/emitter/EmitterSubscription';
 import type {HostComponent} from '../Renderer/shims/ReactNativeTypes';

--- a/Libraries/Components/ScrollResponder.js
+++ b/Libraries/Components/ScrollResponder.js
@@ -24,9 +24,8 @@ const invariant = require('invariant');
 const performanceNow = require('fbjs/lib/performanceNow');
 
 import type {PressEvent, ScrollEvent} from '../Types/CoreEventTypes';
-import type {
+import type ScrollView, {
   Props as ScrollViewProps,
-  ScrollViewType,
 } from './ScrollView/ScrollView';
 import type {KeyboardEvent} from './Keyboard/Keyboard';
 import type EmitterSubscription from '../vendor/emitter/EmitterSubscription';
@@ -470,7 +469,7 @@ const ScrollResponderMixin = {
       ({x, y, animated} = x || {});
     }
 
-    const that: React.ElementRef<ScrollViewType> = (this: any);
+    const that: React.ElementRef<ScrollView> = (this: any);
     invariant(
       that.getNativeScrollRef != null,
       'Expected scrollTo to be called on a scrollViewRef. If this exception occurs it is likely a bug in React Native',
@@ -494,7 +493,7 @@ const ScrollResponderMixin = {
     // Default to true
     const animated = (options && options.animated) !== false;
 
-    const that: React.ElementRef<ScrollViewType> = (this: any);
+    const that: React.ElementRef<ScrollView> = (this: any);
     invariant(
       that.getNativeScrollRef != null,
       'Expected scrollToEnd to be called on a scrollViewRef. If this exception occurs it is likely a bug in React Native',
@@ -533,7 +532,7 @@ const ScrollResponderMixin = {
       );
     }
 
-    const that: React.ElementRef<ScrollViewType> = this;
+    const that: React.ElementRef<ScrollView> = this;
     invariant(
       that.getNativeScrollRef != null,
       'Expected zoomToRect to be called on a scrollViewRef. If this exception occurs it is likely a bug in React Native',
@@ -549,7 +548,7 @@ const ScrollResponderMixin = {
    * Displays the scroll indicators momentarily.
    */
   scrollResponderFlashScrollIndicators: function() {
-    const that: React.ElementRef<ScrollViewType> = (this: any);
+    const that: React.ElementRef<ScrollView> = (this: any);
     invariant(
       that.getNativeScrollRef != null,
       'Expected flashScrollIndicators to be called on a scrollViewRef. If this exception occurs it is likely a bug in React Native',

--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -65,6 +65,8 @@ if (Platform.OS === 'android') {
   RCTScrollContentView = requireNativeComponent('RCTScrollContentView');
 }
 
+export type ScrollViewType = typeof ScrollView;
+
 export type ScrollResponderType = {
   // We'd like to do ...ScrollView here, however Flow doesn't seem
   // to see the imperative methods of ScrollView that way. Workaround the

--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -65,8 +65,6 @@ if (Platform.OS === 'android') {
   RCTScrollContentView = requireNativeComponent('RCTScrollContentView');
 }
 
-export type ScrollViewType = typeof ScrollView;
-
 export type ScrollResponderType = {
   // We'd like to do ...ScrollView here, however Flow doesn't seem
   // to see the imperative methods of ScrollView that way. Workaround the


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

When I was testing React Native 0.62-rc.1, I noticed that console was showing a warning for Require Cycle as shown in image below

![Screen Shot 2020-01-24 at 12 22 38](https://user-images.githubusercontent.com/6936373/73042467-998dff00-3ea4-11ea-911c-955d55fd0743.png)

This is because ScrollResponder was importing `ScrollView` to get the `typeof ScrollView`.
I've made an export for ScrollView type in `ScrollView` so that Require cycle warning will not show up.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[General] [Fixed] - Remove Require cycle warning.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
