### PR TITLE
gradle fix

### DIFF
--- a/packages/rn-tester/android/app/build.gradle
+++ b/packages/rn-tester/android/app/build.gradle
@@ -39,6 +39,14 @@ plugins {
  *   // bundleInPaidRelease: true,
  *   // bundleInBeta: true,
  *
+ *   // whether to set hermes in release mode (reduce size by deleting the debugger/inspector, etc.). 
+ *   // (by default only enabled in release)
+ *   // for example: to set release mode in the staging build type (if configured)
+ *   // hermesReleaseInStaging: true,
+ *   // The configuration property can be in the following formats
+ *   //         'hermesReleaseIn${productFlavor}${buildType}'
+ *   //         'hermesReleaseIn${buildType}'
+ *
  *   // the root of your project, i.e. where "package.json" lives
  *   root: "../../",
  *

--- a/react.gradle
+++ b/react.gradle
@@ -128,6 +128,8 @@ afterEvaluate {
         }
 
         def enableHermes = enableHermesForVariant(variant)
+        def hermesRelease = config."hermesReleaseIn${targetName}"
+                        || targetName.toLowerCase().contains("release")
 
         def currentBundleTask = tasks.create(
             name: "bundle${targetName}JsAndAssets",
@@ -186,7 +188,7 @@ afterEvaluate {
                     def hermesFlags;
                     def hbcTempFile = file("${jsBundleFile}.hbc")
                     exec {
-                        if (targetName.toLowerCase().contains("release")) {
+                        if (hermesRelease) {
                             // Can't use ?: since that will also substitute valid empty lists
                             hermesFlags = config.hermesFlagsRelease
                             if (hermesFlags == null) hermesFlags = ["-O", "-output-source-map"]
@@ -327,7 +329,6 @@ afterEvaluate {
         // This should really be done by packaging all Hermes related libs into
         // two separate HermesDebug and HermesRelease AARs, but until then we'll
         // kludge it by deleting the .so files out of the /transforms/ directory.
-        def isRelease = targetName.toLowerCase().contains("release")
         def libDir = "$buildDir/intermediates/transforms/"
         def vmSelectionAction = {
             fileTree(libDir).matching {
@@ -335,7 +336,7 @@ afterEvaluate {
                     // For Hermes, delete all the libjsc* files
                     include "**/libjsc*.so"
 
-                    if (isRelease) {
+                    if (hermesRelease) {
                         // Reduce size by deleting the debugger/inspector
                         include '**/libhermes-inspector.so'
                         include '**/libhermes-executor-debug.so'

--- a/template/android/app/build.gradle
+++ b/template/android/app/build.gradle
@@ -45,6 +45,14 @@ import com.android.build.OutputFile
  *   //         'devDisabledIn${productFlavor}${buildType}'
  *   //         'devDisabledIn${buildType}'
  *
+ *   // whether to set hermes in release mode (reduce size by deleting the debugger/inspector, etc.). 
+ *   // (by default only enabled in release)
+ *   // for example: to set release mode in the staging build type (if configured)
+ *   // hermesReleaseInStaging: true,
+ *   // The configuration property can be in the following formats
+ *   //         'hermesReleaseIn${productFlavor}${buildType}'
+ *   //         'hermesReleaseIn${buildType}'
+ *
  *   // the root of your project, i.e. where "package.json" lives
  *   root: "../../",
  *


### PR DESCRIPTION
## Summary

Replaced the hardcoded `contains("release")` in *react.gradle* with a new flag to make it possible to config hermes release mode for custom build variants.

## Changelog

[Android] [Added] - A new flag `hermesReleaseIn{targetName}` to enable hermes customization for custom build variants

## Test Plan

1. Add a custom build type

```groovy
buildTypes {
  // ...
  staging {
    initWith release
    applicationIdSuffix ".staging"
    matchingFallbacks =  ['release']
  }
}
```
2. Enable hermes and set the new flag

```groovy
project.ext.react = [
    enableHermes: true,
    bundleInStaging: true,
    devDisabledInStaging: true,
    hermesReleaseInStaging: true
]
```

3. Add dependency implemention

```groovy
dependencies {
  // ...
  if (enableHermes) {
    // ...
    stagingImplementation files(hermesPath + "hermes-release.aar")
  }
}
```
4. Build and run the `staging` variant