### PR TITLE
Fix issue with Swift version compatibility

### DIFF
--- a/template/ios/HelloWorld.xcodeproj/project.pbxproj
+++ b/template/ios/HelloWorld.xcodeproj/project.pbxproj
@@ -420,11 +420,6 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "/usr/lib/swift $(inherited)";
-				LIBRARY_SEARCH_PATHS = (
-					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
-					"\"$(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)\"",
-					"\"$(inherited)\"",
-				);
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -473,11 +468,6 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "/usr/lib/swift $(inherited)";
-				LIBRARY_SEARCH_PATHS = (
-					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
-					"\"$(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)\"",
-					"\"$(inherited)\"",
-				);
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Our app did not build when we added a dependency to our podspec that was built with swift 5.1.

After a lot of back and forth, we found the flag `LIBRARY_SEARCH_PATHS `, and also found that simply clearing it out completely made the app build just fine, and did not cause any other issues with the building or running of our app.

With the flag in place, we got weird errors such as:

```
Undefined symbols for architecture x86_64:
  "type metadata accessor for (extension in Foundation):__C.NSURLSession.DataTaskPublisher", referenced from:
      (extension in TinyNetworkingObjcIO):__C.NSURLSession.load<A>(TinyNetworkingObjcIO.Endpoint<A>) -> Combine.AnyPublisher<A, Swift.Error> in libTinyNetworkingObjcIO.a(Endpoint.o)
      lazy protocol witness table accessor for type (extension in Foundation):__C.NSURLSession.DataTaskPublisher and conformance (extension in Foundation):__C.NSURLSession.DataTaskPublisher : Combine.Publisher in Foundation in libTinyNetworkingObjcIO.a(Endpoint.o)
  "protocol conformance descriptor for (extension in Foundation):__C.NSURLSession.DataTaskPublisher : Combine.Publisher in Foundation", referenced from:
      lazy protocol witness table accessor for type (extension in Foundation):__C.NSURLSession.DataTaskPublisher and conformance (extension in Foundation):__C.NSURLSession.DataTaskPublisher : Combine.Publisher in Foundation in libTinyNetworkingObjcIO.a(Endpoint.o)
  "(extension in Foundation):__C.NSURLSession.dataTaskPublisher(for: Foundation.URLRequest) -> (extension in Foundation):__C.NSURLSession.DataTaskPublisher", referenced from:
      (extension in TinyNetworkingObjcIO):__C.NSURLSession.load<A>(TinyNetworkingObjcIO.Endpoint<A>) -> Combine.AnyPublisher<A, Swift.Error> in libTinyNetworkingObjcIO.a(Endpoint.o)
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

It seems that there are some binary incompatibilities in how Swift 5.1 and newer generates symbols. What used to be NSURLSession.DataTaskPublisher is now URLSession.DataTaskPublisher. We think..

See also: https://stackoverflow.com/questions/62467663/how-to-fix-ios-xcode-build-error-undefined-symbol-c-nsurlsession-datataskpub/62467664#62467664

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [Fixed] - Removed unneedded LIBRARY_SEARCH_PATHS  from xcodebuild config

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

This is not a very testable change. There's an obvious risk of this flag being needed by some projects, even though it worked fine in our project.

So I'm not really able to provide a detailed test plan, unfortunately.