### PR TITLE
only log network performance in __DEV__

### DIFF
--- a/Libraries/Network/XMLHttpRequest.js
+++ b/Libraries/Network/XMLHttpRequest.js
@@ -304,8 +304,10 @@ class XMLHttpRequest extends (EventTarget(...XHR_EVENTS): any) {
     responseURL: ?string,
   ): void {
     if (requestId === this._requestId) {
-      this._perfKey != null &&
-        this._performanceLogger.stopTimespan(this._perfKey);
+      if (__DEV__) {
+        this._perfKey != null &&
+          this._performanceLogger.stopTimespan(this._perfKey);
+      }
       this.status = status;
       this.setResponseHeaders(responseHeaders);
       this.setReadyState(this.HEADERS_RECEIVED);
@@ -529,8 +531,10 @@ class XMLHttpRequest extends (EventTarget(...XHR_EVENTS): any) {
     const doSend = () => {
       const friendlyName =
         this._trackingName !== 'unknown' ? this._trackingName : this._url;
-      this._perfKey = 'network_XMLHttpRequest_' + String(friendlyName);
-      this._performanceLogger.startTimespan(this._perfKey);
+      if (__DEV__) {
+        this._perfKey = 'network_XMLHttpRequest_' + String(friendlyName);
+        this._performanceLogger.startTimespan(this._perfKey);
+      }
       invariant(
         this._method,
         'XMLHttpRequest method needs to be defined (%s).',

--- a/Libraries/Network/__tests__/XMLHttpRequest-test.js
+++ b/Libraries/Network/__tests__/XMLHttpRequest-test.js
@@ -267,6 +267,27 @@ describe('XMLHttpRequest', function() {
     );
   });
 
+  it('should not log to a performance logger if not in __DEV__', () => {
+    const original__DEV__ = global.__DEV__;
+    global.__DEV__ = false;
+
+    xhr.open('GET', 'blabla');
+    xhr.send();
+
+    expect(xhr._perfKey).toBe(null);
+    expect(GlobalPerformanceLogger.startTimespan).not.toHaveBeenCalled();
+
+    setRequestId(8);
+    xhr.__didReceiveResponse(requestId, 200, {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Content-Length': '32',
+    });
+
+    expect(GlobalPerformanceLogger.stopTimespan).not.toHaveBeenCalled();
+
+    global.__DEV__ = original__DEV__;
+  });
+
   it('should log to a custom performance logger if set', () => {
     const performanceLogger = createPerformanceLogger();
     jest.spyOn(performanceLogger, 'startTimespan');


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Fixes https://github.com/facebook/react-native/issues/30288

In an app that makes many requests to unique urls, the [_timespans object](https://github.com/facebook/react-native/blob/017bc911928472e20f37dd9512a2113a7d93c81b/Libraries/Utilities/createPerformanceLogger.js#L65) in the performance logger [grows indefinitely](https://github.com/colbyr/ReactNativeScratch/pull/1) because [XMLHttpRequest records every network request](https://github.com/facebook/react-native/blob/017bc911928472e20f37dd9512a2113a7d93c81b/Libraries/Network/XMLHttpRequest.js#L532-L533).

```js
this._perfKey = 'network_XMLHttpRequest_' + String(friendlyName);
this._performanceLogger.startTimespan(this._perfKey);
```

This prevents a memory leak by disabling the creation of performance timespans outside of the __DEV__ environment.

If this isn't sufficient, I'm happy to explore another avenue. Just point me in the right direction!

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Fixed] - stops a memory leak in productoin builds caused by network performance logging

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
I think the unit test I added confirms that the performance logging is disabled outside the `__DEV__` environment.
