### PR TITLE
Remove filter pills from example page

### DIFF
--- a/packages/rn-tester/js/RNTesterAppShared.js
+++ b/packages/rn-tester/js/RNTesterAppShared.js
@@ -213,7 +213,6 @@ const RNTesterApp = (): React.Node => {
           <RNTesterExampleContainer module={ExampleModule} />
         </View>
       )}
-
       <ExampleListsContainer
         isVisible={!ExampleModule}
         screen={screen || Screens.COMPONENTS}

--- a/packages/rn-tester/js/RNTesterAppShared.js
+++ b/packages/rn-tester/js/RNTesterAppShared.js
@@ -213,6 +213,7 @@ const RNTesterApp = (): React.Node => {
           <RNTesterExampleContainer module={ExampleModule} />
         </View>
       )}
+
       <ExampleListsContainer
         isVisible={!ExampleModule}
         screen={screen || Screens.COMPONENTS}

--- a/packages/rn-tester/js/components/RNTesterExampleList.js
+++ b/packages/rn-tester/js/components/RNTesterExampleList.js
@@ -152,6 +152,7 @@ const RNTesterExampleList: React$AbstractComponent<any, void> = React.memo(
           page="components_page"
           sections={sections}
           filter={filter}
+          hideFilterPills={true}
           render={({filteredSections}) => (
             <SectionList
               sections={filteredSections}


### PR DESCRIPTION
## Summary
@rickhanlonii
Removes filter pills from example page in RNTester app.

## Changelog
Removed filter pills from example page by changing hideFilterPills property to true in RNTesterExampleList.js
<div>
<img src="https://user-images.githubusercontent.com/43835229/96194048-88e05600-0f17-11eb-9262-660a7a4bb170.png" width="200" height="400" style="float:left" />
<img src="https://user-images.githubusercontent.com/43835229/96194345-26d42080-0f18-11eb-9af2-bbf9fcc9518a.png" width="200" height="400" />
</div>

[Android] [Removed] - Remove filter pills
[iOS] [Removed] - Remove filter pills

## Test Plan
RNTester app builds and runs as expected and filter pills are removed from the screen.
<div>
<img src="https://user-images.githubusercontent.com/43835229/96194077-9564ae80-0f17-11eb-821e-13da51d37581.png" width="200" height="400" style="float:left"/>
<img src="https://user-images.githubusercontent.com/43835229/96194532-8fbb9880-0f18-11eb-9ecf-48e1b4a9ac25.png" width="200" height="400" />
</div>