### PR TITLE
Add support for icons in ActionSheetIOS

### DIFF
--- a/Libraries/ActionSheetIOS/ActionSheetIOS.js
+++ b/Libraries/ActionSheetIOS/ActionSheetIOS.js
@@ -12,6 +12,8 @@ import RCTActionSheetManager from './NativeActionSheetManager';
 
 const invariant = require('invariant');
 const processColor = require('../StyleSheet/processColor');
+import type {ImageSource} from '../Image/ImageSource';
+import resolveAssetSource from '../Image/resolveAssetSource';
 import type {ColorValue} from '../StyleSheet/StyleSheet';
 import type {ProcessedColorValue} from '../StyleSheet/processColor';
 
@@ -50,6 +52,8 @@ const ActionSheetIOS = {
       +cancelButtonTintColor?: ColorValue | ProcessedColorValue,
       +userInterfaceStyle?: string,
       +disabledButtonIndices?: Array<number>,
+      +icons?: ?Array<ImageSource>,
+      +shouldTintIcons?: boolean,
     |},
     callback: (buttonIndex: number) => void,
   ) {
@@ -64,6 +68,7 @@ const ActionSheetIOS = {
       tintColor,
       cancelButtonTintColor,
       destructiveButtonIndex,
+      icons,
       ...remainingOptions
     } = options;
     let destructiveButtonIndices = null;
@@ -85,12 +90,20 @@ const ActionSheetIOS = {
         typeof processedCancelButtonTintColor === 'number',
       'Unexpected color given for ActionSheetIOS.showActionSheetWithOptions cancelButtonTintColor',
     );
+
+    let processedIcons = null;
+    if (icons) {
+      invariant(Array.isArray(icons), 'Must provide a valid array of icons');
+      processedIcons = icons.map(icon => resolveAssetSource(icon));
+    }
+
     RCTActionSheetManager.showActionSheetWithOptions(
       {
         ...remainingOptions,
         tintColor: processedTintColor,
         cancelButtonTintColor: processedCancelButtonTintColor,
         destructiveButtonIndices,
+        icons: processedIcons,
       },
       callback,
     );

--- a/Libraries/ActionSheetIOS/NativeActionSheetManager.js
+++ b/Libraries/ActionSheetIOS/NativeActionSheetManager.js
@@ -10,6 +10,7 @@
 
 import type {TurboModule} from '../TurboModule/RCTExport';
 import * as TurboModuleRegistry from '../TurboModule/TurboModuleRegistry';
+import type {ResolvedAssetSource} from '../Image/AssetSourceResolver';
 
 export interface Spec extends TurboModule {
   +getConstants: () => {||};
@@ -25,6 +26,8 @@ export interface Spec extends TurboModule {
       +cancelButtonTintColor?: ?number,
       +userInterfaceStyle?: ?string,
       +disabledButtonIndices?: Array<number>,
+      +icons?: ?Array<ResolvedAssetSource>,
+      +shouldTintIcons?: ?boolean,
     |},
     callback: (buttonIndex: number) => void,
   ) => void;

--- a/packages/rn-tester/js/examples/ActionSheetIOS/ActionSheetIOSExample.js
+++ b/packages/rn-tester/js/examples/ActionSheetIOS/ActionSheetIOSExample.js
@@ -23,6 +23,10 @@ const {
 const ScreenshotManager = NativeModules.ScreenshotManager;
 
 const BUTTONS = ['Option 0', 'Option 1', 'Option 2', 'Delete', 'Cancel'];
+const ICONS = [
+  require('../../assets/call.png'),
+  require('../../assets/dislike.png'),
+];
 const DESTRUCTIVE_INDEX = 3;
 const CANCEL_INDEX = 4;
 const DISABLED_BUTTON_INDICES = [1, 2];
@@ -120,6 +124,144 @@ class ActionSheetCancelButtonTintExample extends React.Component<
         destructiveButtonIndex: DESTRUCTIVE_INDEX,
         tintColor: 'green',
         cancelButtonTintColor: 'brown',
+      },
+      buttonIndex => {
+        this.setState({clicked: BUTTONS[buttonIndex]});
+      },
+    );
+  };
+}
+
+class ActionSheetIconsExample extends React.Component<
+  $FlowFixMeProps,
+  $FlowFixMeState,
+> {
+  state = {
+    clicked: 'none',
+  };
+
+  render() {
+    return (
+      <View>
+        <Text onPress={this.showActionSheet} style={style.button}>
+          Click to show the ActionSheet
+        </Text>
+        <Text>Clicked button: {this.state.clicked}</Text>
+      </View>
+    );
+  }
+
+  showActionSheet = () => {
+    ActionSheetIOS.showActionSheetWithOptions(
+      {
+        options: BUTTONS,
+        icons: ICONS,
+        cancelButtonIndex: CANCEL_INDEX,
+        destructiveButtonIndex: DESTRUCTIVE_INDEX,
+      },
+      buttonIndex => {
+        this.setState({clicked: BUTTONS[buttonIndex]});
+      },
+    );
+  };
+}
+
+class ActionSheetNullIconsExample extends React.Component<
+  $FlowFixMeProps,
+  $FlowFixMeState,
+> {
+  state = {
+    clicked: 'none',
+  };
+
+  render() {
+    return (
+      <View>
+        <Text onPress={this.showActionSheet} style={style.button}>
+          Click to show the ActionSheet
+        </Text>
+        <Text>Clicked button: {this.state.clicked}</Text>
+      </View>
+    );
+  }
+
+  showActionSheet = () => {
+    ActionSheetIOS.showActionSheetWithOptions(
+      {
+        options: BUTTONS,
+        icons: [null, ICONS[1]],
+        cancelButtonIndex: CANCEL_INDEX,
+        destructiveButtonIndex: DESTRUCTIVE_INDEX,
+      },
+      buttonIndex => {
+        this.setState({clicked: BUTTONS[buttonIndex]});
+      },
+    );
+  };
+}
+
+class ActionSheetCustomTintIconsExample extends React.Component<
+  $FlowFixMeProps,
+  $FlowFixMeState,
+> {
+  state = {
+    clicked: 'none',
+  };
+
+  render() {
+    return (
+      <View>
+        <Text onPress={this.showActionSheet} style={style.button}>
+          Click to show the ActionSheet
+        </Text>
+        <Text>Clicked button: {this.state.clicked}</Text>
+      </View>
+    );
+  }
+
+  showActionSheet = () => {
+    ActionSheetIOS.showActionSheetWithOptions(
+      {
+        options: BUTTONS,
+        icons: ICONS,
+        cancelButtonIndex: CANCEL_INDEX,
+        destructiveButtonIndex: DESTRUCTIVE_INDEX,
+        tintColor: 'green',
+      },
+      buttonIndex => {
+        this.setState({clicked: BUTTONS[buttonIndex]});
+      },
+    );
+  };
+}
+
+class ActionSheetUntintedIconsExample extends React.Component<
+  $FlowFixMeProps,
+  $FlowFixMeState,
+> {
+  state = {
+    clicked: 'none',
+  };
+
+  render() {
+    return (
+      <View>
+        <Text onPress={this.showActionSheet} style={style.button}>
+          Click to show the ActionSheet
+        </Text>
+        <Text>Clicked button: {this.state.clicked}</Text>
+      </View>
+    );
+  }
+
+  showActionSheet = () => {
+    ActionSheetIOS.showActionSheetWithOptions(
+      {
+        options: BUTTONS,
+        icons: ICONS,
+        tintIcons: false,
+        cancelButtonIndex: CANCEL_INDEX,
+        destructiveButtonIndex: DESTRUCTIVE_INDEX,
       },
       buttonIndex => {
         this.setState({clicked: BUTTONS[buttonIndex]});
@@ -381,6 +523,30 @@ exports.examples = [
     title: 'Show Action Sheet with cancel tinted button',
     render(): React.Element<any> {
       return <ActionSheetCancelButtonTintExample />;
+    },
+  },
+  {
+    title: 'Show Action Sheet with icons',
+    render(): React.Element<any> {
+      return <ActionSheetIconsExample />;
+    },
+  },
+  {
+    title: 'Show Action Sheet with icons for just the 2nd option',
+    render(): React.Element<any> {
+      return <ActionSheetNullIconsExample />;
+    },
+  },
+  {
+    title: 'Show Action Sheet with icons and tinted buttons',
+    render(): React.Element<any> {
+      return <ActionSheetCustomTintIconsExample />;
+    },
+  },
+  {
+    title: 'Show Action Sheet with untinted icons',
+    render(): React.Element<any> {
+      return <ActionSheetUntintedIconsExample />;
     },
   },
   {


### PR DESCRIPTION
## Summary

This PR adds support for icons next to each option in the iOS Action Sheet Picker. It allows users to specify an array of `icons` which match the indexes of the `options` which are provided. It will show the icon next to each option.

There is also a `tintIcons` option which allows switching between tinting the icon with the given color (the default behaviour) and leaving the icons as they were provided.

These props and defaults were deliberately chosen to match the [`@expo/react-native-action-sheet`](https://github.com/expo/react-native-action-sheet) library. This library uses `ActionSheetIOS` internally, so added support to React Native core would allow the props  in this library to work across Android, Web, and iOS.

## Changelog

[iOS] [Added] - Add support for icons in ActionSheetIOS

## Test Plan

I have added three new cases to RNTester and tested it manually. The screenshots below show it with icons that were already present in RNTester. It would look nicer with smaller icons, but I didn't want to find  suitable icons were had the correct licencing to include in the repo.

**Icons for first two options with default tint**

![Simulator Screen Shot - iPhone 11 Pro Max - 2020-04-16 at 09 31 40](https://user-images.githubusercontent.com/97068/79433551-2a1c3d00-7fc5-11ea-9057-dbfa60ed8a91.png)

**Icons for first two options with custom tint**

![Simulator Screen Shot - iPhone 11 Pro Max - 2020-04-16 at 09 31 44](https://user-images.githubusercontent.com/97068/79433568-30121e00-7fc5-11ea-8892-52c576204abe.png)

**Icons for first two options with tinting turned off**

![Simulator Screen Shot - iPhone 11 Pro Max - 2020-04-16 at 09 31 48](https://user-images.githubusercontent.com/97068/79433588-37d1c280-7fc5-11ea-856d-43eb6088d70d.png)

# TODO

- [x] I have manually modified the `FBReactNativeSpec.h` file to support the new options. This is actually a file which is generated by a Facebook internal version of codegen. Can someone at Facebook generate the new version of this file and commit it to this PR so it is correct?