### PR TITLE
Upgrade tests to Xcode 11.4.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ executors:
   reactnativeios:
     <<: *defaults
     macos:
-      xcode: "11.3.0"
+      xcode: &_XCODE_VERSION "11.4.0"
 
 # -------------------------
 #        COMMANDS


### PR DESCRIPTION
Summary:
Upgrade Sandcastle and Circle CI tests to use Xcode 11.4.0 across the board.

Changelog:
[Internal] - Use Xcode 11.4.0 in tests

Differential Revision: D20821844

