### PR TITLE
Migrate xplat autoglob targets

### DIFF
--- a/Libraries/FBLazyVector/BUCK
+++ b/Libraries/FBLazyVector/BUCK
@@ -1,8 +1,10 @@
+load("@fbsource//tools/build_defs/apple:autoglob.bzl", "EXPORT_UNLESS_INTERNAL")
 load("//tools/build_defs/oss:rn_defs.bzl", "fb_apple_library")
 
 fb_apple_library(
     name = "FBLazyVector",
     autoglob = True,
+    autoglob_mode = EXPORT_UNLESS_INTERNAL,
     complete_nullability = True,
     contacts = ["oncall+react_native@xmail.facebook.com"],
     enable_exceptions = False,

--- a/Libraries/RCTRequired/BUCK
+++ b/Libraries/RCTRequired/BUCK
@@ -1,8 +1,10 @@
+load("@fbsource//tools/build_defs/apple:autoglob.bzl", "EXPORT_UNLESS_INTERNAL")
 load("//tools/build_defs/oss:rn_defs.bzl", "fb_apple_library")
 
 fb_apple_library(
     name = "RCTRequired",
     autoglob = True,
+    autoglob_mode = EXPORT_UNLESS_INTERNAL,
     complete_nullability = True,
     contacts = ["oncall+react_native@xmail.facebook.com"],
     extension_api_only = True,


### PR DESCRIPTION
Summary: Annotate autolgob mode for apple library targets

Reviewed By: adamjernst

Differential Revision: D27890473

