### PR TITLE
Added examples to test tapping on overflowed Views to RNTesterApp

### DIFF
--- a/RNTester/js/examples/PointerEvents/PointerEventsExample.js
+++ b/RNTester/js/examples/PointerEvents/PointerEventsExample.js
@@ -14,12 +14,25 @@ const React = require('react');
 
 const {StyleSheet, Text, View} = require('react-native');
 
-class ExampleBox extends React.Component<$FlowFixMeProps, $FlowFixMeState> {
+type ExampleBoxComponentProps = $ReadOnly<{|
+  onLog: (msg: string) => void,
+|}>;
+
+type ExampleBoxProps = $ReadOnly<{|
+  Component: React.ComponentType<ExampleBoxComponentProps>,
+|}>;
+
+type ExampleBoxState = $ReadOnly<{|
+  log: string[],
+|}>;
+
+class ExampleBox extends React.Component<ExampleBoxProps, ExampleBoxState> {
   state = {
     log: [],
   };
 
-  handleLog = msg => {
+  handleLog = (msg: string) => {
+    // $FlowFixMe
     this.state.log = this.state.log.concat([msg]);
   };
 
@@ -32,19 +45,18 @@ class ExampleBox extends React.Component<$FlowFixMeProps, $FlowFixMeState> {
    * happens.
    */
   handleTouchCapture = () => {
+    // $FlowFixMe
     this.state.log = this.state.log.concat(['---']);
   };
 
   render() {
+    const {Component} = this.props;
     return (
       <View>
         <View
           onTouchEndCapture={this.handleTouchCapture}
           onTouchStart={this.flushReactChanges}>
-          {/* $FlowFixMe(>=0.53.0 site=react_native_fb,react_native_oss) This
-           * comment suppresses an error when upgrading Flow's support for
-           * React. To see the error delete this comment and run Flow. */}
-          <this.props.Component onLog={this.handleLog} />
+          <Component onLog={this.handleLog} />
         </View>
         <View style={styles.logBox}>
           <DemoText style={styles.logText}>
@@ -165,6 +177,57 @@ class BoxOnlyExample extends React.Component<$FlowFixMeProps> {
   }
 }
 
+type OverflowExampleProps = $ReadOnly<{|
+  overflow: 'hidden' | 'visible',
+  onLog: (msg: string) => void,
+|}>;
+
+class OverflowExample extends React.Component<OverflowExampleProps> {
+  render() {
+    const {overflow} = this.props;
+    return (
+      <View
+        onTouchStart={() => this.props.onLog(`A overflow ${overflow} touched`)}
+        style={[
+          styles.box,
+          styles.boxWithOverflowSet,
+          {overflow: this.props.overflow},
+        ]}>
+        <DemoText style={styles.text}>A: overflow: {overflow}</DemoText>
+        <View
+          onTouchStart={() => this.props.onLog('B overflowing touched')}
+          style={[styles.box, styles.boxOverflowing]}>
+          <DemoText style={styles.text}>B: overflowing</DemoText>
+        </View>
+        <View
+          onTouchStart={() => this.props.onLog('C fully outside touched')}
+          style={[styles.box, styles.boxFullyOutside]}>
+          <DemoText style={styles.text}>C: fully outside</DemoText>
+          <View
+            onTouchStart={() =>
+              this.props.onLog('D fully outside child touched')
+            }
+            style={[styles.box, styles.boxFullyOutsideChild]}>
+            <DemoText style={styles.text}>D: child of fully outside</DemoText>
+          </View>
+        </View>
+      </View>
+    );
+  }
+}
+
+class OverflowVisibleExample extends React.Component<ExampleBoxComponentProps> {
+  render() {
+    return <OverflowExample {...this.props} overflow="visible" />;
+  }
+}
+
+class OverflowHiddenExample extends React.Component<ExampleBoxComponentProps> {
+  render() {
+    return <OverflowExample {...this.props} overflow="hidden" />;
+  }
+}
+
 type ExampleClass = {
   Component: React.ComponentType<any>,
   title: string,
@@ -190,6 +253,18 @@ const exampleClasses: Array<ExampleClass> = [
     title: '`box-only`',
     description:
       "`box-only` causes touch events on the container's child components to pass through and will only detect touch events on the container itself.",
+  },
+  {
+    Component: OverflowVisibleExample,
+    title: '`overflow: visible`',
+    description:
+      '`overflow: visible` style should allow subelements that are outside of the parent box to be touchable. Tapping the parts of Box B outside Box A should print "B touched" and "A touched", and tapping Box C should also print "C touched" and "A touched".',
+  },
+  {
+    Component: OverflowHiddenExample,
+    title: '`overflow: hidden`',
+    description:
+      '`overflow: hidden` style should only allow subelements within the parent box to be touchable. Tapping just below Box A (where Box B would otherwise extend if it weren\'t cut off) should not trigger any touches or messages. Touching Box D (inside the bounds) should print "D touched" and "A touched".',
   },
 ];
 
@@ -220,6 +295,26 @@ const styles = StyleSheet.create({
   },
   boxPassedThrough: {
     borderColor: '#99bbee',
+  },
+  boxWithOverflowSet: {
+    paddingBottom: 40,
+    marginBottom: 50,
+  },
+  boxOverflowing: {
+    position: 'absolute',
+    top: 30,
+    paddingBottom: 40,
+  },
+  boxFullyOutside: {
+    position: 'absolute',
+    left: 200,
+    top: 65,
+  },
+  boxFullyOutsideChild: {
+    position: 'absolute',
+    left: 0,
+    top: -65,
+    width: 100,
   },
   logText: {
     fontSize: 9,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

By default, Views in React Native have overflow: visible. When a child view is outside of the parent view's boundaries, it's visible on Android, but not tappable. This behaviour is incorrect, and doesn't match iOS behaviour.

#26374 and #29039 both fix this. @shergin [suggested](https://github.com/facebook/react-native/pull/26374#issuecomment-659108411):

> Can we start from decoupling the example from this diff for quick landing? We think we solved this issue in Fabric on iOS and Android, and the test will be very helpful to verify that.

This change does that.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Internal] [Added] - Added examples to test tapping on overflowed Views to RNTesterApp

## Test Plan

Added tests to RNTesterApp. Here are the current results of testing on Android:

| master | With #29039 | With #26374 |
| --- | --- | --- |
| ![20200716_011417](https://user-images.githubusercontent.com/2937410/87649711-821e2900-c705-11ea-9d60-0c1580c85513.gif) | ![20200716_013136](https://user-images.githubusercontent.com/2937410/87649737-8a766400-c705-11ea-93e2-5ffd3e609391.gif) | ![20200716_013937](https://user-images.githubusercontent.com/2937410/87649842-ab3eb980-c705-11ea-8571-869285ba174c.gif) |
