### PR TITLE
Removed unused accessibility props from TextInput

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -1147,10 +1147,6 @@ function InternalTextInput(props: Props): React.Node {
         onPress={_onPress}
         onPressIn={props.onPressIn}
         onPressOut={props.onPressOut}
-        accessible={props.accessible}
-        accessibilityLabel={props.accessibilityLabel}
-        accessibilityRole={props.accessibilityRole}
-        accessibilityState={props.accessibilityState}
         nativeID={props.nativeID}
         testID={props.testID}
         {...additionalTouchableProps}>


### PR DESCRIPTION
## Summary

`TextInput` component does not support accessibility props. The underlying Native components for both iOS and Android does not support accessibility props. The unused props have been removed from the component.

https://github.com/facebook/react-native/issues/29981

## Changelog

[General] [Removed] - Removed unused, undocumented accessibility props from TextInput

## Test Plan

The `TextInput` component should work without any change in both iOS and Android
