### PR TITLE
Bump hermes to v0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "event-target-shim": "^5.0.1",
     "fbjs": "^1.0.0",
     "fbjs-scripts": "^1.1.0",
-    "hermes-engine": "~0.3.0",
+    "hermes-engine": "~0.4.0",
     "invariant": "^2.2.4",
     "jsc-android": "^245459.0.0",
     "metro-babel-register": "0.57.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3692,10 +3692,10 @@ has@^1.0.1, has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
-hermes-engine@~0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/hermes-engine/-/hermes-engine-0.3.0.tgz#c03ded211102eef775045a5f55e286783db8ad48"
-  integrity sha512-Xl21n/FohkoeQyz/9AeisoePhXaLvXRyT41xkYHOrqoNr+pkLUGc1xIo486ctIxSp5SN4BkN6T3YFWOdD0ntaQ==
+hermes-engine@~0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/hermes-engine/-/hermes-engine-0.4.0.tgz#ea3113d472871ca4791f2d75d9f68b25d82ef92c"
+  integrity sha512-7AO/K64GuVtcpUwUKDxyQXFN45RlqWrMIPMte6AeegMQMBh+MWuMU6ZOw8Jc7FGtsgiRqJRp+UX4+4UrFQXJ/A==
 
 home-or-tmp@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
## Summary

Bump hermes to v0.4.0

## Changelog

See https://github.com/facebook/hermes/releases/tag/v0.4.0

[Android] [Changed] - Bump hermes to v0.4.0

## Test Plan

RNTester builds and runs as expected
