### PR TITLE
ScrollView, HorizontalScrollView: do not ignore `null` `contentOffset` prop

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
@@ -307,6 +307,8 @@ public class ReactHorizontalScrollViewManager extends ViewGroupManager<ReactHori
       double x = value.getDouble("x");
       double y = value.getDouble("y");
       view.reactScrollTo((int) PixelUtil.toPixelFromDIP(x), (int) PixelUtil.toPixelFromDIP(y));
+    } else {
+      view.reactScrollTo(0, 0);
     }
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.java
@@ -311,6 +311,8 @@ public class ReactScrollViewManager extends ViewGroupManager<ReactScrollView>
       double x = value.getDouble("x");
       double y = value.getDouble("y");
       view.reactScrollTo((int) PixelUtil.toPixelFromDIP(x), (int) PixelUtil.toPixelFromDIP(y));
+    } else {
+      view.reactScrollTo(0, 0);
     }
   }
 


### PR DESCRIPTION
## Summary

motivation: I was just checking out https://github.com/facebook/react-native/commit/30cc158a875a0414cf53d4d5155410eea5d5aeea
and noticed that the commit, I believe, is missing logic for when `contentOffset` is actually `null`.

That is, consider you render `ScrollView` with `contentOffset` { x: 0, y: 100 } and then change that to null / undefined. I'd expect the content offset to invalidate (set to 0 - hope that's the default). 

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Fixed] - ScrollView, HorizontalScrollView: do not ignore `null` `contentOffset` prop

## Test Plan

Tested locally within RNTester

<details><summary>code</summary>
<p>

```js
const Ex = () => {
  let _scrollView: ?React.ElementRef<typeof ScrollView> = React.useRef(null);
  const [offset, setOffset] = React.useState({x: 0, y: 20});
  setTimeout(() => {
    setOffset(undefined);
  }, 2000);

  return (
    <View>
      <ScrollView
        ref={_scrollView}
        automaticallyAdjustContentInsets={false}
        onScroll={() => {
          console.log('onScroll!');
        }}
        contentOffset={offset}
        scrollEventThrottle={200}
        style={styles.scrollView}>
        {ITEMS.map(createItemRow)}
      </ScrollView>
      <Button
        label="Scroll to top"
        onPress={() => {
          nullthrows(_scrollView.current).scrollTo({y: 0});
        }}
      />
      <Button
        label="Scroll to bottom"
        onPress={() => {
          nullthrows(_scrollView.current).scrollToEnd({animated: true});
        }}
      />
      <Button
        label="Flash scroll indicators"
        onPress={() => {
          nullthrows(_scrollView.current).flashScrollIndicators();
        }}
      />
    </View>
  );
};
```

</p>
</details>
