### PR TITLE
Add localized accessibility strings to React Core pod

### DIFF
--- a/React-Core.podspec
+++ b/React-Core.podspec
@@ -44,6 +44,7 @@ Pod::Spec.new do |s|
   s.author                 = "Facebook, Inc. and its affiliates"
   s.platforms              = { :ios => "10.0", :tvos => "10.0" }
   s.source                 = source
+  s.resource_bundle        = { "AccessibilityResources" => ["React/AccessibilityResources/*.lproj"]}
   s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
   s.header_dir             = "React"
   s.framework              = "JavaScriptCore"

--- a/React/AccessibilityResources/en.lproj/Localizable.strings
+++ b/React/AccessibilityResources/en.lproj/Localizable.strings
@@ -1,0 +1,26 @@
+/*
+  Localizable.strings
+  React
+*/
+"alert"="alert";
+"checkbox"="checkbox";
+"combobox"="combo box";
+"menu"="menu";
+"menubar"="menu bar";
+"menuitem"="menu item";
+"progressbar"="progress bar";
+"radio"="radio button";
+"radiogroup"="radio group";
+"scrollbar"="scroll bar";
+"spinbutton"="spin button";
+"switch"="switch";
+"tab"="tab description";
+"tablist"="tab list";
+"timer"="timer";
+"toolbar"="tool bar";
+"checked"="checked";
+"unchecked"="not checked";
+"busy"="busy";
+"expanded"="expanded";
+"collapsed"="collapsed";
+"mixed"="mixed";

--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -211,7 +211,12 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:unused)
 
     if (bundle) {
       NSURL *url = [bundle URLForResource:@"Localizable" withExtension:@"strings"];
-      rolesAndStatesDescription = [NSDictionary dictionaryWithContentsOfURL:url];
+      if (@available(iOS 11.0, *)) {
+        rolesAndStatesDescription = [NSDictionary dictionaryWithContentsOfURL:url error:nil];
+      } else {
+        // Fallback on earlier versions
+        rolesAndStatesDescription = [NSDictionary dictionaryWithContentsOfURL:url];
+      }
     }
     if (rolesAndStatesDescription == nil) {
       NSLog(@"Cannot load localized accessibility strings.");

--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -202,6 +202,46 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:unused)
 
 - (NSString *)accessibilityValue
 {
+  static dispatch_once_t onceToken;
+  static NSDictionary<NSString *, NSString *> *rolesAndStatesDescription = nil;
+
+  dispatch_once(&onceToken, ^{
+    NSString *bundlePath = [[NSBundle mainBundle]pathForResource:@"AccessibilityResources" ofType:@"bundle"];
+    NSBundle *bundle = [NSBundle bundleWithPath:bundlePath];
+
+    if (bundle) {
+      NSURL *url = [bundle URLForResource:@"Localizable" withExtension:@"strings"];
+      rolesAndStatesDescription = [NSDictionary dictionaryWithContentsOfURL:url];
+    }
+    if (rolesAndStatesDescription == nil) {
+      NSLog(@"Cannot load localized accessibility strings.");
+      rolesAndStatesDescription = @{
+                           @"alert" : @"alert",
+                           @"checkbox" : @"checkbox",
+                           @"combobox" : @"combo box",
+                           @"menu" : @"menu",
+                           @"menubar" : @"menu bar",
+                           @"menuitem" : @"menu item",
+                           @"progressbar" : @"progress bar",
+                           @"radio" : @"radio button",
+                           @"radiogroup" : @"radio group",
+                           @"scrollbar" : @"scroll bar",
+                           @"spinbutton" : @"spin button",
+                           @"switch" : @"switch",
+                           @"tab" : @"tab",
+                           @"tablist" : @"tab list",
+                           @"timer" : @"timer",
+                           @"toolbar" : @"tool bar",
+                           @"checked" : @"checked",
+                           @"unchecked" : @"not checked",
+                           @"busy" : @"busy",
+                           @"expanded" : @"expanded",
+                           @"collapsed" : @"collapsed",
+                           @"mixed": @"mixed",
+                           };
+      }
+  });
+
   if ((self.accessibilityTraits & SwitchAccessibilityTrait) == SwitchAccessibilityTrait) {
     for (NSString *state in self.accessibilityState) {
       id val = self.accessibilityState[state];
@@ -214,41 +254,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:unused)
     }
   }
   NSMutableArray *valueComponents = [NSMutableArray new];
