### PR TITLE
Upgrade jsc-android to 250230.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "event-target-shim": "^5.0.1",
     "hermes-engine": "~0.7.0",
     "invariant": "^2.2.4",
-    "jsc-android": "^245459.0.0",
+    "jsc-android": "^250230.2.1",
     "metro-babel-register": "0.65.2",
     "metro-react-native-babel-transformer": "0.65.2",
     "metro-runtime": "0.65.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4218,10 +4218,10 @@ jsbn@~0.1.0:
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
   integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
 
-jsc-android@^245459.0.0:
-  version "245459.0.0"
-  resolved "https://registry.yarnpkg.com/jsc-android/-/jsc-android-245459.0.0.tgz#e584258dd0b04c9159a27fb104cd5d491fd202c9"
-  integrity sha512-wkjURqwaB1daNkDi2OYYbsLnIdC/lUM2nPXQKRs5pqEU9chDg435bjvo+LSaHotDENygHQDHe+ntUkkw2gwMtg==
+jsc-android@^250230.2.1:
+  version "250230.2.1"
+  resolved "https://registry.yarnpkg.com/jsc-android/-/jsc-android-250230.2.1.tgz#3790313a970586a03ab0ad47defbc84df54f1b83"
+  integrity sha512-KmxeBlRjwoqCnBBKGsihFtvsBHyUFlBxJPK4FzeYcIuBfdjv6jFys44JITAgSTbQD+vIdwMEfyZklsuQX0yI1Q==
 
 jscodeshift@^0.11.0:
   version "0.11.0"


### PR DESCRIPTION
## Summary

Upgrade jsc-android to latest stable version. Hopefully this should finally fix https://github.com/facebook/react-native/issues/25494.
Before Hermes totally replaced JSC, it should be worth to have this and make JSC stable

## Changelog

[Android] [Changed] - Upgrade jsc-android to 250230.2.1

## Test Plan

Launch app with new jsc-android and see everything works fine.
