### PR TITLE
chore: remove tvOS from the e2e CI tests

### DIFF
--- a/scripts/run-ci-e2e-tests.js
+++ b/scripts/run-ci-e2e-tests.js
@@ -13,7 +13,6 @@
  * This script tests that React Native end to end installation/bootstrap works for different platforms
  * Available arguments:
  * --ios - 'react-native init' and check iOS app doesn't redbox
- * --tvos - 'react-native init' and check tvOS app doesn't redbox
  * --android - 'react-native init' and check Android app doesn't redbox
  * --js - 'react-native init' and only check the packager returns a bundle
  * --skip-cli-install - to skip react-native-cli global installation (for local debugging)
@@ -192,8 +191,7 @@ try {
     }
   }
 
-  if (argv.ios || argv.tvos) {
-    var iosTestType = argv.tvos ? 'tvOS' : 'iOS';
+  if (argv.ios) {
     cd('ios');
     // shelljs exec('', {async: true}) does not emit stdout events, so we rely on good old spawn
     const packagerEnv = Object.create(process.env);
@@ -205,7 +203,7 @@ try {
     });
     SERVER_PID = packagerProcess.pid;
     exec('sleep 15s');
-    // prepare cache to reduce chances of possible red screen "Can't fibd variable __fbBatchedBridge..."
+    // prepare cache to reduce chances of possible red screen "Can't find variable __fbBatchedBridge..."
     exec(
       'response=$(curl --write-out %{http_code} --silent --output /dev/null localhost:8081/index.bundle?platform=ios&dev=true)',
     );
@@ -214,32 +212,22 @@ try {
     describe('Install CocoaPod dependencies');
     exec('pod install');
 
-    describe('Test: ' + iosTestType + ' end-to-end test');
+    describe('Test: iOS end-to-end test');
     if (
       // TODO: Get target OS and simulator from .tests.env
       tryExecNTimes(
         () => {
-          let destination = 'platform=iOS Simulator,name=iPhone 8,OS=13.3';
-          let sdk = 'iphonesimulator';
-          let scheme = 'HelloWorld';
-
-          if (argv.tvos) {
-            destination = 'platform=tvOS Simulator,name=Apple TV,OS=13.3';
-            sdk = 'appletvsimulator';
-            scheme = 'HelloWorld-tvOS';
-          }
-
           return exec(
             [
               'xcodebuild',
               '-workspace',
               '"HelloWorld.xcworkspace"',
               '-destination',
-              `"${destination}"`,
+              '"platform=iOS Simulator,name=iPhone 8,OS=13.3"',
               '-scheme',
-              `"${scheme}"`,
+              '"HelloWorld"',
               '-sdk',
-              sdk,
+              'iphonesimulator',
               '-UseModernBuildSystem=NO',
               'test',
             ].join(' ') +
@@ -249,7 +237,7 @@ try {
                 '--report',
                 'junit',
                 '--output',
-                `"~/react-native/reports/junit/${iosTestType}-e2e/results.xml"`,
+                '"~/react-native/reports/junit/iOS-e2e/results.xml"',
               ].join(' ') +
               ' && exit ${PIPESTATUS[0]}',
           ).code;
@@ -258,7 +246,7 @@ try {
         () => exec('sleep 10s'),
       )
     ) {
-      echo('Failed to run ' + iosTestType + ' end-to-end tests');
+      echo('Failed to run iOS end-to-end tests');
       echo('Most likely the code is broken');
       exitCode = 1;
       throw Error(exitCode);


### PR DESCRIPTION
## Summary

Refs #28706 

This small PR removes `tvOS` platform and `HelloWorld-tvOS` references from the e2e CI tests script. Also a small typo in comment has been fixed.

CC: @dlowder-salesforce  

## Changelog

[Internal] [Removed] - remove tvOS from the e2e CI tests

## Test Plan

Exec during `node ./scripts/run-ci-e2e-tests.js --ios` was successful.
