### PR TITLE
Create JRuntimeExecutor

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/RuntimeExecutor.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/RuntimeExecutor.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.bridge;
+
+import com.facebook.jni.HybridData;
+import com.facebook.proguard.annotations.DoNotStrip;
+
+/** A Java holder for a C++ RuntimeExecutor. */
+public class RuntimeExecutor {
+
+  @DoNotStrip private HybridData mHybridData;
+
+  public RuntimeExecutor(HybridData hybridData) {
+    mHybridData = hybridData;
+  }
+}

--- a/ReactAndroid/src/main/jni/react/jni/Android.mk
+++ b/ReactAndroid/src/main/jni/react/jni/Android.mk
@@ -25,7 +25,7 @@ LOCAL_LDLIBS += -landroid
 LOCAL_SHARED_LIBRARIES := libfolly_json libfb libfbjni libglog_init libyoga
 
 # The static libraries (.a files) that this module depends on.
-LOCAL_STATIC_LIBRARIES := libreactnative libcallinvokerholder
+LOCAL_STATIC_LIBRARIES := libreactnative libcallinvokerholder libruntimeexecutor
 
 # Name of this module.
 #
@@ -70,6 +70,7 @@ $(call import-module,jsi)
 $(call import-module,jsiexecutor)
 $(call import-module,callinvoker)
 $(call import-module,hermes)
+$(call import-module,runtimeexecutor)
 
 include $(REACT_SRC_DIR)/turbomodule/core/jni/Android.mk
 

--- a/ReactAndroid/src/main/jni/react/jni/BUCK
+++ b/ReactAndroid/src/main/jni/react/jni/BUCK
@@ -19,6 +19,7 @@ EXPORTED_HEADERS = [
     "NativeMap.h",
     "ReadableNativeArray.h",
     "ReadableNativeMap.h",
+    "JRuntimeExecutor.h",
     "WritableNativeArray.h",
     "WritableNativeMap.h",
 ]
@@ -64,6 +65,7 @@ rn_xplat_cxx_library(
         react_native_xplat_target("cxxreact:jsbigstring"),
         react_native_xplat_target("cxxreact:module"),
         react_native_xplat_target("jsinspector:jsinspector"),
+        react_native_xplat_target("runtimeexecutor:runtimeexecutor"),
         react_native_xplat_dep("jsi:jsi"),
         FBJNI_TARGET,
     ]) if not IS_OSS_BUILD else [],

--- a/ReactAndroid/src/main/jni/react/jni/JRuntimeExecutor.cpp
+++ b/ReactAndroid/src/main/jni/react/jni/JRuntimeExecutor.cpp
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "JRuntimeExecutor.h"
+
+namespace facebook {
+namespace react {
+
+JRuntimeExecutor::JRuntimeExecutor(RuntimeExecutor runtimeExecutor)
+    : runtimeExecutor_(runtimeExecutor) {}
+
+RuntimeExecutor JRuntimeExecutor::get() {
+  return runtimeExecutor_;
+}
+
+} // namespace react
+} // namespace facebook

--- a/ReactAndroid/src/main/jni/react/jni/JRuntimeExecutor.h
+++ b/ReactAndroid/src/main/jni/react/jni/JRuntimeExecutor.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <ReactCommon/RuntimeExecutor.h>
+#include <fbjni/fbjni.h>
+
+namespace facebook {
+namespace react {
+
+class JRuntimeExecutor : public jni::HybridClass<JRuntimeExecutor> {
+ public:
+  static auto constexpr kJavaDescriptor =
+      "Lcom/facebook/react/bridge/RuntimeExecutor;";
+
+  RuntimeExecutor get();
+
+ private:
+  friend HybridBase;
+  JRuntimeExecutor(RuntimeExecutor runtimeExecutor);
+  RuntimeExecutor runtimeExecutor_;
+};
+
+} // namespace react
+} // namespace facebook

--- a/ReactCommon/runtimeexecutor/Android.mk
+++ b/ReactCommon/runtimeexecutor/Android.mk
@@ -1,0 +1,19 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := runtimeexecutor
+
+LOCAL_SRC_FILES := $(wildcard $(LOCAL_PATH)/ReactCommon/*.cpp)
+
+LOCAL_C_INCLUDES := $(LOCAL_PATH)/ReactCommon
+LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)
+
+LOCAL_CFLAGS += -fexceptions -frtti -std=c++14 -Wall
+
+include $(BUILD_STATIC_LIBRARY)


### PR DESCRIPTION
Summary:
Creating a JNI wrapper class for RuntimeExecutor so we can pass it to Fabric and TurboModules in Java.

Changelog: [Internal]

Reviewed By: RSNara

Differential Revision: D21049385

