### PR TITLE
Fix Platform referencing for JEST

### DIFF
--- a/Libraries/Components/View/ReactNativeViewViewConfig.js
+++ b/Libraries/Components/View/ReactNativeViewViewConfig.js
@@ -12,7 +12,8 @@
 
 import {type ViewConfig} from '../../Renderer/shims/ReactNativeTypes';
 import ReactNativeViewViewConfigAndroid from './ReactNativeViewViewConfigAndroid';
-import {Platform} from 'react-native';
+
+const Platform = require('../../Utilities/Platform')
 
 const ReactNativeViewConfig: ViewConfig = {
   uiViewClassName: 'RCTView',


### PR DESCRIPTION

## Summary

Jest test is failing to reference `Platform` with this import

## Changelog

[General] [Changed] - Use require to import Platform

## Test Plan

Simply run a Jest snapshot test
