### PR TITLE
[TextInput] Call onPress handler

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -982,6 +982,10 @@ function InternalTextInput(props: Props): React.Node {
     if (props.editable || props.editable === undefined) {
       nullthrows(inputRef.current).focus();
     }
+
+    if (props.onPress) {
+      props.onPress(event);
+    }
   };
 
   const _onChange = (event: ChangeEvent) => {


### PR DESCRIPTION
## Summary

I don't have any ideas how handle onPress events on `TextInput` (for web compatibility)
```js
// do not work
<TouchableWithoutFeedback onPress={() => console.log('it works')}>
  <TextInput editable={false} onTouchStart={() => console.log('it works')} />
</TouchableWithoutFeedback>;

// https://github.com/facebook/react-native/issues/14958#issuecomment-324237317
// do not work 
<TouchableWithoutFeedback onPress={()=>{console.log('press')}}>
   <View pointerEvents='none'>
      <TextInput editable={false} />
   </View>
</TouchableWithoutFeedback>
```

## Changelog

[General] [Added] - Add `onPress` prop to TextInput component

## Test Plan

```js
<TextInput
  onPress={() => console.log('it works')}
/>
```
