### PR TITLE
Allow PlatformColor to return user-defined named asset color

### DIFF
--- a/React/Base/RCTConvert.m
+++ b/React/Base/RCTConvert.m
@@ -863,7 +863,11 @@ static NSString *RCTSemanticColorNames()
         return color;
       } else if ([value isKindOfClass:[NSArray class]]) {
         for (id name in value) {
-          UIColor *color = RCTColorFromSemanticColorName(name);
+          UIColor *color = [UIColor colorNamed:name];
+          if (color != nil) {
+            return color;
+          }
+          color = RCTColorFromSemanticColorName(name);
           if (color != nil) {
             return color;
           }

--- a/React/Base/RCTConvert.m
+++ b/React/Base/RCTConvert.m
@@ -850,7 +850,11 @@ static NSString *RCTSemanticColorNames()
     if ((value = [dictionary objectForKey:@"semantic"])) {
       if ([value isKindOfClass:[NSString class]]) {
         NSString *semanticName = value;
-        UIColor *color = RCTColorFromSemanticColorName(semanticName);
+        UIColor *color = [UIColor colorNamed:semanticName];
+        if (color != nil) {
+          return color;
+        }
+        color = RCTColorFromSemanticColorName(semanticName);
         if (color == nil) {
           RCTLogConvertError(
               json,


### PR DESCRIPTION
## Summary

According to https://reactnative.dev/docs/platformcolor:

> You can use the PlatformColor function to access native colors on the target platform by supplying the native color’s corresponding string value.

This should also include named asset colors as they are part of the colors available on the iOS platform.

See 
https://developer.apple.com/documentation/uikit/uicolor/2877380-colornamed?language=objc
https://developer.apple.com/library/archive/documentation/Xcode/Reference/xcode_ref-Asset_Catalog_Format/Named_Color.html

This PR allows using `PlatformColor` to get a user-defined named asset color in the same manner that it works on android via xml resources:

<img width="668" alt="Screenshot 2020-10-05 at 12 45 33" src="https://user-images.githubusercontent.com/996231/95070647-b7388700-0708-11eb-9388-ba3a3c0b6053.png">

```ts
<View style={{ backgroundColor: PlatformColor("MyCustomColor") }}>...</View>
```

would set the background color of the view to the named asset color "MyCustomColor". Currently this doesn't work.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [Added] - Allow PlatformColor to return user-defined named asset color

## Test Plan

1. Define an asset color as specified here: https://developer.apple.com/documentation/xcode/supporting_dark_mode_in_your_interface?language=objc

2. Access the color via `PlatformColor("asset color name")`