### PR TITLE
Fix: Preserve native animated value after animated component unmount

### DIFF
--- a/Libraries/Animated/src/NativeAnimatedHelper.js
+++ b/Libraries/Animated/src/NativeAnimatedHelper.js
@@ -43,7 +43,9 @@ const API = {
     saveValueCallback: (value: number) => void,
   ): void {
     invariant(NativeAnimatedModule, 'Native animated module is not available');
-    NativeAnimatedModule.getValue(tag, saveValueCallback);
+    if (NativeAnimatedModule.getValue) {
+      NativeAnimatedModule.getValue(tag, saveValueCallback);
+    }
   },
   disableQueue: function(): void {
     invariant(NativeAnimatedModule, 'Native animated module is not available');
@@ -242,7 +244,9 @@ function validateTransform(
   configs.forEach(config => {
     if (!TRANSFORM_WHITELIST.hasOwnProperty(config.property)) {
       throw new Error(
-        `Property '${config.property}' is not supported by native animated module`,
+        `Property '${
+          config.property
+        }' is not supported by native animated module`,
       );
     }
   });

--- a/Libraries/Animated/src/NativeAnimatedHelper.js
+++ b/Libraries/Animated/src/NativeAnimatedHelper.js
@@ -38,6 +38,9 @@ const API = {
   enableQueue: function(): void {
     queueConnections = true;
   },
+  getValue: function(tag: number, callback: (value: number) => void): void {
+    NativeAnimatedModule.getValue(tag, callback);
+  },
   disableQueue: function(): void {
     invariant(NativeAnimatedModule, 'Native animated module is not available');
     queueConnections = false;

--- a/Libraries/Animated/src/NativeAnimatedHelper.js
+++ b/Libraries/Animated/src/NativeAnimatedHelper.js
@@ -244,9 +244,7 @@ function validateTransform(
   configs.forEach(config => {
     if (!TRANSFORM_WHITELIST.hasOwnProperty(config.property)) {
       throw new Error(
-        `Property '${
-          config.property
-        }' is not supported by native animated module`,
+        `Property '${config.property}' is not supported by native animated module`,
       );
     }
   });

--- a/Libraries/Animated/src/NativeAnimatedHelper.js
+++ b/Libraries/Animated/src/NativeAnimatedHelper.js
@@ -38,8 +38,11 @@ const API = {
   enableQueue: function(): void {
     queueConnections = true;
   },
-  getValue: function(tag: number, callback: (value: number) => void): void {
-    NativeAnimatedModule.getValue(tag, callback);
+  getValue: function(
+    tag: number,
+    saveValueCallback: (value: number) => void,
+  ): void {
+    NativeAnimatedModule.getValue(tag, saveValueCallback);
   },
   disableQueue: function(): void {
     invariant(NativeAnimatedModule, 'Native animated module is not available');

--- a/Libraries/Animated/src/NativeAnimatedHelper.js
+++ b/Libraries/Animated/src/NativeAnimatedHelper.js
@@ -42,6 +42,7 @@ const API = {
     tag: number,
     saveValueCallback: (value: number) => void,
   ): void {
+    invariant(NativeAnimatedModule, 'Native animated module is not available');
     NativeAnimatedModule.getValue(tag, saveValueCallback);
   },
   disableQueue: function(): void {

--- a/Libraries/Animated/src/NativeAnimatedModule.js
+++ b/Libraries/Animated/src/NativeAnimatedModule.js
@@ -15,6 +15,7 @@ import * as TurboModuleRegistry from '../../TurboModule/TurboModuleRegistry';
 
 type EndResult = {finished: boolean, ...};
 type EndCallback = (result: EndResult) => void;
+type SaveValueCallback = (value: number) => void;
 
 export type EventMapping = {|
   nativeEventPath: Array<string>,
@@ -28,6 +29,7 @@ export type AnimatingNodeConfig = Object;
 
 export interface Spec extends TurboModule {
   +createAnimatedNode: (tag: number, config: AnimatedNodeConfig) => void;
+  +getValue: (tag: number, saveValueCallback: SaveValueCallback) => void;
   +startListeningToAnimatedNodeValue: (tag: number) => void;
   +stopListeningToAnimatedNodeValue: (tag: number) => void;
   +connectAnimatedNodes: (parentTag: number, childTag: number) => void;

--- a/Libraries/Animated/src/__tests__/AnimatedNative-test.js
+++ b/Libraries/Animated/src/__tests__/AnimatedNative-test.js
@@ -36,6 +36,7 @@ describe('Native Animated', () => {
 
   beforeEach(() => {
     Object.assign(NativeAnimatedModule, {
+      getValue: jest.fn(),
       addAnimatedEventToView: jest.fn(),
       connectAnimatedNodes: jest.fn(),
       connectAnimatedNodeToView: jest.fn(),
@@ -113,6 +114,26 @@ describe('Native Animated', () => {
       expect(NativeAnimatedModule.flattenAnimatedNodeOffset).toBeCalledWith(
         expect.any(Number),
       );
+    });
+
+    it('should save value on unmount', () => {
+      NativeAnimatedModule.getValue = jest.fn((tag, saveCallback) => {
+        saveCallback(1);
+      });
+      const opacity = new Animated.Value(0);
+
+      opacity.__makeNative();
+
+      const root = TestRenderer.create(<Animated.View style={{opacity}} />);
+      const tag = opacity.__getNativeTag();
+
+      root.unmount();
+
+      expect(NativeAnimatedModule.getValue).toBeCalledWith(
+        tag,
+        expect.any(Function),
+      );
+      expect(opacity.__getValue()).toBe(1);
     });
 
     it('should extract offset', () => {

--- a/Libraries/Animated/src/nodes/AnimatedValue.js
+++ b/Libraries/Animated/src/nodes/AnimatedValue.js
@@ -86,6 +86,11 @@ class AnimatedValue extends AnimatedWithChildren {
   }
 
   __detach() {
+    if (this.__isNative) {
+      NativeAnimatedAPI.getValue(this.__getNativeTag(), value => {
+        this._value = value;
+      });
+    }
     this.stopAnimation();
     super.__detach();
   }

--- a/Libraries/FBReactNativeSpec/FBReactNativeSpec/FBReactNativeSpec-generated.mm
+++ b/Libraries/FBReactNativeSpec/FBReactNativeSpec/FBReactNativeSpec-generated.mm
@@ -304,6 +304,10 @@ namespace facebook {
     static facebook::jsi::Value __hostFunction_NativeAnimatedModuleSpecJSI_removeListeners(facebook::jsi::Runtime& rt, TurboModule &turboModule, const facebook::jsi::Value* args, size_t count) {
       return static_cast<ObjCTurboModule&>(turboModule).invokeObjCMethod(rt, VoidKind, "removeListeners", @selector(removeListeners:), args, count);
     }
+  
+    static facebook::jsi::Value __hostFunction_NativeAnimatedModuleSpecJSI_getValue(facebook::jsi::Runtime& rt, TurboModule &turboModule, const facebook::jsi::Value* args, size_t count) {
+      return static_cast<ObjCTurboModule&>(turboModule).invokeObjCMethod(rt, VoidKind, "getValue", @selector(getValue:saveCallback:), args, count);
+    }
 
 
     NativeAnimatedModuleSpecJSI::NativeAnimatedModuleSpecJSI(const ObjCTurboModule::InitParams &params)
@@ -365,6 +369,8 @@ namespace facebook {
         
         
         methodMap_["removeListeners"] = MethodMetadata {1, __hostFunction_NativeAnimatedModuleSpecJSI_removeListeners};
+        
+        methodMap_["getValue"] = MethodMetadata {2, __hostFunction_NativeAnimatedModuleSpecJSI_getValue};
         
         
 

--- a/Libraries/FBReactNativeSpec/FBReactNativeSpec/FBReactNativeSpec.h
+++ b/Libraries/FBReactNativeSpec/FBReactNativeSpec/FBReactNativeSpec.h
@@ -302,6 +302,8 @@ namespace JS {
                     animatedNodeTag:(double)animatedNodeTag;
 - (void)addListener:(NSString *)eventName;
 - (void)removeListeners:(double)count;
+- (void)getValue:(double)nodeTag
+    saveCallback:(RCTResponseSenderBlock)saveCallback;
 
 @end
 namespace facebook {

--- a/Libraries/NativeAnimation/RCTNativeAnimatedModule.mm
+++ b/Libraries/NativeAnimation/RCTNativeAnimatedModule.mm
@@ -219,6 +219,13 @@ RCT_EXPORT_METHOD(removeAnimatedEventFromView:(double)viewTag
   }];
 }
 
+RCT_EXPORT_METHOD(getValue:(nonnull NSNumber *)nodeTag
+                  callback:(RCTResponseSenderBlock)callback) {
+  [self addOperationBlock:^(RCTNativeAnimatedNodesManager *nodesManager) {
+      [nodesManager getValue:nodeTag callback:(RCTResponseSenderBlock)callback];
+  }];
+}
+
 #pragma mark -- Batch handling
 
 - (void)addOperationBlock:(AnimatedOperation)operation

--- a/Libraries/NativeAnimation/RCTNativeAnimatedModule.mm
+++ b/Libraries/NativeAnimation/RCTNativeAnimatedModule.mm
@@ -219,10 +219,9 @@ RCT_EXPORT_METHOD(removeAnimatedEventFromView:(double)viewTag
   }];
 }
 
-RCT_EXPORT_METHOD(getValue:(nonnull NSNumber *)nodeTag
-                  callback:(RCTResponseSenderBlock)callback) {
+RCT_EXPORT_METHOD(getValue:(double)nodeTag saveCallback:(RCTResponseSenderBlock)saveCallback) {
   [self addOperationBlock:^(RCTNativeAnimatedNodesManager *nodesManager) {
-      [nodesManager getValue:nodeTag callback:(RCTResponseSenderBlock)callback];
+      [nodesManager getValue:[NSNumber numberWithDouble:nodeTag] saveCallback:saveCallback];
   }];
 }
 
@@ -310,7 +309,7 @@ RCT_EXPORT_METHOD(getValue:(nonnull NSNumber *)nodeTag
       operation(self->_nodesManager);
     }
   }];
-
+ 
   [uiManager addUIBlock:^(__unused RCTUIManager *manager, __unused NSDictionary<NSNumber *, UIView *> *viewRegistry) {
     for (AnimatedOperation operation in operations) {
       operation(self->_nodesManager);

--- a/Libraries/NativeAnimation/RCTNativeAnimatedModule.mm
+++ b/Libraries/NativeAnimation/RCTNativeAnimatedModule.mm
@@ -309,7 +309,6 @@ RCT_EXPORT_METHOD(getValue:(double)nodeTag saveCallback:(RCTResponseSenderBlock)
       operation(self->_nodesManager);
     }
   }];
- 
   [uiManager addUIBlock:^(__unused RCTUIManager *manager, __unused NSDictionary<NSNumber *, UIView *> *viewRegistry) {
     for (AnimatedOperation operation in operations) {
       operation(self->_nodesManager);

--- a/Libraries/NativeAnimation/RCTNativeAnimatedNodesManager.h
+++ b/Libraries/NativeAnimation/RCTNativeAnimatedNodesManager.h
@@ -21,6 +21,9 @@
 
 - (BOOL)isNodeManagedByFabric:(nonnull NSNumber *)tag;
 
+- (void)getValue:(nonnull NSNumber *)nodeTag
+        callback:(nullable RCTResponseSenderBlock) callback;
+
 // graph
 
 - (void)createAnimatedNode:(nonnull NSNumber *)tag

--- a/Libraries/NativeAnimation/RCTNativeAnimatedNodesManager.h
+++ b/Libraries/NativeAnimation/RCTNativeAnimatedNodesManager.h
@@ -22,7 +22,7 @@
 - (BOOL)isNodeManagedByFabric:(nonnull NSNumber *)tag;
 
 - (void)getValue:(nonnull NSNumber *)nodeTag
-        callback:(nullable RCTResponseSenderBlock) callback;
+        saveCallback:(nullable RCTResponseSenderBlock)saveCallback;
 
 // graph
 

--- a/Libraries/NativeAnimation/RCTNativeAnimatedNodesManager.m
+++ b/Libraries/NativeAnimation/RCTNativeAnimatedNodesManager.m
@@ -242,7 +242,7 @@ static NSString *RCTNormalizeAnimatedEventName(NSString *eventName)
   [valueNode extractOffset];
 }
 
-- (void)getValue:(NSNumber *)nodeTag callback:(RCTResponseSenderBlock)callback
+- (void)getValue:(NSNumber *)nodeTag saveCallback:(RCTResponseSenderBlock)saveCallback
 {
      RCTAnimatedNode *node = _animationNodes[nodeTag];
      if (![node isKindOfClass:[RCTValueAnimatedNode class]]) {
@@ -250,7 +250,7 @@ static NSString *RCTNormalizeAnimatedEventName(NSString *eventName)
        return;
      }
     RCTValueAnimatedNode *valueNode = (RCTValueAnimatedNode *)node;;
-    callback(@[@(valueNode.value)]);
+    saveCallback(@[@(valueNode.value)]);
 }
 
 #pragma mark -- Drivers

--- a/Libraries/NativeAnimation/RCTNativeAnimatedNodesManager.m
+++ b/Libraries/NativeAnimation/RCTNativeAnimatedNodesManager.m
@@ -242,6 +242,17 @@ static NSString *RCTNormalizeAnimatedEventName(NSString *eventName)
   [valueNode extractOffset];
 }
 
+- (void)getValue:(NSNumber *)nodeTag callback:(RCTResponseSenderBlock)callback
+{
+     RCTAnimatedNode *node = _animationNodes[nodeTag];
+     if (![node isKindOfClass:[RCTValueAnimatedNode class]]) {
+       RCTLogError(@"Not a value node.");
+       return;
+     }
+    RCTValueAnimatedNode *valueNode = (RCTValueAnimatedNode *)node;;
+    callback(@[@(valueNode.value)]);
+}
+
 #pragma mark -- Drivers
 
 - (void)startAnimatingNode:(nonnull NSNumber *)animationId

--- a/RNTester/RNTesterUnitTests/RCTNativeAnimatedNodesManagerTests.m
+++ b/RNTester/RNTesterUnitTests/RCTNativeAnimatedNodesManagerTests.m
@@ -877,7 +877,7 @@ static id RCTPropChecker(NSString *prop, NSNumber *value)
   
   XCTAssertEqual(saveValueCallbackCalls, 0);
   
-  [_nodesManager getValue:nodeTag callback: saveValueCallback];
+  [_nodesManager getValue:nodeTag saveCallback:saveValueCallback];
   XCTAssertEqual(saveValueCallbackCalls, 1);
 }
 

--- a/RNTester/RNTesterUnitTests/RCTNativeAnimatedNodesManagerTests.m
+++ b/RNTester/RNTesterUnitTests/RCTNativeAnimatedNodesManagerTests.m
@@ -864,6 +864,23 @@ static id RCTPropChecker(NSString *prop, NSNumber *value)
   [_uiManager verify];
 }
 
+- (void) testGetValue
+{
+  __block NSInteger saveValueCallbackCalls = 0;
+  NSNumber *nodeTag = @100;
+  [_nodesManager createAnimatedNode:nodeTag
+                             config:@{@"type": @"value", @"value": @1, @"offset": @0}];
+  RCTResponseSenderBlock saveValueCallback = ^(NSArray *response) {
+    saveValueCallbackCalls++;
+    XCTAssertEqualObjects(response, @[@1]);
+  };
+  
+  XCTAssertEqual(saveValueCallbackCalls, 0);
+  
+  [_nodesManager getValue:nodeTag callback: saveValueCallback];
+  XCTAssertEqual(saveValueCallbackCalls, 1);
+}
+
 /**
  * Creates a following graph of nodes:
  * Value(3, initialValue) ----> Style(4) ---> Props(5) ---> View(viewTag)

--- a/RNTester/js/examples/Animated/AnimatedExample.js
+++ b/RNTester/js/examples/Animated/AnimatedExample.js
@@ -336,6 +336,115 @@ exports.examples = [
     },
   },
   {
+    title: 'Moving box example',
+    description: ('Click arrow buttons to move the box.' +
+      'Then hide the box and reveal it again.' +
+      'After that the box position will reset to initial position.': string),
+    render: (): React.Node => {
+      const containerWidth = 200;
+      const boxSize = 50;
+
+      const movingBoxStyles = StyleSheet.create({
+        container: {
+          display: 'flex',
+          alignItems: 'center',
+          flexDirection: 'column',
+          backgroundColor: '#fff',
+          padding: 30,
+        },
+        boxContainer: {
+          backgroundColor: '#d3d3d3',
+          height: boxSize,
+          width: containerWidth,
+        },
+        box: {
+          width: boxSize,
+          height: boxSize,
+          margin: 0,
+        },
+        buttonsContainer: {
+          marginTop: 20,
+          display: 'flex',
+          flexDirection: 'row',
+          justifyContent: 'space-between',
+          width: containerWidth,
+        },
+      });
+      type Props = $ReadOnly<{||}>;
+      type State = {|boxVisible: boolean|};
+
+      class MovingBoxExample extends React.Component<Props, State> {
+        x: Animated.Value;
+        constructor(props) {
+          super(props);
+          this.x = new Animated.Value(0);
+          this.state = {
+            boxVisible: true,
+          };
+        }
+
+        render() {
+          const {boxVisible} = this.state;
+          const toggleText = boxVisible ? 'Hide' : 'Show';
+          return (
+            <View style={movingBoxStyles.container}>
+              {this.renderBox()}
+              <View style={movingBoxStyles.buttonsContainer}>
+                <RNTesterButton onPress={() => this.moveTo(0)}>
+                  {'<-'}
+                </RNTesterButton>
+                <RNTesterButton onPress={this.toggleVisibility}>
+                  {toggleText}
+                </RNTesterButton>
+                <RNTesterButton
+                  onPress={() => this.moveTo(containerWidth - boxSize)}>
+                  {'->'}
+                </RNTesterButton>
+              </View>
+            </View>
+          );
+        }
+
+        renderBox = () => {
+          if (this.state.boxVisible) {
+            const horizontalLocation = {transform: [{translateX: this.x}]};
+            return (
+              <View style={movingBoxStyles.boxContainer}>
+                <Animated.View
+                  style={[
+                    styles.content,
+                    movingBoxStyles.box,
+                    horizontalLocation,
+                  ]}
+                />
+              </View>
+            );
+          } else {
+            return (
+              <View style={movingBoxStyles.boxContainer}>
+                <Text>The box view is not being rendered</Text>
+              </View>
+            );
+          }
+        };
+
+        moveTo = x => {
+          Animated.timing(this.x, {
+            toValue: x,
+            duration: 1000,
+            useNativeDriver: true,
+          }).start();
+        };
+
+        toggleVisibility = () => {
+          const {boxVisible} = this.state;
+          this.setState({boxVisible: !boxVisible});
+        };
+      }
+      return <MovingBoxExample />;
+    },
+  },
+  {
     title: 'Continuous Interactions',
     description: ('Gesture events, chaining, 2D ' +
       'values, interrupting and transitioning ' +

--- a/ReactAndroid/src/main/java/com/facebook/fbreact/specs/NativeAnimatedModuleSpec.java
+++ b/ReactAndroid/src/main/java/com/facebook/fbreact/specs/NativeAnimatedModuleSpec.java
@@ -84,4 +84,7 @@ public abstract class NativeAnimatedModuleSpec extends ReactContextBaseJavaModul
 
   @ReactMethod
   public abstract void addListener(String eventName);
+
+  @ReactMethod
+  public abstract void getValue (double nodeTag, Callback callback);
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedModule.java
@@ -485,7 +485,7 @@ public class NativeAnimatedModule extends NativeAnimatedModuleSpec
   }
 
   @Override
-  public void getValue(final double animatedValueNodeTagDouble, Callback callback) {
+  public void getValue(final double animatedValueNodeTagDouble, final Callback callback) {
     final int animatedValueNodeTag = (int) animatedValueNodeTagDouble;
     mOperations.add(
       new UIThreadOperation() {

--- a/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedModule.java
@@ -483,4 +483,17 @@ public class NativeAnimatedModule extends NativeAnimatedModuleSpec
   public void removeListeners(double count) {
     // iOS only
   }
+
+  @Override
+  public void getValue(final double animatedValueNodeTagDouble, Callback callback) {
+    final int animatedValueNodeTag = (int) animatedValueNodeTagDouble;
+    mOperations.add(
+      new UIThreadOperation() {
+        @Override
+        public void execute(NativeAnimatedNodesManager animatedNodesManager) {
+          animatedNodesManager.getValue(animatedValueNodeTag, callback);
+        }
+      }
+    );
+  }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedNodesManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedNodesManager.java
@@ -322,6 +322,15 @@ import java.util.Queue;
     propsAnimatedNode.disconnectFromView(viewTag);
   }
 
+  public void getValue(int tag, Callback callback) {
+    AnimatedNode node = mAnimatedNodes.get(tag);
+    if (node == null || !(node instanceof ValueAnimatedNode)) {
+      throw new JSApplicationIllegalArgumentException(
+        "Animated node with tag " + tag + " does not exists or is not a 'value' node");
+    }
+    callback.invoke(((ValueAnimatedNode) node).getValue());
+  }
+
   public void restoreDefaultValues(int animatedNodeTag) {
     AnimatedNode node = mAnimatedNodes.get(animatedNodeTag);
     // Restoring default values needs to happen before UIManager operations so it is

--- a/ReactAndroid/src/test/java/com/facebook/react/animated/NativeAnimatedNodeTraversalTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/animated/NativeAnimatedNodeTraversalTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.atMost;
+import static org.mockito.Mockito.calls;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
@@ -800,6 +801,19 @@ public class NativeAnimatedNodeTraversalTest {
 
     verifyNoMoreInteractions(mUIManagerMock);
     verifyNoMoreInteractions(animationCallback);
+  }
+
+  @Test
+  public void testGetValue() {
+    int tag = 1;
+    mNativeAnimatedNodesManager.createAnimatedNode(
+      tag, JavaOnlyMap.of("type", "value", "value", 1d, "offset", 0d)
+    );
+//    Callback saveValueCallbackMock = mock(Callback.class);
+
+//    mNativeAnimatedNodesManager.getValue(tag, saveValueCallbackMock);
+//
+//    verify(saveValueCallbackMock, calls(1)).invoke(1d);
   }
 
   @Test

--- a/ReactAndroid/src/test/java/com/facebook/react/animated/NativeAnimatedNodeTraversalTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/animated/NativeAnimatedNodeTraversalTest.java
@@ -809,11 +809,12 @@ public class NativeAnimatedNodeTraversalTest {
     mNativeAnimatedNodesManager.createAnimatedNode(
       tag, JavaOnlyMap.of("type", "value", "value", 1d, "offset", 0d)
     );
-//    Callback saveValueCallbackMock = mock(Callback.class);
 
-//    mNativeAnimatedNodesManager.getValue(tag, saveValueCallbackMock);
-//
-//    verify(saveValueCallbackMock, calls(1)).invoke(1d);
+   Callback saveValueCallbackMock = mock(Callback.class);
+
+   mNativeAnimatedNodesManager.getValue(tag, saveValueCallbackMock);
+
+   verify(saveValueCallbackMock, calls(1)).invoke(1d);
   }
 
   @Test

--- a/ReactAndroid/src/test/java/com/facebook/react/animated/NativeAnimatedNodeTraversalTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/animated/NativeAnimatedNodeTraversalTest.java
@@ -12,7 +12,6 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.atMost;
-import static org.mockito.Mockito.calls;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
@@ -814,7 +813,7 @@ public class NativeAnimatedNodeTraversalTest {
 
    mNativeAnimatedNodesManager.getValue(tag, saveValueCallbackMock);
 
-   verify(saveValueCallbackMock, calls(1)).invoke(1d);
+   verify(saveValueCallbackMock, times(1)).invoke(1d);
   }
 
   @Test


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
After animation has been finished using Native driver there is no final value passed from the native to JS side. This causes a bug from #28114.

This PR solves this problem in the same way as `react-native-reanimated` library. When detaching it is calling native side to get the last value from Animated node and stores it on the JS side.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Preserving animated value even if animation was using `useNativeDriver: true`
Fixes #28114 

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Internal] [Fixed] - Save native Animated node value on JS side in detach phase

## Test Plan
Unit tests for added getValue method passed. Green CI
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
