### PR TITLE
Prevent ScrollView From Stealing Responder Capture When Using Physical Keyboard

### DIFF
--- a/Libraries/Components/ScrollResponder.js
+++ b/Libraries/Components/ScrollResponder.js
@@ -223,7 +223,6 @@ const ScrollResponderMixin = {
     // and a new touch starts with a non-textinput target (in which case the
     // first tap should be sent to the scroll view and dismiss the keyboard,
     // then the second tap goes to the actual interior view)
-    const currentlyFocusedTextInput = TextInputState.currentlyFocusedInput();
     const {keyboardShouldPersistTaps} = this.props;
     const keyboardNeverPersistTaps =
       !keyboardShouldPersistTaps || keyboardShouldPersistTaps === 'never';
@@ -240,7 +239,7 @@ const ScrollResponderMixin = {
 
     if (
       keyboardNeverPersistTaps &&
-      currentlyFocusedTextInput != null &&
+      this.keyboardWillOpenTo !== null &&
       e.target != null &&
       !TextInputState.isTextInput(e.target)
     ) {


### PR DESCRIPTION
## Summary

Fixes https://github.com/microsoft/react-native-windows/issues/5867

ScrollResponder has logic so that the first tap exiting out of a soft keyboard is captured instead of leaking to its children. This state is checked by testing if `TextInputState.currentlyFocusedInput()` is non-null. This also fires in cases a soft keyboard is not present (e.g. on Desktop where a physical keyboard is in use). This presents to users as clicks/taps not being registered when moving from a TextInput to something esle.

Instead of checking TextInputState to see if the softKeyboard is open, check `this.keyboardWillOpenTo`, which is tied to keyboard open and close events.

## Changelog

[General] [Fixed] - Prevent ScrollView From Stealing Responder Capture When Using Physical Keyboard

## Test Plan

Validated that on react-native-windows, ScrollView will capture responder events when tapped and a soft-keyboard is open, but will not capture events when clicking from a TextView to a child of a ScrollView and no soft keyboard is open.
