### PR TITLE
fix KeybaordAvoidingView's initialFrameHeight

### DIFF
--- a/Libraries/Components/Keyboard/KeyboardAvoidingView.js
+++ b/Libraries/Components/Keyboard/KeyboardAvoidingView.js
@@ -118,7 +118,7 @@ class KeyboardAvoidingView extends React.Component<Props, State> {
 
   _onLayout = (event: ViewLayoutEvent) => {
     this._frame = event.nativeEvent.layout;
-    if (!this._initialFrameHeight) {
+    if (this.state.bottom == 0 && this._frame) {
       // save the initial frame height, before the keyboard is visible
       this._initialFrameHeight = this._frame.height;
     }


### PR DESCRIPTION
## Summary

In my experience `<KeyboardAvoidingView behavior="height" />` is broken: more often enough it wouldn't resize correctly but instead would be overlapped by the keyboard.

The issue was that `this._initialFrameHeight` would only be set on the very first layout pass which oftentimes wouldn't account for things like safe area insets. Instead it is better to simply set `_initialFrameHeight` on every layout pass when the keyboard isn't visible.

## Changelog

[iOS] [Fixed] KeyboardAvoidingView will properly resize for behavior="height" 

## Test Plan

before:
![Screen Recording 2020-05-01 at 16 07 50](https://user-images.githubusercontent.com/33906/80811567-715e1c80-8bc6-11ea-8f39-d28d68f7aff0.gif)
after:
![Screen Recording 2020-05-01 at 16 08 16](https://user-images.githubusercontent.com/33906/80811507-52f82100-8bc6-11ea-9c34-647f18d8d99c.gif)

sample app:
```javascript
/* eslint-disable react-native/no-inline-styles */
/**
 * Sample React Native App
 * https://github.com/facebook/react-native
 *
 * @format
 * @flow strict-local
 */

import React from 'react';
import {
  SafeAreaView,
  Keyboard,
  TextInput,
  Button,
  KeyboardAvoidingView,
} from 'react-native';

const App = () => {
  return (
    <SafeAreaView style={{flex: 1}}>
      <KeyboardAvoidingView
        behavior="height"
        style={{
          flex: 1,
          alignItems: 'center',
          paddingTop: 60,
          borderColor: '#f00',
          borderWidth: 25,
        }}>
        <TextInput
          style={{
            backgroundColor: 'rgba(0,0,0,0.2)',
            width: 300,
            padding: 10,
          }}
        />
        <Button title="Blur" onPress={Keyboard.dismiss} />
      </KeyboardAvoidingView>
    </SafeAreaView>
  );
};

export default App;
```