### PR TITLE
Clarification of parameters usage for Share.share

### DIFF
--- a/Libraries/Share/Share.js
+++ b/Libraries/Share/Share.js
@@ -55,7 +55,7 @@ class Share {
    *
    *  - `url` - an URL to share
    *
-   * At least one of URL and message is required.
+   * At least one of URL or message is required.
    *
    * #### Android
    *
@@ -84,7 +84,7 @@ class Share {
     );
     invariant(
       typeof content.url === 'string' || typeof content.message === 'string',
-      'At least one of URL and message is required',
+      'At least one of URL or message is required',
     );
     invariant(
       typeof options === 'object' && options !== null,


### PR DESCRIPTION
Documentation clarification for Share.share parameters.

## Summary

The sentence about using either message and url is a bit unclear as it can be understood as "Message and url are required". This sentence can lead to errors.
This StackExchange question sums the difference between using "either X and Y" or "either X and Y": https://english.stackexchange.com/questions/414568/one-of-a-and-b-or-one-of-a-or-b

## Changelog

I just replaced "and" into "or".

General Changed - Clarification of parameters for Share.share

## Test Plan

The doc should be different and show "either message of url". 

