### PR TITLE
Fabric: Replace #import statement in SynchronousEventBeat

### DIFF
--- a/ReactCommon/react/renderer/scheduler/SynchronousEventBeat.cpp
+++ b/ReactCommon/react/renderer/scheduler/SynchronousEventBeat.cpp
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import "SynchronousEventBeat.h"
+#include "SynchronousEventBeat.h"
 
 namespace facebook {
 namespace react {


### PR DESCRIPTION
## Summary

This function replaces the usage of an Objective-C `#import` statement with `#include` in `react/renderer/scheduler/SynchronousEventBeat.cpp`.

Clang seems to have no problems with `#import` being used in CPP files, but it was causing errors in MSVC. ([it has a different purpose](https://docs.microsoft.com/en-us/cpp/preprocessor/hash-import-directive-cpp?view=vs-2019) on Windows)

## Changelog

[Internal] [Changed] - Fabric: Replace #import statement in SynchronousEventBeat

## Test Plan

This CPP file now compiles in MSVC