### PR TITLE
fix: prop name for passwordRules

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -267,7 +267,13 @@ type IOSProps = $ReadOnly<{|
    */
   textContentType?: ?TextContentType,
 
-  PasswordRules?: ?PasswordRules,
+  /**
+   * Provide rules for your password.
+   * For example, say you want to require a password with at least eight characters consisting of a mix of uppercase and lowercase letters, at least one number, and at most two consecutive characters.
+   * "required: upper; required: lower; required: digit; max-consecutive: 2; minlength: 8;"
+   * @platform ios
+   */
+  passwordRules?: ?PasswordRules,
 
   /*
    * @platform ios


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
There was a typo in passwordRules prop for TextInput.

ref: 
https://github.com/facebook/react-native/blob/master/ReactCommon/fabric/components/textinput/iostextinput/propsConversions.h#L106-L110
https://github.com/facebook/react-native/blob/master/Libraries/Components/TextInput/RCTSinglelineTextInputViewConfig.js#L126

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[iOS] [Fixed] - Fix prop name of passwordRules in TextInput

## Test Plan

run `flow` type check with TextInput that has `passwordRules` in the prop.
