### PR TITLE
fix: android artifacts in a release package

### DIFF
--- a/scripts/publish-npm.js
+++ b/scripts/publish-npm.js
@@ -151,7 +151,7 @@ const buildAndroid = (rebuildOnError) => {
     echo(`${aarLocation} is missing contents. Rebuilding with Gradle again in an effort to try to fix it.`);
     buildAndroid(false);
   } else {
-    echo('Artifacts are corrupted. Exiting.');
+    echo(`${aarLocation} is missing contents. Rebuilding did not fix the issue.`);
     exit(1);
   }
 }

--- a/scripts/publish-npm.js
+++ b/scripts/publish-npm.js
@@ -148,7 +148,7 @@ const buildAndroid = (rebuildOnError) => {
 
   // -------- Temporary fix for broken Android artifact is to build with Gradle once again
   if (rebuildOnError) {
-    echo('Artifacts are corrupted. Rebuilding with Gradle once again to fix it.');
+    echo(`${aarLocation} is missing contents. Rebuilding with Gradle again in an effort to try to fix it.`);
     buildAndroid(false);
   } else {
     echo('Artifacts are corrupted. Exiting.');

--- a/scripts/publish-npm.js
+++ b/scripts/publish-npm.js
@@ -134,13 +134,9 @@ const buildAndroid = (rebuildOnError) => {
   }
 
   const aarLocation = `android/com/facebook/react/react-native/${releaseVersion}/react-native-${releaseVersion}.aar`;
-  const tmpLocation = `/tmp/react-native-${releaseVersion}`;
-
-  // -------- Remove unzipped Android artifact (if any) 
-  exec(`rm -rf ${tmpLocation}`);
 
   // -------- Check if Android artifact contains all the files
-  const {stdout: aarContent} = exec(`unzip ${aarLocation} -d ${tmpLocation} | grep libfbjni.so`);
+  const {stdout: aarContent} = exec(`unzip -l ${aarLocation} | grep libfbjni.so`);
   if ((aarContent.match(/libfbjni.so/g) || []).length === 4) {
     echo(`Artifacts validated, continuing.`);
     return;
@@ -183,8 +179,8 @@ artifacts.forEach(name => {
 const tagFlag = nightlyBuild
   ? '--tag nightly'
   : releaseVersion.indexOf('-rc') === -1
-  ? ''
-  : '--tag next';
+    ? ''
+    : '--tag next';
 
 // use otp from envvars if available
 const otpFlag = otp ? `--otp ${otp}` : '';


### PR DESCRIPTION
## Summary

Android artefacts in a release package are missing, as a result, users are not able to run `0.64.0-rc.0` on Android. Locally, everything works.

After several hours of testing, we found out that running `./gradlew ReactAndroid:installArchives` will "sometimes" fix it and I have managed to verify both locally and on the CI, that running Gradle without cache is broken, but when running Gradle once again (right after corrupted build completed, but there is cache already) fixes the issue.

Seems to be Gradle related.

In this PR, I am adding a validation to `publish-npm.js` script to make sure this kind of errors never happen again in the future. We also attempt to rebuild Android once, hoping that it will pass the validation.

Here's the truncated output of the script:

```
BUILD SUCCESSFUL in 8m 9s
41 actionable tasks: 41 executed
Artifacts are corrupted. Rebuilding with Gradle once again to fix it

BUILD SUCCESSFUL in 6s
43 actionable tasks: 12 executed, 31 up-to-date
Artifacts validated, continuing.
```

## Test Plan

Run the newly added code via `node` and you should see the script re-running `installArchives` and creating correct artifact. You can use [this gist](https://gist.github.com/grabbou/6c1351956455e8a7b7e676789b3bd2ff) contents to just paste into `publish-npm.js`.

Remember to update the version in `package.json` to `0.64.0-rc.0` and run:
```bash
rm -rf android
rm -rf .gradle
rm -rf ReactAndroid/build
```
before doing anything, to make sure you start fresh.
