### PR TITLE
Detach thread in executeAsynchronously (RuntimeExecutor.h)

### DIFF
--- a/ReactCommon/runtimeexecutor/ReactCommon/RuntimeExecutor.h
+++ b/ReactCommon/runtimeexecutor/ReactCommon/RuntimeExecutor.h
@@ -39,9 +39,9 @@ using RuntimeExecutor =
 inline static void executeAsynchronously(
     RuntimeExecutor const &runtimeExecutor,
     std::function<void(jsi::Runtime &runtime)> &&callback) noexcept {
-  std::thread{[callback = std::move(callback), runtimeExecutor]() mutable {
+  std::thread([callback = std::move(callback), runtimeExecutor]() mutable {
     runtimeExecutor(std::move(callback));
-  }};
+  }).detach();
 }
 
 /*


### PR DESCRIPTION
std::thread's constructor is nodiscard. This breaks in MSVC 16.9 when nodiscard starts to be enforced. Either we should hold on to the created object or detach the temporary which is what I think this function intends to do anyway.

Fixes #31088 

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Fixes an invalid usage of std::thread's constructor
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Fixed] - fixes usage of std::thread in runtime executor

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
