### PR TITLE
Fix cxx textlayoutmanager build breaking issues

### DIFF
--- a/ReactCommon/react/renderer/textlayoutmanager/BUCK
+++ b/ReactCommon/react/renderer/textlayoutmanager/BUCK
@@ -44,19 +44,19 @@ rn_xplat_cxx_library(
     ],
     cxx_exported_headers = subdir_glob(
         [
-            ("platform/cxx", "*.h"),
+            ("platform/cxx/react/renderer/textlayoutmanager", "**/*.h"),
         ],
         prefix = "react/renderer/textlayoutmanager",
     ),
     cxx_headers = subdir_glob(
         [
-            ("platform/cxx", "**/*.h"),
+            ("platform/cxx/react/renderer/textlayoutmanager", "**/*.h"),
         ],
         prefix = "",
     ),
     cxx_srcs = glob(
         [
-            "platform/cxx/**/*.cpp",
+            "platform/cxx/react/renderer/textlayoutmanager/**/*.cpp",
         ],
     ),
     cxx_tests = [":tests"],

--- a/ReactCommon/react/renderer/textlayoutmanager/platform/cxx/react/renderer/textlayoutmanager/TextLayoutManager.cpp
+++ b/ReactCommon/react/renderer/textlayoutmanager/platform/cxx/react/renderer/textlayoutmanager/TextLayoutManager.cpp
@@ -23,5 +23,12 @@ TextMeasurement TextLayoutManager::measure(
   return TextMeasurement{{0, 0}, {}};
 }
 
+LinesMeasurements TextLayoutManager::measureLines(
+    AttributedString attributedString,
+    ParagraphAttributes paragraphAttributes,
+    Size size) const {
+  return LinesMeasurements{};
+}
+
 } // namespace react
 } // namespace facebook

--- a/ReactCommon/react/renderer/textlayoutmanager/platform/cxx/react/renderer/textlayoutmanager/TextLayoutManager.h
+++ b/ReactCommon/react/renderer/textlayoutmanager/platform/cxx/react/renderer/textlayoutmanager/TextLayoutManager.h
@@ -41,6 +41,15 @@ class TextLayoutManager {
       LayoutConstraints layoutConstraints) const;
 
   /*
+   * Measures lines of `attributedString` using native text rendering
+   * infrastructure.
+   */
+  LinesMeasurements measureLines(
+      AttributedString attributedString,
+      ParagraphAttributes paragraphAttributes,
+      Size size) const;
+
+  /*
    * Returns an opaque pointer to platform-specific TextLayoutManager.
    * Is used on a native views layer to delegate text rendering to the manager.
    */


### PR DESCRIPTION
## Summary

This PR does not introduce any functional changes, just make the unused cxx textlayoutmanager able to build by other building system than BUCK.

1. Move files into react/renderer/textlayoutmanager/ to support other
   building system. This convention follows Android textlayoutmanager.

2. Add empty TextLayoutManager::measureLines() to fix build error.

## Changelog

cxx textlayoutmanager does not be used in iOS/Android.
We could skip this change in release changelog.

[Internal] [Changed] - Fix cxx textlayoutmanager breaking issues.

## Test Plan

Honestly, I am using cxx textlayoutmanager in react-native-skia.
The test plan so far is to pass build from react-native-skia.
