### PR TITLE
Add a test that loads all RNTester pages and improve reliability of RCTTestRunner

### DIFF
--- a/Libraries/Image/RCTImageLoader.h
+++ b/Libraries/Image/RCTImageLoader.h
@@ -22,6 +22,7 @@
 - (instancetype)initWithRedirectDelegate:(id<RCTImageRedirectProtocol>)redirectDelegate
                               loadersProvider:(NSArray<id<RCTImageURLLoader>> * (^)(void))getLoaders
                              decodersProvider:(NSArray<id<RCTImageDataDecoder>> * (^)(void))getDecoders;
+- (NSInteger)activeTasks;
 @end
 
 /**

--- a/Libraries/Image/RCTImageLoader.mm
+++ b/Libraries/Image/RCTImageLoader.mm
@@ -406,6 +406,10 @@ static UIImage *RCTResizeImageIfNeeded(UIImage *image,
   });
 }
 
+- (NSInteger)activeTasks {
+  return _activeTasks;
+}
+
 /**
  * This returns either an image, or raw image data, depending on the loading
  * path taken. This is useful if you want to skip decoding, e.g. when preloading

--- a/RNTester/Podfile.lock
+++ b/RNTester/Podfile.lock
@@ -502,8 +502,8 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: 694058e7c0ed05a9e217d1b3c7ded962f4180845
   CocoaLibEvent: 2fab71b8bd46dd33ddb959f7928ec5909f838e3f
   DoubleConversion: cde416483dac037923206447da6e1454df403714
-  FBLazyVector: f4770b2c41e050486153014b382a0ef4e1873ba1
-  FBReactNativeSpec: 4c75510a37f97c849ad9d36e8818613b375997da
+  FBLazyVector: 555a6c1f198849a2eda493c93fe58e952c0cf4eb
+  FBReactNativeSpec: c38cae163dc178cf07393aaf3639834123ea3ad5
   Flipper: 33585e2d9810fe5528346be33bcf71b37bb7ae13
   Flipper-DoubleConversion: 38631e41ef4f9b12861c67d17cb5518d06badc41
   Flipper-Folly: c12092ea368353b58e992843a990a3225d4533c3
@@ -514,32 +514,32 @@ SPEC CHECKSUMS:
   Folly: b73c3869541e86821df3c387eb0af5f65addfab4
   glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
   OpenSSL-Universal: 8b48cc0d10c1b2923617dfe5c178aa9ed2689355
-  RCTRequired: 7e902f87bfc578dd6a182d994ab8d6e4d1396bd2
-  RCTTypeSafety: 2f03f70aa2201577705494f1f76ad3a7c1063613
-  React: 32c36d9cd712a89f583e8d0a8237084aa14d2011
-  React-ART: 68099b91de835b6915a0ebdd2f431cd0dfd77a71
-  React-callinvoker: 33c27951352d371319a74fc064f12b7616877a59
-  React-Core: daf3dd8b9353db66b059bca6ff0121c8a79f09d5
-  React-CoreModules: 3fa2204802fcf7ccd31e7e70c1a0e682b81fce1f
-  React-cxxreact: bb109f2d73d52e1ace7a3a27292687e271e31e78
-  React-jsi: f3a8201012cec06baa04a0cb60d1da06cfffa416
-  React-jsiexecutor: 61c71e33b4934f25fcff38c43a981c9e2a315ca3
-  React-jsinspector: f6fbcd926d897cef0fc995a9f842ff4f95a6691c
-  React-perflogger: fe56955052443d4f9cc551efb4d05da9564eb060
-  React-RCTActionSheet: 19b61ce66e57aaa82c3a2c79e102bbb49087a556
-  React-RCTAnimation: 8fcc66cd729431162dafdeb443ad91be9e3301e6
-  React-RCTBlob: 70d98b88a40b1d1d8211691f122fbe0e249ec4b0
-  React-RCTImage: 1b1709bff6275aa2fb2d53b68ee8db1b0b693e27
-  React-RCTLinking: e630e69ca412cadc8b1436a30cb8117d49476c43
-  React-RCTNetwork: 7d92f0075226f1c09776e0b87fcb5ff65a21dddc
-  React-RCTPushNotification: 84b1ce7d1b14d96778a840e4d437b1384ba0817e
-  React-RCTSettings: 643839777475f1bd168a80a2e92d531055b697e4
-  React-RCTTest: 68b2a36a83cb7f3b8f18067c259dec4c24a027ab
-  React-RCTText: d1243dfd69c6d0848cfd122c13918de856582a64
-  React-RCTVibration: 468fbe27e26d4a32a741bda491244e402d1ff24e
-  React-runtimeexecutor: 56f253eef3f86aba1afbc16f8ee48c797ec67056
-  ReactCommon: 07c5748cd28fd85ada71cfdf099d85fcf0270ef3
-  Yoga: 4dc04b0c1b81b0920b08b0a2b8c7502c80ffc3b3
+  RCTRequired: b9c4ac0afd0c7a80b2da4eb28cb4446d9ceea548
+  RCTTypeSafety: 27100d715a173724c7087f55a49f60f9f8634dd8
+  React: a93b385f85efd6584b9e9ef35aaa2ba32eef56cb
+  React-ART: 574b92a992ccea0f8c5e7f670d293da75c38ceab
+  React-callinvoker: ae17f1667892d78aef6a2f54684b8970bc251cfe
+  React-Core: 4707441a7e7118c25042d48927637fb2b0c8a82e
+  React-CoreModules: 2551a49feb5d7f5bc0fb43cfb13ddc5428bc2eff
+  React-cxxreact: 4cda5a8a17189571c0c5d48628e9c34b2395e5e4
+  React-jsi: 2f7d1a6d11f2f455215c04b752931e02c7e94d84
+  React-jsiexecutor: 20b4ae4fe459de519ec28cca022bee26ca7cc913
+  React-jsinspector: 2934010979c83fbcd86472ee685f92438e61dd7d
+  React-perflogger: 5ac5d60753392844c169b466b46cd0ceb53245fc
+  React-RCTActionSheet: a329becbfa712628aa2d06ee980076d25e7f89b6
+  React-RCTAnimation: d52775a3f908e78d9ac21d97a0831547d119dddc
+  React-RCTBlob: d3ea9258a8ef701322cb869978239d11f7203359
+  React-RCTImage: 7c823881b77cdf919ab1654107e4a9a722e94520
+  React-RCTLinking: 080e50eafafc3277386311937f5856d519cf5403
+  React-RCTNetwork: aed61a6f60a9419129466783b94d9a2122c260b0
+  React-RCTPushNotification: 11492403752d70771b303f8b3b6385af3d8cb625
+  React-RCTSettings: 69917713340d613895d8847eba254d15168b77c2
+  React-RCTTest: a9efe663b73ee2681d24b229d70f0c996440d6ab
+  React-RCTText: 796488183a4f6d4625fe1c6d00a858f1ec485edc
+  React-RCTVibration: 311f791375fd354f48994dac9ba7a737ae1726ed
+  React-runtimeexecutor: fddee0e1d827ef782386cd8ae3d33c7947d31696
+  ReactCommon: 28057c47ad3fc5c7f0eada74aa738abeaa6ebbbb
+  Yoga: fac11ca4ccf722fd20752423ea3d6e248d24d1fd
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
 PODFILE CHECKSUM: 5f0be4be03d6934478b9dd621bfbab4383b8c85d

--- a/RNTester/Podfile.lock
+++ b/RNTester/Podfile.lock
@@ -502,8 +502,8 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: 694058e7c0ed05a9e217d1b3c7ded962f4180845
   CocoaLibEvent: 2fab71b8bd46dd33ddb959f7928ec5909f838e3f
   DoubleConversion: cde416483dac037923206447da6e1454df403714
-  FBLazyVector: 8ea0285646adaf7fa725c20ed737c49ee5ea680a
-  FBReactNativeSpec: e8f07c749b9cf184c819f5a8ca44b91ab61fca12
+  FBLazyVector: f4770b2c41e050486153014b382a0ef4e1873ba1
+  FBReactNativeSpec: 4c75510a37f97c849ad9d36e8818613b375997da
   Flipper: 33585e2d9810fe5528346be33bcf71b37bb7ae13
   Flipper-DoubleConversion: 38631e41ef4f9b12861c67d17cb5518d06badc41
   Flipper-Folly: c12092ea368353b58e992843a990a3225d4533c3
@@ -514,32 +514,32 @@ SPEC CHECKSUMS:
   Folly: b73c3869541e86821df3c387eb0af5f65addfab4
   glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
   OpenSSL-Universal: 8b48cc0d10c1b2923617dfe5c178aa9ed2689355
-  RCTRequired: 34582e9b3ebe69f244e091f37218d318406d5c4a
-  RCTTypeSafety: 1ade47a69b092cddf1e4ea21e0c5bdc65cc950b4
-  React: cafb3c2321f7df55ce90dbf29d513799a79e4418
-  React-ART: df0460bdff42ef039e28ee3ffd41f50b75644788
-  React-callinvoker: 0dada022d38b73e6e15b33e2a96476153f79bbf6
-  React-Core: d85e4563acbfbb6e6be7414a813ad55d05d675df
-  React-CoreModules: d13d148c851af5780f864be74bc2165140923dc7
-  React-cxxreact: bb64d8c5798d75565870ff1a7a8ac57a09bd9ff8
-  React-jsi: fe94132da767bfc4801968c2a12abae43e9a833e
-  React-jsiexecutor: 959bb48c75a3bfc1b1d2b991087a6d8df721cbcf
-  React-jsinspector: 7fbf9b42b58b02943a0d89b0ba9fff0070f2de98
-  React-perflogger: 1f668f3e4d1adef1fafb3b95e7d6cf922113fe31
-  React-RCTActionSheet: 51c43beeb74ef41189e87fe9823e53ebf6210359
-  React-RCTAnimation: 9d09196c641c1ebfef3a4e9ae670bcda5fadb420
-  React-RCTBlob: 715489626cf44d28ee51e5277a4d559167351696
-  React-RCTImage: 19151d2d071b05c3832a0b212473cafa4ea8948f
-  React-RCTLinking: 7c94c0f2fcc658cb4043dacb4f6621dca2f8f8b5
-  React-RCTNetwork: 7596e84acacd5d0674e9743b55c5bf61a626af69
-  React-RCTPushNotification: 88c9f47ff0d4391d5136d70745f15713cdc5f6bb
-  React-RCTSettings: a29c61f85f535ba2eff54d80bef2ea3cdb6e5fba
-  React-RCTTest: cfe25fcf70b04a747dba4326105db398250caa9a
-  React-RCTText: 6c01963d3e562109f5548262b09b1b2bc260dd60
-  React-RCTVibration: d42d73dafd9f63cf758656ee743aa80c566798ff
-  React-runtimeexecutor: 60dd6204a13f68a1aa1118870edcc604a791df2b
-  ReactCommon: 511b4a9ea129c129c6dbc982942007d195903a9a
-  Yoga: f7fa200d8c49f97b54c9421079e781fb900b5cae
+  RCTRequired: 7e902f87bfc578dd6a182d994ab8d6e4d1396bd2
+  RCTTypeSafety: 2f03f70aa2201577705494f1f76ad3a7c1063613
+  React: 32c36d9cd712a89f583e8d0a8237084aa14d2011
+  React-ART: 68099b91de835b6915a0ebdd2f431cd0dfd77a71
+  React-callinvoker: 33c27951352d371319a74fc064f12b7616877a59
+  React-Core: daf3dd8b9353db66b059bca6ff0121c8a79f09d5
+  React-CoreModules: 3fa2204802fcf7ccd31e7e70c1a0e682b81fce1f
+  React-cxxreact: bb109f2d73d52e1ace7a3a27292687e271e31e78
+  React-jsi: f3a8201012cec06baa04a0cb60d1da06cfffa416
+  React-jsiexecutor: 61c71e33b4934f25fcff38c43a981c9e2a315ca3
+  React-jsinspector: f6fbcd926d897cef0fc995a9f842ff4f95a6691c
+  React-perflogger: fe56955052443d4f9cc551efb4d05da9564eb060
+  React-RCTActionSheet: 19b61ce66e57aaa82c3a2c79e102bbb49087a556
+  React-RCTAnimation: 8fcc66cd729431162dafdeb443ad91be9e3301e6
+  React-RCTBlob: 70d98b88a40b1d1d8211691f122fbe0e249ec4b0
+  React-RCTImage: 1b1709bff6275aa2fb2d53b68ee8db1b0b693e27
+  React-RCTLinking: e630e69ca412cadc8b1436a30cb8117d49476c43
+  React-RCTNetwork: 7d92f0075226f1c09776e0b87fcb5ff65a21dddc
+  React-RCTPushNotification: 84b1ce7d1b14d96778a840e4d437b1384ba0817e
+  React-RCTSettings: 643839777475f1bd168a80a2e92d531055b697e4
+  React-RCTTest: 68b2a36a83cb7f3b8f18067c259dec4c24a027ab
+  React-RCTText: d1243dfd69c6d0848cfd122c13918de856582a64
+  React-RCTVibration: 468fbe27e26d4a32a741bda491244e402d1ff24e
+  React-runtimeexecutor: 56f253eef3f86aba1afbc16f8ee48c797ec67056
+  ReactCommon: 07c5748cd28fd85ada71cfdf099d85fcf0270ef3
+  Yoga: 4dc04b0c1b81b0920b08b0a2b8c7502c80ffc3b3
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
 PODFILE CHECKSUM: 5f0be4be03d6934478b9dd621bfbab4383b8c85d

--- a/RNTester/RCTTest/RCTTestRunner.m
+++ b/RNTester/RCTTest/RCTTestRunner.m
@@ -14,6 +14,8 @@
 #import <React/RCTRootView.h>
 #import <React/RCTUIManager.h>
 #import <React/RCTUtils.h>
+#import <React/RCTBundleURLProvider.h>
+#import <React/RCTImageLoader.h>
 
 #import "FBSnapshotTestController.h"
 #import "RCTTestModule.h"
@@ -199,8 +201,10 @@ expectErrorBlock:(BOOL(^)(NSString *error))expectErrorBlock
         configurationBlock(rootView);
       }
 
+      RCTImageLoader *imageLoader = [bridge moduleForClass:[RCTImageLoader class]];
+
       NSDate *date = [NSDate dateWithTimeIntervalSinceNow:kTestTimeoutSeconds];
-      while (date.timeIntervalSinceNow > 0 && testModule.status == RCTTestStatusPending && errors == nil) {
+      while (date.timeIntervalSinceNow > 0 && (testModule.status == RCTTestStatusPending || [imageLoader activeTasks] > 0) && errors == nil) {
         [[NSRunLoop mainRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
         [[NSRunLoop mainRunLoop] runMode:NSRunLoopCommonModes beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
       }

--- a/RNTester/RNTesterIntegrationTests/RNTesterLoadAllPages.m
+++ b/RNTester/RNTesterIntegrationTests/RNTesterLoadAllPages.m
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+#import <UIKit/UIKit.h>
+#import <XCTest/XCTest.h>
+
+#import <RCTTest/RCTTestRunner.h>
+#import <React/RCTLog.h>
+
+#import <objc/runtime.h>
+
+@interface RNTesterLoadAllPages : XCTestCase
+{
+  RCTTestRunner *_runner;
+  NSString *_testName;
+}
+
+@end
+
+@implementation RNTesterLoadAllPages
+
+- (void)setUp
+{
+  _runner = RCTInitRunnerForApp(@"RNTester/js/RNTesterApp", nil, nil);
+}
+
+- (id)initWithName:(NSString *)testName {
+  // This method for dynamically adding tests borrowed from:
+  // https://github.com/google/google-toolbox-for-mac/blob/master/UnitTesting/GTMGoogleTestRunner.mm
+  // Xcode 6.1 started taking the testName from the selector instead of calling -name.
+  // So we will add selectors to this XCTestCase.
+  Class cls = [self class];
+  NSString *selectorTestName = testName;
+  SEL selector = sel_registerName([selectorTestName UTF8String]);
+  Method method = class_getInstanceMethod(cls, @selector(internalTestRunner));
+  IMP implementation = method_getImplementation(method);
+  const char *encoding = method_getTypeEncoding(method);
+  // We may be called more than once for the same testName. Check before adding new method to avoid
+  // failure from adding multiple methods with the same name.
+  if (!class_getInstanceMethod(cls, selector) &&
+      !class_addMethod(cls, selector, implementation, encoding)) {
+    // If we can't add a method, we should blow up here.
+    [NSException raise:NSInternalInconsistencyException
+                format:@"Unable to add %@ to %@.", testName, cls];
+  }
+  if ((self = [super initWithSelector:selector])) {
+    _testName = testName;
+  }
+  return self;
+}
+
+- (NSString *)name {
+  return _testName;
+}
+
++ (XCTestSuite*)defaultTestSuite {
+  RCTTestRunner *runner = RCTInitRunnerForApp(@"RNTester/js/RNTesterApp", nil, nil);
+
+  __block NSMutableArray<NSString *> *testNames = [NSMutableArray new];
+
+  RCTLogFunction defaultLogFunction = RCTGetLogFunction();
+  RCTSetLogFunction(^(RCTLogLevel level, RCTLogSource source, NSString *fileName, NSNumber *lineNumber, NSString *message) {
+    defaultLogFunction(level, source, fileName, lineNumber, message);
+    if (level == RCTLogLevelTrace) {
+      // message string is in the format:
+      // 'ActivityIndicatorExample', '\n    in EnumerateExamplePages (at renderApplication.js:46)'
+      NSArray *items = [message componentsSeparatedByString:@","];
+      NSString *testName = [items[0] stringByTrimmingCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@"'"]];
+      [testNames addObject:testName];
+    }
+  });
+
+  [runner runTest:_cmd module:@"EnumerateExamplePages"];
+
+  RCTSetLogFunction(defaultLogFunction);
+
+  XCTestSuite *suite = [XCTestSuite testSuiteForTestCaseClass:self];
+
+  for (NSString *testName in testNames) {
+    XCTestCase *testCase = [[self alloc] initWithName:testName];
+    [suite addTest:testCase];
+  }
+  
+  return suite;
+}
+
+- (void)internalTestRunner
+{
+  // this performs the actual test
+  NSString *testName = [@"LoadPageTest_" stringByAppendingString:_testName];
+  [_runner runTest:_cmd module:testName];
+}
+
+@end

--- a/RNTester/RNTesterPods.xcodeproj/project.pbxproj
+++ b/RNTester/RNTesterPods.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		2DDEF0101F84BF7B00DBDF73 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2DDEF00F1F84BF7B00DBDF73 /* Images.xcassets */; };
 		383889DA23A7398900D06C3E /* RCTConvert_UIColorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 383889D923A7398900D06C3E /* RCTConvert_UIColorTests.m */; };
 		3D2AFAF51D646CF80089D1A3 /* legacy_image@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 3D2AFAF41D646CF80089D1A3 /* legacy_image@2x.png */; };
