### PR TITLE
iOS: Update RCTAlertManager to use new RCTAlertController

### DIFF
--- a/React/CoreModules/RCTAlertManager.mm
+++ b/React/CoreModules/RCTAlertManager.mm
@@ -13,6 +13,7 @@
 #import <React/RCTConvert.h>
 #import <React/RCTLog.h>
 #import <React/RCTUtils.h>
+#import <React/RCTAlertController.h>
 
 #import "CoreModulesPlugins.h"
 
@@ -99,27 +100,7 @@ RCT_EXPORT_METHOD(alertWithArgs : (JS::NativeAlertManager::Args &)args callback 
     }
   }
 
-  UIViewController *presentingController = RCTPresentedViewController();
-  if (presentingController == nil) {
-    RCTLogError(@"Tried to display alert view but there is no application window. args: %@", @{
-      @"title" : args.title() ?: [NSNull null],
-      @"message" : args.message() ?: [NSNull null],
-      @"buttons" : RCTConvertOptionalVecToArray(
-          args.buttons(),
-          ^id(id<NSObject> element) {
-            return element;
-          })
-          ?: [NSNull null],
-      @"type" : args.type() ?: [NSNull null],
-      @"defaultValue" : args.defaultValue() ?: [NSNull null],
-      @"cancelButtonKey" : args.cancelButtonKey() ?: [NSNull null],
-      @"destructiveButtonKey" : args.destructiveButtonKey() ?: [NSNull null],
-      @"keyboardType" : args.keyboardType() ?: [NSNull null],
-    });
-    return;
-  }
-
-  UIAlertController *alertController = [UIAlertController alertControllerWithTitle:title
+  RCTAlertController *alertController = [RCTAlertController alertControllerWithTitle:title
                                                                            message:nil
                                                                     preferredStyle:UIAlertControllerStyleAlert];
   switch (type) {
@@ -170,7 +151,7 @@ RCT_EXPORT_METHOD(alertWithArgs : (JS::NativeAlertManager::Args &)args callback 
     } else if ([buttonKey isEqualToString:destructiveButtonKey]) {
       buttonStyle = UIAlertActionStyleDestructive;
     }
-    __weak UIAlertController *weakAlertController = alertController;
+    __weak RCTAlertController *weakAlertController = alertController;
     [alertController
         addAction:[UIAlertAction
                       actionWithTitle:buttonTitle
@@ -202,7 +183,7 @@ RCT_EXPORT_METHOD(alertWithArgs : (JS::NativeAlertManager::Args &)args callback 
   [_alertControllers addObject:alertController];
 
   dispatch_async(dispatch_get_main_queue(), ^{
-    [presentingController presentViewController:alertController animated:YES completion:nil];
+    [alertController show:YES completion:nil];
   });
 }
 

--- a/React/Views/RCTAlertController.h
+++ b/React/Views/RCTAlertController.h
@@ -1,0 +1,7 @@
+#import <UIKit/UIKit.h>
+
+@interface RCTAlertController : UIAlertController
+
+- (void)show:(BOOL)animated completion:(void (^)(void))completion;
+
+@end

--- a/React/Views/RCTAlertController.m
+++ b/React/Views/RCTAlertController.m
@@ -1,0 +1,25 @@
+#import "RCTAlertController.h"
+
+@interface RCTAlertController ()
+
+@property (nonatomic, strong) UIWindow *alertWindow;
+
+@end
+
+@implementation RCTAlertController
+
+- (UIWindow *)alertWindow {
+    if (_alertWindow == nil) {
+        _alertWindow = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
+        _alertWindow.rootViewController = [UIViewController new];
+        _alertWindow.windowLevel = UIWindowLevelAlert + 1;
+    }
+    return _alertWindow;
+}
+
+- (void)show:(BOOL)animated completion:(void (^)(void))completion {
+    [self.alertWindow makeKeyAndVisible];
+    [self.alertWindow.rootViewController presentViewController:self animated:animated completion:completion];
+}
+
+@end

--- a/React/Views/RCTAlertController.m
+++ b/React/Views/RCTAlertController.m
@@ -10,7 +10,7 @@
 
 - (UIWindow *)alertWindow {
     if (_alertWindow == nil) {
-        _alertWindow = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
+        _alertWindow = [[UIWindow alloc] initWithFrame:[[UIApplication sharedApplication] keyWindow].bounds];
         _alertWindow.rootViewController = [UIViewController new];
         _alertWindow.windowLevel = UIWindowLevelAlert + 1;
     }


### PR DESCRIPTION
## Summary

This should fix #29082 and #10471

Currently when an alert is being shown while a modal is being dismissed, it causes the alert not to show and In some cases it causes the UI to become unresponsive. I think this was caused by using RCTPresentedViewController to try and display the Alert the currently presented view. The View the Alert was going to be shown on is dismissed and the modal doesn't show. I implemented a new RCTAlertController to show the alert on top of the view, the modal being dismissed should now not interfere with the alert being shown.

## Changelog

[iOS] [Fixed] - Fixed showing Alert while closing a Modal

## Test Plan

To recreate the bug:

1. npx react-native init Test --version 0.63.0-rc.1
2. Paste the following code into App.js

```javascript
/**
 * Sample React Native App
 * https://github.com/facebook/react-native
 *
 * @format
 * @flow strict-local
 */

import React from 'react';
import {
  SafeAreaView,
  StyleSheet,
  View,
  Text,
  StatusBar,
  Modal,
  Alert
} from 'react-native';

const App: () => React$Node = () => {
  const [visible, setVisible] = React.useState(false)

  const onShowModal = () => {
    setVisible(true)
  }

  onCloseBroken = () => {
    setVisible(false)
    Alert.alert('Alert', 'Alert won\'t show')
  }

  onCloseWorking = () => {
    setVisible(false)
    setTimeout(() => Alert.alert('Alert', 'Works fine'), 10)
  }

  return (
    <>
      <StatusBar barStyle="dark-content" />
      <SafeAreaView style={styles.container}>
        <Text onPress={onShowModal}>Show modal</Text>
      </SafeAreaView>
      <Modal animationType="fade" visible={visible} onRequestClose={onCloseWorking} >
        <View style={styles.container}>
          <Text onPress={onCloseBroken}>Close modal immediately</Text>
          <Text onPress={onCloseWorking}>Close modal with delay</Text>
        </View>
      </Modal>
    </>
  )
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    alignItems: 'center',
    justifyContent: 'space-around',
  },
})

export default App

```

3. cd Test && npx react-native run-ios
4. Show the modal and click the `Close modal immediately` button

The first button doesn't show the alert, the second does because it gets rendered after the modal view is dismissed. After this commit, the alert always shows on top of every view properly. You can test by pointing the react native package to my branch by modifying the package json file like this

```
    "react-native": "https://github.com/devon94/react-native.git#fix-ios-modal"
```

I was unable to reproduce the case where it causes the UI to be responsive in the test app but was able to reproduce it in our react native app at work. I can provide a video later if needed but the code is too complex to simplify into a test case.

