### PR TITLE
Added AccessibilityInfo.setAccessibilityFocus to RNTester a11y examples

### DIFF
--- a/Libraries/Components/Picker/PickerAndroid.android.js
+++ b/Libraries/Components/Picker/PickerAndroid.android.js
@@ -100,7 +100,7 @@ function PickerAndroid(props: Props): React.Node {
           props.mode === 'dropdown'
             ? AndroidDropdownPickerCommands
             : AndroidDialogPickerCommands;
-        Commands.setNativeSelectedPosition(current, selected);
+        Commands.setNativeSelectedPosition(current, position);
       }
     },
     [

--- a/RNTester/js/examples/Accessibility/AccessibilityExample.js
+++ b/RNTester/js/examples/Accessibility/AccessibilityExample.js
@@ -20,6 +20,7 @@ const {
   TouchableWithoutFeedback,
   Alert,
   StyleSheet,
+  findNodeHandle,
 } = require('react-native');
 
 const RNTesterBlock = require('../../components/RNTesterBlock');

--- a/RNTester/js/examples/Accessibility/AccessibilityExample.js
+++ b/RNTester/js/examples/Accessibility/AccessibilityExample.js
@@ -751,24 +751,22 @@ class AnnounceForAccessibility extends React.Component<{}> {
   }
 }
 
-class SetAccessibilityFocus extends React.Component<{}> {
-  _handleOnPress = () => {
-    if (findNodeHandle(this.focusRef.current)) {
-      const reactTag = findNodeHandle(this.focusRef.current);
-      AccessibilityInfo.setAccessibilityFocus(reactTag);
-    }
-  };
-  render() {
-    this.focusRef = React.createRef();
-    return (
-      <View>
-        <Button onPress={this._handleOnPress} title="Set Accessibility Focus" />
-        <Text ref={this.focusRef} accessible={true}>
-          Move focus here on button press.
-        </Text>
-      </View>
-    );
-  }
+
+function SetAccessibilityFocus(){
+  var focusRef = React.createRef();
+  return (
+    <View>
+      <Button onPress={() => {
+          if (findNodeHandle(focusRef.current)) {
+            const reactTag = findNodeHandle(focusRef.current);
+            AccessibilityInfo.setAccessibilityFocus(reactTag);
+          }
+      }} title="Set Accessibility Focus" />
+      <Text ref={focusRef} accessible={true}>
+        Move focus here on button press.
+      </Text>
+    </View>
+  );
 }
 
 exports.title = 'Accessibility';

--- a/RNTester/js/examples/Accessibility/AccessibilityExample.js
+++ b/RNTester/js/examples/Accessibility/AccessibilityExample.js
@@ -751,17 +751,19 @@ class AnnounceForAccessibility extends React.Component<{}> {
   }
 }
 
-
-function SetAccessibilityFocus(){
+function SetAccessibilityFocus() {
   const focusRef = React.createRef();
   return (
     <View>
-      <Button onPress={() => {
-        if (focusRef.current != null) {
-          const reactTag = findNodeHandle(focusRef.current);
-          AccessibilityInfo.setAccessibilityFocus(reactTag);
-        }
-      }} title="Set Accessibility Focus" />
+      <Button
+        onPress={() => {
+          if (focusRef.current != null) {
+            const reactTag = findNodeHandle(focusRef.current);
+            AccessibilityInfo.setAccessibilityFocus(reactTag);
+          }
+        }}
+        title="Set Accessibility Focus"
+      />
       <Text ref={focusRef} accessible={true}>
         Move focus here on button press.
       </Text>

--- a/RNTester/js/examples/Accessibility/AccessibilityExample.js
+++ b/RNTester/js/examples/Accessibility/AccessibilityExample.js
@@ -751,17 +751,19 @@ class AnnounceForAccessibility extends React.Component<{}> {
   }
 }
 
-
-function SetAccessibilityFocus(){
+function SetAccessibilityFocus() {
   var focusRef = React.createRef();
   return (
     <View>
-      <Button onPress={() => {
+      <Button
+        onPress={() => {
           if (findNodeHandle(focusRef.current)) {
             const reactTag = findNodeHandle(focusRef.current);
             AccessibilityInfo.setAccessibilityFocus(reactTag);
           }
-      }} title="Set Accessibility Focus" />
+        }}
+        title="Set Accessibility Focus"
+      />
       <Text ref={focusRef} accessible={true}>
         Move focus here on button press.
       </Text>

--- a/RNTester/js/examples/Accessibility/AccessibilityExample.js
+++ b/RNTester/js/examples/Accessibility/AccessibilityExample.js
@@ -750,6 +750,26 @@ class AnnounceForAccessibility extends React.Component<{}> {
   }
 }
 
+class SetAccessibilityFocus extends React.Component<{}> {
+  _handleOnPress = () => {
+    if (findNodeHandle(this.focusRef.current)) {
+      const reactTag = findNodeHandle(this.focusRef.current);
+      AccessibilityInfo.setAccessibilityFocus(reactTag);
+    }
+  };
+  render() {
+    this.focusRef = React.createRef();
+    return (
+      <View>
+        <Button onPress={this._handleOnPress} title="Set Accessibility Focus" />
+        <Text ref={this.focusRef} accessible={true}>
+          Move focus here on button press.
+        </Text>
+      </View>
+    );
+  }
+}
+
 exports.title = 'Accessibility';
 exports.description = 'Examples of using Accessibility APIs.';
 exports.examples = [
@@ -787,6 +807,12 @@ exports.examples = [
     title: 'Check if the screen reader announces',
     render(): React.Element<typeof AnnounceForAccessibility> {
       return <AnnounceForAccessibility />;
+    },
+  },
+  {
+    title: 'Check if the screen reader focus sets ',
+    render(): React.Element<typeof SetAccessibilityFocus> {
+      return <SetAccessibilityFocus />;
     },
   },
 ];


### PR DESCRIPTION
## Summary

RNTester has Accessibility page which includes examples of many of the AccessibilityInfo methods being used. Until now there was no test for AccessibilityInfo.setAccessibilityFocus. This PR adds a button that–on click–shifts focus to a Text component.

## Changelog

[General] [Added] - Added AccessibilityInfo.SetAccessibilityFocus to RNTester

## Test Plan

1. Run RNTester
2. Go to the accessibility page
3. Scroll to Set Accessibility Focus (the last entry)
4. Toggle VoiceOver in settings.
5. Move VoiceOver Focus to "Set Accessibility Focus"
6. Hit [Space]
- You should see the focus being moved to "Move focus here on button press".
![Screen Shot 2020-06-12 at 10 25 40](https://user-images.githubusercontent.com/65255457/84548048-aa0b0e80-acb9-11ea-92f7-72f5a69a8ac6.png)
![Screen Shot 2020-06-12 at 10 26 12](https://user-images.githubusercontent.com/65255457/84548052-abd4d200-acb9-11ea-9e9a-c042a4df1ddd.png)
