### PR TITLE
[StyleSheet]: Import validations only in development

### DIFF
--- a/Libraries/StyleSheet/StyleSheet.js
+++ b/Libraries/StyleSheet/StyleSheet.js
@@ -10,11 +10,15 @@
 
 'use strict';
 
+let StyleSheetValidation = null;
 const PixelRatio = require('../Utilities/PixelRatio');
 const ReactNativeStyleAttributes = require('../Components/View/ReactNativeStyleAttributes');
-const StyleSheetValidation = require('./StyleSheetValidation');
 
 const flatten = require('./flattenStyle');
+
+if (__DEV__) {
+  StyleSheetValidation = require('./StyleSheetValidation');
+}
 
 import type {
   ____ColorValue_Internal,

--- a/Libraries/StyleSheet/StyleSheet.js
+++ b/Libraries/StyleSheet/StyleSheet.js
@@ -10,14 +10,13 @@
 
 'use strict';
 
-let StyleSheetValidation = null;
 const PixelRatio = require('../Utilities/PixelRatio');
 const ReactNativeStyleAttributes = require('../Components/View/ReactNativeStyleAttributes');
 
 const flatten = require('./flattenStyle');
 
 if (__DEV__) {
-  StyleSheetValidation = require('./StyleSheetValidation');
+  var StyleSheetValidation = require('./StyleSheetValidation');
 }
 
 import type {


### PR DESCRIPTION
## Summary

This PR only Import style validations in development, since it is currently included in production

| Before (8.63 KB) |  After (8.31 KB  |
|----------|:-------------:|
| ![before](https://user-images.githubusercontent.com/20761166/92311627-9f91a580-ef86-11ea-850c-efd208b6559e.png) | ![after](https://user-images.githubusercontent.com/20761166/92311618-8c7ed580-ef86-11ea-8605-ce75705588c9.png)

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[JavaScript] [Changed] - [StyleSheet]: Import validations only in development

## Test Plan

1. yarn test passed
2. RNTester Android app build successfu
3. An invalid style property must throw an error
![Screenshot_1599331090](https://user-images.githubusercontent.com/20761166/92311591-580b1980-ef86-11ea-8eba-c674161e2c2e.png)


