### PR TITLE
Fix Xiaomi TextInput crash: handling more manufacturers

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -48,6 +48,7 @@ import com.facebook.react.views.text.TextAttributes;
 import com.facebook.react.views.text.TextInlineImageSpan;
 import com.facebook.react.views.view.ReactViewBackgroundManager;
 import java.util.ArrayList;
+import java.util.Arrays;
 
 /**
  * A wrapper around the EditText that lets us better control what happens when an EditText gets

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -400,7 +400,7 @@ public class ReactEditText extends AppCompatEditText {
       "M2004J19C",
       "M2007J20CG",
       "Mi",
-      "Mi",
+      "MI",
       "MIX",
       "POCO",
       "POCOPHONE",

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -393,9 +393,24 @@ public class ReactEditText extends AppCompatEditText {
     // ScrollView, a prompt will be triggered but the system fail to locate it properly.
     // Here is an example post discussing about this issue:
     // https://github.com/facebook/react-native/issues/27204
+    String[] xiaomiManufacturers = new String[]{
+      "M2002J9G",
+      "M2002J9G",
+      "M2004J19C",
+      "M2007J20CG",
+      "Mi",
+      "Mi",
+      "MIX",
+      "POCO",
+      "POCOPHONE",
+      "Redmi",
+      "Xiaomi"
+    };
+    boolean isXiaomi = Arrays.asList(xiaomiManufacturers).contains(Build.MANUFACTURER);
+    
     if (inputType == InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS
         && Build.VERSION.SDK_INT == Build.VERSION_CODES.Q
-        && Build.MANUFACTURER.startsWith("Xiaomi")) {
+        && isXiaomi) {
       inputType = InputType.TYPE_CLASS_TEXT;
     }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

v0.63.3 fixed a crash happening with text inputs on Xiaomi phones (https://github.com/facebook/react-native/issues/27204) with this commit https://github.com/facebook/react-native/commit/07a597ad185c8c31ac38bdd4d022b0b880d02859

However this fix is limited to some devices as it only handles devices who have "Xiaomi" as a brand name, and Xiaomi has many more brands (Pocophone, Redmi etc.).

Here I added the list of known manufacturers that have this issue, from my app's monitoring tool but it's probably incomplete.

Maybe there's a more direct way by checking which OS is running (MiUI) ...

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Fixed] - Handle more Xiaomi devices to avoid a crash with `TextInput` when `keyboardType` prop is `"email-address"`

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
