### PR TITLE
Update Android Gradle plugin to 3.6.4

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:3.5.3")
+        classpath("com.android.tools.build:gradle:3.6.4")
         classpath("de.undercouch:gradle-download-task:4.0.2")
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/template/android/build.gradle
+++ b/template/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:3.5.3")
+        classpath("com.android.tools.build:gradle:3.6.4")
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }


### PR DESCRIPTION
## Summary

Android Studio 3.6.3 is now available in the stable channel

https://androidstudio.googleblog.com/2020/04/android-studio-363-available.html

EDIT: Another patch update to `3.6.4` was released in July 2020:

> This minor update supports compatibility with new default settings and features for package visibility in Android 11.

Details: https://developer.android.com/studio/releases/gradle-plugin#3-6-0

## Changelog

[Android] [Changed] - Update Android Gradle plugin to 3.6.4

## Test Plan

Build project