### PR TITLE
Fixes iOS reload through metro "r" command key

### DIFF
--- a/React/Base/RCTBundleURLProvider.m
+++ b/React/Base/RCTBundleURLProvider.m
@@ -121,6 +121,7 @@ static NSURL *serverRootWithHostPort(NSString *hostPort)
 #if RCT_DEV
   NSString *host = [self guessPackagerHost];
   if (host) {
+    self.jsLocation = host;
     return host;
   }
 #endif


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

This allows the iOS device to be reloaded through the metro command line, besides the fact that whenever packagerServerHost is called, it will only get the IP address once when debugging.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[iOS] [Fixed] - Fixed connection of metro reload command to iOS device

