### PR TITLE
Removed usage of legacy context API in AppContainer

### DIFF
--- a/Libraries/ReactNative/AppContainer.js
+++ b/Libraries/ReactNative/AppContainer.js
@@ -15,7 +15,7 @@ import RCTDeviceEventEmitter from '../EventEmitter/RCTDeviceEventEmitter';
 import StyleSheet from '../StyleSheet/StyleSheet';
 import {type EventSubscription} from '../vendor/emitter/EventEmitter';
 import {RootTagContext, createRootTag} from './RootTag';
-import PropTypes from 'prop-types';
+import type {RootTag} from './RootTag';
 import * as React from 'react';
 
 type Context = {rootTag: number, ...};
@@ -47,11 +47,7 @@ class AppContainer extends React.Component<Props, State> {
 
   static getDerivedStateFromError: any = undefined;
 
-  static childContextTypes:
-    | any
-    | {|rootTag: React$PropType$Primitive<number>|} = {
-    rootTag: PropTypes.number,
-  };
+  static childContextTypes: React.Context<RootTag> = RootTagContext;
 
   getChildContext(): Context {
     return {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
1/4 of #28103 and closes it.
Remove usage of the legacy context API in AppContainer to get rid of the old React context API.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

Run the RNTester app and test the AppContainer example. Also, add a `console.warn` to make sure we get the correct context value.

