### PR TITLE
Fix resolving assets outside of the project root

### DIFF
--- a/Libraries/Image/AssetSourceResolver.js
+++ b/Libraries/Image/AssetSourceResolver.js
@@ -114,7 +114,12 @@ class AssetSourceResolver {
    */
   scaledAssetURLNearBundle(): ResolvedAssetSource {
     const path = this.jsbundleUrl || 'file://';
-    return this.fromSource(path + getScaledAssetPath(this.asset));
+    return this.fromSource(
+      // Assets can have relative paths outside of the project root.
+      // When bundling them we replace `../` with `_` to make sure they
+      // don't end up outside of the expected assets directory.
+      path + getScaledAssetPath(this.asset).replace(/\.\.\//g, '_'),
+    );
   }
 
   /**

--- a/Libraries/Image/__tests__/resolveAssetSource-test.js
+++ b/Libraries/Image/__tests__/resolveAssetSource-test.js
@@ -144,7 +144,7 @@ describe('resolveAssetSource', () => {
       );
     });
 
-    it('resolves an image with relative a path outside of root', () => {
+    it('resolves an image with a relative path outside of root', () => {
       expectResolvesAsset(
         {
           __packager_asset: true,
@@ -199,7 +199,7 @@ describe('resolveAssetSource', () => {
       );
     });
 
-    it('resolves an image with relative a path outside of root', () => {
+    it('resolves an image with a relative path outside of root', () => {
       expectResolvesAsset(
         {
           __packager_asset: true,

--- a/Libraries/Image/__tests__/resolveAssetSource-test.js
+++ b/Libraries/Image/__tests__/resolveAssetSource-test.js
@@ -143,6 +143,29 @@ describe('resolveAssetSource', () => {
         },
       );
     });
+
+    it('resolves an image with relative a path outside of root', () => {
+      expectResolvesAsset(
+        {
+          __packager_asset: true,
+          fileSystemLocation: '/module/a',
+          httpServerLocation: '/assets/../../module/a',
+          width: 100,
+          height: 200,
+          scales: [1],
+          hash: '5b6f00f',
+          name: 'logo',
+          type: 'png',
+        },
+        {
+          __packager_asset: true,
+          width: 100,
+          height: 200,
+          uri: 'file:///Path/To/Sample.app/assets/__module/a/logo.png',
+          scale: 1,
+        },
+      );
+    });
   });
 
   describe('bundle was loaded from assets on Android', () => {
@@ -171,6 +194,29 @@ describe('resolveAssetSource', () => {
           width: 100,
           height: 200,
           uri: 'awesomemodule_subdir_logo1_',
+          scale: 1,
+        },
+      );
+    });
+
+    it('resolves an image with relative a path outside of root', () => {
+      expectResolvesAsset(
+        {
+          __packager_asset: true,
+          fileSystemLocation: '/module/a',
+          httpServerLocation: '/assets/../../module/a',
+          width: 100,
+          height: 200,
+          scales: [1],
+          hash: '5b6f00f',
+          name: 'logo',
+          type: 'png',
+        },
+        {
+          __packager_asset: true,
+          width: 100,
+          height: 200,
+          uri: '__module_a_logo',
           scale: 1,
         },
       );


### PR DESCRIPTION
## Summary

When an asset is outside of the metro project root, it can lead to relative paths like `/assets/../../node_modules/coolpackage/image.png` as the `httpServerLocation`. This can happen for example when using yarn workspaces with hoisted node_modules.

This causes issues when bundling on iOS since we use this path in the filesystem. To avoid this we replace `../` with `_` to preserve the uniqueness of the path while avoiding these kind of problematic relative paths. The same logic is used when bundling assets in the rn-cli.

CLI part of this PR: https://github.com/react-native-community/cli/pull/939

## Changelog

[General] [Fixed] - Fix resolving assets outside of the project root

## Test Plan

Tested that an asset in a hoisted node_modules package doesn't show up before this patch and does after in a release build.
