### PR TITLE
Add pixel ratio examples in rn-tester

### DIFF
--- a/packages/rn-tester/js/examples/PixelRatio/PixelRatioExample.js
+++ b/packages/rn-tester/js/examples/PixelRatio/PixelRatioExample.js
@@ -1,0 +1,203 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+'use strict';
+
+import React, {useState} from 'react';
+import {
+  Button,
+  StyleSheet,
+  Text,
+  TextInput,
+  PixelRatio,
+  View,
+} from 'react-native';
+
+import type {Node, Element} from 'react';
+
+function LayoutSizeToPixel() {
+  const [layoutDPSize, setLayoutDPSize] = useState(null);
+  const pixelSize = PixelRatio.getPixelSizeForLayoutSize(
+    layoutDPSize ? layoutDPSize : 0,
+  );
+
+  const handleDPInputChange = changedText => {
+    const layoutSize = parseInt(changedText);
+    setLayoutDPSize(layoutSize);
+  };
+
+  return (
+    <View style={styles.cardContainer}>
+      <View style={styles.card}>
+        <View style={styles.row}>
+          <Text style={styles.inputLabel}>Layout Size(dp): </Text>
+          <TextInput
+            style={styles.input}
+            value={layoutDPSize ? layoutDPSize.toString() : ''}
+            keyboardType={'numeric'}
+            onChangeText={handleDPInputChange}
+          />
+        </View>
+        <View style={[styles.row, styles.outputContainer]}>
+          <Text style={styles.inputLabel}>Pixel Size: </Text>
+          <Text style={styles.output}>{pixelSize}px</Text>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+function RoundToNearestPixel() {
+  const [layoutDPSizeText, setLayoutDPSizeText] = useState('');
+  const layoutDPSize = parseFloat(layoutDPSizeText);
+
+  const pixelSize = PixelRatio.roundToNearestPixel(
+    layoutDPSize ? layoutDPSize : 0,
+  );
+
+  const handleDPInputChange = changedText => {
+    setLayoutDPSizeText(changedText);
+  };
+
+  return (
+    <View style={styles.cardContainer}>
+      <View style={styles.card}>
+        <View style={styles.row}>
+          <Text style={styles.inputLabel}>Layout Size(dp): </Text>
+          <TextInput
+            style={styles.input}
+            value={layoutDPSizeText ? layoutDPSizeText.toString() : ''}
+            keyboardType={'numeric'}
+            onChangeText={handleDPInputChange}
+          />
+        </View>
+        <View style={[styles.row, styles.outputContainer]}>
+          <Text style={styles.inputLabel}>Nearest Layout Size: </Text>
+          <Text style={styles.output}>{pixelSize}dp</Text>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+function GetPixelRatio() {
+  const [pixelDensity, setPixelDensity] = useState(null);
+
+  const getPixelDensityCallback = () => {
+    setPixelDensity(PixelRatio.get());
+  };
+
+  return (
+    <View style={styles.cardContainer}>
+      <View style={styles.card}>
+        <Button onPress={getPixelDensityCallback} title={'Get Pixel Density'} />
+        {pixelDensity ? (
+          <View style={[styles.row, styles.outputContainer]}>
+            <Text style={styles.inputLabel}>Pixel Density: </Text>
+            <Text style={styles.output}>{pixelDensity}</Text>
+          </View>
+        ) : null}
+      </View>
+    </View>
+  );
+}
+
+function GetFontScale() {
+  const [fontScale, setFontScale] = useState(null);
+
+  const getPixelDensityCallback = () => {
+    setFontScale(PixelRatio.getFontScale());
+  };
+
+  return (
+    <View style={styles.cardContainer}>
+      <View style={styles.card}>
+        <Button onPress={getPixelDensityCallback} title={'Get Font Scale'} />
+        {fontScale ? (
+          <View style={[styles.row, styles.outputContainer]}>
+            <Text style={styles.inputLabel}>Font scale: </Text>
+            <Text style={styles.output}>{fontScale}</Text>
+          </View>
+        ) : null}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  cardContainer: {
+    marginVertical: 40,
+    flex: 1,
+    alignSelf: 'center',
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  outputContainer: {
+    marginTop: 16,
+  },
+  inputLabel: {
+    fontWeight: 'bold',
+  },
+  input: {
+    borderRadius: 6,
+    borderWidth: 1,
+    paddingVertical: 0,
+    height: 30,
+    width: 200,
+    alignSelf: 'center',
+    marginLeft: 14,
+    paddingHorizontal: 8,
+  },
+  card: {
+    width: 200,
+    height: 200,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backfaceVisibility: 'hidden',
+  },
+});
+
+exports.title = 'PixelRatio';
+exports.category = 'UI';
+exports.documentationURL = 'https://reactnative.dev/docs/pixelratio';
+exports.description = "Gives access to device's pixel density and font scale";
+exports.examples = [
+  {
+    title: 'Get pixel density',
+    description: 'Get pixel density of the device.',
+    render(): Element<any> {
+      return <GetPixelRatio />;
+    },
+  },
+  {
+    title: 'Get font scale',
+    description: 'Get  the scaling factor for font sizes.',
+    render(): Element<any> {
+      return <GetFontScale />;
+    },
+  },
+  {
+    title: 'Get pixel size from layout size',
+    description: 'layout size (dp) -> pixel size (px)',
+    render(): Element<any> {
+      return <LayoutSizeToPixel />;
+    },
+  },
+  {
+    title: 'Rounds a layout size to the nearest pixel',
+    description:
+      'Rounds a layout size (dp) to the nearest layout size that corresponds to an integer number of pixels',
+    render(): Element<any> {
+      return <RoundToNearestPixel />;
+    },
+  },
+];

--- a/packages/rn-tester/js/examples/PixelRatio/PixelRatioExample.js
+++ b/packages/rn-tester/js/examples/PixelRatio/PixelRatioExample.js
@@ -47,7 +47,7 @@ function LayoutSizeToPixel() {
         </View>
         <View style={[styles.row, styles.outputContainer]}>
           <Text style={styles.inputLabel}>Pixel Size: </Text>
-          <Text style={styles.output}>{pixelSize}px</Text>
+          <Text>{pixelSize}px</Text>
         </View>
       </View>
     </View>
@@ -80,7 +80,7 @@ function RoundToNearestPixel() {
         </View>
         <View style={[styles.row, styles.outputContainer]}>
           <Text style={styles.inputLabel}>Nearest Layout Size: </Text>
-          <Text style={styles.output}>{pixelSize}dp</Text>
+          <Text>{pixelSize}dp</Text>
         </View>
       </View>
     </View>
@@ -101,7 +101,7 @@ function GetPixelRatio() {
         {pixelDensity ? (
           <View style={[styles.row, styles.outputContainer]}>
             <Text style={styles.inputLabel}>Pixel Density: </Text>
-            <Text style={styles.output}>{pixelDensity}</Text>
+            <Text>{pixelDensity}</Text>
           </View>
         ) : null}
       </View>
@@ -123,7 +123,7 @@ function GetFontScale() {
         {fontScale ? (
           <View style={[styles.row, styles.outputContainer]}>
             <Text style={styles.inputLabel}>Font scale: </Text>
-            <Text style={styles.output}>{fontScale}</Text>
+            <Text>{fontScale}</Text>
           </View>
         ) : null}
       </View>

--- a/packages/rn-tester/js/utils/RNTesterList.android.js
+++ b/packages/rn-tester/js/utils/RNTesterList.android.js
@@ -208,6 +208,11 @@ const APIExamples: Array<RNTesterExample> = [
     module: require('../examples/PanResponder/PanResponderExample'),
   },
   {
+    key: 'PixelRatio',
+    category: 'UI',
+    module: require('../examples/PixelRatio/PixelRatioExample'),
+  },
+  {
     key: 'PermissionsExampleAndroid',
     category: 'Android',
     module: require('../examples/PermissionsAndroid/PermissionsExample'),

--- a/packages/rn-tester/js/utils/RNTesterList.ios.js
+++ b/packages/rn-tester/js/utils/RNTesterList.ios.js
@@ -254,6 +254,11 @@ const APIExamples: Array<RNTesterExample> = [
     supportsTVOS: true,
   },
   {
+    key: 'PixelRatio',
+    module: require('../examples/PixelRatio/PixelRatioExample'),
+    supportsTVOS: false,
+  },
+  {
     key: 'PointerEventsExample',
     module: require('../examples/PointerEvents/PointerEventsExample'),
     supportsTVOS: false,


### PR DESCRIPTION
## Summary
Added examples for PixelRatio API for:

1. get()
2. getFontScale()
3. getPixelSizeForLayoutSize()
4. roundToNearestPixel()

## Changelog
[General] [Added] - Add examples for PixelRatio API

## Test Plan
![Screen Recording 2020-12-08 at 12 28 37 AM (1)](https://user-images.githubusercontent.com/16796008/102251096-5e684480-3f2a-11eb-94db-5de0a444b21b.gif)

