### PR TITLE
Fix mock for TextInput

### DIFF
--- a/jest/setup.js
+++ b/jest/setup.js
@@ -92,6 +92,8 @@ jest
     mockComponent('../Libraries/Components/TextInput/TextInput', {
       ...MockNativeMethods,
       isFocused: jest.fn(),
+      clear: jest.fn(),
+      getNativeRef: jest.fn(),
     }),
   )
   .mock('../Libraries/Modal/Modal', () =>

--- a/jest/setup.js
+++ b/jest/setup.js
@@ -89,10 +89,10 @@ jest
     mockComponent('../Libraries/Text/Text', MockNativeMethods),
   )
   .mock('../Libraries/Components/TextInput/TextInput', () =>
-    mockComponent(
-      '../Libraries/Components/TextInput/TextInput',
-      MockNativeMethods,
-    ),
+    mockComponent('../Libraries/Components/TextInput/TextInput', {
+      ...MockNativeMethods,
+      isFocused: jest.fn(),
+    }),
   )
   .mock('../Libraries/Modal/Modal', () =>
     mockComponent('../Libraries/Modal/Modal'),


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This PR adds the `isFocused` method to the mock of the TextInput component. My understanding some of the latest changes on the TextInput to make it use a forwardRef change the way this method is mock giving an error when trying to use in on a mock.
The change suggested here fixes the issue.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[JavaScript] [Fixed] - Fix the mock for TextInput to support the `isFocused` method

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
