### PR TITLE
Issue #28233 :: Ensure frame dimensions are numbers

### DIFF
--- a/Libraries/Inspector/ElementBox.js
+++ b/Libraries/Inspector/ElementBox.js
@@ -32,6 +32,12 @@ class ElementBox extends React.Component<$FlowFixMeProps> {
     };
 
     let frameStyle = {...this.props.frame};
+
+    let contentStyle = {
+      width: this.props.frame.width,
+      height: this.props.frame.height,
+    };
+
     if (isNaN(frameStyle.top)) {
       frameStyle.top = 0;
     }
@@ -40,13 +46,12 @@ class ElementBox extends React.Component<$FlowFixMeProps> {
     }
     if (isNaN(frameStyle.height)) {
       frameStyle.height = 0;
+      contentStyle.height = 0;
     }
     if (isNaN(frameStyle.width)) {
       frameStyle.width = 0;
+      contentStyle.width = 0;
     }
-
-    const contentStyle = {
-
 
     if (margin != null) {
       margin = resolveRelativeSizes(margin);

--- a/Libraries/Inspector/ElementBox.js
+++ b/Libraries/Inspector/ElementBox.js
@@ -31,6 +31,23 @@ class ElementBox extends React.Component<$FlowFixMeProps> {
       height: this.props.frame.height,
     };
 
+    let frameStyle = {...this.props.frame};
+    if (isNaN(frameStyle.top)) {
+      frameStyle.top = 0;
+    }
+    if (isNaN(frameStyle.left)) {
+      frameStyle.left = 0;
+    }
+    if (isNaN(frameStyle.height)) {
+      frameStyle.height = 0;
+    }
+    if (isNaN(frameStyle.width)) {
+      frameStyle.width = 0;
+    }
+
+    const contentStyle = {
+
+
     if (margin != null) {
       margin = resolveRelativeSizes(margin);
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

I experience the following issue : https://github.com/facebook/react-native/issues/28233

I understand that we should understand why these values are passed there, but it seems that it is other components that are passing wrong values, so in order to have a bullet proof component, one should ensure that even if wrong values are passed to a component, the component should not crash.

## Changelog

[Android] [fixed] - I only added verification to ensure that the frame values are numbers

## Test Plan

When Inspecting elements, the debugger crashed but with this fix the debugger stop crashing
