### PR TITLE
[Android] Fixing debug mode android

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/DebugCorePackage.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/DebugCorePackage.java
@@ -52,7 +52,7 @@ public class DebugCorePackage extends TurboReactPackage {
       // In OSS case, the annotation processor does not run. We fall back on creating this by hand
       Class<? extends NativeModule>[] moduleList =
           new Class[] {
-            JSCHeapCapture.class, JSDevSupport.class,
+            JSCHeapCapture.class
           };
 
       final Map<String, ReactModuleInfo> reactModuleInfoMap = new HashMap<>();


### PR DESCRIPTION
## Summary

Currently on react native 0.63-rc.0 and 0.63-rc.1 enabling debugging throws an exception. It looks like something may have been missed in unregistering JSDevSupport here https://github.com/facebook/react-native/commit/c20963e11cc1c10f20a2a0a3c209f5b403c9e899#diff-b539a94028d698eccf3446364e6af469

![crash](https://user-images.githubusercontent.com/14797029/85494431-a6736380-b5a6-11ea-8d2d-0f7ac597fd0c.gif)

This should fix #28746 and #29136 

## Changelog

[Android] [Fixed] - Fix crash when enabling debug

## Test Plan

To recreate the bug:

1. npx react-native init RN063 --version 0.63.0-rc.1
2. react-native start
3. react-native run-android
4. Enable debug mode on react native dev menu

After this commit the crash no longer occurs

![non crash](https://user-images.githubusercontent.com/14797029/85495221-1d5d2c00-b5a8-11ea-9679-80327683d9a8.gif)
