### PR TITLE
Fix statusbar style in RNTester on iOS

### DIFF
--- a/packages/rn-tester/RNTester/Info.plist
+++ b/packages/rn-tester/RNTester/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>UIStatusBarStyle</key>
-	<string>UIStatusBarStyleBlackTranslucent</string>
+	<string>UIStatusBarStyleDefault</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>


### PR DESCRIPTION
## Summary

Status bar is not visible currently because it is white on a white bg.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Internal] [Fixed] - Fix statusbar style in RNTester on iOS

## Test Plan

Before

<img width="436" alt="image" src="https://user-images.githubusercontent.com/2677334/95375393-8fceef00-08ad-11eb-8051-a615ba396c56.png">

After

<img width="429" alt="image" src="https://user-images.githubusercontent.com/2677334/95375292-6c0ba900-08ad-11eb-8171-3e620f07a14b.png">

