### PR TITLE
fix glog pod install with Xcode 12

### DIFF
--- a/scripts/ios-configure-glog.sh
+++ b/scripts/ios-configure-glog.sh
@@ -16,7 +16,7 @@ if [ -z "$CURRENT_ARCH" ] || [ "$CURRENT_ARCH" == "undefined_arch" ]; then
     if [[ "$PLATFORM_NAME" == *"simulator"* ]]; then
         CURRENT_ARCH="x86_64"
     else
-        CURRENT_ARCH="armv7"
+        CURRENT_ARCH="arm64"
     fi
 fi
 


### PR DESCRIPTION
## Summary

Today I created a project with RN 0.63 and it failed to **pod install**, and after some investigation I found following error. It's caused by Xcode 12 because it dropped support for 32 bit architectures, but following script sets architecture to armv7 which is 32bit.

This will change architecture to arm64, 64 bit.

```
configure:3727: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc -arch armv7 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS14.1.sdk    conftest.c  >&5
clang: error: invalid iOS deployment version 'IPHONEOS_DEPLOYMENT_TARGET=12.0', iOS 10 is the maximum deployment target for 32-bit targets [-Winvalid-ios-deployment-target]
configure:3731: $? = 1
```

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[IOS] [Changed] - fix glog pod install with Xcode 12

## Test Plan

Create a new project using react-native init, and it'll fail to do pod install. When this change applied, it'll do it successfully.