### PR TITLE
Update PixelRatio 'getFontScale' method description

### DIFF
--- a/Libraries/Utilities/PixelRatio.js
+++ b/Libraries/Utilities/PixelRatio.js
@@ -92,9 +92,9 @@ class PixelRatio {
    *
    * If a font scale is not set, this returns the device pixel ratio.
    *
-   * Currently this is only implemented on Android and reflects the user preference set in
-   * Settings > Display > Font size, on iOS it will always return the default pixel ratio.
-   * @platform android
+   * This reflects the user preference set in:
+   *  - Settings > Display > Font size on Android,
+   *  - Settings > Display & Brightness > Text Size on iOS.
    */
   static getFontScale(): number {
     return Dimensions.get('window').fontScale || PixelRatio.get();


### PR DESCRIPTION
## Summary

Refs facebook/react-native-website#1776.

Despite in-code description `PixelRatio.getFontScale()` is working properly on the iOS (it also reflects the user settings).

This PR updates the in-code description to match current behaviour. 

I have decided to skip in the code information about additional setting in `Accessibility` menu and in `Control Centre`, but if you think it is important just let me know, I can update this PR.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[Internal] [Fixed] - Fix PixelRatio getFontScale method description

## Test Plan

N/A