### PR TITLE
Fix Animated Value initialized with undefined in ScrollView

### DIFF
--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -716,11 +716,9 @@ class ScrollView extends React.Component<Props, State> {
   UNSAFE_componentWillMount() {
     this._scrollResponder.UNSAFE_componentWillMount();
     this._scrollAnimatedValue = new AnimatedImplementation.Value(
-      this.props.contentOffset ? this.props.contentOffset.y : 0,
+      this.props.contentOffset?.y ?? 0,
     );
-    this._scrollAnimatedValue.setOffset(
-      this.props.contentInset ? this.props.contentInset.top || 0 : 0,
-    );
+    this._scrollAnimatedValue.setOffset(this.props.contentInset?.top ?? 0);
     this._stickyHeaderRefs = new Map();
     this._headerLayoutYs = new Map();
   }


### PR DESCRIPTION
## Summary

When passing an object to contentOffset that doesn't have `y` prop set it causes the following error:

```
 Error: AnimatedValue: Attempting to set value to undefined

This error is located at:
    in ScrollView (at src/index.js:638)
...
```

This happens since a runtime check was added to the `AnimatedValue` constructor. (a3aaa471eca58b31597b9a0669f7ade385ccb175)

According to flow types the object passed to contentOffset should always contain both x and y props but since it worked before when y is undefined I think its fine to patch the runtime behaviour defensively, especially since the code change is simple.

## Changelog

[General] [Fixed] - Fix Animated Value initialized with undefined in ScrollView

## Test Plan

Tested that the crash no longer reproduces when passing an empty object to contentOffset.
