### PR TITLE
[CI] Loosen up restrictions for internal changelogs

### DIFF
--- a/bots/dangerfile.js
+++ b/bots/dangerfile.js
@@ -51,12 +51,14 @@ if (!includesTestPlan) {
 }
 
 // Regex looks for given categories, types, a file/framework/component, and a message - broken into 4 capture groups
-const changelogRegex = /\[\s?(ANDROID|GENERAL|IOS|JS|JAVASCRIPT|INTERNAL)\s?\]\s*?\[\s?(ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY)\s?\]\s*?\-?\s*?(.*)/gi;
+const changelogRegex = /\[\s?(ANDROID|GENERAL|IOS|JS|JAVASCRIPT|INTERNAL)\s?\]\s?\[\s?(ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY)\s?\]\s*?\-?\s*?(.*)/gi;
+const internalChangelogRegex = /\[\s?(INTERNAL)\s?\].*/gi;
 const includesChangelog =
   danger.github.pr.body &&
   (danger.github.pr.body.toLowerCase().includes('## changelog') ||
     danger.github.pr.body.toLowerCase().includes('release notes'));
 const correctlyFormattedChangelog = changelogRegex.test(danger.github.pr.body);
+const containsInternalChangelog = internalChangelogRegex.test(danger.github.pr.body);
 
 // Provides advice if a changelog is missing
 const changelogInstructions =
@@ -68,7 +70,7 @@ if (!includesChangelog) {
     'To do so, add a "## Changelog" section to your PR description. ' +
     changelogInstructions;
   message(`${title} - <i>${idea}</i>`);
-} else if (!correctlyFormattedChangelog) {
+} else if (!correctlyFormattedChangelog && !containsInternalChangelog) {
   const title = ':clipboard: Verify Changelog Format';
   const idea = changelogInstructions;
   message(`${title} - <i>${idea}</i>`);

--- a/bots/dangerfile.js
+++ b/bots/dangerfile.js
@@ -58,7 +58,9 @@ const includesChangelog =
   (danger.github.pr.body.toLowerCase().includes('## changelog') ||
     danger.github.pr.body.toLowerCase().includes('release notes'));
 const correctlyFormattedChangelog = changelogRegex.test(danger.github.pr.body);
-const containsInternalChangelog = internalChangelogRegex.test(danger.github.pr.body);
+const containsInternalChangelog = internalChangelogRegex.test(
+  danger.github.pr.body,
+);
 
 // Provides advice if a changelog is missing
 const changelogInstructions =


### PR DESCRIPTION

## Summary

Do not nag on PRs that contain internal changelogs (meaning, the change doesn't need to be called out in release notes).

## Changelog

[Internal] - This should be acceptable.

## Test Plan

See PR.