### PR TITLE
Make XMLHttpRequest timeout behavior consistent on Android and iOS

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.java
@@ -350,8 +350,8 @@ public final class NetworkingModule extends NativeNetworkingAndroidSpec {
     // client and set the timeout explicitly on the clone.  This is cheap as everything else is
     // shared under the hood.
     // See https://github.com/square/okhttp/wiki/Recipes#per-call-configuration for more information
-    if (timeout != mClient.connectTimeoutMillis()) {
-      clientBuilder.connectTimeout(timeout, TimeUnit.MILLISECONDS);
+    if (timeout != mClient.callTimeoutMillis()) {
+      clientBuilder.callTimeout(timeout, TimeUnit.MILLISECONDS);
     }
     OkHttpClient client = clientBuilder.build();
 

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/network/ResponseUtil.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/network/ResponseUtil.java
@@ -12,7 +12,7 @@ import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEmitter;
-import java.net.SocketTimeoutException;
+import java.io.InterruptedIOException;
 
 /** Util methods to send network responses to JS. */
 public class ResponseUtil {
@@ -84,7 +84,7 @@ public class ResponseUtil {
     args.pushInt(requestId);
     args.pushString(error);
 
-    if ((e != null) && (e.getClass() == SocketTimeoutException.class)) {
+    if ((e != null) && (e.getClass() == InterruptedIOException.class)) {
       args.pushBoolean(true); // last argument is a time out boolean
     }
 


### PR DESCRIPTION
## Summary

Use callTimeout instead of connectTimeout

### Problem: 
the timeout setting of XMLHttpRequest doesn't work.
### Demo code:

```
const log = (s) => {
  let ts = new Date().toISOString()
  console.log("[" + ts + "] " + s)
}

const App: () => React$Node = () => {

  useEffect(() => {
    let request = new XMLHttpRequest()
    request.timeout = 3210
    request.onload = (e) => {
      log("onload")
      log("response: " + e.target.responseText)
    }
    request.ontimeout = () => {
      log("request ontimeout")
    }
    request.onerror = (e) => {
      log("request onerror")
    }
    request.open("GET", "https://httpbin.org/delay/6")
    request.send()
    log("request sent")
  })
```

### On Android
<img width="694" alt="Screen Shot 2020-03-22 at 12 14 44 AM" src="https://user-images.githubusercontent.com/33993573/78226080-c3dfe680-74fd-11ea-8825-6b16268e0b0d.png">

### On iOS
<img width="522" alt="Screen Shot 2020-03-22 at 12 18 22 AM" src="https://user-images.githubusercontent.com/33993573/78226114-d1956c00-74fd-11ea-862a-eb62e332b6fa.png">

## Changelog

[Android] [Fixed] - Fix XMLHttpRequest timeout

## Test Plan

Run the same demo code and check that the timeout event is fired on Android
