### PR TITLE
chore: use es6 import for DrawerLayoutAndroid

### DIFF
--- a/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android.js
+++ b/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android.js
@@ -10,14 +10,14 @@
 
 'use strict';
 
-const Platform = require('../../Utilities/Platform');
-const React = require('react');
-const StatusBar = require('../StatusBar/StatusBar');
-const StyleSheet = require('../../StyleSheet/StyleSheet');
-const View = require('../View/View');
+import Platform from '../../Utilities/Platform'; 
+import * as React from 'react';
+import StatusBar from '../../StatusBar/StatusBar'; 
+import StyleSheet from '../../StyleSheet/StyleSheet'; 
+import View from '../View/View'; 
 
-const dismissKeyboard = require('../../Utilities/dismissKeyboard');
-const nullthrows = require('nullthrows');
+import dismissKeyboard from '../../Utilities/dismissKeyboard';
+import nullthrows from 'nullthrows';
 
 import AndroidDrawerLayoutNativeComponent, {
   Commands,

--- a/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android.js
+++ b/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android.js
@@ -12,7 +12,7 @@
 
 import Platform from '../../Utilities/Platform'; 
 import * as React from 'react';
-import StatusBar from '../../StatusBar/StatusBar'; 
+import StatusBar from '../StatusBar/StatusBar'; 
 import StyleSheet from '../../StyleSheet/StyleSheet'; 
 import View from '../View/View'; 
 


### PR DESCRIPTION
## Summary

Migrating DrawerLayoutAndroid component to use ES6 import

Slowly migrate each file to use es6 import/exports to make this discussion happen
react-native-community/discussions-and-proposals#201 (comment)

## Changelog
[General] [Changed] - Use ES6 import/export syntax for DrawerLayoutAndroid component

## Test Plan

Manual RNTester for Android