### PR TITLE
Assign test_ownership_2020 as owner for unowned robolectric tests in fbandroid

### DIFF
--- a/ReactAndroid/src/test/java/com/facebook/react/util/BUCK
+++ b/ReactAndroid/src/test/java/com/facebook/react/util/BUCK
@@ -3,6 +3,8 @@ load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "react_native_tar
 rn_robolectric_test(
     name = "util",
     srcs = glob(["**/*.java"]),
+    # Please change the contact to the oncall of your team
+    contacts = ["oncall+fbandroid_sheriff@xmail.facebook.com"],
     visibility = [
         "PUBLIC",
     ],


### PR DESCRIPTION
Summary: Changelog: [Internal]

Reviewed By: IanChilds

Differential Revision: D22882186

