### PR TITLE
Add @flow types in AccessibilityAndroidExample.android.js

### DIFF
--- a/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+++ b/Libraries/Components/Touchable/TouchableWithoutFeedback.js
@@ -11,6 +11,8 @@
 import Pressability, {
   type PressabilityConfig,
 } from '../../Pressability/Pressability';
+
+import type {ViewStyleProp} from '../../StyleSheet/StyleSheet';
 import {PressabilityDebugView} from '../../Pressability/PressabilityDebug';
 import type {
   AccessibilityActionEvent,
@@ -62,6 +64,7 @@ type Props = $ReadOnly<{|
   rejectResponderTermination?: ?boolean,
   testID?: ?string,
   touchSoundDisabled?: ?boolean,
+  style?: ?ViewStyleProp,
 |}>;
 
 type State = $ReadOnly<{|

--- a/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+++ b/Libraries/Components/Touchable/TouchableWithoutFeedback.js
@@ -12,7 +12,6 @@ import Pressability, {
   type PressabilityConfig,
 } from '../../Pressability/Pressability';
 
-import type {ViewStyleProp} from '../../StyleSheet/StyleSheet';
 import {PressabilityDebugView} from '../../Pressability/PressabilityDebug';
 import type {
   AccessibilityActionEvent,
@@ -64,7 +63,6 @@ type Props = $ReadOnly<{|
   rejectResponderTermination?: ?boolean,
   testID?: ?string,
   touchSoundDisabled?: ?boolean,
-  style?: ?ViewStyleProp,
 |}>;
 
 type State = $ReadOnly<{|

--- a/Libraries/Text/TextProps.js
+++ b/Libraries/Text/TextProps.js
@@ -44,6 +44,8 @@ export type TextProps = $ReadOnly<{|
   accessibilityRole?: ?AccessibilityRole,
   accessibilityState?: ?AccessibilityState,
 
+  accessibilityLiveRegion?: ?('none' | 'polite' | 'assertive'),
+
   /**
    * Whether font should be scaled down automatically.
    *

--- a/Libraries/Text/TextProps.js
+++ b/Libraries/Text/TextProps.js
@@ -44,8 +44,6 @@ export type TextProps = $ReadOnly<{|
   accessibilityRole?: ?AccessibilityRole,
   accessibilityState?: ?AccessibilityState,
 
-  accessibilityLiveRegion?: ?('none' | 'polite' | 'assertive'),
-
   /**
    * Whether font should be scaled down automatically.
    *

--- a/packages/rn-tester/js/examples/Accessibility/AccessibilityAndroidExample.android.js
+++ b/packages/rn-tester/js/examples/Accessibility/AccessibilityAndroidExample.android.js
@@ -28,12 +28,8 @@ type AccessibilityAndroidExampleState = {
   forgroundImportantForAcc: number,
 };
 
-type Props = $ReadOnly<{|
-  accessibilityLiveRegion?: ?string,
-|}>;
-
 class AccessibilityAndroidExample extends React.Component<
-  Props,
+  {},
   AccessibilityAndroidExampleState,
 > {
   state: AccessibilityAndroidExampleState = {
@@ -69,15 +65,14 @@ class AccessibilityAndroidExample extends React.Component<
               <Text>Click me</Text>
             </View>
           </TouchableWithoutFeedback>
-          <Text accessibilityLiveRegion={'polite'}>
-            Clicked {this.state.count} times
-          </Text>
+          <View accessibilityLiveRegion={'polite'}>
+            <Text>Clicked {this.state.count} times</Text>
+          </View>
         </RNTesterBlock>
 
         <RNTesterBlock title="Overlapping views and importantForAccessibility property">
           <View style={styles.container}>
             <TouchableWithoutFeedback
-              style={styles.touchableContainer}
               accessible={true}
               accessibilityLabel="First layout"
               importantForAccessibility={
@@ -85,7 +80,7 @@ class AccessibilityAndroidExample extends React.Component<
                   this.state.backgroundImportantForAcc
                 ]
               }>
-              <View accessible={true}>
+              <View accessible={true} style={styles.touchableContainer}>
                 <Text style={{fontSize: 25}}>Hello</Text>
               </View>
             </TouchableWithoutFeedback>

--- a/packages/rn-tester/js/examples/Accessibility/AccessibilityAndroidExample.android.js
+++ b/packages/rn-tester/js/examples/Accessibility/AccessibilityAndroidExample.android.js
@@ -9,17 +9,16 @@
  */
 
 'use strict';
-
+const RNTesterBlock = require('../../components/RNTesterBlock');
+const RNTesterPage = require('../../components/RNTesterPage');
 const React = require('react');
+import type {ViewStyleProp} from '../../../../../Libraries/StyleSheet/StyleSheet';
 const {
   StyleSheet,
   Text,
   View,
   TouchableWithoutFeedback,
 } = require('react-native');
-const RNTesterBlock = require('../../components/RNTesterBlock');
-const RNTesterPage = require('../../components/RNTesterPage');
-import type {ViewStyleProp} from 'react-native/Libraries/StyleSheet/StyleSheet';
 
 const importantForAccessibilityValues = [
   'auto',
@@ -35,8 +34,8 @@ type AccessibilityAndroidExampleState = {
 };
 
 type Props = $ReadOnly<{|
-  style?: ?ViewStyleProp,
-  accessibilityLiveRegion?: ?('none' | 'polite' | 'assertive'),
+  accessibilityLiveRegion?: string,
+  style?: ViewStyleProp,
 |}>;
 
 class AccessibilityAndroidExample extends React.Component<
@@ -68,6 +67,7 @@ class AccessibilityAndroidExample extends React.Component<
   };
 
   render(): React.Node {
+    const {style} = this.props;
     return (
       <RNTesterPage title={'Accessibility Android APIs'}>
         <RNTesterBlock title="LiveRegion">
@@ -76,7 +76,7 @@ class AccessibilityAndroidExample extends React.Component<
               <Text>Click me</Text>
             </View>
           </TouchableWithoutFeedback>
-          <Text accessibilityLiveRegion={this.props.accessibilityLiveRegion}>
+          <Text accessibilityLiveRegion={'polite'}>
             Clicked {this.state.count} times
           </Text>
         </RNTesterBlock>
@@ -84,6 +84,7 @@ class AccessibilityAndroidExample extends React.Component<
         <RNTesterBlock title="Overlapping views and importantForAccessibility property">
           <View style={styles.container}>
             <TouchableWithoutFeedback
+              style={[styles.touchableContainer, style]}
               accessible={true}
               accessibilityLabel="First layout"
               importantForAccessibility={
@@ -160,6 +161,14 @@ class AccessibilityAndroidExample extends React.Component<
 }
 
 const styles = StyleSheet.create({
+  touchableContainer: {
+    position: 'absolute',
+    left: 10,
+    top: 10,
+    right: 10,
+    height: 100,
+    backgroundColor: 'green',
+  },
   embedded: {
     backgroundColor: 'yellow',
     padding: 10,

--- a/packages/rn-tester/js/examples/Accessibility/AccessibilityAndroidExample.android.js
+++ b/packages/rn-tester/js/examples/Accessibility/AccessibilityAndroidExample.android.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @flow strict-local
  */
 
 'use strict';
@@ -27,8 +28,17 @@ const importantForAccessibilityValues = [
   'no-hide-descendants',
 ];
 
-class AccessibilityAndroidExample extends React.Component {
-  state = {
+type AccessibilityAndroidExampleState = {
+  count: number,
+  backgroundImportantForAcc: number,
+  forgroundImportantForAcc: number,
+};
+
+class AccessibilityAndroidExample extends React.Component<
+  {},
+  AccessibilityAndroidExampleState,
+> {
+  state: AccessibilityAndroidExampleState = {
     count: 0,
     backgroundImportantForAcc: 0,
     forgroundImportantForAcc: 0,
@@ -52,7 +62,7 @@ class AccessibilityAndroidExample extends React.Component {
     });
   };
 
-  render() {
+  render(): React.Node {
     return (
       <RNTesterPage title={'Accessibility Android APIs'}>
         <RNTesterBlock title="LiveRegion">
@@ -151,19 +161,6 @@ class AccessibilityAndroidExample extends React.Component {
     );
   }
 }
-
-const styles = StyleSheet.create({
-  embedded: {
-    backgroundColor: 'yellow',
-    padding: 10,
-  },
-  container: {
-    flex: 1,
-    backgroundColor: 'white',
-    padding: 10,
-    height: 150,
-  },
-});
 
 exports.title = 'AccessibilityAndroid';
 exports.description = 'Android specific Accessibility APIs.';

--- a/packages/rn-tester/js/examples/Accessibility/AccessibilityAndroidExample.android.js
+++ b/packages/rn-tester/js/examples/Accessibility/AccessibilityAndroidExample.android.js
@@ -9,16 +9,11 @@
  */
 
 'use strict';
-const RNTesterBlock = require('../../components/RNTesterBlock');
-const RNTesterPage = require('../../components/RNTesterPage');
+
 const React = require('react');
-import type {ViewStyleProp} from '../../../../../Libraries/StyleSheet/StyleSheet';
-const {
-  StyleSheet,
-  Text,
-  View,
-  TouchableWithoutFeedback,
-} = require('react-native');
+import RNTesterBlock from '../../components/RNTesterBlock';
+import RNTesterPage from '../../components/RNTesterPage';
+import {StyleSheet, Text, View, TouchableWithoutFeedback} from 'react-native';
 
 const importantForAccessibilityValues = [
   'auto',
@@ -35,7 +30,6 @@ type AccessibilityAndroidExampleState = {
 
 type Props = $ReadOnly<{|
   accessibilityLiveRegion?: ?string,
-  style?: ?ViewStyleProp,
 |}>;
 
 class AccessibilityAndroidExample extends React.Component<
@@ -83,7 +77,7 @@ class AccessibilityAndroidExample extends React.Component<
         <RNTesterBlock title="Overlapping views and importantForAccessibility property">
           <View style={styles.container}>
             <TouchableWithoutFeedback
-              style={[styles.touchableContainer, this.props.style]}
+              style={styles.touchableContainer}
               accessible={true}
               accessibilityLabel="First layout"
               importantForAccessibility={

--- a/packages/rn-tester/js/examples/Accessibility/AccessibilityAndroidExample.android.js
+++ b/packages/rn-tester/js/examples/Accessibility/AccessibilityAndroidExample.android.js
@@ -17,9 +17,9 @@ const {
   View,
   TouchableWithoutFeedback,
 } = require('react-native');
-
 const RNTesterBlock = require('../../components/RNTesterBlock');
 const RNTesterPage = require('../../components/RNTesterPage');
+import type {ViewStyleProp} from 'react-native/Libraries/StyleSheet/StyleSheet';
 
 const importantForAccessibilityValues = [
   'auto',
@@ -32,11 +32,15 @@ type AccessibilityAndroidExampleState = {
   count: number,
   backgroundImportantForAcc: number,
   forgroundImportantForAcc: number,
-  ...
 };
 
+type Props = $ReadOnly<{|
+  style?: ?ViewStyleProp,
+  accessibilityLiveRegion?: ?('none' | 'polite' | 'assertive'),
+|}>;
+
 class AccessibilityAndroidExample extends React.Component<
-  {...},
+  Props,
   AccessibilityAndroidExampleState,
 > {
   state: AccessibilityAndroidExampleState = {
@@ -72,7 +76,7 @@ class AccessibilityAndroidExample extends React.Component<
               <Text>Click me</Text>
             </View>
           </TouchableWithoutFeedback>
-          <Text accessibilityLiveRegion="polite">
+          <Text {...Props} accessibilityLiveRegion="polite">
             Clicked {this.state.count} times
           </Text>
         </RNTesterBlock>
@@ -80,14 +84,6 @@ class AccessibilityAndroidExample extends React.Component<
         <RNTesterBlock title="Overlapping views and importantForAccessibility property">
           <View style={styles.container}>
             <TouchableWithoutFeedback
-              style={{
-                position: 'absolute',
-                left: 10,
-                top: 10,
-                right: 10,
-                height: 100,
-                backgroundColor: 'green',
-              }}
               accessible={true}
               accessibilityLabel="First layout"
               importantForAccessibility={

--- a/packages/rn-tester/js/examples/Accessibility/AccessibilityAndroidExample.android.js
+++ b/packages/rn-tester/js/examples/Accessibility/AccessibilityAndroidExample.android.js
@@ -34,8 +34,8 @@ type AccessibilityAndroidExampleState = {
 };
 
 type Props = $ReadOnly<{|
-  accessibilityLiveRegion?: string,
-  style?: ViewStyleProp,
+  accessibilityLiveRegion?: ?string,
+  style?: ?ViewStyleProp,
 |}>;
 
 class AccessibilityAndroidExample extends React.Component<
@@ -67,7 +67,6 @@ class AccessibilityAndroidExample extends React.Component<
   };
 
   render(): React.Node {
-    const {style} = this.props;
     return (
       <RNTesterPage title={'Accessibility Android APIs'}>
         <RNTesterBlock title="LiveRegion">
@@ -84,7 +83,7 @@ class AccessibilityAndroidExample extends React.Component<
         <RNTesterBlock title="Overlapping views and importantForAccessibility property">
           <View style={styles.container}>
             <TouchableWithoutFeedback
-              style={[styles.touchableContainer, style]}
+              style={[styles.touchableContainer, this.props.style]}
               accessible={true}
               accessibilityLabel="First layout"
               importantForAccessibility={

--- a/packages/rn-tester/js/examples/Accessibility/AccessibilityAndroidExample.android.js
+++ b/packages/rn-tester/js/examples/Accessibility/AccessibilityAndroidExample.android.js
@@ -32,10 +32,11 @@ type AccessibilityAndroidExampleState = {
   count: number,
   backgroundImportantForAcc: number,
   forgroundImportantForAcc: number,
+  ...
 };
 
 class AccessibilityAndroidExample extends React.Component<
-  {},
+  {...},
   AccessibilityAndroidExampleState,
 > {
   state: AccessibilityAndroidExampleState = {
@@ -44,19 +45,19 @@ class AccessibilityAndroidExample extends React.Component<
     forgroundImportantForAcc: 0,
   };
 
-  _addOne = () => {
+  _addOne: (event: any) => void = (event: any) => {
     this.setState({
       count: ++this.state.count,
     });
   };
 
-  _changeBackgroundImportantForAcc = () => {
+  _changeBackgroundImportantForAcc: (event: any) => void = (event: any) => {
     this.setState({
       backgroundImportantForAcc: (this.state.backgroundImportantForAcc + 1) % 4,
     });
   };
 
-  _changeForgroundImportantForAcc = () => {
+  _changeForgroundImportantForAcc: (event: any) => void = (event: any) => {
     this.setState({
       forgroundImportantForAcc: (this.state.forgroundImportantForAcc + 1) % 4,
     });
@@ -161,6 +162,19 @@ class AccessibilityAndroidExample extends React.Component<
     );
   }
 }
+
+const styles = StyleSheet.create({
+  embedded: {
+    backgroundColor: 'yellow',
+    padding: 10,
+  },
+  container: {
+    flex: 1,
+    backgroundColor: 'white',
+    padding: 10,
+    height: 150,
+  },
+});
 
 exports.title = 'AccessibilityAndroid';
 exports.description = 'Android specific Accessibility APIs.';

--- a/packages/rn-tester/js/examples/Accessibility/AccessibilityAndroidExample.android.js
+++ b/packages/rn-tester/js/examples/Accessibility/AccessibilityAndroidExample.android.js
@@ -76,7 +76,7 @@ class AccessibilityAndroidExample extends React.Component<
               <Text>Click me</Text>
             </View>
           </TouchableWithoutFeedback>
-          <Text {...Props} accessibilityLiveRegion="polite">
+          <Text accessibilityLiveRegion={this.props.accessibilityLiveRegion}>
             Clicked {this.state.count} times
           </Text>
         </RNTesterBlock>

--- a/packages/rn-tester/js/examples/Accessibility/AccessibilityAndroidExample.android.js
+++ b/packages/rn-tester/js/examples/Accessibility/AccessibilityAndroidExample.android.js
@@ -45,19 +45,19 @@ class AccessibilityAndroidExample extends React.Component<
     forgroundImportantForAcc: 0,
   };
 
-  _addOne: (event: any) => void = (event: any) => {
+  _addOne = () => {
     this.setState({
       count: ++this.state.count,
     });
   };
 
-  _changeBackgroundImportantForAcc: (event: any) => void = (event: any) => {
+  _changeBackgroundImportantForAcc = () => {
     this.setState({
       backgroundImportantForAcc: (this.state.backgroundImportantForAcc + 1) % 4,
     });
   };
 
-  _changeForgroundImportantForAcc: (event: any) => void = (event: any) => {
+  _changeForgroundImportantForAcc = () => {
     this.setState({
       forgroundImportantForAcc: (this.state.forgroundImportantForAcc + 1) % 4,
     });
@@ -181,7 +181,7 @@ exports.description = 'Android specific Accessibility APIs.';
 exports.examples = [
   {
     title: 'Accessibility elements',
-    render(): React.Element<typeof AccessibilityAndroidExample> {
+    render(): React.Node {
       return <AccessibilityAndroidExample />;
     },
   },

--- a/packages/rn-tester/js/examples/Accessibility/AccessibilityAndroidExample.android.js
+++ b/packages/rn-tester/js/examples/Accessibility/AccessibilityAndroidExample.android.js
@@ -181,7 +181,7 @@ exports.description = 'Android specific Accessibility APIs.';
 exports.examples = [
   {
     title: 'Accessibility elements',
-    render(): React.Node {
+    render(): React.Element<typeof AccessibilityAndroidExample> {
       return <AccessibilityAndroidExample />;
     },
   },


### PR DESCRIPTION
### Summary
[AccessibilityAndroidExample.android.js](https://github.com/facebook/react-native/blob/master/packages/rn-tester/js/examples/Accessibility/AccessibilityAndroidExample.android.js) does not have proper Flow types. Without Flow typing enforced, it is easy for bugs to be introduced when making changes to this file.

### Changelog

[General] [Added] - Added the @flow annotation to `AccessibilityAndroidExample.android.js `
[General] [Added] - Updated the file to use [@flow strict-local](https://flow.org/en/docs/strict/#toc-strict-local)

### Test Plan

Run `flow-check-android` with No Errors in code.
