### PR TITLE
Move hermes to a separate podspec

### DIFF
--- a/React-Core.podspec
+++ b/React-Core.podspec
@@ -62,17 +62,6 @@ Pod::Spec.new do |s|
     ss.private_header_files   = "React/Cxx*/*.h"
   end
 
-  s.subspec "Hermes" do |ss|
-    ss.platforms = { :osx => "10.14", :ios => "10.0" }
-    ss.source_files = "ReactCommon/hermes/executor/*.{cpp,h}",
-                      "ReactCommon/hermes/inspector/*.{cpp,h}",
-                      "ReactCommon/hermes/inspector/chrome/*.{cpp,h}",
-                      "ReactCommon/hermes/inspector/detail/*.{cpp,h}"
-    ss.pod_target_xcconfig = { "GCC_PREPROCESSOR_DEFINITIONS" => "HERMES_ENABLE_DEBUGGER=1" }
-    ss.dependency "RCT-Folly/Futures"
-    ss.dependency "hermes-engine"
-  end
-
   s.subspec "DevSupport" do |ss|
     ss.source_files = "React/DevSupport/*.{h,mm,m}",
                       "React/Inspector/*.{h,mm,m}"

--- a/React/CxxBridge/RCTCxxBridge.mm
+++ b/React/CxxBridge/RCTCxxBridge.mm
@@ -46,7 +46,7 @@
 #endif
 
 #if RCT_USE_HERMES
-#import "HermesExecutorFactory.h"
+#import <reacthermes/HermesExecutorFactory.h">
 #else
 #import "JSCExecutorFactory.h"
 #endif

--- a/ReactCommon/hermes/React-hermes.podspec
+++ b/ReactCommon/hermes/React-hermes.podspec
@@ -42,6 +42,7 @@ Pod::Spec.new do |s|
   s.dependency "React-cxxreact", version
   s.dependency "React-jsi", version
   s.dependency "React-jsiexecutor", version
+  s.dependency "React-jsinspector", version
   s.dependency "React-perflogger", version
   s.dependency "RCT-Folly", folly_version
   s.dependency "RCT-Folly/Futures", folly_version

--- a/ReactCommon/hermes/React-hermes.podspec
+++ b/ReactCommon/hermes/React-hermes.podspec
@@ -1,0 +1,51 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+require "json"
+
+package = JSON.parse(File.read(File.join(__dir__, "..", "..", "package.json")))
+version = package['version']
+
+source = { :git => 'https://github.com/facebook/react-native.git' }
+if version == '1000.0.0'
+  # This is an unpublished version, use the latest commit hash of the react-native repo, which we’re presumably in.
+  source[:commit] = `git rev-parse HEAD`.strip
+else
+  source[:tag] = "v#{version}"
+end
+
+folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
+folly_version = '2020.01.13.00'
+boost_compiler_flags = '-Wno-documentation'
+
+Pod::Spec.new do |s|
+  s.name                   = "React-hermes"
+  s.version                = version
+  s.summary                = "-"  # TODO
+  s.homepage               = "https://reactnative.dev/"
+  s.license                = package["license"]
+  s.author                 = "Facebook, Inc. and its affiliates"
+  s.platforms              = { :osx => "10.14", :ios => "10.0" }
+  s.source                 = source
+  s.source_files           = "executor/*.{cpp,h}",
+                             "inspector/*.{cpp,h}",
+                             "inspector/chrome/*.{cpp,h}",
+                             "inspector/detail/*.{cpp,h}"
+  s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
+  s.pod_target_xcconfig    = {
+                               "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/..\" \"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/DoubleConversion\"",
+                               "GCC_PREPROCESSOR_DEFINITIONS" => "HERMES_ENABLE_DEBUGGER=1",
+                             }
+  s.header_dir             = "React"
+  s.dependency "React-cxxreact", version
+  s.dependency "React-jsi", version
+  s.dependency "React-jsiexecutor", version
+  s.dependency "React-perflogger", version
+  s.dependency "RCT-Folly", folly_version
+  s.dependency "RCT-Folly/Futures", folly_version
+  s.dependency "DoubleConversion"
+  s.dependency "glog"
+  s.dependency "hermes-engine"
+end

--- a/ReactCommon/hermes/React-hermes.podspec
+++ b/ReactCommon/hermes/React-hermes.podspec
@@ -33,12 +33,13 @@ Pod::Spec.new do |s|
                              "inspector/*.{cpp,h}",
                              "inspector/chrome/*.{cpp,h}",
                              "inspector/detail/*.{cpp,h}"
+  s.public_header_files    = "executor/HermesExecutorFactory.h"
   s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
   s.pod_target_xcconfig    = {
                                "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/..\" \"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/DoubleConversion\"",
                                "GCC_PREPROCESSOR_DEFINITIONS" => "HERMES_ENABLE_DEBUGGER=1",
                              }
-  s.header_dir             = "React"
+  s.header_dir             = "reacthermes"
   s.dependency "React-cxxreact", version
   s.dependency "React-jsi", version
   s.dependency "React-jsiexecutor", version

--- a/packages/rn-tester/RNTester/AppDelegate.mm
+++ b/packages/rn-tester/RNTester/AppDelegate.mm
@@ -16,7 +16,7 @@
 #endif
 
 #if RCT_USE_HERMES
-#import <React/HermesExecutorFactory.h>
+#import <reacthermes/HermesExecutorFactory.h>
 #else
 #import <React/JSCExecutorFactory.h>
 #endif

--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -62,7 +62,7 @@ def use_react_native! (options={})
   end
 
   if hermes_enabled
-    pod 'React-Core/Hermes', :path => "#{prefix}/"
+    pod 'React-hermes', :path => "#{prefix}/ReactCommon/hermes"
     pod 'hermes-engine'
     pod 'libevent', :podspec => "#{prefix}/third-party-podspecs/libevent.podspec"
   end


### PR DESCRIPTION
## Summary

Hermes being a subspec of ReactCore causes some build issues when RN is included in 2 different targets. It also causes it to include a lot of additional dependencies that it doesn't need. This moves it to a separate podspec loosely based on other specs in ReactCommon.

## Changelog

[iOS] [Fixed] - Move hermes to a separate podspec

## Test Plan

Test that it builds and run properly in an app
