### PR TITLE
Bump Hermes to 0.7.2 for v0.64

### DIFF
--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -63,7 +63,7 @@ def use_react_native! (options={})
 
   if hermes_enabled
     pod 'React-Core/Hermes', :path => "#{prefix}/"
-    pod 'hermes-engine', '~> 0.7.1'
+    pod 'hermes-engine', '~> 0.7.2'
     pod 'libevent', :podspec => "#{prefix}/third-party-podspecs/libevent.podspec"
   end
 end


### PR DESCRIPTION


<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

https://github.com/facebook/hermes/releases/tag/v0.7.2 is out so we can bump the pod version 🎉

Question:
Is `~> 0.7.2` too strict? Would `>= 0.7.2` be better?
Also, It doesn't look like we are restricting any version on the trunk?

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[INTERNAL] - Bump Hermes version


## Test Plan

Quoting from <https://github.com/facebook/hermes/issues/373>

> I can verify 0.7.2 is working with `USE_HERMES=1 bundle exec pod install --repo-update` 🎉

> Here is a screenshot of the rn-tester connected with the Hermes debugger within Flipper. The code is borrowed from https://github.com/facebook/hermes/issues/403 to prove that the `?.` fix asked by @janicduplessis is patched ;)

![image](https://user-images.githubusercontent.com/5563315/101722918-0cbe4680-3a60-11eb-9824-bf92127b4711.png)

