### PR TITLE
WIP: Add an explicit NDK version to RNTester and ReactAndroid

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -382,7 +382,7 @@ task extractJNIFiles {
 
 android {
     compileSdkVersion 29
-    ndkVersion ndkVersion
+    ndkVersion "20.1.5948944"
     compileOptions {
         sourceCompatibility(JavaVersion.VERSION_1_8)
         targetCompatibility(JavaVersion.VERSION_1_8)
@@ -393,7 +393,6 @@ android {
         targetSdkVersion(28)
         versionCode(1)
         versionName("1.0")
-        ndkVersion "20.1.5948944"
 
         consumerProguardFiles("proguard-rules.pro")
 

--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -247,12 +247,28 @@ def getNdkBuildName() {
 }
 
 def findNdkBuildFullPath() {
-    if (System.getenv("ANDROID_HOME") != null) {
-        def sdkDir = System.getenv("ANDROID_HOME")
-        def ndkDir = new File(sdkDir, "ndk").getAbsolutePath()
-        def ndkVersionedDir = new File(ndkDir, project.android.ndkVersion).getAbsolutePath()
-        return new File(ndkVersionedDir, getNdkBuildName()).getAbsolutePath()
+    // android.ndkDirectory should return project.android.ndkVersion ndkDirectory
+    def ndkDir = android.ndkDirectory ? android.ndkDirectory.absolutePath : null
+    if (ndkDir) {
+        return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
     }
+
+     // we allow to provide full path to ndk-build tool
+    if (hasProperty("ndk.command")) {
+        return property("ndk.command")
+    }
+    // or just a path to the containing directory
+    if (hasProperty("ndk.path")) {
+        ndkDir = property("ndk.path")
+        return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
+    }
+
+    // @TODO ANDROID_NDK && ndk.dir is deprecated and will be removed in the future. 
+    if (System.getenv("ANDROID_NDK") != null) {
+        ndkDir = System.getenv("ANDROID_NDK")
+        return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
+    }
+
     return null
 }
 
@@ -271,14 +287,15 @@ def getNdkBuildFullPath() {
     if (ndkBuildFullPath == null) {
         throw new GradleScriptException(
                 "ndk-build binary cannot be found, check if you've set " +
-                        "\$ANDROID_HOME environment variable correctly and you have installed the correct NDK version (" +
-                       project.android.ndkVersion + ")",
+                        "\$ANDROID_NDK environment variable correctly or if ndk.dir is " +
+                        "setup in local.properties",
                 null)
     }
     if (!new File(ndkBuildFullPath).canExecute()) {
         throw new GradleScriptException(
                 "ndk-build binary " + ndkBuildFullPath + " doesn't exist or isn't executable.\n" +
-                        "Check that you have installed the correct NDK version (" + project.android.ndkVersion + ")",
+                        "Check that the \$ANDROID_NDK environment variable, or ndk.dir in local.properties, is set correctly.\n" +
+                        "(On Windows, make sure you escape backslashes in local.properties or use forward slashes, e.g. C:\\\\ndk or C:/ndk rather than C:\\ndk)",
                 null)
     }
     return ndkBuildFullPath

--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -380,7 +380,7 @@ task extractJNIFiles {
 
 android {
     compileSdkVersion 29
-
+    ndkVersion ndkVersion
     compileOptions {
         sourceCompatibility(JavaVersion.VERSION_1_8)
         targetCompatibility(JavaVersion.VERSION_1_8)
@@ -391,7 +391,7 @@ android {
         targetSdkVersion(28)
         versionCode(1)
         versionName("1.0")
-
+        ndkVersion "20.1.5948944"
         consumerProguardFiles("proguard-rules.pro")
 
         buildConfigField("boolean", "IS_INTERNAL_BUILD", "false")

--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -247,25 +247,11 @@ def getNdkBuildName() {
 }
 
 def findNdkBuildFullPath() {
-    // we allow to provide full path to ndk-build tool
-    if (hasProperty("ndk.command")) {
-        return property("ndk.command")
-    }
-    // or just a path to the containing directory
-    if (hasProperty("ndk.path")) {
-        def ndkDir = property("ndk.path")
-        return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
-    }
-
-    if (System.getenv("ANDROID_NDK") != null) {
-        def ndkDir = System.getenv("ANDROID_NDK")
-        return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
-    }
-
-    def ndkDir = android.ndkDirectory ? android.ndkDirectory.absolutePath : null
-
-    if (ndkDir) {
-        return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
+    if (System.getenv("ANDROID_HOME") != null) {
+        def sdkDir = System.getenv("ANDROID_HOME")
+        def ndkDir = new File(sdkDir, "ndk").getAbsolutePath()
+        def ndkVersionedDir = new File(ndkDir, project.android.ndkVersion).getAbsolutePath()
+        return new File(ndkVersionedDir, getNdkBuildName()).getAbsolutePath()
     }
     return null
 }
@@ -285,15 +271,14 @@ def getNdkBuildFullPath() {
     if (ndkBuildFullPath == null) {
         throw new GradleScriptException(
                 "ndk-build binary cannot be found, check if you've set " +
-                        "\$ANDROID_NDK environment variable correctly or if ndk.dir is " +
-                        "setup in local.properties",
+                        "\$ANDROID_HOME environment variable correctly and you have installed the correct NDK version (" +
+                       project.android.ndkVersion + ")",
                 null)
     }
     if (!new File(ndkBuildFullPath).canExecute()) {
         throw new GradleScriptException(
                 "ndk-build binary " + ndkBuildFullPath + " doesn't exist or isn't executable.\n" +
-                        "Check that the \$ANDROID_NDK environment variable, or ndk.dir in local.properties, is set correctly.\n" +
-                        "(On Windows, make sure you escape backslashes in local.properties or use forward slashes, e.g. C:\\\\ndk or C:/ndk rather than C:\\ndk)",
+                        "Check that you have installed the correct NDK version (" + project.android.ndkVersion + ")",
                 null)
     }
     return ndkBuildFullPath
@@ -392,6 +377,7 @@ android {
         versionCode(1)
         versionName("1.0")
         ndkVersion "20.1.5948944"
+
         consumerProguardFiles("proguard-rules.pro")
 
         buildConfigField("boolean", "IS_INTERNAL_BUILD", "false")

--- a/packages/rn-tester/android/app/build.gradle
+++ b/packages/rn-tester/android/app/build.gradle
@@ -121,7 +121,7 @@ def useIntlJsc = false
 
 android {
     compileSdkVersion 29
-    ndkVersion ndkVersion
+    ndkVersion "20.1.5948944"
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
@@ -142,7 +142,6 @@ android {
     defaultConfig {
         applicationId "com.facebook.react.uiapp"
         minSdkVersion 19
-        ndkVersion "20.1.5948944"
         targetSdkVersion 29
         versionCode 1
         versionName "1.0"

--- a/packages/rn-tester/android/app/build.gradle
+++ b/packages/rn-tester/android/app/build.gradle
@@ -121,7 +121,7 @@ def useIntlJsc = false
 
 android {
     compileSdkVersion 29
-
+    ndkVersion ndkVersion
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
@@ -142,6 +142,7 @@ android {
     defaultConfig {
         applicationId "com.facebook.react.uiapp"
         minSdkVersion 19
+        ndkVersion "20.1.5948944"
         targetSdkVersion 29
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
## Summary

When I try to run RNTester with Gradle the RNTester Required me to use **NDK 20.0.5594570**. I can't seem to find an explicit NDK version anywhere in ReactAndroid and RNTester. This PR Aims to add an explicit NDK version to RNTester and ReactAndroid. 

![Screenshot from 2020-09-19 21-13-17](https://user-images.githubusercontent.com/8868908/93669563-444fcf00-fabf-11ea-8822-93264c5bb736.png)


## Changelog
[Android] [Added] - Add an explicit NDK version to RNTester and ReactAndroid.

## Test Plan
Build manually from RNTester