### PR TITLE
mark 'force' as optional property of PressEvent object

### DIFF
--- a/Libraries/Types/CoreEventTypes.js
+++ b/Libraries/Types/CoreEventTypes.js
@@ -88,7 +88,7 @@ export type TextLayoutEvent = SyntheticEvent<
 export type PressEvent = ResponderSyntheticEvent<
   $ReadOnly<{|
     changedTouches: $ReadOnlyArray<$PropertyType<PressEvent, 'nativeEvent'>>,
-    force: number,
+    force: ?number,
     identifier: number,
     locationX: number,
     locationY: number,

--- a/Libraries/Types/CoreEventTypes.js
+++ b/Libraries/Types/CoreEventTypes.js
@@ -94,7 +94,7 @@ export type PressEvent = ResponderSyntheticEvent<
     locationY: number,
     pageX: number,
     pageY: number,
-    target?: number,
+    target: ?number,
     timestamp: number,
     touches: $ReadOnlyArray<$PropertyType<PressEvent, 'nativeEvent'>>,
   |}>,

--- a/Libraries/Types/CoreEventTypes.js
+++ b/Libraries/Types/CoreEventTypes.js
@@ -88,13 +88,13 @@ export type TextLayoutEvent = SyntheticEvent<
 export type PressEvent = ResponderSyntheticEvent<
   $ReadOnly<{|
     changedTouches: $ReadOnlyArray<$PropertyType<PressEvent, 'nativeEvent'>>,
-    force: ?number,
+    force?: number,
     identifier: number,
     locationX: number,
     locationY: number,
     pageX: number,
     pageY: number,
-    target: ?number,
+    target?: number,
     timestamp: number,
     touches: $ReadOnlyArray<$PropertyType<PressEvent, 'nativeEvent'>>,
   |}>,

--- a/RNTester/js/examples/Pressable/PressableExample.js
+++ b/RNTester/js/examples/Pressable/PressableExample.js
@@ -167,7 +167,7 @@ function ForceTouchExample() {
           style={styles.wrapper}
           testID="pressable_3dtouch_button"
           onStartShouldSetResponder={() => true}
-          onResponderMove={event => setForce(event.nativeEvent.force)}
+          onResponderMove={event => setForce(event.nativeEvent?.force || 1)}
           onResponderRelease={event => setForce(0)}>
           <Text style={styles.button}>Press Me</Text>
         </View>


### PR DESCRIPTION
## Summary

Refs: 
* https://github.com/facebook/react-native/blob/master/React/Fabric/RCTSurfaceTouchHandler.mm#L93
* https://github.com/facebook/react-native/blob/master/RNTester/js/examples/Pressable/PressableExample.js#L25

According to the current implementation `force` will be returned only on `iOS` platform, only on the devices which have a hardware 3D touch capabilities.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Fixed] - mark `force` as an optional property of the PressEvent object

## Test Plan

Go CI!
