### PR TITLE
chore: tweak missing RCTAnimation warning message

### DIFF
--- a/Libraries/Animated/src/NativeAnimatedHelper.js
+++ b/Libraries/Animated/src/NativeAnimatedHelper.js
@@ -292,7 +292,7 @@ function shouldUseNativeDriver(config: AnimationConfig | EventConfig): boolean {
           'animated module is missing. Falling back to JS-based animation. To ' +
           'resolve this, add `RCTAnimation` module to this app, or remove ' +
           '`useNativeDriver`. ' +
-          'More info: https://github.com/facebook/react-native/issues/11094#issuecomment-263240420',
+          'Make sure to run `pod install` first. Read More about autolinking: https://github.com/react-native-community/cli/blob/master/docs/autolinking.md',
       );
       _warnedMissingNativeAnimated = true;
     }


### PR DESCRIPTION
## Summary

As we don't link modules manually anymore it's better to point the user in another direction when he faces this issue.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[Internal] [Changed] - tweak missing RCTAnimation warning message

