### PR TITLE
[Windows CI] Try to install the SDK up to 3 times

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -640,9 +640,10 @@ jobs:
             - C:\Users\circleci\AppData\Local\Yarn
 
       # Try to install the SDK up to 3 times, since network flakiness can cause install failures
+      # Using a timeout of 9 mins, as circle ci will timeout if there is no output for 10 mins
       - run:
           name: Install Android SDK Tools
-          command: choco install android-sdk --timeout 600; if (!$?) { choco install android-sdk --timeout 600}; if (!$?) { choco install android-sdk }
+          command: choco install android-sdk --timeout 540; if (!$?) { choco install android-sdk --timeout 540 --force --forcedependencies}; if (!$?) { choco install android-sdk  --force --forcedependencies}
 
       - run:
           name: Setup Android SDKs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -639,9 +639,10 @@ jobs:
           paths:
             - C:\Users\circleci\AppData\Local\Yarn
 
+      # Try to install the SDK up to 3 times, since network flakiness can cause install failures
       - run:
           name: Install Android SDK Tools
-          command: choco install android-sdk
+          command: choco install android-sdk; if (!$?) { choco install android-sdk }; if (!$?) { choco install android-sdk }
 
       - run:
           name: Setup Android SDKs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -642,7 +642,7 @@ jobs:
       # Try to install the SDK up to 3 times, since network flakiness can cause install failures
       - run:
           name: Install Android SDK Tools
-          command: choco install android-sdk; if (!$?) { choco install android-sdk }; if (!$?) { choco install android-sdk }
+          command: choco install android-sdk --timeout 600; if (!$?) { choco install android-sdk --timeout 600}; if (!$?) { choco install android-sdk }
 
       - run:
           name: Setup Android SDKs


### PR DESCRIPTION
## Summary

The windows CI tests are flaky due to network failures trying to install the android SDK.  This modifies the CI to retry a couple of times if the first install fails.

CircleCI will timeout the command if there is no output to the console for 10mins.  I've added a timeout to the choco command for 9mins, which should cause it to timeout before the circleci one (assuming that it spends a non-zero time with output before hanging on the download)  On successful downloads runs the download seems to be substantially quicker than the 10min timeout.

I added --force and --forcedependencies on the retries, otherwise if the jdk package fails, but the androidsdk package installs, the retry will still not install the jdk package.

This doesn't fully fix the issue, since the CI is still hitting the network, which could be flaky all 3 attempts.  But hopefully it'll improve the success rate somewhat.  -- Really the Windows CI job should have some kind of docker image or something that already has all the prereqs installed.

## Changelog

[Internal] [Fixed] - Windows CI Android SDK install retry

## Test Plan

We'll see if the windows CI becomes more reliable
