### PR TITLE
Prevent native blob resource from being de-allocated prematurely

### DIFF
--- a/Libraries/Blob/Blob.js
+++ b/Libraries/Blob/Blob.js
@@ -104,7 +104,13 @@ class Blob {
     return BlobManager.createFromOptions({
       blobId: this.data.blobId,
       offset,
-      size,
+      size,      
+      /* Since `blob.slice()` creates a new view onto the same binary
+       * data as the original blob, we should re-use the same collector
+       * object so that the underlying resource gets deallocated when
+       * the last view into the data is released, not the first.
+       */
+      __collector: this.data.__collector,
     });
   }
 

--- a/Libraries/Blob/Blob.js
+++ b/Libraries/Blob/Blob.js
@@ -104,7 +104,7 @@ class Blob {
     return BlobManager.createFromOptions({
       blobId: this.data.blobId,
       offset,
-      size,      
+      size,
       /* Since `blob.slice()` creates a new view onto the same binary
        * data as the original blob, we should re-use the same collector
        * object so that the underlying resource gets deallocated when


### PR DESCRIPTION


## Summary

This PR prevents blob data from being prematurely de-allocated in native code when using slice to create views into an existing blob. Currently, whenever a new blob is created via createFromOptions, BlobManager.js creates a new blobCollector object since options.__collector is never provided.

https://github.com/facebook/react-native/blob/dc80b2dcb52fadec6a573a9dd1824393f8c29fdc/Libraries/Blob/BlobManager.js#L115-L123

When the reference to a blobCollector is garbage collected, the corresponding native memory for the blob data is de-allocated.

https://github.com/facebook/react-native/blob/27651720b40cab564a0cbd41be56a02584e0c73a/Libraries/Blob/RCTBlobCollector.mm#L19-L25

Since, `blob.slice()` is supposed to create a new view onto the same binary data as the original blob, we need to re-use the same collector object when slicing so that it is not GC'd until the last reference to the binary data is no longer reachable. Currently, since each blob slice gets a new blobCollector object, the memory is de-allocated when the first blob is GC'd.

Fixes https://github.com/facebook/react-native/issues/29970
Fixes https://github.com/facebook/react-native/issues/27857

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [Fixed] - Blob data is no longer prematurely deallocated when using blob.slice

## Test Plan

I could use help coming up with a test plan here. I could add a referential equality check for the blob.data.__collector in `Blob-test` but it doesn't seem quite right to be testing the implementation detail there.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
