### PR TITLE
Fix KeyboardAvoidingView to keep frame height

### DIFF
--- a/Libraries/Components/Keyboard/KeyboardAvoidingView.js
+++ b/Libraries/Components/Keyboard/KeyboardAvoidingView.js
@@ -87,7 +87,7 @@ class KeyboardAvoidingView extends React.Component<Props, State> {
 
     // Calculate the displacement needed for the view such that it
     // no longer overlaps with the keyboard
-    return Math.max(frame.y + frame.height - keyboardY, 0);
+    return Math.max(frame.y + this._initialFrameHeight - keyboardY, 0);
   }
 
   _onKeyboardChange = (event: ?KeyboardEvent) => {

--- a/RNTester/js/examples/KeyboardAvoidingView/KeyboardAvoidingViewExample.js
+++ b/RNTester/js/examples/KeyboardAvoidingView/KeyboardAvoidingViewExample.js
@@ -24,6 +24,8 @@ const {
 const RNTesterBlock = require('../../components/RNTesterBlock');
 const RNTesterPage = require('../../components/RNTesterPage');
 
+const behaviorOptions = ['padding', 'position', 'height'];
+
 type Props = $ReadOnly<{||}>;
 type State = {|
   behavior: string,
@@ -49,9 +51,9 @@ class KeyboardAvoidingViewExample extends React.Component<Props, State> {
             style={styles.container}>
             <SegmentedControlIOS
               onValueChange={this.onSegmentChange}
-              selectedIndex={this.state.behavior === 'padding' ? 0 : 1}
+              selectedIndex={behaviorOptions.indexOf(this.state.behavior)}
               style={styles.segment}
-              values={['Padding', 'Position']}
+              values={behaviorOptions}
             />
             <TextInput placeholder="<TextInput />" style={styles.textInput} />
           </KeyboardAvoidingView>


### PR DESCRIPTION
## Summary

### KeyboardAvoidingView

There is an issue like below when `behavior="height"` is selected.

KeyboardAvoidingView stops working when you change input type (e.g. from English to Emoji).
This is how to reproduce the issue.

- Use `KeyboardAvoidingView behavior="height"`
- Focus input field
- Keyboard appears
- Change keyboard type
- `KeyboardAvoidingView` goes back to the original height, therefore nested elements return to the original position.

Related issue: https://github.com/facebook/react-native/issues/26293

### KeyboardAvoidingViewExample

Added `height` option example in RNTester.



## Changelog

[General] [Fixed] - Fix KeyboardAvoidingView's behavior "height"



## Test Plan

### Before

![KeyAvoidingView-demo](https://user-images.githubusercontent.com/3123900/85953644-ebcfd080-b9ac-11ea-8c09-8fec99162e53.gif)

### After

![Fixed](https://user-images.githubusercontent.com/3123900/85953762-9ea02e80-b9ad-11ea-9ba7-4cd31a8bd6b3.gif)


