### PR TITLE
chore: update `./scripts/test-manual-e2e.sh`

### DIFF
--- a/scripts/test-manual-e2e.sh
+++ b/scripts/test-manual-e2e.sh
@@ -58,11 +58,14 @@ info ""
 read -n 1
 adb shell am start -n com.facebook.react.uiapp/.RNTesterActivity
 
+success "Installing CocoaPods dependencies"
+rm -rf RNTester/Pods
+(cd RNTester && pod install)
+
 info "Press any key to open the workspace in Xcode, then build and test manually."
 info ""
 read -n 1
-success "Installing CocoaPods dependencies"
-rm -rf RNTester/Pods && cd RNTester && pod install
+
 open "RNTester/RNTesterPods.xcworkspace"
 
 info "When done testing RNTester app on iOS and Android press any key to continue."
@@ -113,7 +116,7 @@ info ""
 info "Press any key to open the project in Xcode"
 info ""
 read -n 1
-open "/tmp/${project_name}/ios/${project_name}.xcodeproj"
+open "/tmp/${project_name}/ios/${project_name}.xcworkspace"
 
 cd "$repo_root"
 


### PR DESCRIPTION
## Summary

Recent changes broke the script - wrong path to open `RNTesterPods.xcworkspace` and other scripts - we change dir with `cd`. 

Another change is incorrect use of `RNTesterProject.xcodeproj` instead of a `xcworkspace`. 

This PR is a simple and short fix to make it run.

## Changelog

[INTERNAL] - chore: update `./scripts/test-manual-e2e.sh`

## Test Plan

Run `./scripts/test-manual-e2e.sh`. Things work.
