### PR TITLE
Fix generate-specs.sh path and allow customizing output dir

### DIFF
--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -156,7 +156,7 @@ def use_react_native_codegen!(spec, options={})
 
   # Library name (e.g. FBReactNativeSpec)
   modules_library_name = spec.name
-  modules_output_dir = "React/#{modules_library_name}/#{modules_library_name}"
+  modules_output_dir = options[:codegen_modules_output_dir] ||= "React/#{modules_library_name}/#{modules_library_name}"
 
   # Run the codegen as part of the Xcode build pipeline.
   env_vars = "SRCS_DIR='#{js_srcs}'"
@@ -190,9 +190,9 @@ def use_react_native_codegen!(spec, options={})
     :name => 'Generate Specs',
     :input_files => [js_srcs],
     :output_files => ["${DERIVED_FILE_DIR}/codegen-#{modules_library_name}.log"].concat(generated_files.map { |filename| "#{prefix}/#{filename}"} ),
-    :script => "set -o pipefail\n\nbash -l -c '#{env_vars} ${PODS_TARGET_SRCROOT}/../../scripts/generate-specs.sh' 2>&1 | tee \"${SCRIPT_OUTPUT_FILE_0}\"",
+    :script => "set -o pipefail\n\nbash -l -c '#{env_vars} #{File.join(__dir__, "generate-specs.sh")}' 2>&1 | tee \"${SCRIPT_OUTPUT_FILE_0}\"",
     :execution_position => :before_compile,
     :show_env_vars_in_log => true
   }
-  spec.prepare_command = "mkdir -p #{generated_dirs.map {|dir| "'../../#{dir}'"}.join(" ")} && touch #{generated_files.map {|file| "'../../#{file}'"}.join(" ")}"
+  spec.prepare_command = "mkdir -p #{generated_dirs.map {|dir| "'#{prefix.sub(/\${?PODS_TARGET_SRCROOT}?/, '.')}/#{dir}'"}.join(" ")} && touch #{generated_files.map {|file| "'#{prefix.sub(/\${?PODS_TARGET_SRCROOT}?/, '.')}/#{file}'"}.join(" ")}"
 end


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

I've been using a custom podspec to use codegen for my app specific native modules. https://github.com/facebook/react-native/commit/bdfe2a51791046c4e6836576e08655431373ed67#diff-adcf572f001c2b710d14f409c14763f1a50b08369b3034548f1602685d21f67f broke that because it assumes `PODS_TARGET_SRCROOT` is the react-native pod and removed the `codegen_modules_output_dir` option.

To fix this I brought back the old way to get RN path for the generate-specs.sh script, it uses relative path to the script file so it will always be right no matter where RN is installed. Then brought back the `codegen_modules_output_dir` config so it is possible to customize where the generated files go instead of `React/specName/specName`. This fixes that use case for now. Might want to revise the api later when looking to better support codegen for external code.

## Changelog

[iOS] [Fixed] - Fix generate-specs.sh path and allow customizing output dir

## Test Plan

Tested using a custom codegen podspec

```
NODE_MODULES_PATH = "../../../../node_modules"
REACT_NATIVE_PATH = "#{NODE_MODULES_PATH}/react-native"

require_relative "#{REACT_NATIVE_PATH}/scripts/react_native_pods.rb"

version = '1000.0.0'

source = { :git => 'repo' }
# This is an unpublished version, use the latest commit hash of the th3rdwave repo, which we’re presumably in.
source[:commit] = `git rev-parse HEAD`.strip

folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
folly_version = '2021.04.26.00'

Pod::Spec.new do |s|
  s.name                   = "TWReactNativeSpec"
  s.version                = version
  s.summary                = "-"  # TODO
  s.homepage               = ""
  s.license                = "Proprietary"
  s.author                 = "Th3rdwave"
  s.platforms              = { :ios => "11.0" }
  s.compiler_flags         = folly_compiler_flags + ' -Wno-nullability-completeness'
  s.source                 = source
  s.source_files           = "**/*.{c,h,m,mm,cpp}"
  s.header_dir             = "TWReactNativeSpec"

  s.pod_target_xcconfig    = {
                               "USE_HEADERMAP" => "YES",
                               "CLANG_CXX_LANGUAGE_STANDARD" => "c++14",
                               "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)\" \"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/RCT-Required\""
                             }

  s.dependency "RCT-Folly", folly_version
  s.dependency "RCTRequired"
  s.dependency "RCTTypeSafety"
  s.dependency "React-Core"
  s.dependency "React-jsi"
  s.dependency "ReactCommon/turbomodule/core"

  use_react_native_codegen!(s, {
    :path => "$PODS_TARGET_SRCROOT",
    :js_srcs_dir => "$PODS_TARGET_SRCROOT/../../src",
    :codegen_modules_output_dir => "TWReactNativeSpec"
  })
end
```

Make sure it builds and proper files are generated. Also check that no absolute paths are preset in the lockfile.