### PR TITLE
iOS: Measure startup memory footprint

### DIFF
--- a/RNTester/RNTesterPods.xcodeproj/project.pbxproj
+++ b/RNTester/RNTesterPods.xcodeproj/project.pbxproj
@@ -3,12 +3,13 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 51;
 	objects = {
 
 /* Begin PBXBuildFile section */
 		13B07FBD1A68108700A75B9A /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB11A68108700A75B9A /* LaunchScreen.xib */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
+		192008DE2405673F0048B8C4 /* RCTMemoryFootprintTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 192008DD2405673F0048B8C4 /* RCTMemoryFootprintTests.m */; };
 		272E6B3F1BEA849E001FCF37 /* UpdatePropertiesExampleView.m in Sources */ = {isa = PBXBuildFile; fileRef = 272E6B3C1BEA849E001FCF37 /* UpdatePropertiesExampleView.m */; };
 		27F441EC1BEBE5030039B79C /* FlexibleSizeExampleView.m in Sources */ = {isa = PBXBuildFile; fileRef = 27F441E81BEBE5030039B79C /* FlexibleSizeExampleView.m */; };
 		2DDEF0101F84BF7B00DBDF73 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2DDEF00F1F84BF7B00DBDF73 /* Images.xcassets */; };
@@ -75,6 +76,7 @@
 		13B07FB21A68108700A75B9A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = RNTester/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = RNTester/main.m; sourceTree = "<group>"; };
+		192008DD2405673F0048B8C4 /* RCTMemoryFootprintTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RCTMemoryFootprintTests.m; sourceTree = "<group>"; };
 		272E6B3B1BEA849E001FCF37 /* UpdatePropertiesExampleView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UpdatePropertiesExampleView.h; path = RNTester/NativeExampleViews/UpdatePropertiesExampleView.h; sourceTree = "<group>"; };
 		272E6B3C1BEA849E001FCF37 /* UpdatePropertiesExampleView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = UpdatePropertiesExampleView.m; path = RNTester/NativeExampleViews/UpdatePropertiesExampleView.m; sourceTree = "<group>"; };
 		27F441E81BEBE5030039B79C /* FlexibleSizeExampleView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FlexibleSizeExampleView.m; path = RNTester/NativeExampleViews/FlexibleSizeExampleView.m; sourceTree = "<group>"; };
@@ -334,6 +336,7 @@
 				E7DB20C222B2BAA4005AC45F /* RCTImageLoaderTests.m */,
 				E7DB20CD22B2BAA5005AC45F /* RCTImageUtilTests.m */,
 				E7DB20B122B2BAA4005AC45F /* RCTJSONTests.m */,
+				192008DD2405673F0048B8C4 /* RCTMemoryFootprintTests.m */,
 				E7DB20C322B2BAA4005AC45F /* RCTMethodArgumentTests.m */,
 				E7DB20AA22B2BAA3005AC45F /* RCTModuleInitNotificationRaceTests.m */,
 				E7DB20B022B2BAA4005AC45F /* RCTModuleInitTests.m */,
@@ -679,6 +682,7 @@
 				E7DB20D922B2BAA6005AC45F /* RCTAnimationUtilsTests.m in Sources */,
 				E7DB20D122B2BAA6005AC45F /* RCTBundleURLProviderTests.m in Sources */,
 				E7DB20EC22B2BAA6005AC45F /* RCTMultipartStreamReaderTests.m in Sources */,
+				192008DE2405673F0048B8C4 /* RCTMemoryFootprintTests.m in Sources */,
 				E7DB20E022B2BAA6005AC45F /* RCTMethodArgumentTests.m in Sources */,
 				E7DB20E822B2BAA6005AC45F /* RCTModuleMethodTests.mm in Sources */,
 				E7DB20E222B2BAA6005AC45F /* RCTGzipTests.m in Sources */,

--- a/RNTester/RNTesterPods.xcodeproj/xcshareddata/xcschemes/RNTester.xcscheme
+++ b/RNTester/RNTesterPods.xcodeproj/xcshareddata/xcschemes/RNTester.xcscheme
@@ -23,7 +23,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "NO">

--- a/RNTester/RNTesterUnitTests/RCTAllocationTests.m
+++ b/RNTester/RNTesterUnitTests/RCTAllocationTests.m
@@ -24,6 +24,11 @@
 
 RCT_EXPORT_MODULE();
 
