### PR TITLE
Fix TextInput in dark mode: Unconditionally apply foreground color

### DIFF
--- a/Libraries/Text/RCTTextAttributes.m
+++ b/Libraries/Text/RCTTextAttributes.m
@@ -131,9 +131,7 @@ NSString *const RCTTextAttributesTagAttributeName = @"RCTTextAttributesTagAttrib
   // Colors
   UIColor *effectiveForegroundColor = self.effectiveForegroundColor;
 
-  if (_foregroundColor || !isnan(_opacity)) {
-    attributes[NSForegroundColorAttributeName] = effectiveForegroundColor;
-  }
+  attributes[NSForegroundColorAttributeName] = effectiveForegroundColor;
 
   if (_backgroundColor || !isnan(_opacity)) {
     attributes[NSBackgroundColorAttributeName] = self.effectiveBackgroundColor;


### PR DESCRIPTION
## Summary

This PR should fix a bug which fixes TextInput color being white in dark mode on iOS.
It seems like on Line 217, the intention is that if no `_foregroundColor` is set, it falls back to `[UIColor blackColor]`.

However, the `effectiveForegroundColor` is only being applied if `_foregroundColor` is not nil. Therefore the fallback is never triggered in the first place. This means that `NSForegroundColorAttributeName` is unintentionally being set to nil, which still meant that by default the text is being rendered black. However in iOS 13, the text would be rendered in white if you have enabled dark mode.

Having a fallback to black that is never triggered makes me believe that this is a bug and that the current behavior is not intended. I am fixing the bug by removing the `if` statement completely as it seems to me that the `effectiveForegroundColor` is already sufficiently performing null checks.

## Changelog

[iOS] [Fixed] - TextInput color has the same default (#000) on iOS whether in light or dark mode

## Test Plan

I have applied this patch in my project and it has solved the bug that the TextInput turns white when in dark mode. I have no further plans on how to perform tests.