### PR TITLE
Remove dependency on Folly in TurboModuleUtils.h

### DIFF
--- a/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleUtils.h
+++ b/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleUtils.h
@@ -10,7 +10,6 @@
 #include <cassert>
 #include <string>
 
-#include <folly/Optional.h>
 #include <jsi/jsi.h>
 
 #include <ReactCommon/CallInvoker.h>


### PR DESCRIPTION
## Summary

The TurboModuleUtils.h includes "folly/Optional.h" which is not used and creates an unnecessary dependency on Folly.
In this PR we remove this unnecessary include.

It is required for the https://github.com/microsoft/react-native-windows/pull/6804 where we add an experimental support for the C++ TurboModules. While the C++ TurboModules use the same JSI and TurboModule code defined in react-native, we provide a layer that let them to work over the ABI-safe Microsoft.ReactNative.dll boundary. The RNW Nuget distribution with DLL files includes a few source files to create native/turbo modules that work through the ABI-safe API. The TurboModuleUtils.h is one of such files. By removing the dependency on Folly we reduce requirements for the native module code. After this PR is merged we will remove the fork of the TurboModuleUtils.h  added in https://github.com/microsoft/react-native-windows/pull/6804.

## Changelog

[Internal] [Fixed] - Remove dependency on Folly in TurboModuleUtils.h

## Test Plan

The change does not bring any functional changes. It may only affect code compilation where some code may depend on TurboModuleUtils.h when it needs the "folly/Optional.h". The fix is add the `#include <folly/Optional.h>` there explicitly.

I had run the iOS tests and they passed:
```
yarn
pod install in packages\rn-tester
./scripts/objc-test.sh test
```