### PR TITLE
[iOS] fix TextInput with autoFocus keyboard issue

### DIFF
--- a/React/Views/UIView+React.m
+++ b/React/Views/UIView+React.m
@@ -259,6 +259,8 @@
 {
   if (![self becomeFirstResponder]) {
     self.reactIsFocusNeeded = YES;
+  } else {
+      self.reactIsFocusNeeded = NO;
   }
 }
 


### PR DESCRIPTION
## Summary
repo with reproducible example https://github.com/alexlomi4/react-native-autoFocus-ios-issue

**issue gif**
<img src="https://raw.githubusercontent.com/alexlomi4/react-native-autoFocus-ios-issue/master/issue.gif" height="600" />

**Issue description**
**1** react-navigation": "^4.4.3 installed
**2** Home screen with autoFocus TextInput is opened on app start up
AR=ER keyboard is opened 
**3** press button to navigate to screen with react-native-image-picker launchImageLibrary api call
AR=ER keyboard is closed
** 4** pick some image
AR: keyboard is opened again
ER: keyboard is not opened as there are not any inputs on this screen

**The root cause**
1 RCTBaseTextInputView.m has method didMoveToWindow which calls   [self.backedTextInputView reactFocus] when screen with TextInput loads initially (self.window is nil). 
Then UIView+React.m reactFocus  set self.reactIsFocusNeeded to YES. 
2 TextInput call useEffect where it calls reactFocus second time (self.window is not nil):
 variable self.reactIsFocusNeeded is not reset (still YES) 
3 When we navigate to next screen and open image picker didMoveToWindow is called again (self.window is nill because screen content is replaced). Flag self.reactIsFocusNeeded is still YES.
4 Image picker closes after image is chosen and  reactFocusIfNeeded is called with self.reactIsFocusNeeded set to YES and keyboard is shown on screen without TextInput 


## Changelog

[iOS] [Fixed] - reset self.reactIsFocusNeeded to NO when component has gain focus successfully 

## Test Plan

Run example provided above with a fix and without (update m file in xcode).