++ (BOOL)requiresMainQueueSetup
+{
+  return NO;
+}
+
 - (instancetype)init
 {
   if ((self = [super init])) {

--- a/RNTester/RNTesterUnitTests/RCTImageLoaderHelpers.m
+++ b/RNTester/RNTesterUnitTests/RCTImageLoaderHelpers.m
@@ -19,6 +19,11 @@
   return nil;
 }
 
++ (BOOL)requiresMainQueueSetup
+{
+  return NO;
+}
+
 - (instancetype)init
 {
   return nil;
@@ -68,6 +73,11 @@
 + (NSString *)moduleName
 {
   return nil;
+}
+
++ (BOOL)requiresMainQueueSetup
+{
+  return NO;
 }
 
 - (instancetype)init

--- a/RNTester/RNTesterUnitTests/RCTMemoryFootprintTests.m
+++ b/RNTester/RNTesterUnitTests/RCTMemoryFootprintTests.m
@@ -1,0 +1,166 @@
+/*
+* Copyright (c) Facebook, Inc. and its affiliates.
+*
+* This source code is licensed under the MIT license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+#import <XCTest/XCTest.h>
+
+#import <mach/mach.h>
+
+#import <RCTTest/RCTTestRunner.h>
+#import <React/RCTBridge.h>
+
+typedef struct {
+  mach_vm_size_t mean;
+  double standardDeviation;
+} Mean;
+
+Mean calculateMean(mach_vm_size_t *measurements, int count);
+NSString *tableRow(NSString *name, mach_vm_size_t *measurements, int count, NSNumberFormatter *numberFormatter);
+
+mach_vm_size_t memoryFootprint(void);
+
+@interface RCTMemoryFootprintTests : XCTestCase <RCTBridgeDelegate> {
+  RCTBridge *_bridge;
+  mach_vm_size_t _memoryFootprintInitial;
+  mach_vm_size_t _memoryFootprintStartLoadJavaScript;
+  mach_vm_size_t _memoryFootprintStartExecuteJavaScript;
+  mach_vm_size_t _memoryFootprintWhenDone;
+}
+@end
+
+@implementation RCTMemoryFootprintTests
+
+- (void)setUp
+{
+  NSNotificationCenter *notificationCenter = NSNotificationCenter.defaultCenter;
+  [notificationCenter addObserver:self
+                         selector:@selector(javaScriptWillStartLoading:)
+                             name:RCTJavaScriptWillStartLoadingNotification
+                           object:nil];
+  [notificationCenter addObserver:self
+                         selector:@selector(javaScriptWillStartExecuting:)
+                             name:RCTJavaScriptWillStartExecutingNotification
+                           object:nil];
+  [notificationCenter addObserver:self
+                         selector:@selector(javaScriptDidLoad:)
+                             name:RCTJavaScriptDidLoadNotification
+                           object:nil];
+}
+
+- (void)tearDown
+{
+  [NSNotificationCenter.defaultCenter removeObserver:self];
+}
+
+- (void)testStartupPerformance
+{
+  const int numRuns = 10;
+
+  mach_vm_size_t startLoadJavaScriptUsage[numRuns];
+  mach_vm_size_t startExecuteJavaScriptUsage[numRuns];
+  mach_vm_size_t whenDoneUsage[numRuns];
+
+  for (int i = 0; i < numRuns; ++i) {
+    _memoryFootprintInitial = memoryFootprint();
+    _memoryFootprintStartLoadJavaScript = 0;
+    _memoryFootprintStartExecuteJavaScript = 0;
+    _memoryFootprintWhenDone = 0;
+
+    @autoreleasepool {
+      RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:nil];
+      RCT_RUN_RUNLOOP_WHILE(_memoryFootprintWhenDone == 0);
+      [bridge invalidate];
+      bridge = nil;
+    }
+
+    // Wait for RCTBridge to finish :(
+    CFRunLoopRunInMode(kCFRunLoopDefaultMode, 1, NO);
+
+    startLoadJavaScriptUsage[i] = _memoryFootprintStartLoadJavaScript - _memoryFootprintInitial;
+    startExecuteJavaScriptUsage[i] = _memoryFootprintStartExecuteJavaScript - _memoryFootprintStartLoadJavaScript;
+    whenDoneUsage[i] = _memoryFootprintWhenDone - _memoryFootprintStartExecuteJavaScript;
+  }
+
+  NSNumberFormatter *numberFormatter = [[NSNumberFormatter alloc] init];
+  numberFormatter.usesGroupingSeparator = YES;
+  numberFormatter.groupingSeparator = @" ";  // non-breaking space
+  numberFormatter.groupingSize = 3;
+
+  NSLog(@"| Checkpoint         | Initial usage | Avg. usage | Std. deviation |");
+  NSLog(@"|:-------------------|--------------:|-----------:|:---------------|");
+  NSLog(@"%@", tableRow(@"Start loading JS", startLoadJavaScriptUsage, numRuns, numberFormatter));
+  NSLog(@"%@", tableRow(@"Start executing JS", startExecuteJavaScriptUsage, numRuns, numberFormatter));
+  NSLog(@"%@", tableRow(@"Done loading JS", whenDoneUsage, numRuns, numberFormatter));
+}
+
+// MARK: - RCTBridgeDelegate
+
+- (NSURL *)sourceURLForBridge:(__unused RCTBridge *)bridge
+{
+  NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+  return [bundle URLForResource:@"RNTesterUnitTestsBundle" withExtension:@"js"];
+}
+
+// MARK: - RCTBridge notifications
+
+- (void)javaScriptDidLoad:(__unused NSNotification *)notification
+{
+  _memoryFootprintWhenDone = memoryFootprint();
+}
+
+- (void)javaScriptWillStartExecuting:(__unused NSNotification *)notification
+{
+  _memoryFootprintStartExecuteJavaScript = memoryFootprint();
+}
+
+- (void)javaScriptWillStartLoading:(__unused NSNotification *)notification
+{
+  _memoryFootprintStartLoadJavaScript = memoryFootprint();
+}
+
+@end
+
+Mean calculateMean(mach_vm_size_t *measurements, int count)
+{
+  Mean measurement;
+
+  double sum = 0;
+  for (int i = 0; i < count; ++i) {
+    sum += measurements[i];
+  }
+
+  const double mean = sum / count;
+
+  double sigmaSq = 0;
+  for (int i = 0; i < count; ++i) {
+    double diff = measurements[i] - mean;
+    sigmaSq += diff * diff / count;
+  }
+
+  measurement.mean = (mach_vm_size_t)mean;
+  measurement.standardDeviation = sqrt(sigmaSq);
+
+  return measurement;
+}
+
+NSString *tableRow(NSString *name, mach_vm_size_t *measurements, int count, NSNumberFormatter *numberFormatter)
+{
+  const Mean mean = calculateMean(measurements, count);
+  return [NSString stringWithFormat:@"| %@ | +%@ | +%@ | ±%@ (±%@%%) |",
+                                    name,
+                                    [numberFormatter stringFromNumber:@(measurements[0])],
+                                    [numberFormatter stringFromNumber:@(mean.mean)],
+                                    [numberFormatter stringFromNumber:@(mean.standardDeviation)],
+                                    [numberFormatter stringFromNumber:@(mean.standardDeviation / mean.mean * 100)]];
+}
+
+mach_vm_size_t memoryFootprint(void)
+{
+  task_vm_info_data_t info;
+  mach_msg_type_number_t count = TASK_VM_INFO_COUNT;
+  kern_return_t kerr = task_info(mach_task_self(), TASK_VM_INFO, (task_info_t)&info, &count);
+  return kerr != KERN_SUCCESS ? 0 : info.phys_footprint;
+}

--- a/RNTester/RNTesterUnitTests/RCTModuleInitTests.m
+++ b/RNTester/RNTesterUnitTests/RCTModuleInitTests.m
@@ -41,6 +41,11 @@ RCT_EXPORT_MODULE()
 
 RCT_EXPORT_MODULE()
 
++ (BOOL)requiresMainQueueSetup
+{
+  return NO;
+}
+
 - (id)init
 {
   if ((self = [super init])) {
@@ -87,6 +92,11 @@ RCT_EXPORT_MODULE()
 @synthesize methodQueue = _methodQueue;
 
 RCT_EXPORT_MODULE()
+
++ (BOOL)requiresMainQueueSetup
+{
+  return NO;
+}
 
 - (NSDictionary<NSString *, id> *)constantsToExport
 {


### PR DESCRIPTION
## Summary

As part of [React Native Benchmark Suite](https://github.com/react-native-community/discussions-and-proposals/issues/186), we are looking to surface the impact of a change on the memory footprint.

I hit an issue with the JavaScriptCore instance seemingly not being cleaned up properly, and somehow gets reused (see example output below). I haven't been able figure out what the deal is, but I think it might be valuable to check this in as is.

## Changelog

[iOS] [Added] - Added initial memory footprint test (this will always pass for now)

## Test Plan

This currently only outputs to the console:

| Checkpoint         | Initial usage | Avg. usage | Std. deviation  |
|:-------------------|--------------:|-----------:|:----------------|
| Start loading JS   |      +118 784 |    +11 878 | ±35 635 (±300%) |
| Start executing JS |    +1 372 160 |   +902 348 | ±156 937 (±17%) |
| Done loading JS    |      +110 592 |    +42 188 | ±22 883 (±54%)  |