### PR TITLE
Improve XMLHttpRequest/Networking API performance

### DIFF
--- a/Libraries/FBReactNativeSpec/FBReactNativeSpec/FBReactNativeSpec-generated.mm
+++ b/Libraries/FBReactNativeSpec/FBReactNativeSpec/FBReactNativeSpec-generated.mm
@@ -1741,7 +1741,7 @@ namespace facebook {
 
     
     static facebook::jsi::Value __hostFunction_NativeNetworkingAndroidSpecJSI_sendRequest(facebook::jsi::Runtime& rt, TurboModule &turboModule, const facebook::jsi::Value* args, size_t count) {
-      return static_cast<ObjCTurboModule&>(turboModule).invokeObjCMethod(rt, VoidKind, "sendRequest", @selector(sendRequest:url:requestId:headers:data:responseType:useIncrementalUpdates:timeout:withCredentials:), args, count);
+      return static_cast<ObjCTurboModule&>(turboModule).invokeObjCMethod(rt, VoidKind, "sendRequest", @selector(sendRequest:url:requestId:headers:data:responseType:useIncrementalUpdates:timeout:withCredentials:useImprovedEvent:), args, count);
     }
 
     static facebook::jsi::Value __hostFunction_NativeNetworkingAndroidSpecJSI_abortRequest(facebook::jsi::Runtime& rt, TurboModule &turboModule, const facebook::jsi::Value* args, size_t count) {

--- a/Libraries/FBReactNativeSpec/FBReactNativeSpec/FBReactNativeSpec.h
+++ b/Libraries/FBReactNativeSpec/FBReactNativeSpec/FBReactNativeSpec.h
@@ -1823,7 +1823,8 @@ namespace facebook {
        responseType:(NSString *)responseType
 useIncrementalUpdates:(BOOL)useIncrementalUpdates
             timeout:(double)timeout
-    withCredentials:(BOOL)withCredentials;
+    withCredentials:(BOOL)withCredentials
+   useImprovedEvent:(BOOL)useImprovedEvent;
 - (void)abortRequest:(double)requestId;
 - (void)clearCookies:(RCTResponseSenderBlock)callback;
 - (void)addListener:(NSString *)eventName;
@@ -1855,6 +1856,7 @@ namespace JS {
       bool incrementalUpdates() const;
       double timeout() const;
       bool withCredentials() const;
+      bool improvedEvent() const;
 
       SpecSendRequestQuery(NSDictionary *const v) : _v(v) {}
     private:
@@ -3591,6 +3593,11 @@ inline double JS::NativeNetworkingIOS::SpecSendRequestQuery::timeout() const
 inline bool JS::NativeNetworkingIOS::SpecSendRequestQuery::withCredentials() const
 {
   id const p = _v[@"withCredentials"];
+  return RCTBridgingToBool(p);
+}
+inline bool JS::NativeNetworkingIOS::SpecSendRequestQuery::improvedEvent() const
+{
+  id const p = _v[@"improvedEvent"];
   return RCTBridgingToBool(p);
 }
 inline JS::NativePlatformConstantsAndroid::ConstantsReactNativeVersion::Builder::Builder(const Input i) : _factory(^{

--- a/Libraries/Network/NativeNetworkingAndroid.js
+++ b/Libraries/Network/NativeNetworkingAndroid.js
@@ -26,6 +26,7 @@ export interface Spec extends TurboModule {
     useIncrementalUpdates: boolean,
     timeout: number,
     withCredentials: boolean,
+    useImprovedEvent?: boolean,
   ) => void;
   +abortRequest: (requestId: number) => void;
   +clearCookies: (callback: (result: boolean) => void) => void;

--- a/Libraries/Network/NativeNetworkingIOS.js
+++ b/Libraries/Network/NativeNetworkingIOS.js
@@ -24,6 +24,7 @@ export interface Spec extends TurboModule {
       incrementalUpdates: boolean,
       timeout: number,
       withCredentials: boolean,
+      improvedEvent?: boolean,
     |},
     callback: (requestId: number) => void,
   ) => void;

--- a/Libraries/Network/RCTNetworking.android.js
+++ b/Libraries/Network/RCTNetworking.android.js
@@ -56,6 +56,7 @@ class RCTNetworking extends NativeEventEmitter {
     timeout: number,
     callback: (requestId: number) => mixed,
     withCredentials: boolean,
+    improvedEvent?: boolean = false,
   ) {
     const body = convertRequestBody(data);
     if (body && body.formData) {
@@ -75,6 +76,7 @@ class RCTNetworking extends NativeEventEmitter {
       incrementalUpdates,
       timeout,
       withCredentials,
+      improvedEvent,
     );
     callback(requestId);
   }

--- a/Libraries/Network/RCTNetworking.ios.js
+++ b/Libraries/Network/RCTNetworking.ios.js
@@ -34,6 +34,7 @@ class RCTNetworking extends NativeEventEmitter {
     timeout: number,
     callback: (requestId: number) => void,
     withCredentials: boolean,
+    improvedEvent?: boolean = false,
   ) {
     const body = convertRequestBody(data);
     NativeNetworkingIOS.sendRequest(
@@ -46,6 +47,7 @@ class RCTNetworking extends NativeEventEmitter {
         incrementalUpdates,
         timeout,
         withCredentials,
+        improvedEvent,
       },
       callback,
     );

--- a/Libraries/Network/RCTNetworking.mm
+++ b/Libraries/Network/RCTNetworking.mm
@@ -147,6 +147,7 @@ static NSString *RCTGenerateFormBoundary()
 @implementation RCTNetworking
 {
   NSMutableDictionary<NSNumber *, RCTNetworkTask *> *_tasksByRequestID;
+  NSMutableDictionary<NSNumber *, NSNumber *> *_improvedEventsByRequestID;
   std::mutex _handlersLock;
   NSArray<id<RCTURLRequestHandler>> *_handlers;
   NSArray<id<RCTURLRequestHandler>> * (^_handlersProvider)(void);
@@ -172,6 +173,7 @@ RCT_EXPORT_MODULE()
     [_tasksByRequestID[requestID] cancel];
   }
   [_tasksByRequestID removeAllObjects];
+  [_improvedEventsByRequestID removeAllObjects];
   _handlers = nil;
   _requestHandlers = nil;
   _responseHandlers = nil;
@@ -184,7 +186,8 @@ RCT_EXPORT_MODULE()
            @"didSendNetworkData",
            @"didReceiveNetworkIncrementalData",
            @"didReceiveNetworkDataProgress",
-           @"didReceiveNetworkData"];
+           @"didReceiveNetworkData",
+           @"events"];
 }
 
 - (id<RCTURLRequestHandler>)handlerForRequest:(NSURLRequest *)request
@@ -508,13 +511,14 @@ RCT_EXPORT_MODULE()
       return;
     }
   }
-
-  [self sendEventWithName:@"didReceiveNetworkData" body:@[task.requestID, responseData]];
+    
+  [self sendEvent:@"didReceiveNetworkData" body:@[task.requestID, responseData] forTask:task];
 }
 
 - (void)sendRequest:(NSURLRequest *)request
        responseType:(NSString *)responseType
  incrementalUpdates:(BOOL)incrementalUpdates
+      improvedEvent:(BOOL)improvedEvent
      responseSender:(RCTResponseSenderBlock)responseSender
 {
   RCTAssertThread(_methodQueue, @"sendRequest: must be called on method queue");
@@ -522,7 +526,7 @@ RCT_EXPORT_MODULE()
   __block RCTNetworkTask *task;
   RCTURLRequestProgressBlock uploadProgressBlock = ^(int64_t progress, int64_t total) {
     NSArray *responseJSON = @[task.requestID, @((double)progress), @((double)total)];
-    [weakSelf sendEventWithName:@"didSendNetworkData" body:responseJSON];
+    [weakSelf sendEvent:@"didSendNetworkData" body:responseJSON forTask:task];
   };
 
   RCTURLRequestResponseBlock responseBlock = ^(NSURLResponse *response) {
@@ -538,7 +542,7 @@ RCT_EXPORT_MODULE()
     }
     id responseURL = response.URL ? response.URL.absoluteString : [NSNull null];
     NSArray<id> *responseJSON = @[task.requestID, @(status), headers, responseURL];
-    [weakSelf sendEventWithName:@"didReceiveNetworkResponse" body:responseJSON];
+    [weakSelf sendEvent:@"didReceiveNetworkResponse" body:responseJSON forTask:task];
   };
 
   // XHR does not allow you to peek at xhr.response before the response is
@@ -571,12 +575,12 @@ RCT_EXPORT_MODULE()
                                       @(progress + initialCarryLength - incrementalDataCarry.length),
                                       @(total)];
 
