### PR TITLE
Restore refresh spinner fix

### DIFF
--- a/React/Views/RefreshControl/RCTRefreshControl.m
+++ b/React/Views/RefreshControl/RCTRefreshControl.m
@@ -41,24 +41,17 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)aDecoder)
 {
   [super layoutSubviews];
 
+  // Fix for bug #7976
+  if (self.backgroundColor == nil) {
+    self.backgroundColor = [UIColor clearColor];
+  }
+  
   // If the control is refreshing when mounted we need to call
   // beginRefreshing in layoutSubview or it doesn't work.
   if (_currentRefreshingState && _isInitialRender) {
     [self beginRefreshingProgrammatically];
   }
   _isInitialRender = false;
-}
-
-- (void)didMoveToWindow
-{
-  [super didMoveToWindow];
-
-  // Since iOS 14 there seems to be a bug where refresh control becomes
-  // visible if the view gets removed from window then added back again.
-  // Calling endRefreshing fixes the layout.
-  if (!_currentRefreshingState) {
-    [super endRefreshing];
-  }
 }
 
 - (void)beginRefreshingProgrammatically


### PR DESCRIPTION
Fixes #30912
Reverts #31024 which did not fix the issue

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

This fix was removed in #28236, however it caused bug #7976 to resurface, as reported in #30912

## Test Plan

This code had been present for quite some time before being removed in #28236

## Changelog

[Internal] [fixed] - regression with refresh control