### PR TITLE
Add support to URI keyboard type in Android

### DIFF
--- a/Libraries/Components/TextInput/AndroidTextInputNativeComponent.js
+++ b/Libraries/Components/TextInput/AndroidTextInputNativeComponent.js
@@ -37,10 +37,10 @@ export type KeyboardType =
   | 'phone-pad'
   | 'number-pad'
   | 'decimal-pad'
+  | 'url'
   // iOS-only
   | 'ascii-capable'
   | 'numbers-and-punctuation'
-  | 'url'
   | 'name-phone-pad'
   | 'twitter'
   | 'web-search'
@@ -244,6 +244,7 @@ export type NativeProps = $ReadOnly<{|
    * - `decimal-pad`
    * - `email-address`
    * - `phone-pad`
+   * - `url`
    *
    * *Android Only*
    *

--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -146,10 +146,10 @@ export type KeyboardType =
   | 'phone-pad'
   | 'number-pad'
   | 'decimal-pad'
+  | 'url'
   // iOS-only
   | 'ascii-capable'
   | 'numbers-and-punctuation'
-  | 'url'
   | 'name-phone-pad'
   | 'twitter'
   | 'web-search'
@@ -501,6 +501,7 @@ export type Props = $ReadOnly<{|
    * - `decimal-pad`
    * - `email-address`
    * - `phone-pad`
+   * - `url`
    *
    * *iOS Only*
    *
@@ -508,7 +509,6 @@ export type Props = $ReadOnly<{|
    *
    * - `ascii-capable`
    * - `numbers-and-punctuation`
-   * - `url`
    * - `name-phone-pad`
    * - `twitter`
    * - `web-search`

--- a/Libraries/DeprecatedPropTypes/DeprecatedTextInputPropTypes.js
+++ b/Libraries/DeprecatedPropTypes/DeprecatedTextInputPropTypes.js
@@ -136,14 +136,14 @@ module.exports = {
    * - `decimal-pad`
    * - `email-address`
    * - `phone-pad`
-   *
+   * - `url`
+   * 
    * *iOS Only*
    *
    * The following values work on iOS only:
    *
    * - `ascii-capable`
    * - `numbers-and-punctuation`
-   * - `url`
    * - `name-phone-pad`
    * - `twitter`
    * - `web-search`
@@ -162,10 +162,10 @@ module.exports = {
     'numeric',
     'phone-pad',
     'number-pad',
+    'url',
     // iOS-only
     'ascii-capable',
     'numbers-and-punctuation',
-    'url',
     'name-phone-pad',
     'decimal-pad',
     'twitter',

--- a/Libraries/DeprecatedPropTypes/DeprecatedTextInputPropTypes.js
+++ b/Libraries/DeprecatedPropTypes/DeprecatedTextInputPropTypes.js
@@ -137,7 +137,7 @@ module.exports = {
    * - `email-address`
    * - `phone-pad`
    * - `url`
-   * 
+   *
    * *iOS Only*
    *
    * The following values work on iOS only:

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -108,6 +108,7 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
   private static final String KEYBOARD_TYPE_NUMBER_PAD = "number-pad";
   private static final String KEYBOARD_TYPE_PHONE_PAD = "phone-pad";
   private static final String KEYBOARD_TYPE_VISIBLE_PASSWORD = "visible-password";
+  private static final String KEYBOARD_TYPE_URI = "url";
   private static final InputFilter[] EMPTY_FILTERS = new InputFilter[0];
   private static final int UNSET = -1;
 
@@ -774,6 +775,8 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
       // This will supercede secureTextEntry={false}. If it doesn't, due to the way
       //  the flags work out, the underlying field will end up a URI-type field.
       flagsToSet = InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD;
+    } else if (KEYBOARD_TYPE_URI.equalsIgnoreCase(keyboardType)) {
+      flagsToSet = InputType.TYPE_TEXT_VARIATION_URI;
     }
 
     updateStagedInputTypeFlag(view, InputType.TYPE_MASK_CLASS, flagsToSet);

--- a/ReactAndroid/src/test/java/com/facebook/react/views/textinput/ReactTextInputPropertyTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/views/textinput/ReactTextInputPropertyTest.java
@@ -221,6 +221,7 @@ public class ReactTextInputPropertyTest {
   public void testKeyboardType() {
     ReactEditText view = mManager.createViewInstance(mThemedContext);
     int numberPadTypeFlags = InputType.TYPE_CLASS_NUMBER;
+    int urlTypeFlags = InputType.TYPE_TEXT_VARIATION_URI;
     int decimalPadTypeFlags = InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_DECIMAL;
     int numericTypeFlags =
         InputType.TYPE_CLASS_NUMBER
@@ -245,6 +246,9 @@ public class ReactTextInputPropertyTest {
 
     mManager.updateProperties(view, buildStyles("keyboardType", "number-pad"));
     assertThat(view.getInputType() & generalKeyboardTypeFlags).isEqualTo(numberPadTypeFlags);
+
+    mManager.updateProperties(view, buildStyles("keyboardType", "url"));
+    assertThat(view.getInputType() & generalKeyboardTypeFlags).isEqualTo(urlTypeFlags);
 
     mManager.updateProperties(view, buildStyles("keyboardType", "decimal-pad"));
     assertThat(view.getInputType() & generalKeyboardTypeFlags).isEqualTo(decimalPadTypeFlags);

--- a/ReactCommon/react/renderer/components/textinput/iostextinput/conversions.h
+++ b/ReactCommon/react/renderer/components/textinput/iostextinput/conversions.h
@@ -163,6 +163,10 @@ inline void fromRawValue(const RawValue &value, KeyboardType &result) {
     result = KeyboardType::NumberPad;
     return;
   }
+  if (string == "url") {
+    result = KeyboardType::URL;
+    return;
+  }
   if (string == "decimal-pad") {
     result = KeyboardType::DecimalPad;
     return;
@@ -175,10 +179,6 @@ inline void fromRawValue(const RawValue &value, KeyboardType &result) {
   }
   if (string == "numbers-and-punctuation") {
     result = KeyboardType::NumbersAndPunctuation;
-    return;
-  }
-  if (string == "url") {
-    result = KeyboardType::URL;
     return;
   }
   if (string == "name-phone-pad") {


### PR DESCRIPTION
## Summary

Android react-native `TextInput` component does nothing if prop `keyboardType` is `url` value. This PR solves that problem.

## Changelog

[Android] [Added] - Add support to URI keyboard type in Android

## Test Plan

Sample image with URI keyboard type.

![URI-Keyboard-in-Android](https://user-images.githubusercontent.com/2545053/123629349-79d6d500-d814-11eb-922b-c40eebb60006.jpg)

