### PR TITLE
fix: Calling synchronous methods on native modules is not supported in Chrome

### DIFF
--- a/Libraries/BatchedBridge/MessageQueue.js
+++ b/Libraries/BatchedBridge/MessageQueue.js
@@ -169,17 +169,11 @@ class MessageQueue {
     onFail: ?(...mixed[]) => void,
     onSucc: ?(...mixed[]) => void,
   ): mixed {
-    if (__DEV__) {
-      invariant(
-        global.nativeCallSyncHook,
-        'Calling synchronous methods on native ' +
-          'modules is not supported in Chrome.\n\n Consider providing alternative ' +
-          'methods to expose this method in debug mode, e.g. by exposing constants ' +
-          'ahead-of-time.',
-      );
-    }
+    const isDebuggingEnabled = typeof atob !== 'undefined';
     this.processCallbacks(moduleID, methodID, params, onFail, onSucc);
-    return global.nativeCallSyncHook(moduleID, methodID, params);
+    if (!isDebuggingEnabled) {
+      return global.nativeCallSyncHook(moduleID, methodID, params);
+    }
   }
 
   processCallbacks(


### PR DESCRIPTION
fix #26705
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
I try this:

1. `react-native init demo`👈 the lastest version
   2.add package "`react-native-device-info`" to the demo
   3.add code to `App.js`:

```
import DeviceInfo from 'react-native-device-info';
console.log(DeviceInfo.isCameraPresentSync());👈 call a sync function
```

4.open debug mode
5.restart app,then show:

![image](https://user-images.githubusercontent.com/10511797/66122212-b6f73e80-e611-11e9-8008-7db7c0ade12a.png)
```
Invariant Violation: Calling synchronous methods on native modules is not supported in Chrome.

 Consider providing alternative methods to expose this method in debug mode, e.g. by exposing constants ahead-of-time.
```



<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Changed] - disable `global.nativeCallSyncHook` in remote debugging to avoid crash

## Test Plan
With this PR you will never get `Calling synchronous methods on native modules is not supported in Chrome.` on remote debugging

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
