### PR TITLE
Add mocks to fix: handleException is not a function (#29849)

### DIFF
--- a/Libraries/LogBox/Data/LogBoxData.js
+++ b/Libraries/LogBox/Data/LogBoxData.js
@@ -23,6 +23,9 @@ import type {
 import parseErrorStack from '../../Core/Devtools/parseErrorStack';
 import type {ExtendedError} from '../../Core/Devtools/parseErrorStack';
 import NativeLogBox from '../../NativeModules/specs/NativeLogBox';
+
+const ExceptionsManager = require('../../Core/ExceptionsManager');
+
 export type LogBoxLogs = Set<LogBoxLog>;
 export type LogData = $ReadOnly<{|
   level: LogLevel,
@@ -98,8 +101,6 @@ export function reportLogBoxError(
   error: ExtendedError,
   componentStack?: string,
 ): void {
-  const ExceptionsManager = require('../../Core/ExceptionsManager');
-
   error.forceRedbox = true;
   error.message = `${LOGBOX_ERROR_MESSAGE}\n\n${error.message}`;
   if (componentStack != null) {

--- a/jest/setup.js
+++ b/jest/setup.js
@@ -45,6 +45,13 @@ jest
       reportException: jest.fn(),
     },
   }))
+  .mock('../Libraries/Core/ExceptionsManager', () => {
+    return {
+      handleException: (...args) => {
+        return;
+      },
+    };
+  })
   .mock('../Libraries/ReactNative/UIManager', () => ({
     AndroidViewPager: {
       Commands: {


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This solves two problems:
1. When an exception is thrown by RN code during testing (e.g. with react-native-testing-library), the exception message is swallowed and instead this message is shown:

> ExceptionsManager.handleException is not a function

2. The inline `require` call that is removed in this commit is also incompatible with running a test suite (at least in react-native-testing-library) because the on-the-fly require fails.  This throws the error:

> ReferenceError: You are trying to `import` a file after the Jest environment has been torn down.

See issue: https://github.com/facebook/react-native/issues/29849

## Changelog

[General] [Fix] - Fix issue where exceptions thrown during test runs could get swallowed and result in these messages:
- ExceptionsManager.handleException is not a function
- ReferenceError: You are trying to `import` a file after the Jest environment has been torn down.

## Test Plan

Before: an exception generated during our test suite is swallowed and shows the errors above
After: no longer repros.  exceptions logged during a test run output their messages to the console as expected

(I def would like verification from a code owner here, this code makes it work but I can't guarantee it's optimal.  Thanks!)