### PR TITLE
[GitHub] Configure no-response bot

### DIFF
--- a/.github/no-response.yml
+++ b/.github/no-response.yml
@@ -1,0 +1,12 @@
+# Configuration for probot-no-response - https://github.com/probot/no-response
+
+# Number of days of inactivity before an Issue is closed for lack of response
+daysUntilClose: 21
+# Label requiring a response
+responseRequiredLabel: "Needs: Author Feedback" 
+# Comment to post when closing an Issue for lack of response. Set to `false` to disable
+closeComment: >
+  It's been three weeks since we asked for additional information from the
+  author of this issue. As it happens, we don't have enough information to
+  take action. We are going to close this issue, but please do not hesitate
+  to open a new issue if you are still encountering this problem.


### PR DESCRIPTION
## Summary

Add configuration for [no-response bot](https://probot.github.io/apps/no-response/). This will make it so that issues tagged with the "Needs: Author Feedback" are closed after 21 days of inactivity. More importantly, it will make it so that the label is removed whenever the original author of the issue adds a comment.
## Changelog

[Internal] - N/A

## Test Plan

Verified no-response is enabled for this repository.