### PR TITLE
Fix Pressables not being tappable in PanResponder Views on Android

### DIFF
--- a/RNTester/js/examples/Pressable/PressableExample.js
+++ b/RNTester/js/examples/Pressable/PressableExample.js
@@ -261,35 +261,39 @@ function PressableInPanResponder() {
   const appendMessage = (message: string) => {
     const lastMessage =
       messages.current.length && messages.current[messages.current.length - 1];
-    if (message === lastMessage) return;
+    if (message === lastMessage) {
+      return; // Reduce duplicate touchMove messages
+    }
     messages.current = [...messages.current, message];
     forceUpdate();
   };
 
-  const panResponder = useMemo(() => {
-    return PanResponder.create({
-      onStartShouldSetPanResponder: (): boolean => {
-        appendMessage('onStartShouldSetPanResponder, returning false');
-        return false;
-      },
-      onStartShouldSetPanResponderCapture: (): boolean => {
-        appendMessage('onStartShouldSetPanResponderCapture, returning false');
-        return false;
-      },
-      onMoveShouldSetPanResponder: (): boolean => {
-        appendMessage('onMoveShouldSetPanResponder, returning true');
-        return true;
-      },
-      onMoveShouldSetPanResponderCapture: (): boolean => {
-        appendMessage('onMoveShouldSetPanResponderCapture, returning false');
-        return false;
-      },
-      onPanResponderGrant: () => appendMessage('onPanResponderGrant'),
-      onPanResponderMove: () => appendMessage('onPanResponderMove'),
-      onPanResponderRelease: () => appendMessage('onPanResponderRelease'),
-      onPanResponderTerminate: () => appendMessage('onPanResponderTerminate'),
-    });
-  });
+  const panResponder = useMemo(
+    () =>
+      PanResponder.create({
+        onStartShouldSetPanResponder: (): boolean => {
+          appendMessage('onStartShouldSetPanResponder, returning false');
+          return false;
+        },
+        onStartShouldSetPanResponderCapture: (): boolean => {
+          appendMessage('onStartShouldSetPanResponderCapture, returning false');
+          return false;
+        },
+        onMoveShouldSetPanResponder: (): boolean => {
+          appendMessage('onMoveShouldSetPanResponder, returning true');
+          return true;
+        },
+        onMoveShouldSetPanResponderCapture: (): boolean => {
+          appendMessage('onMoveShouldSetPanResponderCapture, returning false');
+          return false;
+        },
+        onPanResponderGrant: () => appendMessage('onPanResponderGrant'),
+        onPanResponderMove: () => appendMessage('onPanResponderMove'),
+        onPanResponderRelease: () => appendMessage('onPanResponderRelease'),
+        onPanResponderTerminate: () => appendMessage('onPanResponderTerminate'),
+      }),
+    [],
+  );
 
   return (
     <>

--- a/RNTester/js/examples/Pressable/PressableExample.js
+++ b/RNTester/js/examples/Pressable/PressableExample.js
@@ -259,8 +259,8 @@ function PressableInPanResponder() {
   const [, forceUpdate] = useReducer(x => x + 1, 0);
 
   const appendMessage = (message: string) => {
-    const lastMessage = messages.current.length
-      && messages.current[messages.current.length - 1];
+    const lastMessage =
+      messages.current.length && messages.current[messages.current.length - 1];
     if (message === lastMessage) return;
     messages.current = [...messages.current, message];
     forceUpdate();
@@ -297,8 +297,7 @@ function PressableInPanResponder() {
         <Pressable
           onPress={() => appendMessage('Pressable onPress')}
           onPressIn={() => appendMessage('Pressable onPressIn')}
-          style={[styles.row, styles.block]}
-        >
+          style={[styles.row, styles.block]}>
           <Text style={styles.button}>Pressable</Text>
         </Pressable>
       </View>
@@ -539,7 +538,7 @@ exports.examples = [
     title: 'Pressable in PanResponder',
     description: ('<Pressable> components should be pressable within ' +
       'PanResponders that only handle touch moves. onPress should trigger' +
-      'if you press and don\'t move your finger.': string),
+      "if you press and don't move your finger.": string),
     render: function(): React.Node {
       return <PressableInPanResponder />;
     },

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -197,53 +197,8 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
 
   @Override
   public boolean onInterceptTouchEvent(MotionEvent ev) {
-    if (this.shouldDispatchTouchEvent(ev)) {
-      dispatchJSTouchEvent(ev);
-    }
+    dispatchJSTouchEvent(ev);
     return super.onInterceptTouchEvent(ev);
-  }
-
-  /**
-   * This function prevents `topTouchMove` events from being dispatched if the user hasn't moved
-   * their finger from the start of the last touch, to match the iOS behaviour.
-   *
-   * On Android, `MotionEvent.ACTION_MOVE` events are dispatched even if the user had moved
-   * their finger 0 pixels from the starting point. This is unlike on iOS, where move events
-   * are only dispatched after some distance.
-   *
-   * This causes a problem in the following case:
-   *
-   * - A parent component has a `PanResponder` that responds to all move events
-   * - The parent has a child `Pressable` (or `Touchable`)
-   *
-   * Because the move event is emitted even without any real move, the parent would take over
-   * immediately on press down and no presses would ever register on the child.
-   */
-  private boolean shouldDispatchTouchEvent(MotionEvent ev) {
-    int action = ev.getAction() & MotionEvent.ACTION_MASK;
-    if (action == MotionEvent.ACTION_DOWN) {
-      mLastTouchStartX = ev.getX();
-      mLastTouchStartY = ev.getY();
-    }
-
-    boolean shouldDispatchTouchEvent = true;
-    if (action == MotionEvent.ACTION_MOVE && mTouchMoveStarted == false) {
-      float moveX = ev.getX();
-      float moveY = ev.getY();
-      // Logic based on https://github.com/facebook/react-native/blob/v0.63.2/Libraries/Pressability/Pressability.js#L516
-      // which recognizes only moves of >10 pixels as moves that should
-      // cancel a long press. This matches the behaviour on iOS and prevents
-      // move events that aren't really moves from canceling touches on
-      // child pressables.
-      mTouchMoveStarted = Math.hypot(moveX - mLastTouchStartX, moveY - mLastTouchStartY) > 10;
-      shouldDispatchTouchEvent = mTouchMoveStarted;
-    }
-
-    if (action == MotionEvent.ACTION_UP) {
-      mTouchMoveStarted = false;
-    }
-
-    return shouldDispatchTouchEvent;
   }
 
   @Override

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -95,6 +95,9 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
   private int mLastWidth = 0;
   private int mLastHeight = 0;
   private @UIManagerType int mUIManagerType = DEFAULT;
+  private float mLastTouchStartX = 0;
+  private float mLastTouchStartY = 0;
+  private boolean mTouchMoveStarted = false;
 
   public ReactRootView(Context context) {
     super(context);
@@ -194,8 +197,53 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
 
   @Override
   public boolean onInterceptTouchEvent(MotionEvent ev) {
-    dispatchJSTouchEvent(ev);
+    if (this.shouldDispatchTouchEvent(ev)) {
+      dispatchJSTouchEvent(ev);
+    }
     return super.onInterceptTouchEvent(ev);
+  }
+
+  /**
+   * This function prevents `topTouchMove` events from being dispatched if the user hasn't moved
+   * their finger from the start of the last touch, to match the iOS behaviour.
+   *
+   * On Android, `MotionEvent.ACTION_MOVE` events are dispatched even if the user had moved
+   * their finger 0 pixels from the starting point. This is unlike on iOS, where move events
+   * are only dispatched after some distance.
+   *
+   * This causes a problem in the following case:
+   *
+   * - A parent component has a `PanResponder` that responds to all move events
+   * - The parent has a child `Pressable` (or `Touchable`)
+   *
+   * Because the move event is emitted even without any real move, the parent would take over
+   * immediately on press down and no presses would ever register on the child.
+   */
+  private boolean shouldDispatchTouchEvent(MotionEvent ev) {
+    int action = ev.getAction() & MotionEvent.ACTION_MASK;
+    if (action == MotionEvent.ACTION_DOWN) {
+      mLastTouchStartX = ev.getX();
+      mLastTouchStartY = ev.getY();
+    }
+
+    boolean shouldDispatchTouchEvent = true;
+    if (action == MotionEvent.ACTION_MOVE && mTouchMoveStarted == false) {
+      float moveX = ev.getX();
+      float moveY = ev.getY();
+      // Logic based on https://github.com/facebook/react-native/blob/v0.63.2/Libraries/Pressability/Pressability.js#L516
+      // which recognizes only moves of >10 pixels as moves that should
+      // cancel a long press. This matches the behaviour on iOS and prevents
+      // move events that aren't really moves from canceling touches on
+      // child pressables.
+      mTouchMoveStarted = Math.hypot(moveX - mLastTouchStartX, moveY - mLastTouchStartY) > 10;
+      shouldDispatchTouchEvent = mTouchMoveStarted;
+    }
+
+    if (action == MotionEvent.ACTION_UP) {
+      mTouchMoveStarted = false;
+    }
+
+    return shouldDispatchTouchEvent;
   }
 
   @Override

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -95,9 +95,6 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
   private int mLastWidth = 0;
   private int mLastHeight = 0;
   private @UIManagerType int mUIManagerType = DEFAULT;
-  private float mLastTouchStartX = 0;
-  private float mLastTouchStartY = 0;
-  private boolean mTouchMoveStarted = false;
 
   public ReactRootView(Context context) {
     super(context);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

This fix makes Touchables and Pressables touchable, even if they're inside another view with a PanResponder/GestureResponder that handles touches.

I have an app that had a `TouchableWithoutFeedback` inside of a `View` with a PanResponder attached. The TouchableWithoutFeedback received touches as expected on iOS, but not on Android.

### Debugging

1. Added example to Pressable
2. Compared behaviour on Android and iOS - identified the different events being emitted and set a debug in Pressability.js `onResponderTerminationRequest`
3. Looked at the root event causing the Pressable to lose control of touches ("topTouchMove")
4. Searched for that in Android code to identify the code path that was emitting it
5. Added console.logs to the Android `MotionEvent` handler

### Root cause

After debugging, I realized this is because on Android (tested on Pixel 2 device):

1. As soon as a touch starts, a `topTouchMove` event is emitted from native code, even if the user doesn't move their finger at all
2. The topTouchMove triggers the parent PanResponder
3. This causes the touch on the Pressable to be canceled

This is unintuitive. Instead, the `topTouchMove` event should only be emitted when some actual move happens, like on iOS.

### Fix

To fix this, I added code to only emit a touchMove event if the user's touch has moved at least 10 units away from where it started. This code was based on other code in Pressability that also use this threshold.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Fixed] - Fix Pressables not being tappable in PanResponder Views on Android

## Test Plan

Added a test case in RNTesterApp's Pressable screen:

| iOS | Android (before) | Android (after) |
| --- | --- | --- |
| ![Pressable](https://user-images.githubusercontent.com/2937410/88952220-f996a100-d24b-11ea-8dbc-d079ed4af968.gif) | ![Android before](https://user-images.githubusercontent.com/2937410/88952310-1d59e700-d24c-11ea-980f-579d04986ab5.gif) | ![Android after](https://user-images.githubusercontent.com/2937410/88952283-10d58e80-d24c-11ea-862d-c50e8d3eb871.gif) |

