### PR TITLE
Fail to send unless readyState is CONNECTED

### DIFF
--- a/Libraries/WebSocket/WebSocket.js
+++ b/Libraries/WebSocket/WebSocket.js
@@ -163,7 +163,7 @@ class WebSocket extends (EventTarget(...WEBSOCKET_EVENTS): any) {
   }
 
   send(data: string | ArrayBuffer | ArrayBufferView | Blob): void {
-    if (this.readyState === this.CONNECTING) {
+    if (this.readyState !== this.CONNECTED) {
       throw new Error('INVALID_STATE_ERR');
     }
 


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
According to the [IETF standard](https://tools.ietf.org/html/rfc6455#section-6.1) and the [JS API spec](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/send) for WebSockets, the `send` method should fail if the socket's state is not `CONNECTED`.
The React Native JavaScript implementation of WebSocket only fails if the state is `CONNECTING`, allowing for `send` to be called in both `CLOSING` or `CLOSED` states.

## Changelog

[General] [Changed] - Fail on WebSocket.send unless state is CONNECTED.

## Test Plan

Run existing tests unit and integration tests.
