### PR TITLE
Fix skewX on Android and in the JS decomposition

### DIFF
--- a/Libraries/Utilities/MatrixMath.js
+++ b/Libraries/Utilities/MatrixMath.js
@@ -651,10 +651,6 @@ const MatrixMath = {
     skew[0] = MatrixMath.v3Dot(row[0], row[1]);
     row[1] = MatrixMath.v3Combine(row[1], row[0], 1.0, -skew[0]);
 
-    // Compute XY shear factor and make 2nd row orthogonal to 1st.
-    skew[0] = MatrixMath.v3Dot(row[0], row[1]);
-    row[1] = MatrixMath.v3Combine(row[1], row[0], 1.0, -skew[0]);
-
     // Now, compute Y scale and normalize 2nd row.
     scale[1] = MatrixMath.v3Length(row[1]);
     row[1] = MatrixMath.v3Normalize(row[1], scale[1]);

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/MatrixMathHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/MatrixMathHelper.java
@@ -169,10 +169,6 @@ public class MatrixMathHelper {
     skew[0] = v3Dot(row[0], row[1]);
     row[1] = v3Combine(row[1], row[0], 1.0, -skew[0]);
 
-    // Compute XY shear factor and make 2nd row orthogonal to 1st.
-    skew[0] = v3Dot(row[0], row[1]);
-    row[1] = v3Combine(row[1], row[0], 1.0, -skew[0]);
-
     // Now, compute Y scale and normalize 2nd row.
     scale[1] = v3Length(row[1]);
     row[1] = v3Normalize(row[1], scale[1]);


### PR DESCRIPTION
This issue fixes #27649.

## Summary

By using 2d decomposition that transforms a skewX into a rotate/scale/rotate, the skewX issue on Android was still there which made me suspect that the issue came from the decomposition algorithm. Then I noticed that the bug existed in the JavaScript decomposition as well which led me to a fix on the JS and therefore on the Android side most likely. 

## Changelog

[Android] [Fixed] skewX transforms

## Test Plan

Check that skewX works on Android.
On JS, making sure that processTransform() doesn't skip, you can try the following sequence:

```tsx
  const matrix = processTransform([{ skewX: `${Math.PI / 3}rad` }]);
  const result = MatrixMath.decomposeMatrix(matrix);
  console.log({ result });
```
