### PR TITLE
fix: update to @jest/create-cache-key-function@27

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "react": "17.0.2"
   },
   "dependencies": {
-    "@jest/create-cache-key-function": "^26.5.0",
+    "@jest/create-cache-key-function": "^27.0.0-next.1",
     "@react-native-community/cli": "^5.0.1-alpha.0",
     "@react-native-community/cli-platform-android": "^5.0.1-alpha.0",
     "@react-native-community/cli-platform-ios": "^5.0.1-alpha.0",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "react": "17.0.2"
   },
   "dependencies": {
-    "@jest/create-cache-key-function": "^27.0.0-next.1",
+    "@jest/create-cache-key-function": "^27.0.1",
     "@react-native-community/cli": "^5.0.1-alpha.0",
     "@react-native-community/cli-platform-android": "^5.0.1-alpha.0",
     "@react-native-community/cli-platform-ios": "^5.0.1-alpha.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -827,12 +827,12 @@
     slash "^3.0.0"
     strip-ansi "^6.0.0"
 
-"@jest/create-cache-key-function@^27.0.0-next.1":
-  version "27.0.0-next.1"
-  resolved "https://registry.yarnpkg.com/@jest/create-cache-key-function/-/create-cache-key-function-27.0.0-next.1.tgz#32dad36d2725025dca7616ec4fa27cf145883796"
-  integrity sha512-w/+iXybtNvjdUJ9fobL0WkgMrqBLh41NGBHSPgDf/FE3PqYt6zQBCNVWNJYCuHDHxJsc0nMsmn2uKAMjOSvyQA==
+"@jest/create-cache-key-function@^27.0.1":
+  version "27.0.1"
+  resolved "https://registry.yarnpkg.com/@jest/create-cache-key-function/-/create-cache-key-function-27.0.1.tgz#93f36e543e67a84ef1430e456b750d2271738e90"
+  integrity sha512-cnJPO3//4BXpydHjo7nuI+L7YUktxwWeRCYlRhk6faNuiZpqLbhGZhNOMo8fOcuf3+80UP5vLqDvwM4XcDLpcA==
   dependencies:
-    "@jest/types" "^27.0.0-next.1"
+    "@jest/types" "^27.0.1"
 
 "@jest/environment@^26.6.2":
   version "26.6.2"
@@ -968,15 +968,15 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@jest/types@^27.0.0-next.1":
-  version "27.0.0-next.1"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-27.0.0-next.1.tgz#e194976623088495929f06467e64e669ab780e60"
-  integrity sha512-jlXg6eU9du4FO1HZ/A7idx7SLpBDxHja4E0DmDcWWe0DEYKIKlTvKfJwoK8Px3bJILqPdnmhMusmmcpXTkCRQQ==
+"@jest/types@^27.0.1":
+  version "27.0.1"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-27.0.1.tgz#631738c942e70045ebbf42a3f9b433036d3845e4"
+  integrity sha512-8A25RRV4twZutsx2D+7WphnDsp7If9Yu6ko0Gxwrwv8BiWESFzka34+Aa2kC8w9xewt7SDuCUSZ6IiAFVj3PRg==
   dependencies:
     "@types/istanbul-lib-coverage" "^2.0.0"
     "@types/istanbul-reports" "^3.0.0"
     "@types/node" "*"
-    "@types/yargs" "^15.0.0"
+    "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
 "@react-native-community/cli-debugger-ui@^5.0.1-alpha.1":
@@ -1274,6 +1274,13 @@
   version "15.0.3"
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.3.tgz#41453a0bc7ab393e995d1f5451455638edbd2baf"
   integrity sha512-XCMQRK6kfpNBixHLyHUsGmXrpEmFFxzMrcnSXFMziHd8CoNJo8l16FkHyQq4x+xbM7E2XL83/O78OD8u+iZTdQ==
+  dependencies:
+    "@types/yargs-parser" "*"
+
+"@types/yargs@^16.0.0":
+  version "16.0.3"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-16.0.3.tgz#4b6d35bb8e680510a7dc2308518a80ee1ef27e01"
+  integrity sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==
   dependencies:
     "@types/yargs-parser" "*"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -827,12 +827,12 @@
     slash "^3.0.0"
     strip-ansi "^6.0.0"
 
-"@jest/create-cache-key-function@^26.5.0":
-  version "26.6.2"
-  resolved "https://registry.yarnpkg.com/@jest/create-cache-key-function/-/create-cache-key-function-26.6.2.tgz#04cf439207a4fd12418d8aee551cddc86f9ac5f5"
-  integrity sha512-LgEuqU1f/7WEIPYqwLPIvvHuc1sB6gMVbT6zWhin3txYUNYK/kGQrC1F2WR4gR34YlI9bBtViTm5z98RqVZAaw==
+"@jest/create-cache-key-function@^27.0.0-next.1":
+  version "27.0.0-next.1"
+  resolved "https://registry.yarnpkg.com/@jest/create-cache-key-function/-/create-cache-key-function-27.0.0-next.1.tgz#32dad36d2725025dca7616ec4fa27cf145883796"
+  integrity sha512-w/+iXybtNvjdUJ9fobL0WkgMrqBLh41NGBHSPgDf/FE3PqYt6zQBCNVWNJYCuHDHxJsc0nMsmn2uKAMjOSvyQA==
   dependencies:
-    "@jest/types" "^26.6.2"
+    "@jest/types" "^27.0.0-next.1"
 
 "@jest/environment@^26.6.2":
   version "26.6.2"
@@ -961,6 +961,17 @@
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.6.2.tgz#bef5a532030e1d88a2f5a6d933f84e97226ed48e"
   integrity sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^15.0.0"
+    chalk "^4.0.0"
+
+"@jest/types@^27.0.0-next.1":
+  version "27.0.0-next.1"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-27.0.0-next.1.tgz#e194976623088495929f06467e64e669ab780e60"
+  integrity sha512-jlXg6eU9du4FO1HZ/A7idx7SLpBDxHja4E0DmDcWWe0DEYKIKlTvKfJwoK8Px3bJILqPdnmhMusmmcpXTkCRQQ==
   dependencies:
     "@types/istanbul-lib-coverage" "^2.0.0"
     "@types/istanbul-reports" "^3.0.0"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

API of Jest transformers is changing in Jest 27. The new version of `@jest/create-cache-key-function` handles both current versions of the API and the upcoming 27 API.

Ref: https://github.com/facebook/jest/pull/10834

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Internal] [Changed] - Use version of `@jest/create-cache-key-function` compatible with upcoming Jest v27 release

## Test Plan

I've tested locally that it works with both a `jest@latest` and `jest@next` release.
