### PR TITLE
Add feature: Modal custom background color

### DIFF
--- a/Libraries/Modal/Modal.js
+++ b/Libraries/Modal/Modal.js
@@ -211,7 +211,9 @@ class Modal extends React.Component<Props> {
     }
 
     const containerStyles = {
-      backgroundColor: this.props.transparent ? 'transparent' : this.props.backgroundColor,
+      backgroundColor: this.props.transparent
+        ? 'transparent'
+        : this.props.backgroundColor,
     };
 
     let animationType = this.props.animationType || 'none';

--- a/Libraries/Modal/Modal.js
+++ b/Libraries/Modal/Modal.js
@@ -69,6 +69,14 @@ export type Props = $ReadOnly<{|
   transparent?: ?boolean,
 
   /**
+   * The `backgroundColor` prop controls the background color of the modal if
+   * the transparent property is set.
+   *
+   * See https://facebook.github.io/react-native/docs/modal.html#backgroundColor
+   */
+  backgroundColor?: ?string,
+
+  /**
    * The `statusBarTranslucent` prop determines whether your modal should go under
    * the system statusbar.
    *
@@ -203,7 +211,7 @@ class Modal extends React.Component<Props> {
     }
 
     const containerStyles = {
-      backgroundColor: this.props.transparent ? 'transparent' : 'white',
+      backgroundColor: this.props.transparent ? 'transparent' : this.props.backgroundColor,
     };
 
     let animationType = this.props.animationType || 'none';
@@ -229,6 +237,7 @@ class Modal extends React.Component<Props> {
         animationType={animationType}
         presentationStyle={presentationStyle}
         transparent={this.props.transparent}
+        backgroundColor={this.props.backgroundColor}
         hardwareAccelerated={this.props.hardwareAccelerated}
         onRequestClose={this.props.onRequestClose}
         onShow={this.props.onShow}

--- a/Libraries/Modal/RCTModalHostViewNativeComponent.js
+++ b/Libraries/Modal/RCTModalHostViewNativeComponent.js
@@ -53,6 +53,14 @@ type NativeProps = $ReadOnly<{|
   transparent?: WithDefault<boolean, false>,
 
   /**
+   * The `backgroundColor` prop controls the background color of the modal if
+   * the transparent property is set.
+   *
+   * See https://facebook.github.io/react-native/docs/modal.html#backgroundColor
+   */
+  backgroundColor?: WithDefault<string, 'white'>,
+
+  /**
    * The `statusBarTranslucent` prop determines whether your modal should go under
    * the system statusbar.
    *

--- a/Libraries/Modal/__tests__/__snapshots__/Modal-test.js.snap
+++ b/Libraries/Modal/__tests__/__snapshots__/Modal-test.js.snap
@@ -31,7 +31,7 @@ exports[`<Modal /> should render as <RCTModalHostView> when not mocked 1`] = `
           "top": 0,
         },
         Object {
-          "backgroundColor": "white",
+          "backgroundColor": undefined,
         },
       ]
     }

--- a/packages/babel-plugin-inline-view-configs/__tests__/__snapshots__/index-test.js.snap
+++ b/packages/babel-plugin-inline-view-configs/__tests__/__snapshots__/index-test.js.snap
@@ -136,8 +136,8 @@ exports[`Babel plugin inline view configs can inline config for NotANativeCompon
 export default 'Not a view config';"
 `;
 
-exports[`Babel plugin inline view configs fails on inline config for CommandsExportedWithDifferentNameNativeComponent.js 1`] = `"Native commands must be exported with the name 'Commands'"`;
+exports[`Babel plugin inline view configs fails on inline config for CommandsExportedWithDifferentNameNativeComponent.js 1`] = `"/home/arnold/repos/react-native/CommandsExportedWithDifferentNameNativeComponent.js: Native commands must be exported with the name 'Commands'"`;
 
-exports[`Babel plugin inline view configs fails on inline config for CommandsExportedWithShorthandNativeComponent.js 1`] = `"'Commands' is a reserved export and may only be used to export the result of codegenNativeCommands."`;
+exports[`Babel plugin inline view configs fails on inline config for CommandsExportedWithShorthandNativeComponent.js 1`] = `"/home/arnold/repos/react-native/CommandsExportedWithShorthandNativeComponent.js: 'Commands' is a reserved export and may only be used to export the result of codegenNativeCommands."`;
 
-exports[`Babel plugin inline view configs fails on inline config for OtherCommandsExportNativeComponent.js 1`] = `"'Commands' is a reserved export and may only be used to export the result of codegenNativeCommands."`;
+exports[`Babel plugin inline view configs fails on inline config for OtherCommandsExportNativeComponent.js 1`] = `"/home/arnold/repos/react-native/OtherCommandsExportNativeComponent.js: 'Commands' is a reserved export and may only be used to export the result of codegenNativeCommands."`;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

This is some kind of syntactic sugar to avoid adding a view with some particular styling when trying to add some custom (non-white) overlay over the 'non-reached' parts of the modal.

Works when transparency={false}. So it replaces (`optional`) the hardcoded 'white' color for a custom valid color.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

[General] [Added] - Add backgroundColor property on Modal component
<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

## Test Plan

- [x] npm test
- [x] npm run flow
- [x] npm run lint

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
