### PR TITLE
fix StatusBar showHideTransition flow type issue

### DIFF
--- a/Libraries/Components/StatusBar/StatusBar.js
+++ b/Libraries/Components/StatusBar/StatusBar.js
@@ -87,7 +87,7 @@ type IOSProps = $ReadOnly<{|
    *
    * @platform ios
    */
-  showHideTransition?: ?('fade' | 'slide'),
+  showHideTransition?: ?('fade' | 'slide' | 'none'),
 |}>;
 
 type Props = $ReadOnly<{|


### PR DESCRIPTION
## Summary

This small PR adds third, missing [`StatusBarAnimation`](https://github.com/facebook/react-native/blob/master/Libraries/Components/StatusBar/StatusBar.js#L45) possible value to the `showHideTransition` prop validation - `'none'`. 

This fixes the following issue when `<StatusBar showHideTransition="none" />` code  is used:

<img width="970" alt="Screenshot 2020-06-02 at 22 39 37" src="https://user-images.githubusercontent.com/719641/83567510-f6b85200-a521-11ea-9f1c-48825d0285bf.png">

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [Fixed] - fix StatusBar showHideTransition flow type issue

## Test Plan

I have run the `flow` check in the test project which uses local working copy of `react-native` with this change included.
