### PR TITLE
Add explicit type casts to fix compilation errors on Windows.

### DIFF
--- a/ReactCommon/react/renderer/mapbuffer/MapBufferBuilder.cpp
+++ b/ReactCommon/react/renderer/mapbuffer/MapBufferBuilder.cpp
@@ -127,7 +127,7 @@ void MapBufferBuilder::ensureDynamicDataSpace(int32_t size) {
 }
 
 void MapBufferBuilder::putString(Key key, std::string value) {
-  int32_t strLength = value.length();
+  int32_t strLength = static_cast<int32_t>(value.length());
   const char *cstring = getCstring(&value);
 
   // format [lenght of string (int)] + [Array of Characters in the string]


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Recent changes to `MapBuffer` have broken the compilation on Windows. 
This fix is similar to this recently-merged change: https://github.com/facebook/react-native/pull/31106

Side note - this PR only addresses a build break, but doesn't address the unsafe casting semantics in `MapBuffer`, which can still cause overflows.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Fixed] - Fix compilation errors on Windows.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
RN now builds in Visual Studio on Windows.