### PR TITLE
Fix error message formatting

### DIFF
--- a/scripts/react-native-xcode.sh
+++ b/scripts/react-native-xcode.sh
@@ -175,7 +175,6 @@ else
 fi
 
 if [[ $DEV != true && ! -f "$BUNDLE_FILE" ]]; then
-  echo "error: File $BUNDLE_FILE does not exist. This must be a bug with" >&2
-  echo "React Native, please report it here: https://github.com/facebook/react-native/issues"
+  echo "error: File $BUNDLE_FILE does not exist. This must be a bug with React Native, please report it here: https://github.com/facebook/react-native/issues" >&2
   exit 2
 fi


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

This error message doesn't format correctly when outputted to the terminal.  It seems the 2nd line is missing


## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [Fixed] - bug with error message formatting when bundle is missing


## Test Plan


Before:
![wHHXtKq](https://user-images.githubusercontent.com/4398635/114310176-f11f8700-9ab7-11eb-9de7-b80aab92d440.png)

After:
![6nIjRHc](https://user-images.githubusercontent.com/4398635/114310470-d6014700-9ab8-11eb-9164-d6edde95c6f8.png)
