### PR TITLE
Load jsc or hermes lib in static method

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/hermes/reactexecutor/HermesExecutor.java
+++ b/ReactAndroid/src/main/java/com/facebook/hermes/reactexecutor/HermesExecutor.java
@@ -16,14 +16,20 @@ public class HermesExecutor extends JavaScriptExecutor {
   private static String mode_;
 
   static {
-    // libhermes must be loaded explicitly to invoke its JNI_OnLoad.
-    SoLoader.loadLibrary("hermes");
-    try {
-      SoLoader.loadLibrary("hermes-executor-debug");
-      mode_ = "Debug";
-    } catch (UnsatisfiedLinkError e) {
-      SoLoader.loadLibrary("hermes-executor-release");
-      mode_ = "Release";
+    loadLibrary();
+  }
+
+  public static void loadLibrary() throws UnsatisfiedLinkError {
+    if (mode_ == null) {
+      // libhermes must be loaded explicitly to invoke its JNI_OnLoad.
+      SoLoader.loadLibrary("hermes");
+      try {
+        SoLoader.loadLibrary("hermes-executor-debug");
+        mode_ = "Debug";
+      } catch (UnsatisfiedLinkError e) {
+        SoLoader.loadLibrary("hermes-executor-release");
+        mode_ = "Release";
+      }
     }
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManagerBuilder.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManagerBuilder.java
@@ -14,6 +14,7 @@ import android.app.Activity;
 import android.app.Application;
 import android.content.Context;
 import androidx.annotation.Nullable;
+import com.facebook.hermes.reactexecutor.HermesExecutor;
 import com.facebook.hermes.reactexecutor.HermesExecutorFactory;
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.bridge.JSBundleLoader;
@@ -25,6 +26,7 @@ import com.facebook.react.common.LifecycleState;
 import com.facebook.react.devsupport.RedBoxHandler;
 import com.facebook.react.devsupport.interfaces.DevBundleDownloadListener;
 import com.facebook.react.devsupport.interfaces.DevSupportManager;
+import com.facebook.react.jscexecutor.JSCExecutor;
 import com.facebook.react.jscexecutor.JSCExecutorFactory;
 import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
 import com.facebook.react.packagerconnection.RequestHandler;
@@ -294,7 +296,7 @@ public class ReactInstanceManagerBuilder {
     try {
       // If JSC is included, use it as normal
       initializeSoLoaderIfNecessary(applicationContext);
-      SoLoader.loadLibrary("jscexecutor");
+      JSCExecutor.loadLibrary();
       return new JSCExecutorFactory(appName, deviceName);
     } catch (UnsatisfiedLinkError jscE) {
       // https://github.com/facebook/hermes/issues/78 shows that
@@ -312,6 +314,8 @@ public class ReactInstanceManagerBuilder {
 
       // Otherwise use Hermes
       try {
+        // libhermes must be loaded explicitly to invoke its JNI_OnLoad.
+        HermesExecutor.loadLibrary();
         return new HermesExecutorFactory();
       } catch (UnsatisfiedLinkError hermesE) {
         // If we get here, either this is a JSC build, and of course

--- a/ReactAndroid/src/main/java/com/facebook/react/jscexecutor/JSCExecutor.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/jscexecutor/JSCExecutor.java
@@ -14,9 +14,17 @@ import com.facebook.react.bridge.ReadableNativeMap;
 import com.facebook.soloader.SoLoader;
 
 @DoNotStrip
-/* package */ class JSCExecutor extends JavaScriptExecutor {
+/* package */ public class JSCExecutor extends JavaScriptExecutor {
+  private static boolean loaded = false;
   static {
-    SoLoader.loadLibrary("jscexecutor");
+    loadLibrary();
+  }
+
+  public static void loadLibrary() throws UnsatisfiedLinkError {
+    if (!loaded) {
+      SoLoader.loadLibrary("jscexecutor");
+    }
+    loaded = true;
   }
 
   /* package */ JSCExecutor(ReadableNativeMap jscConfig) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Many have reported about the misguiding error `Fatal Exception: java.lang.UnsatisfiedLinkError: couldn't find DSO to load: libhermes.so` even though they don't use Hermes (for example issues #26075 #25923).

**The current code does not handle errors correctly when loading JSC or Hermes in `ReactInstanceManagerBuilder`**.

**ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManagerBuilder.java:**
```java
try {
  return new HermesExecutorFactory();
} catch (UnsatisfiedLinkError hermesE) {
  // We never get here because "new HermesExecutorFactory()" does not throw an exception!
  hermesE.printStackTrace();
  throw jscE;
}
```

In Java, when an exception is thrown in static block, it will be RuntimeException and it can't be caught. For example the exception from `SoLoader.loadLibrary` can't be caught and it will crash the app.

**ReactAndroid/src/main/java/com/facebook/hermes/reactexecutor/HermesExecutor.java:**
```java
static {
  // Exception from this code block will be RuntimeException and it can't be caught!
  SoLoader.loadLibrary("hermes");
  try {
    SoLoader.loadLibrary("hermes-executor-debug");
    mode_ = "Debug";
  } catch (UnsatisfiedLinkError e) {
    SoLoader.loadLibrary("hermes-executor-release");
    mode_ = "Release";
  }
}
```

This PR fixes the code so that the original exception from failed JSC loading is not swallowed. It does not fix the original issue why JSC loading is failing with some devices, but it can be really helpful to know what the real error is. For example Firebase Crashlytics shows wrong stack trace with current code.

I'm sure that this fix could have been written better. It feels wrong to import `JSCExecutor` and `HermesExecutor` in `ReactInstanceManagerBuilder.java`. However, the main point of this PR is to give the idea what is wrong with the current code.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Fixed] - Fix error handling when loading JSC or Hermes

## Test Plan

* from this PR, modify  `ReactAndroid/src/main/java/com/facebook/react/jscexecutor/JSCExecutor.java` so that JSC loading will fail:
```java
// original
SoLoader.loadLibrary("jscexecutor");
// changed
SoLoader.loadLibrary("jscexecutor-does-not-exist");
```
* Run `rn-tester` app
* Check from Logcat that the app crashed with correct exception and stacktrace. It should **not** be `java.lang.UnsatisfiedLinkError: couldn't find DSO to load: libhermes.so`

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
