### PR TITLE
Fix App Bundle/Release build missing index.android.bundle with  gradle plugin 4.1.0+/gradle 6.5

### DIFF
--- a/react.gradle
+++ b/react.gradle
@@ -302,6 +302,11 @@ afterEvaluate {
             enabled(currentBundleTask.enabled)
         }
 
+        // mergeResources task runs before the bundle file is copied to the intermediate asset directory from Android plugin 4.1+.
+        // This ensures to copy the bundle file before mergeResources task starts
+        def mergeResourcesTask = tasks.findByName("merge${targetName}Resources")
+        mergeResourcesTask.dependsOn(currentAssetsCopyTask)
+
         packageTask.dependsOn(currentAssetsCopyTask)
         if (buildPreBundleTask != null) {
             buildPreBundleTask.dependsOn(currentAssetsCopyTask)


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

- This fix resolves https://github.com/facebook/react-native/issues/29398
- After updating gradle to 6.5+ and android gradle plugin to 4.1.0+(which is recommended in the latest Android Studio 4.1), Running `:app:assembleRelease` or `:app:bundleRelease` will not contain `index.android.bundle` in Apk/AAB. It will be included when the command executed twice.
<img width="949" alt="Screen Shot 2020-10-17 at 11 32 43 PM" src="https://user-images.githubusercontent.com/6277118/96360808-38165c00-10d5-11eb-8b6e-f098517a24c7.png">

- This is caused by the task ordering update introduced in gradle plugin 4.1.0+/gradle 6.5. `mergeResources` task runs before `currentAssetsCopyTask`(copying the bundle asset file to intermediate output directory) which causes generated Apk/AAB not including the bundle file.
- The fix ensures mergeResources task runs after currentAssetsCopyTask


## Changelog

[Android] [Fixed] - Fix App Bundle/Release build missing index.android.bundle with gradle plugin 4.1.0/gradle 6.5

## Test Plan
- Reproducible repository https://github.com/tomoima525/android_build_test_rn 
  -  This project is generated with `create-react-native-app` and updated Gradle version to 6.5 and com.android.tools.build:gradle plugin to 4.1
- Run `./gradlew clean :app:assembleRelease` and `./gradlew clean :app:bundleRelease` => reproduces the issue
- After adding the fix above and run `./gradlew clean :app:assembleRelease` and `./gradlew clean :app:bundleRelease` => The issue is resolved

- Also confirmed the build works properly with android gradle plugin `3.5.3` and `gradle 6.2`(the default value of `create-react-native-app`)