+		38C8AC1F246611E500BA7FAA /* RNTesterLoadAllPages.m in Sources */ = {isa = PBXBuildFile; fileRef = 38C8AC1E246611E500BA7FAA /* RNTesterLoadAllPages.m */; };
+		38C8AC20246611E500BA7FAA /* RNTesterLoadAllPages.m in Sources */ = {isa = PBXBuildFile; fileRef = 38C8AC1E246611E500BA7FAA /* RNTesterLoadAllPages.m */; };
 		5C60EB1C226440DB0018C04F /* AppDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5C60EB1B226440DB0018C04F /* AppDelegate.mm */; };
 		5CB07C9B226467E60039471C /* RNTesterTurboModuleProvider.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5CB07C99226467E60039471C /* RNTesterTurboModuleProvider.mm */; };
 		8145AE06241172D900A3F8DA /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8145AE05241172D900A3F8DA /* LaunchScreen.storyboard */; };
@@ -83,6 +85,7 @@
 		34028D6B10F47E490042EB27 /* Pods-RNTesterUnitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNTesterUnitTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-RNTesterUnitTests/Pods-RNTesterUnitTests.debug.xcconfig"; sourceTree = "<group>"; };
 		383889D923A7398900D06C3E /* RCTConvert_UIColorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTConvert_UIColorTests.m; sourceTree = "<group>"; };
 		3D2AFAF41D646CF80089D1A3 /* legacy_image@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "legacy_image@2x.png"; path = "RNTester/legacy_image@2x.png"; sourceTree = "<group>"; };
+		38C8AC1E246611E500BA7FAA /* RNTesterLoadAllPages.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNTesterLoadAllPages.m; sourceTree = "<group>"; };
 		4C2F0C3405B1D6741F52D4F6 /* libPods-RNTester.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-RNTester.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		5BEC8567F3741044B6A5EFC5 /* Pods-RNTester.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNTester.release.xcconfig"; path = "Pods/Target Support Files/Pods-RNTester/Pods-RNTester.release.xcconfig"; sourceTree = "<group>"; };
 		5C60EB1B226440DB0018C04F /* AppDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = AppDelegate.mm; path = RNTester/AppDelegate.mm; sourceTree = "<group>"; };
@@ -375,6 +378,7 @@
 			isa = PBXGroup;
 			children = (
 				E7C1241922BEC44B00DA25C0 /* RNTesterIntegrationTests.m */,
