### PR TITLE
find-node.sh supports Homebrew on M1

### DIFF
--- a/react.gradle
+++ b/react.gradle
@@ -28,17 +28,11 @@ def detectCliPath(config) {
     if (config.cliPath) {
         return config.cliPath
     }
-
-    def cliPath = ["node", "-e", "console.log(require('react-native/cli').bin);"].execute([], projectDir).text.trim()
-
-    if (cliPath) {
-        return cliPath
-    } else if (new File("${projectDir}/../../node_modules/react-native/cli.js").exists()) {
+    if (new File("${projectDir}/../../node_modules/react-native/cli.js").exists()) {
         return "${projectDir}/../../node_modules/react-native/cli.js"
-    } else {
-        throw new Exception("Couldn't determine CLI location. " +
-            "Please set `project.ext.react.cliPath` to the path of the react-native cli.js");
     }
+    throw new Exception("Couldn't determine CLI location. " +
+             "Please set `project.ext.react.cliPath` to the path of the react-native cli.js");
 }
 
 def composeSourceMapsPath = config.composeSourceMapsPath ?: "node_modules/react-native/scripts/compose-source-maps.js"

--- a/scripts/find-node.sh
+++ b/scripts/find-node.sh
@@ -31,3 +31,9 @@ if [[ ! -x node && -d ${HOME}/.anyenv/bin ]]; then
     eval "$(anyenv init -)"
   fi
 fi
+
+# Support Homebrew on M1
+HOMEBREW_M1_BIN=/opt/homebrew/bin
+if [[ -d $HOMEBREW_M1_BIN && ! $PATH =~ $HOMEBREW_M1_BIN ]]; then
+  export PATH="$HOMEBREW_M1_BIN:$PATH"
+fi


### PR DESCRIPTION
## Summary

Homebrew on M1 installs executable binaries in **/opt/homebrew/bin** (See https://brew.sh/2021/02/05/homebrew-3.0.0/), and FBReactNativeSpec.build is failing because it couldn't find node. This PR changes find-node.sh script to add /opt/homebrew/bin into $PATH.

The way **react.gradle** trying to execute node is not using user environment variables, but system defaults, so it couldn't find it. I removed node execution, and hard coded cli path in parity with iOS https://github.com/facebook/react-native/blob/d1ab03235cb4b93304150878d2b9057ab45bba77/scripts/react-native-xcode.sh#L106

Fixes https://github.com/facebook/react-native/issues/31621 https://github.com/facebook/react-native/issues/31592

## Changelog

[General] [Changed] - find-node.sh supports Homebrew on M1

## Test Plan

On M1, create a RN project and it'll fail to build iOS app. Apply the patch, and build will succeed.