### PR TITLE
chore: fix warning comments of deprecated modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -159,7 +159,7 @@ module.exports = {
       'maskedviewios-moved',
       'MaskedViewIOS has been extracted from react-native core and will be removed in a future release. ' +
         "It can now be installed and imported from '@react-native-masked-view/masked-view' instead of 'react-native'. " +
-        'See https://github.com/react-native-masked-view/react-native-masked-view',
+        'See https://github.com/react-native-masked-view/masked-view',
     );
     return require('./Libraries/Components/MaskedView/MaskedViewIOS');
   },
@@ -171,7 +171,7 @@ module.exports = {
       'picker-moved',
       'Picker has been extracted from react-native core and will be removed in a future release. ' +
         "It can now be installed and imported from '@react-native-picker/picker' instead of 'react-native'. " +
-        'See https://github.com/react-native-picker/react-native-picker',
+        'See https://github.com/react-native-picker/picker',
     );
     return require('./Libraries/Components/Picker/Picker');
   },
@@ -181,7 +181,7 @@ module.exports = {
       'pickerios-moved',
       'PickerIOS has been extracted from react-native core and will be removed in a future release. ' +
         "It can now be installed and imported from '@react-native-picker/picker' instead of 'react-native'. " +
-        'See https://github.com/react-native-picker/react-native-picker',
+        'See https://github.com/react-native-picker/picker',
     );
     return require('./Libraries/Components/Picker/PickerIOS');
   },
@@ -225,7 +225,7 @@ module.exports = {
     warnOnce(
       'segmented-control-ios-moved',
       'SegmentedControlIOS has been extracted from react-native core and will be removed in a future release. ' +
-        "It can now be installed and imported from '@react-native-community/segmented-control' instead of 'react-native'. " +
+        "It can now be installed and imported from '@react-native-segmented-control/segmented-control' instead of 'react-native'. " +
         'See https://github.com/react-native-segmented-control/segmented-control',
     );
     return require('./Libraries/Components/SegmentedControlIOS/SegmentedControlIOS');
@@ -312,7 +312,7 @@ module.exports = {
     warnOnce(
       'clipboard-moved',
       'Clipboard has been extracted from react-native core and will be removed in a future release. ' +
-        "It can now be installed and imported from '@react-native-community/clipboard' instead of 'react-native'. " +
+        "It can now be installed and imported from '@react-native-clipboard/clipboard' instead of 'react-native'. " +
         'See https://github.com/react-native-clipboard/clipboard',
     );
     return require('./Libraries/Components/Clipboard/Clipboard');


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Updated some warning messages that shows up when importing deprecated modules to have the updated name space.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Changed] - Update package name warning of deprecated modules 

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
Updated link works as expected
