### PR TITLE
Change nightly build from hourly to nightly (daily at 00:00)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -746,7 +746,7 @@ workflows:
   nightly:
     triggers:
       - schedule:
-          cron: "0 * * * *"
+          cron: "0 0 * * *"
           filters:
             branches:
               only:


### PR DESCRIPTION
## Summary

We initially added the nightly build test to run every hour, in order to more quickly validate it. Now that it has been validated we can run it every night as it is intended to do.

cc @hramos 

## Changelog

[General] [Changed] - Change nightly build from hourly to nightly
