### PR TITLE
Use $projectDir instead of $rootDir for ReactAndroid codegen

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -478,6 +478,6 @@ apply(from: "release.gradle")
 
 react {
     jsRootDir = file("../Libraries")
-    reactNativeRootDir = file("$rootDir")
+    reactNativeRootDir = file("$projectDir/..")
     useJavaGenerator = System.getenv("USE_CODEGEN_JAVAPOET") ?: false
 }


### PR DESCRIPTION
## Summary

When working with RN installed from npm and a regular project structure `$rootDir` won't be at the react-native package root. Instead we can use `$projectRoot` which will always be the ReactAndroid folder.

## Changelog

[Android] [Internal] - Use $projectDir instead of $rootDir for ReactAndroid codegen

## Test Plan

Test building an app with RN as a regular dep with codegen enabled
