### PR TITLE
Remove left over code from deprecating Android < 21

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/queue/ReactQueueConfigurationSpec.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/queue/ReactQueueConfigurationSpec.java
@@ -19,8 +19,6 @@ import com.facebook.infer.annotation.Assertions;
  */
 public class ReactQueueConfigurationSpec {
 
-  private static final long LEGACY_STACK_SIZE_BYTES = 2000000;
-
   private final MessageQueueThreadSpec mNativeModulesQueueThreadSpec;
   private final MessageQueueThreadSpec mJSQueueThreadSpec;
 
@@ -44,11 +42,7 @@ public class ReactQueueConfigurationSpec {
   }
 
   public static ReactQueueConfigurationSpec createDefault() {
-    MessageQueueThreadSpec spec =
-        Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP
-            ? MessageQueueThreadSpec.newBackgroundThreadSpec(
-                "native_modules", LEGACY_STACK_SIZE_BYTES)
-            : MessageQueueThreadSpec.newBackgroundThreadSpec("native_modules");
+    MessageQueueThreadSpec spec = MessageQueueThreadSpec.newBackgroundThreadSpec("native_modules");
     return builder()
         .setJSQueueThreadSpec(MessageQueueThreadSpec.newBackgroundThreadSpec("js"))
         .setNativeModulesQueueThreadSpec(spec)

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/datepicker/DismissableDatePickerDialog.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/datepicker/DismissableDatePickerDialog.java
@@ -17,12 +17,6 @@ import androidx.annotation.Nullable;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
-/**
- * Certain versions of Android (Jellybean-KitKat) have a bug where when dismissed, the {@link
- * DatePickerDialog} still calls the OnDateSetListener. This class works around that issue.
- *
- * <p>See: <a href="https://code.google.com/p/android/issues/detail?id=34833">Issue 34833</a>
- */
 public class DismissableDatePickerDialog extends DatePickerDialog {
 
   public DismissableDatePickerDialog(
@@ -44,13 +38,6 @@ public class DismissableDatePickerDialog extends DatePickerDialog {
       int dayOfMonth) {
     super(context, theme, callback, year, monthOfYear, dayOfMonth);
     fixSpinner(context, year, monthOfYear, dayOfMonth);
-  }
-
-  @Override
-  protected void onStop() {
-    // do *not* call super.onStop() on KitKat on lower, as that would erroneously call the
-    // OnDateSetListener when the dialog is dismissed, or call it twice when "OK" is pressed.
-    super.onStop();
   }
 
   private void fixSpinner(Context context, int year, int month, int dayOfMonth) {

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/network/ForwardingCookieHandler.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/network/ForwardingCookieHandler.java
@@ -126,7 +126,7 @@ public class ForwardingCookieHandler extends CookieHandler {
   }
 
   /**
-   * Instantiating CookieManager in KitKat+ will load the Chromium task taking a 100ish ms so we do
+   * Instantiating CookieManager will load the Chromium task taking a 100ish ms so we do
    * it lazily to make sure it's done on a background thread as needed.
    */
   private @Nullable CookieManager getCookieManager() {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactDrawableHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactDrawableHelper.java
@@ -73,11 +73,7 @@ public class ReactDrawableHelper {
   }
 
   private static RippleDrawable getRippleDrawable(
-      Context context, ReadableMap drawableDescriptionDict) {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-      throw new JSApplicationIllegalArgumentException(
-          "Ripple drawable is not available on android API <21");
-    }
+    Context context, ReadableMap drawableDescriptionDict) {
     int color = getColor(context, drawableDescriptionDict);
     Drawable mask = getMask(drawableDescriptionDict);
     ColorStateList colorStateList =


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
Came to learn RN is deprecating Android 19, 20: https://github.com/facebook/react-native/commit/a17ff44adcf003dd4e4ef2301e1f80b77913f712

Did a quick check of left over code from the deprecation.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Deprecated] - Cleanup usages of deprecated Android API

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
