### PR TITLE
[android] fbjni version to 0.2.2

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -452,9 +452,9 @@ dependencies {
     api("com.squareup.okhttp3:okhttp:${OKHTTP_VERSION}")
     api("com.squareup.okhttp3:okhttp-urlconnection:${OKHTTP_VERSION}")
     api("com.squareup.okio:okio:1.17.5")
-    api("com.facebook.fbjni:fbjni-java-only:0.0.3")
-    extractHeaders("com.facebook.fbjni:fbjni:0.0.2:headers")
-    extractJNI("com.facebook.fbjni:fbjni:0.0.2")
+    api("com.facebook.fbjni:fbjni-java-only:0.2.2")
+    extractHeaders("com.facebook.fbjni:fbjni:0.2.2:headers")
+    extractJNI("com.facebook.fbjni:fbjni:0.2.2")
 
     javadocDeps("com.squareup:javapoet:1.13.0")
 

--- a/ReactAndroid/src/main/libraries/fbjni/BUCK
+++ b/ReactAndroid/src/main/libraries/fbjni/BUCK
@@ -15,6 +15,6 @@ fb_native.android_prebuilt_aar(
 
 fb_native.remote_file(
     name = "fbjni-binary-aar",
-    sha1 = "d9e1b6ebbe55fe25f6ee6257ef64588e0f8a8db0",
-    url = "mvn:com.facebook.fbjni:fbjni:aar:0.0.2",
+    sha1 = "b20ae3406d911a28315b6ab53f122075500bfa27",
+    url = "mvn:com.facebook.fbjni:fbjni:aar:0.2.2",
 )


### PR DESCRIPTION
android fbjni dependency bump to 0.2.2

## Summary

The motivation is to address https://github.com/pytorch/pytorch/issues/34682 that pytorch_android and react-native use different versions of fbjni with the same name libfbjni.so

In case of loading 0.0.2 version it is missing functions in binary

Fbjni is not changing much, that's why this will solve that problem for a long time (Until fbjni changed and versions will not be aligned)

## Changelog

[Android][Added] fbjni version bump to 0.0.3

## Test Plan

Automated (relying on the test suite) and manual testing.
