### PR TITLE
[Android] support onMomentumScrollEnd event after programmatic scroll to match iOS behavior

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
@@ -192,8 +192,10 @@ public class ReactHorizontalScrollViewManager extends ViewGroupManager<ReactHori
       ReactHorizontalScrollView scrollView, ReactScrollViewCommandHelper.ScrollToCommandData data) {
     if (data.mAnimated) {
       scrollView.reactSmoothScrollTo(data.mDestX, data.mDestY);
+      scrollView.handleSmoothScrollMomentumEvents();
     } else {
       scrollView.reactScrollTo(data.mDestX, data.mDestY);
+      ReactScrollViewHelper.emitScrollMomentumEndEvent(scrollView);
     }
   }
 
@@ -205,8 +207,10 @@ public class ReactHorizontalScrollViewManager extends ViewGroupManager<ReactHori
     int right = scrollView.getChildAt(0).getWidth() + scrollView.getPaddingRight();
     if (data.mAnimated) {
       scrollView.reactSmoothScrollTo(right, scrollView.getScrollY());
+      scrollView.handleSmoothScrollMomentumEvents();
     } else {
       scrollView.reactScrollTo(right, scrollView.getScrollY());
+      ReactScrollViewHelper.emitScrollMomentumEndEvent(scrollView);
     }
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -73,6 +73,7 @@ public class ReactScrollView extends ScrollView
   private boolean mDragging;
   private boolean mPagingEnabled = false;
   private @Nullable Runnable mPostTouchRunnable;
+  private @Nullable Runnable mPostSmoothScrollRunnable;
   private boolean mRemoveClippedSubviews;
   private boolean mScrollEnabled = true;
   private boolean mSendMomentumEvents;
@@ -544,10 +545,10 @@ public class ReactScrollView extends ScrollView
                 ViewCompat.postOnAnimationDelayed(
                     ReactScrollView.this, this, ReactScrollViewHelper.MOMENTUM_DELAY);
               } else {
-                if (mSendMomentumEvents) {
+                if (mSendMomentumEvents && !mRunning) {
                   ReactScrollViewHelper.emitScrollMomentumEndEvent(ReactScrollView.this);
+                  disableFpsListener();
                 }
-                disableFpsListener();
               }
             }
 
@@ -563,6 +564,45 @@ public class ReactScrollView extends ScrollView
     ViewCompat.postOnAnimationDelayed(
         this, mPostTouchRunnable, ReactScrollViewHelper.MOMENTUM_DELAY);
   }
+
+  /**
+   * This handles any sort of animated scrolling that may occur as a result of an API call on ScrollView.
+   * For example, calling scrollTo with animated = true, initiates a scroll effect that runs over time.
+   * To match iOS, and to have a complete API, a onMomentumScrollEnd event should accompany any scroll call
+   * so that actions can be taken when a scroll is complete.  This code maps roughly to handlePostTouchScrolling,
+   * but is much simpler as it results from a simple API call vs. a user interaction.  It only executes if
+   * momentum events are turned on.
+   */
+  public void handleSmoothScrollMomentumEvents() {
+    if (!mSendMomentumEvents || null != mPostSmoothScrollRunnable) {
+      return;
+    }
+
+    enableFpsListener();
+    mActivelyScrolling = false;
+    mPostSmoothScrollRunnable = new Runnable() {
+
+      @Override
+      public void run() {
+        if (mActivelyScrolling) {
+          // We are still scrolling so we just post to check again a frame later
+          mActivelyScrolling = false;
+          ViewCompat.postOnAnimationDelayed(
+            ReactScrollView.this, this, ReactScrollViewHelper.MOMENTUM_DELAY);
+        } else {
+          // There has not been a scroll update since the last time this Runnable executed.
+          updateStateOnScroll();
+          ReactScrollViewHelper.emitScrollMomentumEndEvent(ReactScrollView.this);
+          ReactScrollView.this.mPostSmoothScrollRunnable = null;
+          disableFpsListener();
+        }
+      }
+    };
+    ViewCompat.postOnAnimationDelayed(
+      ReactScrollView.this, mPostSmoothScrollRunnable, ReactScrollViewHelper.MOMENTUM_DELAY);
+
+  }
+
 
   /** Get current X position or position after current animation finishes, if any. */
   private int getPostAnimationScrollX() {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.java
@@ -205,8 +205,10 @@ public class ReactScrollViewManager extends ViewGroupManager<ReactScrollView>
       ReactScrollView scrollView, ReactScrollViewCommandHelper.ScrollToCommandData data) {
     if (data.mAnimated) {
       scrollView.reactSmoothScrollTo(data.mDestX, data.mDestY);
+      scrollView.handleSmoothScrollMomentumEvents();
     } else {
       scrollView.reactScrollTo(data.mDestX, data.mDestY);
+      ReactScrollViewHelper.emitScrollMomentumEndEvent(scrollView);
     }
   }
 
