### PR TITLE
babel-plugin-inline-view-configs cannot run externally

### DIFF
--- a/packages/babel-plugin-inline-view-configs/__tests__/__snapshots__/index-test.js.snap
+++ b/packages/babel-plugin-inline-view-configs/__tests__/__snapshots__/index-test.js.snap
@@ -22,7 +22,7 @@ interface NativeCommands {
   +scrollTo: (viewRef: React.ElementRef<NativeType>, y: Int32, animated: boolean) => void,
 }
 
-const registerGeneratedViewConfig = require('registerGeneratedViewConfig');
+const registerGeneratedViewConfig = require('react-native/Libraries/Utilities/registerGeneratedViewConfig');
 
 const {
   dispatchCommand
@@ -87,7 +87,7 @@ interface NativeCommands {
   +scrollTo: (viewRef: React.ElementRef<NativeType>, y: Int32, animated: boolean) => void,
 }
 
-const registerGeneratedViewConfig = require('registerGeneratedViewConfig');
+const registerGeneratedViewConfig = require('react-native/Libraries/Utilities/registerGeneratedViewConfig');
 
 const {
   dispatchCommand

--- a/packages/babel-plugin-inline-view-configs/index.js
+++ b/packages/babel-plugin-inline-view-configs/index.js
@@ -123,7 +123,7 @@ module.exports = function(context) {
           if (this.defaultExport) {
             const viewConfig = generateViewConfig(this.filename, this.code);
             this.defaultExport.replaceWithMultiple(
-              context.parse(viewConfig).program.body,
+              context.parse(viewConfig, {filename: this.filename}).program.body,
             );
             if (this.commandsExport != null) {
               this.commandsExport.remove();

--- a/packages/react-native-codegen/src/generators/components/GenerateViewConfigJs.js
+++ b/packages/react-native-codegen/src/generators/components/GenerateViewConfigJs.js
@@ -52,14 +52,17 @@ function getReactDiffProcessValue(typeAnnotation) {
     case 'ReservedPropTypeAnnotation':
       switch (typeAnnotation.name) {
         case 'ColorPrimitive':
-          return j.template.expression`{ process: require('processColor') }`;
+          return j.template
+            .expression`{ process: require('react-native/Libraries/StyleSheet/processColor') }`;
         case 'ImageSourcePrimitive':
           return j.template
-            .expression`{ process: require('resolveAssetSource') }`;
+            .expression`{ process: require('react-native/Libraries/Image/resolveAssetSource') }`;
         case 'PointPrimitive':
-          return j.template.expression`{ diff: require('pointsDiffer') }`;
+          return j.template
+            .expression`{ diff: require('react-native/Libraries/Utilities/differ/pointsDiffer') }`;
         case 'EdgeInsetsPrimitive':
-          return j.template.expression`{ diff: require('insetsDiffer') }`;
+          return j.template
+            .expression`{ diff: require('react-native/Libraries/Utilities/differ/insetsDiffer') }`;
         default:
           (typeAnnotation.name: empty);
           throw new Error(
@@ -71,7 +74,7 @@ function getReactDiffProcessValue(typeAnnotation) {
         switch (typeAnnotation.elementType.name) {
           case 'ColorPrimitive':
             return j.template
-              .expression`{ process: require('processColorArray') }`;
+              .expression`{ process: require('react-native/Libraries/StyleSheet/processColorArray') }`;
           case 'ImageSourcePrimitive':
             return j.literal(true);
           case 'PointPrimitive':
@@ -181,7 +184,7 @@ function buildViewConfig(
         switch (extendProps.knownTypeName) {
           case 'ReactNativeCoreViewProps':
             imports.add(
-              "const registerGeneratedViewConfig = require('registerGeneratedViewConfig');",
+              "const registerGeneratedViewConfig = require('react-native/Libraries/Utilities/registerGeneratedViewConfig');",
             );
 
             return;

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GenerateViewConfigJs-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GenerateViewConfigJs-test.js.snap
@@ -14,7 +14,7 @@ Map {
 
 'use strict';
 
-const registerGeneratedViewConfig = require('registerGeneratedViewConfig');
+const registerGeneratedViewConfig = require('react-native/Libraries/Utilities/registerGeneratedViewConfig');
 
 const ArrayPropsNativeComponentViewConfig = {
   uiViewClassName: 'ArrayPropsNativeComponent',
@@ -24,7 +24,7 @@ const ArrayPropsNativeComponentViewConfig = {
     disableds: true,
     progress: true,
     radii: true,
-    colors: { process: require('processColorArray') },
+    colors: { process: require('react-native/Libraries/StyleSheet/processColorArray') },
     srcs: true,
     points: true,
     sizes: true,
@@ -59,7 +59,7 @@ Map {
 
 'use strict';
 
-const registerGeneratedViewConfig = require('registerGeneratedViewConfig');
+const registerGeneratedViewConfig = require('react-native/Libraries/Utilities/registerGeneratedViewConfig');
 
 const ArrayPropsNativeComponentViewConfig = {
   uiViewClassName: 'ArrayPropsNativeComponent',
@@ -94,7 +94,7 @@ Map {
 
 'use strict';
 
-const registerGeneratedViewConfig = require('registerGeneratedViewConfig');
+const registerGeneratedViewConfig = require('react-native/Libraries/Utilities/registerGeneratedViewConfig');
 
 const BooleanPropNativeComponentViewConfig = {
   uiViewClassName: 'BooleanPropNativeComponent',
@@ -129,13 +129,13 @@ Map {
 
 'use strict';
 
-const registerGeneratedViewConfig = require('registerGeneratedViewConfig');
+const registerGeneratedViewConfig = require('react-native/Libraries/Utilities/registerGeneratedViewConfig');
 
 const ColorPropNativeComponentViewConfig = {
   uiViewClassName: 'ColorPropNativeComponent',
 
   validAttributes: {
-    tintColor: { process: require('processColor') },
+    tintColor: { process: require('react-native/Libraries/StyleSheet/processColor') },
   },
 };
 
@@ -164,7 +164,7 @@ Map {
 
 'use strict';
 
-const registerGeneratedViewConfig = require('registerGeneratedViewConfig');
+const registerGeneratedViewConfig = require('react-native/Libraries/Utilities/registerGeneratedViewConfig');
 const {dispatchCommand} = require(\\"react-native/Libraries/Renderer/shims/ReactNative\\");
 
 const CommandNativeComponentViewConfig = {
@@ -207,7 +207,7 @@ Map {
 
 'use strict';
 
-const registerGeneratedViewConfig = require('registerGeneratedViewConfig');
+const registerGeneratedViewConfig = require('react-native/Libraries/Utilities/registerGeneratedViewConfig');
 const {dispatchCommand} = require(\\"react-native/Libraries/Renderer/shims/ReactNative\\");
 
 const CommandNativeComponentViewConfig = {
@@ -253,7 +253,7 @@ Map {
 
 'use strict';
 
-const registerGeneratedViewConfig = require('registerGeneratedViewConfig');
+const registerGeneratedViewConfig = require('react-native/Libraries/Utilities/registerGeneratedViewConfig');
 
 const DoublePropNativeComponentViewConfig = {
   uiViewClassName: 'DoublePropNativeComponent',
@@ -293,7 +293,7 @@ Map {
 
 'use strict';
 
-const registerGeneratedViewConfig = require('registerGeneratedViewConfig');
+const registerGeneratedViewConfig = require('react-native/Libraries/Utilities/registerGeneratedViewConfig');
 
 const EventsNestedObjectNativeComponentViewConfig = {
   uiViewClassName: 'EventsNestedObjectNativeComponent',
@@ -338,7 +338,7 @@ Map {
 
 'use strict';
 
-const registerGeneratedViewConfig = require('registerGeneratedViewConfig');
+const registerGeneratedViewConfig = require('react-native/Libraries/Utilities/registerGeneratedViewConfig');
 
 const EventsNativeComponentViewConfig = {
   uiViewClassName: 'EventsNativeComponent',
@@ -403,7 +403,7 @@ Map {
 
 'use strict';
 
-const registerGeneratedViewConfig = require('registerGeneratedViewConfig');
+const registerGeneratedViewConfig = require('react-native/Libraries/Utilities/registerGeneratedViewConfig');
 
 const InterfaceOnlyComponentViewConfig = {
   uiViewClassName: 'RCTInterfaceOnlyComponent',
@@ -465,7 +465,7 @@ Map {
 
 'use strict';
 
-const registerGeneratedViewConfig = require('registerGeneratedViewConfig');
+const registerGeneratedViewConfig = require('react-native/Libraries/Utilities/registerGeneratedViewConfig');
 
 const ExcludedAndroidComponentViewConfig = {
   uiViewClassName: 'ExcludedAndroidComponent',
@@ -497,7 +497,7 @@ Map {
 
 'use strict';
 
-const registerGeneratedViewConfig = require('registerGeneratedViewConfig');
+const registerGeneratedViewConfig = require('react-native/Libraries/Utilities/registerGeneratedViewConfig');
 
 const ExcludedAndroidIosComponentViewConfig = {
   uiViewClassName: 'ExcludedAndroidIosComponent',
@@ -529,7 +529,7 @@ Map {
 
 'use strict';
 
-const registerGeneratedViewConfig = require('registerGeneratedViewConfig');
+const registerGeneratedViewConfig = require('react-native/Libraries/Utilities/registerGeneratedViewConfig');
 
 const FloatPropNativeComponentViewConfig = {
   uiViewClassName: 'FloatPropNativeComponent',
@@ -569,13 +569,13 @@ Map {
 
 'use strict';
 
-const registerGeneratedViewConfig = require('registerGeneratedViewConfig');
+const registerGeneratedViewConfig = require('react-native/Libraries/Utilities/registerGeneratedViewConfig');
 
 const ImagePropNativeComponentViewConfig = {
   uiViewClassName: 'ImagePropNativeComponent',
 
   validAttributes: {
-    thumbImage: { process: require('resolveAssetSource') },
+    thumbImage: { process: require('react-native/Libraries/Image/resolveAssetSource') },
   },
 };
 
@@ -604,13 +604,13 @@ Map {
 
 'use strict';
 
-const registerGeneratedViewConfig = require('registerGeneratedViewConfig');
+const registerGeneratedViewConfig = require('react-native/Libraries/Utilities/registerGeneratedViewConfig');
 
 const InsetsPropNativeComponentViewConfig = {
   uiViewClassName: 'InsetsPropNativeComponent',
 
   validAttributes: {
-    contentInset: { diff: require('insetsDiffer') },
+    contentInset: { diff: require('react-native/Libraries/Utilities/differ/insetsDiffer') },
   },
 };
 
@@ -639,7 +639,7 @@ Map {
 
 'use strict';
 
-const registerGeneratedViewConfig = require('registerGeneratedViewConfig');
+const registerGeneratedViewConfig = require('react-native/Libraries/Utilities/registerGeneratedViewConfig');
 
 const Int32EnumPropsNativeComponentViewConfig = {
   uiViewClassName: 'Int32EnumPropsNativeComponent',
@@ -674,7 +674,7 @@ Map {
 
 'use strict';
 
-const registerGeneratedViewConfig = require('registerGeneratedViewConfig');
+const registerGeneratedViewConfig = require('react-native/Libraries/Utilities/registerGeneratedViewConfig');
 
 const IntegerPropNativeComponentViewConfig = {
   uiViewClassName: 'IntegerPropNativeComponent',
@@ -711,7 +711,7 @@ Map {
 
 'use strict';
 
-const registerGeneratedViewConfig = require('registerGeneratedViewConfig');
+const registerGeneratedViewConfig = require('react-native/Libraries/Utilities/registerGeneratedViewConfig');
 
 const InterfaceOnlyComponentViewConfig = {
   uiViewClassName: 'RCTInterfaceOnlyComponent',
@@ -756,16 +756,16 @@ Map {
 
 'use strict';
 
-const registerGeneratedViewConfig = require('registerGeneratedViewConfig');
+const registerGeneratedViewConfig = require('react-native/Libraries/Utilities/registerGeneratedViewConfig');
 
 const ImageColorPropNativeComponentViewConfig = {
   uiViewClassName: 'ImageColorPropNativeComponent',
 
   validAttributes: {
-    thumbImage: { process: require('resolveAssetSource') },
-    color: { process: require('processColor') },
-    thumbTintColor: { process: require('processColor') },
-    point: { diff: require('pointsDiffer') },
+    thumbImage: { process: require('react-native/Libraries/Image/resolveAssetSource') },
+    color: { process: require('react-native/Libraries/StyleSheet/processColor') },
+    thumbTintColor: { process: require('react-native/Libraries/StyleSheet/processColor') },
+    point: { diff: require('react-native/Libraries/Utilities/differ/pointsDiffer') },
   },
 };
 
@@ -794,7 +794,7 @@ Map {
 
 'use strict';
 
-const registerGeneratedViewConfig = require('registerGeneratedViewConfig');
+const registerGeneratedViewConfig = require('react-native/Libraries/Utilities/registerGeneratedViewConfig');
 
 const NoPropsNoEventsComponentViewConfig = {
   uiViewClassName: 'NoPropsNoEventsComponent',
@@ -826,7 +826,7 @@ Map {
 
 'use strict';
 
-const registerGeneratedViewConfig = require('registerGeneratedViewConfig');
+const registerGeneratedViewConfig = require('react-native/Libraries/Utilities/registerGeneratedViewConfig');
 
 const ObjectPropsViewConfig = {
   uiViewClassName: 'ObjectProps',
@@ -861,13 +861,13 @@ Map {
 
 'use strict';
 
-const registerGeneratedViewConfig = require('registerGeneratedViewConfig');
+const registerGeneratedViewConfig = require('react-native/Libraries/Utilities/registerGeneratedViewConfig');
 
 const PointPropNativeComponentViewConfig = {
   uiViewClassName: 'PointPropNativeComponent',
 
   validAttributes: {
-    startPoint: { diff: require('pointsDiffer') },
+    startPoint: { diff: require('react-native/Libraries/Utilities/differ/pointsDiffer') },
   },
 };
 
@@ -896,7 +896,7 @@ Map {
 
 'use strict';
 
-const registerGeneratedViewConfig = require('registerGeneratedViewConfig');
+const registerGeneratedViewConfig = require('react-native/Libraries/Utilities/registerGeneratedViewConfig');
 
 const StringEnumPropsNativeComponentViewConfig = {
   uiViewClassName: 'StringEnumPropsNativeComponent',
@@ -931,7 +931,7 @@ Map {
 
 'use strict';
 
-const registerGeneratedViewConfig = require('registerGeneratedViewConfig');
+const registerGeneratedViewConfig = require('react-native/Libraries/Utilities/registerGeneratedViewConfig');
 
 const StringPropComponentViewConfig = {
   uiViewClassName: 'StringPropComponent',
@@ -967,7 +967,7 @@ Map {
 
 'use strict';
 
-const registerGeneratedViewConfig = require('registerGeneratedViewConfig');
+const registerGeneratedViewConfig = require('react-native/Libraries/Utilities/registerGeneratedViewConfig');
 
 const MultiFile1NativeComponentViewConfig = {
   uiViewClassName: 'MultiFile1NativeComponent',
@@ -1018,7 +1018,7 @@ Map {
 
 'use strict';
 
-const registerGeneratedViewConfig = require('registerGeneratedViewConfig');
+const registerGeneratedViewConfig = require('react-native/Libraries/Utilities/registerGeneratedViewConfig');
 
 const MultiComponent1NativeComponentViewConfig = {
   uiViewClassName: 'MultiComponent1NativeComponent',
@@ -1069,7 +1069,7 @@ Map {
 
 'use strict';
 
-const registerGeneratedViewConfig = require('registerGeneratedViewConfig');
+const registerGeneratedViewConfig = require('react-native/Libraries/Utilities/registerGeneratedViewConfig');
 const {UIManager} = require(\\"react-native\\")
 
 const NativeComponentNameViewConfig = {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Attempting to run `babel-plugin-inline-view-configs` in `react-native-windows` to verify our out of tree platform view managers align with core.  Hit a couple of issues.

The first one is that when trying to use the plugin with the standard react-native babel-preset.  The default preset has some plugins which use the test option (in particular the typescript plugins).  In order for babel to know if those plugins should be run or not on the view-config, we need to ensure that we pass along the filename when calling into babel parse.

The second issue is several generated requires are using haste imports - so I changed them to full paths.

Note the `babel-plugin-inline-view-configs` still needs to be published externally at some point, and the `react-native-codegen` package needs to be published without flow types in order to fully unblock this.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Internal] [Fixed] - babel-plugin-inline-view-configs cannot run externally

## Test Plan

I ran a version of this locally in react-native-windows.  But there have been a few changes since the version I was working on.  And this code isn't run in OSS.  So it'll require internal validation.  But this code is all run during build, so it should be safe if the build works.
