### PR TITLE
Fix: URLSearchParams dropped when body of XHR

### DIFF
--- a/Libraries/Network/RCTNetworking.mm
+++ b/Libraries/Network/RCTNetworking.mm
@@ -347,6 +347,8 @@ RCT_EXPORT_MODULE()
  *
  * - {"blob": {...}}: an object representing a blob
  *
+ * - {"urlSearchParams": "..."}: a JS string that is the serialized query string of a urlSearchParams object
+ *
  * If successful, the callback be called with a result dictionary containing the following (optional) keys:
  *
  * - @"body" (NSData): the body of the request
@@ -379,6 +381,10 @@ RCT_EXPORT_MODULE()
   if (base64String) {
     NSData *data = [[NSData alloc] initWithBase64EncodedString:base64String options:0];
     return callback(nil, @{@"body": data});
+  }
+  NSString *urlSearchParamsString = [RCTConvert NSString:query[@"urlSearchParams"]];
+  if (urlSearchParamsString) {
+    return callback(nil, @{@"body": urlSearchParamsString, @"contentType": @"application/x-www-form-urlencoded"});
   }
   NSURLRequest *request = [RCTConvert NSURLRequest:query[@"uri"]];
   if (request) {

--- a/Libraries/Network/convertRequestBody.js
+++ b/Libraries/Network/convertRequestBody.js
@@ -22,6 +22,7 @@ export type RequestBody =
   | {uri: string, ...}
   | ArrayBuffer
   | $ArrayBufferView;
+  | URLSearchParams
 
 function convertRequestBody(body: RequestBody): Object {
   if (typeof body === 'string') {
@@ -36,6 +37,9 @@ function convertRequestBody(body: RequestBody): Object {
   if (body instanceof ArrayBuffer || ArrayBuffer.isView(body)) {
     // $FlowFixMe: no way to assert that 'body' is indeed an ArrayBufferView
     return {base64: binaryToBase64(body)};
+  }
+  if (body instanceof URLSearchParams) {
+    return {urlSearchParams: body.toString()};
   }
   return body;
 }

--- a/Libraries/Network/convertRequestBody.js
+++ b/Libraries/Network/convertRequestBody.js
@@ -21,8 +21,8 @@ export type RequestBody =
   | FormData
   | {uri: string, ...}
   | ArrayBuffer
-  | $ArrayBufferView;
-  | URLSearchParams
+  | $ArrayBufferView
+  | URLSearchParams;
 
 function convertRequestBody(body: RequestBody): Object {
   if (typeof body === 'string') {


### PR DESCRIPTION
**Note: Code untested, help wanted!**

## Summary

Right now, if you set a [URLSearchParams](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) as the body of a XMLHTTPRequest, it is silently dropped. Support for this feature [is in the whatwg fetch spec](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/send) and currently supported in browsers.

## react-native's Code

Before a request gets sent to native code, the body gets run through [a conversion function which lacks support for URLSearchParams](https://github.com/facebook/react-native/blob/master/Libraries/Network/convertRequestBody.js).

Since the body doesn't get converted, it ends up being dropped (silently) in the native code:

```
// Nothing in the data payload, at least nothing we could understand anyway.
// Ignore and treat it as if it were null.
```

https://github.com/facebook/react-native/blob/master/Libraries/Network/RCTNetworking.mm#L337-L412

## The Fix

I see two options here:

1. [Probably not this one] You could just convert the URLSearchParams, calling `.toString()` and then treating it as if it were a regular string. The diff would be short, but the content-type header would incorrectly default to `text/plain;charset=UTF-8` instead of `application/x-www-form-urlencoded;charset=UTF-8`. External callers could still pass the correct headers (and whatwg-fetch, for example, would in fact take care of that for you).
2. From [convertRequestBody](https://github.com/facebook/react-native/blob/master/Libraries/Network/convertRequestBody.js), return an object `{ urlSearchParams: body.toString() }` and update [processDataForHTTPQuery](https://github.com/facebook/react-native/blob/eb6001998be697f6e956eec6eb2385ce7572aa39/Libraries/Network/RCTNetworking.mm#L337-L412) to accept this as an input type. 

As an additional feature, it might be nice to get some sort of warning or error when an unsupported/non-processable object is passed in, instead of silently ignoring it. 

## My Code

I'm going to be real with you: I don't even know what language a `.mm` file is. I don't have an Apple computer to run the tests on, and I don't even know if this code is also run on Android or there's a separate file for that.

That said, I've included my best impression of what this diff should look like.  (Using approach 2.) Would appreciate support from any other contributors.

Edit: [Is this the corresponding Android code?](https://github.com/facebook/react-native/blob/577fdeaa621ac865b9fbbe6f648c6fab05d0abab/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.java#L363-L388)

## Workaround for anyone coming in from the internet

A current workaround found in the wild for this issue seems to be to [call `.toString()` on the URLSearchParams](https://stackoverflow.com/questions/35325370/post-a-x-www-form-urlencoded-request-from-react-native#comment92346211_45357307) yourself.

However, I discovered this issue while using an auto-generated API client library and implementing this workaround will be pretty hacky.

## Reproducible Snack

Here's a reproducible Snack showing that it is broken on the iOS and Android devices: https://snack.expo.io/z4N9PcIR7

Note that the snack doesn't work on the web simulator because of CORS restrictions. However, you can check the network tab to see that in web mode, the data is being sent (because web uses the browser's XMLHttpRequest instead of react-native's)

## Changelog

[General] [Fixed] - Fix body of XMLHttpRequest being dropped when it is a URLSearchParams

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

**HELP WANTED HERE**