### PR TITLE
Remove Okhttp3 Android Proguard Rules

### DIFF
--- a/ReactAndroid/proguard-rules.pro
+++ b/ReactAndroid/proguard-rules.pro
@@ -55,13 +55,10 @@
 # hermes
 -keep class com.facebook.jni.** { *; }
 
-# okhttp
 
 -keepattributes Signature
 -keepattributes *Annotation*
--keep class okhttp3.** { *; }
--keep interface okhttp3.** { *; }
--dontwarn okhttp3.**
+
 
 # okio
 

--- a/ReactAndroid/proguard-rules.pro
+++ b/ReactAndroid/proguard-rules.pro
@@ -56,10 +56,6 @@
 -keep class com.facebook.jni.** { *; }
 
 
--keepattributes Signature
--keepattributes *Annotation*
-
-
 # okio
 
 -keep class sun.misc.Unsafe { *; }


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Remove proguard keep rules on okhttp3. The library already contains its own consumer proguard --> see https://square.github.io/okhttp/r8_proguard/

The keep rules will increase the final apk size of android app. Currently, there is no way to disable proguard rules from transitive dependencies ( https://issuetracker.google.com/issues/37073777). So any android app that use react native will also contains this proguard rules.

## Changelog

[Android] [Removed] - Remove okhttp3 proguard rules

## Test Plan
n/a
