### PR TITLE
Android: exclude ReactNativeFlipper.java from release build

### DIFF
--- a/template/android/app/build.gradle
+++ b/template/android/app/build.gradle
@@ -178,6 +178,17 @@ android {
 
         }
     }
+
+    // Remove Flipper for release build
+    sourceSets {
+        release {
+            main {
+                java {
+                    exclude '**/ReactNativeFlipper.java'
+                }
+            }
+        }
+    }
 }
 
 dependencies {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Exclude `ReactNativeFlipper.java` from build files in release build.

I faced a lot of errors like `com.facebook.flipper.*** does not exist` during `./gradlew assembleRelease` (see a screenshot below) and it prevents creating release apk file. I think this is because we build java sources of Flipper as `debugImplementation`.

![image](https://user-images.githubusercontent.com/10719495/76147661-1803d080-60e2-11ea-9226-fe19cf52cfc1.png)

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[Android] [Changed] - exclude ReactNativeFlipper.java from release build

## Test Plan

`./assembleRelease` works.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

I think #28052 might effect this modification of template file.