### PR TITLE
Misspellings

### DIFF
--- a/Libraries/Animated/src/NativeAnimatedHelper.js
+++ b/Libraries/Animated/src/NativeAnimatedHelper.js
@@ -405,7 +405,7 @@ module.exports = {
   assertNativeAnimatedModule,
   shouldUseNativeDriver,
   transformDataType,
-  // $FlowExpectedError - unsafe getter lint suppresion
+  // $FlowExpectedError - unsafe getter lint suppression
   get nativeEventEmitter(): NativeEventEmitter {
     if (!nativeEventEmitter) {
       nativeEventEmitter = new NativeEventEmitter(NativeAnimatedModule);

--- a/Libraries/Lists/__tests__/VirtualizedList-test.js
+++ b/Libraries/Lists/__tests__/VirtualizedList-test.js
@@ -71,7 +71,7 @@ describe('VirtualizedList', () => {
     // Silence the React error boundary warning; we expect an uncaught error.
     const consoleError = console.error;
     jest.spyOn(console, 'error').mockImplementation(message => {
-      if (message.startsWith('The above error occured in the ')) {
+      if (message.startsWith('The above error occurred in the ')) {
         return;
       }
       consoleError(message);
@@ -393,7 +393,7 @@ describe('VirtualizedList', () => {
     const errors = [];
     jest.spyOn(console, 'error').mockImplementation((...args) => {
       // Silence the DEV-only React error boundary warning.
-      if ((args[0] || '').startsWith('The above error occured in the ')) {
+      if ((args[0] || '').startsWith('The above error occurred in the ')) {
         return;
       }
       errors.push(args);

--- a/Libraries/LogBox/Data/__tests__/LogBoxData-test.js
+++ b/Libraries/LogBox/Data/__tests__/LogBoxData-test.js
@@ -299,7 +299,7 @@ describe('LogBoxData', () => {
     jest.runAllTimers(); // Flush remaining.
 
     // This should still be 0 (the first fatal exception)
-    // becuase it is the most likely source of the error.
+    // because it is the most likely source of the error.
     // If there are more exceptions after this, they
     // are likely caused by this original exception.
     expect(selectedLogIndex()).toBe(0);
@@ -324,7 +324,7 @@ describe('LogBoxData', () => {
     jest.runAllTimers(); // Flush remaining.
 
     // This should still be 0 (the first fatal exception)
-    // becuase it is the most likely source of the error.
+    // because it is the most likely source of the error.
     // If there are more exceptions after this, they
     // are likely caused by this original exception.
     expect(selectedLogIndex()).toBe(0);
@@ -511,7 +511,7 @@ describe('LogBoxData', () => {
     flushToObservers();
     expect(observer.mock.calls.length).toBe(2);
 
-    // We expect observers to recieve the same Set object in sequential updates
+    // We expect observers to receive the same Set object in sequential updates
     // so that it doesn't break memoization for components observing state.
     expect(observer.mock.calls[0][0].logs).toBe(observer.mock.calls[1][0].logs);
   });

--- a/Libraries/LogBox/Data/parseLogBoxLog.js
+++ b/Libraries/LogBox/Data/parseLogBoxLog.js
@@ -311,7 +311,7 @@ export function parseLogBoxException(
   }
 
   // Most `console.error` calls won't have a componentStack. We parse them like
-  // regular logs which have the component stack burried in the message.
+  // regular logs which have the component stack buried in the message.
   return {
     level: 'error',
     stack: error.stack,

--- a/Libraries/Pressability/Pressability.js
+++ b/Libraries/Pressability/Pressability.js
@@ -298,7 +298,7 @@ const DEFAULT_MIN_PRESS_DURATION = 130;
  *
  * - When a press has activated (e.g. highlight an element)
  * - When a press has deactivated (e.g. un-highlight an element)
- * - When a press sould trigger an action, meaning it activated and deactivated
+ * - When a press should trigger an action, meaning it activated and deactivated
  *   while within the geometry of the element without the lock being stolen.
  *
  * A high quality interaction isn't as simple as you might think. There should

--- a/Libraries/Text/Text/NSTextStorage+FontScaling.m
+++ b/Libraries/Text/Text/NSTextStorage+FontScaling.m
@@ -32,15 +32,15 @@ typedef NS_OPTIONS(NSInteger, RCTTextSizeComparisonOptions) {
                  minimumFontSize:minimumFontSize
                  maximumFontSize:maximumFontSize];
 
-    RCTTextSizeComparisonOptions comparsion =
+    RCTTextSizeComparisonOptions comparison =
       [self compareToSize:size thresholdRatio:0.01];
 
     if (
-        (comparsion & RCTTextSizeComparisonWithinRange) &&
-        (comparsion & RCTTextSizeComparisonSmaller)
+        (comparison & RCTTextSizeComparisonWithinRange) &&
+        (comparison & RCTTextSizeComparisonSmaller)
     ) {
       return;
-    } else if (comparsion & RCTTextSizeComparisonSmaller) {
+    } else if (comparison & RCTTextSizeComparisonSmaller) {
       bottomRatio = ratio;
       lastRatioWhichFits = ratio;
     } else {

--- a/Libraries/Text/TextInput/Multiline/RCTUITextView.m
+++ b/Libraries/Text/TextInput/Multiline/RCTUITextView.m
@@ -220,7 +220,7 @@ static UIColor *defaultPlaceholderColor()
 {
   CGSize contentSize = super.contentSize;
   CGSize placeholderSize = _placeholderView.isHidden ? CGSizeZero : self.placeholderSize;
-  // When a text input is empty, it actually displays a placehoder.
+  // When a text input is empty, it actually displays a placeholder.
   // So, we have to consider `placeholderSize` as a minimum `contentSize`.
   // Returning size DOES contain `textContainerInset` (aka `padding`).
   return CGSizeMake(

--- a/Libraries/vendor/emitter/_EventSubscriptionVendor.js
+++ b/Libraries/vendor/emitter/_EventSubscriptionVendor.js
@@ -55,7 +55,7 @@ class EventSubscriptionVendor {
    * Removes a bulk set of the subscriptions.
    *
    * @param {?string} eventType - Optional name of the event type whose
-   *   registered supscriptions to remove, if null remove all subscriptions.
+   *   registered subscriptions to remove, if null remove all subscriptions.
    */
   removeAllSubscriptions(eventType: ?string) {
     if (eventType === undefined) {

--- a/React/Base/RCTConvert.m
+++ b/React/Base/RCTConvert.m
@@ -807,7 +807,7 @@ static UIColor *RCTColorFromSemanticColorName(NSString *semanticColorName)
   return color;
 }
 
-/** Returns an alphabetically sorted comma seperated list of the valid semantic color names
+/** Returns an alphabetically sorted comma separated list of the valid semantic color names
  */
 static NSString *RCTSemanticColorNames()
 {

--- a/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingView.h
+++ b/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingView.h
@@ -44,7 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Convenience initializer.
  * Instanciates a Surface object with given `bridge`, `moduleName`, and
- * `initialProperties`, and then use it to instanciate a view.
+ * `initialProperties`, and then use it to instantiate a view.
  */
 - (instancetype)initWithBridge:(RCTBridge *)bridge
                     moduleName:(NSString *)moduleName

--- a/React/Fabric/RCTSurfacePresenter.h
+++ b/React/Fabric/RCTSurfacePresenter.h
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /*
  * Suspends/resumes all surfaces associated with the presenter.
- * Suspending is a process or gracefull stopping all surfaces and destroying all underlying infrastructure
+ * Suspending is a process or graceful stopping all surfaces and destroying all underlying infrastructure
  * with a future possibility of recreating the infrastructure and restarting the surfaces from scratch.
  * Suspending is usually a part of a bundle reloading process.
  * Can be called on any thread.

--- a/React/Views/SafeAreaView/RCTSafeAreaShadowView.m
+++ b/React/Views/SafeAreaView/RCTSafeAreaShadowView.m
@@ -32,7 +32,7 @@
 
 /**
  * Removing support for setting padding from any outside code
- * to prevent interferring this with local data.
+ * to prevent interfering this with local data.
  */
 - (void)setPadding:(__unused YGValue)value
 {

--- a/ReactAndroid/src/main/java/com/facebook/react/animated/AnimationDriver.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/animated/AnimationDriver.java
@@ -31,7 +31,7 @@ import com.facebook.react.bridge.ReadableMap;
   /**
    * This method will get called when some of the configuration gets updated while the animation is
    * running. In that case animation should restart keeping its internal state to provide a smooth
-   * transision. E.g. in case of a spring animation we want to keep the current value and speed and
+   * transition. E.g. in case of a spring animation we want to keep the current value and speed and
    * start animating with the new properties (different destination or spring settings)
    */
   public void resetConfig(ReadableMap config) {

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/ModuleHolder.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/ModuleHolder.java
@@ -46,7 +46,7 @@ public class ModuleHolder {
   private final ReactModuleInfo mReactModuleInfo;
 
   private @Nullable Provider<? extends NativeModule> mProvider;
-  // Outside of the constructur, these should only be checked or set when synchronized on this
+  // Outside of the constructor, these should only be checked or set when synchronized on this
   private @Nullable @GuardedBy("this") NativeModule mModule;
 
   // These are used to communicate phases of creation and initialization across threads

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/util/ReactFindViewUtil.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/util/ReactFindViewUtil.java
@@ -44,7 +44,7 @@ public class ReactFindViewUtil {
 
     void onViewFound(View view, String nativeId);
     /**
-     * Called when all teh views have been found
+     * Called when all the views have been found
      *
      * @param map
      */

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputShadowNode.java
@@ -258,7 +258,7 @@ public class ReactTextInputShadowNode extends ReactBaseTextShadowNode
   }
 
   /**
-   * May be overriden by subclasses that would like to provide their own instance of the internal
+   * May be overridden by subclasses that would like to provide their own instance of the internal
    * {@code EditText} this class uses to determine the expected size of the view.
    */
   protected EditText createInternalEditText() {

--- a/ReactAndroid/src/main/jni/first-party/yogajni/jni/ScopedGlobalRef.h
+++ b/ReactAndroid/src/main/jni/first-party/yogajni/jni/ScopedGlobalRef.h
@@ -36,8 +36,8 @@ namespace vanillajni {
  * This class is very explicit in its behavior, and it does not allow to perform
  * unexpected conversions or unexpected ownership transfer. In practice, this
  * class acts as a unique pointer where the underying JNI reference can have one
- * and just one owner. Transfering ownership is allowed but it is an explicit
- * operation (implemneted via move semantics and also via explicity API calls).
+ * and just one owner. Transferring ownership is allowed but it is an explicit
+ * operation (implemneted via move semantics and also via explicitly API calls).
  *
  * Note that this class doesn't receive an explicit JNIEnv at construction time.
  * At destruction time it uses vanillajni::getCurrentEnv() to retrieve the

--- a/ReactAndroid/src/main/jni/first-party/yogajni/jni/ScopedLocalRef.h
+++ b/ReactAndroid/src/main/jni/first-party/yogajni/jni/ScopedLocalRef.h
@@ -38,8 +38,8 @@ namespace vanillajni {
  * This class is very explicit in its behavior, and it does not allow to perform
  * unexpected conversions or unexpected ownership transfer. In practice, this
  * class acts as a unique pointer where the underying JNI reference can have one
- * and just one owner. Transfering ownership is allowed but it is an explicit
- * operation (implemneted via move semantics and also via explicity API calls).
+ * and just one owner. Transferring ownership is allowed but it is an explicit
+ * operation (implemneted via move semantics and also via explicitly API calls).
  *
  * As with standard JNI local references it is not a valid operation to keep a
  * reference around between different native method calls.

--- a/ReactAndroid/src/main/jni/react/jni/Android.mk
+++ b/ReactAndroid/src/main/jni/react/jni/Android.mk
@@ -112,7 +112,7 @@ include $(BUILD_SHARED_LIBRARY)
 #
 # What does it mean to include an Android.mk file?
 #   Whenever you encounter an include <dir>/<module-dir>/Android.mk, you
-#   tell andorid-ndk to compile the module in <dir>/<module-dir> according
+#   tell android-ndk to compile the module in <dir>/<module-dir> according
 #   to the specification inside <dir>/<module-dir>/Android.mk.
 $(call import-module,better)
 $(call import-module,folly)

--- a/ReactCommon/hermes/inspector/Inspector.h
+++ b/ReactCommon/hermes/inspector/Inspector.h
@@ -171,7 +171,7 @@ class Inspector : public facebook::hermes::debugger::EventObserver,
 
   /**
    * resume and step methods are only valid when the VM is currently paused. The
-   * returned future suceeds when the VM resumes execution, or fails with an
+   * returned future succeeds when the VM resumes execution, or fails with an
    * InvalidStateException otherwise.
    */
   folly::Future<folly::Unit> resume();
@@ -181,7 +181,7 @@ class Inspector : public facebook::hermes::debugger::EventObserver,
 
   /**
    * pause can be issued at any time while the inspector is enabled. It requests
-   * the VM to asynchronously break execution. The returned future suceeds if
+   * the VM to asynchronously break execution. The returned future succeeds if
    * the VM can be paused in this state and fails with InvalidStateException if
    * otherwise.
    */

--- a/ReactCommon/hermes/inspector/RuntimeAdapter.h
+++ b/ReactCommon/hermes/inspector/RuntimeAdapter.h
@@ -38,7 +38,7 @@ class RuntimeAdapter {
   /// the ability to force the process to enter the Hermes interpreter loop
   /// soon. This is important because the inspector can only do a number of
   /// important operations (like manipulating breakpoints) within the context of
-  /// a Hermes interperter loop.
+  /// a Hermes interpreter loop.
   ///
   /// The default implementation does nothing.
   virtual void tickleJs();

--- a/ReactCommon/jsi/jsi/test/testlib.cpp
+++ b/ReactCommon/jsi/jsi/test/testlib.cpp
@@ -931,14 +931,14 @@ TEST_P(JSITest, PreparedJavaScriptURLInBacktrace) {
 
 namespace {
 
-unsigned countOccurences(const std::string& of, const std::string& in) {
-  unsigned occurences = 0;
+unsigned countOccurrences(const std::string& of, const std::string& in) {
+  unsigned occurrences = 0;
   std::string::size_type lastOccurence = -1;
   while ((lastOccurence = in.find(of, lastOccurence + 1)) !=
          std::string::npos) {
-    occurences++;
+    occurrences++;
   }
-  return occurences;
+  return occurrences;
 }
 
 } // namespace
@@ -967,10 +967,10 @@ TEST_P(JSITest, JSErrorsArePropagatedNicely) {
     sometimesThrows.call(rt, false, callback);
   } catch (JSError& error) {
     EXPECT_EQ(error.getMessage(), "Omg, what a nasty exception");
-    EXPECT_EQ(countOccurences("sometimesThrows", error.getStack()), 6);
+    EXPECT_EQ(countOccurrences("sometimesThrows", error.getStack()), 6);
 
     // system JSC JSI does not implement host function names
-    // EXPECT_EQ(countOccurences("callback", error.getStack(rt)), 5);
+    // EXPECT_EQ(countOccurrences("callback", error.getStack(rt)), 5);
   }
 }
 

--- a/ReactCommon/react/renderer/attributedstring/AttributedString.h
+++ b/ReactCommon/react/renderer/attributedstring/AttributedString.h
@@ -26,7 +26,7 @@ class AttributedString;
 using SharedAttributedString = std::shared_ptr<const AttributedString>;
 
 /*
- * Simple, cross-platfrom, React-specific implementation of attributed string
+ * Simple, cross-platform, React-specific implementation of attributed string
  * (aka spanned string).
  * `AttributedString` is basically a list of `Fragments` which have `string` and
  * `textAttributes` + `shadowNode` associated with the `string`.

--- a/ReactCommon/react/renderer/components/unimplementedview/UnimplementedViewComponentDescriptor.h
+++ b/ReactCommon/react/renderer/components/unimplementedview/UnimplementedViewComponentDescriptor.h
@@ -29,7 +29,7 @@ class UnimplementedViewComponentDescriptor final
   ComponentName getComponentName() const override;
 
   /*
-   * In addtion to base implementation, stores a component name inside cloned
+   * In addition to base implementation, stores a component name inside cloned
    * `Props` object.
    */
   Props::Shared cloneProps(Props::Shared const &props, RawProps const &rawProps)

--- a/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
+++ b/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
@@ -53,7 +53,7 @@ YogaLayoutableShadowNode::YogaLayoutableShadowNode(
       yogaNode_(&initializeYogaConfig(yogaConfig_)) {
   yogaNode_.setContext(this);
 
-  // Newly created node must be `dirty` just becasue it is new.
+  // Newly created node must be `dirty` just because it is new.
   // This is not a default for `YGNode`.
   yogaNode_.setDirty(true);
 

--- a/ReactCommon/react/renderer/core/EventEmitter.cpp
+++ b/ReactCommon/react/renderer/core/EventEmitter.cpp
@@ -20,7 +20,7 @@ namespace react {
 // TODO(T29874519): Get rid of "top" prefix once and for all.
 /*
  * Capitalizes the first letter of the event type and adds "top" prefix if
- * necessary (e.g. "layout" becames "topLayout").
+ * necessary (e.g. "layout" becomes "topLayout").
  */
 static std::string normalizeEventType(const std::string &type) {
   auto prefixedType = type;

--- a/ReactCommon/react/renderer/scheduler/Scheduler.h
+++ b/ReactCommon/react/renderer/scheduler/Scheduler.h
@@ -75,7 +75,7 @@ class Scheduler final : public UIManagerDelegate {
   /*
    * This is broken. Please do not use.
    * `ComponentDescriptor`s are not designed to be used outside of `UIManager`,
-   * there is no any garantees about their lifetime.
+   * there is no any guarantees about their lifetime.
    */
   ComponentDescriptor const *
   findComponentDescriptorByHandle_DO_NOT_USE_THIS_IS_BROKEN(

--- a/ReactCommon/react/renderer/textlayoutmanager/platform/ios/NSTextStorage+FontScaling.m
+++ b/ReactCommon/react/renderer/textlayoutmanager/platform/ios/NSTextStorage+FontScaling.m
@@ -30,11 +30,11 @@ typedef NS_OPTIONS(NSInteger, RCTTextSizeComparisonOptions) {
   while (true) {
     [self scaleFontSizeWithRatio:ratio minimumFontSize:minimumFontSize maximumFontSize:maximumFontSize];
 
-    RCTTextSizeComparisonOptions comparsion = [self compareToSize:size thresholdRatio:0.01];
+    RCTTextSizeComparisonOptions comparison = [self compareToSize:size thresholdRatio:0.01];
 
-    if ((comparsion & RCTTextSizeComparisonWithinRange) && (comparsion & RCTTextSizeComparisonSmaller)) {
+    if ((comparison & RCTTextSizeComparisonWithinRange) && (comparison & RCTTextSizeComparisonSmaller)) {
       return;
-    } else if (comparsion & RCTTextSizeComparisonSmaller) {
+    } else if (comparison & RCTTextSizeComparisonSmaller) {
       bottomRatio = ratio;
       lastRatioWhichFits = ratio;
     } else {

--- a/ReactCommon/yoga/yoga/Utils.h
+++ b/ReactCommon/yoga/yoga/Utils.h
@@ -24,10 +24,10 @@
 //   the remaining space left for the flexible children.
 //
 // - totalFlexGrowFactors: total flex grow factors of flex items which are to be
-//   layed in the current line
+//   laid in the current line
 //
 // - totalFlexShrinkFactors: total flex shrink factors of flex items which are
-//   to be layed in the current line
+//   to be laid in the current line
 //
 // - endOfLineIndex: Its the end index of the last flex item which was examined
 //   and it may or may not be part of the current line(as it may be absolutely

--- a/ReactCommon/yoga/yoga/Yoga.cpp
+++ b/ReactCommon/yoga/yoga/Yoga.cpp
@@ -580,7 +580,7 @@ void updateIndexedStyleProp(
 // MSVC has trouble inferring the return type of pointer to member functions
 // with const and non-const overloads, instead of preferring the non-const
 // overload like clang and GCC. For the purposes of updateStyle(), we can help
-// MSVC by specifying that return type explicitely. In combination with
+// MSVC by specifying that return type explicitly. In combination with
 // decltype, MSVC will prefer the non-const version.
 #define MSVC_HINT(PROP) decltype(YGStyle{}.PROP())
 
@@ -2698,7 +2698,7 @@ static void YGJustifyMainAxis(
 //    but the algorithm below assumes a default of 'column'.
 //
 // Input parameters:
-//    - node: current node to be sized and layed out
+//    - node: current node to be sized and laid out
 //    - availableWidth & availableHeight: available size to be used for sizing
 //      the node or YGUndefined if the size is not available; interpretation
 //      depends on layout flags
@@ -2710,7 +2710,7 @@ static void YGJustifyMainAxis(
 //      for explanation)
 //    - performLayout: specifies whether the caller is interested in just the
 //      dimensions of the node or it requires the entire node and its subtree to
-//      be layed out (with final positions)
+//      be laid out (with final positions)
 //
 // Details:
 //    This routine is called recursively to lay out subtrees of flexbox
@@ -3831,7 +3831,7 @@ bool YGLayoutNodeInternal(
   // Determine whether the results are already cached. We maintain a separate
   // cache for layouts and measurements. A layout operation modifies the
   // positions and dimensions for nodes in the subtree. The algorithm assumes
-  // that each node gets layed out a maximum of one time per tree layout, but
+  // that each node gets laid out a maximum of one time per tree layout, but
   // multiple measurements may be required to resolve all of the flex
   // dimensions. We handle nodes with measure functions specially here because
   // they are the most expensive to measure, so it's worth avoiding redundant

--- a/packages/react-native-codegen/src/parsers/flow/components/__tests__/__snapshots__/component-parser-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/flow/components/__tests__/__snapshots__/component-parser-test.js.snap
@@ -16,7 +16,7 @@ exports[`RN Codegen Flow Parser Fails with error message NON_OPTIONAL_KEY_WITH_D
 
 exports[`RN Codegen Flow Parser Fails with error message NULLABLE_WITH_DEFAULT 1`] = `"WithDefault<> is optional and does not need to be marked as optional. Please remove the ? annotation in front of it."`;
 
-exports[`RN Codegen Flow Parser Fails with error message PROP_ARRAY_ENUM_BOOLEAN 1`] = `"Unsupported union type for \\"someProp\\", recieved \\"BooleanLiteralTypeAnnotation\\""`;
+exports[`RN Codegen Flow Parser Fails with error message PROP_ARRAY_ENUM_BOOLEAN 1`] = `"Unsupported union type for \\"someProp\\", received \\"BooleanLiteralTypeAnnotation\\""`;
 
 exports[`RN Codegen Flow Parser Fails with error message PROP_ARRAY_ENUM_INT 1`] = `"Arrays of int enums are not supported (see: \\"someProp\\")"`;
 

--- a/packages/react-native-codegen/src/parsers/flow/components/props.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/props.js
@@ -158,7 +158,7 @@ function getTypeAnnotationForArray(name, typeAnnotation, defaultValue, types) {
         );
       } else {
         throw new Error(
-          `Unsupported union type for "${name}", recieved "${unionType}"`,
+          `Unsupported union type for "${name}", received "${unionType}"`,
         );
       }
     default:

--- a/packages/react-native-codegen/src/parsers/flow/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/index.js
@@ -86,7 +86,7 @@ function getConfigType(ast, types): 'module' | 'component' {
     return 'component';
   } else {
     throw new Error(
-      `Default export for module specified incorrectly. It should containts
+      `Default export for module specified incorrectly. It should contains
     either type extending "TurboModule" or "codegenNativeComponent".`,
     );
   }

--- a/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-test.js.snap
@@ -15,7 +15,7 @@ exports[`RN Codegen Flow Parser Fails with error message NATIVE_MODULES_WITH_UNN
 exports[`RN Codegen Flow Parser Fails with error message TWO_NATIVE_EXTENDING_TURBO_MODULE 1`] = `"Found two types extending \\"TurboModule\\" is one file. Split them into separated files."`;
 
 exports[`RN Codegen Flow Parser Fails with error message TWO_NATIVE_MODULES_EXPORTED_WITH_DEFAULT 1`] = `
-"Default export for module specified incorrectly. It should containts
+"Default export for module specified incorrectly. It should contains
     either type extending \\"TurboModule\\" or \\"codegenNativeComponent\\"."
 `;
 


### PR DESCRIPTION
Most of them were documentation or method's inline code misspellings. However, the `ReactCommon/jsi/jsi/test/testlib.cpp #countOccurences` name was replaced with `countOccurrences`, it's not used though.

Thanks,
Gerasimos Maropoulos.