### PR TITLE
feat: provide interface to config URLProtocol in iOS

### DIFF
--- a/Libraries/Network/RCTHTTPRequestHandler.mm
+++ b/Libraries/Network/RCTHTTPRequestHandler.mm
@@ -13,6 +13,7 @@
 #import <ReactCommon/RCTTurboModule.h>
 
 #import "RCTNetworkPlugins.h"
+#import "RCTNetworkConfiguration.h"
 
 @interface RCTHTTPRequestHandler () <NSURLSessionDataDelegate, RCTTurboModule>
 
@@ -83,6 +84,10 @@ RCT_EXPORT_MODULE()
     [configuration setHTTPShouldSetCookies:YES];
     [configuration setHTTPCookieAcceptPolicy:NSHTTPCookieAcceptPolicyAlways];
     [configuration setHTTPCookieStorage:[NSHTTPCookieStorage sharedHTTPCookieStorage]];
+    if ([RCTNetworkConfiguration customizeProtocolClasses].count > 0) {
+        NSArray *defaultProtocols = configuration.protocolClasses;
+        configuration.protocolClasses = [[RCTNetworkConfiguration customizeProtocolClasses] arrayByAddingObjectsFromArray:defaultProtocols];
+    }
     _session = [NSURLSession sessionWithConfiguration:configuration
                                              delegate:self
                                         delegateQueue:callbackQueue];

--- a/Libraries/Network/RCTNetworkConfiguration.h
+++ b/Libraries/Network/RCTNetworkConfiguration.h
@@ -1,0 +1,11 @@
+#import <Foundation/Foundation.h>
+
+@interface RCTNetworkConfiguration : NSObject
+
+/*
+ *  @abstract customizeProtocolClasses
+ */
++ (NSArray*)customizeProtocolClasses;
++ (void)setCustomizeProtocolClasses:(NSArray*)customizeProtocolClasses;
+
+@end

--- a/Libraries/Network/RCTNetworkConfiguration.m
+++ b/Libraries/Network/RCTNetworkConfiguration.m
@@ -1,0 +1,28 @@
+#import <React/RCTNetworkConfiguration.h>
+
+@interface RCTNetworkConfiguration ()
+
+@property (nonatomic, strong) NSArray  * customizeProtocolClasses;
+@end
+
+@implementation RCTNetworkConfiguration
+
++ (instancetype)sharedConfiguration
+{
+    static id _sharedInstance = nil;
+    static dispatch_once_t oncePredicate;
+    dispatch_once(&oncePredicate, ^{
+        _sharedInstance = [[self alloc] init];
+    });
+    return _sharedInstance;
+}
+
++ (NSArray*)customizeProtocolClasses{
+    return [RCTNetworkConfiguration sharedConfiguration].customizeProtocolClasses;
+}
+
++ (void)setCustomizeProtocolClasses:(NSArray *)customizeProtocolClasses{
+    [RCTNetworkConfiguration sharedConfiguration].customizeProtocolClasses = customizeProtocolClasses;
+}
+
+@end


### PR DESCRIPTION
## Summary

Generally speaking, App has their own needs to handle network request, such as modifying header, replacing url component and so on. App needs to unified this on both native and others .
This change provides interface for iOS to config URLProtocol for React-Native network request.

## Changelog


[CATEGORY] [TYPE] - Message

## Test Plan

1. add code below to 'xxx-Bridging-Header.h' in swift project .

```
#import <React/RCTNetworkConfiguration.h>
```

2. create your own URLProtocol in your project .

this is an example to modify header :
```
class RNResourceRequestHeaderProtocol: URLProtocol {}
extension RNResourceRequestHeaderProtocol {

    override class func canInit(with request: URLRequest) -> Bool {
        return true
    }

    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
        var newRequest = request
        xxx.defaultHeaders.forEach { (key, value) in
            newRequest.setValue(value, forHTTPHeaderField: key)
        }
        return newRequest
    }

    override func startLoading() {
        RNResourceRequestHeaderProtocol.request(request: request, delegate: self)
    }

    override func stopLoading() {}

    ......
}
```

3. set protocols before React-Native page run .

```
RCTNetworkConfiguration.setCustomizeProtocolClasses([XXXProtocol.self])
```

4. make a network request

```
fetch('https://reactnative.dev/movies.json')
    .then((response) => response.json())
    .then((json) => {
        this.setState({ data: json.movies });
    })
    .catch((error) => console.error(error))
    .finally(() => {
        this.setState({ isLoading: false });
    });
```


Then your network request of  React-Native page will run with custom header .