### PR TITLE
fix ReadableArray annotations

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableArray.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableArray.java
@@ -8,7 +8,6 @@
 package com.facebook.react.bridge;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import java.util.ArrayList;
 
 /**
@@ -27,13 +26,13 @@ public interface ReadableArray {
 
   int getInt(int index);
 
-  @Nullable
+  @NonNull
   String getString(int index);
 
-  @Nullable
+  @NonNull
   ReadableArray getArray(int index);
 
-  @Nullable
+  @NonNull
   ReadableMap getMap(int index);
 
   @NonNull

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableNativeArray.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableNativeArray.java
@@ -98,17 +98,17 @@ public class ReadableNativeArray extends NativeArray implements ReadableArray {
   }
 
   @Override
-  public @Nullable String getString(int index) {
+  public @NonNull String getString(int index) {
     return (String) getLocalArray()[index];
   }
 
   @Override
-  public @Nullable ReadableNativeArray getArray(int index) {
+  public @NonNull ReadableNativeArray getArray(int index) {
     return (ReadableNativeArray) getLocalArray()[index];
   }
 
   @Override
-  public @Nullable ReadableNativeMap getMap(int index) {
+  public @NonNull ReadableNativeMap getMap(int index) {
     return (ReadableNativeMap) getLocalArray()[index];
   }
 


### PR DESCRIPTION
## Summary

Fix ReadableArray annotations, because these methods throw ArrayIndexOutOfBoundsException instead of null if index is not found.

## Changelog

[Android] [Changed] - fix ReadableArray null annotations. Possibly breaking change for Kotlin apps.

## Test Plan

RNTester app builds and runs as expected, and show correct type in when used with Kotlin code.