### PR TITLE
remove -javadoc.jar, -sources.jar from NPM package validation

### DIFF
--- a/scripts/publish-npm.js
+++ b/scripts/publish-npm.js
@@ -137,7 +137,7 @@ exec('git checkout ReactAndroid/gradle.properties');
 
 echo('Generated artifacts for Maven');
 
-let artifacts = ['-javadoc.jar', '-sources.jar', '.aar', '.pom'].map(suffix => {
+let artifacts = ['.aar', '.pom'].map(suffix => {
   return `react-native-${releaseVersion}${suffix}`;
 });
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
In https://github.com/facebook/react-native/commit/a4d8632890df43c40ee3f892dc2817238de143db, I removed javadoc.jar, and sources.jar generation, but forgot to change artifact validation for NPM publish. This PR removes javadoc.jar and sources.jar from validation.

## Changelog

[Internal] [Changed] - remove javadoc.jar, sources.jar from NPM package validation

## Test Plan

publish_npm_package CI job must succeed.