-        [weakSelf sendEventWithName:@"didReceiveNetworkIncrementalData" body:responseJSON];
+        [weakSelf sendEvent:@"didReceiveNetworkIncrementalData" body:responseJSON forTask:task];
       };
     } else {
       downloadProgressBlock = ^(int64_t progress, int64_t total) {
         NSArray<id> *responseJSON = @[task.requestID, @(progress), @(total)];
-        [weakSelf sendEventWithName:@"didReceiveNetworkDataProgress" body:responseJSON];
+        [weakSelf sendEvent:@"didReceiveNetworkDataProgress" body:responseJSON forTask:task];
       };
     }
   }
@@ -601,8 +605,9 @@ RCT_EXPORT_MODULE()
                               error.code == kCFURLErrorTimedOut ? @YES : @NO
                               ];
 
-    [strongSelf sendEventWithName:@"didCompleteNetworkResponse" body:responseJSON];
+    [strongSelf sendEvent:@"didCompleteNetworkResponse" body:responseJSON forTask:task];
     [strongSelf->_tasksByRequestID removeObjectForKey:task.requestID];
+    [strongSelf->_improvedEventsByRequestID removeObjectForKey:task.requestID];
   };
 
   task = [self networkTaskWithRequest:request completionBlock:completionBlock];
