### PR TITLE
enable ArrayBuffer API in JSCRuntime

### DIFF
--- a/ReactCommon/jsi/JSCRuntime.cpp
+++ b/ReactCommon/jsi/JSCRuntime.cpp
@@ -922,24 +922,18 @@ bool JSCRuntime::isArray(const jsi::Object &obj) const {
 #endif
 }
 
-bool JSCRuntime::isArrayBuffer(const jsi::Object & /*obj*/) const {
-  // TODO: T23270523 - This would fail on builds that use our custom JSC
-  // auto typedArrayType = JSValueGetTypedArrayType(ctx_, objectRef(obj),
-  // nullptr);  return typedArrayType == kJSTypedArrayTypeArrayBuffer;
-  throw std::runtime_error("Unsupported");
+bool JSCRuntime::isArrayBuffer(const jsi::Object &obj) const {
+  auto typedArrayType = JSValueGetTypedArrayType(ctx_, objectRef(obj), nullptr);
+  return typedArrayType == kJSTypedArrayTypeArrayBuffer;
 }
 
-uint8_t *JSCRuntime::data(const jsi::ArrayBuffer & /*obj*/) {
-  // TODO: T23270523 - This would fail on builds that use our custom JSC
-  // return static_cast<uint8_t*>(
-  //    JSObjectGetArrayBufferBytesPtr(ctx_, objectRef(obj), nullptr));
-  throw std::runtime_error("Unsupported");
+uint8_t *JSCRuntime::data(const jsi::ArrayBuffer &obj) {
+  return static_cast<uint8_t*>(
+      JSObjectGetArrayBufferBytesPtr(ctx_, objectRef(obj), nullptr));
 }
 
-size_t JSCRuntime::size(const jsi::ArrayBuffer & /*obj*/) {
-  // TODO: T23270523 - This would fail on builds that use our custom JSC
-  // return JSObjectGetArrayBufferByteLength(ctx_, objectRef(obj), nullptr);
-  throw std::runtime_error("Unsupported");
+size_t JSCRuntime::size(const jsi::ArrayBuffer &obj) {
+  return JSObjectGetArrayBufferByteLength(ctx_, objectRef(obj), nullptr);
 }
 
 bool JSCRuntime::isFunction(const jsi::Object &obj) const {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Currently, there is no way to interact with TypedArrays and ArrayBuffers using C++ API.

Comment `T23270523 - This would fail on builds that use our custom JSC` is no longer valid
- on android old JSC was replaced with support for 64-bit builds
- on iOS old JSC was replaced when support for iOS 9 was dropped

## Changelog

[General] [Added] - Add/Enable implementation for ArrayBuffer jsi API

## Test Plan

- I didn't test ArrayBuffer API with this PR in runtime, but I used those exact changes and few others [here](https://github.com/expo/expo/blob/%40wkozyra95/jsi-expo-gl-part5/android/ReactCommon/jsi/JSCRuntime.cpp)