### PR TITLE
Add getLong method on ReadableMap interface and respective necessary implementations

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaOnlyMap.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaOnlyMap.java
@@ -102,6 +102,11 @@ public class JavaOnlyMap implements ReadableMap, WritableMap {
   }
 
   @Override
+  public long getLong(@NonNull String name) {
+    return ((Number) mBackingMap.get(name)).longValue();
+  }
+
+  @Override
   public int getInt(@NonNull String name) {
     return ((Number) mBackingMap.get(name)).intValue();
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableMap.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableMap.java
@@ -27,6 +27,8 @@ public interface ReadableMap {
 
   double getDouble(@NonNull String name);
 
+  long getLong(@NonNull String name);
+
   int getInt(@NonNull String name);
 
   @Nullable

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableNativeMap.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableNativeMap.java
@@ -152,6 +152,11 @@ public class ReadableNativeMap extends NativeMap implements ReadableMap {
   }
 
   @Override
+  public long getLong(@NonNull String name) {
+    return getValue(name, Long.class).longValue();
+  }
+
+  @Override
   public int getInt(@NonNull String name) {
     // All numbers coming out of native are doubles, so cast here then truncate
     return getValue(name, Double.class).intValue();


### PR DESCRIPTION
## Summary

While implementing the integration with Zendesk SDK, I had to get the fields' ids as double values and cast to long, this process is not good for the performance and code clearness.

So the code that looked like this:

```java
private long getFieldId(ReadableMap map, String fieldName) {
  Double fieldIdDouble = map.getDouble(fieldName);
  long fieldId;

  try {
    fieldId = (long) fieldIdDouble;
  } catch(Exception err) {
    String errMessage = String.format(
      "There was an error while trying to get field %s id!",
      name,
      err.getMessage()
    );

    Log.e(TAG, errMessage);
  } 

  return fieldId;
}
```

Will look like this:

```java
private long getFieldId(ReadableMap map, String fieldName) {
  return map.getLong(fieldName);
}
```



## Changelog

[Android] [Added] - Add getLong method in ReadableMap interface
[Android] [Added] - Add getLong method implementation on JavaOnlyMap class
[Android] [Added] - Add getLong method implementation on ReadableNativeMap class

## Test Plan

I just followed the implementation pattern for double but using the Long class

For ReadableNativeMap you can check the documentation below:
https://developer.android.com/reference/java/lang/Long#longValue()

For JavaOnlyMap you can check the documentation below:
https://developer.android.com/reference/java/lang/Number#longValue()
