### PR TITLE
Improving feedback for "Text strings must be rendered within a <Text> component." errors.

### DIFF
--- a/Libraries/Renderer/implementations/ReactFabric-dev.fb.js
+++ b/Libraries/Renderer/implementations/ReactFabric-dev.fb.js
@@ -21,6 +21,7 @@ require("react-native/Libraries/ReactPrivate/ReactNativePrivateInitializeCore");
 var ReactNativePrivateInterface = require("react-native/Libraries/ReactPrivate/ReactNativePrivateInterface");
 var Scheduler = require("scheduler");
 var tracing = require("scheduler/tracing");
+var assertTextRendersInParent = require("react-native/Libraries/Renderer/implementations/assertTextRendersInParent");
 
 var ReactSharedInternals =
   React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
@@ -3874,9 +3875,7 @@ function createTextInstance(
   hostContext,
   internalInstanceHandle
 ) {
-  if (!hostContext.isInAParentText) {
-    throw Error("Text strings must be rendered within a <Text> component.");
-  }
+  assertTextRendersInParent(hostContext, text, internalInstanceHandle);
 
   var tag = nextReactTag;
   nextReactTag += 2;

--- a/Libraries/Renderer/implementations/ReactFabric-dev.js
+++ b/Libraries/Renderer/implementations/ReactFabric-dev.js
@@ -22,6 +22,7 @@ require("react-native/Libraries/ReactPrivate/ReactNativePrivateInitializeCore");
 var ReactNativePrivateInterface = require("react-native/Libraries/ReactPrivate/ReactNativePrivateInterface");
 var Scheduler = require("scheduler");
 var tracing = require("scheduler/tracing");
+var assertTextRendersInParent = require("react-native/Libraries/Renderer/implementations/assertTextRendersInParent");
 
 var ReactSharedInternals =
   React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
@@ -3873,9 +3874,7 @@ function createTextInstance(
   hostContext,
   internalInstanceHandle
 ) {
-  if (!hostContext.isInAParentText) {
-    throw Error("Text strings must be rendered within a <Text> component.");
-  }
+  assertTextRendersInParent(hostContext, text, internalInstanceHandle);
 
   var tag = nextReactTag;
   nextReactTag += 2;

--- a/Libraries/Renderer/implementations/ReactFabric-prod.fb.js
+++ b/Libraries/Renderer/implementations/ReactFabric-prod.fb.js
@@ -14,7 +14,8 @@
 require("react-native/Libraries/ReactPrivate/ReactNativePrivateInitializeCore");
 var ReactNativePrivateInterface = require("react-native/Libraries/ReactPrivate/ReactNativePrivateInterface"),
   React = require("react"),
-  Scheduler = require("scheduler");
+  Scheduler = require("scheduler"),
+  assertTextRendersInParent = require("react-native/Libraries/Renderer/implementations/assertTextRendersInParent");
 function invokeGuardedCallbackImpl(name, func, context, a, b, c, d, e, f) {
   var funcArgs = Array.prototype.slice.call(arguments, 3);
   try {
@@ -1604,8 +1605,7 @@ function createTextInstance(
   hostContext,
   internalInstanceHandle
 ) {
-  if (!hostContext.isInAParentText)
-    throw Error("Text strings must be rendered within a <Text> component.");
+  assertTextRendersInParent(hostContext, text, internalInstanceHandle);
   hostContext = nextReactTag;
   nextReactTag += 2;
   return {

--- a/Libraries/Renderer/implementations/ReactFabric-prod.js
+++ b/Libraries/Renderer/implementations/ReactFabric-prod.js
@@ -15,7 +15,8 @@
 require("react-native/Libraries/ReactPrivate/ReactNativePrivateInitializeCore");
 var ReactNativePrivateInterface = require("react-native/Libraries/ReactPrivate/ReactNativePrivateInterface"),
   React = require("react"),
-  Scheduler = require("scheduler");
+  Scheduler = require("scheduler"),
+  assertTextRendersInParent = require("react-native/Libraries/Renderer/implementations/assertTextRendersInParent");
 function invokeGuardedCallbackImpl(name, func, context, a, b, c, d, e, f) {
   var funcArgs = Array.prototype.slice.call(arguments, 3);
   try {
@@ -1605,8 +1606,7 @@ function createTextInstance(
   hostContext,
   internalInstanceHandle
 ) {
-  if (!hostContext.isInAParentText)
-    throw Error("Text strings must be rendered within a <Text> component.");
+  assertTextRendersInParent(hostContext, text, internalInstanceHandle);
   hostContext = nextReactTag;
   nextReactTag += 2;
   return {

--- a/Libraries/Renderer/implementations/ReactFabric-profiling.fb.js
+++ b/Libraries/Renderer/implementations/ReactFabric-profiling.fb.js
@@ -15,7 +15,8 @@ require("react-native/Libraries/ReactPrivate/ReactNativePrivateInitializeCore");
 var ReactNativePrivateInterface = require("react-native/Libraries/ReactPrivate/ReactNativePrivateInterface"),
   React = require("react"),
   Scheduler = require("scheduler"),
-  tracing = require("scheduler/tracing");
+  tracing = require("scheduler/tracing"),
+  assertTextRendersInParent = require("react-native/Libraries/Renderer/implementations/assertTextRendersInParent");
 function invokeGuardedCallbackImpl(name, func, context, a, b, c, d, e, f) {
   var funcArgs = Array.prototype.slice.call(arguments, 3);
   try {
@@ -1605,8 +1606,7 @@ function createTextInstance(
   hostContext,
   internalInstanceHandle
 ) {
-  if (!hostContext.isInAParentText)
-    throw Error("Text strings must be rendered within a <Text> component.");
+  assertTextRendersInParent(hostContext, text, internalInstanceHandle);
   hostContext = nextReactTag;
   nextReactTag += 2;
   return {

--- a/Libraries/Renderer/implementations/ReactFabric-profiling.js
+++ b/Libraries/Renderer/implementations/ReactFabric-profiling.js
@@ -16,7 +16,8 @@ require("react-native/Libraries/ReactPrivate/ReactNativePrivateInitializeCore");
 var ReactNativePrivateInterface = require("react-native/Libraries/ReactPrivate/ReactNativePrivateInterface"),
   React = require("react"),
   Scheduler = require("scheduler"),
-  tracing = require("scheduler/tracing");
+  tracing = require("scheduler/tracing"),
+  assertTextRendersInParent = require("react-native/Libraries/Renderer/implementations/assertTextRendersInParent");
 function invokeGuardedCallbackImpl(name, func, context, a, b, c, d, e, f) {
   var funcArgs = Array.prototype.slice.call(arguments, 3);
   try {
@@ -1606,8 +1607,7 @@ function createTextInstance(
   hostContext,
   internalInstanceHandle
 ) {
-  if (!hostContext.isInAParentText)
-    throw Error("Text strings must be rendered within a <Text> component.");
+  assertTextRendersInParent(hostContext, text, internalInstanceHandle);
   hostContext = nextReactTag;
   nextReactTag += 2;
   return {

--- a/Libraries/Renderer/implementations/ReactNativeRenderer-dev.fb.js
+++ b/Libraries/Renderer/implementations/ReactNativeRenderer-dev.fb.js
@@ -21,6 +21,7 @@ require("react-native/Libraries/ReactPrivate/ReactNativePrivateInitializeCore");
 var ReactNativePrivateInterface = require("react-native/Libraries/ReactPrivate/ReactNativePrivateInterface");
 var Scheduler = require("scheduler");
 var tracing = require("scheduler/tracing");
+var assertTextRendersInParent = require("react-native/Libraries/Renderer/implementations/assertTextRendersInParent");
 
 var ReactSharedInternals =
   React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
@@ -4052,9 +4053,7 @@ function createTextInstance(
   hostContext,
   internalInstanceHandle
 ) {
-  if (!hostContext.isInAParentText) {
-    throw Error("Text strings must be rendered within a <Text> component.");
-  }
+  assertTextRendersInParent(hostContext, text, internalInstanceHandle);
 
   var tag = allocateTag();
   ReactNativePrivateInterface.UIManager.createView(

--- a/Libraries/Renderer/implementations/ReactNativeRenderer-dev.js
+++ b/Libraries/Renderer/implementations/ReactNativeRenderer-dev.js
@@ -22,6 +22,7 @@ require("react-native/Libraries/ReactPrivate/ReactNativePrivateInitializeCore");
 var ReactNativePrivateInterface = require("react-native/Libraries/ReactPrivate/ReactNativePrivateInterface");
 var Scheduler = require("scheduler");
 var tracing = require("scheduler/tracing");
+var assertTextRendersInParent = require("react-native/Libraries/Renderer/implementations/assertTextRendersInParent");
 
 var ReactSharedInternals =
   React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
@@ -4052,9 +4053,7 @@ function createTextInstance(
   hostContext,
   internalInstanceHandle
 ) {
-  if (!hostContext.isInAParentText) {
-    throw Error("Text strings must be rendered within a <Text> component.");
-  }
+  assertTextRendersInParent(hostContext, text, internalInstanceHandle);
 
   var tag = allocateTag();
   ReactNativePrivateInterface.UIManager.createView(

--- a/Libraries/Renderer/implementations/ReactNativeRenderer-prod.fb.js
+++ b/Libraries/Renderer/implementations/ReactNativeRenderer-prod.fb.js
@@ -4949,7 +4949,7 @@ function completeWork(current, workInProgress, renderLanes) {
         current = requiredContext(rootInstanceStackCursor.current);
         if (!requiredContext(contextStackCursor$1.current).isInAParentText)
           throw Error(
-            "Text strings must be rendered within a <Text> component."
+            "Text string \"" + newProps + "\" must be rendered within a <Text> component.\n\nProbably result of a conditional rendering using boolean concatination as in `cond && <Component ...>`."
           );
         rootContainerInstance = allocateTag();
         ReactNativePrivateInterface.UIManager.createView(

--- a/Libraries/Renderer/implementations/ReactNativeRenderer-prod.js
+++ b/Libraries/Renderer/implementations/ReactNativeRenderer-prod.js
@@ -4950,7 +4950,7 @@ function completeWork(current, workInProgress, renderLanes) {
         current = requiredContext(rootInstanceStackCursor.current);
         if (!requiredContext(contextStackCursor$1.current).isInAParentText)
           throw Error(
-            "Text strings must be rendered within a <Text> component."
+            "Text string \"" + newProps + "\" must be rendered within a <Text> component.\n\nProbably result of a conditional rendering using boolean concatination as in `cond && <Component ...>`."
           );
         rootContainerInstance = allocateTag();
         ReactNativePrivateInterface.UIManager.createView(

--- a/Libraries/Renderer/implementations/ReactNativeRenderer-profiling.fb.js
+++ b/Libraries/Renderer/implementations/ReactNativeRenderer-profiling.fb.js
@@ -4999,7 +4999,7 @@ function completeWork(current, workInProgress, renderLanes) {
         current = requiredContext(rootInstanceStackCursor.current);
         if (!requiredContext(contextStackCursor$1.current).isInAParentText)
           throw Error(
-            "Text strings must be rendered within a <Text> component."
+            "Text string \"" + newProps + "\" must be rendered within a <Text> component.\n\nProbably result of a conditional rendering using boolean concatination as in `cond && <Component ...>`."
           );
         rootContainerInstance = allocateTag();
         ReactNativePrivateInterface.UIManager.createView(

--- a/Libraries/Renderer/implementations/ReactNativeRenderer-profiling.js
+++ b/Libraries/Renderer/implementations/ReactNativeRenderer-profiling.js
@@ -5000,7 +5000,7 @@ function completeWork(current, workInProgress, renderLanes) {
         current = requiredContext(rootInstanceStackCursor.current);
         if (!requiredContext(contextStackCursor$1.current).isInAParentText)
           throw Error(
-            "Text strings must be rendered within a <Text> component."
+            "Text string \"" + newProps + "\" must be rendered within a <Text> component.\n\nProbably result of a conditional rendering using boolean concatination as in `cond && <Component ...>`."
           );
         rootContainerInstance = allocateTag();
         ReactNativePrivateInterface.UIManager.createView(

--- a/Libraries/Renderer/implementations/assertTextRendersInParent.js
+++ b/Libraries/Renderer/implementations/assertTextRendersInParent.js
@@ -1,0 +1,25 @@
+function stripInformation(
+  internalInstanceHandle
+) {
+  var possibleCause = "\n\nProbably result of a conditional rendering using boolean concatination as in `cond && <Component ...>`.";
+  if (internalInstanceHandle && internalInstanceHandle.sibling) {
+    var debugOwner = internalInstanceHandle.sibling._debugOwner;
+    var debugSource = internalInstanceHandle.sibling._debugSource;
+    if (debugOwner && debugSource) {
+      var parentComponentName = debugOwner.type.name;
+      var siblingSource = "\"" + debugSource.fileName + "\" line " + debugSource.lineNumber + ", column " + debugSource.columnNumber;
+      return " Error may have occured in component <" + parentComponentName + "> near " + siblingSource + "." + possibleCause;
+    }
+  }
+  return possibleCause;
+}
+
+module.exports = function assertTextRendersInParent(
+  hostContext,
+  text,
+  internalInstanceHandle
+) {
+  if (!hostContext.isInAParentText) {
+    throw Error("Text string \"" + text + "\" must be rendered within a <Text> component." + stripInformation(internalInstanceHandle));
+  }
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

This PR is meant to be a draft for changes in the renderer. In our company we sometimes facing "Text strings must be rendered within a \<Text\> component." errors related to conditional concatenation with components. Since conditionals are often values provided by services, it is difficult to track down the exact location where they occur. Unfortunately, both the error component stack and the call stack do not provide enough information to find the corresponding location in the code. For this reason, we patched React Native locally to drastically reduce the debugging time associated with such errors.

The provided changes of this PR are basically the patch applied locally to React Native in our project. The improvements to the messages from our patch include the actual text that could not be rendered, as well as a sibling component and its exact location in the source code. This allows my colleagues and me to quickly track down problems and locate the approximate point of failure in our code. It also gives a hint that the problem might be related to a concatenation between a value and a component.

However, this solution is not quite perfect, as the information is not detailed enough in cases where the error is caused by code, such as the following:

```
<View>
  forgot to wrap this text with text component...
</View>
```

Obviously, in this situation, there are no sibling components from which we can infer the source code location or parent component. Nevertheless, in such cases the message contains at least the text which could not be rendered without `<Text>` component. The question we have is whether it is possible to make the error message more verbose in all cases?