### PR TITLE
Add ProGuard rule for hermes

### DIFF
--- a/ReactAndroid/proguard-rules.pro
+++ b/ReactAndroid/proguard-rules.pro
@@ -51,6 +51,9 @@
 -dontwarn com.facebook.react.**
 -keep,includedescriptorclasses class com.facebook.react.bridge.** { *; }
 
+# Required when using hermes
+-keep class com.facebook.jni.** { *; }
+
 # okhttp
 
 -keepattributes Signature

--- a/ReactAndroid/proguard-rules.pro
+++ b/ReactAndroid/proguard-rules.pro
@@ -51,7 +51,7 @@
 -dontwarn com.facebook.react.**
 -keep,includedescriptorclasses class com.facebook.react.bridge.** { *; }
 
-# Required when using hermes
+# hermes
 -keep class com.facebook.jni.** { *; }
 
 # okhttp


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

This adds a ProGuard for `hermes` rule so it does not have to be added by users manually.
https://github.com/facebook/react-native/issues/28270

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Added] - ProGuard rule for hermes

## Test Plan

1. Create a project with/without hermes.
2. Enable proguard.
