### PR TITLE
Migrate deprecated frameInterval to preferredFramesPerSecond

### DIFF
--- a/Libraries/Image/RCTUIImageViewAnimated.m
+++ b/Libraries/Image/RCTUIImageViewAnimated.m
@@ -183,7 +183,7 @@ static NSUInteger RCTDeviceFreeMemory() {
   // TODO: `displayLink.frameInterval` is not available on UIKitForMac
   NSTimeInterval duration = displayLink.duration;
 #else
-  NSTimeInterval duration = displayLink.duration * displayLink.frameInterval;
+  NSTimeInterval duration = displayLink.duration * displayLink.preferredFramesPerSecond;
 #endif
   NSUInteger totalFrameCount = self.totalFrameCount;
   NSUInteger currentFrameIndex = self.currentFrameIndex;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
[frameInterval](https://developer.apple.com/documentation/quartzcore/cadisplaylink/1621231-frameinterval) was deprecated in favor of [preferredFramesPerSecond](https://developer.apple.com/documentation/quartzcore/cadisplaylink/1648421-preferredframespersecond).

This migrates the deprecated call over.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [Fixed] - Migrate frameInterval to preferredFramesPerSecond

## Test Plan
Xcode should no longer throw warnings about the deprecated call.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
