### PR TITLE
Fix border-stroke drawing after resetting border-radius

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewBackgroundDrawable.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewBackgroundDrawable.java
@@ -998,10 +998,11 @@ public class ReactViewBackgroundDrawable extends Drawable {
   }
 
   private void drawRectangularBackgroundWithBorders(Canvas canvas) {
+    mPaint.setStyle(Paint.Style.FILL);
+    
     int useColor = ColorUtil.multiplyColorAlpha(mColor, mAlpha);
     if (Color.alpha(useColor) != 0) { // color is not transparent
       mPaint.setColor(useColor);
-      mPaint.setStyle(Paint.Style.FILL);
       canvas.drawRect(getBounds(), mPaint);
     }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

This PR fixes incorrect drawing of the View borders on Android, after changing the border-radius back to 0 *(and when no background-color is defined)*.

This happens because the `drawRoundedBackgroundWithBorders` function in ReactViewBackgroundDrawable changes the style on the Paint object to `STROKE`. This style is however never reverted back to `FILL`. This change ensures that the Paint style is set to `FILL` for the full execution of the `drawRectangularBackgroundWithBorders` function.

## Changelog

`[Android] [Fixed] - Fix border-drawing when changing border-radius back to 0`


## Test Plan

**Faulty situation:**

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/6184593/77153163-9759b280-6a99-11ea-82bb-33a1e0a4934c.gif)

**After the fix:**

![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/6184593/77153825-c91f4900-6a9a-11ea-8e0c-a4280b9e72b8.gif)


