### PR TITLE
Fixed a bug that when get keyboard height on a full-screen Android phone

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -715,7 +715,7 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
     private void checkForKeyboardEvents() {
       getRootView().getWindowVisibleDisplayFrame(mVisibleViewArea);
       final int heightDiff =
-          DisplayMetricsHolder.getWindowDisplayMetrics().heightPixels - mVisibleViewArea.bottom;
+          DisplayMetricsHolder.getScreenDisplayMetrics().heightPixels - mVisibleViewArea.height();
 
       boolean isKeyboardShowingOrKeyboardHeightChanged =
           mKeyboardHeight != heightDiff && heightDiff > mMinKeyboardHeightDetected;


### PR DESCRIPTION
## Summary
I found a bug. In the react-native program, I listened to the "keyboardDidShow" method and obtained the keyboard height through "e.endCoordinates.height". When I tested it on a full-screen mobile phone (xiaomi mix2s), When the virtual navigation bar at the bottom of the phone is shown or hidden, the height obtained in the two cases is different.
The specific reason is shown in this picture [reason link](https://github.com/codekongs/imgs/blob/master/1.png). I fixed the bug and replaced the "getWindowDisplayMetrics ()" method with the "getScreenDisplayMetrics ()" method, because the height obtained by the "getWindowDisplayMetrics ()" method on a full-screen device is also incorrect

## Changelog
[Android] [Fixed] - Fix get keyboard height error on a full-screen Android phone

## Test Plan
run Android Test is passed
