### PR TITLE
[CI] fix test_android RootViewTest after latest refactor

### DIFF
--- a/ReactAndroid/src/test/java/com/facebook/react/RootViewTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/RootViewTest.java
@@ -149,6 +149,8 @@ public class RootViewTest {
                 "timestamp",
                 (double) ts,
                 "identifier",
+                0.,
+                "targetSurface",
                 0.));
 
     // Test ACTION_UP event
@@ -185,6 +187,8 @@ public class RootViewTest {
                 "timestamp",
                 (double) ts,
                 "identifier",
+                0.,
+                "targetSurface",
                 0.));
 
     // Test other action


### PR DESCRIPTION
## Summary

This small PR fixes the `RootViewTest` failing on the CI:
* https://app.circleci.com/pipelines/github/facebook/react-native/8048/workflows/452151df-9700-4cb8-9654-b5afbba03a56/jobs/188238/steps,
* https://app.circleci.com/pipelines/github/facebook/react-native/8014/workflows/41b14ece-3fb9-44da-b8e5-320845c5dbe9/jobs/187824/steps.

The test started to fail after latest `EventEmitters` refactor, which took place in this commit:
* https://github.com/facebook/react-native/commit/708038d80ed5793ae97bc49802bffef23df72bc3#diff-96085f5785576d57cbb29894083a9d82a4352bc05d435f46e7d9c58cbaf0ce8b

The reason for fail is that the change has introduced new `targetSurface` field, which was not added to the touch arguments map dump in the test.

CC: @JoshuaGross

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Fixed] - fix RootViewTest after targetSurface addition

## Test Plan

CI run which should not fail at "Run Tests: Android Unit Tests" step in `test_android` pipeline.