### PR TITLE
Move isColorMeaningful to platform specific code

### DIFF
--- a/ReactCommon/react/renderer/components/view/ViewShadowNode.cpp
+++ b/ReactCommon/react/renderer/components/view/ViewShadowNode.cpp
@@ -28,14 +28,6 @@ ViewShadowNode::ViewShadowNode(
   initialize();
 }
 
-static bool isColorMeaningful(SharedColor const &color) noexcept {
-  if (!color) {
-    return false;
-  }
-
-  return colorComponentsFromColor(color).alpha > 0;
-}
-
 void ViewShadowNode::initialize() noexcept {
   auto &viewProps = static_cast<ViewProps const &>(*props_);
 

--- a/ReactCommon/react/renderer/graphics/platform/cxx/react/renderer/graphics/Color.cpp
+++ b/ReactCommon/react/renderer/graphics/platform/cxx/react/renderer/graphics/Color.cpp
@@ -10,6 +10,14 @@
 namespace facebook {
 namespace react {
 
+bool isColorMeaningful(SharedColor const &color) noexcept {
+    if (!color) {
+    return false;
+  }
+
+  return colorComponentsFromColor(color).alpha > 0;
+}
+
 SharedColor colorFromComponents(ColorComponents components) {
   float ratio = 255;
   return SharedColor(

--- a/ReactCommon/react/renderer/graphics/platform/cxx/react/renderer/graphics/Color.h
+++ b/ReactCommon/react/renderer/graphics/platform/cxx/react/renderer/graphics/Color.h
@@ -59,6 +59,7 @@ class SharedColor {
   Color color_;
 };
 
+bool isColorMeaningful(SharedColor const &color) noexcept;
 SharedColor colorFromComponents(ColorComponents components);
 ColorComponents colorComponentsFromColor(SharedColor color);
 

--- a/ReactCommon/react/renderer/graphics/platform/ios/Color.cpp
+++ b/ReactCommon/react/renderer/graphics/platform/ios/Color.cpp
@@ -11,6 +11,14 @@
 namespace facebook {
 namespace react {
 
+bool isColorMeaningful(SharedColor const &color) noexcept {
+    if (!color) {
+    return false;
+  }
+
+  return colorComponentsFromColor(color).alpha > 0;
+}
+
 SharedColor colorFromComponents(ColorComponents components) {
   float ratio = 255;
   return SharedColor(

--- a/ReactCommon/react/renderer/graphics/platform/ios/Color.h
+++ b/ReactCommon/react/renderer/graphics/platform/ios/Color.h
@@ -20,6 +20,7 @@ using Color = int32_t;
 
 using SharedColor = better::optional<Color>;
 
+bool isColorMeaningful(SharedColor const &color) noexcept;
 SharedColor colorFromComponents(ColorComponents components);
 ColorComponents colorComponentsFromColor(SharedColor color);
 


### PR DESCRIPTION
## Summary

`isColorMeaningful` is the only place in xplat code that currently uses `colorComponentsFromColor`, which assumes that a color is an RGBA value.  When implementing `PlatformColor` for windows, where colors might be complex patterns or effects, I'd like to keep the details of `SharedColor` isolated within `SharedColor`.  This change moves `isColorMeaningful` into `color.cpp`, where each platform can provide an implementation that takes into account its platform specific color capabilities.

See https://github.com/microsoft/react-native-windows/pull/7801 for an example of window's SharedColor which can be either an RGBA value, or a name of a native color/brush.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Internal] [Changed] - Move isColorMeaningful to platform specific code

## Test Plan

This shouldn't change any of the code, its just moving the existing function - normal CI/automation should be plenty of validation.
