### PR TITLE
Exclude `i386` from valid architectures when building with Hermes on iOS

### DIFF
--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -62,8 +62,8 @@ def use_react_native! (options={})
   end
 
   if hermes_enabled
-    pod 'React-Core/Hermes', :path => "#{prefix}/"
-    pod 'hermes-engine', '~> 0.7.2'
+    pod 'React-hermes', :path => "#{prefix}/ReactCommon/hermes"
+    pod 'hermes-engine'
     pod 'libevent', :podspec => "#{prefix}/third-party-podspecs/libevent.podspec"
   end
 end

--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -62,8 +62,8 @@ def use_react_native! (options={})
   end
 
   if hermes_enabled
-    pod 'React-hermes', :path => "#{prefix}/ReactCommon/hermes"
-    pod 'hermes-engine'
+    pod 'React-Core/Hermes', :path => "#{prefix}/"
+    pod 'hermes-engine', '~> 0.7.2'
     pod 'libevent', :podspec => "#{prefix}/third-party-podspecs/libevent.podspec"
   end
 end
@@ -120,9 +120,9 @@ def react_native_post_install(installer)
   projects.each do |project|
     project.build_configurations.each do |config|
       if arm_value == 1 then
-        config.build_settings.delete("EXCLUDED_ARCHS[sdk=iphonesimulator*]")
+        config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"] = "i386"
       else
-        config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"] = "arm64"
+        config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"] = "arm64 i386"
       end
     end
 

--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -98,6 +98,10 @@ def use_flipper!(versions = {}, configurations: ['Debug'])
   pod 'FlipperKit/FlipperKitNetworkPlugin', versions['Flipper'], :configurations => configurations
 end
 
+def has_pod(installer, name)
+  installer.pods_project.pod_group(name) != nil
+end
+
 # Post Install processing for Flipper
 def flipper_post_install(installer)
   installer.pods_project.targets.each do |target|
@@ -109,7 +113,7 @@ def flipper_post_install(installer)
   end
 end
 
-def react_native_post_install(installer)
+def exclude_architectures(installer)
   projects = installer.aggregate_targets
     .map{ |t| t.user_project }
     .uniq{ |p| p.path }
@@ -117,15 +121,26 @@ def react_native_post_install(installer)
 
   arm_value = `/usr/sbin/sysctl -n hw.optional.arm64 2>&1`.to_i
 
+  # Hermes does not support `i386` architecture
+  excluded_archs_default = has_pod(installer, 'hermes-engine') ? "i386" : ""
+
   projects.each do |project|
     project.build_configurations.each do |config|
       if arm_value == 1 then
-        config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"] = "i386"
+        config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"] = excluded_archs_default
       else
-        config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"] = "arm64 i386"
+        config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"] = "arm64 " + excluded_archs_default
       end
     end
 
     project.save()
   end
+end
+
+def react_native_post_install(installer)
+  if has_pod(installer, 'Flipper')
+    flipper_post_install(installer)
+  end
+
+  exclude_architectures(installer)
 end

--- a/template/ios/Podfile
+++ b/template/ios/Podfile
@@ -25,10 +25,5 @@ target 'HelloWorld' do
 
   post_install do |installer|
     react_native_post_install(installer)
-
-    # Enables Flipper.
-    #
-    # Disable the next line if you are not using Flipper.
-    flipper_post_install(installer)  
   end
 end


### PR DESCRIPTION
## Summary

When building React Native application in Release mode for an iPhone Simulator _and_ targeting `armv7`, Xcode will build all architectures (due to `ONLY_ACTIVE_ARCH` set to `false`, unlike in Debug mode). As a result, Xcode will try building for `i386` (32-bit iPhone Simulator), which fails as we don’t build Hermes binaries for `i386`.

Fix is to disable `i386`, since it is not supported by `Hermes` and certain `Folly` features.

## Changelog

[IOS] [BREAKING] - `i386` architecture will be automatically disabled when Hermes is being used. This might be potentially breaking for your workflow if you target `armv7` devices, as you will no longer be able to test on the simulator.
[IOS] [FEATURE] - Replace `flipper_post_install` with `react_native_post_install` hook. Will automatically detect if Flipper is enabled.

## Test Plan

Run React Native application with Hermes enabled (or Flipper) in Release mode and it should work just fine.
