### PR TITLE
iOS WebSocket Support System Socks5 Proxy

### DIFF
--- a/Libraries/WebSocket/RCTSRWebSocket.m
+++ b/Libraries/WebSocket/RCTSRWebSocket.m
@@ -497,11 +497,14 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
   CFStreamCreatePairWithSocketToHost(NULL, (__bridge CFStringRef)host, port, &readStream, &writeStream);
     
   CFDictionaryRef proxySettings = CFNetworkCopySystemProxySettings();
-  
-  if (CFDictionaryContainsKey(proxySettings, kCFStreamPropertySOCKSProxyHost)) {
-    NSLog(@"SocketRocket: kCFStreamPropertySOCKSProxyHost found in proxy settings, using it as our proxy. ");
-    CFReadStreamSetProperty((CFReadStreamRef)readStream, kCFStreamPropertySOCKSProxy, (CFTypeRef)proxySettings);
-    CFReadStreamSetProperty((CFReadStreamRef)writeStream, kCFStreamPropertySOCKSProxy, (CFTypeRef)proxySettings);
+  if (proxySettings != NULL) {
+    CFRelease(proxySettings);
+    
+    if (CFDictionaryContainsKey(proxySettings, kCFStreamPropertySOCKSProxyHost)) {
+      NSLog(@"SocketRocket: kCFStreamPropertySOCKSProxyHost found in proxy settings, using it as our proxy. ");
+      CFReadStreamSetProperty((CFReadStreamRef)readStream, kCFStreamPropertySOCKSProxy, (CFTypeRef)proxySettings);
+      CFReadStreamSetProperty((CFReadStreamRef)writeStream, kCFStreamPropertySOCKSProxy, (CFTypeRef)proxySettings);
+    }
   }
 
   _outputStream = CFBridgingRelease(writeStream);

--- a/Libraries/WebSocket/RCTSRWebSocket.m
+++ b/Libraries/WebSocket/RCTSRWebSocket.m
@@ -498,8 +498,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
     
   CFDictionaryRef proxySettings = CFNetworkCopySystemProxySettings();
   if (proxySettings != NULL) {
-    CFRelease(proxySettings);
-    
+    CFBridgingRelease(proxySettings);
     if (CFDictionaryContainsKey(proxySettings, kCFStreamPropertySOCKSProxyHost)) {
       NSLog(@"SocketRocket: kCFStreamPropertySOCKSProxyHost found in proxy settings, using it as our proxy. ");
       CFReadStreamSetProperty((CFReadStreamRef)readStream, kCFStreamPropertySOCKSProxy, (CFTypeRef)proxySettings);

--- a/Libraries/WebSocket/RCTSRWebSocket.m
+++ b/Libraries/WebSocket/RCTSRWebSocket.m
@@ -495,6 +495,14 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
   CFWriteStreamRef writeStream = NULL;
 
   CFStreamCreatePairWithSocketToHost(NULL, (__bridge CFStringRef)host, port, &readStream, &writeStream);
+    
+  CFDictionaryRef proxySettings = CFNetworkCopySystemProxySettings();
+  
+  if (CFDictionaryContainsKey(proxySettings, kCFStreamPropertySOCKSProxyHost)) {
+    NSLog(@"SocketRocket: kCFStreamPropertySOCKSProxyHost found in proxy settings, using it as our proxy. ");
+    CFReadStreamSetProperty((CFReadStreamRef)readStream, kCFStreamPropertySOCKSProxy, (CFTypeRef)proxySettings);
+    CFReadStreamSetProperty((CFReadStreamRef)writeStream, kCFStreamPropertySOCKSProxy, (CFTypeRef)proxySettings);
+  }
 
   _outputStream = CFBridgingRelease(writeStream);
   _inputStream = CFBridgingRelease(readStream);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Currently, RCTSRWebSocket does not read settings from System Proxy, so it'll bypass debugging proxy, e.g. Charles. 

This patch adds a few lines after `CFStreamCreatePairWithSocketToHost` is called, to read current system SOCKS proxy and apply it to the stream, as suggested by https://github.com/facebook/react-native/issues/29408.

I'm a beginner of Obj-C so correct me if there're any naive mistakes :)

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [Added] - Support System Socks5 Proxy

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

No UI or API changes