### PR TITLE
Fix measureInWindow feature parity between iOS and Android

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java
@@ -712,7 +712,7 @@ public class NativeViewHierarchyManager {
     Rect visibleWindowFrame = new Rect();
     v.getWindowVisibleDisplayFrame(visibleWindowFrame);
     outputBuffer[0] = outputBuffer[0] - visibleWindowFrame.left;
-    outputBuffer[1] = outputBuffer[1] - visibleWindowFrame.top;
+    outputBuffer[1] = outputBuffer[1] + visibleWindowFrame.top;
 
     // outputBuffer[0,1] already contain what we want
     outputBuffer[2] = v.getWidth();


### PR DESCRIPTION
## Summary
This PR aims to fix a feature parity problem between iOS and Android. The iOS return y with status bar height while the android implementation does not. This issue is first discovered on #19497 and mentioned on RN Issue Triage Group 2 https://github.com/facebook/react-native/issues/24029. 

Related Issue:
resolve #29638 #19497

`visibleWindowFrame.top` returns the StatusBar height. `outputBuffer[1]` does not contain the StatusBar height.

## Changelog
[Android] [Fixed] - Fix measureInWindow y axis not including StatusBar

## Test Plan
RNTester for Android

This is the correct result when `measureInWindow` is called on hello.
 `y` is `44` from the top and `24` from the status bar. ( `Hello` have a 20 margin-top and status bar height is 24 ).

![Screenshot from 2020-08-19 15-00-46](https://user-images.githubusercontent.com/8868908/90611264-b4550600-e230-11ea-9d78-81467aa1bbed.png)

