### PR TITLE
Publish Custom Flow Library Definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "!template/yarn.lock",
     "cli.js",
     "flow",
+    "flow-typed",
     "index.js",
     "interface.js",
     "jest-preset.js",


### PR DESCRIPTION
## Summary

react-native has moved more code to be flow-strict. Part of this move involved adding custom flow-typed definitions for some third-party dependencies where not previously present. These definitions are not currently published, which prevents type-checking some parts of react-native externally.

This change publishes these type definitions as part of the react-native NPM package. Impact to package size is pretty negligible.

## Changelog

[Internal] [Fixed] - Publish Custom Flow Library Definitions
