### PR TITLE
stacktrace-parser: move `require` further up in the file

### DIFF
--- a/Libraries/Core/Devtools/parseErrorStack.js
+++ b/Libraries/Core/Devtools/parseErrorStack.js
@@ -13,6 +13,7 @@
 import type {StackFrame} from '../NativeExceptionsManager';
 import type {HermesParsedStack} from './parseHermesStack';
 
+const stacktraceParser = require('stacktrace-parser');
 const parseHermesStack = require('./parseHermesStack');
 
 export type ExtendedError = Error & {
@@ -52,7 +53,6 @@ function parseErrorStack(errorStack?: string): Array<StackFrame> {
     return [];
   }
 
-  const stacktraceParser = require('stacktrace-parser');
   const parsedStack = Array.isArray(errorStack)
     ? errorStack
     : global.HermesInternal


### PR DESCRIPTION
## Summary

When running jest tests on 0.63.3, for some reason we kept getting the following error on CircleCI:

```
#!/bin/bash -eo pipefail
ls test-results.json || yarn jest --outputFile test-results.json --json --ci --forceExit --runInBand

ls: cannot access 'test-results.json': No such file or directory
yarn run v1.22.4
$ /home/circleci/project/node_modules/.bin/jest --outputFile test-results.json --json --ci --forceExit --runInBand
 PASS  src/lib/utils/ArtworkFilter/__tests__/ArtworkFiltersStore-tests.tsx
 PASS  src/lib/Components/Bidding/Screens/__tests__/ConfirmBid-tests.tsx (20.415s)
 PASS  src/lib/navigation/__tests__/routes-tests.tsx
 PASS  src/lib/Components/Bidding/Screens/__tests__/Registration-tests.tsx
/home/circleci/project/node_modules/react-native/Libraries/Core/Devtools/parseErrorStack.js:55
  var stack = Array.isArray(e.stack) ? e.stack : global.HermesInternal ? convertHermesStack(parseHermesStack(e.stack)) : stacktraceParser.parse(e.stack).map(function (frame) {
                                                                                                                                          ^

TypeError: stacktraceParser.parse is not a function
    at parse (/home/circleci/project/node_modules/react-native/Libraries/Core/Devtools/parseErrorStack.js:60:24)
    at parseErrorStack (/home/circleci/project/node_modules/react-native/Libraries/Core/ExceptionsManager.js:63:19)
    at Object.reportException (/home/circleci/project/node_modules/react-native/Libraries/Core/ExceptionsManager.js:171:5)
    at handleException (/home/circleci/project/node_modules/react-native/Libraries/LogBox/Data/LogBoxData.js:108:21)
    at Immediate.reportLogBoxError (/home/circleci/project/node_modules/react-native/Libraries/LogBox/Data/LogBoxData.js:217:7)
    at processImmediate (internal/timers.js:456:21)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

Exited with code exit status 1
```

This `TypeError: stacktraceParser.parse is not a function` kept appearing at random tests.

After we moved the `require` higher up in the file, it never appeared again.


## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Internal] [Fixed] - stacktrack-parser import fix

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
