### PR TITLE
use React.Children.count for counting children

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -1095,8 +1095,7 @@ function InternalTextInput(props: Props): React.Node {
     const style = [props.style];
     const autoCapitalize = props.autoCapitalize || 'sentences';
     let children = props.children;
-    let childCount = 0;
-    React.Children.forEach(children, () => ++childCount);
+    const childCount = React.Children.count(children);
     invariant(
       !(props.value && childCount),
       'Cannot specify both value and children.',


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

just a minor change - uses the [count api](https://reactjs.org/docs/react-api.html#reactchildrencount)

> Returns the total number of components in children, equal to the number of times that a callback passed to map or forEach would be invoked.



## Changelog

not needed I think

## Test Plan

tested locally

