### PR TITLE
[Android][LogBox] Set windowTranslucentNavigation to false

### DIFF
--- a/ReactAndroid/src/main/res/devsupport/values/styles.xml
+++ b/ReactAndroid/src/main/res/devsupport/values/styles.xml
@@ -11,6 +11,7 @@
   </style>
   <style name="Theme.Catalyst.LogBox">
     <item name="android:windowTranslucentStatus">true</item>
+    <item name="android:windowTranslucentNavigation">false</item>
     <item name="android:windowBackground">@android:color/transparent</item>
     <item name="android:windowAnimationStyle">@style/Animation.Catalyst.LogBox</item>
     <item name="android:inAnimation">@android:anim/fade_in</item>


### PR DESCRIPTION
## Summary

This fixes https://github.com/facebook/react-native/issues/29397. Without this, apps that specify `android:windowTranslucentNavigation` draw the `LogBox` buttons underneath the soft navigation bar, making the buttons unpressable.

Before             |  After
:-------------------------:|:-------------------------:
<img src="http://ashoat.com/AndroidTranslucentNavigationLogBox.png" width="300" />  |  <img src="http://ashoat.com/AndroidTranslucentNavigationLogBoxFixed.png" width="300" />


## Changelog

[Android] [Fixed] - Set LogBox windowTranslucentNavigation to false

## Test Plan

I tested this change on the [repo](https://github.com/Ashoat/LogBoxTest) I set up to reproduce the issue. I set it up to [build `ReactAndroid` from source](https://github.com/Ashoat/LogBoxTest/commit/3a2cdab8777ac381cd3be5a84a5bf3250751ac11) and then edited `node_modules/react-native/ReactAndroid/src/main/res/devsupport/values/styles.xml` directly.