### PR TITLE
[RN v0.63.2] Fix Xcode bundler in staging and release

### DIFF
--- a/scripts/react-native-xcode.sh
+++ b/scripts/react-native-xcode.sh
@@ -56,17 +56,11 @@ case "$CONFIGURATION" in
     ;;
 esac
 
-# Setting up a project root was a workaround to enable support for non-standard
-# structures, including monorepos. Today, CLI supports that out of the box
-# and setting custom `PROJECT_ROOT` only makes it confusing. 
-#
-# As a backwards-compatible change, I am leaving "PROJECT_ROOT" support for those
-# who already use it - it is likely a non-breaking removal.
-#
-# For new users, we default to $PWD - not changing things all.
-#
-# For context: https://github.com/facebook/react-native/commit/9ccde378b6e6379df61f9d968be6346ca6be7ead#commitcomment-37914902
-PROJECT_ROOT=${PROJECT_ROOT:-$PWD}
+# Path to react-native folder inside node_modules
+REACT_NATIVE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# The project should be located next to where react-native is installed
+# in node_modules.
+PROJECT_ROOT=${PROJECT_ROOT:-"$REACT_NATIVE_DIR/../.."}
 
 cd "$PROJECT_ROOT" || exit
 
@@ -108,9 +102,6 @@ if [[ ! -x node && -d ${HOME}/.anyenv/bin ]]; then
     eval "$(anyenv init -)"
   fi
 fi
-
-# Path to react-native folder inside node_modules
-REACT_NATIVE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 # check and assign NODE_BINARY env
 # shellcheck source=/dev/null


### PR DESCRIPTION
Revert "feat: improve monorepo support by removing redundant PROJECT_ROOT (#28354)"

This reverts commit a8e85026cfa60056b1bcbcd39cde789e4d65f9cb.

## Summary

This commit a8e85026cfa60056b1bcbcd39cde789e4d65f9cb somehow broke the bundler when making a staging or release build in Xcode that results in unresolved files and main.jsbundle nonexistance issue. I figured this out by replacing react-native-xcode.sh from RN v0.63.2 by the one from v0.62.2 where everything works just fine and then reverting the changes line by line. It seems like this pr will fix similar issues stated here https://stackoverflow.com/questions/62806319/main-jsbundle-does-not-exist-this-must-be-a-bug-with-main-jsbundle-issue-afte/62829256#62829256 and here https://github.com/facebook/react-native/issues/29205

## Changelog

[iOS] [Fixed] - fix "main.jsbundle does not exist" issue

## Test Plan

With react-native-xcode.sh from RN v0.63.2
![image](https://user-images.githubusercontent.com/32848434/88342113-7ce55d80-cd47-11ea-9dab-bf41ec6d6ab5.png)

With my changes
![image](https://user-images.githubusercontent.com/32848434/88342376-f0876a80-cd47-11ea-9c08-96b892784da1.png)

