### PR TITLE
Add `Animated.useValue` hook

### DIFF
--- a/Libraries/Animated/src/AnimatedImplementation.js
+++ b/Libraries/Animated/src/AnimatedImplementation.js
@@ -29,6 +29,7 @@ const SpringAnimation = require('./animations/SpringAnimation');
 const TimingAnimation = require('./animations/TimingAnimation');
 
 const createAnimatedComponent = require('./createAnimatedComponent');
+const useValue = require('./useValue');
 
 import type {
   AnimationConfig,
@@ -707,6 +708,12 @@ module.exports = {
    * Expose Event class, so it can be used as a type for type checkers.
    */
   Event: AnimatedEvent,
+
+  /**
+   * React hook for keeping the same instance of AnimatedValue in functional
+   * components
+   */
+  useValue,
 
   __PropsOnlyForTests: AnimatedProps,
 };

--- a/Libraries/Animated/src/AnimatedMock.js
+++ b/Libraries/Animated/src/AnimatedMock.js
@@ -19,6 +19,7 @@ const AnimatedValue = require('./nodes/AnimatedValue');
 const AnimatedValueXY = require('./nodes/AnimatedValueXY');
 
 const createAnimatedComponent = require('./createAnimatedComponent');
+const useValue = require('./useValue');
 
 import type {EndCallback} from './animations/Animation';
 import type {TimingAnimationConfig} from './animations/TimingAnimation';
@@ -152,5 +153,6 @@ module.exports = {
   forkEvent: AnimatedImplementation.forkEvent,
   unforkEvent: AnimatedImplementation.unforkEvent,
   Event: AnimatedEvent,
+  useValue,
   __PropsOnlyForTests: AnimatedProps,
 };

--- a/Libraries/Animated/src/useValue.js
+++ b/Libraries/Animated/src/useValue.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+'use strict';
+
+import * as React from 'react';
+
+const AnimatedValue = require('./nodes/AnimatedValue');
+
+function useValue(initialValue: number): AnimatedValue {
+  const ref = React.useRef(null);
+  if (ref.current === null) {
+    ref.current = new AnimatedValue(initialValue);
+  }
+  return ref.current;
+}
+
+module.exports = useValue;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

When working with functional components this is easy to make bugs with statement, that I already saw several times from different people:

```js
function MyComponent() {
  const value = new Value(...);
}
```

This will lead to creating new value instance for every re-render. And components, that use internal value of previous instance will be reset to the new one, and this will lead to visual bugs. So one should always keep the same instance wrapping it either in `useRef(new Value(...))` or `useMemo(() => new Value(...), [])`.

This PR adds hook, that could be used in very often simple case of creating instance of Value without extra wrap:

```js
function MyComponent() {
  const value = useValue(...);
}
```

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Added] - Animated.useValue hook

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->