### PR TITLE
Publish nightly builds from master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -705,6 +705,7 @@ workflows:
             tags:
               only: /v[0-9]+(\.[0-9]+)*(\-rc(\.[0-9]+)?)?/
       - publish_npm_package:
+          publish_npm_args:
           requires:
             - setup_android
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -752,11 +752,11 @@ workflows:
       - nightly_job
 
       - setup:
-        name: setup_android
-        checkout_type: android
-        executor: reactnativeandroid
+          name: setup_android
+          checkout_type: android
+          executor: reactnativeandroid
 
       - publish_npm_package:
-        publish_npm_args: --nightly
-        requires:
-          - setup_android
+          publish_npm_args: --nightly
+          requires:
+            - setup_android

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -605,7 +605,7 @@ jobs:
     parameters:
       publish_npm_args:
         type: string
-        default:
+        default: --nonightly
     executor: reactnativeandroid
     steps:
       - restore_cache_checkout:
@@ -705,7 +705,6 @@ workflows:
             tags:
               only: /v[0-9]+(\.[0-9]+)*(\-rc(\.[0-9]+)?)?/
       - publish_npm_package:
-          publish_npm_args:
           requires:
             - setup_android
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -602,6 +602,10 @@ jobs:
   # Publishes new version onto npm
   # Only works on stable branches when a properly tagged commit is pushed
   publish_npm_package:
+    parameters:
+      publish_npm_args:
+        type: string
+        default:
     executor: reactnativeandroid
     steps:
       - restore_cache_checkout:
@@ -615,7 +619,7 @@ jobs:
           git config --global user.email "react-native-bot@users.noreply.github.com"
           git config --global user.name "npm Deployment Script"
           echo "machine github.com login react-native-bot password $GITHUB_TOKEN" > ~/.netrc
-      - run: node ./scripts/publish-npm.js
+      - run: node ./scripts/publish-npm.js << parameters.publish_npm_args >>
 
   # -------------------------
   #    JOBS: Nightly
@@ -746,3 +750,13 @@ workflows:
                 - master
     jobs:
       - nightly_job
+
+      - setup:
+        name: setup_android
+        checkout_type: android
+        executor: reactnativeandroid
+
+      - publish_npm_package:
+        publish_npm_args: --nightly
+        requires:
+          - setup_android

--- a/scripts/bump-oss-version.js
+++ b/scripts/bump-oss-version.js
@@ -23,29 +23,42 @@ const yargs = require('yargs');
 let argv = yargs.option('r', {
   alias: 'remote',
   default: 'origin',
+})
+.option('n', {
+  alias: 'nightly',
+  type: 'boolean',
+  default: false,
 }).argv;
 
-// Check we are in release branch, e.g. 0.33-stable
-let branch = exec('git symbolic-ref --short HEAD', {
-  silent: true,
-}).stdout.trim();
+const nightlyBuild = argv.nightly;
 
