### PR TITLE
[Fix] `Android`: font-family is not apply when secureTextEntry is true

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -418,11 +418,10 @@ public class ReactEditText extends AppCompatEditText
   @Override
   public void setInputType(int type) {
     Typeface tf = super.getTypeface();
-    // Input type password defaults to monospace font, so we need to re-apply the font
-    super.setTypeface(tf);
-
     super.setInputType(type);
     mStagedInputType = type;
+    // Input type password defaults to monospace font, so we need to re-apply the font
+    super.setTypeface(tf);
 
     /**
      * If set forces multiline on input, because of a restriction on Android source that enables


### PR DESCRIPTION
## Summary

This pr fixes: #30123 .

When secureTextEntry is true, setInputType will set the inputType of textInput to password type.
Password type default font-family will be monospace font, so we need to setTypeface after the setInputType.

## Changelog

[Android] [Fixed] - Font family is not apply when secureTextEntry is true.

## Test Plan
Before this pr:
![alt text](https://i.imgur.com/mAxLhnB.png)

After this pr:
![alt text](https://i.imgur.com/zoGYDxN.png)


Please initiated a new project and replaced the App.js with the following code:
```
iimport React from 'react';
import {SafeAreaView, TextInput} from 'react-native';

const App = () => {
  return (
    <SafeAreaView>
      <TextInput
        id={'email'}
        placeholder={'Email'}
        secureTextEntry={false}
        style={{fontFamily: 'Helvetica', fontSize: 14, fontWeight: '400'}}
      />

      <TextInput
        id={'password'}
        placeholder={'Password'}
        secureTextEntry={true}
        style={{fontFamily: 'Helvetica', fontSize: 14, fontWeight: '400'}}
      />
    </SafeAreaView>
  );
};

export default App;
```

Thanks you so much for your code review!
