### PR TITLE
[iOS] Fix cannot working Modal's onDismiss.

### DIFF
--- a/Libraries/Modal/RCTModalHostViewNativeComponent.js
+++ b/Libraries/Modal/RCTModalHostViewNativeComponent.js
@@ -15,6 +15,7 @@ import type {HostComponent} from '../Renderer/shims/ReactNativeTypes';
 import type {
   WithDefault,
   DirectEventHandler,
+  BubblingEventHandler,
   Int32,
 } from '../Types/CodegenTypes';
 
@@ -85,6 +86,14 @@ type NativeProps = $ReadOnly<{|
    * See https://reactnative.dev/docs/modal.html#onshow
    */
   onShow?: ?DirectEventHandler<null>,
+
+  /**
+   * The `onDismiss` prop allows passing a function that will be called once
+   * the modal has been dismissed.
+   *
+   * See https://reactnative.dev/docs/modal.html#ondismiss
+   */
+  onDismiss?: ?BubblingEventHandler<null>,
 
   /**
    * Deprecated. Use the `animationType` prop instead.

--- a/React/Views/RCTModalManager.h
+++ b/React/Views/RCTModalManager.h
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <UIKit/UIKit.h>
+
+#import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
+
+@interface RCTModalManager : RCTEventEmitter <RCTBridgeModule>
+
+- (void)modalDismissed:(NSNumber *)modalID;
+
+@end

--- a/React/Views/RCTModalManager.m
+++ b/React/Views/RCTModalManager.m
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RCTModalManager.h"
+
+@interface RCTModalManager ()
+
+@property BOOL shouldEmit;
+
+@end
+
+@implementation RCTModalManager
+
+RCT_EXPORT_MODULE();
+
+- (NSArray<NSString *> *)supportedEvents
+{
+  return @[ @"modalDismissed" ];
+}
+
+- (void)startObserving
+{
+  _shouldEmit = YES;
+}
+
+- (void)stopObserving
+{
+  _shouldEmit = NO;
+}
+
+- (void)modalDismissed:(NSNumber *)modalID
+{
+  if (_shouldEmit) {
+    [self sendEventWithName:@"modalDismissed" body:@{ @"modalID": modalID }];
+  }
+}
+
+@end


### PR DESCRIPTION
Fixes: #29455

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Modal's onDismiss is not called on iOS.
This issue occurred the commit https://github.com/facebook/react-native/commit/bd2b7d6c0366b5f19de56b71cb706a0af4b0be43 and was fixed the commit https://github.com/facebook/react-native/commit/27a3248a3b37410b5ee6dda421ae00fa485b525c.
However, the master and stable-0.63 branches do not have this modified commit applied to them.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [Fixed] - Modal's onDismiss prop will now be called successfully.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Tested on iOS with this change:

1. Set function Modal's onDismiss prop.
1. Set Modal's visible props is true. (show Modal)
1. Set Modal's visible props is false. (close Modal)
1. The set function in onDismiss is called.
