### PR TITLE
Fix passing react native path in Podfile template

### DIFF
--- a/template/ios/Podfile
+++ b/template/ios/Podfile
@@ -6,7 +6,7 @@ platform :ios, '10.0'
 target 'HelloWorld' do
   config = use_native_modules!
 
-  use_react_native!(:path => config["reactNativePath"])
+  use_react_native!(:path => config[:reactNativePath])
 
   target 'HelloWorldTests' do
     inherit! :complete


### PR DESCRIPTION
## Summary

Since https://github.com/react-native-community/cli/commit/e949e234b03fb65f8e4ed2706dfaa745aa59a14f#diff-d1800049b92343288bcbc1c484575058 the RN cli script returns an object with `:reactNativePath` instead of just JSON. Not super familiar with how objects / JSON works in ruby but using this syntax instead works.
 
## Changelog

[Fixed] [iOS] - Fix passing react native path in Podfile template

## Test Plan

Tested in a project inside a monorepo using the latest version of RN CLI that the proper react-native path is now passed.
