### PR TITLE
Quote --sourcemap-output argument during ios build

### DIFF
--- a/scripts/react-native-xcode.sh
+++ b/scripts/react-native-xcode.sh
@@ -117,7 +117,7 @@ fi
 
 BUNDLE_FILE="$CONFIGURATION_BUILD_DIR/main.jsbundle"
 
-EXTRA_ARGS=
+EXTRA_ARGS=()
 
 case "$PLATFORM_NAME" in
   "macosx")
@@ -144,12 +144,12 @@ if [[ $EMIT_SOURCEMAP == true ]]; then
   else
     PACKAGER_SOURCEMAP_FILE="$SOURCEMAP_FILE"
   fi
-  EXTRA_ARGS="$EXTRA_ARGS --sourcemap-output $PACKAGER_SOURCEMAP_FILE"
+  EXTRA_ARGS+=("--sourcemap-output" "$PACKAGER_SOURCEMAP_FILE")
 fi
 
 # Hermes doesn't require JS minification.
 if [[ $USE_HERMES == true && $DEV == false ]]; then
-  EXTRA_ARGS="$EXTRA_ARGS --minify false"
+  EXTRA_ARGS+=("--minify" "false")
 fi
 
 "$NODE_BINARY" $NODE_ARGS "$CLI_PATH" $BUNDLE_COMMAND \
@@ -160,8 +160,8 @@ fi
   --reset-cache \
   --bundle-output "$BUNDLE_FILE" \
   --assets-dest "$DEST" \
-  $EXTRA_ARGS \
-  $EXTRA_PACKAGER_ARGS
+  "${EXTRA_ARGS[@]}" \
+  "${EXTRA_PACKAGER_ARGS[@]}"
 
 if [[ $USE_HERMES != true ]]; then
   cp "$BUNDLE_FILE" "$DEST/"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Scheme names may contain whitespace characters is used as path of the
path for various files during build time. This means any path that
includes the scheme name in it needs to be surrounded by quotes.

You can see the generated command below for a project with a scheme
called `Some Scheme`:

    node ./node_modules/react-native/cli.js bundle \
      --entry-file index.js \
      --platform ios \
      --dev false \
      --reset-cache \
      --bundle-output './ios/derivedDataBuild/Build/Intermediates.noindex/ArchiveIntermediates/Some Scheme/BuildProductsPath/Release-iphoneos/Some Scheme.app/main.jsbundle' \
      --assets-dest './ios/derivedDataBuild/Build/Intermediates.noindex/ArchiveIntermediates/Some Scheme/BuildProductsPath/Release-iphoneos/Some Scheme.app' \
      --sourcemap-output ./ios/derivedDataBuild/Build/Intermediates.noindex/ArchiveIntermediates/Some Scheme/BuildProductsPath/Release-iphoneos/Some Scheme.app/main.jsbundle.map

`--bundle-output` and `--assets-dest` are properly quoted, but
`--sourcemap-output` is not.

This changes `$EXTRA_ARGS` to an array of strings so that we can
propertly quote `$PACKAGER_SOURCEMAP_FILE` when passing it to the
`--sourcemap-output` argument. When running the bundle command, this
array is unwrapped and all its elements passed as individual arguments.

It also applies the same unwrapping to `$EXTRA_PACKAGER_ARGS` so that
users can also pass an array of options when arguments containing spaces
are needed.

It's important to note that these changes ARE backwards compatible: if
`$EXTRA_PACKAGER_ARGS` is defined as a simple string, instead of an
array of strings, the command won't break, as it will still expand
correctly.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [Fixed] - Source map path for schemes containing whitespaces

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

With the new change, the generated command becomes:

    node ./node_modules/react-native/cli.js bundle \
      --entry-file index.js \
      --platform ios \
      --dev false \
      --reset-cache \
      --bundle-output './ios/derivedDataBuild/Build/Intermediates.noindex/ArchiveIntermediates/Some Scheme/BuildProductsPath/Release-iphoneos/Some Scheme.app/main.jsbundle' \
      --assets-dest './ios/derivedDataBuild/Build/Intermediates.noindex/ArchiveIntermediates/Some Scheme/BuildProductsPath/Release-iphoneos/Some Scheme.app' \
      --sourcemap-output './ios/derivedDataBuild/Build/Intermediates.noindex/ArchiveIntermediates/Some Scheme/BuildProductsPath/Release-iphoneos/Some Scheme.app/main.jsbundle.map'

