### PR TITLE
[Backport from 0.62-stable] Add androidx.swiperefreshlayout to template build.gradle

### DIFF
--- a/template/android/app/build.gradle
+++ b/template/android/app/build.gradle
@@ -185,6 +185,8 @@ dependencies {
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"  // From node_modules
 
+    implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
+
     debugImplementation("com.facebook.flipper:flipper:${FLIPPER_VERSION}") {
       exclude group:'com.facebook.fbjni'
     }


### PR DESCRIPTION
## Summary

Same as @rickhanlonii’s 2c89e5150736dbfb2d5f594a6fd483a90fe8685d, but for the application template.

## Changelog

Changelog: [Android] [Fixed] Template instacrash from missing androidx dependency

## Test Plan

Apps build with the template from v0.62.0-rc.2 don’t instacrash.