### PR TITLE
add iOS support for progressViewOffset on RefreshControl

### DIFF
--- a/Libraries/Components/RefreshControl/RefreshControl.js
+++ b/Libraries/Components/RefreshControl/RefreshControl.js
@@ -69,10 +69,6 @@ type AndroidProps = $ReadOnly<{|
     | typeof RefreshLayoutConsts.SIZE.DEFAULT
     | typeof RefreshLayoutConsts.SIZE.LARGE
   ),
-  /**
-   * Progress view top offset
-   */
-  progressViewOffset?: ?number,
 |}>;
 
 export type RefreshControlProps = $ReadOnly<{|
@@ -89,6 +85,11 @@ export type RefreshControlProps = $ReadOnly<{|
    * Whether the view should be indicating an active refresh.
    */
   refreshing: boolean,
+
+  /**
+   * Progress view top offset
+   */
+  progressViewOffset?: ?number,
 |}>;
 
 /**
@@ -181,7 +182,6 @@ class RefreshControl extends React.Component<RefreshControlProps> {
         colors,
         progressBackgroundColor,
         size,
-        progressViewOffset,
         ...props
       } = this.props;
       return (

--- a/React/Views/RefreshControl/RCTRefreshControl.m
+++ b/React/Views/RefreshControl/RCTRefreshControl.m
@@ -21,6 +21,7 @@
   BOOL _refreshingProgrammatically;
   NSString *_title;
   UIColor *_titleColor;
+  float _progressViewOffset;
 }
 
 - (instancetype)init
@@ -47,6 +48,8 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)aDecoder)
     [self beginRefreshingProgrammatically];
   }
   _isInitialRender = false;
+
+  self.frame = CGRectOffset(self.frame, 0, _progressViewOffset);
 }
 
 - (void)beginRefreshingProgrammatically
@@ -158,6 +161,11 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)aDecoder)
 {
   _currentRefreshingState = refreshing;
   _currentRefreshingStateTimestamp = _currentRefreshingStateClock++;
+}
+
+- (void)setProgressViewOffset:(float)offset
+{
+	_progressViewOffset = offset / UIScreen.mainScreen.scale;
 }
 
 - (void)refreshControlValueChanged

--- a/React/Views/RefreshControl/RCTRefreshControlManager.m
+++ b/React/Views/RefreshControl/RCTRefreshControlManager.m
@@ -25,6 +25,7 @@ RCT_EXPORT_VIEW_PROPERTY(refreshing, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(tintColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(title, NSString)
 RCT_EXPORT_VIEW_PROPERTY(titleColor, UIColor)
+RCT_EXPORT_VIEW_PROPERTY(progressViewOffset, float)
 
 RCT_EXPORT_METHOD(setNativeRefreshing : (nonnull NSNumber *)viewTag toRefreshing : (BOOL)refreshing)
 {


### PR DESCRIPTION
## Summary

fix #10718

Add `progressViewOffset` support to `RefreshControl` in iOS for better feature parity with Android.

## Changelog

[iOS] [Fix] - Add `progressViewOffset` support to `RefreshControl` in iOS for better feature parity with Android.

## Test Plan

Tested locally
