### PR TITLE
Fabric Tests: Change null ShadowNode creation in StateReconciliationTest

### DIFF
--- a/ReactCommon/react/renderer/mounting/tests/StateReconciliationTest.cpp
+++ b/ReactCommon/react/renderer/mounting/tests/StateReconciliationTest.cpp
@@ -32,7 +32,7 @@ class DummyShadowTreeDelegate : public ShadowTreeDelegate {
 inline ShadowNode const *findDescendantNode(
     ShadowNode const &shadowNode,
     ShadowNodeFamily const &family) {
-  auto result = (ShadowNode const *){nullptr};
+  ShadowNode const *result = nullptr;
   shadowNode.cloneTree(family, [&](ShadowNode const &oldShadowNode) {
     result = &oldShadowNode;
     return oldShadowNode.clone({});
@@ -43,7 +43,7 @@ inline ShadowNode const *findDescendantNode(
 inline ShadowNode const *findDescendantNode(
     ShadowTree const &shadowTree,
     ShadowNodeFamily const &family) {
-  auto result = (ShadowNode const *){nullptr};
+  ShadowNode const *result = nullptr;
 
   shadowTree.tryCommit(
       [&](RootShadowNode::Shared const &oldRootShadowNode) {


### PR DESCRIPTION
## Summary

In `StateReconciliationTest`, the way initializer lists are used to create null `ShadowNode`s causes this error on Visual Studio 2017 on Windows:

```cpp
auto result = (ShadowNode const *){nullptr};
```

---

```
StateReconciliationTest.cpp(35): error C4576: a parenthesized type followed by an init 
ializer list is a non-standard explicit type conversion syntax
```

This change allows this test to compile in Visual Studio 2017, and the effected tests successfully compile and pass on Windows. They also compile and pass on Linux and macOS (both built with Clang)

## Changelog

[Internal] [Changed] - Fabric Tests: Change null ShadowNode creation in StateReconciliationTest

## Test Plan

The Fabric test suite passes on Windows after this change is made. I also tested it under macOS and Linux built with Clang and they both pass with this change made.