### PR TITLE
Remove usages of RTTI in places used by react-native-windows

### DIFF
--- a/ReactCommon/react/renderer/components/text/BaseTextShadowNode.cpp
+++ b/ReactCommon/react/renderer/components/text/BaseTextShadowNode.cpp
@@ -32,7 +32,8 @@ void BaseTextShadowNode::buildAttributedString(
     Attachments &outAttachments) {
   for (auto const &childNode : parentNode.getChildren()) {
     // RawShadowNode
-    auto rawTextShadowNode = traitCast<RawTextShadowNode const>(childNode);
+    auto rawTextShadowNode =
+        traitCast<RawTextShadowNode const*>(childNode.get());
     if (rawTextShadowNode) {
       auto fragment = AttributedString::Fragment{};
       fragment.string = rawTextShadowNode->getConcreteProps().text;
@@ -48,7 +49,7 @@ void BaseTextShadowNode::buildAttributedString(
     }
 
     // TextShadowNode
-    auto textShadowNode = traitCast<TextShadowNode const>(childNode);
+    auto textShadowNode = traitCast<TextShadowNode const*>(childNode.get());
     if (textShadowNode) {
       auto localTextAttributes = baseTextAttributes;
       localTextAttributes.apply(

--- a/ReactCommon/react/renderer/components/text/BaseTextShadowNode.cpp
+++ b/ReactCommon/react/renderer/components/text/BaseTextShadowNode.cpp
@@ -32,8 +32,7 @@ void BaseTextShadowNode::buildAttributedString(
     Attachments &outAttachments) {
   for (auto const &childNode : parentNode.getChildren()) {
     // RawShadowNode
-    auto rawTextShadowNode =
-        std::dynamic_pointer_cast<RawTextShadowNode const>(childNode);
+    auto rawTextShadowNode = traitCast<RawTextShadowNode const>(childNode);
     if (rawTextShadowNode) {
       auto fragment = AttributedString::Fragment{};
       fragment.string = rawTextShadowNode->getConcreteProps().text;
@@ -49,8 +48,7 @@ void BaseTextShadowNode::buildAttributedString(
     }
 
     // TextShadowNode
-    auto textShadowNode =
-        std::dynamic_pointer_cast<TextShadowNode const>(childNode);
+    auto textShadowNode = traitCast<TextShadowNode const>(childNode);
     if (textShadowNode) {
       auto localTextAttributes = baseTextAttributes;
       localTextAttributes.apply(

--- a/ReactCommon/react/renderer/components/text/RawTextShadowNode.h
+++ b/ReactCommon/react/renderer/components/text/RawTextShadowNode.h
@@ -21,14 +21,12 @@ extern const char RawTextComponentName[];
  * is represented as `<RawText text="Hello!"/>`.
  * <RawText> component must not have any children.
  */
-using RawTextShadowNode =
-    ConcreteShadowNode<RawTextComponentName, ShadowNode, RawTextProps>;
-
 class RawTextShadowNode : public ConcreteShadowNode<
                            RawTextComponentName,
                            ShadowNode,
                            RawTextProps> {
  public:
+  using ConcreteShadowNode::ConcreteShadowNode;
   static ShadowNodeTraits BaseTraits() {
     auto traits = ConcreteShadowNode::BaseTraits();
     traits.set(ShadowNodeTraits::Trait::RawText);

--- a/ReactCommon/react/renderer/components/text/RawTextShadowNode.h
+++ b/ReactCommon/react/renderer/components/text/RawTextShadowNode.h
@@ -24,5 +24,48 @@ extern const char RawTextComponentName[];
 using RawTextShadowNode =
     ConcreteShadowNode<RawTextComponentName, ShadowNode, RawTextProps>;
 
+class RawTextShadowNode : public ConcreteShadowNode<
+                           RawTextComponentName,
+                           ShadowNode,
+                           RawTextProps> {
+ public:
+  static ShadowNodeTraits BaseTraits() {
+    auto traits = ConcreteShadowNode::BaseTraits();
+    traits.set(ShadowNodeTraits::Trait::RawText);
+    return traits;
+  }
+};
+
+template <>
+inline RawTextShadowNode const& traitCast<RawTextShadowNode const&>(
+   ShadowNode const& shadowNode) {
+   bool castable =
+      shadowNode.getTraits().check(ShadowNodeTraits::Trait::RawText);
+   react_native_assert(
+      castable ==
+      (dynamic_cast<RawTextShadowNode const*>(&shadowNode) != nullptr));
+   react_native_assert(castable);
+   (void)castable;
+   return static_cast<RawTextShadowNode const&>(shadowNode);
+}
+
+template <>
+inline RawTextShadowNode const* traitCast<RawTextShadowNode const*>(
+   ShadowNode const* shadowNode) {
+   if (!shadowNode) {
+      return nullptr;
+   }
+   bool castable =
+      shadowNode->getTraits().check(ShadowNodeTraits::Trait::RawText);
+   react_native_assert(
+      castable ==
+      (dynamic_cast<RawTextShadowNode const*>(shadowNode) != nullptr));
+   if (!castable) {
+      return nullptr;
+   }
+   return static_cast<RawTextShadowNode const*>(shadowNode);
+}
+
+
 } // namespace react
 } // namespace facebook

--- a/ReactCommon/react/renderer/components/text/TextShadowNode.h
+++ b/ReactCommon/react/renderer/components/text/TextShadowNode.h
@@ -34,6 +34,7 @@ class TextShadowNode : public ConcreteShadowNode<
 #ifdef ANDROID
     traits.set(ShadowNodeTraits::Trait::FormsView);
 #endif
+    traits.set(ShadowNodeTraits::Trait::Text);
 
     return traits;
   }
@@ -56,6 +57,37 @@ class TextShadowNode : public ConcreteShadowNode<
   }
 #endif
 };
+
+
+template <>
+inline TextShadowNode const& traitCast<TextShadowNode const&>(
+   ShadowNode const& shadowNode) {
+   bool castable =
+      shadowNode.getTraits().check(ShadowNodeTraits::Trait::Text);
+   react_native_assert(
+      castable ==
+      (dynamic_cast<TextShadowNode const*>(&shadowNode) != nullptr));
+   react_native_assert(castable);
+   (void)castable;
+   return static_cast<TextShadowNode const&>(shadowNode);
+}
+
+template <>
+inline TextShadowNode const* traitCast<TextShadowNode const*>(
+   ShadowNode const* shadowNode) {
+   if (!shadowNode) {
+      return nullptr;
+   }
+   bool castable =
+      shadowNode->getTraits().check(ShadowNodeTraits::Trait::Text);
+   react_native_assert(
+      castable ==
+      (dynamic_cast<TextShadowNode const*>(shadowNode) != nullptr));
+   if (!castable) {
+      return nullptr;
+   }
+   return static_cast<TextShadowNode const*>(shadowNode);
+}
 
 } // namespace react
 } // namespace facebook

--- a/ReactCommon/react/renderer/components/view/ViewPropsInterpolation.h
+++ b/ReactCommon/react/renderer/components/view/ViewPropsInterpolation.h
@@ -24,16 +24,19 @@ static inline void interpolateViewProps(
     const SharedProps &oldPropsShared,
     const SharedProps &newPropsShared,
     SharedProps &interpolatedPropsShared) {
-  ViewProps const *oldViewProps =
-      dynamic_cast<ViewProps const *>(oldPropsShared.get());
-  ViewProps const *newViewProps =
-      dynamic_cast<ViewProps const *>(newPropsShared.get());
-  ViewProps *interpolatedProps = const_cast<ViewProps *>(
-      dynamic_cast<ViewProps const *>(interpolatedPropsShared.get()));
 
+  // Verify the static_casts below are safe        
   react_native_assert(
-      oldViewProps != nullptr && newViewProps != nullptr &&
-      interpolatedProps != nullptr);
+      dynamic_cast<ViewProps const *>(oldPropsShared.get()) != nullptr &&
+      dynamic_cast<ViewProps const *>(newPropsShared.get()) != nullptr &&
+      dynamic_cast<ViewProps const *>(interpolatedPropsShared.get()) != nullptr);
+
+  ViewProps const *oldViewProps =
+      static_cast<ViewProps const *>(oldPropsShared.get());
+  ViewProps const *newViewProps =
+      static_cast<ViewProps const *>(newPropsShared.get());
+  ViewProps *interpolatedProps = const_cast<ViewProps *>(
+      static_cast<ViewProps const *>(interpolatedPropsShared.get()));
 
   interpolatedProps->opacity = oldViewProps->opacity +
       (newViewProps->opacity - oldViewProps->opacity) * animationProgress;

--- a/ReactCommon/react/renderer/core/LayoutableShadowNode.cpp
+++ b/ReactCommon/react/renderer/core/LayoutableShadowNode.cpp
@@ -216,7 +216,7 @@ ShadowNode::Shared LayoutableShadowNode::findNodeAtPoint(
     ShadowNode::Shared node,
     Point point) {
   auto layoutableShadowNode =
-      dynamic_cast<const LayoutableShadowNode *>(node.get());
+    traitCast<const LayoutableShadowNode *>(node.get());
 
   if (!layoutableShadowNode) {
     return nullptr;

--- a/ReactCommon/react/renderer/core/ShadowNodeTraits.h
+++ b/ReactCommon/react/renderer/core/ShadowNodeTraits.h
@@ -21,7 +21,7 @@ class ShadowNodeTraits {
  public:
   /*
    * Underlying type for the traits.
-   * The first 16 bits are reserved for Core.
+   * The first 18 bits are reserved for Core.
    */
   enum Trait : int32_t {
     None = 0,
@@ -82,6 +82,12 @@ class ShadowNodeTraits {
     // Indicates that `children` list is shared between nodes and need
     // to be cloned before the first mutation.
     ChildrenAreShared = 1 << 15,
+
+    // Inherits 'RawTextShadowNode'
+    RawText = 1 << 16,
+
+    // Inherits 'TextShadowNode'
+    Text = 1 << 17,
   };
 
   /*

--- a/ReactCommon/react/renderer/core/tests/traitCastTest.cpp
+++ b/ReactCommon/react/renderer/core/tests/traitCastTest.cpp
@@ -111,29 +111,29 @@ TEST(traitCastTest, testOne) {
   EXPECT_TRUE(
       traitCast<RawTextShadowNode const *>(shadowNodeForRawTextShadowNode.get()));
   EXPECT_NO_FATAL_FAILURE(
-      traitCast<RawTextShadowNode const &>(*shadowNodeForRawTextShadowNode), "");
+      traitCast<RawTextShadowNode const &>(*shadowNodeForRawTextShadowNode));
   EXPECT_FALSE(
       traitCast<RawTextShadowNode const *>(shadowNodeForTextShadowNode.get()));
   EXPECT_DEATH_IF_SUPPORTED(
-      traitCast<RawTextShadowNode const &>(*shadowNodeForTextShadowNode));
+      traitCast<RawTextShadowNode const &>(*shadowNodeForTextShadowNode), "");
   EXPECT_FALSE(
       traitCast<RawTextShadowNode const *>(viewShadowNode.get()));
   EXPECT_DEATH_IF_SUPPORTED(
-      traitCast<RawTextShadowNode const &>(*viewShadowNode));
+      traitCast<RawTextShadowNode const &>(*viewShadowNode), "");
 
   // trait cast to `TextShadowNode` works on `TextShadowNode`
   // and not on RawTextShadowNode or ViewShadowNode
   EXPECT_TRUE(
       traitCast<TextShadowNode const *>(shadowNodeForTextShadowNode.get()));
   EXPECT_NO_FATAL_FAILURE(
-      traitCast<TextShadowNode const &>(*shadowNodeForTextShadowNode), "");
+      traitCast<TextShadowNode const &>(*shadowNodeForTextShadowNode));
   EXPECT_FALSE(
       traitCast<TextShadowNode const *>(shadowNodeForRawTextShadowNode.get()));
   EXPECT_DEATH_IF_SUPPORTED(
-      traitCast<TextShadowNode const &>(*shadowNodeForRawTextShadowNode));
+      traitCast<TextShadowNode const &>(*shadowNodeForRawTextShadowNode), "");
   EXPECT_FALSE(
       traitCast<TextShadowNode const *>(viewShadowNode.get()));
   EXPECT_DEATH_IF_SUPPORTED(
-      traitCast<TextShadowNode const &>(*viewShadowNode));
+      traitCast<TextShadowNode const &>(*viewShadowNode), "");
   
 }

--- a/ReactCommon/react/renderer/core/tests/traitCastTest.cpp
+++ b/ReactCommon/react/renderer/core/tests/traitCastTest.cpp
@@ -47,6 +47,9 @@ TEST(traitCastTest, testOne) {
 
   auto rootShadowNode = builder.build(element);
 
+  std::shared_ptr<ShadowNode> shadowNodeForRawTextShadowNode{rawTextShadowNode};
+  std::shared_ptr<ShadowNode> shadowNodeForTextShadowNode{textShadowNode};
+
   // Casting `nullptr` returns `nullptrs`.
   EXPECT_FALSE(traitCast<LayoutableShadowNode const *>(nullptr));
   EXPECT_FALSE(traitCast<YogaLayoutableShadowNode const *>(nullptr));
@@ -102,4 +105,35 @@ TEST(traitCastTest, testOne) {
       traitCast<LayoutableShadowNode const &>(*rawTextShadowNode), "");
   EXPECT_DEATH_IF_SUPPORTED(
       traitCast<YogaLayoutableShadowNode const &>(*rawTextShadowNode), "");
+
+  // trait cast to `RawTextShadowNode` works on `RawTextShadowNode`
+  // and not on TextShadowNode or ViewShadowNode
+  EXPECT_TRUE(
+      traitCast<RawTextShadowNode const *>(shadowNodeForRawTextShadowNode.get()));
+  EXPECT_DEATH_IF_SUPPORTED(
+      traitCast<RawTextShadowNode const &>(*shadowNodeForRawTextShadowNode), "");
+  EXPECT_FALSE(
+      traitCast<RawTextShadowNode const *>(shadowNodeForTextShadowNode.get()));
+  EXPECT_NO_FATAL_FAILURE(
+      traitCast<RawTextShadowNode const &>(*shadowNodeForTextShadowNode));
+  EXPECT_FALSE(
+      traitCast<RawTextShadowNode const *>(viewShadowNode.get()));
+  EXPECT_NO_FATAL_FAILURE(
+      traitCast<RawTextShadowNode const &>(*viewShadowNode));
+
+  // trait cast to `TextShadowNode` works on `TextShadowNode`
+  // and not on RawTextShadowNode or ViewShadowNode
+  EXPECT_TRUE(
+      traitCast<TextShadowNode const *>(shadowNodeForTextShadowNode.get()));
+  EXPECT_DEATH_IF_SUPPORTED(
+      traitCast<TextShadowNode const &>(*shadowNodeForTextShadowNode), "");
+  EXPECT_FALSE(
+      traitCast<TextShadowNode const *>(shadowNodeForRawTextShadowNode.get()));
+  EXPECT_NO_FATAL_FAILURE(
+      traitCast<TextShadowNode const &>(*shadowNodeForRawTextShadowNode));
+  EXPECT_FALSE(
+      traitCast<TextShadowNode const *>(viewShadowNode.get()));
+  EXPECT_NO_FATAL_FAILURE(
+      traitCast<TextShadowNode const &>(*viewShadowNode));
+  
 }

--- a/ReactCommon/react/renderer/core/tests/traitCastTest.cpp
+++ b/ReactCommon/react/renderer/core/tests/traitCastTest.cpp
@@ -110,30 +110,30 @@ TEST(traitCastTest, testOne) {
   // and not on TextShadowNode or ViewShadowNode
   EXPECT_TRUE(
       traitCast<RawTextShadowNode const *>(shadowNodeForRawTextShadowNode.get()));
-  EXPECT_DEATH_IF_SUPPORTED(
+  EXPECT_NO_FATAL_FAILURE(
       traitCast<RawTextShadowNode const &>(*shadowNodeForRawTextShadowNode), "");
   EXPECT_FALSE(
       traitCast<RawTextShadowNode const *>(shadowNodeForTextShadowNode.get()));
-  EXPECT_NO_FATAL_FAILURE(
+  EXPECT_DEATH_IF_SUPPORTED(
       traitCast<RawTextShadowNode const &>(*shadowNodeForTextShadowNode));
   EXPECT_FALSE(
       traitCast<RawTextShadowNode const *>(viewShadowNode.get()));
-  EXPECT_NO_FATAL_FAILURE(
+  EXPECT_DEATH_IF_SUPPORTED(
       traitCast<RawTextShadowNode const &>(*viewShadowNode));
 
   // trait cast to `TextShadowNode` works on `TextShadowNode`
   // and not on RawTextShadowNode or ViewShadowNode
   EXPECT_TRUE(
       traitCast<TextShadowNode const *>(shadowNodeForTextShadowNode.get()));
-  EXPECT_DEATH_IF_SUPPORTED(
+  EXPECT_NO_FATAL_FAILURE(
       traitCast<TextShadowNode const &>(*shadowNodeForTextShadowNode), "");
   EXPECT_FALSE(
       traitCast<TextShadowNode const *>(shadowNodeForRawTextShadowNode.get()));
-  EXPECT_NO_FATAL_FAILURE(
+  EXPECT_DEATH_IF_SUPPORTED(
       traitCast<TextShadowNode const &>(*shadowNodeForRawTextShadowNode));
   EXPECT_FALSE(
       traitCast<TextShadowNode const *>(viewShadowNode.get()));
-  EXPECT_NO_FATAL_FAILURE(
+  EXPECT_DEATH_IF_SUPPORTED(
       traitCast<TextShadowNode const &>(*viewShadowNode));
   
 }


### PR DESCRIPTION
## Summary

Adding runtime type information adds greatly to the binary size, so react-native-windows builds without it.  But some parts of the fabric code currently uses dynamic_cast, which means to use fabric we have to build with RTTI turned on.  This PR removes the usages of dynamic_cast that are hit in release builds, which should allow react-native-windows to turn off RTTI in release builds.

Required for:  https://github.com/microsoft/react-native-windows/issues/7981

One thing to note, the comment in ShadowNodeTraits indicates that core was reserving the first 16 bits.  I'm adding two more.  Is that ok?  Should core be reserving more for future use?

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Internal] [Fixed] - Remove uses of dynamic_cast in release builds

## Test Plan

Verified that I can build react-native-windows with Fabric in release, without RTTI.  
Boot / clicked around in RNW RNTester