### PR TITLE
Fixed dynamic behavior of <Text adjustsFontSizeToFit={true}> on Android

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
@@ -327,6 +327,11 @@ public class ReactTextShadowNode extends ReactBaseTextShadowNode {
               mJustificationMode);
       uiViewOperationQueue.enqueueUpdateExtraData(getReactTag(), reactTextUpdate);
     }
+
+    if (mAdjustsFontSizeToFit) {
+      // Nodes with `adjustsFontSizeToFit` enabled need to be remeasured on every relayout.
+      markUpdated();
+    }
   }
 
   @ReactProp(name = "onTextLayout")


### PR DESCRIPTION
## Summary
This PR fixes #30717, a bug in `<Text adjustsFontSizeToFit={true}>` implementation that prevents it from adjusting text size dynamically on Android.

The way `adjustsFontSizeToFit` was implemented in #26389 (and the design of ReactTextShadowNode) implies that Yoga will call `onMeasure` on every size change of a `<Text>` component, which is actually not the case (Yoga can cache the results of the measures, call the function multiple times or do not call at all inferring the size from the size constraints). The implementation of `adjustsFontSizeToFit` computes the adjusted string inside the measure function and then eventually passes that to the view layer where it's being rendered.

The proper fix of this issue requires the full redesign of the measure and rendering pipelines and separating them, and that... would be too invasive. And, I believe, this issue is already fixed in Fabric where this part is already designed this way.

Instead, this diff implements a small workaround: if `adjustsFontSizeToFit` is enabled, we manually dirty the Yoga node and mark the shadow node updated to force remeasuring.

## Changelog

[Android] [Fixed] - Fixed dynamic behavior of <Text adjustsFontSizeToFit={true}> on Android

## Test Plan


https://user-images.githubusercontent.com/22032/118508162-8c79cc80-b6f4-11eb-853f-a1a09f82935f.mov

