### PR TITLE
Add URLSearchParams and Headers to eslint globals

### DIFF
--- a/packages/eslint-config-react-native-community/index.js
+++ b/packages/eslint-config-react-native-community/index.js
@@ -97,6 +97,7 @@ module.exports = {
     fetch: false,
     FormData: false,
     global: false,
+    Headers: false,
     Intl: false,
     Map: true,
     module: false,

--- a/packages/eslint-config-react-native-community/index.js
+++ b/packages/eslint-config-react-native-community/index.js
@@ -111,6 +111,7 @@ module.exports = {
     setInterval: false,
     setTimeout: false,
     URL: false,
+    URLSearchParams: false,
     WebSocket: true,
     window: false,
     XMLHttpRequest: false,

--- a/packages/eslint-config-react-native-community/package.json
+++ b/packages/eslint-config-react-native-community/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-community/eslint-config",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "ESLint config for React Native",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
Fix eslint complaining about `URLSearchParams` and `Headers` not being defined.