### PR TITLE
Native component check in deprecatedPropType was inverted

### DIFF
--- a/Libraries/ReactNative/PaperUIManager.js
+++ b/Libraries/ReactNative/PaperUIManager.js
@@ -33,6 +33,7 @@ function getConstants(): Object {
 function getViewManagerConfig(viewManagerName: string): any {
   if (
     viewManagerConfigs[viewManagerName] === undefined &&
+    global.nativeCallSyncHook && // If we're in the Chrome Debugger, let's not even try calling the sync method
     NativeUIManager.getConstantsForViewManager
   ) {
     try {

--- a/Libraries/Utilities/deprecatedPropType.js
+++ b/Libraries/Utilities/deprecatedPropType.js
@@ -21,7 +21,7 @@ function deprecatedPropType(
     // Don't warn for native components.
     if (
       !global.RN$Bridgeless &&
-      UIManager.hasViewManagerConfig(componentName) &&
+      !UIManager.hasViewManagerConfig(componentName) &&
       props[propName] !== undefined
     ) {
       console.warn(


### PR DESCRIPTION
## Summary

While investigating an issue hit on a recent sync of [react-native-windows](https://github.com/microsoft/react-native-windows) I noticed that https://github.com/facebook/react-native/commit/e68cf7cee9d36271a1d3899fecff817304bb8bdc appears to have accidently inverted the logic to avoid checking native components.  

`!UIManager.getViewManagerConfig(componentName)`
become 
`UIManager.hasViewManagerConfig(componentName)`
losing the !

Also adding a check in PaperUIManager's getViewManagerConfig to avoid trying to call a sync method when using Chrome Debugging.

## Changelog

[Internal] [Fixed] - Restored the previous logic of deprecatedPropType

## Test Plan

Change tested and being submitted in react-native-windows:
https://github.com/microsoft/react-native-windows/pull/7397
