### PR TITLE
More reliable way to get ReactAndroid build dir in Android-prebuilt.mk

### DIFF
--- a/ReactAndroid/Android-prebuilt.mk
+++ b/ReactAndroid/Android-prebuilt.mk
@@ -14,10 +14,6 @@
 
 LOCAL_PATH := $(call my-dir)
 
-REACT_ANDROID_DIR := $(LOCAL_PATH)
-# TODO: Find a better way without pointing to ReactAndroid/build dir.
-REACT_ANDROID_BUILD_DIR := $(REACT_ANDROID_DIR)/build
-
 FIRST_PARTY_NDK_DIR := $(REACT_ANDROID_DIR)/src/main/jni/first-party
 THIRD_PARTY_NDK_DIR := $(REACT_ANDROID_BUILD_DIR)/third-party-ndk
 REACT_ANDROID_SRC_DIR := $(REACT_ANDROID_DIR)/src/main

--- a/packages/rn-tester/android/app/build.gradle
+++ b/packages/rn-tester/android/app/build.gradle
@@ -256,7 +256,8 @@ if (enableCodegen) {
                             // The following paths assume building React Native from source.
                             "GENERATED_SRC_DIR=$buildDir/generated/source",
                             "PROJECT_BUILD_DIR=$buildDir",
-                            "REACT_ANDROID_DIR=$reactAndroidProjectDir"
+                            "REACT_ANDROID_DIR=$reactAndroidProjectDir",
+                            "REACT_ANDROID_BUILD_DIR=$reactAndroidBuildDir"
                     cFlags "-Wall", "-Werror", "-fexceptions", "-frtti", "-DWITH_INSPECTOR=1"
                     cppFlags "-std=c++1y"
                     targets "rntester_appmodules"


### PR DESCRIPTION
## Summary

Pass the ReactAndroid project build directory as a variable to the ndk build so it can be used instead of assuming that the build directory is under ReactAndroid/build.

## Changelog

[Internal]

## Test Plan

Tested in an app with a custom build directory
