### PR TITLE
cleanup release.gradle

### DIFF
--- a/ReactAndroid/release.gradle
+++ b/ReactAndroid/release.gradle
@@ -20,18 +20,6 @@ def isReleaseBuild() {
     return VERSION_NAME.contains("SNAPSHOT") == false
 }
 
-def getRepositoryUrl() {
-    return project.findProperty("repositoryUrl") ?: "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
-}
-
-def getRepositoryUsername() {
-    return project.findProperty("repositoryUsername") ?: ""
-}
-
-def getRepositoryPassword() {
-    return project.findProperty("repositoryPassword") ?: ""
-}
-
 def configureReactNativePom(def pom) {
     pom.project {
         name(POM_NAME)
@@ -111,24 +99,6 @@ afterEvaluate { project ->
     signing {
         required { isReleaseBuild() && gradle.taskGraph.hasTask("uploadArchives") }
         sign(configurations.archives)
-    }
-
-    uploadArchives {
-        configuration = configurations.archives
-        repositories.mavenDeployer {
-            beforeDeployment {
-                MavenDeployment deployment -> signing.signPom(deployment)
-            }
-
-            repository(url: getRepositoryUrl()) {
-                authentication(
-                        userName: getRepositoryUsername(),
-                        password: getRepositoryPassword())
-
-            }
-
-            configureReactNativePom(pom)
-        }
     }
 
     task installArchives(type: Upload) {

--- a/ReactAndroid/release.gradle
+++ b/ReactAndroid/release.gradle
@@ -60,37 +60,11 @@ if (JavaVersion.current().isJava8Compatible()) {
 }
 
 afterEvaluate { project ->
-
-    task androidJavadoc(type: Javadoc, dependsOn: generateReleaseBuildConfig) {
-        source = android.sourceSets.main.java.srcDirs
-        classpath += files(android.bootClasspath)
-        classpath += files("$buildDir/generated/source/buildConfig/release")
-        // Note: this doesn't handle .aar files, only .jar.
-        classpath += configurations.javadocDeps
-        include("**/*.java")
-    }
-
-    task androidJavadocJar(type: Jar, dependsOn: androidJavadoc) {
-        classifier = "javadoc"
-        from(androidJavadoc.destinationDir)
-    }
-
-    task androidSourcesJar(type: Jar) {
-        classifier = "sources"
-        from(android.sourceSets.main.java.srcDirs)
-        include("**/*.java")
-    }
-
     android.libraryVariants.all { variant ->
         def name = variant.name.capitalize()
         task "jar${name}"(type: Jar, dependsOn: variant.javaCompileProvider.get()) {
             from(variant.javaCompileProvider.get().destinationDir)
         }
-    }
-
-    artifacts {
-        archives(androidSourcesJar)
-        archives(androidJavadocJar)
     }
 
     version = VERSION_NAME


### PR DESCRIPTION
## Summary

Cleanup release.gradle and remove code used to upload RN to maven repository, which is not longer used. Also removed configuration to include Javadoc, Sources in maven repo, thus reduce NPM package size.

## Changelog

[Internal] [Changed] - cleanup and remove maven upload from release.gradle

## Test Plan

you will no longer see *uploadArchives* in ./gradlew tasks. Also you can run **./gradlew :ReactAndroid:installArchives**