### PR TITLE
Fixed eslint warnings 

### DIFF
--- a/Libraries/Pressability/PressabilityDebug.js
+++ b/Libraries/Pressability/PressabilityDebug.js
@@ -52,22 +52,19 @@ export function PressabilityDebugView({color, hitSlop}: Props): React.Node {
       const baseColor =
         '#' + (normalizedColor ?? 0).toString(16).padStart(8, '0');
 
-      return (
-        <View
-          pointerEvents="none"
-          style={{
-            backgroundColor: baseColor.slice(0, -2) + '0F', // 15%
-            borderColor: baseColor.slice(0, -2) + '55', // 85%
-            borderStyle: 'dashed',
-            borderWidth: 1,
-            bottom: -(hitSlop?.bottom ?? 0),
-            left: -(hitSlop?.left ?? 0),
-            position: 'absolute',
-            right: -(hitSlop?.right ?? 0),
-            top: -(hitSlop?.top ?? 0),
-          }}
-        />
-      );
+      const pressibilityViewStyle = {
+        backgroundColor: baseColor.slice(0, -2) + '0F', // 15%
+        borderColor: baseColor.slice(0, -2) + '55', // 85%
+        borderStyle: 'dashed',
+        borderWidth: 1,
+        bottom: -(hitSlop?.bottom ?? 0),
+        left: -(hitSlop?.left ?? 0),
+        position: 'absolute',
+        right: -(hitSlop?.right ?? 0),
+        top: -(hitSlop?.top ?? 0),
+      };
+
+      return <View pointerEvents="none" style={pressibilityViewStyle} />;
     }
   }
   return null;

--- a/Libraries/Pressability/PressabilityDebug.js
+++ b/Libraries/Pressability/PressabilityDebug.js
@@ -16,6 +16,7 @@ import type {ColorValue} from '../StyleSheet/StyleSheet';
 import Touchable from '../Components/Touchable/Touchable';
 import View from '../Components/View/View';
 import * as React from 'react';
+import {StyleSheet} from 'react-native';
 
 type Props = $ReadOnly<{|
   color: ColorValue,
@@ -52,23 +53,34 @@ export function PressabilityDebugView({color, hitSlop}: Props): React.Node {
       const baseColor =
         '#' + (normalizedColor ?? 0).toString(16).padStart(8, '0');
 
-      const pressibilityViewStyle = {
-        backgroundColor: baseColor.slice(0, -2) + '0F', // 15%
-        borderColor: baseColor.slice(0, -2) + '55', // 85%
-        borderStyle: 'dashed',
-        borderWidth: 1,
-        bottom: -(hitSlop?.bottom ?? 0),
-        left: -(hitSlop?.left ?? 0),
-        position: 'absolute',
-        right: -(hitSlop?.right ?? 0),
-        top: -(hitSlop?.top ?? 0),
-      };
-
-      return <View pointerEvents="none" style={pressibilityViewStyle} />;
+      return (
+        <View
+          pointerEvents="none"
+          style={[
+            {
+              right: -(hitSlop?.right ?? 0),
+              top: -(hitSlop?.top ?? 0),
+              bottom: -(hitSlop?.bottom ?? 0),
+              left: -(hitSlop?.left ?? 0),
+              backgroundColor: baseColor.slice(0, -2) + '0F', // 15%
+              borderColor: baseColor.slice(0, -2) + '55', // 85%
+            },
+            styles.pressibilityViewStyle,
+          ]}
+        />
+      );
     }
   }
   return null;
 }
+
+const styles = StyleSheet.create({
+  pressibilityViewStyle: {
+    borderStyle: 'dashed',
+    borderWidth: 1,
+    position: 'absolute',
+  },
+});
 
 export function isEnabled(): boolean {
   if (__DEV__) {

--- a/bots/make-comment.js
+++ b/bots/make-comment.js
@@ -36,7 +36,8 @@ async function updateComment(octokit, issueParams, body, replacePattern) {
   const authedUserId = authenticatedUser.data.id;
   const pattern = new RegExp(replacePattern, 'g');
   const comment = comments.data.find(
-    ({user, body}) => user.id === authedUserId && pattern.test(body),
+    ({user, commentBody}) =>
+      user.id === authedUserId && pattern.test(commentBody),
   );
   if (!comment) {
     return false;

--- a/packages/rn-tester/js/components/RNTesterExampleFilter.js
+++ b/packages/rn-tester/js/components/RNTesterExampleFilter.js
@@ -20,7 +20,6 @@ const {
   Image,
 } = require('react-native');
 import {RNTesterThemeContext} from './RNTesterTheme';
-import type {RNTesterExample} from '../types/RNTesterTypes';
 
 import type {SectionData} from '../types/RNTesterTypes';
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
I noticed there were some eslint warnings and decided to make 3 changes to get rid of three of the warnings
> removed inline styling

> used different variable name cause current one is already defined in upper scope

> removed unused type import

## Changelog
[Internal] [Fixed] - reduced eslint warnings by making minor changes

## Test Plan
Running `yarn lint` and seeing fewer warnings show up
