### PR TITLE
Fix image cannot show in iOS 14

### DIFF
--- a/Libraries/Image/RCTUIImageViewAnimated.m
+++ b/Libraries/Image/RCTUIImageViewAnimated.m
@@ -285,6 +285,8 @@ static NSUInteger RCTDeviceFreeMemory() {
   if (_currentFrame) {
     layer.contentsScale = self.animatedImageScale;
     layer.contents = (__bridge id)_currentFrame.CGImage;
+  } else {
+    [super displayLayer:layer];
   }
 }
 


### PR DESCRIPTION
## Summary

This PR is to fix https://github.com/facebook/react-native/issues/29279, which image cannot show in iOS 14
As https://github.com/facebook/react-native/issues/29279#issuecomment-658244428 mention, this issue can be fixed by calling ` [super displayLayer:layer];` it it is still image, to let `UIImageView` handle still image rendering

## Changelog

[iOS] [Fixed] - Fix image cannot show in iOS 14

## Test Plan

Image can be shown in iOS 14 build with Xcode 12 beta, using 
```js
<Image source={require('./images/some_local_image.jpg')}/>
```

It may also need to test gif image is render correctly
```js
<Image source={{uri: 'https://some_remote_gif_image.gif'}}/>
```
