### PR TITLE
Removing unused import on RCTMultilineTextInputNativeComponent & RCTSingelineTextInputNativeComponent spec. 

### DIFF
--- a/Libraries/Components/TextInput/RCTMultilineTextInputNativeComponent.js
+++ b/Libraries/Components/TextInput/RCTMultilineTextInputNativeComponent.js
@@ -13,9 +13,7 @@
 import type {HostComponent} from '../../Renderer/shims/ReactNativeTypes';
 import requireNativeComponent from '../../ReactNative/requireNativeComponent';
 import codegenNativeCommands from '../../Utilities/codegenNativeCommands';
-import type {Int32} from '../../Types/CodegenTypes';
 import type {TextInputNativeCommands} from './TextInputNativeCommands';
-import * as React from 'react';
 
 type NativeType = HostComponent<mixed>;
 

--- a/Libraries/Components/TextInput/RCTSingelineTextInputNativeComponent.js
+++ b/Libraries/Components/TextInput/RCTSingelineTextInputNativeComponent.js
@@ -13,8 +13,6 @@
 import type {HostComponent} from '../../Renderer/shims/ReactNativeTypes';
 import requireNativeComponent from '../../ReactNative/requireNativeComponent';
 import codegenNativeCommands from '../../Utilities/codegenNativeCommands';
-import type {Int32} from '../../Types/CodegenTypes';
-import * as React from 'react';
 import type {TextInputNativeCommands} from './TextInputNativeCommands';
 import RCTSinglelineTextInputViewConfig from './RCTSinglelineTextInputViewConfig';
 const ReactNativeViewConfigRegistry = require('../../Renderer/shims/ReactNativeViewConfigRegistry');


### PR DESCRIPTION
## Summary
This pr removes unused import on RCTMultilineTextInputNativeComponent & RCTSingelineTextInputNativeComponent spec. 

## Changelog

[General] [Changed] - Removing unused import on RCTMultilineTextInputNativeComponent & RCTSingelineTextInputNativeComponent spec. 


## Test Plan
@TODO
