### PR TITLE
fix: removing overrides for onopen, onclose, onmessage, onerror

### DIFF
--- a/Libraries/WebSocket/WebSocket.js
+++ b/Libraries/WebSocket/WebSocket.js
@@ -68,11 +68,6 @@ class WebSocket extends (EventTarget(...WEBSOCKET_EVENTS): any) {
   _subscriptions: Array<EventSubscription>;
   _binaryType: ?BinaryType;
 
-  onclose: ?Function;
-  onerror: ?Function;
-  onmessage: ?Function;
-  onopen: ?Function;
-
   bufferedAmount: number;
   extension: ?string;
   protocol: ?string;


### PR DESCRIPTION
## Summary

Flow type definitions added as part of ebb44d202b909a09f643f50bf3f9e7e42ce6b676 in 2016 are overriding the getters/setters being assigned by the parent `EventTarget` class, setting them to `undefined`, which in turn results in the inability to assign listeners with `onopen`, `onmessage`, `onclose` and `onerror`.

The current workaround is to use `webSocketInstance.addEventListener('open', () => 'foo');` in order to listen in on the events sent over the WebSocket as opposed to using `webSocketInstance.onopen = () => 'foo';`.

## Changelog
[General] [Fixed] - WebSocket listeners

## Test Plan

```js
const ws = new WebSocket('ws://foo.bar');
ws.onopen = () => console.log('WebSocket open event maybe?'); // won't work in 0.63.0
ws.addEventListener('open', () => console.log('No, really, here it is')); // will work every time
```