### PR TITLE
Dark mode support for RCTPerfMonitor

### DIFF
--- a/React/CoreModules/RCTFPSGraph.m
+++ b/React/CoreModules/RCTFPSGraph.m
@@ -79,6 +79,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
     _label = [[UILabel alloc] initWithFrame:self.bounds];
     _label.font = [UIFont boldSystemFontOfSize:13];
     _label.textAlignment = NSTextAlignmentCenter;
+    _label.textColor = UIColor.blackColor;
   }
 
   return _label;

--- a/React/CoreModules/RCTFPSGraph.m
+++ b/React/CoreModules/RCTFPSGraph.m
@@ -79,7 +79,6 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
     _label = [[UILabel alloc] initWithFrame:self.bounds];
     _label.font = [UIFont boldSystemFontOfSize:13];
     _label.textAlignment = NSTextAlignmentCenter;
-    _label.textColor = UIColor.blackColor;
   }
 
   return _label;

--- a/React/CoreModules/RCTPerfMonitor.mm
+++ b/React/CoreModules/RCTPerfMonitor.mm
@@ -302,7 +302,6 @@ RCT_EXPORT_MODULE()
     )];
     _metrics.dataSource = self;
     _metrics.delegate = self;
-    _metrics.backgroundColor = UIColor.whiteColor;
     _metrics.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
     [_metrics registerClass:[UITableViewCell class] forCellReuseIdentifier:RCTPerfMonitorCellIdentifier];
   }

--- a/React/CoreModules/RCTPerfMonitor.mm
+++ b/React/CoreModules/RCTPerfMonitor.mm
@@ -215,6 +215,7 @@ RCT_EXPORT_MODULE()
     _memory.font = [UIFont systemFontOfSize:12];
     _memory.numberOfLines = 3;
     _memory.textAlignment = NSTextAlignmentCenter;
+    _memory.textColor = UIColor.blackColor;
   }
 
   return _memory;
@@ -227,6 +228,7 @@ RCT_EXPORT_MODULE()
     _heap.font = [UIFont systemFontOfSize:12];
     _heap.numberOfLines = 3;
     _heap.textAlignment = NSTextAlignmentCenter;
+    _heap.textColor = UIColor.blackColor;
   }
 
   return _heap;
@@ -239,6 +241,7 @@ RCT_EXPORT_MODULE()
     _views.font = [UIFont systemFontOfSize:12];
     _views.numberOfLines = 3;
     _views.textAlignment = NSTextAlignmentCenter;
+    _views.textColor = UIColor.blackColor;
   }
 
   return _views;
@@ -269,6 +272,7 @@ RCT_EXPORT_MODULE()
     _uiGraphLabel.font = [UIFont systemFontOfSize:11];
     _uiGraphLabel.textAlignment = NSTextAlignmentCenter;
     _uiGraphLabel.text = @"UI";
+    _uiGraphLabel.textColor = UIColor.blackColor;
   }
 
   return _uiGraphLabel;
@@ -281,6 +285,7 @@ RCT_EXPORT_MODULE()
     _jsGraphLabel.font = [UIFont systemFontOfSize:11];
     _jsGraphLabel.textAlignment = NSTextAlignmentCenter;
     _jsGraphLabel.text = @"JS";
+    _jsGraphLabel.textColor = UIColor.blackColor;
   }
 
   return _jsGraphLabel;

--- a/React/CoreModules/RCTPerfMonitor.mm
+++ b/React/CoreModules/RCTPerfMonitor.mm
@@ -199,6 +199,8 @@ RCT_EXPORT_MODULE()
     _container = [[UIView alloc] initWithFrame:CGRectMake(10, 25, 180, RCTPerfMonitorBarHeight)];
     if (@available(iOS 13.0, *)) {
       _container.backgroundColor = UIColor.systemBackgroundColor;
+    } else {
+      _container.backgroundColor = UIColor.whiteColor;
     }
     _container.layer.borderWidth = 2;
     _container.layer.borderColor = [UIColor lightGrayColor].CGColor;

--- a/React/CoreModules/RCTPerfMonitor.mm
+++ b/React/CoreModules/RCTPerfMonitor.mm
@@ -215,7 +215,6 @@ RCT_EXPORT_MODULE()
     _memory.font = [UIFont systemFontOfSize:12];
     _memory.numberOfLines = 3;
     _memory.textAlignment = NSTextAlignmentCenter;
-    _memory.textColor = UIColor.blackColor;
   }
 
   return _memory;
