### PR TITLE
Codegen: Add prepublish script to build Flow files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,7 @@ RNTester/Pods/*
 # react-native-codegen
 /ReactCommon/fabric/components/rncore/
 /schema-rncore.json
+/packages/react-native-codegen/lib
 
 # Visual studio
 .vscode

--- a/packages/react-native-codegen/package.json
+++ b/packages/react-native-codegen/package.json
@@ -7,13 +7,22 @@
     "type": "git",
     "url": "git@github.com:facebook/react-native.git"
   },
+  "scripts": {
+    "build": "yarn clean && yarn flow-remove-types src/ -d lib/ -q && yarn flow-copy-source src/ lib/",
+    "clean": "rm -rf lib",
+    "prepublish": "yarn run build"
+  },
   "license": "MIT",
   "files": [
-    "src"
+    "lib"
   ],
   "dependencies": {
     "flow-parser": "^0.121.0",
     "jscodeshift": "^0.7.0",
     "nullthrows": "^1.1.1"
+  },
+  "devDependencies": {
+    "flow-copy-source": "^2.0.9",
+    "flow-remove-types": "^2.122.0"
   }
 }


### PR DESCRIPTION
## Summary

This pull request adds a build step to `react-native-codegen` that builds the Flow-annotated JS files so that users of the NPM module `react-native-codegen` do not need to use require hooks to be able to import it.

The `flow-remove-types` CLI script is used to build the JS files in `src/` and it outputs them into `lib/`. Then, the CLI tool `flow-copy-source` copies over the original Flow annotated files to `lib/` with a `.js.flow` extension, so users of `react-native-codegen` can still typecheck against it using Flow.

## Changelog

[General] [Added] - Codegen: Add prepublish script to build Flow files

## Test Plan

I am able to make use of the Codegen scripts without needing to use the `flow-node` CLI or the `flow-remove-types/register` require hook.