### PR TITLE
[iOS] Use relative paths for pod spec to keep checksum stable

### DIFF
--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -192,7 +192,7 @@ def use_react_native_codegen!(spec, options={})
     :name => 'Generate Specs',
     :input_files => [srcs_dir],
     :output_files => ["$(DERIVED_FILE_DIR)/codegen-#{codegen_modules_library_name}.log"].concat(generated_files),
-    :script => "set -o pipefail\n\nbash -l -c '#{env_vars} CODEGEN_MODULES_LIBRARY_NAME=#{codegen_modules_library_name} #{File.join("../..", "node_modules/react-native/scripts/generate-specs.sh")}' 2>&1 | tee \"${SCRIPT_OUTPUT_FILE_0}\"",
+    :script => "set -o pipefail\n\nbash -l -c '#{env_vars} CODEGEN_MODULES_LIBRARY_NAME=#{codegen_modules_library_name} ../../node_modules/react-native/scripts/generate-specs.sh' 2>&1 | tee \"${SCRIPT_OUTPUT_FILE_0}\"",
     :execution_position => :before_compile,
     :show_env_vars_in_log => true
   }

--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -197,5 +197,5 @@ def use_react_native_codegen!(spec, options={})
     :show_env_vars_in_log => true
   }
 
-  spec.prepare_command = "#{mkdir_command} && touch #{generated_files.reduce() { |str, file| str + " " + file }}"
+  spec.prepare_command = "cd ../.. && #{mkdir_command} && touch #{generated_files.reduce() { |str, file| str + " " + file }}"
 end

--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -192,7 +192,7 @@ def use_react_native_codegen!(spec, options={})
     :name => 'Generate Specs',
     :input_files => [srcs_dir],
     :output_files => ["$(DERIVED_FILE_DIR)/codegen-#{codegen_modules_library_name}.log"].concat(generated_files),
-    :script => "set -o pipefail\n\nbash -l -c '#{env_vars} CODEGEN_MODULES_LIBRARY_NAME=#{codegen_modules_library_name} #{File.join(__dir__, "generate-specs.sh")}' 2>&1 | tee \"${SCRIPT_OUTPUT_FILE_0}\"",
+    :script => "set -o pipefail\n\nbash -l -c '#{env_vars} CODEGEN_MODULES_LIBRARY_NAME=#{codegen_modules_library_name} #{File.join("../..", "node_modules/react-native/scripts/generate-specs.sh")}' 2>&1 | tee \"${SCRIPT_OUTPUT_FILE_0}\"",
     :execution_position => :before_compile,
     :show_env_vars_in_log => true
   }

--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -149,7 +149,7 @@ def use_react_native_codegen!(spec, options={})
   return if ENV['DISABLE_CODEGEN'] == '1'
 
   # The path to react-native (e.g. react_native_path)
-  prefix = options[:path] ||= File.join(__dir__, "..")
+  prefix = options[:path] ||= "../../node_modules/react-native"
 
   # The path to JavaScript files
   srcs_dir = options[:srcs_dir] ||= File.join(prefix, "Libraries")


### PR DESCRIPTION
## Summary

The `SPEC CHECKSUM` for `FBReactNativeSpec` in `ios/Podfile.lock` varies between development machines. This is caused by local paths in the output of `pod ipc spec FBReactNativeSpec.podspec`, such as `output_files` and `prepare_command`. This causes the Podfile.lock to constantly change when `pod install` is run on different developers' machines.

See issue: https://github.com/facebook/react-native/issues/31193

## Changelog

[iOS] [Fixed] - Fixed pod spec generation to produce relative paths to keep FBReactNativeSpec pod checksum stable

## Test Plan

Apply the changes , run `pod install` and do a full rebuild for the iOS project (delete `~/Library/Developer/Xcode/DerivedData` before building). You should get a working app even with the paths changed.

Also verify that prepare phase creates the correct directory and empty files. I.e., there should not be extranous `node_modules/react-native/React/FBReactNativeSpec` subpaths anywhere (such as under the actual `node_modules/react-native` folder).