### PR TITLE
[AppContainer] Add back legacy rootTag childContex

### DIFF
--- a/Libraries/ReactNative/AppContainer.js
+++ b/Libraries/ReactNative/AppContainer.js
@@ -14,7 +14,10 @@ import StyleSheet from '../StyleSheet/StyleSheet';
 import {type EventSubscription} from '../vendor/emitter/EventEmitter';
 import {RootTagContext, createRootTag} from './RootTag';
 import type {RootTag} from './RootTag';
+import PropTypes from 'prop-types';
 import * as React from 'react';
+
+type Context = {rootTag: number | RootTag, ...};
 
 type Props = $ReadOnly<{|
   children?: React.Node,
@@ -42,6 +45,18 @@ class AppContainer extends React.Component<Props, State> {
   _subscription: ?EventSubscription = null;
 
   static getDerivedStateFromError: any = undefined;
+
+  static childContextTypes:
+    | any
+    | {|rootTag: React$PropType$Primitive<number>|} = {
+    rootTag: PropTypes.number,
+  };
+
+  getChildContext(): Context {
+    return {
+      rootTag: this.props.rootTag,
+    };
+  }
 
   componentDidMount(): void {
     if (__DEV__) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Reverting the legacy rootTag childContext in AppContainer for 0.65 release. It will be deprecated and removed in the following release.

## Changelog

[General] [Changed] - [AppContainer] Add back legacy rootTag childContex 

## Test Plan
CI test run

