### PR TITLE
[General] [Fixed] Flow errors from YellowBox and BubblingEventHandler

### DIFF
--- a/Libraries/Modal/RCTModalHostViewNativeComponent.js
+++ b/Libraries/Modal/RCTModalHostViewNativeComponent.js
@@ -15,6 +15,7 @@ import type {HostComponent} from '../Renderer/shims/ReactNativeTypes';
 import type {
   WithDefault,
   DirectEventHandler,
+  BubblingEventHandler,
   Int32,
 } from '../Types/CodegenTypes';
 

--- a/Libraries/YellowBox/UI/YellowBoxInspectorHeader.js
+++ b/Libraries/YellowBox/UI/YellowBoxInspectorHeader.js
@@ -61,7 +61,7 @@ const YellowBoxInspectorHeader = (props: Props): React.Node => {
 const YellowBoxInspectorHeaderButton = (
   props: $ReadOnly<{|
     disabled: boolean,
-    image: string,
+    image: number,
     onPress?: ?() => void,
   |}>,
 ): React.Node => (


### PR DESCRIPTION
## Summary

Fixes Flow errors that surfaced with 0.62.1 release. 

Targeting `0.62-stable` branch, because this is an effect of applying patches that were relying on prior changes:
- YellowBox is now removed from from master 
- `BubblingEventHandler` was removed in 0676ebf79a3fd98ed411a3a37c1ee121eb3eef68 which partially built on top of bd2b7d6c0366b5f19de56b71cb706a0af4b0be43, later reverted in 27a3248a3b 

cc @alloy @kelset 

## Changelog

[General] [Fixed] Flow errors from YellowBox and BubblingEventHandler

## Test Plan

Flow check passes
