### PR TITLE
trigger infoLog only in __DEV__ mode

### DIFF
--- a/Libraries/Utilities/infoLog.js
+++ b/Libraries/Utilities/infoLog.js
@@ -14,7 +14,9 @@
  * Intentional info-level logging for clear separation from ad-hoc console debug logging.
  */
 function infoLog(...args: Array<mixed>): void {
-  return console.log(...args);
+  if (__DEV__) {
+    return console.log(...args);
+  }
 }
 
 module.exports = infoLog;


### PR DESCRIPTION
## Summary

When running in release mode, React-native will display info logs (as also mentioned in this issue:  https://github.com/facebook/react-native/issues/18584)

For instance, using `react-native-navigation`, the following logs are displayed (because of `Libraries/ReactNative/AppRegistry.js:186`): 

```
Running "main.Session" with {"initialProps":{"componentId":"Component1"},"rootTag":1301}
```

Causing them to appear in report logs like Bugsnag:

![Capture d’écran 2020-12-13 à 10 28 43](https://user-images.githubusercontent.com/5070712/102009248-652e6600-3d36-11eb-8f6f-60f5d9f6b981.png)

## Changelog

[General] [Changed] - Added an `if(__DEV__) `condition before running `console.log`

## Test Plan

A successful CI build seems to be enough in this case.
