### PR TITLE
Update Android build tools to 29.0.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -607,7 +607,7 @@ jobs:
       - ANDROID_HOME: "C:\\Android\\android-sdk"
       - ANDROID_NDK: "C:\\Android\\android-sdk\\ndk\\19.2.5345600"
       - ANDROID_BUILD_VERSION: 28
-      - ANDROID_TOOLS_VERSION: 29.0.2
+      - ANDROID_TOOLS_VERSION: 29.0.3
       - GRADLE_OPTS: -Dorg.gradle.daemon=false
       - NDK_VERSION: 19.2.5345600
     steps:

--- a/scripts/.tests.env
+++ b/scripts/.tests.env
@@ -4,7 +4,7 @@
 
 ## ANDROID ##
 # Android SDK Build Tools revision
-export ANDROID_SDK_BUILD_TOOLS_REVISION=29.0.2
+export ANDROID_SDK_BUILD_TOOLS_REVISION=29.0.3
 # Android API Level we build with
 export ANDROID_SDK_BUILD_API_LEVEL="28"
 # Google APIs for Android level

--- a/template/android/build.gradle
+++ b/template/android/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     ext {
-        buildToolsVersion = "29.0.2"
+        buildToolsVersion = "29.0.3"
         minSdkVersion = 16
         compileSdkVersion = 29
         targetSdkVersion = 29


### PR DESCRIPTION
## Summary

A small patch update of the Android build tools from 29.0.2 to 29.0.3. It's the default for newly generated Android projects.

## Changelog

[Android] [Changed] - Update Android build tools to 29.0.3

## Test Plan

Build project
