### PR TITLE
Fix eslint-plugin README.md

### DIFF
--- a/packages/eslint-plugin-react-native-community/README.md
+++ b/packages/eslint-plugin-react-native-community/README.md
@@ -1,6 +1,6 @@
 # eslint-plugin-react-native-community
 
-This plugin is intended to be used in `@react-native-community/eslint-plugin`. You probably want to install that package instead.
+This plugin is intended to be used in [`@react-native-community/eslint-config`](https://github.com/facebook/react-native/tree/master/packages/eslint-config-react-native-community). You probably want to install that package instead.
 
 ## Installation
 


### PR DESCRIPTION
## Summary
The `eslint-plugin` package intent notice at the top of the README mistakenly refers to itself, it should instead refer to `@react-native-community/eslint-config`

## Changelog
[Internal] [Fixed] - Fix typo in `eslint-plugin` README

## Test Plan
1. ensure link works properly

