### PR TITLE
Add support for uppercase named colors

### DIFF
--- a/Libraries/StyleSheet/normalizeColor.js
+++ b/Libraries/StyleSheet/normalizeColor.js
@@ -28,8 +28,8 @@ function normalizeColor(color: string | number): ?number {
     return parseInt(match[1] + 'ff', 16) >>> 0;
   }
 
-  if (names.hasOwnProperty(color)) {
-    return names[color];
+  if (names.hasOwnProperty(color.toLowerCase())) {
+    return names[color.toLowerCase()];
   }
 
   if ((match = matchers.rgb.exec(color))) {


### PR DESCRIPTION
## Summary

Sometimes by accident, we can specify color in uppercase: `RED, WHITE`, which is currently not supported by React Native. So basically this small change will add support for those. And it also goes along with the web spec here: https://www.w3.org/TR/css-color-3/#html4
**TLDR**: `The color names are case-insensitive.`

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[General] [Added] - Support uppercase named colors (RED, WHITE,...)

## Test Plan

Simply test with: `<Text style={{ color: 'RED' }}>I'm red!</Text>`
