### PR TITLE
Codegen Android: update Docker configuration to support codegen

### DIFF
--- a/.circleci/Dockerfiles/Dockerfile.android
+++ b/.circleci/Dockerfiles/Dockerfile.android
@@ -25,11 +25,13 @@ ENV JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
 
 ADD .buckconfig /app/.buckconfig
 ADD .buckjavaargs /app/.buckjavaargs
-ADD tools /app/tools
+ADD Libraries /app/Libraries
 ADD ReactAndroid /app/ReactAndroid
 ADD ReactCommon /app/ReactCommon
 ADD React /app/React
 ADD keystores /app/keystores
+ADD packages/react-native-codegen /app/packages/react-native-codegen
+ADD tools /app/tools
 
 WORKDIR /app
 
@@ -49,4 +51,3 @@ RUN yarn
 RUN ./gradlew :ReactAndroid:downloadBoost :ReactAndroid:downloadDoubleConversion :ReactAndroid:downloadFolly :ReactAndroid:downloadGlog
 
 RUN ./gradlew :ReactAndroid:packageReactNdkLibsForBuck -Pjobs=1
-

--- a/metro.config.js
+++ b/metro.config.js
@@ -18,6 +18,8 @@ const getPolyfills = require('./rn-get-polyfills');
  */
 module.exports = {
   resolver: {
+    // $FlowFixMe[signature-verification-failure] Can't infer RegExp type.
+    blacklistRE: /buck-out/,
     extraNodeModules: {
       'react-native': __dirname,
     },

--- a/packages/react-native-codegen/package.json
+++ b/packages/react-native-codegen/package.json
@@ -34,6 +34,7 @@
     "@babel/plugin-transform-flow-strip-types": "^7.0.0",
     "chalk": "^4.0.0",
     "glob": "^7.1.1",
+    "invariant": "^2.2.4",
     "micromatch": "^4.0.2",
     "mkdirp": "^0.5.1",
     "prettier": "1.19.1"


### PR DESCRIPTION
Summary:
This addresses the following CI failure:
https://app.circleci.com/pipelines/github/facebook/react-native/6847/workflows/36d59aab-bc4a-4d21-9ce1-a8348e71aea3/jobs/173669

The problem was missing directories because we didn't copy the relevant ones for docker build.

In addition:
* The codegen depends on `invariant`, but didn't specify the dep in package.json. This fixes it.
* Also ask Metro to ignore buck-out

Note that this will depend on docker image v1.0.5 (to be released later) to fully build. v1.0.5 will need to install `rsync`, see this patch: https://gist.github.com/fkgozali/1d8cae92a5bc521e0f2e4f275008db93. With my test image (of 1.0.5 local build), I got the docker build to pass:

```
$ docker build -t reactnativeci/android -f .circleci/Dockerfiles/Dockerfile.android .
[+] Building 1624.2s (27/27) FINISHED
 => [internal] load build definition from Dockerfile.android                                                                                           0.0s
 => => transferring dockerfile: 52B                                                                                                                    0.0s
 => [internal] load .dockerignore                                                                                                                      0.0s
 => => transferring context: 2B                                                                                                                        0.0s
 => [internal] load metadata for docker.io/reactnativecommunity/react-native-android:1.0.5                                                             0.0s
 => [1/22] FROM docker.io/reactnativecommunity/react-native-android:1.0.5                                                                              0.0s
 => [internal] load build context                                                                                                                      5.6s
 => => transferring context: 7.11MB                                                                                                                    5.5s
 => CACHED [2/22] ADD .buckconfig /app/.buckconfig                                                                                                     0.0s
 => CACHED [3/22] ADD .buckjavaargs /app/.buckjavaargs                                                                                                 0.0s
 => CACHED [4/22] ADD Libraries /app/Libraries                                                                                                         0.0s
 => CACHED [5/22] ADD ReactAndroid /app/ReactAndroid                                                                                                   0.0s
 => CACHED [6/22] ADD ReactCommon /app/ReactCommon                                                                                                     0.0s
 => CACHED [7/22] ADD React /app/React                                                                                                                 0.0s
 => CACHED [8/22] ADD keystores /app/keystores                                                                                                         0.0s
 => CACHED [9/22] ADD packages/react-native-codegen /app/packages/react-native-codegen                                                                 0.0s
 => CACHED [10/22] ADD tools /app/tools                                                                                                                0.0s
 => CACHED [11/22] WORKDIR /app                                                                                                                        0.0s
 => CACHED [12/22] RUN buck fetch ReactAndroid/src/test/java/com/facebook/react/modules                                                                0.0s
 => CACHED [13/22] RUN buck fetch ReactAndroid/src/main/java/com/facebook/react                                                                        0.0s
 => CACHED [14/22] RUN buck fetch ReactAndroid/src/main/java/com/facebook/react/shell                                                                  0.0s
 => CACHED [15/22] RUN buck fetch ReactAndroid/src/test/...                                                                                            0.0s
 => CACHED [16/22] RUN buck fetch ReactAndroid/src/androidTest/...                                                                                     0.0s
 => CACHED [17/22] RUN buck build ReactAndroid/src/main/java/com/facebook/react                                                                        0.0s
 => CACHED [18/22] RUN buck build ReactAndroid/src/main/java/com/facebook/react/shell                                                                  0.0s
 => [19/22] ADD . /app                                                                                                                                28.1s
 => [20/22] RUN yarn                                                                                                                                  50.2s
 => [21/22] RUN ./gradlew :ReactAndroid:downloadBoost :ReactAndroid:downloadDoubleConversion :ReactAndroid:downloadFolly :ReactAndroid:downloadGlog  235.8s
 => [22/22] RUN ./gradlew :ReactAndroid:packageReactNdkLibsForBuck -Pjobs=1                                                                         1240.1s
 => exporting to image                                                                                                                                64.2s
 => => exporting layers                                                                                                                               64.2s
 => => writing image sha256:6449dc629ed12395c9c98d880fb421284193bc9b5d2a77578760a23b5c3c1acd                                                           0.0s
 => => naming to docker.io/reactnativeci/android
```

To test with a custom local docker image:
* https://docs.docker.com/get-started/ (install the Mac client)
* git clone https://github.com/react-native-community/docker-android
* Make the local change then create the fake v1.0.5 image:
  * `docker build --tag reactnativecommunity/react-native-android:1.0.5 .`
  * Run the image from Docker Mac client
* Then build RN docker test pasted above.

Changelog: [Internal]

Reviewed By: shergin

Differential Revision: D24611539

