### PR TITLE
fix [RCTWeakProxy displayDidRefresh:] crash

### DIFF
--- a/React/Base/RCTWeakProxy.m
+++ b/React/Base/RCTWeakProxy.m
@@ -27,4 +27,16 @@
   return _target;
 }
 
+- (void)forwardInvocation:(NSInvocation *)invocation
+{
+    void *nullPointer = NULL;
+    [invocation setReturnValue:&nullPointer];
+}
+
+
+- (NSMethodSignature *)methodSignatureForSelector:(SEL)selector
+{
+    return [NSObject instanceMethodSignatureForSelector:@selector(init)];
+}
+
 @end


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
Fix small probability crash: -[RCTWeakProxy displayDidRefresh:]: unrecognized selector sent to instance.   
#27463 can be fixed then. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[iOS] [Fixed] - Fix crash -[RCTWeakProxy displayDidRefresh:]

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
This crash occurred randomly in our app of previous version. This crash has not occurred again after this commit.