### PR TITLE
Make sure LogBox is not included in production bundles

### DIFF
--- a/Libraries/Core/ExceptionsManager.js
+++ b/Libraries/Core/ExceptionsManager.js
@@ -11,7 +11,6 @@
 'use strict';
 
 import type {ExtendedError} from './Devtools/parseErrorStack';
-import * as LogBoxData from '../LogBox/Data/LogBoxData';
 import type {ExceptionData} from './NativeExceptionsManager';
 
 class SyntheticError extends Error {
@@ -104,7 +103,8 @@ function reportException(
       console.error(data.message);
     }
 
-    if (isHandledByLogBox) {
+    if (__DEV__ && isHandledByLogBox) {
+      const LogBoxData = require('../LogBox/Data/LogBoxData');
       LogBoxData.addException({
         ...data,
         isComponentError: !!e.isComponentError,

--- a/Libraries/LogBox/LogBox.js
+++ b/Libraries/LogBox/LogBox.js
@@ -12,8 +12,6 @@
 
 import Platform from '../Utilities/Platform';
 import RCTLog from '../Utilities/RCTLog';
-import * as LogBoxData from './Data/LogBoxData';
-import {parseLogBoxLog, parseInterpolation} from './Data/parseLogBoxLog';
 
 import type {IgnorePattern} from './Data/LogBoxData';
 
@@ -23,6 +21,9 @@ let LogBox;
  * LogBox displays logs in the app.
  */
 if (__DEV__) {
+  const LogBoxData = require('./Data/LogBoxData');
+  const {parseLogBoxLog, parseInterpolation} = require('./Data/parseLogBoxLog');
+
   // LogBox needs to insert itself early,
   // in order to access the component stacks appended by React DevTools.
   const {error, warn} = console;


### PR DESCRIPTION
## Summary

I was doing some bundle inspection and noticed the LogBox module was included. It does amount to around 15kb so I think it is worth making sure it is not there.

To fix it I moved some imports to require inside __DEV__ blocks to make sure metro is able to remove these imports.

## Changelog

[General] [Fixed] - Make sure LogBox is not included in production bundles

## Test Plan

Tested using react-native-bundle-visualizer and made sure nothing from LogBox was included in the bundle after these changes.
