### PR TITLE
Avoid encoding local path in Podfile.lock

### DIFF
--- a/scripts/generate-specs.sh
+++ b/scripts/generate-specs.sh
@@ -10,14 +10,14 @@
 #
 # Optionally, set these envvars to override defaults:
 # - SRCS_DIR: Path to JavaScript sources
-# - CODEGEN_MODULES_LIBRARY_NAME: Defaults to FBReactNativeSpec
-# - CODEGEN_MODULES_OUTPUT_DIR: Defaults to React/$CODEGEN_MODULES_LIBRARY_NAME/$CODEGEN_MODULES_LIBRARY_NAME
-# - CODEGEN_COMPONENTS_LIBRARY_NAME: Defaults to rncore
-# - CODEGEN_COMPONENTS_OUTPUT_DIR: Defaults to ReactCommon/react/renderer/components/$CODEGEN_COMPONENTS_LIBRARY_NAME
+# - MODULES_LIBRARY_NAME: Defaults to FBReactNativeSpec
+# - MODULES_OUTPUT_DIR: Defaults to React/$MODULES_LIBRARY_NAME/$MODULES_LIBRARY_NAME
+# - COMPONENTS_LIBRARY_NAME: Defaults to rncore
+# - COMPONENTS_OUTPUT_DIR: Defaults to ReactCommon/react/renderer/components/$COMPONENTS_LIBRARY_NAME
 #
 # Usage:
 #   ./scripts/generate-specs.sh
-#   SRCS_DIR=myapp/js CODEGEN_MODULES_LIBRARY_NAME=MySpecs CODEGEN_MODULES_OUTPUT_DIR=myapp/MySpecs ./scripts/generate-specs.sh
+#   SRCS_DIR=myapp/js MODULES_LIBRARY_NAME=MySpecs MODULES_OUTPUT_DIR=myapp/MySpecs ./scripts/generate-specs.sh
 #
 
 # shellcheck disable=SC2038
@@ -46,13 +46,13 @@ describe () {
 
 main() {
   SRCS_DIR=${SRCS_DIR:-$(cd "$RN_DIR/Libraries" && pwd)}
-  CODEGEN_MODULES_LIBRARY_NAME=${CODEGEN_MODULES_LIBRARY_NAME:-FBReactNativeSpec}
+  MODULES_LIBRARY_NAME=${MODULES_LIBRARY_NAME:-FBReactNativeSpec}
 
-  CODEGEN_COMPONENTS_LIBRARY_NAME=${CODEGEN_COMPONENTS_LIBRARY_NAME:-rncore}
-  CODEGEN_MODULES_OUTPUT_DIR=${CODEGEN_MODULES_OUTPUT_DIR:-"$RN_DIR/React/$CODEGEN_MODULES_LIBRARY_NAME/$CODEGEN_MODULES_LIBRARY_NAME"}
-  # TODO: $CODEGEN_COMPONENTS_PATH should be programmatically specified, and may change with use_frameworks! support.
-  CODEGEN_COMPONENTS_PATH="ReactCommon/react/renderer/components"
-  CODEGEN_COMPONENTS_OUTPUT_DIR=${CODEGEN_COMPONENTS_OUTPUT_DIR:-"$RN_DIR/$CODEGEN_COMPONENTS_PATH/$CODEGEN_COMPONENTS_LIBRARY_NAME"}
+  COMPONENTS_LIBRARY_NAME=${COMPONENTS_LIBRARY_NAME:-rncore}
+  MODULES_OUTPUT_DIR=${MODULES_OUTPUT_DIR:-"$RN_DIR/React/$MODULES_LIBRARY_NAME/$MODULES_LIBRARY_NAME"}
+  # TODO: $COMPONENTS_PATH should be programmatically specified, and may change with use_frameworks! support.
+  COMPONENTS_PATH="ReactCommon/react/renderer/components"
+  COMPONENTS_OUTPUT_DIR=${COMPONENTS_OUTPUT_DIR:-"$RN_DIR/$COMPONENTS_PATH/$COMPONENTS_LIBRARY_NAME"}
 
   TEMP_OUTPUT_DIR="$TEMP_DIR/out"
   SCHEMA_FILE="$TEMP_DIR/schema.json"
@@ -75,14 +75,14 @@ main() {
 
   describe "Generating native code from schema (iOS)"
   pushd "$RN_DIR" >/dev/null || exit 1
-    "$NODE_BINARY" scripts/generate-specs-cli.js ios "$SCHEMA_FILE" "$TEMP_OUTPUT_DIR" "$CODEGEN_MODULES_LIBRARY_NAME"
+    "$NODE_BINARY" scripts/generate-specs-cli.js ios "$SCHEMA_FILE" "$TEMP_OUTPUT_DIR" "$MODULES_LIBRARY_NAME"
   popd >/dev/null || exit 1
 
   describe "Copying output to final directory"
-  mkdir -p "$CODEGEN_COMPONENTS_OUTPUT_DIR" "$CODEGEN_MODULES_OUTPUT_DIR"
-  cp -R "$TEMP_OUTPUT_DIR/$CODEGEN_MODULES_LIBRARY_NAME.h" "$TEMP_OUTPUT_DIR/$CODEGEN_MODULES_LIBRARY_NAME-generated.mm" "$CODEGEN_MODULES_OUTPUT_DIR" || exit 1
-  find "$TEMP_OUTPUT_DIR" -type f | xargs sed -i.bak "s/$CODEGEN_MODULES_LIBRARY_NAME/$CODEGEN_COMPONENTS_LIBRARY_NAME/g" || exit 1
-  find "$TEMP_OUTPUT_DIR" -type f -not -iname "$CODEGEN_MODULES_LIBRARY_NAME*" -exec cp '{}' "$CODEGEN_COMPONENTS_OUTPUT_DIR/" ';' || exit 1
+  mkdir -p "$COMPONENTS_OUTPUT_DIR" "$MODULES_OUTPUT_DIR"
+  cp -R "$TEMP_OUTPUT_DIR/$MODULES_LIBRARY_NAME.h" "$TEMP_OUTPUT_DIR/$MODULES_LIBRARY_NAME-generated.mm" "$MODULES_OUTPUT_DIR" || exit 1
+  find "$TEMP_OUTPUT_DIR" -type f | xargs sed -i.bak "s/$MODULES_LIBRARY_NAME/$COMPONENTS_LIBRARY_NAME/g" || exit 1
+  find "$TEMP_OUTPUT_DIR" -type f -not -iname "$MODULES_LIBRARY_NAME*" -exec cp '{}' "$COMPONENTS_OUTPUT_DIR/" ';' || exit 1
 
   echo >&2 'Done.'
 }


### PR DESCRIPTION
## Summary

This PR backports https://github.com/facebook/react-native/commit/bdfe2a5 (already in master) to 0.64-stable, so that this fix can be included in 0.64.3, see discussion:  https://github.com/react-native-community/releases/issues/232.  There were some conflicts applying the original commit to 0.64-stable, this commit by @danilobuerger from their fork https://github.com/feastr/react-native/commit/d9f7770e9d26ac29f0af9178b49a08aaba7584a2 has resolved those.

## Changelog

* Avoid encoding local path in Podfile.lock

## Test Plan

1. Run `pod install` and commit Podfile.lock
2. Move project somewhere else
3. Run `pod install` again. It should not fail.
