### PR TITLE
fix: Let react.gradle Hermes config use devDisabledIn-flag

### DIFF
--- a/react.gradle
+++ b/react.gradle
@@ -116,6 +116,10 @@ afterEvaluate {
 
         def enableHermes = enableHermesForVariant(variant)
 
+        // Set up dev mode
+        def devEnabled = !(config."devDisabledIn${targetName}"
+            || targetName.toLowerCase().contains("release"))
+
         def currentBundleTask = tasks.create(
             name: "bundle${targetName}JsAndAssets",
             type: Exec) {
@@ -142,10 +146,6 @@ afterEvaluate {
             // Set up the call to the react-native cli
             workingDir(reactRoot)
 
-            // Set up dev mode
-            def devEnabled = !(config."devDisabledIn${targetName}"
-                || targetName.toLowerCase().contains("release"))
-
             def extraArgs = extraPackagerArgs;
 
             if (bundleConfig) {
@@ -164,7 +164,7 @@ afterEvaluate {
                     def hermesFlags;
                     def hbcTempFile = file("${jsBundleFile}.hbc")
                     exec {
-                        if (targetName.toLowerCase().contains("release")) {
+                        if (!devEnabled) {
                             // Can't use ?: since that will also substitute valid empty lists
                             hermesFlags = config.hermesFlagsRelease
                             if (hermesFlags == null) hermesFlags = ["-O", "-output-source-map"]
@@ -300,7 +300,6 @@ afterEvaluate {
         // This should really be done by packaging all Hermes releated libs into
         // two separate HermesDebug and HermesRelease AARs, but until then we'll
         // kludge it by deleting the .so files out of the /transforms/ directory.
-        def isRelease = targetName.toLowerCase().contains("release")
         def libDir = "$buildDir/intermediates/transforms/"
         def vmSelectionAction = {
             fileTree(libDir).matching {
@@ -308,7 +307,7 @@ afterEvaluate {
                     // For Hermes, delete all the libjsc* files
                     include "**/libjsc*.so"
 
-                    if (isRelease) {
+                    if (!devEnabled) {
                         // Reduce size by deleting the debugger/inspector
                         include '**/libhermes-inspector.so'
                         include '**/libhermes-executor-debug.so'


### PR DESCRIPTION
## Summary

Issues: #27829 #25601

At the moment `react.gradle` doesn't support custom build variants for Hermes in release-builds. Say I have have a build type in my `android/app/build.gradle` named `store`, which is supposed to be a release-build:
```gradle
buildTypes {
    store {
        initWith buildTypes.release
        matchingFallbacks = ['release']
    }
}
```

Then the explicit check for the target name in `react.gradle` will not work:
```gradle
targetName.toLowerCase().contains("release")
```

My suggestion is that we let "release"-check for Hermes be the `"devDisabledIn${targetName}"` flag, which also does the `targetName`-check, and should in this case be backwards-compatible.

This would let me config the behaviour through the pre-existing `devDisabledIn`-flag in my `android/app/build.gradle`:
```gradle
project.ext.react = [
    entryFile: "index.js",
    enableHermes: true,
    devDisabledInStore: true,
    bundleInStore: true
]
```

## Changelog

[Android] [Added] - Hermes now supports the `devDisabledIn{targetName}`-flag for custom build variants in `build.gradle`

## Test Plan

1. Create a new React Native-project
2. Add a new build type inits with `release`:
```gradle
buildTypes {
    staging {
        initWith buildTypes.release
        matchingFallbacks = ['release']
    }
}
```

3. Disable dev for `staging` build variant in config, enable Hermes:
```gradle
project.ext.react = [
    entryFile: "index.js",
    enableHermes: true,  // clean and rebuild if changing
    devDisabledInStaging: true,
    bundleInStaging: true
]
```

4. Add extra necessary Hermes-config in `dependencies` for build variant (`stagingImplementation)`:
```gradle
if (enableHermes) {
    def hermesPath = "../../node_modules/hermes-engine/android/";
    debugImplementation files(hermesPath + "hermes-debug.aar")
    releaseImplementation files(hermesPath + "hermes-release.aar")
    stagingImplementation files(hermesPath + "hermes-release.aar")
} else {
    implementation jscFlavor
}
``` 
5. Build the `staging` variant and run on device to verify that it works.