### PR TITLE
Add methods to create ArrayBuffers from byte arrays

### DIFF
--- a/ReactCommon/jsi/JSCRuntime.cpp
+++ b/ReactCommon/jsi/JSCRuntime.cpp
@@ -155,6 +155,7 @@ class JSCRuntime : public jsi::Runtime {
 
   jsi::String createStringFromAscii(const char *str, size_t length) override;
   jsi::String createStringFromUtf8(const uint8_t *utf8, size_t length) override;
+  jsi::Object createArrayBufferFromBytes(const void* bytes, size_t length) override;
   std::string utf8(const jsi::String &) override;
 
   jsi::Object createObject() override;
@@ -673,6 +674,17 @@ jsi::String JSCRuntime::createStringFromUtf8(
   auto result = createString(stringRef);
   JSStringRelease(stringRef);
   return result;
+}
+
+static void freePtr(void* ptr, void*) {
+  free(ptr);
+}
+
+jsi::Object JSCRuntime::createArrayBufferFromBytes(const void* bytes, size_t length) {
+  void* buf = malloc(length);
+  memcpy(buf, bytes, length);
+  JSObjectRef ref = JSObjectMakeArrayBufferWithBytesNoCopy(ctx_, buf, length, freePtr, nullptr, nullptr);
+  return createObject(ref);
 }
 
 std::string JSCRuntime::utf8(const jsi::String &str) {

--- a/ReactCommon/jsi/JSCRuntime.cpp
+++ b/ReactCommon/jsi/JSCRuntime.cpp
@@ -155,8 +155,9 @@ class JSCRuntime : public jsi::Runtime {
 
   jsi::String createStringFromAscii(const char *str, size_t length) override;
   jsi::String createStringFromUtf8(const uint8_t *utf8, size_t length) override;
-  jsi::Object createArrayBufferFromBytes(const void* bytes, size_t length) override;
   std::string utf8(const jsi::String &) override;
+
+  jsi::Object createArrayBufferFromBytes(const void* bytes, size_t length) override;
 
   jsi::Object createObject() override;
   jsi::Object createObject(std::shared_ptr<jsi::HostObject> ho) override;
@@ -676,6 +677,10 @@ jsi::String JSCRuntime::createStringFromUtf8(
   return result;
 }
 
+std::string JSCRuntime::utf8(const jsi::String &str) {
+  return JSStringToSTLString(stringRef(str));
+}
+
 static void freePtr(void* ptr, void*) {
   free(ptr);
 }
@@ -685,10 +690,6 @@ jsi::Object JSCRuntime::createArrayBufferFromBytes(const void* bytes, size_t len
   memcpy(buf, bytes, length);
   JSObjectRef ref = JSObjectMakeArrayBufferWithBytesNoCopy(ctx_, buf, length, freePtr, nullptr, nullptr);
   return createObject(ref);
-}
-
-std::string JSCRuntime::utf8(const jsi::String &str) {
-  return JSStringToSTLString(stringRef(str));
 }
 
 jsi::Object JSCRuntime::createObject() {

--- a/ReactCommon/jsi/jsi/decorator.h
+++ b/ReactCommon/jsi/jsi/decorator.h
@@ -190,12 +190,13 @@ class RuntimeDecorator : public Base, private jsi::Instrumentation {
   String createStringFromUtf8(const uint8_t* utf8, size_t length) override {
     return plain_.createStringFromUtf8(utf8, length);
   };
-  Object createArrayBufferFromBytes(const void* bytes, size_t length) override {
-    return plain_.createArrayBufferFromBytes(bytes, length);
-  };
   std::string utf8(const String& s) override {
     return plain_.utf8(s);
   }
+
+  Object createArrayBufferFromBytes(const void* bytes, size_t length) override {
+    return plain_.createArrayBufferFromBytes(bytes, length);
+  };
 
   Object createObject() override {
     return plain_.createObject();
@@ -563,14 +564,15 @@ class WithRuntimeDecorator : public RuntimeDecorator<Plain, Base> {
     Around around{with_};
     return RD::createStringFromUtf8(utf8, length);
   };
-  Object createArrayBufferFromBytes(const void* bytes, size_t length) override {
-    Around around{with_};
-    return RD::createArrayBufferFromBytes(bytes, length);
-  };
   std::string utf8(const String& s) override {
     Around around{with_};
     return RD::utf8(s);
   }
+
+  Object createArrayBufferFromBytes(const void* bytes, size_t length) override {
+    Around around{with_};
+    return RD::createArrayBufferFromBytes(bytes, length);
+  };
 
   Object createObject() override {
     Around around{with_};

--- a/ReactCommon/jsi/jsi/decorator.h
+++ b/ReactCommon/jsi/jsi/decorator.h
@@ -190,6 +190,9 @@ class RuntimeDecorator : public Base, private jsi::Instrumentation {
   String createStringFromUtf8(const uint8_t* utf8, size_t length) override {
     return plain_.createStringFromUtf8(utf8, length);
   };
+  Object createArrayBufferFromBytes(const void* bytes, size_t length) override {
+    return plain_.createArrayBufferFromBytes(bytes, length);
+  };
   std::string utf8(const String& s) override {
     return plain_.utf8(s);
   }
@@ -559,6 +562,10 @@ class WithRuntimeDecorator : public RuntimeDecorator<Plain, Base> {
   String createStringFromUtf8(const uint8_t* utf8, size_t length) override {
     Around around{with_};
     return RD::createStringFromUtf8(utf8, length);
+  };
+  Object createArrayBufferFromBytes(const void* bytes, size_t length) override {
+    Around around{with_};
+    return RD::createArrayBufferFromBytes(bytes, length);
   };
   std::string utf8(const String& s) override {
     Around around{with_};

--- a/ReactCommon/jsi/jsi/jsi.h
+++ b/ReactCommon/jsi/jsi/jsi.h
@@ -252,12 +252,15 @@ class JSI_EXPORT Runtime {
 
   virtual String createStringFromAscii(const char* str, size_t length) = 0;
   virtual String createStringFromUtf8(const uint8_t* utf8, size_t length) = 0;
-  virtual Object createArrayBufferFromBytes(const void* bytes, size_t length) = 0;
   virtual std::string utf8(const String&) = 0;
 
   // \return a \c Value created from a utf8-encoded JSON string. The default
   // implementation creates a \c String and invokes JSON.parse.
   virtual Value createValueFromJsonUtf8(const uint8_t* json, size_t length);
+
+  virtual Object createArrayBufferFromBytes(const void* bytes, size_t length) {
+    throw std::runtime_error{"Not implemented."}; 
+  }
 
   virtual Object createObject() = 0;
   virtual Object createObject(std::shared_ptr<HostObject> ho) = 0;

--- a/ReactCommon/jsi/jsi/jsi.h
+++ b/ReactCommon/jsi/jsi/jsi.h
@@ -252,6 +252,7 @@ class JSI_EXPORT Runtime {
 
   virtual String createStringFromAscii(const char* str, size_t length) = 0;
   virtual String createStringFromUtf8(const uint8_t* utf8, size_t length) = 0;
+  virtual Object createArrayBufferFromBytes(const void* bytes, size_t length) = 0;
   virtual std::string utf8(const String&) = 0;
 
   // \return a \c Value created from a utf8-encoded JSON string. The default
@@ -786,6 +787,11 @@ class JSI_EXPORT ArrayBuffer : public Object {
 
   uint8_t* data(Runtime& runtime) {
     return runtime.data(*this);
+  }
+
+  static Object
+  createFromBytes(Runtime& runtime, const void* bytes, size_t length) {
+    return runtime.createArrayBufferFromBytes(bytes, length);
   }
 
  private:


### PR DESCRIPTION

## Summary
This PR adds a factory method to the ArrayBuffer class, so that JSI methods can return them as results.

## Changelog
[General] [Added] - Factory method for ArrayBuffer in the JavaScriptCore implementation of JSI


## Test Plan
I have a test app where I can directly return data from LevelDB and see ArrayBuffers on the JS side! Let me know if I should add a test case to rn-tester.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/facebook/react-native/30445)
<!-- Reviewable:end -->
