### PR TITLE
Fix crash when enabling Performance Monitor on iOS 13.4

### DIFF
--- a/React/CoreModules/RCTPerfMonitor.mm
+++ b/React/CoreModules/RCTPerfMonitor.mm
@@ -44,6 +44,14 @@ static BOOL RCTJSCSetOption(const char *option)
   static RCTJSCSetOptionType setOption;
   static dispatch_once_t onceToken;
 
+  // As of iOS 13.4, it is no longer possible to change the JavaScriptCore
+  // options at runtime. The options are protected and will cause an
+  // exception when you try to change them after the VM has been initialized.
+  // https://github.com/facebook/react-native/issues/28414
+  if (@available(iOS 13.4, *)) {
+    return NO;
+  }
+
   dispatch_once(&onceToken, ^{
     /**
      * JSC private C++ static method to toggle options at runtime


### PR DESCRIPTION
## Summary

This PR fixes a crash when opening the Performance Monitor on iOS 13.4.
Detailed info: #28414

## Changelog

`[iOS] [Fixed] - Fix crash when enabling Performance Monitor on iOS 13.4`

## How

This PR prevents the JavaScriptCore option from being set altogether.
This ensures that the performance monitor keeps working, but on iOS 13.4 and higher, it will no longer crash trying to show the GC usage.

## Test Plan

Tested on iOS 13.4 (simulator):

![image](https://user-images.githubusercontent.com/6184593/77903803-c6370c00-7283-11ea-8b71-b6b6546c82f6.png)


Tested on iOS 13.1 (simulator)

![image](https://user-images.githubusercontent.com/6184593/77903499-41e48900-7283-11ea-9d14-83f67a3b7b77.png)

- Verified that the `setOption` was called, but the Performance Monitor didn't show any GC usage regardless.
- Identical PR https://github.com/expo/react-native/pull/21 has been shipped and tested in Expo Client 37

Fixes #28414