### PR TITLE
TextInput: Added new docs to PasswordRules Prop

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -267,6 +267,12 @@ type IOSProps = $ReadOnly<{|
    */
   textContentType?: ?TextContentType,
 
+  /**
+   * When using `textContentType` as `newPassword` on iOS we can let the OS know the
+   * minimum requirements of the password so that it can generate one that will
+   * satisfy them. In order to create a valid string for `PasswordRules` take
+   * a look to the [Apple Docs](https://developer.apple.com/password-rules/).
+   */
   PasswordRules?: ?PasswordRules,
 
   /*


### PR DESCRIPTION
## Changelog
[iOS] [Added] - TextInput: Added new docs to PasswordRules Prop

## Test Plan
No need of a test plan

## Summary
This wasn't documented when merged #25407 , spotted it while working on [#1579](https://github.com/facebook/react-native-website/issues/1579)
