### PR TITLE
fix(iOS): `pod install` fails outside `ios` folder

### DIFF
--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -3,7 +3,12 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-def use_react_native! (options={})
+def resolve_module(request)
+  script = "console.log(path.dirname(require.resolve('#{request}/package.json')));"
+  Pod::Executable.execute_command('node', ['-e', script], true).strip
+end
+
+def use_react_native!(options={})
   # The prefix to the react-native
   prefix = options[:path] ||= "../node_modules/react-native"
 
@@ -111,11 +116,15 @@ end
 
 # Pre Install processing for Native Modules
 def codegen_pre_install(installer, options={})
-  # Path to React Native
-  prefix = options[:path] ||= "../node_modules/react-native"
+  # Path to React Native relative to where `pod install` was invoked. This can
+  # sometimes be inside the `ios` folder (i.e. `pod install `), or outside
+  # (e.g. `pod install --project_directory=ios`).
+  prefix = options[:path] ||= resolve_module "react-native"
 
-  # Path to react-native-codegen
-  codegen_path = options[:codegen_path] ||= "#{prefix}/../react-native-codegen"
+  # Path to react-native-codegen relative to where `pod install` was invoked.
+  # This can sometimes be inside the `ios` folder (i.e. `pod install `), or
+  # outside (e.g. `pod install --project_directory=ios`).
+  codegen_path = options[:codegen_path] ||= resolve_module "react-native-codegen"
 
   # Handle Core Modules
   Dir.mktmpdir do |dir|


### PR DESCRIPTION
## Summary

Invoking `pod install` outside the `ios` folder fails because `codegen_pre_install()` looks for `node_modules` in the parent folder.

```
example % pod install --project-directory=ios
Auto-linking React Native module for target `ReactTestApp`: ReactTestApp-DevSupport
Analyzing dependencies
Downloading dependencies
internal/modules/cjs/loader.js:834
  throw err;
  ^

Error: Cannot find module '/~/node_modules/react-native-codegen/lib/cli/combine/combine-js-to-schema-cli.js'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:831:15)
    at Function.Module._load (internal/modules/cjs/loader.js:687:27)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:60:12)
    at internal/main/run_main_module.js:17:47 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}
[!] An error occurred while processing the pre-install hook of the Podfile.

Could not generate Native Module schema
```

## Changelog

[iOS] [Fixed] - `pod install --project-directory=ios` fails to find `react-native-codegen`

## Test Plan

Both `pod install` (inside `ios` folder) and `pod install --project-directory=ios` (outside `ios` folder) should work.