### PR TITLE
chore(android, build): use new gradle ABI split API

### DIFF
--- a/template/android/app/build.gradle
+++ b/template/android/app/build.gradle
@@ -1,7 +1,5 @@
 apply plugin: "com.android.application"
 
-import com.android.build.OutputFile
-
 /**
  * The react.gradle file registers a task for each build variant (e.g. bundleDebugJsAndAssets
  * and bundleReleaseJsAndAssets).
@@ -173,12 +171,15 @@ android {
             // https://developer.android.com/studio/build/configure-apk-splits.html
             // Example: versionCode 1 will generate 1001 for armeabi-v7a, 1002 for x86, etc.
             def versionCodes = ["armeabi-v7a": 1, "x86": 2, "arm64-v8a": 3, "x86_64": 4]
-            def abi = output.getFilter(OutputFile.ABI)
-            if (abi != null) {  // null for the universal-debug, universal-release variants
-                output.versionCodeOverride =
-                        defaultConfig.versionCode * 1000 + versionCodes.get(abi)
+            
+            def outputFile = output.outputFile
+            if (outputFile != null && outputFile.name.endsWith('.apk')) {
+                def abi = output.getFilter("ABI")
+                if (abi != null) {  // null for the universal-debug, universal-release variants
+                    output.versionCodeOverride =
+                            defaultConfig.versionCode * 1000 + versionCodes.get(abi)
+                }
             }
-
         }
     }
 }


### PR DESCRIPTION
## Summary

The build.gradle file generates a deprecation warning on use of the OutputFile symbol.

OutputFile is deprecated in the android gradle plugin, there is a new way to find ABI splits

Source file log indicates the method has been available for at least 6 years?
https://android.googlesource.com/platform/tools/base/+/master/build-system/gradle-core/src/main/groovy/com/android/build/gradle/api/ApkOutputFile.java#146

I am forever curious what @friederbluemle thinks when I touch gradle things :-)


## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Fixed] - use new gradle ABI split API

## Test Plan

I tested this on another project that was also using the same old split style - as is still documented by google: https://developer.android.com/studio/build/configure-apk-splits#configure-APK-versions

I was able to successfully generate expected different version codes for each of the APK files resulting from the ABI splits, verifiable via `apkanalyzer manifest version-code <apk file>` (assuming you have apkanalyzer tool installed)
