### PR TITLE
Add Fragment support to Modal component on Android

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -26,6 +26,8 @@ import android.view.ViewTreeObserver;
 import android.view.WindowManager;
 import android.widget.FrameLayout;
 import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+
 import com.facebook.common.logging.FLog;
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.infer.annotation.ThreadConfined;
@@ -662,6 +664,11 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
 
     Exception e = new IllegalViewOperationException(t.getMessage(), this, t);
     mReactInstanceManager.getCurrentReactContext().handleException(e);
+  }
+
+  @Override
+  public Fragment getFragment() {
+    return null;
   }
 
   public void setIsFabric(boolean isFabric) {

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -26,7 +26,6 @@ import android.view.ViewTreeObserver;
 import android.view.WindowManager;
 import android.widget.FrameLayout;
 import androidx.annotation.Nullable;
-
 import com.facebook.common.logging.FLog;
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.infer.annotation.ThreadConfined;

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -27,7 +27,6 @@ import android.view.WindowManager;
 import android.widget.FrameLayout;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
-
 import com.facebook.common.logging.FLog;
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.infer.annotation.ThreadConfined;

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -26,7 +26,6 @@ import android.view.ViewTreeObserver;
 import android.view.WindowManager;
 import android.widget.FrameLayout;
 import androidx.annotation.Nullable;
-import androidx.fragment.app.Fragment;
 
 import com.facebook.common.logging.FLog;
 import com.facebook.infer.annotation.Assertions;
@@ -664,11 +663,6 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
 
     Exception e = new IllegalViewOperationException(t.getMessage(), this, t);
     mReactInstanceManager.getCurrentReactContext().handleException(e);
-  }
-
-  @Override
-  public Fragment getFragment() {
-    return null;
   }
 
   public void setIsFabric(boolean isFabric) {

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/RootView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/RootView.java
@@ -22,7 +22,5 @@ public interface RootView {
 
   void handleException(Throwable t);
 
-  default Fragment getFragment() {
-    return null;
-  }
+  Fragment getFragment();
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/RootView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/RootView.java
@@ -22,5 +22,7 @@ public interface RootView {
 
   void handleException(Throwable t);
 
-  Fragment getFragment();
+  default Fragment getFragment() {
+    return null;
+  }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/RootView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/RootView.java
@@ -9,6 +9,8 @@ package com.facebook.react.uimanager;
 
 import android.view.MotionEvent;
 
+import androidx.fragment.app.Fragment;
+
 /** Interface for the root native view of a React native application. */
 public interface RootView {
 
@@ -19,4 +21,6 @@ public interface RootView {
   void onChildStartedNativeGesture(MotionEvent androidEvent);
 
   void handleException(Throwable t);
+
+  Fragment getFragment();
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/modal/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/modal/BUCK
@@ -6,6 +6,7 @@ rn_android_library(
     is_androidx = True,
     provided_deps = [
         react_native_dep("third-party/android/androidx:annotation"),
+        react_native_dep("third-party/android/androidx:fragment"),
     ],
     required_for_source_only_abi = True,
     visibility = [

--- a/ReactAndroid/src/main/java/com/facebook/react/views/modal/ModalHostFragment.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/modal/ModalHostFragment.java
@@ -2,6 +2,9 @@ package com.facebook.react.views.modal;
 
 import android.app.Dialog;
 import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -10,9 +13,17 @@ import androidx.fragment.app.DialogFragment;
 public class ModalHostFragment extends DialogFragment {
 
     private Dialog mDialog;
+    private View mView;
 
-    ModalHostFragment(Dialog dialog) {
+    ModalHostFragment(Dialog dialog, View view) {
         mDialog = dialog;
+        mView = view;
+    }
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        return mView;
     }
 
     @NonNull

--- a/ReactAndroid/src/main/java/com/facebook/react/views/modal/ModalHostFragment.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/modal/ModalHostFragment.java
@@ -1,0 +1,23 @@
+package com.facebook.react.views.modal;
+
+import android.app.Dialog;
+import android.os.Bundle;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.DialogFragment;
+
+public class ModalHostFragment extends DialogFragment {
+
+    private Dialog mDialog;
+
+    ModalHostFragment(Dialog dialog) {
+        mDialog = dialog;
+    }
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(@Nullable Bundle savedInstanceState) {
+        return mDialog;
+    }
+}

--- a/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
@@ -311,7 +311,7 @@ public class ReactModalHostView extends ViewGroup implements LifecycleEventListe
     if (currentActivity != null && !currentActivity.isFinishing()) {
       ModalHostFragment hostFragment = new ModalHostFragment(mDialog);
       FragmentManager fragmentManager = ((FragmentActivity) currentActivity).getSupportFragmentManager();
-      hostFragment.show(fragmentManager,  "modal");
+      hostFragment.show(fragmentManager,  "modalHost");
       mHostView.mHostFragment = hostFragment;
       if (context instanceof Activity) {
         mDialog

--- a/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
@@ -268,7 +268,6 @@ public class ReactModalHostView extends ViewGroup implements LifecycleEventListe
             WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE,
             WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE);
 
-    mDialog.setContentView(getContentView());
     updateProperties();
 
     mDialog.setOnShowListener(mOnShowListener);
@@ -310,7 +309,7 @@ public class ReactModalHostView extends ViewGroup implements LifecycleEventListe
       mDialog.getWindow().addFlags(WindowManager.LayoutParams.FLAG_HARDWARE_ACCELERATED);
     }
     if (currentActivity != null && !currentActivity.isFinishing()) {
-      ModalHostFragment hostFragment = new ModalHostFragment(mDialog);
+      ModalHostFragment hostFragment = new ModalHostFragment(mDialog, getContentView());
       FragmentManager fragmentManager = ((FragmentActivity) currentActivity).getSupportFragmentManager();
       hostFragment.show(fragmentManager, FRAGMENT_TAG);
       mHostView.mHostFragment = hostFragment;

--- a/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
@@ -22,6 +22,9 @@ import android.view.accessibility.AccessibilityEvent;
 import android.widget.FrameLayout;
 import androidx.annotation.Nullable;
 import androidx.annotation.UiThread;
+import androidx.fragment.app.FragmentActivity;
+import androidx.fragment.app.FragmentManager;
+
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.R;
 import com.facebook.react.bridge.GuardedRunnable;
@@ -304,7 +307,9 @@ public class ReactModalHostView extends ViewGroup implements LifecycleEventListe
       mDialog.getWindow().addFlags(WindowManager.LayoutParams.FLAG_HARDWARE_ACCELERATED);
     }
     if (currentActivity != null && !currentActivity.isFinishing()) {
-      mDialog.show();
+      ModalHostFragment hostFragment = new ModalHostFragment(mDialog);
+      FragmentManager fragmentManager = ((FragmentActivity) currentActivity).getSupportFragmentManager();
+      hostFragment.show(fragmentManager,  "modal");
       if (context instanceof Activity) {
         mDialog
             .getWindow()

--- a/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
@@ -22,6 +22,7 @@ import android.view.accessibility.AccessibilityEvent;
 import android.widget.FrameLayout;
 import androidx.annotation.Nullable;
 import androidx.annotation.UiThread;
+import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
 
@@ -172,6 +173,7 @@ public class ReactModalHostView extends ViewGroup implements LifecycleEventListe
       // It is possible we are dismissing this dialog and reattaching the hostView to another
       ViewGroup parent = (ViewGroup) mHostView.getParent();
       parent.removeViewAt(0);
+      mHostView.mHostFragment = null;
     }
   }
 
@@ -310,6 +312,7 @@ public class ReactModalHostView extends ViewGroup implements LifecycleEventListe
       ModalHostFragment hostFragment = new ModalHostFragment(mDialog);
       FragmentManager fragmentManager = ((FragmentActivity) currentActivity).getSupportFragmentManager();
       hostFragment.show(fragmentManager,  "modal");
+      mHostView.mHostFragment = hostFragment;
       if (context instanceof Activity) {
         mDialog
             .getWindow()
@@ -388,6 +391,7 @@ public class ReactModalHostView extends ViewGroup implements LifecycleEventListe
     private boolean hasAdjustedSize = false;
     private int viewWidth;
     private int viewHeight;
+    private ModalHostFragment mHostFragment;
 
     private @Nullable StateWrapper mStateWrapper;
 
@@ -450,6 +454,11 @@ public class ReactModalHostView extends ViewGroup implements LifecycleEventListe
     @Override
     public void handleException(Throwable t) {
       getReactContext().handleException(new RuntimeException(t));
+    }
+
+    @Override
+    public Fragment getFragment() {
+      return mHostFragment;
     }
 
     private ReactContext getReactContext() {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
@@ -81,6 +81,7 @@ public class ReactModalHostView extends ViewGroup implements LifecycleEventListe
   private boolean mPropertyRequiresNewDialog;
   private @Nullable DialogInterface.OnShowListener mOnShowListener;
   private @Nullable OnRequestCloseListener mOnRequestCloseListener;
+  private static final String FRAGMENT_TAG = "ModalAndroid";
 
   public ReactModalHostView(Context context) {
     super(context);
@@ -311,7 +312,7 @@ public class ReactModalHostView extends ViewGroup implements LifecycleEventListe
     if (currentActivity != null && !currentActivity.isFinishing()) {
       ModalHostFragment hostFragment = new ModalHostFragment(mDialog);
       FragmentManager fragmentManager = ((FragmentActivity) currentActivity).getSupportFragmentManager();
-      hostFragment.show(fragmentManager,  "modalHost");
+      hostFragment.show(fragmentManager, FRAGMENT_TAG);
       mHostView.mHostFragment = hostFragment;
       if (context instanceof Activity) {
         mDialog


### PR DESCRIPTION
## Summary

Displayed the Modal by showing a `DialogFragment` instead of a `Dailog`. Made this Fragment available to Modal descendants so they can add their own View Fragments.

### Example Use-case - Native Stack Navigation

Native Navigation libraries use Fragments to manage the stack on Android. Adding Fragment support to the Modal component means you can render a navigation stack inside of a Modal. iOS already supports this use-case because the Modal component renders as a UIViewController. 

## Changelog

[Android] [Added] - Add Fragment support to Modal component

## Test Plan

After building React Native from my branch by following [the guidelines](https://github.com/facebook/react-native/wiki/Building-from-source), I ran the following tests:

1. I created a project with a Modal and checked that it opened and closed. I checked that the Fragment was removed when the Modal was closed.
2. I created a project with a Modal containing a native navigation stack from [the Navigation router](https://grahammendick.github.io/navigation/documentation/native/hello-world.html). I checked the scenes as I pushed them onto the stack and then popped them off again.
3. I created a project with a Modal opening from another Modal on Android. Each Modal contained a native navigation stack. I checked both Modals opened and closed and that the stacks operated independently.
