### PR TITLE
Fix Android Hermes Test

### DIFF
--- a/packages/rn-tester/android/app/build.gradle
+++ b/packages/rn-tester/android/app/build.gradle
@@ -82,7 +82,7 @@ project.ext.react = [
     root: "$rootDir",
     inputExcludes: ["android/**", "./**", ".gradle/**"],
     composeSourceMapsPath: "$rootDir/scripts/compose-source-maps.js",
-    hermesCommand: "../../../node_modules/hermes-engine/%OS-BIN%/hermesc",
+    hermesCommand: "$rootDir/node_modules/hermes-engine/%OS-BIN%/hermesc",
     enableHermesForVariant: { def v -> v.name.contains("hermes") },
     jsRootDir: "$rootDir/RNTester",
     enableCodegen: System.getenv('USE_CODEGEN'),


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

This PR fixes the Hermes/Android test failing in RNTester

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Fixed] - Fixes Android/Hermes Test

## Test Plan

On running the command `./gradlew packages:rn-tester:android:app:assembleRelease`

We get the following output:
![Screenshot 2020-08-20 at 6 46 02 PM](https://user-images.githubusercontent.com/29942790/90774641-6960ee80-e315-11ea-8e39-40e9de237ede.png)


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
