### PR TITLE
Change iOS default simulator to iPhone 11 Pro Max

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "android": "react-native run-android",
-    "ios": "react-native run-ios",
+    "ios": "react-native run-ios --simulator \"iPhone 11 Pro Max\"",
     "start": "react-native start",
     "test": "jest",
     "lint": "eslint ."


### PR DESCRIPTION
## Summary

Changing from iPhone 11 to iPhone 11 Pro Max due to screen resolution. When uploading screenshots to app store you are required to open iPhone 11 Pro Max and take screenshots. So it is better to use iPhone 11 Pro Max from beginning.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[General] [Changed] - Change iOS default simulator to iPhone 11 Pro Max

## Test Plan

Run `npm run ios` and it should open iPhone 11 Pro Max