### PR TITLE
Use autolink script in template on iOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "ReactCommon",
     "README.md",
     "rn-get-polyfills.js",
+    "scripts/autolink-ios.rb",
     "scripts/compose-source-maps.js",
     "scripts/ios-configure-glog.sh",
     "scripts/launchPackager.bat",

--- a/scripts/autolink-ios.rb
+++ b/scripts/autolink-ios.rb
@@ -43,7 +43,7 @@ def use_react_native! (options={})
   pod 'React-jsinspector', :path => "#{prefix}/ReactCommon/jsinspector"
   pod 'ReactCommon/callinvoker', :path => "#{prefix}/ReactCommon"
   pod 'ReactCommon/turbomodule/core', :path => "#{prefix}/ReactCommon"
-  pod 'Yoga', :path => "#{prefix}/ReactCommon/yoga"
+  pod 'Yoga', :path => "#{prefix}/ReactCommon/yoga", :modular_headers => true
 
   pod 'DoubleConversion', :podspec => "#{prefix}/third-party-podspecs/DoubleConversion.podspec"
   pod 'glog', :podspec => "#{prefix}/third-party-podspecs/glog.podspec"

--- a/template/ios/Podfile
+++ b/template/ios/Podfile
@@ -1,4 +1,5 @@
 platform :ios, '10.0'
+require_relative '../node_modules/react-native/scripts/autolink-ios'
 require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
 
 # Add Flipper Pods
@@ -39,36 +40,7 @@ end
 
 target 'HelloWorld' do
   # Pods for HelloWorld
-  pod 'FBLazyVector', :path => "../node_modules/react-native/Libraries/FBLazyVector"
-  pod 'FBReactNativeSpec', :path => "../node_modules/react-native/Libraries/FBReactNativeSpec"
-  pod 'RCTRequired', :path => "../node_modules/react-native/Libraries/RCTRequired"
-  pod 'RCTTypeSafety', :path => "../node_modules/react-native/Libraries/TypeSafety"
-  pod 'React', :path => '../node_modules/react-native/'
-  pod 'React-Core', :path => '../node_modules/react-native/'
-  pod 'React-CoreModules', :path => '../node_modules/react-native/React/CoreModules'
-  pod 'React-Core/DevSupport', :path => '../node_modules/react-native/'
-  pod 'React-RCTActionSheet', :path => '../node_modules/react-native/Libraries/ActionSheetIOS'
-  pod 'React-RCTAnimation', :path => '../node_modules/react-native/Libraries/NativeAnimation'
-  pod 'React-RCTBlob', :path => '../node_modules/react-native/Libraries/Blob'
-  pod 'React-RCTImage', :path => '../node_modules/react-native/Libraries/Image'
-  pod 'React-RCTLinking', :path => '../node_modules/react-native/Libraries/LinkingIOS'
-  pod 'React-RCTNetwork', :path => '../node_modules/react-native/Libraries/Network'
-  pod 'React-RCTSettings', :path => '../node_modules/react-native/Libraries/Settings'
-  pod 'React-RCTText', :path => '../node_modules/react-native/Libraries/Text'
-  pod 'React-RCTVibration', :path => '../node_modules/react-native/Libraries/Vibration'
-  pod 'React-Core/RCTWebSocket', :path => '../node_modules/react-native/'
-
-  pod 'React-cxxreact', :path => '../node_modules/react-native/ReactCommon/cxxreact'
-  pod 'React-jsi', :path => '../node_modules/react-native/ReactCommon/jsi'
-  pod 'React-jsiexecutor', :path => '../node_modules/react-native/ReactCommon/jsiexecutor'
-  pod 'React-jsinspector', :path => '../node_modules/react-native/ReactCommon/jsinspector'
-  pod 'ReactCommon/callinvoker', :path => "../node_modules/react-native/ReactCommon"
-  pod 'ReactCommon/turbomodule/core', :path => "../node_modules/react-native/ReactCommon"
-  pod 'Yoga', :path => '../node_modules/react-native/ReactCommon/yoga', :modular_headers => true
-
-  pod 'DoubleConversion', :podspec => '../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec'
-  pod 'glog', :podspec => '../node_modules/react-native/third-party-podspecs/glog.podspec'
-  pod 'Folly', :podspec => '../node_modules/react-native/third-party-podspecs/Folly.podspec'
+  use_react_native!
 
   target 'HelloWorldTests' do
     inherit! :complete


### PR DESCRIPTION
## Summary

We use this for RN tester but it is not currently included in npm releases. It cleans up the podfile a lot and will make adding / removing pods easier in the future since it won't require users to update their project.

## Changelog

[iOS] [Added] - Use autolink script in template on iOS

## Test Plan

Not sure if there is a way to end to end test this but I've been using this autolink script in my fork for a while.