### PR TITLE
Adding Accessibility Display Options Enabled to RNTester

### DIFF
--- a/RNTester/js/examples/Accessibility/AccessibilityExample.js
+++ b/RNTester/js/examples/Accessibility/AccessibilityExample.js
@@ -750,6 +750,62 @@ class AnnounceForAccessibility extends React.Component<{}> {
   }
 }
 
+class DisplayOptionsStatusExample extends React.Component<{}> {
+  render() {
+    return (
+      <View>
+        <DisplayOptionStatusExample
+          optionName={'Bold Text'}
+          optionChecker={AccessibilityInfo.isBoldTextEnabled}
+          notification={'boldTextChanged'}
+        />
+        <DisplayOptionStatusExample
+          optionName={'Grayscale'}
+          optionChecker={AccessibilityInfo.isGrayscaleEnabled}
+          notification={'grayscaleChanged'}
+        />
+        <DisplayOptionStatusExample
+          optionName={'Invert Colors'}
+          optionChecker={AccessibilityInfo.isInvertColorsEnabled}
+          notification={'invertColorsChanged'}
+        />
+        <DisplayOptionStatusExample
+          optionName={'Reduce Motion'}
+          optionChecker={AccessibilityInfo.isReduceMotionEnabled}
+          notification={'reduceMotionChanged'}
+        />
+        <DisplayOptionStatusExample
+          optionName={'Reduce Transparency'}
+          optionChecker={AccessibilityInfo.isReduceTransparencyEnabled}
+          notification={'reduceTransparencyChanged'}
+        />
+      </View>
+    );
+  }
+}
+
+function DisplayOptionStatusExample({optionName, optionChecker, notification}) {
+  const [statusEnabled, setStatusEnabled] = React.useState(false);
+  React.useEffect(() => {
+    AccessibilityInfo.addEventListener(notification, setStatusEnabled);
+    optionChecker().then(isEnabled => {
+      setStatusEnabled(isEnabled);
+    });
+    return function cleanup() {
+      AccessibilityInfo.removeEventListener(notification, setStatusEnabled);
+    };
+  }, []);
+  return (
+    <View>
+      <Text>
+        {optionName}
+        {' is '}
+        {statusEnabled ? 'enabled' : 'disabled'}.
+      </Text>
+    </View>
+  );
+}
+
 exports.title = 'Accessibility';
 exports.description = 'Examples of using Accessibility APIs.';
 exports.examples = [
@@ -781,6 +837,12 @@ exports.examples = [
     title: 'Check if the screen reader is enabled',
     render(): React.Element<typeof ScreenReaderStatusExample> {
       return <ScreenReaderStatusExample />;
+    },
+  },
+  {
+    title: 'Check if the display options are enabled',
+    render(): React.Element<typeof DisplayOptionsStatusExample> {
+      return <DisplayOptionsStatusExample />;
     },
   },
   {


### PR DESCRIPTION
## Summary

Currently there isn't any way to test if the Accessibility Display Options or the event listeners for them were working properly within RNTester. It turns out that because of changes to the accessibility API Apple made when they added Smart Invert AccessibilityInfo.isInvertColorsEnabled() and the associated event listener are working incorrectly. You can see this if you take a look at how RNTester (with this PR incorporated) responds to toggling Invert Colors. I've submitted a bug report to Apple, but this might have been caught earlier if this had been implemented.

## Changelog

[General] [Added] - Adding Accessibility Display Options Enabled to RNTester

## Test Plan

![Simulator Screen Shot - iPhone 11 - 2020-06-26 at 21 13 16](https://user-images.githubusercontent.com/65255457/85914380-f09c5500-b7f1-11ea-98db-b83fb4ab5305.png)
![Simulator Screen Shot - iPhone 11 - 2020-06-26 at 21 13 39](https://user-images.githubusercontent.com/65255457/85914382-f2feaf00-b7f1-11ea-8ebf-cdb2b703c731.png)

1. Build iOS app
2. Navigate to the Accessibility page
3. Switch over to settings and change any of the settings at
  - Settings>Accessibility>Display and Text Size>Bold Text
  - Settings>Accessibility>Display and Text Size>Color Filters>Grayscale
  - Settings>Accessibility>Display and Text Size>Smart Invert (or Classic Invert)
  - Settings>Accessibility>Motion>Reduce Motion
  - Settings>Accessibility>VoiceOver>VoiceOver
4. Switch back to the app and see the results
