### PR TITLE
Chore: Upgrade Detox to 16.7.2

### DIFF
--- a/packages/rn-tester/package.json
+++ b/packages/rn-tester/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "connect": "^3.6.5",
-    "detox": "15.4.4",
+    "detox": "16.7.2",
     "ws": "^6.1.4"
   }
 }

--- a/repo-config/package.json
+++ b/repo-config/package.json
@@ -18,7 +18,7 @@
     "clang-format": "^1.2.4",
     "connect": "^3.6.5",
     "coveralls": "^3.0.2",
-    "detox": "15.4.4",
+    "detox": "16.7.2",
     "eslint": "6.8.0",
     "eslint-config-fb-strict": "^24.9.0",
     "eslint-config-fbjs": "2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1729,10 +1729,10 @@ big-integer@^1.6.7:
   resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.36.tgz#78631076265d4ae3555c04f85e7d9d2f3a071a36"
   integrity sha512-t70bfa7HYEA1D9idDbmuv7YbsbVkQ+Hp+8KFSul4aE5e/i1bjCNIRYJZlA8Q8p0r9T8cF/RVvwUgRA//FydEyg==
 
-bluebird@3.5.x:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.2.tgz#1be0908e054a751754549c270489c1505d4ab15a"
-  integrity sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg==
+bluebird@^3.5.4:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
+  integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
 bplist-creator@0.0.7:
   version "0.0.7"
@@ -2407,16 +2407,17 @@ detect-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
-detox@15.4.4:
-  version "15.4.4"
-  resolved "https://registry.yarnpkg.com/detox/-/detox-15.4.4.tgz#0f56b0eb9dd81b65e9bd6b3a8730f323dd6cd897"
-  integrity sha512-mbsw/REE3yDuq+0fbPZSktfV5OVO/80LMHsistgKUcBEEM3BrwLkZsji8a7syJj9tiDo+SsUjEzXGhQwDLlitA==
+detox@16.7.2:
+  version "16.7.2"
+  resolved "https://registry.yarnpkg.com/detox/-/detox-16.7.2.tgz#531c98416adf52d4ba95601b669969acadafb970"
+  integrity sha512-+837eRgk4xOewXmeF5H6vOTn0RbKUFIyCi5UsTXEhvplsMk+KrrqfKik2j8fvubJkByry7HqIN/JF9jKe+meIQ==
   dependencies:
     "@babel/core" "^7.4.5"
     bunyan "^1.8.12"
     bunyan-debug-stream "^1.1.0"
     chalk "^2.4.2"
     child-process-promise "^2.2.0"
+    find-up "^4.1.0"
     fs-extra "^4.0.2"
     funpermaproxy "^1.0.1"
     get-port "^2.1.0"
@@ -2427,7 +2428,7 @@ detox@15.4.4:
     sanitize-filename "^1.6.1"
     shell-utils "^1.0.9"
     tail "^2.0.0"
-    telnet-client "0.15.3"
+    telnet-client "1.2.8"
     tempfile "^2.0.0"
     which "^1.3.1"
     ws "^3.3.1"
@@ -6821,12 +6822,12 @@ tar@^4:
     safe-buffer "^5.1.2"
     yallist "^3.0.2"
 
-telnet-client@0.15.3:
-  version "0.15.3"
-  resolved "https://registry.yarnpkg.com/telnet-client/-/telnet-client-0.15.3.tgz#99ec754e4acf6fa51dc69898f574df3c2550712e"
-  integrity sha512-GSfdzQV0BKIYsmeXq7bJFJ2wHeJud6icaIxCUf6QCGQUD6R0BBGbT1+yLDhq67JRdgRpwyPwUbV7JxFeRrZomQ==
+telnet-client@1.2.8:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/telnet-client/-/telnet-client-1.2.8.tgz#946c0dadc8daa3f19bb40a3e898cb870403a4ca4"
+  integrity sha512-W+w4k3QAmULVNhBVT2Fei369kGZCh/TH25M7caJAXW+hLxwoQRuw0di3cX4l0S9fgH3Mvq7u+IFMoBDpEw/eIg==
   dependencies:
-    bluebird "3.5.x"
+    bluebird "^3.5.4"
 
 temp-dir@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

With Xcode 12 being the latest, Detox 15.x has issues - in particular, it means that if you try to `yarn install` the dependencies for the repo, you'll be greeted by this error:

```bash
error /<stuff>/react-native/node_modules/detox: Command failed.
Exit code: 1
Command: node scripts/postinstall.js
Arguments:
Directory: /<stuff>/react-native/node_modules/detox
Output:
/<stuff>/Library/Detox/ios/5824c837515589f21c08f09b716a6eda088aa31f was found, but could not find Detox.framework inside it. This means that the Detox framework build process was interrupted.
         deleting /<stuff>/Library/Detox/ios/5824c837515589f21c08f09b716a6eda088aa31f and trying to rebuild.
Extracting Detox sources...
Building Detox.framework from /<stuff>/Developer/OSS/react-native/node_modules/detox/ios_src...
child_process.js:637
    throw err;
    ^
```

With the 👍 of @hramos & @alloy I've prep'd up a small defensive PR that can be quickly merged before cutting 0.64, that bumps the version of Detox from 15.4.4 to the highest version available within the reach of "no breaking changes" in changelog.

The main reason why with 16.x this error doesn't happen is that from [16.0.0](https://github.com/wix/Detox/releases/tag/16.0.0):

> Detox now comes as a prebuilt framework on iOS, thus lowering npm install times and saving some build issues that happen due to unexpected Xcode setups.

It would have been better to update directly to latest (at the time of writing 17.7.1) but there are at least two versions that had changelogs that seem to involve bigger changes:

* https://github.com/wix/Detox/releases/tag/17.4.7
* https://github.com/wix/Detox/releases/tag/16.8.0

Hopefully CI will will show that the bump doesn't break any test 🤞

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Internal] [Changed] - Bumped Detox in the repo to 16.7.2 for Xcode 12 compatibility

## Test Plan

Running yarn in the main repo with Node 14 & Xcode 12, without this change, will cause the error copy-pasted above. After upgrading to this version, the error disappear.
