### PR TITLE
Convert JSEngineInstance into a runtime factory, move runtime ownership to ReactInstance

### DIFF
--- a/RNTester/RNTester/AppDelegate.mm
+++ b/RNTester/RNTester/AppDelegate.mm
@@ -169,7 +169,10 @@
     }
     __typeof(self) strongSelf = weakSelf;
     if (strongSelf) {
-      [strongSelf->_turboModuleManager installJSBindingWithRuntime:&runtime];
+      facebook::react::RuntimeExecutor syncRuntimeExecutor = [&](std::function<void(facebook::jsi::Runtime &runtime_)> &&callback) {
+        callback(runtime);
+      };
+      [strongSelf->_turboModuleManager installJSBindingWithRuntimeExecutor:syncRuntimeExecutor];
     }
   });
 }

--- a/ReactCommon/turbomodule/core/platform/ios/RCTTurboModuleManager.h
+++ b/ReactCommon/turbomodule/core/platform/ios/RCTTurboModuleManager.h
@@ -11,6 +11,8 @@
 
 #import "RCTTurboModule.h"
 
+#import <ReactCommon/RuntimeExecutor.h>
+
 @protocol RCTTurboModuleManagerDelegate <NSObject>
 
 // TODO: Move to xplat codegen.
@@ -45,7 +47,7 @@
                       delegate:(id<RCTTurboModuleManagerDelegate>)delegate
                      jsInvoker:(std::shared_ptr<facebook::react::CallInvoker>)jsInvoker;
 
-- (void)installJSBindingWithRuntime:(facebook::jsi::Runtime *)runtime;
+- (void)installJSBindingWithRuntimeExecutor:(facebook::react::RuntimeExecutor)runtimeExecutor;
 
 - (void)invalidate;
 


### PR DESCRIPTION
Summary: OSS changes: Update RCTTurboModuleManager to accept a RuntimeExecutor instead of a `jsi::Runtime`.

Reviewed By: RSNara

Differential Revision: D21270243