-  static NSDictionary<NSString *, NSString *> *roleDescriptions = nil;
-  static dispatch_once_t onceToken1;
-  dispatch_once(&onceToken1, ^{
-    roleDescriptions = @{
-                         @"alert" : @"alert",
-                         @"checkbox" : @"checkbox",
-                         @"combobox" : @"combo box",
-                         @"menu" : @"menu",
-                         @"menubar" : @"menu bar",
-                         @"menuitem" : @"menu item",
-                         @"progressbar" : @"progress bar",
-                         @"radio" : @"radio button",
-                         @"radiogroup" : @"radio group",
-                         @"scrollbar" : @"scroll bar",
-                         @"spinbutton" : @"spin button",
-                         @"switch" : @"switch",
-                         @"tab" : @"tab",
-                         @"tablist" : @"tab list",
-                         @"timer" : @"timer",
-                         @"toolbar" : @"tool bar",
-                         };
-  });
-  static NSDictionary<NSString *, NSString *> *stateDescriptions = nil;
-  static dispatch_once_t onceToken2;
-  dispatch_once(&onceToken2, ^{
-    stateDescriptions = @{
-                          @"checked" : @"checked",
-                          @"unchecked" : @"not checked",
-                          @"busy" : @"busy",
-                          @"expanded" : @"expanded",
-                          @"collapsed" : @"collapsed",
-                          @"mixed": @"mixed",
-                          };
-  });
-  NSString *roleDescription = self.accessibilityRole ? roleDescriptions[self.accessibilityRole]: nil;
+  NSString *roleDescription = self.accessibilityRole ? rolesAndStatesDescription[self.accessibilityRole]: nil;
   if (roleDescription) {
     [valueComponents addObject:roleDescription];
   }
@@ -259,16 +265,16 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:unused)
     }
     if ([state isEqualToString:@"checked"]) {
       if ([val isKindOfClass:[NSNumber class]]) {
-        [valueComponents addObject:stateDescriptions[[val boolValue] ? @"checked" : @"unchecked"]];
+        [valueComponents addObject:rolesAndStatesDescription[[val boolValue] ? @"checked" : @"unchecked"]];
       } else if ([val isKindOfClass:[NSString class]] && [val isEqualToString:@"mixed"]) {
-        [valueComponents addObject:stateDescriptions[@"mixed"]];
+        [valueComponents addObject:rolesAndStatesDescription[@"mixed"]];
       }
     }
     if ([state isEqualToString:@"expanded"] && [val isKindOfClass:[NSNumber class]]) {
-      [valueComponents addObject:stateDescriptions[[val boolValue] ? @"expanded" : @"collapsed"]];
+      [valueComponents addObject:rolesAndStatesDescription[[val boolValue] ? @"expanded" : @"collapsed"]];
     }
     if ([state isEqualToString:@"busy"] && [val isKindOfClass:[NSNumber class]] && [val boolValue]) {
-      [valueComponents addObject:stateDescriptions[@"busy"]];
+      [valueComponents addObject:rolesAndStatesDescription[@"busy"]];
     }
   }
   


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

The accessibility roles and states description strings are not able to be localized on iOS platform. Those strings are exposed to the end users so it should be localized. This PR is to add localized strings as a resource bundle to the React Core Pod so that any React Native app integrating the React Native dependencies using CocoaPods can get the localized accessibility roles and states description.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[iOS] [Added] - Add localized accessibility strings to React Core pod

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
Verified with RNTester app. 