### PR TITLE
Use RTL in RTLExample when Platform != android

### DIFF
--- a/RNTester/js/examples/RTL/RTLExample.js
+++ b/RNTester/js/examples/RTL/RTLExample.js
@@ -521,7 +521,7 @@ const BorderExample = withRTLState(({isRTL, setRTL}) => {
 });
 
 const directionStyle = isRTL =>
-  Platform.OS === 'ios' ? {direction: isRTL ? 'rtl' : 'ltr'} : null;
+  Platform.OS !== 'android' ? {direction: isRTL ? 'rtl' : 'ltr'} : null;
 
 const styles = StyleSheet.create({
   container: {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

This change upstreams a small change we did in react-native-windows to allow the RTLExample RNTester page to function correctly on Windows.  The change is part of this Pr:
https://github.com/microsoft/react-native-windows/pull/4683
Currently the direction property is gated behind a check for Platform == 'iOS', which means it only works on iOS.  Windows supports direction = 'rtl' so I've chanced this check to Platform != 'android'.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Internal] [Changed] - Changed RTLExample RNTester page to use direction = 'rtl' when Platform is not Android.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
Confirmed this change works correctly in RNTester on Windows.  Have not confirmed iOS as I don't have Mac hardware.
