### PR TITLE
Use default for hermes es6 proxy enabled

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/hermes/reactexecutor/HermesExecutor.java
+++ b/ReactAndroid/src/main/java/com/facebook/hermes/reactexecutor/HermesExecutor.java
@@ -31,7 +31,7 @@ public class HermesExecutor extends JavaScriptExecutor {
     super(
         config == null
             ? initHybridDefaultConfig()
-            : initHybrid(config.heapSizeMB, config.es6Proxy));
+            : initHybrid(config.heapSizeMB));
   }
 
   @Override
@@ -50,5 +50,5 @@ public class HermesExecutor extends JavaScriptExecutor {
 
   private static native HybridData initHybridDefaultConfig();
 
-  private static native HybridData initHybrid(long heapSizeMB, boolean es6Proxy);
+  private static native HybridData initHybrid(long heapSizeMB);
 }

--- a/ReactAndroid/src/main/java/com/facebook/hermes/reactexecutor/OnLoad.cpp
+++ b/ReactAndroid/src/main/java/com/facebook/hermes/reactexecutor/OnLoad.cpp
@@ -22,8 +22,7 @@ namespace facebook {
 namespace react {
 
 static ::hermes::vm::RuntimeConfig makeRuntimeConfig(
-    jlong heapSizeMB,
-    bool es6Proxy) {
+    jlong heapSizeMB) {
   namespace vm = ::hermes::vm;
   auto gcConfigBuilder =
       vm::GCConfig::Builder()
@@ -40,7 +39,6 @@ static ::hermes::vm::RuntimeConfig makeRuntimeConfig(
 
   return vm::RuntimeConfig::Builder()
       .withGCConfig(gcConfigBuilder.build())
-      .withES6Proxy(es6Proxy)
       .build();
 }
 
@@ -70,9 +68,9 @@ class HermesExecutorHolder
   }
 
   static jni::local_ref<jhybriddata>
-  initHybrid(jni::alias_ref<jclass>, jlong heapSizeMB, bool es6Proxy) {
+  initHybrid(jni::alias_ref<jclass>, jlong heapSizeMB) {
     JReactMarker::setLogPerfMarkerIfNeeded();
-    auto runtimeConfig = makeRuntimeConfig(heapSizeMB, es6Proxy);
+    auto runtimeConfig = makeRuntimeConfig(heapSizeMB);
     return makeCxxInstance(std::make_unique<HermesExecutorFactory>(
         installBindings, JSIExecutor::defaultTimeoutInvoker, runtimeConfig));
   }

--- a/ReactAndroid/src/main/java/com/facebook/hermes/reactexecutor/RuntimeConfig.java
+++ b/ReactAndroid/src/main/java/com/facebook/hermes/reactexecutor/RuntimeConfig.java
@@ -10,7 +10,6 @@ package com.facebook.hermes.reactexecutor;
 /** Holds runtime configuration for a Hermes VM instance (master or snapshot). */
 public final class RuntimeConfig {
   public long heapSizeMB;
-  public boolean es6Proxy;
 
   RuntimeConfig() {}
 


### PR DESCRIPTION
## Summary

Proxy is now enabled by default in hermes 0.7 (https://github.com/facebook/hermes/releases/tag/v0.7.0). However we currently disable it because of the config we pass.

This removes the config so proxy is now enabled.

## Changelog

[Android] [Changed] - Use default for hermes es6 proxy enabled

## Test Plan

Tested that proxy is now enabled (typeof Proxy !== 'undefined') with hermes 0.7.