### PR TITLE
[Fix] `iOS/TextInput`: Edit text and then mutate props multiline cause empty fields

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -873,13 +873,13 @@ function InternalTextInput(props: Props): React.Node {
   useEffect(() => {
     const nativeUpdate = {};
     let eventTag = mostRecentEventCount;
-
     // In iOS, if multiline prop has changed, uiManager will create a new nativeTag(RCTMultilineTextInputView or RCTSinglelineTextInputView)
     // With a new nativeTag, we need to set mostRecentEventCount to 0.
     if (Platform.OS === 'ios') {
       if (props.multiline !== lastMultiline) {
         setLastMultiline(props.multiline);
         setMostRecentEventCount(0);
+        nativeUpdate.multiline = true;
         eventTag = 0;
       }
     }

--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -875,7 +875,7 @@ function InternalTextInput(props: Props): React.Node {
     let eventTag = mostRecentEventCount;
 
     // In iOS, if multiline prop has changed, uiManager will create a new nativeTag(RCTMultilineTextInputView or RCTSinglelineTextInputView)
-    // With a new nativeTag, we need to mostRecentEventCount to 0.
+    // With a new nativeTag, we need to set mostRecentEventCount to 0.
     if (Platform.OS === 'ios') {
       if (props.multiline !== lastMultiline) {
         setLastMultiline(props.multiline);


### PR DESCRIPTION
## Summary

First of all, thanks all of you for code review and support! 

This PR fixes: #29569 

The main reason of this issue is caused by mostRecentEventCount and nativeEventCount.
When we change multiline from undefined(or false) into true, uiManager will create a new RCTMultilineTextInputView with new nativeEventCount(0).
In  [InternalTextInput](https://github.com/facebook/react-native/blob/471c2ebe5b84adb60d588b4b281e433324dc7f48/Libraries/Components/TextInput/TextInput.js), if text has been edit and then we change props multiline into true.InternalTextInput will still hold the old mostRecentEventCount, and the new RCTMultilineTextInputView nativeEventCount is 0.
This will caused eventLag will always return negative value.
This will have an effect on following code.
https://github.com/facebook/react-native/blob/471c2ebe5b84adb60d588b4b281e433324dc7f48/Libraries/Text/TextInput/RCTBaseTextInputViewManager.m#L128-L132
and some eventLag in [RCTBaseTextInputView](https://github.com/facebook/react-native/blob/master/Libraries/Text/TextInput/RCTBaseTextInputView.m).

I let InternalTextInput has to refresh mostRecentEventCount when multiline props has been changed. So nativeEventCount will be same as mostRecentEventCount.

This issue does not happen on android, because changing the multiline props in android won't create a new nativeViewComponent.
 

## Changelog

[iOS] [Fixed] -  TextInput edit text and then mutate props multiline cause empty fields

## Test Plan
Please initiated a new project and replaced the app with the following code:
```
/**
 * Sample React Native App
 * https://github.com/facebook/react-native
 *
 * @format
 */

import React, {useState} from 'react';
import {
  SafeAreaView,
  StyleSheet,
  ScrollView,
  View,
  Text,
  TextInput,
  StatusBar,
  TouchableOpacity,
} from 'react-native';

const items = {
  facebook: {},
  musicalStyles: {},
  presentation: {
    placeholder: 'Votre présentation',
    maxLength: 180,
  },
  tel: {
    keyboardType: 'phone-pad',
    placeholder: 'Numéro de téléphone',
  },
  website: {
    placeholder: 'Votre site internet',
  },
};

const App = () => {
  const [user, setUser] = useState({
    facebook: 'ParisCity',
    musicalStyles: 'Disco, Funk, House, Latino, ...',
    presentation: 'Here since 1900',
    tel: '0606060606',
    website: 'paris.fr',
  });

  const [multiline, setMultiline] = useState({
    facebook: false,
    musicalStyles: false,
    presentation: false,
    tel: false,
    website: false,
  });

  const [name, setName] = useState('');

  const renderContentBottomSheet = () => {
    return (
      <TextInput
        {...items[name]}
        style={styles.itemContentBS}
        value={user[name]}
        multiline={multiline[name]}
        onChangeText={(text) => {
          inputHandler(text, name);
        }}
      />
    );
  };

  const inputHandler = (text, _objectName) => {
    setUser((prevUser) => {
      return {
        ...prevUser,
        [_objectName]: text.toString(),
      };
    });
  };

  return (
    <View style={styles.container}>
      <SafeAreaView>
        {Object.keys(items).map((item) => (
          <TouchableOpacity
            key={item}
            onPress={() => {
              setName(item);
            }}>
            <Text style={styles.editme}>{`${user[item]} ${
              multiline[item] ? '// is multiline' : ''
            }`}</Text>
          </TouchableOpacity>
        ))}

        {renderContentBottomSheet()}
        <TouchableOpacity
          onPress={() => {
            setMultiline((prev) => ({...prev, [name]: !prev[name]}));
          }}>
          <Text style={styles.editme}>{'Mutate multiline'}</Text>
        </TouchableOpacity>
      </SafeAreaView>
    </View>
  );
};

const styles = StyleSheet.create({
  container: {
    backgroundColor: '#F7F9FC',
    flex: 1,
  },
  containerBS: {
    backgroundColor: '#F7F9FC',
    paddingHorizontal: 12,
    paddingVertical: 8,
    paddingTop: 2,
  },
  itemContentBS: {
    color: '#25265E',
    borderRadius: 4,
    backgroundColor: '#FFF',
    borderBottomColor: '#787993',
    borderBottomWidth: 2,
    fontSize: 18,
    marginBottom: 18,
    paddingHorizontal: 16,
    paddingVertical: 18,
    shadowColor: '#787993',
    shadowOffset: {
      width: 0,
      height: 5,
    },
    shadowOpacity: 0.18,
    shadowRadius: 4.65,

    elevation: 8,
  },
  shadowBox: {
    shadowColor: '#787993',
    shadowOffset: {
      width: 0,
      height: 5,
    },
    shadowOpacity: 0.18,
    shadowRadius: 4.65,

    elevation: 8,
  },
  editme: {
    paddingVertical: 8,
    paddingHorizontal: 12,
    backgroundColor: '#000030',
    color: '#FFF',
    marginHorizontal: 8,
    marginVertical: 3,
  },
});

export default App;
```
Try to edit some text and mutate multiline props by pressing button.