### PR TITLE
compute correct Keyboard Height with Notch

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -776,9 +776,9 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
         }
       }
       final int heightDiff =
-        DisplayMetricsHolder.getWindowDisplayMetrics().heightPixels
-          - mVisibleViewArea.bottom
-          + notchHeight;
+          DisplayMetricsHolder.getWindowDisplayMetrics().heightPixels
+            - mVisibleViewArea.bottom
+            + notchHeight;
 
       boolean isKeyboardShowingOrKeyboardHeightChanged =
           mKeyboardHeight != heightDiff && heightDiff > mMinKeyboardHeightDetected;

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -19,6 +19,7 @@ import android.graphics.Rect;
 import android.os.Build;
 import android.os.Bundle;
 import android.util.AttributeSet;
+import android.view.DisplayCutout;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.Surface;
@@ -26,7 +27,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewTreeObserver;
 import android.view.WindowManager;
-import android.view.DisplayCutout;
 import android.widget.FrameLayout;
 import androidx.annotation.Nullable;
 import com.facebook.common.logging.FLog;
@@ -774,7 +774,9 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
         if (displayCutout != null)  notchHeight = displayCutout.getSafeInsetTop();
       }
       final int heightDiff =
-          DisplayMetricsHolder.getWindowDisplayMetrics().heightPixels - mVisibleViewArea.bottom + notchHeight;
+          DisplayMetricsHolder.getWindowDisplayMetrics().heightPixels
+              - mVisibleViewArea.bottom
+              + notchHeight;
 
       boolean isKeyboardShowingOrKeyboardHeightChanged =
           mKeyboardHeight != heightDiff && heightDiff > mMinKeyboardHeightDetected;

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -25,6 +25,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewTreeObserver;
 import android.view.WindowManager;
+import android.view.DisplayCutout;
 import android.widget.FrameLayout;
 import androidx.annotation.Nullable;
 import com.facebook.common.logging.FLog;
@@ -766,8 +767,10 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
 
     private void checkForKeyboardEvents() {
       getRootView().getWindowVisibleDisplayFrame(mVisibleViewArea);
+      DisplayCutout displayCutout = getRootView().getRootWindowInsets().getDisplayCutout();
+      int notchHeight = displayCutout == null ? 0 : displayCutout.getSafeInsetTop();
       final int heightDiff =
-          DisplayMetricsHolder.getWindowDisplayMetrics().heightPixels - mVisibleViewArea.bottom;
+          DisplayMetricsHolder.getWindowDisplayMetrics().heightPixels - mVisibleViewArea.bottom + notchHeight;
 
       boolean isKeyboardShowingOrKeyboardHeightChanged =
           mKeyboardHeight != heightDiff && heightDiff > mMinKeyboardHeightDetected;

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -649,6 +649,11 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
     mJSTouchDispatcher = new JSTouchDispatcher(this);
   }
 
+  @VisibleForTesting
+  /* package */ void simulateCheckForKeyboardForTesting() {
+    getCustomGlobalLayoutListener().checkForKeyboardEvents();
+  }
+
   private CustomGlobalLayoutListener getCustomGlobalLayoutListener() {
     if (mCustomGlobalLayoutListener == null) {
       mCustomGlobalLayoutListener = new CustomGlobalLayoutListener();

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -777,8 +777,8 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
       }
       final int heightDiff =
           DisplayMetricsHolder.getWindowDisplayMetrics().heightPixels
-            - mVisibleViewArea.bottom
-            + notchHeight;
+              - mVisibleViewArea.bottom
+              + notchHeight;
 
       boolean isKeyboardShowingOrKeyboardHeightChanged =
           mKeyboardHeight != heightDiff && heightDiff > mMinKeyboardHeightDetected;

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -16,6 +16,7 @@ import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Point;
 import android.graphics.Rect;
+import android.os.Build;
 import android.os.Bundle;
 import android.util.AttributeSet;
 import android.view.KeyEvent;
@@ -767,8 +768,11 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
 
     private void checkForKeyboardEvents() {
       getRootView().getWindowVisibleDisplayFrame(mVisibleViewArea);
-      DisplayCutout displayCutout = getRootView().getRootWindowInsets().getDisplayCutout();
-      int notchHeight = displayCutout == null ? 0 : displayCutout.getSafeInsetTop();
+      int notchHeight = 0;
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+        DisplayCutout displayCutout = getRootView().getRootWindowInsets().getDisplayCutout();
+        if (displayCutout != null)  notchHeight = displayCutout.getSafeInsetTop();
+      }
       final int heightDiff =
           DisplayMetricsHolder.getWindowDisplayMetrics().heightPixels - mVisibleViewArea.bottom + notchHeight;
 

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -771,12 +771,14 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
       int notchHeight = 0;
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
         DisplayCutout displayCutout = getRootView().getRootWindowInsets().getDisplayCutout();
-        if (displayCutout != null)  notchHeight = displayCutout.getSafeInsetTop();
+        if (displayCutout != null) {
+          notchHeight = displayCutout.getSafeInsetTop();
+        }
       }
       final int heightDiff =
