### PR TITLE
fix(logging): avoid logging sensitive param values

### DIFF
--- a/Libraries/ReactNative/AppRegistry.js
+++ b/Libraries/ReactNative/AppRegistry.js
@@ -188,8 +188,10 @@ const AppRegistry = {
     displayMode?: number,
   ): void {
     if (appKey !== 'LogBox') {
-      const msg =
-        'Running "' + appKey + '" with ' + JSON.stringify(appParameters);
+      const logParams = __DEV__
+        ? '" with ' + JSON.stringify(appParameters)
+        : '';
+      const msg = 'Running "' + appKey + logParams;
       infoLog(msg);
       BugReporting.addSource(
         'AppRegistry.runApplication' + runCount++,


### PR DESCRIPTION
## Summary

We noticed that by default when the RootView / ReactView calls runApplication, we're logging at an info level any props ("params") passed to that component. In our case, one of these props was sensitive in nature, causing the value to leak out in logs for our release builds. This is especially problematic on Android where device logs can be accessed by any app which requests that permission.

This is probably more of a concern for brownfield react-native apps, but it seems worthwhile locking this down in non-dev builds.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Security] - Avoiding logging root view params outside of dev / debug mode builds

## Test Plan

* build app in release mode on Android and verified I could not see: `Running "my app" with { sensitive: 'thing' }` in logcat in Android Studio with a tethered device
