### PR TITLE
Fabric: Add Unicode prefix to AttachmentCharacter

### DIFF
--- a/ReactCommon/fabric/attributedstring/AttributedString.cpp
+++ b/ReactCommon/fabric/attributedstring/AttributedString.cpp
@@ -18,7 +18,7 @@ using Fragments = AttributedString::Fragments;
 #pragma mark - Fragment
 
 std::string Fragment::AttachmentCharacter() {
-  return "\uFFFC"; // Unicode `OBJECT REPLACEMENT CHARACTER`
+  return u8"\uFFFC"; // Unicode `OBJECT REPLACEMENT CHARACTER`
 }
 
 bool Fragment::isAttachment() const {


### PR DESCRIPTION
## Summary

This pull request adds a Unicode `u8` prefix to the string literal returned in `AttributedString.cpp`'s `Fragment::AttachmentCharacter()`.

This fixes the following error when building on MSVC:

```
react\attributedstring\AttributedString.cpp(21): error C4566: character represented by universal-character-name '\uFFFC' cannot be represented in the current code page (1252) 
```

## Changelog

[Internal] [Fixed] - Fabric: Add Unicode prefix to AttachmentCharacter

## Test Plan

The Fabric test suite has been ran on a Clang-based build of Fabric on macOS, and no regressions in it have been noted.