### PR TITLE
Fixing resetting image tintColor on Android

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagersPropertyCache.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagersPropertyCache.java
@@ -214,6 +214,29 @@ import java.util.Map;
     }
   }
 
+  private static class NullableColorPropSetter extends PropSetter {
+
+    private final int mDefaultValue;
+
+    public NullableColorPropSetter(ReactProp prop, Method setter) {
+      this(prop, setter, 0);
+    }
+
+    public NullableColorPropSetter(ReactProp prop, Method setter, int defaultValue) {
+      super(prop, "mixed", setter);
+      mDefaultValue = defaultValue;
+    }
+
+    @Override
+    protected Object getValueOrDefault(Object value, Context context) {
+      if (value == null) {
+        return null;
+      }
+
+      return ColorPropConverter.getColor(value, context);
+    }
+  }
+
   private static class BooleanPropSetter extends PropSetter {
 
     private final boolean mDefaultValue;
@@ -407,6 +430,9 @@ import java.util.Map;
       if ("Color".equals(annotation.customType())) {
         return new ColorPropSetter(annotation, method, annotation.defaultInt());
       }
+      if ("NullableColor".equals(annotation.customType())) {
+        return new NullableColorPropSetter(annotation, method, annotation.defaultInt());
+      }
       return new IntPropSetter(annotation, method, annotation.defaultInt());
     } else if (propTypeClass == float.class) {
       return new FloatPropSetter(annotation, method, annotation.defaultFloat());
@@ -419,6 +445,9 @@ import java.util.Map;
     } else if (propTypeClass == Integer.class) {
       if ("Color".equals(annotation.customType())) {
         return new ColorPropSetter(annotation, method);
+      }
+      if ("NullableColor".equals(annotation.customType())) {
+        return new NullableColorPropSetter(annotation, method, annotation.defaultInt());
       }
       return new BoxedIntPropSetter(annotation, method);
     } else if (propTypeClass == ReadableArray.class) {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageManager.java
@@ -145,7 +145,7 @@ public class ReactImageManager extends SimpleViewManager<ReactImageView> {
     view.setLoadingIndicatorSource(source);
   }
 
-  @ReactProp(name = "borderColor", customType = "Color")
+  @ReactProp(name = "borderColor", customType = "NullableColor")
   public void setBorderColor(ReactImageView view, @Nullable Integer borderColor) {
     if (borderColor == null) {
       view.setBorderColor(Color.TRANSPARENT);
@@ -154,7 +154,7 @@ public class ReactImageManager extends SimpleViewManager<ReactImageView> {
     }
   }
 
-  @ReactProp(name = "overlayColor", customType = "Color")
+  @ReactProp(name = "overlayColor", customType = "NullableColor")
   public void setOverlayColor(ReactImageView view, @Nullable Integer overlayColor) {
     if (overlayColor == null) {
       view.setOverlayColor(Color.TRANSPARENT);
@@ -209,7 +209,7 @@ public class ReactImageManager extends SimpleViewManager<ReactImageView> {
     }
   }
 
-  @ReactProp(name = "tintColor", customType = "Color")
+  @ReactProp(name = "tintColor", customType = "NullableColor")
   public void setTintColor(ReactImageView view, @Nullable Integer tintColor) {
     if (tintColor == null) {
       view.clearColorFilter();


### PR DESCRIPTION

On Android, trying to reset the 'tintColor' prop of an Image (by removing the prop from the component) is not removing the color filter from the native view, but tries to set the filter value to artibitrary default value. In our feature (just upgraded to RN 0.63), it results in the image going invisible as the view manager tries to set the color filter to the default value of '0'. 

Attaching a snippet below with the repro.

The image view manager assumes that the react JS sents the prop updates with value set to 'null' when the intention is to remove the attribute. [This PR](https://github.com/facebook/react-native/commit/f4de45800f25930a1c70f757d12269d859066d3d#diff-eff5941efbad2c12a91cdca5bba1ee1ec305b8146f692e8c50b6ad8cbeb5ec03) by @tom-un introduced a change in behavior to send a default value when the prop value from JS is set to null. The change affects a couple of other properties too.

This change introduces a new PropSetter which allows null values and associates it with props which expects null values.

.........................................

class MyTouchable extends React.Component {
  constructor(props) {
    super(props);
    this.state = {imageStyle: [{tintColor: '#D2D2D2'}]};
  }

  _onPressButton() {
    this.setState({imageStyle: [undefined]});
  }

  render() {
    return (
      <View>
        <TouchableNativeFeedback
          onPress={this._onPressButton.bind(this)}
          background={TouchableNativeFeedback.SelectableBackground()}>
          <Image
            source={require('../../assets/uie_thumb_normal.png')}
            style={this.state.imageStyle}
          />
        </TouchableNativeFeedback>
      </View>
    );
  }
}

## Changelog

On Android, resetting the 'tintColor' prop of an Image is not removing the color filter. In our feature, it results in the image going invisible as the view manager tried to set the color filter to the default value of '0'.

The image view manager assumes that the react sends the prop updates with value set to 'null' when the intention is to remove the attribute. [This PR](https://github.com/facebook/react-native/commit/f4de45800f25930a1c70f757d12269d859066d3d#diff-eff5941efbad2c12a91cdca5bba1ee1ec305b8146f692e8c50b6ad8cbeb5ec03) by @tom-un introduced a change in behavior to send a default value when the prop value from JS is set to null.

[CATEGORY] [TYPE] - Message

## Test Plan

Fixing a regression. Not a new behaviour or API. Verified that the behaviour of the Image component is identical to RN62.
