### PR TITLE
Fixed TextInput not being selectable in removeClippedSubviews FlatLists

### DIFF
--- a/RNTester/js/components/ListExampleShared.js
+++ b/RNTester/js/components/ListExampleShared.js
@@ -123,6 +123,12 @@ class HeaderComponent extends React.PureComponent<{...}> {
         <View style={styles.headerFooter}>
           <Text>LIST HEADER</Text>
         </View>
+        <View style={styles.headerInputContainer}>
+          <TextInput
+            defaultValue="Use this input to test text selection"
+            style={styles.headerInput}
+          />
+        </View>
         <SeparatorComponent />
       </View>
     );
@@ -280,6 +286,15 @@ const styles = StyleSheet.create({
   },
   headerFooterContainer: {
     backgroundColor: 'rgb(239, 239, 244)',
+  },
+  headerInputContainer: {
+    backgroundColor: 'white',
+    margin: 5,
+    borderWidth: 1,
+    borderColor: '#cccccc',
+  },
+  headerInput: {
+    padding: 2,
   },
   listEmpty: {
     alignItems: 'center',

--- a/RNTester/js/examples/FlatList/FlatListExample.js
+++ b/RNTester/js/examples/FlatList/FlatListExample.js
@@ -56,6 +56,7 @@ type State = {|
   fixedHeight: boolean,
   logViewable: boolean,
   virtualized: boolean,
+  removeClippedSubviews: boolean,
   empty: boolean,
   useFlatListItemComponent: boolean,
   fadingEdgeLength: number,
@@ -71,6 +72,7 @@ class FlatListExample extends React.PureComponent<Props, State> {
     fixedHeight: true,
     logViewable: false,
     virtualized: true,
+    removeClippedSubviews: false,
     empty: false,
     useFlatListItemComponent: false,
     fadingEdgeLength: 0,
@@ -131,6 +133,7 @@ class FlatListExample extends React.PureComponent<Props, State> {
               {renderSmallSwitchOption(this, 'empty')}
               {renderSmallSwitchOption(this, 'debug')}
               {renderSmallSwitchOption(this, 'useFlatListItemComponent')}
+              {renderSmallSwitchOption(this, 'removeClippedSubviews')}
               {Platform.OS === 'android' && (
                 <View>
                   <TextInput
@@ -165,7 +168,8 @@ class FlatListExample extends React.PureComponent<Props, State> {
             inverted={this.state.inverted}
             key={
               (this.state.horizontal ? 'h' : 'v') +
-              (this.state.fixedHeight ? 'f' : 'd')
+              (this.state.fixedHeight ? 'f' : 'd') +
+              (this.state.removeClippedSubviews ? 'r' : 's')
             }
             keyboardShouldPersistTaps="always"
             keyboardDismissMode="on-drag"
@@ -180,6 +184,7 @@ class FlatListExample extends React.PureComponent<Props, State> {
             refreshing={false}
             contentContainerStyle={styles.list}
             viewabilityConfig={VIEWABILITY_CONFIG}
+            removeClippedSubviews={this.state.removeClippedSubviews}
             {...flatListItemRendererProps}
           />
         </View>

--- a/RNTester/js/examples/SectionList/SectionListExample.js
+++ b/RNTester/js/examples/SectionList/SectionListExample.js
@@ -77,6 +77,7 @@ class SectionListExample extends React.PureComponent<{...}, $FlowFixMeState> {
         inverted: boolean,
         logViewable: boolean,
         virtualized: boolean,
+        removeClippedSubviews: boolean,
       |} = {
     data: genItemData(1000),
     debug: false,
@@ -84,6 +85,7 @@ class SectionListExample extends React.PureComponent<{...}, $FlowFixMeState> {
     logViewable: false,
     virtualized: true,
     inverted: false,
+    removeClippedSubviews: false,
   };
 
   _scrollPos = new Animated.Value(0);
@@ -134,6 +136,7 @@ class SectionListExample extends React.PureComponent<{...}, $FlowFixMeState> {
             {renderSmallSwitchOption(this, 'logViewable')}
             {renderSmallSwitchOption(this, 'debug')}
             {renderSmallSwitchOption(this, 'inverted')}
+            {renderSmallSwitchOption(this, 'removeClippedSubviews')}
             <Spindicator value={this._scrollPos} />
           </View>
           <View style={styles.scrollToRow}>
@@ -211,6 +214,8 @@ class SectionListExample extends React.PureComponent<{...}, $FlowFixMeState> {
           ]}
           style={styles.list}
           viewabilityConfig={VIEWABILITY_CONFIG}
+          removeClippedSubviews={this.state.removeClippedSubviews}
+          key={this.state.removeClippedSubviews ? 'r' : 's'}
         />
       </RNTesterPage>
     );
@@ -292,6 +297,7 @@ const styles = StyleSheet.create({
 
 exports.title = '<SectionList>';
 exports.description = 'Performant, scrollable list of data.';
+exports.simpleExampleContainer = true;
 exports.examples = [
   {
     title: 'Simple scrollable list',

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -724,6 +724,10 @@ public class ReactEditText extends AppCompatEditText {
   @Override
   public void onAttachedToWindow() {
     super.onAttachedToWindow();
+    // Used to ensure that text is selectable inside of removeClippedSubviews
+    // See https://github.com/facebook/react-native/issues/6805 for original
+    // fix that was ported to here.
+    super.setTextIsSelectable(true);
     if (mContainsImages) {
       Spanned text = getText();
       TextInlineImageSpan[] spans = text.getSpans(0, text.length(), TextInlineImageSpan.class);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Text in TextInputs can't be selected by long press. This happens only when they're inside of FlatLists that are rendered with `removeClippedSubview` prop set to true on Android.

Fixes #27787

Issue #6085 2 years ago had fixed this issue with a quick fix, but the code has since disappeared in another change. It has a longer explanation for why it's fixed, but essentially - the text is assumed to be not selectable since the TextInput is initialized without being attached to the window. We need to explicitly set the text to be selectable on attachment. This change redoes that change with a 1-line fix.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Fixed] - Fixed TextInput not being selectable in removeClippedSubviews FlatLists

## Test Plan

This can be tested with a new toggle in RNTesterApp.

1. Go to the FlatList in RNTesterApp
2. Toggle on "removeClippedSubviews"
3. Try selecting some text in the list header. It should fail without this comment but succeed with it

| Before | After |
| --- | --- |
| ![Android before](https://user-images.githubusercontent.com/2937410/81353729-b1b61280-907e-11ea-9485-463b414f7aea.gif) | ![Android after](https://user-images.githubusercontent.com/2937410/81353742-b975b700-907e-11ea-8e7a-a5a2a9864824.gif) |