### PR TITLE
fix truncated value from getTotalTimeMS

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/debug/FpsDebugFrameCallback.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/debug/FpsDebugFrameCallback.java
@@ -187,7 +187,7 @@ public class FpsDebugFrameCallback extends ChoreographerCompat.FrameCallback {
   }
 
   public int getTotalTimeMS() {
-    return (int) ((double) mLastFrameTime - mFirstFrameTime) / 1000000;
+    return (int) (((double) mLastFrameTime - mFirstFrameTime) / 1000000);
   }
 
   /**


### PR DESCRIPTION
## Summary
Fixes #30440

FpsDebugFrameCallback.getTotalTimeMS() returns error time which may be used by apps to monitor performance.
THE CAUSE: the value from getTotalTimeMS is far less than getNumFrames() multiplied by 16.6. Because type casting operator precedes division and (mLastFrameTime - mFirstFrameTime) overflows int, then the truncated value is divided by 1,000,000 and return.

## Changelog
[Android][Fixed] - Fix truncated value from getTotalTimeMS

## Test Plan
None
