### PR TITLE
Fabric Tests: Change default constructor in TestComponents' TestProps

### DIFF
--- a/ReactCommon/react/renderer/core/tests/TestComponent.h
+++ b/ReactCommon/react/renderer/core/tests/TestComponent.h
@@ -33,7 +33,7 @@ static const char TestComponentName[] = "Test";
 
 class TestProps : public ViewProps {
  public:
-  using ViewProps::ViewProps;
+  TestProps() = default;
 
   TestProps(const TestProps &sourceProps, const RawProps &rawProps)
       : ViewProps(sourceProps, rawProps) {}


### PR DESCRIPTION
## Summary

This pull request changes the default constructor in the `TestProps` class in `react/renderer/core/tests/TestComponent.h`

`using ViewProps::ViewProps;` was causing problems in Visual Studio 2017 - changing it to ` TestProps() = default;` allowed dependent CPP files to compile on MSVC and caused no regressions in the Fabric test suite.

## Changelog

[Internal] [Changed] - Fabric Tests: Change default constructor in TestComponents' TestProps

## Test Plan

The Fabric test suite passes on Windows after this change is made. I also tested it under macOS and Linux built with Clang and they both pass with this change made.

