### PR TITLE
don't install rsync, zip

### DIFF
--- a/.circleci/Dockerfiles/Dockerfile.android
+++ b/.circleci/Dockerfiles/Dockerfile.android
@@ -14,7 +14,7 @@
 # and build a Android application that can be used to run the
 # tests specified in the scripts/ directory.
 #
-FROM reactnativecommunity/react-native-android:2.1
+FROM reactnativecommunity/react-native-android:2.2
 
 LABEL Description="React Native Android Test Image"
 LABEL maintainer="Héctor Ramos <hector@fb.com>"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -501,11 +501,6 @@ jobs:
           background: true
 
       # Keep configuring Android dependencies while AVD boots up
-
-      - run:
-          name: Install rsync, zip
-          command: apt-get update -y && apt-get install rsync zip -y
-
       # Install Buck
       - install_buck_tooling
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ executors:
   reactnativeandroid:
     <<: *defaults
     docker:
-      - image: reactnativecommunity/react-native-android:2.1
+      - image: reactnativecommunity/react-native-android:2.2
     resource_class: "large"
     environment:
       - TERM: "dumb"

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "prettier": "prettier --write \"./**/*.{js,md,yml}\"",
     "format-check": "prettier --list-different \"./**/*.{js,md,yml}\"",
     "update-lock": "npx yarn-deduplicate",
-    "docker-setup-android": "docker pull reactnativecommunity/react-native-android:2.1",
+    "docker-setup-android": "docker pull reactnativecommunity/react-native-android:2.2",
     "docker-build-android": "docker build -t reactnativeci/android -f .circleci/Dockerfiles/Dockerfile.android .",
     "test-android-run-instrumentation": "docker run --cap-add=SYS_ADMIN -it reactnativeci/android bash .circleci/Dockerfiles/scripts/run-android-docker-instrumentation-tests.sh",
     "test-android-run-unit": "docker run --cap-add=SYS_ADMIN -it reactnativeci/android bash .circleci/Dockerfiles/scripts/run-android-docker-unit-tests.sh",


### PR DESCRIPTION
## Summary

Don't install rsync, zip which included in docker-android v2.2, thus reduce CI jobs/time.

## Changelog

[Internal] [Changed] - don't install rsync,zip because included in the docker image

## Test Plan

CI is green.