### PR TITLE
[ios] Time out packager liveness check after 10s

### DIFF
--- a/React/Base/RCTBundleURLProvider.mm
+++ b/React/Base/RCTBundleURLProvider.mm
@@ -72,7 +72,9 @@ static NSURL *serverRootWithHostPort(NSString *hostPort)
   NSURL *url = [serverRootWithHostPort(hostPort) URLByAppendingPathComponent:@"status"];
 
   NSURLSession *session = [NSURLSession sharedSession];
-  NSURLRequest *request = [NSURLRequest requestWithURL:url];
+  NSURLRequest *request = [NSURLRequest requestWithURL:url
+                                           cachePolicy:NSURLRequestUseProtocolCachePolicy
+                                       timeoutInterval:10];
   __block NSURLResponse *response;
   __block NSData *data;
 


### PR DESCRIPTION

## Summary

`isPackagerRunning` check on iOS makes a http request to packager's /status endpoint to check if it's alive... The problem is if the packager can't be reached, but doesn't error out immediately. This can happen, for example, if running the app on device, and host computer's firewall doesn't allow a :8081 connection. In that case, the request will never succeed or fail until default timeout of 60s. It makes debugging the underlying issue quite unbearable. It's hard for me to imagine a legitimate packager connection that wouldn't respond in less than a second, so I propose a conservative timeout of 10s

## Changelog

[iOS] [Fix] - Don't hang app for 60s if packager can't be reached

## Test Plan

Checked my app in dev mode to see if packager connects properly.
