### PR TITLE
[Android] Remove `pickFirst` arguments

### DIFF
--- a/RNTester/android/app/build.gradle
+++ b/RNTester/android/app/build.gradle
@@ -103,13 +103,6 @@ def useIntlJsc = false
 android {
     compileSdkVersion 29
 
-    packagingOptions {
-        pickFirst '**/armeabi-v7a/libc++_shared.so'
-        pickFirst '**/x86/libc++_shared.so'
-        pickFirst '**/x86_64/libc++_shared.so'
-        pickFirst '**/arm64-v8a/libc++_shared.so'
-    }
-
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8

--- a/template/android/app/build.gradle
+++ b/template/android/app/build.gradle
@@ -164,13 +164,6 @@ android {
         }
     }
 
-    packagingOptions {
-        pickFirst "lib/armeabi-v7a/libc++_shared.so"
-        pickFirst "lib/arm64-v8a/libc++_shared.so"
-        pickFirst "lib/x86/libc++_shared.so"
-        pickFirst "lib/x86_64/libc++_shared.so"
-    }
-
     // applicationVariants are e.g. debug, release
     applicationVariants.all { variant ->
         variant.outputs.each { output ->


### PR DESCRIPTION
## Summary
This is no longer necessary with the new Flipper release.

## Test Plan
This was a built-time problem so the CI jobs would catch this.

## Changelog

[Android] [Removed] - pickFirst options for RNTester and template
