### PR TITLE
LogBox fixes for Mac Catalyst

### DIFF
--- a/Libraries/LogBox/LogBoxInspectorContainer.js
+++ b/Libraries/LogBox/LogBoxInspectorContainer.js
@@ -21,8 +21,8 @@ type Props = $ReadOnly<{|
 |}>;
 
 export class _LogBoxInspectorContainer extends React.Component<Props> {
-  const {width, height} = Dimensions.get('window');
   render(): React.Node {
+    const {width, height} = Dimensions.get('window');
     return (
       <View style={[StyleSheet.absoluteFill, {width, height}]}>
         <LogBoxInspector

--- a/Libraries/LogBox/LogBoxInspectorContainer.js
+++ b/Libraries/LogBox/LogBoxInspectorContainer.js
@@ -9,7 +9,7 @@
  */
 
 import * as React from 'react';
-import {View, StyleSheet} from 'react-native';
+import {Dimensions, View, StyleSheet} from 'react-native';
 import * as LogBoxData from './Data/LogBoxData';
 import LogBoxInspector from './UI/LogBoxInspector';
 import type LogBoxLog from './Data/LogBoxLog';
@@ -21,9 +21,10 @@ type Props = $ReadOnly<{|
 |}>;
 
 export class _LogBoxInspectorContainer extends React.Component<Props> {
+  const {width, height} = Dimensions.get('window');
   render(): React.Node {
     return (
-      <View style={StyleSheet.absoluteFill}>
+      <View style={[StyleSheet.absoluteFill, {width, height}]}>
         <LogBoxInspector
           onDismiss={this._handleDismiss}
           onMinimize={this._handleMinimize}

--- a/React/CoreModules/RCTDevLoadingView.mm
+++ b/React/CoreModules/RCTDevLoadingView.mm
@@ -132,6 +132,16 @@ RCT_EXPORT_MODULE()
         self->_window = [[UIWindow alloc] initWithFrame:CGRectMake(0, 0, screenSize.width, 20)];
         self->_label = [[UILabel alloc] initWithFrame:self->_window.bounds];
       }
+        
+      #if TARGET_OS_MACCATALYST
+        UIView *mainWindow = RCTKeyWindow();
+        CGSize windowSize = mainWindow ? mainWindow.bounds.size : screenSize;
+        self->_window =
+            [[UIWindow alloc] initWithFrame:CGRectMake(0, 0, windowSize.width, mainWindow.safeAreaInsets.top + 10)];
+        self->_label =
+            [[UILabel alloc] initWithFrame:CGRectMake(0, mainWindow.safeAreaInsets.top - 10, windowSize.width, 20)];
+      #endif
+        
       [self->_window addSubview:self->_label];
 
       self->_window.windowLevel = UIWindowLevelStatusBar + 1;


### PR DESCRIPTION
## Summary

Fixes #30741

## Changelog

[iOS] [Fixed] - Fixes incorrect LogBox and RCTDevLoadingView dimensions when building for Mac Catalyst

## Test Plan

- enable "Mac" checkbox in Xcode's General tab for the main target ("Deployment Info" section)
- select "My Mac" as a destination
- build & run sample app on the Debug scheme
- simulate any warning or error
- RCTDevLoadingView width and LogBox width & height are computed correctly according to real window width and height

<img width="1394" alt="Снимок экрана 2021-03-22 в 12 10 56" src="https://user-images.githubusercontent.com/20115419/111966317-d769d000-8b07-11eb-91d0-385ef9411908.png">
