### PR TITLE
feat: add Android 12 BLUETOOTH_[CONNECT/SCAN] to PermissionsAndroid

### DIFF
--- a/Libraries/PermissionsAndroid/NativePermissionsAndroid.js
+++ b/Libraries/PermissionsAndroid/NativePermissionsAndroid.js
@@ -41,7 +41,9 @@ export type PermissionType =
   | 'android.permission.RECEIVE_WAP_PUSH'
   | 'android.permission.RECEIVE_MMS'
   | 'android.permission.READ_EXTERNAL_STORAGE'
-  | 'android.permission.WRITE_EXTERNAL_STORAGE';
+  | 'android.permission.WRITE_EXTERNAL_STORAGE'
+  | 'android.permission.BLUETOOTH_CONNECT'
+  | 'android.permission.BLUETOOTH_SCAN';
 */
 
 export interface Spec extends TurboModule {

--- a/Libraries/PermissionsAndroid/PermissionsAndroid.js
+++ b/Libraries/PermissionsAndroid/PermissionsAndroid.js
@@ -59,6 +59,8 @@ const PERMISSIONS = Object.freeze({
   RECEIVE_MMS: 'android.permission.RECEIVE_MMS',
   READ_EXTERNAL_STORAGE: 'android.permission.READ_EXTERNAL_STORAGE',
   WRITE_EXTERNAL_STORAGE: 'android.permission.WRITE_EXTERNAL_STORAGE',
+  BLUETOOTH_CONNECT: 'android.permission.BLUETOOTH_CONNECT',
+  BLUETOOTH_SCAN: 'android.permission.BLUETOOTH_SCAN',
 });
 
 /**
@@ -73,6 +75,8 @@ class PermissionsAndroid {
     ACCESS_COARSE_LOCATION: string,
     ACCESS_FINE_LOCATION: string,
     ADD_VOICEMAIL: string,
+    BLUETOOTH_CONNECT: string,
+    BLUETOOTH_SCAN: string,
     BODY_SENSORS: string,
     CALL_PHONE: string,
     CAMERA: string,


### PR DESCRIPTION
## Summary

This PR adds BLUETOOTH_CONNECT / BLUETOOTH_SCAN, which showed up in the latest Android 12 Preview build as new `dangerous` permissions requiring approval for them.

https://developer.android.com/reference/android/Manifest.permission.html#BLUETOOTH_CONNECT
https://developer.android.com/reference/android/Manifest.permission.html#BLUETOOTH_SCAN

## Changelog

[Android] [Changed] - Add BLUETOOTH_CONNECT and BLUETOOTH_SCAN to PermissionsAndroid

## Test Plan

```
PermissionsAndroid.BLUETOOTH_CONNECT === 'android.permission.BLUETOOTH_CONNECT'
PermissionsAndroid.BLUETOOTH_SCAN === 'android.permission.BLUETOOTH_SCAN'
```
