### PR TITLE
[Android]  do not call setHyphenationFrequency on AndroidSdk < 23

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextAnchorViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextAnchorViewManager.java
@@ -7,6 +7,7 @@
 
 package com.facebook.react.views.text;
 
+import android.os.Build;
 import android.text.Layout;
 import android.text.Spannable;
 import android.text.TextUtils;
@@ -23,6 +24,7 @@ import com.facebook.react.uimanager.ViewProps;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.annotations.ReactPropGroup;
 import com.facebook.yoga.YogaConstants;
+import com.facebook.common.logging.FLog;
 
 /**
  * Abstract class for anchor {@code <Text>}-ish spannable views, such as {@link TextView} or {@link
@@ -39,6 +41,7 @@ public abstract class ReactTextAnchorViewManager<T extends View, C extends React
   private static final int[] SPACING_TYPES = {
     Spacing.ALL, Spacing.LEFT, Spacing.RIGHT, Spacing.TOP, Spacing.BOTTOM,
   };
+  private static final String TAG = "ReactTextAnchorViewManager";
 
   // maxLines can only be set in master view (block), doesn't really make sense to set in a span
   @ReactProp(name = ViewProps.NUMBER_OF_LINES, defaultInt = ViewDefaults.NUMBER_OF_LINES)
@@ -99,6 +102,10 @@ public abstract class ReactTextAnchorViewManager<T extends View, C extends React
 
   @ReactProp(name = "android_hyphenationFrequency")
   public void setAndroidHyphenationFrequency(ReactTextView view, @Nullable String frequency) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+      FLog.w(TAG, "android_hyphenationFrequency only available since android 23");
+      return;
+    }
     if (frequency == null || frequency.equals("none")) {
       view.setHyphenationFrequency(Layout.HYPHENATION_FREQUENCY_NONE);
     } else if (frequency.equals("full")) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

@JoshuaGross This issue fixes https://github.com/facebook/react-native/issues/28279 as discussed in https://github.com/facebook/react-native/pull/29157#issuecomment-649993571
Avoid calling [setHyphenationFrequency](https://developer.android.com/reference/android/widget/TextView#setHyphenationFrequency(int)) on Android Sdk < 23. 

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Fixed] - do not call setHyphenationFrequency on AndroidSdk < 23

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

| **BEFORE** | **AFTER** | 
|:-------------------------:|:-------------------------:|
|  <img src="https://user-images.githubusercontent.com/24992535/86214122-05bf0e00-bb7b-11ea-93b5-2174812bfec9.png"  width="300" height="" />| <img src="https://user-images.githubusercontent.com/24992535/86214130-08216800-bb7b-11ea-9fc0-68b28638bf57.png" width="300" height="" /> |

The warning displayed with `adb logcat | grep -P "ReactTextAnchorViewManager"`

![image](https://user-images.githubusercontent.com/24992535/86214242-34d57f80-bb7b-11ea-9945-30ae25332bfb.png)

I remain available to do improvements. Thanks a lot. Fabrizio.

