### PR TITLE
Android: Add support to pass Touch events through native views

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/touch/JSResponderView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/touch/JSResponderView.java
@@ -1,0 +1,14 @@
+package com.facebook.react.touch;
+
+/**
+ * This interface should be implemented by all {@link View} subclasses that want to use
+ * JSResponder's touches
+ */
+public interface JSResponderView {
+
+  /**
+   * Basically this is onTouchEvent replacement for JSTouchDispatcher
+   * Overriding it and returning "false" will lead to pass JSTouchDispatcher underneath the view
+   */
+  boolean onJSTouchEvent(float x, float y);
+}

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/TouchTargetHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/TouchTargetHelper.java
@@ -16,8 +16,8 @@ import android.view.ViewGroup;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
 import com.facebook.react.bridge.UiThreadUtil;
+import com.facebook.react.touch.JSResponderView;
 import com.facebook.react.touch.ReactHitSlopView;
-import com.facebook.react.views.view.ReactViewGroup;
 
 /**
  * Class responsible for identifying which react view should handle a given {@link MotionEvent}. It
@@ -163,7 +163,7 @@ public class TouchTargetHelper {
       localX = localXY[0];
       localY = localXY[1];
     }
-    if (child instanceof ReactViewGroup && !((ReactViewGroup) child).onJSTouchEvent(localX, localY)){
+    if (child instanceof JSResponderView && !((JSResponderView) child).onJSTouchEvent(localX, localY)){
       return false;
 
     }

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/TouchTargetHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/TouchTargetHelper.java
@@ -17,6 +17,7 @@ import androidx.annotation.Nullable;
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
 import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.touch.ReactHitSlopView;
+import com.facebook.react.views.view.ReactViewGroup;
 
 /**
  * Class responsible for identifying which react view should handle a given {@link MotionEvent}. It
@@ -161,6 +162,10 @@ public class TouchTargetHelper {
       inverseMatrix.mapPoints(localXY);
       localX = localXY[0];
       localY = localXY[1];
+    }
+    if (child instanceof ReactViewGroup && !((ReactViewGroup) child).onJSTouchEvent(localX, localY)){
+      return false;
+
     }
     if (child instanceof ReactHitSlopView && ((ReactHitSlopView) child).getHitSlopRect() != null) {
       Rect hitSlopRect = ((ReactHitSlopView) child).getHitSlopRect();

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -33,6 +33,7 @@ import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.common.annotations.VisibleForTesting;
 import com.facebook.react.config.ReactFeatureFlags;
 import com.facebook.react.modules.i18nmanager.I18nUtil;
+import com.facebook.react.touch.JSResponderView;
 import com.facebook.react.touch.OnInterceptTouchEventListener;
 import com.facebook.react.touch.ReactHitSlopView;
 import com.facebook.react.touch.ReactInterceptingViewGroup;
@@ -58,7 +59,8 @@ public class ReactViewGroup extends ViewGroup
         ReactClippingViewGroup,
         ReactPointerEventsView,
         ReactHitSlopView,
-        ReactZIndexedViewGroup {
+        ReactZIndexedViewGroup,
+        JSResponderView {
 
   private static final int ARRAY_CAPACITY_INCREMENT = 12;
   private static final int DEFAULT_BACKGROUND_COLOR = Color.TRANSPARENT;
@@ -231,9 +233,10 @@ public class ReactViewGroup extends ViewGroup
     return true;
   }
 
-  /** Basically this is onTouchEvent replacement for JSTouchDispatcher
-   * Overriding it and returning "false" will lead to pass JSTouchDispatcher underneath the view
-   * */
+  /**
+   * We override this to allow developers to determine whether they need to pass click through view
+   */
+  @Override
   public boolean onJSTouchEvent(float x, float y) {
     return true;
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -231,6 +231,13 @@ public class ReactViewGroup extends ViewGroup
     return true;
   }
 
+  /** Basically this is onTouchEvent replacement for JSTouchDispatcher
+   * Overriding it and returning "false" will lead to pass JSTouchDispatcher underneath the view
+   * */
+  public boolean onJSTouchEvent(float x, float y) {
+    return true;
+  }
+
   /**
    * We override this to allow developers to determine whether they need offscreen alpha compositing
    * or not. See the documentation of needsOffscreenAlphaCompositing in View.js.


### PR DESCRIPTION
## Summary
The main reason explained here:
https://github.com/facebook/react-native/issues/28953

## Changelog
[Android] [Added] - **onTouchEvent**-alternative for JSTouchDispatcher ReactViewGroup

## Test Plan
Now we can easily do things like this:
![out](https://user-images.githubusercontent.com/5202281/82733195-e8e12080-9d1a-11ea-8b0d-98d226fed3df.gif)

