### PR TITLE
Fix Image component crashing when uri is null

### DIFF
--- a/React/Base/RCTConvert.m
+++ b/React/Base/RCTConvert.m
@@ -146,7 +146,7 @@ RCT_ENUM_CONVERTER(NSURLRequestCachePolicy, (@{
       URLString = [NSString stringWithFormat:@"%@.bundle/%@", bundleName, URLString];
     }
 
-    URL = [self NSURL:URLString];
+    URL = [self NSURL:RCTNilIfNull(URLString)];
     if (!URL) {
       return nil;
     }

--- a/React/Base/RCTConvert.m
+++ b/React/Base/RCTConvert.m
@@ -75,7 +75,7 @@ RCT_CUSTOM_CONVERTER(NSData *, NSData, [json dataUsingEncoding:NSUTF8StringEncod
 
 + (NSURL *)NSURL:(id)json
 {
-  NSString *path = [self NSString:json];
+  NSString *path = [self NSString:RCTNilIfNull(json)];
   if (!path) {
     return nil;
   }
@@ -146,7 +146,7 @@ RCT_ENUM_CONVERTER(NSURLRequestCachePolicy, (@{
       URLString = [NSString stringWithFormat:@"%@.bundle/%@", bundleName, URLString];
     }
 
-    URL = [self NSURL:RCTNilIfNull(URLString)];
+    URL = [self NSURL:URLString];
     if (!URL) {
       return nil;
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This fixes https://github.com/facebook/react-native/issues/28060 with a fix similar to https://github.com/facebook/react-native/commit/f940e7c4a61e6c29d88cf01b91f8fff1afe68b85

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[iOS] [Fixed] - Fix Image component crashing when uri is null

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
Run an app on iOS that renders `<Image source={{ uri: null }} />`. It should not crash.
![error](https://user-images.githubusercontent.com/4928274/74492398-6bb23e00-4ed7-11ea-8482-664e1786bba8.png)

