### PR TITLE
Sort index.js by alphabetical order and add category comments.

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@
 
 'use strict';
 
+// Components
 import typeof AccessibilityInfo from './Libraries/Components/AccessibilityInfo/AccessibilityInfo';
 import typeof ActivityIndicator from './Libraries/Components/ActivityIndicator/ActivityIndicator';
 import typeof Button from './Libraries/Components/Button';
@@ -27,14 +28,14 @@ import typeof PickerIOS from './Libraries/Components/Picker/PickerIOS';
 import typeof Pressable from './Libraries/Components/Pressable/Pressable';
 import typeof ProgressBarAndroid from './Libraries/Components/ProgressBarAndroid/ProgressBarAndroid';
 import typeof ProgressViewIOS from './Libraries/Components/ProgressViewIOS/ProgressViewIOS';
+import typeof RefreshControl from './Libraries/Components/RefreshControl/RefreshControl';
 import typeof SafeAreaView from './Libraries/Components/SafeAreaView/SafeAreaView';
 import typeof ScrollView from './Libraries/Components/ScrollView/ScrollView';
 import typeof SectionList from './Libraries/Lists/SectionList';
 import typeof SegmentedControlIOS from './Libraries/Components/SegmentedControlIOS/SegmentedControlIOS';
 import typeof Slider from './Libraries/Components/Slider/Slider';
-import typeof Switch from './Libraries/Components/Switch/Switch';
-import typeof RefreshControl from './Libraries/Components/RefreshControl/RefreshControl';
 import typeof StatusBar from './Libraries/Components/StatusBar/StatusBar';
+import typeof Switch from './Libraries/Components/Switch/Switch';
 import typeof Text from './Libraries/Text/Text';
 import typeof TextInput from './Libraries/Components/TextInput/TextInput';
 import typeof Touchable from './Libraries/Components/Touchable/Touchable';
@@ -45,6 +46,8 @@ import typeof TouchableWithoutFeedback from './Libraries/Components/Touchable/To
 import typeof View from './Libraries/Components/View/View';
 import typeof VirtualizedList from './Libraries/Lists/VirtualizedList';
 import typeof VirtualizedSectionList from './Libraries/Lists/VirtualizedSectionList';
+
+// APIs
 import typeof ActionSheetIOS from './Libraries/ActionSheetIOS/ActionSheetIOS';
 import typeof Alert from './Libraries/Alert/Alert';
 import typeof Animated from './Libraries/Animated/Animated';
@@ -66,6 +69,7 @@ import typeof InteractionManager from './Libraries/Interaction/InteractionManage
 import typeof Keyboard from './Libraries/Components/Keyboard/Keyboard';
 import typeof LayoutAnimation from './Libraries/LayoutAnimation/LayoutAnimation';
 import typeof Linking from './Libraries/Linking/Linking';
+import typeof LogBox from './Libraries/LogBox/LogBox';
 import typeof NativeDialogManagerAndroid from './Libraries/NativeModules/specs/NativeDialogManagerAndroid';
 import typeof NativeEventEmitter from './Libraries/EventEmitter/NativeEventEmitter';
 import typeof Networking from './Libraries/Network/RCTNetworking';
@@ -86,15 +90,18 @@ import typeof useWindowDimensions from './Libraries/Utilities/useWindowDimension
 import typeof UTFSequence from './Libraries/UTFSequence';
 import typeof Vibration from './Libraries/Vibration/Vibration';
 import typeof YellowBox from './Libraries/YellowBox/YellowBoxDeprecated';
-import typeof LogBox from './Libraries/LogBox/LogBox';
-import typeof RCTDeviceEventEmitter from './Libraries/EventEmitter/RCTDeviceEventEmitter';
-import typeof RCTNativeAppEventEmitter from './Libraries/EventEmitter/RCTNativeAppEventEmitter';
+
+// Plugins
+import typeof {DynamicColorIOS} from './Libraries/StyleSheet/PlatformColorValueTypesIOS';
 import typeof NativeModules from './Libraries/BatchedBridge/NativeModules';
 import typeof Platform from './Libraries/Utilities/Platform';
