### PR TITLE
Fix typo in invariant message

### DIFF
--- a/Libraries/ActionSheetIOS/ActionSheetIOS.js
+++ b/Libraries/ActionSheetIOS/ActionSheetIOS.js
@@ -57,7 +57,7 @@ const ActionSheetIOS = {
       'Options must be a valid object',
     );
     invariant(typeof callback === 'function', 'Must provide a valid callback');
-    invariant(RCTActionSheetManager, "ActionSheetManager does't exist");
+    invariant(RCTActionSheetManager, "ActionSheetManager doesn't exist");
 
     const {tintColor, destructiveButtonIndex, ...remainingOptions} = options;
     let destructiveButtonIndices = null;
@@ -123,7 +123,7 @@ const ActionSheetIOS = {
       typeof successCallback === 'function',
       'Must provide a valid successCallback',
     );
-    invariant(RCTActionSheetManager, "ActionSheetManager does't exist");
+    invariant(RCTActionSheetManager, "ActionSheetManager doesn't exist");
     RCTActionSheetManager.showShareActionSheetWithOptions(
       {...options, tintColor: processColor(options.tintColor)},
       failureCallback,


### PR DESCRIPTION
## Summary

Fix a typo in the invariant message presented when ActionSheetManager does not exist (typo was found in 2 places)

## Changelog

[General] [Fixed] - Fix typo in invariant message

## Test Plan

Run ActionSheetIOS.showActionSheetWithOptions(...) on an Android emulator to get this invariant message to appear.
