### PR TITLE
Fabric: Explicitly include algorithm in Rect.h

### DIFF
--- a/ReactCommon/react/renderer/graphics/Rect.h
+++ b/ReactCommon/react/renderer/graphics/Rect.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <tuple>
 
 #include <folly/Hash.h>


### PR DESCRIPTION
## Summary

This pull request adds an include statement including the header `<algorithm>` to `react/renderer/graphics/Rect.h`.

It is needed for building with MSVC because of the use of the `std::max` function. It seems that this header is included as a side effect of some other header that's being used when building with Clang, and for some reason it is not included when being built with MSVC.

## Changelog

[Internal] [Added] - Fabric: Explicitly include algorithm in Rect.h

## Test Plan

Files that include this header now successfully compile on MSVC.