@@ -616,10 +621,33 @@ RCT_EXPORT_MODULE()
       _tasksByRequestID = [NSMutableDictionary new];
     }
     _tasksByRequestID[task.requestID] = task;
+
+    if (improvedEvent) {
+      if (!_improvedEventsByRequestID) {
+        _improvedEventsByRequestID = [NSMutableDictionary new];
+      }
+      _improvedEventsByRequestID[task.requestID] = @YES;
+    }
+
     responseSender(@[task.requestID]);
   }
 
   [task start];
+}
+
+- (void)sendEvent:(NSString *)eventName
+             body:(NSArray *)body
+          forTask:(RCTNetworkTask *)task
+{
+  if (_improvedEventsByRequestID[task.requestID]) {
+    NSDictionary *eventsBody = @{
+                                @"eventName": eventName,
+                                @"args": body
+                               };
+    [self sendEventWithName:@"events" body:eventsBody];
+  } else {
+    [self sendEventWithName:eventName body:body];
+  }
 }
 
 #pragma mark - Public API
@@ -679,6 +707,7 @@ RCT_EXPORT_METHOD(sendRequest:(JS::NativeNetworkingIOS::SpecSendRequestQuery &)q
     @"incrementalUpdates": @(query.incrementalUpdates()),
     @"timeout": @(query.timeout()),
     @"withCredentials": @(query.withCredentials()),
+    @"improvedEvent": @(query.improvedEvent()),
   };
   
   // TODO: buildRequest returns a cancellation block, but there's currently
@@ -687,9 +716,11 @@ RCT_EXPORT_METHOD(sendRequest:(JS::NativeNetworkingIOS::SpecSendRequestQuery &)q
   [self buildRequest:queryDict completionBlock:^(NSURLRequest *request) {
     NSString *responseType = [RCTConvert NSString:queryDict[@"responseType"]];
     BOOL incrementalUpdates = [RCTConvert BOOL:queryDict[@"incrementalUpdates"]];
+    BOOL improvedEvent = [RCTConvert BOOL:queryDict[@"improvedEvent"]];
     [self sendRequest:request
          responseType:responseType
    incrementalUpdates:incrementalUpdates
+        improvedEvent:improvedEvent
        responseSender:responseSender];
   }];
 }

--- a/Libraries/Network/__tests__/XMLHttpRequest-test.js
+++ b/Libraries/Network/__tests__/XMLHttpRequest-test.js
@@ -140,7 +140,7 @@ describe('XMLHttpRequest', function() {
     xhr.open('GET', 'blabla');
     xhr.send();
     setRequestId(2);
-    xhr.__didReceiveData(requestId, 'Some data');
+    xhr._didReceiveData([requestId, 'Some data']);
     expect(xhr.responseText).toBe('Some data');
   });
 
