### PR TITLE
iOS: Fix dev menu sometimes not showing

### DIFF
--- a/React/CoreModules/RCTDevMenu.mm
+++ b/React/CoreModules/RCTDevMenu.mm
@@ -183,7 +183,7 @@ RCT_EXPORT_MODULE()
 
 - (BOOL)isActionSheetShown
 {
-  return _actionSheet != nil;
+  return _actionSheet.beingPresented;
 }
 
 - (void)addItem:(NSString *)title handler:(void (^)(void))handler
@@ -418,7 +418,7 @@ RCT_EXPORT_MODULE()
 
 RCT_EXPORT_METHOD(show)
 {
-  if (_actionSheet || !_bridge || RCTRunningInAppExtension()) {
+  if ([self isActionSheetShown] || !_bridge || RCTRunningInAppExtension()) {
     return;
   }
 

--- a/React/CoreModules/RCTDevMenu.mm
+++ b/React/CoreModules/RCTDevMenu.mm
@@ -149,6 +149,11 @@ RCT_EXPORT_MODULE()
   return self;
 }
 
+- (UIAlertController *)alertController
+{
+  return _actionSheet;
+}
+
 - (dispatch_queue_t)methodQueue
 {
   return dispatch_get_main_queue();

--- a/packages/rn-tester/RNTesterUnitTests/RCTDevMenuTests.m
+++ b/packages/rn-tester/RNTesterUnitTests/RCTDevMenuTests.m
@@ -54,15 +54,20 @@ typedef void(^RCTDevMenuAlertActionHandler)(UIAlertAction *action);
 
 - (void)testClosingActionSheetAfterAction
 {
+  XCTAssertNil([_bridge.devMenu alertController]);
+  XCTAssertFalse([_bridge.devMenu isActionSheetShown]);
+
+  [_bridge.devMenu show];
+
   for (RCTDevMenuItem *item in _bridge.devMenu.presentedItems) {
     RCTDevMenuAlertActionHandler handler = [_bridge.devMenu alertActionHandlerForDevItem:item];
-    XCTAssertTrue([_bridge.devMenu isActionSheetShown]);
+    XCTAssertNotNil([_bridge.devMenu alertController]);
 
     handler(nil);
-    XCTAssertFalse([_bridge.devMenu isActionSheetShown]);
+    XCTAssertNil([_bridge.devMenu alertController]);
 
     [_bridge.devMenu show];
-    XCTAssertTrue([_bridge.devMenu isActionSheetShown]);
+    XCTAssertNotNil([_bridge.devMenu alertController]);
   }
 }
 

--- a/packages/rn-tester/RNTesterUnitTests/RCTDevMenuTests.m
+++ b/packages/rn-tester/RNTesterUnitTests/RCTDevMenuTests.m
@@ -15,6 +15,7 @@ typedef void(^RCTDevMenuAlertActionHandler)(UIAlertAction *action);
 
 @interface RCTDevMenu ()
 
+- (UIAlertController *)alertController;
 - (RCTDevMenuAlertActionHandler)alertActionHandlerForDevItem:(RCTDevMenuItem *)item;
 
 @end
@@ -42,9 +43,13 @@ typedef void(^RCTDevMenuAlertActionHandler)(UIAlertAction *action);
 
 - (void)testShowCreatingActionSheet
 {
+  XCTAssertNil([_bridge.devMenu alertController]);
   XCTAssertFalse([_bridge.devMenu isActionSheetShown]);
+
   [_bridge.devMenu show];
-  XCTAssertTrue([_bridge.devMenu isActionSheetShown]);
+
+  XCTAssertNotNil([_bridge.devMenu alertController]);
+  XCTAssertFalse([_bridge.devMenu isActionSheetShown]);
 }
 
 - (void)testClosingActionSheetAfterAction


### PR DESCRIPTION
## Summary

RCTDevMenu can get into a state where a UIAlertController is created but
never presented. When in this state, we will never be able to show the
dev menu unless we restart the app.

## Changelog

[iOS] [Fixed] - Fix dev menu sometimes not showing

## Test Plan

This is a bit difficult to test as I cannot consistently get the
module into this state. It seems to trigger if one randomly shakes the
device while navigating.
