### PR TITLE
Update podspecs for latest Fabric changes

### DIFF
--- a/React-Core.podspec
+++ b/React-Core.podspec
@@ -65,8 +65,7 @@ Pod::Spec.new do |s|
                                 "React/Views/RCTPicker*",
                                 "React/Views/RCTRefreshControl*",
                                 "React/Views/RCTSlider*",
-                                "React/Views/RCTSwitch*",
-    ss.private_header_files   = "React/Cxx*/*.h"
+                                "React/Views/RCTSwitch*"
   end
 
   s.subspec "DevSupport" do |ss|

--- a/React-Core.podspec
+++ b/React-Core.podspec
@@ -65,7 +65,8 @@ Pod::Spec.new do |s|
                                 "React/Views/RCTPicker*",
                                 "React/Views/RCTRefreshControl*",
                                 "React/Views/RCTSlider*",
-                                "React/Views/RCTSwitch*"
+                                "React/Views/RCTSwitch*",
+    ss.private_header_files   = "React/Cxx*/*.h"
   end
 
   s.subspec "DevSupport" do |ss|

--- a/ReactCommon/React-Fabric.podspec
+++ b/ReactCommon/React-Fabric.podspec
@@ -102,7 +102,7 @@ Pod::Spec.new do |s|
       sss.source_files         = "fabric/components/legacyviewmanagerinterop/**/*.{m,mm,cpp,h}"
       sss.exclude_files        = "**/tests/*"
       sss.header_dir           = "react/components/legacyviewmanagerinterop"
-      sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\"" }
+      sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\" \"$(PODS_ROOT)/Headers/Private/React-Core\"" }
     end
 
     ss.subspec "modal" do |sss|

--- a/ReactCommon/React-Fabric.podspec
+++ b/ReactCommon/React-Fabric.podspec
@@ -96,6 +96,15 @@ Pod::Spec.new do |s|
       sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\"" }
     end
 
+    ss.subspec "legacyviewmanagerinterop" do |sss|
+      sss.dependency             folly_dep_name, folly_version
+      sss.compiler_flags       = folly_compiler_flags
+      sss.source_files         = "fabric/components/legacyviewmanagerinterop/**/*.{m,mm,cpp,h}"
+      sss.exclude_files        = "**/tests/*"
+      sss.header_dir           = "react/components/legacyviewmanagerinterop"
+      sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\"" }
+    end
+
     ss.subspec "modal" do |sss|
       sss.dependency             folly_dep_name, folly_version
       sss.compiler_flags       = folly_compiler_flags
@@ -109,7 +118,9 @@ Pod::Spec.new do |s|
       sss.dependency             folly_dep_name, folly_version
       sss.compiler_flags       = folly_compiler_flags
       sss.source_files         = "fabric/components/rncore/*.{m,mm,cpp,h}"
-      sss.exclude_files        = "**/tests/*", "fabric/components/rncore/*Tests.{h,cpp}"
+      sss.exclude_files        = "**/tests/*", "fabric/components/rncore/*Tests.{h,cpp}",
+                                 # TODO: These should be re-enabled later when Codegen Native Module support is needed.
+                                 "fabric/components/rncore/rncore-generated.mm", "fabric/components/rncore/NativeModules.{h,cpp}"
       sss.header_dir           = "react/components/rncore"
       sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\"" }
     end
@@ -120,6 +131,15 @@ Pod::Spec.new do |s|
       sss.source_files         = "fabric/components/root/**/*.{m,mm,cpp,h}"
       sss.exclude_files        = "**/tests/*"
       sss.header_dir           = "react/components/root"
+      sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\"" }
+    end
+
+    ss.subspec "safeareaview" do |sss|
+      sss.dependency             folly_dep_name, folly_version
+      sss.compiler_flags       = folly_compiler_flags
+      sss.source_files         = "fabric/components/safeareaview/**/*.{m,mm,cpp,h}"
+      sss.exclude_files        = "**/tests/*"
+      sss.header_dir           = "react/components/safeareaview"
       sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\"" }
     end
 
@@ -148,6 +168,24 @@ Pod::Spec.new do |s|
       sss.source_files         = "fabric/components/text/**/*.{m,mm,cpp,h}"
       sss.exclude_files        = "**/tests/*"
       sss.header_dir           = "react/components/text"
+      sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\"" }
+    end
+
+    ss.subspec "textinput" do |sss|
+      sss.dependency             folly_dep_name, folly_version
+      sss.compiler_flags       = folly_compiler_flags
+      sss.source_files         = "fabric/components/textinput/iostextinput/**/*.{m,mm,cpp,h}"
+      sss.exclude_files        = "**/tests/*"
+      sss.header_dir           = "react/components/iostextinput"
+      sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\"" }
+    end
+
+    ss.subspec "unimplementedview" do |sss|
+      sss.dependency             folly_dep_name, folly_version
+      sss.compiler_flags       = folly_compiler_flags
+      sss.source_files         = "fabric/components/unimplementedview/**/*.{m,mm,cpp,h}"
+      sss.exclude_files        = "**/tests/*"
+      sss.header_dir           = "react/components/unimplementedview"
       sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\"" }
     end
 

--- a/ReactCommon/fabric/graphics/React-graphics.podspec
+++ b/ReactCommon/fabric/graphics/React-graphics.podspec
@@ -18,6 +18,7 @@ end
 
 folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
 folly_version = '2020.01.13.00'
+boost_compiler_flags = '-Wno-documentation'
 
 Pod::Spec.new do |s|
   s.name                   = "React-graphics"
@@ -29,13 +30,13 @@ Pod::Spec.new do |s|
   s.platforms              = { :ios => "9.0", :tvos => "10.0" }
   s.source                 = source
   s.library                = "stdc++"
-  s.compiler_flags         = folly_compiler_flags
+  s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
   s.source_files           = "**/*.{m,mm,cpp,h}"
   s.exclude_files          = "**/tests/*",
                              "**/android/*",
                              "**/cxx/*"
   s.header_dir             = "react/graphics"
-  s.pod_target_xcconfig  = { "USE_HEADERMAP" => "NO", "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\"" }
+  s.pod_target_xcconfig  = { "USE_HEADERMAP" => "NO", "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\"" }
 
   s.dependency "Folly/Fabric", folly_version
 end


### PR DESCRIPTION
## Summary

This pull request updates the Podspecs to reflect recent changes to Fabric, so they build with Fabric enabled again.

In `React-Fabric.podspec`, subspecs for the views `legacyviewmanagerinterop`, `safeareaview`, `textinput`, and `unimplementedview` are added. A minor tweak to the subspec for `rncore` was added blacklisting two codegen-generated files that have issues building, but are not actually needed yet and are empty.

In `React-graphics.podspec`, the header paths for Boost were added.

This is partially a retread of #26805, which had to be backed out due to issues with the changes to the Yoga podspec.

## Changelog

[Internal] [Fixed] - Fixed building Fabric with the Cocoapods

## Test Plan

RNTester can now compile.