### PR TITLE
Fix Switch ref forwarding

### DIFF
--- a/Libraries/Components/Switch/Switch.js
+++ b/Libraries/Components/Switch/Switch.js
@@ -150,9 +150,9 @@ const SwitchWithForwardedRef: React.AbstractComponent<
   const trackColorForFalse = trackColor?.false;
   const trackColorForTrue = trackColor?.true;
 
-  const nativeSwitchRef = React.useRef<?React.ElementRef<
+  const nativeSwitchRef = React.useRef<React.ElementRef<
     typeof SwitchNativeComponent | typeof AndroidSwitchNativeComponent,
-  >>(null);
+  > | null>(null);
   React.useImperativeHandle(forwardedRef, () => nativeSwitchRef.current);
 
   const [native, setNative] = React.useState({value: null});

--- a/Libraries/Components/Switch/Switch.js
+++ b/Libraries/Components/Switch/Switch.js
@@ -12,7 +12,6 @@
 import Platform from '../../Utilities/Platform';
 import * as React from 'react';
 import StyleSheet from '../../StyleSheet/StyleSheet';
-import setAndForwardRef from '../../Utilities/setAndForwardRef';
 
 import AndroidSwitchNativeComponent, {
   Commands as AndroidSwitchCommands,
@@ -154,12 +153,7 @@ const SwitchWithForwardedRef: React.AbstractComponent<
   const nativeSwitchRef = React.useRef<?React.ElementRef<
     typeof SwitchNativeComponent | typeof AndroidSwitchNativeComponent,
   >>(null);
-  const _setNativeRef = setAndForwardRef({
-    getForwardedRef: () => forwardedRef,
-    setLocalRef: ref => {
-      nativeSwitchRef.current = ref;
-    },
-  });
+  React.useImperativeHandle(forwardedRef, () => nativeSwitchRef.current);
 
   const [native, setNative] = React.useState({value: null});
 
@@ -206,7 +200,7 @@ const SwitchWithForwardedRef: React.AbstractComponent<
         onChange={handleChange}
         onResponderTerminationRequest={returnsFalse}
         onStartShouldSetResponder={returnsTrue}
-        ref={_setNativeRef}
+        ref={nativeSwitchRef}
       />
     );
   } else {
@@ -238,7 +232,7 @@ const SwitchWithForwardedRef: React.AbstractComponent<
         onChange={handleChange}
         onResponderTerminationRequest={returnsFalse}
         onStartShouldSetResponder={returnsTrue}
-        ref={_setNativeRef}
+        ref={nativeSwitchRef}
       />
     );
   }

--- a/Libraries/Components/Switch/Switch.js
+++ b/Libraries/Components/Switch/Switch.js
@@ -12,6 +12,7 @@
 import Platform from '../../Utilities/Platform';
 import * as React from 'react';
 import StyleSheet from '../../StyleSheet/StyleSheet';
+import setAndForwardRef from '../../Utilities/setAndForwardRef';
 
 import AndroidSwitchNativeComponent, {
   Commands as AndroidSwitchCommands,
@@ -129,7 +130,13 @@ const returnsTrue = () => true;
   export default App;
   ```
  */
-export default function Switch(props: Props): React.Node {
+
+const SwitchWithForwardedRef: React.AbstractComponent<
+  Props,
+  React.ElementRef<
+    typeof SwitchNativeComponent | typeof AndroidSwitchNativeComponent,
+  >,
+> = React.forwardRef(function Switch(props, forwardedRef): React.Node {
   const {
     disabled,
     ios_backgroundColor,
@@ -147,6 +154,13 @@ export default function Switch(props: Props): React.Node {
   const nativeSwitchRef = React.useRef<?React.ElementRef<
     typeof SwitchNativeComponent | typeof AndroidSwitchNativeComponent,
   >>(null);
+  const _setNativeRef = setAndForwardRef({
+    getForwardedRef: () => forwardedRef,
+    setLocalRef: ref => {
+      nativeSwitchRef.current = ref;
+    },
+  });
+
   const [native, setNative] = React.useState({value: null});
 
   const handleChange = (event: SwitchChangeEvent) => {
@@ -192,7 +206,7 @@ export default function Switch(props: Props): React.Node {
         onChange={handleChange}
         onResponderTerminationRequest={returnsFalse}
         onStartShouldSetResponder={returnsTrue}
-        ref={nativeSwitchRef}
+        ref={_setNativeRef}
       />
     );
   } else {
@@ -224,8 +238,10 @@ export default function Switch(props: Props): React.Node {
         onChange={handleChange}
         onResponderTerminationRequest={returnsFalse}
         onStartShouldSetResponder={returnsTrue}
-        ref={nativeSwitchRef}
+        ref={_setNativeRef}
       />
     );
   }
-}
+});
+
+export default SwitchWithForwardedRef;


### PR DESCRIPTION
## Summary

Since moving Switch to a function component it is no longer possible to get the native switch ref. This adds forwardRef so it is possible again.

## Changelog

[General] [Fixed] - Fix Switch ref forwarding

## Test Plan

Tested the change in an app using react-native-gesture-handler, which tries to set a ref on Switch. Also made sure flow still passes.
