### PR TITLE
chore(version): major version to go with dependency update

### DIFF
--- a/packages/eslint-config-react-native-community/package.json
+++ b/packages/eslint-config-react-native-community/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-community/eslint-config",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "ESLint config for React Native",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
## Summary

#31490 bumped the dependency versions of `@typescript-eslint` project across a semver major,
bumping the package version here a semver major to correspond, prior to publishing

This is being done [in concert with](https://github.com/facebook/react-native/pull/31490#issuecomment-862122615) @matt-oakes who may hopefully publish the result and @PeteTheHeat
who merged #31490 (thanks!)

I copied the changelog chunk from the last version bump merged here, hopefully it is correct + useful

## Changelog

[General] [Fixed] - Upgrade dependencies / version of eslint package

## Test Plan

Run in local project