### PR TITLE
Use GradleScriptException constructor with two parameters

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -98,12 +98,14 @@ task prepareFolly(dependsOn: dependenciesPath ? [] : [downloadFolly], type: Copy
 task prepareHermes() {
     def hermesPackagePath = findNodeModulePath(projectDir, "hermes-engine")
     if (!hermesPackagePath) {
-        throw new GradleScriptException("Could not find the hermes-engine npm package")
+        throw new GradleScriptException("Could not find the hermes-engine npm package", null)
     }
 
     def hermesAAR = file("$hermesPackagePath/android/hermes-debug.aar")
     if (!hermesAAR.exists()) {
-        throw new GradleScriptException("The hermes-engine npm package is missing \"android/hermes-debug.aar\"")
+        throw new GradleScriptException(
+            "The hermes-engine npm package is missing \"android/hermes-debug.aar\"",
+            null)
     }
 
     def soFiles = zipTree(hermesAAR).matching({ it.include "**/*.so" })
@@ -165,12 +167,14 @@ task prepareJSC {
     doLast {
         def jscPackagePath = findNodeModulePath(projectDir, "jsc-android")
         if (!jscPackagePath) {
-            throw new GradleScriptException("Could not find the jsc-android npm package")
+            throw new GradleScriptException("Could not find the jsc-android npm package", null)
         } 
 
         def jscDist = file("$jscPackagePath/dist")
         if (!jscDist.exists()) {
-            throw new GradleScriptException("The jsc-android npm package is missing its \"dist\" directory")
+            throw new GradleScriptException(
+                "The jsc-android npm package is missing its \"dist\" directory",
+                null)
         }
 
         def jscAAR = fileTree(jscDist).matching({ it.include "**/android-jsc/**/*.aar" }).singleFile


### PR DESCRIPTION
## Summary

GradleScriptException used to have a constructor with one string parameter. But in the latest 6.3 version, it has a constructor with two parameters. [GradleScriptException  docs](https://docs.gradle.org/current/javadoc/org/gradle/api/GradleScriptException.html)

It led to Gradle sync errors in Android Studio.

`caused by: groovy.lang.groovyruntimeexception: could not find matching constructor for: org.gradle.api.gradlescriptexception(string)`

## Changelog

[Internal] [Fixed] - Fix gradle sync error. Use GradleScriptException constructor with two parameters

## Test Plan

Open root folder in Android Studio without calling `yarn install`. During the sync phase, it can't find Hermes and it tries to throw GradleScriptException with one parameter. Android Studio shows:
`caused by: groovy.lang.groovyruntimeexception: could not find matching constructor for: org.gradle.api.gradlescriptexception(string)`.

Thank you :)