### PR TITLE
Fix loading from Metro in Bridgeless mode

### DIFF
--- a/React/Base/RCTJSScriptLoaderModule.h
+++ b/React/Base/RCTJSScriptLoaderModule.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+@class RCTSource;
+
+/**
+ * This protocol should be adopted when a turbo module needs to tell React Native to load a script.
+ * In bridge-less React Native, it is a replacement for [_bridge loadAndExecuteSplitBundleURL:].
+ */
+@protocol RCTJSScriptLoaderModule <NSObject>
+
+@property (nonatomic, copy, nonnull) void (^loadScript)(RCTSource *source);
+
+@end

--- a/React/CoreModules/RCTDevSplitBundleLoader.h
+++ b/React/CoreModules/RCTDevSplitBundleLoader.h
@@ -6,7 +6,8 @@
  */
 
 #import <React/RCTBridgeModule.h>
+#import <React/RCTJSScriptLoaderModule.h>
 #import <UIKit/UIKit.h>
 
-@interface RCTDevSplitBundleLoader : NSObject <RCTBridgeModule>
+@interface RCTDevSplitBundleLoader : NSObject <RCTBridgeModule, RCTJSScriptLoaderModule>
 @end

--- a/React/CoreModules/RCTDevSplitBundleLoader.mm
+++ b/React/CoreModules/RCTDevSplitBundleLoader.mm
@@ -12,6 +12,7 @@
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTConvert.h>
 #import <React/RCTDefines.h>
+#import <React/RCTDevSettings.h>
 #import <React/RCTUtils.h>
 
 #import "CoreModulesPlugins.h"
@@ -23,10 +24,11 @@ using namespace facebook::react;
 
 #if RCT_DEV_MENU
 
-@implementation RCTDevSplitBundleLoader {
-}
+@implementation RCTDevSplitBundleLoader
 
 @synthesize bridge = _bridge;
+@synthesize loadScript = _loadScript;
+@synthesize turboModuleRegistry = _turboModuleRegistry;
 
 RCT_EXPORT_MODULE()
 
@@ -46,13 +48,32 @@ RCT_EXPORT_METHOD(loadBundle
                   : (RCTPromiseRejectBlock)reject)
 {
   NSURL *sourceURL = [[RCTBundleURLProvider sharedSettings] jsBundleURLForSplitBundleRoot:bundlePath];
-  [_bridge loadAndExecuteSplitBundleURL:sourceURL
-      onError:^(NSError *error) {
-        reject(@"E_BUNDLE_LOAD_ERROR", [error localizedDescription], error);
-      }
-      onComplete:^() {
-        resolve(@YES);
-      }];
+  if (_bridge) {
+    [_bridge loadAndExecuteSplitBundleURL:sourceURL
+        onError:^(NSError *error) {
+          reject(@"E_BUNDLE_LOAD_ERROR", [error localizedDescription], error);
+        }
+        onComplete:^() {
+          resolve(@YES);
+        }];
+  } else {
+    __weak __typeof(self) weakSelf = self;
+    [RCTJavaScriptLoader loadBundleAtURL:sourceURL
+        onProgress:^(RCTLoadingProgress *progressData) {
+          // TODO: Setup loading bar.
+        }
+        onComplete:^(NSError *error, RCTSource *source) {
+          if (error) {
+            reject(@"E_BUNDLE_LOAD_ERROR", [error localizedDescription], error);
+            return;
+          }
+          __typeof(self) strongSelf = weakSelf;
+          strongSelf->_loadScript(source);
+          RCTDevSettings *devSettings = [strongSelf->_turboModuleRegistry moduleForName:"RCTDevSettings"];
+          [devSettings setupHMRClientWithAdditionalBundleURL:source.url];
+          resolve(@YES);
+        }];
+  }
 }
 
 - (std::shared_ptr<TurboModule>)getTurboModule:(const ObjCTurboModule::InitParams &)params


### PR DESCRIPTION
Summary:
Problem Statement: A native module needs to call a function on `ReactInstance` (in this case `loadScript`). Typically, this is handled by the bridge.
Current Bridgeless Solution: Create a new protocol (in this case `RCTJSScriptLoaderModule`) which lets a block be passed in TM init to forward the method call to `ReactInstance`. This is the best thing I could think of right now.

Reviewed By: RSNara

Differential Revision: D22512748

