### PR TITLE
fix(android): Double run installArchive to fix jni files not being included

### DIFF
--- a/.circleci/Dockerfiles/scripts/run-ci-e2e-tests.sh
+++ b/.circleci/Dockerfiles/scripts/run-ci-e2e-tests.sh
@@ -139,6 +139,11 @@ function e2e_suite() {
         echo "Failed to compile Android binaries"
         return 1
       fi
+      if ! ./gradlew :ReactAndroid:installArchives -Pjobs=1 -Dorg.gradle.jvmargs="-Xmx512m -XX:+HeapDumpOnOutOfMemoryError"
+      then
+        echo "Failed to compile Android binaries"
+        return 1
+      fi
     fi
 
     if ! npm pack

--- a/scripts/publish-npm.js
+++ b/scripts/publish-npm.js
@@ -127,7 +127,7 @@ if (nightlyBuild) {
 }
 
 // -------- Generating Android Artifacts with JavaDoc
-if (exec('./gradlew :ReactAndroid:installArchives').code) {
+if (exec('./gradlew :ReactAndroid:installArchives').code || exec('./gradlew :ReactAndroid:installArchives').code) {
   echo('Could not generate artifacts');
   exit(1);
 }

--- a/scripts/run-ci-e2e-tests.js
+++ b/scripts/run-ci-e2e-tests.js
@@ -48,6 +48,8 @@ try {
     if (
       exec(
         './gradlew :ReactAndroid:installArchives -Pjobs=1 -Dorg.gradle.jvmargs="-Xmx512m -XX:+HeapDumpOnOutOfMemoryError"',
+      ).code || exec(
+        './gradlew :ReactAndroid:installArchives -Pjobs=1 -Dorg.gradle.jvmargs="-Xmx512m -XX:+HeapDumpOnOutOfMemoryError"',
       ).code
     ) {
       echo('Failed to compile Android binaries');

--- a/scripts/test-manual-e2e.sh
+++ b/scripts/test-manual-e2e.sh
@@ -37,6 +37,7 @@ repo_root=$(pwd)
 
 rm -rf android
 ./gradlew :ReactAndroid:installArchives || error "Couldn't generate artifacts"
+./gradlew :ReactAndroid:installArchives || error "Couldn't generate artifacts"
 
 success "Generated artifacts for Maven"
 


### PR DESCRIPTION
## Summary

JNI files don't get bundled when running once, but running it again works. It is not a pretty fix and is only meant to unlock 0.65
