### PR TITLE
Fix crash on StatusBar.pushStackEntry if animated property is not provided

### DIFF
--- a/Libraries/Components/StatusBar/StatusBar.js
+++ b/Libraries/Components/StatusBar/StatusBar.js
@@ -473,7 +473,7 @@ class StatusBar extends React.Component<Props> {
           );
           NativeStatusBarManagerAndroid.setColor(
             processedColor,
-            mergedProps.backgroundColor.animated,
+            mergedProps.backgroundColor.animated || false,
           );
         }
         if (!oldProps || oldProps.hidden.value !== mergedProps.hidden.value) {

--- a/Libraries/Components/StatusBar/StatusBar.js
+++ b/Libraries/Components/StatusBar/StatusBar.js
@@ -473,7 +473,7 @@ class StatusBar extends React.Component<Props> {
           );
           NativeStatusBarManagerAndroid.setColor(
             processedColor,
-            mergedProps.backgroundColor.animated || false,
+            Boolean(mergedProps.backgroundColor.animated),
           );
         }
         if (!oldProps || oldProps.hidden.value !== mergedProps.hidden.value) {

--- a/Libraries/Components/StatusBar/StatusBar.js
+++ b/Libraries/Components/StatusBar/StatusBar.js
@@ -473,7 +473,7 @@ class StatusBar extends React.Component<Props> {
           );
           NativeStatusBarManagerAndroid.setColor(
             processedColor,
-            Boolean(mergedProps.backgroundColor.animated),
+            mergedProps.backgroundColor.animated || false,
           );
         }
         if (!oldProps || oldProps.hidden.value !== mergedProps.hidden.value) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

On Android, `StatusBar.pushStackEntry` with `backgroundColor` only causes crash unless animated is specified. as reported in this bug https://github.com/facebook/react-native/issues/29282

This is fixed by simply providing false as a default value.

## Changelog

[Android] [fixed] - Fix android crash when calling `StatusBar.pushStackEntry` without provide animated property value.

## Test Plan

- Create a new project and call on app start

```
StatusBar.pushStackEntry({
  backgroundColor: 'white',
});
```
It should not cause a crash.

Here is a [Expo snack](https://snack.expo.dev/@drmas/f64393) for testing the crash
