### PR TITLE
remove accessibilityStates validAttributes config from ReactNativeViewViewConfig.js

### DIFF
--- a/Libraries/Components/View/ReactNativeViewViewConfig.js
+++ b/Libraries/Components/View/ReactNativeViewViewConfig.js
@@ -122,7 +122,6 @@ const ReactNativeViewConfig = {
     accessibilityLabel: true,
     accessibilityLiveRegion: true,
     accessibilityRole: true,
-    accessibilityStates: true, // TODO: Can be removed after next release
     accessibilityState: true,
     accessibilityValue: true,
     accessibilityViewIsModal: true,


### PR DESCRIPTION
## Summary
this little PR remove `accesibilityStates` config in validAttributes, like comment says it can be removed after next release.

## Changelog
Javascript
## Test Plan
