### PR TITLE
chore: updating createAnimatedComponent to es6 and removing unused import

### DIFF
--- a/Libraries/Animated/src/createAnimatedComponent.js
+++ b/Libraries/Animated/src/createAnimatedComponent.js
@@ -10,15 +10,14 @@
 
 'use strict';
 
-const View = require('../../Components/View/View');
-const Platform = require('../../Utilities/Platform');
-const {AnimatedEvent} = require('./AnimatedEvent');
-const AnimatedProps = require('./nodes/AnimatedProps');
-const React = require('react');
-const NativeAnimatedHelper = require('./NativeAnimatedHelper');
+import View from '../../Components/View/View';
+import {AnimatedEvent} from './AnimatedEvent';
+import AnimatedProps from './nodes/AnimatedProps';
+import * as React from 'react';
+import * as NativeAnimatedHelper from './NativeAnimatedHelper';
 
-const invariant = require('invariant');
-const setAndForwardRef = require('../../Utilities/setAndForwardRef');
+import invariant from 'invariant';
+import setAndForwardRef from '../../Utilities/setAndForwardRef';
 
 let animatedComponentNextId = 1;
 


### PR DESCRIPTION
##  Summary

Migrating createAnimatedComponent component to use ES6 import and also removing unused platform import.

As per this commit, https://github.com/facebook/react-native/commit/cc0cca60c18b5570d0fb139b94aab9f4bd64b5ab by @sammy-SC Platform import is no longer needed. 

Slowly migrate each file to use es6 import/exports to make this discussion happen
react-native-community/discussions-and-proposals#201 (comment)


## Changelog
[General] [Changed] - Use ES6 import/export syntax for createAnimatedComponent component and removing unused import

## Test Plan
RNTester 
