### PR TITLE
[Android] fix DPAD scrolling scrollView even when scrollEnabled is set to false

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
@@ -426,14 +426,14 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
   }
 
   @Override
-  public boolean executeKeyEvent(KeyEvent event) {
+  public boolean dispatchKeyEvent(KeyEvent event) {
     int eventKeyCode = event.getKeyCode();
     if (!mScrollEnabled
         && (eventKeyCode == KeyEvent.KEYCODE_DPAD_LEFT
             || eventKeyCode == KeyEvent.KEYCODE_DPAD_RIGHT)) {
       return false;
     }
-    return super.executeKeyEvent(event);
+    return super.dispatchKeyEvent(event);
   }
 
   @Override

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -336,14 +336,14 @@ public class ReactScrollView extends ScrollView
   }
 
   @Override
-  public boolean executeKeyEvent(KeyEvent event) {
+  public boolean dispatchKeyEvent(KeyEvent event) {
     int eventKeyCode = event.getKeyCode();
     if (!mScrollEnabled
         && (eventKeyCode == KeyEvent.KEYCODE_DPAD_UP
             || eventKeyCode == KeyEvent.KEYCODE_DPAD_DOWN)) {
       return false;
     }
-    return super.executeKeyEvent(event);
+    return super.dispatchKeyEvent(event);
   }
 
   @Override


### PR DESCRIPTION
## Summary

https://github.com/facebook/react-native/issues/29774
Fixes scrollView behaviour on DPAD input when scrollEnabled is set to false

## Changelog

[Android] [Fixed] - fix DPAD scrolling scrollView even when scrollEnabled is set to false
