### PR TITLE
Android: Ensure RN_FABRIC_ENABLED is defined when building with Fabric

### DIFF
--- a/ReactCommon/jsi/Android.mk
+++ b/ReactCommon/jsi/Android.mk
@@ -32,4 +32,8 @@ LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)
 LOCAL_CFLAGS := -fexceptions -frtti -O3
 LOCAL_SHARED_LIBRARIES := libfolly_json libjsc glog
 
+ifeq ($(BUILD_FABRIC),true)
+  LOCAL_CFLAGS += -DRN_FABRIC_ENABLED
+endif
+
 include $(BUILD_STATIC_LIBRARY)


### PR DESCRIPTION
## Summary

This pull request tweaks the build script for `jsiruntime` to ensure that `RN_FABRIC_ENABLED` is defined when building for Android with Fabric enabled, and using the JavascriptCore JS engine. Without it, the `createWeakObject` and `lockWeakObject` methods in `JSCRuntime.cpp` will throw an exception.

## Changelog

[Internal] [Changed] - Android: Ensure RN_FABRIC_ENABLED is defined when building with Fabric

## Test Plan

RNTester with JSC now builds and runs on Android with Fabric enabled.