### PR TITLE
Fix RNTester Path 

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -11,4 +11,4 @@
   jcenter = https://jcenter.bintray.com/
 
 [alias]
-  rntester = //RNTester/android/app:app
+  rntester = //packages/rn-tester/android/app:app

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,12 +72,12 @@ We recommend referring to the [CONTRIBUTING](https://github.com/facebook/react-n
 
 ## Contributing Code
 
-Code-level contributions to React Native generally come in the form of [pull requests](https://help.github.com/en/articles/about-pull-requests). These are done by forking the repo and making changes locally. Directly in the repo, there is the [`RNTester` app](/RNTester) that you can install on your device (or simulators) and use to test the changes you're making to React Native sources.
+Code-level contributions to React Native generally come in the form of [pull requests](https://help.github.com/en/articles/about-pull-requests). These are done by forking the repo and making changes locally. Directly in the repo, there is the [`rn-tester` app](/packages/rn-tester) that you can install on your device (or simulators) and use to test the changes you're making to React Native sources.
 
 The process of proposing a change to React Native can be summarized as follows:
 
 1. Fork the React Native repository and create your branch from `master`.
-2. Make the desired changes to React Native sources. Use the `RNTester` app to test them out.
+2. Make the desired changes to React Native sources. Use the `packages/rn-tester` app to test them out.
 3. If you've added code that should be tested, add tests.
 4. If you've changed APIs, update the documentation, which lives in [another repo](https://github.com/facebook/react-native-website/).
 5. Ensure the test suite passes, either locally or on CI once you opened a pull request.

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
       "android.emu.release": {
         "binaryPath": "packages/rn-tester/android/app/build/outputs/apk/hermes/release/app-hermes-x86-release.apk",
         "testBinaryPath": "packages/rn-tester/android/app/build/outputs/apk/androidTest/hermes/release/app-hermes-release-androidTest.apk",
-        "build": "./gradlew :packages:rn-tester:android:app:assembleRelease RNTester:android:app:assembleAndroidTest -DtestBuildType=release",
+        "build": "./gradlew :packages:rn-tester:android:app:assembleRelease :packages:rn-tester:android:app:assembleAndroidTest -DtestBuildType=release",
         "type": "android.emulator",
         "device": {
           "avdName": "Nexus_6_API_29"
@@ -139,7 +139,7 @@
       "android.emu.debug": {
         "binaryPath": "packages/rn-tester/android/app/build/outputs/apk/hermes/debug/app-hermes-x86-debug.apk",
         "testBinaryPath": "packages/rn-tester/android/app/build/outputs/apk/androidTest/hermes/debug/app-hermes-debug-androidTest.apk",
-        "build": "./gradlew :packages:rn-tester:android:app:assembleDebug RNTester:android:app:assembleAndroidTest -DtestBuildType=debug",
+        "build": "./gradlew :packages:rn-tester:android:app:assembleDebug :packages:rn-tester:android:app:assembleAndroidTest -DtestBuildType=debug",
         "type": "android.emulator",
         "device": {
           "avdName": "Nexus_6_API_29"

--- a/packages/rn-tester/README.md
+++ b/packages/rn-tester/README.md
@@ -25,7 +25,7 @@ You'll need to have all the [prerequisites](https://github.com/facebook/react-na
 Start an Android emulator.
 
     cd react-native
-    ./gradlew :RNTester:android:app:installJscDebug
+    ./gradlew :packages:rn-tester:android:app:installJscDebug
     ./scripts/packager.sh
 
 _Note: Building for the first time can take a while._


### PR DESCRIPTION
## Summary

 * Corrects running on android instructions for rn-tester
 * Corrects path for rn-tester in package.json, contributing.md and .buckconfig

## Changelog

[General] [Fixed] - Fix rn-tester path in documentation and configs

