### PR TITLE
Upgrade internal packages to support ESLint >= 6

### DIFF
--- a/packages/eslint-config-react-native-community/package.json
+++ b/packages/eslint-config-react-native-community/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-community/eslint-config",
-  "version": "0.0.7",
+  "version": "1.0.0",
   "description": "ESLint config for React Native",
   "main": "index.js",
   "license": "MIT",
@@ -24,9 +24,9 @@
     "prettier": "^2.0.2"
   },
   "peerDependencies": {
-    "eslint": ">=5"
+    "eslint": ">=6"
   },
   "devDependencies": {
-    "eslint": "^5.1.0"
+    "eslint": "^6.5.1"
   }
 }

--- a/packages/eslint-config-react-native-community/package.json
+++ b/packages/eslint-config-react-native-community/package.json
@@ -10,18 +10,18 @@
   },
   "dependencies": {
     "@react-native-community/eslint-plugin": "^1.0.0",
-    "@typescript-eslint/eslint-plugin": "^1.5.0",
-    "@typescript-eslint/parser": "^1.5.0",
-    "babel-eslint": "10.0.3",
-    "eslint-config-prettier": "^6.0.0",
+    "@typescript-eslint/eslint-plugin": "^2.25.0",
+    "@typescript-eslint/parser": "^2.25.0",
+    "babel-eslint": "10.1.0",
+    "eslint-config-prettier": "^6.10.1",
     "eslint-plugin-eslint-comments": "^3.1.2",
     "eslint-plugin-flowtype": "2.50.3",
     "eslint-plugin-jest": "22.4.1",
-    "eslint-plugin-prettier": "2.6.2",
-    "eslint-plugin-react": "7.16.0",
-    "eslint-plugin-react-hooks": "^2.0.1",
+    "eslint-plugin-prettier": "3.1.2",
+    "eslint-plugin-react": "7.19.0",
+    "eslint-plugin-react-hooks": "^2.5.1",
     "eslint-plugin-react-native": "3.8.1",
-    "prettier": "1.17.0"
+    "prettier": "^2.0.2"
   },
   "peerDependencies": {
     "eslint": ">=5"


### PR DESCRIPTION
Fixes #28293

I've tested it with https://github.com/react-native-community/react-native-template-typescript and it seems to be working as expected - no warnings, supports typescript 3.8. 

(note: I didn't upgrade the package version as I don't know how the releases work for this package)

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[CATEGORY] [TYPE] - Message

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
