### PR TITLE
Enable nested scrolling of horizontal scrollviews on Android

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
@@ -21,6 +21,7 @@ import android.view.FocusFinder;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.View;
+import android.view.ViewGroup;
 import android.view.accessibility.AccessibilityEvent;
 import android.widget.HorizontalScrollView;
 import android.widget.OverScroller;
@@ -45,7 +46,9 @@ import com.facebook.react.uimanager.events.NativeGestureUtil;
 import com.facebook.react.views.view.ReactViewBackgroundManager;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Queue;
 
 /** Similar to {@link ReactScrollView} but only supports horizontal scrolling. */
 public class ReactHorizontalScrollView extends HorizontalScrollView
@@ -423,9 +426,53 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
     }
   }
 
+  private HorizontalScrollView findNestedScrollViewForMotionEvent(MotionEvent ev) {
+    Queue<ViewGroup> viewsToSearch = new LinkedList<>();
+    viewsToSearch.add(this);
+
+    HorizontalScrollView foundScrollView = null;
+    ViewGroup view;
+    Rect rectOnScreen = new Rect();
+
+    while ((view = viewsToSearch.poll()) != null) {
+
+      for (int j = 0, len = view.getChildCount(); j < len; j++) {
+        View child = view.getChildAt(j);
+
+        child.getGlobalVisibleRect(rectOnScreen);
+
+        if (!rectOnScreen.contains((int)ev.getRawX(), (int)ev.getRawY())) {
+          continue;
+        }
+
+        if (child instanceof ViewGroup) {
+          viewsToSearch.offer((ViewGroup)child);
+        }
+
+        if (child instanceof ReactHorizontalScrollView) {
+          ReactHorizontalScrollView scrollView = (ReactHorizontalScrollView)child;
+
+          if (!scrollView.mScrollEnabled) {
+            continue;
+          }
+        }
+
+        if (child instanceof HorizontalScrollView) {
+          foundScrollView = (HorizontalScrollView)child;
+        }
+      }
+    }
+
+    return foundScrollView;
+  }
+
   @Override
   public boolean onInterceptTouchEvent(MotionEvent ev) {
     if (!mScrollEnabled) {
+      return false;
+    }
+
+    if (ev.getAction() == MotionEvent.ACTION_DOWN && findNestedScrollViewForMotionEvent(ev) != null) {
       return false;
     }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
@@ -441,16 +441,16 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
 
         child.getGlobalVisibleRect(rectOnScreen);
 
-        if (!rectOnScreen.contains((int)ev.getRawX(), (int)ev.getRawY())) {
+        if (!rectOnScreen.contains((int) ev.getRawX(), (int) ev.getRawY())) {
           continue;
         }
 
         if (child instanceof ViewGroup) {
-          viewsToSearch.offer((ViewGroup)child);
+          viewsToSearch.offer((ViewGroup) child);
         }
 
         if (child instanceof ReactHorizontalScrollView) {
-          ReactHorizontalScrollView scrollView = (ReactHorizontalScrollView)child;
+          ReactHorizontalScrollView scrollView = (ReactHorizontalScrollView) child;
 
           if (!scrollView.mScrollEnabled) {
             continue;
@@ -458,7 +458,7 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
         }
 
         if (child instanceof HorizontalScrollView) {
-          foundScrollView = (HorizontalScrollView)child;
+          foundScrollView = (HorizontalScrollView) child;
         }
       }
     }
@@ -472,7 +472,8 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
       return false;
     }
 
-    if (ev.getAction() == MotionEvent.ACTION_DOWN && findNestedScrollViewForMotionEvent(ev) != null) {
+    if (ev.getAction() == MotionEvent.ACTION_DOWN
+        && findNestedScrollViewForMotionEvent(ev) != null) {
       return false;
     }
 


### PR DESCRIPTION
## Summary
On iOS nested scrolling in horizontal ScrollViews work out of box, on Android it's actually limited by Android's HorizontalScrollView implementation. By slight adjustment in ReactHorizontalScrollView we can have feature parity on Android as well.

## Changelog
[Android] [Changed] - Enabled scrolling in nested horizontal ScrollViews

Only the top ScrollView is consuming the gesture so nested one doesn't have a chance	After the fix the bottom one is targeted by gesture and nested scrolling works
## Test Plan
| Before     | After      |
| ---------- | ---------- |
| Only the top ScrollView is consuming the gesture so nested one doesn't have a chance | After the fix the bottom one is targeted by gesture and nested scrolling works |
| ![android-before](https://user-images.githubusercontent.com/546887/74921268-d549b500-53cd-11ea-92c1-e62bdd6cb7cd.gif) | ![android-after](https://user-images.githubusercontent.com/546887/74921295-e2ff3a80-53cd-11ea-8f76-f331d8615c14.gif) |

### Steps to test
1. Create fresh react native app with react native [compiled](https://github.com/facebook/react-native/wiki/Building-from-source) from this branch
2. Replace `App.js` with [this gist](https://gist.github.com/isnotgood/f7cbe1dc84f0ffa8dfa6da8878cba875)
3. Run android app and observe the nested horizontal scrollviews behaves as expected


Resolves #21436
