### PR TITLE
fix community link [404 not found]

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
   <span> · </span>
   <a href="https://reactnative.dev/docs/contributing">Contribute</a>
   <span> · </span>
-  <a href="https://reactnative.dev/en/help">Community</a>
+  <a href="https://reactnative.dev/help">Community</a>
   <span> · </span>
   <a href="https://github.com/facebook/react-native/blob/master/.github/SUPPORT.md">Support</a>
 </h3>


### PR DESCRIPTION
# Summary

The README file in this repo has a bad link - [404:NotFound]

Status code [404:NotFound] - Link: https://reactnative.dev/en/help

## Changelog

fixed link: https://reactnative.dev/help

[Link] [fixed] - fixed broken link.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

![image](https://user-images.githubusercontent.com/46071874/98048666-5fe91c00-1e58-11eb-804e-b90f6d77b15f.png)
