### PR TITLE
use a WeakMap in BlobRegistry to prevent a memory leak

### DIFF
--- a/Libraries/Blob/Blob.js
+++ b/Libraries/Blob/Blob.js
@@ -122,7 +122,7 @@ class Blob {
    */
   close() {
     const BlobManager = require('./BlobManager');
-    BlobManager.release(this.data.blobId);
+    BlobManager.release(this);
     this.data = null;
   }
 

--- a/Libraries/Blob/BlobRegistry.js
+++ b/Libraries/Blob/BlobRegistry.js
@@ -7,28 +7,37 @@
  * @flow strict
  * @format
  */
+import type {BlobCollector} from './BlobTypes';
 
-const registry: {[key: string]: number, ...} = {};
+const registry: WeakMap<BlobCollector, number> = new WeakMap();
 
-const register = (id: string) => {
-  if (registry[id]) {
-    registry[id]++;
-  } else {
-    registry[id] = 1;
+const register = (collector: BlobCollector) => {
+  if (!registry.has(collector)) {
+    registry.set(collector, 1);
+    return;
   }
+
+  const currentCount = registry.get(collector);
+  registry.set(collector, currentCount + 1);
 };
 
-const unregister = (id: string) => {
-  if (registry[id]) {
-    registry[id]--;
-    if (registry[id] <= 0) {
-      delete registry[id];
-    }
+const unregister = (collector: BlobCollector) => {
+  if (!registry.has(collector)) {
+    return;
   }
+
+  const currentCount = registry.get(collector);
+
+  if (currentCount <= 1) {
+    registry.delete(collector);
+    return;
+  }
+
+  registry.set(collector, currentCount - 1);
 };
 
-const has = (id: string): number | boolean => {
-  return registry[id] && registry[id] > 0;
+const has = (collector: BlobCollector): boolean => {
+  return registry.has(collector) && registry.get(collector) > 0;
 };
 
 module.exports = {

--- a/Libraries/Blob/BlobRegistry.js
+++ b/Libraries/Blob/BlobRegistry.js
@@ -12,21 +12,12 @@ import type {BlobCollector} from './BlobTypes';
 const registry: WeakMap<BlobCollector, number> = new WeakMap();
 
 const register = (collector: BlobCollector) => {
-  if (!registry.has(collector)) {
-    registry.set(collector, 1);
-    return;
-  }
-
-  const currentCount = registry.get(collector);
+  const currentCount = registry.get(collector) || 0;
   registry.set(collector, currentCount + 1);
 };
 
 const unregister = (collector: BlobCollector) => {
-  if (!registry.has(collector)) {
-    return;
-  }
-
-  const currentCount = registry.get(collector);
+  const currentCount = registry.get(collector) || 0;
 
   if (currentCount <= 1) {
     registry.delete(collector);
@@ -37,7 +28,8 @@ const unregister = (collector: BlobCollector) => {
 };
 
 const has = (collector: BlobCollector): boolean => {
-  return registry.has(collector) && registry.get(collector) > 0;
+  const currentCount = registry.get(collector) || 0;
+  return currentCount > 0;
 };
 
 module.exports = {

--- a/Libraries/Blob/BlobTypes.js
+++ b/Libraries/Blob/BlobTypes.js
@@ -10,7 +10,22 @@
 
 'use strict';
 
-export opaque type BlobCollector = {...};
+export opaque type BlobCollector: {...} = {...};
+
+// **Temporary workaround**
+// TODO(#24654): Use turbomodules for the Blob module.
+// Blob collector is a jsi::HostObject that is used by native to know
+// when the a Blob instance is deallocated. This allows to free the
+// underlying native resources. This is a hack to workaround the fact
+// that the current bridge infra doesn't allow to track js objects
+// deallocation. Ideally the whole Blob object should be a jsi::HostObject.
+export function createBlobCollector(blobId: string): BlobCollector {
+  if (global.__blobCollectorProvider == null) {
+    return {};
+  } else {
+    return global.__blobCollectorProvider(blobId);
+  }
+}
 
 export type BlobData = {
   blobId: string,

--- a/Libraries/Blob/__tests__/BlobRegistry-test.js
+++ b/Libraries/Blob/__tests__/BlobRegistry-test.js
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+describe('BlobRegistry', () => {
+  let BlobRegistry;
+
+  beforeEach(() => {
+    jest.isolateModules(() => {
+      BlobRegistry = require('react-native/Libraries/Blob/BlobRegistry');
+    });
+  });
+
+  it('register adds a reference', () => {
+    const collector = {};
+    BlobRegistry.register(collector);
+    expect(BlobRegistry.has(collector)).toBe(true);
+  });
+
+  it('registering the same reference multiple times requires unregistering mutliple times', () => {
+    const collector = {};
+    BlobRegistry.register(collector);
+    BlobRegistry.register(collector);
+    BlobRegistry.register(collector);
+    BlobRegistry.unregister(collector);
+    expect(BlobRegistry.has(collector)).toBe(true);
+    BlobRegistry.unregister(collector);
+    BlobRegistry.unregister(collector);
+    expect(BlobRegistry.has(collector)).toBe(false);
+  });
+
+  it('has no reference for an unregistered object', () => {
+    expect(BlobRegistry.has({})).toBe(false);
+  });
+
+  it('does nothing if you unregister an unregistered object', () => {
+    const unknownCollector = {};
+    expect(() => BlobRegistry.unregister(unknownCollector)).not.toThrow();
+    expect(BlobRegistry.has(unknownCollector)).toBe(false);
+  });
+});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Fixes https://github.com/facebook/react-native/issues/30329

The blobIds for network requests are never unregistered from the blob registry, so the registry object [grows indefinitely](https://github.com/colbyr/ReactNativeScratch/pull/2). 

Instead of registering blobId strings in an object, we can track the "blob collector" reference in a `WeakMap`. That way if the collector is garbage collected, the entry in the registry will be collected as well.

If this isn't sufficient, I'm happy to explore another avenue. This works in the app I work on, but we don't really use Blobs outside of the network stack.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Fixed] - stop memory leak caused by stale blobIds

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
WeakMaps make this tricky to test. If you log them to the console in safari, the keys end up getting retained until you clear the console 🤪

1. Install an XCode Profile build of an app that makes subsequent network requests
2.Use safari to connect to the JSContext of the running app, take a heap snapshot and find the registry's WeakMap. Log it out to see the entries.
3. Clear the console and press the collect garbage button
4. Take a second heap snapshot and find the registry's WeakMap. Log it out to see the entries have updated, and the entries from the first snapshot are no longer in the registry.

