### PR TITLE
Added prop isModalInPresentation to Modal for iOS >= 13

### DIFF
--- a/Libraries/Modal/Modal.js
+++ b/Libraries/Modal/Modal.js
@@ -70,6 +70,12 @@ export type Props = $ReadOnly<{|
    * See https://reactnative.dev/docs/modal.html#transparent
    */
   transparent?: ?boolean,
+                               
+  /**
+   * The `isModalInPresentation` prop determines whether whether the view controller
+   * enforces a modal behavior.
+   */
+  isModalInPresentation?: ?boolean,
 
   /**
    * The `statusBarTranslucent` prop determines whether your modal should go under

--- a/Libraries/Modal/RCTModalHostViewNativeComponent.js
+++ b/Libraries/Modal/RCTModalHostViewNativeComponent.js
@@ -51,6 +51,12 @@ type NativeProps = $ReadOnly<{|
    * See https://reactnative.dev/docs/modal.html#transparent
    */
   transparent?: WithDefault<boolean, false>,
+                              
+  /**
+   * The `isModalInPresentation` callback is used to indicate whether the view controller enforces a modal behavior.
+   *
+   */
+  isModalInPresentation?: WithDefault<boolean, false>,
 
   /**
    * The `statusBarTranslucent` prop determines whether your modal should go under

--- a/React/Views/RCTModalHostView.h
+++ b/React/Views/RCTModalHostView.h
@@ -22,7 +22,7 @@
 @property (nonatomic, copy) NSString *animationType;
 @property (nonatomic, assign) UIModalPresentationStyle presentationStyle;
 @property (nonatomic, assign, getter=isTransparent) BOOL transparent;
-
+@property(nonatomic, getter=isModalInPresentation) BOOL modalInPresentation;
 @property (nonatomic, copy) RCTDirectEventBlock onShow;
 
 @property (nonatomic, copy) NSNumber *identifier;

--- a/React/Views/RCTModalHostView.m
+++ b/React/Views/RCTModalHostView.m
@@ -228,6 +228,11 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : coder)
       transparent ? UIModalPresentationOverFullScreen : UIModalPresentationFullScreen;
 }
 
+- (BOOL)isModalInPresentation
+{
+  return _modalViewController.modalInPresentation;
+}
+
 - (void)setIsModalInPresentation:(BOOL)isInPresentation
 {
   if (@available(iOS 13.0, *)) {

--- a/React/Views/RCTModalHostView.m
+++ b/React/Views/RCTModalHostView.m
@@ -228,6 +228,13 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : coder)
       transparent ? UIModalPresentationOverFullScreen : UIModalPresentationFullScreen;
 }
 
+- (void)setIsModalInPresentation:(BOOL)isInPresentation
+{
+  if (@available(iOS 13.0, *)) {
+    _modalViewController.modalInPresentation = isInPresentation;
+  }
+}
+
 #if !TARGET_OS_TV
 - (UIInterfaceOrientationMask)supportedOrientationsMask
 {

--- a/React/Views/RCTModalHostViewManager.m
+++ b/React/Views/RCTModalHostViewManager.m
@@ -111,6 +111,7 @@ RCT_EXPORT_MODULE()
 
 RCT_EXPORT_VIEW_PROPERTY(animationType, NSString)
 RCT_EXPORT_VIEW_PROPERTY(presentationStyle, UIModalPresentationStyle)
+RCT_EXPORT_VIEW_PROPERTY(isModalInPresentation, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(transparent, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(onShow, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(identifier, NSNumber)


### PR DESCRIPTION
## Summary

Adds a `isModalInPresentation` for  iOS >= 13, which prevents the modal with `presentationStyle` set as `pageSheet` or `formSheet` being dismissed with swipe down.

## Changelog

[iOS] [Added] - `isModalInPresentation` Modal prop for  iOS >= 13 for preventing modal with `presentationStyle` set as `pageSheet` or `formSheet` being dismissed with swipe down.

## Test Plan

![ezgif-4-4e84d1284557](https://user-images.githubusercontent.com/246373/85312011-a2ebb980-b48c-11ea-9eda-5013beee9f49.gif)

