### PR TITLE
feat(alert): use support library for alert dialog

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/AlertFragment.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/AlertFragment.java
@@ -8,12 +8,12 @@
 package com.facebook.react.modules.dialog;
 
 import android.annotation.SuppressLint;
-import android.app.AlertDialog;
 import android.app.Dialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Bundle;
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.DialogFragment;
 
 /** A fragment used to display the dialog. */

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/BUCK
@@ -7,6 +7,7 @@ rn_android_library(
     labels = ["supermodule:xplat/default/public.react_native.infra"],
     provided_deps = [
         react_native_dep("third-party/android/androidx:annotation"),
+        react_native_dep("third-party/android/androidx:app"),
         react_native_dep("third-party/android/androidx:core"),
         react_native_dep("third-party/android/androidx:fragment"),
         react_native_dep("third-party/android/androidx:legacy-support-core-ui"),

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/BUCK
@@ -6,12 +6,7 @@ rn_android_library(
     is_androidx = True,
     labels = ["supermodule:xplat/default/public.react_native.infra"],
     provided_deps = [
-        react_native_dep("third-party/android/androidx:annotation"),
-        react_native_dep("third-party/android/androidx:app"),
-        react_native_dep("third-party/android/androidx:core"),
-        react_native_dep("third-party/android/androidx:fragment"),
-        react_native_dep("third-party/android/androidx:legacy-support-core-ui"),
-        react_native_dep("third-party/android/androidx:legacy-support-core-utils"),
+        react_native_dep("third-party/android/androidx:appcompat")
     ],
     visibility = [
         "PUBLIC",

--- a/ReactAndroid/src/test/java/com/facebook/react/modules/BUCK
+++ b/ReactAndroid/src/test/java/com/facebook/react/modules/BUCK
@@ -9,7 +9,11 @@ rn_robolectric_test(
     ],
     deps = [
         YOGA_TARGET,
-        react_native_dep("third-party/android/androidx:appcompat"),
+        react_native_dep("third-party/android/androidx:annotation"),
+        react_native_dep("third-party/android/androidx:core"),
+        react_native_dep("third-party/android/androidx:fragment"),
+        react_native_dep("third-party/android/androidx:legacy-support-core-ui"),
+        react_native_dep("third-party/android/androidx:legacy-support-core-utils"),
         react_native_dep("third-party/java/fest:fest"),
         react_native_dep("third-party/java/jsr-305:jsr-305"),
         react_native_dep("third-party/java/junit:junit"),

--- a/ReactAndroid/src/test/java/com/facebook/react/modules/BUCK
+++ b/ReactAndroid/src/test/java/com/facebook/react/modules/BUCK
@@ -9,11 +9,7 @@ rn_robolectric_test(
     ],
     deps = [
         YOGA_TARGET,
-        react_native_dep("third-party/android/androidx:annotation"),
-        react_native_dep("third-party/android/androidx:core"),
-        react_native_dep("third-party/android/androidx:fragment"),
-        react_native_dep("third-party/android/androidx:legacy-support-core-ui"),
-        react_native_dep("third-party/android/androidx:legacy-support-core-utils"),
+        react_native_dep("third-party/android/androidx:appcompat"),
         react_native_dep("third-party/java/fest:fest"),
         react_native_dep("third-party/java/jsr-305:jsr-305"),
         react_native_dep("third-party/java/junit:junit"),

--- a/ReactAndroid/src/test/java/com/facebook/react/modules/BUCK
+++ b/ReactAndroid/src/test/java/com/facebook/react/modules/BUCK
@@ -9,12 +9,8 @@ rn_robolectric_test(
     ],
     deps = [
         YOGA_TARGET,
-        react_native_dep("third-party/android/androidx:appcompat-binary"),
-        react_native_dep("third-party/android/androidx:annotation"),
-        react_native_dep("third-party/android/androidx:core"),
-        react_native_dep("third-party/android/androidx:fragment"),
+        react_native_dep("third-party/android/androidx:appcompat"),
         react_native_dep("third-party/android/androidx:legacy-support-core-ui"),
-        react_native_dep("third-party/android/androidx:legacy-support-core-utils"),
         react_native_dep("third-party/java/fest:fest"),
         react_native_dep("third-party/java/jsr-305:jsr-305"),
         react_native_dep("third-party/java/junit:junit"),

--- a/ReactAndroid/src/test/java/com/facebook/react/modules/BUCK
+++ b/ReactAndroid/src/test/java/com/facebook/react/modules/BUCK
@@ -9,6 +9,7 @@ rn_robolectric_test(
     ],
     deps = [
         YOGA_TARGET,
+        react_native_dep("third-party/android/androidx:appcompat-binary"),
         react_native_dep("third-party/android/androidx:annotation"),
         react_native_dep("third-party/android/androidx:core"),
         react_native_dep("third-party/android/androidx:fragment"),


### PR DESCRIPTION
## Summary

Instead of using the AlertDialog from the android library we use the AlertDialog from the support library to render dialogs properly on Lollipop phones.

## Changelog

[Android] [Fixed] - Fix AlertDialog for older android devices by using AlertDialog from the androidx support library

## Test Plan

Visual inspection.
With old AlertDialog:
![ddd1692b-2bcb-424a-9355-1b54515c6618 - Donald Duck (1)](https://user-images.githubusercontent.com/1834664/91998740-e63f8f80-ed3b-11ea-9bd2-f9d7365d2d44.JPG)

With compat AlertDialog:
![Screenshot_1973-06-21-21-23-28](https://user-images.githubusercontent.com/1834664/91998780-f22b5180-ed3b-11ea-84bb-d17d4e8f2d94.png)
