### PR TITLE
Fix dashed/dotted border drawing when border-radius is 0

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewBackgroundDrawable.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewBackgroundDrawable.java
@@ -128,7 +128,7 @@ public class ReactViewBackgroundDrawable extends Drawable {
   @Override
   public void draw(Canvas canvas) {
     updatePathEffect();
-    if (!hasRoundedBorders()) {
+    if (!hasRoundedBorders() && mBorderStyle == BorderStyle.SOLID) {
       drawRectangularBackgroundWithBorders(canvas);
     } else {
       drawRoundedBackgroundWithBorders(canvas);


### PR DESCRIPTION
## Summary

This PR fixes the border-style that is not respected when drawing a border with 0 border-radius on Android. This would cause the faster `drawRectangularBackgroundWithBorders` path to be used, but that uses rectangular drawing and doesn't support dashed/dotted stroke patterns.
This PR changes the behavior to use the generic `drawRoundedBackgroundWithBorders` code-path which does support dashed/dotted border-styles.

## Changelog

`[Android] [Fixed] - Fix dashed/dotted border-drawing when border-radius is 0`

## Test Plan

**Faulty situation:**

![Screenshot_1584721992](https://user-images.githubusercontent.com/6184593/77184987-e838cd80-6ad0-11ea-9585-058eafbd361a.png)

**After the fix:**

![Screenshot_1584721410](https://user-images.githubusercontent.com/6184593/77184801-9d1eba80-6ad0-11ea-92a7-7212f40ace73.png)
