### PR TITLE
Update: Fixing typo on Modal comment code 👀

### DIFF
--- a/Libraries/Modal/Modal.js
+++ b/Libraries/Modal/Modal.js
@@ -80,7 +80,7 @@ export type Props = $ReadOnly<{|
    * The `hardwareAccelerated` prop controls whether to force hardware
    * acceleration for the underlying window.
    *
-   * This prop works inly on Android.
+   * This prop works only on Android.
    *
    * See https://facebook.github.io/react-native/docs/modal.html#hardwareaccelerated
    */


### PR DESCRIPTION
## Summary

This PR only fixes a little typo that I noticed working on the documentation of React Native website taking reference from this source code, and then saw it 😅 

## Changelog

[General] [Fixed] - Fixed typo from `inly` to `only` inside `Modal.js` library code.

## Test Plan

Not needed.