### PR TITLE
Fix CIRCLE_PR_NUMBER may not always be set

### DIFF
--- a/scripts/circleci/report-bundle-size.sh
+++ b/scripts/circleci/report-bundle-size.sh
@@ -8,7 +8,7 @@ case $1 in
   "android" | "ios")
     GITHUB_OWNER=${CIRCLE_PROJECT_USERNAME:-facebook} \
     GITHUB_REPO=${CIRCLE_PROJECT_REPONAME:-react-native} \
-    GITHUB_PR_NUMBER="$CIRCLE_PR_NUMBER" \
+    GITHUB_PR_NUMBER="${CIRCLE_PR_NUMBER:-${CIRCLE_PULL_REQUEST##*/}}" \
     GITHUB_REF=${CIRCLE_BRANCH} \
     GITHUB_SHA=${CIRCLE_SHA1} \
     node bots/report-bundle-size.js "$1"


### PR DESCRIPTION
## Summary

This fixes build failures where `CIRCLE_PR_NUMBER` is not set. This can happen if the PR did not come from a fork.

## Changelog

[Internal] [Fixed] - Fix CIRCLE_PR_NUMBER may not always be set

## Test Plan

Report bundle size step should pass on both this PR and #28641.