### PR TITLE
Make platformColors test page render with out of tree platforms

### DIFF
--- a/RNTester/js/examples/PlatformColor/PlatformColorExample.js
+++ b/RNTester/js/examples/PlatformColor/PlatformColorExample.js
@@ -199,7 +199,10 @@ function FallbackColorsExample() {
       color: PlatformColor('bogus', '@color/catalyst_redbox_background'),
     };
   } else {
-    throw 'Unexpected Platform.OS: ' + Platform.OS;
+    color = {
+      label: 'Unexpected Platform.OS: ' + Platform.OS,
+      color: 'red',
+    };
   }
 
   return (
@@ -261,9 +264,11 @@ function VariantColorsExample() {
     <View style={styles.column}>
       <View style={styles.row}>
         <Text style={styles.labelCell}>
-          {Platform.OS === 'ios'
-            ? "DynamicColorIOS({light: 'red', dark: 'blue'})"
-            : "PlatformColor('?attr/colorAccent')"}
+          {Platform.select({
+            ios: "DynamicColorIOS({light: 'red', dark: 'blue'})",
+            android: "PlatformColor('?attr/colorAccent')",
+            default: 'Unexpected Platform.OS: ' + Platform.OS,
+          })}
         </Text>
         <View
           style={{
@@ -271,7 +276,9 @@ function VariantColorsExample() {
             backgroundColor:
               Platform.OS === 'ios'
                 ? DynamicColorIOS({light: 'red', dark: 'blue'})
-                : PlatformColor('?attr/colorAccent'),
+                : Platform.OS === 'android'
+                ? PlatformColor('?attr/colorAccent')
+                : 'red',
           }}
         />
       </View>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

PlatformColorExample RNTester page crashes when running on platforms other than iOS/Android.
Changed some very minor logic to take into account that platforms other than iOS/Android exist.

## Changelog

[Internal] [Fixed] - PlatformColorExample RNTester page crashes when running on platforms other than iOS/Android.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
