### PR TITLE
Codegen: Use rimraf for 'clean' command

### DIFF
--- a/packages/react-native-codegen/package.json
+++ b/packages/react-native-codegen/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "build": "yarn clean && node scripts/build.js --verbose",
-    "clean": "rm -rf lib",
+    "clean": "rimraf lib",
     "prepublish": "yarn run build"
   },
   "license": "MIT",
@@ -36,6 +36,7 @@
     "glob": "^7.1.1",
     "micromatch": "^4.0.2",
     "mkdirp": "^0.5.1",
-    "prettier": "1.19.1"
+    "prettier": "1.19.1",
+    "rimraf": "^3.0.2"
   }
 }


### PR DESCRIPTION
## Summary

This pull request adds a minor tweak to Codegen's build process to use the command `rimraf` to clean the `lib` folder, rather than `rm -rf`. This improves support on Windows for cases where coreutils/unix commands aren't available.

## Changelog

[Internal] [Changed] - Codegen: Use rimraf for 'clean' command

## Test Plan

`yarn build` now successfully runs for `react-native-codegen` on Windows when `rm` is not available.