### PR TITLE
Fixed missing encoding via URLSearchParams

### DIFF
--- a/Libraries/Blob/URL.js
+++ b/Libraries/Blob/URL.js
@@ -99,8 +99,8 @@ export class URLSearchParams {
       return '';
     }
     const last = this._searchParams.length - 1;
-    return this._searchParams.reduce((acc, curr, index) => {
-      return acc + curr.join('=') + (index === last ? '' : '&');
+    return this._searchParams.reduce((acc, [key, value], index) => {
+      return `${acc}${key}=${encodeURIComponent(value)}${index === last ? '' : '&'}`;
     }, '');
   }
 }


### PR DESCRIPTION
Fixes #28966

## Summary

URLSearchParams was largely useless, as it did not encode the parameters at all. This PR simply encodes the parameters as per the standard.

## Changelog

[General] [Fixed] - URLSearchParams now URL encodes passed values

## Test Plan

Ran the new code using jsc (`/System/iOSSupport/System/Library/Frameworks/JavaScriptCore.framework/Versions/A/Helpers/jsc`)
```
_searchParams=[['size', 42],['limit', false],['baz','boing+foo&bang']]; last = this._searchParams.length - 1;
_searchParams.reduce((acc, [key, value], index) => {
  return `${acc}${key}=${encodeURIComponent(value)}${index === last ? '' : '&'}`;
}, '');
// which yields: 
// 'size=42&limit=false&baz=boing%2Bfoo%26bang'
```
And compared it running similar code but with a browser-shipped URLSearchParams in the browser console of this page:
```
_searchParams=[['size', 42],['limit', false],['baz','boing+foo&bang']]; last = this._searchParams.length - 1;
new URLSearchParams(_searchParams).toString()
// which yields:
// "size=42&limit=false&baz=boing%2Bfoo%26bang"
```
Comparing the two:
```
'size=42&limit=false&baz=boing%2Bfoo%26bang' === "size=42&limit=false&baz=boing%2Bfoo%26bang"
// returns true
```