@@ -228,7 +227,6 @@ RCT_EXPORT_MODULE()
     _heap.font = [UIFont systemFontOfSize:12];
     _heap.numberOfLines = 3;
     _heap.textAlignment = NSTextAlignmentCenter;
-    _heap.textColor = UIColor.blackColor;
   }
 
   return _heap;
@@ -241,7 +239,6 @@ RCT_EXPORT_MODULE()
     _views.font = [UIFont systemFontOfSize:12];
     _views.numberOfLines = 3;
     _views.textAlignment = NSTextAlignmentCenter;
-    _views.textColor = UIColor.blackColor;
   }
 
   return _views;
@@ -272,7 +269,6 @@ RCT_EXPORT_MODULE()
     _uiGraphLabel.font = [UIFont systemFontOfSize:11];
     _uiGraphLabel.textAlignment = NSTextAlignmentCenter;
     _uiGraphLabel.text = @"UI";
-    _uiGraphLabel.textColor = UIColor.blackColor;
   }
 
   return _uiGraphLabel;
@@ -285,7 +281,6 @@ RCT_EXPORT_MODULE()
     _jsGraphLabel.font = [UIFont systemFontOfSize:11];
     _jsGraphLabel.textAlignment = NSTextAlignmentCenter;
     _jsGraphLabel.text = @"JS";
-    _jsGraphLabel.textColor = UIColor.blackColor;
   }
 
   return _jsGraphLabel;

--- a/React/CoreModules/RCTPerfMonitor.mm
+++ b/React/CoreModules/RCTPerfMonitor.mm
@@ -565,8 +565,6 @@ RCT_EXPORT_MODULE()
 
   cell.textLabel.text = _perfLoggerMarks[indexPath.row];
   cell.textLabel.font = [UIFont systemFontOfSize:12];
-  cell.textLabel.textColor = UIColor.blackColor;
-  cell.backgroundColor = UIColor.whiteColor;
 
   return cell;
 }

--- a/React/CoreModules/RCTPerfMonitor.mm
+++ b/React/CoreModules/RCTPerfMonitor.mm
@@ -302,6 +302,7 @@ RCT_EXPORT_MODULE()
     )];
     _metrics.dataSource = self;
     _metrics.delegate = self;
+    _metrics.backgroundColor = UIColor.whiteColor;
     _metrics.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
     [_metrics registerClass:[UITableViewCell class] forCellReuseIdentifier:RCTPerfMonitorCellIdentifier];
   }

--- a/React/CoreModules/RCTPerfMonitor.mm
+++ b/React/CoreModules/RCTPerfMonitor.mm
@@ -571,6 +571,8 @@ RCT_EXPORT_MODULE()
 
   cell.textLabel.text = _perfLoggerMarks[indexPath.row];
   cell.textLabel.font = [UIFont systemFontOfSize:12];
+  cell.textLabel.textColor = UIColor.blackColor;
+  cell.backgroundColor = UIColor.whiteColor;
 
   return cell;
 }

--- a/React/CoreModules/RCTPerfMonitor.mm
+++ b/React/CoreModules/RCTPerfMonitor.mm
@@ -197,7 +197,9 @@ RCT_EXPORT_MODULE()
 {
   if (!_container) {
     _container = [[UIView alloc] initWithFrame:CGRectMake(10, 25, 180, RCTPerfMonitorBarHeight)];
-    _container.backgroundColor = UIColor.whiteColor;
+    if (@available(iOS 13.0, *)) {
+      _container.backgroundColor = UIColor.systemBackgroundColor;
+    }
     _container.layer.borderWidth = 2;
     _container.layer.borderColor = [UIColor lightGrayColor].CGColor;
     [_container addGestureRecognizer:self.gestureRecognizer];


### PR DESCRIPTION
## Summary

Hi There 👋,

While I'm developing on iOS with dark appearance enabled, i notice that `Pref Monitor` view doesn't support dark mode yet, so here is the PR to fix it :)  

## Changelog

[iOS] [Fixed] - Fix Pref Monitor in dark appearance 

## Test Plan
Run any React Native app on iOS > Turn on dark appearance
### Before
![Before](https://user-images.githubusercontent.com/4061838/74872974-8b75b600-535e-11ea-8550-763a598547ec.png)
### After
![After](https://user-images.githubusercontent.com/4061838/74872978-8ca6e300-535e-11ea-9862-4d3014e849f7.png)