-          DisplayMetricsHolder.getWindowDisplayMetrics().heightPixels
-              - mVisibleViewArea.bottom
-              + notchHeight;
+        DisplayMetricsHolder.getWindowDisplayMetrics().heightPixels
+          - mVisibleViewArea.bottom
+          + notchHeight;
 
       boolean isKeyboardShowingOrKeyboardHeightChanged =
           mKeyboardHeight != heightDiff && heightDiff > mMinKeyboardHeightDetected;

--- a/ReactAndroid/src/test/java/com/facebook/react/RootViewTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/RootViewTest.java
@@ -26,6 +26,7 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReactTestHelper;
 import com.facebook.react.bridge.WritableArray;
+import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.common.SystemClock;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.facebook.react.uimanager.DisplayMetricsHolder;
@@ -214,7 +215,7 @@ public class RootViewTest {
   }
 
   @Test
-  public void testCheckForKeyboardEvents() {
+  public void testCheckForKeyboardDidShow() {
     ReactInstanceManager instanceManager = mock(ReactInstanceManager.class);
     when(instanceManager.getCurrentReactContext()).thenReturn(mReactContext);
     UIManagerModule uiManager = mock(UIManagerModule.class);
@@ -240,6 +241,15 @@ public class RootViewTest {
     rootView.startReactApplication(instanceManager, "");
     rootView.simulateAttachForTesting();
     rootView.simulateCheckForKeyboardForTesting();
-    verify(instanceManager, Mockito.times(1)).getCurrentReactContext();
+    WritableMap params = Arguments.createMap();
+    WritableMap endCoordinates = Arguments.createMap();
+    params.putDouble("duration", 0.0);
+    endCoordinates.putDouble("width", 0.0);
+    endCoordinates.putDouble("screenX", 0.0);
+    endCoordinates.putDouble("height", 370.0);
+    endCoordinates.putDouble("screenY", 100.0);
+    params.putMap("endCoordinates", endCoordinates);
+    params.putString("easing", "keyboard");
+    verify(eventEmitterModuleMock, Mockito.times(1)).emit("keyboardDidShow", params);
   }
 }

--- a/ReactAndroid/src/test/java/com/facebook/react/RootViewTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/RootViewTest.java
@@ -7,10 +7,19 @@
 
 package com.facebook.react;
 
+import com.facebook.react.uimanager.ReactRoot;
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.modules.core.DeviceEventManagerModule;
+import com.facebook.react.bridge.WritableMap;
+import android.util.Log;
+import android.graphics.Rect;
+
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
+import org.mockito.Mockito;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -208,5 +217,32 @@ public class RootViewTest {
     rootView.startReactApplication(instanceManager, "");
     rootView.unmountReactApplication();
     rootView.startReactApplication(instanceManager, "");
+  }
+
+  @Test
+  public void testCheckForKeyboardEvents() {
+    ReactInstanceManager instanceManager = mock(ReactInstanceManager.class);
+    when(instanceManager.getCurrentReactContext()).thenReturn(mReactContext);
+    UIManagerModule uiManager = mock(UIManagerModule.class);
+    EventDispatcher eventDispatcher = mock(EventDispatcher.class);
+    DeviceEventManagerModule.RCTDeviceEventEmitter eventEmitterModuleMock = mock(DeviceEventManagerModule.RCTDeviceEventEmitter.class);
+    when(mReactContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)).thenReturn(eventEmitterModuleMock);
+    when(mCatalystInstanceMock.getNativeModule(UIManagerModule.class)).thenReturn(uiManager);
+    when(uiManager.getEventDispatcher()).thenReturn(eventDispatcher);
+
+    int rootViewId = 7;
+
+    ReactRootView rootView = new ReactRootView(mReactContext) {
+      @Override
+      public void getWindowVisibleDisplayFrame(Rect outRect) {
+        outRect.bottom += 100;
+      }
+    };
+    rootView.setId(rootViewId);
+    rootView.setRootViewTag(rootViewId);
+    rootView.startReactApplication(instanceManager, "");
+    rootView.simulateAttachForTesting();
+    rootView.getCustomGlobalLayoutListener().checkForKeyboardEvents();
+    verify(instanceManager, Mockito.times(2)).getCurrentReactContext();
   }
 }