@@ -148,8 +148,8 @@ describe('XMLHttpRequest', function() {
     xhr.open('GET', 'blabla');
     xhr.send();
     setRequestId(3);
-    xhr.__didCompleteResponse(requestId, 'Timeout', true);
-    xhr.__didCompleteResponse(requestId, 'Timeout', true);
+    xhr._didCompleteResponse([requestId, 'Timeout', true]);
+    xhr._didCompleteResponse([requestId, 'Timeout', true]);
 
     expect(xhr.readyState).toBe(xhr.DONE);
 
@@ -168,7 +168,7 @@ describe('XMLHttpRequest', function() {
     xhr.open('GET', 'blabla');
     xhr.send();
     setRequestId(4);
-    xhr.__didCompleteResponse(requestId, 'Generic error');
+    xhr._didCompleteResponse([requestId, 'Generic error']);
 
     expect(xhr.readyState).toBe(xhr.DONE);
 
@@ -189,7 +189,7 @@ describe('XMLHttpRequest', function() {
     xhr.open('GET', 'blabla');
     xhr.send();
     setRequestId(5);
-    xhr.__didCompleteResponse(requestId, null);
+    xhr._didCompleteResponse([requestId, null]);
 
     expect(xhr.readyState).toBe(xhr.DONE);
 
@@ -214,7 +214,7 @@ describe('XMLHttpRequest', function() {
     const handleProgress = jest.fn();
     xhr.upload.addEventListener('progress', handleProgress);
     setRequestId(6);
-    xhr.__didUploadProgress(requestId, 42, 100);
+    xhr._didUploadProgress([requestId, 42, 100]);
 
     expect(xhr.upload.onprogress.mock.calls.length).toBe(1);
     expect(handleProgress.mock.calls.length).toBe(1);
@@ -229,10 +229,11 @@ describe('XMLHttpRequest', function() {
     xhr.open('GET', 'blabla');
     xhr.send();
     setRequestId(7);
-    xhr.__didReceiveResponse(requestId, 200, {
+    const header = {
       'Content-Type': 'text/plain; charset=utf-8',
       'Content-Length': '32',
-    });
+    };
+    xhr._didReceiveResponse([requestId, 200, header]);
 
     expect(xhr.getAllResponseHeaders()).toBe(
       'Content-Type: text/plain; charset=utf-8\r\n' + 'Content-Length: 32',

--- a/ReactAndroid/src/main/java/com/facebook/fbreact/specs/NativeNetworkingAndroidSpec.java
+++ b/ReactAndroid/src/main/java/com/facebook/fbreact/specs/NativeNetworkingAndroidSpec.java
@@ -38,7 +38,7 @@ public abstract class NativeNetworkingAndroidSpec extends ReactContextBaseJavaMo
   @ReactMethod
   public abstract void sendRequest(String method, String url, double requestId,
       ReadableArray headers, ReadableMap data, String responseType, boolean useIncrementalUpdates,
-      double timeout, boolean withCredentials);
+      double timeout, boolean withCredentials, boolean useImprovedEvent);
 
   @ReactMethod
   public abstract void addListener(String eventName);

--- a/ReactAndroid/src/main/java/com/facebook/fbreact/specs/jni/FBReactNativeSpec-generated.cpp
+++ b/ReactAndroid/src/main/java/com/facebook/fbreact/specs/jni/FBReactNativeSpec-generated.cpp
@@ -1501,7 +1501,7 @@ namespace facebook {
 
     
     static facebook::jsi::Value __hostFunction_NativeNetworkingAndroidSpecJSI_sendRequest(facebook::jsi::Runtime& rt, TurboModule &turboModule, const facebook::jsi::Value* args, size_t count) {
-      return static_cast<JavaTurboModule&>(turboModule).invokeJavaMethod(rt, VoidKind, "sendRequest", "(Ljava/lang/String;Ljava/lang/String;DLcom/facebook/react/bridge/ReadableArray;Lcom/facebook/react/bridge/ReadableMap;Ljava/lang/String;ZDZ)V", args, count);
+      return static_cast<JavaTurboModule&>(turboModule).invokeJavaMethod(rt, VoidKind, "sendRequest", "(Ljava/lang/String;Ljava/lang/String;DLcom/facebook/react/bridge/ReadableArray;Lcom/facebook/react/bridge/ReadableMap;Ljava/lang/String;ZDZZ)V", args, count);
     }
 
     static facebook::jsi::Value __hostFunction_NativeNetworkingAndroidSpecJSI_abortRequest(facebook::jsi::Runtime& rt, TurboModule &turboModule, const facebook::jsi::Value* args, size_t count) {

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.java
@@ -236,10 +236,14 @@ public final class NetworkingModule extends NativeNetworkingAndroidSpec {
       String responseType,
       boolean useIncrementalUpdates,
       double timeoutAsDouble,
-      boolean withCredentials) {
+      boolean withCredentials,
+      boolean useImprovedEvent) {
     int requestId = (int) requestIdAsDouble;
     int timeout = (int) timeoutAsDouble;
+    
     try {
+      ResponseUtil.setImprovedEvent(requestId, useImprovedEvent);
+
       sendRequestInternal(
           method,
           url,
@@ -255,6 +259,8 @@ public final class NetworkingModule extends NativeNetworkingAndroidSpec {
       final RCTDeviceEventEmitter eventEmitter = getEventEmitter("sendRequest error");
       if (eventEmitter != null) {
         ResponseUtil.onRequestError(eventEmitter, requestId, th.getMessage(), th);
+      } else if (useImprovedEvent) {
+        ResponseUtil.removeImprovedEvent(requestId);
       }
     }
   }

--- a/ReactAndroid/src/test/java/com/facebook/react/modules/network/NetworkingModuleTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/modules/network/NetworkingModuleTest.java
@@ -112,7 +112,8 @@ public class NetworkingModuleTest {
         /* responseType */ "text",
         /* useIncrementalUpdates*/ true,
         /* timeout */ 0,
-        /* withCredentials */ false);
+        /* withCredentials */ false,
+        /* useImprovedEvent */ true);
 
     ArgumentCaptor<Request> argumentCaptor = ArgumentCaptor.forClass(Request.class);
     verify(mHttpClient).newCall(argumentCaptor.capture());
@@ -131,15 +132,16 @@ public class NetworkingModuleTest {
     mNetworkingModule.sendRequest(
         "GET",
         "http://somedoman/foo",
-        /* requestId */ 0,
+        /* requestId */ 1,
         /* headers */ JavaOnlyArray.from(invalidHeaders),
         /* body */ null,
         /* responseType */ "text",
         /* useIncrementalUpdates*/ true,
         /* timeout */ 0,
-        /* withCredentials */ false);
+        /* withCredentials */ false,
+        /* useImprovedEvent */ false);
 
-    verifyErrorEmit(mEmitter, 0);
+    verifyErrorEmit(mEmitter, 1);
   }
 
   @Test
@@ -152,15 +154,16 @@ public class NetworkingModuleTest {
     mNetworkingModule.sendRequest(
         "POST",
         "http://somedomain/bar",
-        0,
+        1,
         JavaOnlyArray.of(),
         body,
         /* responseType */ "text",
         /* useIncrementalUpdates*/ true,
         /* timeout */ 0,
-        /* withCredentials */ false);
+        /* withCredentials */ false,
+        /* useImprovedEvent */ false);
 
-    verifyErrorEmit(mEmitter, 0);
+    verifyErrorEmit(mEmitter, 1);
   }
 
   @Test
@@ -170,15 +173,16 @@ public class NetworkingModuleTest {
     mNetworkingModule.sendRequest(
         "GET",
         "aaa",
-        /* requestId */ 0,
+        /* requestId */ 1,
         /* headers */ JavaOnlyArray.of(),
         /* body */ null,
         /* responseType */ "text",
         /* useIncrementalUpdates*/ true,
         /* timeout */ 0,
-        /* withCredentials */ false);
+        /* withCredentials */ false,
+        /* useImprovedEvent */ false);
 
-    verifyErrorEmit(mEmitter, 0);
+    verifyErrorEmit(mEmitter, 1);
   }
 
   private static void verifyErrorEmit(RCTDeviceEventEmitter emitter, int requestId) {
@@ -227,7 +231,8 @@ public class NetworkingModuleTest {
         /* responseType */ "text",
         /* useIncrementalUpdates*/ true,
         /* timeout */ 0,
-        /* withCredentials */ false);
+        /* withCredentials */ false,
+        /* useImprovedEvent */ true);
 
     ArgumentCaptor<Request> argumentCaptor = ArgumentCaptor.forClass(Request.class);
     verify(mHttpClient).newCall(argumentCaptor.capture());
@@ -257,7 +262,8 @@ public class NetworkingModuleTest {
         /* responseType */ "text",
         /* useIncrementalUpdates*/ true,
         /* timeout */ 0,
-        /* withCredentials */ false);
+        /* withCredentials */ false,
+        /* useImprovedEvent */ true);
     ArgumentCaptor<Request> argumentCaptor = ArgumentCaptor.forClass(Request.class);
     verify(mHttpClient).newCall(argumentCaptor.capture());
     Headers requestHeaders = argumentCaptor.getValue().headers();
@@ -281,7 +287,8 @@ public class NetworkingModuleTest {
         /* responseType */ "text",
         /* useIncrementalUpdates*/ true,
         /* timeout */ 0,
-        /* withCredentials */ false);
+        /* withCredentials */ false,
+        /* useImprovedEvent */ true);
 
     ArgumentCaptor<Request> argumentCaptor = ArgumentCaptor.forClass(Request.class);
     verify(mHttpClient).newCall(argumentCaptor.capture());
@@ -307,7 +314,8 @@ public class NetworkingModuleTest {
         /* responseType */ "text",
         /* useIncrementalUpdates*/ true,
         /* timeout */ 0,
-        /* withCredentials */ false);
+        /* withCredentials */ false,
+        /* useImprovedEvent */ true);
 
     ArgumentCaptor<Request> argumentCaptor = ArgumentCaptor.forClass(Request.class);
     verify(mHttpClient).newCall(argumentCaptor.capture());
@@ -333,7 +341,8 @@ public class NetworkingModuleTest {
         /* responseType */ "text",
         /* useIncrementalUpdates*/ true,
         /* timeout */ 0,
-        /* withCredentials */ false);
+        /* withCredentials */ false,
+        /* useImprovedEvent */ true);
 
     ArgumentCaptor<Request> argumentCaptor = ArgumentCaptor.forClass(Request.class);
     verify(mHttpClient).newCall(argumentCaptor.capture());
@@ -374,7 +383,8 @@ public class NetworkingModuleTest {
         /* responseType */ "text",
         /* useIncrementalUpdates*/ true,
         /* timeout */ 0,
-        /* withCredentials */ false);
+        /* withCredentials */ false,
+        /* useImprovedEvent */ true);
 
     // verify url, method, headers
     ArgumentCaptor<Request> argumentCaptor = ArgumentCaptor.forClass(Request.class);
@@ -424,7 +434,8 @@ public class NetworkingModuleTest {
         /* responseType */ "text",
         /* useIncrementalUpdates*/ true,
         /* timeout */ 0,
-        /* withCredentials */ false);
+        /* withCredentials */ false,
+        /* useImprovedEvent */ true);
 
     // verify url, method, headers
     ArgumentCaptor<Request> argumentCaptor = ArgumentCaptor.forClass(Request.class);
@@ -515,7 +526,8 @@ public class NetworkingModuleTest {
         /* responseType */ "text",
         /* useIncrementalUpdates*/ true,
         /* timeout */ 0,
-        /* withCredentials */ false);
+        /* withCredentials */ false,
+        /* useImprovedEvent */ true);
 
     // verify RequestBodyPart for image
     PowerMockito.verifyStatic(times(1));
@@ -574,7 +586,8 @@ public class NetworkingModuleTest {
           /* responseType */ "text",
           /* useIncrementalUpdates*/ true,
           /* timeout */ 0,
-          /* withCredentials */ false);
+          /* withCredentials */ false,
+        /* useImprovedEvent */ true);
     }
     verify(mHttpClient, times(3)).newCall(any(Request.class));
 
@@ -619,7 +632,8 @@ public class NetworkingModuleTest {
           /* responseType */ "text",
           /* useIncrementalUpdates*/ true,
           /* timeout */ 0,
-          /* withCredentials */ false);
+          /* withCredentials */ false,
+        /* useImprovedEvent */ true);
     }
     verify(mHttpClient, times(3)).newCall(any(Request.class));
 


### PR DESCRIPTION
## Summary

Probably, there're no apps that do not use `fetch`. `XMLHtttpRequest API`, implemented as `RCTNetworking` native module, uses 6 event listeners to process networking events. For each request, these 6 listeners are registered and removed after processing. I thought this was quite inefficient.

My implementation uses only one event listener. I worked with the following purpose.

### * Increases performance
When tested in my environments(iOS Simulator, Android device), there was about 20% improvement in performance. Here is the simple [benchmark code](https://gist.github.com/ifsnow/670fa52e1707b072722431b53dc4cb13) I used.

### * Keeps backward compatibility
In 0.62 version, `RCTNetworking` was exposed as a public `Networking` API. There may not be many, but I didn't want to affect the modules that use this API. So, I was working on using the improved event option only on the RN core.

------------

Please let me know if there is anything else I have to consider.

## Changelog

[General] [Added] - Improve XMLHttpRequest/Networking API performance

## Test Plan
I confirmed that `fetch` works well in my modified version.
