### PR TITLE
Use RuntimeExecutor from CatalystInstance in Fabric's Binding

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/fabric/Binding.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/fabric/Binding.java
@@ -13,6 +13,7 @@ import com.facebook.jni.HybridData;
 import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.bridge.JavaScriptContextHolder;
 import com.facebook.react.bridge.NativeMap;
+import com.facebook.react.bridge.RuntimeExecutor;
 import com.facebook.react.bridge.queue.MessageQueueThread;
 import com.facebook.react.fabric.events.EventBeatManager;
 import com.facebook.react.uimanager.PixelUtil;
@@ -35,6 +36,7 @@ public class Binding {
 
   private native void installFabricUIManager(
       long jsContextNativePointer,
+      RuntimeExecutor runtimeExecutor,
       Object uiManager,
       EventBeatManager eventBeatManager,
       MessageQueueThread jsMessageQueueThread,
@@ -72,8 +74,10 @@ public class Binding {
 
   public native void driveCxxAnimations();
 
+  // TODO (T67721598) Remove the jsContext param once we've migrated to using RuntimeExecutor
   public void register(
       @NonNull JavaScriptContextHolder jsContext,
+      @NonNull RuntimeExecutor runtimeExecutor,
       @NonNull FabricUIManager fabricUIManager,
       @NonNull EventBeatManager eventBeatManager,
       @NonNull MessageQueueThread jsMessageQueueThread,
@@ -82,6 +86,7 @@ public class Binding {
     fabricUIManager.setBinding(this);
     installFabricUIManager(
         jsContext.get(),
+        runtimeExecutor,
         fabricUIManager,
         eventBeatManager,
         jsMessageQueueThread,

--- a/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricJSIModuleProvider.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricJSIModuleProvider.java
@@ -74,8 +74,10 @@ public class FabricJSIModuleProvider implements JSIModuleProvider<UIManager> {
             .getCatalystInstance()
             .getReactQueueConfiguration()
             .getJSQueueThread();
+
     binding.register(
         mJSContext,
+        mReactApplicationContext.getCatalystInstance().getRuntimeExecutor(),
         uiManager,
         eventBeatManager,
         jsMessageQueueThread,

--- a/ReactAndroid/src/main/java/com/facebook/react/fabric/jni/Binding.cpp
+++ b/ReactAndroid/src/main/java/com/facebook/react/fabric/jni/Binding.cpp
@@ -214,6 +214,7 @@ void Binding::setConstraints(
 
 void Binding::installFabricUIManager(
     jlong jsContextNativePointer,
+    jni::alias_ref<JRuntimeExecutor::javaobject> runtimeExecutorHolder,
     jni::alias_ref<jobject> javaUIManager,
     EventBeatManager *eventBeatManager,
     jni::alias_ref<JavaMessageQueueThread::javaobject> jsMessageQueueThread,
@@ -247,15 +248,23 @@ void Binding::installFabricUIManager(
   auto sharedJSMessageQueueThread =
       std::make_shared<JMessageQueueThread>(jsMessageQueueThread);
 
-  Runtime *runtime = (Runtime *)jsContextNativePointer;
-  RuntimeExecutor runtimeExecutor =
-      [runtime, sharedJSMessageQueueThread](
-          std::function<void(facebook::jsi::Runtime & runtime)> &&callback) {
-        sharedJSMessageQueueThread->runOnQueue(
-            [runtime, callback = std::move(callback)]() {
-              callback(*runtime);
-            });
-      };
+  bool useRuntimeExecutor =
+      config->getBool("react_fabric:use_shared_runtime_executor_android");
+
+  RuntimeExecutor runtimeExecutor;
+  if (useRuntimeExecutor) {
+    runtimeExecutor = runtimeExecutorHolder->cthis()->get();
+  } else {
+    Runtime *runtime = (Runtime *)jsContextNativePointer;
+    runtimeExecutor =
+        [runtime, sharedJSMessageQueueThread](
+            std::function<void(facebook::jsi::Runtime & runtime)> &&callback) {
+          sharedJSMessageQueueThread->runOnQueue(
+              [runtime, callback = std::move(callback)]() {
+                callback(*runtime);
+              });
+        };
+  }
 
   // TODO: T31905686 Create synchronous Event Beat
   jni::global_ref<jobject> localJavaUIManager = javaUIManager_;

--- a/ReactAndroid/src/main/java/com/facebook/react/fabric/jni/Binding.h
+++ b/ReactAndroid/src/main/java/com/facebook/react/fabric/jni/Binding.h
@@ -10,6 +10,7 @@
 #include <fbjni/fbjni.h>
 #include <react/animations/LayoutAnimationDriver.h>
 #include <react/jni/JMessageQueueThread.h>
+#include <react/jni/JRuntimeExecutor.h>
 #include <react/jni/ReadableNativeMap.h>
 #include <react/scheduler/Scheduler.h>
 #include <react/scheduler/SchedulerDelegate.h>
@@ -50,6 +51,7 @@ class Binding : public jni::HybridClass<Binding>,
 
   void installFabricUIManager(
       jlong jsContextNativePointer,
+      jni::alias_ref<JRuntimeExecutor::javaobject> runtimeExecutorHolder,
       jni::alias_ref<jobject> javaUIManager,
       EventBeatManager *eventBeatManager,
       jni::alias_ref<JavaMessageQueueThread::javaobject> jsMessageQueueThread,


### PR DESCRIPTION
Summary:
Update Fabric's Android binding to use a RuntimeExecutor instead of the `jsContext`, which is actually just the runtime pointer. This diff uses the RuntimeExecutor from CatalystInstanceImpl (in the previous diff) which uses the bridge under the hood.

Changelog: [Android][Changed] Modified Fabric's public-facing API on Android

Reviewed By: mdvacca

Differential Revision: D21051975

