### PR TITLE
Fix RefreshControl layout when removed from window

### DIFF
--- a/React/Views/RefreshControl/RCTRefreshControl.m
+++ b/React/Views/RefreshControl/RCTRefreshControl.m
@@ -51,6 +51,8 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)aDecoder)
 
 - (void)didMoveToWindow
 {
+  [super didMoveToWindow];
+
   // Since iOS 14 there seems to be a bug where refresh control becomes
   // visible if the view gets removed from window then added back again.
   // Calling endRefreshing fixes the layout.

--- a/React/Views/RefreshControl/RCTRefreshControl.m
+++ b/React/Views/RefreshControl/RCTRefreshControl.m
@@ -49,6 +49,16 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)aDecoder)
   _isInitialRender = false;
 }
 
+- (void)didMoveToWindow
+{
+  // Since iOS 14 there seems to be a bug where refresh control becomes
+  // visible if the view gets removed from window then added back again.
+  // Calling endRefreshing fixes the layout.
+  if (!_currentRefreshingState) {
+    [super endRefreshing];
+  }
+}
+
 - (void)beginRefreshingProgrammatically
 {
   UInt64 beginRefreshingTimestamp = _currentRefreshingStateTimestamp;


### PR DESCRIPTION
## Summary

Since iOS 14 refresh control is sometimes visible when it shouldn't. It seems to happen when it is removed and added back to the window. This repros easily when using react-native-screens with react-navigation tabs. Inactive tabs are detached from the window to save resources.

Calling endRefreshing when refresh control is added to the window fixes the layout. It will also be called on first mount where it is not necessary, but should be a no-op and didn't cause any issues. I also decided to call it for all ios versions, although it is only needed on iOS 14+ to avoid forking behavior more.

## Changelog

[iOS] [Fixed] - Fix RefreshControl layout when removed from window

## Test Plan

Before:

https://user-images.githubusercontent.com/2677334/108666197-93ea5a80-74a4-11eb-839b-8a4916967bf8.mov

After:

https://user-images.githubusercontent.com/2677334/108666223-9ea4ef80-74a4-11eb-8489-4e5d257299c8.mov


