### PR TITLE
chore: updated url of deprecated modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,7 +131,7 @@ module.exports = {
       'DatePickerIOS-merged',
       'DatePickerIOS has been merged with DatePickerAndroid and will be removed in a future release. ' +
         "It can now be installed and imported from '@react-native-community/datetimepicker' instead of 'react-native'. " +
-        'See https://github.com/react-native-community/datetimepicker',
+        'See https://github.com/react-native-datetimepicker/datetimepicker',
     );
     return require('./Libraries/Components/DatePicker/DatePickerIOS');
   },
@@ -158,8 +158,8 @@ module.exports = {
     warnOnce(
       'maskedviewios-moved',
       'MaskedViewIOS has been extracted from react-native core and will be removed in a future release. ' +
-        "It can now be installed and imported from '@react-native-community/masked-view' instead of 'react-native'. " +
-        'See https://github.com/react-native-community/react-native-masked-view',
+        "It can now be installed and imported from '@react-native-masked-view/masked-view' instead of 'react-native'. " +
+        'See https://github.com/react-native-masked-view/react-native-masked-view',
     );
     return require('./Libraries/Components/MaskedView/MaskedViewIOS');
   },
@@ -170,8 +170,8 @@ module.exports = {
     warnOnce(
       'picker-moved',
       'Picker has been extracted from react-native core and will be removed in a future release. ' +
-        "It can now be installed and imported from '@react-native-community/picker' instead of 'react-native'. " +
-        'See https://github.com/react-native-community/react-native-picker',
+        "It can now be installed and imported from '@react-native-picker/picker' instead of 'react-native'. " +
+        'See https://github.com/react-native-picker/react-native-picker',
     );
     return require('./Libraries/Components/Picker/Picker');
   },
@@ -180,8 +180,8 @@ module.exports = {
     warnOnce(
       'pickerios-moved',
       'PickerIOS has been extracted from react-native core and will be removed in a future release. ' +
-        "It can now be installed and imported from '@react-native-community/picker' instead of 'react-native'. " +
-        'See https://github.com/react-native-community/react-native-picker',
+        "It can now be installed and imported from '@react-native-picker/picker' instead of 'react-native'. " +
+        'See https://github.com/react-native-picker/react-native-picker',
     );
     return require('./Libraries/Components/Picker/PickerIOS');
   },
@@ -194,7 +194,7 @@ module.exports = {
       'progress-bar-android-moved',
       'ProgressBarAndroid has been extracted from react-native core and will be removed in a future release. ' +
         "It can now be installed and imported from '@react-native-community/progress-bar-android' instead of 'react-native'. " +
-        'See https://github.com/react-native-community/progress-bar-android',
+        'See https://github.com/react-native-progress-view/progress-bar-android',
     );
     return require('./Libraries/Components/ProgressBarAndroid/ProgressBarAndroid');
   },
@@ -204,7 +204,7 @@ module.exports = {
       'progress-view-ios-moved',
       'ProgressViewIOS has been extracted from react-native core and will be removed in a future release. ' +
         "It can now be installed and imported from '@react-native-community/progress-view' instead of 'react-native'. " +
-        'See https://github.com/react-native-community/progress-view',
+        'See https://github.com/react-native-progress-view/progress-view',
     );
     return require('./Libraries/Components/ProgressViewIOS/ProgressViewIOS');
   },
@@ -226,7 +226,7 @@ module.exports = {
       'segmented-control-ios-moved',
       'SegmentedControlIOS has been extracted from react-native core and will be removed in a future release. ' +
         "It can now be installed and imported from '@react-native-community/segmented-control' instead of 'react-native'. " +
-        'See https://github.com/react-native-community/segmented-control',
+        'See https://github.com/react-native-segmented-control/segmented-control',
     );
     return require('./Libraries/Components/SegmentedControlIOS/SegmentedControlIOS');
   },
@@ -235,7 +235,7 @@ module.exports = {
       'slider-moved',
       'Slider has been extracted from react-native core and will be removed in a future release. ' +
         "It can now be installed and imported from '@react-native-community/slider' instead of 'react-native'. " +
-        'See https://github.com/react-native-community/react-native-slider',
+        'See https://github.com/callstack/react-native-slider',
     );
     return require('./Libraries/Components/Slider/Slider');
   },
@@ -300,8 +300,8 @@ module.exports = {
     warnOnce(
       'async-storage-moved',
       'AsyncStorage has been extracted from react-native core and will be removed in a future release. ' +
-        "It can now be installed and imported from '@react-native-community/async-storage' instead of 'react-native'. " +
-        'See https://github.com/react-native-community/async-storage',
+        "It can now be installed and imported from '@react-native-async-storage/async-storage' instead of 'react-native'. " +
+        'See https://github.com/react-native-async-storage/async-storage',
     );
     return require('./Libraries/Storage/AsyncStorage');
   },
@@ -313,7 +313,7 @@ module.exports = {
       'clipboard-moved',
       'Clipboard has been extracted from react-native core and will be removed in a future release. ' +
         "It can now be installed and imported from '@react-native-community/clipboard' instead of 'react-native'. " +
-        'See https://github.com/react-native-community/clipboard',
+        'See https://github.com/react-native-clipboard/clipboard',
     );
     return require('./Libraries/Components/Clipboard/Clipboard');
   },
