### PR TITLE
Test fixes related to changes in Jest's Fake Timer behavior

### DIFF
--- a/Libraries/LogBox/Data/__tests__/LogBoxData-test.js
+++ b/Libraries/LogBox/Data/__tests__/LogBoxData-test.js
@@ -137,7 +137,6 @@ beforeEach(() => {
 });
 
 const flushLogs = () => {
-  jest.runAllImmediates();
   jest.runAllTimers();
 };
 
@@ -240,7 +239,7 @@ describe('LogBoxData', () => {
     expect(logs[3].category).toEqual('D');
 
     addLogs(['A']);
-    jest.runAllImmediates();
+    flushLogs();
 
     // Expect `A` to be added to the end of the registry.
     logs = registry();
@@ -280,7 +279,6 @@ describe('LogBoxData', () => {
 
     // Order maters for symbolication before timeout.
     flushLogs();
-    jest.runAllTimers();
 
     expect(selectedLogIndex()).toBe(0);
 
@@ -289,7 +287,6 @@ describe('LogBoxData', () => {
 
     // Order maters for symbolication before timeout.
     flushLogs();
-    jest.runAllTimers();
 
     // This should still be 0 (the first fatal exception)
     // becuase it is the most likely source of the error.
@@ -302,7 +299,6 @@ describe('LogBoxData', () => {
     addFatalErrors(['A']);
 
     // Order maters for timeout before symbolication.
-    jest.runAllTimers();
     flushLogs();
 
     expect(selectedLogIndex()).toBe(0);
@@ -311,7 +307,6 @@ describe('LogBoxData', () => {
     addFatalErrors(['C']);
 
     // Order maters for timeout before symbolication.
-    jest.runAllTimers();
     flushLogs();
 
     // This should still be 0 (the first fatal exception)
@@ -546,12 +541,12 @@ describe('LogBoxData', () => {
 
     const lastLog = Array.from(observer.mock.calls[1][0].logs)[0];
     LogBoxData.dismiss(lastLog);
-    jest.runAllImmediates();
+    flushLogs();
     expect(observer.mock.calls.length).toBe(3);
 
     // Does nothing when category does not exist.
     LogBoxData.dismiss(lastLog);
-    jest.runAllImmediates();
+    flushLogs();
     expect(observer.mock.calls.length).toBe(3);
   });
 
@@ -564,12 +559,12 @@ describe('LogBoxData', () => {
     expect(observer.mock.calls.length).toBe(2);
 
     LogBoxData.clear();
-    jest.runAllImmediates();
+    flushLogs();
     expect(observer.mock.calls.length).toBe(3);
 
     // Does nothing when already empty.
     LogBoxData.clear();
-    jest.runAllImmediates();
+    flushLogs();
     expect(observer.mock.calls.length).toBe(3);
   });
 
@@ -581,17 +576,17 @@ describe('LogBoxData', () => {
     addSoftErrors(['B']);
     addFatalErrors(['C']);
     addSyntaxError();
-    jest.runAllImmediates();
-    expect(observer.mock.calls.length).toBe(2);
+    flushLogs();
+    expect(observer.mock.calls.length).toBe(3);
 
     LogBoxData.clearWarnings();
-    jest.runAllImmediates();
-    expect(observer.mock.calls.length).toBe(3);
+    flushLogs();
+    expect(observer.mock.calls.length).toBe(4);
 
     // Does nothing when already empty.
     LogBoxData.clearWarnings();
-    jest.runAllImmediates();
-    expect(observer.mock.calls.length).toBe(3);
+    flushLogs();
+    expect(observer.mock.calls.length).toBe(4);
   });
 
   it('updates observers when errors cleared', () => {
@@ -602,17 +597,17 @@ describe('LogBoxData', () => {
     addSoftErrors(['B']);
     addFatalErrors(['C']);
     addSyntaxError();
-    jest.runAllImmediates();
-    expect(observer.mock.calls.length).toBe(2);
+    flushLogs();
+    expect(observer.mock.calls.length).toBe(3);
 
     LogBoxData.clearErrors();
-    jest.runAllImmediates();
-    expect(observer.mock.calls.length).toBe(3);
+    flushLogs();
+    expect(observer.mock.calls.length).toBe(4);
 
     // Does nothing when already empty.
     LogBoxData.clearErrors();
-    jest.runAllImmediates();
-    expect(observer.mock.calls.length).toBe(3);
+    flushLogs();
+    expect(observer.mock.calls.length).toBe(4);
   });
 
   it('updates observers when an ignore pattern is added', () => {
@@ -620,16 +615,16 @@ describe('LogBoxData', () => {
     expect(observer.mock.calls.length).toBe(1);
 
     LogBoxData.addIgnorePatterns(['?']);
-    jest.runAllImmediates();
+    flushLogs();
     expect(observer.mock.calls.length).toBe(2);
 
     LogBoxData.addIgnorePatterns(['!']);
-    jest.runAllImmediates();
+    flushLogs();
     expect(observer.mock.calls.length).toBe(3);
 
     // Does nothing for an existing ignore pattern.
     LogBoxData.addIgnorePatterns(['!']);
-    jest.runAllImmediates();
+    flushLogs();
     expect(observer.mock.calls.length).toBe(3);
   });
 
@@ -638,21 +633,21 @@ describe('LogBoxData', () => {
     expect(observer.mock.calls.length).toBe(1);
 
     LogBoxData.setDisabled(true);
-    jest.runAllImmediates();
+    flushLogs();
     expect(observer.mock.calls.length).toBe(2);
 
     // Does nothing when already disabled.
     LogBoxData.setDisabled(true);
-    jest.runAllImmediates();
+    flushLogs();
     expect(observer.mock.calls.length).toBe(2);
 
     LogBoxData.setDisabled(false);
-    jest.runAllImmediates();
+    flushLogs();
     expect(observer.mock.calls.length).toBe(3);
 
     // Does nothing when already enabled.
     LogBoxData.setDisabled(false);
-    jest.runAllImmediates();
+    flushLogs();
     expect(observer.mock.calls.length).toBe(3);
   });
 


### PR DESCRIPTION
## Summary
Fixed tests related to changing Jest's fake timer behavior. 
And some of the test code in LogBoxData-test.js itself was incorrect so I am fixing it.

LogBoxData-test.js fails when I try to build a new local development environment and fork the React Native source to run a JavaScript test.
The error message is:
runAllImmediates is not available when using modern timers

After checking, runAllImmediates could not be used with the following modification.
https://github.com/facebook/jest/commit/71631f6bf9ccf8937f02a5ecfb64b62712b86c19

## Changelog

[Internal] [Fixed] - Test fixes related to changes in Jest's Fake Timer behavior

## Test Plan
Ran JavaScript Tests locally.
