### PR TITLE
fix(RCTUITextField): apply workaround for UIKit bug that works for multiline to singleline

### DIFF
--- a/Libraries/Text/TextInput/Singleline/RCTUITextField.m
+++ b/Libraries/Text/TextInput/Singleline/RCTUITextField.m
@@ -192,6 +192,17 @@
   _textWasPasted = YES;
 }
 
+- (void)selectAll:(id)sender
+{
+  [super selectAll:sender];
+
+  // `selectAll:` does not work for UITextView when it's being called inside UITextView's delegate methods.
+  dispatch_async(dispatch_get_main_queue(), ^{
+    UITextRange *selectionRange = [self textRangeFromPosition:self.beginningOfDocument toPosition:self.endOfDocument];
+    [self setSelectedTextRange:selectionRange notifyDelegate:NO];
+  });
+}
+
 #pragma mark - Layout
 
 - (CGSize)contentSize


### PR DESCRIPTION
## Summary

See https://github.com/facebook/react-native/commit/e020576b34fb6ca6d3f9fe38916844b78a45c0e3 for rational.

This bug in UIKit does apply for all UITextInput views. So this PR copies over the fix from multiline-view to singleline-view.

## Changelog

[iOS] [Fixed] - Make selectTextOnFocus for iOS single line text input fields work every time


## Test Plan

Visual inspection. Same bug fix for multiline does work for singleline.
