### PR TITLE
Use recent Vibrator Android API

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/vibration/VibrationModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/vibration/VibrationModule.java
@@ -9,6 +9,8 @@ package com.facebook.react.modules.vibration;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
+import android.os.Build;
+import android.os.VibrationEffect;
 import android.os.Vibrator;
 import com.facebook.fbreact.specs.NativeVibrationSpec;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -35,7 +37,13 @@ public class VibrationModule extends NativeVibrationSpec {
     int duration = (int) durationDouble;
 
     Vibrator v = (Vibrator) getReactApplicationContext().getSystemService(Context.VIBRATOR_SERVICE);
-    if (v != null) {
+    if (v == null) {
+      return;
+    }
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      v.vibrate(VibrationEffect.createOneShot(duration, VibrationEffect.DEFAULT_AMPLITUDE));
+    } else {
       v.vibrate(duration);
     }
   }
@@ -45,11 +53,18 @@ public class VibrationModule extends NativeVibrationSpec {
     int repeat = (int) repeatDouble;
 
     Vibrator v = (Vibrator) getReactApplicationContext().getSystemService(Context.VIBRATOR_SERVICE);
-    if (v != null) {
-      long[] patternLong = new long[pattern.size()];
-      for (int i = 0; i < pattern.size(); i++) {
-        patternLong[i] = pattern.getInt(i);
-      }
+    if (v == null) {
+      return;
+    }
+
+    long[] patternLong = new long[pattern.size()];
+    for (int i = 0; i < pattern.size(); i++) {
+      patternLong[i] = pattern.getInt(i);
+    }
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      v.vibrate(VibrationEffect.createWaveform(patternLong, repeat));
+    } else {
       v.vibrate(patternLong, repeat);
     }
   }


### PR DESCRIPTION


<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Android's `VibrationModule` uses deprecated `vibrate(long milliseconds)` and `vibrate(long[] pattern, int repeat)` methods. Deprecation notes: [[1]](https://developer.android.com/reference/android/os/Vibrator#vibrate(long)) [[2]](https://developer.android.com/reference/android/os/Vibrator#vibrate(long[],%20int)).
Changes in this pull request use recent `Vibrator` API for devices with API Level >= 26 (since mentioned methods were depreceted in API Level 26).

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Internal] - Use non-deprecated `Vibrator` API in `VibrationModule`

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
API is the same as before, but it uses recent `Vibrator` API.
