### PR TITLE
Fix imports in `RCTUtilsUIOverride.h`

### DIFF
--- a/React/Base/RCTUtilsUIOverride.h
+++ b/React/Base/RCTUtilsUIOverride.h
@@ -5,6 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
 @interface RCTUtilsUIOverride : NSObject
 /**
  Set the global presented view controller instance override.


### PR DESCRIPTION
## Summary

While we build react native 0.62.2 via our Bazel build system, encountered those following errors due to lack of appropriate imports:
```
external/React-Core/React/Base/RCTUtilsUIOverride.h:8:33: error: cannot find interface declaration for 'NSObject', superclass of 'RCTUtilsUIOverride'
@interface RCTUtilsUIOverride : NSObject
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   ^
external/React-Core/React/Base/RCTUtilsUIOverride.h:12:37: error: expected a type
+ (void)setPresentedViewController:(UIViewController *)presentedViewController;
                                    ^
```
Add the appropriate imports `<Foundation/Foundation.h>` and `<UIKit/UIKit.h>` fix those errors. 

Honestly I dont know how it's supposed to work without those imports. Also all the siblings files have the correct imports. e.g. [RCTUtils.h](https://github.com/discord/react-native/blob/15a5f3624c40624d8dd0307bbcc1f2b2aba15a1b/React/Base/RCTUtils.h)

## Changelog

[iOS] [Fixed] - Fix imports in `RCTUtilsUIOverride.h`

## Test Plan

RN tester iOS app runs fine.

