### PR TITLE
Enable usesCleartextTraffic in main manifest

### DIFF
--- a/template/android/app/src/main/AndroidManifest.xml
+++ b/template/android/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
+      android:usesCleartextTraffic="true"
       android:name=".MainApplication"
       android:label="@string/app_name"
       android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
This setting might cause trouble to freshmen and they won't realize it until they send an release apk to their boss which is ...

So why not make it consistent with ios, which enables NSAllowsArbitraryLoads by default.
