### PR TITLE
[other] Remove an example folder from npm package

### DIFF
--- a/Libraries/.npmignore
+++ b/Libraries/.npmignore
@@ -1,1 +1,2 @@
+Animated/examples
 __tests__


### PR DESCRIPTION
## Summary

Currently, RN includes demo files in npm:

- https://unpkg.com/browse/react-native@0.63.3/Libraries/Animated/examples/


## Changelog

[General] [Fixed] - Reduce npm package size


## Test Plan

```sh
npm pack --dry-run
```
