### PR TITLE
include android in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "!template/node_modules",
     "!template/package-lock.json",
     "!template/yarn.lock",
+    "android",
     "cli.js",
     "flow",
     "flow-typed",


### PR DESCRIPTION
## Summary

RN app expects **android** folder with maven artifacts in NPM package, and *test-manual-e2e.sh* fails on **0.64-stable** because it couldn't find **android** folder, therefore looks into remote repos and finds 0.20.1 version on bintray.

See https://github.com/facebook/react-native/blob/e99b8bbb404f8cd1f11b6c7998083be530d7b8a4/template/android/build.gradle#L27

This PR will change npm pack to include **android** folder with maven artifacts in NPM package, thus RN android apps can find RN in node_modules.

## Changelog

[Internal] [Changed] - include *android* in npm package

## Test Plan

With this change  *test-manual-e2e.sh* will run successfully, previous it was failing due to duplicate classes error.