@@ -284,8 +286,10 @@ public class ReactScrollViewManager extends ViewGroupManager<ReactScrollView>
     int bottom = child.getHeight() + scrollView.getPaddingBottom();
     if (data.mAnimated) {
       scrollView.reactSmoothScrollTo(scrollView.getScrollX(), bottom);
+      scrollView.handleSmoothScrollMomentumEvents();
     } else {
       scrollView.reactScrollTo(scrollView.getScrollX(), bottom);
+      ReactScrollViewHelper.emitScrollMomentumEndEvent(scrollView);
     }
   }
 

--- a/packages/rn-tester/js/examples/FlatList/FlatListExample.js
+++ b/packages/rn-tester/js/examples/FlatList/FlatListExample.js
@@ -84,6 +84,10 @@ class FlatListExample extends React.PureComponent<Props, State> {
     this._listRef.scrollToIndex({viewPosition: 0.5, index: Number(text)});
   };
 
+  _onChangeScrollOffset = text => {
+    this._listRef.scrollToOffset({offset: Number(text), animated: false});
+  };
+
   _scrollPos = new Animated.Value(0);
   _scrollSinkX = Animated.event(
     [{nativeEvent: {contentOffset: {x: this._scrollPos}}}],
@@ -120,6 +124,10 @@ class FlatListExample extends React.PureComponent<Props, State> {
               <PlainInput
                 onChangeText={this._onChangeScrollToIndex}
                 placeholder="scrollToIndex..."
+              />
+              <PlainInput
+                onChangeText={this._onChangeScrollOffset}
+                placeholder="scrollToOffset..."
               />
             </View>
             <View style={styles.options}>
@@ -175,6 +183,12 @@ class FlatListExample extends React.PureComponent<Props, State> {
             onScroll={
               this.state.horizontal ? this._scrollSinkX : this._scrollSinkY
             }
+            onMomentumScrollEnd={() => {
+              console.log('onMomentumScrollEnd');
+            }}
+            onMomentumScrollBegin={e => {
+              console.log('onMomentumScrollBegin', e.nativeEvent);
+            }}
             onViewableItemsChanged={this._onViewableItemsChanged}
             ref={this._captureRef}
             refreshing={false}

--- a/packages/rn-tester/js/examples/ScrollView/ScrollViewSimpleExample.js
+++ b/packages/rn-tester/js/examples/ScrollView/ScrollViewSimpleExample.js
@@ -24,7 +24,7 @@ const nullthrows = require('nullthrows');
 
 const NUM_ITEMS = 20;
 
-class ScrollViewSimpleExample extends React.Component<{...}> {
+class ScrollViewSimpleExample extends React.Component<{ ... }> {
   makeItems: (nItems: number, styles: any) => Array<any> = (
     nItems: number,
     styles,
@@ -48,7 +48,18 @@ class ScrollViewSimpleExample extends React.Component<{...}> {
     // One of the items is a horizontal scroll view
     const items = this.makeItems(NUM_ITEMS, styles.itemWrapper);
     items[4] = (
-      <ScrollView key={'scrollView'} horizontal={true}>
+      <ScrollView
+        ref={scrollView => {
+          _horizontalScrollView1 = scrollView;
+        }}
+        key={'scrollView'}
+        horizontal={true}
+        onMomentumScrollEnd={() => {
+          console.log('First Horizontal ScrollView onMomentumScrollEnd');
+        }}
+        onMomentumScrollBegin={e => {
+          console.log('First Horizontal ScrollView onMomentumScrollBegin', e.nativeEvent);
+        }}>
         {this.makeItems(NUM_ITEMS, [
           styles.itemWrapper,
           styles.horizontalItemWrapper,
@@ -57,10 +68,19 @@ class ScrollViewSimpleExample extends React.Component<{...}> {
     );
     items.push(
       <ScrollView
+        ref={scrollView => {
+          _horizontalScrollView2 = scrollView;
+        }}
         key={'scrollViewSnap'}
         horizontal
         snapToInterval={210.0}
-        pagingEnabled>
+        pagingEnabled
+        onMomentumScrollEnd={() => {
+          console.log('Paging Horizontal ScrollView onMomentumScrollEnd');
+        }}
+        onMomentumScrollBegin={e => {
+          console.log('Paging Horizontal ScrollView onMomentumScrollBegin', e.nativeEvent);
+        }}>
         {this.makeItems(NUM_ITEMS, [
           styles.itemWrapper,
           styles.horizontalItemWrapper,
@@ -69,13 +89,15 @@ class ScrollViewSimpleExample extends React.Component<{...}> {
       </ScrollView>,
     );
 
-return (
+    return (
       <View style={styles.container}>
         <View style={styles.options}>
           <Button
             title="Animated Scroll to top"
             onPress={() => {
-              nullthrows(_scrollView).scrollTo({x: 0, y:0, animated: true});
+              nullthrows(_scrollView).scrollTo({x: 0, y: 0, animated: true});
+              nullthrows(_horizontalScrollView1).scrollTo({x: 0, y: 0, animated: true});
+              nullthrows(_horizontalScrollView2).scrollTo({x: 0, y: 0, animated: true});
             }}
             style={styles.button}
           />
@@ -83,6 +105,8 @@ return (
             title="Animated Scroll to End"
             onPress={() => {
               nullthrows(_scrollView).scrollToEnd({animated: true});
+              nullthrows(_horizontalScrollView1).scrollToEnd({animated: true});
+              nullthrows(_horizontalScrollView2).scrollToEnd({animated: true});
             }}
             style={styles.button}
             color={'blue'}
@@ -94,10 +118,10 @@ return (
           }}
           style={styles.verticalScrollView}
           onMomentumScrollEnd={() => {
-            console.log('onMomentumScrollEnd');
+            console.log('Vertical ScrollView onMomentumScrollEnd');
           }}
           onMomentumScrollBegin={e => {
-            console.log('onMomentumScrollBegin', e.nativeEvent);
+            console.log('Vertical ScrollView onMomentumScrollBegin', e.nativeEvent);
           }}>
           {items}
         </ScrollView>
@@ -143,8 +167,8 @@ exports.description =
 exports.examples = [
   {
     title: 'Simple scroll view',
-    render: function(): React.Element<typeof ScrollViewSimpleExample> {
-      return <ScrollViewSimpleExample />;
+    render: function (): React.Element<typeof ScrollViewSimpleExample> {
+      return <ScrollViewSimpleExample/>;
     },
   },
 ];

--- a/packages/rn-tester/js/examples/ScrollView/ScrollViewSimpleExample.js
+++ b/packages/rn-tester/js/examples/ScrollView/ScrollViewSimpleExample.js
@@ -17,7 +17,10 @@ const {
   StyleSheet,
   Text,
   TouchableOpacity,
+  View,
+  Button,
 } = require('react-native');
+const nullthrows = require('nullthrows');
 
 const NUM_ITEMS = 20;
 
@@ -38,6 +41,10 @@ class ScrollViewSimpleExample extends React.Component<{...}> {
   };
 
   render(): React.Node {
+    let _scrollView: ?React.ElementRef<typeof ScrollView>;
+    let _horizontalScrollView1: ?React.ElementRef<typeof ScrollView>;
+    let _horizontalScrollView2: ?React.ElementRef<typeof ScrollView>;
+
     // One of the items is a horizontal scroll view
     const items = this.makeItems(NUM_ITEMS, styles.itemWrapper);
     items[4] = (
@@ -62,17 +69,54 @@ class ScrollViewSimpleExample extends React.Component<{...}> {
       </ScrollView>,
     );
 
-    const verticalScrollView = (
-      <ScrollView style={styles.verticalScrollView}>{items}</ScrollView>
+return (
+      <View style={styles.container}>
+        <View style={styles.options}>
+          <Button
+            title="Animated Scroll to top"
+            onPress={() => {
+              nullthrows(_scrollView).scrollTo({x: 0, y:0, animated: true});
+            }}
+            style={styles.button}
+          />
+          <Button
+            title="Animated Scroll to End"
+            onPress={() => {
+              nullthrows(_scrollView).scrollToEnd({animated: true});
+            }}
+            style={styles.button}
+            color={'blue'}
+          />
+        </View>
+        <ScrollView
+          ref={scrollView => {
+            _scrollView = scrollView;
+          }}
+          style={styles.verticalScrollView}
+          onMomentumScrollEnd={() => {
+            console.log('onMomentumScrollEnd');
+          }}
+          onMomentumScrollBegin={e => {
+            console.log('onMomentumScrollBegin', e.nativeEvent);
+          }}>
+          {items}
+        </ScrollView>
+      </View>
     );
-
-    return verticalScrollView;
   }
 }
 
 const styles = StyleSheet.create({
   verticalScrollView: {
     margin: 10,
+    backgroundColor: 'white',
+    flexGrow: 1,
+  },
+  options: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   itemWrapper: {
     backgroundColor: '#dddddd',

--- a/packages/rn-tester/js/examples/ScrollView/ScrollViewSimpleExample.js
+++ b/packages/rn-tester/js/examples/ScrollView/ScrollViewSimpleExample.js
@@ -24,7 +24,7 @@ const nullthrows = require('nullthrows');
 
 const NUM_ITEMS = 20;
 
-class ScrollViewSimpleExample extends React.Component<{ ... }> {
+class ScrollViewSimpleExample extends React.Component<{...}> {
   makeItems: (nItems: number, styles: any) => Array<any> = (
     nItems: number,
     styles,
@@ -58,7 +58,10 @@ class ScrollViewSimpleExample extends React.Component<{ ... }> {
           console.log('First Horizontal ScrollView onMomentumScrollEnd');
         }}
         onMomentumScrollBegin={e => {
-          console.log('First Horizontal ScrollView onMomentumScrollBegin', e.nativeEvent);
+          console.log(
+            'First Horizontal ScrollView onMomentumScrollBegin',
+            e.nativeEvent,
+          );
         }}>
         {this.makeItems(NUM_ITEMS, [
           styles.itemWrapper,
@@ -79,7 +82,10 @@ class ScrollViewSimpleExample extends React.Component<{ ... }> {
           console.log('Paging Horizontal ScrollView onMomentumScrollEnd');
         }}
         onMomentumScrollBegin={e => {
-          console.log('Paging Horizontal ScrollView onMomentumScrollBegin', e.nativeEvent);
+          console.log(
+            'Paging Horizontal ScrollView onMomentumScrollBegin',
+            e.nativeEvent,
+          );
         }}>
         {this.makeItems(NUM_ITEMS, [
           styles.itemWrapper,
@@ -96,8 +102,16 @@ class ScrollViewSimpleExample extends React.Component<{ ... }> {
             title="Animated Scroll to top"
             onPress={() => {
               nullthrows(_scrollView).scrollTo({x: 0, y: 0, animated: true});
-              nullthrows(_horizontalScrollView1).scrollTo({x: 0, y: 0, animated: true});
-              nullthrows(_horizontalScrollView2).scrollTo({x: 0, y: 0, animated: true});
+              nullthrows(_horizontalScrollView1).scrollTo({
+                x: 0,
+                y: 0,
+                animated: true,
+              });
+              nullthrows(_horizontalScrollView2).scrollTo({
+                x: 0,
+                y: 0,
+                animated: true,
+              });
             }}
             style={styles.button}
           />
@@ -121,7 +135,10 @@ class ScrollViewSimpleExample extends React.Component<{ ... }> {
             console.log('Vertical ScrollView onMomentumScrollEnd');
           }}
           onMomentumScrollBegin={e => {
-            console.log('Vertical ScrollView onMomentumScrollBegin', e.nativeEvent);
+            console.log(
+              'Vertical ScrollView onMomentumScrollBegin',
+              e.nativeEvent,
+            );
           }}>
           {items}
         </ScrollView>
@@ -167,8 +184,8 @@ exports.description =
 exports.examples = [
   {
     title: 'Simple scroll view',
-    render: function (): React.Element<typeof ScrollViewSimpleExample> {
-      return <ScrollViewSimpleExample/>;
+    render: function(): React.Element<typeof ScrollViewSimpleExample> {
+      return <ScrollViewSimpleExample />;
     },
   },
 ];

--- a/packages/rn-tester/js/examples/ScrollView/ScrollViewSimpleExample.js
+++ b/packages/rn-tester/js/examples/ScrollView/ScrollViewSimpleExample.js
@@ -113,7 +113,6 @@ class ScrollViewSimpleExample extends React.Component<{...}> {
                 animated: true,
               });
             }}
-            style={styles.button}
           />
           <Button
             title="Animated Scroll to End"
@@ -122,7 +121,6 @@ class ScrollViewSimpleExample extends React.Component<{...}> {
               nullthrows(_horizontalScrollView1).scrollToEnd({animated: true});
               nullthrows(_horizontalScrollView2).scrollToEnd({animated: true});
             }}
-            style={styles.button}
             color={'blue'}
           />
         </View>
@@ -173,9 +171,6 @@ const styles = StyleSheet.create({
   },
   horizontalPagingItemWrapper: {
     width: 200,
-  },
-  button: {
-    margin: 10,
   },
 });
 

--- a/packages/rn-tester/js/examples/ScrollView/ScrollViewSimpleExample.js
+++ b/packages/rn-tester/js/examples/ScrollView/ScrollViewSimpleExample.js
@@ -174,6 +174,9 @@ const styles = StyleSheet.create({
   horizontalPagingItemWrapper: {
     width: 200,
   },
+  button: {
+    margin: 10,
+  },
 });
 
 exports.title = 'ScrollViewSimpleExample';

--- a/packages/rn-tester/js/examples/ScrollView/ScrollViewSimpleExample.js
+++ b/packages/rn-tester/js/examples/ScrollView/ScrollViewSimpleExample.js
@@ -146,6 +146,10 @@ class ScrollViewSimpleExample extends React.Component<{...}> {
 }
 
 const styles = StyleSheet.create({
+  container: {
+    backgroundColor: 'rgb(239, 239, 244)',
+    flex: 1,
+  },
   verticalScrollView: {
     margin: 10,
     backgroundColor: 'white',


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
This commit addresses two issues:
1) The recent changes to handlePostTouchScrolling introduced two extra onMomentumScrollEnd events.  Only one should be fired when the scroll is complete, not three
2) on iOS, an onMomentScrollEnd event is fired even when the scroll is caused programmatically.  These changes make Android behave in the same manner, ensuring that you get an end event, regardless of how the scroll was initiated.

This addresses this issue that was raised over a year ago:
https://github.com/facebook/react-native/issues/26661

and this issue from 2018
https://github.com/facebook/react-native/issues/21718

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Fixed] - Support onMomentumScrollEnd event after programmatic scroll to match iOS behavior

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
I have made updates to the RNTester app to demonstrate the changes, specifically in FlatListExample and ScrollViewSimpleExample.  
With the FlatListExample, type into either the scrollToIndex... or the (new) scrollToOffset... text boxes and watch the onMomentumScrollEnd log message appear.  Similarly, you can manually scroll the scroll view and see both begin and end scroll events (and only one end scroll event)
With the ScrollViewSimpleExample, tap the new buttons on the top and watch the logs.

You can now run the app on both Android and iOS and see the same behavior. 
