### PR TITLE
Fix detox e2e tests

### DIFF
--- a/React/Views/UIView+React.m
+++ b/React/Views/UIView+React.m
@@ -259,8 +259,6 @@
 {
   if (![self becomeFirstResponder]) {
     self.reactIsFocusNeeded = YES;
-  } else {
-      self.reactIsFocusNeeded = NO;
   }
 }
 

--- a/React/Views/UIView+React.m
+++ b/React/Views/UIView+React.m
@@ -259,6 +259,8 @@
 {
   if (![self becomeFirstResponder]) {
     self.reactIsFocusNeeded = YES;
+  } else {
+      self.reactIsFocusNeeded = NO;
   }
 }
 

--- a/packages/rn-tester/e2e/__tests__/Button-test.js
+++ b/packages/rn-tester/e2e/__tests__/Button-test.js
@@ -10,17 +10,14 @@
 
 /* global device, element, by, expect */
 const {
-  openComponentWithLabel,
+  openComponentWithId,
   openExampleWithTitle,
 } = require('../e2e-helpers');
 
 describe('Button', () => {
   beforeAll(async () => {
     await device.reloadReactNative();
-    await openComponentWithLabel(
-      'Button',
-      'Button Simple React Native button component.',
-    );
+    await openComponentWithId('Button', 'Button');
   });
 
   it('Default Styling button should be tappable', async () => {

--- a/packages/rn-tester/e2e/__tests__/TextInput-test.js
+++ b/packages/rn-tester/e2e/__tests__/TextInput-test.js
@@ -10,17 +10,14 @@
 
 /* global device, element, by, expect */
 const {
-  openComponentWithLabel,
+  openComponentWithId,
   openExampleWithTitle,
 } = require('../e2e-helpers');
 
 describe('TextInput', () => {
   beforeAll(async () => {
     await device.reloadReactNative();
-    await openComponentWithLabel(
-      'TextInput',
-      'Single and multi-line text inputs.',
-    );
+    await openComponentWithId('TextInput', 'TextInput');
   });
 
   it('Live rewrite with spaces should replace spaces and enforce max length', async () => {

--- a/packages/rn-tester/e2e/__tests__/Touchable-test.js
+++ b/packages/rn-tester/e2e/__tests__/Touchable-test.js
@@ -10,17 +10,14 @@
 
 /* global device, element, by, expect */
 const {
-  openComponentWithLabel,
+  openComponentWithId,
   openExampleWithTitle,
 } = require('../e2e-helpers');
 
 describe('Touchable', () => {
   beforeAll(async () => {
     await device.reloadReactNative();
-    await openComponentWithLabel(
-      'Touchable*',
-      'Touchable* and onPress Touchable and onPress examples.',
-    );
+    await openComponentWithId('Touchable', 'Touchable* and onPress');
   });
 
   it('Touchable Highlight should be tappable', async () => {

--- a/packages/rn-tester/e2e/e2e-helpers.js
+++ b/packages/rn-tester/e2e/e2e-helpers.js
@@ -12,9 +12,9 @@
 
 // Will open a component example from the root list
 // by filtering by component and then tapping on the label
-exports.openComponentWithLabel = async (component, label) => {
+exports.openComponentWithId = async (component, id) => {
   await element(by.id('explorer_search')).replaceText(component);
-  await element(by.label(label)).tap();
+  await element(by.id(id)).tap();
 };
 
 // Will open an individual example for a component


### PR DESCRIPTION
## Summary

Detox tests stated here https://github.com/facebook/react-native/wiki/Tests fails because example Touchable component's accessibilityLabel wasn't equal to passed (it was concatenated as item.module.title + ' ' + item.module.description) and by.label check wasn't working

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Fixed] - tests were fixed by using by.id instead of by.label

## Test Plan

run tests:

npm run build-ios-e2e
npm run test-ios-e2e
