### PR TITLE
iOS: Add UIScene support to RCTImageView

### DIFF
--- a/Libraries/Image/RCTImageView.mm
+++ b/Libraries/Image/RCTImageView.mm
@@ -86,6 +86,10 @@ static NSDictionary *onLoadParamsForSource(RCTImageSource *source)
 {
   if ((self = [super initWithFrame:CGRectZero])) {
     _bridge = bridge;
+    _imageView = [[RCTUIImageViewAnimated alloc] init];
+    _imageView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    [self addSubview:_imageView];
+
     NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
     [center addObserver:self
                selector:@selector(clearImageIfDetached)
@@ -95,9 +99,12 @@ static NSDictionary *onLoadParamsForSource(RCTImageSource *source)
                selector:@selector(clearImageIfDetached)
                    name:UIApplicationDidEnterBackgroundNotification
                  object:nil];
-    _imageView = [[RCTUIImageViewAnimated alloc] init];
-    _imageView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-    [self addSubview:_imageView];
+    if (@available(iOS 13.0, *)) {
+      [center addObserver:self
+                 selector:@selector(clearImageIfDetached)
+                     name:UISceneDidEnterBackgroundNotification
+                   object:nil];
+    }
   }
   return self;
 }


### PR DESCRIPTION
## Summary

Apps implementing `UISceneDelegate` no longer clear out images when backgrounded because `UIApplicationDidEnterBackgroundNotification` no longer gets fired.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[iOS] [Added] - UIScene support for RCTImageView

## Test Plan

1. Create a new iOS app implementing `UISceneDelegate` or modify an existing one
2. Open a React view with some images
3. Switch to another app, or background the current app
4. Observe that `-[RCTImageView clearImageIfDetached]` gets called