### PR TITLE
Making Android versionCodeOverride for new apps using the template human-readable

### DIFF
--- a/template/android/app/build.gradle
+++ b/template/android/app/build.gradle
@@ -173,7 +173,7 @@ android {
             def abi = output.getFilter(OutputFile.ABI)
             if (abi != null) {  // null for the universal-debug, universal-release variants
                 output.versionCodeOverride =
-                        versionCodes.get(abi) * 1048576 + defaultConfig.versionCode
+                        versionCodes.get(abi) * 1000 + defaultConfig.versionCode
             }
 
         }

--- a/template/android/app/build.gradle
+++ b/template/android/app/build.gradle
@@ -173,7 +173,7 @@ android {
             def abi = output.getFilter(OutputFile.ABI)
             if (abi != null) {  // null for the universal-debug, universal-release variants
                 output.versionCodeOverride =
-                        versionCodes.get(abi) * 1000 + defaultConfig.versionCode
+                        defaultConfig.versionCode * 1000 + versionCodes.get(abi)
             }
 
         }

--- a/template/android/app/build.gradle
+++ b/template/android/app/build.gradle
@@ -169,6 +169,7 @@ android {
         variant.outputs.each { output ->
             // For each separate APK per architecture, set a unique version code as described here:
             // https://developer.android.com/studio/build/configure-apk-splits.html
+            // Example: versionCode 1 will generate 1001 for armeabi-v7a, 1002 for x86, etc.
             def versionCodes = ["armeabi-v7a": 1, "x86": 2, "arm64-v8a": 3, "x86_64": 4]
             def abi = output.getFilter(OutputFile.ABI)
             if (abi != null) {  // null for the universal-debug, universal-release variants


### PR DESCRIPTION
## Summary

The current calculation on versionCodeOverride is not human-readable. 

Imagine if we have an android app with **versionName** `4.0` and **version code** `4`.

In the current implementation, the result of **versionCode** `4` for `armeabi-v7a` will be the seemingly arbitrary **1048580**. This makes the version code to be seemingly arbitrary and hard to read for humans. This PR proposes to change this calculation closer to google implementation of build number in Flutter (`abiVersionCode * 1000 + variant.versionCode`). 
https://github.com/flutter/flutter/blob/39d7a019c150ca421b980426e85b254a0ec63ebd/packages/flutter_tools/gradle/flutter.gradle#L643-L647

With this change, our app with `versionCode 4 versionName "4.0"` for  `armeabi-v7a`  will have **1004**  as the version code instead of the seemingly arbitrary **1048580**. As you can see adopting the flutter style implementation make the version code easier to read and debug. 

**1004** 
**1** - The ABI Type `["armeabi-v7a": 1, "x86": 2, "arm64-v8a": 3, "x86_64": 4]`
**004** - Our versionCode. 

Hopefully, this can prevent future issues like this https://github.com/facebook/react-native/issues/29790.

## Changelog

[Android] [Changed] - Making Android versionCodeOverride for new apps using the template human-readable

## Test Plan
