### PR TITLE
Update default Podfile to not depend on a path

### DIFF
--- a/template/ios/Podfile
+++ b/template/ios/Podfile
@@ -1,4 +1,3 @@
-
 require_relative '../node_modules/react-native/scripts/react_native_pods'
 require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
 

--- a/template/ios/Podfile
+++ b/template/ios/Podfile
@@ -1,18 +1,18 @@
+
 require_relative '../node_modules/react-native/scripts/react_native_pods'
 require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
 
 platform :ios, '10.0'
 
-target 'HelloWorld' do
-  # Pods for HelloWorld
-  use_react_native!
+target 'RNTestProject' do
+  config = use_native_modules!
 
-  target 'HelloWorldTests' do
+  use_react_native!(:path => config["reactNativePath"])
+
+  target 'RNTestProjectTests' do
     inherit! :complete
     # Pods for testing
   end
-
-  use_native_modules!
 
   # Enables Flipper.
   #

--- a/template/ios/Podfile
+++ b/template/ios/Podfile
@@ -4,12 +4,12 @@ require_relative '../node_modules/@react-native-community/cli-platform-ios/nativ
 
 platform :ios, '10.0'
 
-target 'RNTestProject' do
+target 'HelloWorld' do
   config = use_native_modules!
 
   use_react_native!(:path => config["reactNativePath"])
 
-  target 'RNTestProjectTests' do
+  target 'HelloWorldTests' do
     inherit! :complete
     # Pods for testing
   end


### PR DESCRIPTION
##  Summary

Recently, a default Podfile has been modified to not contain all the React Native pods, but use a helper method `use_react_native!`.

While this is great, it assumes a hardcoded path of `../node_modules/react-native` to be always the correct location of the React Native. 

https://github.com/facebook/react-native/blob/d4d8887b5018782eeb3f26efa85125e6bbff73e4/scripts/autolink-ios.rb#L7-L9

Unfortunately, due to the way Ruby works, this completely hides the path away from the users. 

Before, they could have seen the wrong path explicitly in a Podfile and knew to update it to resolve path-related issues.

With the current version in `master`, I can see a lot of issues where developers wonder how to resolve the path issues and how to pass the path itself.

https://github.com/facebook/react-native/blob/4118d798265341061105f3a53550db83c66a71cb/template/ios/Podfile#L5-L10

This PR uses React Native CLI configuration (that is already used to link 3rd party dependencies) to explicitly define the correct path to the React Native.

As a result, we don't have to change the paths here whether we're running monorepo or not. 

## Changelog

[IOS] [INTERNAL] - Always provide an explicit path to React Native

