### PR TITLE
E2E for keyboardType breaking autoCapitalize

### DIFF
--- a/RNTester/e2e/__tests__/TextInput-test.js
+++ b/RNTester/e2e/__tests__/TextInput-test.js
@@ -59,4 +59,16 @@ describe('TextInput', () => {
 
     await expect(element(by.id('rewrite_clear_input'))).toHaveText('');
   });
+
+  if ('When keyboardType is set to default, autoCapitalize should work correctly', async () => {
+    await openExampleWithTitle('Auto-capitalize');
+
+    await element(by.id('autocapitalize_with_default_keyboardtype')).typeText(
+      'this text should be all in capitals!!'
+    );
+
+    await expect(element(by.id('autocapitalize_with_default_keyboardtype'))).toHaveText(
+      'THIS TEXT SHOULD BE ALL IN CAPITALS!!',
+    );
+  })
 });

--- a/RNTester/e2e/__tests__/TextInput-test.js
+++ b/RNTester/e2e/__tests__/TextInput-test.js
@@ -60,7 +60,7 @@ describe('TextInput', () => {
     await expect(element(by.id('rewrite_clear_input'))).toHaveText('');
   });
 
-  if ('When keyboardType is set to default, autoCapitalize should work correctly', async () => {
+  it('When keyboardType is set to default, autoCapitalize should work correctly', async () => {
     await openExampleWithTitle('Auto-capitalize');
 
     await element(by.id('autocapitalize_with_default_keyboardtype')).typeText(
@@ -70,5 +70,5 @@ describe('TextInput', () => {
     await expect(element(by.id('autocapitalize_with_default_keyboardtype'))).toHaveText(
       'THIS TEXT SHOULD BE ALL IN CAPITALS!!',
     );
-  })
+  });
 });

--- a/RNTester/js/examples/TextInput/TextInputSharedExamples.js
+++ b/RNTester/js/examples/TextInput/TextInputSharedExamples.js
@@ -489,7 +489,7 @@ module.exports = ([
             <TextInput autoCapitalize="words" style={styles.default} />
           </WithLabel>
           <WithLabel label="characters">
-            <TextInput autoCapitalize="characters" style={styles.default} />
+            <TextInput testID="autocapitalize_with_default_keyboardtype" autoCapitalize="characters" keyboardType="default" style={styles.default} />
           </WithLabel>
         </View>
       );


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
E2E for when keyboardType is set to default, autoCapitalize should work correctly. Mentioned here: https://github.com/facebook/react-native/pull/27523#issuecomment-577960694

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[Internal] [Added] - E2E for when keyboardType is set to default, autoCapitalize should work correctly

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
Added tests; however, noticed CircleCI Android tests do not run the E2E tests.