### PR TITLE
[iOS] - Display Alert correctly if app is using iOS13 Scenes API.

### DIFF
--- a/React/CoreModules/RCTAlertController.m
+++ b/React/CoreModules/RCTAlertController.m
@@ -20,7 +20,15 @@
 - (UIWindow *)alertWindow
 {
   if (_alertWindow == nil) {
-    _alertWindow = [[UIWindow alloc] initWithFrame:RCTSharedApplication().keyWindow.bounds];
+      if (@available(iOS 13, *)) {
+        UIWindowScene *windowScene = [self windowScene];
+        if (windowScene != nil) {
+          _alertWindow = [[UIWindow alloc] initWithWindowScene:windowScene];
+        }
+    }
+    if (_alertWindow == nil) {
+      _alertWindow = [[UIWindow alloc] initWithFrame:RCTSharedApplication().keyWindow.bounds];
+    }
     _alertWindow.rootViewController = [UIViewController new];
     _alertWindow.windowLevel = UIWindowLevelAlert + 1;
   }
@@ -36,6 +44,19 @@
 - (void)hide
 {
   _alertWindow = nil;
+}
+
+- (UIWindowScene * _Nullable)windowScene API_AVAILABLE(ios(13))
+{
+    NSSet<UIScene *> *connectedScenes = RCTSharedApplication().connectedScenes;
+    for (UIScene *scene in connectedScenes) {
+        BOOL isActive = scene.activationState == UISceneActivationStateForegroundActive;
+        BOOL isWindowScene = [scene isKindOfClass: [UIWindowScene class]];
+        if (isActive && isWindowScene) {
+            return (UIWindowScene *) scene;
+        }
+    }
+    return nil;
 }
 
 @end


### PR DESCRIPTION
## Summary

`UIApplication.keyWindow` is deprecated. This is only a problem if an app is using the [Scenes API](https://developer.apple.com/documentation/uikit/app_and_environment/scenes). An app includes Scenes to display multiple windows and/or to enable the latest CarPlay. Using this API breaks Alerts. RCTAlertController uses `UIApplication.keyWindow` to display an alert. It does not display if using the Scenes API. This PR fixes this issue by doing a check for iOS13 and use of the Scenes API. It then grabs the foreground window. It falls back to the previous implementation in the else case. 

## Changelog
[iOS] [Fixed] - Display Alert correctly if app is using iOS13 Scenes API. 

## Test Plan
See React Native test app to demonstrate the fix below:
https://github.com/mixcloud/SceneApiAlertTest
