### PR TITLE
Fix cli bundle platform for Mac Catalyst in `react-native-xcode.sh`

### DIFF
--- a/scripts/react-native-xcode.sh
+++ b/scripts/react-native-xcode.sh
@@ -148,6 +148,10 @@ case "$PLATFORM_NAME" in
     ;;
 esac
 
+if [ "${IS_MACCATALYST}" = "YES" ]; then
+  BUNDLE_PLATFORM="ios"
+fi
+
 EMIT_SOURCEMAP=
 if [[ ! -z "$SOURCEMAP_FILE" ]]; then
   EMIT_SOURCEMAP=true


### PR DESCRIPTION
## Summary

A recent commit https://github.com/facebook/react-native/commit/941bc0ec195716e6a505a3c3a67f97a87ea9bcdc#diff-0eeea47fa4bace26fa6c492a03fa0ea3923a2d8d54b7894f7760cb9131ab65eb on Hermes macOS brings a regression for Mac Catalyst target.

Once hardcoded cli bundle platform `ios` can now be either `ios` or `macos`. However, Mac Catalyst is identified as `macos` rather than `ios`.

This PR should fix it and close https://github.com/facebook/react-native/issues/31061.

## Changelog

[iOS] [Fixed] - Fix cli bundle platform for Mac Catalyst in `react-native-xcode.sh`

## Test Plan

1. Build fails on a new RN 0.64-rc.3 project.
2. Apply the fix.
3. Build passes.