### PR TITLE
Upgrade flow-remove-types version to 2.122.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-react-native": "3.8.1",
     "eslint-plugin-relay": "1.7.0",
     "flow-bin": "^0.122.0",
-    "flow-remove-types": "1.2.3",
+    "flow-remove-types": "^2.122.0",
     "jest": "^24.9.0",
     "jest-junit": "^6.3.0",
     "jscodeshift": "^0.7.0",


### PR DESCRIPTION
## Summary

This pull request upgrades `flow-remove-types` to version  `2.122.0`.
 
`flow-node` in the older version was not able to work with the Codegen files that `scripts/generate-rncore.sh` depended on.

## Changelog

[Internal] [Changed] - Upgraded flow-remove-types version to 2.122.0

## Test Plan

`scripts/generate-rncore.sh` now runs without issue.