### PR TITLE
Fabric: Fix CXX Stub for TextLayoutManager

### DIFF
--- a/ReactCommon/fabric/textlayoutmanager/platform/cxx/TextLayoutManager.cpp
+++ b/ReactCommon/fabric/textlayoutmanager/platform/cxx/TextLayoutManager.cpp
@@ -17,7 +17,7 @@ void *TextLayoutManager::getNativeTextLayoutManager() const {
 }
 
 Size TextLayoutManager::measure(
-    AttributedString attributedString,
+    AttributedStringBox attributedStringBox,
     ParagraphAttributes paragraphAttributes,
     LayoutConstraints layoutConstraints) const {
   return Size{0, 0};

--- a/ReactCommon/fabric/textlayoutmanager/platform/cxx/TextLayoutManager.h
+++ b/ReactCommon/fabric/textlayoutmanager/platform/cxx/TextLayoutManager.h
@@ -10,6 +10,7 @@
 #include <memory>
 
 #include <react/attributedstring/AttributedString.h>
+#include <react/attributedstring/AttributedStringBox.h>
 #include <react/attributedstring/ParagraphAttributes.h>
 #include <react/core/LayoutConstraints.h>
 #include <react/utils/ContextContainer.h>
@@ -31,10 +32,10 @@ class TextLayoutManager {
   ~TextLayoutManager();
 
   /*
-   * Measures `attributedString` using native text rendering infrastructure.
+   * Measures `attributedStringBox` using native text rendering infrastructure.
    */
   Size measure(
-      AttributedString attributedString,
+      AttributedStringBox attributedStringBox,
       ParagraphAttributes paragraphAttributes,
       LayoutConstraints layoutConstraints) const;
 


### PR DESCRIPTION
## Summary

This pull request fixes the CXX stub for `TextLayoutManager`. The signature for `TextLayoutManager::measure` changed slightly, and this patch updates the stub to reflect that.

## Changelog

[Internal] [Fixed] - Fabric: Fix CXX Stub for TextLayoutManager

## Test Plan

Fabric compiles, and the Fabric test suite passes.