### PR TITLE
Change LogBox level from "fatal" to "error" for component errors caught with ErrorBoundary

### DIFF
--- a/Libraries/Core/Devtools/parseErrorStack.js
+++ b/Libraries/Core/Devtools/parseErrorStack.js
@@ -21,6 +21,7 @@ export type ExtendedError = Error & {
   componentStack?: string,
   forceRedbox?: boolean,
   isComponentError?: boolean,
+  isErrorBoundaryFound?: boolean,
   ...
 };
 

--- a/Libraries/Core/ExceptionsManager.js
+++ b/Libraries/Core/ExceptionsManager.js
@@ -109,6 +109,7 @@ function reportException(
       LogBoxData.addException({
         ...data,
         isComponentError: !!e.isComponentError,
+        isErrorBoundaryFound: !!e.isErrorBoundaryFound,
       });
     }
 

--- a/Libraries/Core/ReactFiberErrorDialog.js
+++ b/Libraries/Core/ReactFiberErrorDialog.js
@@ -12,7 +12,6 @@ export type CapturedError = {
   +componentStack: string,
   +error: mixed,
   +errorBoundary: ?{...},
-  +errorBoundaryFound: ?boolean,
   ...
 };
 
@@ -25,7 +24,7 @@ import {handleException, SyntheticError} from './ExceptionsManager';
  * trace within the native redbox component.
  */
 function showErrorDialog(capturedError: CapturedError): boolean {
-  const {componentStack, error, errorBoundaryFound} = capturedError;
+  const {componentStack, error, errorBoundary} = capturedError;
 
   let errorToHandle;
 
@@ -40,7 +39,7 @@ function showErrorDialog(capturedError: CapturedError): boolean {
   try {
     errorToHandle.componentStack = componentStack;
     errorToHandle.isComponentError = true;
-    errorToHandle.isErrorBoundaryFound = errorBoundaryFound;
+    errorToHandle.isErrorBoundaryFound = !!errorBoundary;
   } catch (e) {}
   handleException(errorToHandle, false);
 

--- a/Libraries/Core/ReactFiberErrorDialog.js
+++ b/Libraries/Core/ReactFiberErrorDialog.js
@@ -12,6 +12,7 @@ export type CapturedError = {
   +componentStack: string,
   +error: mixed,
   +errorBoundary: ?{...},
+  +errorBoundaryFound: ?boolean,
   ...
 };
 
@@ -24,7 +25,7 @@ import {handleException, SyntheticError} from './ExceptionsManager';
  * trace within the native redbox component.
  */
 function showErrorDialog(capturedError: CapturedError): boolean {
-  const {componentStack, error} = capturedError;
+  const {componentStack, error, errorBoundaryFound} = capturedError;
 
   let errorToHandle;
 
@@ -39,6 +40,7 @@ function showErrorDialog(capturedError: CapturedError): boolean {
   try {
     errorToHandle.componentStack = componentStack;
     errorToHandle.isComponentError = true;
+    errorToHandle.isErrorBoundaryFound = errorBoundaryFound;
   } catch (e) {}
   handleException(errorToHandle, false);
 

--- a/Libraries/LogBox/Data/parseLogBoxLog.js
+++ b/Libraries/LogBox/Data/parseLogBoxLog.js
@@ -22,6 +22,7 @@ const METRO_ERROR_FORMAT = /^(?:InternalError Metro has encountered an error:) (
 
 export type ExtendedExceptionData = ExceptionData & {
   isComponentError: boolean,
+  isErrorBoundaryFound: boolean,
   ...
 };
 export type Category = string;
@@ -288,7 +289,10 @@ export function parseLogBoxException(
   }
 
   const componentStack = error.componentStack;
-  if (error.isFatal || error.isComponentError) {
+  if (
+    error.isFatal ||
+    (error.isComponentError && !error.isErrorBoundaryFound)
+  ) {
     return {
       level: 'fatal',
       stack: error.stack,


### PR DESCRIPTION
## Summary

Error Screen displayed by ErrorBoundary is just another state of the app. It should not be treated as fatal crash. Showing LogBox Notification is better in this case than showing LogBox full screen.

## Changelog

[General] [Changed] - Change LogBox level from "fatal" to "error" for component errors caught with ErrorBoundary

## Test Plan

1. Start the app in dev mode
2. Wrap your app with ErrorBoundary
```
class ErrorBoundary extends Component {
  static getDerivedStateFromError(error) {
    return { hasError: true }
  }

  state = {
    hasError: false,
  }

  render() {
    const { hasError } = this.state

    if (hasError) {
      return (
        <View
          style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}
        >
          <Text>Sorry, something went wrong</Text>
        </View>
      )
    }

    return this.props.children
  }

  componentDidCatch(error, extraInfo) {}
}
```
3. Raise a rendering error on any level of your app. You can just add an undeclared variable inside rendering code or try to read some property from existing variable with nullish value.

You should see "Sorry, something went wrong" text in the middle of the screen and LogBox Notification with error message at the bottom. 

![Simulator Screen Shot - iPhone 8 - 2021-01-02 at 22 24 29](https://user-images.githubusercontent.com/14208343/103466080-3f4f1c80-4d4a-11eb-96d3-5cea45dc68ac.png)

You should not see a full screen LogBox.

![Simulator Screen Shot - iPhone 8 - 2021-01-02 at 22 13 17](https://user-images.githubusercontent.com/14208343/103466097-5857cd80-4d4a-11eb-8a8e-2bc063b0b0b5.png)

