### PR TITLE
[CI] Add Author Feedback label automatically

### DIFF
--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -1,47 +1,52 @@
-# Configuration for Label Actions - https://github.com/dessant/label-actions
+# Configuration for Label Actions - https://github.com/marketplace/actions/label-actions
 
-# Configuration settings just for issues
-issues:
-  actions:
-    "Type: Invalid":
-      close: true
-    "Type: Question":
-      comment: >
-        We are using GitHub issues exclusively to track bugs in React Native. GitHub may not be the ideal place to ask a question, but you can try asking over on [Stack Overflow](http://stackoverflow.com/questions/tagged/react-native), or on [Reactiflux](https://www.reactiflux.com/).
-      close: true
-    "Type: Docs":
-      comment: >
-        Please report documentation issues in the [`react-native-website`](https://github.com/facebook/react-native-website/issues) repository.
-      close: true
-    "Resolution: For Stack Overflow":
-      comment: >
-        We are using GitHub issues exclusively to track bugs in the core React Native library. Please try asking over on [Stack Overflow](http://stackoverflow.com/questions/tagged/react-native) as it is better suited for this type of question.
-      close: true
-    "Needs: Issue Template":
-      comment: >
-        <table><tbody><tr><th width="50">:warning:</th><th width="100%">
-        Missing Required Fields
-        </th></tr><tr><td>:information_source:</td><td>
-        It looks like your issue may be missing some necessary information. GitHub provides an example template whenever a <a href="https://github.com/facebook/react-native/issues/new?template=bug_report.md">new issue is created</a>. Could you go back and make sure to fill out the template? You may edit this issue, or close it and open a new one.
-        </td></tr></tbody></table>
-    "Needs: Environment Info":
-      comment: >
-        <table><tbody><tr><th width="50">:warning:</th><th width="100%">
-        Missing Environment Information
-        </th></tr><tr><td>:information_source:</td><td>
-        Your issue may be missing information about your development environment. You can obtain the missing information by running <code>react-native info</code> in a console.
-        </td></tr></tbody></table>
-    "Needs: Verify on Latest Version":
-      comment: >
-        <table><tbody><tr><th width="50">:warning:</th><th width="100%">
-        Using Old Version
-        </th></tr><tr><td>:information_source:</td><td>
-        It looks like you are using an older version of React Native. Please <a href="https://reactnative.dev/docs/upgrading">upgrade</a> to the latest version, and verify if the issue persists. If it does not, please let us know so we can close out this issue. This helps us ensure we are looking at issues that still exist in the current release.
-        </td></tr></tbody></table>
-    "Needs: Repro":
-      comment: >
-        <table><tbody><tr><th width="50">:warning:</th><th width="100%">
-        Missing Reproducible Example
-        </th></tr><tr><td>:information_source:</td><td>
-        It looks like your issue is missing a reproducible example. Please provide a <a href="https://snack.expo.io">Snack</a> or a repository that demonstrates the issue you are reporting in a <a href="https://stackoverflow.com/help/minimal-reproducible-example">minimal, complete, and reproducible</a> manner.
-        </td></tr></tbody></table>
+"Type: Invalid":
+  close: true
+"Type: Question":
+  comment: >
+    We are using GitHub issues exclusively to track bugs in React Native. GitHub may not be the ideal place to ask a question, but you can try asking over on [Stack Overflow](http://stackoverflow.com/questions/tagged/react-native), or on [Reactiflux](https://www.reactiflux.com/).
+  close: true
+"Type: Docs":
+  comment: >
+    Please report documentation issues in the [`react-native-website`](https://github.com/facebook/react-native-website/issues) repository.
+  close: true
+"Resolution: For Stack Overflow":
+  comment: >
+    We are using GitHub issues exclusively to track bugs in the core React Native library. Please try asking over on [Stack Overflow](http://stackoverflow.com/questions/tagged/react-native) as it is better suited for this type of question.
+  close: true
+"Needs: Issue Template":
+  comment: >
+    <table><tbody><tr><th width="50">:warning:</th><th width="100%">
+    Missing Required Fields
+    </th></tr><tr><td>:information_source:</td><td>
+    It looks like your issue may be missing some necessary information. GitHub provides an example template whenever a <a href="https://github.com/facebook/react-native/issues/new?template=bug_report.md">new issue is created</a>. Could you go back and make sure to fill out the template? You may edit this issue, or close it and open a new one.
+    </td></tr></tbody></table>
+  labels:
+    - "Needs: Author Feedback"
+"Needs: Environment Info":
+  comment: >
+    <table><tbody><tr><th width="50">:warning:</th><th width="100%">
+    Missing Environment Information
+    </th></tr><tr><td>:information_source:</td><td>
+    Your issue may be missing information about your development environment. You can obtain the missing information by running <code>react-native info</code> in a console.
+    </td></tr></tbody></table>
+  labels:
+    - "Needs: Author Feedback"
+"Needs: Verify on Latest Version":
+  comment: >
+    <table><tbody><tr><th width="50">:warning:</th><th width="100%">
+    Using Old Version
+    </th></tr><tr><td>:information_source:</td><td>
+    It looks like you are using an older version of React Native. Please <a href="https://reactnative.dev/docs/upgrading">upgrade</a> to the latest version, and verify if the issue persists. If it does not, please let us know so we can close out this issue. This helps us ensure we are looking at issues that still exist in the current release.
+    </td></tr></tbody></table>
+  labels:
+    - "Needs: Author Feedback"
+"Needs: Repro":
+  comment: >
+    <table><tbody><tr><th width="50">:warning:</th><th width="100%">
+    Missing Reproducible Example
+    </th></tr><tr><td>:information_source:</td><td>
+    It looks like your issue is missing a reproducible example. Please provide a <a href="https://snack.expo.io">Snack</a> or a repository that demonstrates the issue you are reporting in a <a href="https://stackoverflow.com/help/minimal-reproducible-example">minimal, complete, and reproducible</a> manner.
+    </td></tr></tbody></table>
+  labels:
+    - "Needs: Author Feedback"

--- a/.github/workflows/process-label-actions.yml
+++ b/.github/workflows/process-label-actions.yml
@@ -1,0 +1,16 @@
+name: Label Actions
+# This workflow is triggered when a label is added to an issue.
+on:
+  issues:
+    types: labeled
+
+jobs:
+  processLabelAction:
+    name: Process Label Action
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Process Label Action
+        uses: hramos/label-actions@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Improve issue triage by automatically adding the "Needs: Author Feedback" label.

NOTE: The old label-actions app should be disabled when this PR is merged: https://github.com/apps/label-actions/installations/7445225

## Changelog

[Internal] - Issue Triage

## Test Plan

Verified the same `label-actions.yml` and workflow config on a private repo.