### PR TITLE
fix: Android gradle config when bundling for release

### DIFF
--- a/RNTester/android/app/build.gradle
+++ b/RNTester/android/app/build.gradle
@@ -65,6 +65,7 @@ plugins {
  */
 
 project.ext.react = [
+    cliPath: "../../../node_modules/react-native/cli.js",
     bundleAssetName: "RNTesterApp.android.bundle",
     entryFile: file("../../js/RNTesterApp.android.js"),
     root: "$rootDir",

--- a/RNTester/android/app/build.gradle
+++ b/RNTester/android/app/build.gradle
@@ -65,7 +65,7 @@ plugins {
  */
 
 project.ext.react = [
-    cliPath: "../../../node_modules/react-native/cli.js",
+    cliPath: "../../../cli.js",
     bundleAssetName: "RNTesterApp.android.bundle",
     entryFile: file("../../js/RNTesterApp.android.js"),
     root: "$rootDir",

--- a/RNTester/android/app/build.gradle
+++ b/RNTester/android/app/build.gradle
@@ -65,7 +65,7 @@ plugins {
  */
 
 project.ext.react = [
-    cliPath: "../../../cli.js",
+    cliPath: "$rootDir/cli.js",
     bundleAssetName: "RNTesterApp.android.bundle",
     entryFile: file("../../js/RNTesterApp.android.js"),
     root: "$rootDir",

--- a/react.gradle
+++ b/react.gradle
@@ -111,7 +111,7 @@ afterEvaluate {
             }
         } else {
             throw new Exception("Missing cliPath or nodeExecutableAndArgs from build config. " +
-                "Please set set project.ext.react.cliPath to the path of the react-native cli.js");
+                "Please set project.ext.react.cliPath to the path of the react-native cli.js");
         }
 
         def enableHermes = enableHermesForVariant(variant)

--- a/react.gradle
+++ b/react.gradle
@@ -110,7 +110,8 @@ afterEvaluate {
                 execCommand.addAll([*nodeExecutableAndArgs, cliPath])
             }
         } else {
-            execCommand.addAll([npx, "react-native"])
+            throw new Exception("Missing cliPath or nodeExecutableAndArgs from build config. " +
+                "Please set set project.ext.react.cliPath to the path of the react-native cli.js");
         }
 
         def enableHermes = enableHermesForVariant(variant)


### PR DESCRIPTION
## Summary
This fix aims to address the issue when bundling an Android app for release and getting the error exhibited in #28002 which I also encountered myself.

The config was changed sometime in November 2019 (as part of #26940, commit https://github.com/facebook/react-native/commit/a3b08048674e324dbe1f0ca816f35607e9e06a2f) to be very opinionated when it comes to the use of `npx` which Gradle itself cannot find anyway (I have `npx` installed globally and it didn't pick it up).

Another issue that the use of `npx` creates is that Gradle should only ever use the currently installed react-native cli rather than a (possibly) higher version which may not always have backward compatibility.

The proposed change simply throws a more descriptive error rather than defaulting to a tool which may or may not exist on the machine, be it CI or a development environment. I've also modified the RNTester app to reflect the correct config implementation relative to the RNTester app itself.

In real projects, the config inside `android/app/build.gradle` should look similar to the following snippet:

```
project.ext.react = [
  cliPath: "$rootDir/../node_modules/react-native/cli.js",
  entryFile: "index.js"
];
```

## Changelog
[Android] [Fixed] - Gradle release config

## Test Plan
- [x] Successfully bundled an Android release build with correct config
- [x] Works with RNTester app
