### PR TITLE
Rename duplicate name `<ScrollView>` example on RNTester

### DIFF
--- a/RNTester/js/examples/ScrollView/ScrollViewSimpleExample.js
+++ b/RNTester/js/examples/ScrollView/ScrollViewSimpleExample.js
@@ -91,7 +91,7 @@ const styles = StyleSheet.create({
   },
 });
 
-exports.title = '<ScrollView>';
+exports.title = '<ScrollSimpleView>';
 exports.description =
   'Component that enables scrolling through child components.';
 


### PR DESCRIPTION
## Summary

Tiny change. When searching for `scro` in the RNTester, two `<ScrollView>`s come up, from different example files. One is the "simple" one and the other is the "regular" one.

Before:
<img width="370" alt="Screen Shot 2020-04-03 at 17 14 01" src="https://user-images.githubusercontent.com/100233/78377338-c6ab0c00-75cf-11ea-9c45-2dcdd6460f6d.png">

After:
<img width="369" alt="Screen Shot 2020-04-03 at 17 13 38" src="https://user-images.githubusercontent.com/100233/78377371-cf034700-75cf-11ea-89ea-aa3ff2f3988c.png">


## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[Internal] [Changed] - Rename the "simple" ScrollView example in RNTester to "ScrollSimpleView".

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

- Try to search for `scro` in RNTester.