### PR TITLE
[CI] Buck: Use Android SDK 29 during build

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -1,6 +1,6 @@
 
 [android]
-  target = android-28
+  target = android-29
 
 [download]
   max_number_of_retries = 3


### PR DESCRIPTION
Fixes `test_android` and `test_docker` build failures. Thanks to @dulmandakh for identifying the fix.

Changelog:
[Internal] [Android] [Changed] - Use Android SDK 29 to build during CI tests