### PR TITLE
fix android ci from fbobjc_target_sdk_version

### DIFF
--- a/tools/build_defs/oss/rn_defs.bzl
+++ b/tools/build_defs/oss/rn_defs.bzl
@@ -65,7 +65,6 @@ def rn_xplat_cxx_library(name, **kwargs):
         for k, v in kwargs.items()
         if k.startswith("exported_")
     }
-    new_kwargs.setdefault("fbobjc_target_sdk_version", "10.0")
 
     native.cxx_library(
         name = name,


### PR DESCRIPTION
## Summary

fbobjc_target_sdk_version is not available in Buck used for OSS, and broke Android CI.

## Changelog

[Android] [Fixed] - Android CI dependency fetch

## Test Plan

./scripts/circleci/buck_fetch.sh will successfully run on CI,