### PR TITLE
Fix: race condition in android copy vs bundle phases

### DIFF
--- a/react.gradle
+++ b/react.gradle
@@ -298,6 +298,7 @@ afterEvaluate {
 
             // mergeAssets must run first, as it clears the intermediates directory
             dependsOn(variant.mergeAssetsProvider.get())
+            dependsOn(currentBundleTask)
 
             enabled(currentBundleTask.enabled)
         }


### PR DESCRIPTION
## Summary

We ran into an issue where our `index.android.bundle` was not included in our generated `.aab` file (strangely, it was only happening on CI builds). I enabled `--info` level logging on the gradle command on our CI and noticed that `> Task :app:copyPlaystoreReleaseBundledJs NO-SOURCE` was there with the info that the source file didn't exist. This led me to believe that the `copyXXXBundledJs` task and `bundleXXXJsAndAssets` tasks were not executing in the proper order.

Strangely, this issue only started to occur for us after updating a dependency on Android, but I suspect it's always been a race condition and we've just gotten lucky.

This change ensures that the `bundleJsAndAssets` task runs before the `copyBundledJs` task.

I've tested locally with our code and also on our CI.

## Changelog

[Android] [Fix] - Ensure gradle task order (`bundleJsAndAssets` occurs before `copyBundledJs`)

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

`./gradlew clean && ./gradlew cleanBuildCache && ./gradle bundleFlavourRelease`

The generated bundle now includes `index.android.bundle`
