### PR TITLE
feat: pass null to onCreate

### DIFF
--- a/template/android/app/src/main/java/com/helloworld/MainActivity.java
+++ b/template/android/app/src/main/java/com/helloworld/MainActivity.java
@@ -2,6 +2,8 @@ package com.helloworld;
 
 import com.facebook.react.ReactActivity;
 
+import android.os.Bundle;
+
 public class MainActivity extends ReactActivity {
 
   /**
@@ -11,5 +13,10 @@ public class MainActivity extends ReactActivity {
   @Override
   protected String getMainComponentName() {
     return "HelloWorld";
+  }
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(null);
   }
 }


### PR DESCRIPTION
## Summary

Suggested by @kmagiera change of the default App template to not include the Bundle in `onCreate` method since, on Android, the view state is not persisted consistently across Activity restarts, which can lead to crashes in those cases. More information about it is gathered in here: https://github.com/software-mansion/react-native-screens/issues/17#issuecomment-425027574 and replies.

## Changelog

[Android] [added] - passed null to `onCreate` method in `MainActivity`.

## Test Plan

It is not a trivial PR to be tested since it includes various scenarios. Use cases are recreation of the app state after e.g. backgrounding the app.