### PR TITLE
Fix image loop counter on iOS 14

### DIFF
--- a/Libraries/Image/RCTAnimatedImage.m
+++ b/Libraries/Image/RCTAnimatedImage.m
@@ -87,9 +87,12 @@
     NSNumber *gifLoopCount = gifProperties[(__bridge NSString *)kCGImagePropertyGIFLoopCount];
     if (gifLoopCount != nil) {
       loopCount = gifLoopCount.unsignedIntegerValue;
+      if (@available(iOS 14, *)) {
+      } else {
       // A loop count of 1 means it should repeat twice, 2 means, thrice, etc.
-      if (loopCount != 0) {
-        loopCount++;
+        if (loopCount != 0) {
+          loopCount++;
+        }
       }
     }
   }

--- a/Libraries/Image/RCTAnimatedImage.m
+++ b/Libraries/Image/RCTAnimatedImage.m
@@ -89,7 +89,7 @@
       loopCount = gifLoopCount.unsignedIntegerValue;
       if (@available(iOS 14, *)) {
       } else {
-      // A loop count of 1 means it should repeat twice, 2 means, thrice, etc.
+      // A loop count of 1 means it should animate twice, 2 means, thrice, etc.
         if (loopCount != 0) {
           loopCount++;
         }


### PR DESCRIPTION
## Summary

Animated gifs, which do not loop, currently animate twice on iOS 14.
See: https://github.com/facebook/react-native/issues/30147

## Changelog

[iOS] [Fixed] - Animated images without loop no longer animate twice

## Test Plan

Run the example app with any animated gif. I attached a gif, which is affected.

![checkmark](https://user-images.githubusercontent.com/54310840/104746529-b2e02900-574f-11eb-9870-0c03c769c990.gif)

