### PR TITLE
💄Fix minor eslint/prettier conflict

### DIFF
--- a/packages/eslint-config-react-native-community/index.js
+++ b/packages/eslint-config-react-native-community/index.js
@@ -120,7 +120,7 @@ module.exports = {
 
   rules: {
     // General
-    'comma-dangle': [1, 'always-multiline'], // allow or disallow trailing commas
+    'comma-dangle': 0, // allow or disallow trailing commas, disabled in favour of prettier "trailingComma" option
     'no-cond-assign': 1, // disallow assignment in conditional expressions
     'no-console': 0, // disallow use of console (off by default in the node environment)
     'no-const-assign': 2, // disallow assignment to const-declared variables


### PR DESCRIPTION
This fix the issue where double commas would appear from both the comma-dangle rule and the prettier trailingComma option. This issue can only be fixed by changing the value of comma-dangle. If we change the prettier option, it would then try to remove commas added by comma-dangle.