### PR TITLE
Flow: fix few issues in integration test files, remove few suppressions

### DIFF
--- a/IntegrationTests/AsyncStorageTest.js
+++ b/IntegrationTests/AsyncStorageTest.js
@@ -196,10 +196,7 @@ class AsyncStorageTest extends React.Component<{...}, $FlowFixMeState> {
     return (
       <View style={styles.container}>
         <Text>
-          {/* $FlowFixMe(>=0.54.0 site=react_native_fb,react_native_oss) This
-           * comment suppresses an error found when Flow v0.54 was deployed.
-           * To see the error delete this comment and run Flow. */
-          this.constructor.displayName + ': '}
+          {this.constructor.displayName || 'unknown' + ': '}
           {this.state.done ? 'Done' : 'Testing...'}
           {'\n\n' + this.state.messages}
         </Text>

--- a/IntegrationTests/IntegrationTestHarnessTest.js
+++ b/IntegrationTests/IntegrationTestHarnessTest.js
@@ -56,10 +56,7 @@ class IntegrationTestHarnessTest extends React.Component<Props, State> {
     return (
       <View style={styles.container}>
         <Text>
-          {/* $FlowFixMe(>=0.54.0 site=react_native_fb,react_native_oss) This
-           * comment suppresses an error found when Flow v0.54 was deployed.
-           * To see the error delete this comment and run Flow. */
-          this.constructor.displayName + ': '}
+          {this.constructor.displayName || 'unknown' + ': '}
           {this.state.done ? 'Done' : 'Testing...'}
         </Text>
       </View>

--- a/IntegrationTests/IntegrationTestsApp.js
+++ b/IntegrationTests/IntegrationTestsApp.js
@@ -39,11 +39,8 @@ const TESTS = [
   require('./GlobalEvalWithSourceUrlTest'),
 ];
 
-TESTS.forEach(
-  /* $FlowFixMe(>=0.54.0 site=react_native_fb,react_native_oss) This comment
-   * suppresses an error found when Flow v0.54 was deployed. To see the error
-   * delete this comment and run Flow. */
-  test => AppRegistry.registerComponent(test.displayName, () => test),
+TESTS.forEach(test =>
+  AppRegistry.registerComponent(test.displayName || 'unknown', () => test),
 );
 
 // Modules required for integration tests
@@ -58,12 +55,10 @@ class IntegrationTestsApp extends React.Component<{...}, $FlowFixMeState> {
 
   render() {
     if (this.state.test) {
+      const TestComponent = this.state.test;
       return (
         <ScrollView>
-          {/* $FlowFixMe(>=0.53.0 site=react_native_fb,react_native_oss) This
-           * comment suppresses an error when upgrading Flow's support for
-           * React. To see the error delete this comment and run Flow. */}
-          <this.state.test />
+          <TestComponent />
         </ScrollView>
       );
     }

--- a/Libraries/WebSocket/WebSocket.js
+++ b/Libraries/WebSocket/WebSocket.js
@@ -92,9 +92,6 @@ class WebSocket extends (EventTarget(...WEBSOCKET_EVENTS): any) {
     const {headers = {}, ...unrecognized} = options || {};
 
     // Preserve deprecated backwards compatibility for the 'origin' option
-    /* $FlowFixMe(>=0.68.0 site=react_native_fb) This comment suppresses an
-     * error found when Flow v0.68 was deployed. To see the error delete this
-     * comment and run Flow. */
     if (unrecognized && typeof unrecognized.origin === 'string') {
       console.warn(
         'Specifying `origin` as a WebSocket connection option is deprecated. Include it under `headers` instead.',

--- a/jest/renderer.js
+++ b/jest/renderer.js
@@ -16,9 +16,6 @@ const React = require('react');
 const ShallowRenderer = require('react-shallow-renderer');
 const TestRenderer = require('react-test-renderer');
 
-/* $FlowFixMe(>=0.125.1 site=react_native_fb) This comment suppresses an error
- * found when Flow v0.125.1 was deployed. To see the error, delete this comment
- * and run Flow. */
 const renderer = new ShallowRenderer();
 
 export const shallow = (Component: React.Element<any>): any => {


### PR DESCRIPTION
## Summary

This PR resolves few Flow issues suppressed in the integration test files. 

`displayName` is marked as nullable property so the fallback is required to make the Flow checker happy. The similar fallback is already present in jest mock:
* https://github.com/facebook/react-native/blob/master/jest/mockComponent.js#L23

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Fixed] - Flow: fix few issues in integration test files

## Test Plan

Successful run of:
* `yarn flow`
* `yarn flow-check-ios`
* `yarn flow-check-android`
