### PR TITLE
Fix Cocoapods builds

### DIFF
--- a/Libraries/Blob/React-RCTBlob.podspec
+++ b/Libraries/Blob/React-RCTBlob.podspec
@@ -41,6 +41,7 @@ Pod::Spec.new do |s|
   s.dependency "Folly", folly_version
   s.dependency "FBReactNativeSpec", version
   s.dependency "ReactCommon/turbomodule/core", version
+s.dependency "React-jsi", version
   s.dependency "React-Core/RCTBlobHeaders", version
   s.dependency "React-Core/RCTWebSocket", version
   s.dependency "React-RCTNetwork", version

--- a/Libraries/Image/React-RCTImage.podspec
+++ b/Libraries/Image/React-RCTImage.podspec
@@ -43,6 +43,7 @@ Pod::Spec.new do |s|
   s.dependency "FBReactNativeSpec", version
   s.dependency "RCTTypeSafety", version
   s.dependency "ReactCommon/turbomodule/core", version
+  s.dependency "React-jsi", version
   s.dependency "React-Core/RCTImageHeaders", version
   s.dependency "React-RCTNetwork", version
 end

--- a/Libraries/LinkingIOS/React-RCTLinking.podspec
+++ b/Libraries/LinkingIOS/React-RCTLinking.podspec
@@ -42,4 +42,5 @@ Pod::Spec.new do |s|
   s.dependency "FBReactNativeSpec", version
   s.dependency "React-Core/RCTLinkingHeaders", version
   s.dependency "ReactCommon/turbomodule/core", version
+  s.dependency "React-jsi", version
 end

--- a/Libraries/NativeAnimation/React-RCTAnimation.podspec
+++ b/Libraries/NativeAnimation/React-RCTAnimation.podspec
@@ -41,6 +41,7 @@ Pod::Spec.new do |s|
   s.dependency "Folly", folly_version
   s.dependency "RCTTypeSafety", version
   s.dependency "ReactCommon/turbomodule/core", version
+  s.dependency "React-jsi", version
   s.dependency "FBReactNativeSpec", version
   s.dependency "React-Core/RCTAnimationHeaders", version
 end

--- a/Libraries/Network/React-RCTNetwork.podspec
+++ b/Libraries/Network/React-RCTNetwork.podspec
@@ -43,5 +43,6 @@ Pod::Spec.new do |s|
   s.dependency "FBReactNativeSpec", version
   s.dependency "RCTTypeSafety", version
   s.dependency "ReactCommon/turbomodule/core", version
+  s.dependency "React-jsi", version
   s.dependency "React-Core/RCTNetworkHeaders", version
 end

--- a/Libraries/PushNotificationIOS/React-RCTPushNotification.podspec
+++ b/Libraries/PushNotificationIOS/React-RCTPushNotification.podspec
@@ -44,4 +44,5 @@ Pod::Spec.new do |s|
   s.dependency "RCTTypeSafety", version
   s.dependency "React-Core/RCTPushNotificationHeaders", version
   s.dependency "ReactCommon/turbomodule/core", version
+  s.dependency "React-jsi", version
 end

--- a/Libraries/Settings/React-RCTSettings.podspec
+++ b/Libraries/Settings/React-RCTSettings.podspec
@@ -43,5 +43,6 @@ Pod::Spec.new do |s|
   s.dependency "FBReactNativeSpec", version
   s.dependency "RCTTypeSafety", version
   s.dependency "ReactCommon/turbomodule/core", version
+  s.dependency "React-jsi", version
   s.dependency "React-Core/RCTSettingsHeaders", version
 end

--- a/Libraries/Vibration/React-RCTVibration.podspec
+++ b/Libraries/Vibration/React-RCTVibration.podspec
@@ -43,5 +43,6 @@ Pod::Spec.new do |s|
   s.dependency "Folly", folly_version
   s.dependency "FBReactNativeSpec", version
   s.dependency "ReactCommon/turbomodule/core", version
+  s.dependency "React-jsi", version
   s.dependency "React-Core/RCTVibrationHeaders", version
 end

--- a/RNTester/Podfile.lock
+++ b/RNTester/Podfile.lock
@@ -226,6 +226,7 @@ PODS:
     - Folly (= 2020.01.13.00)
     - RCTTypeSafety (= 1000.0.0)
     - React-Core/CoreModulesHeaders (= 1000.0.0)
+    - React-jsi (= 1000.0.0)
     - React-RCTImage (= 1000.0.0)
     - ReactCommon/turbomodule/core (= 1000.0.0)
   - React-cxxreact (1000.0.0):
@@ -260,6 +261,7 @@ PODS:
     - Folly (= 2020.01.13.00)
     - RCTTypeSafety (= 1000.0.0)
     - React-Core/RCTAnimationHeaders (= 1000.0.0)
+    - React-jsi (= 1000.0.0)
     - ReactCommon/turbomodule/core (= 1000.0.0)
   - React-RCTBlob (1000.0.0):
     - FBReactNativeSpec (= 1000.0.0)
