### PR TITLE
Capitalizing FormData header field name

### DIFF
--- a/Libraries/Network/FormData.js
+++ b/Libraries/Network/FormData.js
@@ -68,7 +68,7 @@ class FormData {
     return this._parts.map(([name, value]) => {
       const contentDisposition = 'form-data; name="' + name + '"';
 
-      const headers: Headers = {'content-disposition': contentDisposition};
+      const headers: Headers = {'Content-Disposition': contentDisposition};
 
       // The body part is a "blob", which in React Native just means
       // an object with a `uri` attribute. Optionally, it can also
@@ -76,10 +76,10 @@ class FormData {
       // content type (cf. web Blob interface.)
       if (typeof value === 'object' && value) {
         if (typeof value.name === 'string') {
-          headers['content-disposition'] += '; filename="' + value.name + '"';
+          headers['Content-Disposition'] += '; filename="' + value.name + '"';
         }
         if (typeof value.type === 'string') {
-          headers['content-type'] = value.type;
+          headers['Content-Type'] = value.type;
         }
         return {...value, headers, fieldName: name};
       }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
In general, the header field name should be Capitalizing. 
Lowercase FormData field name will cause `Stream ended unexpectedly` in same server.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[General] [Fixed] Capitalizing FormData header field name
