### PR TITLE
improve "not a registered callable module" error message

### DIFF
--- a/Libraries/BatchedBridge/MessageQueue.js
+++ b/Libraries/BatchedBridge/MessageQueue.js
@@ -396,10 +396,8 @@ class MessageQueue {
     const moduleMethods = this.getCallableModule(module);
     invariant(
       !!moduleMethods,
-      `Module ${module} is not a registered callable module (calling ${method}). This can happen when the application entry file path is incorrect.
-      On Android, verify 'getJSMainModuleName()' in 'MainApplication.java' and 'project.ext.react.entryFile' in 'android/app/build.gradle'.
-      On iOS, verify '- (NSURL *)sourceURLForBridge:(RCTBridge *)bridge' in 'AppDelegate.m' and 'ENTRY_FILE' env. variable passed to 'react-native-xcode.sh' (if any) in 'Build Phases' -> 'Bundle React Native code and images'.
-      `,
+      `Module ${module} is not a registered callable module (calling ${method}). A frequent cause of the error is that the application entry file path is incorrect. 
+      This can also happen when the JS bundle is corrupt or there is an early initialization error when loading React Native.`,
     );
     invariant(
       !!moduleMethods[method],

--- a/Libraries/BatchedBridge/MessageQueue.js
+++ b/Libraries/BatchedBridge/MessageQueue.js
@@ -396,15 +396,14 @@ class MessageQueue {
     const moduleMethods = this.getCallableModule(module);
     invariant(
       !!moduleMethods,
-      'Module %s is not a registered callable module (calling %s)',
-      module,
-      method,
+      `Module ${module} is not a registered callable module (calling ${method}). This can happen when the application entry file path is incorrect.
+      On Android, verify 'getJSMainModuleName()' in 'MainApplication.java' and 'project.ext.react.entryFile' in 'android/app/build.gradle'.
+      On iOS, verify '- (NSURL *)sourceURLForBridge:(RCTBridge *)bridge' in 'AppDelegate.m' and 'ENTRY_FILE' env. variable passed to 'react-native-xcode.sh' (if any) in 'Build Phases' -> 'Bundle React Native code and images'.
+      `,
     );
     invariant(
       !!moduleMethods[method],
-      'Method %s does not exist on module %s',
-      method,
-      module,
+      `Method ${method} does not exist on module ${module}`,
     );
     moduleMethods[method].apply(moduleMethods, args);
     Systrace.endEvent();

--- a/Libraries/BatchedBridge/__tests__/MessageQueue-test.js
+++ b/Libraries/BatchedBridge/__tests__/MessageQueue-test.js
@@ -108,7 +108,7 @@ describe('MessageQueue', function() {
     const unknownModule = 'UnknownModule',
       unknownMethod = 'UnknownMethod';
     expect(() => queue.__callFunction(unknownModule, unknownMethod)).toThrow(
-      `Module ${unknownModule} is not a registered callable module (calling ${unknownMethod})`,
+      `Module ${unknownModule} is not a registered callable module (calling ${unknownMethod}). This can happen when the application entry file path is incorrect.`,
     );
   });
 

--- a/Libraries/BatchedBridge/__tests__/MessageQueue-test.js
+++ b/Libraries/BatchedBridge/__tests__/MessageQueue-test.js
@@ -108,7 +108,8 @@ describe('MessageQueue', function() {
     const unknownModule = 'UnknownModule',
       unknownMethod = 'UnknownMethod';
     expect(() => queue.__callFunction(unknownModule, unknownMethod)).toThrow(
-      `Module ${unknownModule} is not a registered callable module (calling ${unknownMethod}). This can happen when the application entry file path is incorrect.`,
+      `Module ${unknownModule} is not a registered callable module (calling ${unknownMethod}). A frequent cause of the error is that the application entry file path is incorrect. 
+      This can also happen when the JS bundle is corrupt or there is an early initialization error when loading React Native.`,
     );
   });
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Motivation: 

`Invariant Violation: Module AppRegistry is not a registered callable module (calling runApplication).` is an error that happens rarely, and most SO answers end up recommending to use `react-native bundle` to work around. I stumbled upon this error the other day and it took me a while to figure out that the error was caused by the fact that my `entryFile` path was pointing to an existing but invalid file. I figured it would be nice to mention this because I believe this will be a frequent cause of the error.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Changed] - improve "not a registered callable module error message"

## Test Plan

tested locally with RNTester, prints

```
[Sun May 17 2020 18:15:55.396]  ERROR    Invariant Violation: Module AppRegistry is not a registered callable module (calling runApplication). This can happen when the application entry file path is incorrect.
      On Android, verify 'getJSMainModuleName()' in 'MainApplication.java' and 'project.ext.react.entryFile' in 'android/app/build.gradle'.
      On iOS, verify '- (NSURL *)sourceURLForBridge:(RCTBridge *)bridge' in 'AppDelegate.m' and 'ENTRY_FILE' env. variable passed to 'react-native-xcode.sh' (if any) in 'Build Phases' -> 'Bundle React Native code and images'.
```

in metro logs
