### PR TITLE
Add nightly build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -617,6 +617,17 @@ jobs:
           echo "machine github.com login react-native-bot password $GITHUB_TOKEN" > ~/.netrc
       - run: node ./scripts/publish-npm.js
 
+  # -------------------------
+  #    JOBS: Nightly
+  # -------------------------
+  nightly_job:
+    machine: true
+    steps:
+      - run:
+          name: Nightly
+          command: |
+            echo "Nightly build run"
+
 # -------------------------
 #        WORK FLOWS
 # -------------------------
@@ -722,3 +733,14 @@ workflows:
       - js_coverage:
           requires:
             - setup
+
+  nightly:
+    triggers:
+      - schedule:
+          cron: "30 8 * * *"
+          filters:
+            branches:
+              only:
+                - sweggersen/nightly-ci
+    jobs:
+      - nightly_job

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -632,6 +632,8 @@ jobs:
 #        WORK FLOWS
 # -------------------------
 workflows:
+  version: 2
+
   tests:
     jobs:
       - setup:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -737,10 +737,10 @@ workflows:
   nightly:
     triggers:
       - schedule:
-          cron: "30 8 * * *"
+          cron: "37 8 * * *"
           filters:
             branches:
               only:
-                - sweggersen/nightly-ci
+                - pull/28066
     jobs:
       - nightly_job

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -737,10 +737,10 @@ workflows:
   nightly:
     triggers:
       - schedule:
-          cron: "37 8 * * *"
+          cron: "0 * * * *"
           filters:
             branches:
               only:
-                - pull/28066
+                - master
     jobs:
       - nightly_job


### PR DESCRIPTION
Note: I'm currently testing this, so do not review just yet.

## Summary

Adding a nightly CI build in preparation for further work on [React Native: Benchmark Suite](https://github.com/react-native-community/discussions-and-proposals/issues/186.)

Currently it will only run the job `nightly_job` which will simply run `$ echo "Nightly build run"`. The plan is to do nightly checks and performance status on the React Native repo, and create a dashboard where we can see performance changes over time. More on this in the proposal: [React Native: Benchmark Suite](https://github.com/react-native-community/discussions-and-proposals/issues/186.)

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[General] [Added] - Add nightly CI build

## Test Plan

Individual jobs will have their own test plan.
