### PR TITLE
add render node utility

### DIFF
--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -19,6 +19,7 @@ const ViewabilityHelper = require('./ViewabilityHelper');
 
 const flattenStyle = require('../StyleSheet/flattenStyle');
 const infoLog = require('../Utilities/infoLog');
+const renderNode = require('../Utilities/renderNode');
 const invariant = require('invariant');
 
 const {computeWindowedRenderLimits} = require('./VirtualizeUtils');
@@ -877,12 +878,7 @@ class VirtualizedList extends React.PureComponent<Props, State> {
       if (stickyIndicesFromProps.has(0)) {
         stickyHeaderIndices.push(0);
       }
-      const element = React.isValidElement(ListHeaderComponent) ? (
-        ListHeaderComponent
-      ) : (
-        // $FlowFixMe
-        <ListHeaderComponent />
-      );
+      const element = renderNode(ListHeaderComponent);
       cells.push(
         <VirtualizedListCellContextProvider
           cellKey={this._getCellKey() + '-header'}
@@ -998,14 +994,7 @@ class VirtualizedList extends React.PureComponent<Props, State> {
         );
       }
     } else if (ListEmptyComponent) {
-      const element: React.Element<any> = ((React.isValidElement(
-        ListEmptyComponent,
-      ) ? (
-        ListEmptyComponent
-      ) : (
-        // $FlowFixMe
-        <ListEmptyComponent />
-      )): any);
+      const element: React.Element<any> = (renderNode(ListEmptyComponent): any);
       cells.push(
         React.cloneElement(element, {
           key: '$empty',
@@ -1020,12 +1009,7 @@ class VirtualizedList extends React.PureComponent<Props, State> {
       );
     }
     if (ListFooterComponent) {
-      const element = React.isValidElement(ListFooterComponent) ? (
-        ListFooterComponent
-      ) : (
-        // $FlowFixMe
-        <ListFooterComponent />
-      );
+      const element = renderNode(ListFooterComponent);
       cells.push(
         <VirtualizedListCellContextProvider
           cellKey={this._getFooterCellKey()}

--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -889,10 +889,7 @@ class VirtualizedList extends React.PureComponent<Props, State> {
               inversionStyle,
               this.props.ListHeaderComponentStyle,
             )}>
-            {
-              // $FlowFixMe - Typing ReactNativeComponent revealed errors
-              element
-            }
+            {element}
           </View>
         </VirtualizedListCellContextProvider>,
       );
@@ -1020,10 +1017,7 @@ class VirtualizedList extends React.PureComponent<Props, State> {
               inversionStyle,
               this.props.ListFooterComponentStyle,
             )}>
-            {
-              // $FlowFixMe - Typing ReactNativeComponent revealed errors
-              element
-            }
+            {element}
           </View>
         </VirtualizedListCellContextProvider>,
       );

--- a/Libraries/Utilities/__tests__/__snapshots__/renderNode-test.js.snap
+++ b/Libraries/Utilities/__tests__/__snapshots__/renderNode-test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renderNode renders simple component 1`] = `null`;

--- a/Libraries/Utilities/__tests__/renderNode-test.js
+++ b/Libraries/Utilities/__tests__/renderNode-test.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @emails oncall+react_native
+ */
+
+'use strict';
+
+const React = require('react');
+const ReactTestRenderer = require('react-test-renderer');
+const renderNode = require('../renderNode');
+
+describe('renderNode', () => {
+  it('renders simple component', () => {
+    class Test extends React.Component<{||}> {
+      render() {
+        return null;
+      }
+    }
+
+    const component = ReactTestRenderer.create(
+      renderNode(Test),
+    );
+    expect(component).toMatchSnapshot();
+  });
+});

--- a/Libraries/Utilities/__tests__/renderNode-test.js
+++ b/Libraries/Utilities/__tests__/renderNode-test.js
@@ -22,9 +22,7 @@ describe('renderNode', () => {
       }
     }
 
-    const component = ReactTestRenderer.create(
-      renderNode(Test),
-    );
+    const component = ReactTestRenderer.create(renderNode(Test));
     expect(component).toMatchSnapshot();
   });
 });

--- a/Libraries/Utilities/renderNode.js
+++ b/Libraries/Utilities/renderNode.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow strict
+ */
+
+'use strict';
+
+const React = require('react');
+
+/**
+ * A simple function that renders a React Node.
+ * 
+ * @param {string} Component - A React Node. Can be a React Component Class, a render function, or a rendered element.
+ */
+function renderNode(Component?: React.ReactNode) {
+  if (!Component) {
+    return null;
+  } else if (React.isValidElement(Component) || typeof Component !== 'function') {
+    return Component;
+  } else {
+    return (
+      // $FlowFixMe
+      <Component />
+    );
+  }
+}
+ 
+module.exports = renderNode;

--- a/Libraries/Utilities/renderNode.js
+++ b/Libraries/Utilities/renderNode.js
@@ -5,35 +5,30 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @flow strict
+ * @flow
  */
 
 'use strict';
 
 const React = require('react');
 
+type ReactNode = React.ComponentType<any> | React.Element<any> | boolean | null;
+
 /**
  * A simple function that renders a React Node.
  *
- * @param {React.ReactNode} Component - A React Node. Can be a React Component Class, a render function, or a rendered element.
+ * @param {ReactNode} Component - Can be a React Component Class, a render function, or a rendered element.
  */
-function renderNode(
-  // $FlowFixMe
-  Component?: React.ReactNode,
-): React.ElementType | null {
-  // $FlowFixMe
+function renderNode(Component?: ReactNode): React.Element<any> | null {
   if (!Component) {
     return null;
   } else if (
     React.isValidElement(Component) ||
     typeof Component !== 'function'
   ) {
-    return Component;
+    return (Component: any);
   } else {
-    return (
-      // $FlowFixMe
-      <Component />
-    );
+    return <Component />;
   }
 }
 

--- a/Libraries/Utilities/renderNode.js
+++ b/Libraries/Utilities/renderNode.js
@@ -17,7 +17,11 @@ const React = require('react');
  *
  * @param {React.ReactNode} Component - A React Node. Can be a React Component Class, a render function, or a rendered element.
  */
-function renderNode(Component?: React.ReactNode) {
+function renderNode(
+  // $FlowFixMe
+  Component?: React.ReactNode,
+): React.ElementType | null {
+  // $FlowFixMe
   if (!Component) {
     return null;
   } else if (

--- a/Libraries/Utilities/renderNode.js
+++ b/Libraries/Utilities/renderNode.js
@@ -15,7 +15,7 @@ const React = require('react');
 /**
  * A simple function that renders a React Node.
  * 
- * @param {string} Component - A React Node. Can be a React Component Class, a render function, or a rendered element.
+ * @param {React.ReactNode} Component - A React Node. Can be a React Component Class, a render function, or a rendered element.
  */
 function renderNode(Component?: React.ReactNode) {
   if (!Component) {

--- a/Libraries/Utilities/renderNode.js
+++ b/Libraries/Utilities/renderNode.js
@@ -14,13 +14,16 @@ const React = require('react');
 
 /**
  * A simple function that renders a React Node.
- * 
+ *
  * @param {React.ReactNode} Component - A React Node. Can be a React Component Class, a render function, or a rendered element.
  */
 function renderNode(Component?: React.ReactNode) {
   if (!Component) {
     return null;
-  } else if (React.isValidElement(Component) || typeof Component !== 'function') {
+  } else if (
+    React.isValidElement(Component) ||
+    typeof Component !== 'function'
+  ) {
     return Component;
   } else {
     return (
@@ -29,5 +32,5 @@ function renderNode(Component?: React.ReactNode) {
     );
   }
 }
- 
+
 module.exports = renderNode;


### PR DESCRIPTION
## Summary

Motivation is to create a simple utility to reuse the validation to render a node from any component.

## Changelog

[General] [Added] - Add render node utility to be used with component props

## Test Plan

Added test with `react-test-renderer` to validate the same output for a simple test component