### PR TITLE
Move RNTester Buck library to GitHub

### DIFF
--- a/packages/rn-tester/BUCK
+++ b/packages/rn-tester/BUCK
@@ -1,3 +1,4 @@
+load("@fbsource//tools/build_defs/oss:metro_defs.bzl", "rn_library")
 load("@fbsource//tools/build_defs/third_party:yarn_defs.bzl", "yarn_workspace")
 
 yarn_workspace(
@@ -20,4 +21,31 @@ yarn_workspace(
         ],
     ),
     visibility = ["PUBLIC"],
+)
+
+rn_library(
+    name = "rn-tester",
+    srcs = glob(
+        [
+            "js/**/*",
+            "NativeModuleExample/**/*",
+            "RCTTest/**/*",
+        ],
+        exclude = [
+            "**/__*__/**",
+            "**/*.md",
+            "js/examples/WebSocket/http_test_server.js",
+            "js/examples/WebSocket/websocket_test_server.js",
+        ],
+    ),
+    labels = ["supermodule:xplat/default/public.react_native.playground"],
+    skip_processors = True,
+    visibility = ["PUBLIC"],
+    deps = [
+        "//xplat/js:node_modules__nullthrows",
+        "//xplat/js:react-native",
+        "//xplat/js/RKJSModules/Libraries/Core:Core",
+        "//xplat/js/RKJSModules/vendor/react:react",
+        "//xplat/js/react-native-github/packages/assets:assets",
+    ],
 )

--- a/tools/build_defs/oss/metro_defs.bzl
+++ b/tools/build_defs/oss/metro_defs.bzl
@@ -1,0 +1,4 @@
+# metro-buck integration
+def rn_library(**kwargs):
+    # Noop for now
+    pass


### PR DESCRIPTION
Summary:
Moves the Facebook-internal Buck target definition for RNTester closer to the actual source files. This does not affect how RNTester is built in open source.

Changelog: [Internal]

Reviewed By: MichaReiser

Differential Revision: D27942209

