### PR TITLE
Jest setup: Stop polyfilling Promise.

### DIFF
--- a/jest/setup.js
+++ b/jest/setup.js
@@ -21,7 +21,6 @@ global.performance = {
   now: jest.fn(Date.now),
 };
 
-global.Promise = jest.requireActual('promise');
 global.regeneratorRuntime = jest.requireActual('regenerator-runtime/runtime');
 
 global.requestAnimationFrame = function(callback) {


### PR DESCRIPTION
Hi! 👋 I hope anyone reading this is doing OK these days. Thanks, in any case, for continuing to put your time into the awesome React Native ecosystem.

## Summary

It looks like this line was introduced in 3ff3987, in 2015, and it
has remained in a similar form since then. I haven't found any
explanation for it.

At facebook/jest#10221 [1], a core Jest maintainer says,

"""
As an aside, one should never replace `global.Promise` [...]. E.g.
when using `async-await` you will always get the native `Promise`
regardless of the value of `global.Promise`.
"""

facebook/jest#10221 is one issue this line has raised, for anyone
using the latest features of Jest to test async code in their React
Native projects.

[1] https://github.com/facebook/jest/issues/10221#issuecomment-654687396

Fixes: #29303

## Changelog

[General] [Fixed] - Fix issue with testing async code with Jest's fake timers.

## Test Plan

It looks like there's still an effort to keep up-to-date with new versions of the `promise` NPM package; see https://github.com/facebook/react-native/commit/b23efc526446cad53adc3de7465fd8be7309d84e. But that commit still leaves it a mystery why we're polyfilling `Promise` here.

I also see [Libraries/Core/polyfillPromise.js](https://github.com/facebook/react-native/blob/master/Libraries/Core/polyfillPromise.js), but I haven't run into any problems that I can trace to that file.

It's hard to say what side effects might arise from removing the line without knowing what it's for. (https://github.com/facebook/react-native/issues/29303 exists mostly to ask that question.)