### PR TITLE
[Android ]Fix debugging on android for 0.63

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/DebugCorePackage.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/DebugCorePackage.java
@@ -52,7 +52,7 @@ public class DebugCorePackage extends TurboReactPackage {
       // In OSS case, the annotation processor does not run. We fall back on creating this by hand
       Class<? extends NativeModule>[] moduleList =
           new Class[] {
-            JSCHeapCapture.class, JSDevSupport.class,
+            JSCHeapCapture.class
           };
 
       final Map<String, ReactModuleInfo> reactModuleInfoMap = new HashMap<>();


### PR DESCRIPTION
## Summary
Currently on react native 0.63-rc.0 and 0.63-rc.1 enabling debugging throws an exception. It looks like something may have been missed in unregistering JSDevSupport in this commit c20963e

![crash](https://user-images.githubusercontent.com/14797029/85500252-2acae400-b5b1-11ea-938a-674b55e649b2.gif)

This should fix #28746 and #29136

## Changelog
[Android] [Fixed] - Fix crash when enabling debug

## Test Plan
To recreate the bug:

npx react-native init RN063 --version 0.63.0-rc.1
react-native start
react-native run-android
Enable debug mode from react native dev menu


After this commit, the crash no longer occurs

![non crash](https://user-images.githubusercontent.com/14797029/85500241-269ec680-b5b1-11ea-8cfe-85bfda4dd222.gif)
