### PR TITLE
[iOS] Fix for loading state of Fast Refresh from user defaults

### DIFF
--- a/React/CoreModules/RCTDevSettings.mm
+++ b/React/CoreModules/RCTDevSettings.mm
@@ -405,17 +405,18 @@ RCT_EXPORT_METHOD(addMenuItem : (NSString *)title)
 
 - (void)setupHMRClientWithBundleURL:(NSURL *)bundleURL
 {
-  if (bundleURL && !bundleURL.fileURL) { // isHotLoadingAvailable check
+  if (bundleURL && !bundleURL.fileURL) {
     NSString *const path = [bundleURL.path substringFromIndex:1]; // Strip initial slash.
     NSString *const host = bundleURL.host;
     NSNumber *const port = bundleURL.port;
+    BOOL isHotLoadingEnabled = self.isHotLoadingEnabled;
     if (self.bridge) {
       [self.bridge enqueueJSCall:@"HMRClient"
                           method:@"setup"
-                            args:@[ @"ios", path, host, RCTNullIfNil(port), @(YES) ]
+                            args:@[ @"ios", path, host, RCTNullIfNil(port), @(isHotLoadingEnabled) ]
                       completion:NULL];
     } else {
-      self.invokeJS(@"HMRClient", @"setup", @[ @"ios", path, host, RCTNullIfNil(port), @(YES) ]);
+      self.invokeJS(@"HMRClient", @"setup", @[ @"ios", path, host, RCTNullIfNil(port), @(isHotLoadingEnabled) ]);
     }
   }
 }


### PR DESCRIPTION
## Summary

Disabling Fast Refresh won't be persisted when restarting the app.

I believe this regressed with https://github.com/facebook/react-native/commit/824e1711172d14a9373209bbae63d1ae50601625. In this commit `HMRClient.setup` will always be called with `enabled` being set true. This PR loads the _enabled_ state from the user defaults (as it was done before).

## Changelog

[iOS] [Fixed] - Enable Fast Refresh gets persisted across app launches

## Test Plan

Without this change Fast Refresh is enabled on every app restart.

Tested with this change:
- Disabling Fast Refresh
- Restarting App -> Fast Refresh still disabled
- Enabled Fast Refresh again
- Restarting App -> Fast Refresh still enabled again