### PR TITLE
Added the TextPropTypes and ImagePropTypes to the react native properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -496,7 +496,7 @@ module.exports = {
   },
   get ImagePropTypes(): DeprecatedImagePropTypes {
     return require('./Libraries/DeprecatedPropTypes/DeprecatedImagePropType');
-  }
+  },
 };
 
 if (__DEV__) {

--- a/index.js
+++ b/index.js
@@ -100,6 +100,8 @@ import typeof DeprecatedColorPropType from './Libraries/DeprecatedPropTypes/Depr
 import typeof DeprecatedEdgeInsetsPropType from './Libraries/DeprecatedPropTypes/DeprecatedEdgeInsetsPropType';
 import typeof DeprecatedPointPropType from './Libraries/DeprecatedPropTypes/DeprecatedPointPropType';
 import typeof DeprecatedViewPropTypes from './Libraries/DeprecatedPropTypes/DeprecatedViewPropTypes';
+import typeof DeprecatedTextPropTypes from './Libraries/DeprecatedPropTypes/DeprecatedTextPropTypes';
+import typeof DeprecatedImagePropTypes from './Libraries/DeprecatedPropTypes/DeprecatedImagePropType';
 
 import type {HostComponent as _HostComponentInternal} from './Libraries/Renderer/shims/ReactNativeTypes';
 
@@ -489,6 +491,12 @@ module.exports = {
   get ViewPropTypes(): DeprecatedViewPropTypes {
     return require('./Libraries/DeprecatedPropTypes/DeprecatedViewPropTypes');
   },
+  get TextPropTypes(): DeprecatedTextPropTypes {
+    return require('./Libraries/DeprecatedPropTypes/DeprecatedTextPropTypes');
+  },
+  get ImagePropTypes(): DeprecatedImagePropTypes {
+    return require('./Libraries/DeprecatedPropTypes/DeprecatedImagePropType');
+  }
 };
 
 if (__DEV__) {


### PR DESCRIPTION
## Summary

The types added allow for PropTypes prop validation when passing textStyles to a custom component, or to pass an imported image as a source for an image contained inside a custom component. This edit is needed when using TypeScript.

## Changelog

[General] [Added] - Added the TextPropTypes and ImagePropTypes to the react native properties.

## Test Plan

Create a View component that contains an Image and/or a Text component. The View component takes in as props the textStyle and the image source. When you need to specify the propTypes for the View component you can type:
`MyView.propTypes = {textStyle: TextPropTypes.style, icon: ImagePropTypes.source}`.