### PR TITLE
fix: add an ability to dispatch view manager commands on chosen queue

### DIFF
--- a/React/Modules/RCTUIManager.m
+++ b/React/Modules/RCTUIManager.m
@@ -1135,7 +1135,13 @@ RCT_EXPORT_METHOD(dispatchViewManagerCommand
   }
 
   NSArray *args = [@[ reactTag ] arrayByAddingObjectsFromArray:commandArgs];
-  [method invokeWithBridge:_bridge module:componentData.manager arguments:args];
+  if (moduleData.methodQueue) {
+    dispatch_async(moduleData.methodQueue, ^{
+      [method invokeWithBridge:self->_bridge module:componentData.manager arguments:args];
+    });
+  } else {
+    [method invokeWithBridge:_bridge module:componentData.manager arguments:args];
+  }
 }
 
 - (void)batchDidComplete


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
Issue: we have to wrap all methods with "Dispatch.main.async" otherwise there will be an error that said that you wanted to call method on a ui manager queue. Instead we wanted module's method to be called on the "main" queue.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

We've observed an issue with calling view manager's methods on UI Manager queue even if `methodQueue` is explicitly specified to a different queue. In order to dispatch given code on different queue we need to wrap the code within those methods with `dispatch_async`.

This PR fixes following behaviour by dispatching a method on provided queue, falling back to UI Manager queue if it's not specified.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [Fixed] - Add an ability to dispatch view manager commands on chosen queue

## Test Plan

Tested on a ViewManager that contains the code that should be ran on a main queue, by adding following code: 

```objc
- (dispatch_queue_t)methodQueue
{
    return dispatch_get_main_queue();
}
```

and getting rid of errors.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->


