### PR TITLE
Update reference to statusBarTranslucent in Modal comment

### DIFF
--- a/Libraries/Modal/Modal.js
+++ b/Libraries/Modal/Modal.js
@@ -76,7 +76,7 @@ export type Props = $ReadOnly<{|
    * The `statusBarTranslucent` prop determines whether your modal should go under
    * the system statusbar.
    *
-   * See https://reactnative.dev/docs/modal.html#transparent
+   * See https://reactnative.dev/docs/modal.html#statusbartranslucent
    */
   statusBarTranslucent?: ?boolean,
 


### PR DESCRIPTION
The comment that points to the documentation for statusBarTranslucent was pointing to the incorrect property.

## Summary

Noticed the link to the documentation was incorrect when making this change to the docs: https://github.com/facebook/react-native-website/pull/2023

## Changelog

[Internal] [Fixed] - Updated comment in Modal to point to the correct section of the documentation for `statusBarTranslucent` property

## Test Plan

N/A