### PR TITLE
Update Android Gradle plugin to 4.0.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:3.6.4")
+        classpath("com.android.tools.build:gradle:4.0.1")
         classpath("de.undercouch:gradle-download-task:4.0.2")
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/template/android/build.gradle
+++ b/template/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:3.6.4")
+        classpath("com.android.tools.build:gradle:4.0.1")
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }


### PR DESCRIPTION
This is a major version update that needs to be tested thoroughly.

## Summary

Android Studio 4.0.1 is now available in the stable channel

https://androidstudio.googleblog.com/2020/05/android-studio-40-available-in-stable.html
https://developer.android.com/studio/releases/gradle-plugin#4.0.1

## Changelog

[Android] [Changed] - Update Android Gradle plugin to 4.0.1

## Test Plan

Build project

Closes #29044 