### PR TITLE
[android] Replace duplicate code in AndroidInfoModule with call to AndroidInfoHelpers

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/AndroidInfoModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/AndroidInfoModule.java
@@ -73,7 +73,7 @@ public class AndroidInfoModule extends NativePlatformConstantsAndroidSpec implem
     constants.put("Fingerprint", Build.FINGERPRINT);
     constants.put("Model", Build.MODEL);
     if (ReactBuildConfig.DEBUG) {
-      constants.put("ServerHost", getServerHost());
+      constants.put("ServerHost", AndroidInfoHelpers.getServerHost(getReactApplicationContext().getApplicationContext()));
     }
     constants.put(
         "isTesting", "true".equals(System.getProperty(IS_TESTING)) || isRunningScreenshotTest());
@@ -97,13 +97,5 @@ public class AndroidInfoModule extends NativePlatformConstantsAndroidSpec implem
     } catch (ClassNotFoundException ignored) {
       return false;
     }
-  }
-
-  private String getServerHost() {
-    Resources resources = getReactApplicationContext().getApplicationContext().getResources();
-
-    Integer devServerPort = resources.getInteger(R.integer.react_native_dev_server_port);
-
-    return AndroidInfoHelpers.getServerHost(devServerPort);
   }
 }


### PR DESCRIPTION
## Summary

The AndroidInfoModule class defines a `getServerHost()` method that duplicates the logic in `AndroidInfoHelpers.getServerHost(context)`. This commit makes AndroidInfoModule call into AndroidInfoHelpers so that potential future changes to `AndroidInfoHelpers.getServerHost` don't need to be duplicated in `AndroidInfoModule.getServerHost`.

## Changelog

[Android] [Changed] - Internal change to make `PlatformConstants` use the same method to determine `ServerHost` as other code paths

## Test Plan

Tested by running the RNTester app and editing the root component to print out `NativeModules.PlatformConstants.getConstants()` and verified one of the properties was: `"ServerHost": "10.0.2.2:8081"`.
