### PR TITLE
RN project wide Kotlin version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,9 +17,10 @@ buildscript {
         }
     }
     dependencies {
+        val kotlin_version: String by project
         classpath("com.android.tools.build:gradle:4.2.1")
         classpath("de.undercouch:gradle-download-task:4.1.1")
-
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version")
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,3 +6,4 @@ org.gradle.parallel=true
 
 ANDROID_NDK_VERSION=20.1.5948944
 android.useAndroidX=true
+kotlin_version=1.4.21

--- a/packages/react-native-gradle-plugin/build.gradle.kts
+++ b/packages/react-native-gradle-plugin/build.gradle.kts
@@ -8,7 +8,6 @@
 plugins {
   `java-gradle-plugin`
   `kotlin-dsl`
-  kotlin("jvm") version "1.4.20"
 }
 
 repositories {


### PR DESCRIPTION
## Summary

This PR sets project wide Kotlin version to 1.4.21, supported in Buck https://github.com/facebook/buck/tree/dev/third-party/java/kotlin.

We had to specify version for both kotlin-dsl and kotlin('jvm') plugins to remove version mismatch warnings in **react-native-gradle-plugin**. Also I expect more Kotlin code in RN, so instead of specifying version for each sub-project it's better to have project wide setting.

We don't need to load Kotlin in react-native-gradle-plugin because Kotlin is available RN project wide.

## Changelog

[Internal] [Changed] - Project wide Kotlin version set to 1.4.21

## Test Plan

Everything works as expected, no visible change for developers.