### PR TITLE
Set black as default text color for <TextInput/> on iOS

### DIFF
--- a/Libraries/Text/TextInput/RCTBaseTextInputView.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputView.m
@@ -68,7 +68,12 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
 - (void)enforceTextAttributesIfNeeded
 {
   id<RCTBackedTextInputViewProtocol> backedTextInputView = self.backedTextInputView;
-  backedTextInputView.defaultTextAttributes = [_textAttributes effectiveTextAttributes];
+  
+  NSDictionary<NSAttributedStringKey,id> *copied =  [[_textAttributes effectiveTextAttributes] mutableCopy];
+  if ([copied valueForKey:NSForegroundColorAttributeName] == nil) {
+      [copied setValue:[UIColor blackColor] forKey:NSForegroundColorAttributeName];
+  }
+  backedTextInputView.defaultTextAttributes = copied;
 }
 
 - (void)setReactPaddingInsets:(UIEdgeInsets)reactPaddingInsets

--- a/Libraries/Text/TextInput/RCTBaseTextInputView.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputView.m
@@ -68,12 +68,13 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
 - (void)enforceTextAttributesIfNeeded
 {
   id<RCTBackedTextInputViewProtocol> backedTextInputView = self.backedTextInputView;
-  
-  NSDictionary<NSAttributedStringKey,id> *copied =  [[_textAttributes effectiveTextAttributes] mutableCopy];
-  if ([copied valueForKey:NSForegroundColorAttributeName] == nil) {
-      [copied setValue:[UIColor blackColor] forKey:NSForegroundColorAttributeName];
+
+  NSDictionary<NSAttributedStringKey,id> *textAttributes = [[_textAttributes effectiveTextAttributes] mutableCopy];
+  if ([textAttributes valueForKey:NSForegroundColorAttributeName] == nil) {
+      [textAttributes setValue:[UIColor blackColor] forKey:NSForegroundColorAttributeName];
   }
-  backedTextInputView.defaultTextAttributes = copied;
+
+  backedTextInputView.defaultTextAttributes = textAttributes;
 }
 
 - (void)setReactPaddingInsets:(UIEdgeInsets)reactPaddingInsets


### PR DESCRIPTION
## Summary

This is a follow-up pull request to #28280 (reviewed by @shergin).
This pull request tried to solve the problem of the default color in a TextInput in dark mode on iOS being white instead of black. I got suggested to solve the problem not on the level of RCTTextAttributes, but on the level of RCTUITextField.

Setting `self.textColor = [UIColor black];` in the constructor did not work, because it gets overwritten by nil in `RCTBaseTextInputView.m`. There I implemented the logic that if NSForegroundColorAttributeName color is nil then the color is being set to black. I think the `defaultTextAttributes` property confuses here, because it ends up being the effective text attributes, e.g. if I unconditionally set the default text color to black, it cannot be changed in React Native anymore. So I put the nil check in. 

## Changelog

[iOS] [Fixed] - TextInput color has the same default (#000) on iOS whether in light or dark mode

## Test Plan

I have manually tested the following:
- The default text color in light mode is black
- The default text color in dark mode is black
- The color can be changed using the `style.color` attribute
- Setting the opacity to 0.5 results in the desired behavior, the whole TextInput becoming half the opacity.
– Setting the `style.color` to rgba(0, 0, 0, 0.5) works as intended, creating a half-opaque text color.