### PR TITLE
Don't crash when promise task is cancelled before its resolved

### DIFF
--- a/Libraries/Interaction/TaskQueue.js
+++ b/Libraries/Interaction/TaskQueue.js
@@ -156,6 +156,7 @@ class TaskQueue {
     // happens once it is fully processed.
     this._queueStack.push({tasks: [], popable: false});
     const stackIdx = this._queueStack.length - 1;
+    const stackItem = this._queueStack[stackIdx];
     DEBUG && infoLog('TaskQueue: push new queue: ', {stackIdx});
     DEBUG && infoLog('TaskQueue: exec gen task ' + task.name);
     task
@@ -166,7 +167,7 @@ class TaskQueue {
             stackIdx,
             queueStackSize: this._queueStack.length,
           });
-        this._queueStack[stackIdx].popable = true;
+        stackItem.popable = true;
         this.hasTasksToProcess() && this._onMoreTasks();
       })
       .catch(ex => {

--- a/Libraries/Interaction/__tests__/TaskQueue-test.js
+++ b/Libraries/Interaction/__tests__/TaskQueue-test.js
@@ -150,4 +150,20 @@ describe('TaskQueue', () => {
     expect(task1).not.toBeCalled();
     expect(taskQueue.hasTasksToProcess()).toBe(false);
   });
+
+  it('should not crash when task is cancelled between being started and resolved', () => {
+    const task1 = jest.fn(() => {
+      return new Promise(resolve => {
+        setTimeout(() => {
+          resolve();
+        }, 1);
+      });
+    });
+
+    taskQueue.enqueue({gen: task1, name: 'gen1'});
+    taskQueue.processNext();
+    taskQueue.cancelTasks([task1]);
+
+    jest.runAllTimers();
+  });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

This pull request fixes a potential `TypeError` in TaskQueue.js, that happens if a promise is added to the task queue, which is cancelled between the promise starting and resolving.

The exact error this resolves is 
```js
TypeError: TaskQueue: Error resolving Promise in task gen1: Cannot set property ‘popable’ of undefined
      167 |           queueStackSize: this._queueStack.length,
      168 |         });
    > 169 |       this._queueStack[stackIdx].popable = true;
          |                                              ^
      170 |       this.hasTasksToProcess() && this._onMoreTasks();
      171 |     })
      172 |     .catch(ex => {
      at Libraries/Interaction/TaskQueue.js:169:46
```

This specific error was also reported in #16321

## Changelog

[General] [Fixed] - Prevent TypeError in TaskQueue when cancelling a started but not resolved promise.

## Test Plan

The added test demonstrates the error, if run without the fixed applied to TaskQueue.js.
This is a race condition error, so is difficult to replicate!