### PR TITLE
Added Refresh Control title font support for iOS

### DIFF
--- a/Libraries/Components/RefreshControl/PullToRefreshViewNativeComponent.js
+++ b/Libraries/Components/RefreshControl/PullToRefreshViewNativeComponent.js
@@ -44,6 +44,21 @@ type NativeProps = $ReadOnly<{|
    * Whether the view should be indicating an active refresh.
    */
   refreshing: boolean,
+  
+  /**
+   * Title font family.
+   */
+  titleFontFamily?: ?string;
+
+  /**
+   * Title font size.
+   */
+  titleFontSize?: ?Number;
+
+  /**
+   * Title title font weight.
+   */
+  titleFontWeight?: ?string;
 |}>;
 
 type ComponentType = HostComponent<NativeProps>;

--- a/Libraries/Components/RefreshControl/RefreshControl.js
+++ b/Libraries/Components/RefreshControl/RefreshControl.js
@@ -47,6 +47,18 @@ type IOSProps = $ReadOnly<{|
    * The title displayed under the refresh indicator.
    */
   title?: ?string,
+  /**
+   * Title font family.
+   */
+  titleFontFamily?: ?string;
+  /**
+   * Title font size.
+   */
+  titleFontSize?: ?Number;
+  /**
+   * Title title font weight.
+   */
+  titleFontWeight?: ?string;
 |}>;
 
 type AndroidProps = $ReadOnly<{|

--- a/RNTester/js/examples/RefreshControl/RefreshControlExample.js
+++ b/RNTester/js/examples/RefreshControl/RefreshControlExample.js
@@ -85,6 +85,9 @@ class RefreshControlExample extends React.Component {
             tintColor="#ff0000"
             title="Loading..."
             titleColor="#00ff00"
+            titleFontFamily= 'Cochin'
+            titleFontSize={30}
+            titleFontWeight= 'bold'
             colors={['#ff0000', '#00ff00', '#0000ff']}
             progressBackgroundColor="#ffff00"
           />

--- a/React/Views/RefreshControl/RCTRefreshControl.m
+++ b/React/Views/RefreshControl/RCTRefreshControl.m
@@ -168,7 +168,11 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
   if (_titleColor) {
     attributes[NSForegroundColorAttributeName] = _titleColor;
   }
-
+    
+  UIFont *font = [self titleFont];
+  if (font) {
+    attributes[NSFontAttributeName] = font;
+  }
   self.attributedTitle = [[NSAttributedString alloc] initWithString:_title attributes:attributes];
 }
 

--- a/React/Views/RefreshControl/RCTRefreshControl.m
+++ b/React/Views/RefreshControl/RCTRefreshControl.m
@@ -9,6 +9,7 @@
 #import "RCTRefreshableProtocol.h"
 
 #import "RCTUtils.h"
+#import <React/RCTFont.h>
 
 @interface RCTRefreshControl () <RCTRefreshableProtocol>
 @end
@@ -21,6 +22,9 @@
   BOOL _refreshingProgrammatically;
   NSString *_title;
   UIColor *_titleColor;
+  NSString *_titleFontFamily;
+  NSNumber *_titleFontSize;
+  NSString *_titleFontWeight;
 }
 
 - (instancetype)init
@@ -119,6 +123,39 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 {
   _titleColor = color;
   [self _updateTitle];
+}
+
+- (void)setTitleFontSize:(NSNumber *)size
+{
+  _titleFontSize = size;
+  [self _updateTitle];
+}
+
+- (void)setTitleFontWeight:(NSString *)weight
+{
+  _titleFontWeight = weight;
+  [self _updateTitle];
+}
+
+- (void)setTitleFontFamily:(NSString *)name
+{
+  _titleFontFamily = name;
+  [self _updateTitle];
+}
+
+- (UIFont *)titleFont
+{
+    NSNumber *fontSize = 0;
+    if (_titleFontSize != nil) {
+        fontSize = _titleFontSize;
+    }
+  return [RCTFont updateFont:nil
+                  withFamily:_titleFontFamily
+                        size:_titleFontSize
+                      weight:_titleFontWeight
+                       style:nil
+                     variant:nil
+             scaleMultiplier:1];
 }
 
 - (void)_updateTitle

--- a/React/Views/RefreshControl/RCTRefreshControlManager.m
+++ b/React/Views/RefreshControl/RCTRefreshControlManager.m
@@ -25,6 +25,9 @@ RCT_EXPORT_VIEW_PROPERTY(refreshing, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(tintColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(title, NSString)
 RCT_EXPORT_VIEW_PROPERTY(titleColor, UIColor)
+RCT_EXPORT_VIEW_PROPERTY(titleFontSize, NSNumber)
+RCT_EXPORT_VIEW_PROPERTY(titleFontWeight, NSString)
+RCT_EXPORT_VIEW_PROPERTY(titleFontFamily, NSString)
 
 RCT_EXPORT_METHOD(setNativeRefreshing : (nonnull NSNumber *)viewTag toRefreshing : (BOOL)refreshing)
 {


### PR DESCRIPTION
 ## Summary
#27817
Added Refresh Control title font support for iOS. Updated sample example in RNTester
            titleFontFamily= 'Cochin'
            titleFontSize={30}
            titleFontWeight= 'bold'
https://github.com/facebook/react-native/issues/27817


## Changelog
[iOS] [Added] - Added Refresh Control title font support for iOS. Updated sample example in RNTester
            titleFontFamily= 'Cochin'
            titleFontSize={30}
            titleFontWeight= 'bold'

## Test Plan
![27817](https://user-images.githubusercontent.com/60604183/74032687-a1888b80-49da-11ea-88e4-47c89b2232b0.png)

