### PR TITLE
fix(styles): apply LogBox message colors & styles

### DIFF
--- a/Libraries/LogBox/UI/LogBoxInspectorMessageHeader.js
+++ b/Libraries/LogBox/UI/LogBoxInspectorMessageHeader.js
@@ -107,6 +107,7 @@ const messageStyles = StyleSheet.create({
   },
   messageText: {
     color: LogBoxStyle.getTextColor(0.6),
+    fontSize: 14,
   },
   collapse: {
     color: LogBoxStyle.getTextColor(0.7),

--- a/Libraries/LogBox/UI/LogBoxMessage.js
+++ b/Libraries/LogBox/UI/LogBoxMessage.js
@@ -29,7 +29,7 @@ function LogBoxMessage(props: Props): React.Node {
   const {content, substitutions}: Message = props.message;
 
   if (props.plaintext === true) {
-    return <Text>{cleanContent(content)}</Text>;
+    return <Text style={props.style}>{cleanContent(content)}</Text>;
   }
 
   const maxLength = props.maxLength != null ? props.maxLength : Infinity;
@@ -63,7 +63,7 @@ function LogBoxMessage(props: Props): React.Node {
         substitution.offset - prevOffset,
       );
 
-      createUnderLength(key, prevPart);
+      createUnderLength(key, prevPart, substitutionStyle);
     }
 
     const substititionPart = content.substr(
@@ -77,7 +77,7 @@ function LogBoxMessage(props: Props): React.Node {
 
   if (lastOffset < content.length) {
     const lastPart = content.substr(lastOffset);
-    createUnderLength('-1', lastPart);
+    createUnderLength('-1', lastPart, substitutionStyle);
   }
 
   return <>{elements}</>;

--- a/Libraries/LogBox/UI/LogBoxNotification.js
+++ b/Libraries/LogBox/UI/LogBoxNotification.js
@@ -162,6 +162,7 @@ const messageStyles = StyleSheet.create({
   },
   substitutionText: {
     color: LogBoxStyle.getTextColor(0.6),
+    fontSize: 14,
   },
 });
 


### PR DESCRIPTION
## Summary

Using `setCustomText` from `react-native-global-props` overrides styles for some components of `LogBox`, because these component were missing their own definition of styles and colors, which gives way to `react-native-global-props` to override those styles.

## Problem statement:
using below code sets global props / styles for all text components in the project including LogBox components:
```javascript
import { setCustomText } from 'react-native-global-props'

const customTextProps = {
  allowFontScaling: false,
  style: {
    fontSize: 18,
    fontFamily: 'OpenSans',
    color: '#333',
  },
}

setCustomText(customTextProps)
```
## Changelog

[General] [Changed] - apply LogBox message colors & styles

### Explanation
- color of the text and styles of LogBox are overridden if used with `setCustomText` of `react-native-global-props`
- no new styles or colors are created, just applied the same old styles and colors in components where they was missing their own definition
- missing LogBox colors or styles definition on these components gives way to `react-native-global-props` to override these styles

## Test Plan
With this PR in place problem and Fixes look like this:
BEFORE | AFTER
-------- | -------
![Simulator Screen Shot - iPhone 11 - 2021-03-13 at 18 08 09](https://user-images.githubusercontent.com/6568048/111031014-3a33db00-8427-11eb-908f-7bdf568d5f17.png) | ![Simulator Screen Shot - iPhone 11 - 2021-03-13 at 18 17 26](https://user-images.githubusercontent.com/6568048/111031266-63a13680-8428-11eb-8a27-d70892f1167d.png)