@@ -274,28 +276,33 @@ PODS:
     - Folly (= 2020.01.13.00)
     - RCTTypeSafety (= 1000.0.0)
     - React-Core/RCTImageHeaders (= 1000.0.0)
+    - React-jsi (= 1000.0.0)
     - React-RCTNetwork (= 1000.0.0)
     - ReactCommon/turbomodule/core (= 1000.0.0)
   - React-RCTLinking (1000.0.0):
     - FBReactNativeSpec (= 1000.0.0)
     - React-Core/RCTLinkingHeaders (= 1000.0.0)
+    - React-jsi (= 1000.0.0)
     - ReactCommon/turbomodule/core (= 1000.0.0)
   - React-RCTNetwork (1000.0.0):
     - FBReactNativeSpec (= 1000.0.0)
     - Folly (= 2020.01.13.00)
     - RCTTypeSafety (= 1000.0.0)
     - React-Core/RCTNetworkHeaders (= 1000.0.0)
+    - React-jsi (= 1000.0.0)
     - ReactCommon/turbomodule/core (= 1000.0.0)
   - React-RCTPushNotification (1000.0.0):
     - FBReactNativeSpec (= 1000.0.0)
     - RCTTypeSafety (= 1000.0.0)
     - React-Core/RCTPushNotificationHeaders (= 1000.0.0)
+    - React-jsi (= 1000.0.0)
     - ReactCommon/turbomodule/core (= 1000.0.0)
   - React-RCTSettings (1000.0.0):
     - FBReactNativeSpec (= 1000.0.0)
     - Folly (= 2020.01.13.00)
     - RCTTypeSafety (= 1000.0.0)
     - React-Core/RCTSettingsHeaders (= 1000.0.0)
+    - React-jsi (= 1000.0.0)
     - ReactCommon/turbomodule/core (= 1000.0.0)
   - React-RCTTest (1000.0.0):
     - Folly (= 2020.01.13.00)
@@ -309,6 +316,7 @@ PODS:
     - FBReactNativeSpec (= 1000.0.0)
     - Folly (= 2020.01.13.00)
     - React-Core/RCTVibrationHeaders (= 1000.0.0)
+    - React-jsi (= 1000.0.0)
     - ReactCommon/turbomodule/core (= 1000.0.0)
   - ReactCommon/turbomodule/core (1000.0.0):
     - DoubleConversion
@@ -335,8 +343,22 @@ DEPENDENCIES:
   - DoubleConversion (from `../third-party-podspecs/DoubleConversion.podspec`)
   - FBLazyVector (from `../Libraries/FBLazyVector`)
   - FBReactNativeSpec (from `../Libraries/FBReactNativeSpec`)
+  - Flipper (~> 0.33.1)
+  - Flipper-DoubleConversion (= 1.1.7)
+  - Flipper-Folly (~> 2.1)
+  - Flipper-Glog (= 0.3.6)
+  - Flipper-PeerTalk (~> 0.0.4)
+  - Flipper-RSocket (~> 1.0)
   - FlipperKit (~> 0.33.1)
+  - FlipperKit/Core (~> 0.33.1)
+  - FlipperKit/CppBridge (~> 0.33.1)
+  - FlipperKit/FBCxxFollyDynamicConvert (~> 0.33.1)
+  - FlipperKit/FBDefines (~> 0.33.1)
+  - FlipperKit/FKPortForwarding (~> 0.33.1)
+  - FlipperKit/FlipperKitHighlightOverlay (~> 0.33.1)
   - FlipperKit/FlipperKitLayoutPlugin (~> 0.33.1)
+  - FlipperKit/FlipperKitLayoutTextSearchable (~> 0.33.1)
+  - FlipperKit/FlipperKitNetworkPlugin (~> 0.33.1)
   - FlipperKit/FlipperKitReactPlugin (~> 0.33.1)
   - FlipperKit/FlipperKitUserDefaultsPlugin (~> 0.33.1)
   - FlipperKit/SKIOSNetworkPlugin (~> 0.33.1)
@@ -468,22 +490,22 @@ SPEC CHECKSUMS:
   React-ART: df0460bdff42ef039e28ee3ffd41f50b75644788
   React-callinvoker: 0dada022d38b73e6e15b33e2a96476153f79bbf6
   React-Core: 08c69f013e6fd654ea8f9fd84bbd66780a54d886
-  React-CoreModules: 0b59c833afcc9735e5a0220997fb18876dc9e52c
+  React-CoreModules: d13d148c851af5780f864be74bc2165140923dc7
   React-cxxreact: 091da030e879ed93d970e95dd74fcbacb2a1d661
   React-jsi: fe94132da767bfc4801968c2a12abae43e9a833e
   React-jsiexecutor: 55eff40b2e0696e7a979016e321793ec8b28a2ac
   React-jsinspector: 7fbf9b42b58b02943a0d89b0ba9fff0070f2de98
   React-RCTActionSheet: 51c43beeb74ef41189e87fe9823e53ebf6210359
