### PR TITLE
Remove JS autoFocus implementation

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -686,42 +686,6 @@ type ImperativeMethods = $ReadOnly<{|
 
 const emptyFunctionThatReturnsTrue = () => true;
 
-function useFocusOnMount(
-  initialAutoFocus: ?boolean,
-  inputRef: {|
-    current: null | React.ElementRef<HostComponent<mixed>>,
-  |},
-) {
-  const initialAutoFocusValue = useRef<?boolean>(initialAutoFocus);
-
-  useEffect(() => {
-    // We only want to autofocus on initial mount.
-    // Since initialAutoFocusValue and inputRef will never change
-    // this should match the expected behavior
-    if (initialAutoFocusValue.current) {
-      const focus = () => {
-        if (inputRef.current != null) {
-          inputRef.current.focus();
-        }
-      };
-
-      let rafId;
-      if (Platform.OS === 'android') {
-        // On Android this needs to be executed in a rAF callback
-        // otherwise the keyboard opens then closes immediately.
-        rafId = requestAnimationFrame(focus);
-      } else {
-        focus();
-      }
-
-      return () => {
-        if (rafId != null) {
-          cancelAnimationFrame(rafId);
-        }
-      };
-    }
-  }, [initialAutoFocusValue, inputRef]);
-}
 /**
  * A foundational component for inputting text into the app via a
  * keyboard. Props provide configurability for several features, such as
@@ -874,8 +838,6 @@ function InternalTextInput(props: Props): React.Node {
       inputRef.current.setNativeProps(nativeUpdate);
     }
   }, [inputRef, props.value, lastNativeText, selection, lastNativeSelection]);
-
-  useFocusOnMount(props.autoFocus, inputRef);
 
   useEffect(() => {
     const tag = ReactNative.findNodeHandle(inputRef.current);


### PR DESCRIPTION
## Summary

Follow up to #27803 and #27924. We no longer need to call focus on mount from JS as both iOS and Android implements it natively now.

## Changelog

[General] [Fixed] - Remove JS autoFocus implementation

## Test Plan

Test that focus works in RN Tester with this, #27803 and #27924