### PR TITLE
Move error handling with JSI into a separate helper function

### DIFF
--- a/ReactCommon/cxxreact/BUCK
+++ b/ReactCommon/cxxreact/BUCK
@@ -84,6 +84,7 @@ rn_xplat_cxx_library(
 
 CXXREACT_PUBLIC_HEADERS = [
     "CxxNativeModule.h",
+    "ErrorUtils.h",
     "Instance.h",
     "JSBundleType.h",
     "JSDeltaBundleClient.h",

--- a/ReactCommon/cxxreact/ErrorUtils.h
+++ b/ReactCommon/cxxreact/ErrorUtils.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <jsi/jsi.h>
+
+namespace facebook {
+namespace react {
+
+inline static void handleJSError(
+    jsi::Runtime &runtime,
+    const jsi::JSError &error) {
+  auto errorUtils = runtime.global().getProperty(runtime, "ErrorUtils");
+  if (errorUtils.isUndefined() || !errorUtils.isObject() ||
+      !errorUtils.getObject(runtime).hasProperty(runtime, "reportFatalError")) {
+    // ErrorUtils was not set up. This probably means the bundle didn't
+    // load properly.
+    throw jsi::JSError(
+        runtime,
+        "ErrorUtils is not set up properly. Something probably went wrong trying to load the JS bundle. Trying to report error " +
+            error.getMessage(),
+        error.getStack());
+  }
+  // TODO(janzer): Rewrite this function to return the processed error
+  // instead of just reporting it through the native module
+  auto func = errorUtils.asObject(runtime).getPropertyAsFunction(
+      runtime, "reportFatalError");
+  func.call(runtime, error.value(), jsi::Value(true));
+}
+
+} // namespace react
+} // namespace facebook

--- a/ReactCommon/cxxreact/NativeToJsBridge.cpp
+++ b/ReactCommon/cxxreact/NativeToJsBridge.cpp
@@ -14,6 +14,7 @@
 #include <jsi/jsi.h>
 #include <reactperflogger/BridgeNativeModulePerfLogger.h>
 
+#include "ErrorUtils.h"
 #include "Instance.h"
 #include "JSBigString.h"
 #include "MessageQueueThread.h"
@@ -26,6 +27,8 @@
 
 #ifdef WITH_FBSYSTRACE
 #include <fbsystrace.h>
+#include <jsi/jsi/jsi.h>
+
 using fbsystrace::FbSystraceAsyncFlow;
 #endif
 
@@ -338,37 +341,23 @@ std::shared_ptr<CallInvoker> NativeToJsBridge::getDecoratedNativeCallInvoker(
 }
 
 RuntimeExecutor NativeToJsBridge::getRuntimeExecutor() {
-  auto runtimeExecutor = [this, isDestroyed = m_destroyed](
-                             std::function<void(jsi::Runtime & runtime)>
-                                 &&callback) {
-    if (*isDestroyed) {
-      return;
-    }
-    runOnExecutorQueue([callback = std::move(callback)](JSExecutor *executor) {
-      jsi::Runtime *runtime = (jsi::Runtime *)executor->getJavaScriptContext();
-      try {
-        callback(*runtime);
-      } catch (jsi::JSError &originalError) {
-        auto errorUtils = runtime->global().getProperty(*runtime, "ErrorUtils");
-        if (errorUtils.isUndefined() || !errorUtils.isObject() ||
-            !errorUtils.getObject(*runtime).hasProperty(
-                *runtime, "reportFatalError")) {
-          // ErrorUtils was not set up. This probably means the bundle didn't
-          // load properly.
-          throw jsi::JSError(
-              *runtime,
-              "ErrorUtils is not set up properly. Something probably went wrong trying to load the JS bundle. Trying to report error " +
-                  originalError.getMessage(),
-              originalError.getStack());
+  auto runtimeExecutor =
+      [this, isDestroyed = m_destroyed](
+          std::function<void(jsi::Runtime & runtime)> &&callback) {
+        if (*isDestroyed) {
+          return;
         }
-        // TODO(janzer): Rewrite this function to return the processed error
-        // instead of just reporting it through the native module
-        auto func = errorUtils.asObject(*runtime).getPropertyAsFunction(
-            *runtime, "reportFatalError");
-        func.call(*runtime, originalError.value(), jsi::Value(true));
-      }
-    });
-  };
+        runOnExecutorQueue(
+            [callback = std::move(callback)](JSExecutor *executor) {
+              jsi::Runtime *runtime =
+                  (jsi::Runtime *)executor->getJavaScriptContext();
+              try {
+                callback(*runtime);
+              } catch (jsi::JSError &originalError) {
+                handleJSError(*runtime, originalError);
+              }
+            });
+      };
   return runtimeExecutor;
 }
 


### PR DESCRIPTION
Summary: Moving the logic for calling into JS to handle errors into ErrorUtils, where it can be reused outside of the bridge.

Differential Revision: D21939254

