### PR TITLE
fix: building in release mode for simulator

### DIFF
--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -108,3 +108,24 @@ def flipper_post_install(installer)
     end
   end
 end
+
+def react_native_post_install(installer)
+  projects = installer.aggregate_targets
+    .map{ |t| t.user_project }
+    .uniq{ |p| p.path }
+    .push(installer.pods_project)
+
+  arm_value = `/usr/sbin/sysctl -n hw.optional.arm64 2>&1`.to_i
+
+  projects.each do |project|
+    project.build_configurations.each do |config|
+      if arm_value == 1 then
+        config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"] = "arm64"
+      else
+        config.build_settings.delete("EXCLUDED_ARCHS[sdk=iphonesimulator*]")
+      end
+    end
+
+    project.save()
+  end
+end

--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -120,9 +120,9 @@ def react_native_post_install(installer)
   projects.each do |project|
     project.build_configurations.each do |config|
       if arm_value == 1 then
-        config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"] = "arm64"
-      else
         config.build_settings.delete("EXCLUDED_ARCHS[sdk=iphonesimulator*]")
+      else
+        config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"] = "arm64"
       end
     end
 

--- a/template/ios/Podfile
+++ b/template/ios/Podfile
@@ -16,9 +16,15 @@ target 'HelloWorld' do
   # Enables Flipper.
   #
   # Note that if you have use_frameworks! enabled, Flipper will not work and
-  # you should disable these next few lines.
-  use_flipper!
+  # you should disable the next line.
+  use_flipper!()
+
   post_install do |installer|
-    flipper_post_install(installer)
+    react_native_post_install(installer)
+
+    # Enables Flipper.
+    #
+    # Disable the next line if you are not using Flipper.
+    flipper_post_install(installer)  
   end
 end


### PR DESCRIPTION
## Summary

Fixes #29984

Right now, running a React Native application with Xcode 12 in Release mode on an iPhone Simulator will fail with something like below:

> [some file path], building for iOS Simulator, but linking in object file built for iOS, file '[some file path]' for architecture arm64

The best explanation of this issue has been provided by @alloy in #29984:

> This issue has started coming up with Xcode 12 and support for the new ARM based Macs, as `arm64` now no longer can be assumed to _only_ be for iOS devices. This means Xcode 12 will now also build for `arm64` simulator SDKs and it has become ambiguous if an arch slice in a prebuilt binary is meant for a simulator or device.
> 
> In any case, for now this means that you can configure your Xcode project to exclude `arm64` when building for any iOS simulator SDK.

This PR implements aforementioned workaround.

## Changelog

[FIX] [IOS] - Fix running React Native project with Xcode 12 in Release on iPhone Simulator

## Test Plan

Switch your scheme to Release and run the app on simulator. Will complete w/o issues.