### PR TITLE
PermissionsAndroid: Request permission only when response from rationale is positive

### DIFF
--- a/Libraries/PermissionsAndroid/PermissionsAndroid.js
+++ b/Libraries/PermissionsAndroid/PermissionsAndroid.js
@@ -216,14 +216,20 @@ class PermissionsAndroid {
           const options = {
             ...rationale,
           };
+          const constants = NativeDialogManagerAndroid.getConstants();
           NativeDialogManagerAndroid.showAlert(
             /* $FlowFixMe(>=0.111.0 site=react_native_fb) This comment
              * suppresses an error found when Flow v0.111 was deployed. To see
              * the error, delete this comment and run Flow. */
             options,
             () => reject(new Error('Error showing rationale')),
-            () =>
-              resolve(NativePermissionsAndroid.requestPermission(permission)),
+            (action, buttonKey) => {
+              if (action === constants.buttonClicked && buttonKey === constants.buttonPositive) {
+                resolve(NativePermissionsAndroid.requestPermission(permission));
+              } else {
+                resolve(this.RESULTS.DENIED);
+              }
+            },
           );
         });
       }


### PR DESCRIPTION
##  Summary

Currently, the library makes a call to request permission even though the user taps on a neutral or negative response in the rationale dialog after initially denying permission. The mods in this PR will make it so we only make a call to request for permissions when a user taps on a positive response.

## Changelog

[Android][Changed] - Only request permission when the user gives a positive response to the rationale dialog.

## Test Plan
- For the following test cases, Camera permission was used to test.

1. Tap on a button that requests permissions. Approve the permission and make sure the function returns valid permission granted value `true`
-- Reset the permissions after this by either reinstalling or running `adb shell pm reset-permissions`
2. Tap on a button that requests permissions. Deny the permission and make sure the function returns valid permission granted value `false`.
3. Continuation from test case 2, tap on the button again so the rationale dialog pops up with three options. (buttonPositive, buttonNegative, buttonNeutral)
4. Continuation from test case 3, tap on buttonNegative, the dialog disappears and the function returns valid permission granted value `false`.
5. Continuation from test case 4, tap on buttonNeutral, the dialog disappears and the function returns valid permission granted value `false`.
6. Continuation from test case 5, tap on buttonPositive, the dialog disappears and a native android dialog appears to take user's permission.
7. Continuation from test case 6, tap on `Deny`. The native dialog disappears and the function returns a valid permission granted value `false`. This puts you back at 3
8. Tap on `Approve`. The native dialog disappears and the function returns a valid permission granted value `true`.