### PR TITLE
Don't mess with Windows line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
-# Force LF line endings for Bash scripts.   On Windows the rest of the source
-# files will typically have CR+LF endings (Git default on Windows), but Bash
-# scripts need to have LF endings to work (under Cygwin), thus override to force
-# that.
+# Force correct line endings.
+# On Windows the git default is CR+LF and on macOS/*nix the git default is LF.
+# Regardless of OS, bash scripts should have LF endings (handled by Cygwin on Windows),
+# and bat files should have CR+LF (only used on Windows).
 gradlew text eol=lf
 *.sh text eol=lf
+*.bat text eol=crlf

--- a/template/_gitattributes
+++ b/template/_gitattributes
@@ -1,1 +1,4 @@
 *.pbxproj -text
+
+# specific for windows script files
+*.bat text eol=crlf

--- a/template/_gitattributes
+++ b/template/_gitattributes
@@ -1,4 +1,1 @@
 *.pbxproj -text
-
-# specific for windows script files
-*.bat text eol=crlf


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

During some rc releases we have seen the file `gradlew.bat` get diffs from release to release, and sometimes the diff is nothing, except some script messing with the line endings of that file.

According to [this](https://help.github.com/en/github/using-git/configuring-git-to-handle-line-endings#example) and my own experiments using `unix2dos` and `dos2unix` to swap the line endings of that file, this change fixes this problem.
We specify all the `.bat` files should have the Windows line endings.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[General] [Fixed] - Specify line endings of `.bat` files for Windows in `.gitattributes`

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

To assist with the test, you can use `brew install unix2dos`.

- Init a new project or use an existing one.
- Make sure in your `.gitattributes` of the project and of the user (home dir or `.config/git/attributes` don't have anything about `.bat` files, or `* text=auto`.
- Run `unix2dos ./android/gradlew.bat`.
- Check git status.
- Run `dos2unix ./android/gradlew.bat`.
- Check git status.
- You will notice that the changes when swapping around are the whole file changed.

- Using the changes in this PR, and doing the above, the git status will be no changes, as it should be. The line changes stay Windows-style.