### PR TITLE
Image: remove unused ImageProps

### DIFF
--- a/Libraries/Image/ImageProps.js
+++ b/Libraries/Image/ImageProps.js
@@ -149,10 +149,6 @@ export type ImageProps = {|
    */
   style?: ?ImageStyleProp,
 
-  // Can be set via props or style, for now
-  height?: ?DimensionValue,
-  width?: ?DimensionValue,
-
   /**
    * Determines how to resize the image when the frame doesn't match the raw
    * image dimensions.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
I noticed that there was a `height` and `width` props in `Image` component, but those props are not being used in `RCTImageView`(ios) or `ReactImageView`(android).

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[GENERAL] [Removed] - Remove Unused ImageProp

## Test Plan

Start a new React Native Project, and use `Image` component with `width` and `height` props and verify that it does not display the image on both iOS and Android

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
