### PR TITLE
Fix ActionSheetiOS examples and ScreenshotManager Native Module in rn-tester

### DIFF
--- a/packages/rn-tester/RNTesterPods.xcodeproj/project.pbxproj
+++ b/packages/rn-tester/RNTesterPods.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		5C60EB1C226440DB0018C04F /* AppDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5C60EB1B226440DB0018C04F /* AppDelegate.mm */; };
 		5CB07C9B226467E60039471C /* RNTesterTurboModuleProvider.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5CB07C99226467E60039471C /* RNTesterTurboModuleProvider.mm */; };
 		8145AE06241172D900A3F8DA /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8145AE05241172D900A3F8DA /* LaunchScreen.storyboard */; };
+		AAFA26EA257E61EF00DCFA2D /* Screenshot.m in Sources */ = {isa = PBXBuildFile; fileRef = AAFA26E8257E61EF00DCFA2D /* Screenshot.m */; };
 		CE8B4DF18C0491DAC01826D8 /* libPods-RNTesterUnitTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 240ABDF8133AF49081795AFC /* libPods-RNTesterUnitTests.a */; };
 		DBA671A0680021020B916DDB /* libPods-RNTesterIntegrationTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E4C76DE6ECEDBBAA2CA41B4D /* libPods-RNTesterIntegrationTests.a */; };
 		E7C1241A22BEC44B00DA25C0 /* RNTesterIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E7C1241922BEC44B00DA25C0 /* RNTesterIntegrationTests.m */; };
@@ -99,6 +100,8 @@
 		8145AE05241172D900A3F8DA /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = RNTester/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		972A459EE6CF8CC63531A088 /* Pods-RNTesterIntegrationTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNTesterIntegrationTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-RNTesterIntegrationTests/Pods-RNTesterIntegrationTests.debug.xcconfig"; sourceTree = "<group>"; };
 		98233960D1D6A1977D1C7EAF /* Pods-RNTester.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNTester.debug.xcconfig"; path = "Pods/Target Support Files/Pods-RNTester/Pods-RNTester.debug.xcconfig"; sourceTree = "<group>"; };
+		AAFA26E8257E61EF00DCFA2D /* Screenshot.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = Screenshot.m; path = NativeModuleExample/Screenshot.m; sourceTree = SOURCE_ROOT; };
+		AAFA26E9257E61EF00DCFA2D /* Screenshot.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Screenshot.h; path = NativeModuleExample/Screenshot.h; sourceTree = SOURCE_ROOT; };
 		E4C76DE6ECEDBBAA2CA41B4D /* libPods-RNTesterIntegrationTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-RNTesterIntegrationTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E771AEEA22B44E3100EA1189 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = RNTester/Info.plist; sourceTree = "<group>"; };
 		E7C1241922BEC44B00DA25C0 /* RNTesterIntegrationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNTesterIntegrationTests.m; sourceTree = "<group>"; };
@@ -219,6 +222,7 @@
 		13B07FAE1A68108700A75B9A /* RNTester */ = {
 			isa = PBXGroup;
 			children = (
+				AAFA26E7257E61B500DCFA2D /* ScreenshotManagerModule */,
 				E771AEEA22B44E3100EA1189 /* Info.plist */,
 				13B07FAF1A68108700A75B9A /* AppDelegate.h */,
 				5C60EB1B226440DB0018C04F /* AppDelegate.mm */,
@@ -320,6 +324,15 @@
 				E7DB215322B2F332005AC45F /* RNTesterIntegrationTests.xctest */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		AAFA26E7257E61B500DCFA2D /* ScreenshotManagerModule */ = {
+			isa = PBXGroup;
+			children = (
+				AAFA26E9257E61EF00DCFA2D /* Screenshot.h */,
+				AAFA26E8257E61EF00DCFA2D /* Screenshot.m */,
+			);
+			path = ScreenshotManagerModule;
 			sourceTree = "<group>";
 		};
 		E7DB20A022B2BA84005AC45F /* RNTesterUnitTests */ = {
@@ -675,6 +688,7 @@
 				272E6B3F1BEA849E001FCF37 /* UpdatePropertiesExampleView.m in Sources */,
 				5CB07C9B226467E60039471C /* RNTesterTurboModuleProvider.mm in Sources */,
 				27F441EC1BEBE5030039B79C /* FlexibleSizeExampleView.m in Sources */,
+				AAFA26EA257E61EF00DCFA2D /* Screenshot.m in Sources */,
 				5C60EB1C226440DB0018C04F /* AppDelegate.mm in Sources */,
 				13B07FC11A68108700A75B9A /* main.m in Sources */,
 			);

--- a/packages/rn-tester/js/examples/ActionSheetIOS/ActionSheetIOSExample.js
+++ b/packages/rn-tester/js/examples/ActionSheetIOS/ActionSheetIOSExample.js
@@ -232,7 +232,7 @@ class ShareScreenshotExample extends React.Component<
 
   showShareActionSheet = () => {
     // Take the snapshot (returns a temp file uri)
-    ScreenshotManager.takeScreenshot('window')
+    ScreenshotManager.takeScreenshot('window', {})
       .then(uri => {
         // Share image data
         ActionSheetIOS.showShareActionSheetWithOptions(
@@ -287,7 +287,7 @@ class ShareScreenshotAnchorExample extends React.Component<
 
   showShareActionSheet = () => {
     // Take the snapshot (returns a temp file uri)
-    ScreenshotManager.takeScreenshot('window')
+    ScreenshotManager.takeScreenshot('window', {})
       .then(uri => {
         // Share image data
         ActionSheetIOS.showShareActionSheetWithOptions(


### PR DESCRIPTION
## Summary
Fix ActionSheetiOS examples and ScreenshotManager native module.

## Changelog
[General] [Fixed] - Fix "Share from Anchor" and "Share Screenshot" examples which uses ScreenshotManager native module. They were throwing error because ScreenshotManager was not defined as NativeModule.
[General] [Added] - Added ScreenshotManager as native module in iOS
