### PR TITLE
[Circle CI] Bump Node LTS to 14, and Node PrevLTS to 12.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,11 +28,11 @@ executors:
   nodelts:
     <<: *defaults
     docker:
-      - image: circleci/node:12
+      - image: circleci/node:14
   nodeprevlts:
     <<: *defaults
     docker:
-      - image: circleci/node:10
+      - image: circleci/node:12
   reactnativeandroid:
     <<: *defaults
     docker:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

On October 27, 2020, Node 14 will enter active LTS status, and Node 12 will enter maintenance LTS status at the end of November.

With these upcoming dates in mind, I am bumping the Circle CI NodeLTS executor to use Node 14, and the NodePrevLTS executor to use Node 12.

With these changes, Node 12 will be hereto considered the minimum supported version.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Changed] [JavaScript] - Bump minimum Node version to 12 LTS

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
Circle CI