### PR TITLE
iOS: Install Node 10 as 8 got dropped

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -378,14 +378,14 @@ jobs:
       - run:
           name: Configure Environment Variables
           command: |
-            echo 'export PATH=/usr/local/opt/node@8/bin:$PATH' >> $BASH_ENV
+            echo 'export PATH=/usr/local/opt/node@10/bin:$PATH' >> $BASH_ENV
             source $BASH_ENV
 
       # Brew
       - with_brew_cache_span:
           steps:
             - brew_install:
-                package: node@8
+                package: node@10
             - run: HOMEBREW_NO_AUTO_UPDATE=1 brew tap wix/brew >/dev/null
             - brew_install:
                 package: applesimutils


### PR DESCRIPTION
## Summary

We recently bumped our engine requirement in #28174 but are still installing an older Node version.

## Changelog

[Internal] [Fixed] - Install Node 10 as is required for `test_ios_e2e`

## Test Plan

`test_ios_e2e` should start building again.