### PR TITLE
[GitHub] Issues without any template will get closed

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
-👉 Please follow one of these issue templates:
-- https://github.com/facebook/react-native/issues/new/choose
+✋ To keep the backlog clean and actionable, issues will be
+🚫 closed if they do not follow one of the issue templates:
+👉 https://github.com/facebook/react-native/issues/new/choose
 
-Note: to keep the backlog clean and actionable, issues may be immediately closed if they do not follow one of the above issue templates.


### PR DESCRIPTION
## Summary

Update the default issue template (e.g. the one shown when no custom template is chosen at https://github.com/facebook/react-native/issues/new/choose, and instead a new issue is opened via https://github.com/facebook/react-native/issues/new) to clarify that moving forward without a template will result in the issue getting closed.

The bot will aggressively close issues that have no labels, and only using a custom template will guarantee your issue has a label.

## Changelog


[Internal] - GitHub-only change.

## Test Plan

N/A