### PR TITLE
bump buildToolsVersion to 30.0.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -618,7 +618,7 @@ jobs:
       - ANDROID_HOME: "C:\\Android\\android-sdk"
       - ANDROID_NDK: "C:\\Android\\android-sdk\\ndk\\20.1.5948944"
       - ANDROID_BUILD_VERSION: 30
-      - ANDROID_TOOLS_VERSION: 29.0.3
+      - ANDROID_TOOLS_VERSION: 30.0.2
       - GRADLE_OPTS: -Dorg.gradle.daemon=false
       - NDK_VERSION: 20.1.5948944
     steps:

--- a/scripts/.tests.env
+++ b/scripts/.tests.env
@@ -4,7 +4,7 @@
 
 ## ANDROID ##
 # Android SDK Build Tools revision
-export ANDROID_SDK_BUILD_TOOLS_REVISION=29.0.3
+export ANDROID_SDK_BUILD_TOOLS_REVISION=30.0.2
 # Android API Level we build with
 export ANDROID_SDK_BUILD_API_LEVEL="28"
 # Google APIs for Android level

--- a/template/android/build.gradle
+++ b/template/android/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     ext {
-        buildToolsVersion = "29.0.3"
+        buildToolsVersion = "30.0.2"
         minSdkVersion = 21
         compileSdkVersion = 30
         targetSdkVersion = 30


### PR DESCRIPTION
## Summary

Bump buildToolsVersion to 30.0.2, default version of Android Gradle Plugin 4.2.0. Fixes parity with https://github.com/facebook/react-native/pull/31593

## Changelog

[Android] [Changed] - Bump buildToolsVersion to 30.0.2,

## Test Plan

Newly created projects will use build tools 30.0.2 to build dependencies.