### PR TITLE
fixed copying index.android.bundle with gradle 4.1

### DIFF
--- a/react.gradle
+++ b/react.gradle
@@ -307,6 +307,8 @@ afterEvaluate {
 
             // mergeAssets must run first, as it clears the intermediates directory
             dependsOn(variant.mergeAssetsProvider.get())
+            // currentBundleTask must run before currentAssetsCopyTask (fix copying index.android.bundle to intermediates assets dir with Android plugin 4.1+)
+            dependsOn(currentBundleTask)
 
             enabled(currentBundleTask.enabled)
         }


### PR DESCRIPTION
Hi guys. 
I have many flavors and dependencies in project and when i call bundle<MyFlavor>Release - result aab file has built without index.android.bundle file
This PR should fix copying  index.android.bundle to intermediates assets dir with Android plugin 4.1+
currentBundleTask must run before currentAssetsCopyTask

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Fixed] - copying  index.android.bundle to intermediates assets dir with Android plugin 4.1+. related #29398 #31157

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
