### PR TITLE
Fix various c++ warnings

### DIFF
--- a/ReactCommon/react/renderer/components/scrollview/ScrollViewProps.h
+++ b/ReactCommon/react/renderer/components/scrollview/ScrollViewProps.h
@@ -28,12 +28,12 @@ class ScrollViewProps final : public ViewProps {
   bool canCancelContentTouches{true};
   bool centerContent{};
   bool automaticallyAdjustContentInsets{};
-  Float decelerationRate{0.998};
+  Float decelerationRate{0.998f};
   bool directionalLockEnabled{};
   ScrollViewIndicatorStyle indicatorStyle{};
   ScrollViewKeyboardDismissMode keyboardDismissMode{};
-  Float maximumZoomScale{1.0};
-  Float minimumZoomScale{1.0};
+  Float maximumZoomScale{1.0f};
+  Float minimumZoomScale{1.0f};
   bool scrollEnabled{true};
   bool pagingEnabled{};
   bool pinchGestureEnabled{true};
@@ -41,7 +41,7 @@ class ScrollViewProps final : public ViewProps {
   bool showsHorizontalScrollIndicator{true};
   bool showsVerticalScrollIndicator{true};
   Float scrollEventThrottle{};
-  Float zoomScale{1.0};
+  Float zoomScale{1.0f};
   EdgeInsets contentInset{};
   Point contentOffset{};
   EdgeInsets scrollIndicatorInsets{};

--- a/ReactCommon/react/renderer/components/text/ParagraphShadowNode.cpp
+++ b/ReactCommon/react/renderer/components/text/ParagraphShadowNode.cpp
@@ -78,8 +78,8 @@ Content ParagraphShadowNode::getContentWithMeasuredAttachments(
         laytableShadowNode->measure(layoutContext, localLayoutConstraints);
 
     // Rounding to *next* value on the pixel grid.
-    size.width += 0.01;
-    size.height += 0.01;
+    size.width += 0.01f;
+    size.height += 0.01f;
     size = roundToPixel<&ceil>(size, layoutContext.pointScaleFactor);
 
     auto fragmentLayoutMetrics = LayoutMetrics{};
@@ -186,7 +186,7 @@ void ParagraphShadowNode::layout(LayoutContext layoutContext) {
   react_native_assert(
       content.attachments.size() == measurement.attachments.size());
 
-  for (auto i = 0; i < content.attachments.size(); i++) {
+  for (size_t i = 0; i < content.attachments.size(); i++) {
     auto &attachment = content.attachments.at(i);
 
     if (!traitCast<LayoutableShadowNode const *>(attachment.shadowNode)) {

--- a/ReactCommon/react/renderer/components/view/primitives.h
+++ b/ReactCommon/react/renderer/components/view/primitives.h
@@ -38,18 +38,18 @@ struct CascadedRectangleEdges {
   OptionalT all{};
 
   Counterpart resolve(bool isRTL, T defaults) const {
-    const auto leading = isRTL ? end : start;
-    const auto trailing = isRTL ? start : end;
+    const auto leadingEdge = isRTL ? end : start;
+    const auto trailingEdge = isRTL ? start : end;
     const auto horizontalOrAllOrDefault =
         horizontal.value_or(all.value_or(defaults));
     const auto verticalOrAllOrDefault =
         vertical.value_or(all.value_or(defaults));
 
     return {
-        /* .left = */ left.value_or(leading.value_or(horizontalOrAllOrDefault)),
+        /* .left = */ left.value_or(leadingEdge.value_or(horizontalOrAllOrDefault)),
         /* .top = */ top.value_or(verticalOrAllOrDefault),
         /* .right = */
-        right.value_or(trailing.value_or(horizontalOrAllOrDefault)),
+        right.value_or(trailingEdge.value_or(horizontalOrAllOrDefault)),
         /* .bottom = */ bottom.value_or(verticalOrAllOrDefault),
     };
   }

--- a/ReactCommon/react/renderer/core/EventEmitter.cpp
+++ b/ReactCommon/react/renderer/core/EventEmitter.cpp
@@ -26,7 +26,7 @@ static std::string normalizeEventType(const std::string &type) {
   auto prefixedType = type;
   if (type.find("top", 0) != 0) {
     prefixedType.insert(0, "top");
-    prefixedType[3] = toupper(prefixedType[3]);
+    prefixedType[3] = static_cast<char>(toupper(prefixedType[3]));
   }
   return prefixedType;
 }

--- a/ReactCommon/react/renderer/core/RawPropsKeyMap.cpp
+++ b/ReactCommon/react/renderer/core/RawPropsKeyMap.cpp
@@ -63,7 +63,7 @@ void RawPropsKeyMap::reindex() noexcept {
   buckets_.resize(kPropNameLengthHardCap);
 
   auto length = RawPropsPropNameLength{0};
-  for (auto i = 0; i < items_.size(); i++) {
+  for (size_t i = 0; i < items_.size(); i++) {
     auto &item = items_[i];
     if (item.length != length) {
       for (auto j = length; j < item.length; j++) {

--- a/ReactCommon/react/renderer/core/RawPropsParser.cpp
+++ b/ReactCommon/react/renderer/core/RawPropsParser.cpp
@@ -114,7 +114,7 @@ void RawPropsParser::preparse(RawProps const &rawProps) const noexcept {
       auto count = names.size(runtime);
       auto valueIndex = RawPropsValueIndex{0};
 
-      for (auto i = 0; i < count; i++) {
+      for (size_t i = 0; i < count; i++) {
         auto nameValue = names.getValueAtIndex(runtime, i).getString(runtime);
         auto value = object.getProperty(runtime, nameValue);
 

--- a/ReactCommon/react/renderer/core/ShadowNode.cpp
+++ b/ReactCommon/react/renderer/core/ShadowNode.cpp
@@ -213,7 +213,7 @@ void ShadowNode::replaceChild(
       *std::const_pointer_cast<ShadowNode::ListOfShared>(children_);
   auto size = children.size();
 
-  if (suggestedIndex != -1 && suggestedIndex < size) {
+  if (suggestedIndex != -1 && static_cast<size_t>(suggestedIndex) < size) {
     // If provided `suggestedIndex` is accurate,
     // replacing in place using the index.
     if (children.at(suggestedIndex).get() == &oldChild) {
@@ -222,7 +222,7 @@ void ShadowNode::replaceChild(
     }
   }
 
-  for (auto index = 0; index < size; index++) {
+  for (size_t index = 0; index < size; index++) {
     if (children.at(index).get() == &oldChild) {
       children[index] = newChild;
       return;

--- a/ReactCommon/react/renderer/core/propsConversions.h
+++ b/ReactCommon/react/renderer/core/propsConversions.h
@@ -30,7 +30,7 @@ void fromRawValue(RawValue const &rawValue, std::vector<T> &result) {
     auto length = items.size();
     result.clear();
     result.reserve(length);
-    for (int i = 0; i < length; i++) {
+    for (size_t i = 0; i < length; i++) {
       T itemResult;
       fromRawValue(items.at(i), itemResult);
       result.push_back(itemResult);

--- a/ReactCommon/react/renderer/debug/DebugStringConvertible.h
+++ b/ReactCommon/react/renderer/debug/DebugStringConvertible.h
@@ -192,16 +192,16 @@ std::string getDebugChildrenDescription(
     return "";
   }
 
-  auto trailing = options.format ? std::string{"\n"} : std::string{""};
+  auto separator = options.format ? std::string{"\n"} : std::string{""};
   auto childrenString = std::string{""};
   options.depth++;
 
   for (auto child : getDebugChildren(object, options)) {
-    childrenString += getDebugDescription(child, options) + trailing;
+    childrenString += getDebugDescription(child, options) + separator;
   }
 
-  if (!childrenString.empty() && !trailing.empty()) {
-    // Removing trailing fragment.
+  if (!childrenString.empty() && !separator.empty()) {
+    // Removing separator fragment.
     childrenString.erase(childrenString.end() - 1);
   }
 
@@ -230,16 +230,16 @@ std::string getDebugDescription(
   auto childrenString = getDebugChildrenDescription(object, options);
   auto propsString = getDebugPropsDescription(object, options);
 
-  auto leading =
+  auto prefix =
       options.format ? std::string(options.depth * 2, ' ') : std::string{""};
-  auto trailing = options.format ? std::string{"\n"} : std::string{""};
+  auto separator = options.format ? std::string{"\n"} : std::string{""};
 
-  return leading + "<" + nameString +
+  return prefix + "<" + nameString +
       (valueString.empty() ? "" : "=" + valueString) +
       (propsString.empty() ? "" : " " + propsString) +
       (childrenString.empty() ? "/>"
-                              : ">" + trailing + childrenString + trailing +
-               leading + "</" + nameString + ">");
+                              : ">" + separator + childrenString + separator +
+               prefix + "</" + nameString + ">");
 }
 
 /*

--- a/ReactCommon/react/renderer/graphics/Transform.cpp
+++ b/ReactCommon/react/renderer/graphics/Transform.cpp
@@ -190,7 +190,7 @@ Transform Transform::Interpolate(
   // transform If at any point we hit an "Arbitrary" Transform, return at that
   // point
   Transform result = Transform::Identity();
-  for (int i = 0, j = 0;
+  for (size_t i = 0, j = 0;
        i < lhs.operations.size() || j < rhs.operations.size();) {
     bool haveLHS = i < lhs.operations.size();
     bool haveRHS = j < rhs.operations.size();

--- a/ReactCommon/react/renderer/leakchecker/LeakChecker.cpp
+++ b/ReactCommon/react/renderer/leakchecker/LeakChecker.cpp
@@ -44,7 +44,7 @@ void LeakChecker::stopSurface(SurfaceId surfaceId) {
 
 void LeakChecker::checkSurfaceForLeaks(SurfaceId surfaceId) const {
   auto weakFamilies = registry_.weakFamiliesForSurfaceId(surfaceId);
-  uint numberOfLeaks = 0;
+  unsigned int numberOfLeaks = 0;
   for (auto const &weakFamily : weakFamilies) {
     auto strong = weakFamily.lock();
     if (strong) {

--- a/ReactCommon/react/renderer/mounting/Differentiator.cpp
+++ b/ReactCommon/react/renderer/mounting/Differentiator.cpp
@@ -170,8 +170,8 @@ class TinyMap final {
   }
 
   better::small_vector<Pair, DefaultSize> vector_;
-  int numErased_{0};
-  int erasedAtFront_{0};
+  size_t numErased_{0};
+  size_t erasedAtFront_{0};
 };
 
 /*

--- a/ReactCommon/react/renderer/mounting/ShadowTree.cpp
+++ b/ReactCommon/react/renderer/mounting/ShadowTree.cpp
@@ -178,7 +178,7 @@ static void updateMountedFlag(
     return;
   }
 
-  int index;
+  size_t index;
 
   // Stage 1: Mount and unmount "updated" children.
   for (index = 0; index < oldChildren.size() && index < newChildren.size();
@@ -202,7 +202,7 @@ static void updateMountedFlag(
     updateMountedFlag(oldChild->getChildren(), newChild->getChildren());
   }
 
-  int lastIndexAfterFirstStage = index;
+  size_t lastIndexAfterFirstStage = index;
 
   // State 2: Mount new children.
   for (index = lastIndexAfterFirstStage; index < newChildren.size(); index++) {

--- a/ReactCommon/react/renderer/mounting/StubViewTree.cpp
+++ b/ReactCommon/react/renderer/mounting/StubViewTree.cpp
@@ -116,8 +116,8 @@ void StubViewTree::mutate(ShadowViewMutationList const &mutations) {
                        << parentStubView->children.size() << " children)";
           });
           react_native_assert(childStubView->parentTag == NO_VIEW_TAG);
-          react_native_assert(
-              parentStubView->children.size() >= mutation.index);
+          react_native_assert(mutation.index < 0 || 
+              parentStubView->children.size() >= static_cast<size_t>(mutation.index));
           childStubView->parentTag = parentTag;
           parentStubView->children.insert(
               parentStubView->children.begin() + mutation.index, childStubView);
@@ -147,7 +147,7 @@ void StubViewTree::mutate(ShadowViewMutationList const &mutations) {
                        << parentTag << "] @" << mutation.index << " with "
                        << parentStubView->children.size() << " children";
           });
-          react_native_assert(parentStubView->children.size() > mutation.index);
+          react_native_assert(mutation.index > 0 && parentStubView->children.size() > static_cast<size_t>(mutation.index));
           react_native_assert(registry.find(childTag) != registry.end());
           auto childStubView = registry[childTag];
           if ((ShadowView)(*childStubView) != mutation.oldChildShadowView) {
@@ -183,7 +183,8 @@ void StubViewTree::mutate(ShadowViewMutationList const &mutations) {
                        << ": " << strChildList;
           });
           react_native_assert(
-              parentStubView->children.size() > mutation.index &&
+            mutation.index >= 0 &&
+              parentStubView->children.size() > static_cast<size_t>(mutation.index) &&
               parentStubView->children[mutation.index]->tag ==
                   childStubView->tag);
           childStubView->parentTag = NO_VIEW_TAG;

--- a/ReactCommon/react/renderer/mounting/TelemetryController.cpp
+++ b/ReactCommon/react/renderer/mounting/TelemetryController.cpp
@@ -30,7 +30,7 @@ bool TelemetryController::pullTransaction(
   auto surfaceId = transaction.getSurfaceId();
   auto number = transaction.getNumber();
   auto telemetry = transaction.getTelemetry();
-  auto numberOfMutations = transaction.getMutations().size();
+  auto numberOfMutations = static_cast<int>(transaction.getMutations().size());
 
   mutex_.lock();
   auto compoundTelemetry = compoundTelemetry_;

--- a/ReactCommon/react/renderer/mounting/stubs.cpp
+++ b/ReactCommon/react/renderer/mounting/stubs.cpp
@@ -47,13 +47,13 @@ static void calculateShadowViewMutationsForNewTree(
   // Sorting pairs based on `orderIndex` if needed.
   reorderInPlaceIfNeeded(newChildPairs);
 
-  for (auto index = 0; index < newChildPairs.size(); index++) {
+  for (size_t index = 0; index < newChildPairs.size(); index++) {
     auto const &newChildPair = newChildPairs[index];
 
     mutations.push_back(
         ShadowViewMutation::CreateMutation(newChildPair.shadowView));
     mutations.push_back(ShadowViewMutation::InsertMutation(
-        parentShadowView, newChildPair.shadowView, index));
+        parentShadowView, newChildPair.shadowView, static_cast<int>(index)));
 
     auto newGrandChildPairs =
         sliceChildShadowNodeViewPairsLegacy(*newChildPair.shadowNode);

--- a/ReactCommon/react/renderer/templateprocessor/UITemplateProcessor.cpp
+++ b/ReactCommon/react/renderer/templateprocessor/UITemplateProcessor.cpp
@@ -44,14 +44,14 @@ SharedShadowNode UITemplateProcessor::runCommand(
   const int tagOffset = 420000;
   // TODO: change to integer codes and a switch statement
   if (opcode == "createNode") {
-    int tag = command[1].asInt();
+    Tag tag = static_cast<Tag>(command[1].asInt());
     const auto &type = command[2].asString();
     const auto parentTag = command[3].asInt();
     const auto &props = command[4];
     nodes[tag] = componentDescriptorRegistry.createNode(
         tag + tagOffset, type, surfaceId, props, nullptr);
     if (parentTag > -1) { // parentTag == -1 indicates root node
-      auto parentShadowNode = nodes[parentTag];
+      auto parentShadowNode = nodes[static_cast<size_t>(parentTag)];
       auto const &componentDescriptor = componentDescriptorRegistry.at(
           parentShadowNode->getComponentHandle());
       componentDescriptor.appendChild(parentShadowNode, nodes[tag]);
@@ -61,13 +61,13 @@ SharedShadowNode UITemplateProcessor::runCommand(
       LOG(INFO)
           << "(stop) UITemplateProcessor inject serialized 'server rendered' view tree";
     }
-    return nodes[command[1].asInt()];
+    return nodes[static_cast<Tag>(command[1].asInt())];
   } else if (opcode == "loadNativeBool") {
-    int registerNumber = command[1].asInt();
+    auto registerNumber = static_cast<size_t>(command[1].asInt());
     std::string param = command[4][0].asString();
     registers[registerNumber] = reactNativeConfig->getBool(param);
   } else if (opcode == "conditional") {
-    int registerNumber = command[1].asInt();
+    auto registerNumber = static_cast<size_t>(command[1].asInt());
     auto conditionDynamic = registers[registerNumber];
     if (conditionDynamic.isNull()) {
       // TODO: provide original command or command line?


### PR DESCRIPTION
## Summary

react-native-windows runs with a more strict set of warnings as errors.  This fixes a bunch of warnings being hit while compiling core react-native code as part of react-native-windows.  In particular warnings about mismatched signed/unsigned comparisons, lossy conversions, and variable names that conflict with names in outer scopes (yoga has a global for `leading` and `trailing` that conflicts with some local variable names)

## Changelog

[Internal] [Fixed] - Fix various C++ warnings

## Test Plan

I've run these changes in react-native-windows. -- Shouldn't have any functionality difference.