### PR TITLE
[CI] Disable "Report size of RNTester.apk" on test_android

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -461,7 +461,6 @@ jobs:
     environment:
       - PUBLIC_GITHUB_TOKEN_A: "78a72af35445ca3f8180"
       - PUBLIC_GITHUB_TOKEN_B: "b1a98e0bbd56ff1ccba1"
-      - GITHUB_PR_NUMBER: $CIRCLE_PR_NUMBER
     steps:
       - restore_cache_checkout:
           checkout_type: android
@@ -537,6 +536,10 @@ jobs:
       - run:
           name: Report size of RNTester.apk
           command: GITHUB_TOKEN="$PUBLIC_GITHUB_TOKEN_A""$PUBLIC_GITHUB_TOKEN_B" scripts/circleci/report-bundle-size.sh android
+          when: |
+                  if [ "$CIRCLE_BRANCH" = "master" ]; then
+                    circleci-agent step halt
+                  fi
 
       # Collect Results
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -461,6 +461,7 @@ jobs:
     environment:
       - PUBLIC_GITHUB_TOKEN_A: "78a72af35445ca3f8180"
       - PUBLIC_GITHUB_TOKEN_B: "b1a98e0bbd56ff1ccba1"
+      - GITHUB_PR_NUMBER: $CIRCLE_PR_NUMBER
     steps:
       - restore_cache_checkout:
           checkout_type: android


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
test_android currently fails because it relies on a PR number.
<img width="1076" alt="Screen Shot 2020-02-18 at 5 39 27 PM" src="https://user-images.githubusercontent.com/8675043/74793588-9e608b80-5275-11ea-96d9-64546e84b5ba.png">


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[Internal] [Fixed] - Disable "Report size of RNTester.apk" on test_android

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
Should report APK size to this PR
