### PR TITLE
fix: do not throw on missing `cliPath`, use the default value

### DIFF
--- a/RNTester/android/app/build.gradle
+++ b/RNTester/android/app/build.gradle
@@ -65,7 +65,6 @@ plugins {
  */
 
 project.ext.react = [
-    cliPath: "$rootDir/cli.js",
     bundleAssetName: "RNTesterApp.android.bundle",
     entryFile: file("../../js/RNTesterApp.android.js"),
     root: "$rootDir",

--- a/RNTester/android/app/build.gradle
+++ b/RNTester/android/app/build.gradle
@@ -65,6 +65,7 @@ plugins {
  */
 
 project.ext.react = [
+    cliPath: "$rootDir/cli.js",
     bundleAssetName: "RNTesterApp.android.bundle",
     entryFile: file("../../js/RNTesterApp.android.js"),
     root: "$rootDir",

--- a/react.gradle
+++ b/react.gradle
@@ -21,7 +21,22 @@ def detectEntryFile(config) {
     return "index.js";
 }
 
-def defaultCliPath = "node_modules/react-native/cli.js"
+/**
+ * Detects CLI location in a similar fashion to the React Native CLI
+ */
+def detectCliPath(config) {
+    def cliPath = ["node", "-e", "console.log(require('react-native/cli').bin);"].execute([], projectDir).text
+
+    if (cliPath) {
+        return cliPath
+    } else if (new File("node_modules/react-native/cli.js").exists()) {
+        return "node_modules/react-native/cli.js"
+    } else {
+        throw new Exception("Couldn't determine CLI location. " +
+            "Please set `project.ext.react.cliPath` to the path of the react-native cli.js");
+    }
+}
+
 def composeSourceMapsPath = config.composeSourceMapsPath ?: "node_modules/react-native/scripts/compose-source-maps.js"
 def bundleAssetName = config.bundleAssetName ?: "index.android.bundle"
 def entryFile = detectEntryFile(config)
@@ -109,7 +124,7 @@ afterEvaluate {
                 execCommand.addAll([*nodeExecutableAndArgs, config.cliPath])
             }
         } else {
-            execCommand.add(defaultCliPath)
+            execCommand.add(defaultCliPath())
         }
 
         def enableHermes = enableHermesForVariant(variant)

--- a/react.gradle
+++ b/react.gradle
@@ -26,10 +26,10 @@ def detectEntryFile(config) {
  */
 def detectCliPath(config) {
     def cliPath = ["node", "-e", "console.log(require('react-native/cli').bin);"].execute([], projectDir).text
-
+    
     if (cliPath) {
         return cliPath
-    } else if (new File("node_modules/react-native/cli.js").exists()) {
+    } else if (new File("${projectDir}/../../node_modules/react-native/cli.js").exists()) {
         return "node_modules/react-native/cli.js"
     } else {
         throw new Exception("Couldn't determine CLI location. " +

--- a/react.gradle
+++ b/react.gradle
@@ -34,7 +34,7 @@ def detectCliPath(config) {
     if (cliPath) {
         return cliPath
     } else if (new File("${projectDir}/../../node_modules/react-native/cli.js").exists()) {
-        return "node_modules/react-native/cli.js"
+        return "${projectDir}/../../node_modules/react-native/cli.js"
     } else {
         throw new Exception("Couldn't determine CLI location. " +
             "Please set `project.ext.react.cliPath` to the path of the react-native cli.js");

--- a/react.gradle
+++ b/react.gradle
@@ -25,6 +25,10 @@ def detectEntryFile(config) {
  * Detects CLI location in a similar fashion to the React Native CLI
  */
 def detectCliPath(config) {
+    if (config.cliPath) {
+        return config.cliPath
+    }
+
     def cliPath = ["node", "-e", "console.log(require('react-native/cli').bin);"].execute([], projectDir).text
     
     if (cliPath) {
@@ -113,20 +117,16 @@ afterEvaluate {
 
         // Additional node and packager commandline arguments
         def nodeExecutableAndArgs = config.nodeExecutableAndArgs ?: ["node"]
-        def extraPackagerArgs = config.extraPackagerArgs ?: []
+        def cliPath = detectCliPath(config)
 
         def execCommand = []
 
-        if (config.cliPath || config.nodeExecutableAndArgs) {
-            if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                execCommand.addAll(["cmd", "/c", *nodeExecutableAndArgs, config.cliPath])
-            } else {
-                execCommand.addAll([*nodeExecutableAndArgs, config.cliPath])
-            }
+        if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+            execCommand.addAll(["cmd", "/c", *nodeExecutableAndArgs, cliPath])
         } else {
-            execCommand.add(defaultCliPath())
+            execCommand.addAll([*nodeExecutableAndArgs, cliPath])
         }
-
+        
         def enableHermes = enableHermesForVariant(variant)
 
         def currentBundleTask = tasks.create(
@@ -159,7 +159,7 @@ afterEvaluate {
             def devEnabled = !(config."devDisabledIn${targetName}"
                 || targetName.toLowerCase().contains("release"))
 
-            def extraArgs = extraPackagerArgs;
+            def extraArgs = config.extraPackagerArgs ?: [];
 
             if (bundleConfig) {
                 extraArgs = extraArgs.clone()

--- a/react.gradle
+++ b/react.gradle
@@ -21,7 +21,7 @@ def detectEntryFile(config) {
     return "index.js";
 }
 
-def cliPath = config.cliPath ?: "node_modules/react-native/cli.js"
+def defaultCliPath = "node_modules/react-native/cli.js"
 def composeSourceMapsPath = config.composeSourceMapsPath ?: "node_modules/react-native/scripts/compose-source-maps.js"
 def bundleAssetName = config.bundleAssetName ?: "index.android.bundle"
 def entryFile = detectEntryFile(config)
@@ -104,13 +104,12 @@ afterEvaluate {
 
         if (config.cliPath || config.nodeExecutableAndArgs) {
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                execCommand.addAll(["cmd", "/c", *nodeExecutableAndArgs, cliPath])
+                execCommand.addAll(["cmd", "/c", *nodeExecutableAndArgs, config.cliPath])
             } else {
-                execCommand.addAll([*nodeExecutableAndArgs, cliPath])
+                execCommand.addAll([*nodeExecutableAndArgs, config.cliPath])
             }
         } else {
-            throw new Exception("Missing cliPath or nodeExecutableAndArgs from build config. " +
-                "Please set project.ext.react.cliPath to the path of the react-native cli.js");
+            execCommand.add(defaultCliPath)
         }
 
         def enableHermes = enableHermesForVariant(variant)


### PR DESCRIPTION
## Summary

The `cliPath` has always been optional value and in fact, even had its default value hardcoded in the React gradle file.

In this PR, I am just taking use of it and remove throwing an error, which is going to be a really annoying breaking change.

## Changelog

[ANDROID] [INTERNAL] - Don't require `cliPath`

## Test Plan

Run Android project, everything works. 
Provide custom `cliPath`, it gets respected
