### PR TITLE
Align onKeyPress behavior with iOS

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditTextInputConnectionWrapper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditTextInputConnectionWrapper.java
@@ -98,7 +98,7 @@ class ReactEditTextInputConnectionWrapper extends InputConnectionWrapper {
     if (cursorMovedBackwardsOrAtBeginningOfInput || (!noPreviousSelection && cursorDidNotMove)) {
       key = BACKSPACE_KEY_VALUE;
     } else {
-      key = String.valueOf(mEditText.getText().charAt(currentSelectionStart - 1));
+      key = String.valueOf(text.charAt(text.length() -1));
     }
     dispatchKeyEventOrEnqueue(key);
     return consumed;


### PR DESCRIPTION
## Summary

Align onKeyPress behavior with iOS, onKeyPress should handle latest entered keypress independant whether the character is added in the textfield or not

## Changelog
[Android] [Fixed] - Use latest input to get the latest key pressed instead of derive the latest key pressed by content of textinput

There is currently a different onKeyPress behavior between iOS and android in case of length limited textinputs 
[snack](https://snack.expo.io/@m.bahl/android-onkeypress) 

## Test Plan
Open up RNTester app on android. Select the TextInput test if event handling works as expected