### PR TITLE
Fix app bundle size diff not always being compared against latest commit

### DIFF
--- a/bots/datastore.js
+++ b/bots/datastore.js
@@ -89,7 +89,7 @@ function getBinarySizesCollection(firestore) {
 function createOrUpdateDocument(collection, sha, data) {
   const stampedData = {
     ...data,
-    timestamp: Date.now(),
+    timestamp: firebase.firestore.Timestamp.now(),
   };
   const docRef = collection.doc(sha);
   return docRef.update(stampedData).catch(async error => {

--- a/bots/report-bundle-size.js
+++ b/bots/report-bundle-size.js
@@ -163,7 +163,7 @@ function report(target) {
           'android-jsc-x86': android_getApkSize('jsc', 'x86'),
           'android-jsc-x86_64': android_getApkSize('jsc', 'x86_64'),
         },
-        '| android | hermes | arm',
+        '\\| android \\| hermes \\| arm',
       );
       break;
 
@@ -174,7 +174,7 @@ function report(target) {
             'RNTester/build/Build/Products/Release-iphonesimulator/RNTester.app/RNTester',
           ),
         },
-        '| ios | - | universal |',
+        '\\| ios \\| - \\| universal \\|',
       );
       break;
 


### PR DESCRIPTION
## Summary

- Timestamp of entries in our Firebase instance sometimes get stored as number. This means that we may not always be diffing against the latest master commit.
- Size report of Android and iOS gets overwritten depending on which build finishes first.

## Changelog

[Internal] [Fixed] - App bundle size diff not always being compared against latest commit
[Internal] [Fixed] - Android and iOS app bundle size diff overwrite each other

## Test Plan

- We are now using Firebase's own [firebase.firestore.Timestamp.now](https://firebase.google.com/docs/reference/js/firebase.firestore.Timestamp#now) to ensure that we always get a timestamp in the preferred format. This has been tested locally but can only be verified when merged to master and we start getting new data. In the meantime, I'll manually fix up all the entries in the store.
- There should be one app bundle size comment for Android and one for iOS in this PR.