### PR TITLE
Fix font variant crash on Android < 4.4

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactBaseTextShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactBaseTextShadowNode.java
@@ -14,6 +14,7 @@ import android.os.Build;
 import android.text.Layout;
 import android.text.Spannable;
 import android.text.SpannableStringBuilder;
+import android.text.TextUtils;
 import android.view.Gravity;
 import androidx.annotation.Nullable;
 import com.facebook.infer.annotation.Assertions;
@@ -34,7 +35,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 /**
  * {@link ReactShadowNode} abstract class for spannable text nodes.
@@ -512,7 +512,7 @@ public abstract class ReactBaseTextShadowNode extends LayoutShadowNode {
   public void setFontVariant(@Nullable ReadableArray fontVariantArray) {
     String fontFeatureSettings = ReactTypefaceUtils.parseFontVariant(fontVariantArray);
 
-    if (!Objects.equals(fontFeatureSettings, mFontFeatureSettings)) {
+    if (!TextUtils.equals(fontFeatureSettings, mFontFeatureSettings)) {
       mFontFeatureSettings = fontFeatureSettings;
       markUpdated();
     }


### PR DESCRIPTION
## Summary

In RN 0.62 support for `fontVariant` was added on Android.
Using that prop crashes the app on Android below KitKat (4.3 and below)

To reproduce just add any Text with the `fontVariant` styling prop in the app:
```js
<Text style={{fontVariant: ['tabular-nums']}}>This will crash</Text>
```
It will crash any device running Android below KitKat with the error:

![image](https://user-images.githubusercontent.com/4534323/85073452-18206b80-b1bb-11ea-8d7e-96f27fa1a320.png)

This is caused by `java.utils.Objects` only being available on Android 4.4+

## Changelog

[Android] [Fixed] - Fix font variant crash on Android < 4.4

## Test Plan

[TextUtils.equals](https://developer.android.com/reference/android/text/TextUtils#equals) was added as soon as API level 1, so no compatibility issue here.
Tested on Emulator running Android 4.1, no crash anymore.

I've searched for other occurences of `java.utils.Objects` in the project, and this was the only one, so no need to remove other occurences ✅ 
