### PR TITLE
fix: default template on iOS

### DIFF
--- a/template/ios/Podfile
+++ b/template/ios/Podfile
@@ -6,7 +6,7 @@ platform :ios, '10.0'
 target 'HelloWorld' do
   config = use_native_modules!
 
-  use_react_native(
+  use_react_native!(
     :path => config[:reactNativePath],
     # to enable hermes on iOS, change `false` to `true` and then install pods
     :hermes_enabled => false


### PR DESCRIPTION
## Summary

Recently introduced steps to run Hermes accidentally removed `!` from the `use_react_native`, causing `pod install` to fail with an error.

## Changelog

[INTERNAL] [iOS] - Fix Podfle in default template

## Test Plan

Run `pod install` with this file and it should work.
