### PR TITLE
Migrate away from "@fbsource//tools/build_defs/apple:flag_defs.bzl"

### DIFF
--- a/ReactCommon/better/BUCK
+++ b/ReactCommon/better/BUCK
@@ -1,4 +1,3 @@
-load("@fbsource//tools/build_defs/apple:flag_defs.bzl", "get_preprocessor_flags_for_build_mode")
 load(
     "//tools/build_defs/oss:rn_defs.bzl",
     "ANDROID",
@@ -6,6 +5,7 @@ load(
     "CXX",
     "get_apple_compiler_flags",
     "get_apple_inspector_flags",
+    "get_preprocessor_flags_for_build_mode",
     "rn_xplat_cxx_library",
     "subdir_glob",
 )

--- a/ReactCommon/react/nativemodule/core/BUCK
+++ b/ReactCommon/react/nativemodule/core/BUCK
@@ -1,5 +1,4 @@
-load("@fbsource//tools/build_defs/apple:flag_defs.bzl", "get_objc_arc_preprocessor_flags")
-load("//tools/build_defs/oss:rn_defs.bzl", "ANDROID", "APPLE", "FBJNI_TARGET", "get_preprocessor_flags_for_build_mode", "get_static_library_ios_flags", "react_native_target", "react_native_xplat_shared_library_target", "react_native_xplat_target", "rn_xplat_cxx_library", "subdir_glob")
+load("//tools/build_defs/oss:rn_defs.bzl", "ANDROID", "APPLE", "FBJNI_TARGET", "get_objc_arc_preprocessor_flags", "get_preprocessor_flags_for_build_mode", "get_static_library_ios_flags", "react_native_target", "react_native_xplat_shared_library_target", "react_native_xplat_target", "rn_xplat_cxx_library", "subdir_glob")
 
 rn_xplat_cxx_library(
     name = "core",

--- a/ReactCommon/react/nativemodule/samples/BUCK
+++ b/ReactCommon/react/nativemodule/samples/BUCK
@@ -1,5 +1,4 @@
-load("@fbsource//tools/build_defs/apple:flag_defs.bzl", "get_objc_arc_preprocessor_flags", "get_preprocessor_flags_for_build_mode", "get_static_library_ios_flags")
-load("//tools/build_defs/oss:rn_defs.bzl", "ANDROID", "APPLE", "FBJNI_TARGET", "react_native_dep", "react_native_target", "react_native_xplat_target", "rn_android_library", "rn_xplat_cxx_library", "subdir_glob")
+load("//tools/build_defs/oss:rn_defs.bzl", "ANDROID", "APPLE", "FBJNI_TARGET", "get_objc_arc_preprocessor_flags", "get_preprocessor_flags_for_build_mode", "get_static_library_ios_flags", "react_native_dep", "react_native_target", "react_native_xplat_target", "rn_android_library", "rn_xplat_cxx_library", "subdir_glob")
 
 rn_xplat_cxx_library(
     name = "samples",

--- a/ReactCommon/react/renderer/animations/BUCK
+++ b/ReactCommon/react/renderer/animations/BUCK
@@ -1,4 +1,3 @@
-load("@fbsource//tools/build_defs/apple:flag_defs.bzl", "get_preprocessor_flags_for_build_mode")
 load(
     "//tools/build_defs/oss:rn_defs.bzl",
     "ANDROID",
@@ -7,6 +6,7 @@ load(
     "fb_xplat_cxx_test",
     "get_apple_compiler_flags",
     "get_apple_inspector_flags",
+    "get_preprocessor_flags_for_build_mode",
     "react_native_xplat_target",
     "rn_xplat_cxx_library",
     "subdir_glob",

--- a/ReactCommon/react/renderer/attributedstring/BUCK
+++ b/ReactCommon/react/renderer/attributedstring/BUCK
@@ -1,4 +1,3 @@
-load("@fbsource//tools/build_defs/apple:flag_defs.bzl", "get_preprocessor_flags_for_build_mode")
 load(
     "//tools/build_defs/oss:rn_defs.bzl",
     "ANDROID",
@@ -7,6 +6,7 @@ load(
     "fb_xplat_cxx_test",
     "get_apple_compiler_flags",
     "get_apple_inspector_flags",
+    "get_preprocessor_flags_for_build_mode",
     "react_native_xplat_target",
     "rn_xplat_cxx_library",
     "subdir_glob",

--- a/ReactCommon/react/renderer/componentregistry/BUCK
+++ b/ReactCommon/react/renderer/componentregistry/BUCK
@@ -1,4 +1,3 @@
-load("@fbsource//tools/build_defs/apple:flag_defs.bzl", "get_preprocessor_flags_for_build_mode")
 load(
     "//tools/build_defs/oss:rn_defs.bzl",
     "ANDROID",
@@ -6,6 +5,7 @@ load(
     "CXX",
     "get_apple_compiler_flags",
     "get_apple_inspector_flags",
+    "get_preprocessor_flags_for_build_mode",
     "react_native_xplat_target",
     "rn_xplat_cxx_library",
     "subdir_glob",

--- a/ReactCommon/react/renderer/components/image/BUCK
+++ b/ReactCommon/react/renderer/components/image/BUCK
@@ -1,4 +1,3 @@
-load("@fbsource//tools/build_defs/apple:flag_defs.bzl", "get_preprocessor_flags_for_build_mode")
 load(
     "//tools/build_defs/oss:rn_defs.bzl",
     "ANDROID",
@@ -8,6 +7,7 @@ load(
     "fb_xplat_cxx_test",
     "get_apple_compiler_flags",
     "get_apple_inspector_flags",
+    "get_preprocessor_flags_for_build_mode",
     "react_native_xplat_target",
     "rn_xplat_cxx_library",
     "subdir_glob",

--- a/ReactCommon/react/renderer/components/inputaccessory/BUCK
+++ b/ReactCommon/react/renderer/components/inputaccessory/BUCK
@@ -1,9 +1,9 @@
-load("@fbsource//tools/build_defs/apple:flag_defs.bzl", "get_preprocessor_flags_for_build_mode")
 load(
     "//tools/build_defs/oss:rn_defs.bzl",
     "APPLE",
     "get_apple_compiler_flags",
     "get_apple_inspector_flags",
+    "get_preprocessor_flags_for_build_mode",
     "react_native_xplat_target",
     "rn_xplat_cxx_library",
     "subdir_glob",

--- a/ReactCommon/react/renderer/components/legacyviewmanagerinterop/BUCK
+++ b/ReactCommon/react/renderer/components/legacyviewmanagerinterop/BUCK
@@ -1,9 +1,9 @@
-load("@fbsource//tools/build_defs/apple:flag_defs.bzl", "get_preprocessor_flags_for_build_mode")
 load(
     "//tools/build_defs/oss:rn_defs.bzl",
     "APPLE",
     "get_apple_compiler_flags",
     "get_apple_inspector_flags",
+    "get_preprocessor_flags_for_build_mode",
     "react_native_xplat_target",
     "rn_xplat_cxx_library",
     "subdir_glob",

--- a/ReactCommon/react/renderer/components/modal/BUCK
+++ b/ReactCommon/react/renderer/components/modal/BUCK
@@ -1,4 +1,3 @@
-load("@fbsource//tools/build_defs/apple:flag_defs.bzl", "get_preprocessor_flags_for_build_mode")
 load(
     "//tools/build_defs/oss:rn_defs.bzl",
     "ANDROID",
@@ -7,6 +6,7 @@ load(
     "YOGA_CXX_TARGET",
     "get_apple_compiler_flags",
     "get_apple_inspector_flags",
+    "get_preprocessor_flags_for_build_mode",
     "react_native_xplat_target",
     "rn_xplat_cxx_library",
     "subdir_glob",

--- a/ReactCommon/react/renderer/components/picker/BUCK
+++ b/ReactCommon/react/renderer/components/picker/BUCK
@@ -1,4 +1,3 @@
-load("@fbsource//tools/build_defs/apple:flag_defs.bzl", "get_preprocessor_flags_for_build_mode")
 load(
     "//tools/build_defs/oss:rn_defs.bzl",
     "ANDROID",
@@ -8,6 +7,7 @@ load(
     "fb_xplat_cxx_test",
     "get_apple_compiler_flags",
     "get_apple_inspector_flags",
+    "get_preprocessor_flags_for_build_mode",
     "react_native_target",
     "react_native_xplat_target",
     "rn_xplat_cxx_library",

--- a/ReactCommon/react/renderer/components/picker/iospicker/BUCK
+++ b/ReactCommon/react/renderer/components/picker/iospicker/BUCK
@@ -1,4 +1,3 @@
-load("@fbsource//tools/build_defs/apple:flag_defs.bzl", "get_preprocessor_flags_for_build_mode")
 load(
     "//tools/build_defs/oss:rn_defs.bzl",
     "ANDROID",
@@ -7,6 +6,7 @@ load(
     "YOGA_CXX_TARGET",
     "get_apple_compiler_flags",
     "get_apple_inspector_flags",
+    "get_preprocessor_flags_for_build_mode",
     "react_native_xplat_target",
     "rn_xplat_cxx_library",
     "subdir_glob",

--- a/ReactCommon/react/renderer/components/progressbar/BUCK
+++ b/ReactCommon/react/renderer/components/progressbar/BUCK
@@ -1,4 +1,3 @@
-load("@fbsource//tools/build_defs/apple:flag_defs.bzl", "get_preprocessor_flags_for_build_mode")
 load(
     "//tools/build_defs/oss:rn_defs.bzl",
     "ANDROID",
@@ -8,6 +7,7 @@ load(
     "fb_xplat_cxx_test",
     "get_apple_compiler_flags",
     "get_apple_inspector_flags",
+    "get_preprocessor_flags_for_build_mode",
     "react_native_target",
     "react_native_xplat_target",
     "rn_xplat_cxx_library",

--- a/ReactCommon/react/renderer/components/root/BUCK
+++ b/ReactCommon/react/renderer/components/root/BUCK
@@ -1,4 +1,3 @@
-load("@fbsource//tools/build_defs/apple:flag_defs.bzl", "get_preprocessor_flags_for_build_mode")
 load(
     "//tools/build_defs/oss:rn_defs.bzl",
     "ANDROID",
@@ -8,6 +7,7 @@ load(
     "fb_xplat_cxx_test",
     "get_apple_compiler_flags",
     "get_apple_inspector_flags",
+    "get_preprocessor_flags_for_build_mode",
     "react_native_xplat_target",
     "rn_xplat_cxx_library",
     "subdir_glob",

--- a/ReactCommon/react/renderer/components/safeareaview/BUCK
+++ b/ReactCommon/react/renderer/components/safeareaview/BUCK
@@ -1,9 +1,9 @@
-load("@fbsource//tools/build_defs/apple:flag_defs.bzl", "get_preprocessor_flags_for_build_mode")
 load(
     "//tools/build_defs/oss:rn_defs.bzl",
     "APPLE",
     "get_apple_compiler_flags",
     "get_apple_inspector_flags",
+    "get_preprocessor_flags_for_build_mode",
     "react_native_xplat_target",
     "rn_xplat_cxx_library",
     "subdir_glob",

--- a/ReactCommon/react/renderer/components/scrollview/BUCK
+++ b/ReactCommon/react/renderer/components/scrollview/BUCK
@@ -1,4 +1,3 @@
-load("@fbsource//tools/build_defs/apple:flag_defs.bzl", "get_preprocessor_flags_for_build_mode")
 load(
     "//tools/build_defs/oss:rn_defs.bzl",
     "ANDROID",
@@ -8,6 +7,7 @@ load(
     "fb_xplat_cxx_test",
     "get_apple_compiler_flags",
     "get_apple_inspector_flags",
+    "get_preprocessor_flags_for_build_mode",
     "react_native_xplat_target",
     "rn_xplat_cxx_library",
     "subdir_glob",

--- a/ReactCommon/react/renderer/components/slider/BUCK
+++ b/ReactCommon/react/renderer/components/slider/BUCK
@@ -1,4 +1,3 @@
-load("@fbsource//tools/build_defs/apple:flag_defs.bzl", "get_preprocessor_flags_for_build_mode")
 load(
     "//tools/build_defs/oss:rn_defs.bzl",
     "ANDROID",
@@ -8,6 +7,7 @@ load(
     "fb_xplat_cxx_test",
     "get_apple_compiler_flags",
     "get_apple_inspector_flags",
+    "get_preprocessor_flags_for_build_mode",
     "react_native_target",
     "react_native_xplat_target",
     "rn_xplat_cxx_library",

--- a/ReactCommon/react/renderer/components/switch/BUCK
+++ b/ReactCommon/react/renderer/components/switch/BUCK
@@ -1,4 +1,3 @@
-load("@fbsource//tools/build_defs/apple:flag_defs.bzl", "get_preprocessor_flags_for_build_mode")
 load(
     "//tools/build_defs/oss:rn_defs.bzl",
     "ANDROID",
@@ -8,6 +7,7 @@ load(
     "fb_xplat_cxx_test",
     "get_apple_compiler_flags",
     "get_apple_inspector_flags",
+    "get_preprocessor_flags_for_build_mode",
     "react_native_target",
     "react_native_xplat_target",
     "rn_xplat_cxx_library",

--- a/ReactCommon/react/renderer/components/text/BUCK
+++ b/ReactCommon/react/renderer/components/text/BUCK
@@ -1,4 +1,3 @@
-load("@fbsource//tools/build_defs/apple:flag_defs.bzl", "get_preprocessor_flags_for_build_mode")
 load(
     "//tools/build_defs/oss:rn_defs.bzl",
     "ANDROID",
@@ -8,6 +7,7 @@ load(
     "fb_xplat_cxx_test",
     "get_apple_compiler_flags",
     "get_apple_inspector_flags",
+    "get_preprocessor_flags_for_build_mode",
     "react_native_xplat_target",
     "rn_xplat_cxx_library",
     "subdir_glob",

--- a/ReactCommon/react/renderer/components/textinput/BUCK
+++ b/ReactCommon/react/renderer/components/textinput/BUCK
@@ -1,4 +1,3 @@
-load("@fbsource//tools/build_defs/apple:flag_defs.bzl", "get_preprocessor_flags_for_build_mode")
 load(
     "//tools/build_defs/oss:rn_defs.bzl",
     "ANDROID",
@@ -8,6 +7,7 @@ load(
     "fb_xplat_cxx_test",
     "get_apple_compiler_flags",
     "get_apple_inspector_flags",
+    "get_preprocessor_flags_for_build_mode",
     "react_native_xplat_target",
     "rn_xplat_cxx_library",
     "subdir_glob",

--- a/ReactCommon/react/renderer/components/textinput/iostextinput/BUCK
+++ b/ReactCommon/react/renderer/components/textinput/iostextinput/BUCK
@@ -1,4 +1,3 @@
-load("@fbsource//tools/build_defs/apple:flag_defs.bzl", "get_preprocessor_flags_for_build_mode")
 load(
     "//tools/build_defs/oss:rn_defs.bzl",
     "ANDROID",
@@ -8,6 +7,7 @@ load(
     "fb_xplat_cxx_test",
     "get_apple_compiler_flags",
     "get_apple_inspector_flags",
+    "get_preprocessor_flags_for_build_mode",
     "react_native_xplat_target",
     "rn_xplat_cxx_library",
     "subdir_glob",

--- a/ReactCommon/react/renderer/components/unimplementedview/BUCK
+++ b/ReactCommon/react/renderer/components/unimplementedview/BUCK
@@ -1,4 +1,3 @@
-load("@fbsource//tools/build_defs/apple:flag_defs.bzl", "get_preprocessor_flags_for_build_mode")
 load(
     "//tools/build_defs/oss:rn_defs.bzl",
     "ANDROID",
@@ -8,6 +7,7 @@ load(
     "fb_xplat_cxx_test",
     "get_apple_compiler_flags",
     "get_apple_inspector_flags",
+    "get_preprocessor_flags_for_build_mode",
     "react_native_xplat_target",
     "rn_xplat_cxx_library",
     "subdir_glob",

--- a/ReactCommon/react/renderer/components/view/BUCK
+++ b/ReactCommon/react/renderer/components/view/BUCK
@@ -1,4 +1,3 @@
-load("@fbsource//tools/build_defs/apple:flag_defs.bzl", "get_preprocessor_flags_for_build_mode")
 load(
     "//tools/build_defs/oss:rn_defs.bzl",
     "ANDROID",
@@ -8,6 +7,7 @@ load(
     "fb_xplat_cxx_test",
     "get_apple_compiler_flags",
     "get_apple_inspector_flags",
+    "get_preprocessor_flags_for_build_mode",
     "react_native_xplat_target",
     "rn_xplat_cxx_library",
     "subdir_glob",

--- a/ReactCommon/react/renderer/core/BUCK
+++ b/ReactCommon/react/renderer/core/BUCK
@@ -1,5 +1,4 @@
 load("@fbsource//tools/build_defs:fb_xplat_cxx_binary.bzl", "fb_xplat_cxx_binary")
-load("@fbsource//tools/build_defs/apple:flag_defs.bzl", "get_preprocessor_flags_for_build_mode")
 load(
     "//tools/build_defs/oss:rn_defs.bzl",
     "ANDROID",
@@ -8,6 +7,7 @@ load(
     "fb_xplat_cxx_test",
     "get_apple_compiler_flags",
     "get_apple_inspector_flags",
+    "get_preprocessor_flags_for_build_mode",
     "react_native_xplat_target",
     "rn_xplat_cxx_library",
     "subdir_glob",

--- a/ReactCommon/react/renderer/debug/BUCK
+++ b/ReactCommon/react/renderer/debug/BUCK
@@ -1,15 +1,12 @@
 load("@fbsource//tools/build_defs:platform_defs.bzl", "CXX")
 load(
-    "@fbsource//tools/build_defs/apple:flag_defs.bzl",
-    "get_preprocessor_flags_for_build_mode",
-)
-load(
     "//tools/build_defs/oss:rn_defs.bzl",
     "ANDROID",
     "APPLE",
     "fb_xplat_cxx_test",
     "get_apple_compiler_flags",
     "get_apple_inspector_flags",
+    "get_preprocessor_flags_for_build_mode",
     "react_native_xplat_target",
     "rn_xplat_cxx_library",
     "subdir_glob",

--- a/ReactCommon/react/renderer/element/BUCK
+++ b/ReactCommon/react/renderer/element/BUCK
@@ -1,4 +1,3 @@
-load("@fbsource//tools/build_defs/apple:flag_defs.bzl", "get_preprocessor_flags_for_build_mode")
 load(
     "//tools/build_defs/oss:rn_defs.bzl",
     "ANDROID",
@@ -7,6 +6,7 @@ load(
     "fb_xplat_cxx_test",
     "get_apple_compiler_flags",
     "get_apple_inspector_flags",
+    "get_preprocessor_flags_for_build_mode",
     "react_native_xplat_target",
     "rn_xplat_cxx_library",
     "subdir_glob",

--- a/ReactCommon/react/renderer/graphics/BUCK
+++ b/ReactCommon/react/renderer/graphics/BUCK
@@ -1,4 +1,3 @@
-load("@fbsource//tools/build_defs/apple:flag_defs.bzl", "get_preprocessor_flags_for_build_mode")
 load(
     "//tools/build_defs/oss:rn_defs.bzl",
     "ANDROID",
@@ -7,6 +6,7 @@ load(
     "fb_xplat_cxx_test",
     "get_apple_compiler_flags",
     "get_apple_inspector_flags",
+    "get_preprocessor_flags_for_build_mode",
     "react_native_xplat_target",
     "rn_xplat_cxx_library",
     "subdir_glob",

--- a/ReactCommon/react/renderer/imagemanager/BUCK
+++ b/ReactCommon/react/renderer/imagemanager/BUCK
@@ -1,4 +1,3 @@
-load("@fbsource//tools/build_defs/apple:flag_defs.bzl", "get_preprocessor_flags_for_build_mode")
 load(
     "//tools/build_defs/oss:rn_defs.bzl",
     "ANDROID",
@@ -8,6 +7,7 @@ load(
     "fb_xplat_cxx_test",
     "get_apple_compiler_flags",
     "get_apple_inspector_flags",
+    "get_preprocessor_flags_for_build_mode",
     "react_native_xplat_target",
     "rn_xplat_cxx_library",
     "subdir_glob",

--- a/ReactCommon/react/renderer/mounting/BUCK
+++ b/ReactCommon/react/renderer/mounting/BUCK
@@ -1,4 +1,3 @@
-load("@fbsource//tools/build_defs/apple:flag_defs.bzl", "get_preprocessor_flags_for_build_mode")
 load(
     "//tools/build_defs/oss:rn_defs.bzl",
     "ANDROID",
@@ -7,6 +6,7 @@ load(
     "fb_xplat_cxx_test",
     "get_apple_compiler_flags",
     "get_apple_inspector_flags",
+    "get_preprocessor_flags_for_build_mode",
     "react_native_xplat_target",
     "rn_xplat_cxx_library",
     "subdir_glob",

--- a/ReactCommon/react/renderer/scheduler/BUCK
+++ b/ReactCommon/react/renderer/scheduler/BUCK
@@ -1,4 +1,3 @@
-load("@fbsource//tools/build_defs/apple:flag_defs.bzl", "get_preprocessor_flags_for_build_mode")
 load(
     "//tools/build_defs/oss:rn_defs.bzl",
     "ANDROID",
@@ -6,6 +5,7 @@ load(
     "CXX",
     "get_apple_compiler_flags",
     "get_apple_inspector_flags",
+    "get_preprocessor_flags_for_build_mode",
     "react_native_xplat_target",
     "rn_xplat_cxx_library",
     "subdir_glob",

--- a/ReactCommon/react/renderer/templateprocessor/BUCK
+++ b/ReactCommon/react/renderer/templateprocessor/BUCK
@@ -1,4 +1,3 @@
-load("@fbsource//tools/build_defs/apple:flag_defs.bzl", "get_preprocessor_flags_for_build_mode")
 load(
     "//tools/build_defs/oss:rn_defs.bzl",
     "ANDROID",
@@ -7,6 +6,7 @@ load(
     "fb_xplat_cxx_test",
     "get_apple_compiler_flags",
     "get_apple_inspector_flags",
+    "get_preprocessor_flags_for_build_mode",
     "react_native_xplat_target",
     "rn_xplat_cxx_library",
     "subdir_glob",

--- a/ReactCommon/react/renderer/textlayoutmanager/BUCK
+++ b/ReactCommon/react/renderer/textlayoutmanager/BUCK
@@ -1,4 +1,3 @@
-load("@fbsource//tools/build_defs/apple:flag_defs.bzl", "get_preprocessor_flags_for_build_mode")
 load(
     "//tools/build_defs/oss:rn_defs.bzl",
     "ANDROID",
@@ -8,6 +7,7 @@ load(
     "fb_xplat_cxx_test",
     "get_apple_compiler_flags",
     "get_apple_inspector_flags",
+    "get_preprocessor_flags_for_build_mode",
     "react_native_target",
     "react_native_xplat_target",
     "rn_xplat_cxx_library",

--- a/ReactCommon/react/renderer/uimanager/BUCK
+++ b/ReactCommon/react/renderer/uimanager/BUCK
@@ -1,4 +1,3 @@
-load("@fbsource//tools/build_defs/apple:flag_defs.bzl", "get_preprocessor_flags_for_build_mode")
 load(
     "//tools/build_defs/oss:rn_defs.bzl",
     "ANDROID",
@@ -7,6 +6,7 @@ load(
     "fb_xplat_cxx_test",
     "get_apple_compiler_flags",
     "get_apple_inspector_flags",
+    "get_preprocessor_flags_for_build_mode",
     "react_native_xplat_target",
     "rn_xplat_cxx_library",
     "subdir_glob",

--- a/ReactCommon/react/utils/BUCK
+++ b/ReactCommon/react/utils/BUCK
@@ -1,4 +1,3 @@
-load("@fbsource//tools/build_defs/apple:flag_defs.bzl", "get_preprocessor_flags_for_build_mode")
 load(
     "//tools/build_defs/oss:rn_defs.bzl",
     "ANDROID",
@@ -6,6 +5,7 @@ load(
     "CXX",
     "get_apple_compiler_flags",
     "get_apple_inspector_flags",
+    "get_preprocessor_flags_for_build_mode",
     "react_native_xplat_target",
     "rn_xplat_cxx_library",
     "subdir_glob",

--- a/ReactCommon/runtimeexecutor/BUCK
+++ b/ReactCommon/runtimeexecutor/BUCK
@@ -1,4 +1,3 @@
-load("@fbsource//tools/build_defs/apple:flag_defs.bzl", "get_preprocessor_flags_for_build_mode")
 load(
     "//tools/build_defs/oss:rn_defs.bzl",
     "ANDROID",
@@ -6,6 +5,7 @@ load(
     "CXX",
     "get_apple_compiler_flags",
     "get_apple_inspector_flags",
+    "get_preprocessor_flags_for_build_mode",
     "rn_xplat_cxx_library",
 )
 

--- a/tools/build_defs/oss/rn_defs.bzl
+++ b/tools/build_defs/oss/rn_defs.bzl
@@ -24,11 +24,12 @@ def get_preprocessor_flags_for_build_mode():
 def get_static_library_ios_flags():
     return _APPLE_COMPILER_FLAGS
 
-OBJC_ARC_PREPROCESSOR_FLAGS = [
-    "-fobjc-arc",
-    "-fno-objc-arc-exceptions",
-    "-Qunused-arguments",
-]
+def get_objc_arc_preprocessor_flags():
+    return [
+        "-fobjc-arc",
+        "-fno-objc-arc-exceptions",
+        "-Qunused-arguments",
+    ]
 
 IS_OSS_BUILD = True
 


### PR DESCRIPTION
Summary:
We still have usages of "fbsource//tools/build_defs/apple:flag_defs.bzl" in react-native-github. But this should get us closer towards not using the fbsource cell. Hopefully, this is enough to unbreak the  test_docker CircleCI build.

Changelog: [Internal]

Reviewed By: fkgozali

Differential Revision: D26289304

