### PR TITLE
Enable array buffers in JSCRuntime.cpp

### DIFF
--- a/ReactCommon/jsi/JSCRuntime.cpp
+++ b/ReactCommon/jsi/JSCRuntime.cpp
@@ -922,24 +922,17 @@ bool JSCRuntime::isArray(const jsi::Object &obj) const {
 #endif
 }
 
-bool JSCRuntime::isArrayBuffer(const jsi::Object & /*obj*/) const {
-  // TODO: T23270523 - This would fail on builds that use our custom JSC
-  // auto typedArrayType = JSValueGetTypedArrayType(ctx_, objectRef(obj),
-  // nullptr);  return typedArrayType == kJSTypedArrayTypeArrayBuffer;
-  throw std::runtime_error("Unsupported");
+bool JSCRuntime::isArrayBuffer(const jsi::Object &obj) const {
+  auto typedArrayType = JSValueGetTypedArrayType(ctx_, objectRef(obj), nullptr);
+  return typedArrayType == kJSTypedArrayTypeArrayBuffer;
 }
 
-uint8_t *JSCRuntime::data(const jsi::ArrayBuffer & /*obj*/) {
-  // TODO: T23270523 - This would fail on builds that use our custom JSC
-  // return static_cast<uint8_t*>(
-  //    JSObjectGetArrayBufferBytesPtr(ctx_, objectRef(obj), nullptr));
-  throw std::runtime_error("Unsupported");
+uint8_t *JSCRuntime::data(const jsi::ArrayBuffer &obj) {
+  return static_cast<uint8_t*>(JSObjectGetArrayBufferBytesPtr(ctx_, objectRef(obj), nullptr));
 }
 
-size_t JSCRuntime::size(const jsi::ArrayBuffer & /*obj*/) {
-  // TODO: T23270523 - This would fail on builds that use our custom JSC
-  // return JSObjectGetArrayBufferByteLength(ctx_, objectRef(obj), nullptr);
-  throw std::runtime_error("Unsupported");
+size_t JSCRuntime::size(const jsi::ArrayBuffer &obj) {
+  return JSObjectGetArrayBufferByteLength(ctx_, objectRef(obj), nullptr);
 }
 
 bool JSCRuntime::isFunction(const jsi::Object &obj) const {

--- a/ReactCommon/jsi/JSCRuntime.cpp
+++ b/ReactCommon/jsi/JSCRuntime.cpp
@@ -276,6 +276,9 @@ class JSCRuntime : public jsi::Runtime {
 #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_9_0
 #define _JSC_FAST_IS_ARRAY
 #endif
+#if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_10_0
+#define _JSC_NO_ARRAY_BUFFERS
+#endif
 #endif
 #if defined(__MAC_OS_X_VERSION_MIN_REQUIRED)
 #if __MAC_OS_X_VERSION_MIN_REQUIRED >= __MAC_10_11
@@ -283,6 +286,9 @@ class JSCRuntime : public jsi::Runtime {
 // true, this will be a compile-time error and it can be resolved when
 // we understand why.
 #define _JSC_FAST_IS_ARRAY
+#endif
+#if __MAC_OS_X_VERSION_MIN_REQUIRED < __MAC_10_12
+#define _JSC_NO_ARRAY_BUFFERS
 #endif
 #endif
 
@@ -923,16 +929,28 @@ bool JSCRuntime::isArray(const jsi::Object &obj) const {
 }
 
 bool JSCRuntime::isArrayBuffer(const jsi::Object &obj) const {
+#if defined(_JSC_NO_ARRAY_BUFFERS)
+  throw std::runtime_error("Unsupported");
+#else
   auto typedArrayType = JSValueGetTypedArrayType(ctx_, objectRef(obj), nullptr);
   return typedArrayType == kJSTypedArrayTypeArrayBuffer;
+#endif
 }
 
 uint8_t *JSCRuntime::data(const jsi::ArrayBuffer &obj) {
+#if defined(_JSC_NO_ARRAY_BUFFERS)
+  throw std::runtime_error("Unsupported");
+#else
   return static_cast<uint8_t*>(JSObjectGetArrayBufferBytesPtr(ctx_, objectRef(obj), nullptr));
+#endif
 }
 
 size_t JSCRuntime::size(const jsi::ArrayBuffer &obj) {
+#if defined(_JSC_NO_ARRAY_BUFFERS)
+  throw std::runtime_error("Unsupported");
+#else
   return JSObjectGetArrayBufferByteLength(ctx_, objectRef(obj), nullptr);
+#endif
 }
 
 bool JSCRuntime::isFunction(const jsi::Object &obj) const {

--- a/ReactCommon/jsi/JSCRuntime.cpp
+++ b/ReactCommon/jsi/JSCRuntime.cpp
@@ -932,7 +932,8 @@ bool JSCRuntime::isArrayBuffer(const jsi::Object &obj) const {
 #if defined(_JSC_NO_ARRAY_BUFFERS)
   throw std::runtime_error("Unsupported");
 #else
-  auto typedArrayType = JSValueGetTypedArrayType(ctx_, objectRef(obj), nullptr);
+  auto typedArrayType = JSValueGetTypedArrayType(ctx_, objectRef(obj),
+    nullptr);
   return typedArrayType == kJSTypedArrayTypeArrayBuffer;
 #endif
 }
@@ -941,7 +942,8 @@ uint8_t *JSCRuntime::data(const jsi::ArrayBuffer &obj) {
 #if defined(_JSC_NO_ARRAY_BUFFERS)
   throw std::runtime_error("Unsupported");
 #else
-  return static_cast<uint8_t*>(JSObjectGetArrayBufferBytesPtr(ctx_, objectRef(obj), nullptr));
+  return static_cast<uint8_t*>(
+    JSObjectGetArrayBufferBytesPtr(ctx_, objectRef(obj), nullptr));
 #endif
 }
 


### PR DESCRIPTION
## Summary

The JavaScriptCore implementation of JSI [does not currently support array buffers](https://github.com/facebook/react-native/blob/master/ReactCommon/jsi/JSCRuntime.cpp#L925-L943). The comments in the code suggest the JSC version used by React Native does not work with array buffers, but this seems to be out of date since the current version of JSC used by React Native does indeed support array buffers. This change just enables array buffers in JSCRuntime.cpp.

NOTE: See https://github.com/react-native-community/discussions-and-proposals/issues/91#issuecomment-632371219 for more background on this change.

## Changelog

[General] [Added] - Support for array buffers in the JavaScriptCore implementation of JSI

## Test Plan

To test these changes, I just made some temporary changes to RNTester to use JSI to inject a test function into the JS runtime that reads from and writes to an array buffer, and call that function from the JS of the RNTester app (see https://github.com/ryantrem/react-native/commit/28152ce3f4ae0fa906557415d106399b3f072118).

For the JS side of this, specifically look at https://github.com/ryantrem/react-native/blob/28152ce3f4ae0fa906557415d106399b3f072118/RNTester/js/RNTesterApp.android.js#L13-L18

For the native side of this, specifically look at https://github.com/ryantrem/react-native/blob/28152ce3f4ae0fa906557415d106399b3f072118/RNTester/android/app/src/main/cpp/JSITest.cpp#L22-L38
