### PR TITLE
Fix :ReactAndroid:androidJavadoc task

### DIFF
--- a/ReactAndroid/release.gradle
+++ b/ReactAndroid/release.gradle
@@ -79,6 +79,7 @@ afterEvaluate { project ->
         classpath += files(project.getConfigurations().getByName("compile").asList())
         include("**/*.java")
         exclude("**/ReactBuildConfig.java")
+        exclude("**/ReactEditText.java")
     }
 
     task androidJavadocJar(type: Jar, dependsOn: androidJavadoc) {

--- a/ReactAndroid/release.gradle
+++ b/ReactAndroid/release.gradle
@@ -73,13 +73,12 @@ if (JavaVersion.current().isJava8Compatible()) {
 
 afterEvaluate { project ->
 
-    task androidJavadoc(type: Javadoc) {
+    task androidJavadoc(type: Javadoc, dependsOn: generateReleaseBuildConfig) {
         source = android.sourceSets.main.java.srcDirs
         classpath += files(android.bootClasspath)
         classpath += files(project.getConfigurations().getByName("compile").asList())
+        classpath += files("$buildDir/generated/source/buildConfig/release")
         include("**/*.java")
-        exclude("**/ReactBuildConfig.java")
-        exclude("**/ReactEditText.java")
     }
 
     task androidJavadocJar(type: Jar, dependsOn: androidJavadoc) {


### PR DESCRIPTION
## Summary

Fixes #30415

This is a quick and dirty fix to unblock publish, of excluding a class from Javadoc generation that is importing a class current build logic cannot handle. This is not a long-term fix for the issue.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Internal] [Fixed] - Fix :ReactAndroid:androidJavadoc task

## Test Plan

Tested that the task now completes locally.
