### PR TITLE
Add onFocus and onBlur to Pressable.

### DIFF
--- a/Libraries/Components/Pressable/Pressable.js
+++ b/Libraries/Components/Pressable/Pressable.js
@@ -25,7 +25,12 @@ import type {
 import {PressabilityDebugView} from '../../Pressability/PressabilityDebug';
 import usePressability from '../../Pressability/usePressability';
 import {normalizeRect, type RectOrSize} from '../../StyleSheet/Rect';
-import type {LayoutEvent, PressEvent} from '../../Types/CoreEventTypes';
+import type {
+  LayoutEvent,
+  PressEvent,
+  BlurEvent,
+  FocusEvent,
+} from '../../Types/CoreEventTypes';
 import View from '../View/View';
 
 type ViewStyleProp = $ElementType<React.ElementConfig<typeof View>, 'style'>;
@@ -106,6 +111,16 @@ type Props = $ReadOnly<{|
   onPressOut?: ?(event: PressEvent) => void,
 
   /**
+   * Called after the element loses focus.
+   */
+  onBlur?: ?(event: BlurEvent) => mixed,
+
+  /**
+   * Called after the element is focused.
+   */
+  onFocus?: ?(event: FocusEvent) => mixed,
+
+  /**
    * Either view styles or a function that receives a boolean reflecting whether
    * the component is currently pressed and returns view styles.
    */
@@ -154,6 +169,8 @@ function Pressable(props: Props, forwardedRef): React.Node {
     onPress,
     onPressIn,
     onPressOut,
+    onBlur,
+    onFocus,
     pressRetentionOffset,
     style,
     testOnly_pressed,
@@ -207,6 +224,8 @@ function Pressable(props: Props, forwardedRef): React.Node {
           onPressOut(event);
         }
       },
+      onBlur,
+      onFocus,
     }),
     [
       android_disableSound,
@@ -218,6 +237,8 @@ function Pressable(props: Props, forwardedRef): React.Node {
       onPress,
       onPressIn,
       onPressOut,
+      onBlur,
+      onFocus,
       pressRetentionOffset,
       setPressed,
       unstable_pressDelay,

--- a/Libraries/Components/View/View.js
+++ b/Libraries/Components/View/View.js
@@ -11,10 +11,15 @@
 'use strict';
 
 import type {ViewProps} from './ViewPropTypes';
-
+import type {BlurEvent, FocusEvent} from '../../Types/CoreEventTypes';
 const React = require('react');
 import ViewNativeComponent from './ViewNativeComponent';
 const TextAncestor = require('../../Text/TextAncestor');
+const TextInputState = require('../TextInput/TextInputState');
+import type {HostComponent} from '../../Renderer/shims/ReactNativeTypes';
+type ComponentRef = React.ElementRef<HostComponent<mixed>>;
+const setAndForwardRef = require('../../Utilities/setAndForwardRef');
+const {useRef} = React;
 
 export type Props = ViewProps;
 
@@ -29,9 +34,37 @@ const View: React.AbstractComponent<
   ViewProps,
   React.ElementRef<typeof ViewNativeComponent>,
 > = React.forwardRef((props: ViewProps, forwardedRef) => {
+  const viewRef = useRef<null | React.ElementRef<HostComponent<mixed>>>(null);
+
+  const _setNativeRef = setAndForwardRef({
+    getForwardedRef: () => forwardedRef,
+    setLocalRef: ref => {
+      viewRef.current = ref;
+    },
+  });
+
+  const _onBlur = (event: BlurEvent) => {
+    TextInputState.blurInput(viewRef.current);
+    if (props.onBlur) {
+      props.onBlur(event);
+    }
+  };
+
+  const _onFocus = (event: FocusEvent) => {
+    TextInputState.focusInput(viewRef.current);
+    if (props.onFocus) {
+      props.onFocus(event);
+    }
+  };
+
   return (
     <TextAncestor.Provider value={false}>
-      <ViewNativeComponent {...props} ref={forwardedRef} />
+      <ViewNativeComponent
+        onBlur={_onBlur}
+        onFocus={_onFocus}
+        {...props}
+        ref={_setNativeRef}
+      />
     </TextAncestor.Provider>
   );
 });

--- a/Libraries/Components/View/View.js
+++ b/Libraries/Components/View/View.js
@@ -17,7 +17,6 @@ import ViewNativeComponent from './ViewNativeComponent';
 const TextAncestor = require('../../Text/TextAncestor');
 const TextInputState = require('../TextInput/TextInputState');
 import type {HostComponent} from '../../Renderer/shims/ReactNativeTypes';
-type ComponentRef = React.ElementRef<HostComponent<mixed>>;
 const setAndForwardRef = require('../../Utilities/setAndForwardRef');
 const {useRef} = React;
 
@@ -60,9 +59,9 @@ const View: React.AbstractComponent<
   return (
     <TextAncestor.Provider value={false}>
       <ViewNativeComponent
+        {...props}
         onBlur={_onBlur}
         onFocus={_onFocus}
-        {...props}
         ref={_setNativeRef}
       />
     </TextAncestor.Provider>

--- a/ReactAndroid/src/main/java/com/facebook/react/views/common/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/common/BUCK
@@ -1,4 +1,4 @@
-load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "rn_android_library")
+load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "rn_android_library", "react_native_target")
 
 rn_android_library(
     name = "common",
@@ -17,5 +17,8 @@ rn_android_library(
         "PUBLIC",
     ],
     deps = [
+        react_native_target("java/com/facebook/react/uimanager:uimanager"),
+        react_native_target("java/com/facebook/react/uimanager/annotations:annotations"),
+        react_native_target("java/com/facebook/react/bridge:bridge"),
     ],
 )

--- a/ReactAndroid/src/main/java/com/facebook/react/views/common/ReactViewBlurEvent.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/common/ReactViewBlurEvent.java
@@ -12,7 +12,7 @@ import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.uimanager.events.Event;
 import com.facebook.react.uimanager.events.RCTEventEmitter;
 
-/** Event emitted a native view when it loses focus. */
+/** Event emitted by a native view when it loses focus. */
 public class ReactViewBlurEvent extends Event<ReactViewBlurEvent> {
 
   private static final String EVENT_NAME = "topBlur";

--- a/ReactAndroid/src/main/java/com/facebook/react/views/common/ReactViewBlurEvent.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/common/ReactViewBlurEvent.java
@@ -5,19 +5,19 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-package com.facebook.react.views.textinput;
+package com.facebook.react.views.common;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.uimanager.events.Event;
 import com.facebook.react.uimanager.events.RCTEventEmitter;
 
-/** Event emitted by EditText native view when it loses focus. */
-/* package */ class ReactTextInputBlurEvent extends Event<ReactTextInputBlurEvent> {
+/** Event emitted a native view when it loses focus. */
+public class ReactViewBlurEvent extends Event<ReactViewBlurEvent> {
 
   private static final String EVENT_NAME = "topBlur";
 
-  public ReactTextInputBlurEvent(int viewId) {
+  public ReactViewBlurEvent(int viewId) {
     super(viewId);
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/common/ReactViewFocusEvent.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/common/ReactViewFocusEvent.java
@@ -5,19 +5,19 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-package com.facebook.react.views.textinput;
+package com.facebook.react.views.common;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.uimanager.events.Event;
 import com.facebook.react.uimanager.events.RCTEventEmitter;
 
-/** Event emitted by EditText native view when it receives focus. */
-/* package */ class ReactTextInputFocusEvent extends Event<ReactTextInputFocusEvent> {
+/** Event emitted by a native view when it receives focus. */
+public class ReactViewFocusEvent extends Event<ReactViewFocusEvent> {
 
   private static final String EVENT_NAME = "topFocus";
 
-  public ReactTextInputFocusEvent(int viewId) {
+  public ReactViewFocusEvent(int viewId) {
     super(viewId);
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/BUCK
@@ -20,6 +20,7 @@ rn_android_library(
         react_native_target("java/com/facebook/react/modules/core:core"),
         react_native_target("java/com/facebook/react/uimanager:uimanager"),
         react_native_target("java/com/facebook/react/uimanager/annotations:annotations"),
+        react_native_target("java/com/facebook/react/views/common:common"),
         react_native_target("java/com/facebook/react/views/imagehelper:imagehelper"),
         react_native_target("java/com/facebook/react/views/scroll:scroll"),
         react_native_target("java/com/facebook/react/views/text:text"),

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -59,6 +59,8 @@ import com.facebook.react.uimanager.ViewProps;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.annotations.ReactPropGroup;
 import com.facebook.react.uimanager.events.EventDispatcher;
+import com.facebook.react.views.common.ReactViewBlurEvent;
+import com.facebook.react.views.common.ReactViewFocusEvent;
 import com.facebook.react.views.imagehelper.ResourceDrawableIdHelper;
 import com.facebook.react.views.scroll.ScrollEvent;
 import com.facebook.react.views.scroll.ScrollEventType;
@@ -974,9 +976,9 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
           public void onFocusChange(View v, boolean hasFocus) {
             EventDispatcher eventDispatcher = getEventDispatcher(reactContext, editText);
             if (hasFocus) {
-              eventDispatcher.dispatchEvent(new ReactTextInputFocusEvent(editText.getId()));
+              eventDispatcher.dispatchEvent(new ReactViewFocusEvent(editText.getId()));
             } else {
-              eventDispatcher.dispatchEvent(new ReactTextInputBlurEvent(editText.getId()));
+              eventDispatcher.dispatchEvent(new ReactViewBlurEvent(editText.getId()));
 
               eventDispatcher.dispatchEvent(
                   new ReactTextInputEndEditingEvent(

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
@@ -29,6 +29,8 @@ import com.facebook.react.uimanager.ViewProps;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.annotations.ReactPropGroup;
 import com.facebook.react.uimanager.events.EventDispatcher;
+import com.facebook.react.views.common.ReactViewBlurEvent;
+import com.facebook.react.views.common.ReactViewFocusEvent;
 import com.facebook.yoga.YogaConstants;
 import java.util.Locale;
 import java.util.Map;
@@ -234,8 +236,7 @@ public class ReactViewManager extends ReactClippingViewManager<ReactViewGroup> {
             @Override
             public void onClick(View v) {
               final EventDispatcher mEventDispatcher =
-                  UIManagerHelper.getEventDispatcherForReactTag(
-                      (ReactContext) view.getContext(), view.getId());
+                getEventDispatcher((ReactContext) view.getContext(), view);
               if (mEventDispatcher == null) {
                 return;
               }
@@ -252,6 +253,26 @@ public class ReactViewManager extends ReactClippingViewManager<ReactViewGroup> {
       // Don't set view.setFocusable(false) because we might still want it to be focusable for
       // accessibility reasons
     }
+  }
+
+  private static EventDispatcher getEventDispatcher(
+      ReactContext reactContext, ReactViewGroup view) {
+    return UIManagerHelper.getEventDispatcherForReactTag(reactContext, view.getId());
+  }
+
+  @Override
+  protected void addEventEmitters(final ThemedReactContext reactContext, final ReactViewGroup view) {
+    view.setOnFocusChangeListener(
+      new View.OnFocusChangeListener() {
+        public void onFocusChange(View v, boolean hasFocus) {
+            EventDispatcher eventDispatcher = getEventDispatcher(reactContext, view);
+          if (hasFocus) {
+            eventDispatcher.dispatchEvent(new ReactViewFocusEvent(view.getId()));
+          } else {
+            eventDispatcher.dispatchEvent(new ReactViewBlurEvent(view.getId()));
+          }
+        }
+      });
   }
 
   @ReactProp(name = ViewProps.OVERFLOW)

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
@@ -265,7 +265,7 @@ public class ReactViewManager extends ReactClippingViewManager<ReactViewGroup> {
     view.setOnFocusChangeListener(
       new View.OnFocusChangeListener() {
         public void onFocusChange(View v, boolean hasFocus) {
-            EventDispatcher eventDispatcher = getEventDispatcher(reactContext, view);
+          EventDispatcher eventDispatcher = getEventDispatcher(reactContext, view);
           if (hasFocus) {
             eventDispatcher.dispatchEvent(new ReactViewFocusEvent(view.getId()));
           } else {

--- a/packages/rn-tester/js/examples/Pressable/PressableExample.js
+++ b/packages/rn-tester/js/examples/Pressable/PressableExample.js
@@ -39,6 +39,12 @@ function ContentPress() {
     <>
       <View style={styles.row}>
         <Pressable
+          onFocus={() => {
+            console.log('Focused!!!');
+          }}
+          onBlur={() => {
+            console.log('Blurred!');
+          }}
           onPress={() => {
             setTimesPressed(current => current + 1);
           }}>
@@ -247,6 +253,31 @@ function PressableDisabled() {
         <Text style={styles.button}>Enabled Pressable</Text>
       </Pressable>
     </>
+  );
+}
+
+function PressableFocusBlurEvents() {
+  const [lastEvent, setLastEvent] = useState('');
+
+  return (
+    <View testID="pressable_hit_slop">
+      <View style={[styles.row, styles.centered]}>
+        <Pressable
+          onFocus={() => {
+            console.log('focused lol');
+            setLastEvent('received focus event');
+          }}
+          onBlur={() => {
+            setLastEvent('received blur event');
+          }}
+          testID="pressable_focus_blur_button">
+          <Text style={styles.text}>Use keyboard to move focus to me</Text>
+        </Pressable>
+      </View>
+      <View style={styles.logBox}>
+        <Text>{lastEvent}</Text>
+      </View>
+    </View>
   );
 }
 
@@ -476,6 +507,14 @@ exports.examples = [
       'any interaction with component': string),
     render: function(): React.Node {
       return <PressableDisabled />;
+    },
+  },
+  {
+    title: 'Pressable onFocus/onBlur',
+    description: ('<Pressable> components can receive focus/blur events.': string),
+    platform: 'android',
+    render: function(): React.Node {
+      return <PressableFocusBlurEvents />;
     },
   },
 ];

--- a/packages/rn-tester/js/examples/Pressable/PressableExample.js
+++ b/packages/rn-tester/js/examples/Pressable/PressableExample.js
@@ -39,12 +39,6 @@ function ContentPress() {
     <>
       <View style={styles.row}>
         <Pressable
-          onFocus={() => {
-            console.log('Focused!!!');
-          }}
-          onBlur={() => {
-            console.log('Blurred!');
-          }}
           onPress={() => {
             setTimesPressed(current => current + 1);
           }}>
@@ -264,11 +258,12 @@ function PressableFocusBlurEvents() {
       <View style={[styles.row, styles.centered]}>
         <Pressable
           onFocus={() => {
-            console.log('focused lol');
-            setLastEvent('received focus event');
+            console.log('Focused!');
+            setLastEvent('Received focus event');
           }}
           onBlur={() => {
-            setLastEvent('received blur event');
+            console.log('Blurred!');
+            setLastEvent('Received blur event');
           }}
           testID="pressable_focus_blur_button">
           <Text style={styles.text}>Use keyboard to move focus to me</Text>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Starting to upstream keyboard-related features from React Native Windows - this is the Android implementation.
Exposing onFocus and onBlur callbacks on Pressable; they're already declared for View in ViewPropTypes.js, which Pressable wraps.

Registering event listeners in ReactViewManager to listen for native focus events.
## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Added] - Add onFocus/onBlur for Pressable on Android.

## Test Plan
Tested on v63-stable, since building master on Windows is now broken. Screenshots from RNTester running on the emulator:
![image](https://user-images.githubusercontent.com/12816515/99320373-59777e80-2820-11eb-91a8-704fff4aa13d.png)
![image](https://user-images.githubusercontent.com/12816515/99320412-6f853f00-2820-11eb-98f2-f9cd29e8aa0d.png)


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
