### PR TITLE
[Fix] `Android/Fetch`: Handle IOException when using fetch with HEAD method

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/blob/BlobModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/blob/BlobModule.java
@@ -136,7 +136,7 @@ public class BlobModule extends NativeBlobModuleSpec {
           try {
             data = response.body().bytes();
           } catch (IOException e) {
-            if (response.request().method().equalsIgnoreCase("HEAD")) {
+            if (response.request().method().equalsIgnoreCase("HEAD") || response.code() == 204) {
               // The request is an `HEAD` and the body is empty,
               // the OkHttp will produce an exception.
               // Ignore the exception to not invalidate the request in the

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.java
@@ -80,7 +80,7 @@ public final class NetworkingModule extends NativeNetworkingAndroidSpec {
     boolean supports(String responseType);
 
     /** Returns the JS body payload for the {@link ResponseBody}. */
-    WritableMap toResponseData(ResponseBody body) throws IOException;
+    WritableMap toResponseData(Response response) throws IOException;
   }
 
   public static final String NAME = "Networking";
@@ -509,7 +509,7 @@ public final class NetworkingModule extends NativeNetworkingAndroidSpec {
                   // Check if a handler is registered
                   for (ResponseHandler handler : mResponseHandlers) {
                     if (handler.supports(responseType)) {
-                      WritableMap res = handler.toResponseData(responseBody);
+                      WritableMap res = handler.toResponseData(response);
                       ResponseUtil.onDataReceived(eventEmitter, requestId, res);
                       ResponseUtil.onRequestSuccess(eventEmitter, requestId);
                       return;


### PR DESCRIPTION
## Summary

This pr fixes: #30055 .

Since fetch with HEAD method did not have body. 
We should handle the error from Okhttp when it consuming the empty body.


## Changelog

[Android] [Fixed] - HEAD requests with fetch should not be failed.

## Test Plan

Please initiated a new project and replaced the app with the following code:

```
import React, { useEffect } from 'react';
import { StyleSheet, Text, View } from 'react-native';

export default function App() {
  useEffect(() => {
    fetch('https://determined-panini-990054.netlify.app/demo-image.png', {
      method: 'HEAD',
    })
      .then(console.warn)
      .catch(console.error);
  }, []);
  return (
    <View style={styles.container}>
      <Text>Open up App.js to start working on your app!</Text>
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    backgroundColor: '#fff',
    alignItems: 'center',
    justifyContent: 'center',
  },
});
```
It should console warn the result instead of `Network request failed` .

Thanks you so much for your code review!
