### PR TITLE
fix uninitialized C++ ReactMarker

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/hermes/reactexecutor/OnLoad.cpp
+++ b/ReactAndroid/src/main/java/com/facebook/hermes/reactexecutor/OnLoad.cpp
@@ -60,8 +60,6 @@ class HermesExecutorHolder
 
   static jni::local_ref<jhybriddata> initHybridDefaultConfig(
       jni::alias_ref<jclass>) {
-    JReactMarker::setLogPerfMarkerIfNeeded();
-
     return makeCxxInstance(
         std::make_unique<HermesExecutorFactory>(installBindings));
   }
@@ -69,7 +67,6 @@ class HermesExecutorHolder
   static jni::local_ref<jhybriddata> initHybrid(
       jni::alias_ref<jclass>,
       jlong heapSizeMB) {
-    JReactMarker::setLogPerfMarkerIfNeeded();
     auto runtimeConfig = makeRuntimeConfig(heapSizeMB);
     return makeCxxInstance(std::make_unique<HermesExecutorFactory>(
         installBindings, JSIExecutor::defaultTimeoutInvoker, runtimeConfig));

--- a/ReactAndroid/src/main/java/com/facebook/react/jscexecutor/OnLoad.cpp
+++ b/ReactAndroid/src/main/java/com/facebook/react/jscexecutor/OnLoad.cpp
@@ -57,10 +57,6 @@ class JSCExecutorHolder
   static jni::local_ref<jhybriddata> initHybrid(
       jni::alias_ref<jclass>,
       ReadableNativeMap *) {
-    // This is kind of a weird place for stuff, but there's no other
-    // good place for initialization which is specific to JSC on
-    // Android.
-    JReactMarker::setLogPerfMarkerIfNeeded();
     // TODO mhorowitz T28461666 fill in some missing nice to have glue
     return makeCxxInstance(std::make_unique<JSCExecutorFactory>());
   }

--- a/ReactAndroid/src/main/jni/react/jni/Android.mk
+++ b/ReactAndroid/src/main/jni/react/jni/Android.mk
@@ -27,7 +27,7 @@ LOCAL_CFLAGS += -fexceptions -frtti -Wno-unused-lambda-capture
 LOCAL_LDLIBS += -landroid
 
 # The dynamic libraries (.so files) that this module depends on.
-LOCAL_SHARED_LIBRARIES := libfolly_json libfb libfbjni libglog_init libyoga
+LOCAL_SHARED_LIBRARIES := libfolly_json libfb libfbjni libglog_init libyoga libreactmarker
 
 # The static libraries (.a files) that this module depends on.
 LOCAL_STATIC_LIBRARIES := libreactnative libcallinvokerholder libruntimeexecutor

--- a/ReactAndroid/src/main/jni/react/jni/OnLoad.cpp
+++ b/ReactAndroid/src/main/jni/react/jni/OnLoad.cpp
@@ -21,7 +21,7 @@
 #include "WritableNativeArray.h"
 #include "WritableNativeMap.h"
 
-#include <JReactMarker.h>
+#include "JReactMarker.h"
 #ifdef WITH_INSPECTOR
 #include "JInspector.h"
 #endif

--- a/ReactAndroid/src/main/jni/react/jni/OnLoad.cpp
+++ b/ReactAndroid/src/main/jni/react/jni/OnLoad.cpp
@@ -21,6 +21,7 @@
 #include "WritableNativeArray.h"
 #include "WritableNativeMap.h"
 
+#include <JReactMarker.h>
 #ifdef WITH_INSPECTOR
 #include "JInspector.h"
 #endif
@@ -84,6 +85,7 @@ extern "C" JNIEXPORT jint JNI_OnLoad(JavaVM *vm, void *reserved) {
 #ifdef WITH_INSPECTOR
     JInspector::registerNatives();
 #endif
+    JReactMarker::setLogPerfMarkerIfNeeded();
   });
 }
 

--- a/ReactCommon/cxxreact/Android.mk
+++ b/ReactCommon/cxxreact/Android.mk
@@ -34,8 +34,6 @@ LOCAL_MODULE := reactmarker
 
 LOCAL_SRC_FILES := $(LOCAL_PATH)/ReactMarker.cpp
 
-# LOCAL_LDLIBS := -lm -llog
-
 LOCAL_C_INCLUDES := $(LOCAL_PATH)/..
 LOCAL_EXPORT_C_INCLUDES := $(LOCAL_C_INCLUDES)
 

--- a/ReactCommon/cxxreact/Android.mk
+++ b/ReactCommon/cxxreact/Android.mk
@@ -9,7 +9,7 @@ include $(CLEAR_VARS)
 
 LOCAL_MODULE := reactnative
 
-LOCAL_SRC_FILES := $(wildcard $(LOCAL_PATH)/*.cpp)
+LOCAL_SRC_FILES := $(filter-out $(LOCAL_PATH)/ReactMarker.cpp, $(wildcard $(LOCAL_PATH)/*.cpp))
 
 LOCAL_C_INCLUDES := $(LOCAL_PATH)/..
 LOCAL_EXPORT_C_INCLUDES := $(LOCAL_C_INCLUDES)
@@ -20,9 +20,28 @@ LOCAL_CFLAGS := \
 LOCAL_CFLAGS += -fexceptions -frtti -Wno-unused-lambda-capture
 
 LOCAL_STATIC_LIBRARIES := boost jsi callinvoker reactperflogger runtimeexecutor
-LOCAL_SHARED_LIBRARIES := jsinspector libfolly_json glog
+LOCAL_SHARED_LIBRARIES := jsinspector libfolly_json glog reactmarker
 
 include $(BUILD_STATIC_LIBRARY)
+
+##################################
+###       reactmarker          ###
+##################################
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := reactmarker
+
+LOCAL_SRC_FILES := $(LOCAL_PATH)/ReactMarker.cpp
+
+# LOCAL_LDLIBS := -lm -llog
+
+LOCAL_C_INCLUDES := $(LOCAL_PATH)/..
+LOCAL_EXPORT_C_INCLUDES := $(LOCAL_C_INCLUDES)
+
+LOCAL_CFLAGS += -fexceptions
+
+include $(BUILD_SHARED_LIBRARY)
 
 $(call import-module,fb)
 $(call import-module,folly)


### PR DESCRIPTION

## Summary

fix #30315, #23771
The problem and root cause is pretty clear by karanjthakkar [here](https://github.com/facebook/react-native/issues/23771). This is to provide another solution without changing ReactMarker API and touching code on iOS. The idea is to move ReactMarker::logTaggedMarker implementation to libreactmarker.so and ensure the address of logTaggedMarker are all the same in runtime. 

## Changelog

[Android][Fixed] fix uninitialized C++ ReactMarker

## Test Plan

Example can be found in #23771.
