### PR TITLE
Add flow types to AccessibilityExample.js 

### DIFF
--- a/packages/rn-tester/js/examples/Accessibility/AccessibilityExample.js
+++ b/packages/rn-tester/js/examples/Accessibility/AccessibilityExample.js
@@ -261,7 +261,9 @@ class SelectionExample extends React.Component<
     super(props);
     this.selectableElement = createRef();
   }
-  selectableElement: {current: React.ElementRef<any> | null};
+  selectableElement: {
+    current: React.ElementRef<typeof TouchableOpacity> | null,
+  };
 
   state = {
     isSelected: true,
@@ -677,14 +679,12 @@ class AccessibilityActionsExample extends React.Component<{}> {
   }
 }
 
-class FakeSliderExample extends React.Component<
-  {},
-  {
-    current: number,
-    textualValue: 'center' | 'right' | 'left',
-  },
-> {
-  state: {current: number, textualValue: 'center' | 'left' | 'right'} = {
+type FakeSliderExampleState = {
+  current: number,
+  textualValue: 'center' | 'left' | 'right',
+};
+class FakeSliderExample extends React.Component<{}, FakeSliderExampleState> {
+  state: FakeSliderExampleState = {
     current: 50,
     textualValue: 'center',
   };
@@ -880,7 +880,7 @@ class EnabledExample extends React.Component<
     test: string,
   },
   {
-    isEnabled: void | boolean,
+    isEnabled: boolean,
   },
 > {
   state = {
@@ -907,7 +907,7 @@ class EnabledExample extends React.Component<
     this._subscription?.remove();
   }
 
-  _handleToggled = () => {
+  _handleToggled = isEnabled => {
     if (!this.state.isEnabled) {
       this.setState({isEnabled: true});
     } else {

--- a/packages/rn-tester/js/examples/Accessibility/AccessibilityExample.js
+++ b/packages/rn-tester/js/examples/Accessibility/AccessibilityExample.js
@@ -892,7 +892,7 @@ exports.examples = [
   },
   {
     title: 'New accessibility roles and states',
-    render(): React.Element<typeof AccessibilityRoleAndStateExamples> {
+    render(): React.Element<typeof AccessibilityRoleAndStateExample> {
       return <AccessibilityRoleAndStateExample />;
     },
   },

--- a/packages/rn-tester/js/examples/Accessibility/AccessibilityExample.js
+++ b/packages/rn-tester/js/examples/Accessibility/AccessibilityExample.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @flow
  */
 
 'use strict';
@@ -60,8 +61,8 @@ const styles = StyleSheet.create({
   },
 });
 
-class AccessibilityExample extends React.Component {
-  render() {
+class AccessibilityExample extends React.Component<{}> {
+  render(): React.Node {
     return (
       <View>
         <RNTesterBlock title="TextView without label">
@@ -101,7 +102,7 @@ class AccessibilityExample extends React.Component {
         </RNTesterBlock>
 
         {/* Android screen readers will say the accessibility hint instead of the text
-        since the view doesn't have a label. */}
+           since the view doesn't have a label. */}
         <RNTesterBlock title="Accessible view with TextViews with hint">
           <View accessibilityHint="Accessibility hint." accessible={true}>
             <Text style={{color: 'green'}}>This is text one.</Text>
@@ -178,7 +179,12 @@ class AccessibilityExample extends React.Component {
   }
 }
 
-class CheckboxExample extends React.Component {
+class CheckboxExample extends React.Component<
+  {},
+  {
+    checkboxState: boolean | 'mixed',
+  },
+> {
   state = {
     checkboxState: true,
   };
@@ -212,7 +218,12 @@ class CheckboxExample extends React.Component {
   }
 }
 
-class SwitchExample extends React.Component {
+class SwitchExample extends React.Component<
+  {},
+  {
+    switchState: boolean,
+  },
+> {
   state = {
     switchState: true,
   };
@@ -239,18 +250,25 @@ class SwitchExample extends React.Component {
   }
 }
 
-class SelectionExample extends React.Component {
-  constructor(props) {
+class SelectionExample extends React.Component<
+  {},
+  {
+    isSelected: boolean,
+    isEnabled: boolean,
+  },
+> {
+  constructor(props: {}) {
     super(props);
-    this.selectableElement = React.createRef();
+    this.selectableElement = createRef();
   }
+  selectableElement: {current: React.ElementRef<any> | null};
 
   state = {
     isSelected: true,
     isEnabled: false,
   };
 
-  render() {
+  render(): React.Node {
     const {isSelected, isEnabled} = this.state;
     let accessibilityHint = 'click me to select';
     if (isSelected) {
@@ -311,7 +329,12 @@ class SelectionExample extends React.Component {
   }
 }
 
-class ExpandableElementExample extends React.Component {
+class ExpandableElementExample extends React.Component<
+  {},
+  {
+    expandState: boolean,
+  },
+> {
   state = {
     expandState: false,
   };
@@ -337,7 +360,14 @@ class ExpandableElementExample extends React.Component {
   }
 }
 
-class NestedCheckBox extends React.Component {
+class NestedCheckBox extends React.Component<
+  {},
+  {
+    checkbox1: boolean | 'mixed',
+    checkbox2: boolean | 'mixed',
+    checkbox3: boolean | 'mixed',
+  },
+> {
   state = {
     checkbox1: false,
     checkbox2: false,
@@ -446,7 +476,7 @@ class NestedCheckBox extends React.Component {
 }
 
 class AccessibilityRoleAndStateExample extends React.Component<{}> {
-  render() {
+  render(): React.Node {
     return (
       <View>
         <View
@@ -551,8 +581,8 @@ class AccessibilityRoleAndStateExample extends React.Component<{}> {
   }
 }
 
-class AccessibilityActionsExample extends React.Component {
-  render() {
+class AccessibilityActionsExample extends React.Component<{}> {
+  render(): React.Node {
     return (
       <View>
         <RNTesterBlock title="Non-touchable with activate action">
@@ -647,13 +677,19 @@ class AccessibilityActionsExample extends React.Component {
   }
 }
 
-class FakeSliderExample extends React.Component {
-  state = {
+class FakeSliderExample extends React.Component<
+  {},
+  {
+    current: number,
+    textualValue: 'center' | 'right' | 'left',
+  },
+> {
+  state: {current: number, textualValue: 'center' | 'left' | 'right'} = {
     current: 50,
     textualValue: 'center',
   };
 
-  increment = () => {
+  increment: () => void = () => {
     let newValue = this.state.current + 2;
     if (newValue > 100) {
       newValue = 100;
@@ -663,7 +699,7 @@ class FakeSliderExample extends React.Component {
     });
   };
 
-  decrement = () => {
+  decrement: () => void = () => {
     let newValue = this.state.current - 2;
     if (newValue < 0) {
       newValue = 0;
@@ -673,7 +709,7 @@ class FakeSliderExample extends React.Component {
     });
   };
 
-  render() {
+  render(): React.Node {
     return (
       <View>
         <View
@@ -735,7 +771,7 @@ class AnnounceForAccessibility extends React.Component<{}> {
   _handleOnPress = () =>
     AccessibilityInfo.announceForAccessibility('Announcement Test');
 
-  render() {
+  render(): React.Node {
     return (
       <View>
         <Button
@@ -748,8 +784,8 @@ class AnnounceForAccessibility extends React.Component<{}> {
 }
 
 class SetAccessibilityFocusExample extends React.Component<{}> {
-  render() {
-    const myRef = createRef();
+  render(): React.Node {
+    const myRef: {current: React.ElementRef<any> | null} = createRef();
 
     const onClose = () => {
       if (myRef && myRef.current) {
@@ -781,7 +817,7 @@ class SetAccessibilityFocusExample extends React.Component<{}> {
 }
 
 class EnabledExamples extends React.Component<{}> {
-  render() {
+  render(): React.Node {
     return (
       <View>
         {Platform.OS === 'ios' ? (
@@ -831,11 +867,26 @@ class EnabledExamples extends React.Component<{}> {
   }
 }
 
-class EnabledExample extends React.Component<{}> {
+class EnabledExample extends React.Component<
+  {
+    eventListener:
+      | 'reduceMotionChanged'
+      | 'boldTextChanged'
+      | 'grayscaleChanged'
+      | 'invertColorsChanged'
+      | 'reduceTransparencyChanged'
+      | 'reduceMotionChanged'
+      | 'screenReaderChanged',
+    test: string,
+  },
+  {
+    isEnabled: void | boolean,
+  },
+> {
   state = {
     isEnabled: false,
   };
-
+  _subscription;
   componentDidMount() {
     this._subscription = AccessibilityInfo.addEventListener(
       this.props.eventListener,
@@ -856,15 +907,15 @@ class EnabledExample extends React.Component<{}> {
     this._subscription?.remove();
   }
 
-  _handleToggled = isEnabled => {
+  _handleToggled = () => {
     if (!this.state.isEnabled) {
-      this.setState({isEnabled});
+      this.setState({isEnabled: true});
     } else {
       this.setState({isEnabled: false});
     }
   };
 
-  render() {
+  render(): React.Node {
     return (
       <View>
         <Text>


### PR DESCRIPTION
## Summary

[AccessibilityExample.js](https://github.com/facebook/react-native/blob/master/packages/rn-tester/js/examples/Accessibility/AccessibilityExample.js) does not have proper Flow types. Without Flow typing enforced, it is easy for bugs to be introduced when making changes to this file. This pull request enforces Flow typing in this file.

## Changelog
[General] [Fixed] - Fixed return type of `AccessibilityRoleAndStateExample`
[General] [Added] - Added Flow Types to AccessibilityExample.js

## Test Plan
Before:
![Screen Shot 2021-04-19 at 7 39 58 PM](https://user-images.githubusercontent.com/12180395/115248265-42c6b200-a147-11eb-8dad-058f646a1550.png)

After:
![Screen Shot 2021-04-19 at 7 40 10 PM](https://user-images.githubusercontent.com/12180395/115248284-465a3900-a147-11eb-8bff-4050ce6bd806.png)


