### PR TITLE
Add timeout support to `Networking`

### DIFF
--- a/Libraries/Network/RCTNetworking.android.js
+++ b/Libraries/Network/RCTNetworking.android.js
@@ -41,6 +41,8 @@ function generateRequestId(): number {
  * requestId to each network request that can be used to abort that request later on.
  */
 class RCTNetworking extends NativeEventEmitter {
+  _timeout: number = 0;
+
   constructor() {
     super(NativeNetworkingAndroid);
   }
@@ -73,7 +75,7 @@ class RCTNetworking extends NativeEventEmitter {
       {...body, trackingName},
       responseType,
       incrementalUpdates,
-      timeout,
+      timeout || this._timeout,
       withCredentials,
     );
     callback(requestId);
@@ -85,6 +87,10 @@ class RCTNetworking extends NativeEventEmitter {
 
   clearCookies(callback: (result: boolean) => any) {
     NativeNetworkingAndroid.clearCookies(callback);
+  }
+
+  setTimeout(timeout: number) {
+    this._timeout = timeout;
   }
 }
 

--- a/Libraries/Network/RCTNetworking.ios.js
+++ b/Libraries/Network/RCTNetworking.ios.js
@@ -19,6 +19,8 @@ import type {NativeResponseType} from './XMLHttpRequest';
 import type {RequestBody} from './convertRequestBody';
 
 class RCTNetworking extends NativeEventEmitter {
+  _timeout: number = 0;
+
   constructor() {
     super(NativeNetworkingIOS);
   }
@@ -44,7 +46,7 @@ class RCTNetworking extends NativeEventEmitter {
         headers,
         responseType,
         incrementalUpdates,
-        timeout,
+        timeout: timeout || this._timeout,
         withCredentials,
       },
       callback,
@@ -57,6 +59,10 @@ class RCTNetworking extends NativeEventEmitter {
 
   clearCookies(callback: (result: boolean) => void) {
     NativeNetworkingIOS.clearCookies(callback);
+  }
+
+  setTimeout(timeout: number) {
+    this._timeout = timeout;
   }
 }
 


### PR DESCRIPTION
## Summary

As we all know, `fetch` has no built-in timeout option. But, there are many workarounds such as using `XMLHttpRequest API`, `AbortController` and `setTimeout + Promise`

Since it is rare to set a timeout for each API function, I thought I would like to have an easy way to set global settings without these workarounds.

Looking at the internal implementation, the final function called `RCTNetworking.sendRequest` has already a timeout parameter. Also, `Networking` module are exported externally.

I guess it would be nice to have a global setting function as shown below.

```javascript
// App.js
import { Networking } from 'react-native';

// Setting default timeout
Networking.setTimeout(5000);
```

If timeout is set in XMLHttpRequest, it does not affect and has backward compatibility. We can set a default timeout with `Networking.setTimeout` and have individual timeouts for each function.

```javascript
// Component.js
import axios from 'axios';

// Its timeout is 1 second, not 5 seconds.
const instance = axios.create({
  baseURL: 'https://some-domain.com/api/',
  timeout: 1000,
});
```

Please comment on a better implementation.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Added] - Add timeout support to `Networking`

## Test Plan

Tested in my development environment.
