### PR TITLE
Use Node v14 in Windows CircleCI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,7 @@ executors:
   nodelts:
     <<: *defaults
     docker:
+      # Note: Version set separately for Windows builds, see below.
       - image: circleci/node:14
   nodeprevlts:
     <<: *defaults
@@ -623,6 +624,13 @@ jobs:
       - NDK_VERSION: 20.1.5948944
     steps:
       - checkout
+
+      - run:
+          name: Install Node
+          # Note: Version set separately for non-Windows builds, see above.
+          command: |
+            nvm install 14.17.0
+            nvm use 14.17.0
 
       # Setup Dependencies
       - run:


### PR DESCRIPTION
Summary:
CircleCI's Windows executor currently ships with a pre-LTS release of Node v12, breaking our Windows jobs ([example](https://app.circleci.com/pipelines/github/facebook/react-native/9280/workflows/21e6e59c-d853-47a1-af62-1368c8ce10ce/jobs/203983)) following https://github.com/facebook/react-native/pull/30637, ultimately due to https://github.com/facebook/jest/pull/10685 dropping support for non-LTS versions in the Node v12 release line.

Luckily, the Windows executor [does ship with nvm](https://github.com/circleci/circleci-docs/issues/3733) so we can use that to install a desired Node version. Rather than just pinning a later v12 release that is LTS, we pin a v14 release that is currently the most recent LTS version.

NOTE: The nvm on CircleCI is https://github.com/coreybutler/nvm-windows, not https://github.com/nvm-sh/nvm, and the two aren't interchangeable. [nvm-windows has no functionality to install the latest version of a release line](https://github.com/coreybutler/nvm-windows/issues/156) so we're forced to specify an exact version, which will need to be bumped manually in the future. This isn't great, but IMO it's no worse than the current situation, where we use whichever stale version of Node happens to be bundled with the Windows CircleCI executor.

Changelog:
[Internal]

Differential Revision: D28896581

