### PR TITLE
Fix missing nullability specifiers when compiling native modules

### DIFF
--- a/React/Base/RCTJSInvokerModule.h
+++ b/React/Base/RCTJSInvokerModule.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * This protocol should be adopted when a turbo module needs to directly call into JavaScript.
  * In bridge-less React Native, it is a replacement for [_bridge enqueueJSCall:].
@@ -16,3 +18,5 @@
 @property (nonatomic, copy) void (^invokeJSWithModuleDotMethod)(NSString *moduleDotMethod, NSArray *args);
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/React/Modules/RCTEventEmitter.h
+++ b/React/Modules/RCTEventEmitter.h
@@ -8,15 +8,17 @@
 #import <React/RCTBridge.h>
 #import <React/RCTJSInvokerModule.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * RCTEventEmitter is an abstract base class to be used for modules that emit
  * events to be observed by JS.
  */
 @interface RCTEventEmitter : NSObject <RCTBridgeModule, RCTJSInvokerModule, RCTInvalidating>
 
-@property (nonatomic, weak) RCTBridge *bridge;
-@property (nonatomic, weak) RCTModuleRegistry *moduleRegistry;
-@property (nonatomic, weak) RCTViewRegistry *viewRegistry_DEPRECATED;
+@property (nonatomic, weak) RCTBridge *_Nullable bridge;
+@property (nonatomic, weak) RCTModuleRegistry *_Nullable moduleRegistry;
+@property (nonatomic, weak) RCTViewRegistry *_Nullable viewRegistry_DEPRECATED;
 
 - (instancetype)initWithDisabledObservation;
 
@@ -25,13 +27,13 @@
  * to observe or send an event that isn't included in this list will result in
  * an error.
  */
-- (NSArray<NSString *> *)supportedEvents;
+- (NSArray<NSString *> *_Nullable)supportedEvents;
 
 /**
  * Send an event that does not relate to a specific view, e.g. a navigation
  * or data update notification.
  */
-- (void)sendEventWithName:(NSString *)name body:(id)body;
+- (void)sendEventWithName:(NSString *)name body:(_Nullable id)body;
 
 /**
  * These methods will be called when the first observer is added and when the
@@ -47,3 +49,5 @@
 - (void)removeListeners:(double)count;
 
 @end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
## Summary

Our application has native modules and 3rd party native modules. When we compile them, we get warnings such as:
> Showing All Issues
my_project/node_modules/@react-native-community/netinfo/ios/RNCNetInfo.m:8:9: In file included from  my_project/node_modules/@react-native-community/netinfo/ios/RNCNetInfo.m:8:
my_project/node_modules/@react-native-community/netinfo/ios/RNCNetInfo.h:8:9: In file included from my_project/node_modules/@react-native-community/netinfo/ios/RNCNetInfo.h:8:
my_project/ios/Pods/Headers/Public/React-Core/React/RCTEventEmitter.h:9:9: In file included from my_project/ios/Pods/Headers/Public/React-Core/React/RCTEventEmitter.h:9:
my_project/ios/Pods/Headers/Public/React-Core/React/RCTJSInvokerModule.h:14:64: Insert '_Nullable' if the pointer may be null
my_project/ios/Pods/Headers/Public/React-Core/React/RCTJSInvokerModule.h:14:64: Insert '_Nonnull' if the pointer should never be null

## Changelog

[iOS] [Fixed] -  Fix "Pointer is missing a nullability type specifier (_Nonnull, _Nullable, or _Null_unspecified)" warning caused by declarations in `RCTEventEmitter.h` and `RCTJSInvokerModule.h`.

## Test Plan

- Updated the files in our project and verified the build warnings are no longer reported.
- Built and ran the RNTester app in the simulator with no problems.