### PR TITLE
Address @octokit/rest deprecation warnings

### DIFF
--- a/bots/make-comment.js
+++ b/bots/make-comment.js
@@ -35,10 +35,9 @@ if (!body) {
   process.exit(0);
 }
 
-const octokit = require('@octokit/rest')();
-octokit.authenticate({
-  type: 'oauth',
-  token: GITHUB_TOKEN,
+const {Octokit} = require('@octokit/rest');
+const octokit = new Octokit({
+  auth: GITHUB_TOKEN,
 });
 octokit.issues.createComment({
   owner: GITHUB_OWNER,


### PR DESCRIPTION
## Summary

Addresses deprecation warnings from `@octokit/rest`. This is a follow up to #28019.

## Changelog

[Internal] [Fixed] - Address deprecation warnings from `@octokit/rest`

## Test Plan

PRs should still get app bundle sizes report, but the warnings in the build logs should be gone.