### PR TITLE
Implement FormData.set method and handle Blob instances

### DIFF
--- a/Libraries/Network/__tests__/FormData-test.js
+++ b/Libraries/Network/__tests__/FormData-test.js
@@ -10,12 +10,40 @@
 
 'use strict';
 
+const Blob = require('../../Blob/Blob');
+const File = require('../../Blob/File');
+const BlobManager = require('../../Blob/BlobManager');
+
 const FormData = require('../FormData');
+
+jest.mock('../../Blob/BlobManager', () => ({
+  createFromParts: jest.fn(() => ({
+    data: {
+      size: 100,
+      offset: 40,
+      type: 'image/jpeg',
+      blobId: '5CADECF8-F32A-4068-8209-5ED18B2648D9',
+    },
+  })),
+  release() {},
+}));
 
 describe('FormData', function() {
   var formData;
+  var originalURL = global.URL;
+
+  beforeAll(() => {
+    global.Blob = Blob;
+    global.File = File;
+    global.URL = {
+      createObjectURL(blob) {
+        return `blob:${blob.data.blobId}?offset=${blob.data.offset}&size=${blob.size}`;
+      },
+    };
+  });
 
   beforeEach(() => {
+    jest.clearAllMocks();
     formData = new FormData();
   });
 
@@ -23,36 +51,311 @@ describe('FormData', function() {
     formData = null;
   });
 
-  it('should return non blob null', function() {
-    formData.append('null', null);
-
-    const expectedPart = {
-      string: 'null',
-      headers: {
-        'content-disposition': 'form-data; name="null"',
-      },
-      fieldName: 'null',
-    };
-    expect(formData.getParts()[0]).toMatchObject(expectedPart);
+  afterAll(() => {
+    delete global.Blob;
+    delete global.File;
+    global.URL = originalURL;
   });
 
-  it('should return blob', function() {
-    formData.append('photo', {
-      uri: 'arbitrary/path',
-      type: 'image/jpeg',
-      name: 'photo.jpg',
+  describe('append', function() {
+    it('should return non blob null', function() {
+      formData.append('null', null);
+
+      const expectedPart = {
+        string: 'null',
+        headers: {
+          'content-disposition': 'form-data; name="null"',
+        },
+        fieldName: 'null',
+      };
+      expect(formData.getParts()[0]).toMatchObject(expectedPart);
     });
 
-    const expectedPart = {
-      uri: 'arbitrary/path',
-      type: 'image/jpeg',
-      name: 'photo.jpg',
-      headers: {
-        'content-disposition': 'form-data; name="photo"; filename="photo.jpg"',
-        'content-type': 'image/jpeg',
-      },
-      fieldName: 'photo',
-    };
-    expect(formData.getParts()[0]).toMatchObject(expectedPart);
+    it('should return blob', function() {
+      formData.append('photo', {
+        uri: 'arbitrary/path',
+        type: 'image/jpeg',
+        name: 'photo.jpg',
+      });
+
+      const expectedPart = {
+        uri: 'arbitrary/path',
+        type: 'image/jpeg',
+        name: 'photo.jpg',
+        headers: {
+          'content-disposition':
+            'form-data; name="photo"; filename="photo.jpg"',
+          'content-type': 'image/jpeg',
+        },
+        fieldName: 'photo',
+      };
+      expect(formData.getParts()[0]).toMatchObject(expectedPart);
+    });
+
+    it('should append multiple values with the same key', function() {
+      formData.append('photo', {
+        uri: 'arbitrary/path',
+        type: 'image/jpeg',
+        name: 'photo.jpg',
+      });
+      formData.append('photo', {
+        uri: 'arbitrary/path',
+        type: 'image/jpeg',
+        name: 'photo.jpg',
+      });
+
+      expect(formData.getParts()).toEqual([
+        {
+          uri: 'arbitrary/path',
+          type: 'image/jpeg',
+          name: 'photo.jpg',
+          headers: {
+            'content-disposition':
+              'form-data; name="photo"; filename="photo.jpg"',
+            'content-type': 'image/jpeg',
+          },
+          fieldName: 'photo',
+        },
+        {
+          uri: 'arbitrary/path',
+          type: 'image/jpeg',
+          name: 'photo.jpg',
+          headers: {
+            'content-disposition':
+              'form-data; name="photo"; filename="photo.jpg"',
+            'content-type': 'image/jpeg',
+          },
+          fieldName: 'photo',
+        },
+      ]);
+    });
+
+    it('should ignore server file name when value is not File, Blob or blob-like object', function() {
+      formData.append('foo', 'bar', 'file.ext');
+
+      const expectedPart = {
+        string: 'bar',
+        headers: {
+          'content-disposition': 'form-data; name="foo"',
+        },
+        fieldName: 'foo',
+      };
+      expect(formData.getParts()[0]).toMatchObject(expectedPart);
+    });
+  });
+
+  describe('set', function() {
+    it('should accept null and return a blob part', function() {
+      formData.set('null', null);
+
+      const expectedPart = {
+        string: 'null',
+        headers: {
+          'content-disposition': 'form-data; name="null"',
+        },
+        fieldName: 'null',
+      };
+      expect(formData.getParts()[0]).toMatchObject(expectedPart);
+    });
+
+    it('should accept a blob-like object and return a blob part', function() {
+      formData.set('photo', {
+        uri: 'arbitrary/path',
+        type: 'image/jpeg',
+        name: 'photo.jpg',
+      });
+
+      const expectedPart = {
+        uri: 'arbitrary/path',
+        type: 'image/jpeg',
+        name: 'photo.jpg',
+        headers: {
+          'content-disposition':
+            'form-data; name="photo"; filename="photo.jpg"',
+          'content-type': 'image/jpeg',
+        },
+        fieldName: 'photo',
+      };
+      expect(formData.getParts()[0]).toMatchObject(expectedPart);
+    });
+
+    it('should accept a Blob instance without server file name and return a blob part', function() {
+      formData.set('photo', new Blob());
+
+      const expectedPart = {
+        uri: 'blob:5CADECF8-F32A-4068-8209-5ED18B2648D9?offset=40&size=100',
+        type: 'image/jpeg',
+        name: 'blob',
+        headers: {
+          'content-disposition': 'form-data; name="photo"; filename="blob"',
+          'content-type': 'image/jpeg',
+        },
+        fieldName: 'photo',
+      };
+      expect(formData.getParts()[0]).toMatchObject(expectedPart);
+    });
+
+    it('should accept a Blob instance with server file name and return a blob part', function() {
+      formData.set('photo', new Blob(), 'photo.jpg');
+
+      const expectedPart = {
+        uri: 'blob:5CADECF8-F32A-4068-8209-5ED18B2648D9?offset=40&size=100',
+        type: 'image/jpeg',
+        name: 'photo.jpg',
+        headers: {
+          'content-disposition':
+            'form-data; name="photo"; filename="photo.jpg"',
+          'content-type': 'image/jpeg',
+        },
+        fieldName: 'photo',
+      };
+      expect(formData.getParts()[0]).toMatchObject(expectedPart);
+    });
+
+    it('should accept a File instance without server file name and return a blob part', function() {
+      formData.set('photo', new File([], 'photo.jpg'));
+
+      const expectedPart = {
+        uri: 'blob:5CADECF8-F32A-4068-8209-5ED18B2648D9?offset=40&size=100',
+        type: 'image/jpeg',
+        name: 'photo.jpg',
+        headers: {
+          'content-disposition':
+            'form-data; name="photo"; filename="photo.jpg"',
+          'content-type': 'image/jpeg',
+        },
+        fieldName: 'photo',
+      };
+      expect(formData.getParts()[0]).toMatchObject(expectedPart);
+    });
+
+    it('should accept a File instance with server file name and return a blob part', function() {
+      formData.set('photo', new File([], 'photo1.jpg'), 'photo2.jpg');
+
+      const expectedPart = {
+        uri: 'blob:5CADECF8-F32A-4068-8209-5ED18B2648D9?offset=40&size=100',
+        type: 'image/jpeg',
+        name: 'photo2.jpg',
+        headers: {
+          'content-disposition':
+            'form-data; name="photo"; filename="photo2.jpg"',
+          'content-type': 'image/jpeg',
+        },
+        fieldName: 'photo',
+      };
+      expect(formData.getParts()[0]).toMatchObject(expectedPart);
+    });
+
+    it('should accept a string and return a blob part', function() {
+      formData.set('foo', 'bar');
+
+      const expectedPart = {
+        string: 'bar',
+        headers: {
+          'content-disposition': 'form-data; name="foo"',
+        },
+        fieldName: 'foo',
+      };
+      expect(formData.getParts()[0]).toMatchObject(expectedPart);
+    });
+
+    it('should replace existing key', function() {
+      BlobManager.createFromParts
+        .mockReturnValueOnce({
+          data: {
+            size: 300,
+            offset: 60,
+            type: 'image/jpeg',
+            blobId: '3761FC36-18B8-4D61-9077-61D436FF0075',
+          },
+        })
+        .mockReturnValueOnce({
+          data: {
+            size: 100,
+            offset: 40,
+            type: 'image/jpeg',
+            blobId: '5CADECF8-F32A-4068-8209-5ED18B2648D9',
+          },
+        });
+
+      formData.set('photo', new File([], 'photo1.jpg'), 'photo2.jpg');
+      formData.set('photo', new Blob(), 'photo3.jpg');
+
+      const expectedPart = {
+        uri: 'blob:5CADECF8-F32A-4068-8209-5ED18B2648D9?offset=40&size=100',
+        type: 'image/jpeg',
+        name: 'photo3.jpg',
+        headers: {
+          'content-disposition':
+            'form-data; name="photo"; filename="photo3.jpg"',
+          'content-type': 'image/jpeg',
+        },
+        fieldName: 'photo',
+      };
+      expect(formData.getParts()[0]).toMatchObject(expectedPart);
+    });
+
+    it('should ignore server file name when value is not File, Blob or blob-like object', function() {
+      formData.set('foo', 'bar', 'file.ext');
+
+      const expectedPart = {
+        string: 'bar',
+        headers: {
+          'content-disposition': 'form-data; name="foo"',
+        },
+        fieldName: 'foo',
+      };
+      expect(formData.getParts()[0]).toMatchObject(expectedPart);
+    });
+  });
+
+  describe('getParts', function() {
+    it('should return multiple parts', function() {
+      BlobManager.createFromParts
+        .mockReturnValueOnce({
+          data: {
+            size: 300,
+            offset: 60,
+            type: 'image/jpeg',
+            blobId: '3761FC36-18B8-4D61-9077-61D436FF0075',
+          },
+        })
+        .mockReturnValueOnce({
+          data: {
+            size: 100,
+            offset: 40,
+            type: 'image/jpeg',
+            blobId: '5CADECF8-F32A-4068-8209-5ED18B2648D9',
+          },
+        });
+
+      formData.append('photo', new File([], 'photo1.jpg'), 'photo2.jpg');
+      formData.append('photo', new Blob(), 'photo3.jpg');
+
+      expect(formData.getParts()).toEqual([
+        {
+          uri: 'blob:3761FC36-18B8-4D61-9077-61D436FF0075?offset=60&size=300',
+          type: 'image/jpeg',
+          name: 'photo2.jpg',
+          headers: {
+            'content-disposition':
+              'form-data; name="photo"; filename="photo2.jpg"',
+            'content-type': 'image/jpeg',
+          },
+          fieldName: 'photo',
+        },
+        {
+          uri: 'blob:5CADECF8-F32A-4068-8209-5ED18B2648D9?offset=40&size=100',
+          type: 'image/jpeg',
+          name: 'photo3.jpg',
+          headers: {
+            'content-disposition':
+              'form-data; name="photo"; filename="photo3.jpg"',
+            'content-type': 'image/jpeg',
+          },
+          fieldName: 'photo',
+        },
+      ]);
+    });
   });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

The proposed changes brings `FormData`'s implementation one step closer to spec compliance by:
- Implementing `.set` method.
- Adding support to `filename` argument on both [`.set`](https://developer.mozilla.org/en-US/docs/Web/API/FormData/set) and [`.append`](https://developer.mozilla.org/en-US/docs/Web/API/FormData/append) for `Blob` and `File` values.
- Handling `Blob` instances in `.getParts` instead of just blob-like objects with the `uri` property.

Additionally, I've took the opportunity to improve `FormData`s test suite overall by adding more test cases.

It's worth noting that according to the implementation of `URL.createObjectURL`, the call may [fail](https://github.com/facebook/react-native/blob/v0.63.4/Libraries/Blob/URL.js#L120) if the native blob module is not available. However, I don't know which circumstances determine its availability:
- Is it the native platform?
- Is it the React Native version?

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[JavaScript] [Added] - Implement `FormData.set`.
[JavaScript] [Added] - Add support to `filename` argument on both `FormData.set` and `FormData.append` for `Blob` and `File` values. 

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
Run the following command at the root of React Native's directory:

```
npm t -- FormData-test.js
```