### PR TITLE
Changed Flow Typings for dispatchViewManagerCommand

### DIFF
--- a/Libraries/ReactNative/DummyUIManager.js
+++ b/Libraries/ReactNative/DummyUIManager.js
@@ -46,7 +46,7 @@ module.exports = {
   ) => {},
   dispatchViewManagerCommand: (
     reactTag: ?number,
-    commandID: number,
+    commandID: number | string,
     commandArgs: ?Array<string | number | boolean>,
   ) => {},
   measure: (

--- a/Libraries/ReactNative/NativeUIManager.js
+++ b/Libraries/ReactNative/NativeUIManager.js
@@ -40,7 +40,7 @@ export interface Spec extends TurboModule {
   ) => void;
   +dispatchViewManagerCommand: (
     reactTag: ?number,
-    commandID: number,
+    commandID: number | string,
     commandArgs: ?Array<any>,
   ) => void;
   +measure: (


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
The Flow types for `dispatchViewManagerCommand` were not reflective of its implementations in Java and Objective-C. Both allow for a number or a string `commandID`, but the typings on the JavaScript interface only allowed for a number.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Internal] [Changed] - Change type of `commandID` to `number | string`

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
Because this was just a typing change, I simply made sure Flow didn't yell at me when I passed a string into `dispatchViewManagerCommand`.
