### PR TITLE
LifecycleEventListener provide default implementations

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -12,3 +12,7 @@
 
 [alias]
   rntester = //packages/rn-tester/android/app:app
+
+[java]
+  source_level = 8
+  target_level = 8

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/LifecycleEventListener.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/LifecycleEventListener.java
@@ -34,17 +34,17 @@ public interface LifecycleEventListener {
    * if the native module that implements this is initialized while the host activity is already
    * resumed. Always called for the most current activity.
    */
-  void onHostResume();
+  default void onHostResume() {};
 
   /**
    * Called when host activity receives pause event (e.g. {@link Activity#onPause}. Always called
    * for the most current activity.
    */
-  void onHostPause();
+  default void onHostPause() {};
 
   /**
    * Called when host activity receives destroy event (e.g. {@link Activity#onDestroy}. Only called
    * for the last React activity to be destroyed.
    */
-  void onHostDestroy();
+  default void onHostDestroy() {};
 }


### PR DESCRIPTION
## Summary

LifecycleEventListener provide default implementations so that developers override only methods they need, thus reduce boilerplate code.

Also changed .buckconfig to be consistent with gradle, and target Java 8.

## Changelog

[Android] [Changed] - LifecycleEventListener provide default implementations

## Test Plan

CI is green.
