### PR TITLE
[Android] Enable isInvertColorsEnabled property to AccessibilityInfo component

### DIFF
--- a/Libraries/Components/AccessibilityInfo/AccessibilityInfo.android.js
+++ b/Libraries/Components/AccessibilityInfo/AccessibilityInfo.android.js
@@ -18,10 +18,12 @@ import {type ElementRef} from 'react';
 
 const REDUCE_MOTION_EVENT = 'reduceMotionDidChange';
 const TOUCH_EXPLORATION_EVENT = 'touchExplorationDidChange';
+const INVERT_COLORS_EVENT = 'invertColorsDidChange;';
 
 type AccessibilityEventDefinitions = {
   reduceMotionChanged: [boolean],
   screenReaderChanged: [boolean],
+  invertColorsChanged: [boolean],
   // alias for screenReaderChanged
   change: [boolean],
 };
@@ -55,11 +57,14 @@ const AccessibilityInfo = {
     return Promise.resolve(false);
   },
 
-  /**
-   * iOS only
-   */
   isInvertColorsEnabled: function(): Promise<boolean> {
-    return Promise.resolve(false);
+    return new Promise((resolve, reject) => {
+      if (NativeAccessibilityInfo) {
+        NativeAccessibilityInfo.isInvertColorsEnabled(resolve);
+      } else {
+        reject(false);
+      }
+    });
   },
 
   isReduceMotionEnabled: function(): Promise<boolean> {
@@ -116,6 +121,11 @@ const AccessibilityInfo = {
     } else if (eventName === 'reduceMotionChanged') {
       listener = RCTDeviceEventEmitter.addListener(
         REDUCE_MOTION_EVENT,
+        handler,
+      );
+    } else if (eventName === 'invertColorsChanged') {
+      listener = RCTDeviceEventEmitter.addListener(
+        INVERT_COLORS_EVENT,
         handler,
       );
     }

--- a/Libraries/Components/AccessibilityInfo/NativeAccessibilityInfo.js
+++ b/Libraries/Components/AccessibilityInfo/NativeAccessibilityInfo.js
@@ -15,6 +15,9 @@ export interface Spec extends TurboModule {
   +isReduceMotionEnabled: (
     onSuccess: (isReduceMotionEnabled: boolean) => void,
   ) => void;
+  +isInvertColorsEnabled: (
+    onSuccess: (isInvertColorsEnabled: boolean) => void,
+  ) => void;
   +isTouchExplorationEnabled: (
     onSuccess: (isScreenReaderEnabled: boolean) => void,
   ) => void;

--- a/packages/rn-tester/js/examples/Accessibility/AccessibilityExample.js
+++ b/packages/rn-tester/js/examples/Accessibility/AccessibilityExample.js
@@ -761,12 +761,6 @@ class EnabledExamples extends React.Component<{}> {
                 eventListener="grayscaleChanged"
               />
             </RNTesterBlock>
-            <RNTesterBlock title="isInvertColorsEnabled()">
-              <EnabledExample
-                test="invert colors"
-                eventListener="invertColorsChanged"
-              />
-            </RNTesterBlock>
             <RNTesterBlock title="isReduceTransparencyEnabled()">
               <EnabledExample
                 test="reduce transparency"
@@ -787,6 +781,13 @@ class EnabledExamples extends React.Component<{}> {
           <EnabledExample
             test="screen reader"
             eventListener="screenReaderChanged"
+          />
+        </RNTesterBlock>
+
+        <RNTesterBlock title="isInvertColorsEnabled()">
+          <EnabledExample
+            test="invert colors"
+            eventListener="invertColorsChanged"
           />
         </RNTesterBlock>
       </View>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

This PR enables `isInvertColorsEnabled()` of `AccessibilityInfo` for Android.

That setting is queried using the Settings.Secure.ACCESSIBILITY_DISPLAY_INVERSION_ENABLED property.
https://developer.android.com/reference/android/provider/Settings.Secure#ACCESSIBILITY_DISPLAY_INVERSION_ENABLED

## Changelog

[Android] [Added] -  `isInvertColorsEnabled()` of `AccessibilityInfo`
<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

## Test Plan

Enable and disable color inversion setting in device/emulator accessibility settings and check if property getter updates with a new value.
