### PR TITLE
interface: Stop erasing Flow's internal `fetch` type def and friends.

### DIFF
--- a/interface.js
+++ b/interface.js
@@ -16,10 +16,6 @@ declare var __REACT_DEVTOOLS_GLOBAL_HOOK__: any; /*?{
   inject: ?((stuff: Object) => void)
 };*/
 
-declare var fetch: any;
-declare var Headers: any;
-declare var Request: any;
-declare var Response: any;
 declare module requestAnimationFrame {
   declare module.exports: (callback: any) => any;
 }


### PR DESCRIPTION
## Summary

Let `fetch` get type-checked by not overriding Flow's internal type definition for it (and a few types it uses) with `any`.

Fixes: #29866

## Changelog
[General] [Fixed] - `fetch` is now type-checked by Flow.

## Test Plan

`yarn flow` passes in `react-native`, and the repro recipe in #29866 shows that `fetch` is type-checked in a new React Native project.