### PR TITLE
[ScrollView] remove remnants of VR platform

### DIFF
--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -26,7 +26,6 @@ import dismissKeyboard from '../../Utilities/dismissKeyboard';
 import flattenStyle from '../../StyleSheet/flattenStyle';
 import invariant from 'invariant';
 import processDecelerationRate from './processDecelerationRate';
-import resolveAssetSource from '../../Image/resolveAssetSource';
 import splitLayoutProps from '../../StyleSheet/splitLayoutProps';
 import setAndForwardRef from '../../Utilities/setAndForwardRef';
 
@@ -428,22 +427,6 @@ type AndroidProps = $ReadOnly<{|
   fadingEdgeLength?: ?number,
 |}>;
 
-type VRProps = $ReadOnly<{|
-  /**
-   * Optionally an image can be used for the scroll bar thumb. This will
-   * override the color. While the image is loading or the image fails to
-   * load the color will be used instead. Use an alpha of 0 in the color
-   * to avoid seeing it while the image is loading.
-   *
-   * - `uri` - a string representing the resource identifier for the image, which
-   * should be either a local file path or the name of a static image resource
-   * - `number` - Opaque type returned by something like
-   * `import IMAGE from './image.jpg'`.
-   * @platform vr
-   */
-  scrollBarThumbImage?: ?($ReadOnly<{||}> | number), // Opaque type returned by import IMAGE from './image.jpg'
-|}>;
-
 type StickyHeaderComponentType = React.AbstractComponent<
   ScrollViewStickyHeaderProps,
   $ReadOnly<interface {setNextHeaderY: number => void}>,
@@ -453,7 +436,6 @@ export type Props = $ReadOnly<{|
   ...ViewProps,
   ...IOSProps,
   ...AndroidProps,
-  ...VRProps,
 
   /**
    * These styles will be applied to the scroll view content container which
@@ -1724,7 +1706,6 @@ class ScrollView extends React.Component<Props, State> {
       onTouchStart: this._handleTouchStart,
       onTouchCancel: this._handleTouchCancel,
       onScroll: this._handleScroll,
-      scrollBarThumbImage: resolveAssetSource(this.props.scrollBarThumbImage),
       scrollEventThrottle: hasStickyHeaders
         ? 1
         : this.props.scrollEventThrottle,

--- a/Libraries/Components/ScrollView/__tests__/__snapshots__/ScrollView-test.js.snap
+++ b/Libraries/Components/ScrollView/__tests__/__snapshots__/ScrollView-test.js.snap
@@ -34,7 +34,6 @@ exports[`<ScrollView /> should render as expected: should deep render when not m
   onTouchMove={[Function]}
   onTouchStart={[Function]}
   pagingEnabled={false}
-  scrollBarThumbImage={null}
   scrollViewRef={null}
   sendMomentumEvents={false}
   snapToEnd={true}


### PR DESCRIPTION
## Summary

It looks like `ScrollView` still contains the remnant props for VR platform, which afaik has be discontinued a while ago (please correct me, if I'm wrong).

This PR removes `scrollBarThumbImage` prop marked as VR platform only prop from `ScrollView`.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[VR] [Removed] - remove VR platform specific `scrollBarThumbImage` prop from `ScrollView`

## Test Plan

CI
