### PR TITLE
Animated: Interpolation: add 'immutable' configuration property

### DIFF
--- a/Libraries/Animated/src/nodes/AnimatedInterpolation.js
+++ b/Libraries/Animated/src/nodes/AnimatedInterpolation.js
@@ -28,6 +28,7 @@ export type InterpolationConfigType = {
   extrapolate?: ExtrapolateType,
   extrapolateLeft?: ExtrapolateType,
   extrapolateRight?: ExtrapolateType,
+  immutable?: boolean,
 };
 
 const linear = t => t;
@@ -75,6 +76,8 @@ function createInterpolation(
     extrapolateRight = config.extrapolate;
   }
 
+  const immutable = config.immutable || false;
+
   return input => {
     invariant(
       typeof input === 'number',
@@ -91,6 +94,7 @@ function createInterpolation(
       easing,
       extrapolateLeft,
       extrapolateRight,
+      immutable,
     );
   };
 }
@@ -104,7 +108,12 @@ function interpolate(
   easing: (input: number) => number,
   extrapolateLeft: ExtrapolateType,
   extrapolateRight: ExtrapolateType,
+  immutable: boolean,
 ) {
+  if (immutable) {
+    return outputMax;
+  }
+
   let result = input;
 
   // Extrapolate


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Hello everybody,
In my case I have a complex animated svg path. 
So I am calculating all the coordinates for each step of the animation.

This PR adds a property called immutable, adding the behavior of not trying to calculate the coordinates again but just using my previously calculated values as is.

## Changelog

[General] [Added] - Add immutable prop to AnimatedInterpolation

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
