### PR TITLE
fix: type for Pressable children prop

### DIFF
--- a/Libraries/Components/Pressable/Pressable.js
+++ b/Libraries/Components/Pressable/Pressable.js
@@ -57,7 +57,7 @@ type Props = $ReadOnly<{|
    * Either children or a render prop that receives a boolean reflecting whether
    * the component is currently pressed.
    */
-  children: React.Node | ((state: StateCallbackType) => React.Node),
+  children?: ?React.Node | ?((state: StateCallbackType) => React.Node),
 
   /**
    * Duration (in milliseconds) from `onPressIn` before `onLongPress` is called.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

According to the [documentation](https://reactnative.dev/docs/pressable#children) the `children` prop on the `Pressable` component is not required. This optional type is not reflected in the type annotations which causes a compiler error when trying to implement the `Pressable` component using flow or TypeScript.

This PR updates the type annotations to reflect the optional type of the `children` prop in the `Pressable` component

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Fixed] - Fixed Pressable children prop type annotation

## Test Plan

Tested using `rn-tester` package by adding an example that renders a `Pressable` with a fixed width and height without children