### PR TITLE
[CircleCI] Bump brew cache key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,13 +133,13 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - v3-brew
+            - v4-brew
       - steps: << parameters.steps >>
       - save_cache:
           paths:
             - /usr/local/Homebrew
             - ~/Library/Caches/Homebrew
-          key: v3-brew
+          key: v4-brew
 
   with_rntester_pods_cache_span:
     parameters:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

The Circle CI iOS jobs are failing when installing Watchman:

```
#!/bin/bash --login -eo pipefail
HOMEBREW_NO_AUTO_UPDATE=1 brew install watchman >/dev/null
Error: The `brew link` step did not complete successfully

Exited with code exit status 1
CircleCI received exit code 1
```

The commit associates with the job where this issue first appeared did not make any changes to Watchman, but it did change the VM used by Circle CI for these jobs. Flushing the homebrew cache might help.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[INTERNAL]

## Test Plan

Run on Circle CI.