### PR TITLE
move prettier to peerDeps in eslint-config-react-native-community

### DIFF
--- a/packages/eslint-config-react-native-community/package.json
+++ b/packages/eslint-config-react-native-community/package.json
@@ -26,9 +26,11 @@
     "prettier": "^2.0.2"
   },
   "peerDependencies": {
-    "eslint": ">=7"
+    "eslint": ">=7",
+    "prettier": ">=2"
   },
   "devDependencies": {
-    "eslint": "7.12.0"
+    "eslint": "7.12.0",
+    "prettier": "^2.3.2"
   }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

In monorepo environment, prettier-plugin in some editor load from nearest `node_modules`. Older version of eslint-config-react-native-community includes prettier v1 in their dependencies. It cause conflict of code style inside the monorepo.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Internal] [Fixed] - move prettier to peerDependencies in eslint-config-react-native-community


## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
I think it would be good with no plan to test.