### PR TITLE
iOS: Fix RCTDevLoadingView not showing up with UIScene

### DIFF
--- a/React/DevSupport/RCTDevLoadingView.m
+++ b/React/DevSupport/RCTDevLoadingView.m
@@ -94,6 +94,11 @@ RCT_EXPORT_METHOD(showMessage:(NSString *)message color:(UIColor *)color backgro
     self->_label.textColor = color;
     self->_window.backgroundColor = backgroundColor;
     self->_window.hidden = NO;
+
+    if (@available(iOS 13.0, *)) {
+      UIWindowScene *scene = (UIWindowScene *)RCTSharedApplication().connectedScenes.anyObject;
+      self->_window.windowScene = scene;
+    }
   });
 }
 


### PR DESCRIPTION
## Summary

Attaches the loading view to a `UIScene` in apps using the new Scenes API (iOS 13+).

## Changelog

[iOS] [Fixed] - Fix RCTDevLoadingView not showing up with UIScene

## Test Plan

Create a new app based on UIScene and integrate React Native.

| Before | After  |
|:------:|:------:|
 | <img width="453" alt="image" src="https://user-images.githubusercontent.com/4123478/73485717-eccfe800-43a3-11ea-96fd-f7077a348345.png"> | <img width="453" alt="image" src="https://user-images.githubusercontent.com/4123478/73485749-f9ecd700-43a3-11ea-8a18-2e2185e62e78.png"> |