### PR TITLE
Better error message when missing entry file 

### DIFF
--- a/scripts/react-native-xcode.sh
+++ b/scripts/react-native-xcode.sh
@@ -67,9 +67,9 @@ if [[ "$ENTRY_FILE" ]]; then
   # Use ENTRY_FILE defined by user
   :
 elif [[ -s "index.ios.js" ]]; then
-   ENTRY_FILE=${1:-index.ios.js}
+  ENTRY_FILE=${1:-index.ios.js}
 else
-   ENTRY_FILE=${1:-index.js}
+  ENTRY_FILE=${1:-index.js}
 fi
 
 if [[ $DEV != true && ! -f "$ENTRY_FILE" ]]; then

--- a/scripts/react-native-xcode.sh
+++ b/scripts/react-native-xcode.sh
@@ -68,8 +68,13 @@ if [[ "$ENTRY_FILE" ]]; then
   :
 elif [[ -s "index.ios.js" ]]; then
    ENTRY_FILE=${1:-index.ios.js}
- else
+else
    ENTRY_FILE=${1:-index.js}
+fi
+
+if [[ $DEV != true && ! -f "$ENTRY_FILE" ]]; then
+  echo "error: Entry file $ENTRY_FILE does not exist. If you use another file as your entry point, pass ENTRY_FILE=myindex.js" >&2
+  exit 2
 fi
 
 if [[ -s "$HOME/.nvm/nvm.sh" ]]; then


### PR DESCRIPTION
## Summary

If the entry file has been renamed (e.g., to `index.ts`), the script currently fails silently and prints out that the bundle file does not exist.

This change will print the correct error message instead.

## Changelog

[iOS] [Fixed] - Better error message when missing entry file 

## Test Plan

N/A