### PR TITLE
Add RNTester example for multi-line interleaved <View> and <Text>

### DIFF
--- a/RNTester/js/examples/Text/TextExample.ios.js
+++ b/RNTester/js/examples/Text/TextExample.ios.js
@@ -318,6 +318,23 @@ class TextBaseLineLayoutExample extends React.Component<*, *> {
           {marker}
         </View>
 
+        <Text style={subtitleStyle}>
+          {'Multi-line interleaved <View> and <Text>:'}
+        </Text>
+        <View style={{flexDirection: 'row', alignItems: 'baseline'}}>
+          <Text selectable={true}>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris
+            venenatis,{' '}
+            <View
+              style={{
+                backgroundColor: 'yellow',
+              }}>
+              <Text>mauris eu commodo maximus</Text>
+            </View>{' '}
+            , ante arcu vestibulum ligula, et scelerisque diam.
+          </Text>
+        </View>
+
         <Text style={subtitleStyle}>{'<TextInput/>:'}</Text>
         <View style={{flexDirection: 'row', alignItems: 'baseline'}}>
           {marker}


### PR DESCRIPTION
## Summary

Currently, using `alignSelf: "baseline"` on a `<View>` nested in a `<Text>` fails to position the view properly. Using `alignItems: "baseline"` on the parent `<Text>` doesn't work either.

/cc @shergin 

### Current Result
![rn-baseline-nested-view](https://user-images.githubusercontent.com/1925840/76032574-29918080-5f08-11ea-8ee8-cf3106ef0e06.jpg)

### Expected Result
![rn-baseline-nested-text](https://user-images.githubusercontent.com/1925840/76032575-2a2a1700-5f08-11ea-9efa-4026bc824ed5.jpg)