### PR TITLE
Check en0..en8 when generating ip.txt for iOS debug builds

### DIFF
--- a/scripts/react-native-xcode.sh
+++ b/scripts/react-native-xcode.sh
@@ -14,10 +14,12 @@ DEST=$CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH
 
 # Enables iOS devices to get the IP address of the machine running Metro
 if [[ "$CONFIGURATION" = *Debug* && ! "$PLATFORM_NAME" == *simulator ]]; then
-  IP=$(ipconfig getifaddr en0)
-  if [[ -z "$IP" || -n "`ifconfig $value | grep 'baseT'`" ]]; then
-    IP=$(ipconfig getifaddr en1)
-  fi
+  for num in 0 1 2 3 4 5 6 7 8; do
+    IP=$(ipconfig getifaddr en${num})
+    if [ ! -z "$IP" ]; then
+      break
+    fi
+  done
   if [ -z "$IP" ]; then
     IP=$(ifconfig | grep 'inet ' | grep -v ' 127.' | grep -v ' 169.254.' |cut -d\   -f2  | awk 'NR==1{print $1}')
   fi


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

When generating ip.txt in an iOS debug build, search en0 through en8 for an IP address rather than only checking en0 and en1.  For example, on my Mac, the IP address I needed to use was on en5 and the IP address actually detected was a private network of one of my Parallels virtual machines (interface vnic0).

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [Fixed] - Search en0 through en8 for the Metro Bundler's IP address when generating iOS debug builds

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Should make no difference to users for whom react-native-xcode.sh already worked. On a Mac with multiple virtual machines installed, should prevent ip.txt getting the private IP address of a virtual machine.