### PR TITLE
Respect paddings and border in shadow input view

### DIFF
--- a/Libraries/Text/TextInput/RCTBaseTextInputShadowView.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputShadowView.m
@@ -92,8 +92,10 @@
 
   if (_maximumNumberOfLines == 1) {
     maximumSize.width = CGFLOAT_MAX;
+    maximumSize.height -= self.paddingTop.value + self.paddingBottom.value + self.borderWidth;
   } else {
     maximumSize.height = CGFLOAT_MAX;
+    maximumSize.width -= self.paddingLeft.value + self.paddingRight.value + self.borderWidth;
   }
 
   CGSize contentSize = [self sizeThatFitsMinimumSize:(CGSize)CGSizeZero maximumSize:maximumSize];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Fixes #28012
After adding some symbols to the input view with paddings, UI renders these symbols on the new line, but returned contentSize from `onContentSizeChange` callback gives a box a bit wider but with the same height. Only after adding some more symbols returned height would be changed.

Now it respects set paddings and border width.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [Fixed] - Fix for height calculation for input view 

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

This is how control works before made changes:
![before-changes](https://user-images.githubusercontent.com/4902794/86252569-0e840400-bbbc-11ea-8bf5-71bbd5f6abdd.gif)

And this is after:
![after-changes](https://user-images.githubusercontent.com/4902794/86252578-12178b00-bbbc-11ea-8c9e-e1fe2653fa46.gif)

This is a sample code that could help reproduce the issue. It would just print `contentSize` without any changes to height of the input view.

```javascript
const onContentSizeChange = (e) => {
    const { contentSize } = e.nativeEvent;
    console.log("contentSize: ", contentSize);
};
const onChangeText = (text) => {
    setText(text);
};
const renderInput = (props) => (
        <TextInput
            value={text}
            placeholder="Your text"
            multiline={true}
            onContentSizeChange={onContentSizeChange}
            onChangeText={onChangeText}
            style={[
                {
                    minHeight: 44,
                    maxHeight: 84,
                    flex: 1,
                    borderRadius: 22,
                    borderColor: 'gray',
                    borderWidth: 1,
                    paddingTop: 12,
                    paddingLeft: 16,
                    paddingRight: 16,
                    paddingBottom: 12,
                    lineHeight: 20,
                    fontSize: 16,
                    marginRight: 16,
                    marginLeft: 16,
                    marginTop: 16,
                    marginBottom: 16,
                    backgroundColor: 'white',
                }
            ]}
        />
);
```
