### PR TITLE
Fix CircleCI breakage in RCTPropsAnimatedNode

### DIFF
--- a/Libraries/FBReactNativeSpec/FBReactNativeSpec/FBReactNativeSpec-generated.mm
+++ b/Libraries/FBReactNativeSpec/FBReactNativeSpec/FBReactNativeSpec-generated.mm
@@ -979,39 +979,11 @@ namespace facebook {
       return static_cast<ObjCTurboModule&>(turboModule).invokeObjCMethod(rt, VoidKind, "show", @selector(show), args, count);
     }
 
-    static facebook::jsi::Value __hostFunction_NativeDevMenuSpecJSI_reload(facebook::jsi::Runtime& rt, TurboModule &turboModule, const facebook::jsi::Value* args, size_t count) {
-      return static_cast<ObjCTurboModule&>(turboModule).invokeObjCMethod(rt, VoidKind, "reload", @selector(reload), args, count);
-    }
-
-    static facebook::jsi::Value __hostFunction_NativeDevMenuSpecJSI_debugRemotely(facebook::jsi::Runtime& rt, TurboModule &turboModule, const facebook::jsi::Value* args, size_t count) {
-      return static_cast<ObjCTurboModule&>(turboModule).invokeObjCMethod(rt, VoidKind, "debugRemotely", @selector(debugRemotely:), args, count);
-    }
-
-    static facebook::jsi::Value __hostFunction_NativeDevMenuSpecJSI_setProfilingEnabled(facebook::jsi::Runtime& rt, TurboModule &turboModule, const facebook::jsi::Value* args, size_t count) {
-      return static_cast<ObjCTurboModule&>(turboModule).invokeObjCMethod(rt, VoidKind, "setProfilingEnabled", @selector(setProfilingEnabled:), args, count);
-    }
-
-    static facebook::jsi::Value __hostFunction_NativeDevMenuSpecJSI_setHotLoadingEnabled(facebook::jsi::Runtime& rt, TurboModule &turboModule, const facebook::jsi::Value* args, size_t count) {
-      return static_cast<ObjCTurboModule&>(turboModule).invokeObjCMethod(rt, VoidKind, "setHotLoadingEnabled", @selector(setHotLoadingEnabled:), args, count);
-    }
-
 
     NativeDevMenuSpecJSI::NativeDevMenuSpecJSI(const ObjCTurboModule::InitParams &params)
       : ObjCTurboModule(params) {
         
         methodMap_["show"] = MethodMetadata {0, __hostFunction_NativeDevMenuSpecJSI_show};
-        
-        
-        methodMap_["reload"] = MethodMetadata {0, __hostFunction_NativeDevMenuSpecJSI_reload};
-        
-        
-        methodMap_["debugRemotely"] = MethodMetadata {1, __hostFunction_NativeDevMenuSpecJSI_debugRemotely};
-        
-        
-        methodMap_["setProfilingEnabled"] = MethodMetadata {1, __hostFunction_NativeDevMenuSpecJSI_setProfilingEnabled};
-        
-        
-        methodMap_["setHotLoadingEnabled"] = MethodMetadata {1, __hostFunction_NativeDevMenuSpecJSI_setHotLoadingEnabled};
         
         
 

--- a/Libraries/FBReactNativeSpec/FBReactNativeSpec/FBReactNativeSpec.h
+++ b/Libraries/FBReactNativeSpec/FBReactNativeSpec/FBReactNativeSpec.h
@@ -801,10 +801,6 @@ namespace facebook {
 @protocol NativeDevMenuSpec <RCTBridgeModule, RCTTurboModule>
 
 - (void)show;
-- (void)reload;
-- (void)debugRemotely:(BOOL)enableDebug;
-- (void)setProfilingEnabled:(BOOL)enabled;
-- (void)setHotLoadingEnabled:(BOOL)enabled;
 
 @end
 namespace facebook {

--- a/Libraries/NativeAnimation/Nodes/RCTPropsAnimatedNode.m
+++ b/Libraries/NativeAnimation/Nodes/RCTPropsAnimatedNode.m
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import "RCTPropsAnimatedNode.h"
+#import <React/RCTPropsAnimatedNode.h>
 
 #import <React/RCTAnimationUtils.h>
 #import <React/RCTLog.h>

--- a/Libraries/NativeModules/specs/NativeDevMenu.js
+++ b/Libraries/NativeModules/specs/NativeDevMenu.js
@@ -15,10 +15,6 @@ import * as TurboModuleRegistry from '../../TurboModule/TurboModuleRegistry';
 
 export interface Spec extends TurboModule {
   +show: () => void;
-  +reload: () => void;
-  +debugRemotely: (enableDebug: boolean) => void;
-  +setProfilingEnabled: (enabled: boolean) => void;
-  +setHotLoadingEnabled: (enabled: boolean) => void;
 }
 
 export default (TurboModuleRegistry.getEnforcing<Spec>('DevMenu'): Spec);

--- a/React/CoreModules/RCTDevMenu.h
+++ b/React/CoreModules/RCTDevMenu.h
@@ -25,26 +25,6 @@ RCT_EXTERN NSString *const RCTShowDevMenuNotification;
 @interface RCTDevMenu : NSObject
 
 /**
- * Deprecated, use RCTDevSettings instead.
- */
-@property (nonatomic, assign) BOOL shakeToShow DEPRECATED_ATTRIBUTE;
-
-/**
- * Deprecated, use RCTDevSettings instead.
- */
-@property (nonatomic, assign) BOOL profilingEnabled DEPRECATED_ATTRIBUTE;
-
-/**
- * Deprecated, use RCTDevSettings instead.
- */
-@property (nonatomic, assign) BOOL liveReloadEnabled DEPRECATED_ATTRIBUTE;
-
-/**
- * Deprecated, use RCTDevSettings instead.
- */
-@property (nonatomic, assign) BOOL hotLoadingEnabled DEPRECATED_ATTRIBUTE;
-
-/**
  * Presented items in development menu
  */
 @property (nonatomic, copy, readonly) NSArray<RCTDevMenuItem *> *presentedItems;
@@ -58,16 +38,6 @@ RCT_EXTERN NSString *const RCTShowDevMenuNotification;
  * Manually show the dev menu (can be called from JS).
  */
 - (void)show;
-
-/**
- * Deprecated, use `RCTReloadCommand` instead.
- */
-- (void)reload DEPRECATED_ATTRIBUTE;
-
-/**
- * Deprecated. Use the `-addItem:` method instead.
- */
-- (void)addItem:(NSString *)title handler:(void (^)(void))handler DEPRECATED_ATTRIBUTE;
 
 /**
  * Add custom item to the development menu. The handler will be called

--- a/React/CoreModules/RCTDevMenu.mm
+++ b/React/CoreModules/RCTDevMenu.mm
@@ -462,55 +462,6 @@ RCT_EXPORT_METHOD(show)
   };
 }
 
-#pragma mark - deprecated methods and properties
-
-#define WARN_DEPRECATED_DEV_MENU_EXPORT() \
-  RCTLogWarn(@"Using deprecated method %s, use RCTDevSettings instead", __func__)
-
-- (void)setShakeToShow:(BOOL)shakeToShow
-{
-  _bridge.devSettings.isShakeToShowDevMenuEnabled = shakeToShow;
-}
-
-- (BOOL)shakeToShow
-{
-  return _bridge.devSettings.isShakeToShowDevMenuEnabled;
-}
-
-RCT_EXPORT_METHOD(reload)
-{
-  WARN_DEPRECATED_DEV_MENU_EXPORT();
-  RCTTriggerReloadCommandListeners(@"Unknown from JS");
-}
-
-RCT_EXPORT_METHOD(debugRemotely : (BOOL)enableDebug)
-{
-  WARN_DEPRECATED_DEV_MENU_EXPORT();
-  _bridge.devSettings.isDebuggingRemotely = enableDebug;
-}
-
-RCT_EXPORT_METHOD(setProfilingEnabled : (BOOL)enabled)
-{
-  WARN_DEPRECATED_DEV_MENU_EXPORT();
-  _bridge.devSettings.isProfilingEnabled = enabled;
-}
-
-- (BOOL)profilingEnabled
-{
-  return _bridge.devSettings.isProfilingEnabled;
-}
-
-RCT_EXPORT_METHOD(setHotLoadingEnabled : (BOOL)enabled)
-{
-  WARN_DEPRECATED_DEV_MENU_EXPORT();
-  _bridge.devSettings.isHotLoadingEnabled = enabled;
-}
-
-- (BOOL)hotLoadingEnabled
-{
-  return _bridge.devSettings.isHotLoadingEnabled;
-}
-
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
     (const facebook::react::ObjCTurboModule::InitParams &)params
 {
@@ -538,11 +489,9 @@ RCT_EXPORT_METHOD(setHotLoadingEnabled : (BOOL)enabled)
 - (void)addItem:(RCTDevMenu *)item
 {
 }
-
 - (void)debugRemotely:(BOOL)enableDebug
 {
 }
-
 - (BOOL)isActionSheetShown
 {
   return NO;
@@ -551,7 +500,6 @@ RCT_EXPORT_METHOD(setHotLoadingEnabled : (BOOL)enabled)
 {
   return @"DevMenu";
 }
-
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
     (const facebook::react::ObjCTurboModule::InitParams &)params
 {


### PR DESCRIPTION
Summary:
I changed this line in D23272735 (https://github.com/facebook/react-native/commit/700960c9f1a27a12d703b4f0a17673690799f019), to conform to normal ObjC semantics: impl files can import their header by file name.

I forgot that their's some special linking logic happening in this directory that doesn't allow for this import type.

This diff just reverts one line to fix CircleCI builds.

Changelog: [Internal]

Differential Revision: D23399893

