### PR TITLE
Add onPressIn & onPressOut props to Text

### DIFF
--- a/Libraries/Text/Text.js
+++ b/Libraries/Text/Text.js
@@ -86,6 +86,8 @@ const Text: React.AbstractComponent<
       pressRetentionOffset,
       onLongPress,
       onPress,
+      onPressIn,
+      onPressOut,
       onResponderTerminationRequest,
       onStartShouldSetResponder,
       suppressHighlighting,

--- a/Libraries/Text/Text.js
+++ b/Libraries/Text/Text.js
@@ -34,6 +34,8 @@ const Text: React.AbstractComponent<
     ellipsizeMode,
     onLongPress,
     onPress,
+    onPressIn,
+    onPressOut,
     onResponderGrant,
     onResponderMove,
     onResponderRelease,
@@ -64,9 +66,15 @@ const Text: React.AbstractComponent<
             onPress,
             onPressIn(event) {
               setHighlighted(!suppressHighlighting);
+              if (onPressIn) {
+                onPressIn(event);
+              }
             },
             onPressOut(event) {
               setHighlighted(false);
+              if (onPressOut) {
+                onPressOut(event);
+              }
             },
             onResponderTerminationRequest_DEPRECATED: onResponderTerminationRequest,
             onStartShouldSetResponder_DEPRECATED: onStartShouldSetResponder,

--- a/Libraries/Text/TextProps.js
+++ b/Libraries/Text/TextProps.js
@@ -122,6 +122,8 @@ export type TextProps = $ReadOnly<{|
    * See https://reactnative.dev/docs/text.html#onpress
    */
   onPress?: ?(event: PressEvent) => mixed,
+  onPressIn?: ?(event: PressEvent) => mixed,
+  onPressOut?: ?(event: PressEvent) => mixed,
   onResponderGrant?: ?(event: PressEvent) => void,
   onResponderMove?: ?(event: PressEvent) => void,
   onResponderRelease?: ?(event: PressEvent) => void,


### PR DESCRIPTION
## Summary

I added onPressIn & onPressOut props to Text to help implement custom highlighting logic (e.g. when clicking on a Text segment). Since TouchableOpacity can't be nested in Text having custom lineHeights without bugs in some occasions, this modification helps to replicate its behavior.

## Changelog

[General] [Added] - Add onPressIn & onPressOut props to Text

## Test Plan

```
const [pressing, setPressing] = useState(false);

<Text
  onPressIn={() => setPressing(true)}
  onPressOut={() => setPressing(false)}
  style={{ opacity: pressing ? 0.5 : 1 }}
/>
```

Thanks in advance!