### PR TITLE
Upgrade tests to Xcode 11.4.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ executors:
   reactnativeios:
     <<: *defaults
     macos:
-      xcode: "11.3.0"
+      xcode: &_XCODE_VERSION "11.4.0"
 
 # -------------------------
 #        COMMANDS

--- a/scripts/.tests.env
+++ b/scripts/.tests.env
@@ -17,7 +17,7 @@ export AVD_NAME="testAVD"
 export AVD_ABI=x86
 
 ## IOS ##
-export IOS_TARGET_OS="13.3"
+export IOS_TARGET_OS="13.4"
 export IOS_DEVICE="iPhone 8"
 export TVOS_DEVICE="Apple TV"
 export SDK_IOS="iphonesimulator"


### PR DESCRIPTION
Summary:
Upgrade Sandcastle and Circle CI tests to use Xcode 11.4.0 across the board.

Changelog:
[Internal] - Use Xcode 11.4.0 in tests

Differential Revision: D20821844

