### PR TITLE
WIP: specify ndkVersion, buildToolsVersion

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -382,6 +382,7 @@ task extractJNIFiles {
 
 android {
     compileSdkVersion 29
+    buildToolsVersion "29.0.3"
 
     compileOptions {
         sourceCompatibility(JavaVersion.VERSION_1_8)

--- a/packages/rn-tester/android/app/build.gradle
+++ b/packages/rn-tester/android/app/build.gradle
@@ -127,7 +127,7 @@ def useIntlJsc = false
 
 android {
     compileSdkVersion 29
-
+    ndkVersion "20.1.5948944"
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
## Summary

Specify buildToolsVersion in ReactAndroid, because docker image include 29.0.3 only and AGP uses 29.0.2 by default, also  specify ndkVersion in RNTester because docker image include 20 only. Specifying all these will reduce CI time, thus improve DX.

## Changelog

[Internal] [Changed] - Specify buildToolsVersion in ReactAndroid, and ndkVersion in RNTester

## Test Plan

Download dependencies using Gradle job will succeed instantaneously, instead of running more than a minute. See https://app.circleci.com/pipelines/github/facebook/react-native/7053/workflows/2b355a77-8057-458d-8123-78d7492a978d/jobs/176107/parallel-runs/0/steps/0-116