### PR TITLE
Fixes Global Node Prefix Error

### DIFF
--- a/scripts/find-node.sh
+++ b/scripts/find-node.sh
@@ -6,6 +6,10 @@
 
 set -e
 
+# remove global prefix if it's already set
+# the running shell process will choose a node binary and a global package directory breaks version managers
+unset PREFIX
+
 # Support Homebrew on M1
 HOMEBREW_M1_BIN=/opt/homebrew/bin
 if [[ -d $HOMEBREW_M1_BIN && ! $PATH =~ $HOMEBREW_M1_BIN ]]; then


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Some users have `node` installed globally which sets a `PREFIX` by default (so it knows where to put pkgs). We are looking for the "right" node on the next step anyway and if the user is using `nvm`, `PREFIX` breaks it. 

closes #31181

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [Fixed] - Ignores global npm prefix

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

`yarn ios` now works, even if there's a `usr/local/bin/npm`

<img width="493" alt="Screen Shot 2021-06-17 at 10 14 08 AM" src="https://user-images.githubusercontent.com/2659478/122413946-c2f57200-cf54-11eb-817c-bd3c07ac50bf.png">

