### PR TITLE
switch Readme version badge source to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
     <img src="https://circleci.com/gh/facebook/react-native.svg?style=shield" alt="Current CircleCI build status." />
   </a>
   <a href="https://www.npmjs.org/package/react-native">
-    <img src="https://badge.fury.io/js/react-native.svg" alt="Current npm package version." />
+    <img src="https://img.shields.io/npm/v/react-native?color=brightgreen&label=npm%20package" alt="Current npm package version." />
   </a>
   <a href="https://reactnative.dev/docs/contributing">
     <img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs welcome!" />


### PR DESCRIPTION
## Summary

Lately there are some loading issues for the `fury.io` badges service which results in missing image and alt text visible in the Readme. 

This PR fixes that issue by switching to `shields.io` version badge - badge service that has been used for few other badges already.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Internal] [Changed] - change Readme npm version badge to `shields.io`

## Test Plan

All badges will appear in the Readme file. 🙂 
