### PR TITLE
Fix test_docker: confirm envinfo package install during Docker container setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -587,7 +587,7 @@ jobs:
           name: Build Docker container for Android RNTester App
           command: |
             source ~/.bashrc
-            nvm install 'lts/*'
+            nvm i node
             npm i -g yarn
             echo y | npx envinfo@latest
             yarn run docker-setup-android

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -587,7 +587,7 @@ jobs:
           name: Build Docker container for Android RNTester App
           command: |
             source ~/.bashrc
-            nvm i --lts
+            nvm install 'lts/*'
             npm i -g yarn
             echo y | npx envinfo@latest
             yarn run docker-setup-android

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -587,9 +587,9 @@ jobs:
           name: Build Docker container for Android RNTester App
           command: |
             source ~/.bashrc
-            nvm i node
+            nvm i --lts
             npm i -g yarn
-            npx envinfo@latest
+            echo y | npx envinfo@latest
             yarn run docker-setup-android
             yarn run docker-build-android
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

With the release of Node 15 on October 20, 2020, the `nvm i node` command started installing Node 15 by default during the Docker setup step on Circle CI. This version of Node now requires user interaction down in `npx envinfo@latest` during the same step.

With these changes, we ensure we automatically accept the installation of any necessary packages.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[CATEGORY] - Internal

## Test Plan

Circle CI.