### PR TITLE
Fix an infinite loop during getTypeface() due to a bug in HashMap.containsKey()

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactFontManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactFontManager.java
@@ -56,8 +56,8 @@ public class ReactFontManager {
 
   public @Nullable Typeface getTypeface(
       String fontFamilyName, int style, int weight, AssetManager assetManager) {
-    if (mCustomTypefaceCache.containsKey(fontFamilyName)) {
-      Typeface typeface = mCustomTypefaceCache.get(fontFamilyName);
+    Typeface typeface = mCustomTypefaceCache.get(fontFamilyName);
+    if (typeface != null) {
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && weight >= 100 && weight <= 1000) {
         return Typeface.create(typeface, weight, (style & Typeface.ITALIC) != 0);
       }
@@ -70,7 +70,7 @@ public class ReactFontManager {
       mFontCache.put(fontFamilyName, fontFamily);
     }
 
-    Typeface typeface = fontFamily.getTypeface(style);
+    typeface = fontFamily.getTypeface(style);
     if (typeface == null) {
       typeface = createTypeface(fontFamilyName, style, assetManager);
       if (typeface != null) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Our Crashlytics tool has been shown to have some crash issues on some devices running Android 4.4 (I cannot reproduce myself). It problems is from [Line 59 of ReactFontManager.java](https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactFontManager.java#L59). You can see the below image for better clarity.

![alt text](https://i.imgur.com/0w0Ptiy.png "Logo Title Text 1")

Next, my understanding is that this StackOverflowError is due to a bug in containsKey() method of HashMap. The algorithm used within this method probably contains an unexpected bug. As a result, we have an infinite loop here.

Moreover, from the code, I notice that the variable "typeface" declared on line 60 is never checked null before the usage on the following lines. This shows that the value would not contain null. In this case, containsKey() would be redundant as the null value is not really possible here.

Eventually, by getting rid of containsKey(), we prevent this mysterious crash and benefit some speed up also.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->
[Android] [Fixed] - Fix a crash due to a bug in containsKey causing an infinite loop in ReactFontManager.getTypeface()

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
I didn't have the devices with the crash myself. What I can do here is to see whether or not this same crash disappeared with the patched version.