### PR TITLE
remove defaultProps from picker of components

### DIFF
--- a/Libraries/Components/Picker/Picker.js
+++ b/Libraries/Components/Picker/Picker.js
@@ -167,20 +167,22 @@ class Picker extends React.Component<PickerProps> {
   static Item: typeof PickerItem = PickerItem;
 
   render(): React.Node {
-    const { mode = MODE_DIALOG, ...rest } = this.props;
+    const {mode = MODE_DIALOG, ...rest} = this.props;
     if (Platform.OS === 'ios') {
       /* $FlowFixMe[prop-missing] (>=0.81.0 site=react_native_ios_fb) This
        * suppression was added when renaming suppression sites. */
       /* $FlowFixMe[incompatible-type] (>=0.81.0 site=react_native_ios_fb) This
        * suppression was added when renaming suppression sites. */
-      return <PickerIOS {...{mode,...rest}}>{this.props.children}</PickerIOS>;
+      return <PickerIOS {...{mode, ...rest}}>{this.props.children}</PickerIOS>;
     } else if (Platform.OS === 'android') {
       return (
         /* $FlowFixMe[incompatible-type] (>=0.81.0 site=react_native_android_fb) This
          * suppression was added when renaming suppression sites. */
         /* $FlowFixMe[prop-missing] (>=0.81.0 site=react_native_android_fb) This
          * suppression was added when renaming suppression sites. */
-        <PickerAndroid {...{mode,...rest}}>{this.props.children}</PickerAndroid>
+        <PickerAndroid {...{mode, ...rest}}>
+          {this.props.children}
+        </PickerAndroid>
       );
     } else {
       return <UnimplementedView />;

--- a/Libraries/Components/Picker/Picker.js
+++ b/Libraries/Components/Picker/Picker.js
@@ -166,24 +166,21 @@ class Picker extends React.Component<PickerProps> {
 
   static Item: typeof PickerItem = PickerItem;
 
-  static defaultProps: {|mode: $TEMPORARY$string<'dialog'>|} = {
-    mode: MODE_DIALOG,
-  };
-
   render(): React.Node {
+    const { mode = MODE_DIALOG, ...rest } = this.props;
     if (Platform.OS === 'ios') {
       /* $FlowFixMe[prop-missing] (>=0.81.0 site=react_native_ios_fb) This
        * suppression was added when renaming suppression sites. */
       /* $FlowFixMe[incompatible-type] (>=0.81.0 site=react_native_ios_fb) This
        * suppression was added when renaming suppression sites. */
-      return <PickerIOS {...this.props}>{this.props.children}</PickerIOS>;
+      return <PickerIOS {...{mode,...rest}}>{this.props.children}</PickerIOS>;
     } else if (Platform.OS === 'android') {
       return (
         /* $FlowFixMe[incompatible-type] (>=0.81.0 site=react_native_android_fb) This
          * suppression was added when renaming suppression sites. */
         /* $FlowFixMe[prop-missing] (>=0.81.0 site=react_native_android_fb) This
          * suppression was added when renaming suppression sites. */
-        <PickerAndroid {...this.props}>{this.props.children}</PickerAndroid>
+        <PickerAndroid {...{mode,...rest}}>{this.props.children}</PickerAndroid>
       );
     } else {
       return <UnimplementedView />;

--- a/Libraries/Components/Picker/Picker.js
+++ b/Libraries/Components/Picker/Picker.js
@@ -174,18 +174,14 @@ class Picker extends React.Component<PickerProps> {
        * suppression was added when renaming suppression sites. */
       /* $FlowFixMe[incompatible-type] (>=0.81.0 site=react_native_ios_fb) This
        * suppression was added when renaming suppression sites. */
-      return (
-        <PickerIOS mode={mode} {...rest}>
-          {this.props.children}
-        </PickerIOS>
-      );
+      return <PickerIOS {...{mode, ...rest}}>{this.props.children}</PickerIOS>;
     } else if (Platform.OS === 'android') {
       return (
         /* $FlowFixMe[incompatible-type] (>=0.81.0 site=react_native_android_fb) This
          * suppression was added when renaming suppression sites. */
         /* $FlowFixMe[prop-missing] (>=0.81.0 site=react_native_android_fb) This
          * suppression was added when renaming suppression sites. */
-        <PickerAndroid mode={mode} {...rest}>
+        <PickerAndroid {...{mode, ...rest}}>
           {this.props.children}
         </PickerAndroid>
       );

--- a/Libraries/Components/Picker/Picker.js
+++ b/Libraries/Components/Picker/Picker.js
@@ -174,16 +174,14 @@ class Picker extends React.Component<PickerProps> {
        * suppression was added when renaming suppression sites. */
       /* $FlowFixMe[incompatible-type] (>=0.81.0 site=react_native_ios_fb) This
        * suppression was added when renaming suppression sites. */
-      return <PickerIOS {...{mode, ...rest}}>{this.props.children}</PickerIOS>;
+      return <PickerIOS mode={mode} {...rest} />;
     } else if (Platform.OS === 'android') {
       return (
         /* $FlowFixMe[incompatible-type] (>=0.81.0 site=react_native_android_fb) This
          * suppression was added when renaming suppression sites. */
         /* $FlowFixMe[prop-missing] (>=0.81.0 site=react_native_android_fb) This
          * suppression was added when renaming suppression sites. */
-        <PickerAndroid {...{mode, ...rest}}>
-          {this.props.children}
-        </PickerAndroid>
+        <PickerAndroid mode={mode} {...rest} />
       );
     } else {
       return <UnimplementedView />;

--- a/Libraries/Components/Picker/Picker.js
+++ b/Libraries/Components/Picker/Picker.js
@@ -168,19 +168,24 @@ class Picker extends React.Component<PickerProps> {
 
   render(): React.Node {
     const {mode = MODE_DIALOG, ...rest} = this.props;
+
     if (Platform.OS === 'ios') {
       /* $FlowFixMe[prop-missing] (>=0.81.0 site=react_native_ios_fb) This
        * suppression was added when renaming suppression sites. */
       /* $FlowFixMe[incompatible-type] (>=0.81.0 site=react_native_ios_fb) This
        * suppression was added when renaming suppression sites. */
-      return <PickerIOS {...{mode, ...rest}}>{this.props.children}</PickerIOS>;
+      return (
+        <PickerIOS mode={mode} {...rest}>
+          {this.props.children}
+        </PickerIOS>
+      );
     } else if (Platform.OS === 'android') {
       return (
         /* $FlowFixMe[incompatible-type] (>=0.81.0 site=react_native_android_fb) This
          * suppression was added when renaming suppression sites. */
         /* $FlowFixMe[prop-missing] (>=0.81.0 site=react_native_android_fb) This
          * suppression was added when renaming suppression sites. */
-        <PickerAndroid {...{mode, ...rest}}>
+        <PickerAndroid mode={mode} {...rest}>
           {this.props.children}
         </PickerAndroid>
       );

--- a/Libraries/Components/Picker/__tests__/Picker-test.js
+++ b/Libraries/Components/Picker/__tests__/Picker-test.js
@@ -6,13 +6,15 @@
  *
  * @format
  * @emails oncall+react_native
- * @flow strict-local
+ * @flow
  */
 
 'use strict';
 
 const React = require('react');
 const Picker = require('../Picker');
+const PickerIOS = require('../PickerIOS');
+const ReactTestRenderer = require('react-test-renderer');
 
 const ReactNativeTestTools = require('../../../Utilities/ReactNativeTestTools');
 
@@ -30,5 +32,10 @@ describe('<Picker />', () => {
         jest.dontMock('../Picker');
       },
     );
+  });
+
+  it('defaultProps should work as expected', () => {
+    const component = ReactTestRenderer.create(<Picker />);
+    expect(component.root.findByType(PickerIOS).props.mode).toBe('dialog');
   });
 });

--- a/Libraries/Components/Picker/__tests__/__snapshots__/Picker-test.js.snap
+++ b/Libraries/Components/Picker/__tests__/__snapshots__/Picker-test.js.snap
@@ -64,7 +64,6 @@ exports[`<Picker /> should render as expected: should deep render when not mocke
 
 exports[`<Picker /> should render as expected: should shallow render as <Picker /> when mocked 1`] = `
 <Picker
-  mode="dialog"
   onValueChange={[MockFunction]}
   selectedValue="foo"
 >
@@ -81,7 +80,6 @@ exports[`<Picker /> should render as expected: should shallow render as <Picker 
 
 exports[`<Picker /> should render as expected: should shallow render as <Picker /> when not mocked 1`] = `
 <Picker
-  mode="dialog"
   onValueChange={[MockFunction]}
   selectedValue="foo"
 >


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Remove `defaultProps` from `Picker` of components, replace it with destructuring assignment.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[JavaScript] [Changed] - Remove defaultProps from picker

close https://github.com/facebook/react-native/issues/31603

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

all test suite and CI passes.
