### PR TITLE
guard the Alert.alert against wrong arguments

### DIFF
--- a/Libraries/Alert/Alert.js
+++ b/Libraries/Alert/Alert.js
@@ -47,6 +47,11 @@ class Alert {
     buttons?: Buttons,
     options?: Options,
   ): void {
+    if (buttons && !buttons.length) {
+      throw new Error(
+        'Alert.alert function 3rd argument must be of type array',
+      );
+    }
     if (Platform.OS === 'ios') {
       Alert.prompt(title, message, buttons, 'default');
     } else if (Platform.OS === 'android') {


### PR DESCRIPTION
### Description
if we pass a non array value as the 3rd argument to the Alert.alert function
it will throw this error => "buttons.slice is not a function"
if instead we show a peaceful message then it will be easier to spot

## Solving this issue #27708

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

sometimes it's hard to spot the error ```buttons.slice is not a function``` in Alert.alert function. because of passing an object or any data type instead of array as the 3rd argument.

so in this commit it will throw a peaceful error that's easy to spot the issue.
## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Fixed] - Alert.alert() peaceful error when wrong argument passed

## Test Plan
```js
Alert.alert("title", "a message", {text: "OK", onPress: () => // doSomething })
```
#### Error message in current api
```console
buttons.slice(0, 2) is not a function
```
#### Error message with this commit
``` console
Alert.alert function 3rd argument must be of type array
```

## Diff
```diff
    buttons?: Buttons,
    options?: Options,
  ): void {
+    if (buttons && !buttons.length) {
+      throw new Error(
+        'Alert.alert function 3rd argument must be of type array',
+      );
+    }
    if (Platform.OS === 'ios') {
      Alert.prompt(title, message, buttons, 'default');
    } else if (Platform.OS === 'android') {
```