### PR TITLE
Fix duplicate accessibilityLabels & app crash on iOS

### DIFF
--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -199,15 +199,6 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
 
 #pragma mark - Accessibility
 
-- (NSString *)accessibilityLabel
-{
-  NSString *label = super.accessibilityLabel;
-  if (label) {
-    return label;
-  }
-  return nil;
-}
-
 - (NSArray<UIAccessibilityCustomAction *> *)accessibilityCustomActions
 {
   if (!self.accessibilityActions.count) {

--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -80,24 +80,6 @@ UIAccessibilityTraits const SwitchAccessibilityTrait = 0x20000000000001;
 
 @end
 
-static NSString *RCTRecursiveAccessibilityLabel(UIView *view)
-{
-  NSMutableString *str = [NSMutableString stringWithString:@""];
-  for (UIView *subview in view.subviews) {
-    NSString *label = subview.accessibilityLabel;
-    if (!label) {
-      label = RCTRecursiveAccessibilityLabel(subview);
-    }
-    if (label && label.length > 0) {
-      if (str.length > 0) {
-        [str appendString:@" "];
-      }
-      [str appendString:label];
-    }
-  }
-  return str.length == 0 ? nil : str;
-}
-
 @implementation RCTView {
   UIColor *_backgroundColor;
   NSMutableDictionary<NSString *, NSDictionary *> *accessibilityActionsNameMap;
@@ -223,7 +205,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
   if (label) {
     return label;
   }
-  return RCTRecursiveAccessibilityLabel(self);
+  return nil;
 }
 
 - (NSArray<UIAccessibilityCustomAction *> *)accessibilityCustomActions


### PR DESCRIPTION
## Summary

I came across this because one of my customer's apps was freezing and crashing when my code tries to read the `accessibilityLabel` of a view containing a chat component. Because the labels are recursively generated from the text content, any sufficiently long chat ends up with all of the parent views having a ridiculously long `accessibilityLabel`. 

After 10 seconds of non-responsiveness from trying to generate all of this on the UI thread (when backgrounded), iOS decides the app has crashed and force-closes it.

Before this change, every single view in a RN app returned true for the conditional. 

I believe this change will also improve both the accessibility and the testability of RN apps, in addition to fixing that crash.

This change also allows for correct behavior with this code:

```objective-c
if ([view respondsToSelector:@selector(accessibilityLabel)])
    return view.accessibilityLabel;
```

Before this change, any RCTView could potentially scan its entire tree and return `nil`. 
After, only RCTViews that actually have an `accessibilityLabel` set will return one, and ones that don't will be skipped by the above code.

This PR supersedes or fixes #21830, #25963, #24113, #24118, https://github.com/appium/appium/issues/10654, possibly #25220, and probably a few other tickets I haven't identified.

The changes in this PR are for `RCTView`. It's worth mentioning that there is very similar code in [`RCTViewComponentView`](https://github.com/facebook/react-native/blob/ebf2fb7868d92661772ec59d6592f14786e9673b/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm#L526-L552) - I haven't dug into that as much, but I suspect it should probably get the same treatment. If desired, I can include it in this PR.

I also haven't yet reviewed the Android side of things to see what happens there, but whatever the case, the same component structure doesn't seem to be leading to crashes in Android.

I might need to change the documentation too. 

## Changelog

[iOS] [Removed] - Deleted RCTView's accessibilityLabel wrapper and RCTRecursiveAccessibilityLabel, allowing for default native behavior

## Test Plan

This is where I need a little help. What's a good way to test this? 

I spent a while digging through the RN iOS tests, I can run the tests, and even step through the harness, but I still don't feel like I fully understand what's happening. I don't have a ton of iOS or RN experience, so it may be something obvious, but I'm just not sure what I'm missing.
