### PR TITLE
[iOS] Avoid redundant recursion in RCTView accessibilityLabel

### DIFF
--- a/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -558,7 +558,12 @@ static NSString *RCTRecursiveAccessibilityLabel(UIView *view)
   NSMutableString *result = [NSMutableString stringWithString:@""];
   for (UIView *subview in view.subviews) {
     NSString *label = subview.accessibilityLabel;
-    static Class otherClass = NSClassFromString(@"RCTView");
+    static Class otherClass = nil;
+    static BOOL otherClassLookedUp = NO;
+    if (!otherClass && !otherClassLookedUp) {
+      otherClass = NSClassFromString(@"RCTView");
+      otherClassLookedUp = YES;
+    }
     if (!label && ![subview isKindOfClass:[RCTViewComponentView class]] && ![subview isKindOfClass:otherClass]) {
       label = RCTRecursiveAccessibilityLabel(subview);
     }

--- a/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -558,7 +558,7 @@ static NSString *RCTRecursiveAccessibilityLabel(UIView *view)
   NSMutableString *result = [NSMutableString stringWithString:@""];
   for (UIView *subview in view.subviews) {
     NSString *label = subview.accessibilityLabel;
-    if (!label) {
+    if (!label && ![subview isKindOfClass:[RCTViewComponentView class]]) {
       label = RCTRecursiveAccessibilityLabel(subview);
     }
     if (label && label.length > 0) {

--- a/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -558,7 +558,8 @@ static NSString *RCTRecursiveAccessibilityLabel(UIView *view)
   NSMutableString *result = [NSMutableString stringWithString:@""];
   for (UIView *subview in view.subviews) {
     NSString *label = subview.accessibilityLabel;
-    if (!label && ![subview isKindOfClass:[RCTViewComponentView class]]) {
+    static Class otherClass = NSClassFromString(@"RCTView");
+    if (!label && ![subview isKindOfClass:[RCTViewComponentView class]] && ![subview isKindOfClass:otherClass]) {
       label = RCTRecursiveAccessibilityLabel(subview);
     }
     if (label && label.length > 0) {

--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -85,7 +85,7 @@ static NSString *RCTRecursiveAccessibilityLabel(UIView *view)
   NSMutableString *str = [NSMutableString stringWithString:@""];
   for (UIView *subview in view.subviews) {
     NSString *label = subview.accessibilityLabel;
-    if (!label) {
+    if (!label && ![subview isKindOfClass:[RCTView class]]) {
       label = RCTRecursiveAccessibilityLabel(subview);
     }
     if (label && label.length > 0) {

--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -85,7 +85,12 @@ static NSString *RCTRecursiveAccessibilityLabel(UIView *view)
   NSMutableString *str = [NSMutableString stringWithString:@""];
   for (UIView *subview in view.subviews) {
     NSString *label = subview.accessibilityLabel;
-    static Class otherClass = NSClassFromString(@"RCTViewComponentView");
+    static Class otherClass = nil;
+    static BOOL otherClassLookedUp = NO;
+    if (!otherClass && !otherClassLookedUp) {
+      otherClass = NSClassFromString(@"RCTViewComponentView");
+      otherClassLookedUp = YES;
+    }
     if (!label && ![subview isKindOfClass:[RCTView class]] && ![subview isKindOfClass:otherClass]) {
       label = RCTRecursiveAccessibilityLabel(subview);
     }

--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -85,7 +85,8 @@ static NSString *RCTRecursiveAccessibilityLabel(UIView *view)
   NSMutableString *str = [NSMutableString stringWithString:@""];
   for (UIView *subview in view.subviews) {
     NSString *label = subview.accessibilityLabel;
-    if (!label && ![subview isKindOfClass:[RCTView class]]) {
+    static Class otherClass = NSClassFromString(@"RCTViewComponentView");
+    if (!label && ![subview isKindOfClass:[RCTView class]] && ![subview isKindOfClass:otherClass]) {
       label = RCTRecursiveAccessibilityLabel(subview);
     }
     if (label && label.length > 0) {


### PR DESCRIPTION
## Summary

This is a more conservative approach to address the exact same problems highlighted in this other pull request: https://github.com/facebook/react-native/pull/29801 (which i prefer to this one in the longer term, to be clear).

This change greatly improves performance (and stability) when testing ReactNative iOS apps using XCTest or Appium, which heavily rely on accessibility queries in order to interact with UI elements.

In particular, if `subview` is a `RCTView` or subclass, there's no need to trigger the recursion again, because it already did implicitly when accessing the `.accessibilityLabel` property in the previous line.

Doing the recursion twice is expensive in general, but in this particular situation especially because the recursion is always exhaustive so the entire subtree has been walked, and the existing code will trigger another one just right after, which will lead to the same result but at twice cost (and that's only for a single visited node in the recursion).

Now let's imagine all this expensive stuff going on when asking for a property which usually it's just a stored value, and XCTest basically does this for pretty much every element in the ui, in its own recursion of the hierarchy each time it interacts with an element. Plus the fact that all this happens on the main thread: with apps over a certain threshold of structural complexity this is indistinguishable from an infinite loop which keeps allocating memory, so the UI freezes up for a while and eventually iOS kills the app for jetsam.

This change shouldn't affect the result of `-[RCTView accessibilityLabel]` in any other way than improving performance.

The reasoning is the same for `-[RCTViewComponentView accessibilityLabel]`.

## Changelog

[iOS] [Fixed] - Avoid redundant recursion in `-[RCTView accessibilityLabel]` and `-[RCTViewComponentView accessibilityLabel]`

## Test Plan

Nothing easy to share.
