### PR TITLE
feat: make AppContainer public

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@
 
 import typeof AccessibilityInfo from './Libraries/Components/AccessibilityInfo/AccessibilityInfo';
 import typeof ActivityIndicator from './Libraries/Components/ActivityIndicator/ActivityIndicator';
+import typeof AppContainer from './Libraries/ReactNative/AppContainer';
 import typeof Button from './Libraries/Components/Button';
 import typeof DatePickerIOS from './Libraries/Components/DatePicker/DatePickerIOS';
 import typeof DrawerLayoutAndroid from './Libraries/Components/DrawerAndroid/DrawerLayoutAndroid';
@@ -114,6 +115,9 @@ module.exports = {
   },
   get ActivityIndicator(): ActivityIndicator {
     return require('./Libraries/Components/ActivityIndicator/ActivityIndicator');
+  },
+  get AppContainer(): AppContainer {
+    return require('./Libraries/ReactNative/AppContainer');
   },
   get Button(): Button {
     return require('./Libraries/Components/Button');


### PR DESCRIPTION
`AppContainer` is used in react-native's `Modal` component to make the `LogBox` and `ElementInspector` components appear on top of them due to modal screens not being under `RCTRootView` in the native view hierarchy on iOS. It makes sense to make such an option available for other libraries. Another thing is that `react-native-modal` could be removed from the core. Having to import it directly from the file can also raise problems with `react-native-web` like this one: https://github.com/software-mansion/react-native-screens/issues/641.


## Summary

Export `AppContainer` component.

## Changelog

[Internal] [Added] - Added `AppContainer` as a public API.

## Test Plan
None
