### PR TITLE
Fix iOS Image.getSizeWithHeaders

### DIFF
--- a/Libraries/Image/RCTImageLoader.mm
+++ b/Libraries/Image/RCTImageLoader.mm
@@ -1163,7 +1163,11 @@ RCT_EXPORT_METHOD(getSizeWithHeaders:(NSString *)uri
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 {
-  NSURLRequest *request = [RCTConvert NSURLRequest:uri];
+  NSURL *URL = [RCTConvert NSURL:uri];
+  NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:URL];
+  [headers enumerateKeysAndObjectsUsingBlock:^(NSString *key, id value, BOOL *stop) {
+    [request addValue:[RCTConvert NSString:value] forHTTPHeaderField:key];
+  }];
   [self getImageSizeForURLRequest:request
    block:^(NSError *error, CGSize size) {
      if (error) {


### PR DESCRIPTION
Fixes #28632 

## Summary

Image.getSizeWithHeaders() was not working as intended on iOS.

## Changelog

[iOS] [Fixed] - Fixed headers in `Image.getSizeWithHeaders`.

## Test Plan

Used RNTester and an Image URL requiring a Bearer token to test.

Code:
<img width="720" alt="Screen Shot 2020-07-10 at 3 00 58 PM" src="https://user-images.githubusercontent.com/4108718/87189376-850cba00-c2be-11ea-851c-d9fa37d88de4.png">

With Bearer Token:
<img width="456" alt="Screen Shot 2020-07-10 at 3 02 48 PM" src="https://user-images.githubusercontent.com/4108718/87189349-7de5ac00-c2be-11ea-8d82-c74cae6d904b.png">

Without Bearer Token:
<img width="559" alt="Screen Shot 2020-07-10 at 3 04 32 PM" src="https://user-images.githubusercontent.com/4108718/87189458-aff70e00-c2be-11ea-82b7-34a14ec465f1.png">

