### PR TITLE
Prevent TextInputExample from Redboxing

### DIFF
--- a/packages/rn-tester/js/examples/TextInput/TextInputExample.android.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputExample.android.js
@@ -339,7 +339,6 @@ exports.examples = ([
             returnKeyType="done"
             multiline={true}
             style={{maxHeight: 400, minHeight: 20, backgroundColor: '#eeeeee'}}>
-            generic generic generic
             <Text style={{fontSize: 6, color: 'red'}}>
               small small small small small small
             </Text>
@@ -347,7 +346,6 @@ exports.examples = ([
             <Text style={{fontSize: 30, color: 'green'}}>
               huge huge huge huge huge
             </Text>
-            generic generic generic
           </AutogrowingTextInputExample>
         </View>
       );

--- a/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
@@ -625,7 +625,6 @@ exports.examples = ([
               color: 'blue',
             }}>
             <Text style={{fontSize: 30, color: 'green'}}>huge</Text>
-            generic generic generic
             <Text style={{fontSize: 6, color: 'red'}}>
               small small small small small small
             </Text>
@@ -633,7 +632,6 @@ exports.examples = ([
             <Text style={{fontSize: 30, color: 'green'}}>
               huge huge huge huge huge
             </Text>
-            generic generic generic
           </AutogrowingTextInputExample>
         </View>
       );


### PR DESCRIPTION
## Summary

Freestanding text in these examples cause the public dev-mode React renderer to redbox saying:
> Text strings must be rendered within a <Text> component.

 See https://snack.expo.io/@chrisglein/repro5688 to repo the same behavior on iOS or Android. Remove the offending text to prevent the example from redboxing.

Relates to https://github.com/microsoft/react-native-windows/issues/5688

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Fixed] - Prevent TextInputExample from Redboxing

## Test Plan

Making this change stopped RNW from redboxing on the example, and in the min repo case stops Android/iOS from redboxing.
