### PR TITLE
fix reset RCT_jsLocation

### DIFF
--- a/React/Base/RCTBundleURLProvider.m
+++ b/React/Base/RCTBundleURLProvider.m
@@ -56,6 +56,7 @@ static NSString *const kRCTEnableMinificationKey = @"RCT_enableMinification";
   for (NSString *key in [[self defaults] allKeys]) {
     [[NSUserDefaults standardUserDefaults] removeObjectForKey:key];
   }
+  [[NSUserDefaults standardUserDefaults] removeObjectForKey:kRCTJsLocationKey];
   [self setDefaults];
   [self settingsUpdated];
 }


### PR DESCRIPTION
## Summary

When debugging React Native on iOS, after connecting to the js server and debugging, the local jsLocation cannot be reset.

Generally hope that after debugging is completed, reconnect to the local main.jsbundle

So this pl can solve this problem

## Changelog

[iOS] [Fixed] reset RCT_jsLocation

## Test Plan
