### PR TITLE
Changing blob[@"type"] to blobType

### DIFF
--- a/Libraries/Blob/RCTBlobManager.mm
+++ b/Libraries/Blob/RCTBlobManager.mm
@@ -260,7 +260,7 @@ RCT_EXPORT_METHOD(release:(NSString *)blobId)
   NSString *contentType = @"application/octet-stream";
   NSString *blobType = [RCTConvert NSString:blob[@"type"]];
   if (blobType != nil && blobType.length > 0) {
-    contentType = blob[@"type"];
+    contentType = blobType;
   }
 
   return @{@"body": [self resolve:blob], @"contentType": contentType};


### PR DESCRIPTION
## Summary 

## Issue and Motivation:
A crash occurring in the react-native application due to a code defect in this line of the library.

## Root Cause:
The issue is being caused because blob[@'type"] is assigned to contentType and whenever it will be nil, there would be a crash.

## Fix
 Variable blobType is created from blob[@"type"] and that should be used to be assigned to contentType. Also, the nil check was already done for blobType only.

## Changelog
Crash Fix in RCTBlobManager.mm

## Test Plan
Tested in the RN application, the crash is not occurring anymore.
