### PR TITLE
Make sure js bundle still exists at bundle-output path

### DIFF
--- a/scripts/react-native-xcode.sh
+++ b/scripts/react-native-xcode.sh
@@ -168,7 +168,7 @@ fi
   $EXTRA_PACKAGER_ARGS
 
 if [[ $USE_HERMES != true ]]; then
-  mv "$BUNDLE_FILE" "$DEST/"
+  cp "$BUNDLE_FILE" "$DEST/"
   BUNDLE_FILE="$DEST/main.jsbundle"
 else
   EXTRA_COMPILER_ARGS=


### PR DESCRIPTION
## Summary

Since changes to support hermes on iOS the js bundled is moved away from the location where it is generated when calling metro. This causes issues with the RN sentry integration since it relies on intercepting this path to find the bundle file after running react-native-xcode.sh. Seems kind of like a hacky way to get the bundle location, but let's avoid breaking it.

https://github.com/getsentry/sentry-cli/blob/master/src/commands/react_native_xcode.rs

## Changelog

[iOS] [Fixed] - Make sure js bundle still exists at bundle-output path

## Test Plan

Checked that the bundle file exists both at bundle-output path and in the .app.
Checked that the sentry release script works.
