### PR TITLE
fix#29319 - ios dismiss modal 

### DIFF
--- a/React/Views/RCTModalHostView.h
+++ b/React/Views/RCTModalHostView.h
@@ -16,7 +16,7 @@
 
 @protocol RCTModalHostViewInteractor;
 
-@interface RCTModalHostView : UIView <RCTInvalidating>
+@interface RCTModalHostView : UIView <RCTInvalidating, UIAdaptivePresentationControllerDelegate>
 
 @property (nonatomic, copy) NSString *animationType;
 @property (nonatomic, assign) UIModalPresentationStyle presentationStyle;

--- a/React/Views/RCTModalHostView.m
+++ b/React/Views/RCTModalHostView.m
@@ -62,13 +62,9 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : coder)
 - (void)setOnRequestClose:(RCTDirectEventBlock)onRequestClose
 {
   _onRequestClose = onRequestClose;
-    // if onRequestClose is present, we set the modalInPresentation to false to support the swipe gesture
-    if (@available(iOS 13.0, *)) {
-        _modalViewController.modalInPresentation = NO;
-    }
 }
 
-- (void)presentationControllerDidDismiss:(UIPresentationController *)controller
+- (void)presentationControllerDidAttemptToDismiss:(UIPresentationController *)controller
 {
     if (_onRequestClose != nil) {
         _onRequestClose(nil);

--- a/React/Views/RCTModalHostView.m
+++ b/React/Views/RCTModalHostView.m
@@ -24,6 +24,7 @@
   RCTTouchHandler *_touchHandler;
   UIView *_reactSubview;
   UIInterfaceOrientation _lastKnownOrientation;
+  RCTDirectEventBlock _onRequestClose;
 }
 
 RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
@@ -40,6 +41,10 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : coder)
     _touchHandler = [[RCTTouchHandler alloc] initWithBridge:bridge];
     _isPresented = NO;
 
+    if (@available(iOS 13.0, *)) {
+      _modalViewController.presentationController.delegate = self;
+    }
+      
     __weak typeof(self) weakSelf = self;
     _modalViewController.boundsDidChangeBlock = ^(CGRect newBounds) {
       [weakSelf notifyForBoundsChange:newBounds];
@@ -56,6 +61,20 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : coder)
     [self notifyForOrientationChange];
   }
 }
+
+
+- (void)setOnRequestClose:(RCTDirectEventBlock)onRequestClose
+{
+  _onRequestClose = onRequestClose;
+}
+
+- (void)presentationControllerDidAttemptToDismiss:(UIPresentationController *)controller
+{
+    if (_onRequestClose != nil) {
+        _onRequestClose(nil);
+    }
+}
+
 
 - (void)notifyForOrientationChange
 {

--- a/React/Views/RCTModalHostView.m
+++ b/React/Views/RCTModalHostView.m
@@ -41,10 +41,6 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : coder)
     _touchHandler = [[RCTTouchHandler alloc] initWithBridge:bridge];
     _isPresented = NO;
 
-    if (@available(iOS 13.0, *)) {
-      _modalViewController.presentationController.delegate = self;
-    }
-      
     __weak typeof(self) weakSelf = self;
     _modalViewController.boundsDidChangeBlock = ^(CGRect newBounds) {
       [weakSelf notifyForBoundsChange:newBounds];
@@ -191,6 +187,9 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : coder)
     }
     if (self.presentationStyle != UIModalPresentationNone) {
       _modalViewController.modalPresentationStyle = self.presentationStyle;
+    }
+    if (@available(iOS 13.0, *)) {
+      _modalViewController.presentationController.delegate = self;
     }
     [_delegate presentModalHostView:self withViewController:_modalViewController animated:[self hasAnimationType]];
     _isPresented = YES;

--- a/React/Views/RCTModalHostView.m
+++ b/React/Views/RCTModalHostView.m
@@ -66,9 +66,13 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : coder)
 - (void)setOnRequestClose:(RCTDirectEventBlock)onRequestClose
 {
   _onRequestClose = onRequestClose;
+    // if onRequestClose is present, we set the modalInPresentation to false to support the swipe gesture
+    if (@available(iOS 13.0, *)) {
+        _modalViewController.modalInPresentation = NO;
+    }
 }
 
-- (void)presentationControllerDidAttemptToDismiss:(UIPresentationController *)controller
+- (void)presentationControllerDidDismiss:(UIPresentationController *)controller
 {
     if (_onRequestClose != nil) {
         _onRequestClose(nil);

--- a/React/Views/RCTModalHostViewManager.m
+++ b/React/Views/RCTModalHostViewManager.m
@@ -121,6 +121,7 @@ RCT_EXPORT_VIEW_PROPERTY(identifier, NSNumber)
 RCT_EXPORT_VIEW_PROPERTY(supportedOrientations, NSArray)
 RCT_EXPORT_VIEW_PROPERTY(onOrientationChange, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(visible, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(onRequestClose, RCTDirectEventBlock)
 
 // Fabric only
 RCT_EXPORT_VIEW_PROPERTY(onDismiss, RCTDirectEventBlock)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->
This PR aims to resolve iOS can't dismiss Modal on swipe gesture.
https://github.com/facebook/react-native/issues/29319
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
When modal presentationStyle is pageSheet, iOS allows to dismiss the modal using swipe gesture. This PR adds support for that feature
## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [Added] - Support for onRequestClose for iOS Modal component.


## Test Plan
- If onRequestClose updates the visibility state, modal will be closed.

```
<Modal
    visible={visible}
    animationType="slide"
    presentationStyle="pageSheet"
    onRequestClose={dismiss}>
</Modal>
```


https://user-images.githubusercontent.com/23293248/117590263-36cd7f00-b14c-11eb-940c-86e700c0b8e7.mov



## Notes
- In this PR, only support for partial drag is added. i.e. user can't drag the modal up and down completely. I added full user dragging but reverted in this [commit](https://github.com/facebook/react-native/commit/bb65b9a60d54b61652d608661eba876b49be3b17) to support controllable onRequestClose. If someone has any suggestion to have full draggable support + controllable onRequestClose, please let me know.


<!-- 

 the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
