### PR TITLE
Fix hairline width/height view disappear

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyOptimizer.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyOptimizer.java
@@ -342,8 +342,8 @@ public class NativeViewHierarchyOptimizer {
     // We use screenX/screenY (which round to integer pixels) at each node in the hierarchy to
     // emulate what the layout would look like if it were actually built with native views which
     // have to have integral top/left/bottom/right values
-    int x = node.getScreenX();
-    int y = node.getScreenY();
+    float x = node.getLayoutX();
+    float y = node.getLayoutY();
 
     while (parent != null && parent.getNativeKind() != NativeKind.PARENT) {
       if (!parent.isVirtual()) {
@@ -352,8 +352,8 @@ public class NativeViewHierarchyOptimizer {
         // them.
 
         // TODO(7854667): handle and test proper clipping
-        x += Math.round(parent.getLayoutX());
-        y += Math.round(parent.getLayoutY());
+        x += parent.getLayoutX();
+        y += parent.getLayoutY();
       }
 
       parent = parent.getParent();
@@ -362,14 +362,14 @@ public class NativeViewHierarchyOptimizer {
     applyLayoutRecursive(node, x, y);
   }
 
-  private void applyLayoutRecursive(ReactShadowNode toUpdate, int x, int y) {
+  private void applyLayoutRecursive(ReactShadowNode toUpdate, float x, float y) {
     if (toUpdate.getNativeKind() != NativeKind.NONE && toUpdate.getNativeParent() != null) {
       int tag = toUpdate.getReactTag();
       mUIViewOperationQueue.enqueueUpdateLayout(
           toUpdate.getLayoutParent().getReactTag(),
           tag,
-          x,
-          y,
+          Math.round(x),
+          Math.round(y),
           toUpdate.getScreenWidth(),
           toUpdate.getScreenHeight());
       return;
@@ -383,8 +383,8 @@ public class NativeViewHierarchyOptimizer {
       }
       mTagsWithLayoutVisited.put(childTag, true);
 
-      int childX = child.getScreenX();
-      int childY = child.getScreenY();
+      float childX = child.getLayoutX();
+      float childY = child.getLayoutY();
 
       childX += x;
       childY += y;


### PR DESCRIPTION
On Android devices with a non integer DPI (for example, 2.75), View layoutX/Y may be  decimal (for example, 3.25). Using integer type in recursive calculation may cause 1 pixel margin or 1 pixel overlap between adjacent views. The dividing line of 1 pixel (StyleSheet.hairlineWidth) may disappear.

Fixes #22927

####  reproduce steps
- APP Without FabricUIManager
- Dividing line, width/height set to 1 pixel(StyleSheet.hairlineWidth)
- Adjacent view opaque
- Android devices with a non integer DPI (for example, 2.75)

## demo code

```
import React,{Component} from 'react';
import {StyleSheet, View, Text} from 'react-native';

export default class App extends Component{
  // some line disappear on decimal dpi Android device
  render() {
    return (
        <View>
          {['1','2','3','4','5','6'].map((row, index) => (
              <View>
                <View style={{height: 54, flexDirection: 'row', alignItems: 'center', backgroundColor: '#ffffff' }}>
                    {['1','2','3','4','5','6'].map(column=>{
                        return(
                            <View style={{flexDirection: 'row'}}>
                                <View style={{width: 61, backgroundColor: '#ffffff', justifyContent: 'center', alignItems: 'center'}}>
                                    <Text>{`R${row}C${column}`}</Text>
                                </View>
                                <View style={{width: StyleSheet.hairlineWidth,backgroundColor: '#ff0000' }} />
                            </View>)
                    })}
                </View>
                <View style={{height: StyleSheet.hairlineWidth,backgroundColor: '#ff0000'}} />
              </View>
          ))}
        </View>);
  }
};

```


## Screenshot

### Before Fix

#### device : Android MI8SE (dpi 2.75)
![disappear](https://user-images.githubusercontent.com/10259917/100327490-52155980-3006-11eb-8f78-b2acc34a1e21.jpg)


### Fixed
![fixed](https://user-images.githubusercontent.com/10259917/100327517-5a6d9480-3006-11eb-9e02-27c4bef77ada.jpg)
