### PR TITLE
Use react-native-codegen build script in rn-tester

### DIFF
--- a/packages/rn-tester/Podfile
+++ b/packages/rn-tester/Podfile
@@ -61,7 +61,7 @@ pre_install do |installer|
   if ENV['USE_CODEGEN'] != '0'
     prefix_path = "../.."
     codegen_path = "../../packages/react-native-codegen"
-    system("(cd #{codegen_path} && yarn install && yarn run build)")
+    system("#{codegen_path}/scripts/oss/build.sh")
     codegen_pre_install(installer, {path:prefix_path, codegen_path:codegen_path})
   end
 end


### PR DESCRIPTION
## Summary

Use the same script as android to build the codegen package. This also fixes the issue in #30292.

## Changelog

[Internal] - Use react-native-codegen build script in rn-tester

## Test Plan

Tested that using the script works when using pod install