### PR TITLE
Support nvm in Xcode bundle phase

### DIFF
--- a/template/ios/HelloWorld.xcodeproj/project.pbxproj
+++ b/template/ios/HelloWorld.xcodeproj/project.pbxproj
@@ -236,7 +236,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export NODE_BINARY=node\n../node_modules/react-native/scripts/react-native-xcode.sh";
+			shellScript = "# first run the nvm initialization script (if it exists, which it would if the user uses nvm) so as to make the `node` command available\ntest ~/.nvm/nvm.sh && . ~/.nvm/nvm.sh\n\nexport NODE_BINARY=node\n../node_modules/react-native/scripts/react-native-xcode.sh";
 		};
 		FD10A7F022414F080027D42C /* Start Packager */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
## Changelog
[iOS] [Added] - Support nvm in Xcode bundle phase

## Test Plan
- Install [`nvm`](https://github.com/nvm-sh/nvm)
- Notice how Xcode will now throw an error on "Build": [`Error: cannot find the node binary. Try setting the NODE_BINARY variable in the  "Bundle React Native code and images" Build Phase to the absolute path to your node binary.  You can find it by executing "which node" in a terminal window.`](https://github.com/facebook/react-native/blob/master/scripts/node-binary.sh#L11-L14)
- Prepend `test ~/.nvm/nvm.sh && . ~/.nvm/nvm.sh` to the ["Bundle React Native code and images"](https://github.com/facebook/react-native/blob/7bb1c4e1b8715a5c9cb6f9e4e77a6df783481d3d/template/ios/HelloWorld.xcodeproj/project.pbxproj#L239) script, which will run `nvm`'s initialization scripts _if they exist_ so as to make `node` available

## Summary
In the "Bundle React Native code and images" Xcode build phase of the HelloWorld template, first run the nvm initialization script (if it exists, which it would if the user uses nvm) so as to make the `node` command available