### PR TITLE
Find node on m1 via homebrew node managers

### DIFF
--- a/scripts/find-node.sh
+++ b/scripts/find-node.sh
@@ -6,6 +6,12 @@
 
 set -e
 
+# Support Homebrew on M1
+HOMEBREW_M1_BIN=/opt/homebrew/bin
+if [[ -d $HOMEBREW_M1_BIN && ! $PATH =~ $HOMEBREW_M1_BIN ]]; then
+  export PATH="$HOMEBREW_M1_BIN:$PATH"
+fi
+
 # Define NVM_DIR and source the nvm.sh setup script
 [ -z "$NVM_DIR" ] && export NVM_DIR="$HOME/.nvm"
 
@@ -30,10 +36,4 @@ if [[ ! -x node && -d ${HOME}/.anyenv/bin ]]; then
   if [[ "$(anyenv envs | grep -c ndenv )" -eq 1 ]]; then
     eval "$(anyenv init -)"
   fi
-fi
-
-# Support Homebrew on M1
-HOMEBREW_M1_BIN=/opt/homebrew/bin
-if [[ -d $HOMEBREW_M1_BIN && ! $PATH =~ $HOMEBREW_M1_BIN ]]; then
-  export PATH="$HOMEBREW_M1_BIN:$PATH"
 fi


### PR DESCRIPTION
## Summary

Adds homebrew on m1 to path before evaluating `command -v brew` to support nvm on m1 via homebrew.

## Changelog

[General] [Changed] - Find node on m1 via homebrew node managers

## Test Plan

On M1, use nvm via homebrew. Create a RN project and it'll fail to build iOS app. Apply the patch, and build will succeed.

cc: @dulmandakh as discussed in https://github.com/facebook/react-native/pull/31622