### PR TITLE
Fix ArrayIndexOutOfBoundsException in ReactTextInputManager.setMaxLength

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -643,7 +643,7 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
         if (!replaced) {
           newFilters = new InputFilter[currentFilters.length + 1];
           System.arraycopy(currentFilters, 0, newFilters, 0, currentFilters.length);
-          currentFilters[currentFilters.length] = new InputFilter.LengthFilter(maxLength);
+          newFilters[currentFilters.length] = new InputFilter.LengthFilter(maxLength);
         }
       } else {
         newFilters = new InputFilter[1];


### PR DESCRIPTION
## Summary

Fix ArrayIndexOutOfBoundsException in ReactTextInputManager.setMaxLength

## Changelog

[Android] [Fixed] - ReactTextInputManager.setMaxLength will throw ArrayIndexOutOfBoundsException when inserting LengthFilter to view's non-empty mFilters.

## Test Plan

-
