### PR TITLE
Convert Bundle, List and Arrays in android bridges

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/Arguments.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/Arguments.java
@@ -179,6 +179,12 @@ public class Arguments {
         arguments.pushMap((WritableNativeMap) argument);
       } else if (argumentClass == WritableNativeArray.class) {
         arguments.pushArray((WritableNativeArray) argument);
+      } else if (argumentClass == Bundle.class) {
+        arguments.pushMap(fromBundle((Bundle) argument));
+      } else if (argumentClass.isArray()) {
+        arguments.pushArray(fromArray(argument));
+      } else if (argument instanceof List) {
+        arguments.pushArray(fromList((List) argument));
       } else {
         throw new RuntimeException("Cannot convert argument of type " + argumentClass);
       }


### PR DESCRIPTION
## Summary

If you're writing a bridge wrapping a native SDK, it's likely the native SDK will provide methods returning `Bundle`, `List` and `Arrays`. 
Having React Native automatically convert them to `WritableMap` or `WritableArray` would be a comfort for developers writing such bridges.

If we fail to convert them, we end up with a crash at runtime:

<img width="444" alt="image" src="https://user-images.githubusercontent.com/4534323/87077831-006d5d80-c224-11ea-82e6-b0d9190a9a48.png">

## Changelog

[Android] [Changed] - Convert Bundle, List and Arrays in android promises in Bridge

## Test Plan

[Here is a repository demonstrating the issue](https://github.com/Almouro/react-native-convert-args-test)
The last commit adds a forked version of React Native which fixes the issue.

### 1. Create the native bridge

Add 3 methods returning Bundle, List or Array:
```java
    @ReactMethod
    public void getBundle(Promise promise) {
        final Bundle bundle = new Bundle();
        bundle.putStringArray("strings", new String[] {"youpi"});

        final Bundle nestedBundle = new Bundle();
        nestedBundle.putFloat("float", 3.14f);
        bundle.putBundle("bundle", nestedBundle);

        promise.resolve(bundle);
    }

    @ReactMethod
    public void getList(Promise promise) {
        promise.resolve(Arrays.asList("youpi", "this", "should", "work"));
    }

    @ReactMethod
    public void getArray(Promise promise) {
        promise.resolve(new String[] {"youpi", "this", "should", "work"});
    }
```

### 2. Call the methods from the JS

```js
NativeModules.Bridge.getBundle().then((bundle) =>
  console.log('bundle', bundle),
);
NativeModules.Bridge.getList().then((list) => console.log('list', list));
NativeModules.Bridge.getArray().then((array) => console.log('array', array));
```

Each of the method will crash the app at runtime

### 3. Use forked version containing the fix from this branch

```
yarn add almouro/react-native#feat/convert-more-android-arguments-release
```

We now see the proper logs:

```
Running "BundleTest" with {"rootTag":71}
 bundle {"bundle": {"float": 3.140000104904175}, "strings": ["youpi"]}
list ["youpi", "this", "should", "work"]
array ["youpi", "this", "should", "work"]
```