### PR TITLE
Use Updated Android Locale API

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/i18nmanager/I18nManagerModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/i18nmanager/I18nManagerModule.java
@@ -8,12 +8,12 @@
 package com.facebook.react.modules.i18nmanager;
 
 import android.content.Context;
+import android.os.Build;
 import com.facebook.fbreact.specs.NativeI18nManagerSpec;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.module.annotations.ReactModule;
-import android.os.Build;
 import java.util.Locale;
 import java.util.Map;
 

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/i18nmanager/I18nManagerModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/i18nmanager/I18nManagerModule.java
@@ -13,6 +13,7 @@ import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.module.annotations.ReactModule;
+import android.os.Build;
 import java.util.Locale;
 import java.util.Map;
 
@@ -36,7 +37,12 @@ public class I18nManagerModule extends NativeI18nManagerSpec {
   @Override
   public Map<String, Object> getTypedExportedConstants() {
     final Context context = getReactApplicationContext();
-    final Locale locale = context.getResources().getConfiguration().locale;
+    final Locale locale;
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+      locale = context.getResources().getConfiguration().getLocales().get(0);
+    } else {
+      locale = context.getResources().getConfiguration().locale;
+    }
 
     final Map<String, Object> constants = MapBuilder.newHashMap();
     constants.put("isRTL", sharedI18nUtilInstance.isRTL(context));


### PR DESCRIPTION
## Summary

This change migrates fetching locale information from the deprecated Android locale api to the new locale api on sdk version 30+. The old api was deprecated some time ago and should not be used.

https://developer.android.com/reference/android/content/res/Configuration#locale

## Changelog

[Android] [Changed] - Use new Locale API on Android 11 (API 30)+

## Test Plan

```js
if (Platform.OS === 'android') {
  locale = NativeModules.I18nManager.localeIdentifier; // returns ex. 'EN_us'
}
```
