### PR TITLE
[CI] Seed ssh-agent with github's fingerprint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -604,6 +604,9 @@ jobs:
   publish_npm_package:
     executor: reactnativeandroid
     steps:
+      - add_ssh_keys:
+        fingerprints:
+          - "SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8"
       - restore_cache_checkout:
           checkout_type: android
       - run_yarn

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -605,8 +605,8 @@ jobs:
     executor: reactnativeandroid
     steps:
       - add_ssh_keys:
-        fingerprints:
-          - "SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8"
+          fingerprints:
+            - "SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8"
       - restore_cache_checkout:
           checkout_type: android
       - run_yarn


### PR DESCRIPTION
Fixes https://github.com/facebook/react-native/issues/28295

## Summary

Currently [the publish job](https://circleci.com/gh/facebook/react-native/138343) fails with:

```
The authenticity of host 'github.com (192.30.253.113)' can't be established.
RSA key fingerprint is SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8.
Are you sure you want to continue connecting (yes/no)? 
```

As per the [CircleCI docs](https://support.circleci.com/hc/en-us/articles/115015628247-Are-you-sure-you-want-to-continue-connecting-yes-no-), I’ve added a step to seed the ssh-agent with [github’s SHA256 RSA fingerprint](https://help.github.com/en/github/authenticating-to-github/githubs-ssh-key-fingerprints).

## Changelog

[Internal] [Fixed] - Make automated publishing of packages from CI work again

## Test Plan

We’ll have to see during the next round of releasing.