### PR TITLE
Replace folly::Optional with better::optional in Fabric C++ files

### DIFF
--- a/ReactCommon/fabric/attributedstring/TextAttributes.h
+++ b/ReactCommon/fabric/attributedstring/TextAttributes.h
@@ -46,38 +46,38 @@ class TextAttributes : public DebugStringConvertible {
   std::string fontFamily{""};
   Float fontSize{std::numeric_limits<Float>::quiet_NaN()};
   Float fontSizeMultiplier{std::numeric_limits<Float>::quiet_NaN()};
-  folly::Optional<FontWeight> fontWeight{};
-  folly::Optional<FontStyle> fontStyle{};
-  folly::Optional<FontVariant> fontVariant{};
-  folly::Optional<bool> allowFontScaling{};
+  better::optional<FontWeight> fontWeight{};
+  better::optional<FontStyle> fontStyle{};
+  better::optional<FontVariant> fontVariant{};
+  better::optional<bool> allowFontScaling{};
   Float letterSpacing{std::numeric_limits<Float>::quiet_NaN()};
 
   // Paragraph Styles
   Float lineHeight{std::numeric_limits<Float>::quiet_NaN()};
-  folly::Optional<TextAlignment> alignment{};
-  folly::Optional<WritingDirection> baseWritingDirection{};
+  better::optional<TextAlignment> alignment{};
+  better::optional<WritingDirection> baseWritingDirection{};
 
   // Decoration
   SharedColor textDecorationColor{};
-  folly::Optional<TextDecorationLineType> textDecorationLineType{};
-  folly::Optional<TextDecorationLineStyle> textDecorationLineStyle{};
-  folly::Optional<TextDecorationLinePattern> textDecorationLinePattern{};
+  better::optional<TextDecorationLineType> textDecorationLineType{};
+  better::optional<TextDecorationLineStyle> textDecorationLineStyle{};
+  better::optional<TextDecorationLinePattern> textDecorationLinePattern{};
 
   // Shadow
   // TODO: Use `Point` type instead of `Size` for `textShadowOffset` attribute.
-  folly::Optional<Size> textShadowOffset{};
+  better::optional<Size> textShadowOffset{};
   Float textShadowRadius{std::numeric_limits<Float>::quiet_NaN()};
   SharedColor textShadowColor{};
 
   // Special
-  folly::Optional<bool> isHighlighted{};
+  better::optional<bool> isHighlighted{};
 
   // TODO T59221129: document where this value comes from and how it is set.
   // It's not clear if this is being used properly, or if it's being set at all.
   // Currently, it is intentionally *not* being set as part of BaseTextProps
   // construction.
-  folly::Optional<LayoutDirection> layoutDirection{};
-  folly::Optional<AccessibilityRole> accessibilityRole{};
+  better::optional<LayoutDirection> layoutDirection{};
+  better::optional<AccessibilityRole> accessibilityRole{};
 
 #pragma mark - Operations
 

--- a/ReactCommon/fabric/components/textinput/androidtextinput/AndroidTextInputShadowNode.h
+++ b/ReactCommon/fabric/components/textinput/androidtextinput/AndroidTextInputShadowNode.h
@@ -81,7 +81,7 @@ class AndroidTextInputShadowNode : public ConcreteViewShadowNode<
    * Cached attributed string that represents the content of the subtree started
    * from the node.
    */
-  mutable folly::Optional<AttributedString> cachedAttributedString_{};
+  mutable better::optional<AttributedString> cachedAttributedString_{};
 };
 
 } // namespace react

--- a/ReactCommon/fabric/components/view/conversions.h
+++ b/ReactCommon/fabric/components/view/conversions.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <better/map.h>
+#include <better/optional.h>
 #include <folly/Conv.h>
 #include <folly/dynamic.h>
 #include <glog/logging.h>
@@ -95,9 +96,9 @@ inline YGValue yogaStyleValueFromFloat(
   return {(float)value, unit};
 }
 
-inline folly::Optional<Float> optionalFloatFromYogaValue(
+inline better::optional<Float> optionalFloatFromYogaValue(
     const YGValue value,
-    folly::Optional<Float> base = {}) {
+    better::optional<Float> base = {}) {
   switch (value.unit) {
     case YGUnitUndefined:
       return {};
@@ -105,9 +106,9 @@ inline folly::Optional<Float> optionalFloatFromYogaValue(
       return floatFromYogaFloat(value.value);
     case YGUnitPercent:
       return base.has_value()
-          ? folly::Optional<Float>(
+          ? better::optional<Float>(
                 base.value() * floatFromYogaFloat(value.value))
-          : folly::Optional<Float>();
+          : better::optional<Float>();
     case YGUnitAuto:
       return {};
   }

--- a/ReactCommon/fabric/components/view/primitives.h
+++ b/ReactCommon/fabric/components/view/primitives.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <folly/Optional.h>
+#include <better/optional.h>
 #include <react/graphics/Color.h>
 #include <react/graphics/Geometry.h>
 #include <array>
@@ -25,7 +25,7 @@ enum class BorderStyle { Solid, Dotted, Dashed };
 template <typename T>
 struct CascadedRectangleEdges {
   using Counterpart = RectangleEdges<T>;
-  using OptionalT = folly::Optional<T>;
+  using OptionalT = better::optional<T>;
 
   OptionalT left{};
   OptionalT top{};
@@ -85,7 +85,7 @@ struct CascadedRectangleEdges {
 template <typename T>
 struct CascadedRectangleCorners {
   using Counterpart = RectangleCorners<T>;
-  using OptionalT = folly::Optional<T>;
+  using OptionalT = better::optional<T>;
 
   OptionalT topLeft{};
   OptionalT topRight{};

--- a/ReactCommon/fabric/debug/BUCK
+++ b/ReactCommon/fabric/debug/BUCK
@@ -10,6 +10,7 @@ load(
     "fb_xplat_cxx_test",
     "get_apple_compiler_flags",
     "get_apple_inspector_flags",
+    "react_native_xplat_target",
     "rn_xplat_cxx_library",
     "subdir_glob",
 )
@@ -56,6 +57,7 @@ rn_xplat_cxx_library(
         "//xplat/folly:headers_only",
         "//xplat/folly:memory",
         "//xplat/folly:molly",
+        react_native_xplat_target("better:better"),
     ],
 )
 

--- a/ReactCommon/fabric/debug/debugStringConvertibleUtils.h
+++ b/ReactCommon/fabric/debug/debugStringConvertibleUtils.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <better/optional.h>
 #include <limits>
 #include <memory>
 #include <string>
@@ -33,7 +34,7 @@ debugStringConvertibleItem(std::string name, T value, T defaultValue = {}) {
 template <typename T>
 inline SharedDebugStringConvertible debugStringConvertibleItem(
     std::string name,
-    folly::Optional<T> value,
+    better::optional<T> value,
     T defaultValue = {}) {
   if (!value.hasValue()) {
     return nullptr;


### PR DESCRIPTION
Summary:
Changelog:
[Internal] - Replace folly::Optional with better::optional in Fabric C++ file

Reviewed By: shergin

Differential Revision: D22696909

