### PR TITLE
Fixing CI error "Entry file RNTester/js/RNTesterApp.ios.js does not exist"

### DIFF
--- a/scripts/react-native-xcode.sh
+++ b/scripts/react-native-xcode.sh
@@ -83,7 +83,7 @@ else
   ENTRY_FILE=${1:-index.js}
 fi
 
-if [[ $DEV != true && ! -f "$ENTRY_FILE" ]]; then
+if [[ $DEV != true && ! -f "../$ENTRY_FILE" ]]; then
   echo "error: Entry file $ENTRY_FILE does not exist. If you use another file as your entry point, pass ENTRY_FILE=myindex.js" >&2
   exit 2
 fi


### PR DESCRIPTION
## Summary

PRs are failing with the error "Entry file RNTester/js/RNTesterApp.ios.js does not exist", despite it existing. The if statement around the checker will always trigger because when it looks to see if RNTester/js/RNTesterApp.ios.js exists it's inside of RNTester instead of root. I've added a "../" to solve this.

## Changelog

[Internal] [Fixed] - Fixing CI error "Entry file RNTester/js/RNTesterApp.ios.js does not exist"

## Test Plan
![Screen Shot 2020-07-01 at 11 25 03](https://user-images.githubusercontent.com/65255457/86278790-cc43ce00-bb8d-11ea-8098-9f4a751667ae.png)
![Screen Shot 2020-07-01 at 11 26 52](https://user-images.githubusercontent.com/65255457/86278796-ccdc6480-bb8d-11ea-9d73-63801f77e840.png)

