### PR TITLE
Make dependencies cache more reliable on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,6 @@ commands:
       - restore_cache:
           keys:
             - v4-yarn-cache-{{ arch }}-{{ checksum "yarn.lock" }}
-            - v4-yarn-cache-{{ arch }}
       - run:
           name: "Yarn: Install Dependencies"
           command: |
@@ -94,7 +93,6 @@ commands:
       - restore_cache:
           keys:
             - v3-buck-v2019.01.10.01-{{ checksum "scripts/circleci/buck_fetch.sh" }}}
-            - v3-buck-v2019.01.10.01-
       - run:
           name: Install BUCK
           command: |
@@ -151,20 +149,20 @@ commands:
           command: cp packages/rn-tester/Podfile.lock packages/rn-tester/Podfile.lock.bak
       - restore_cache:
           keys:
-            - v3-pods-{{ .Environment.CIRCLE_JOB }}-{{ checksum "packages/rn-tester/Podfile.lock.bak" }}
-            - v3-pods-{{ .Environment.CIRCLE_JOB }}-
+            # The committed lockfile is generated using USE_FRAMEWORKS=0 and USE_HERMES=0 so it could load an outdated cache if a change
+            # only affects the frameworks or hermes config. To help prevent this also cache based on the content of Podfile.
+            - v3-pods-{{ .Environment.CIRCLE_JOB }}-{{ checksum "packages/rn-tester/Podfile.lock.bak" }}-{{ checksum "packages/rn-tester/Podfile" }}
       - steps: << parameters.steps >>
       - save_cache:
           paths:
             - packages/rn-tester/Pods
-          key: v3-pods-{{ .Environment.CIRCLE_JOB }}-{{ checksum "packages/rn-tester/Podfile.lock.bak" }}
+          key: v3-pods-{{ .Environment.CIRCLE_JOB }}-{{ checksum "packages/rn-tester/Podfile.lock.bak" }}-{{ checksum "packages/rn-tester/Podfile" }}
 
   download_gradle_dependencies:
     steps:
       - restore_cache:
           keys:
             - v1-gradle-{{ checksum "ReactAndroid/build.gradle" }}-{{ checksum "scripts/circleci/gradle_download_deps.sh" }}
-            - v1-gradle-
       - run:
           name: Download Dependencies Using Gradle
           command: ./scripts/circleci/gradle_download_deps.sh
@@ -626,7 +624,6 @@ jobs:
       - restore_cache:
           keys:
             - v1-win-yarn-cache-{{ arch }}-{{ checksum "yarn.lock" }}
-            - v1-win-yarn-cache-{{ arch }}-
       - run:
           name: "Yarn: Install Dependencies"
           command: yarn install --frozen-lockfile --non-interactive


### PR DESCRIPTION
## Summary

I was looking into why CI was failing and could not reproduce locally, also noticed the errors seemed to come from old version of files being used, for example a missing symbol added in a JSI commit ~1 month ago.  I noticed that we were using multiple cache keys for a lot of deps in the following format:

```
- v3-pods-{{ .Environment.CIRCLE_JOB }}-{{ checksum "packages/rn-tester/Podfile.lock.bak" }}
- v3-pods-{{ .Environment.CIRCLE_JOB }}-
```

This means that if the cache doesn't exist for the checksum of the lockfile it will get one for any other checksum. This can lead to loading old version of files that cocoapod / yarn probably doesn't detect and keeps instead of getting the proper version. To make things worst it then caches the broken dep package after.

This removes all of these key fallbacks and use the cache only if we have a perfect match. This should make CI more reliable and fix random breaks after updating deps / pod configs.

## Changelog

[Internal] [Fixed] - Make dependencies cache more reliable on CI

## Test Plan

- Check that tests now pass when cache is bypassed
- Check that it still passes with cache
- Hope the issue stops happening the next time someone updates deps :)

