### PR TITLE
Fix LogBox.ignoreAllLogs used with no argument

### DIFF
--- a/Libraries/LogBox/LogBox.js
+++ b/Libraries/LogBox/LogBox.js
@@ -43,7 +43,7 @@ if (__DEV__) {
     },
 
     ignoreAllLogs: (value?: ?boolean): void => {
-      LogBoxData.setDisabled(!!value);
+      LogBoxData.setDisabled(value == null ? true : value);
     },
 
     uninstall: (): void => {

--- a/Libraries/LogBox/__tests__/LogBox-test.js
+++ b/Libraries/LogBox/__tests__/LogBox-test.js
@@ -69,6 +69,30 @@ describe('LogBox', () => {
     expect(LogBoxData.isDisabled()).toBe(true);
   });
 
+  it('will not ignore logs for `ignoreAllLogs(false)`', () => {
+    expect(LogBoxData.isDisabled()).toBe(false);
+
+    LogBox.install();
+
+    expect(LogBoxData.isDisabled()).toBe(false);
+
+    LogBox.ignoreAllLogs(false);
+
+    expect(LogBoxData.isDisabled()).toBe(false);
+  });
+
+  it('will ignore logs for `ignoreAllLogs()`', () => {
+    expect(LogBoxData.isDisabled()).toBe(false);
+
+    LogBox.install();
+
+    expect(LogBoxData.isDisabled()).toBe(false);
+
+    LogBox.ignoreAllLogs();
+
+    expect(LogBoxData.isDisabled()).toBe(true);
+  });
+
   it('registers warnings', () => {
     jest.mock('../Data/LogBoxData');
 


### PR DESCRIPTION
## Summary

When you call `LogBox.ignoreAllLogs()` it should ignore logs.

This fixes a bug that made this equivalent to `LogBox.ignoreAllLogs(false)`

## Changelog

[General] [Fixed] - LogBox.ignoreAllLogs() should ignore logs

## Test Plan

Added tests