-  React-RCTAnimation: 528462d8fe78787f2e058062cd9a4b44735ea579
-  React-RCTBlob: e29e0277cbcd91f07719d8411a3fa5db6600b4cf
-  React-RCTImage: a24587309c984427ec74d3c7be13b00ca0caabeb
-  React-RCTLinking: 696a3911a5d380ba87e29fde099a811e51e69e2f
-  React-RCTNetwork: cc2ccdcbf13dbea0710ef887e0b9ceae7f5aef28
-  React-RCTPushNotification: 13befc7c6efba31625fd9a945dfa71a31b724b4a
-  React-RCTSettings: a2b148ef74dcb98369e5bb0def506d2d29125ab3
+  React-RCTAnimation: 9d09196c641c1ebfef3a4e9ae670bcda5fadb420
+  React-RCTBlob: 715489626cf44d28ee51e5277a4d559167351696
+  React-RCTImage: 19151d2d071b05c3832a0b212473cafa4ea8948f
+  React-RCTLinking: 7c94c0f2fcc658cb4043dacb4f6621dca2f8f8b5
+  React-RCTNetwork: 7596e84acacd5d0674e9743b55c5bf61a626af69
+  React-RCTPushNotification: 88c9f47ff0d4391d5136d70745f15713cdc5f6bb
+  React-RCTSettings: a29c61f85f535ba2eff54d80bef2ea3cdb6e5fba
   React-RCTTest: cfe25fcf70b04a747dba4326105db398250caa9a
   React-RCTText: 6c01963d3e562109f5548262b09b1b2bc260dd60
-  React-RCTVibration: d218336fa28ade97e99b4ddb935f1de5c670e361
+  React-RCTVibration: d42d73dafd9f63cf758656ee743aa80c566798ff
   ReactCommon: 39e00b754f5e1628804fab28f44146d06280f700
   Yoga: f7fa200d8c49f97b54c9421079e781fb900b5cae
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a

--- a/React/CoreModules/React-CoreModules.podspec
+++ b/React/CoreModules/React-CoreModules.podspec
@@ -43,4 +43,5 @@ Pod::Spec.new do |s|
   s.dependency "React-Core/CoreModulesHeaders", version
   s.dependency "React-RCTImage", version
   s.dependency "ReactCommon/turbomodule/core", version
+  s.dependency "React-jsi", version
 end

--- a/ReactCommon/React-Fabric.podspec
+++ b/ReactCommon/React-Fabric.podspec
@@ -42,6 +42,7 @@ Pod::Spec.new do |s|
   s.dependency "RCTRequired", version
   s.dependency "RCTTypeSafety", version
   s.dependency "ReactCommon/turbomodule/core", version
+  s.dependency "React-jsi", version
 
   s.subspec "attributedstring" do |ss|
     ss.dependency             folly_dep_name, folly_version


### PR DESCRIPTION
Summary:
## Problem
For some reason, D20831545 broke the `use_frameworks!` build of RNTester.

## Building RNTester
```
pushd ~/fbsource/xplat/js/react-native-github/RNTester && USE_FRAMEWORKS=1 pod install && open RNTesterPods.xcworkspace && popd;
```

## Error
I built RNTester locally, and the error was this:

```
Undefined symbols for architecture x86_64:
  "facebook::jsi::HostObject::set(facebook::jsi::Runtime&, facebook::jsi::PropNameID const&, facebook::jsi::Value const&)", referenced from:
      vtable for facebook::react::ObjCTurboModule in RCTImageEditingManager.o
      vtable for facebook::react::ObjCTurboModule in RCTImageLoader.o
      vtable for facebook::react::ObjCTurboModule in RCTImageStoreManager.o
  "facebook::jsi::HostObject::getPropertyNames(facebook::jsi::Runtime&)", referenced from:
      vtable for facebook::react::ObjCTurboModule in RCTImageEditingManager.o
      vtable for facebook::react::ObjCTurboModule in RCTImageLoader.o
      vtable for facebook::react::ObjCTurboModule in RCTImageStoreManager.o
ld: symbol(s) not found for architecture x86_64
```

## Fix
It looked like libraries that depend on "ReactCommon/turbomodule/core" weren't linking to JSI correctly. So, I modified all such Podspecs to also depend on "React-jsi":

```
arc rfr '  s.dependency "ReactCommon/turbomodule/core", version' '  s.dependency "ReactCommon/turbomodule/core", version\n  s.dependency "React-jsi", version'
```

This seemed to do the trick. In buck, we'd fix this problem using exported_dependencies. I skimmed through cocoapods, and couldn't find such a configuration option there. So, I guess this will have to do?

Changelog:
[iOS][Fixed] - Fix Cocoapods builds of RNTester

Differential Revision: D20905465

