### PR TITLE
Fix react-native-oss-ios by bumping Xcode to 12.4.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ executors:
   reactnativeios:
     <<: *defaults
     macos:
-      xcode: &_XCODE_VERSION "12.1.0"
+      xcode: &_XCODE_VERSION "12.4.0"
 
 # -------------------------
 #        COMMANDS

--- a/scripts/.tests.env
+++ b/scripts/.tests.env
@@ -24,7 +24,7 @@ export AVD_ABI=x86
 export ANDROID_DISABLE_AVD_TESTS=1
 
 ## IOS ##
-export IOS_TARGET_OS="14.1"
+export IOS_TARGET_OS="14.4"
 export IOS_DEVICE="iPhone 8"
 export SDK_IOS="iphonesimulator"
 


### PR DESCRIPTION
Summary:
## Changes
This diff bumps Xcode to 12.4.0 both internally, and in Circle CI.

- According to [Circle CI docs](https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions), their environments support Xcode 12.4.0.
- According to the [Apple Docs](https://developer.apple.com/support/xcode/), Xcode 12.4.0 matches iOS 14.4.

Changelog: [Internal]

Differential Revision: D28547839

