### PR TITLE
Default color for ActivityIndicator on Android

### DIFF
--- a/Libraries/Components/ActivityIndicator/ActivityIndicator.js
+++ b/Libraries/Components/ActivityIndicator/ActivityIndicator.js
@@ -14,7 +14,7 @@
 const Platform = require('../../Utilities/Platform');
 const React = require('react');
 const StyleSheet = require('../../StyleSheet/StyleSheet');
-const { PlatformColor } = require('../../StyleSheet/PlatformColorValueTypes');
+const {PlatformColor} = require('../../StyleSheet/PlatformColorValueTypes');
 const View = require('../View/View');
 import type {HostComponent} from '../../Renderer/shims/ReactNativeTypes';
 import type {ViewProps} from '../View/ViewPropTypes';
@@ -184,7 +184,8 @@ ActivityIndicatorWithRef.displayName = 'ActivityIndicator';
  * and run Flow. */
 ActivityIndicatorWithRef.defaultProps = {
   animating: true,
-  color: Platform.OS === 'ios' ? GRAY : PlatformColor('?attr/colorControlActivated'),
+  color:
+    Platform.OS === 'ios' ? GRAY : PlatformColor('?attr/colorControlActivated'),
   hidesWhenStopped: true,
   size: 'small',
 };

--- a/Libraries/Components/ActivityIndicator/ActivityIndicator.js
+++ b/Libraries/Components/ActivityIndicator/ActivityIndicator.js
@@ -14,6 +14,7 @@
 const Platform = require('../../Utilities/Platform');
 const React = require('react');
 const StyleSheet = require('../../StyleSheet/StyleSheet');
+const { PlatformColor } = require('../../StyleSheet/PlatformColorValueTypes');
 const View = require('../View/View');
 import type {HostComponent} from '../../Renderer/shims/ReactNativeTypes';
 import type {ViewProps} from '../View/ViewPropTypes';
@@ -183,7 +184,7 @@ ActivityIndicatorWithRef.displayName = 'ActivityIndicator';
  * and run Flow. */
 ActivityIndicatorWithRef.defaultProps = {
   animating: true,
-  color: Platform.OS === 'ios' ? GRAY : null,
+  color: Platform.OS === 'ios' ? GRAY : PlatformColor('?attr/colorControlActivated'),
   hidesWhenStopped: true,
   size: 'small',
 };

--- a/Libraries/Components/ActivityIndicator/ActivityIndicator.js
+++ b/Libraries/Components/ActivityIndicator/ActivityIndicator.js
@@ -184,8 +184,11 @@ ActivityIndicatorWithRef.displayName = 'ActivityIndicator';
  * and run Flow. */
 ActivityIndicatorWithRef.defaultProps = {
   animating: true,
-  color:
-    Platform.OS === 'ios' ? GRAY : PlatformColor('?attr/colorControlActivated'),
+  color: Platform.select({
+    ios: GRAY,
+    android: PlatformColor('?attr/colorControlActivated'),
+    default: GRAY,
+  }),
   hidesWhenStopped: true,
   size: 'small',
 };

--- a/Libraries/Components/ActivityIndicator/ActivityIndicator.js
+++ b/Libraries/Components/ActivityIndicator/ActivityIndicator.js
@@ -187,7 +187,7 @@ ActivityIndicatorWithRef.defaultProps = {
   color: Platform.select({
     ios: GRAY,
     android: PlatformColor('?attr/colorControlActivated'),
-    default: GRAY,
+    default: null,
   }),
   hidesWhenStopped: true,
   size: 'small',


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

ActivityIndicator is blank after RN 0.63, and does not show up unless explicit `color` prop is provided.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Fixes https://github.com/facebook/react-native/issues/30056, 
https://github.com/facebook/react-native/issues/29495, https://github.com/facebook/react-native/issues/29378

Fix By using `PlatformColor` API to set default platform color which is according to https://developer.android.com/reference/android/R.attr#colorControlActivated

Before fix:
![Screenshot_20200928-220924_RNTester App](https://user-images.githubusercontent.com/659202/94462334-fc285f00-01d8-11eb-86c6-f9ca3b5f77cc.jpg)

After fix:
![Screenshot_20200928-221153_RNTester App](https://user-images.githubusercontent.com/659202/94462343-021e4000-01d9-11eb-9a65-a837b35ce038.jpg)


## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Fixed] - Show default platform color for Android ActivityIndicator when no color supplied in prop.

## Test Plan

Go to AppTester App > ActivityIndicator > Android Activity indicator should be seen with default platform color.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
