### PR TITLE
Fix/30842 - Add accessibilityState prop in slider

### DIFF
--- a/Libraries/Components/Slider/Slider.js
+++ b/Libraries/Components/Slider/Slider.js
@@ -18,6 +18,7 @@ import type {ViewStyleProp} from '../../StyleSheet/StyleSheet';
 import type {ColorValue} from '../../StyleSheet/StyleSheet';
 import type {ViewProps} from '../View/ViewPropTypes';
 import type {SyntheticEvent} from '../../Types/CoreEventTypes';
+import type {AccessibilityState} from './View/ViewAccessibility';
 
 type Event = SyntheticEvent<
   $ReadOnly<{|
@@ -130,6 +131,12 @@ type Props = $ReadOnly<{|
    * Used to locate this view in UI automation tests.
    */
   testID?: ?string,
+
+  /**
+    Indicates to accessibility services that UI Component is in a specific State.
+   */
+  accessibilityState?: ?AccessibilityState,
+
 |}>;
 
 /**
@@ -197,6 +204,7 @@ const Slider = (
   forwardedRef?: ?React.Ref<typeof SliderNativeComponent>,
 ) => {
   const style = StyleSheet.compose(styles.slider, props.style);
+  const accessibilityState = props.accessibilityState || {};
 
   const {
     disabled = false,
@@ -233,6 +241,7 @@ const Slider = (
     <SliderNativeComponent
       {...localProps}
       // TODO: Reconcile these across the two platforms.
+      accessibilityState={accessibilityState}
       enabled={!disabled}
       disabled={disabled}
       maximumValue={maximumValue}

--- a/packages/rn-tester/js/examples/Accessibility/AccessibilityExample.js
+++ b/packages/rn-tester/js/examples/Accessibility/AccessibilityExample.js
@@ -20,6 +20,7 @@ const {
   TouchableWithoutFeedback,
   Alert,
   StyleSheet,
+  Slider,
   Platform,
 } = require('react-native');
 
@@ -604,6 +605,25 @@ class AccessibilityActionsExample extends React.Component {
               <Text>Click me</Text>
             </View>
           </TouchableWithoutFeedback>
+        </RNTesterBlock>
+
+        <RNTesterBlock title="Fake slider example">
+          <View
+            accessible={true}
+            accessibilityRole="adjustable"
+            accessibilityActions={[{name: 'increment'}, {name: 'decrement'}]}
+            onAccessibilityAction={event => {
+              switch (event.nativeEvent.actionName) {
+                case 'increment':
+                  Alert.alert('Alert', 'increment action success');
+                  break;
+                case 'decrement':
+                  Alert.alert('Alert', 'decrement action success');
+                  break;
+              }
+            }}>
+            <Text>Slider</Text>
+          </View>
         </RNTesterBlock>
       </View>
     );

--- a/packages/rn-tester/js/examples/Accessibility/AccessibilityExample.js
+++ b/packages/rn-tester/js/examples/Accessibility/AccessibilityExample.js
@@ -608,22 +608,12 @@ class AccessibilityActionsExample extends React.Component {
         </RNTesterBlock>
 
         <RNTesterBlock title="Fake slider example">
-          <View
-            accessible={true}
-            accessibilityRole="adjustable"
-            accessibilityActions={[{name: 'increment'}, {name: 'decrement'}]}
-            onAccessibilityAction={event => {
-              switch (event.nativeEvent.actionName) {
-                case 'increment':
-                  Alert.alert('Alert', 'increment action success');
-                  break;
-                case 'decrement':
-                  Alert.alert('Alert', 'decrement action success');
-                  break;
-              }
-            }}>
+          <SliderNativeComponent
+           maximumValue={maximumValue}
+           minimumValue={minimumValue}
+           onPress={() => Alert.alert('Alert has been moved')}
+          />
             <Text>Slider</Text>
-          </View>
         </RNTesterBlock>
       </View>
     );


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Accessibility service does not announce "selected" on accessibilityState = {selected: true} of the Button Component.
Issue link - #30956



## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Added] - Add accessibilityState prop to Slider component

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Need to create a slider example and tested it on VoiceOver and Talkback
