### PR TITLE
[iOS] [Changed] Pass reactNativePath to codegen_pre_install

### DIFF
--- a/template/ios/Podfile
+++ b/template/ios/Podfile
@@ -14,7 +14,7 @@ target 'HelloWorld' do
   end
 
   pre_install do |installer|
-    codegen_pre_install(installer)
+    codegen_pre_install(installer, :path => config[:reactNativePath])
   end
 
   # Enables Flipper.


### PR DESCRIPTION
## Summary 

`codegen_pre_install` needs the `path` param as much as `use_react_native`, and we pass to `use_react_native` by default.

https://github.com/facebook/react-native/blob/c0a2998387d1730d38a28cbe296520400a645b25/template/ios/Podfile#L9

https://github.com/facebook/react-native/blob/c0a2998387d1730d38a28cbe296520400a645b25/template/ios/Podfile#L16-L18

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [Changed] - Pass reactNativePath to codegen_pre_install

## Test Plan

Tested on my local machine, `pod install` fails if I set `reactNativePath` to an wrong path and works if it's correct:

![image](https://user-images.githubusercontent.com/619186/99864008-ba37eb80-2b7f-11eb-8205-9ecd011ca38d.png)

ping: https://github.com/react-native-community/releases/issues/207 