### PR TITLE
TextInput editable=false focus fix

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -945,6 +945,15 @@ function InternalTextInput(props: Props): React.Node {
     }
   }
 
+  function focus(): void {
+    const {current} = inputRef;
+    if (props.editable === false || current === null) {
+      return;
+    }
+    // $FlowFixMe - `focus` is missing in `$ReadOnly`
+    Object.getPrototypeOf(current)?.focus?.call(current);
+  }
+
   // TODO: Fix this returning true on null === null, when no input is focused
   function isFocused(): boolean {
     return TextInputState.currentlyFocusedInput() === inputRef.current;
@@ -983,6 +992,7 @@ function InternalTextInput(props: Props): React.Node {
         */
       if (ref) {
         ref.clear = clear;
+        ref.focus = focus;
         ref.isFocused = isFocused;
         ref.getNativeRef = getNativeRef;
       }

--- a/Libraries/Components/TextInput/__tests__/TextInput-test.js
+++ b/Libraries/Components/TextInput/__tests__/TextInput-test.js
@@ -57,7 +57,7 @@ describe('TextInput tests', () => {
   it('has expected instance functions', () => {
     expect(inputRef.current.isFocused).toBeInstanceOf(Function); // Would have prevented S168585
     expect(inputRef.current.clear).toBeInstanceOf(Function);
-    expect(inputRef.current.focus).toBeInstanceOf(jest.fn().constructor);
+    expect(inputRef.current.focus).toBeInstanceOf(Function);
     expect(inputRef.current.blur).toBeInstanceOf(jest.fn().constructor);
     expect(inputRef.current.setNativeProps).toBeInstanceOf(
       jest.fn().constructor,


### PR DESCRIPTION
## Summary 

Fixed problem: when we call `focus()` upon `TextInput` ref which has prop `editable=false` it marks the textinput as focused in `TextInputState` even though the focus is rejected by textinput because it is not editable.

## Changelog

[General] [Fixed] - TextInput editable=false focus fix

## Test Plan

Create a `TextInput` with prop `editable=false` and call `ref.current.focus()` upon its ref. `TextInput` should not be marked as focused.
