### PR TITLE
[CI] Fix `test_android`: Remove references to fbsource cell

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/fbreact/specs/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/fbreact/specs/BUCK
@@ -1,5 +1,4 @@
-load("@fbsource//tools/build_defs:platform_defs.bzl", "ANDROID")
-load("@fbsource//tools/build_defs/oss:rn_defs.bzl", "FBJNI_TARGET", "react_native_dep", "react_native_target", "react_native_xplat_target", "rn_android_library", "rn_xplat_cxx_library")
+load("//tools/build_defs/oss:rn_defs.bzl", "ANDROID", "FBJNI_TARGET", "IS_OSS_BUILD", "react_native_dep", "react_native_target", "react_native_xplat_target", "rn_android_library", "rn_xplat_cxx_library")
 
 rn_android_library(
     name = "FBReactNativeSpec",
@@ -46,13 +45,14 @@ rn_xplat_cxx_library(
     ],
     deps = [
         FBJNI_TARGET,
-        "fbsource//xplat/folly:molly",
-        "fbsource//xplat/jsi:JSIDynamic",
+        "//xplat/folly:molly",
+        "//xplat/jsi:JSIDynamic",
         react_native_target("jni/react/jni:jni"),
         react_native_xplat_target("cxxreact:bridge"),
     ],
-    exported_deps = [
-        "fbsource//xplat/jsi:jsi",
+    exported_deps = ([
         react_native_xplat_target("turbomodule/core:core"),
-    ],
+    ]) + ([
+        "//xplat/jsi:jsi"        
+    ]) if not IS_OSS_BUILD else [],
 )


### PR DESCRIPTION
## Summary

Fixes #28361. 

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[Internal] [CI] - Fix test_android

## Test Plan

Prior to fix:

```
react-native $ ./scripts/circleci/buck_fetch.sh 
Guessing 168a69309928ba16065cdb33b1775a4af9f924a6 as the last one used version.
Using additional configuration options from /Users/hramos/.buckconfig.d/experiments, /etc/buckconfig.d/fb_chef.ini, /etc/buckconfig.d/fb_chef_override.ini
Invalidating internal cached state: Watchman failed to start. This may cause slower builds.
Parsing buck files: finished in 1.5 sec
Buck wasn't able to parse /Users/hramos/git/react-native/ReactAndroid/src/main/java/com/facebook/fbreact/specs/BUCK:
IOError: [Errno 2] No such file or directory: '/Users/hramos/git/react-native/tools/build_defs/platform_defs.bzl'
Call stack:
  File "/Users/hramos/git/react-native/.buckd/resources/168a69309928ba16065cdb33b1775a4af9f924a6/buck_server/buck_parser/profiler.py", line 507, in wrapped
    return func(*args, **kwargs)
  File "/Users/hramos/git/react-native/ReactAndroid/src/main/java/com/facebook/fbreact/specs/BUCK", line 1
    load("//tools/build_defs:platform_defs.bzl", "ANDROID")
  File "/Users/hramos/git/react-native/.buckd/resources/168a69309928ba16065cdb33b1775a4af9f924a6/buck_server/buck_parser/profiler.py", line 507, in wrapped
    return func(*args, **kwargs)


This error happened while trying to get dependency '//ReactAndroid/src/main/java/com/facebook/fbreact/specs:FBReactNativeSpec' of target '//ReactAndroid/src/main/java/com/facebook/react/devsupport:devsupport'
```
After fix:

```
react-native $ ./scripts/circleci/buck_fetch.sh 
+ buck fetch ReactAndroid/src/test/java/com/facebook/react/modules
Guessing 168a69309928ba16065cdb33b1775a4af9f924a6 as the last one used version.
Using additional configuration options from /Users/hramos/.buckconfig.d/experiments, /etc/buckconfig.d/fb_chef.ini, /etc/buckconfig.d/fb_chef_override.ini
Invalidating internal cached state: Watchman failed to start. This may cause slower builds.
Parsing buck files: finished in 1.1 sec
Configuration 'ANDROID_SDK' points to an invalid directory '/opt/android_sdk'.
    When creating rule //ReactAndroid/src/main/java/com/facebook/hermes/instrumentation:instrumentation.
```
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
