### PR TITLE
enable hermes by default

### DIFF
--- a/template/android/app/build.gradle
+++ b/template/android/app/build.gradle
@@ -78,7 +78,7 @@ import com.android.build.OutputFile
  */
 
 project.ext.react = [
-    enableHermes: false,  // clean and rebuild if changing
+    enableHermes: true,  // clean and rebuild if changing
 ]
 
 apply from: "../../node_modules/react-native/react.gradle"


### PR DESCRIPTION
## Summary

Hermes landed Proxy and supports most ES6 features, and IIRC, we talked and agreed to enable Hermes by default.

## Changelog

[Android] [Changed] - enable Hermes by default

## Test Plan

New projects will default to Hermes.
