### PR TITLE
check if passed argument to Alert.alert buttons parameter is an array

### DIFF
--- a/Libraries/Alert/Alert.js
+++ b/Libraries/Alert/Alert.js
@@ -67,7 +67,8 @@ class Alert {
       // At most three buttons (neutral, negative, positive). Ignore rest.
       // The text 'OK' should be probably localized. iOS Alert does that in native.
       const defaultPositiveText = 'OK';
-      const validButtons: Buttons = (buttons && buttons.length)
+      const validButtons: Buttons = 
+        buttons && buttons.length
         ? buttons.slice(0, 3)
         : [{text: defaultPositiveText}];
       const buttonPositive = validButtons.pop();

--- a/Libraries/Alert/Alert.js
+++ b/Libraries/Alert/Alert.js
@@ -67,7 +67,7 @@ class Alert {
       // At most three buttons (neutral, negative, positive). Ignore rest.
       // The text 'OK' should be probably localized. iOS Alert does that in native.
       const defaultPositiveText = 'OK';
-      const validButtons: Buttons = buttons
+      const validButtons: Buttons = (buttons && buttons.length)
         ? buttons.slice(0, 3)
         : [{text: defaultPositiveText}];
       const buttonPositive = validButtons.pop();

--- a/Libraries/Alert/Alert.js
+++ b/Libraries/Alert/Alert.js
@@ -67,7 +67,7 @@ class Alert {
       // At most three buttons (neutral, negative, positive). Ignore rest.
       // The text 'OK' should be probably localized. iOS Alert does that in native.
       const defaultPositiveText = 'OK';
-      const validButtons: Buttons = 
+      const validButtons: Buttons =
         buttons && buttons.length
         ? buttons.slice(0, 3)
         : [{text: defaultPositiveText}];

--- a/Libraries/Alert/Alert.js
+++ b/Libraries/Alert/Alert.js
@@ -47,6 +47,7 @@ class Alert {
     buttons?: Buttons,
     options?: Options,
   ): void {
+    if(buttons && !buttons.lenght) throw new Error("Alert.alert function `buttons` parameter must be of type array")
     if (Platform.OS === 'ios') {
       Alert.prompt(title, message, buttons, 'default');
     } else if (Platform.OS === 'android') {
@@ -67,8 +68,7 @@ class Alert {
       // At most three buttons (neutral, negative, positive). Ignore rest.
       // The text 'OK' should be probably localized. iOS Alert does that in native.
       const defaultPositiveText = 'OK';
-      const validButtons: Buttons =
-        buttons && buttons.length
+      const validButtons: Buttons = buttons
         ? buttons.slice(0, 3)
         : [{text: defaultPositiveText}];
       const buttonPositive = validButtons.pop();

--- a/Libraries/Alert/Alert.js
+++ b/Libraries/Alert/Alert.js
@@ -47,7 +47,7 @@ class Alert {
     buttons?: Buttons,
     options?: Options,
   ): void {
-    if(buttons && !buttons.lenght) throw new Error("Alert.alert function `buttons` parameter must be of type array")
+    if(buttons && !buttons.length) throw new Error("Alert.alert function `buttons` parameter must be of type array");
     if (Platform.OS === 'ios') {
       Alert.prompt(title, message, buttons, 'default');
     } else if (Platform.OS === 'android') {

--- a/Libraries/Alert/Alert.js
+++ b/Libraries/Alert/Alert.js
@@ -47,7 +47,10 @@ class Alert {
     buttons?: Buttons,
     options?: Options,
   ): void {
-    if(buttons && !buttons.length) throw new Error("Alert.alert function `buttons` parameter must be of type array");
+    if (buttons && !buttons.length)
+      throw new Error(
+        'Alert.alert function 3rd argument must be of type array',
+      );
     if (Platform.OS === 'ios') {
       Alert.prompt(title, message, buttons, 'default');
     } else if (Platform.OS === 'android') {


### PR DESCRIPTION
## Solve passing wrong argument to Alert.alert buttons parameter.
## Resolving this issue #27708

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

peoples may pass wrong arg to buttons array and it will raise the exception that ```slice is not a function```

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

just this line of code added to the file

[GENERAL] [FIXED] - slice is not a function when passing wrongs args to Alert.alert

#### just this line added
```diff
+ if(buttons && !buttons.length) throw new Error("Alert.alert function `buttons` parameter must be of type array");
```