### PR TITLE
fix: release branches miss workspace dependencies

### DIFF
--- a/scripts/bump-oss-version.js
+++ b/scripts/bump-oss-version.js
@@ -128,8 +128,6 @@ fs.writeFileSync(
 
 let packageJson = JSON.parse(cat('package.json'));
 packageJson.version = version;
-delete packageJson.workspaces;
-delete packageJson.private;
 fs.writeFileSync('package.json', JSON.stringify(packageJson, null, 2), 'utf-8');
 
 // Change ReactAndroid/gradle.properties

--- a/scripts/publish-npm.js
+++ b/scripts/publish-npm.js
@@ -126,6 +126,13 @@ if (nightlyBuild) {
   releaseVersion = tagsWithVersion[tagsWithVersion.length - 1].slice(1);
 }
 
+// Remove `workspaces` and `private` from React Native `package.json`
+let packageJson = JSON.parse(cat('package.json'));
+packageJson.version = version;
+delete packageJson.workspaces;
+delete packageJson.private;
+fs.writeFileSync('package.json', JSON.stringify(packageJson, null, 2), 'utf-8');
+
 // -------- Generating Android Artifacts with JavaDoc
 if (exec('./gradlew :ReactAndroid:installArchives').code) {
   echo('Could not generate artifacts');
@@ -157,8 +164,8 @@ artifacts.forEach(name => {
 const tagFlag = nightlyBuild
   ? '--tag nightly'
   : releaseVersion.indexOf('-rc') === -1
-  ? ''
-  : '--tag next';
+    ? ''
+    : '--tag next';
 
 // use otp from envvars if available
 const otpFlag = otp ? `--otp ${otp}` : '';


### PR DESCRIPTION
## Summary

On the CI, e.g. inside `publish-npm.js`, we're missing `shelljs` dependency, which comes from `repo-config` package. This error started happening after introduction of Yarn workspaces.

During `bump-oss-version.js`, [we remove `private` and `workspaces` settings](https://github.com/facebook/react-native/commit/0117077b9572f5b674578e19073e31e4693e9d41#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L81-L84), preparing it for publishing. As a result, CI steps testing and running on `0.64-stable` branch can potentially fail due to missing dependencies.

Such case is `publish-npm.js`. There might be other errors too (that we haven't run into yet), because we do some development on release branches as well.

A better solution would be to not modify anything while doing `bump-oss-versions.js` (just bump them) and remove extraneous properties from `package.json` while preparing a package.

CC: @cpojer
