### PR TITLE
dont rerender list items

### DIFF
--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -1995,6 +1995,14 @@ class CellRenderer extends React.Component<
     this.props.onUnmount(this.props.cellKey);
   }
 
+  shouldComponentUpdate(nextProps, nextState) {
+    return !!(
+      (this.props.ItemSeparatorComponent &&
+        this.state.separatorProps !== nextState.separatorProps) ||
+      this.props.item !== nextProps.item
+    );
+  }
+
   _renderElement(renderItem, ListItemComponent, item, index) {
     if (renderItem && ListItemComponent) {
       console.warn(


### PR DESCRIPTION
## Summary

Using FlatList components with 50 items, and the default values for `initialNumToRender` and `maxToRenderPerBatch`, the following happens:
- Render first 10 items (Items[0 .. 9]).
- Sleep.
- Render first 20 items (Items[0 .. 19]). **It should be rendering items [10 .. 19] instead.**
- Sleep.
- Render first 30 items (Items[0 .. 29]).
- Sleep.
- Render first 40 items (Items[0 .. 39]).
- Sleep.
- Render all items (Items[0..49]).

So the flat list is rendering the first 10 items 5 times. It is a performance issue when the items are complicated, or the FlatList has many items. Having N items the FlatList will render O(N^2) items over time.

This PR adds a `shouldComponentUpdate()` for the `CellRenderer` that always return false to disable redundant renders. It seems it doesn't break anything. For our apps it also reduces about 1 second of CPU usage of calls to `React.createElement` when rendering some components in our app. 

An alternative to this PR is to add the same shouldComponentUpdate() in our own items. However, that is a problem for functional components and not as efficient as checking for update in FlatList itself.
https://reactnative.dev/docs/optimizing-flatlist-configuration#use-shouldcomponentupdate

If this change breaks something that I am not aware of, we can add some flag/function prop to FlagList, so the logic in `CellRenderer.shouldComponentUpdate()` can be set by the users.


## Changelog

[JavaScript] [Fixed] - Don't render list items if not changed.


## Test Plan
Current tests should pass.