-if (branch.indexOf('-stable') === -1) {
-  echo('You must be in 0.XX-stable branch to bump a version');
-  exit(1);
-}
+let version, branch;
+if (nightlyBuild) {
+  const currentCommit = exec('git rev-parse HEAD', {silent: true}).stdout.trim();
+  version = `0.0.0-${currentCommit.slice(0, 9)}`;
+} else {
+  // Check we are in release branch, e.g. 0.33-stable
+  branch = exec('git symbolic-ref --short HEAD', {
+    silent: true,
+  }).stdout.trim();
 
-// e.g. 0.33
-let versionMajor = branch.slice(0, branch.indexOf('-stable'));
+  if (branch.indexOf('-stable') === -1) {
+    echo('You must be in 0.XX-stable branch to bump a version');
+    exit(1);
+  }
 
-// - check that argument version matches branch
-// e.g. 0.33.1 or 0.33.0-rc4
-let version = argv._[0];
-if (!version || version.indexOf(versionMajor) !== 0) {
-  echo(
-    `You must pass a tag like 0.${versionMajor}.[X]-rc[Y] to bump a version`,
-  );
-  exit(1);
+  // e.g. 0.33
+  let versionMajor = branch.slice(0, branch.indexOf('-stable'));
+
+  // - check that argument version matches branch
+  // e.g. 0.33.1 or 0.33.0-rc4
+  version = argv._[0];
+  if (!version || version.indexOf(versionMajor) !== 0) {
+    echo(
+      `You must pass a tag like 0.${versionMajor}.[X]-rc[Y] to bump a version`,
+    );
+    exit(1);
+  }
 }
 
 // Generate version files to detect mismatches between JS and native.
@@ -135,43 +148,48 @@ let numberOfChangedLinesWithNewVersion = exec(
   `git diff -U0 | grep '^[+]' | grep -c ${version} `,
   {silent: true},
 ).stdout.trim();
-if (+numberOfChangedLinesWithNewVersion !== 3) {
-  echo(
-    'Failed to update all the files. package.json and gradle.properties must have versions in them',
-  );
-  echo('Fix the issue, revert and try again');
-  exec('git diff');
-  exit(1);
+
+// Release builds should commit the version bumps, and create tags.
+// Nightly builds do not need to do that.
+if (!nightlyBuild) {
+  if (+numberOfChangedLinesWithNewVersion !== 3) {
+    echo(
+      'Failed to update all the files. package.json and gradle.properties must have versions in them',
+    );
+    echo('Fix the issue, revert and try again');
+    exec('git diff');
+    exit(1);
+  }
+
+  // Make commit [0.21.0-rc] Bump version numbers
+  if (exec(`git commit -a -m "[${version}] Bump version numbers"`).code) {
+    echo('failed to commit');
+    exit(1);
+  }
+
+  // Add tag v0.21.0-rc
+  if (exec(`git tag v${version}`).code) {
+    echo(
+      `failed to tag the commit with v${version}, are you sure this release wasn't made earlier?`,
+    );
+    echo('You may want to rollback the last commit');
+    echo('git reset --hard HEAD~1');
+    exit(1);
+  }
+
+  // Push newly created tag
+  let remote = argv.remote;
+  exec(`git push ${remote} v${version}`);
+
+  // Tag latest if doing stable release
+  if (version.indexOf('rc') === -1) {
+    exec('git tag -d latest');
+    exec(`git push ${remote} :latest`);
+    exec('git tag latest');
+    exec(`git push ${remote} latest`);
+  }
+
+  exec(`git push ${remote} ${branch} --follow-tags`);
 }
-
-// Make commit [0.21.0-rc] Bump version numbers
-if (exec(`git commit -a -m "[${version}] Bump version numbers"`).code) {
-  echo('failed to commit');
-  exit(1);
-}
-
-// Add tag v0.21.0-rc
-if (exec(`git tag v${version}`).code) {
-  echo(
-    `failed to tag the commit with v${version}, are you sure this release wasn't made earlier?`,
-  );
-  echo('You may want to rollback the last commit');
-  echo('git reset --hard HEAD~1');
-  exit(1);
-}
-
-// Push newly created tag
-let remote = argv.remote;
-exec(`git push ${remote} v${version}`);
-
-// Tag latest if doing stable release
-if (version.indexOf('rc') === -1) {
-  exec('git tag -d latest');
-  exec(`git push ${remote} :latest`);
-  exec('git tag latest');
-  exec(`git push ${remote} latest`);
-}
-
-exec(`git push ${remote} ${branch} --follow-tags`);
 
 exit(0);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Publish builds of react-native from master on a nightly basis.

Nightly builds will publish versions of `react-native` as: `0.0.0-<first 9-digits-of-latest-commit>`.  This is inline with how `react` publishes nightly builds.  These builds will be tagged as `@nightly`.

This should make it easier for developers to try latest builds of react-native before a stable release, which may improve early reporting of bugs.  It is also a prereq to enable `react-native-windows`, and any other community platform or community module to be able to more aggressively track react-native master and be up to date with RN releases.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[Internal] [Added] - Publish nightly builds from master

## Test Plan

I attempted to run publish-npm.js and bump-oss-version.js manually, but due to the nature of the scripts its a little hard to do end to end testing.
