### PR TITLE
Add Linking examples in rn-tester

### DIFF
--- a/packages/rn-tester/RNTester/Info.plist
+++ b/packages/rn-tester/RNTester/Info.plist
@@ -2,6 +2,14 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>tel</string>
+		<string>telprompt</string>
+		<string>http</string>
+		<string>fb</string>
+		<string>geo</string>
+	</array>
 	<key>UIStatusBarStyle</key>
 	<string>UIStatusBarStyleBlackTranslucent</string>
 	<key>CFBundleDevelopmentRegion</key>

--- a/packages/rn-tester/js/examples/Linking/LinkingExample.js
+++ b/packages/rn-tester/js/examples/Linking/LinkingExample.js
@@ -11,6 +11,7 @@
 
 const React = require('react');
 const {
+  Button,
   Linking,
   Platform,
   StyleSheet,
@@ -48,6 +49,16 @@ class OpenURLButton extends React.Component<Props> {
   }
 }
 
+class OpenSettingsExample extends React.Component<Props, any> {
+  openSettings() {
+    Linking.openSettings();
+  }
+
+  render() {
+    return <Button onPress={this.openSettings} title={'Open Settings'} />;
+  }
+}
+
 class SendIntentButton extends React.Component<Props> {
   handleIntent = async () => {
     try {
@@ -72,14 +83,14 @@ class IntentAndroidExample extends React.Component {
   render() {
     return (
       <View>
-        <RNTesterBlock title="Open external URLs">
+        <View>
           <OpenURLButton url={'https://www.facebook.com'} />
           <OpenURLButton url={'http://www.facebook.com'} />
           <OpenURLButton url={'http://facebook.com'} />
           <OpenURLButton url={'fb://notifications'} />
           <OpenURLButton url={'geo:37.484847,-122.148386'} />
           <OpenURLButton url={'tel:9876543210'} />
-        </RNTesterBlock>
+        </View>
         {Platform.OS === 'android' && (
           <RNTesterBlock title="Send intents">
             <SendIntentButton action="android.intent.action.POWER_USAGE_SUMMARY" />
@@ -122,9 +133,15 @@ exports.documentationURL = 'https://reactnative.dev/docs/linking';
 exports.description = 'Shows how to use Linking to open URLs.';
 exports.examples = [
   {
-    title: 'Simple list of items',
+    title: 'Open external URLs',
     render: function(): React.Element<typeof IntentAndroidExample> {
       return <IntentAndroidExample />;
+    },
+  },
+  {
+    title: 'Open settings app',
+    render: function(): React.Element<typeof LinkingChangesListenerExample> {
+      return <OpenSettingsExample />;
     },
   },
 ];


### PR DESCRIPTION
## Summary
Added examples to RNTester for the Linking API.

## Changelog
[General] [Added] - Added example for openSettings() for Linking API.
[General] [Added] - Added [LSApplicationQueriesSchemes](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/LaunchServicesKeys.html#//apple_ref/doc/uid/TP40009250-SW14) in info.plist with entries tel, telprompt, http, fb, geo

## Test Plan
![Screen Recording 2020-12-07 at 11 19 13 PM (1)](https://user-images.githubusercontent.com/16796008/102250807-05001580-3f2a-11eb-9ce0-58de4d6fca54.gif)
