### PR TITLE
Fix missing webview provider crash on Android

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/network/ForwardingCookieHandler.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/network/ForwardingCookieHandler.java
@@ -187,11 +187,7 @@ public class ForwardingCookieHandler extends CookieHandler {
         // class. This validates the exception's message to ensure we are only handling this
         // specific exception.
         // https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/webkit/WebViewFactory.java#348
-        if (message != null
-            && exception
-                .getClass()
-                .getCanonicalName()
-                .equals("android.webkit.WebViewFactory.MissingWebViewPackageException")) {
+        if (message != null && message.contains("WebView")) {
           return null;
         } else {
           throw exception;


### PR DESCRIPTION
## Summary

We upgraded to RN 0.62.2 on our latest release and started to see again the "Failed to load WebView provider: No WebView installed" (see below for Crashlytics screenshot)

![image](https://user-images.githubusercontent.com/4534323/84021918-bf183280-a985-11ea-96f9-9acdccf4f493.png)

This crash had been fixed by https://github.com/facebook/react-native/pull/24533 but https://github.com/facebook/react-native/pull/26189 (added in 0.62) reverted the fix

Indeed the exception raised in Crashlytics is actually a `AndroidRuntimeException` and `MissingWebViewPackageException` is only part of the message.

For instance, in the screenshot above, the exception message is `android.webkit.WebViewFactory$MissingWebViewPackageException: Failed to load WebView provider: No WebView installed`

Now these crashes are quite tricky to reproduce, so to be on the safe side, I'm filtering out all exceptions containing `WebView` as suggested by @thorbenprimke on the original fix.

If my reasoning is correct, it should fix @siddhantsoni 's issue as well, since `WebView` is included in `MissingWebViewPackageException` 
But following that reasoning, I am not sure https://github.com/facebook/react-native/pull/26189 fixed @siddhantsoni 's issue, so @siddhantsoni if you could check that this PR also fixes your issue, that would be great!

## Changelog

[Android] [Fixed] - Fix missing WebView provider crash in ForwardingCookieHandler

## Test Plan

I created a version of react native with this patch applied
```json
"react-native": "almouro/react-native#release/062-2-fix-missing-webview-provider"
```

*Before the fix ~0.1% of our users were impacted on Android, no new crashes have occurred after the update.*

This is putting back what was already in place and working for us, but making the check wider to catch more errors.