### PR TITLE
Improve test manual e2e script

### DIFF
--- a/scripts/test-manual-e2e.sh
+++ b/scripts/test-manual-e2e.sh
@@ -126,7 +126,7 @@ PACKAGE_VERSION=$(cat package.json \
             info "Press any key to run the sample in Android emulator/device"
             info ""
             read -n 1
-            npx react-native run-android
+            node "$CLI_PATH" run-android
         }
 
         # iOS
@@ -142,7 +142,7 @@ PACKAGE_VERSION=$(cat package.json \
             info "Press any key to open the project in Xcode"
             info ""
             read -n 1
-            open "ios/${project_name}.xcodeproj"
+            node "$CLI_PATH" run-ios
         }
     }
     popd

--- a/scripts/test-manual-e2e.sh
+++ b/scripts/test-manual-e2e.sh
@@ -24,6 +24,15 @@ info() {
     echo -e "$BLUE""$*""$ENDCOLOR"
 }
 
+kill_packagers() {
+    success "Killing any running packagers"
+    lsof -i :8081 | grep LISTEN
+    lsof -i :8081 | grep LISTEN | /usr/bin/awk '{print $2}' | xargs kill
+}
+
+REPO_ROOT=$(pwd)
+CLI_PATH="$REPO_ROOT/cli.js"
+
 PACKAGE_VERSION=$(cat package.json \
   | grep version \
   | head -1 \
@@ -31,91 +40,113 @@ PACKAGE_VERSION=$(cat package.json \
   | sed 's/[",]//g' \
   | tr -d '[[:space:]]')
 
-success "Preparing version $PACKAGE_VERSION"
+# Prepare
+{
+    info "Preparing version $PACKAGE_VERSION"
 
-repo_root=$(pwd)
+    npm install
 
-rm -rf android
-./gradlew :ReactAndroid:installArchives || error "Couldn't generate artifacts"
+    rm -rf android
+    ./gradlew :ReactAndroid:installArchives || error "Couldn't generate artifacts"
 
-success "Generated artifacts for Maven"
+    kill_packagers
+}
 
-npm install
+# Test RNTester
+{
+    info "Start the packager in another terminal by running 'npm start' from the root"
+    info "and then press any key."
+    info ""
+    read -n 1
 
-success "Killing any running packagers"
-lsof -i :8081 | grep LISTEN
-lsof -i :8081 | grep LISTEN | /usr/bin/awk '{print $2}' | xargs kill
+    # Android
+    {
+        ./gradlew :RNTester:android:app:installJscDebug || error "Couldn't build RNTester Android"
 
-info "Start the packager in another terminal by running 'npm start' from the root"
-info "and then press any key."
-info ""
-read -n 1
+        info "Press any key to run RNTester in an already running Android emulator/device"
+        info ""
+        read -n 1
+        adb shell am start -n com.facebook.react.uiapp/.RNTesterActivity
+    }
 
-./gradlew :RNTester:android:app:installJscDebug || error "Couldn't build RNTester Android"
+    # iOS
+    pushd RNTester
+    {
+        info "Press any key to open the workspace in Xcode, then build and test manually."
+        info ""
+        read -n 1
+        success "Installing CocoaPods dependencies"
+        rm -rf Pods && pod install
+        open "RNTesterPods.xcworkspace"
+    }
+    popd
 
-info "Press any key to run RNTester in an already running Android emulator/device"
-info ""
-read -n 1
-adb shell am start -n com.facebook.react.uiapp/.RNTesterActivity
+    info "When done testing RNTester app on iOS and Android press any key to continue."
+    info ""
+    read -n 1
 
-info "Press any key to open the workspace in Xcode, then build and test manually."
-info ""
-read -n 1
-success "Installing CocoaPods dependencies"
-rm -rf RNTester/Pods && cd RNTester && pod install
-open "RNTester/RNTesterPods.xcworkspace"
+    kill_packagers
+}
 
-info "When done testing RNTester app on iOS and Android press any key to continue."
-info ""
-read -n 1
+# Test new app from template
+{
+    npm pack
 
-success "Killing packager"
-lsof -i :8081 | grep LISTEN
-lsof -i :8081 | grep LISTEN | /usr/bin/awk '{print $2}' | xargs kill
+    PACKAGE=$(pwd)/react-native-$PACKAGE_VERSION.tgz
+    success "Package bundled ($PACKAGE)"
 
-npm pack
+    node scripts/set-rn-template-version.js "file:$PACKAGE"
+    success "React Native version changed in the template"
 
-PACKAGE=$(pwd)/react-native-$PACKAGE_VERSION.tgz
-success "Package bundled ($PACKAGE)"
+    project_name="RNTestProject"
+    project_dirname="/tmp"
+    project_path="${project_dirname}/${project_name}"
 
-node scripts/set-rn-template-version.js "file:$PACKAGE"
-success "React Native version changed in the template"
+    pushd "$project_dirname"
+    {
+        rm -rf "$project_name"
+        node "$CLI_PATH" init "$project_name" --template "$REPO_ROOT"
+    }
+    popd
 
-project_name="RNTestProject"
+    info "Double checking the versions in package.json are correct:"
+    grep "\"react-native\": \".*react-native-$PACKAGE_VERSION.tgz\"" "${project_path}/package.json" || error "Incorrect version number in ${project_path}/package.json"
+    grep -E "com.facebook.react:react-native:\\+" "${project_path}/android/app/build.gradle" || error "Dependency in ${project_path}/android/app/build.gradle must be com.facebook.react:react-native:+"
 
-cd /tmp/
-rm -rf "$project_name"
-node "$repo_root/cli.js" init "$project_name" --template "$repo_root"
+    success "New sample project generated at ${project_path}"
 
-info "Double checking the versions in package.json are correct:"
-grep "\"react-native\": \".*react-native-$PACKAGE_VERSION.tgz\"" "/tmp/${project_name}/package.json" || error "Incorrect version number in /tmp/${project_name}/package.json"
-grep -E "com.facebook.react:react-native:\\+" "${project_name}/android/app/build.gradle" || error "Dependency in /tmp/${project_name}/android/app/build.gradle must be com.facebook.react:react-native:+"
+    pushd "$project_path"
+    {
+        # Android
+        {
+            info "Test the following on Android:"
+            info "   - Disable Fast Refresh. It might be enabled from last time (the setting is stored on the device)"
+            info "   - Verify 'Reload JS' works"
+            info ""
+            info "Press any key to run the sample in Android emulator/device"
+            info ""
+            read -n 1
+            npx react-native run-android
+        }
 
-success "New sample project generated at /tmp/${project_name}"
-
-info "Test the following on Android:"
-info "   - Disable Fast Refresh. It might be enabled from last time (the setting is stored on the device)"
-info "   - Verify 'Reload JS' works"
-info ""
-info "Press any key to run the sample in Android emulator/device"
-info ""
-read -n 1
-cd "/tmp/${project_name}" && npx react-native run-android
-
-info "Test the following on iOS:"
-info "   - Disable Fast Refresh. It might be enabled from last time (the setting is stored on the device)"
-info "   - Verify 'Reload JS' works"
-info "   - Test Chrome debugger by adding breakpoints and reloading JS. We don't have tests for Chrome debugging."
-info "   - Disable Chrome debugging."
-info "   - Enable Fast Refresh, change a file (index.js) and save. The UI should refresh."
-info "   - Disable Fast Refresh."
-info ""
-info "Press any key to open the project in Xcode"
-info ""
-read -n 1
-open "/tmp/${project_name}/ios/${project_name}.xcodeproj"
-
-cd "$repo_root"
+        # iOS
+        {
+            info "Test the following on iOS:"
+            info "   - Disable Fast Refresh. It might be enabled from last time (the setting is stored on the device)"
+            info "   - Verify 'Reload JS' works"
+            info "   - Test Chrome debugger by adding breakpoints and reloading JS. We don't have tests for Chrome debugging."
+            info "   - Disable Chrome debugging."
+            info "   - Enable Fast Refresh, change a file (index.js) and save. The UI should refresh."
+            info "   - Disable Fast Refresh."
+            info ""
+            info "Press any key to open the project in Xcode"
+            info ""
+            read -n 1
+            open "ios/${project_name}.xcodeproj"
+        }
+    }
+    popd
+}
 
 info "Next steps:"
 info "   - https://github.com/facebook/react-native/blob/master/Releases.md"

--- a/scripts/test-manual-e2e.sh
+++ b/scripts/test-manual-e2e.sh
@@ -44,7 +44,7 @@ PACKAGE_VERSION=$(cat package.json \
 {
     info "Preparing version $PACKAGE_VERSION"
 
-    npm install
+    yarn install
 
     rm -rf android
     ./gradlew :ReactAndroid:installArchives || error "Couldn't generate artifacts"

--- a/scripts/test-manual-e2e.sh
+++ b/scripts/test-manual-e2e.sh
@@ -54,10 +54,8 @@ PACKAGE_VERSION=$(cat package.json \
 
 # Test RNTester
 {
-    info "Start the packager in another terminal by running 'npm start' from the root"
-    info "and then press any key."
-    info ""
-    read -n 1
+    info "Starting the packager in the background"
+    node "$CLI_PATH" start &
 
     # Android
     {


### PR DESCRIPTION
## Summary

Cleans up and improves the manual e2e test script:

* Use `yarn` instead of `npm` to install dependencies that have previously been recorded in `yarn.lock`
* Fix incorrectly opening the Xcode project, rather than workspace, of the iOS `RNTestProject`
* Use RN CLI to build/run both Android and iOS test apps
* Launch and prepare Android emulator and iOS simulators instead of requiring manual intervention:
  - Delete `RNTester` app
  - Delete `RNTestProject` app
* Launch packager for `RNTester` automatically in background instead of requiring manual intervention
* Refactor and organise differently to allow for easier future maintenance

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[Internal] [Fixed] - Fix and smoothen usage of `test-manual-e2e.sh` script

## Test Plan

Ran it manually many times.
