### PR TITLE
fix attempting to focus disabled textinputs

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -1063,6 +1063,15 @@ function InternalTextInput(props: Props): React.Node {
     return TextInputState.currentlyFocusedInput() === inputRef.current;
   }
 
+  function focus(): void {
+    const {current} = inputRef;
+    if (props.editable === false || current === null) {
+      return;
+    }
+    // $FlowFixMe - `focus` is missing in `$ReadOnly`
+    Object.getPrototypeOf(current)?.focus?.call(current);
+  }
+
   function getNativeRef(): ?React.ElementRef<HostComponent<mixed>> {
     return inputRef.current;
   }
@@ -1096,6 +1105,7 @@ function InternalTextInput(props: Props): React.Node {
         */
       if (ref) {
         ref.clear = clear;
+        ref.focus = focus;
         ref.isFocused = isFocused;
         ref.getNativeRef = getNativeRef;
         ref.setSelection = setSelection;

--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -1063,15 +1063,6 @@ function InternalTextInput(props: Props): React.Node {
     return TextInputState.currentlyFocusedInput() === inputRef.current;
   }
 
-  function focus(): void {
-    const {current} = inputRef;
-    if (props.editable === false || current === null) {
-      return;
-    }
-    // $FlowFixMe - `focus` is missing in `$ReadOnly`
-    Object.getPrototypeOf(current)?.focus?.call(current);
-  }
-
   function getNativeRef(): ?React.ElementRef<HostComponent<mixed>> {
     return inputRef.current;
   }
@@ -1105,7 +1096,6 @@ function InternalTextInput(props: Props): React.Node {
         */
       if (ref) {
         ref.clear = clear;
-        ref.focus = focus;
         ref.isFocused = isFocused;
         ref.getNativeRef = getNativeRef;
         ref.setSelection = setSelection;

--- a/Libraries/Components/TextInput/TextInputState.js
+++ b/Libraries/Components/TextInput/TextInputState.js
@@ -73,7 +73,7 @@ function blurField(textFieldID: ?number) {
 /**
  * @param {number} TextInputID id of the text field to focus
  * Focuses the specified text field
- * noop if the text field was already focused
+ * noop if the text field was already focused or is the field is not editable
  */
 function focusTextInput(textField: ?ComponentRef) {
   if (typeof textField === 'number') {
@@ -86,7 +86,15 @@ function focusTextInput(textField: ?ComponentRef) {
     return;
   }
 
-  if (currentlyFocusedInputRef !== textField && textField != null) {
+  if (textField != null) {
+    const fieldCanBeFocused =
+      currentlyFocusedInputRef !== textField &&
+      // $FlowFixMe - `currentProps` is missing in `NativeMethods`
+      textField.currentProps?.editable !== false;
+
+    if (!fieldCanBeFocused) {
+      return;
+    }
     focusInput(textField);
     if (Platform.OS === 'ios') {
       // This isn't necessarily a single line text input

--- a/Libraries/Components/TextInput/__tests__/TextInput-test.js
+++ b/Libraries/Components/TextInput/__tests__/TextInput-test.js
@@ -55,7 +55,7 @@ describe('TextInput tests', () => {
   it('has expected instance functions', () => {
     expect(inputRef.current.isFocused).toBeInstanceOf(Function); // Would have prevented S168585
     expect(inputRef.current.clear).toBeInstanceOf(Function);
-    expect(inputRef.current.focus).toBeInstanceOf(jest.fn().constructor);
+    expect(inputRef.current.focus).toBeInstanceOf(Function);
     expect(inputRef.current.blur).toBeInstanceOf(jest.fn().constructor);
     expect(inputRef.current.setNativeProps).toBeInstanceOf(
       jest.fn().constructor,
@@ -106,6 +106,32 @@ describe('TextInput tests', () => {
     TextInput.State.blurTextInput(textInputRef.current);
     expect(textInputRef.current.isFocused()).toBe(false);
     expect(TextInput.State.currentlyFocusedInput()).toBe(null);
+  });
+
+  describe('focus()', () => {
+    function createTextInput(extraProps) {
+      const textInputRef = React.createRef(null);
+      ReactTestRenderer.create(
+        <TextInput ref={textInputRef} value="value1" {...extraProps} />,
+      );
+      const {current} = textInputRef;
+      const mockComponent = Object.getPrototypeOf(current);
+      mockComponent.focus = jest.fn();
+      return {ref: current, mockComponent};
+    }
+
+    it('should call focus() up on the prototype (ReactNativeFiberHostComponent on device / mockComponent.js in tests)', () => {
+      const {ref, mockComponent} = createTextInput();
+      ref.focus();
+
+      expect(mockComponent.focus).toHaveBeenCalled();
+    });
+    it('should not do anything if the TextInput is not editable', () => {
+      const {ref, mockComponent} = createTextInput({editable: false});
+      ref.focus();
+
+      expect(mockComponent.focus).not.toHaveBeenCalled();
+    });
   });
 
   it('should unfocus when other TextInput is focused', () => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

when we call `focus()` upon a TextInput ref which has prop `editable=false` it marks the textinput as focused in `TextInputState` even though the focus is rejected by textinput itself because it is not editable.



then, when you change `editable` prop to `true` and call `focus` again, [this condition](https://github.com/facebook/react-native/blob/e912c462eb0b7166ca5947bb5a3ee20761d910b6/Libraries/Components/TextInput/TextInputState.js#L46) or rather [this one](https://github.com/facebook/react-native/blob/1b2b2198e1b2383523b4655dc8c220d251b057d6/Libraries/Components/TextInput/TextInputState.js#L89) will evaluate to `false` and focus will not happen even though it can and should happen.


see also https://github.com/facebook/react-native/blob/0.64-stable/Libraries/Renderer/implementations/ReactNativeRenderer-dev.js#L3895


## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Fixed] - `focus()` on TextInput to respect its `editable` state

## Test Plan

Create a `TextInput` with prop `editable=false` and call `ref.current.focus()` upon its ref. TextInput should not be marked as focused in `TextInputState`.