### PR TITLE
Set text color to white instead of dark grey

### DIFF
--- a/Libraries/LogBox/UI/LogBoxMessage.js
+++ b/Libraries/LogBox/UI/LogBoxMessage.js
@@ -8,6 +8,7 @@
  * @format
  */
 
+import * as LogBoxStyle from './LogBoxStyle';
 import * as React from 'react';
 import Text from '../../Text/Text';
 
@@ -29,7 +30,7 @@ function LogBoxMessage(props: Props): React.Node {
   const {content, substitutions}: Message = props.message;
 
   if (props.plaintext === true) {
-    return <Text>{cleanContent(content)}</Text>;
+    return <Text style={{color: LogBoxStyle.getTextColor(1)}}>{cleanContent(content)}</Text>;
   }
 
   const maxLength = props.maxLength != null ? props.maxLength : Infinity;


### PR DESCRIPTION
## Summary

Hello! I'm working on the Messenger Desktop team at Facebook, and I noticed that the message text in the LogBox is not very visible on the dark background.
https://ibb.co/Hg0WYj9

Proposing this change so that the text is more visible- not sure this is the right change (or color), but getting my foot in the door! :)

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Changed] - Updated plaintext message text to be white so it show up against dark background

## Test Plan

I'm not exactly sure how to test this out on my personal machine. This is my first time touching React Native code
