### PR TITLE
remove operation to `ensureNullTerminated ` when loading JS Bundle

### DIFF
--- a/React/CxxBridge/NSDataBigString.mm
+++ b/React/CxxBridge/NSDataBigString.mm
@@ -10,33 +10,10 @@
 namespace facebook {
 namespace react {
 
-static NSData *ensureNullTerminated(NSData *source)
-{
-  if (!source || source.length == 0) {
-    return nil;
-  }
-
-  NSUInteger sourceLength = source.length;
-  unsigned char lastByte;
-  [source getBytes:&lastByte range:NSMakeRange(sourceLength - 1, 1)];
-
-  // TODO: bundles from the packager should always include a NULL byte
-  // or we should we relax this requirement and only read as much from the
-  // buffer as length indicates
-  if (lastByte == '\0') {
-    return source;
-  } else {
-    NSMutableData *data = [source mutableCopy];
-    unsigned char nullByte = '\0';
-    [data appendBytes:&nullByte length:1];
-    return data;
-  }
-}
-
 NSDataBigString::NSDataBigString(NSData *data)
 {
   m_length = [data length];
-  m_data = ensureNullTerminated(data);
+  m_data = data;
 }
 
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Previously, I have found an [issue 30145](https://github.com/facebook/react-native/issues/30145). 
- Actually, there is no need for this `ensureNullTerminated`  because the actual size is used in [evaluateJavaScript](https://github.com/sueLan/react-native/blob/3bbb0a43c2e84991f70ad7b15741ecac5d31ba66/ReactCommon/jsi/JSCRuntime.cpp#L417) phase 
- it has impact in memory footprint. The size of memory usage is related to JS Bundle size. [my test here](https://github.com/facebook/react-native/issues/30145#issuecomment-805003901)
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [Fixed] - Fix an issue for costly copy and ensure null terminated operation when loading JS bundle 

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
The command I run: 
```
./scripts/objc-test.sh test
```
![image](https://user-images.githubusercontent.com/7471672/112449948-d4ccdc00-8d8e-11eb-906d-7444b83c7633.png)


Only  test case for `testBundleURL` failed. But it seems this test case itself was broken. I didn't make any change related to `[RCTBundleURLProvider sharedSettings]`
![image](https://user-images.githubusercontent.com/7471672/112450382-5290e780-8d8f-11eb-843d-c0ab7864646c.png)
![image](https://user-images.githubusercontent.com/7471672/112450711-9e439100-8d8f-11eb-8cad-a944ea4258ac.png)

```
Printing description of URL:
http://localhost:8081/test.jsbundle.bundle?platform=ios&dev=true&minify=false&modulesOnly=false&runModule=true&app=com.apple.dt.xctest.tool
(lldb) po mainBundleURL()
file:///Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/Library/Xcode/Agents/main.jsbundle
```



