### PR TITLE
Adds an error message in the Alert.alert method if buttons is not an array

### DIFF
--- a/Libraries/Alert/Alert.js
+++ b/Libraries/Alert/Alert.js
@@ -47,6 +47,10 @@ class Alert {
     buttons?: Buttons,
     options?: Options,
   ): void {
+    if (buttons && !Array.isArray(buttons)) {
+      console.error('buttons must be an array of buttons');
+    }
+
     if (Platform.OS === 'ios') {
       Alert.prompt(title, message, buttons, 'default');
     } else if (Platform.OS === 'android') {


### PR DESCRIPTION
## Summary

I've found that developers (especially beginners) will often provide an object as the third argument to `Alert.alert` if they only want one button. This provides a cleaner error message instead of making the application crash a few lines later (in the `buttons.slice` method for Android).

## Changelog

[General] [Changed] - Alert.alert will now throw an error if the third argument is not an array.

## Test Plan

Prettier + eslint + jest. RNTester.