### PR TITLE
Fix "'RCTBlobPlugins.h' file not found" on iOS

### DIFF
--- a/Libraries/Blob/React-RCTBlob.podspec
+++ b/Libraries/Blob/React-RCTBlob.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |s|
   s.platforms              = { :ios => "10.0", :tvos => "10.0" }
   s.compiler_flags         = folly_compiler_flags + ' -Wno-nullability-completeness'
   s.source                 = source
-  s.source_files           = "*.{m,mm}"
+  s.source_files           = "*.{h,m,mm}"
   s.preserve_paths         = "package.json", "LICENSE", "LICENSE-docs"
   s.header_dir             = "RCTBlob"
   s.pod_target_xcconfig    = {


### PR DESCRIPTION
## Summary

Fixes iOS builds failing with the following error in certain setups:

```
/~/Pods/React-RCTBlob/Libraries/Blob/RCTBlobPlugins.mm:14:9: fatal error: 'RCTBlobPlugins.h' file not found
#import "RCTBlobPlugins.h"
        ^~~~~~~~~~~~~~~~~~
1 error generated.
```

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [Fixed] - "'RCTBlobPlugins.h' file not found" when building iOS

## Test Plan

- Existing builds should not fail
- Tested this change internally where we are seeing this build failure

cc @hramos 