### PR TITLE
Android - pass initial props to ViewManager createView in non-Fabric

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java
@@ -278,7 +278,7 @@ public class NativeViewHierarchyManager {
     try {
       ViewManager viewManager = mViewManagers.get(className);
 
-      View view = viewManager.createView(tag, themedContext, null, null, mJSResponderHandler);
+      View view = viewManager.createView(tag, themedContext, initialProps, null, mJSResponderHandler);
       mTagsToViews.put(tag, view);
       mTagsToViewManagers.put(tag, viewManager);
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

https://github.com/facebook/react-native/issues/31051
When trying to create custom viewmanagers,  we don't have props, I have a use case where I want to create views on the basis of provided react prop from react native. 
## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[CATEGORY] [TYPE] - ReactNative WebView

## Test Plan

Tested Manually. 