--- a/ReactAndroid/src/test/java/com/facebook/react/RootViewTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/RootViewTest.java
@@ -217,17 +217,10 @@ public class RootViewTest {
   @Test
   public void testCheckForKeyboardEvents() {
     ReactInstanceManager instanceManager = mock(ReactInstanceManager.class);
-    when(instanceManager.getCurrentReactContext()).thenReturn(mReactContext);
-
-    UIManagerModule uiManager = mock(UIManagerModule.class);
-    EventDispatcher eventDispatcher = mock(EventDispatcher.class);
     RCTDeviceEventEmitter eventEmitterModuleMock = mock(RCTDeviceEventEmitter.class);
 
+    when(instanceManager.getCurrentReactContext()).thenReturn(mReactContext);
     when(mReactContext.getJSModule(RCTDeviceEventEmitter.class)).thenReturn(eventEmitterModuleMock);
-    when(mCatalystInstanceMock.getNativeModule(UIManagerModule.class)).thenReturn(uiManager);
-    when(uiManager.getEventDispatcher()).thenReturn(eventDispatcher);
-
-    int rootViewId = 7;
 
     ReactRootView rootView =
         new ReactRootView(mReactContext) {
@@ -242,19 +235,18 @@ public class RootViewTest {
           }
         };
 
-    rootView.setId(rootViewId);
-    rootView.setRootViewTag(rootViewId);
     rootView.startReactApplication(instanceManager, "");
-    rootView.simulateAttachForTesting();
     rootView.simulateCheckForKeyboardForTesting();
 
     WritableMap params = Arguments.createMap();
     WritableMap endCoordinates = Arguments.createMap();
+    double screenHeight = 470.0;
+    double keyboardHeight = 100.0;
     params.putDouble("duration", 0.0);
-    endCoordinates.putDouble("width", 370.0);
+    endCoordinates.putDouble("width", screenHeight - keyboardHeight);
     endCoordinates.putDouble("screenX", 0.0);
-    endCoordinates.putDouble("height", 370.0);
-    endCoordinates.putDouble("screenY", 100.0);
+    endCoordinates.putDouble("height", screenHeight - keyboardHeight);
+    endCoordinates.putDouble("screenY", keyboardHeight);
     params.putMap("endCoordinates", endCoordinates);
     params.putString("easing", "keyboard");
 

--- a/ReactAndroid/src/test/java/com/facebook/react/RootViewTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/RootViewTest.java
@@ -7,24 +7,16 @@
 
 package com.facebook.react;
 
-import com.facebook.react.uimanager.ReactRoot;
-import com.facebook.react.bridge.Arguments;
-import com.facebook.react.modules.core.DeviceEventManagerModule;
-import com.facebook.react.bridge.WritableMap;
-import android.util.Log;
-import android.graphics.Rect;
-
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
-import org.mockito.Mockito;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import android.graphics.Rect;
 import android.view.MotionEvent;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.CatalystInstance;
@@ -35,6 +27,7 @@ import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReactTestHelper;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.common.SystemClock;
+import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.facebook.react.uimanager.DisplayMetricsHolder;
 import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.events.Event;
@@ -46,6 +39,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.powermock.api.mockito.PowerMockito;
@@ -225,24 +219,27 @@ public class RootViewTest {
     when(instanceManager.getCurrentReactContext()).thenReturn(mReactContext);
     UIManagerModule uiManager = mock(UIManagerModule.class);
     EventDispatcher eventDispatcher = mock(EventDispatcher.class);
-    DeviceEventManagerModule.RCTDeviceEventEmitter eventEmitterModuleMock = mock(DeviceEventManagerModule.RCTDeviceEventEmitter.class);
-    when(mReactContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)).thenReturn(eventEmitterModuleMock);
+    DeviceEventManagerModule.RCTDeviceEventEmitter eventEmitterModuleMock =
+        mock(DeviceEventManagerModule.RCTDeviceEventEmitter.class);
+    when(mReactContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class))
+        .thenReturn(eventEmitterModuleMock);
     when(mCatalystInstanceMock.getNativeModule(UIManagerModule.class)).thenReturn(uiManager);
     when(uiManager.getEventDispatcher()).thenReturn(eventDispatcher);
 
     int rootViewId = 7;
 
-    ReactRootView rootView = new ReactRootView(mReactContext) {
-      @Override
-      public void getWindowVisibleDisplayFrame(Rect outRect) {
-        outRect.bottom += 100;
-      }
-    };
+    ReactRootView rootView =
+        new ReactRootView(mReactContext) {
+          @Override
+          public void getWindowVisibleDisplayFrame(Rect outRect) {
+            outRect.bottom += 100;
+          }
+        };
     rootView.setId(rootViewId);
     rootView.setRootViewTag(rootViewId);
     rootView.startReactApplication(instanceManager, "");
     rootView.simulateAttachForTesting();
-    rootView.getCustomGlobalLayoutListener().checkForKeyboardEvents();
-    verify(instanceManager, Mockito.times(2)).getCurrentReactContext();
+    rootView.simulateCheckForKeyboardForTesting();
+    verify(instanceManager, Mockito.times(1)).getCurrentReactContext();
   }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