@@ -322,7 +322,7 @@ module.exports = {
       'DatePickerAndroid-merged',
       'DatePickerAndroid has been merged with DatePickerIOS and will be removed in a future release. ' +
         "It can now be installed and imported from '@react-native-community/datetimepicker' instead of 'react-native'. " +
-        'See https://github.com/react-native-community/datetimepicker',
+        'See https://github.com/react-native-datetimepicker/datetimepicker',
     );
     return require('./Libraries/Components/DatePickerAndroid/DatePickerAndroid');
   },
@@ -350,7 +350,7 @@ module.exports = {
       'ImagePickerIOS has been extracted from react-native core and will be removed in a future release. ' +
         "Please upgrade to use either '@react-native-community/react-native-image-picker' or 'expo-image-picker'. " +
         "If you cannot upgrade to a different library, please install the deprecated '@react-native-community/image-picker-ios' package. " +
-        'See https://github.com/react-native-community/react-native-image-picker-ios',
+        'See https://github.com/rnc-archive/react-native-image-picker-ios',
     );
     return require('./Libraries/Image/ImagePickerIOS');
   },
@@ -393,7 +393,7 @@ module.exports = {
       'pushNotificationIOS-moved',
       'PushNotificationIOS has been extracted from react-native core and will be removed in a future release. ' +
         "It can now be installed and imported from '@react-native-community/push-notification-ios' instead of 'react-native'. " +
-        'See https://github.com/react-native-community/push-notification-ios',
+        'See https://github.com/react-native-push-notification-ios/push-notification-ios',
     );
     return require('./Libraries/PushNotificationIOS/PushNotificationIOS');
   },
@@ -512,7 +512,7 @@ if (__DEV__) {
         false,
         'ART has been removed from React Native. ' +
           "It can now be installed and imported from '@react-native-community/art' instead of 'react-native'. " +
-          'See https://github.com/react-native-community/art',
+          'See https://github.com/react-native-art/art',
       );
     },
   });
@@ -551,7 +551,7 @@ if (__DEV__) {
         false,
         'WebView has been removed from React Native. ' +
           "It can now be installed and imported from 'react-native-webview' instead of 'react-native'. " +
-          'See https://github.com/react-native-community/react-native-webview',
+          'See https://github.com/react-native-webview/react-native-webview',
       );
     },
   });
@@ -564,7 +564,7 @@ if (__DEV__) {
         false,
         'NetInfo has been removed from React Native. ' +
           "It can now be installed and imported from '@react-native-community/netinfo' instead of 'react-native'. " +
-          'See https://github.com/react-native-community/react-native-netinfo',
+          'See https://github.com/react-native-netinfo/react-native-netinfo',
       );
     },
   });
@@ -577,7 +577,7 @@ if (__DEV__) {
         false,
         'CameraRoll has been removed from React Native. ' +
           "It can now be installed and imported from '@react-native-community/cameraroll' instead of 'react-native'. " +
-          'See https://github.com/react-native-community/react-native-cameraroll',
+          'See https://github.com/react-native-cameraroll/react-native-cameraroll',
       );
     },
   });
@@ -604,7 +604,7 @@ if (__DEV__) {
         false,
         'ImageEditor has been removed from React Native. ' +
           "It can now be installed and imported from '@react-native-community/image-editor' instead of 'react-native'. " +
-          'See https://github.com/react-native-community/react-native-image-editor',
+          'See https://github.com/callstack/react-native-image-editor',
       );
     },
   });
@@ -617,7 +617,7 @@ if (__DEV__) {
         false,
         'TimePickerAndroid has been removed from React Native. ' +
           "It can now be installed and imported from '@react-native-community/datetimepicker' instead of 'react-native'. " +
-          'See https://github.com/react-native-community/datetimepicker',
+          'See https://github.com/react-native-datetimepicker/datetimepicker',
       );
     },
   });
@@ -630,7 +630,7 @@ if (__DEV__) {
         false,
         'ToolbarAndroid has been removed from React Native. ' +
           "It can now be installed and imported from '@react-native-community/toolbar-android' instead of 'react-native'. " +
-          'See https://github.com/react-native-community/toolbar-android',
+          'See https://github.com/react-native-toolbar-android/toolbar-android',
       );
     },
   });
@@ -643,7 +643,7 @@ if (__DEV__) {
         false,
         'ViewPagerAndroid has been removed from React Native. ' +
           "It can now be installed and imported from '@react-native-community/viewpager' instead of 'react-native'. " +
-          'See https://github.com/react-native-community/react-native-viewpager',
+          'See https://github.com/callstack/react-native-viewpager',
       );
     },
   });
@@ -656,7 +656,7 @@ if (__DEV__) {
         false,
         'CheckBox has been removed from React Native. ' +
           "It can now be installed and imported from '@react-native-community/checkbox' instead of 'react-native'. " +
-          'See https://github.com/react-native-community/react-native-checkbox',
+          'See https://github.com/react-native-checkbox/react-native-checkbox',
       );
     },
   });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Part of https://github.com/react-native-community/releases/issues/207
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Migrate warnings in index.js to point to new lean core repos

NOTE: some npm modules has been transferred to new nom namespace, such as `@react-native-picker/picker` `@react-native-async-storage/async-storage` `@react-native-masked-view/masked-view`.
Some lean core repo has been transferred to new repo, but its npm namespace remains the same. ex: clipboard module exists in react-native-clipboard/clipboard repo, but npm package name is still `@react-native-community/clipboard` (they're planned to be migrated in the future)

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Changed] - Migrate warnings in index.js to point to new lean core repos

## Test Plan
- Updated repo URL can be accessed
- Updated npm package can be installed
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
