### PR TITLE
Disable tests with USE_FRAMEWORKS=1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -781,30 +781,34 @@ workflows:
           run_unit_tests: true
           requires:
             - setup_ios
-      - test_ios:
-          name: test_ios_unit_frameworks_jsc
-          use_frameworks: true
-          run_unit_tests: true
-          requires:
-            - setup_ios
+      # DISABLED: USE_FRAMEWORKS=1 not supported by Flipper
+      # - test_ios:
+      #     name: test_ios_unit_frameworks_jsc
+      #     use_frameworks: true
+      #     run_unit_tests: true
+      #     requires:
+      #       - setup_ios
       - test_ios:
           name: test_ios_unit_hermes
           use_hermes: true
           run_unit_tests: true
           requires:
             - setup_ios
-      - test_ios:
-          name: test_ios_unit_frameworks_hermes
-          use_hermes: true
-          use_frameworks: true
-          run_unit_tests: true
-          requires:
-            - setup_ios
+      # DISABLED: USE_FRAMEWORKS=1 not supported by Flipper
+      # - test_ios:
+      #     name: test_ios_unit_frameworks_hermes
+      #     use_hermes: true
+      #     use_frameworks: true
+      #     run_unit_tests: true
+      #     requires:
+      #       - setup_ios
+      # DISABLED: Detox tests need to be fixed
       # - test_ios:
       #     name: test_ios_detox
       #     run_detox_tests: true
       #     requires:
       #       - setup_ios
+      # DISABLED: USE_FRAMEWORKS=1 not supported by Flipper
       # - test_ios:
       #     name: test_ios_detox_frameworks
       #     use_frameworks: true


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Tests that set USE_FRAMEWORKS=1 will fail because Flipper does not currently support the use of frameworks. These tests should be re-enabled once this issue is addressed.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Internal] - Disable USE_FRAMEWORKS=1 tests

## Test Plan

CI