### PR TITLE
Make Vibration.vibrate compatible with TurboModules

### DIFF
--- a/Libraries/Vibration/NativeVibration.js
+++ b/Libraries/Vibration/NativeVibration.js
@@ -15,7 +15,7 @@ import * as TurboModuleRegistry from '../TurboModule/TurboModuleRegistry';
 
 export interface Spec extends TurboModule {
   +getConstants: () => {||};
-  +vibrate: (pattern?: ?number) => void;
+  +vibrate: (pattern: number) => void;
 
   // Android only
   +vibrateByPattern: (pattern: Array<number>, repeat: number) => void;

--- a/Libraries/Vibration/RCTVibration.mm
+++ b/Libraries/Vibration/RCTVibration.mm
@@ -25,7 +25,7 @@ RCT_EXPORT_MODULE()
   AudioServicesPlaySystemSound(kSystemSoundID_Vibrate);
 }
 
-RCT_EXPORT_METHOD(vibrate:(NSNumber *)pattern)
+RCT_EXPORT_METHOD(vibrate:(nonnull NSNumber *)pattern)
 {
   [self vibrate];
 }

--- a/Libraries/Vibration/Vibration.js
+++ b/Libraries/Vibration/Vibration.js
@@ -86,7 +86,7 @@ const Vibration = {
         return;
       }
       if (typeof pattern === 'number') {
-        NativeVibration.vibrate();
+        NativeVibration.vibrate(pattern);
       } else if (Array.isArray(pattern)) {
         vibrateByPattern(pattern, repeat);
       } else {

--- a/Libraries/Vibration/Vibration.js
+++ b/Libraries/Vibration/Vibration.js
@@ -22,6 +22,7 @@ const Platform = require('../Utilities/Platform');
 
 let _vibrating: boolean = false;
 let _id: number = 0; // _id is necessary to prevent race condition.
+const _default_vibration_length = 400;
 
 function vibrateByPattern(pattern: Array<number>, repeat: boolean = false) {
   if (_vibrating) {
@@ -29,7 +30,7 @@ function vibrateByPattern(pattern: Array<number>, repeat: boolean = false) {
   }
   _vibrating = true;
   if (pattern[0] === 0) {
-    NativeVibration.vibrate();
+    NativeVibration.vibrate(_default_vibration_length);
     pattern = pattern.slice(1);
   }
   if (pattern.length === 0) {
@@ -48,7 +49,7 @@ function vibrateScheduler(
   if (!_vibrating || id !== _id) {
     return;
   }
-  NativeVibration.vibrate();
+  NativeVibration.vibrate(_default_vibration_length);
   if (nextIndex >= pattern.length) {
     if (repeat) {
       nextIndex = 0;
@@ -70,7 +71,7 @@ const Vibration = {
    * See https://facebook.github.io/react-native/docs/vibration.html#vibrate
    */
   vibrate: function(
-    pattern: number | Array<number> = 400,
+    pattern: number | Array<number> = _default_vibration_length,
     repeat: boolean = false,
   ) {
     if (Platform.OS === 'android') {

--- a/ReactAndroid/src/main/java/com/facebook/fbreact/specs/NativeVibrationSpec.java
+++ b/ReactAndroid/src/main/java/com/facebook/fbreact/specs/NativeVibrationSpec.java
@@ -18,6 +18,7 @@ import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReactModuleWithSpec;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.turbomodule.core.interfaces.TurboModule;
+import javax.annotation.Nonnull;
 
 public abstract class NativeVibrationSpec extends ReactContextBaseJavaModule implements ReactModuleWithSpec, TurboModule {
   public NativeVibrationSpec(ReactApplicationContext reactContext) {
@@ -31,5 +32,5 @@ public abstract class NativeVibrationSpec extends ReactContextBaseJavaModule imp
   public abstract void vibrateByPattern(ReadableArray pattern, double repeat);
 
   @ReactMethod
-  public abstract void vibrate(Double pattern);
+  public abstract void vibrate(@Nonnull Double pattern);
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/vibration/VibrationModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/vibration/VibrationModule.java
@@ -8,6 +8,7 @@
 package com.facebook.react.modules.vibration;
 
 import android.annotation.SuppressLint;
+import androidx.annotation.NonNull;
 import android.content.Context;
 import android.os.Vibrator;
 import com.facebook.fbreact.specs.NativeVibrationSpec;
@@ -31,7 +32,7 @@ public class VibrationModule extends NativeVibrationSpec {
   }
 
   @Override
-  public void vibrate(Double durationDouble) {
+  public void vibrate(@NonNull Double durationDouble) {
     int duration = (int) durationDouble.doubleValue();
 
     Vibrator v = (Vibrator) getReactApplicationContext().getSystemService(Context.VIBRATOR_SERVICE);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
This PR fixes a compatibility issue with the Vibration module and TurboModules.
The TurboModules spec doesn't allow nullable arguments of type Number, causing the following problem: 

![IMG_3758](https://user-images.githubusercontent.com/1247834/73803879-10be6f80-4790-11ea-92d4-a008f0007681.PNG)


## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[iOS] [Fixed] - Make Vibration library compatible with TurboModules.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Just submitted a PR to my own app to fix the issue [here](https://github.com/rainbow-me/rainbow/pull/340) 

The problem should be reproducible on RNTester due to this line: https://github.com/facebook/react-native/blob/91f139b94118fe8db29728ea8ad855fc4a13f743/RNTester/js/examples/Vibration/VibrationExample.js#L66  and should be working on this branch.
