### PR TITLE
Use newer metro language: `blacklistRE` -> `blockList`

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -19,7 +19,7 @@ const getPolyfills = require('./rn-get-polyfills');
 module.exports = {
   resolver: {
     // $FlowFixMe[signature-verification-failure] Can't infer RegExp type.
-    blacklistRE: /buck-out/,
+    blockList: /buck-out/,
     extraNodeModules: {
       'react-native': __dirname,
     },


### PR DESCRIPTION
## Summary

An [update to `metro`](https://github.com/facebook/metro/commit/94c0b541b4bfa17aee4efa0f1969565522ce830d#diff-1a3c1a959bb8c4e2e9743c03cb7a6d0c56648ffcfe129a11b9090bfc139622dd) which landed in metro 0.60 (RN 0.64+) deprecates the config `blacklistRE`, renaming it to `blockList`. Although the former is still supported it now generates a deprecation warning.

## Changelog

[General] [Fixed] - Update metro config language to `blockList`

## Test Plan

Confirm that the config is still respected (`/buck-out/` should be excluded), and that no deprecation warning is issued.