### PR TITLE
chore: use es6 import for SafeAreaView component

### DIFF
--- a/Libraries/Components/SafeAreaView/SafeAreaView.js
+++ b/Libraries/Components/SafeAreaView/SafeAreaView.js
@@ -8,9 +8,9 @@
  * @format
  */
 
-const Platform = require('../../Utilities/Platform');
-const React = require('react');
-const View = require('../View/View');
+import Platform from '../../Utilities/Platform';
+import React from 'react';
+import View from '../View/View';
 
 import type {HostComponent} from '../../Renderer/shims/ReactNativeTypes';
 import type {ViewProps} from '../View/ViewPropTypes';

--- a/Libraries/Components/SafeAreaView/SafeAreaView.js
+++ b/Libraries/Components/SafeAreaView/SafeAreaView.js
@@ -9,7 +9,7 @@
  */
 
 import Platform from '../../Utilities/Platform';
-import React from 'react';
+import * as React from 'react';
 import View from '../View/View';
 
 import type {HostComponent} from '../../Renderer/shims/ReactNativeTypes';


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

This PR is to help proceed this discussion. https://github.com/react-native-community/discussions-and-proposals/issues/201#issuecomment-588454552

Converted `require` to `import` for SafeAreaView.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Changed] - switched to es6 import for SafeAreaView

## Test Plan

Tested that App runs on RNTester
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
