### PR TITLE
Add quotes around paths in shell script call

### DIFF
--- a/RNTester/RNTesterPods.xcodeproj/project.pbxproj
+++ b/RNTester/RNTesterPods.xcodeproj/project.pbxproj
@@ -586,7 +586,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export NODE_BINARY=node\nPROJECT_ROOT=\"$SRCROOT/..\" \n\"$SRCROOT/../scripts/react-native-xcode.sh\" RNTester/js/RNTesterApp.ios.js\n";
+			shellScript = "export NODE_BINARY=node\n\"$SRCROOT/../scripts/react-native-xcode.sh\" RNTester/js/RNTesterApp.ios.js\n";
 		};
 		C1C7A9D58CE1D09515F20577 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/RNTester/RNTesterPods.xcodeproj/project.pbxproj
+++ b/RNTester/RNTesterPods.xcodeproj/project.pbxproj
@@ -586,7 +586,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export NODE_BINARY=node\nPROJECT_ROOT=$SRCROOT/.. $SRCROOT/../scripts/react-native-xcode.sh RNTester/js/RNTesterApp.ios.js\n";
+			shellScript = "export NODE_BINARY=node\nPROJECT_ROOT=\"$SRCROOT/..\" \n\"$SRCROOT/../scripts/react-native-xcode.sh\" RNTester/js/RNTesterApp.ios.js\n";
 		};
 		C1C7A9D58CE1D09515F20577 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION


<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Without this the RNTester app on iOS can’t be built in a folder that has a space in the path.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [FIXED] - RNTester app builds in a path that contains a space

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

1. Clone react-native into a folder where the path has a space
2. Follow the instructions at https://github.com/facebook/react-native/blob/master/RNTester/README.md to get the RNTesterPods.xcworkspace
3. Open the workspace and build the project. Path to workspace was /Users/richard/UX Cam/Code/Test Projects/ReactNative/react-native/RNTester/RNTesterPods.xcworkspace

4. See error message - '/Users/richard/UX' is the first part of my path before the space

/Users/richard/Library/Developer/Xcode/DerivedData/RNTesterPods-ctjcmrlwzntpssgmcjydmovoztwl/Build/Intermediates.noindex/RNTesterPods.build/Debug-iphonesimulator/RNTester.build/Script-68CD48B71D2BCB2C007E06A9.sh: line 3: /Users/richard/UX: No such file or directory

