### PR TITLE
pass context to OkHttpClientFactory.createNewNetworkModuleClient

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/network/OkHttpClientFactory.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/network/OkHttpClientFactory.java
@@ -7,8 +7,10 @@
 
 package com.facebook.react.modules.network;
 
+import android.content.Context;
+
 import okhttp3.OkHttpClient;
 
 public interface OkHttpClientFactory {
-  OkHttpClient createNewNetworkModuleClient();
+  OkHttpClient createNewNetworkModuleClient(Context context);
 };

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/network/OkHttpClientProvider.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/network/OkHttpClientProvider.java
@@ -47,14 +47,14 @@ public class OkHttpClientProvider {
 
   public static OkHttpClient createClient() {
     if (sFactory != null) {
-      return sFactory.createNewNetworkModuleClient();
+      return sFactory.createNewNetworkModuleClient(null);
     }
     return createClientBuilder().build();
   }
 
   public static OkHttpClient createClient(Context context) {
     if (sFactory != null) {
-      return sFactory.createNewNetworkModuleClient();
+      return sFactory.createNewNetworkModuleClient(context);
     }
     return createClientBuilder(context).build();
   }


### PR DESCRIPTION
## Summary

It make it possible to customize the okhttp client used for images, without losing configurability of other clients, e.g. the one created by NetworkingModule. See https://github.com/react-native-community/discussions-and-proposals/issues/245

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Changed] - pass context to OkHttpClientFactory.createNewNetworkModuleClient

## Test Plan

It seems setOkHttpClientFactory has never been used or tested. So I am not sure how to suggest any test plan.
