### PR TITLE
Fixes in react-native inspector to build on Windows universal environment

### DIFF
--- a/ReactCommon/hermes/executor/HermesExecutorFactory.cpp
+++ b/ReactCommon/hermes/executor/HermesExecutorFactory.cpp
@@ -120,7 +120,11 @@ struct ReentrancyCheck {
       // programmer error, where VM methods were called on two
       // different threads unsafely.  Fail fast (and hard) so the
       // crash can be analyzed.
+#ifdef _MSC_VER
+      __debugbreak();
+#else
       __builtin_trap();
+#endif
     }
   }
 

--- a/ReactCommon/hermes/inspector/Inspector.cpp
+++ b/ReactCommon/hermes/inspector/Inspector.cpp
@@ -32,6 +32,7 @@ namespace futures {
 
 SemiFuture<Unit> sleep(Duration, Timekeeper *) {
   LOG(FATAL) << "folly::futures::sleep() not implemented";
+  return SemiFuture<Unit>();
 }
 
 } // namespace futures
@@ -40,6 +41,7 @@ namespace detail {
 
 std::shared_ptr<Timekeeper> getTimekeeperSingleton() {
   LOG(FATAL) << "folly::detail::getTimekeeperSingleton() not implemented";
+  return nullptr;
 }
 
 } // namespace detail

--- a/ReactCommon/hermes/inspector/chrome/AutoAttachUtils.cpp
+++ b/ReactCommon/hermes/inspector/chrome/AutoAttachUtils.cpp
@@ -7,7 +7,7 @@
 
 #include "AutoAttachUtils.h"
 
-#ifdef _WINDOWS
+#ifdef _MSC_VER
 namespace facebook {
 namespace hermes {
 namespace inspector {

--- a/ReactCommon/hermes/inspector/detail/Thread.h
+++ b/ReactCommon/hermes/inspector/detail/Thread.h
@@ -10,7 +10,7 @@
 #include <functional>
 #include <memory>
 
-#ifdef _WINDOWS
+#ifdef _MSC_VER
 #include <thread>
 #elif !defined(__ANDROID__)
 #include <pthread.h>


### PR DESCRIPTION
## Summary
We are working on bringing up React native inspector with Hermes on React Native For Windows. This PR has some minor fixups required to build the code under UWP build environment. Essentially, _WINDOWS macro is not available but _MSC_VER is always guaranteed to be present when building for WIndows.

Another change is due to the fact the GLOG APIs are stubbed out using preprocessor macros in RNW, which can't marked as "noreturn", hence forcing us to have return statements after the fatal error log statements.

Here is the link to the corresponding PR in React-Native-Windows repo for reference: https://github.com/microsoft/react-native-windows/pull/6964

## Changelog

We are working on bringing up React native inspector with Hermes on React Native For Windows. This PR has some minor fixups required to build the code under UWP build environment. Essentially, _WINDOWS macro is not available but _MSC_VER is always guaranteed to be present when building for WIndows.

Another change is due to the fact the GLOG APIs are stubbed out using preprocessor macros in RNW, which can't marked as "noreturn", hence forcing us to have return statements after the fatal error log statements.

[CATEGORY] [TYPE] - Message

## Test Plan

The change only affect windows builds.