### PR TITLE
iOS: Make RCTKeyWindow multi-window aware and add UIScene support to RCTRedBox

### DIFF
--- a/React/Base/RCTUtils.m
+++ b/React/Base/RCTUtils.m
@@ -497,7 +497,12 @@ UIWindow *__nullable RCTKeyWindow(void)
   }
 
   // TODO: replace with a more robust solution
-  return RCTSharedApplication().keyWindow;
+  for (UIWindow *window in RCTSharedApplication().windows) {
+    if (window.keyWindow) {
+      return window;
+    }
+  }
+  return nil;
 }
 
 UIViewController *__nullable RCTPresentedViewController(void)


### PR DESCRIPTION
## Summary

`RCTRedBox` doesn't appear in apps implementing `UISceneDelegate`.

## Changelog

[iOS] [Changed] - `RCTKeyWindow()` is now multi-window aware
[iOS] [Fixed] - `RCTRedBox` doesn't appear in apps implementing `UISceneDelegate`

## Test Plan

- Trigger an error in RNTester
- Trigger an error in an app implementing `UISceneDelegate`

![Simulator Screen Shot - iPhone 11 Pro Max - 2020-02-21 at 14 17 54](https://user-images.githubusercontent.com/4123478/75037702-14066a80-54b5-11ea-9373-b56b467be845.png)
