### PR TITLE
Lint: fix few "no-unused-var" warnings for imports

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -8,5 +8,3 @@ Libraries/vendor/**/*
 node_modules/
 packages/*/node_modules
 packages/react-native-codegen/lib
-pr-inactivity-bookmarklet.js
-question-bookmarklet.js

--- a/Libraries/Animated/createAnimatedComponent.js
+++ b/Libraries/Animated/createAnimatedComponent.js
@@ -11,7 +11,6 @@
 'use strict';
 
 const View = require('../Components/View/View');
-const Platform = require('../Utilities/Platform');
 const {AnimatedEvent} = require('./AnimatedEvent');
 const AnimatedProps = require('./nodes/AnimatedProps');
 const React = require('react');

--- a/Libraries/Components/Touchable/Touchable.js
+++ b/Libraries/Components/Touchable/Touchable.js
@@ -14,7 +14,6 @@ const BoundingDimensions = require('./BoundingDimensions');
 const Platform = require('../../Utilities/Platform');
 const Position = require('./Position');
 const React = require('react');
-const ReactNative = require('../../Renderer/shims/ReactNative');
 const StyleSheet = require('../../StyleSheet/StyleSheet');
 const UIManager = require('../../ReactNative/UIManager');
 const View = require('../View/View');

--- a/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+++ b/Libraries/Components/Touchable/TouchableWithoutFeedback.js
@@ -28,7 +28,6 @@ import type {
   LayoutEvent,
   PressEvent,
 } from '../../Types/CoreEventTypes';
-import Platform from '../../Utilities/Platform';
 import View from '../../Components/View/View';
 import * as React from 'react';
 


### PR DESCRIPTION
## Summary

This small PR fixes few "no-unused-var" issues and  and removes two old entries for no longer existing files from the `.eslintignore`.

## Changelog

[Internal] [Fixed] - Lint: fix few "no-unused-var" warnings for imports

## Test Plan

Successfully run of `yarn lint` script. Warnings count has been reduced from `61` to `58`.
