### PR TITLE
Implement native TextInput autoFocus on Android

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -100,6 +100,8 @@ public class ReactEditText extends AppCompatEditText {
   private @Nullable String mFontFamily = null;
   private int mFontWeight = ReactTypefaceUtils.UNSET;
   private int mFontStyle = ReactTypefaceUtils.UNSET;
+  private boolean mAutoFocus = false;
+  private boolean mDidAttachToWindow = false;
 
   private ReactViewBackgroundManager mReactBackgroundManager;
 
@@ -750,6 +752,14 @@ public class ReactEditText extends AppCompatEditText {
         span.onAttachedToWindow();
       }
     }
+
+    if (mAutoFocus && !mDidAttachToWindow) {
+      mShouldAllowFocus = true;
+      requestFocus();
+      mShouldAllowFocus = false;
+    }
+
+    mDidAttachToWindow = true;
   }
 
   @Override
@@ -811,6 +821,10 @@ public class ReactEditText extends AppCompatEditText {
       mTextAttributes.setMaxFontSizeMultiplier(maxFontSizeMultiplier);
       applyTextAttributes();
     }
+  }
+
+  public void setAutoFocus(boolean autoFocus) {
+    mAutoFocus = autoFocus;
   }
 
   protected void applyTextAttributes() {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -795,6 +795,11 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
     view.setShowSoftInputOnFocus(showKeyboardOnFocus);
   }
 
+  @ReactProp(name = "autoFocus", defaultBoolean = false)
+  public void setAutoFocus(ReactEditText view, boolean autoFocus) {
+    view.setAutoFocus(autoFocus);
+  }
+
   @ReactPropGroup(
       names = {
         ViewProps.BORDER_WIDTH,


### PR DESCRIPTION
## Summary

Follow up to #27803. To keep consistency between the implementations this also implements autoFocus natively on Android. This will allow removing the JS auto focus logic completely.

## Changelog

[Android] [Fixed] - Implement native TextInput autoFocus on Android

## Test Plan

Test using the TextInput example in RN tester.
