### PR TITLE
Update React.podspec to require cocoapods >= 1.10.1

### DIFF
--- a/React.podspec
+++ b/React.podspec
@@ -39,7 +39,7 @@ Pod::Spec.new do |s|
   s.platforms              = { :ios => "11.0" }
   s.source                 = source
   s.preserve_paths         = "package.json", "LICENSE", "LICENSE-docs"
-  s.cocoapods_version      = ">= 1.10.0"
+  s.cocoapods_version      = ">= 1.10.1"
 
   s.dependency "React-Core", version
   s.dependency "React-Core/DevSupport", version

--- a/React.podspec
+++ b/React.podspec
@@ -39,7 +39,7 @@ Pod::Spec.new do |s|
   s.platforms              = { :ios => "11.0" }
   s.source                 = source
   s.preserve_paths         = "package.json", "LICENSE", "LICENSE-docs"
-  s.cocoapods_version      = ">= 1.2.0"
+  s.cocoapods_version      = ">= 1.10.0"
 
   s.dependency "React-Core", version
   s.dependency "React-Core/DevSupport", version


### PR DESCRIPTION
According to https://github.com/facebook/react-native/issues/30922#issuecomment-778700328
Cocoapods 1.10.1 is required to compile iOS deps (OpenSSL).

Fixes https://github.com/facebook/react-native/issues/30922#issuecomment-778700328

