### PR TITLE
Make ScrollViewStickyHeader work on android

### DIFF
--- a/Libraries/Components/ScrollView/ScrollViewStickyHeader.js
+++ b/Libraries/Components/ScrollView/ScrollViewStickyHeader.js
@@ -298,7 +298,7 @@ class ScrollViewStickyHeader extends React.Component<Props, State> {
 const styles = StyleSheet.create({
   header: {
     zIndex: 10,
-    position: 'relative',
+    elevation: 10,
   },
   fill: {
     flex: 1,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
On Android, the zIndex alone does not bring the sticky header on top of
all rows that follow inside of the scrollview. As a result, the sticky header will be rendered 
below other rows of the scrollview.

Using elevation in conjunction with zIndex will resolve this issue so that both, ios and
android behave exactly the same.
Also removed the relative positioning as it was causing visual issues
as well on the rows that come before the sticky header. 
Only zIndex and elevation are needed to make both platforms match.

## Changelog

[Android] [Fixed] - Sticky header inside ScrollView rendered below other rows

## Test Plan
I've fixed this issue in context of my app that heavily makes use of sticky headers inside ScrollViews and FlatLists.
Once I fixed it, all sticky header related issues went away application wide.  