### PR TITLE
Fix Xcode warnings in React-Core pod

### DIFF
--- a/Libraries/Image/RCTImageLoaderProtocol.h
+++ b/Libraries/Image/RCTImageLoaderProtocol.h
@@ -14,6 +14,8 @@
 #import <React/RCTImageURLLoader.h>
 #import <React/RCTImageCache.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * If available, RCTImageRedirectProtocol is invoked before loading an asset.
  * Implementation should return either a new URL or nil when redirection is
@@ -132,3 +134,5 @@ typedef NS_ENUM(NSUInteger, RCTImageLoaderPriority) {
 - (void)setImageCache:(id<RCTImageCache>)cache;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Libraries/Image/RCTImageURLLoader.h
+++ b/Libraries/Image/RCTImageURLLoader.h
@@ -10,9 +10,11 @@
 #import <React/RCTBridge.h>
 #import <React/RCTResizeMode.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 typedef void (^RCTImageLoaderProgressBlock)(int64_t progress, int64_t total);
 typedef void (^RCTImageLoaderPartialLoadBlock)(UIImage *image);
-typedef void (^RCTImageLoaderCompletionBlock)(NSError *error, UIImage *image);
+typedef void (^RCTImageLoaderCompletionBlock)(NSError * _Nullable error, UIImage * _Nullable image);
 typedef dispatch_block_t RCTImageLoaderCancellationBlock;
 
 /**
@@ -71,3 +73,5 @@ typedef dispatch_block_t RCTImageLoaderCancellationBlock;
 - (BOOL)shouldCacheLoadedImages;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/React/Base/RCTBridge.m
+++ b/React/Base/RCTBridge.m
@@ -207,7 +207,10 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
 
 - (void)didReceiveReloadCommand
 {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   [self reloadWithReason:@"Command"];
+#pragma clang diagnostic pop
 }
 
 - (NSArray<Class> *)moduleClasses

--- a/React/Base/RCTJSStackFrame.h
+++ b/React/Base/RCTJSStackFrame.h
@@ -13,13 +13,13 @@
 @property (nonatomic, copy, readonly) NSString *file;
 @property (nonatomic, readonly) NSInteger lineNumber;
 @property (nonatomic, readonly) NSInteger column;
-@property (nonatomic, readonly) NSInteger collapse;
+@property (nonatomic, readonly) BOOL collapse;
 
 - (instancetype)initWithMethodName:(NSString *)methodName
                               file:(NSString *)file
                         lineNumber:(NSInteger)lineNumber
                             column:(NSInteger)column
-                          collapse:(NSInteger)collapse;
+                          collapse:(BOOL)collapse;
 - (NSDictionary *)toDictionary;
 
 + (instancetype)stackFrameWithLine:(NSString *)line;

--- a/React/Base/RCTJSStackFrame.m
+++ b/React/Base/RCTJSStackFrame.m
@@ -57,7 +57,7 @@ static NSRegularExpression *RCTJSStackFrameRegex()
                               file:(NSString *)file
                         lineNumber:(NSInteger)lineNumber
                             column:(NSInteger)column
-                          collapse:(NSInteger)collapse
+                          collapse:(BOOL)collapse
 {
   if (self = [super init]) {
     _methodName = methodName;
@@ -100,7 +100,7 @@ static NSRegularExpression *RCTJSStackFrameRegex()
                                      file:file
                                lineNumber:[lineNumber integerValue]
                                    column:[column integerValue]
-                                 collapse:@NO.integerValue];
+                                 collapse:NO];
 }
 
 + (instancetype)stackFrameWithDictionary:(NSDictionary *)dict
@@ -109,7 +109,7 @@ static NSRegularExpression *RCTJSStackFrameRegex()
                                      file:dict[@"file"]
                                lineNumber:[RCTNilIfNull(dict[@"lineNumber"]) integerValue]
                                    column:[RCTNilIfNull(dict[@"column"]) integerValue]
-                                 collapse:[RCTNilIfNull(dict[@"collapse"]) integerValue]];
+                                 collapse:[RCTNilIfNull(dict[@"collapse"]) boolValue]];
 }
 
 + (NSArray<RCTJSStackFrame *> *)stackFramesWithLines:(NSString *)lines

--- a/React/Base/RCTJSStackFrame.m
+++ b/React/Base/RCTJSStackFrame.m
@@ -100,7 +100,7 @@ static NSRegularExpression *RCTJSStackFrameRegex()
                                      file:file
                                lineNumber:[lineNumber integerValue]
                                    column:[column integerValue]
-                                 collapse:@NO];
+                                 collapse:@NO.integerValue];
 }
 
 + (instancetype)stackFrameWithDictionary:(NSDictionary *)dict

--- a/React/Base/RCTKeyCommands.m
+++ b/React/Base/RCTKeyCommands.m
@@ -113,7 +113,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
 - (void)handleKeyUIEventSwizzle:(UIEvent *)event
 {
   NSString *modifiedInput = nil;
-  UIKeyModifierFlags *modifierFlags = nil;
+  UIKeyModifierFlags modifierFlags = 0;
   BOOL isKeyDown = NO;
 
   if ([event respondsToSelector:@selector(_modifiedInput)]) {

--- a/React/Base/RCTModuleData.h
+++ b/React/Base/RCTModuleData.h
@@ -97,4 +97,4 @@ typedef id<RCTBridgeModule> (^RCTBridgeModuleProvider)(void);
 @end
 
 RCT_EXTERN void RCTSetIsMainQueueExecutionOfConstantsToExportDisabled(BOOL val);
-RCT_EXTERN BOOL RCTIsMainQueueExecutionOfConstantsToExportDisabled();
+RCT_EXTERN BOOL RCTIsMainQueueExecutionOfConstantsToExportDisabled(void);

--- a/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingProxyRootView.h
+++ b/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingProxyRootView.h
@@ -36,6 +36,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) NSTimeInterval loadingViewFadeDelay;
 @property (nonatomic, assign) NSTimeInterval loadingViewFadeDuration;
 
+- (instancetype)initWithSurface:(RCTSurface *)surface
+                sizeMeasureMode:(RCTSurfaceSizeMeasureMode)sizeMeasureMode NS_UNAVAILABLE;
+
 - (instancetype)initWithBridge:(RCTBridge *)bridge
                     moduleName:(NSString *)moduleName
              initialProperties:(NSDictionary *)initialProperties NS_DESIGNATED_INITIALIZER;

--- a/React/CxxBridge/RCTCxxBridge.mm
+++ b/React/CxxBridge/RCTCxxBridge.mm
@@ -1105,6 +1105,9 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithBundleURL
 {
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
+
 - (void)reload
 {
   if (!_valid) {
@@ -1124,6 +1127,8 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithBundleURL
   }
   RCTTriggerReloadCommandListeners(reason);
 }
+
+#pragma clang diagnostic pop
 
 - (Class)executorClass
 {

--- a/React/CxxBridge/RCTCxxBridge.mm
+++ b/React/CxxBridge/RCTCxxBridge.mm
@@ -1105,31 +1105,6 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithBundleURL
 {
 }
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-implementations"
-
-- (void)reload
-{
-  if (!_valid) {
-    RCTLogWarn(
-        @"Attempting to reload bridge before it's valid: %@. Try restarting the development server if connected.",
-        self);
-  }
-  RCTTriggerReloadCommandListeners(@"Unknown from cxx bridge");
-}
-
-- (void)reloadWithReason:(NSString *)reason
-{
-  if (!_valid) {
-    RCTLogWarn(
-        @"Attempting to reload bridge before it's valid: %@. Try restarting the development server if connected.",
-        self);
-  }
-  RCTTriggerReloadCommandListeners(reason);
-}
-
-#pragma clang diagnostic pop
-
 - (Class)executorClass
 {
   return _parentBridge.executorClass;

--- a/React/Modules/RCTUIManagerUtils.m
+++ b/React/Modules/RCTUIManagerUtils.m
@@ -8,6 +8,7 @@
 #import "RCTUIManagerUtils.h"
 
 #import <libkern/OSAtomic.h>
+#import <stdatomic.h>
 
 #import "RCTAssert.h"
 
@@ -98,6 +99,6 @@ void RCTUnsafeExecuteOnUIManagerQueueSync(dispatch_block_t block)
 NSNumber *RCTAllocateRootViewTag()
 {
   // Numbering of these tags goes from 1, 11, 21, 31, ..., 100501, ...
-  static int64_t rootViewTagCounter = -1;
-  return @(OSAtomicIncrement64(&rootViewTagCounter) * 10 + 1);
+  static _Atomic int64_t rootViewTagCounter = 0;
+  return @(atomic_fetch_add_explicit(&rootViewTagCounter, 1, memory_order_relaxed) * 10 + 1);
 }

--- a/React/Modules/RCTUIManagerUtils.m
+++ b/React/Modules/RCTUIManagerUtils.m
@@ -7,7 +7,6 @@
 
 #import "RCTUIManagerUtils.h"
 
-#import <libkern/OSAtomic.h>
 #import <stdatomic.h>
 
 #import "RCTAssert.h"

--- a/React/Profiler/RCTProfile.m
+++ b/React/Profiler/RCTProfile.m
@@ -378,7 +378,10 @@ void RCTProfileUnhookModules(RCTBridge *bridge)
 
 + (void)reload
 {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   [RCTProfilingBridge() reloadWithReason:@"Profiling controls"];
+#pragma clang diagnostic pop
 }
 
 + (void)toggle:(UIButton *)target

--- a/React/Profiler/RCTProfile.m
+++ b/React/Profiler/RCTProfile.m
@@ -22,6 +22,7 @@
 #import "RCTDefines.h"
 #import "RCTLog.h"
 #import "RCTModuleData.h"
+#import "RCTReloadCommand.h"
 #import "RCTUIManager.h"
 #import "RCTUIManagerUtils.h"
 #import "RCTUtils.h"
@@ -378,10 +379,7 @@ void RCTProfileUnhookModules(RCTBridge *bridge)
 
 + (void)reload
 {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  [RCTProfilingBridge() reloadWithReason:@"Profiling controls"];
-#pragma clang diagnostic pop
+  RCTTriggerReloadCommandListeners(@"Profiling controls");
 }
 
 + (void)toggle:(UIButton *)target

--- a/React/Views/RCTComponentData.h
+++ b/React/Views/RCTComponentData.h
@@ -15,6 +15,8 @@
 @class RCTShadowView;
 @class UIView;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface RCTComponentData : NSObject
 
 @property (nonatomic, readonly) Class managerClass;
@@ -23,7 +25,7 @@
 
 - (instancetype)initWithManagerClass:(Class)managerClass bridge:(RCTBridge *)bridge NS_DESIGNATED_INITIALIZER;
 
-- (UIView *)createViewWithTag:(NSNumber *)tag rootTag:(NSNumber *)rootTag;
+- (UIView *)createViewWithTag:(nullable NSNumber *)tag rootTag:(nullable NSNumber *)rootTag;
 - (RCTShadowView *)createShadowViewWithTag:(NSNumber *)tag;
 - (void)setProps:(NSDictionary<NSString *, id> *)props forView:(id<RCTComponent>)view;
 - (void)setProps:(NSDictionary<NSString *, id> *)props forShadowView:(RCTShadowView *)shadowView;
@@ -34,3 +36,5 @@
 - (NSDictionary<NSString *, id> *)viewConfig;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/React/Views/RCTComponentData.m
+++ b/React/Views/RCTComponentData.m
@@ -63,7 +63,7 @@ static SEL selectorForType(NSString *type)
 
 RCT_NOT_IMPLEMENTED(-(instancetype)init)
 
-- (UIView *)createViewWithTag:(NSNumber *)tag rootTag:(NSNumber *)rootTag
+- (UIView *)createViewWithTag:(nullable NSNumber *)tag rootTag:(nullable NSNumber *)rootTag
 {
   RCTAssertMainQueue();
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
With the upgrade to React Native 0.63, we started running into nullability warnings that were breaking our build. This PR fixes those nullability warnings as well as a few other warnings in React-Core.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [Fixed] - Fix xcodebuild warnings in React-Core

## Test Plan

- Nullability annotations should only affect compilation, but even though RNTester compiles, I'm not fully convinced that this won't break projects downstream. It would be good to get another opinion on this.
- The change in `RCTAllocateRootViewTag` is the only real logic change in this PR. We throw an exception if the root view tag is not in the correct format, so this change seems safe after some basic manual testing in RNTester. 