### PR TITLE
Align multi-line TextInput onSubmitEditing behavior

### DIFF
--- a/Libraries/Text/TextInput/RCTBaseTextInputView.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputView.m
@@ -365,11 +365,13 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
   // `onSubmitEditing` is called when "Submit" button
   // (the blue key on onscreen keyboard) did pressed
   // (no connection to any specific "submitting" process).
-  [_eventDispatcher sendTextEventWithType:RCTTextEventTypeSubmit
-                                 reactTag:self.reactTag
-                                     text:self.backedTextInputView.attributedText.string
-                                      key:nil
-                               eventCount:_nativeEventCount];
+  if (_blurOnSubmit) {
+    [_eventDispatcher sendTextEventWithType:RCTTextEventTypeSubmit
+                                   reactTag:self.reactTag
+                                       text:self.backedTextInputView.attributedText.string
+                                        key:nil
+                                 eventCount:_nativeEventCount];
+  }
 
   return _blurOnSubmit;
 }


### PR DESCRIPTION
## Summary

Aligns behavior to be consistent with Android and the [documentation](https://reactnative.dev/docs/textinput#bluronsubmit). `onSubmitEditing` should not be called when `blurOnSubmit=false`.

## Changelog

[iOS] [Fixed] - Align multi-line TextInput onSubmitEditing behavior

## Test Plan

![textinput-blur-align](https://user-images.githubusercontent.com/4123478/85121116-85b4b200-b224-11ea-86c5-065e9e6d22ba.gif)
