### PR TITLE
Update SafeAreaView documentation

### DIFF
--- a/Libraries/Components/SafeAreaView/SafeAreaView.js
+++ b/Libraries/Components/SafeAreaView/SafeAreaView.js
@@ -17,6 +17,9 @@ import type {ViewProps} from '../View/ViewPropTypes';
 
 type Props = $ReadOnly<{|
   ...ViewProps,
+  /**
+    @default true
+   */
   emulateUnlessSupported?: boolean,
 |}>;
 
@@ -26,13 +29,40 @@ let exported: React.AbstractComponent<
 >;
 
 /**
- * Renders nested content and automatically applies paddings reflect the portion
- * of the view that is not covered by navigation bars, tab bars, toolbars, and
- * other ancestor views.
- *
- * Moreover, and most importantly, Safe Area's paddings reflect physical
- * limitation of the screen, such as rounded corners or camera notches (aka
- * sensor housing area on iPhone X).
+  The purpose of `SafeAreaView` is to render content within the safe area
+  boundaries of a device. It is currently only applicable to iOS devices with
+  iOS version 11 or later.
+
+  `SafeAreaView` renders nested content and automatically applies padding to
+  reflect the portion of the view that is not covered by navigation bars, tab
+  bars, toolbars, and other ancestor views. Moreover, and most importantly, Safe
+  Area's paddings reflect the physical limitation of the screen, such as rounded
+  corners or camera notches (i.e. the sensor housing area on iPhone X).
+
+  To use, wrap your top level view with a `SafeAreaView` with a `flex: 1` style
+  applied to it. You may also want to use a background color that matches your
+  application's design.
+
+  ```SnackPlayer name=SafeAreaView
+  import React from 'react';
+  import { StyleSheet, Text, SafeAreaView } from 'react-native';
+
+  const App = () => {
+    return (
+      <SafeAreaView style={styles.container}>
+        <Text>Page content</Text>
+      </SafeAreaView>
+    );
+  }
+
+  const styles = StyleSheet.create({
+    container: {
+      flex: 1,
+    },
+  });
+
+  export default App;
+  ```
  */
 if (Platform.OS === 'android') {
   exported = React.forwardRef<Props, React.ElementRef<HostComponent<mixed>>>(


### PR DESCRIPTION
Fixes https://github.com/MLH-Fellowship/react-native/issues/187

## Summary
The PR is part of an effort to update the code comments to match the current documentation on the React Native website. The project is a part of MLH fellowship program and involves automatic generation of the website docs from code comments and flow types as the end result.

To learn more about the project you can visit the project wiki: 
- [Project details](https://github.com/MLH-Fellowship/0.4.x-projects/wiki/React-Native-Flowtype-API-Docs-Generator)
- [RN Docs Standards](https://github.com/MLH-Fellowship/react-native/wiki/RN-Docs-standards)

Link to the documentation(the source of truth): 
- [SafeAreaView.md](https://github.com/MLH-Fellowship/react-native-website/blob/master/docs/safeareaview.md)

## Changes
* Update the title and prop description from docs.
* Remove unnecessary * from the code comments.
* Add Snack player example specified in the docs to the code comments.
* Cap comments to 80 characters.

## Changelog
[Internal]

## Test Plan
All changes are made to the code comments and thus there is no need for testing.
