### PR TITLE
set`NSAllowsArbitraryLoads` to false by default in template

### DIFF
--- a/template/ios/HelloWorld/Info.plist
+++ b/template/ios/HelloWorld/Info.plist
@@ -26,8 +26,6 @@
 	<true/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
-		<key>NSAllowsArbitraryLoads</key>
-		<true/>
 		<key>NSExceptionDomains</key>
 		<dict>
 			<key>localhost</key>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Since we already have `localhost` as`Exception Domains` in NSAppTransportSecurity to allow connect to dev server, the template should set `NSAllowsArbitraryLoads` to false by default, as exaplained in [Apple's document](https://developer.apple.com/documentation/bundleresources/information_property_list/nsapptransportsecurity/nsallowsarbitraryloads) as a good practice.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [enhancement] - set `NSAllowsArbitraryLoads` to `false` by default in template
