### PR TITLE
VoiceOver reads Tab elements as "Tab Description"

### DIFF
--- a/React/AccessibilityResources/en.lproj/Localizable.strings
+++ b/React/AccessibilityResources/en.lproj/Localizable.strings
@@ -14,7 +14,7 @@
 "scrollbar"="scroll bar";
 "spinbutton"="spin button";
 "switch"="switch";
-"tab"="tab description";
+"tab"="tab";
 "tablist"="tab list";
 "timer"="timer";
 "toolbar"="tool bar";


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

On iOS, VoiceOver reads Tab accessibility role elements as "tab description" rather than "tab". See issue #30589 and #30610

Looking at the file history the bug appears to have been introduced in #27995

## Changelog

[iOS] [Fixed] - Tab Accessibility Role had incorrect localization string 

## Test Plan

Tested with voice over using the RNTester app
