### PR TITLE
Fix RNTester Not Resizing Examples on Rotation/Resize

### DIFF
--- a/packages/rn-tester/js/components/ExamplePage.js
+++ b/packages/rn-tester/js/components/ExamplePage.js
@@ -11,7 +11,7 @@
 'use strict';
 
 import * as React from 'react';
-import {StyleSheet, View, Text, Dimensions} from 'react-native';
+import {StyleSheet, View, Text} from 'react-native';
 
 type Props = $ReadOnly<{|
   children?: React.Node,
@@ -22,7 +22,6 @@ type Props = $ReadOnly<{|
   android?: ?boolean,
 |}>;
 
-const ScreenWidth = Dimensions.get('window').width;
 import {RNTesterThemeContext} from './RNTesterTheme';
 
 export default function ExamplePage(props: Props): React.Node {
@@ -76,7 +75,6 @@ const styles = StyleSheet.create({
     justifyContent: 'flex-end',
   },
   examplesContainer: {
-    width: ScreenWidth,
     flexGrow: 1,
   },
   description: {


### PR DESCRIPTION
## Summary

Fixes #30325

After the RNTester redesign, a style started globally caching screen width. This isn't needed, but means that width is incorrect if the device is rotated, or a window is resized. Rely on default layout which will be 100% width instead.
## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Internal] [Fixed] - Fix RNTester Not Resizing Examples on Rotation/Resize

## Test Plan

Tested viewing an example and rotating the device in iOS simulator
