### PR TITLE
Fix test for C++20 where u8 produces an array of char8_t, not char

### DIFF
--- a/ReactCommon/jsi/jsi/test/testlib.cpp
+++ b/ReactCommon/jsi/jsi/test/testlib.cpp
@@ -50,7 +50,7 @@ TEST_P(JSITest, PropNameIDTest) {
       rt, movedQuux, PropNameID::forAscii(rt, std::string("foo"))));
   uint8_t utf8[] = {0xF0, 0x9F, 0x86, 0x97};
   PropNameID utf8PropNameID = PropNameID::forUtf8(rt, utf8, sizeof(utf8));
-  EXPECT_EQ(utf8PropNameID.utf8(rt), u8"\U0001F197");
+  EXPECT_EQ(utf8PropNameID.utf8(rt), "\U0001F197");
   EXPECT_TRUE(PropNameID::compare(
       rt, utf8PropNameID, PropNameID::forUtf8(rt, utf8, sizeof(utf8))));
   PropNameID nonUtf8PropNameID = PropNameID::forUtf8(rt, "meow");
@@ -518,7 +518,7 @@ TEST_P(JSITest, FunctionTest) {
                    "s1",
                    String::createFromAscii(rt, "s2"),
                    std::string{"s3"},
-                   std::string{u8"s\u2600"},
+                   std::string{"s\u2600"},
                    // invalid UTF8 sequence due to unexpected continuation byte
                    std::string{"s\x80"},
                    Object(rt),


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

In C++17, `u8"foo"` was a `char` array literal.  In C++20, it is a `char8_t` array literal. `std::string` uses only `char`.
When building RN with MSVC in c++latest (i.e. C++20), we get an error:

```
12>C:\rnw\node_modules\react-native\ReactCommon\jsi\jsi\test\testlib.cpp(511,1): error C2440: '<function-style-cast>': cannot convert from 'initializer list' to 'std::string'
12>C:\rnw\node_modules\react-native\ReactCommon\jsi\jsi\test\testlib.cpp(528,1): message : No constructor could take the source type, or constructor overload resolution was ambiguous
```

See http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0482r6.html

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Fixed] - Fix test code usage of utf8 string in C++20

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
