### PR TITLE
Fix/30842 accessibility selected state button

### DIFF
--- a/Libraries/Components/Button.js
+++ b/Libraries/Components/Button.js
@@ -263,6 +263,7 @@ class Button extends React.Component<ButtonProps> {
       nextFocusUp,
       disabled,
       testID,
+      accessibilityState = {},
     } = this.props;
     const buttonStyles = [styles.button];
     const textStyles = [styles.text];
@@ -273,7 +274,6 @@ class Button extends React.Component<ButtonProps> {
         buttonStyles.push({backgroundColor: color});
       }
     }
-    const accessibilityState = {};
     if (disabled) {
       buttonStyles.push(styles.buttonDisabled);
       textStyles.push(styles.textDisabled);

--- a/Libraries/Components/Button.js
+++ b/Libraries/Components/Button.js
@@ -23,6 +23,7 @@ const invariant = require('invariant');
 
 import type {PressEvent} from '../Types/CoreEventTypes';
 import type {ColorValue} from '../StyleSheet/StyleSheet';
+import type {AccessibilityState} from './View/ViewAccessibility';
 
 type ButtonProps = $ReadOnly<{|
   /**
@@ -122,6 +123,11 @@ type ButtonProps = $ReadOnly<{|
     Text to display for blindness accessibility features.
    */
   accessibilityLabel?: ?string,
+
+  /**
+    Indicates to accessibility services that UI Component is in a specific State.
+   */
+  accessibilityState?: ?AccessibilityState,
 
   /**
     If `true`, disable all interactions for this component.

--- a/Libraries/Components/Button.js
+++ b/Libraries/Components/Button.js
@@ -269,7 +269,6 @@ class Button extends React.Component<ButtonProps> {
       nextFocusUp,
       disabled,
       testID,
-      accessibilityState = {},
     } = this.props;
     const buttonStyles = [styles.button];
     const textStyles = [styles.text];
@@ -280,6 +279,7 @@ class Button extends React.Component<ButtonProps> {
         buttonStyles.push({backgroundColor: color});
       }
     }
+    let accessibilityState = this.props.accessibilityState || {};
     if (disabled) {
       buttonStyles.push(styles.buttonDisabled);
       textStyles.push(styles.textDisabled);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
Accessibility service does not announce "selected" on accessibilityState = {selected: true} of the Button Component.
Issue link - https://github.com/facebook/react-native/issues/30954
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog
- [General] [Added] - Add accessibilityState prop to Button component
<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

## Test Plan
- Created a button example and tested it on VoiceOver and Talkback
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
