### PR TITLE
Exclude all FlipperKit transitive dependencies from iOS Release builds

### DIFF
--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -63,6 +63,23 @@ def use_flipper!(version = '~> 0.33.1')
   pod 'FlipperKit/SKIOSNetworkPlugin', version, :configuration => 'Debug'
   pod 'FlipperKit/FlipperKitUserDefaultsPlugin', version, :configuration => 'Debug'
   pod 'FlipperKit/FlipperKitReactPlugin', version, :configuration => 'Debug'
+
+  # List all transitive dependencies for FlipperKit pods
+  # to avoid them being linked in Release builds
+  pod 'Flipper', version, :configuration => 'Debug'
+  pod 'Flipper-DoubleConversion', '1.1.7', :configuration => 'Debug'
+  pod 'Flipper-Folly', '~> 2.1', :configuration => 'Debug'
+  pod 'Flipper-Glog', '0.3.6', :configuration => 'Debug'
+  pod 'Flipper-PeerTalk', '~> 0.0.4', :configuration => 'Debug'
+  pod 'Flipper-RSocket', '~> 1.0', :configuration => 'Debug'
+  pod 'FlipperKit/Core', version, :configuration => 'Debug'
+  pod 'FlipperKit/CppBridge', version, :configuration => 'Debug'
+  pod 'FlipperKit/FBCxxFollyDynamicConvert', version, :configuration => 'Debug'
+  pod 'FlipperKit/FBDefines', version, :configuration => 'Debug'
+  pod 'FlipperKit/FKPortForwarding', version, :configuration => 'Debug'
+  pod 'FlipperKit/FlipperKitHighlightOverlay', version, :configuration => 'Debug'
+  pod 'FlipperKit/FlipperKitLayoutTextSearchable', version, :configuration => 'Debug'
+  pod 'FlipperKit/FlipperKitNetworkPlugin', version, :configuration => 'Debug'
 end
 
 # Post Install processing for Flipper

--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -57,29 +57,36 @@ def use_react_native! (options={})
   end
 end
 
-def use_flipper!(version = '~> 0.33.1')
-  pod 'FlipperKit', version, :configuration => 'Debug'
-  pod 'FlipperKit/FlipperKitLayoutPlugin', version, :configuration => 'Debug'
-  pod 'FlipperKit/SKIOSNetworkPlugin', version, :configuration => 'Debug'
-  pod 'FlipperKit/FlipperKitUserDefaultsPlugin', version, :configuration => 'Debug'
-  pod 'FlipperKit/FlipperKitReactPlugin', version, :configuration => 'Debug'
+def use_flipper!(versions = {})
+  versions['Flipper'] ||= '~> 0.33.1'
+  versions['DoubleConversion'] ||= '1.1.7'
+  versions['Flipper-Folly'] ||= '~> 2.1'
+  versions['Flipper-Glog'] ||= '0.3.6'
+  versions['Flipper-PeerTalk'] ||= '~> 0.0.4'
+  versions['Flipper-RSocket'] ||= '~> 1.0'
+
+  pod 'FlipperKit', versions['Flipper'], :configuration => 'Debug'
+  pod 'FlipperKit/FlipperKitLayoutPlugin', versions['Flipper'], :configuration => 'Debug'
+  pod 'FlipperKit/SKIOSNetworkPlugin', versions['Flipper'], :configuration => 'Debug'
+  pod 'FlipperKit/FlipperKitUserDefaultsPlugin', versions['Flipper'], :configuration => 'Debug'
+  pod 'FlipperKit/FlipperKitReactPlugin', versions['Flipper'], :configuration => 'Debug'
 
   # List all transitive dependencies for FlipperKit pods
   # to avoid them being linked in Release builds
-  pod 'Flipper', version, :configuration => 'Debug'
-  pod 'Flipper-DoubleConversion', '1.1.7', :configuration => 'Debug'
-  pod 'Flipper-Folly', '~> 2.1', :configuration => 'Debug'
-  pod 'Flipper-Glog', '0.3.6', :configuration => 'Debug'
-  pod 'Flipper-PeerTalk', '~> 0.0.4', :configuration => 'Debug'
-  pod 'Flipper-RSocket', '~> 1.0', :configuration => 'Debug'
-  pod 'FlipperKit/Core', version, :configuration => 'Debug'
-  pod 'FlipperKit/CppBridge', version, :configuration => 'Debug'
-  pod 'FlipperKit/FBCxxFollyDynamicConvert', version, :configuration => 'Debug'
-  pod 'FlipperKit/FBDefines', version, :configuration => 'Debug'
-  pod 'FlipperKit/FKPortForwarding', version, :configuration => 'Debug'
-  pod 'FlipperKit/FlipperKitHighlightOverlay', version, :configuration => 'Debug'
-  pod 'FlipperKit/FlipperKitLayoutTextSearchable', version, :configuration => 'Debug'
-  pod 'FlipperKit/FlipperKitNetworkPlugin', version, :configuration => 'Debug'
+  pod 'Flipper', versions['Flipper'], :configuration => 'Debug'
+  pod 'Flipper-DoubleConversion', versions['DoubleConversion'], :configuration => 'Debug'
+  pod 'Flipper-Folly', versions['Flipper-Folly'], :configuration => 'Debug'
+  pod 'Flipper-Glog', versions['Flipper-Glog'], :configuration => 'Debug'
+  pod 'Flipper-PeerTalk', versions['Flipper-PeerTalk'], :configuration => 'Debug'
+  pod 'Flipper-RSocket', versions['Flipper-RSocket'], :configuration => 'Debug'
+  pod 'FlipperKit/Core', versions['Flipper'], :configuration => 'Debug'
+  pod 'FlipperKit/CppBridge', versions['Flipper'], :configuration => 'Debug'
+  pod 'FlipperKit/FBCxxFollyDynamicConvert', versions['Flipper'], :configuration => 'Debug'
+  pod 'FlipperKit/FBDefines', versions['Flipper'], :configuration => 'Debug'
+  pod 'FlipperKit/FKPortForwarding', versions['Flipper'], :configuration => 'Debug'
+  pod 'FlipperKit/FlipperKitHighlightOverlay', versions['Flipper'], :configuration => 'Debug'
+  pod 'FlipperKit/FlipperKitLayoutTextSearchable', versions['Flipper'], :configuration => 'Debug'
+  pod 'FlipperKit/FlipperKitNetworkPlugin', versions['Flipper'], :configuration => 'Debug'
 end
 
 # Post Install processing for Flipper


### PR DESCRIPTION
## Summary

The `:configuration` option from `pod` only affects the specified pod and not its dependencies [1]. Therefore in order to avoid all transitive dependencies being linked in the resulting Release IPA we need to list them in the `Podfile`.

Note that this will still build Flipper's pods when doing a Release, but it won't link it in the resulting IPA.

[1] https://guides.cocoapods.org/syntax/podfile.html#pod

Fixes https://github.com/react-native-community/upgrade-support/issues/28
Related https://github.com/CocoaPods/CocoaPods/issues/9658

## Changelog

* [iOS] [Fixed] - Exclude Flipper from iOS Release builds

## Test Plan

Create a new React Native 0.62 project, run `pod install`, then diff:
```
ProjectName/ios/Pods/Target Support Files/Pods-ProjectName/Pods-ProjectName.debug.xcconfig`
```
and 
```
ProjectName/ios/Pods/Target Support Files/Pods-ProjectName/Pods-ProjectName.relaese.xcconfig
```

![image](https://user-images.githubusercontent.com/855995/78337679-a3fa0280-7591-11ea-8142-6f82cbc6be58.png)
