### PR TITLE
docs: mention prettier in eslint-config README

### DIFF
--- a/packages/eslint-config-react-native-community/README.md
+++ b/packages/eslint-config-react-native-community/README.md
@@ -5,7 +5,7 @@
 ## Installation
 
 ```
-yarn add --dev eslint @react-native-community/eslint-config
+yarn add --dev eslint prettier @react-native-community/eslint-config
 ```
 
 *Note: We're using `yarn` to install deps. Feel free to change commands to use `npm` 3+ and `npx` if you like*


### PR DESCRIPTION
## Summary

The combination of `eslint` (v7.0.0), `@react-native-community/eslint-config` (v1.1.0), and `flow-typed` (v3.1.0) causes the following error (`ESLint couldn't find the plugin "eslint-plugin-prettier"`) because `flow-typed` (v3.1.0) depends on `prettier: ^1.19.1` (c.f. https://github.com/flow-typed/flow-typed/blob/master/cli/package.json#L38).
To deal with the error, developers should install `prettier` (v2.x) directly in `devDependencies`.

```
Oops! Something went wrong! :(

ESLint: 7.0.0

ESLint couldn't find the plugin "eslint-plugin-prettier".

(The package "eslint-plugin-prettier" was not found when loaded as a Node module from the directory "/Users/exkazuu/Projects/test".)

It's likely that the plugin isn't installed correctly. Try reinstalling by running the following:

    npm install eslint-plugin-prettier@latest --save-dev

The plugin "eslint-plugin-prettier" was referenced from the config file in ".eslintrc.js » @react-native-community/eslint-config".

If you still can't figure out the problem, please stop by https://gitter.im/eslint/eslint to chat with the team.
```

## Changelog

[Internal] [Changed] - `@react-native-community/eslint-config` README recommends developers to install prettier directly

## Test Plan

This PR changes only README, so tests are not required.