### PR TITLE
docs: Fix simple typo, reverseable -> reversible

### DIFF
--- a/Libraries/Renderer/implementations/ReactFabric-dev.fb.js
+++ b/Libraries/Renderer/implementations/ReactFabric-dev.fb.js
@@ -6709,7 +6709,7 @@ function processUpdateQueue(
             newBaseQueueLast = newBaseQueueLast.next = _clone;
           } // Mark the event time of this update as relevant to this render pass.
           // TODO: This should ideally use the true event time of this update rather than
-          // its priority which is a derived and not reverseable value.
+          // its priority which is a derived and not reversible value.
           // TODO: We should skip this update if it was already committed but currently
           // we have no way of detecting the difference between a committed and suspended
           // update here.
@@ -10096,7 +10096,7 @@ function updateReducer(reducer, initialArg, init) {
           newBaseQueueLast = newBaseQueueLast.next = _clone;
         } // Mark the event time of this update as relevant to this render pass.
         // TODO: This should ideally use the true event time of this update rather than
-        // its priority which is a derived and not reverseable value.
+        // its priority which is a derived and not reversible value.
         // TODO: We should skip this update if it was already committed but currently
         // we have no way of detecting the difference between a committed and suspended
         // update here.

--- a/Libraries/Renderer/implementations/ReactFabric-dev.js
+++ b/Libraries/Renderer/implementations/ReactFabric-dev.js
@@ -6702,7 +6702,7 @@ function processUpdateQueue(
             newBaseQueueLast = newBaseQueueLast.next = _clone;
           } // Mark the event time of this update as relevant to this render pass.
           // TODO: This should ideally use the true event time of this update rather than
-          // its priority which is a derived and not reverseable value.
+          // its priority which is a derived and not reversible value.
           // TODO: We should skip this update if it was already committed but currently
           // we have no way of detecting the difference between a committed and suspended
           // update here.
@@ -10069,7 +10069,7 @@ function updateReducer(reducer, initialArg, init) {
           newBaseQueueLast = newBaseQueueLast.next = _clone;
         } // Mark the event time of this update as relevant to this render pass.
         // TODO: This should ideally use the true event time of this update rather than
-        // its priority which is a derived and not reverseable value.
+        // its priority which is a derived and not reversible value.
         // TODO: We should skip this update if it was already committed but currently
         // we have no way of detecting the difference between a committed and suspended
         // update here.

--- a/Libraries/Renderer/implementations/ReactNativeRenderer-dev.fb.js
+++ b/Libraries/Renderer/implementations/ReactNativeRenderer-dev.fb.js
@@ -7026,7 +7026,7 @@ function processUpdateQueue(
             newBaseQueueLast = newBaseQueueLast.next = _clone;
           } // Mark the event time of this update as relevant to this render pass.
           // TODO: This should ideally use the true event time of this update rather than
-          // its priority which is a derived and not reverseable value.
+          // its priority which is a derived and not reversible value.
           // TODO: We should skip this update if it was already committed but currently
           // we have no way of detecting the difference between a committed and suspended
           // update here.
@@ -10413,7 +10413,7 @@ function updateReducer(reducer, initialArg, init) {
           newBaseQueueLast = newBaseQueueLast.next = _clone;
         } // Mark the event time of this update as relevant to this render pass.
         // TODO: This should ideally use the true event time of this update rather than
-        // its priority which is a derived and not reverseable value.
+        // its priority which is a derived and not reversible value.
         // TODO: We should skip this update if it was already committed but currently
         // we have no way of detecting the difference between a committed and suspended
         // update here.

--- a/Libraries/Renderer/implementations/ReactNativeRenderer-dev.js
+++ b/Libraries/Renderer/implementations/ReactNativeRenderer-dev.js
@@ -7019,7 +7019,7 @@ function processUpdateQueue(
             newBaseQueueLast = newBaseQueueLast.next = _clone;
           } // Mark the event time of this update as relevant to this render pass.
           // TODO: This should ideally use the true event time of this update rather than
-          // its priority which is a derived and not reverseable value.
+          // its priority which is a derived and not reversible value.
           // TODO: We should skip this update if it was already committed but currently
           // we have no way of detecting the difference between a committed and suspended
           // update here.
@@ -10386,7 +10386,7 @@ function updateReducer(reducer, initialArg, init) {
           newBaseQueueLast = newBaseQueueLast.next = _clone;
         } // Mark the event time of this update as relevant to this render pass.
         // TODO: This should ideally use the true event time of this update rather than
-        // its priority which is a derived and not reverseable value.
+        // its priority which is a derived and not reversible value.
         // TODO: We should skip this update if it was already committed but currently
         // we have no way of detecting the difference between a committed and suspended
         // update here.


### PR DESCRIPTION
There is a small typo in Libraries/Renderer/implementations/ReactFabric-dev.fb.js, Libraries/Renderer/implementations/ReactFabric-dev.js, Libraries/Renderer/implementations/ReactNativeRenderer-dev.fb.js, Libraries/Renderer/implementations/ReactNativeRenderer-dev.js.

Should read `reversible` rather than `reverseable`.

