### PR TITLE
Fix calculating View position within a Window in split-screen mode on Android

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java
@@ -7,8 +7,8 @@
 
 package com.facebook.react.uimanager;
 
-import android.content.res.Resources;
 import android.graphics.Matrix;
+import android.graphics.Rect;
 import android.graphics.RectF;
 import android.util.SparseArray;
 import android.util.SparseBooleanArray;
@@ -721,14 +721,11 @@ public class NativeViewHierarchyManager {
 
     v.getLocationOnScreen(outputBuffer);
 
-    // We need to remove the status bar from the height.  getLocationOnScreen will include the
-    // status bar.
-    Resources resources = v.getContext().getResources();
-    int statusBarId = resources.getIdentifier("status_bar_height", "dimen", "android");
-    if (statusBarId > 0) {
-      int height = (int) resources.getDimension(statusBarId);
-      outputBuffer[1] -= height;
-    }
+    // we need to subtract visibleWindowCoords - to subtract possible window insets, split screen or multi window
+    Rect visibleWindowFrame = new Rect();
+    v.getWindowVisibleDisplayFrame(visibleWindowFrame);
+    outputBuffer[0] = outputBuffer[0] - visibleWindowFrame.left;
+    outputBuffer[1] = outputBuffer[1] - visibleWindowFrame.top;
 
     // outputBuffer[0,1] already contain what we want
     outputBuffer[2] = v.getWidth();


### PR DESCRIPTION
## Summary

On Android, when using split-screen mode, the Window-relative position of a native View is not calculated properly when the app is running on the right (or bottom) half of the screen. The coordinates are currently calculated only based on View.getLocationOnScreen() with subtracting status bar height. Scenarios, where the window does not fill the entire screen (such as split-screen mode) are not supported. 

We need to use a more general solution to subtract the actual position of the window from position of the view within the screen. This PR fixes the issue by subtracting coordinates of the Window retrieved from View.getWindowVisibleDisplayFrame(), which covers all scenarios when Window can be in a different position than the screen (incl. status bar offset).

## Changelog

[Android] [Fixed] - Calculating view position within the window in split-screen mode

## Test Plan

1. Run an app in split-screen mode on the right half of the screen
2. Call UIManagerModule.measureInWindow() from JS to fetch a position of a View within a Window
3. Observe the wrong coordinates returned
4. Try the same with the fix 
