### PR TITLE
Fixing #26716 - GIFs were animating too fast on iOS

### DIFF
--- a/Libraries/Image/RCTAnimatedImage.m
+++ b/Libraries/Image/RCTAnimatedImage.m
@@ -107,7 +107,7 @@
   NSDictionary *gifProperties = frameProperties[(NSString *)kCGImagePropertyGIFDictionary];
 
   NSNumber *delayTimeUnclampedProp = gifProperties[(NSString *)kCGImagePropertyGIFUnclampedDelayTime];
-  if (delayTimeUnclampedProp != nil) {
+  if (delayTimeUnclampedProp != nil && [delayTimeUnclampedProp floatValue] != 0.0f) {
     frameDuration = [delayTimeUnclampedProp floatValue];
   } else {
     NSNumber *delayTimeProp = gifProperties[(NSString *)kCGImagePropertyGIFDelayTime];


### PR DESCRIPTION
Submitting on behalf of @mk0116, who found the fix but has been (presumably) too busy to make the pull request.
See https://github.com/facebook/react-native/issues/26716#issuecomment-586537895

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Certain GIFs have a zero'd property for kCGImagePropertyGIFUnclampedDelayTime, but a non-zero'd kCGImagePropertyGIFDelayTime property, so the second property should be used.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[iOS] [Fixed] - Certain GIFs were animating too rapidly

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

I unfortunately don't have any non-trademarked GIFs to test, but someone in the issue thread may.
