### PR TITLE
Implement FileReader.readAsArrayBuffer

### DIFF
--- a/Libraries/Blob/FileReader.js
+++ b/Libraries/Blob/FileReader.js
@@ -9,6 +9,7 @@
  */
 
 const Blob = require('./Blob');
+const {toByteArray} = require('base64-js');
 const EventTarget = require('event-target-shim');
 
 import NativeFileReaderModule from './NativeFileReaderModule';
@@ -79,8 +80,35 @@ class FileReader extends (EventTarget(...READER_EVENTS): any) {
     }
   }
 
-  readAsArrayBuffer() {
-    throw new Error('FileReader.readAsArrayBuffer is not implemented');
+  readAsArrayBuffer(blob: ?Blob) {
+    this._aborted = false;
+
+    if (blob == null) {
+      throw new TypeError(
+        "Failed to execute 'readAsArrayBuffer' on 'FileReader': parameter 1 is not of type 'Blob'",
+      );
+    }
+
+    NativeFileReaderModule.readAsDataURL(blob.data).then(
+      (text: string) => {
+        if (this._aborted) {
+          return;
+        }
+
+        const base64 = text.split(',')[1];
+        const typedArray = toByteArray(base64);
+
+        this._result = typedArray.buffer;
+        this._setReadyState(DONE);
+      },
+      error => {
+        if (this._aborted) {
+          return;
+        }
+        this._error = error;
+        this._setReadyState(DONE);
+      },
+    );
   }
 
   readAsDataURL(blob: ?Blob) {

--- a/Libraries/Blob/__tests__/FileReader-test.js
+++ b/Libraries/Blob/__tests__/FileReader-test.js
@@ -38,4 +38,15 @@ describe('FileReader', function () {
     });
     expect(e.target.result).toBe('data:text/plain;base64,NDI=');
   });
+
+  it('should read blob as ArrayBuffer', async () => {
+    const e = await new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = resolve;
+      reader.onerror = reject;
+      reader.readAsArrayBuffer(new Blob());
+    });
+    /* eslint-disable-next-line no-undef */
+    expect(new TextDecoder().decode(e.target.result)).toBe('42');
+  });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
The proposed implementation is not an efficient solution as is requires to encode the raw binary of a `Blob` into base64 natively and then decode the base64 into an `ArrayBuffer` in JS land. We have to do this for the time being because it's not yet possible to share/manipulate native memory or object references with JS. However, it works as a workaround for the short term.

Related: https://github.com/facebook/react-native/issues/21209

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[JavaScript] [Added] - Implement `FileReader.readAsArrayBuffer`

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Run the following command at the root of React Native's directory:

```
npm t -- FileReader-test.js
```