### PR TITLE
[Android] Adding Hyphenation Frequency prop for Text component

### DIFF
--- a/Libraries/Text/Text.js
+++ b/Libraries/Text/Text.js
@@ -68,7 +68,7 @@ const viewConfig = {
     onTextLayout: true,
     onInlineViewLayout: true,
     dataDetectorType: true,
-    androidHyphenationFrequency: true,
+    android_hyphenationFrequency: true,
   },
   directEventTypes: {
     topTextLayout: {

--- a/Libraries/Text/Text.js
+++ b/Libraries/Text/Text.js
@@ -68,6 +68,7 @@ const viewConfig = {
     onTextLayout: true,
     onInlineViewLayout: true,
     dataDetectorType: true,
+    androidHyphenationFrequency: true,
   },
   directEventTypes: {
     topTextLayout: {

--- a/Libraries/Text/TextProps.js
+++ b/Libraries/Text/TextProps.js
@@ -62,7 +62,13 @@ export type TextProps = $ReadOnly<{|
    * Set hyphenation strategy on Android.
    *
    */
-  androidHyphenationFrequency?: ?('normal' | 'none' | 'full' | 'high' | 'balanced'),
+  androidHyphenationFrequency?: ?(
+    | 'normal'
+    | 'none'
+    | 'full'
+    | 'high'
+    | 'balanced'
+  ),
   children?: ?Node,
 
   /**

--- a/Libraries/Text/TextProps.js
+++ b/Libraries/Text/TextProps.js
@@ -57,6 +57,12 @@ export type TextProps = $ReadOnly<{|
    * See https://reactnative.dev/docs/text.html#allowfontscaling
    */
   allowFontScaling?: ?boolean,
+
+  /**
+   * Set hyphenation strategy on Android.
+   *
+   */
+  androidHyphenationFrequency?: ?('normal' | 'none' | 'full' | 'high' | 'balanced'),
   children?: ?Node,
 
   /**

--- a/Libraries/Text/TextProps.js
+++ b/Libraries/Text/TextProps.js
@@ -62,7 +62,7 @@ export type TextProps = $ReadOnly<{|
    * Set hyphenation strategy on Android.
    *
    */
-  androidHyphenationFrequency?: ?(
+  android_hyphenationFrequency?: ?(
     | 'normal'
     | 'none'
     | 'full'

--- a/RNTester/js/examples/Text/TextExample.android.js
+++ b/RNTester/js/examples/Text/TextExample.android.js
@@ -209,35 +209,25 @@ class TextExample extends React.Component<{...}> {
           </Text>
         </RNTesterBlock>
         <RNTesterBlock title="Hyphenation">
-          <Text
-            androidHyphenationFrequency="normal">
-            <Text style={{color: 'red'}}>
-              Normal:
-            </Text> WillHaveAnHyphenWhenBreakingForNewLine
+          <Text androidHyphenationFrequency="normal">
+            <Text style={{color: 'red'}}>Normal:</Text>
+            WillHaveAnHyphenWhenBreakingForNewLine
           </Text>
-          <Text
-            androidHyphenationFrequency="none">
-            <Text style={{color: 'red'}}>
-              None:
-            </Text> WillNotHaveAnHyphenWhenBreakingForNewLine
+          <Text androidHyphenationFrequency="none">
+            <Text style={{color: 'red'}}>None:</Text>
+            WillNotHaveAnHyphenWhenBreakingForNewLine
           </Text>
-          <Text
-            androidHyphenationFrequency="full">
-            <Text style={{color: 'red'}}>
-              Full:
-            </Text> WillHaveAnHyphenWhenBreakingForNewLine
+          <Text androidHyphenationFrequency="full">
+            <Text style={{color: 'red'}}>Full:</Text>
+            WillHaveAnHyphenWhenBreakingForNewLine
           </Text>
-          <Text
-            androidHyphenationFrequency="high">
-            <Text style={{color: 'red'}}>
-            High:
-            </Text> WillHaveAnHyphenWhenBreakingForNewLine
+          <Text androidHyphenationFrequency="high">
+            <Text style={{color: 'red'}}>High:</Text>
+            WillHaveAnHyphenWhenBreakingForNewLine
           </Text>
-          <Text
-            androidHyphenationFrequency="balanced">
-            <Text style={{color: 'red'}}>
-              Balanced: 
-            </Text> WillHaveAnHyphenWhenBreakingForNewLine
+          <Text androidHyphenationFrequency="balanced">
+            <Text style={{color: 'red'}}>Balanced:</Text>
+            WillHaveAnHyphenWhenBreakingForNewLine
           </Text>
         </RNTesterBlock>
         <RNTesterBlock title="Padding">

--- a/RNTester/js/examples/Text/TextExample.android.js
+++ b/RNTester/js/examples/Text/TextExample.android.js
@@ -146,7 +146,7 @@ class AdjustingFontSize extends React.Component<
         <Text
           adjustsFontSizeToFit={true}
           numberOfLines={4}
-          androidHyphenationFrequency="normal"
+          android_hyphenationFrequency="normal"
           style={{fontSize: 20, marginVertical: 6}}>
           {'Multiline text component shrinking is supported, watch as this reeeeaaaally loooooong teeeeeeext grooooows and then shriiiinks as you add text to me! ioahsdia soady auydoa aoisyd aosdy ' +
             ' ' +
@@ -209,23 +209,23 @@ class TextExample extends React.Component<{...}> {
           </Text>
         </RNTesterBlock>
         <RNTesterBlock title="Hyphenation">
-          <Text androidHyphenationFrequency="normal">
+          <Text android_hyphenationFrequency="normal">
             <Text style={{color: 'red'}}>Normal: </Text>
             WillHaveAnHyphenWhenBreakingForNewLine
           </Text>
-          <Text androidHyphenationFrequency="none">
+          <Text android_hyphenationFrequency="none">
             <Text style={{color: 'red'}}>None: </Text>
             WillNotHaveAnHyphenWhenBreakingForNewLine
           </Text>
-          <Text androidHyphenationFrequency="full">
+          <Text android_hyphenationFrequency="full">
             <Text style={{color: 'red'}}>Full: </Text>
             WillHaveAnHyphenWhenBreakingForNewLine
           </Text>
-          <Text androidHyphenationFrequency="high">
+          <Text android_hyphenationFrequency="high">
             <Text style={{color: 'red'}}>High: </Text>
             WillHaveAnHyphenWhenBreakingForNewLine
           </Text>
-          <Text androidHyphenationFrequency="balanced">
+          <Text android_hyphenationFrequency="balanced">
             <Text style={{color: 'red'}}>Balanced: </Text>
             WillHaveAnHyphenWhenBreakingForNewLine
           </Text>

--- a/RNTester/js/examples/Text/TextExample.android.js
+++ b/RNTester/js/examples/Text/TextExample.android.js
@@ -195,7 +195,6 @@ class AdjustingFontSize extends React.Component<
   }
 }
 
-const testString = 'sup\u00ADer\u00ADfrag\u00ADilis\u00ADtice\u00ADxpial\u00ADidocious'
 class TextExample extends React.Component<{...}> {
   render(): React.Node {
     return (

--- a/RNTester/js/examples/Text/TextExample.android.js
+++ b/RNTester/js/examples/Text/TextExample.android.js
@@ -210,23 +210,23 @@ class TextExample extends React.Component<{...}> {
         </RNTesterBlock>
         <RNTesterBlock title="Hyphenation">
           <Text androidHyphenationFrequency="normal">
-            <Text style={{color: 'red'}}>Normal:</Text>
+            <Text style={{color: 'red'}}>Normal: </Text>
             WillHaveAnHyphenWhenBreakingForNewLine
           </Text>
           <Text androidHyphenationFrequency="none">
-            <Text style={{color: 'red'}}>None:</Text>
+            <Text style={{color: 'red'}}>None: </Text>
             WillNotHaveAnHyphenWhenBreakingForNewLine
           </Text>
           <Text androidHyphenationFrequency="full">
-            <Text style={{color: 'red'}}>Full:</Text>
+            <Text style={{color: 'red'}}>Full: </Text>
             WillHaveAnHyphenWhenBreakingForNewLine
           </Text>
           <Text androidHyphenationFrequency="high">
-            <Text style={{color: 'red'}}>High:</Text>
+            <Text style={{color: 'red'}}>High: </Text>
             WillHaveAnHyphenWhenBreakingForNewLine
           </Text>
           <Text androidHyphenationFrequency="balanced">
-            <Text style={{color: 'red'}}>Balanced:</Text>
+            <Text style={{color: 'red'}}>Balanced: </Text>
             WillHaveAnHyphenWhenBreakingForNewLine
           </Text>
         </RNTesterBlock>

--- a/RNTester/js/examples/Text/TextExample.android.js
+++ b/RNTester/js/examples/Text/TextExample.android.js
@@ -146,6 +146,7 @@ class AdjustingFontSize extends React.Component<
         <Text
           adjustsFontSizeToFit={true}
           numberOfLines={4}
+          androidHyphenationFrequency="normal"
           style={{fontSize: 20, marginVertical: 6}}>
           {'Multiline text component shrinking is supported, watch as this reeeeaaaally loooooong teeeeeeext grooooows and then shriiiinks as you add text to me! ioahsdia soady auydoa aoisyd aosdy ' +
             ' ' +
@@ -194,6 +195,7 @@ class AdjustingFontSize extends React.Component<
   }
 }
 
+const testString = 'sup\u00ADer\u00ADfrag\u00ADilis\u00ADtice\u00ADxpial\u00ADidocious'
 class TextExample extends React.Component<{...}> {
   render(): React.Node {
     return (
@@ -205,6 +207,38 @@ class TextExample extends React.Component<{...}> {
           <Text>
             The text should wrap if it goes on multiple lines. See, this is
             going to the next line.
+          </Text>
+        </RNTesterBlock>
+        <RNTesterBlock title="Hyphenation">
+          <Text
+            androidHyphenationFrequency="normal">
+            <Text style={{color: 'red'}}>
+              Normal:
+            </Text> WillHaveAnHyphenWhenBreakingForNewLine
+          </Text>
+          <Text
+            androidHyphenationFrequency="none">
+            <Text style={{color: 'red'}}>
+              None:
+            </Text> WillNotHaveAnHyphenWhenBreakingForNewLine
+          </Text>
+          <Text
+            androidHyphenationFrequency="full">
+            <Text style={{color: 'red'}}>
+              Full:
+            </Text> WillHaveAnHyphenWhenBreakingForNewLine
+          </Text>
+          <Text
+            androidHyphenationFrequency="high">
+            <Text style={{color: 'red'}}>
+            High:
+            </Text> WillHaveAnHyphenWhenBreakingForNewLine
+          </Text>
+          <Text
+            androidHyphenationFrequency="balanced">
+            <Text style={{color: 'red'}}>
+              Balanced: 
+            </Text> WillHaveAnHyphenWhenBreakingForNewLine
           </Text>
         </RNTesterBlock>
         <RNTesterBlock title="Padding">

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextAnchorViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextAnchorViewManager.java
@@ -7,6 +7,7 @@
 
 package com.facebook.react.views.text;
 
+import android.text.Layout;
 import android.text.Spannable;
 import android.text.TextUtils;
 import android.text.util.Linkify;
@@ -93,6 +94,23 @@ public abstract class ReactTextAnchorViewManager<T extends View, C extends React
           DefaultStyleValuesUtil.getDefaultTextColorHighlight(view.getContext()));
     } else {
       view.setHighlightColor(color);
+    }
+  }
+
+  @ReactProp(name = "androidHyphenationFrequency")
+  public void setAndroidHyphenationFrequency(ReactTextView view, @Nullable String frequency) {
+    if (frequency == null || frequency.equals("none")) {
+      view.setHyphenationFrequency(Layout.HYPHENATION_FREQUENCY_NONE);
+    } else if (frequency.equals("full")) {
+      view.setHyphenationFrequency(Layout.HYPHENATION_FREQUENCY_FULL);
+    } else if (frequency.equals("balanced")) {
+      view.setHyphenationFrequency(Layout.BREAK_STRATEGY_BALANCED);
+    } else if (frequency.equals("high")) {
+      view.setHyphenationFrequency(Layout.BREAK_STRATEGY_HIGH_QUALITY);
+    } else if (frequency.equals("normal")) {
+      view.setHyphenationFrequency(Layout.HYPHENATION_FREQUENCY_NORMAL);
+    } else {
+      throw new JSApplicationIllegalArgumentException("Invalid androidHyphenationFrequency: " + frequency);
     }
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextAnchorViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextAnchorViewManager.java
@@ -7,6 +7,7 @@
 
 package com.facebook.react.views.text;
 
+import android.os.Build;
 import android.text.Layout;
 import android.text.Spannable;
 import android.text.TextUtils;
@@ -99,6 +100,9 @@ public abstract class ReactTextAnchorViewManager<T extends View, C extends React
 
   @ReactProp(name = "android_hyphenationFrequency")
   public void setAndroidHyphenationFrequency(ReactTextView view, @Nullable String frequency) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+      return;
+    }
     if (frequency == null || frequency.equals("none")) {
       view.setHyphenationFrequency(Layout.HYPHENATION_FREQUENCY_NONE);
     } else if (frequency.equals("full")) {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextAnchorViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextAnchorViewManager.java
@@ -97,7 +97,7 @@ public abstract class ReactTextAnchorViewManager<T extends View, C extends React
     }
   }
 
-  @ReactProp(name = "androidHyphenationFrequency")
+  @ReactProp(name = "android_hyphenationFrequency")
   public void setAndroidHyphenationFrequency(ReactTextView view, @Nullable String frequency) {
     if (frequency == null || frequency.equals("none")) {
       view.setHyphenationFrequency(Layout.HYPHENATION_FREQUENCY_NONE);
@@ -110,7 +110,7 @@ public abstract class ReactTextAnchorViewManager<T extends View, C extends React
     } else if (frequency.equals("normal")) {
       view.setHyphenationFrequency(Layout.HYPHENATION_FREQUENCY_NORMAL);
     } else {
-      throw new JSApplicationIllegalArgumentException("Invalid androidHyphenationFrequency: " + frequency);
+      throw new JSApplicationIllegalArgumentException("Invalid android_hyphenationFrequency: " + frequency);
     }
   }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This issue fixes https://github.com/facebook/react-native/issues/28279
android_hyphenationFrequency prop for Android Text component which sets the frequency of automatic hyphenation to use when determining word breaks. 

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Fixed] - Adding Hyphenation Frequency prop for Text component

## Test Plan

More info are available in the [android docs](https://developer.android.com/reference/android/widget/TextView#setHyphenationFrequency(int)). I will add the documentation to the docs later once the pull request is taken in consideration for merging.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

| **AFTER** | 
|:-------------------------:|
|  <img src="https://user-images.githubusercontent.com/24992535/84919245-f8f1e300-b0c1-11ea-8a33-f30d0c9a75b7.png"  width="300" height="" />| 

I remain available to do improvements. Thanks a lot. Fabrizio.

