### PR TITLE
Bump FlipperKit version on iOS to be compatible with react-native-fli…

### DIFF
--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -57,7 +57,7 @@ def use_react_native! (options={})
   end
 end
 
-def use_flipper!(version = '~> 0.30.2')
+def use_flipper!(version = '~> 0.32.2')
   pod 'FlipperKit', version, :configuration => 'Debug'
   pod 'FlipperKit/FlipperKitLayoutPlugin', version, :configuration => 'Debug'
   pod 'FlipperKit/SKIOSNetworkPlugin', version, :configuration => 'Debug'


### PR DESCRIPTION
## Summary

This diff updated FlipperKit to be compatible with the latest react-native-flipper version. 

## Changelog

(nothing changes compared to what is already in the changelog for RN 0.62.0)

[iOS][Fixed] - Upgraded FlipperKit to 0.32.2 to ensure compatibility with latest `react-native-flipper`

## Test Plan

Tested by upgrading the ReactNativeFlipperExample (https://github.com/facebook/flipper/tree/master/react-native/ReactNativeFlipperExample) to RN 0.62.0-rc.3 and verified the example plugin works. (In D20221558)

![Screen Shot 2020-03-04 at 11 26 52](https://user-images.githubusercontent.com/1820292/75875163-18167e80-5e0b-11ea-8a7d-504bb27757db.png)
