### PR TITLE
Add ScrollView.automaticallyAdjustsScrollIndicatorInsets prop (on iOS)

### DIFF
--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -172,6 +172,12 @@ type IOSProps = $ReadOnly<{|
    */
   automaticallyAdjustContentInsets?: ?boolean,
   /**
+   * Controls whether iOS should automatically adjust the scroll indicator
+   * insets. The default value is true. Available on iOS 13 and later.
+   * @platform ios
+   */
+  automaticallyAdjustsScrollIndicatorInsets?: ?boolean,
+  /**
    * The amount by which the scroll view content is inset from the edges
    * of the scroll view. Defaults to `{top: 0, left: 0, bottom: 0, right: 0}`.
    * @platform ios

--- a/Libraries/Components/ScrollView/ScrollViewNativeComponent.js
+++ b/Libraries/Components/ScrollView/ScrollViewNativeComponent.js
@@ -26,6 +26,7 @@ const ScrollViewNativeComponent: HostComponent<Props> = NativeComponentRegistry.
       alwaysBounceHorizontal: true,
       alwaysBounceVertical: true,
       automaticallyAdjustContentInsets: true,
+      automaticallyAdjustsScrollIndicatorInsets: true,
       bounces: true,
       bouncesZoom: true,
       canCancelContentTouches: true,

--- a/Libraries/Components/ScrollView/ScrollViewNativeComponentType.js
+++ b/Libraries/Components/ScrollView/ScrollViewNativeComponentType.js
@@ -21,6 +21,7 @@ export type ScrollViewNativeProps = $ReadOnly<{
   alwaysBounceHorizontal?: ?boolean,
   alwaysBounceVertical?: ?boolean,
   automaticallyAdjustContentInsets?: ?boolean,
+  automaticallyAdjustsScrollIndicatorInsets?: ?boolean,
   bounces?: ?boolean,
   bouncesZoom?: ?boolean,
   canCancelContentTouches?: ?boolean,

--- a/Libraries/Components/ScrollView/ScrollViewViewConfig.js
+++ b/Libraries/Components/ScrollView/ScrollViewViewConfig.js
@@ -24,6 +24,7 @@ const ScrollViewViewConfig = {
     alwaysBounceHorizontal: true,
     alwaysBounceVertical: true,
     automaticallyAdjustContentInsets: true,
+    automaticallyAdjustsScrollIndicatorInsets: true,
     bounces: true,
     bouncesZoom: true,
     canCancelContentTouches: true,

--- a/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -254,6 +254,12 @@ static void RCTSendPaperScrollEvent_DEPRECATED(UIScrollView *scrollView, NSInteg
     scrollView.snapToOffsets = snapToOffsets;
   }
 
+  if (@available(iOS 13.0, *)) {
+    if (oldScrollViewProps.automaticallyAdjustsScrollIndicatorInsets != newScrollViewProps.automaticallyAdjustsScrollIndicatorInsets) {
+      scrollView.automaticallyAdjustsScrollIndicatorInsets = newScrollViewProps.automaticallyAdjustsScrollIndicatorInsets;
+    }
+  }
+
   if (@available(iOS 11.0, *)) {
     if (oldScrollViewProps.contentInsetAdjustmentBehavior != newScrollViewProps.contentInsetAdjustmentBehavior) {
       auto const contentInsetAdjustmentBehavior = newScrollViewProps.contentInsetAdjustmentBehavior;

--- a/React/Views/ScrollView/RCTScrollView.m
+++ b/React/Views/ScrollView/RCTScrollView.m
@@ -928,6 +928,18 @@ RCT_SET_AND_PRESERVE_OFFSET(setShowsVerticalScrollIndicator, showsVerticalScroll
 RCT_SET_AND_PRESERVE_OFFSET(setZoomScale, zoomScale, CGFloat);
 RCT_SET_AND_PRESERVE_OFFSET(setScrollIndicatorInsets, scrollIndicatorInsets, UIEdgeInsets);
 
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000 /* __IPHONE_13_0 */
+- (void)setAutomaticallyAdjustsScrollIndicatorInsets:(BOOL)automaticallyAdjusts API_AVAILABLE(ios(13.0))
+{
+  // `automaticallyAdjustsScrollIndicatorInsets` is available since iOS 13.
+  if ([_scrollView respondsToSelector:@selector(setAutomaticallyAdjustsScrollIndicatorInsets:)]) {
+    if (@available(iOS 13.0, *)) {
+      _scrollView.automaticallyAdjustsScrollIndicatorInsets = automaticallyAdjusts;
+    }
+  }
+}
+#endif
+
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000 /* __IPHONE_11_0 */
 - (void)setContentInsetAdjustmentBehavior:(UIScrollViewContentInsetAdjustmentBehavior)behavior API_AVAILABLE(ios(11.0))
 {

--- a/React/Views/ScrollView/RCTScrollViewManager.m
+++ b/React/Views/ScrollView/RCTScrollViewManager.m
@@ -102,6 +102,9 @@ RCT_EXPORT_VIEW_PROPERTY(onScrollEndDrag, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onMomentumScrollBegin, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onMomentumScrollEnd, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(inverted, BOOL)
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000 /* __IPHONE_13_0 */
+RCT_EXPORT_VIEW_PROPERTY(automaticallyAdjustsScrollIndicatorInsets, BOOL)
+#endif
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000 /* __IPHONE_11_0 */
 RCT_EXPORT_VIEW_PROPERTY(contentInsetAdjustmentBehavior, UIScrollViewContentInsetAdjustmentBehavior)
 #endif

--- a/ReactCommon/react/renderer/components/scrollview/ScrollViewProps.cpp
+++ b/ReactCommon/react/renderer/components/scrollview/ScrollViewProps.cpp
@@ -51,6 +51,11 @@ ScrollViewProps::ScrollViewProps(
           "automaticallyAdjustContentInsets",
           sourceProps.automaticallyAdjustContentInsets,
           {})),
+      automaticallyAdjustsScrollIndicatorInsets(convertRawProp(
+          rawProps,
+          "automaticallyAdjustsScrollIndicatorInsets",
+          sourceProps.automaticallyAdjustsScrollIndicatorInsets,
+          true)),
       decelerationRate(convertRawProp(
           rawProps,
           "decelerationRate",
@@ -206,6 +211,10 @@ SharedDebugStringConvertibleList ScrollViewProps::getDebugProps() const {
               "automaticallyAdjustContentInsets",
               automaticallyAdjustContentInsets,
               defaultScrollViewProps.automaticallyAdjustContentInsets),
+          debugStringConvertibleItem(
+              "automaticallyAdjustsScrollIndicatorInsets",
+              automaticallyAdjustsScrollIndicatorInsets,
+              defaultScrollViewProps.automaticallyAdjustsScrollIndicatorInsets),
           debugStringConvertibleItem(
               "decelerationRate",
               decelerationRate,

--- a/ReactCommon/react/renderer/components/scrollview/ScrollViewProps.h
+++ b/ReactCommon/react/renderer/components/scrollview/ScrollViewProps.h
@@ -28,6 +28,7 @@ class ScrollViewProps final : public ViewProps {
   bool canCancelContentTouches{true};
   bool centerContent{};
   bool automaticallyAdjustContentInsets{};
+  bool automaticallyAdjustsScrollIndicatorInsets{true};
   Float decelerationRate{0.998f};
   bool directionalLockEnabled{};
   ScrollViewIndicatorStyle indicatorStyle{};

--- a/packages/rn-tester/js/examples/ScrollView/ScrollViewIndicatorInsetsExample.ios.js
+++ b/packages/rn-tester/js/examples/ScrollView/ScrollViewIndicatorInsetsExample.ios.js
@@ -1,0 +1,116 @@
+'use strict';
+
+const React = require('react');
+
+const {
+  Button,
+  Dimensions,
+  Modal,
+  ScrollView,
+  StyleSheet,
+  Switch,
+  Text,
+  View,
+} = require('react-native');
+
+class ScrollViewIndicatorInsetsExample extends React.Component<
+  {...},
+  {|
+    enableAutoIndicatorInsets: boolean,
+    modalPresentationStyle: string,
+    modalVisible: boolean,
+  |},
+> {
+  state = {
+    enableAutoIndicatorInsets: true,
+    modalPresentationStyle: null,
+    modalVisible: false,
+  };
+
+  _setModalVisible = (modalVisible, modalPresentationStyle) => {
+    this.setState({
+      enableAutoIndicatorInsets: true,
+      modalVisible,
+      modalPresentationStyle,
+    });
+  };
+
+  _setEnableAutoIndicatorInsets = enableAutoIndicatorInsets => {
+    this.setState({
+      enableAutoIndicatorInsets,
+    });
+  };
+
+  render() {
+    const {height, width} = Dimensions.get('window');
+    return (
+      <View>
+        <Modal
+          animationType="slide"
+          visible={this.state.modalVisible}
+          onRequestClose={() => this._setModalVisible(false)}
+          presentationStyle={this.state.modalPresentationStyle}
+          statusBarTranslucent={false}
+          supportedOrientations={['portrait', 'landscape']}>
+          <View style={styles.modal}>
+            <ScrollView
+              contentContainerStyle={[
+                styles.scrollViewContent,
+                {
+                  height: (height * 1.2),
+                  width: (width * 1.2),
+                },
+              ]}
+              automaticallyAdjustsScrollIndicatorInsets={this.state.enableAutoIndicatorInsets}
+              style={styles.scrollView}>
+              <Text>automaticallyAdjustsScrollIndicatorInsets</Text>
+              <Switch
+                onValueChange={v => this._setEnableAutoIndicatorInsets(v)}
+                value={this.state.enableAutoIndicatorInsets}
+                style={styles.switch}/>
+              <Button
+                onPress={() => this._setModalVisible(false)}
+                title="Close"/>
+            </ScrollView>
+          </View>
+        </Modal>
+        <Button
+          onPress={() => this._setModalVisible(true, 'pageSheet')}
+          title="Present Sheet Modal with ScrollView"/>
+        <Button
+          onPress={() => this._setModalVisible(true, 'fullscreen')}
+          title="Present Fullscreen Modal with ScrollView"/>
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  modal: {
+    flex: 1,
+  },
+  scrollView: {
+    flex: 1,
+    height: 1000,
+  },
+  scrollViewContent: {
+    alignItems: 'center',
+    backgroundColor: '#ffaaaa',
+    justifyContent: 'flex-start',
+    paddingTop: 200,
+  },
+  switch: {
+    marginBottom: 40,
+  },
+});
+
+exports.title = 'ScrollViewIndicatorInsets';
+exports.category = 'iOS';
+exports.description =
+  'ScrollView automaticallyAdjustsScrollIndicatorInsets adjusts scroll indicator insets using OS-defined logic on iOS 13+.';
+exports.examples = [
+  {
+    title: '<ScrollView> automaticallyAdjustsScrollIndicatorInsets Example',
+    render: (): React.Node => <ScrollViewIndicatorInsetsExample/>,
+  },
+];

--- a/packages/rn-tester/js/utils/RNTesterList.ios.js
+++ b/packages/rn-tester/js/utils/RNTesterList.ios.js
@@ -119,6 +119,10 @@ const ComponentExamples: Array<RNTesterExample> = [
     supportsTVOS: true,
   },
   {
+    key: 'ScrollViewIndicatorInsetsExample',
+    module: require('../examples/ScrollView/ScrollViewIndicatorInsetsExample'),
+  },
+  {
     key: 'SectionList-inverted',
     module: require('../examples/SectionList/SectionList-inverted'),
     category: 'ListView',


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

iOS 13 added a new property to `UIScrollView`: `automaticallyAdjustsScrollIndicatorInsets`, which is `YES` by default.  The property changes the meaning of the `scrollIndicatorInsets` property.  When `YES`, any such insets are **in addition to** whatever insets would be applied by the device's safe area.  When `NO`, the iOS <13 behavior is restored, which is for such insets to not account for safe area.

In other words, this effects ScrollViews that underlay the device's safe area (i.e. under the notch).  When `YES`, the OS "automatically" insets the scroll indicators, when `NO` it does not.

There are two problems with the default `YES` setting:

1. It means applying `scrollIndicatorInsets` to a `ScrollView` has a different effect on iOS 13 versus iOS 12.
2. It limits developers' control over `scrollIndicatorInsets`.  Since negative insets are not supported, if the insets the OS chooses are too large for your app, you cannot fix it.

Further explanation & sample code is available in issue #28140 .

This change sets the default for this property to `NO`, making the behavior consistent across iOS versions, and allowing developers full control.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [Changed] - ScrollView scrollIndicatorInsets to not automatically add safe area on iOS13+

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Here are screenshots of the demo app (from the original bug) before (with safe area applied to insets) & after (without safe area applied to insets):

![before](https://user-images.githubusercontent.com/428831/91644197-ea03a700-ea07-11ea-9489-be27820930eb.png)

![after](https://user-images.githubusercontent.com/428831/91644200-eff98800-ea07-11ea-8788-daf1e783639d.png)