-import typeof processColor from './Libraries/StyleSheet/processColor';
 import typeof {PlatformColor} from './Libraries/StyleSheet/PlatformColorValueTypes';
-import typeof {DynamicColorIOS} from './Libraries/StyleSheet/PlatformColorValueTypesIOS';
+import typeof processColor from './Libraries/StyleSheet/processColor';
+import typeof RCTDeviceEventEmitter from './Libraries/EventEmitter/RCTDeviceEventEmitter';
+import typeof RCTNativeAppEventEmitter from './Libraries/EventEmitter/RCTNativeAppEventEmitter';
 import typeof {RootTagContext} from './Libraries/ReactNative/RootTag';
+
+// Prop Types
 import typeof DeprecatedColorPropType from './Libraries/DeprecatedPropTypes/DeprecatedColorPropType';
 import typeof DeprecatedEdgeInsetsPropType from './Libraries/DeprecatedPropTypes/DeprecatedEdgeInsetsPropType';
 import typeof DeprecatedPointPropType from './Libraries/DeprecatedPropTypes/DeprecatedPointPropType';
@@ -201,6 +208,9 @@ module.exports = {
     );
     return require('./Libraries/Components/ProgressViewIOS/ProgressViewIOS');
   },
+  get RefreshControl(): RefreshControl {
+    return require('./Libraries/Components/RefreshControl/RefreshControl');
+  },
   get SafeAreaView(): SafeAreaView {
     return require('./Libraries/Components/SafeAreaView/SafeAreaView');
   },
@@ -229,14 +239,11 @@ module.exports = {
     );
     return require('./Libraries/Components/Slider/Slider');
   },
-  get Switch(): Switch {
-    return require('./Libraries/Components/Switch/Switch');
-  },
-  get RefreshControl(): RefreshControl {
-    return require('./Libraries/Components/RefreshControl/RefreshControl');
-  },
   get StatusBar(): StatusBar {
     return require('./Libraries/Components/StatusBar/StatusBar');
+  },
+  get Switch(): Switch {
+    return require('./Libraries/Components/Switch/Switch');
   },
   get Text(): Text {
     return require('./Libraries/Text/Text');
@@ -446,6 +453,10 @@ module.exports = {
   get DeviceEventEmitter(): RCTDeviceEventEmitter {
     return require('./Libraries/EventEmitter/RCTDeviceEventEmitter').default;
   },
+  get DynamicColorIOS(): DynamicColorIOS {
+    return require('./Libraries/StyleSheet/PlatformColorValueTypesIOS')
+      .DynamicColorIOS;
+  },
   get NativeAppEventEmitter(): RCTNativeAppEventEmitter {
     return require('./Libraries/EventEmitter/RCTNativeAppEventEmitter');
   },
@@ -455,16 +466,12 @@ module.exports = {
   get Platform(): Platform {
     return require('./Libraries/Utilities/Platform');
   },
-  get processColor(): processColor {
-    return require('./Libraries/StyleSheet/processColor');
-  },
   get PlatformColor(): PlatformColor {
     return require('./Libraries/StyleSheet/PlatformColorValueTypes')
       .PlatformColor;
   },
-  get DynamicColorIOS(): DynamicColorIOS {
-    return require('./Libraries/StyleSheet/PlatformColorValueTypesIOS')
-      .DynamicColorIOS;
+  get processColor(): processColor {
+    return require('./Libraries/StyleSheet/processColor');
   },
   get requireNativeComponent(): <T>(
     uiViewClassName: string,


### PR DESCRIPTION
## Summary

As of right now, index.js contains a big blob of imports that are mostly in alphabetical order, with a few exceptions. In addition, the imports aren't separated by Components / API / Plugins, so comments were added for ease of future maintainability. 

## Changelog

[Internal] [Changed] - Reordered imports into alphabetical order and added comments to divide imports into sections (components, apis, plugins, prop types)

## Test Plan

This change did not change the codebase. Building rn-tester still works.

@rickhanlonii