### PR TITLE
Check if scheme exists even after formatting the path

### DIFF
--- a/React/Base/RCTConvert.m
+++ b/React/Base/RCTConvert.m
@@ -101,7 +101,7 @@ RCT_CUSTOM_CONVERTER(NSData *, NSData, [json dataUsingEncoding:NSUTF8StringEncod
       [urlAllowedCharacterSet formUnionWithCharacterSet:[NSCharacterSet URLFragmentAllowedCharacterSet]];
       path = [path stringByAddingPercentEncodingWithAllowedCharacters:urlAllowedCharacterSet];
       URL = [NSURL URLWithString:path];
-      if (URL) {
+      if (URL.scheme) {
         return URL;
       }
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
RCTConvert checks if scheme exists [here](https://github.com/facebook/react-native/blob/master/React/Base/RCTConvert.m#L89), tries to percent encode the path and then attempt again to make the URL again when the path contains `:`, even though it's valid that url has `:` in its local file path.
This change adds to check the scheme existence to see if it really is a remote URL.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [Fixed] - Fix an issue that RCTConvert fails to convert file URL when the path contains `:`

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Regression test should be enough.