### PR TITLE
Fix building RN Android from source on Windows.

### DIFF
--- a/packages/react-native-codegen/android/build.gradle
+++ b/packages/react-native-codegen/android/build.gradle
@@ -4,6 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+import org.apache.tools.ant.taskdefs.condition.Os
 
 buildscript {
     repositories {
@@ -42,5 +43,25 @@ task('buildCodegenCLI', type: Exec) {
     nodeModulesDir.mkdirs();
     outputs.dirs(libDir, nodeModulesDir)
 
-    commandLine("$codegenRoot/scripts/oss/build.sh")
+    if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+      // Convert path to Linux format: use canonical path to strip it off relative elements in the middle of the string.
+      // Then replace baskslashes with slashes, remove leading colon, add leading slash.
+      // Eg. D:\path1\sub2/.. -> /D/path1/path2
+      String canonicalPath = new File(codegenRoot).getCanonicalPath()
+      String linuxPath = canonicalPath.replace('\\', '/');
+      linuxPath = linuxPath.replace(':', '')
+      linuxPath = '/' + linuxPath
+      codegenRoot = linuxPath
+      
+      // Get the location of bash in the system; assume environment variable created to store it.
+      String bashHome = "$System.env.REACT_WINDOWS_BASH"
+      if (bashHome == null) {
+        throw new GradleException("REACT_WINDOWS_BASH is not defined.")
+      }
+      commandLine(bashHome, "-c", "$linuxPath/scripts/oss/build.sh")
+    }
+    else {
+        commandLine("$codegenRoot/scripts/oss/build.sh")
+    }
+    
 }

--- a/packages/react-native-codegen/android/build.gradle
+++ b/packages/react-native-codegen/android/build.gradle
@@ -51,8 +51,7 @@ task('buildCodegenCLI', type: Exec) {
       String linuxPath = canonicalPath.replace('\\', '/');
       linuxPath = linuxPath.replace(':', '')
       linuxPath = '/' + linuxPath
-      codegenRoot = linuxPath
-      
+
       // Get the location of bash in the system; assume environment variable created to store it.
       String bashHome = "$System.env.REACT_WINDOWS_BASH"
       if (bashHome == null) {
@@ -63,5 +62,4 @@ task('buildCodegenCLI', type: Exec) {
     else {
         commandLine("$codegenRoot/scripts/oss/build.sh")
     }
-    
 }

--- a/packages/react-native-codegen/android/gradlePlugin-build/gradlePlugin/src/main/java/com/facebook/react/codegen/plugin/CodegenPlugin.java
+++ b/packages/react-native-codegen/android/gradlePlugin-build/gradlePlugin/src/main/java/com/facebook/react/codegen/plugin/CodegenPlugin.java
@@ -33,6 +33,8 @@ public class CodegenPlugin implements Plugin<Project> {
     final File generatedSchemaFile = new File(generatedSrcDir, "schema.json");
 
     // 2. Task: produce schema from JS files.
+    String os = System.getProperty("os.name").toLowerCase();
+
     project
         .getTasks()
         .register(
@@ -62,7 +64,7 @@ public class CodegenPlugin implements Plugin<Project> {
 
               ImmutableList<String> execCommands =
                   new ImmutableList.Builder<String>()
-                      .add("yarn")
+                      .add(os.contains("windows") ? "yarn.cmd" : "yarn")
                       .addAll(ImmutableList.copyOf(extension.nodeExecutableAndArgs))
                       .add(extension.codegenGenerateSchemaCLI().getAbsolutePath())
                       .add(generatedSchemaFile.getAbsolutePath())
@@ -96,7 +98,7 @@ public class CodegenPlugin implements Plugin<Project> {
 
               ImmutableList<String> execCommands =
                   new ImmutableList.Builder<String>()
-                      .add("yarn")
+                      .add(os.contains("windows") ? "yarn.cmd" : "yarn")
                       .addAll(ImmutableList.copyOf(extension.nodeExecutableAndArgs))
                       .add(extension.codegenGenerateNativeModuleSpecsCLI().getAbsolutePath())
                       .add("android")

--- a/packages/react-native-codegen/scripts/oss/build.sh
+++ b/packages/react-native-codegen/scripts/oss/build.sh
@@ -32,12 +32,24 @@ if [[ ${FBSOURCE_ENV:-0} -eq 1 ]]; then
   "$YARN_BINARY" run build
 
   popd >/dev/null
+
 else
   # Run yarn install in a separate tmp dir to avoid conflict with the rest of the repo.
   # Note: OSS-only.
   TMP_DIR=$(mktemp -d)
 
-  cp -R "$CODEGEN_DIR/." "$TMP_DIR"
+  # On Windows this script gets run by a seprate Git Bash instance, which cannot perform the copy
+  # due to file locks created by the host process. Need to exclude .lock files while copying.
+  # Using in-memory tar operation because piping `find` and `grep` doesn't preserve folder structure
+  # during recursive copying, and `rsync` is not installed by default in Git Bash.
+  # As an added benefit, blob copy is faster.
+  if [ "$OSTYPE" = "msys" ]; then
+    my_dir=`pwd`;
+    tar cf - --exclude=*.lock $CODEGEN_DIR | (cd $TMP_DIR && tar xvf - );
+    cd $my_dir;
+  else  
+    cp -R "$CODEGEN_DIR/." "$TMP_DIR";
+  fi
 
   pushd "$TMP_DIR" >/dev/null
 
@@ -48,4 +60,5 @@ else
 
   mv "$TMP_DIR/lib" "$TMP_DIR/node_modules" "$CODEGEN_DIR"
   rm -rf "$TMP_DIR"
+
 fi

--- a/packages/react-native-codegen/scripts/oss/build.sh
+++ b/packages/react-native-codegen/scripts/oss/build.sh
@@ -43,11 +43,9 @@ else
   # Using in-memory tar operation because piping `find` and `grep` doesn't preserve folder structure
   # during recursive copying, and `rsync` is not installed by default in Git Bash.
   # As an added benefit, blob copy is faster.
-  if [ "$OSTYPE" = "msys" ]; then
-    my_dir=`pwd`;
+  if [ "$OSTYPE" = "msys" ] || [ "$OSTYPE" = "cygwin" ]; then
     tar cf - --exclude=*.lock $CODEGEN_DIR | (cd $TMP_DIR && tar xvf - );
-    cd $my_dir;
-  else  
+  else
     cp -R "$CODEGEN_DIR/." "$TMP_DIR";
   fi
 
@@ -60,5 +58,4 @@ else
 
   mv "$TMP_DIR/lib" "$TMP_DIR/node_modules" "$CODEGEN_DIR"
   rm -rf "$TMP_DIR"
-
 fi


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Running `.\gradlew installArchives` is currently broken on Windows. This is because .sh scripts were added in the codegen module, which cannot be run by the Command Prompt on Windows. It can be worked around by installing eg. Git Bash., which can be then leveraged using the code modifications in this PR, which include sanitizing mixed Linux-Windows relative paths, and other minor Windows-specific adjustments.

It's required that the user adds a Windows Environment variable storing the path to their bash binary named `REACT_WINDOWS_BASH`.

Pair-programmed with @davinci26
## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Fix] - Fix building React Android on Windows.

Fixes #30271 