### PR TITLE
Update react.gradle

### DIFF
--- a/react.gradle
+++ b/react.gradle
@@ -29,7 +29,7 @@ def detectCliPath(config) {
         return config.cliPath
     }
 
-    def cliPath = ["node", "-e", "console.log(require('react-native/cli').bin);"].execute([], projectDir).text
+    def cliPath = ["node", "-e", "console.log(require('react-native/cli').bin);"].execute([], projectDir).text.trim()
     
     if (cliPath) {
         return cliPath


### PR DESCRIPTION
## Summary

Running `./gradlew assembleRelease` fails as the path to the CLI contains a new line at the end. We don't run this command in `debug` mode, hence it passed the testing. My bad.

Fixed, checked in both `debug` with `bundleInDebug: true` and `release`.

## Changelog

[INTERNAL] [ANDROID] - Fix `React.gradle` to build Android apps in production

## Test Plan

Running `./gradlew assembleRelease` works
