### PR TITLE
Inverted flatlist refresh control

### DIFF
--- a/Libraries/Lists/FlatList.js
+++ b/Libraries/Lists/FlatList.js
@@ -16,6 +16,8 @@ const React = require('react');
 const View = require('../Components/View/View');
 const VirtualizedList = require('./VirtualizedList');
 const StyleSheet = require('../StyleSheet/StyleSheet');
+const ScrollView = require('../Components/ScrollView/ScrollView');
+const RefreshControl = require('../Components/RefreshControl/RefreshControl');
 
 const invariant = require('invariant');
 
@@ -615,7 +617,26 @@ class FlatList<ItemT> extends React.PureComponent<Props<ItemT>, void> {
 
   render(): React.Node {
     const {numColumns, columnWrapperStyle, ...restProps} = this.props;
-
+    let {inverted, invertedRefreshControlUp,onRefresh} = this.props;
+    if(inverted && invertedRefreshControlUp && onRefresh){
+      let {numColumns, columnWrapperStyle, onRefresh, refreshing, ...restProps} = this.props;
+      return (
+        <ScrollView
+          contentContainerStyle={styles.invertedScrollContainerStyle}
+          refreshControl={<RefreshControl refreshing={this.props.refreshing} onRefresh={this.props.onRefresh} />}
+          >
+          <VirtualizedList
+            {...restProps}
+            getItem={this._getItem}
+            getItemCount={this._getItemCount}
+            keyExtractor={this._keyExtractor}
+            ref={this._captureRef}
+            viewabilityConfigCallbackPairs={this._virtualizedListPairs}
+            {...this._renderer()}
+          />
+        </ScrollView>
+      )
+    }
     return (
       <VirtualizedList
         {...restProps}

--- a/Libraries/Lists/FlatList.js
+++ b/Libraries/Lists/FlatList.js
@@ -653,6 +653,11 @@ class FlatList<ItemT> extends React.PureComponent<Props<ItemT>, void> {
 
 const styles = StyleSheet.create({
   row: {flexDirection: 'row'},
+  invertedScrollContainerStyle: {
+    flexDirection: 'row',
+    alignSelf: 'flex-end',
+    flexGrow: 1
+  }
 });
 
 module.exports = FlatList;

--- a/RNTester/js/examples/FlatList/FlatListExample.js
+++ b/RNTester/js/examples/FlatList/FlatListExample.js
@@ -55,6 +55,7 @@ type State = {|
   filterText: string,
   fixedHeight: boolean,
   logViewable: boolean,
+  invertedRefreshControlUp:boolean,
   virtualized: boolean,
   empty: boolean,
   useFlatListItemComponent: boolean,
@@ -67,6 +68,7 @@ class FlatListExample extends React.PureComponent<Props, State> {
     debug: false,
     horizontal: false,
     inverted: false,
+    invertedRefreshControlUp: false,
     filterText: '',
     fixedHeight: true,
     logViewable: false,
@@ -130,6 +132,7 @@ class FlatListExample extends React.PureComponent<Props, State> {
               {renderSmallSwitchOption(this, 'fixedHeight')}
               {renderSmallSwitchOption(this, 'log')}
               {renderSmallSwitchOption(this, 'inverted')}
+              {renderSmallSwitchOption(this, 'invertedRefreshControlUp')}
               {renderSmallSwitchOption(this, 'empty')}
               {renderSmallSwitchOption(this, 'debug')}
               {renderSmallSwitchOption(this, 'useFlatListItemComponent')}
@@ -165,6 +168,7 @@ class FlatListExample extends React.PureComponent<Props, State> {
             }
             horizontal={this.state.horizontal}
             inverted={this.state.inverted}
+            invertedRefreshControlUp={this.state.invertedRefreshControlUp}
             key={
               (this.state.horizontal ? 'h' : 'v') +
               (this.state.fixedHeight ? 'f' : 'd')


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
This add a quick fix [issue #17553](https://github.com/facebook/react-native/issues/17553) on showing the refresh control at the top when Flatlist is INVERTED. A prop named **invertedRefreshControlUp** has been added to control whether refresh control will be displayed at the top or not when FlatList is Inverted
## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Added] - Add invertedRefreshControlUp prop to Flatlist component

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
Add prop to RNTester and below is a video demo

![file](https://user-images.githubusercontent.com/28825947/81435952-26a94b00-9158-11ea-9bc7-286fbd20c975.gif)

