### PR TITLE
[chore] Migrate `Keyboard` to ES6 imports

### DIFF
--- a/Libraries/Components/Keyboard/Keyboard.js
+++ b/Libraries/Components/Keyboard/Keyboard.js
@@ -10,11 +10,11 @@
 
 'use strict';
 
-const LayoutAnimation = require('../../LayoutAnimation/LayoutAnimation');
-const NativeEventEmitter = require('../../EventEmitter/NativeEventEmitter');
+import LayoutAnimation from '../../LayoutAnimation/LayoutAnimation';
+import NativeEventEmitter from '../../EventEmitter/NativeEventEmitter';
 
-const dismissKeyboard = require('../../Utilities/dismissKeyboard');
-const invariant = require('invariant');
+import dismissKeyboard from '../../Utilities/dismissKeyboard';
+import invariant from 'invariant';
 
 import NativeKeyboardObserver from './NativeKeyboardObserver';
 const KeyboardEventEmitter: NativeEventEmitter = new NativeEventEmitter(


### PR DESCRIPTION
## Summary
This PR is to help proceed this discussion. react-native-community/discussions-and-proposals#201 (comment)

Converted `require` to `import` for `Keyboard`.

## Changelog
[General] [Changed] - switched to es6 import for `Keyboard`

## Test Plan
Tested that App runs on RNTester