### PR TITLE
Template: Make sure correct buildToolsVersion when building android app

### DIFF
--- a/template/android/app/build.gradle
+++ b/template/android/app/build.gradle
@@ -124,6 +124,7 @@ android {
     ndkVersion rootProject.ext.ndkVersion
 
     compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
When building an empty template project, build-tools 29.0.2 is downloaded, but build.gradle specified 29.0.3

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog
This issue was introduced when upgrading com.android.tools.build:gradle to a version >=4.0. (commit dfa9db49e34c6f54c04148b877de938bf103a059)

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Fixed] - Template: Make sure build respects buildToolsVersion specified in build.gradle instead of using default 29.0.2

## Test Plan

```
npx @react-native-community/cli init testapp --template path/to/repository/react-native/
```

```

               ######                ######
             ###     ####        ####     ###
            ##          ###    ###          ##
            ##             ####             ##
            ##             ####             ##
            ##           ##    ##           ##
            ##         ###      ###         ##
             ##  ########################  ##
          ######    ###            ###    ######
      ###     ##    ##              ##    ##     ###
   ###         ## ###      ####      ### ##         ###
  ##           ####      ########      ####           ##
 ##             ###     ##########     ###             ##
  ##           ####      ########      ####           ##
   ###         ## ###      ####      ### ##         ###
      ###     ##    ##              ##    ##     ###
          ######    ###            ###    ######
             ##  ########################  ##
            ##         ###      ###         ##
            ##           ##    ##           ##
            ##             ####             ##
            ##             ####             ##
            ##          ###    ###          ##
             ###     ####        ####     ###
               ######                ######


                  Welcome to React Native!
                 Learn once, write anywhere

✔ Downloading template
✔ Copying template
✔ Processing template
✔ Installing CocoaPods dependencies (this may take a few minutes)

  Run instructions for iOS:
    • cd "/private/tmp/testapp" && npx react-native run-ios
    - or -
    • Open testapp/ios/testapp.xcworkspace in Xcode or run "xed -b ios"
    • Hit the Run button

  Run instructions for Android:
    • Have an Android emulator running (quickest way to get started), or a device connected.
    • cd "/private/tmp/testapp" && npx react-native run-android

  Run instructions for Windows and macOS:
    • See https://aka.ms/ReactNative for the latest up-to-date instructions.
 ```

```
cd testapp/android
./gradlew assemble
```

```

> Task :app:compileDebugJavaWithJavac
Note: /private/tmp/testapp/android/app/src/debug/java/com/testapp/ReactNativeFlipper.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.

> Task :app:bundleReleaseJsAndAssets
warning: the transform cache was reset.
                    Welcome to Metro!
              Fast - Scalable - Integrated


info Writing bundle output to:, /private/tmp/testapp/android/app/build/generated/assets/react/release/index.android.bundle
info Writing sourcemap output to:, /private/tmp/testapp/android/app/build/generated/sourcemaps/react/release/index.android.bundle.map
info Done writing bundle output
info Done writing sourcemap output
info Copying 2 asset files
info Done copying assets

> Task :app:stripDebugDebugSymbols
Unable to strip the following libraries, packaging them as they are: libc++_shared.so, libevent-2.1.so, libevent_core-2.1.so, libevent_extra-2.1.so, libfb.so, libfbjni.so, libflipper.so, libfolly_futures.so, libfolly_json.so, libglog.so, libglog_init.so, libhermes-executor-common-debug.so, libhermes-executor-common-release.so, libhermes-executor-debug.so, libhermes-executor-release.so, libhermes-inspector.so, libimagepipeline.so, libjsc.so, libjscexecutor.so, libjsijniprofiler.so, libjsinspector.so, libnative-filters.so, libnative-imagetranscoder.so, libreact_codegen_reactandroidspec.so, libreact_nativemodule_core.so, libreactnativeblob.so, libreactnativejni.so, libreactnativeutilsjni.so, libreactperfloggerjni.so, libturbomodulejsijni.so, libyoga.so.

> Task :app:processReleaseMainManifest
[androidx.vectordrawable:vectordrawable-animated:1.0.0] /Users/cgritschenberger/.gradle/caches/transforms-2/files-2.1/a3d70fc7ec641cd22191d41c9098d3d5/vectordrawable-animated-1.0.0/AndroidManifest.xml Warning:
        Package name 'androidx.vectordrawable' used in: androidx.vectordrawable:vectordrawable-animated:1.0.0, androidx.vectordrawable:vectordrawable:1.0.1.

> Task :app:stripReleaseDebugSymbols
Unable to strip the following libraries, packaging them as they are: libc++_shared.so, libfb.so, libfbjni.so, libfolly_futures.so, libfolly_json.so, libglog.so, libglog_init.so, libhermes-executor-common-debug.so, libhermes-executor-common-release.so, libhermes-executor-debug.so, libhermes-executor-release.so, libhermes-inspector.so, libimagepipeline.so, libjsc.so, libjscexecutor.so, libjsijniprofiler.so, libjsinspector.so, libnative-filters.so, libnative-imagetranscoder.so, libreact_codegen_reactandroidspec.so, libreact_nativemodule_core.so, libreactnativeblob.so, libreactnativejni.so, libreactnativeutilsjni.so, libreactperfloggerjni.so, libturbomodulejsijni.so, libyoga.so.

BUILD SUCCESSFUL in 1m 1s
59 actionable tasks: 59 executed
```

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
