### PR TITLE
PlatformColors: add missing clearColor for iOS

### DIFF
--- a/React/Base/RCTConvert.m
+++ b/React/Base/RCTConvert.m
@@ -727,6 +727,11 @@ static NSDictionary<NSString *, NSDictionary *> *RCTSemanticColorsMap()
         // iOS 13.0
         RCTFallbackARGB : @(0xFFf2f2f7)
       },
+      // Transparent Color
+      @"clearColor" : @{
+        // iOS 13.0
+        RCTFallbackARGB : @(0x00000000)
+      },
     } mutableCopy];
     // The color names are the Objective-C UIColor selector names,
     // but Swift selector names are valid as well, so make aliases.

--- a/packages/rn-tester/RNTesterUnitTests/RCTConvert_UIColorTests.m
+++ b/packages/rn-tester/RNTesterUnitTests/RCTConvert_UIColorTests.m
@@ -154,6 +154,8 @@ static BOOL CGColorsAreEqual(CGColorRef color1, CGColorRef color2) {
     @"systemGray4Color": @(0xFFd1d1d6),
     @"systemGray5Color": @(0xFFe5e5ea),
     @"systemGray6Color": @(0xFFf2f2f7),
+    // Clear Color
+    @"clearColor": @(0x00000000),
   };
 
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000

--- a/packages/rn-tester/js/examples/PlatformColor/PlatformColorExample.js
+++ b/packages/rn-tester/js/examples/PlatformColor/PlatformColorExample.js
@@ -110,6 +110,8 @@ function PlatformColorsExample() {
         {label: 'systemGray4', color: PlatformColor('systemGray4')},
         {label: 'systemGray5', color: PlatformColor('systemGray5')},
         {label: 'systemGray6', color: PlatformColor('systemGray6')},
+        // Transparent Color
+        {label: 'clear', color: PlatformColor('clear')},
       ];
     } else if (Platform.OS === 'android') {
       colors = [


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

This small PR adds missing [`clearColor`](https://developer.apple.com/documentation/uikit/uicolor/1621945-clearcolor?language=objc) to the avaiable PlatformColors on iOS.

**Please let me know** if you would like to see ["Fixed colors"](https://developer.apple.com/documentation/uikit/uicolor/standard_colors?language=objc) added to the `PlatformColors`. I can address this within this PR or create a separate one.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [Added] - PlatformColors: add missing `clearColor`

## Test Plan

[(I had to disable the Dark Mode to fix the RNTester readability problems)](https://user-images.githubusercontent.com/719641/94453196-b35cb000-01b0-11eb-8d7d-73d48ceecf53.PNG)

Transparent/clear color has been added to the RNTester PlatformColors API example:
![IMG_6782](https://user-images.githubusercontent.com/719641/94453172-ae97fc00-01b0-11eb-9bef-1a1a387ac009.PNG)

