### PR TITLE
[Android] Fix WebView gets focus upon first touch

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -23,6 +23,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.OverScroller;
 import android.widget.ScrollView;
+import android.webkit.WebView;
 import androidx.annotation.Nullable;
 import androidx.core.view.ViewCompat;
 import com.facebook.common.logging.FLog;
@@ -250,7 +251,8 @@ public class ReactScrollView extends ScrollView
    */
   @Override
   public void requestChildFocus(View child, View focused) {
-    if (focused != null) {
+    Boolean isWebView = focused instanceof WebView;
+    if (focused != null && !isWebView) {
       scrollToChild(focused);
     }
     super.requestChildFocus(child, focused);

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -251,7 +251,7 @@ public class ReactScrollView extends ScrollView
    */
   @Override
   public void requestChildFocus(View child, View focused) {
-    Boolean isWebView = focused instanceof WebView;
+    boolean isWebView = focused instanceof WebView;
     if (focused != null && !isWebView) {
       scrollToChild(focused);
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does this pull request solve? -->

This issue fixes https://github.com/facebook/react-native/issues/28011 fixes https://github.com/facebook/react-native/issues/26858
A wrapped Webview inside a ScrollView is scrolled to upon the first touch. The pull request removes this behaviour for all instances of WebView included inside a ScrollView.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Fixed] - adding check for WebView instance inside requestChildFocus

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

**<details><summary>CLICK TO OPEN TESTS RESULTS</summary>**
<p>

The solution checks that `focused` is not an instance of `WebView` before calling `scrollToChild()`. The below images test this functionality inside the `RNTester` and other examples that use this sourcecode. 

| **BEFORE** | **AFTER** | 
|:-------------------------:|:-------------------------:|
| <img src="https://user-images.githubusercontent.com/24992535/82907036-65b40a80-9f66-11ea-9993-a8871ef082df.gif" width="200" height="" /> | <img src="https://user-images.githubusercontent.com/24992535/82907033-6482dd80-9f66-11ea-81f8-6790efb2017a.gif"  width="200" height="" /> |

| **AFTER** | **AFTER** | 
|:-------------------------:|:-------------------------:|
| <img src="https://user-images.githubusercontent.com/24992535/82907257-aa3fa600-9f66-11ea-8638-142774f59c43.gif" width="200" height="" /> | <img src="https://user-images.githubusercontent.com/24992535/82907447-eb37ba80-9f66-11ea-9060-e5aa33869e11.gif"  width="200" height="" /> |

</p>
</details>