### PR TITLE
fix: pin hermes-engine to 0.7.x

### DIFF
--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -63,7 +63,7 @@ def use_react_native! (options={})
 
   if hermes_enabled
     pod 'React-Core/Hermes', :path => "#{prefix}/"
-    pod 'hermes-engine'
+    pod 'hermes-engine', '~> 0.7.1'
     pod 'libevent', :podspec => "#{prefix}/third-party-podspecs/libevent.podspec"
   end
 end


### PR DESCRIPTION
## Summary

Right now, Hermes is not pinned to any version and CocoaPods will install latest. This PR pins it using the same way Flipper is pinned, to keep it easier to track.

## Changelog

[INTERNAL] [IOS] - Pin Hermes on iOS