### PR TITLE
Allow passing partial contentOffset to ScrollView on Android

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
@@ -304,8 +304,8 @@ public class ReactHorizontalScrollViewManager extends ViewGroupManager<ReactHori
   @ReactProp(name = "contentOffset")
   public void setContentOffset(ReactHorizontalScrollView view, ReadableMap value) {
     if (value != null) {
-      double x = value.getDouble("x");
-      double y = value.getDouble("y");
+      double x = value.hasKey("x") ? value.getDouble("x") : 0;
+      double y = value.hasKey("y") ? value.getDouble("y") : 0;
       view.reactScrollTo((int) PixelUtil.toPixelFromDIP(x), (int) PixelUtil.toPixelFromDIP(y));
     }
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.java
@@ -308,8 +308,8 @@ public class ReactScrollViewManager extends ViewGroupManager<ReactScrollView>
   @ReactProp(name = "contentOffset")
   public void setContentOffset(ReactScrollView view, ReadableMap value) {
     if (value != null) {
-      double x = value.getDouble("x");
-      double y = value.getDouble("y");
+      double x = value.hasKey("x") ? value.getDouble("x") : 0;
+      double y = value.hasKey("y") ? value.getDouble("y") : 0;
       view.reactScrollTo((int) PixelUtil.toPixelFromDIP(x), (int) PixelUtil.toPixelFromDIP(y));
     }
   }


### PR DESCRIPTION
## Summary

Since support for contentOffset was added to horizontal ScrollView on android (30cc158a875a0414cf53d4d5155410eea5d5aeea) I'm seeing a crash in my app because of a library. What happens is that it passes a partial object for contentOffset so something like `{x: 1}` which causes a crash on Android.

According to the flow types the object should always contain both x and y but I think we should preserve the runtime behaviour and just use 0 like iOS does. 

## Changelog

[Android] [Fixed] - Allow passing partial contentOffset to ScrollView on Android

## Test Plan

Tested that passing partial object for contentOffset does not crash.
