### PR TITLE
Move TurboModuleManager to use RuntimeExecutor instead of jsContext

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/TurboModuleManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/TurboModuleManager.java
@@ -15,8 +15,8 @@ import com.facebook.jni.HybridData;
 import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.bridge.CxxModuleWrapper;
 import com.facebook.react.bridge.JSIModule;
-import com.facebook.react.bridge.JavaScriptContextHolder;
 import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.RuntimeExecutor;
 import com.facebook.react.config.ReactFeatureFlags;
 import com.facebook.react.turbomodule.core.interfaces.CallInvokerHolder;
 import com.facebook.react.turbomodule.core.interfaces.TurboModule;
@@ -50,14 +50,14 @@ public class TurboModuleManager implements JSIModule, TurboModuleRegistry {
   private final HybridData mHybridData;
 
   public TurboModuleManager(
-      JavaScriptContextHolder jsContext,
+      RuntimeExecutor runtimeExecutor,
       @Nullable final TurboModuleManagerDelegate delegate,
       CallInvokerHolder jsCallInvokerHolder,
       CallInvokerHolder nativeCallInvokerHolder) {
     maybeLoadSoLibrary();
     mHybridData =
         initHybrid(
-            jsContext.get(),
+            runtimeExecutor,
             (CallInvokerHolderImpl) jsCallInvokerHolder,
             (CallInvokerHolderImpl) nativeCallInvokerHolder,
             delegate,
@@ -291,7 +291,7 @@ public class TurboModuleManager implements JSIModule, TurboModuleRegistry {
   }
 
   private native HybridData initHybrid(
-      long jsContext,
+      RuntimeExecutor runtimeExecutor,
       CallInvokerHolderImpl jsCallInvokerHolder,
       CallInvokerHolderImpl nativeCallInvokerHolder,
       TurboModuleManagerDelegate tmmDelegate,

--- a/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/jni/Android.mk
+++ b/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/jni/Android.mk
@@ -19,9 +19,9 @@ LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)
 
 LOCAL_CFLAGS += -fexceptions -frtti -std=c++14 -Wall
 
-LOCAL_SHARED_LIBRARIES = libfb libfbjni
+LOCAL_SHARED_LIBRARIES = libfb libfbjni libreactnativeutilsjni
 
-LOCAL_STATIC_LIBRARIES = libcallinvoker libreactperfloggerjni
+LOCAL_STATIC_LIBRARIES = libcallinvoker libreactperfloggerjni libruntimeexecutor
 
 # Name of this module.
 LOCAL_MODULE := callinvokerholder

--- a/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/jni/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/jni/BUCK
@@ -35,6 +35,7 @@ rn_xplat_cxx_library(
         ":callinvokerholder",
         react_native_xplat_shared_library_target("jsi:jsi"),
         react_native_xplat_target("react/nativemodule/core:core"),
+        react_native_xplat_target("runtimeexecutor:runtimeexecutor"),
         react_native_target("java/com/facebook/react/reactperflogger/jni:jni"),
     ],
 )

--- a/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/jni/ReactCommon/TurboModuleManager.h
+++ b/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/jni/ReactCommon/TurboModuleManager.h
@@ -9,12 +9,14 @@
 
 #include <ReactCommon/CallInvokerHolder.h>
 #include <ReactCommon/JavaTurboModule.h>
+#include <ReactCommon/RuntimeExecutor.h>
 #include <ReactCommon/TurboModule.h>
 #include <ReactCommon/TurboModuleManagerDelegate.h>
 #include <fbjni/fbjni.h>
 #include <jsi/jsi.h>
 #include <react/jni/CxxModuleWrapper.h>
 #include <react/jni/JMessageQueueThread.h>
+#include <react/jni/JRuntimeExecutor.h>
 #include <memory>
 #include <unordered_map>
 
@@ -27,7 +29,7 @@ class TurboModuleManager : public jni::HybridClass<TurboModuleManager> {
       "Lcom/facebook/react/turbomodule/core/TurboModuleManager;";
   static jni::local_ref<jhybriddata> initHybrid(
       jni::alias_ref<jhybridobject> jThis,
-      jlong jsContext,
+      jni::alias_ref<JRuntimeExecutor::javaobject> runtimeExecutor,
       jni::alias_ref<CallInvokerHolder::javaobject> jsCallInvokerHolder,
       jni::alias_ref<CallInvokerHolder::javaobject> nativeCallInvokerHolder,
       jni::alias_ref<TurboModuleManagerDelegate::javaobject> delegate,
@@ -38,7 +40,7 @@ class TurboModuleManager : public jni::HybridClass<TurboModuleManager> {
  private:
   friend HybridBase;
   jni::global_ref<TurboModuleManager::javaobject> javaPart_;
-  jsi::Runtime *runtime_;
+  RuntimeExecutor runtimeExecutor_;
   std::shared_ptr<CallInvoker> jsCallInvoker_;
   std::shared_ptr<CallInvoker> nativeCallInvoker_;
   jni::global_ref<TurboModuleManagerDelegate::javaobject> delegate_;
@@ -58,7 +60,7 @@ class TurboModuleManager : public jni::HybridClass<TurboModuleManager> {
   void installJSIBindings();
   explicit TurboModuleManager(
       jni::alias_ref<TurboModuleManager::jhybridobject> jThis,
-      jsi::Runtime *rt,
+      RuntimeExecutor runtimeExecutor,
       std::shared_ptr<CallInvoker> jsCallInvoker,
       std::shared_ptr<CallInvoker> nativeCallInvoker,
       jni::alias_ref<TurboModuleManagerDelegate::javaobject> delegate,

--- a/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.java
+++ b/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.java
@@ -140,7 +140,7 @@ public class RNTesterApplication extends Application implements ReactApplication
                             final List<ReactPackage> packages = reactInstanceManager.getPackages();
 
                             return new TurboModuleManager(
-                                jsContext,
+                                reactApplicationContext.getCatalystInstance().getRuntimeExecutor(),
                                 new RNTesterTurboModuleManagerDelegate(
                                     reactApplicationContext, packages),
                                 reactApplicationContext


### PR DESCRIPTION
Summary:
This diff changes the constructor param for TurboModuleManager from jsContext (a long representing the `jsi::Runtime` pointer) to a RuntimeExecutor. It also updates callsites to use the new RuntimeExecutor created by CatalystInstance. This is only used for installing the TurboModule JSI binding; it's not currently used for JS invocation in TurboModules, which is handled separately by JSCallInvoker. Ultimately we may be able to implement JSCallInvoker *with* the provided RuntimeExecutor, but there's some additional logic in JSCallInvoker that we don't have here yet.

Changelog: [Internal]

Reviewed By: RSNara

Differential Revision: D21338930

