### PR TITLE
fix: remove fixed width for InputAccessoryView

### DIFF
--- a/Libraries/Text/TextInput/RCTInputAccessoryShadowView.m
+++ b/Libraries/Text/TextInput/RCTInputAccessoryShadowView.m
@@ -14,7 +14,6 @@
 - (void)insertReactSubview:(RCTShadowView *)subview atIndex:(NSInteger)atIndex
 {
   [super insertReactSubview:subview atIndex:atIndex];
-  subview.width = (YGValue) { RCTScreenSize().width, YGUnitPoint };
 }
 
 @end

--- a/packages/rn-tester/js/examples/InputAccessoryView/InputAccessoryViewExample.js
+++ b/packages/rn-tester/js/examples/InputAccessoryView/InputAccessoryViewExample.js
@@ -19,6 +19,7 @@ const {
   StyleSheet,
   Text,
   TextInput,
+  useWindowDimensions,
   View,
 } = require('react-native');
 
@@ -33,32 +34,26 @@ class Message extends React.PureComponent<MessageProps> {
   }
 }
 
-type TextInputProps = $ReadOnly<{||}>;
-type TextInputState = {|text: string|};
-class TextInputBar extends React.PureComponent<TextInputProps, TextInputState> {
-  state: TextInputState = {text: ''};
-
-  render(): React.Node {
-    return (
-      <View style={styles.textInputContainer}>
-        <TextInput
-          style={styles.textInput}
-          onChangeText={text => {
-            this.setState({text});
-          }}
-          value={this.state.text}
-          placeholder={'Type a message...'}
-        />
-        <Button
-          onPress={() => {
-            Alert.alert('You tapped the button!');
-          }}
-          title="Send"
-        />
-      </View>
-    );
-  }
-}
+const TextInputBar = (): React.Node => {
+  const [text, setText] = React.useState('');
+  const {width} = useWindowDimensions();
+  return (
+    <View style={[styles.textInputContainer, {width}]}>
+      <TextInput
+        style={styles.textInput}
+        onChangeText={setText}
+        value={text}
+        placeholder={'Type a message...'}
+      />
+      <Button
+        onPress={() => {
+          Alert.alert('You tapped the button!');
+        }}
+        title="Send"
+      />
+    </View>
+  );
+};
 
 const BAR_HEIGHT = 44;
 type InputAccessoryProps = $ReadOnly<{||}>;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Related to #27887

I've removed the fixed width in InputAccessoryView, which was preventing InputAccessoryView to change its width on Viewport change. This allows user to freely set the width of InputAccessoryView, working on bot Portrait and Landscape mode.


It does cause a BreakingChange, as width will need to be implicitly set on the View side, but it also allows a more flexible way of displaying InputAccessoryView without the width constraint.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [Fixed] - Removed fixed width for InputAccessoryView

## Test Plan
Tested wit RNTester
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

![output](https://user-images.githubusercontent.com/6936373/85252018-cebf6d00-b495-11ea-9ff0-c3c3da890741.gif)

