### PR TITLE
add asdf-vm support in react-native-xcode.sh

### DIFF
--- a/scripts/find-node.sh
+++ b/scripts/find-node.sh
@@ -37,3 +37,10 @@ if [[ ! -x node && -d ${HOME}/.anyenv/bin ]]; then
     eval "$(anyenv init -)"
   fi
 fi
+
+# Set up asdf-vm if present
+if [[ -f "$HOME/.asdf/asdf.sh" ]]; then
+  . "$HOME/.asdf/asdf.sh"
+elif [[ -x "$(command -v brew)" && -f "$(brew --prefix asdf)/asdf.sh" ]]; then
+  . "$(brew --prefix asdf)/asdf.sh"
+fi


### PR DESCRIPTION
About asdf-vm: https://asdf-vm.com/

## Summary

This PR add [asdf-vm](https://asdf-vm.com/) support to `find-node.sh` for `scripts/react-native-xcode.sh` in `Bundle React Native code and images` build phrase and potentially other scripts using `find-node.sh` to get executable nodejs

## Changelog

[iOS] [Added] - add asdf-vm support in find-node.sh

## Test Plan

Xcode is able to complete `Bundle React Native code and images` build phrase without errors when node is installed by asdf-vm