### PR TITLE
feat: soft input view iOS component

### DIFF
--- a/Libraries/Components/TextInput/RCTSoftInputViewNativeComponent.js
+++ b/Libraries/Components/TextInput/RCTSoftInputViewNativeComponent.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {ViewProps} from '../View/ViewPropTypes';
+
+import codegenNativeComponent from '../../Utilities/codegenNativeComponent';
+import type {HostComponent} from '../../Renderer/shims/ReactNativeTypes';
+
+type NativeProps = $ReadOnly<{|
+  ...ViewProps,
+|}>;
+
+export default (codegenNativeComponent<NativeProps>('SoftInput', {
+  interfaceOnly: true,
+  paperComponentName: 'RCTSoftInputView',
+  excludedPlatforms: ['android'],
+}): HostComponent<NativeProps>);

--- a/Libraries/Components/TextInput/RCTTextInputViewConfig.js
+++ b/Libraries/Components/TextInput/RCTTextInputViewConfig.js
@@ -96,6 +96,7 @@ const RCTTextInputViewConfig = {
     textShadowColor: {process: require('../../StyleSheet/processColor')},
     editable: true,
     inputAccessoryViewID: true,
+    softInputViewID: true,
     caretHidden: true,
     enablesReturnKeyAutomatically: true,
     placeholderTextColor: {process: require('../../StyleSheet/processColor')},

--- a/Libraries/Components/TextInput/SoftInputView.js
+++ b/Libraries/Components/TextInput/SoftInputView.js
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+const Platform = require('../../Utilities/Platform');
+const React = require('react');
+const StyleSheet = require('../../StyleSheet/StyleSheet');
+
+import RCTSoftInputViewNativeComponent from './RCTSoftInputViewNativeComponent';
+
+import type {ViewStyleProp} from '../../StyleSheet/StyleSheet';
+
+/**
+ * Note: iOS only
+ *
+ * A component which enables customization of the soft input view.
+ * This component can be used to display e.g. date pickers, pickers or other custom way of inputting data.
+ *
+ * To use this component wrap your custom input component with the
+ * SoftInputView component, and set a nativeID. Then, pass that nativeID
+ * as the softInputViewID of whatever TextInput you desire. A simple
+ * example:
+ *
+ * ```ReactNativeWebPlayer
+ * import React, { Component } from 'react';
+ * import { AppRegistry, TextInput, SoftInputView, Button } from 'react-native';
+ *
+ * export default class UselessTextInput extends Component {
+ *   constructor(props) {
+ *     super(props);
+ *     this.state = {platform: 'Android'};
+ *   }
+ *
+ *   render() {
+ *     const softInputViewID = "uniqueID";
+ *     return (
+ *       <View>
+ *         <ScrollView keyboardDismissMode="interactive">
+ *           <TextInput
+ *             style={{
+ *               padding: 10,
+ *               paddingTop: 50,
+ *             }}
+ *             softInputViewID={softInputViewID}
+ *             value={this.state.platform}
+ *           />
+ *         </ScrollView>
+ *         <SoftInputView nativeID={softInputViewID}>
+ *           <Button
+ *             onPress={() => this.setState({platform: 'Android'})}
+ *             title="Android"
+ *           />
+ *           <Button
+ *             onPress={() => this.setState({platform: 'iOS'})}
+ *             title="iOS"
+ *           />
+ *         </SoftInputView>
+ *       </View>
+ *     );
+ *   }
+ * }
+ *
+ * // skip this line if using Create React Native App
+ * AppRegistry.registerComponent('AwesomeProject', () => UselessTextInput);
+ * ```
+ */
+
+type Props = $ReadOnly<{|
+  +children: React.Node,
+  /**
+   * An ID which is used to associate this `SoftInputView` to
+   * specified TextInput(s).
+   */
+  nativeID?: ?string,
+  style?: ?ViewStyleProp,
+|}>;
+
+class SoftInputView extends React.Component<Props> {
+  render(): React.Node {
+    if (Platform.OS !== 'ios') {
+      console.warn('<SoftInputView> is only supported on iOS.');
+    }
+
+    if (
+      React.Children.count(this.props.children) === 0 ||
+      !this.props.nativeID
+    ) {
+      return null;
+    }
+
+    return (
+      <RCTSoftInputViewNativeComponent
+        style={[this.props.style, styles.container]}
+        nativeID={this.props.nativeID}>
+        {this.props.children}
+      </RCTSoftInputViewNativeComponent>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+  },
+});
+
+module.exports = SoftInputView;

--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -292,6 +292,14 @@ type IOSProps = $ReadOnly<{|
   scrollEnabled?: ?boolean,
 
   /**
+   * An optional identifier which links a custom SoftInputView to
+   * this text input. The SoftInputView is rendered instead of keyboard when
+   * this text input is focused.
+   * @platform ios
+   */
+  softInputViewID?: ?string,
+
+  /**
    * If `false`, disables spell-check style (i.e. red underlines).
    * The default value is inherited from `autoCorrect`.
    * @platform ios
@@ -1200,6 +1208,7 @@ const ExportedForwardRef: React.AbstractComponent<
   {
     allowFontScaling = true,
     rejectResponderTermination = true,
+    showSoftInputOnFocus = true,
     underlineColorAndroid = 'transparent',
     ...restProps
   },
@@ -1211,6 +1220,7 @@ const ExportedForwardRef: React.AbstractComponent<
     <InternalTextInput
       allowFontScaling={allowFontScaling}
       rejectResponderTermination={rejectResponderTermination}
+      showSoftInputOnFocus={showSoftInputOnFocus}
       underlineColorAndroid={underlineColorAndroid}
       {...restProps}
       forwardedRef={forwardedRef}

--- a/Libraries/Components/TextInput/__tests__/SoftInputView-test.js
+++ b/Libraries/Components/TextInput/__tests__/SoftInputView-test.js
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @emails oncall+react_native
+ * @flow strict-local
+ */
+
+'use strict';
+
+const React = require('react');
+const View = require('../../View/View');
+const SoftInputView = require('../SoftInputView');
+const render = require('../../../../jest/renderer');
+
+describe('<SoftInputView />', () => {
+  it('should render as <RCTSoftInputView> when mocked', () => {
+    const instance = render.create(
+      <SoftInputView nativeID="1">
+        <View />
+      </SoftInputView>,
+    );
+    expect(instance).toMatchSnapshot();
+  });
+
+  it('should shallow render as <SoftInputView> when mocked', () => {
+    const output = render.shallow(
+      <SoftInputView nativeID="1">
+        <View />
+      </SoftInputView>,
+    );
+    expect(output).toMatchSnapshot();
+  });
+
+  it('should shallow render as <SoftInputView> when not mocked', () => {
+    jest.dontMock('../SoftInputView');
+
+    const output = render.shallow(
+      <SoftInputView nativeID="1">
+        <View />
+      </SoftInputView>,
+    );
+    expect(output).toMatchSnapshot();
+  });
+
+  it('should render as <RCTSoftInputView> when not mocked', () => {
+    jest.dontMock('../SoftInputView');
+
+    const instance = render.create(
+      <SoftInputView nativeID="1">
+        <View />
+      </SoftInputView>,
+    );
+    expect(instance).toMatchSnapshot();
+  });
+});

--- a/Libraries/Components/TextInput/__tests__/__snapshots__/SoftInputView-test.js.snap
+++ b/Libraries/Components/TextInput/__tests__/__snapshots__/SoftInputView-test.js.snap
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<SoftInputView /> should render as <RCTSoftInputView> when mocked 1`] = `
+<RCTSoftInputView
+  nativeID="1"
+  style={
+    Array [
+      undefined,
+      Object {
+        "position": "absolute",
+      },
+    ]
+  }
+>
+  <View />
+</RCTSoftInputView>
+`;
+
+exports[`<SoftInputView /> should render as <RCTSoftInputView> when not mocked 1`] = `
+<RCTSoftInputView
+  nativeID="1"
+  style={
+    Array [
+      undefined,
+      Object {
+        "position": "absolute",
+      },
+    ]
+  }
+>
+  <View />
+</RCTSoftInputView>
+`;
+
+exports[`<SoftInputView /> should shallow render as <SoftInputView> when mocked 1`] = `
+<SoftInputView
+  nativeID="1"
+>
+  <View />
+</SoftInputView>
+`;
+
+exports[`<SoftInputView /> should shallow render as <SoftInputView> when not mocked 1`] = `
+<SoftInputView
+  nativeID="1"
+>
+  <View />
+</SoftInputView>
+`;

--- a/Libraries/Components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
+++ b/Libraries/Components/TextInput/__tests__/__snapshots__/TextInput-test.js.snap
@@ -23,6 +23,7 @@ exports[`TextInput tests should render as expected: should deep render when mock
   onStartShouldSetResponder={[Function]}
   rejectResponderTermination={true}
   selection={null}
+  showSoftInputOnFocus={true}
   text=""
   underlineColorAndroid="transparent"
 />
@@ -51,6 +52,7 @@ exports[`TextInput tests should render as expected: should deep render when not 
   onStartShouldSetResponder={[Function]}
   rejectResponderTermination={true}
   selection={null}
+  showSoftInputOnFocus={true}
   text=""
   underlineColorAndroid="transparent"
 />

--- a/Libraries/DeprecatedPropTypes/DeprecatedTextInputPropTypes.js
+++ b/Libraries/DeprecatedPropTypes/DeprecatedTextInputPropTypes.js
@@ -551,6 +551,13 @@ module.exports = {
    */
   inputAccessoryViewID: PropTypes.string,
   /**
+   * An optional identifier which links a custom SoftInputView to
+   * this text input. The SoftInputView is rendered instead of keyboard when
+   * this text input is focused.
+   * @platform ios
+   */
+  softInputViewID: PropTypes.string,
+  /**
    * Give the keyboard and the system information about the
    * expected semantic meaning for the content that users enter.
    * @platform ios

--- a/Libraries/Text/TextInput/Multiline/RCTUITextView.h
+++ b/Libraries/Text/TextInput/Multiline/RCTUITextView.h
@@ -36,6 +36,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) BOOL caretHidden;
 
 @property (nonatomic, strong, nullable) NSString *inputAccessoryViewID;
+@property (nonatomic, strong, nullable) NSString *softInputViewID;
+@property (nonatomic, assign) BOOL showSoftInputOnFocus;
 
 @end
 

--- a/Libraries/Text/TextInput/RCTBackedTextInputViewProtocol.h
+++ b/Libraries/Text/TextInput/RCTBackedTextInputViewProtocol.h
@@ -31,6 +31,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) UITextFieldViewMode clearButtonMode;
 @property (nonatomic, getter=isScrollEnabled) BOOL scrollEnabled;
 @property (nonatomic, strong, nullable) NSString *inputAccessoryViewID;
+@property (nonatomic, strong, nullable) NSString *softInputViewID;
+@property (nonatomic, assign) BOOL showSoftInputOnFocus;
 
 // This protocol disallows direct access to `selectedTextRange` property because
 // unwise usage of it can break the `delegate` behavior. So, we always have to

--- a/Libraries/Text/TextInput/RCTBaseTextInputView.h
+++ b/Libraries/Text/TextInput/RCTBaseTextInputView.h
@@ -49,6 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, nullable) NSNumber *maxLength;
 @property (nonatomic, copy, nullable) NSAttributedString *attributedText;
 @property (nonatomic, copy) NSString *inputAccessoryViewID;
+@property (nonatomic, copy) NSString *softInputViewID;
 @property (nonatomic, assign) UIKeyboardType keyboardType;
 @property (nonatomic, assign) BOOL showSoftInputOnFocus;
 

--- a/Libraries/Text/TextInput/RCTBaseTextInputViewManager.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputViewManager.m
@@ -57,6 +57,7 @@ RCT_EXPORT_VIEW_PROPERTY(maxLength, NSNumber)
 RCT_EXPORT_VIEW_PROPERTY(selectTextOnFocus, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(selection, RCTTextSelection)
 RCT_EXPORT_VIEW_PROPERTY(inputAccessoryViewID, NSString)
+RCT_EXPORT_VIEW_PROPERTY(softInputViewID, NSString)
 RCT_EXPORT_VIEW_PROPERTY(textContentType, NSString)
 RCT_EXPORT_VIEW_PROPERTY(passwordRules, NSString)
 

--- a/Libraries/Text/TextInput/RCTSoftInputShadowView.h
+++ b/Libraries/Text/TextInput/RCTSoftInputShadowView.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <React/RCTShadowView.h>
+
+@interface RCTSoftInputShadowView : RCTShadowView
+
+@end

--- a/Libraries/Text/TextInput/RCTSoftInputShadowView.m
+++ b/Libraries/Text/TextInput/RCTSoftInputShadowView.m
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <React/RCTSoftInputShadowView.h>
+
+#import <React/RCTUtils.h>
+
+@implementation RCTSoftInputShadowView
+
+- (void)insertReactSubview:(RCTShadowView *)subview atIndex:(NSInteger)atIndex
+{
+  [super insertReactSubview:subview atIndex:atIndex];
+  subview.width = (YGValue) { RCTScreenSize().width, YGUnitPoint };
+}
+
+@end

--- a/Libraries/Text/TextInput/RCTSoftInputView.h
+++ b/Libraries/Text/TextInput/RCTSoftInputView.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <UIKit/UIKit.h>
+
+@class RCTBridge;
+@class RCTSoftInputViewContent;
+
+@interface RCTSoftInputView : UIView
+
+- (instancetype)initWithBridge:(RCTBridge *)bridge;
+
+@end

--- a/Libraries/Text/TextInput/RCTSoftInputView.m
+++ b/Libraries/Text/TextInput/RCTSoftInputView.m
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <React/RCTSoftInputView.h>
+
+#import <React/RCTBridge.h>
+#import <React/RCTTouchHandler.h>
+#import <React/UIView+React.h>
+
+#import <React/RCTSoftInputViewContent.h>
+
+@interface RCTSoftInputView()
+
+// Overriding `softInputView` to `readwrite`.
+@property (nonatomic, readwrite, retain) UIView *inputView;
+
+@end
+
+@implementation RCTSoftInputView
+
+- (instancetype)initWithBridge:(RCTBridge *)bridge
+{
+  if (self = [super init]) {
+    _inputView = [RCTSoftInputViewContent new];
+    RCTTouchHandler *const touchHandler = [[RCTTouchHandler alloc] initWithBridge:bridge];
+    [touchHandler attachToView:_inputView];
+  }
+  return self;
+}
+
+- (BOOL)canBecomeFirstResponder
+{
+  return true;
+}
+
+- (void)reactSetFrame:(CGRect)frame
+{
+  [_inputView reactSetFrame:frame];
+}
+
+- (void)insertReactSubview:(UIView *)subview atIndex:(NSInteger)index
+{
+  [super insertReactSubview:subview atIndex:index];
+  [_inputView insertReactSubview:subview atIndex:index];
+}
+
+- (void)removeReactSubview:(UIView *)subview
+{
+  [super removeReactSubview:subview];
+  [_inputView removeReactSubview:subview];
+}
+
+- (void)didUpdateReactSubviews
+{
+  // Do nothing, as subviews are managed by `insertReactSubview:atIndex:`.
+}
+
+@end

--- a/Libraries/Text/TextInput/RCTSoftInputViewContent.h
+++ b/Libraries/Text/TextInput/RCTSoftInputViewContent.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <UIKit/UIKit.h>
+
+@interface RCTSoftInputViewContent : UIView
+
+@end

--- a/Libraries/Text/TextInput/RCTSoftInputViewContent.m
+++ b/Libraries/Text/TextInput/RCTSoftInputViewContent.m
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <React/RCTSoftInputViewContent.h>
+
+#import <React/UIView+React.h>
+
+@implementation RCTSoftInputViewContent
+{
+  UIView *_safeAreaContainer;
+  NSLayoutConstraint *_heightConstraint;
+}
+
+- (instancetype)init
+{
+  if (self = [super init]) {
+    _safeAreaContainer = [UIView new];
+    [self addSubview:_safeAreaContainer];
+
+    // Use autolayout to position the view properly and take into account
+    // safe area insets on iPhone X.
+    // TODO: Support rotation, anchor to left and right without breaking frame x coordinate (T27974328).
+    self.autoresizingMask = UIViewAutoresizingFlexibleHeight;
+    _safeAreaContainer.translatesAutoresizingMaskIntoConstraints = NO;
+
+    _heightConstraint = [_safeAreaContainer.heightAnchor constraintEqualToConstant:0];
+    _heightConstraint.active = YES;
+
+    if (@available(iOS 11.0, *)) {
+      [_safeAreaContainer.bottomAnchor constraintEqualToAnchor:self.safeAreaLayoutGuide.bottomAnchor].active = YES;
+      [_safeAreaContainer.topAnchor constraintEqualToAnchor:self.safeAreaLayoutGuide.topAnchor].active = YES;
+      [_safeAreaContainer.leadingAnchor constraintEqualToAnchor:self.safeAreaLayoutGuide.leadingAnchor].active = YES;
+      [_safeAreaContainer.trailingAnchor constraintEqualToAnchor:self.safeAreaLayoutGuide.trailingAnchor].active = YES;
+    } else {
+      [_safeAreaContainer.bottomAnchor constraintEqualToAnchor:self.bottomAnchor].active = YES;
+      [_safeAreaContainer.topAnchor constraintEqualToAnchor:self.topAnchor].active = YES;
+      [_safeAreaContainer.leadingAnchor constraintEqualToAnchor:self.leadingAnchor].active = YES;
+      [_safeAreaContainer.trailingAnchor constraintEqualToAnchor:self.trailingAnchor].active = YES;
+    }
+  }
+  return self;
+}
+
+- (CGSize)intrinsicContentSize
+{
+  // This is needed so the view size is based on autolayout constraints.
+  return CGSizeZero;
+}
+
+- (void)reactSetFrame:(CGRect)frame
+{
+  // We still need to set the frame here, otherwise it won't be
+  // measured until moved to the window during the keyboard opening
+  // animation. If this happens, the height will be animated from 0 to
+  // its actual size and we don't want that.
+  [self setFrame:frame];
+  [_safeAreaContainer setFrame:frame];
+
+  _heightConstraint.constant = frame.size.height;
+  [self layoutIfNeeded];
+}
+
+- (void)insertReactSubview:(UIView *)subview atIndex:(NSInteger)index
+{
+  [super insertReactSubview:subview atIndex:index];
+  [_safeAreaContainer insertSubview:subview atIndex:index];
+}
+
+- (void)removeReactSubview:(UIView *)subview
+{
+  [super removeReactSubview:subview];
+  [subview removeFromSuperview];
+  if ([[_safeAreaContainer subviews] count] == 0 && [self isFirstResponder]) {
+    [self resignFirstResponder];
+  }
+}
+
+@end

--- a/Libraries/Text/TextInput/RCTSoftInputViewManager.h
+++ b/Libraries/Text/TextInput/RCTSoftInputViewManager.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <React/RCTViewManager.h>
+
+@interface RCTSoftInputViewManager : RCTViewManager
+
+@end

--- a/Libraries/Text/TextInput/RCTSoftInputViewManager.m
+++ b/Libraries/Text/TextInput/RCTSoftInputViewManager.m
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <React/RCTSoftInputViewManager.h>
+
+#import <React/RCTSoftInputShadowView.h>
+#import <React/RCTSoftInputView.h>
+
+@implementation RCTSoftInputViewManager
+
+RCT_EXPORT_MODULE()
+
++ (BOOL)requiresMainQueueSetup
+{
+  return NO;
+}
+
+- (UIView *)view
+{
+  return [[RCTSoftInputView alloc] initWithBridge:self.bridge];
+}
+
+- (RCTShadowView *)shadowView
+{
+  return [RCTSoftInputShadowView new];
+}
+
+@end

--- a/Libraries/Text/TextInput/Singleline/RCTUITextField.h
+++ b/Libraries/Text/TextInput/Singleline/RCTUITextField.h
@@ -29,6 +29,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign, getter=isEditable) BOOL editable;
 @property (nonatomic, getter=isScrollEnabled) BOOL scrollEnabled;
 @property (nonatomic, strong, nullable) NSString *inputAccessoryViewID;
+@property (nonatomic, strong, nullable) NSString *softInputViewID;
+@property (nonatomic, assign) BOOL showSoftInputOnFocus;
 
 @end
 

--- a/React/Fabric/Mounting/ComponentViews/RCTFabricComponentsPlugins.h
+++ b/React/Fabric/Mounting/ComponentViews/RCTFabricComponentsPlugins.h
@@ -40,6 +40,7 @@ Class<RCTComponentViewProtocol> RCTUnimplementedNativeViewCls(void) __attribute_
 Class<RCTComponentViewProtocol> RCTParagraphCls(void) __attribute__((used));
 Class<RCTComponentViewProtocol> RCTTextInputCls(void) __attribute__((used));
 Class<RCTComponentViewProtocol> RCTInputAccessoryCls(void) __attribute__((used));
+Class<RCTComponentViewProtocol> RCTSoftInputCls(void) __attribute__((used));
 Class<RCTComponentViewProtocol> RCTViewCls(void) __attribute__((used));
 Class<RCTComponentViewProtocol> RCTImageCls(void) __attribute__((used));
 

--- a/React/Fabric/Mounting/ComponentViews/RCTFabricComponentsPlugins.mm
+++ b/React/Fabric/Mounting/ComponentViews/RCTFabricComponentsPlugins.mm
@@ -29,6 +29,7 @@ Class<RCTComponentViewProtocol> RCTFabricComponentsProvider(const char *name) {
     {"Paragraph", RCTParagraphCls},
     {"TextInput", RCTTextInputCls},
     {"InputAccessoryView", RCTInputAccessoryCls},
+    {"SoftInputView", RCTSoftInputCls},
     {"View", RCTViewCls},
     {"Image", RCTImageCls},
   };

--- a/React/Fabric/Mounting/ComponentViews/SoftInput/RCTSoftInputComponentView.h
+++ b/React/Fabric/Mounting/ComponentViews/SoftInput/RCTSoftInputComponentView.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <UIKit/UIKit.h>
+
+#import <React/RCTViewComponentView.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * UIView class for root <SoftInputView> component.
+ */
+@interface RCTSoftInputComponentView : RCTViewComponentView
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/React/Fabric/Mounting/ComponentViews/SoftInput/RCTSoftInputComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/SoftInput/RCTSoftInputComponentView.mm
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RCTSoftInputComponentView.h"
+
+#import <React/RCTBackedTextInputViewProtocol.h>
+#import <React/RCTConversions.h>
+#import <React/RCTSurfaceTouchHandler.h>
+#import <React/RCTUtils.h>
+#import <React/UIView+React.h>
+#import <react/renderer/components/softinput/SoftInputComponentDescriptor.h>
+#import <react/renderer/components/rncore/Props.h>
+#import "RCTSoftInputContentView.h"
+
+#import "RCTFabricComponentsPlugins.h"
+
+using namespace facebook::react;
+
+static UIView<RCTBackedTextInputViewProtocol> *_Nullable RCTFindTextInputWithNativeId(UIView *view, NSString *nativeId)
+{
+  if ([view respondsToSelector:@selector(softInputViewID)] &&
+      [view respondsToSelector:@selector(setInputView:)]) {
+    UIView<RCTBackedTextInputViewProtocol> *typed = (UIView<RCTBackedTextInputViewProtocol> *)view;
+    if (!nativeId || [typed.softInputViewID isEqualToString:nativeId]) {
+      return typed;
+    }
+  }
+
+  for (UIView *subview in view.subviews) {
+    UIView<RCTBackedTextInputViewProtocol> *result = RCTFindTextInputWithNativeId(subview, nativeId);
+    if (result) {
+      return result;
+    }
+  }
+
+  return nil;
+}
+
+@implementation RCTSoftInputComponentView {
+  SoftInputShadowNode::ConcreteState::Shared _state;
+  RCTSoftInputContentView *_contentView;
+  RCTSurfaceTouchHandler *_touchHandler;
+  UIView<RCTBackedTextInputViewProtocol> __weak *_textInput;
+}
+
+- (instancetype)initWithFrame:(CGRect)frame
+{
+  if (self = [super initWithFrame:frame]) {
+    static const auto defaultProps = std::make_shared<const SoftInputProps>();
+    _props = defaultProps;
+    _contentView = [RCTSoftInputContentView new];
+    _touchHandler = [RCTSurfaceTouchHandler new];
+    [_touchHandler attachToView:_contentView];
+  }
+
+  return self;
+}
+
+- (void)didMoveToWindow
+{
+  [super didMoveToWindow];
+
+  if (self.window && !_textInput) {
+    _textInput = RCTFindTextInputWithNativeId(self.window, self.nativeId);
+    if (_textInput.showSoftInputOnFocus) {
+      _textInput.inputView = _contentView;
+    } else {
+      _textInput.inputView = [[UIView alloc] init];
+    }
+  }
+}
+
+- (BOOL)canBecomeFirstResponder
+{
+  return true;
+}
+
+- (UIView *)inputView
+{
+  return _contentView;
+}
+
+#pragma mark - RCTComponentViewProtocol
+
++ (ComponentDescriptorProvider)componentDescriptorProvider
+{
+  return concreteComponentDescriptorProvider<SoftInputComponentDescriptor>();
+}
+
+- (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
+{
+  [_contentView insertSubview:childComponentView atIndex:index];
+}
+
+- (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
+{
+  [childComponentView removeFromSuperview];
+}
+
+- (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
+{
+  [super updateProps:props oldProps:oldProps];
+  self.hidden = true;
+}
+
+- (void)updateState:(const facebook::react::State::Shared &)state
+           oldState:(const facebook::react::State::Shared &)oldState
+{
+  _state = std::static_pointer_cast<SoftInputShadowNode::ConcreteState const>(state);
+  CGSize oldScreenSize = RCTCGSizeFromSize(_state->getData().viewportSize);
+  CGSize viewportSize = RCTViewportSize();
+  viewportSize.height = std::nan("");
+  if (oldScreenSize.width != viewportSize.width) {
+    auto stateData = SoftInputState{RCTSizeFromCGSize(viewportSize)};
+    _state->updateState(std::move(stateData));
+  }
+}
+
+- (void)updateLayoutMetrics:(LayoutMetrics const &)layoutMetrics
+           oldLayoutMetrics:(LayoutMetrics const &)oldLayoutMetrics
+{
+  [super updateLayoutMetrics:layoutMetrics oldLayoutMetrics:oldLayoutMetrics];
+
+  [_contentView setFrame:RCTCGRectFromRect(layoutMetrics.getContentFrame())];
+}
+
+- (void)prepareForRecycle
+{
+  [super prepareForRecycle];
+  _state.reset();
+  _textInput = nil;
+}
+
+@end
+
+Class<RCTComponentViewProtocol> RCTSoftInputCls(void)
+{
+  return RCTSoftInputComponentView.class;
+}

--- a/React/Fabric/Mounting/ComponentViews/SoftInput/RCTSoftInputContentView.h
+++ b/React/Fabric/Mounting/ComponentViews/SoftInput/RCTSoftInputContentView.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <UIKit/UIKit.h>
+
+@interface RCTSoftInputContentView : UIView
+
+@end

--- a/React/Fabric/Mounting/ComponentViews/SoftInput/RCTSoftInputContentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/SoftInput/RCTSoftInputContentView.mm
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RCTSoftInputContentView.h"
+
+@implementation RCTSoftInputContentView {
+  UIView *_safeAreaContainer;
+  NSLayoutConstraint *_heightConstraint;
+}
+
+- (instancetype)init
+{
+  if (self = [super init]) {
+    self.autoresizingMask = UIViewAutoresizingFlexibleHeight;
+
+    _safeAreaContainer = [UIView new];
+    _safeAreaContainer.translatesAutoresizingMaskIntoConstraints = NO;
+    [self addSubview:_safeAreaContainer];
+
+    _heightConstraint = [_safeAreaContainer.heightAnchor constraintEqualToConstant:0];
+    _heightConstraint.active = YES;
+
+    if (@available(iOS 11.0, *)) {
+      [NSLayoutConstraint activateConstraints:@[
+        [_safeAreaContainer.bottomAnchor constraintEqualToAnchor:self.safeAreaLayoutGuide.bottomAnchor],
+        [_safeAreaContainer.topAnchor constraintEqualToAnchor:self.safeAreaLayoutGuide.topAnchor],
+        [_safeAreaContainer.leadingAnchor constraintEqualToAnchor:self.safeAreaLayoutGuide.leadingAnchor],
+        [_safeAreaContainer.trailingAnchor constraintEqualToAnchor:self.safeAreaLayoutGuide.trailingAnchor]
+      ]];
+    } else {
+      [NSLayoutConstraint activateConstraints:@[
+        [_safeAreaContainer.bottomAnchor constraintEqualToAnchor:self.bottomAnchor],
+        [_safeAreaContainer.topAnchor constraintEqualToAnchor:self.topAnchor],
+        [_safeAreaContainer.leadingAnchor constraintEqualToAnchor:self.leadingAnchor],
+        [_safeAreaContainer.trailingAnchor constraintEqualToAnchor:self.trailingAnchor]
+      ]];
+    }
+  }
+  return self;
+}
+
+- (CGSize)intrinsicContentSize
+{
+  // This is needed so the view size is based on autolayout constraints.
+  return CGSizeZero;
+}
+
+- (void)insertSubview:(UIView *)view atIndex:(NSInteger)index
+{
+  [_safeAreaContainer insertSubview:view atIndex:index];
+}
+
+- (void)setFrame:(CGRect)frame
+{
+  [super setFrame:frame];
+  [_safeAreaContainer setFrame:frame];
+  _heightConstraint.constant = frame.size.height;
+  [self layoutIfNeeded];
+}
+
+- (BOOL)canBecomeFirstResponder
+{
+  return true;
+}
+
+@end

--- a/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.mm
+++ b/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.mm
@@ -27,6 +27,7 @@ void RCTCopyBackedTextInput(
   toTextInput.placeholderColor = fromTextInput.placeholderColor;
   toTextInput.textContainerInset = fromTextInput.textContainerInset;
   toTextInput.inputAccessoryView = fromTextInput.inputAccessoryView;
+  toTextInput.inputView = fromTextInput.inputView;
   toTextInput.textInputDelegate = fromTextInput.textInputDelegate;
   toTextInput.placeholderColor = fromTextInput.placeholderColor;
   toTextInput.defaultTextAttributes = fromTextInput.defaultTextAttributes;
@@ -43,6 +44,7 @@ void RCTCopyBackedTextInput(
   toTextInput.secureTextEntry = fromTextInput.secureTextEntry;
   toTextInput.keyboardType = fromTextInput.keyboardType;
   toTextInput.textContentType = fromTextInput.textContentType;
+  toTextInput.showSoftInputOnFocus = fromTextInput.showSoftInputOnFocus;
 
   if (@available(iOS 12.0, *)) {
     toTextInput.passwordRules = fromTextInput.passwordRules;

--- a/ReactCommon/React-Fabric.podspec
+++ b/ReactCommon/React-Fabric.podspec
@@ -202,6 +202,15 @@ Pod::Spec.new do |s|
       sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
     end
 
+    ss.subspec "softinput" do |sss|
+      sss.dependency             folly_dep_name, folly_version
+      sss.compiler_flags       = folly_compiler_flags
+      sss.source_files         = "react/renderer/components/softinput/**/*.{m,mm,cpp,h}"
+      sss.exclude_files        = "react/renderer/components/softinput/tests"
+      sss.header_dir           = "react/renderer/components/softinput"
+      sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
+    end
+
     ss.subspec "text" do |sss|
       sss.dependency             folly_dep_name, folly_version
       sss.compiler_flags       = folly_compiler_flags

--- a/ReactCommon/react/renderer/components/softinput/BUCK
+++ b/ReactCommon/react/renderer/components/softinput/BUCK
@@ -1,0 +1,48 @@
+load(
+    "//tools/build_defs/oss:rn_defs.bzl",
+    "APPLE",
+    "get_apple_compiler_flags",
+    "get_apple_inspector_flags",
+    "get_preprocessor_flags_for_build_mode",
+    "react_native_xplat_target",
+    "rn_xplat_cxx_library",
+    "subdir_glob",
+)
+
+APPLE_COMPILER_FLAGS = get_apple_compiler_flags()
+
+rn_xplat_cxx_library(
+    name = "softinput",
+    srcs = glob(
+        ["**/*.cpp"],
+    ),
+    headers = [],
+    header_namespace = "",
+    exported_headers = subdir_glob(
+        [
+            ("", "*.h"),
+        ],
+        prefix = "react/renderer/components/softinput",
+    ),
+    compiler_flags = [
+        "-fexceptions",
+        "-frtti",
+        "-std=c++14",
+        "-Wall",
+    ],
+    fbobjc_compiler_flags = APPLE_COMPILER_FLAGS,
+    fbobjc_preprocessor_flags = get_preprocessor_flags_for_build_mode() + get_apple_inspector_flags(),
+    force_static = True,
+    labels = ["supermodule:xplat/default/public.react_native.infra"],
+    platforms = (APPLE),
+    preprocessor_flags = [
+        "-DLOG_TAG=\"ReactNative\"",
+        "-DWITH_FBSYSTRACE=1",
+    ],
+    visibility = ["PUBLIC"],
+    deps = [
+        react_native_xplat_target("react/debug:debug"),
+        react_native_xplat_target("react/renderer/core:core"),
+        "//xplat/js/react-native-github:generated_components-rncore",
+    ],
+)

--- a/ReactCommon/react/renderer/components/softinput/SoftInputComponentDescriptor.h
+++ b/ReactCommon/react/renderer/components/softinput/SoftInputComponentDescriptor.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <react/debug/react_native_assert.h>
+#include <react/renderer/components/softinput/SoftInputShadowNode.h>
+#include <react/renderer/core/ConcreteComponentDescriptor.h>
+
+namespace facebook {
+namespace react {
+
+/*
+ * Descriptor for <SoftInputView> component.
+ */
+class SoftInputComponentDescriptor final
+    : public ConcreteComponentDescriptor<SoftInputShadowNode> {
+ public:
+  using ConcreteComponentDescriptor::ConcreteComponentDescriptor;
+
+  void adopt(ShadowNode::Unshared const &shadowNode) const override {
+    react_native_assert(
+        std::dynamic_pointer_cast<SoftInputShadowNode>(shadowNode));
+    auto concreteShadowNode =
+        std::static_pointer_cast<SoftInputShadowNode>(shadowNode);
+
+    react_native_assert(std::dynamic_pointer_cast<YogaLayoutableShadowNode>(
+        concreteShadowNode));
+    auto layoutableShadowNode =
+        std::static_pointer_cast<YogaLayoutableShadowNode>(concreteShadowNode);
+
+    auto state =
+        std::static_pointer_cast<const SoftInputShadowNode::ConcreteState>(
+            shadowNode->getState());
+    auto stateData = state->getData();
+
+    layoutableShadowNode->setSize(
+        Size{stateData.viewportSize.width, stateData.viewportSize.height});
+    layoutableShadowNode->setPositionType(YGPositionTypeAbsolute);
+
+    ConcreteComponentDescriptor::adopt(shadowNode);
+  }
+};
+
+} // namespace react
+} // namespace facebook

--- a/ReactCommon/react/renderer/components/softinput/SoftInputShadowNode.cpp
+++ b/ReactCommon/react/renderer/components/softinput/SoftInputShadowNode.cpp
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "SoftInputShadowNode.h"
+
+namespace facebook {
+namespace react {
+
+extern const char SoftInputComponentName[] = "SoftInputView";
+
+} // namespace react
+} // namespace facebook

--- a/ReactCommon/react/renderer/components/softinput/SoftInputShadowNode.h
+++ b/ReactCommon/react/renderer/components/softinput/SoftInputShadowNode.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <react/renderer/components/rncore/EventEmitters.h>
+#include <react/renderer/components/rncore/Props.h>
+#include <react/renderer/components/softinput/SoftInputState.h>
+#include <react/renderer/components/view/ConcreteViewShadowNode.h>
+
+namespace facebook {
+namespace react {
+
+extern const char SoftInputComponentName[];
+
+/*
+ * `ShadowNode` for <SoftInputView> component.
+ */
+class SoftInputShadowNode final : public ConcreteViewShadowNode<
+                                          SoftInputComponentName,
+                                          SoftInputProps,
+                                          SoftInputEventEmitter,
+                                          SoftInputState> {
+ public:
+  using ConcreteViewShadowNode::ConcreteViewShadowNode;
+
+  static ShadowNodeTraits BaseTraits() {
+    auto traits = ConcreteViewShadowNode::BaseTraits();
+    traits.set(ShadowNodeTraits::Trait::RootNodeKind);
+    return traits;
+  }
+};
+
+} // namespace react
+} // namespace facebook

--- a/ReactCommon/react/renderer/components/softinput/SoftInputState.h
+++ b/ReactCommon/react/renderer/components/softinput/SoftInputState.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <react/renderer/graphics/Float.h>
+#include <react/renderer/graphics/Geometry.h>
+#include <react/renderer/graphics/conversions.h>
+
+namespace facebook {
+namespace react {
+
+/*
+ * State for <SoftInputView> component.
+ */
+class SoftInputState final {
+ public:
+  SoftInputState(){};
+  SoftInputState(Size viewportSize_) : viewportSize(viewportSize_){};
+
+  const Size viewportSize{};
+};
+
+} // namespace react
+} // namespace facebook

--- a/ReactCommon/react/renderer/components/textinput/iostextinput/TextInputProps.cpp
+++ b/ReactCommon/react/renderer/components/textinput/iostextinput/TextInputProps.cpp
@@ -57,10 +57,20 @@ TextInputProps::TextInputProps(
           {})),
       autoFocus(
           convertRawProp(rawProps, "autoFocus", sourceProps.autoFocus, {})),
+      showSoftInputOnFocus(convertRawProp(
+          rawProps,
+          "showSoftInputOnFocus",
+          sourceProps.showSoftInputOnFocus,
+          {})),
       inputAccessoryViewID(convertRawProp(
           rawProps,
           "inputAccessoryViewID",
           sourceProps.inputAccessoryViewID,
+          {})),
+      softInputViewID(convertRawProp(
+          rawProps,
+          "softInputViewID",
+          sourceProps.softInputViewID,
           {})){};
 
 TextAttributes TextInputProps::getEffectiveTextAttributes(

--- a/ReactCommon/react/renderer/components/textinput/iostextinput/TextInputProps.h
+++ b/ReactCommon/react/renderer/components/textinput/iostextinput/TextInputProps.h
@@ -54,8 +54,10 @@ class TextInputProps final : public ViewProps, public BaseTextProps {
   int const mostRecentEventCount{0};
 
   bool autoFocus{false};
+  const bool showSoftInputOnFocus{true};
 
   std::string const inputAccessoryViewID{};
+  std::string const softInputViewID{};
 
   /*
    * Accessors

--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ import typeof ScrollView from './Libraries/Components/ScrollView/ScrollView';
 import typeof SectionList from './Libraries/Lists/SectionList';
 import typeof SegmentedControlIOS from './Libraries/Components/SegmentedControlIOS/SegmentedControlIOS';
 import typeof Slider from './Libraries/Components/Slider/Slider';
+import typeof SoftInputView from './Libraries/Components/TextInput/SoftInputView';
 import typeof StatusBar from './Libraries/Components/StatusBar/StatusBar';
 import typeof Switch from './Libraries/Components/Switch/Switch';
 import typeof Text from './Libraries/Text/Text';
@@ -219,6 +220,9 @@ module.exports = {
         'See https://github.com/callstack/react-native-slider',
     );
     return require('./Libraries/Components/Slider/Slider');
+  },
+  get SoftInputView(): SoftInputView {
+    return require('./Libraries/Components/TextInput/SoftInputView');
   },
   get StatusBar(): StatusBar {
     return require('./Libraries/Components/StatusBar/StatusBar');

--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -347,6 +347,7 @@ PODS:
     - React-Fabric/components/safeareaview (= 1000.0.0)
     - React-Fabric/components/scrollview (= 1000.0.0)
     - React-Fabric/components/slider (= 1000.0.0)
+    - React-Fabric/components/softinput (= 1000.0.0)
     - React-Fabric/components/text (= 1000.0.0)
     - React-Fabric/components/textinput (= 1000.0.0)
     - React-Fabric/components/unimplementedview (= 1000.0.0)
@@ -436,6 +437,14 @@ PODS:
     - React-jsiexecutor (= 1000.0.0)
     - ReactCommon/turbomodule/core (= 1000.0.0)
   - React-Fabric/components/slider (1000.0.0):
+    - RCT-Folly/Fabric (= 2021.04.26.00)
+    - RCTRequired (= 1000.0.0)
+    - RCTTypeSafety (= 1000.0.0)
+    - React-graphics (= 1000.0.0)
+    - React-jsi (= 1000.0.0)
+    - React-jsiexecutor (= 1000.0.0)
+    - ReactCommon/turbomodule/core (= 1000.0.0)
+  - React-Fabric/components/softinput (1000.0.0):
     - RCT-Folly/Fabric (= 2021.04.26.00)
     - RCTRequired (= 1000.0.0)
     - RCTTypeSafety (= 1000.0.0)
@@ -862,8 +871,8 @@ SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
-  FBLazyVector: b81a2b70c72d8b0aefb652cea22c11e9ffd02949
-  FBReactNativeSpec: 9317c06a8fcc6ff3de6f045d45186523d4fe3458
+  FBLazyVector: 5340ea88aff481cc869243205b2572ce4c561253
+  FBReactNativeSpec: 16fd4b103138328bb126434927ae127e628b8dbd
   Flipper: b1fddf9a17c32097b2b4c806ad158b2f36bb2692
   Flipper-Boost-iOSX: fd1e2b8cbef7e662a122412d7ac5f5bea715403c
   Flipper-DoubleConversion: 57ffbe81ef95306cc9e69c4aa3aeeeeb58a6a28c
@@ -878,34 +887,34 @@ SPEC CHECKSUMS:
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: 1aa4f6a6ee7256b83db99ec1ccdaa80d10f9af9b
   RCT-Folly: 0dd9e1eb86348ecab5ba76f910b56f4b5fef3c46
-  RCTRequired: af2d6080a4b9ba0885b28ca78879a92066c71cab
-  RCTTypeSafety: f5405e0143bb2addae97ce33e4c87d9284a48fe2
-  React: f64c9f6db5428717922a3292ba6a448615a2e143
-  React-callinvoker: c5d61e29df57793f0dc10ec2bc01c846f863e51f
-  React-Core: f5b65410a2ecdbb4560f23dc4525588390b0b3b1
-  React-CoreModules: 818e75a3eb8f431be8fc3d8c8eb15206b3f52e81
-  React-cxxreact: fa0884110d142f7e1600a86ae769d5fd43ec8a69
-  React-Fabric: ee21f85af985320ca427353e95821a5b4d6f4f46
-  React-graphics: 57cb7ea16c092a9953c96549a29b49d5e207c25c
-  React-jsi: 93fc7d193c0499a9b10157655e6f1e755f67b3d0
-  React-jsiexecutor: 1e995bed2de8965703917c562fe35ec023a68ae5
-  React-jsinspector: 7d223826b0e7a61b3540c21b9eca2603b1d4e823
-  React-perflogger: fe66bd6d8b17ebcfdf0159bf41fe28d8035ac20c
-  React-RCTActionSheet: 3131a0b9280aa0e51bdf54b3d79aecd8503db62c
-  React-RCTAnimation: 6da530a8df8b3d33fb1f3743dcf1edeffa547cac
-  React-RCTBlob: ae75308b7097049c0c41319e171ba07a74783a81
-  React-RCTFabric: 378a2432b9e2afae5b304f56fa4f3a0d802ca89d
-  React-RCTImage: ec3ee93093128e4acb3c5c4a7ead7d490154f124
-  React-RCTLinking: 559c9223212ab2824950883220582c5e29a6fcb2
-  React-RCTNetwork: 26b845e36ae19fe497db021be2c4e7b1a69db21e
-  React-RCTPushNotification: fafeb247db030c4d3f0a098d729e49f62ed32b3f
-  React-RCTSettings: a5e305535f7f32ee35d2d7741309e421aee2bef4
-  React-RCTTest: dfeff675d31fbdf0596e87ca68011fcbb69fee42
-  React-RCTText: e9146b2c0550a83d1335bfe2553760070a2d75c7
-  React-RCTVibration: 8501f7658810d80a2d7f1dcdaf2d257e3609e072
-  React-runtimeexecutor: 4b0c6eb341c7d3ceb5e2385cb0fdb9bf701024f3
-  ReactCommon: 19e102b75b4f384f2f017f3d6e973c78963d299d
-  Yoga: c0d06f5380d34e939f55420669a60fe08b79bd75
+  RCTRequired: c41def3566d061d346b278ee8c62cb7dc3e109a7
+  RCTTypeSafety: 7e2e0d4b21dd53921d7f812b1b937e0b9edba9b6
+  React: 24658db6ba70524e43e51fe4d2edee8542495115
+  React-callinvoker: c7bfa9993ab1164ff44045e5ee5d733103620d24
+  React-Core: f2cc94902ec7c858eb9b077fe5845eff54c4d28f
+  React-CoreModules: 4d8e0a9a9aa9fe266ace5788aff460396e57bc49
+  React-cxxreact: a1f60a398e07236055971962a0c6fc29b68c8f85
+  React-Fabric: 7f022ea63c39b50e1cb5936eba6179c126cd740d
+  React-graphics: ebc4f1959e61d7f376ffa8b79db92d66d379bb44
+  React-jsi: 3362f8961c92805661c667ca15d76c89e57ae085
+  React-jsiexecutor: e977afae6b49838ebd19b62967aee10ec3f824cf
+  React-jsinspector: cb6810aa83094a207199853dc13b2b8b3d66adc3
+  React-perflogger: 4b747447176d9f005aaef7d813b57d515d34bc2b
+  React-RCTActionSheet: 85621fde1e1a2afbe7b9daf34243bb75ff81b1e7
+  React-RCTAnimation: 75f3adaff504a571e3701c2d30bb849ed6ecaa37
+  React-RCTBlob: edb1246884c675f5788e75656d816414b733bfc1
+  React-RCTFabric: 2d2b805c81adc808e9960d026d75b510c2609c25
+  React-RCTImage: f18185ec9c675447ac8cf8691a64a1f124d637dd
+  React-RCTLinking: 20958c45f9020bc6b7f1e4a09828562f8f81f77c
+  React-RCTNetwork: ce06beb814f5792ad626982c4686cf9dafffd077
+  React-RCTPushNotification: d48dbd88142a37f7bd702f4d1e1c44c5f64b8842
+  React-RCTSettings: 1bc7e5b579f6e2e09be8d722b33f93b2b1a8542a
+  React-RCTTest: ca2fc6a5c576aaf4f0eb4ecda2c3636c4b4e3e12
+  React-RCTText: c46dafa51b0ff5ceaf189b5508f51639ae44b8c3
+  React-RCTVibration: 87dde41fccf7809a5557f3f956ac2b69dd3732f1
+  React-runtimeexecutor: 52b1bf458b7bc4d53d5a014ae38885706748c123
+  ReactCommon: d1d61a5170585ea42b03f4b1f0acfa9ef3bbc27f
+  Yoga: bb079d5191dcea00a812022f543306d84473cb94
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
 PODFILE CHECKSUM: 6e910a576b7db9347c60dfc58f7852f692200116

--- a/packages/rn-tester/RNTesterPods.xcodeproj/project.pbxproj
+++ b/packages/rn-tester/RNTesterPods.xcodeproj/project.pbxproj
@@ -408,8 +408,8 @@
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				68CD48B71D2BCB2C007E06A9 /* Build JS Bundle */,
 				5CF0FD27207FC6EC00C13D65 /* Start Metro */,
-				7F1F8D267AA3C5E850B51DD3 /* [CP] Embed Pods Frameworks */,
 				8D3C37296BA387DCE6709551 /* [CP] Copy Pods Resources */,
+				7F455EB5842BE12F4117C872 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -622,7 +622,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		7F1F8D267AA3C5E850B51DD3 /* [CP] Embed Pods Frameworks */ = {
+		7F455EB5842BE12F4117C872 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (

--- a/packages/rn-tester/js/examples/SoftInputView/SoftInputViewExample.js
+++ b/packages/rn-tester/js/examples/SoftInputView/SoftInputViewExample.js
@@ -1,0 +1,150 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+'use strict';
+
+const React = require('react');
+const {
+  Button,
+  ScrollView,
+  SoftInputView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} = require('react-native');
+
+const PRIMARY = 'rgb(100,200,250)';
+const SECONDARY = 'rgb(240,120,160)';
+
+const customInputNativeID = 'customSoftInputViewID';
+const customInputHideOnFocusNativeID = 'customInputHideOnFocusNativeID';
+
+type SoftInputProps = $ReadOnly<{||}>;
+type SoftInputExampleState = $ReadOnly<{
+  custom: ?boolean | null,
+  text: string,
+}>;
+class SoftInputViewExample extends React.Component<
+  SoftInputProps,
+  SoftInputExampleState,
+> {
+  state = {
+    custom: null,
+    text: '',
+  };
+  render() {
+    return (
+      <>
+        <View style={styles.fill}>
+          <ScrollView style={styles.fill} keyboardDismissMode="interactive">
+            <View style={styles.textInputContainer}>
+              <Text style={styles.text}>Default input</Text>
+              <TextInput
+                onChangeText={newText => this.setState({text: newText})}
+                placeholder="Default input"
+                style={styles.textInput}
+                value={this.state.text}
+              />
+            </View>
+            <View style={styles.textInputContainer}>
+              <Text style={styles.text}>Custom input</Text>
+              <TextInput
+                showSoftInputOnFocus={true}
+                softInputViewID={customInputNativeID}
+                style={styles.textInput}
+                value={String(this.state.custom)}
+              />
+            </View>
+            <View style={styles.textInputContainer}>
+              <Text style={styles.text}>
+                Custom input without soft input on focus
+              </Text>
+              <TextInput
+                showSoftInputOnFocus={false}
+                softInputViewID={customInputHideOnFocusNativeID}
+                style={styles.textInput}
+                value={String(this.state.custom)}
+              />
+            </View>
+          </ScrollView>
+          <SoftInputView nativeID={customInputNativeID}>
+            <View style={styles.softInputContainer}>
+              {[null, false, true].map(value => (
+                <Button
+                  color={this.state.custom === value ? SECONDARY : PRIMARY}
+                  key={String(value)}
+                  onPress={() => this.setState({custom: value})}
+                  title={String(value)}
+                />
+              ))}
+            </View>
+          </SoftInputView>
+          <SoftInputView nativeID={customInputHideOnFocusNativeID}>
+            <View style={styles.softInputContainer}>
+              {[null, false, true].map(value => (
+                <Button
+                  color={this.state.custom === value ? SECONDARY : PRIMARY}
+                  key={String(value)}
+                  onPress={() => this.setState({custom: value})}
+                  title={String(value)}
+                />
+              ))}
+            </View>
+          </SoftInputView>
+        </View>
+      </>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  fill: {
+    flex: 1,
+  },
+  softInputContainer: {
+    alignItems: 'center',
+    backgroundColor: 'white',
+    borderTopWidth: 1,
+    borderTopColor: SECONDARY,
+    flex: 1,
+    justifyContent: 'center',
+    minWidth: 200,
+  },
+  textInputContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: 'rgba(100,200,250,0.6)',
+    borderTopWidth: 1,
+    borderTopColor: '#eee',
+    height: 60,
+  },
+  textInput: {
+    alignSelf: 'stretch',
+    color: SECONDARY,
+    flex: 1,
+    paddingLeft: 10,
+  },
+  text: {
+    padding: 10,
+    color: 'white',
+  },
+});
+
+exports.title = 'SoftInputView';
+exports.description = 'Example showing how to use an SoftInputView';
+exports.examples = [
+  {
+    title: 'Simple view with non-text soft input',
+    render: function(): React.Node {
+      return <SoftInputViewExample />;
+    },
+  },
+];

--- a/packages/rn-tester/js/utils/RNTesterList.ios.js
+++ b/packages/rn-tester/js/utils/RNTesterList.ios.js
@@ -125,6 +125,11 @@ const Components: Array<RNTesterModuleInfo> = [
     supportsTVOS: true,
   },
   {
+    key: 'SoftInputViewExample',
+    module: require('../examples/SoftInputView/SoftInputViewExample'),
+    supportsTVOS: true,
+  },
+  {
     key: 'StatusBarExample',
     module: require('../examples/StatusBar/StatusBarExample'),
     supportsTVOS: false,


### PR DESCRIPTION
## Summary

Add soft input view iOS functionality (in non-Fabric and Fabric), to enable displaying custom input views (e.g. date/time input with date/timepicker displayed as soft input). Implementation is inspired by the way `InputAccessoryView` is implemented.

## Changelog

[General] [Added] - soft input view iOS component
Resolves #31300

## Test Plan

Run rn-tester app in both Fabric and non-Fabric mode, and check `SoftInputViewExample`