### PR TITLE
localeIdentifier missing from flow type of I18nManager

### DIFF
--- a/Libraries/ReactNative/I18nManager.js
+++ b/Libraries/ReactNative/I18nManager.js
@@ -18,7 +18,11 @@ const i18nConstants: {|
 
 function getI18nManagerConstants() {
   if (NativeI18nManager) {
-    const {isRTL, doLeftAndRightSwapInRTL, localeIdentifier} = NativeI18nManager.getConstants();
+    const {
+      isRTL,
+      doLeftAndRightSwapInRTL,
+      localeIdentifier,
+    } = NativeI18nManager.getConstants();
     return {isRTL, doLeftAndRightSwapInRTL, localeIdentifier};
   }
 

--- a/Libraries/ReactNative/I18nManager.js
+++ b/Libraries/ReactNative/I18nManager.js
@@ -13,13 +13,13 @@ import NativeI18nManager from './NativeI18nManager';
 const i18nConstants: {|
   doLeftAndRightSwapInRTL: boolean,
   isRTL: boolean,
-  localeIdentifier: ?string,
+  localeIdentifier?: ?string,
 |} = getI18nManagerConstants();
 
 function getI18nManagerConstants() {
   if (NativeI18nManager) {
-    const {isRTL, doLeftAndRightSwapInRTL} = NativeI18nManager.getConstants();
-    return {isRTL, doLeftAndRightSwapInRTL};
+    const {isRTL, doLeftAndRightSwapInRTL, localeIdentifier} = NativeI18nManager.getConstants();
+    return {isRTL, doLeftAndRightSwapInRTL, localeIdentifier};
   }
 
   return {

--- a/Libraries/ReactNative/I18nManager.js
+++ b/Libraries/ReactNative/I18nManager.js
@@ -13,6 +13,7 @@ import NativeI18nManager from './NativeI18nManager';
 const i18nConstants: {|
   doLeftAndRightSwapInRTL: boolean,
   isRTL: boolean,
+  localeIdentifier: ?string,
 |} = getI18nManagerConstants();
 
 function getI18nManagerConstants() {
@@ -28,7 +29,11 @@ function getI18nManagerConstants() {
 }
 
 module.exports = {
-  getConstants: (): {|doLeftAndRightSwapInRTL: boolean, isRTL: boolean|} => {
+  getConstants: (): {|
+    doLeftAndRightSwapInRTL: boolean,
+    isRTL: boolean,
+    localeIdentifier: ?string,
+  |} => {
     return i18nConstants;
   },
 


### PR DESCRIPTION
## Summary

https://github.com/facebook/react-native/commit/23d9bf1a24f80003a8a3c0b82e9b5691e4e6544e looks like it accidently removed `localeIdentifier` from I18nManager.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Fixed] - Re-added localeIdentifier to I18nManager constants

## Test Plan


