### PR TITLE
fix(android): Ensure the MultiPostprocessor cache key is set correctly

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/image/MultiPostprocessor.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/image/MultiPostprocessor.java
@@ -8,6 +8,7 @@
 package com.facebook.react.views.image;
 
 import android.graphics.Bitmap;
+import androidx.annotation.Nullable;
 import com.facebook.cache.common.CacheKey;
 import com.facebook.cache.common.MultiCacheKey;
 import com.facebook.common.references.CloseableReference;
@@ -49,6 +50,7 @@ public class MultiPostprocessor implements Postprocessor {
   }
 
   @Override
+  @Nullable
   public CacheKey getPostprocessorCacheKey() {
     LinkedList<CacheKey> keys = new LinkedList<>();
     for (Postprocessor p : mPostprocessors) {
@@ -58,7 +60,7 @@ public class MultiPostprocessor implements Postprocessor {
       }
     }
 
-    switch (postprocessors.size()) {
+    switch (keys.size()) {
       case 0:
         return null;
       case 1:

--- a/ReactAndroid/src/main/java/com/facebook/react/views/image/MultiPostprocessor.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/image/MultiPostprocessor.java
@@ -52,9 +52,20 @@ public class MultiPostprocessor implements Postprocessor {
   public CacheKey getPostprocessorCacheKey() {
     LinkedList<CacheKey> keys = new LinkedList<>();
     for (Postprocessor p : mPostprocessors) {
-      keys.push(p.getPostprocessorCacheKey());
+      CacheKey cacheKey = p.getPostprocessorCacheKey();
+      if (cacheKey != null) {
+        keys.push(cacheKey);
+      }
     }
-    return new MultiCacheKey(keys);
+
+    switch (postprocessors.size()) {
+      case 0:
+        return null;
+      case 1:
+        return keys.get(0);
+      default:
+        return new MultiCacheKey(keys);
+    }
   }
 
   @Override


### PR DESCRIPTION
## Summary

If the `MultiPostprocessor` wrapped postprocessors which returned a `null` cache key, it would return a `MultiCacheKey` with `mull` elements in the list. When compared these would match in the cache, causing issues where cached values were used where they shouldn't be.

This was causing issues when an `Image` component was using `resizeMode="repeat"` once, and then drawing another component with the same image source but with a different size. Because the source matched and the MultiPostprocessor cache key was incorrectly matching, it would return the repeated image with the wrong size, causing issues.

With this fix cache is now correctly implemented.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[Android] [Fixed] - Ensure the MultiPostprocessor cache key is set correctly to avoid issues when redisplaying images with a different size with resizeMode="repeat"

## Test Plan

