### PR TITLE
[Android] Update the cached dimensions when orientation changes

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -711,7 +711,9 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
         return;
       }
       checkForKeyboardEvents();
-      checkForDeviceOrientationChanges();
+      if (checkForDeviceOrientationChanges()) {
+        DisplayMetricsHolder.initDisplayMetrics(getContext().getApplicationContext());
+      }
       checkForDeviceDimensionsChanges();
     }
 
@@ -747,16 +749,17 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
       }
     }
 
-    private void checkForDeviceOrientationChanges() {
+    private boolean checkForDeviceOrientationChanges() {
       final int rotation =
           ((WindowManager) getContext().getSystemService(Context.WINDOW_SERVICE))
               .getDefaultDisplay()
               .getRotation();
       if (mDeviceRotation == rotation) {
-        return;
+        return false;
       }
       mDeviceRotation = rotation;
       emitOrientationChanged(rotation);
+      return true;
     }
 
     private void checkForDeviceDimensionsChanges() {


### PR DESCRIPTION

## Summary

Currently the dimensions are created once, and then cached.  This change will reload the dimensions when the device orientation changes to insure that dimension update events follow orientation changed events.

this should help address the following issues, that I know of:
https://github.com/facebook/react-native/issues/29105
https://github.com/facebook/react-native/issues/29451
https://github.com/facebook/react-native/issues/29323

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Fixed] - Dimension update events are now properly sent following orientation change

## Test Plan

Open up RNTester app.  Select the Dimensions API list item.  Rotate the device and verify that the dimensions are correct based on orientation.