### PR TITLE
Updating emitTimeDriftWarning adb shell command

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/core/JavaTimerManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/core/JavaTimerManager.java
@@ -329,7 +329,7 @@ public class JavaTimerManager {
       if (driftTime > 60000) {
         mJavaScriptTimerManager.emitTimeDriftWarning(
             "Debugger and device times have drifted by more than 60s. Please correct this by "
-                + "running adb shell \"date `date +%m%d%H%M%Y.%S`\" on your debugger machine.");
+                + "running adb shell \"date `date +%m%d%H%M%Y.%S%3N`\" on your debugger machine.");
       }
     }
 


### PR DESCRIPTION
## Summary

See related discussion here, 
https://github.com/facebook/react-native-website/pull/2149

This PR update emitTimeDriftWarning adb shell command to prevent possible sync error up to 999ms which can cause issues and performance problems.

## Changelog
[Android] [Changed] - Updating emitTimeDriftWarning adb shell command

## Test Plan
RNTester Android
