### PR TITLE
refactor: remove DefaultProps from the StatusBar Component

### DIFF
--- a/Libraries/Components/StatusBar/StatusBar.js
+++ b/Libraries/Components/StatusBar/StatusBar.js
@@ -383,15 +383,7 @@ class StatusBar extends React.Component<Props> {
     StatusBar._updatePropsStack();
     return newEntry;
   }
-
-  static defaultProps: {|
-    animated: boolean,
-    showHideTransition: $TEMPORARY$string<'fade'>,
-  |} = {
-    animated: false,
-    showHideTransition: 'fade',
-  };
-
+  
   _stackEntry = null;
 
   componentDidMount() {

--- a/Libraries/Components/StatusBar/StatusBar.js
+++ b/Libraries/Components/StatusBar/StatusBar.js
@@ -383,7 +383,7 @@ class StatusBar extends React.Component<Props> {
     StatusBar._updatePropsStack();
     return newEntry;
   }
-  
+
   _stackEntry = null;
 
   componentDidMount() {

--- a/Libraries/Components/StatusBar/StatusBar.js
+++ b/Libraries/Components/StatusBar/StatusBar.js
@@ -132,14 +132,14 @@ function createStackEntry(props: any): any {
       props.backgroundColor != null
         ? {
             value: props.backgroundColor,
-            animated: props.animated,
+            animated: props.animated || false,
           }
         : null,
     barStyle:
       props.barStyle != null
         ? {
             value: props.barStyle,
-            animated: props.animated,
+            animated: props.animated || false,
           }
         : null,
     translucent: props.translucent,
@@ -147,8 +147,8 @@ function createStackEntry(props: any): any {
       props.hidden != null
         ? {
             value: props.hidden,
-            animated: props.animated,
-            transition: props.showHideTransition,
+            animated: props.animated || false,
+            transition: props.showHideTransition || 'fade',
           }
         : null,
     networkActivityIndicatorVisible: props.networkActivityIndicatorVisible,

--- a/Libraries/Components/StatusBar/__tests__/StatusBar-test.js
+++ b/Libraries/Components/StatusBar/__tests__/StatusBar-test.js
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @emails oncall+react_native
+ */
+
+'use strict';
+
+const React = require('react');
+const ReactTestRenderer = require('react-test-renderer');
+
+const StatusBar = require('../StatusBar');
+
+describe('StatusBar', () => {
+  it('renders the statusbar', () => {
+    const component = ReactTestRenderer.create(<StatusBar />);
+    expect(component).not.toBeNull();
+  });
+  it('renders the statusbar animated enabled', () => {
+    const component = ReactTestRenderer.create(<StatusBar animated={true} />);
+    expect(component.toTree().props.animated).toBe(true);
+  });
+  it('renders the statusbar with fade transition on hide', () => {
+    const component = ReactTestRenderer.create(<StatusBar hidden={true} />);
+    expect(component.toTree().props.hidden).toBe(true);
+  });
+  it('renders the statusbar with a background color', () => {
+    const component = ReactTestRenderer.create(
+      <StatusBar backgroundColor={'#fff'} />,
+    );
+    expect(component.toTree().props.backgroundColor).toBe('#fff');
+    expect(component.toTree().type._defaultProps.backgroundColor.animated).toBe(
+      false,
+    );
+  });
+  it('renders the statusbar with default barStyle', () => {
+    const component = ReactTestRenderer.create(<StatusBar />);
+    StatusBar.setBarStyle('default');
+    expect(component.toTree().type._defaultProps.barStyle.value).toBe(
+      'default',
+    );
+    expect(component.toTree().type._defaultProps.barStyle.animated).toBe(false);
+  });
+  it('renders the statusbar but should not be visible', () => {
+    const component = ReactTestRenderer.create(<StatusBar hidden={true} />);
+    expect(component.toTree().props.hidden).toBe(true);
+    expect(component.toTree().type._defaultProps.hidden.animated).toBe(false);
+    expect(component.toTree().type._defaultProps.hidden.transition).toBe(
+      'fade',
+    );
+  });
+  it('renders the statusbar with networkActivityIndicatorVisible true', () => {
+    const component = ReactTestRenderer.create(
+      <StatusBar networkActivityIndicatorVisible={true} />,
+    );
+    expect(component.toTree().props.networkActivityIndicatorVisible).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Issue #31607. defaultProps makes it difficult to migrate components to functional.

## Changelog

[General] [Changed] -  Remove defaultProps from the StatusBar Component.

## Test Plan

Verified the behaviour of the existing functionality after the removal on the RN Tester app.

https://user-images.githubusercontent.com/11355609/120085709-a2b35f80-c0da-11eb-94f2-2649270155ef.mov

