### PR TITLE
imp: Remove unused `npx` reference

### DIFF
--- a/react.gradle
+++ b/react.gradle
@@ -99,7 +99,6 @@ afterEvaluate {
         // Additional node and packager commandline arguments
         def nodeExecutableAndArgs = config.nodeExecutableAndArgs ?: ["node"]
         def extraPackagerArgs = config.extraPackagerArgs ?: []
-        def npx = Os.isFamily(Os.FAMILY_WINDOWS) ? "npx.cmd" : "npx"
 
         def execCommand = []
 


### PR DESCRIPTION
## Summary

Recently we removed `npx` usage from `react-native-cli` flow. After checking usages in this repo I found unused reference.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Internal] [Removed] - Remove unused `npx` reference

## Test Plan

Tests pass
