### PR TITLE
JSI: Fix converting funtion to dynamic

### DIFF
--- a/ReactCommon/jsi/jsi/JSIDynamic.cpp
+++ b/ReactCommon/jsi/jsi/JSIDynamic.cpp
@@ -76,7 +76,10 @@ folly::dynamic dynamicFromValue(Runtime& runtime, const Value& value) {
       }
       return ret;
     } else if (obj.isFunction(runtime)) {
-      throw JSError(runtime, "JS Functions are not convertible to dynamic");
+      // The JSC conversion uses JSON.stringify, which substitutes
+      // null for a function, so we do the same here.  Just dropping
+      // the pair might also work, but would require more testing.
+      return nullptr;
     } else {
       folly::dynamic ret = folly::dynamic::object();
       Array names = obj.getPropertyNames(runtime);


### PR DESCRIPTION
Apply the same logic as in object properties, return nullptr for a
function object.

Fixes: https://github.com/facebook/react-native/issues/27203

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Fixes https://github.com/facebook/react-native/issues/27203. I haven't quite narrowed down what code triggers the dynamic value conversion (the stack trace is of no help, alas), but I noticed we skip functions when attached to an object as a property, so I guess it makes sense to do the same when we request an actual function to be converted.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[General] [Fixed] - JSI: Fix converting funtion to dynamic

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

I don't know how to test this.