### PR TITLE
feat: add displayName to touchables

### DIFF
--- a/Libraries/Components/Touchable/TouchableHighlight.js
+++ b/Libraries/Components/Touchable/TouchableHighlight.js
@@ -357,9 +357,13 @@ class TouchableHighlight extends React.Component<Props, State> {
   }
 }
 
-module.exports = (React.forwardRef((props, hostRef) => (
+const Touchable = (React.forwardRef((props, hostRef) => (
   <TouchableHighlight {...props} hostRef={hostRef} />
 )): React.AbstractComponent<
   $ReadOnly<$Diff<Props, {|hostRef: React.Ref<typeof View>|}>>,
   React.ElementRef<typeof View>,
 >);
+
+Touchable.displayName = 'TouchableHighlight';
+
+module.exports = Touchable;

--- a/Libraries/Components/Touchable/TouchableNativeFeedback.js
+++ b/Libraries/Components/Touchable/TouchableNativeFeedback.js
@@ -313,4 +313,6 @@ const getBackgroundProp =
           : {nativeBackgroundAndroid: background}
     : (background, useForeground) => null;
 
+TouchableNativeFeedback.displayName = 'TouchableNativeFeedback';
+
 module.exports = TouchableNativeFeedback;

--- a/Libraries/Components/Touchable/TouchableOpacity.js
+++ b/Libraries/Components/Touchable/TouchableOpacity.js
@@ -265,6 +265,10 @@ class TouchableOpacity extends React.Component<Props, State> {
   }
 }
 
-module.exports = (React.forwardRef((props, ref) => (
+const Touchable = (React.forwardRef((props, ref) => (
   <TouchableOpacity {...props} hostRef={ref} />
 )): React.AbstractComponent<Props, React.ElementRef<typeof Animated.View>>);
+
+Touchable.displayName = 'TouchableOpacity';
+
+module.exports = Touchable;

--- a/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+++ b/Libraries/Components/Touchable/TouchableWithoutFeedback.js
@@ -157,4 +157,6 @@ function createPressabilityConfig(props: Props): PressabilityConfig {
   };
 }
 
+TouchableWithoutFeedback.displayName = 'TouchableWithoutFeedback';
+
 module.exports = TouchableWithoutFeedback;

--- a/Libraries/Components/Touchable/__tests__/TouchableHighlight-test.js
+++ b/Libraries/Components/Touchable/__tests__/TouchableHighlight-test.js
@@ -82,4 +82,8 @@ describe('TouchableHighlight with disabled state', () => {
       ),
     ).toMatchSnapshot();
   });
+
+  it('has displayName', () => {
+    expect(TouchableHighlight.displayName).toEqual('TouchableHighlight');
+  });
 });

--- a/Libraries/Components/Touchable/__tests__/TouchableNativeFeedback-test.js
+++ b/Libraries/Components/Touchable/__tests__/TouchableNativeFeedback-test.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @emails oncall+react_native
+ */
+
+'use strict';
+
+const React = require('react');
+const Text = require('../../../Text/Text');
+const TouchableNativeFeedback = require('../TouchableNativeFeedback');
+
+const render = require('../../../../jest/renderer');
+
+describe('TouchableWithoutFeedback', () => {
+  it('renders correctly', () => {
+    const instance = render.create(
+      <TouchableNativeFeedback style={{}}>
+        <Text>Touchable</Text>
+      </TouchableNativeFeedback>,
+    );
+
+    expect(instance.toJSON()).toMatchSnapshot();
+  });
+
+  it('has displayName', () => {
+    expect(TouchableNativeFeedback.displayName).toEqual(
+      'TouchableNativeFeedback',
+    );
+  });
+});

--- a/Libraries/Components/Touchable/__tests__/TouchableOpacity-test.js
+++ b/Libraries/Components/Touchable/__tests__/TouchableOpacity-test.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @emails oncall+react_native
+ */
+
+'use strict';
+
+const React = require('react');
+const Text = require('../../../Text/Text');
+const TouchableOpacity = require('../TouchableOpacity');
+
+const render = require('../../../../jest/renderer');
+
+describe('TouchableOpacity', () => {
+  it('renders correctly', () => {
+    const instance = render.create(
+      <TouchableOpacity style={{}}>
+        <Text>Touchable</Text>
+      </TouchableOpacity>,
+    );
+
+    expect(instance.toJSON()).toMatchSnapshot();
+  });
+
+  it('has displayName', () => {
+    expect(TouchableOpacity.displayName).toEqual('TouchableOpacity');
+  });
+});

--- a/Libraries/Components/Touchable/__tests__/TouchableWithoutFeedback-test.js
+++ b/Libraries/Components/Touchable/__tests__/TouchableWithoutFeedback-test.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @emails oncall+react_native
+ */
+
+'use strict';
+
+const React = require('react');
+const Text = require('../../../Text/Text');
+const TouchableWithoutFeedback = require('../TouchableWithoutFeedback');
+
+const render = require('../../../../jest/renderer');
+
+describe('TouchableWithoutFeedback', () => {
+  it('renders correctly', () => {
+    const instance = render.create(
+      <TouchableWithoutFeedback style={{}}>
+        <Text>Touchable</Text>
+      </TouchableWithoutFeedback>,
+    );
+
+    expect(instance.toJSON()).toMatchSnapshot();
+  });
+
+  it('has displayName', () => {
+    expect(TouchableWithoutFeedback.displayName).toEqual(
+      'TouchableWithoutFeedback',
+    );
+  });
+});

--- a/Libraries/Components/Touchable/__tests__/__snapshots__/TouchableNativeFeedback-test.js.snap
+++ b/Libraries/Components/Touchable/__tests__/__snapshots__/TouchableNativeFeedback-test.js.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TouchableWithoutFeedback renders correctly 1`] = `
+<Text
+  accessible={true}
+  focusable={false}
+  onClick={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+>
+  Touchable
+</Text>
+`;

--- a/Libraries/Components/Touchable/__tests__/__snapshots__/TouchableOpacity-test.js.snap
+++ b/Libraries/Components/Touchable/__tests__/__snapshots__/TouchableOpacity-test.js.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TouchableOpacity renders correctly 1`] = `
+<View
+  accessible={true}
+  collapsable={false}
+  focusable={false}
+  nativeID="animatedComponent"
+  onClick={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Object {
+      "opacity": 1,
+    }
+  }
+>
+  <Text>
+    Touchable
+  </Text>
+</View>
+`;

--- a/Libraries/Components/Touchable/__tests__/__snapshots__/TouchableWithoutFeedback-test.js.snap
+++ b/Libraries/Components/Touchable/__tests__/__snapshots__/TouchableWithoutFeedback-test.js.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TouchableWithoutFeedback renders correctly 1`] = `
+<Text
+  accessible={true}
+  focusable={false}
+  onClick={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+>
+  Touchable
+</Text>
+`;


### PR DESCRIPTION
## Summary

Since TouchableHighlight and TouchableOpacity are being exported using `forwardRef`, it's messing up jest's snapshots and some matchers.
This commit 4b935ae95f09e4a1eb1e5ac8089eb258222a0f8b fixed this for components being mocked on [setup.js](https://github.com/facebook/react-native/blob/master/jest/setup.js). However, these Touchables aren't being mocked.

It resolves #27721 

## Changelog

[General] [Added] - Add displayName to TouchableHighlight, TouchableOpacity, TouchableNativeFeedback, TouchableWithoutFeedback

## Test Plan

Check the new snapshots.
