### PR TITLE
Don't minify JS bundle by default when using hermes

### DIFF
--- a/react.gradle
+++ b/react.gradle
@@ -159,12 +159,21 @@ afterEvaluate {
             def devEnabled = !(config."devDisabledIn${targetName}"
                 || targetName.toLowerCase().contains("release"))
 
-            def extraArgs = config.extraPackagerArgs ?: [];
+            def extraArgs = []
 
             if (bundleConfig) {
-                extraArgs = extraArgs.clone()
-                extraArgs.add("--config");
-                extraArgs.add(bundleConfig);
+                extraArgs.add("--config")
+                extraArgs.add(bundleConfig)
+            }
+
+            // Hermes doesn't require JS minification.
+            if (enableHermes && !devEnabled) {
+                extraArgs.add("--minify")
+                extraArgs.add("false")
+            }
+
+            if (config.extraPackagerArgs) {
+                extraArgs.addAll(config.extraPackagerArgs)
             }
 
             commandLine(*execCommand, bundleCommand, "--platform", "android", "--dev", "${devEnabled}",

--- a/scripts/react-native-xcode.sh
+++ b/scripts/react-native-xcode.sh
@@ -163,6 +163,11 @@ if [[ $EMIT_SOURCEMAP == true ]]; then
   EXTRA_ARGS="$EXTRA_ARGS --sourcemap-output $PACKAGER_SOURCEMAP_FILE"
 fi
 
+# Hermes doesn't require JS minification.
+if [[ $USE_HERMES == true && $DEV == false ]]; then
+  EXTRA_ARGS="$EXTRA_ARGS --minify false"
+fi
+
 "$NODE_BINARY" $NODE_ARGS "$CLI_PATH" $BUNDLE_COMMAND \
   $CONFIG_ARG \
   --entry-file "$ENTRY_FILE" \
@@ -187,7 +192,7 @@ else
   if [[ $EMIT_SOURCEMAP == true ]]; then
     EXTRA_COMPILER_ARGS="$EXTRA_COMPILER_ARGS -output-source-map"
   fi
-  "$HERMES_CLI_PATH" -emit-binary $EXTRA_COMPILER_ARGS -out "$DEST/main.jsbundle" "$BUNDLE_FILE" 
+  "$HERMES_CLI_PATH" -emit-binary $EXTRA_COMPILER_ARGS -out "$DEST/main.jsbundle" "$BUNDLE_FILE"
   if [[ $EMIT_SOURCEMAP == true ]]; then
     HBC_SOURCEMAP_FILE="$BUNDLE_FILE.map"
     "$NODE_BINARY" "$COMPOSE_SOURCEMAP_PATH" "$PACKAGER_SOURCEMAP_FILE" "$HBC_SOURCEMAP_FILE" -o "$SOURCEMAP_FILE"


### PR DESCRIPTION
## Summary

Minification is not needed for hermes as it does all required optimisations on the bytecode. This is what facebook does internally for hermes bundles and I also validated by comparing the bytecode bundle size on a minified and non-minified bundle.

## Changelog

[General] [Changed] - Don't minify JS bundle by default when using hermes

## Test Plan

Verified that the JS bundled generated on Android and iOS when using hermes is not minified by checking the generated JS file manually.
