### PR TITLE
include android in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "!template/node_modules",
     "!template/package-lock.json",
     "!template/yarn.lock",
+    "android",
     "cli.js",
     "flow",
     "flow-typed",


### PR DESCRIPTION
## Summary

This PR is duplicate of https://github.com/facebook/react-native/pull/30451 for 0.64 branch, and will fix android packaging.

## Changelog

[Internal] [Changed] - include android in npm package

## Test Plan

With this change test-manual-e2e.sh will run successfully, previous it was failing due to duplicate classes error.