### PR TITLE
Bump flipper version from 0.33.1 to 0.37.0

### DIFF
--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -58,7 +58,7 @@ def use_react_native! (options={})
 end
 
 def use_flipper!(versions = {})
-  versions['Flipper'] ||= '~> 0.33.1'
+  versions['Flipper'] ||= '~> 0.37.0'
   versions['DoubleConversion'] ||= '1.1.7'
   versions['Flipper-Folly'] ||= '~> 2.1'
   versions['Flipper-Glog'] ||= '0.3.6'

--- a/template/android/gradle.properties
+++ b/template/android/gradle.properties
@@ -25,4 +25,4 @@ android.useAndroidX=true
 android.enableJetifier=true
 
 # Version of flipper SDK to use with React Native
-FLIPPER_VERSION=0.33.1
+FLIPPER_VERSION=0.37.0


### PR DESCRIPTION
##  Summary

Updating Flipper version from 0.33.1 to 0.37.0 to [fix a crash in iOS when Image source is a base64 string](https://github.com/facebook/react-native/issues/28583) (also reported in https://github.com/facebook/react-native/issues/28589 and https://github.com/facebook/react-native/issues/28530). This issue has been fixed in the latest build of Flipper https://github.com/facebook/flipper/pull/978

## Changelog

[iOS] [Changed] - Updated Flipper pod version to 0.37.0
[Android] [Changed] - Updated Flipper version to 0.37.0

## Test Plan

App no longer crashes on iOS when using the below Image component

`<Image style={{ width: 1, height: 1 }} source={{ uri: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVR4nGP6DwABBQECz6AuzQAAAABJRU5ErkJggg==" }} />`