### PR TITLE
Update RCTSRWebSocket.m

### DIFF
--- a/Libraries/WebSocket/RCTSRWebSocket.m
+++ b/Libraries/WebSocket/RCTSRWebSocket.m
@@ -462,7 +462,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
 
   CFHTTPMessageSetHeaderFieldValue(request, CFSTR("Origin"), (__bridge CFStringRef)_url.RCTSR_origin);
 
-  if (_requestedProtocols) {
+  if (_requestedProtocols && _requestedProtocols.count > 0) {
     CFHTTPMessageSetHeaderFieldValue(request, CFSTR("Sec-WebSocket-Protocol"), (__bridge CFStringRef)[_requestedProtocols componentsJoinedByString:@", "]);
   }
 


### PR DESCRIPTION
## Summary

Only add Sec-WebSocket-Protocol header if has _requestedProtocols.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [Fixed] - when Sec-WebSocket-Protocol header is empty vaulue, IIS server will return error 502. 

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
