### PR TITLE
Remove `babel-jest` from template

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -17,7 +17,6 @@
     "@babel/core": "^7.8.4",
     "@babel/runtime": "^7.8.4",
     "@react-native-community/eslint-config": "^1.1.0",
-    "babel-jest": "^25.1.0",
     "eslint": "^6.5.1",
     "jest": "^25.1.0",
     "metro-react-native-babel-preset": "^0.63.0",


### PR DESCRIPTION
## Summary

This removes babel-jest from the init template as it is now part of core and is installed when adding jest to a project.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Removed] - Remove babel-jest from init template

## Test Plan

N/A
