### PR TITLE
[DO NOT MERGE] Fix CIRCLE_PR_NUMBER may not always be set

### DIFF
--- a/scripts/circleci/report-bundle-size.sh
+++ b/scripts/circleci/report-bundle-size.sh
@@ -8,7 +8,7 @@ case $1 in
   "android" | "ios")
     GITHUB_OWNER=${CIRCLE_PROJECT_USERNAME:-facebook} \
     GITHUB_REPO=${CIRCLE_PROJECT_REPONAME:-react-native} \
-    GITHUB_PR_NUMBER="$CIRCLE_PR_NUMBER" \
+    GITHUB_PR_NUMBER="${CIRCLE_PR_NUMBER:-${CIRCLE_PULL_REQUEST##*/}}" \
     GITHUB_REF=${CIRCLE_BRANCH} \
     GITHUB_SHA=${CIRCLE_SHA1} \
     node bots/report-bundle-size.js "$1"


### PR DESCRIPTION
Testing that https://github.com/facebook/react-native/pull/28640 fixes the jobs for PRs opened from branches on the same repo (not a fork). 