### PR TITLE
Platform: Implement Platform.isCatalyst

### DIFF
--- a/Libraries/FBReactNativeSpec/FBReactNativeSpec/FBReactNativeSpec.h
+++ b/Libraries/FBReactNativeSpec/FBReactNativeSpec/FBReactNativeSpec.h
@@ -2001,6 +2001,7 @@ namespace JS {
           RCTRequired<NSString *> osVersion;
           RCTRequired<NSString *> systemName;
           RCTRequired<NSString *> interfaceIdiom;
+          RCTRequired<bool> isCatalyst;
         };
 
         /** Initialize with a set of values */
@@ -3431,6 +3432,8 @@ inline JS::NativePlatformConstantsIOS::Constants::Builder::Builder(const Input i
   d[@"systemName"] = systemName;
   auto interfaceIdiom = i.interfaceIdiom.get();
   d[@"interfaceIdiom"] = interfaceIdiom;
+  auto isCatalyst = i.isCatalyst.get();
+  d[@"isCatalyst"] = @(isCatalyst);
   return d;
 }) {}
 inline JS::NativePlatformConstantsIOS::Constants::Builder::Builder(Constants i) : _factory(^{

--- a/Libraries/Utilities/NativePlatformConstantsIOS.js
+++ b/Libraries/Utilities/NativePlatformConstantsIOS.js
@@ -26,6 +26,7 @@ export interface Spec extends TurboModule {
     osVersion: string,
     systemName: string,
     interfaceIdiom: string,
+    isCatalyst: boolean,
   |};
 }
 

--- a/Libraries/Utilities/Platform.android.js
+++ b/Libraries/Utilities/Platform.android.js
@@ -61,6 +61,10 @@ const Platform = {
   get isTV(): boolean {
     return this.constants.uiMode === 'tv';
   },
+  // $FlowFixMe[unsafe-getters-setters]
+  get isCatalyst(): boolean {
+    return false;
+  },
   select: <A, N, D>(spec: PlatformSelectSpec<A, N, D>): A | N | D =>
     'android' in spec
       ? spec.android

--- a/Libraries/Utilities/Platform.ios.js
+++ b/Libraries/Utilities/Platform.ios.js
@@ -39,6 +39,7 @@ const Platform = {
       prerelease: ?number,
     |},
     systemName: string,
+    isCatalyst: boolean,
   |} {
     if (this.__constants == null) {
       this.__constants = NativePlatformConstantsIOS.getConstants();
@@ -66,6 +67,10 @@ const Platform = {
       return this.constants.isTesting;
     }
     return false;
+  },
+  // $FlowFixMe[unsafe-getters-setters]
+  get isCatalyst(): boolean {
+    return this.constants.isCatalyst;
   },
   select: <D, N, I>(spec: PlatformSelectSpec<D, N, I>): D | N | I =>
     'ios' in spec ? spec.ios : 'native' in spec ? spec.native : spec.default,

--- a/Libraries/Utilities/__tests__/Platform-test.js
+++ b/Libraries/Utilities/__tests__/Platform-test.js
@@ -40,4 +40,10 @@ describe('Platform', () => {
       expect(PlatformAndroid.select(obj)).toEqual(obj.default);
     });
   });
+
+  describe('isCatalyst', () => {
+    it('should return false for android', () => {
+      expect(PlatformAndroid.isCatalyst).toBe(false);
+    });
+  });
 });

--- a/React/CoreModules/RCTPlatform.mm
+++ b/React/CoreModules/RCTPlatform.mm
@@ -33,6 +33,14 @@ static NSString *interfaceIdiom(UIUserInterfaceIdiom idiom)
   }
 }
 
+static BOOL isCatalyst() {
+#if TARGET_OS_MACCATALYST
+  return YES;
+#else
+  return NO;
+#endif
+}
+
 @interface RCTPlatform () <NativePlatformConstantsIOSSpec>
 @end
 
@@ -68,6 +76,7 @@ RCT_EXPORT_MODULE(PlatformConstants)
         .systemName = [device systemName],
         .interfaceIdiom = interfaceIdiom([device userInterfaceIdiom]),
         .isTesting = RCTRunningInTestEnvironment() ? true : false,
+        .isCatalyst = isCatalyst() ? true : false,
         .reactNativeVersion = JS::NativePlatformConstantsIOS::ConstantsReactNativeVersion::Builder(
             {.minor = [versions[@"minor"] doubleValue],
              .major = [versions[@"major"] doubleValue],


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Following up on #27484, instead of adding `Platform.isMac` this pull request is proposing `Platform.isCatalyst` to avoid a collision with [`react-native-macos`](https://github.com/microsoft/react-native-macos).

⚠️ Note that `Platform.OS` is still returning `ios`, even on macOS with Catalyst.

In the meantime, you can rely on [`react-native-is-catalyst`](https://github.com/charpeni/react-native-is-catalyst) as an external dependency.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Added] - Implement Platform.isCatalyst to know if we're running on macOS with Catalyst.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

| macOS | iOS |
| - | - |
| <img height="300" src="https://user-images.githubusercontent.com/7189823/92966140-f8f54b00-f444-11ea-82ce-b671048f9cab.png" /> | <img height="400" src="https://user-images.githubusercontent.com/7189823/92966159-04e10d00-f445-11ea-85c2-c3e273c9515a.png" /> |

