### PR TITLE
Add testID to NewAppScreen Header Component

### DIFF
--- a/Libraries/NewAppScreen/components/Header.js
+++ b/Libraries/NewAppScreen/components/Header.js
@@ -19,6 +19,7 @@ const Header = (): Node => {
   return (
     <ImageBackground
       accessibilityRole="image"
+      testID="new-app-screen-header"
       source={require('./logo.png')}
       style={[
         styles.background,


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

The RN OSS release process includes manual testing that a new template app can be started under various platforms, JS engines, etc. This should ideally be automated, to help reduce wasted engineer-time, and to allow reliably increasing release velocity.

`react-native-windows` does already have tests to create and build template projects across our matrix, but they do not do any runtime validation on the newly created app. Adding a `testID` to the new app screen header gives us something to search for in black-box testing to validate that the app started successfully. This should help catch cases where a sample project in repo has changes not reflected in a newly created template app.


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Internal] [Added] - Add testID to NewAppScreen Header Component

## Test Plan

Did not manually validate the change, though did check that `ImageBackground` forwards props to `Image`, and that `Image` is aware of `testID` and will forward to the native component.
