### PR TITLE
Fix ScrollView getInnerViewNode and getInnerViewRef ref methods

### DIFF
--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -778,8 +778,8 @@ class ScrollView extends React.Component<Props, State> {
       if (ref) {
         ref.getScrollResponder = this.getScrollResponder;
         ref.getScrollableNode = this.getScrollableNode;
-        ref.getInnerViewNode = this.getInnerViewNode.bind(this);
-        ref.getInnerViewRef = this.getInnerViewRef.bind(this);
+        ref.getInnerViewNode = this.getInnerViewNode;
+        ref.getInnerViewRef = this.getInnerViewRef;
         ref.getNativeScrollRef = this.getNativeScrollRef;
         ref.scrollTo = this.scrollTo;
         ref.scrollToEnd = this.scrollToEnd;
@@ -808,13 +808,13 @@ class ScrollView extends React.Component<Props, State> {
     return ReactNative.findNodeHandle(this._scrollViewRef);
   };
 
-  getInnerViewNode(): ?number {
+  getInnerViewNode: () => ?number = () => {
     return ReactNative.findNodeHandle(this._innerViewRef);
-  }
+  };
 
-  getInnerViewRef(): ?React.ElementRef<typeof View> {
+  getInnerViewRef: () => ?React.ElementRef<typeof View> = () => {
     return this._innerViewRef;
-  }
+  };
 
   getNativeScrollRef: () => ?React.ElementRef<HostComponent<mixed>> = () => {
     return this._scrollViewRef;

--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -778,8 +778,8 @@ class ScrollView extends React.Component<Props, State> {
       if (ref) {
         ref.getScrollResponder = this.getScrollResponder;
         ref.getScrollableNode = this.getScrollableNode;
-        ref.getInnerViewNode = this.getInnerViewNode;
-        ref.getInnerViewRef = this.getInnerViewRef;
+        ref.getInnerViewNode = this.getInnerViewNode.bind(this);
+        ref.getInnerViewRef = this.getInnerViewRef.bind(this);
         ref.getNativeScrollRef = this.getNativeScrollRef;
         ref.scrollTo = this.scrollTo;
         ref.scrollToEnd = this.scrollToEnd;

--- a/Libraries/Components/ScrollView/__tests__/ScrollView-test.js
+++ b/Libraries/Components/ScrollView/__tests__/ScrollView-test.js
@@ -48,4 +48,20 @@ describe('<ScrollView />', () => {
       jest.fn().constructor,
     );
   });
+  it('getInnerViewRef for case where it returns a native view', () => {
+    jest.resetModules();
+    jest.unmock('../ScrollView');
+
+    const scrollViewRef = React.createRef(null);
+
+    ReactTestRenderer.create(<ScrollView ref={scrollViewRef} />);
+
+    const innerViewRef = scrollViewRef.current.getInnerViewRef();
+
+    // This is checking if the ref acts like a host component. If we had an
+    // `isHostComponent(ref)` method, that would be preferred.
+    expect(innerViewRef.measure).toBeInstanceOf(jest.fn().constructor);
+    expect(innerViewRef.measureLayout).toBeInstanceOf(jest.fn().constructor);
+    expect(innerViewRef.measureInWindow).toBeInstanceOf(jest.fn().constructor);
+  });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Currently ScrollView ref's `getInnerViewNode` and `getInnerViewRef` are unbound and don't work as expected returning empty values. The origin of this problem probably is issued by https://github.com/facebook/react-native/commit/d2f314af75b63443db23e131aaf93c2d064e4f44

Working example of the problem is available here: https://github.com/vshab/RNGetInnerViewBug

This PR binds getInnerViewNode and getInnerViewRef to ScrollView and adds test checking the value of getInnerViewRef.

Before:
![Simulator Screen Shot - iPhone 11 - 2020-12-15 at 02 07 03](https://user-images.githubusercontent.com/6755908/102149544-c7df4900-3e7f-11eb-89de-de39a28fbdb3.png)
After:
![Simulator Screen Shot - iPhone 11 - 2020-12-15 at 01 49 31](https://user-images.githubusercontent.com/6755908/102149559-d168b100-3e7f-11eb-8b27-031c9e43112c.png)


## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[JavaScript] [Fixed] - ScrollView: Fix `getInnerViewNode` and `getInnerViewRef` ref methods

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
1. The test checking the value of getInnerViewRef is added.
2. Example app demonstrating the problem is provided with before/after screenshots. 
