### PR TITLE
Avoid Repo Structure Assumptions in RNTester Imports

### DIFF
--- a/packages/rn-tester/NativeModuleExample/NativeScreenshotManager.js
+++ b/packages/rn-tester/NativeModuleExample/NativeScreenshotManager.js
@@ -10,8 +10,8 @@
 
 'use strict';
 
-import type {TurboModule} from '../../../Libraries/TurboModule/RCTExport';
-import * as TurboModuleRegistry from '../../../Libraries/TurboModule/TurboModuleRegistry';
+import type {TurboModule} from 'react-native/Libraries/TurboModule/RCTExport';
+import * as TurboModuleRegistry from 'react-native/Libraries/TurboModule/TurboModuleRegistry';
 
 export interface Spec extends TurboModule {
   +getConstants: () => {||};

--- a/packages/rn-tester/RCTTest/RCTSnapshotNativeComponent.js
+++ b/packages/rn-tester/RCTTest/RCTSnapshotNativeComponent.js
@@ -12,9 +12,9 @@
 
 const {requireNativeComponent} = require('react-native');
 
-import type {HostComponent} from '../../../Libraries/Renderer/shims/ReactNativeTypes';
-import type {SyntheticEvent} from '../../../Libraries/Types/CoreEventTypes';
-import type {ViewProps} from '../../../Libraries/Components/View/ViewPropTypes';
+import type {HostComponent} from 'react-native/Libraries/Renderer/shims/ReactNativeTypes';
+import type {SyntheticEvent} from 'react-native/Libraries/Types/CoreEventTypes';
+import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
 
 type SnapshotReadyEvent = SyntheticEvent<
   $ReadOnly<{testIdentifier: string, ...}>,

--- a/packages/rn-tester/js/components/RNTesterButton.js
+++ b/packages/rn-tester/js/components/RNTesterButton.js
@@ -14,7 +14,7 @@ const React = require('react');
 
 const {StyleSheet, Text, TouchableHighlight} = require('react-native');
 
-import type {PressEvent} from '../../../../Libraries/Types/CoreEventTypes';
+import type {PressEvent} from 'react-native/Libraries/Types/CoreEventTypes';
 
 type Props = $ReadOnly<{|
   children?: React.Node,

--- a/packages/rn-tester/js/examples/Appearance/AppearanceExample.js
+++ b/packages/rn-tester/js/examples/Appearance/AppearanceExample.js
@@ -12,7 +12,7 @@
 
 import * as React from 'react';
 import {Appearance, Text, useColorScheme, View} from 'react-native';
-import type {AppearancePreferences} from '../../../../../Libraries/Utilities/NativeAppearance';
+import type {AppearancePreferences} from 'react-native/Libraries/Utilities/NativeAppearance';
 import {RNTesterThemeContext, themes} from '../../components/RNTesterTheme';
 
 class ColorSchemeSubscription extends React.Component<

--- a/packages/rn-tester/js/examples/FlatList/FlatListExample.js
+++ b/packages/rn-tester/js/examples/FlatList/FlatListExample.js
@@ -13,7 +13,7 @@
 const RNTesterPage = require('../../components/RNTesterPage');
 const React = require('react');
 
-const infoLog = require('../../../../../Libraries/Utilities/infoLog');
+const infoLog = require('react-native/Libraries/Utilities/infoLog');
 
 const {
   FooterComponent,

--- a/packages/rn-tester/js/examples/Image/ImageCapInsetsExample.js
+++ b/packages/rn-tester/js/examples/Image/ImageCapInsetsExample.js
@@ -13,7 +13,7 @@
 const React = require('react');
 const ReactNative = require('react-native');
 
-const nativeImageSource = require('../../../../../Libraries/Image/nativeImageSource');
+const nativeImageSource = require('react-native/Libraries/Image/nativeImageSource');
 const {Image, StyleSheet, Text, View} = ReactNative;
 
 type Props = $ReadOnly<{||}>;

--- a/packages/rn-tester/js/examples/Layout/LayoutEventsExample.js
+++ b/packages/rn-tester/js/examples/Layout/LayoutEventsExample.js
@@ -23,7 +23,7 @@ const {
 import type {
   ViewLayout,
   ViewLayoutEvent,
-} from '../../../../../Libraries/Components/View/ViewPropTypes';
+} from 'react-native/Libraries/Components/View/ViewPropTypes';
 
 type Props = $ReadOnly<{||}>;
 type State = {

--- a/packages/rn-tester/js/examples/MultiColumn/MultiColumnExample.js
+++ b/packages/rn-tester/js/examples/MultiColumn/MultiColumnExample.js
@@ -12,7 +12,7 @@
 const RNTesterPage = require('../../components/RNTesterPage');
 const React = require('react');
 
-const infoLog = require('../../../../../Libraries/Utilities/infoLog');
+const infoLog = require('react-native/Libraries/Utilities/infoLog');
 
 const {
   FooterComponent,

--- a/packages/rn-tester/js/examples/NativeAnimation/NativeAnimationsExample.js
+++ b/packages/rn-tester/js/examples/NativeAnimation/NativeAnimationsExample.js
@@ -195,13 +195,13 @@ class InternalSettings extends React.Component<
           initialValue={false}
           label="Track JS Stalls"
           onEnable={() => {
-            require('../../../../../Libraries/Interaction/JSEventLoopWatchdog').install(
+            require('react-native/Libraries/Interaction/JSEventLoopWatchdog').install(
               {
                 thresholdMS: 25,
               },
             );
             this.setState({busyTime: '<none>'});
-            require('../../../../../Libraries/Interaction/JSEventLoopWatchdog').addHandler(
+            require('react-native/Libraries/Interaction/JSEventLoopWatchdog').addHandler(
               {
                 onStall: ({busyTime}) =>
                   this.setState(state => ({

--- a/packages/rn-tester/js/examples/NewAppScreen/NewAppScreenExample.js
+++ b/packages/rn-tester/js/examples/NewAppScreen/NewAppScreenExample.js
@@ -18,7 +18,7 @@ const {
   Colors,
   DebugInstructions,
   ReloadInstructions,
-} = require('../../../../../Libraries/NewAppScreen');
+} = require('react-native/Libraries/NewAppScreen');
 
 exports.title = 'New App Screen';
 exports.description = 'Displays the content of the new app screen';

--- a/packages/rn-tester/js/examples/OrientationChange/OrientationChangeExample.js
+++ b/packages/rn-tester/js/examples/OrientationChange/OrientationChangeExample.js
@@ -14,7 +14,7 @@ const React = require('react');
 
 const {DeviceEventEmitter, Text, View} = require('react-native');
 
-import {type EventSubscription} from '../../../../../Libraries/vendor/emitter/EventEmitter';
+import {type EventSubscription} from 'react-native/Libraries/vendor/emitter/EventEmitter';
 
 class OrientationChangeExample extends React.Component<{...}, $FlowFixMeState> {
   _orientationSubscription: EventSubscription;

--- a/packages/rn-tester/js/examples/PanResponder/PanResponderExample.js
+++ b/packages/rn-tester/js/examples/PanResponder/PanResponderExample.js
@@ -17,8 +17,8 @@ const RNTesterPage = require('../../components/RNTesterPage');
 import type {
   PanResponderInstance,
   GestureState,
-} from '../../../../../Libraries/Interaction/PanResponder';
-import type {PressEvent} from '../../../../../Libraries/Types/CoreEventTypes';
+} from 'react-native/Libraries/Interaction/PanResponder';
+import type {PressEvent} from 'react-native/Libraries/Types/CoreEventTypes';
 
 type CircleStyles = {
   backgroundColor?: string,

--- a/packages/rn-tester/js/examples/PlatformColor/PlatformColorExample.js
+++ b/packages/rn-tester/js/examples/PlatformColor/PlatformColorExample.js
@@ -12,7 +12,7 @@
 
 const React = require('react');
 const ReactNative = require('react-native');
-import Platform from '../../../../../Libraries/Utilities/Platform';
+import Platform from 'react-native/Libraries/Utilities/Platform';
 const {DynamicColorIOS, PlatformColor, StyleSheet, Text, View} = ReactNative;
 
 function PlatformColorsExample() {

--- a/packages/rn-tester/js/examples/ScrollView/ScrollViewExample.js
+++ b/packages/rn-tester/js/examples/ScrollView/ScrollViewExample.js
@@ -23,7 +23,7 @@ const {
 
 const nullthrows = require('nullthrows');
 
-import type {ViewStyleProp} from '../../../../../Libraries/StyleSheet/StyleSheet';
+import type {ViewStyleProp} from 'react-native/Libraries/StyleSheet/StyleSheet';
 
 exports.displayName = 'ScrollViewExample';
 exports.title = 'ScrollView';

--- a/packages/rn-tester/js/examples/SectionList/SectionListExample.js
+++ b/packages/rn-tester/js/examples/SectionList/SectionListExample.js
@@ -12,7 +12,7 @@
 const RNTesterPage = require('../../components/RNTesterPage');
 const React = require('react');
 
-const infoLog = require('../../../../../Libraries/Utilities/infoLog');
+const infoLog = require('react-native/Libraries/Utilities/infoLog');
 
 const {
   HeaderComponent,

--- a/packages/rn-tester/js/examples/Snapshot/SnapshotViewIOS.android.js
+++ b/packages/rn-tester/js/examples/Snapshot/SnapshotViewIOS.android.js
@@ -9,4 +9,4 @@
 
 'use strict';
 
-module.exports = require('../../../../../Libraries/Components/UnimplementedViews/UnimplementedView');
+module.exports = require('react-native/Libraries/Components/UnimplementedViews/UnimplementedView');

--- a/packages/rn-tester/js/examples/Snapshot/SnapshotViewIOS.ios.js
+++ b/packages/rn-tester/js/examples/Snapshot/SnapshotViewIOS.ios.js
@@ -16,8 +16,8 @@ const {NativeModules, StyleSheet, UIManager, View} = require('react-native');
 
 const {TestModule} = NativeModules;
 
-import type {SyntheticEvent} from '../../../../../Libraries/Types/CoreEventTypes';
-import type {ViewProps} from '../../../../../Libraries/Components/View/ViewPropTypes';
+import type {SyntheticEvent} from 'react-native/Libraries/Types/CoreEventTypes';
+import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
 
 // Verify that RCTSnapshot is part of the UIManager since it is only loaded
 // if you have linked against RCTTest like in tests, otherwise we will have

--- a/packages/rn-tester/js/examples/Text/TextExample.ios.js
+++ b/packages/rn-tester/js/examples/Text/TextExample.ios.js
@@ -11,7 +11,7 @@
 'use strict';
 
 const React = require('react');
-const TextAncestor = require('../../../../../Libraries/Text/TextAncestor');
+const TextAncestor = require('react-native/Libraries/Text/TextAncestor');
 const TextInlineView = require('../../components/TextInlineView');
 const TextLegend = require('../../components/TextLegend');
 

--- a/packages/rn-tester/js/examples/TurboModule/SampleTurboModuleExample.js
+++ b/packages/rn-tester/js/examples/TurboModule/SampleTurboModuleExample.js
@@ -10,8 +10,8 @@
 
 'use strict';
 
-import NativeSampleTurboModule from '../../../../../Libraries/TurboModule/samples/NativeSampleTurboModule';
-import type {RootTag} from '../../../../../Libraries/ReactNative/RootTag';
+import NativeSampleTurboModule from 'react-native/Libraries/TurboModule/samples/NativeSampleTurboModule';
+import type {RootTag} from 'react-native/Libraries/ReactNative/RootTag';
 import {
   StyleSheet,
   Text,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

RNTester has some imports left over that operate on directory traversal, assuming it is contained within react-native sources. This change makes these imports relative to react-native, enabling usage outside of the RN repo.

Relates to https://github.com/microsoft/react-native-windows/issues/6210

## Changelog

[Internal] [Fixed] - Avoid File Structure Assumptions in RNTester Imports

## Test Plan

Validated we can bundle and flow-check both iOS + Android

