### PR TITLE
chore: remove Kotlin version from the default template

### DIFF
--- a/template/android/build.gradle
+++ b/template/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
         google()
         jcenter()
     }
-    ext.kotlinVersion = '1.3.0'
+    ext.kotlinVersion = '1.3.10'
     dependencies {
         classpath("com.android.tools.build:gradle:3.5.3")
         // for Detox

--- a/template/android/build.gradle
+++ b/template/android/build.gradle
@@ -11,11 +11,8 @@ buildscript {
         google()
         jcenter()
     }
-    ext.kotlinVersion = '1.3.10'
     dependencies {
         classpath("com.android.tools.build:gradle:3.5.3")
-        // for Detox
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }


### PR DESCRIPTION
## Summary

The default application requires Kotlin version that is not supported by the Gradle plugin (should be at least `1.3.10`). However, instead of upgrading, we should remove it entirely. Here's why.

This commit https://github.com/facebook/react-native/commit/29d3dfbd196176af98c9727c82ff2668e697d78e introduced Detox for RNTester Android application.

Since the commit doesn't mention Detox for the default application and there are no Detox tests present by default in the default application, I believe that this addition was performed by a mistake.

The best way is to remove Kotlin from the default template. This step is described in the Detox documentation and all users that are integrating Detox will be asked to perform it anyway. No need to do it for them.

## Changelog

[ANDROID] [INTERNAL] - remove Kotlin from the default template

## Test Plan

Building a brand new project with `master` should work
