### PR TITLE
URL.href has an extraneous slash

### DIFF
--- a/Libraries/Blob/URL.js
+++ b/Libraries/Blob/URL.js
@@ -128,9 +128,6 @@ export class URL {
     let baseUrl = null;
     if (!base || validateBaseUrl(url)) {
       this._url = url;
-      if (!this._url.endsWith('/')) {
-        this._url += '/';
-      }
     } else {
       if (typeof base === 'string') {
         baseUrl = base;

--- a/Libraries/Blob/__tests__/URL-test.js
+++ b/Libraries/Blob/__tests__/URL-test.js
@@ -33,7 +33,7 @@ describe('URL', function() {
     const h = new URL('/en-US/docs', a);
     expect(h.href).toBe('https://developer.mozilla.org/en-US/docs');
     const i = new URL('http://github.com', 'http://google.com');
-    expect(i.href).toBe('http://github.com/');
+    expect(i.href).toBe('http://github.com');
     // Support Bare Hosts
     const j = new URL('home', 'http://localhost');
     expect(j.href).toBe('http://localhost/home');

--- a/Libraries/Blob/__tests__/URL-test.js
+++ b/Libraries/Blob/__tests__/URL-test.js
@@ -17,7 +17,7 @@ describe('URL', function() {
     const a = new URL('/', 'https://developer.mozilla.org');
     expect(a.href).toBe('https://developer.mozilla.org/');
     const b = new URL('https://developer.mozilla.org');
-    expect(b.href).toBe('https://developer.mozilla.org/');
+    expect(b.href).toBe('https://developer.mozilla.org');
     const c = new URL('en-US/docs', b);
     expect(c.href).toBe('https://developer.mozilla.org/en-US/docs');
     const d = new URL('/en-US/docs', b);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
This issue fixes https://github.com/facebook/react-native/issues/30914
The logic of adding extraneous slash to url was introduced with pr https://github.com/facebook/react-native/pull/22901 but It should be removed for the following reasons:

- does not respect the [WHATWG URL standard](https://github.com/facebook/react-native/issues/30914#issue-803832412)
- the logic was introduced with https://github.com/facebook/react-native/pull/22901 to add compatability with apollo-server https://github.com/facebook/react-native/issues/22594 but apollo-server seems to already [add](https://github.com/apollographql/apollo-server/blob/458bc71eadde52483ccaef209df3eb1f1bcb4424/packages/apollo-datasource-rest/src/RESTDataSource.ts#L76-L78) the slash to the end of urls
## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Fixed] - Avoid adding extraneous slash to end of url

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

TODO:
- [ ] increase test coverage for https://github.com/facebook/react-native/pull/26009 https://github.com/facebook/react-native/issues/26006 https://github.com/facebook/react-native/issues/26019 https://github.com/facebook/react-native/pull/25719