### PR TITLE
Updated Pressable Prop Names To camelCase To Maintain Consistency

### DIFF
--- a/Libraries/Components/Pressable/Pressable.js
+++ b/Libraries/Components/Pressable/Pressable.js
@@ -124,7 +124,7 @@ type Props = $ReadOnly<{|
   /**
    * Enables the Android ripple effect and configures its color.
    */
-  android_ripple?: ?RippleConfig,
+  androidRipple?: ?RippleConfig,
 
   /**
    * Used only for documentation or testing (e.g. snapshot testing).
@@ -145,7 +145,7 @@ function Pressable(props: Props, forwardedRef): React.Node {
   const {
     accessible,
     androidDisableSound,
-    android_ripple,
+    androidRipple,
     children,
     delayLongPress,
     disabled,
@@ -164,7 +164,7 @@ function Pressable(props: Props, forwardedRef): React.Node {
   const viewRef = useRef<React.ElementRef<typeof View> | null>(null);
   useImperativeHandle(forwardedRef, () => viewRef.current);
 
-  const android_rippleConfig = useAndroidRippleForView(android_ripple, viewRef);
+  const androidRippleConfig = useAndroidRippleForView(androidRipple, viewRef);
 
   const [pressed, setPressed] = usePressState(testOnly_pressed === true);
 
@@ -172,7 +172,7 @@ function Pressable(props: Props, forwardedRef): React.Node {
 
   const restPropsWithDefaults: React.ElementConfig<typeof View> = {
     ...restProps,
-    ...android_rippleConfig?.viewProps,
+    ...androidRippleConfig?.viewProps,
     accessible: accessible !== false,
     focusable: focusable !== false,
     hitSlop,
@@ -189,18 +189,18 @@ function Pressable(props: Props, forwardedRef): React.Node {
       onLongPress,
       onPress,
       onPressIn(event: PressEvent): void {
-        if (android_rippleConfig != null) {
-          android_rippleConfig.onPressIn(event);
+        if (androidRippleConfig != null) {
+          androidRippleConfig.onPressIn(event);
         }
         setPressed(true);
         if (onPressIn != null) {
           onPressIn(event);
         }
       },
-      onPressMove: android_rippleConfig?.onPressMove,
+      onPressMove: androidRippleConfig?.onPressMove,
       onPressOut(event: PressEvent): void {
-        if (android_rippleConfig != null) {
-          android_rippleConfig.onPressOut(event);
+        if (androidRippleConfig != null) {
+          androidRippleConfig.onPressOut(event);
         }
         setPressed(false);
         if (onPressOut != null) {
@@ -210,7 +210,7 @@ function Pressable(props: Props, forwardedRef): React.Node {
     }),
     [
       androidDisableSound,
-      android_rippleConfig,
+      androidRippleConfig,
       delayLongPress,
       disabled,
       hitSlop,

--- a/Libraries/Components/Pressable/Pressable.js
+++ b/Libraries/Components/Pressable/Pressable.js
@@ -119,7 +119,7 @@ type Props = $ReadOnly<{|
   /**
    * If true, doesn't play system sound on touch.
    */
-  android_disableSound?: ?boolean,
+  androidDisableSound?: ?boolean,
 
   /**
    * Enables the Android ripple effect and configures its color.
@@ -144,7 +144,7 @@ type Props = $ReadOnly<{|
 function Pressable(props: Props, forwardedRef): React.Node {
   const {
     accessible,
-    android_disableSound,
+    androidDisableSound,
     android_ripple,
     children,
     delayLongPress,
@@ -183,7 +183,7 @@ function Pressable(props: Props, forwardedRef): React.Node {
       disabled,
       hitSlop,
       pressRectOffset: pressRetentionOffset,
-      android_disableSound,
+      androidDisableSound,
       delayLongPress,
       delayPressIn: unstable_pressDelay,
       onLongPress,
@@ -209,7 +209,7 @@ function Pressable(props: Props, forwardedRef): React.Node {
       },
     }),
     [
-      android_disableSound,
+      androidDisableSound,
       android_rippleConfig,
       delayLongPress,
       disabled,

--- a/Libraries/Components/Pressable/Pressable.js
+++ b/Libraries/Components/Pressable/Pressable.js
@@ -129,7 +129,7 @@ type Props = $ReadOnly<{|
   /**
    * Used only for documentation or testing (e.g. snapshot testing).
    */
-  testOnly_pressed?: ?boolean,
+  testOnlyPressed?: ?boolean,
 
   /**
    * Duration to wait after press down before calling `onPressIn`.
@@ -156,7 +156,7 @@ function Pressable(props: Props, forwardedRef): React.Node {
     onPressOut,
     pressRetentionOffset,
     style,
-    testOnly_pressed,
+    testOnlyPressed,
     unstable_pressDelay,
     ...restProps
   } = props;
@@ -166,7 +166,7 @@ function Pressable(props: Props, forwardedRef): React.Node {
 
   const androidRippleConfig = useAndroidRippleForView(androidRipple, viewRef);
 
-  const [pressed, setPressed] = usePressState(testOnly_pressed === true);
+  const [pressed, setPressed] = usePressState(testOnlyPressed === true);
 
   const hitSlop = normalizeRect(props.hitSlop);
 

--- a/Libraries/Components/Touchable/TouchableBounce.js
+++ b/Libraries/Components/Touchable/TouchableBounce.js
@@ -52,7 +52,7 @@ class TouchableBounce extends React.Component<Props, State> {
       delayPressOut: this.props.delayPressOut,
       minPressDuration: 0,
       pressRectOffset: this.props.pressRetentionOffset,
-      android_disableSound: this.props.touchSoundDisabled,
+      androidDisableSound: this.props.touchSoundDisabled,
       onBlur: event => {
         if (Platform.isTV) {
           this._bounceTo(1, 0.4, 0);

--- a/Libraries/Components/Touchable/TouchableHighlight.js
+++ b/Libraries/Components/Touchable/TouchableHighlight.js
@@ -174,7 +174,7 @@ class TouchableHighlight extends React.Component<Props, State> {
       delayPressOut: this.props.delayPressOut,
       minPressDuration: 0,
       pressRectOffset: this.props.pressRetentionOffset,
-      android_disableSound: this.props.touchSoundDisabled,
+      androidDisableSound: this.props.touchSoundDisabled,
       onBlur: event => {
         if (Platform.isTV) {
           this._hideUnderlay();

--- a/Libraries/Components/Touchable/TouchableHighlight.js
+++ b/Libraries/Components/Touchable/TouchableHighlight.js
@@ -43,7 +43,7 @@ type Props = $ReadOnly<{|
   style?: ?ViewStyleProp,
   onShowUnderlay?: ?() => void,
   onHideUnderlay?: ?() => void,
-  testOnly_pressed?: ?boolean,
+  testOnlyPressed?: ?boolean,
 
   hostRef: React.Ref<typeof View>,
 |}>;
@@ -161,7 +161,7 @@ class TouchableHighlight extends React.Component<Props, State> {
   state: State = {
     pressability: new Pressability(this._createPressabilityConfig()),
     extraStyles:
-      this.props.testOnly_pressed === true ? this._createExtraStyles() : null,
+      this.props.testOnlyPressed === true ? this._createExtraStyles() : null,
   };
 
   _createPressabilityConfig(): PressabilityConfig {
@@ -254,7 +254,7 @@ class TouchableHighlight extends React.Component<Props, State> {
       clearTimeout(this._hideTimeout);
       this._hideTimeout = null;
     }
-    if (this.props.testOnly_pressed === true) {
+    if (this.props.testOnlyPressed === true) {
       return;
     }
     if (this._hasPressHandler()) {

--- a/Libraries/Components/Touchable/TouchableNativeFeedback.js
+++ b/Libraries/Components/Touchable/TouchableNativeFeedback.js
@@ -177,7 +177,7 @@ class TouchableNativeFeedback extends React.Component<Props, State> {
       delayPressOut: this.props.delayPressOut,
       minPressDuration: 0,
       pressRectOffset: this.props.pressRetentionOffset,
-      android_disableSound: this.props.touchSoundDisabled,
+      androidDisableSound: this.props.touchSoundDisabled,
       onLongPress: this.props.onLongPress,
       onPress: this.props.onPress,
       onPressIn: event => {

--- a/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+++ b/Libraries/Components/Touchable/TouchableWithoutFeedback.js
@@ -149,7 +149,7 @@ function createPressabilityConfig(props: Props): PressabilityConfig {
     delayPressOut: props.delayPressOut,
     minPressDuration: 0,
     pressRectOffset: props.pressRetentionOffset,
-    android_disableSound: props.touchSoundDisabled,
+    androidDisableSound: props.touchSoundDisabled,
     onBlur: props.onBlur,
     onFocus: props.onFocus,
     onLongPress: props.onLongPress,

--- a/Libraries/Pressability/Pressability.js
+++ b/Libraries/Pressability/Pressability.js
@@ -50,7 +50,7 @@ export type PressabilityConfig = $ReadOnly<{|
   /**
    * Whether to disable the systemm sound when `onPress` fires on Android.
    **/
-  android_disableSound?: ?boolean,
+  androidDisableSound?: ?boolean,
 
   /**
    * Duration to wait after hover in before calling `onHoverIn`.
@@ -684,14 +684,14 @@ export default class Pressability {
         this._activate(event);
         this._deactivate(event);
       }
-      const {onLongPress, onPress, android_disableSound} = this._config;
+      const {onLongPress, onPress, androidDisableSound} = this._config;
       if (onPress != null) {
         const isPressCanceledByLongPress =
           onLongPress != null &&
           prevState === 'RESPONDER_ACTIVE_LONG_PRESS_IN' &&
           this._shouldLongPressCancelPress();
         if (!isPressCanceledByLongPress) {
-          if (Platform.OS === 'android' && android_disableSound !== true) {
+          if (Platform.OS === 'android' && androidDisableSound !== true) {
             SoundManager.playTouchSound();
           }
           onPress(event);

--- a/packages/rn-tester/js/examples/Pressable/PressableExample.js
+++ b/packages/rn-tester/js/examples/Pressable/PressableExample.js
@@ -371,7 +371,7 @@ exports.examples = [
       };
       return (
         <View style={styles.row}>
-          <Pressable android_ripple={{color: 'green'}}>
+          <Pressable androidRipple={{color: 'green'}}>
             <Animated.View style={style} />
           </Pressable>
         </View>
@@ -395,7 +395,7 @@ exports.examples = [
               {justifyContent: 'space-around', alignItems: 'center'},
             ]}>
             <Pressable
-              android_ripple={{color: 'orange', borderless: true, radius: 30}}>
+              androidRipple={{color: 'orange', borderless: true, radius: 30}}>
               <View>
                 <Text style={[styles.button, nativeFeedbackButton]}>
                   radius 30
@@ -403,7 +403,7 @@ exports.examples = [
               </View>
             </Pressable>
 
-            <Pressable android_ripple={{borderless: true, radius: 150}}>
+            <Pressable androidRipple={{borderless: true, radius: 150}}>
               <View>
                 <Text style={[styles.button, nativeFeedbackButton]}>
                   radius 150
@@ -411,7 +411,7 @@ exports.examples = [
               </View>
             </Pressable>
 
-            <Pressable android_ripple={{borderless: false, radius: 70}}>
+            <Pressable androidRipple={{borderless: false, radius: 70}}>
               <View style={styles.block}>
                 <Text style={[styles.button, nativeFeedbackButton]}>
                   radius 70, with border
@@ -420,7 +420,7 @@ exports.examples = [
             </Pressable>
           </View>
 
-          <Pressable android_ripple={{borderless: false}}>
+          <Pressable androidRipple={{borderless: false}}>
             <View style={styles.block}>
               <Text style={[styles.button, nativeFeedbackButton]}>
                 with border, default color and radius


### PR DESCRIPTION
## Summary
This PR updates three of the Pressable prop names to camelCase to maintain consistency.
The changes are as follows:

- android_disableSound -> androidDisableSound
- android_ripple -> androidRipple
- testOnly_pressed -> testOnlyPressed

## Changelog
[General] [Changed] - Changed android_disableSound, android_ripple & testOnly_pressed props in Pressable to androidDisableSound, androidRipple & testOnlyPressed respectively.

## Test Plan
Test Pressable component using new prop names.