### PR TITLE
Update RCTModalHostViewManager.m

### DIFF
--- a/React/Views/RCTModalHostViewManager.m
+++ b/React/Views/RCTModalHostViewManager.m
@@ -99,7 +99,7 @@ RCT_EXPORT_MODULE()
     _dismissalBlock([modalHostView reactViewController], viewController, animated, nil);
   } else {
     self.dismissWaitingBlock = ^{
-      [viewController.presentingViewController dismissViewControllerAnimated:animated completion:completionBlock];
+      [viewController.presentingViewController dismissViewControllerAnimated:animated completion:nil];
     };
     if (viewController.presentingViewController) {
       self.dismissWaitingBlock();


### PR DESCRIPTION
Fix a issue that RCTModalHostView can't be dismissed while being presented

## Summary

Steps To Reproduce
A native modal presented view controller is being dismissed before the first screen shows.
A RCTModalHostView is presented when the first screen shows.
The RCTModalHostView will be dismissed after an asynchronous callback.
If the callback was called before the completion of the presenting animation, the RCTModalHostView will not be dismissed.

## Changelog

[iOS] [Fixed] - Fix that RCTModalHostView can't be dismissed while being presented

## Test Plan

