### PR TITLE
fix flipper crash on startup

### DIFF
--- a/packages/rn-tester/android/app/gradle.properties
+++ b/packages/rn-tester/android/app/gradle.properties
@@ -10,4 +10,4 @@ android.useAndroidX=true
 android.enableJetifier=true
 
 # Version of flipper SDK to use with React Native
-FLIPPER_VERSION=0.75.1
+FLIPPER_VERSION=0.78.0

--- a/template/android/gradle.properties
+++ b/template/android/gradle.properties
@@ -25,4 +25,4 @@ android.useAndroidX=true
 android.enableJetifier=true
 
 # Version of flipper SDK to use with React Native
-FLIPPER_VERSION=0.75.1
+FLIPPER_VERSION=0.78.0


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

fixes https://github.com/facebook/react-native/issues/28163, related https://github.com/facebook/flipper/issues/120 https://github.com/react-native-community/releases/issues/157

This pr fixes a runtime of the rn-tester app caused by bumping flipper dependencies
https://github.com/facebook/react-native/pull/31010/files

The issue was fixed in filpper 0.78.0
https://github.com/facebook/flipper/blob/master/desktop/static/CHANGELOG.md#0780-2622021

D26664846 - fixed possible crash on startup after updating from a previous Flipper version to 0.77.0
https://github.com/facebook/flipper/commit/414e90730b83aabdf46f3b8039a2a7c85f20c962

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Fixed] - bump flipper android dependency

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->


**<details><summary>CLICK TO OPEN TESTS RESULTS - FLIPPER VERSION 0.75.1</summary>**
<p>

TEST SCENARIO
- running `react-native/packages/rn-tester` app on android emulator

RESULT
- the app crashes after startup with `FATAL EXCEPTION: FlipperEventBaseThread`

**<details><summary>CLICK TO OPEN FULL STACK</summary>**
<p>

```
 05-02 06:40:06.760 12378 12403 W System.err: java.lang.UnsatisfiedLinkError: dlopen failed: cannot locate symbol "_Unwind_Resume" referenced by "/
data/app/com.facebook.react.uiapp-bXGOC3bGEtYxre-HBfSW0A==/lib/x86/libflipper.so"...                                                              
05-02 06:40:06.760 12378 12403 W System.err:    at java.lang.Runtime.load0(Runtime.java:938)                                                      
05-02 06:40:06.760 12378 12403 W System.err:    at java.lang.System.load(System.java:1631)                                                        
05-02 06:40:06.760 12378 12403 W System.err:    at com.facebook.soloader.SoLoader$1.load(SoLoader.java:405)                                       
05-02 06:40:06.760 12378 12403 W System.err:    at com.facebook.soloader.DirectorySoSource.loadLibraryFrom(DirectorySoSource.java:77)             
05-02 06:40:06.760 12378 12403 W System.err:    at com.facebook.soloader.DirectorySoSource.loadLibrary(DirectorySoSource.java:50)                 
05-02 06:40:06.760 12378 12403 W System.err:    at com.facebook.soloader.ApplicationSoSource.loadLibrary(ApplicationSoSource.java:89)             
05-02 06:40:06.760 12378 12403 W System.err:    at com.facebook.soloader.SoLoader.doLoadLibraryBySoName(SoLoader.java:860)                        
05-02 06:40:06.760 12378 12403 W System.err:    at com.facebook.soloader.SoLoader.loadLibraryBySoNameImpl(SoLoader.java:740)                      
05-02 06:40:06.760 12378 12403 W System.err:    at com.facebook.soloader.SoLoader.loadLibraryBySoName(SoLoader.java:654)                          
05-02 06:40:06.760 12378 12403 W System.err:    at com.facebook.soloader.SoLoader.loadLibrary(SoLoader.java:634)                                  
05-02 06:40:06.760 12378 12403 W System.err:    at com.facebook.soloader.SoLoader.loadLibrary(SoLoader.java:582)                                  
05-02 06:40:06.760 12378 12403 W System.err:    at com.facebook.flipper.android.EventBase.<clinit>(EventBase.java:19)                             
05-02 06:40:06.760 12378 12403 W System.err:    at com.facebook.flipper.android.FlipperThread.run(FlipperThread.java:25)                          
05-02 06:40:06.761  1798  1798 W EmuHWC2 : validate: layer 175 CompositionType 1, fallback                                                        
05-02 06:40:06.760 12378 12403 E SoLoader: couldn't find DSO to load: libflipper.so caused by: dlopen failed: cannot locate symbol "_Unwind_Resume
" referenced by "/data/app/com.facebook.react.uiapp-bXGOC3bGEtYxre-HBfSW0A==/lib/x86/libflipper.so"... result: 0                                  
05-02 06:40:06.765 12378 12404 E AndroidRuntime: FATAL EXCEPTION: FlipperConnectionThread                                                         
05-02 06:40:06.765 12378 12404 E AndroidRuntime: Process: com.facebook.react.uiapp, PID: 12378                                                    
05-02 06:40:06.765 12378 12404 E AndroidRuntime: java.lang.NoClassDefFoundError: <clinit> failed for class com.facebook.flipper.android.EventBase;
 see exception in other thread                                                                                                                    
05-02 06:40:06.765 12378 12404 E AndroidRuntime:        at com.facebook.flipper.android.FlipperThread.run(FlipperThread.java:25)                  
05-02 06:40:06.767 12378 12403 E AndroidRuntime: FATAL EXCEPTION: FlipperEventBaseThread   
```


</p>
</details>

<video src="https://user-images.githubusercontent.com/24992535/116804835-9af0b180-ab54-11eb-927e-57abb3bba6f4.mp4" width="700" height="" />

</p>
</details>

**<details><summary>CLICK TO OPEN TESTS RESULTS - FLIPPER VERSION 0.78.0</summary>**
<p>

TEST SCENARIO
- running `react-native/packages/rn-tester` app on android emulator after bumping flipper to `0.78.0`

RESULT
- the app does not crash after startup

<video src="https://user-images.githubusercontent.com/24992535/116804993-ca53ee00-ab55-11eb-8302-3ccd9e55a1c3.mp4" width="300" height="" />

</p>
</details>