### PR TITLE
Fix static method in file header

### DIFF
--- a/ReactCommon/utils/ManagedObjectWrapper.h
+++ b/ReactCommon/utils/ManagedObjectWrapper.h
@@ -27,7 +27,7 @@ namespace detail {
  * A custom deleter used for the deallocation of Objective-C managed objects.
  * To be used only by `wrapManagedObject`.
  */
-static void wrappedManagedObjectDeleter(void *cfPointer) noexcept
+void wrappedManagedObjectDeleter(void *cfPointer) noexcept
 {
   // A shared pointer does call custom deleter on `nullptr`s.
   // This is somewhat counter-intuitively but makes sense considering the type-erasured nature of shared pointer and an


### PR DESCRIPTION
## Summary

I have looked into recent commits and found a typical mistake when static is used in .h file.
Here static is not necessary. See link: https://stackoverflow.com/questions/780730/c-c-static-function-in-header-file-what-does-it-mean

## Changelog

[General] [Fixed] - Removed static key word

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
