### PR TITLE
Fix CI "Build Tests: Android Instrumentation Tests" errors

### DIFF
--- a/ReactAndroid/src/main/jni/first-party/fb/BUCK
+++ b/ReactAndroid/src/main/jni/first-party/fb/BUCK
@@ -28,4 +28,8 @@ oss_cxx_library(
     deps = [
         JNI_TARGET,
     ],
+    linker_flags = [
+        "-llog",
+    ],
+    preferred_linkage  = "static",
 )


### PR DESCRIPTION
## Summary
  To fix [the CI error](https://app.circleci.com/pipelines/github/facebook/react-native/8708/workflows/d584348e-941f-4653-96c2-46375894dfaa/jobs/196410)
  There are two errors:
  `error: undefined reference to '__android_log_write'` which solved by adding `-llog` linker flag.

  `ld: error: cannot find -lc++` which workaround by static linking.
  For the root cause, I am thinking that is after [NDK r19](https://developer.android.com/ndk/guides/other_build_systems),
  the `-target` should specificy api level.
  However, buck does not add this accordingly, e.g. `-target armv7-none-linux-androideabi`
  Given wrong target will make NDK to have `cannot find -lc++` error.
  The workaround is to use static linking.
  Since it was an oss_cxx_library, the change should not have impact to Facebook internal testing.

## Changelog

[Internal] [Fixed] - Fix CI "Build Tests: Android Instrumentation Tests" errors

## Test Plan

Make CI green
