### PR TITLE
fix(ios bundle): add jsbundle source map for iOS builds

### DIFF
--- a/scripts/react-native-xcode.sh
+++ b/scripts/react-native-xcode.sh
@@ -131,6 +131,7 @@ BUNDLE_FILE="$DEST/main.jsbundle"
   --reset-cache \
   --bundle-output "$BUNDLE_FILE" \
   --assets-dest "$DEST" \
+  --sourcemap-output "$BUNDLE_FILE.map" \
   $EXTRA_PACKAGER_ARGS
 
 if [[ $DEV != true && ! -f "$BUNDLE_FILE" ]]; then


### PR DESCRIPTION
## Summary

Addresses issue #27914 where the iOS sourcemap for the jsbundle was not at parity with Android. This PR auto builds the sourcemap with the same name supplied to the bundle.

## Changelog

[iOS] [Added] - add jsbundle sourcemap for iOS builds.

## Test Plan
- Ran react-native run-ios
  - New RN App
    - In Debug configuration ✅
    - In Release configuration ✅
  - New RN App with space in name (see https://github.com/philipshurpik/react-native-source-maps/issues/4#issuecomment-524201077)
    - In Debug configuration ✅
    - In Release configuration ✅