### PR TITLE
Updated hyperlinks for Issues(line 33) and Pull Requests(line 34)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,8 +30,8 @@ We use GitHub issues and pull requests to keep track of bug reports and contribu
 
 You can learn more about the contribution process in the following documents:
 
-* [Issues](https://github.com/facebook/react-native/wiki/Issues)
-* [Pull Requests](https://github.com/facebook/react-native/wiki/Pull-Requests)
+* [Issues](https://github.com/facebook/react-native/wiki/Triaging-GitHub-Issues)
+* [Pull Requests](https://github.com/facebook/react-native/wiki/Managing-Pull-Requests)
 
 We also have a thriving community of contributors who would be happy to help you get set up. You can reach out to us through [@ReactNative](http://twitter.com/reactnative) (the React Native team) and [@ReactNativeComm](http://twitter.com/reactnativecomm) (the React Native Community organization).
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

In the CONTRIBUTING.md file, when a user clicks on the hyperlink for either issues(line 33) or pull requests(line 34), they are directed to a filler page which has them click on an additional hyperlink to take them to the page they are looking for. The only thing present on the filler page is a hyperlink. So, in terms of usability, it does not make sense to have users go through an extra click to get to the page they want. I have changed the hyperlinks of Issues(line 33) and Pull Requests(line 34) to takes users directly to Triaging GitHub Issues and Managing-Pull-Requests


## Changelog

[GENERAL][CHANGED]-See lines 33 and 34 of https://github.com/facebook/react-native/blob/master/CONTRIBUTING.md


## Test Plan

First, I ensured that the code lints and the test suite passes. For testing the links, I opened my fork in GitHub and opened the CONTRIBUTING.md file. I clicked on both hyperlinks to ensure that they both worked properly. No tests were added for this code. 
