### PR TITLE
Fix RNTester TurboModules loading

### DIFF
--- a/RNTester/RNTester/AppDelegate.mm
+++ b/RNTester/RNTester/AppDelegate.mm
@@ -153,6 +153,7 @@
   _turboModuleManager = [[RCTTurboModuleManager alloc] initWithBridge:bridge
                                                              delegate:self
                                                             jsInvoker:bridge.jsCallInvoker];
+  [bridge setRCTTurboModuleRegistry:_turboModuleManager];
 
 #if RCT_DEV
   /**


### PR DESCRIPTION
## Summary

It is now required to call RCTBridge.setRCTTurboModuleRegistry for turbo modules to work properly on iOS.

## Changelog

[Internal] [Fix] - Fix RNTester TurboModules loading

## Test Plan

Tested that images in RNTester now loads properly and Redbox module missing warning are gone.
