### PR TITLE
Invoke `node` directly in generate-specs.sh

### DIFF
--- a/scripts/generate-specs.sh
+++ b/scripts/generate-specs.sh
@@ -28,6 +28,7 @@ THIS_DIR=$(cd -P "$(dirname "$(readlink "${BASH_SOURCE[0]}" || echo "${BASH_SOUR
 TEMP_DIR=$(mktemp -d /tmp/react-native-codegen-XXXXXXXX)
 RN_DIR=$(cd "$THIS_DIR/.." && pwd)
 YARN_BINARY="${YARN_BINARY:-$(command -v yarn)}"
+NODE_BINARY="${NODE_BINARY:-$(command -v node)}"
 USE_FABRIC="${USE_FABRIC:-0}"
 
 cleanup () {
@@ -74,11 +75,11 @@ main() {
   fi
 
   describe "Generating schema from flow types"
-  "$YARN_BINARY" node "$CODEGEN_PATH/lib/cli/combine/combine-js-to-schema-cli.js" "$SCHEMA_FILE" "$SRCS_DIR"
+  "$NODE_BINARY" "$CODEGEN_PATH/lib/cli/combine/combine-js-to-schema-cli.js" "$SCHEMA_FILE" "$SRCS_DIR"
 
   describe "Generating native code from schema (iOS)"
   pushd "$RN_DIR" >/dev/null || exit
-    "$YARN_BINARY" --silent node scripts/generate-specs-cli.js ios "$SCHEMA_FILE" "$TEMP_OUTPUT_DIR" "$CODEGEN_MODULES_LIBRARY_NAME"
+    "$NODE_BINARY" scripts/generate-specs-cli.js ios "$SCHEMA_FILE" "$TEMP_OUTPUT_DIR" "$CODEGEN_MODULES_LIBRARY_NAME"
   popd >/dev/null || exit
 
   mkdir -p "$CODEGEN_COMPONENTS_OUTPUT_DIR" "$CODEGEN_MODULES_OUTPUT_DIR"

--- a/scripts/generate-specs.sh
+++ b/scripts/generate-specs.sh
@@ -27,7 +27,7 @@ set -e
 THIS_DIR=$(cd -P "$(dirname "$(readlink "${BASH_SOURCE[0]}" || echo "${BASH_SOURCE[0]}")")" && pwd)
 TEMP_DIR=$(mktemp -d /tmp/react-native-codegen-XXXXXXXX)
 RN_DIR=$(cd "$THIS_DIR/.." && pwd)
-NODE_BINARY="${NODE_BINARY:-$(command -v node)}"
+NODE_BINARY="${NODE_BINARY:-$(command -v node || true)}"
 USE_FABRIC="${USE_FABRIC:-0}"
 
 cleanup () {
@@ -64,10 +64,15 @@ main() {
     echo "Error: Could not determine react-native-codegen location. Try running 'yarn install' or 'npm install' in your project root." 1>&2
     exit 1
   fi
-
+  
   if [ ! -d "$CODEGEN_PATH/lib" ]; then
     describe "Building react-native-codegen package"
     bash "$CODEGEN_PATH/scripts/oss/build.sh"
+  fi
+
+  if [ -z "$NODE_BINARY" ]; then
+    echo "Error: Could not find node. Make sure it is in bash PATH or set the NODE_BINARY environment variable." 1>&2
+    exit 1
   fi
 
   describe "Generating schema from flow types"

--- a/scripts/generate-specs.sh
+++ b/scripts/generate-specs.sh
@@ -27,7 +27,6 @@ set -e
 THIS_DIR=$(cd -P "$(dirname "$(readlink "${BASH_SOURCE[0]}" || echo "${BASH_SOURCE[0]}")")" && pwd)
 TEMP_DIR=$(mktemp -d /tmp/react-native-codegen-XXXXXXXX)
 RN_DIR=$(cd "$THIS_DIR/.." && pwd)
-YARN_BINARY="${YARN_BINARY:-$(command -v yarn)}"
 NODE_BINARY="${NODE_BINARY:-$(command -v node)}"
 USE_FABRIC="${USE_FABRIC:-0}"
 
@@ -68,10 +67,7 @@ main() {
 
   if [ ! -d "$CODEGEN_PATH/lib" ]; then
     describe "Building react-native-codegen package"
-    pushd "$CODEGEN_PATH" >/dev/null || exit
-      "$YARN_BINARY"
-      "$YARN_BINARY" build
-    popd >/dev/null || exit
+    bash "$CODEGEN_PATH/scripts/oss/build.sh"
   fi
 
   describe "Generating schema from flow types"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Currently, Codegen bash wrapper (`generate-specs.sh`) for Xcode invokes JS-based Codegen tooling via `yarn --silent node <...>`. This breaks both: 

- when Yarn is not installed (if NPM is used), for obvious reasons
- when Yarn v2 ("Berry") is active
 
This PR changes the way `generate-specs.sh` locates `node` executable to the following algorithm: 

- use the path provided in the `NODE_BINARY` env var
- if `NODE_BINARY` env var is not defined, find `node` with `command -v node`

## Changelog

[iOS] [Fixed] - Fix Codegen silently failing when Yarn is not installed, or when Yarn v2 is active.

## Test Plan

### Case 1 (no Yarn installed)

1. Ensure `yarn` is not present in PATH
2. Run Xcode build
3. Check that Codegen artifacts are produced

### Case 2 (Yarn v2 is used)

1. Ensure `yarn` is running in the v2 ("Berry") mode
2. Run Xcode build
3. Check that Codegen artifacts are produced
