### PR TITLE
removal of textColor from base application theme

### DIFF
--- a/template/android/app/src/main/res/values/styles.xml
+++ b/template/android/app/src/main/res/values/styles.xml
@@ -3,7 +3,6 @@
     <!-- Base application theme. -->
     <style name="AppTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
         <!-- Customize your theme here. -->
-        <item name="android:textColor">#000000</item>
     </style>
 
 </resources>


### PR DESCRIPTION
## Summary
#31345 

The issue to` android/app/src/main/res/values/styles.xml.`
In the base application theme, there is an explicitly added item
`<item name="android:textColor">#000000</item>`
This leads the `textColor` of the app to be black even though the theme is actually DayNight. 
A permanent fix would be to not have this item added by default when creating a new project, as it is buggy behavior


## Changelog


[General] [removed] -  line `<item name="android:textColor">#000000</item>` in this file `android/app/src/main/res/values/styles.xml `for the inital setup

## Test Plan
Removing this has fixed the issue for me.