### PR TITLE
Add new DoNotStrip class to proguard config

### DIFF
--- a/ReactAndroid/proguard-rules.pro
+++ b/ReactAndroid/proguard-rules.pro
@@ -25,13 +25,16 @@
 -keep,allowobfuscation @interface com.facebook.proguard.annotations.DoNotStrip
 -keep,allowobfuscation @interface com.facebook.proguard.annotations.KeepGettersAndSetters
 -keep,allowobfuscation @interface com.facebook.common.internal.DoNotStrip
+-keep,allowobfuscation @interface com.facebook.jni.annotations.DoNotStrip
 
 # Do not strip any method/class that is annotated with @DoNotStrip
 -keep @com.facebook.proguard.annotations.DoNotStrip class *
 -keep @com.facebook.common.internal.DoNotStrip class *
+-keep @com.facebook.jni.annotations.DoNotStrip class *
 -keepclassmembers class * {
     @com.facebook.proguard.annotations.DoNotStrip *;
     @com.facebook.common.internal.DoNotStrip *;
+    @com.facebook.jni.annotations.DoNotStrip *;
 }
 
 -keepclassmembers @com.facebook.proguard.annotations.KeepGettersAndSetters class * {


### PR DESCRIPTION
## Summary

JNI now comes from https://github.com/facebookincubator/fbjni and it uses a different DoNotStrip class (https://github.com/facebookincubator/fbjni/blob/master/java/com/facebook/jni/annotations/DoNotStrip.java) so we need to include it in the proguard config. 

## Changelog

[Android] [Fixed] - Add new DoNotStrip class to proguard config

## Test Plan

Test that it fixes a crash related to missing NativeRunnable class in release builds.
