### PR TITLE
Fabric: Use std::move on callback in Element::stateData

### DIFF
--- a/ReactCommon/react/renderer/element/Element.h
+++ b/ReactCommon/react/renderer/element/Element.h
@@ -93,7 +93,8 @@ class Element final {
    * Sets `state` using callback.
    */
   Element &stateData(std::function<void(ConcreteStateData &)> callback) {
-    fragment_.stateCallback = [&]() -> StateData::Shared {
+    fragment_.stateCallback = [callback =
+                                   std::move(callback)]() -> StateData::Shared {
       auto stateData = ConcreteStateData();
       callback(stateData);
       return std::make_shared<ConcreteStateData>(stateData);


### PR DESCRIPTION
## Summary

This pull request adds a call to `std::move` on the lambda capture in `Element::stateData`.

On Windows/Visual Studio 2017, this fixes a failure in the test `LayoutableShadowNodeTest.contentOriginOffset` where the error `std::bad_function_call` was being thrown. This was narrowed down to the callback being empty when called in `Element::stateData`.

https://github.com/facebook/react-native/blob/7e899348c74238a4a042380f86a8fe0d7e05511b/ReactCommon/react/renderer/element/Element.h#L98

Making sure the callback survives with `std::move` allows that test to pass under Windows.

## Changelog

[Internal] [Changed] - Fabric: Use std::move on callback in Element::stateData

## Test Plan

The Fabric test suite passes on Windows after this change is made. I also tested it under macOS and Linux built with Clang and they both pass with this change made.