### PR TITLE
Update JSLoader.cpp

### DIFF
--- a/ReactAndroid/src/main/jni/react/jni/JSLoader.cpp
+++ b/ReactAndroid/src/main/jni/react/jni/JSLoader.cpp
@@ -66,7 +66,7 @@ loadScriptFromAssets(AAssetManager *manager, const std::string &assetName) {
 
   throw std::runtime_error(folly::to<std::string>(
       "Unable to load script. Make sure you're "
-      "either running Metro (run 'react-native start') or that your bundle '",
+      "either running Metro (run 'npx react-native start') or that your bundle '",
       assetName,
       "' is packaged correctly for release."));
 }


### PR DESCRIPTION
Since react-native-cli is deprecated, the correct command should be `npx react-native start`