+				38C8AC1E246611E500BA7FAA /* RNTesterLoadAllPages.m */,
 				E7DB215E22B2F3EC005AC45F /* RCTLoggingTests.m */,
 				E7DB216122B2F3EC005AC45F /* RCTRootViewIntegrationTests.m */,
 				E7DB215F22B2F3EC005AC45F /* RCTUIManagerScenarioTests.m */,
@@ -717,6 +721,7 @@
 				E7DB216622B2F3EC005AC45F /* RCTRootViewIntegrationTests.m in Sources */,
 				E7DB216422B2F3EC005AC45F /* RCTUIManagerScenarioTests.m in Sources */,
 				E7DB216522B2F3EC005AC45F /* RNTesterSnapshotTests.m in Sources */,
+				38C8AC1F246611E500BA7FAA /* RNTesterLoadAllPages.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RNTester/js/RNTesterApp.ios.js
+++ b/RNTester/js/RNTesterApp.ios.js
@@ -25,6 +25,7 @@ const {
   BackHandler,
   Button,
   Linking,
+  NativeModules,
   Platform,
   SafeAreaView,
   StyleSheet,
@@ -33,6 +34,9 @@ const {
   View,
   LogBox,
 } = require('react-native');
+
+const {TestModule} = NativeModules;
+const requestAnimationFrame = require('fbjs/lib/requestAnimationFrame');
 
 import type {RNTesterExample} from './types/RNTesterTypes';
 import type {RNTesterAction} from './utils/RNTesterActions';
@@ -266,7 +270,50 @@ RNTesterList.ComponentExamples.concat(RNTesterList.APIExamples).forEach(
         () => Snapshotter,
       );
     }
+
+    class LoadPageTest extends React.Component<{}> {
+      componentDidMount() {
+        requestAnimationFrame(() => {
+          TestModule.markTestCompleted();
+        });
+      }
+
+      render() {
+        return <RNTesterExampleContainer module={ExampleModule} />;
+      }
+    }
+
+    AppRegistry.registerComponent(
+      'LoadPageTest_' + Example.key,
+      () => LoadPageTest,
+    );
   },
+);
+
+class EnumerateExamplePages extends React.Component<{}> {
+  render() {
+    RNTesterList.ComponentExamples.concat(RNTesterList.APIExamples).forEach(
+      (Example: RNTesterExample) => {
+        let skipTest = false;
+        if ('skipTest' in Example) {
+          const platforms = Example.skipTest;
+          skipTest =
+            platforms !== undefined &&
+            (Platform.OS in platforms || 'default' in platforms);
+        }
+        if (!skipTest) {
+          console.trace(Example.key);
+        }
+      },
+    );
+    TestModule.markTestCompleted();
+    return <View />;
+  }
+}
+
+AppRegistry.registerComponent(
+  'EnumerateExamplePages',
+  () => EnumerateExamplePages,
 );
 
 module.exports = RNTesterApp;

--- a/RNTester/js/types/RNTesterTypes.js
+++ b/RNTester/js/types/RNTesterTypes.js
@@ -44,4 +44,5 @@ export type RNTesterExample = $ReadOnly<{|
   key: string,
   module: RNTesterExampleModule,
   supportsTVOS?: boolean,
+  skipTest?: {[string]: string}, 
 |}>;

--- a/RNTester/js/types/RNTesterTypes.js
+++ b/RNTester/js/types/RNTesterTypes.js
@@ -50,5 +50,5 @@ export type RNTesterExample = $ReadOnly<{|
   key: string,
   module: RNTesterExampleModule,
   supportsTVOS?: boolean,
-  skipTest?: RNSkipTests, 
+  skipTest?: RNSkipTests,
 |}>;

--- a/RNTester/js/types/RNTesterTypes.js
+++ b/RNTester/js/types/RNTesterTypes.js
@@ -40,9 +40,15 @@ export type RNTesterExampleModule = $ReadOnly<{|
   simpleExampleContainer?: ?boolean,
 |}>;
 
+export type RNSkipTests = $ReadOnly<{|
+  default?: string,
+  ios?: string,
+  android?: string,
+|}>;
+
 export type RNTesterExample = $ReadOnly<{|
   key: string,
   module: RNTesterExampleModule,
   supportsTVOS?: boolean,
-  skipTest?: {[string]: string}, 
+  skipTest?: RNSkipTests, 
 |}>;

--- a/RNTester/js/utils/RNTesterList.ios.js
+++ b/RNTester/js/utils/RNTesterList.ios.js
@@ -71,6 +71,10 @@ const ComponentExamples: Array<RNTesterExample> = [
     key: 'MultiColumnExample',
     module: require('../examples/MultiColumn/MultiColumnExample'),
     supportsTVOS: true,
+    skipTest: {
+      default:
+        'Reason: Intermittent failure: Terminating app due to uncaught exception: Application tried to present modally an active controller: Missing request token for request:  http://localhost:8081/assets/RNTester/js/assets/like.png...',
+    },
   },
   {
     key: 'NewAppScreenExample',
@@ -126,6 +130,10 @@ const ComponentExamples: Array<RNTesterExample> = [
     key: 'SectionListExample',
     module: require('../examples/SectionList/SectionListExample'),
     supportsTVOS: true,
+    skipTest: {
+      default:
+        'Reason: Intermittent failure: Terminating app due to uncaught exception: Application tried to present modally an active controller: Missing request token for request:  http://localhost:8081/assets/RNTester/js/assets/like.png...',
+    },
   },
   {
     key: 'SegmentedControlIOSExample',
@@ -293,11 +301,19 @@ const APIExamples: Array<RNTesterExample> = [
     key: 'PushNotificationIOSExample',
     module: require('../examples/PushNotificationIOS/PushNotificationIOSExample'),
     supportsTVOS: false,
+    skipTest: {
+      ios:
+        'Reason: Requires remote notifications which are not supported in iOS Simulator.',
+    },
   },
   {
     key: 'RCTRootViewIOSExample',
     module: require('../examples/RCTRootView/RCTRootViewIOSExample'),
     supportsTVOS: true,
+    skipTest: {
+      default:
+        'Reason: requires native components and is convered by RCTRootViewIntegrationTests',
+    },
   },
   {
     key: 'RTLExample',
@@ -323,11 +339,17 @@ const APIExamples: Array<RNTesterExample> = [
     key: 'TransformExample',
     module: require('../examples/Transform/TransformExample'),
     supportsTVOS: true,
+    skipTest: {
+      default: 'Reason: Stack overflow in jsi.',
+    },
   },
   {
     key: 'TurboModuleExample',
     module: require('../examples/TurboModule/TurboModuleExample'),
     supportsTVOS: false,
+    skipTest: {
+      default: 'Reason: requires TurboModule to be configured in host app.',
+    },
   },
   {
     key: 'TVEventHandlerExample',

--- a/RNTester/js/utils/RNTesterList.ios.js
+++ b/RNTester/js/utils/RNTesterList.ios.js
@@ -71,10 +71,6 @@ const ComponentExamples: Array<RNTesterExample> = [
     key: 'MultiColumnExample',
     module: require('../examples/MultiColumn/MultiColumnExample'),
     supportsTVOS: true,
-    skipTest: {
-      default:
-        'Reason: Intermittent failure: Terminating app due to uncaught exception: Application tried to present modally an active controller: Missing request token for request:  http://localhost:8081/assets/RNTester/js/assets/like.png...',
-    },
   },
   {
     key: 'NewAppScreenExample',
@@ -130,10 +126,6 @@ const ComponentExamples: Array<RNTesterExample> = [
     key: 'SectionListExample',
     module: require('../examples/SectionList/SectionListExample'),
     supportsTVOS: true,
-    skipTest: {
-      default:
-        'Reason: Intermittent failure: Terminating app due to uncaught exception: Application tried to present modally an active controller: Missing request token for request:  http://localhost:8081/assets/RNTester/js/assets/like.png...',
-    },
   },
   {
     key: 'SegmentedControlIOSExample',


### PR DESCRIPTION
## Summary

This change adds an iOS integration test that loads each of the RNTester example pages ensuring that all the tests are free of RedBox errors on load.   Several of these test pages and some of the existing integration tests suffer intermittent failures due to unfinished RCTImageLoader tasks when the test loader deallocs.  

The `RNTesterLoadAllPages` is an `XCTestCase` sublcass that overrides the `defaultTestSuite` class method. In this method it run uses the `RCTTestRunner` to run a new JavaScript "test" in `RNTester.ios.js` called `EnumerateExamplePages`. This JavaScript test simply writes to console the key names of each test page in the `RNTesterList.ios.js` map.  In `defaultTestSuite` a bridge log block function captures the console and builds up an array of the test names. It creates an `XCTestCase` for each test and returns the tests. This method for dynamically creating the tests at runtime was borrowed from GTMGoogleTestRunner.

When each dynamically created `XCTestCase` is executed, it's selector IMP also uses `RCTTestRunner` to run an RNTester test named `"LoadPageTest_<key>"`. In `RNTesterApp.ios.js` instances of a new component LoadPageTest is created for each RNTester page and registered using the scheme `"LoadPageTest_<key>"` in a way similar to how the existing Snapshot tests are registered.

Some RNTester pages cannot be tested in this manner: some pages require native modules that only function in the full RNTester app (these pages have their own dedicated integration test code), don't function in the iOS Simulator, or have other issues. A new skipTest key is added the `RNTesterTypes` to allow individual tests to be skipped by providing a "reason" string.

`RCTImageLoader` is modified to expose a `activeTasks` readonly property that returns the value of the `_activeTasks` ivar.   `RCTTestRunnder`'s while loop that waits for the test to complete is modified to wait until activeTasks to be zero.

This contribution was implemented in the https://github.com/microsoft/react-native-macos fork and has proven to be very useful in catching regressions in RNTester examples and in the general reliability of the iOS and macOS integration tests.  https://github.com/microsoft/react-native-macos/issues/368

## Changelog

[iOS] [Fixed] - Add a test that loads all RNTester pages and improve reliability of RCTTestRunner

## Test Plan

Ran RNTester integration tests locally.