### PR TITLE
RN(View): Remove TextAncestor provider

### DIFF
--- a/Libraries/Components/View/View.js
+++ b/Libraries/Components/View/View.js
@@ -14,7 +14,6 @@ import type {ViewProps} from './ViewPropTypes';
 
 const React = require('react');
 import ViewNativeComponent from './ViewNativeComponent';
-const TextAncestor = require('../../Text/TextAncestor');
 
 export type Props = ViewProps;
 
@@ -29,11 +28,7 @@ const View: React.AbstractComponent<
   ViewProps,
   React.ElementRef<typeof ViewNativeComponent>,
 > = React.forwardRef((props: ViewProps, forwardedRef) => {
-  return (
-    <TextAncestor.Provider value={false}>
-      <ViewNativeComponent {...props} ref={forwardedRef} />
-    </TextAncestor.Provider>
-  );
+  return <ViewNativeComponent {...props} ref={forwardedRef} />;
 });
 
 View.displayName = 'View';


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

I think the `TextAncestor` provider is unnecessary in the `View` component as the [renderer](https://github.com/facebook/react-native/blob/master/Libraries/Renderer/implementations/ReactNativeRenderer-dev.js#L4039)
will throw an error if it doesn't find the value in the context anyway.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[JavaScript] [Changed] - Remove TextAncestor provider for `View`

## Test Plan
- yarn test passed
- RNTester `Android` app build successful

- A `View` component with text must throw error: `Text strings must be rendered within a <Text> component.`
```jsx
<View>Hello error</View>
```

Below we can see that all the providers of the `View` component have been eliminated from the component hierarchy

| Before |  After   |
|----------|:-------------:|
| ![image](https://user-images.githubusercontent.com/20761166/90970343-c0abbe00-e4d1-11ea-9eea-ecfcb555c322.png) | ![image](https://user-images.githubusercontent.com/20761166/90970345-c86b6280-e4d1-11ea-9e01-0d4c45673cf5.png) |

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
