### PR TITLE
[Android] [Fixed] Make canOpenUrl & openUrl consistent regarding Uri scheme

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/intent/IntentModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/intent/IntentModule.java
@@ -128,7 +128,7 @@ public class IntentModule extends NativeLinkingSpec {
     }
 
     try {
-      Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+      Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url).normalizeScheme());
       // We need Intent.FLAG_ACTIVITY_NEW_TASK since getReactApplicationContext() returns
       // the ApplicationContext instead of the Activity context.
       intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Assuming that I have an android app that accept the scheme `Test://`

`Linking.canOpenUrl("Test://")` will return a `Promise<true>`.
But `Linking.openUrl()` is using [Uri#normalizeScheme()](https://developer.android.com/reference/android/net/Uri.html#normalizeScheme()) since https://github.com/facebook/react-native/pull/21561
This creates an inconsistant behaviour (false positive) when testing if an app can open a scheme that is not in lower case.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Fixed] Make canOpenUrl & openUrl consistent regarding the Uri scheme

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

This will prevent issue when you try to open an uri with a uppercase letter and fails miserably

Ex of this kind of error (note the upper case first letter i "Ilevia" in comparison with "ilevia" at the end of the error)

![image](https://user-images.githubusercontent.com/157534/83022197-711d3980-a02b-11ea-9a1d-09eab455a6b5.png)