fixes https://github.com/facebook/react-native/issues/27089 fixes https://github.com/facebook/react-native/issues/30191 fixes https://github.com/facebook/react-native/issues/26296 fixes https://github.com/facebook/react-native/issues/24353
Related https://github.com/facebook/react-native/issues/30052 https://github.com/facebook/react-native/issues/28004 https://github.com/facebook/react-native/issues/26536

The keyboard height of event keyboardDidShow is computed as the difference of two variables:

- The screen height excluding the Android Notch
DisplayMetricsHolder.getWindowDisplayMetrics().heightPixels returns the screen height excluding the Android Notch
- The Visible Area excluding the Keyboard, but including the Android Notch
getWindowVisibleDisplayFrame() which returns the visible area including the Android Notch

The computation of the keyboard height is wrong when the device has an Android Notch.
This pr adds the Android Notch computation for API levels 28+

More info at https://github.com/facebook/react-native/issues/27089#issuecomment-775821333

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Fixed] - Compute Android Notch in keyboardDidShow height calculation API 28+

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

adding a ReactRootViewTest for keyboardDidShow verifying correct functionality on API < 28

**<details><summary>TEST CASE - BEFORE FIX</summary>**
<p>

**WITHOUT NOTCH** 
- The black view on the bottom is visible
- The keyboard height is 282

| **Full Screen** | **Keyboard Did Show** | 
|:-------------------------:|:-------------------------:|
| <img src="https://user-images.githubusercontent.com/24992535/107212700-a1fd9d00-6a07-11eb-9248-26f9c4d92ae3.png" width="300" height="" /> | <img src="https://user-images.githubusercontent.com/24992535/107212590-7975a300-6a07-11eb-89f4-891a37a7c406.png"  width="300" height="" /> |

**WITH NOTCH**
- The black view on the bottom is **not** visible. The black view is not visible because keyboardDidHide is sending the wrong keyboard height value.
- The keyboard height changes to 234. The keyboard height is the same from the previous test, but the value sent from keyboardDidHide changed for the Notch.

| **Full Screen** | **Keyboard Did Show** | 
|:-------------------------:|:-------------------------:|
| <img src="https://user-images.githubusercontent.com/24992535/107212619-81cdde00-6a07-11eb-9630-7e7c8c34d798.png" width="300" height="" /> | <img src="https://user-images.githubusercontent.com/24992535/107212707-a4f88d80-6a07-11eb-9134-f077059c83a6.png"  width="300" height="" /> |

</p>
</details>

**<details><summary>TEST CASE - AFTER FIX</summary>**
<p>

**WITH NOTCH**
- The black view on the bottom is visible
- The keyboard height is 282

| **Full Screen** | **Keyboard Did Show** | 
|:-------------------------:|:-------------------------:|
| <img src="https://user-images.githubusercontent.com/24992535/107212619-81cdde00-6a07-11eb-9630-7e7c8c34d798.png" width="300" height="" /> | <img src="https://user-images.githubusercontent.com/24992535/107349053-0d0ea880-6ac8-11eb-9695-33128080b6b8.png"  width="300" height="" /> |

</p>
</details>
