### PR TITLE
added onTouch event to picker

### DIFF
--- a/Libraries/Components/Picker/Picker.js
+++ b/Libraries/Components/Picker/Picker.js
@@ -18,6 +18,7 @@ const UnimplementedView = require('../UnimplementedViews/UnimplementedView');
 
 import type {TextStyleProp} from '../../StyleSheet/StyleSheet';
 import type {ColorValue} from '../../StyleSheet/StyleSheetTypes';
+import type {PressEvent} from '../../Types/CoreEventTypes.js';
 
 const MODE_DIALOG = 'dialog';
 const MODE_DROPDOWN = 'dropdown';
@@ -110,6 +111,11 @@ type PickerProps = $ReadOnly<{|
    * The string used for the accessibility label. Will be read once focused on the picker but not on change.
    */
   accessibilityLabel?: ?string,
+  /**
+   * Used to emit onTouch events.
+   * @platform android
+   */
+  onTouch?: ?(event: PressEvent) => boolean,
 |}>;
 
 /**

--- a/Libraries/Components/Picker/PickerAndroid.android.js
+++ b/Libraries/Components/Picker/PickerAndroid.android.js
@@ -30,6 +30,12 @@ type PickerItemSelectSyntheticEvent = SyntheticEvent<
   |}>,
 >;
 
+type AndroidOnTouchEvent = SyntheticEvent<
+  $ReadOnly<{
+    hasBeenTouched: boolean,
+  }>,
+>;
+
 type PickerItemValue = number | string;
 
 type Props = $ReadOnly<{|
@@ -40,6 +46,7 @@ type Props = $ReadOnly<{|
   enabled?: ?boolean,
   mode?: ?('dialog' | 'dropdown'),
   onValueChange?: ?(itemValue: ?PickerItemValue, itemIndex: number) => mixed,
+  onTouch?: ?(event: AndroidOnTouchEvent) => boolean,
   prompt?: ?string,
   testID?: string,
 |}>;

--- a/Libraries/Components/Picker/RCTPickerNativeComponent.js
+++ b/Libraries/Components/Picker/RCTPickerNativeComponent.js
@@ -25,6 +25,12 @@ type PickerIOSChangeEvent = SyntheticEvent<
   |}>,
 >;
 
+type AndroidOnTouchEvent = SyntheticEvent<
+  $ReadOnly<{
+    hasBeenTouched: boolean,
+  }>,
+>;
+
 type RCTPickerIOSItemType = $ReadOnly<{|
   label: ?Label,
   value: ?(number | string),
@@ -40,6 +46,7 @@ type NativeProps = $ReadOnly<{|
   style?: ?TextStyleProp,
   testID?: ?string,
   accessibilityLabel?: ?string,
+  onTouch?: ?(event: AndroidOnTouchEvent) => boolean,
 |}>;
 
 type ComponentType = HostComponent<NativeProps>;

--- a/Libraries/Components/Picker/__tests__/Picker-test.js
+++ b/Libraries/Components/Picker/__tests__/Picker-test.js
@@ -21,7 +21,10 @@ describe('<Picker />', () => {
     ReactNativeTestTools.expectRendersMatchingSnapshot(
       'Picker',
       () => (
-        <Picker selectedValue="foo" onValueChange={jest.fn()}>
+        <Picker
+          selectedValue="foo"
+          onValueChange={jest.fn()}
+          onTouch={jest.fn()}>
           <Picker.Item label="foo" value="foo" />
           <Picker.Item label="bar" value="bar" />
         </Picker>

--- a/Libraries/Components/Picker/__tests__/__snapshots__/Picker-test.js.snap
+++ b/Libraries/Components/Picker/__tests__/__snapshots__/Picker-test.js.snap
@@ -65,6 +65,7 @@ exports[`<Picker /> should render as expected: should deep render when not mocke
 exports[`<Picker /> should render as expected: should shallow render as <Picker /> when mocked 1`] = `
 <Picker
   mode="dialog"
+  onTouch={[MockFunction]}
   onValueChange={[MockFunction]}
   selectedValue="foo"
 >
@@ -82,6 +83,7 @@ exports[`<Picker /> should render as expected: should shallow render as <Picker 
 exports[`<Picker /> should render as expected: should shallow render as <Picker /> when not mocked 1`] = `
 <Picker
   mode="dialog"
+  onTouch={[MockFunction]}
   onValueChange={[MockFunction]}
   selectedValue="foo"
 >


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
As mentioned in [https://github.com/facebook/react-native/issues/28065](url) , the current picker does not have any event listeners for onTouch events. So it is impossible in the app to know if the user has interacted with the picker component. This pull request uses a `SyntheticEvent` type to return a boolean i.e. touched is true or false.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->
[Android] [Added]

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
Check the Props of the Picker component.
