### PR TITLE
Add fetch to global scope during Jest setup

### DIFF
--- a/jest/setup.js
+++ b/jest/setup.js
@@ -24,10 +24,10 @@ global.performance = {
 global.Promise = jest.requireActual('promise');
 global.regeneratorRuntime = jest.requireActual('regenerator-runtime/runtime');
 
-global.requestAnimationFrame = function (callback) {
+global.requestAnimationFrame = function(callback) {
   return setTimeout(callback, 0);
 };
-global.cancelAnimationFrame = function (id) {
+global.cancelAnimationFrame = function(id) {
   clearTimeout(id);
 };
 
@@ -343,7 +343,7 @@ jest
   })
   .mock(
     '../Libraries/Utilities/verifyComponentAttributeEquivalence',
-    () => function () {},
+    () => function() {},
   )
   .mock('../Libraries/Components/View/ViewNativeComponent', () => {
     const React = require('react');

--- a/jest/setup.js
+++ b/jest/setup.js
@@ -31,6 +31,8 @@ global.cancelAnimationFrame = function(id) {
   clearTimeout(id);
 };
 
+require('whatwg-fetch');
+
 // there's a __mock__ for it.
 jest.setMock(
   '../Libraries/vendor/core/ErrorUtils',

--- a/jest/setup.js
+++ b/jest/setup.js
@@ -24,14 +24,14 @@ global.performance = {
 global.Promise = jest.requireActual('promise');
 global.regeneratorRuntime = jest.requireActual('regenerator-runtime/runtime');
 
-global.requestAnimationFrame = function(callback) {
+global.requestAnimationFrame = function (callback) {
   return setTimeout(callback, 0);
 };
-global.cancelAnimationFrame = function(id) {
+global.cancelAnimationFrame = function (id) {
   clearTimeout(id);
 };
 
-require('whatwg-fetch');
+jest.requireActual('../Libraries/Network/fetch');
 
 // there's a __mock__ for it.
 jest.setMock(
@@ -343,7 +343,7 @@ jest
   })
   .mock(
     '../Libraries/Utilities/verifyComponentAttributeEquivalence',
-    () => function() {},
+    () => function () {},
   )
   .mock('../Libraries/Components/View/ViewNativeComponent', () => {
     const React = require('react');

--- a/yarn.lock
+++ b/yarn.lock
@@ -6905,9 +6905,9 @@ whatwg-encoding@^1.0.5:
     iconv-lite "0.4.24"
 
 whatwg-fetch@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
-  integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.5.0.tgz#605a2cd0a7146e5db141e29d1c62ab84c0c4c868"
+  integrity sha512-jXkLtsR42xhXg7akoDKvKWE40eJeI+2KZqcp2h3NsOrRnDvtWX36KcKl30dy+hxECivdk2BVUHVNrPtoMBUx6A==
 
 whatwg-mimetype@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

In the [Jest documentation](https://jestjs.io/docs/en/tutorial-react-native), the `react-native` preset in this repo is described as follows:

> The preset is a node environment that mimics the environment of a React Native app.

However, while writing unit tests, I noticed that the Jest environment is missing a `fetch` implementation. According to the [React Native docs](https://reactnative.dev/docs/javascript-environment), React Native includes a polyfill for `fetch`. Putting these two statements together, it follows that there should be an implementation of `fetch` present in the Jest environment while testing.

This PR adds a single line, `jest.requireActual('../Libraries/Network/fetch')`, to the Jest setup script. (As an alternative, I believe I could just use `require('whatwg-fetch')`, so if that's preferred please let me know and I'll update the PR.)

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Fixed] - Added `fetch` to global scope during Jest tests

## Test Plan

I'm not sure if this change would require any updates to existing tests. If that's not the case, please let me know! As far as I can tell, there aren't any tests specific to the Jest preset.
