### PR TITLE
Bump NDK to 21.4.7075529

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -510,7 +510,7 @@ jobs:
           name: Install rsync, zip
           command: |
             curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-            apt-get update -y && apt-get install rsync zip -y
+            apt-get update -y && apt-get install patch rsync zip -y
 
       # Install Buck
       - install_buck_tooling

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -621,7 +621,7 @@ jobs:
       - ANDROID_BUILD_VERSION: 30
       - ANDROID_TOOLS_VERSION: 30.0.2
       - GRADLE_OPTS: -Dorg.gradle.daemon=false
-      - NDK_VERSION: 20.1.5948944
+      - NDK_VERSION: 21.4.7075529
     steps:
       - checkout
 

--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -96,6 +96,12 @@ task prepareFolly(dependsOn: dependenciesPath ? [] : [downloadFolly], type: Copy
     eachFile { fname -> fname.path = (fname.path - "folly-${FOLLY_VERSION}/") }
     includeEmptyDirs = false
     into("$thirdPartyNdkDir/folly")
+    doLast {
+        ant.patch(
+            patchfile: "src/main/jni/third-party/folly/FileUtil.cpp.patch",
+            originalFile: "$thirdPartyNdkDir/folly/folly/FileUtil.cpp"
+        )
+    }
 }
 
 task downloadFmt(dependsOn: createNativeDepsDirectories, type: Download) {

--- a/ReactAndroid/src/main/jni/third-party/folly/FileUtil.cpp.patch
+++ b/ReactAndroid/src/main/jni/third-party/folly/FileUtil.cpp.patch
@@ -1,0 +1,29 @@
+--- FileUtil.cpp.orig	2021-06-16 20:53:12.000000000 +0800
++++ FileUtil.cpp	2021-06-16 20:53:37.000000000 +0800
+@@ -35,7 +35,26 @@
+ using namespace fileutil_detail;
+ 
+ int openNoInt(const char* name, int flags, mode_t mode) {
++#if defined(__ANDROID__)
++  // NDK bionic with FORTIFY has this definition:
++  // https://android.googlesource.com/platform/bionic/+/9349b9e51b/libc/include/bits/fortify/fcntl.h
++  // ```
++  // __BIONIC_ERROR_FUNCTION_VISIBILITY
++  // int open(const char* pathname, int flags, mode_t modes, ...) __overloadable
++  //         __errorattr(__open_too_many_args_error);
++  // ```
++  // This is originally to prevent open() with incorrect parameters.
++  //
++  // However, combined with folly wrapNotInt, template deduction will fail.
++  // In this case, we create a custom Open lambda to bypass the error.
++  // The solution is referenced from
++  // https://github.com/llvm/llvm-project/commit/0a0e411204a2baa520fd73a8d69b664f98b428ba
++  //
++  auto Open = [&]() { return open(name, flags, mode); };
++  return int(wrapNoInt(Open));
++#else
+   return int(wrapNoInt(open, name, flags, mode));
++#endif
+ }
+ 
+ static int filterCloseReturn(int r) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,6 @@ org.gradle.daemon=true
 org.gradle.jvmargs=-Xmx4g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 org.gradle.parallel=true
 
-ANDROID_NDK_VERSION=20.1.5948944
+ANDROID_NDK_VERSION=21.4.7075529
 android.useAndroidX=true
 kotlin_version=1.4.21

--- a/template/android/build.gradle
+++ b/template/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         minSdkVersion = 21
         compileSdkVersion = 30
         targetSdkVersion = 30
-        ndkVersion = "20.1.5948944"
+        ndkVersion = "21.4.7075529"
     }
     repositories {
         google()


### PR DESCRIPTION
## Summary

This PR bumps NDK_VERSION to 21.4.7075529, and patches FileUtil.cpp from folly based on patch from https://github.com/facebook/folly/pull/1593. We can remove the patch once PR lands in Folly and bump Folly version in RN.

FYI, NDK 20 is deprecated and 21 is LTS release.

## Changelog

[Android] [Changed] - Bump NDK to 21.4.7075529

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
