### PR TITLE
Fix glog build failed on Apple Silicon

### DIFF
--- a/scripts/ios-configure-glog.sh
+++ b/scripts/ios-configure-glog.sh
@@ -9,6 +9,10 @@ set -e
 PLATFORM_NAME="${PLATFORM_NAME:-iphoneos}"
 CURRENT_ARCH="${CURRENT_ARCH}"
 
+# Fix build on Apple Silicon
+wget -O config.guess 'https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD'
+wget -O config.sub 'https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD'
+
 if [ -z "$CURRENT_ARCH" ] || [ "$CURRENT_ARCH" == "undefined_arch" ]; then
     # Xcode 10 beta sets CURRENT_ARCH to "undefined_arch", this leads to incorrect linker arg.
     # it's better to rely on platform name as fallback because architecture differs between simulator and device


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Because glog's `config.stub` && `config.guess` is too old, so execute `pod install` on Apple Silicon devices will failed, error message is `Invalid configuration 'arm64-apple-darwin20.2.0': machine 'arm64-apple' not recognized`. 

So we need to update these 2 files from [GNU](https://www.gnu.org/software/gettext/manual/html_node/config_002eguess.html) to fix this problem.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [Fixed] - Fix glog build failed on Apple Silicon

## Test Plan

1. Clone this repo on Apple Silicon device.
2. Disable flipper in `packages/rn-tester/Podfile`(becase Flipper-Glog has this problem too).
3. `pod install`, build and run tester app.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
