### PR TITLE
Fix Hermes sourcemaps for custom build variants

### DIFF
--- a/react.gradle
+++ b/react.gradle
@@ -103,6 +103,7 @@ afterEvaluate {
         // Create variant and target names
         def targetName = variant.name.capitalize()
         def targetPath = variant.dirName
+        def isRelease = targetName.toLowerCase().contains("release")
 
         // React js bundle directories
         def jsBundleDir = file("$buildDir/generated/assets/react/${targetPath}")
@@ -313,7 +314,6 @@ afterEvaluate {
         // This should really be done by packaging all Hermes releated libs into
         // two separate HermesDebug and HermesRelease AARs, but until then we'll
         // kludge it by deleting the .so files out of the /transforms/ directory.
-        def isRelease = targetName.toLowerCase().contains("release")
         def libDir = "$buildDir/intermediates/transforms/"
         def vmSelectionAction = {
             fileTree(libDir).matching {

--- a/react.gradle
+++ b/react.gradle
@@ -158,7 +158,7 @@ afterEvaluate {
 
             // Set up dev mode
             def devEnabled = !(config."devDisabledIn${targetName}"
-                || targetName.toLowerCase().contains("release"))
+                || isRelease)
 
             def extraArgs = config.extraPackagerArgs ?: [];
 
@@ -178,7 +178,7 @@ afterEvaluate {
                     def hermesFlags;
                     def hbcTempFile = file("${jsBundleFile}.hbc")
                     exec {
-                        if (targetName.toLowerCase().contains("release")) {
+                        if (isRelease) {
                             // Can't use ?: since that will also substitute valid empty lists
                             hermesFlags = config.hermesFlagsRelease
                             if (hermesFlags == null) hermesFlags = ["-O", "-output-source-map"]
@@ -222,7 +222,7 @@ afterEvaluate {
                 ? config."bundleIn${targetName}"
                 : config."bundleIn${variant.buildType.name.capitalize()}" != null
                     ? config."bundleIn${variant.buildType.name.capitalize()}"
-                    : targetName.toLowerCase().contains("release")
+                    : isRelease
         }
 
         // Expose a minimal interface on the application variant and the task itself:

--- a/react.gradle
+++ b/react.gradle
@@ -103,7 +103,7 @@ afterEvaluate {
         // Create variant and target names
         def targetName = variant.name.capitalize()
         def targetPath = variant.dirName
-        def isRelease = targetName.toLowerCase().contains("release")
+        def isRelease = targetName.toLowerCase().contains("release") || config."useReleaseConfigIn${targetName}"
 
         // React js bundle directories
         def jsBundleDir = file("$buildDir/generated/assets/react/${targetPath}")

--- a/template/android/app/build.gradle
+++ b/template/android/app/build.gradle
@@ -23,6 +23,10 @@ import com.android.build.OutputFile
  *   // https://reactnative.dev/docs/performance#enable-the-ram-format
  *   bundleCommand: "ram-bundle",
  *
+ *   // whether to use same config as release in another build variant
+ *   // This includes bundleInBeta and devDisabledInBeta
+ *   useReleaseConfigInBeta: false,
+ *
  *   // whether to bundle JS and assets in debug mode
  *   bundleInDebug: false,
  *


### PR DESCRIPTION
## Summary

It's a common use case to have a custom `buildType` on android that should be similar to `release` for staging builds
For those, due to [this line](https://github.com/facebook/react-native/blob/master/react.gradle#L180) there is no easy way to make sure the sourcemaps are output. 

This leads to issues such as https://github.com/getsentry/sentry-react-native/issues/1105
At the moment, this is one of the blockers to use Hermes on our side, and oh boy do we want to use it! Congrats on that, it's quite fantastic!

One option would be to add a flag specific for Hermes, like `useHermesReleaseConfigIn`, but then that would be an additional flag to set to true in addition to `bundleIn` and `devDisabledIn`. You'd have something like:

```gradle
project.ext.react = [
        entryFile        : "index.js",
        bundleInBeta     : true,
        devDisabledInBeta: true,
        useHermesReleaseConfigIn: true,
        enableHermes: true,  // clean and rebuild if changing
]
```

My suggestion is then to have one flag to rule them all for such variants so that you only have to add:

```gradle
project.ext.react = [
        entryFile        : "index.js",
        useReleaseConfigInBeta: true,
        enableHermes: true,  // clean and rebuild if changing
]
```

I started by refactoring and moving all uses of `targetName.toLowerCase().contains("release")`  into a single variable, then I introduced the new flag.

Of course, open to any challenges/feedbacks!

## Changelog

[Android] [Added] - Add gradle flag to enable all release config
[Android] [Fixed] - Allow Hermes sourcemaps for custom build types

## Test Plan

1. I have a project with 3 build types:

```gradle
    buildTypes {
        debug {
            applicationIdSuffix ".debug"
            signingConfig signingConfigs.debug
        }

        beta {
            applicationIdSuffix ".beta"
            signingConfig signingConfigs.beta
            matchingFallbacks = ['release']
        }

        release {
            minifyEnabled enableProguardInReleaseBuilds
            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
            signingConfig signingConfigs.release
        }
    }
```

2. I've replaced my config which was previously:

```gradle
project.ext.react = [
        entryFile        : "index.js",
        bundleInBeta     : true,
        devDisabledInBeta: true,
        enableHermes: true,  // clean and rebuild if changing
]
```
by
```gradle
project.ext.react = [
        entryFile        : "index.js",
        useReleaseConfigInBeta: true,
        enableHermes: true,  // clean and rebuild if changing
]
```

3. I've built all variants of the app:
```gradle
./gradlew clean assembleRelease
./gradlew clean assembleBeta
./gradlew clean assembleDebug
```

- [x] All 3 builds now work. `assembleBeta` was not working because we use `Sentry` for crash reporting, and it wasn't able to find any sourcemaps.
- [x] On Beta and Release sourcemaps are now correctly uploaded to Sentry and the app runs fine.
- [x] On Debug, the app runs fine, the `bundle` task was not run, dev menu and reload work as expected