### PR TITLE
[InputAccessoryView] Fix backgroundColor typing.

### DIFF
--- a/Libraries/Components/TextInput/InputAccessoryView.js
+++ b/Libraries/Components/TextInput/InputAccessoryView.js
@@ -10,7 +10,6 @@
 
 'use strict';
 
-const DeprecatedColorPropType = require('../../DeprecatedPropTypes/DeprecatedColorPropType');
 const Platform = require('../../Utilities/Platform');
 const React = require('react');
 const StyleSheet = require('../../StyleSheet/StyleSheet');
@@ -18,6 +17,7 @@ const StyleSheet = require('../../StyleSheet/StyleSheet');
 import RCTInputAccessoryViewNativeComponent from './RCTInputAccessoryViewNativeComponent';
 
 import type {ViewStyleProp} from '../../StyleSheet/StyleSheet';
+import type {ColorValue} from '../../StyleSheet/StyleSheetTypes';
 
 /**
  * Note: iOS only
@@ -85,7 +85,7 @@ type Props = $ReadOnly<{|
    */
   nativeID?: ?string,
   style?: ?ViewStyleProp,
-  backgroundColor?: ?DeprecatedColorPropType,
+  backgroundColor?: ?ColorValue,
 |}>;
 
 class InputAccessoryView extends React.Component<Props> {


### PR DESCRIPTION
## Summary

TextInput’s `InputAccessoryView` was using a [deprecated] prop-type as a Flow type, which @TheSavior asked me to fix [here](https://github.com/alloy/rn2dts/commit/6ba4b28a22d8c0bd346996d78743016eaae707e1#r37343692).

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[iOS] [Fixed] - Fixes the `InputAccessoryView.backgroundColor` prop’s typing to use `ColorValue`.

## Test Plan

Passes:

```bash
yarn flow-check-ios
```
