### PR TITLE
Fix a couple of missing display names in integration test components

### DIFF
--- a/IntegrationTests/LayoutEventsTest.js
+++ b/IntegrationTests/LayoutEventsTest.js
@@ -197,4 +197,5 @@ const styles = StyleSheet.create({
   },
 });
 
+LayoutEventsTest.displayName = 'LayoutEventsTest';
 module.exports = LayoutEventsTest;

--- a/IntegrationTests/TimersTest.js
+++ b/IntegrationTests/TimersTest.js
@@ -267,4 +267,5 @@ const styles = StyleSheet.create({
   },
 });
 
+TimersTest.displayName = 'TimersTest';
 module.exports = TimersTest;


### PR DESCRIPTION
## Summary

IntegtationTestsApp looks for a display name of each component to register it in the AppRegistry, along with show its name in the tests lists. Add the missing display names back to these tests.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [Fixed] - Fix a couple of missing display names in integration test components

## Test Plan

All integration tests now show up in the list.
