### PR TITLE
Fixed italic style not being removed on TextInput on Android

### DIFF
--- a/RNTester/js/examples/TextInput/TextInputSharedExamples.js
+++ b/RNTester/js/examples/TextInput/TextInputSharedExamples.js
@@ -627,7 +627,7 @@ module.exports = ([
     },
   },
   {
-    title: 'fontFamily and fontWeight',
+    title: 'fontWeight and fontStyle with toggles',
     render: function(): React.Node {
       return <FontWeightStyleToggleExample />;
     },

--- a/RNTester/js/examples/TextInput/TextInputSharedExamples.js
+++ b/RNTester/js/examples/TextInput/TextInputSharedExamples.js
@@ -458,18 +458,18 @@ class FontWeightStyleToggleExample extends React.Component<
   render() {
     return (
       <View>
-        {Object.entries(this.state).map(
-          ([stateKey, value]: [string, boolean]) => (
-            <WithLabel label={stateKey} key={stateKey}>
-              <Switch
-                value={value}
-                onValueChange={newValue =>
-                  this.setState({[stateKey]: newValue})
-                }
-              />
-            </WithLabel>
-          ),
-        )}
+        <WithLabel label="bold">
+          <Switch
+            value={this.state.bold}
+            onValueChange={newValue => this.setState({bold: newValue})}
+          />
+        </WithLabel>
+        <WithLabel label="italic">
+          <Switch
+            value={this.state.italic}
+            onValueChange={newValue => this.setState({italic: newValue})}
+          />
+        </WithLabel>
         <TextInput
           defaultValue="Some text that can be formatted"
           style={[

--- a/RNTester/js/examples/TextInput/TextInputSharedExamples.js
+++ b/RNTester/js/examples/TextInput/TextInputSharedExamples.js
@@ -19,6 +19,7 @@ const {
   TextInput,
   View,
   StyleSheet,
+  Switch,
 } = require('react-native');
 
 import type {RNTesterExampleModuleItem} from '../../types/RNTesterTypes';
@@ -443,6 +444,40 @@ class SelectionExample extends React.Component<
   }
 }
 
+type FontWeightStyleToggleExampleState = {
+  bold: boolean,
+  italic: boolean,
+};
+
+class FontWeightStyleToggleExample extends React.Component<
+  {},
+  FontWeightStyleToggleExampleState,
+> {
+  state: FontWeightStyleToggleExampleState = {bold: false, italic: false};
+
+  render() {
+    return (
+      <View>
+        {Object.entries(this.state).map(([stateKey, value]) => (
+          <WithLabel label={stateKey} key={stateKey}>
+            <Switch
+              value={value}
+              onValueChange={newValue => this.setState({[stateKey]: newValue})}
+            />
+          </WithLabel>
+        ))}
+        <TextInput
+          defaultValue="Some text that can be formatted"
+          style={[
+            this.state.bold && {fontWeight: 'bold'},
+            this.state.italic && {fontStyle: 'italic'},
+          ]}
+        />
+      </View>
+    );
+  }
+}
+
 module.exports = ([
   {
     title: 'Auto-focus',
@@ -589,6 +624,12 @@ module.exports = ([
           />
         </View>
       );
+    },
+  },
+  {
+    title: 'fontFamily and fontWeight',
+    render: function(): React.Node {
+      return <FontWeightStyleToggleExample />;
     },
   },
   {

--- a/RNTester/js/examples/TextInput/TextInputSharedExamples.js
+++ b/RNTester/js/examples/TextInput/TextInputSharedExamples.js
@@ -458,14 +458,18 @@ class FontWeightStyleToggleExample extends React.Component<
   render() {
     return (
       <View>
-        {Object.entries(this.state).map(([stateKey, value]) => (
-          <WithLabel label={stateKey} key={stateKey}>
-            <Switch
-              value={value}
-              onValueChange={newValue => this.setState({[stateKey]: newValue})}
-            />
-          </WithLabel>
-        ))}
+        {Object.entries(this.state).map(
+          ([stateKey, value]: [string, boolean]) => (
+            <WithLabel label={stateKey} key={stateKey}>
+              <Switch
+                value={value}
+                onValueChange={newValue =>
+                  this.setState({[stateKey]: newValue})
+                }
+              />
+            </WithLabel>
+          ),
+        )}
         <TextInput
           defaultValue="Some text that can be formatted"
           style={[

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -46,7 +46,6 @@ import com.facebook.react.views.text.ReactTextUpdate;
 import com.facebook.react.views.text.ReactTypefaceUtils;
 import com.facebook.react.views.text.TextAttributes;
 import com.facebook.react.views.text.TextInlineImageSpan;
-import com.facebook.react.views.text.ReactTextShadowNode;
 import com.facebook.react.views.view.ReactViewBackgroundManager;
 import java.util.ArrayList;
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -46,6 +46,7 @@ import com.facebook.react.views.text.ReactTextUpdate;
 import com.facebook.react.views.text.ReactTypefaceUtils;
 import com.facebook.react.views.text.TextAttributes;
 import com.facebook.react.views.text.TextInlineImageSpan;
+import com.facebook.react.views.text.ReactTextShadowNode;
 import com.facebook.react.views.view.ReactViewBackgroundManager;
 import java.util.ArrayList;
 
@@ -412,6 +413,12 @@ public class ReactEditText extends AppCompatEditText {
 
   public void setFontWeight(String fontWeightString) {
     int fontWeight = ReactTypefaceUtils.parseFontWeight(fontWeightString);
+    if (fontWeight == ReactTypefaceUtils.UNSET) {
+      // If a user removes a `fontWeight: 'bold'`, they would get UNSET as the
+      // fontWeight. ReactTypefaceUtils doesn't remove the bold style. We
+      // explicitly set it to NORMAL to ensure it resets as expected
+      fontWeight = Typeface.NORMAL;
+    }
     if (fontWeight != mFontWeight) {
       mFontWeight = fontWeight;
       mTypefaceDirty = true;
@@ -420,6 +427,12 @@ public class ReactEditText extends AppCompatEditText {
 
   public void setFontStyle(String fontStyleString) {
     int fontStyle = ReactTypefaceUtils.parseFontStyle(fontStyleString);
+    if (fontStyle == ReactTypefaceUtils.UNSET) {
+      // If a user removes a `fontStyle: 'italic'`, they would get UNSET as the
+      // fontStyle. ReactTypefaceUtils doesn't remove the italic style. We
+      // explicitly set it to NORMAL to ensure it resets as expected
+      fontStyle = Typeface.NORMAL;
+    }
     if (fontStyle != mFontStyle) {
       mFontStyle = fontStyle;
       mTypefaceDirty = true;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

When a user removes `{ fontStyle: 'italic' }` from a TextInput on Android, the text remains italic. This is because the `fontStyle` is set to UNSET, which just retains the previous style.

The user would rather expect that the `fontStyle` be set back to 'normal'

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Fixed] - Fixed so that removing `fontStyle: 'italic'` style from TextInput correctly resets to font-style to be non-italic

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Added a new TextInput test in RNTesterApp called "fontWeight and fontStyle with toggles"

See behaviour:

| Before | After |
| --- | --- |
| ![Before](https://user-images.githubusercontent.com/2937410/81512082-a8bd7f00-92d2-11ea-9c24-fe1ad118f43a.gif) | ![Before](https://user-images.githubusercontent.com/2937410/81512103-cbe82e80-92d2-11ea-9839-26f9196a4a2d.gif) |