### PR TITLE
Build rn-codegen in a temporary directory

### DIFF
--- a/packages/react-native-codegen/scripts/oss/build.sh
+++ b/packages/react-native-codegen/scripts/oss/build.sh
@@ -11,9 +11,18 @@ THIS_DIR=$(cd -P "$(dirname "$(readlink "${BASH_SOURCE[0]}" || echo "${BASH_SOUR
 set -e
 set -u
 
-pushd "$THIS_DIR/../.." >/dev/null
+TMP_DIR=$(mktemp -d)
+CODEGEN_DIR="$THIS_DIR/../.."
+
+rm -rf "$CODEGEN_DIR/lib"
+
+cp -R "$CODEGEN_DIR/." "$TMP_DIR"
+
+pushd "$TMP_DIR" >/dev/null
 
 yarn install 2> >(grep -v '^warning' 1>&2)
-yarn run build
 
 popd >/dev/null
+
+mv "$TMP_DIR/lib" "$CODEGEN_DIR"
+rm -rf "$TMP_DIR"

--- a/packages/react-native-codegen/scripts/oss/build.sh
+++ b/packages/react-native-codegen/scripts/oss/build.sh
@@ -14,7 +14,7 @@ set -u
 TMP_DIR=$(mktemp -d)
 CODEGEN_DIR="$THIS_DIR/../.."
 
-rm -rf "$CODEGEN_DIR/lib"
+rm -rf "$CODEGEN_DIR/lib" "$CODEGEN_DIR/node_modules"
 
 cp -R "$CODEGEN_DIR/." "$TMP_DIR"
 
@@ -24,5 +24,5 @@ yarn install 2> >(grep -v '^warning' 1>&2)
 
 popd >/dev/null
 
-mv "$TMP_DIR/lib" "$CODEGEN_DIR"
+mv "$TMP_DIR/lib" "$TMP_DIR/node_modules" "$CODEGEN_DIR"
 rm -rf "$TMP_DIR"


### PR DESCRIPTION
## Summary

When running yarn install from the codegen directory it will reinstall all dependencies for the react-native workspace inside the react-native package. In my case this caused issues with metro because it would now have 2 copies of it (node_modules/metro and node_modules/react-native/node_modules/metro).

To avoid this copy the react-native-codegen source in a temporary directory and yarn install from there, then copy the built files back.

## Changelog

[Internal] - Build rn-codegen in a temporary directory

## Test Plan

Tested the script in an app with codegen enabled. Fresh install with rn-codegen not built, made sure no extra modules are installed under node_modules/react-native/node_modules.
