### PR TITLE
Enable disable interval momentum for snap to offsets

### DIFF
--- a/React/Views/ScrollView/RCTScrollView.m
+++ b/React/Views/ScrollView/RCTScrollView.m
@@ -639,7 +639,13 @@ RCT_SCROLL_EVENT_HANDLER(scrollViewDidScrollToTop, onScrollToTop)
                                          : MAX(0, _scrollView.contentSize.height - viewportSize.height);
 
     // Calculate the snap offsets adjacent to the initial offset target
-    CGFloat targetOffset = isHorizontal ? targetContentOffset->x : targetContentOffset->y;
+    CGFloat targetOffset = targetContentOffset->y;
+    if (isHorizontal) {
+      // Use current scroll offset to determine the next index to snap to when momentum disabled
+      targetOffset = self.disableIntervalMomentum ? scrollView.contentOffset.x : targetContentOffset->x;
+    } else {
+      targetOffset = self.disableIntervalMomentum ? scrollView.contentOffset.y : targetContentOffset->y;
+    }
     CGFloat smallerOffset = 0.0;
     CGFloat largerOffset = maximumOffset;
 

--- a/packages/rn-tester/js/examples/ScrollView/ScrollViewExample.js
+++ b/packages/rn-tester/js/examples/ScrollView/ScrollViewExample.js
@@ -321,6 +321,48 @@ if (Platform.OS === 'ios') {
       return <CenterContentList />;
     },
   });
+  exports.examples.push({
+    title: '<ScrollView> (snapToOffsets = [100, 200, 300], disableIntervalMomentum)\n',
+    description:
+      'ScrollView can snap to custom intervals. Using disableIntervalMomentum controls whether the momentum of the scroll can go past intervals.',
+    render: function(): React.Node {
+      class SnapToOffsets extends React.Component<{...}, *> {
+        state = {
+          disableIntervalMomentum: false,
+        };
+        render() {
+          return (
+            <View>
+              <ScrollView
+                style={[styles.scrollView, {height: 100}]}
+                horizontal={true}
+                snapToOffsets={ITEMS.map((_, i) => 106 * i)}
+                disableIntervalMomentum={this.state.disableIntervalMomentum}>
+                {ITEMS.map(createItemRow)}
+              </ScrollView>
+              <Text>
+                {'Scroll momentum past intervals enabled = ' +
+                  (!this.state.disableIntervalMomentum).toString()}
+              </Text>
+              <Button
+                label="Disable Scroll momentum past intervals"
+                onPress={() => {
+                  this.setState({disableIntervalMomentum: true});
+                }}
+              />
+              <Button
+                label="Enable Scroll momentum past intervals"
+                onPress={() => {
+                  this.setState({disableIntervalMomentum: false});
+                }}
+              />
+            </View>
+          );
+        }
+      }
+      return <SnapToOffsets />;
+    },
+  });
 }
 
 class Item extends React.PureComponent<{|


### PR DESCRIPTION
## Summary

`disableIntervalMomentum` is a nice feature that works when using `snapToInterval`, but not when using the more low-level `snapToOffsets`. This PR enables `disableIntervalMomentum` to work with `snapToOffsets`. I simply copy-pasted the logic implemented for `snapToInterval`: https://github.com/facebook/react-native/blob/master/React/Views/ScrollView/RCTScrollView.m#L714

## Changelog

Not sure if this is considered a feature or a fix. Leaning towards fix because the documentation for disableIntervalMomentum didn't mention that it doesn't work with snapToOffsets, and I was expecting that it would.

[ScrollView] [Fixed] - disableIntervalMomentum now works with snapToOffsets

## Test Plan

I've added a test for this in rn-tester so it can be tested manually

![Sep-25-2020 13-32-29](https://user-images.githubusercontent.com/10407025/94262324-98313c80-ff33-11ea-8154-6a63af631b6b.gif)
