### PR TITLE
Fix: Detection of host ip address for running on a device

### DIFF
--- a/scripts/react-native-xcode.sh
+++ b/scripts/react-native-xcode.sh
@@ -20,6 +20,11 @@ if [[ "$CONFIGURATION" = *Debug* && ! "$PLATFORM_NAME" == *simulator ]]; then
       break
     fi
   done
+  # if en0 and en1 both point to local addresses, try something else
+  if [[ "$IP" == *"169.254"* ||  "$IP" == *"127.0"* ]]; then
+    IP=""
+  fi
+
   if [ -z "$IP" ]; then
     IP=$(ifconfig | grep 'inet ' | grep -v ' 127.' | grep -v ' 169.254.' |cut -d\   -f2  | awk 'NR==1{print $1}')
   fi


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

If your host machine has both en0 and en1 disabled/point to local network, `scripts/react-native-xcode.sh` does not try to determine a more suitable IP.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
We're making this change to be able to let the app connect to bundler even when en0 and en1 are disabled/point to local network. 

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [Fixed] - Fixed incorrect IP detection for host machines having both en0 and en1 point to local addresses.

## Test Plan

Disable your wifi and en0 and connect network to en2 if you have it. Run the app from XCode on a device. Confirm that the app can detect IP address correctly by verifying ip.txt.
