### PR TITLE
Fix support for blobs larger than 64 KB on Android

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/blob/BlobProvider.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/blob/BlobProvider.java
@@ -23,7 +23,7 @@ import java.io.OutputStream;
 
 public final class BlobProvider extends ContentProvider {
 
-  private final static int PIPE_CAPACITY = 65536;
+  private static final int PIPE_CAPACITY = 65536;
 
   @Override
   public boolean onCreate() {
@@ -103,16 +103,16 @@ public final class BlobProvider extends ContentProvider {
       // immediately so that both writer and reader can work concurrently.
       // Reading from the pipe empties the buffer and allows the next chunks to be written.
       Thread writer =
-        new Thread() {
-          public void run() {
-            try (OutputStream outputStream =
-                new ParcelFileDescriptor.AutoCloseOutputStream(writeSide)) {
-              outputStream.write(data);
-            } catch (IOException exception) {
-              // no-op
+          new Thread() {
+            public void run() {
+              try (OutputStream outputStream =
+                  new ParcelFileDescriptor.AutoCloseOutputStream(writeSide)) {
+                outputStream.write(data);
+              } catch (IOException exception) {
+                // no-op
+              }
             }
-          }
-        };
+          };
       writer.start();
     }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/blob/BlobProvider.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/blob/BlobProvider.java
@@ -72,7 +72,7 @@ public final class BlobProvider extends ContentProvider {
       throw new RuntimeException("No blob module associated with BlobProvider");
     }
 
-    byte[] data = blobModule.resolve(uri);
+    final byte[] data = blobModule.resolve(uri);
     if (data == null) {
       throw new FileNotFoundException("Cannot open " + uri.toString() + ", blob not found.");
     }
@@ -84,7 +84,7 @@ public final class BlobProvider extends ContentProvider {
       return null;
     }
     ParcelFileDescriptor readSide = pipe[0];
-    ParcelFileDescriptor writeSide = pipe[1];
+    final ParcelFileDescriptor writeSide = pipe[1];
 
     Thread writer = new Thread() {
       public void run() {

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/blob/BlobProvider.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/blob/BlobProvider.java
@@ -86,19 +86,21 @@ public final class BlobProvider extends ContentProvider {
     ParcelFileDescriptor readSide = pipe[0];
     final ParcelFileDescriptor writeSide = pipe[1];
 
-    Thread writer = new Thread() {
-      public void run() {
-        try (OutputStream outputStream = new ParcelFileDescriptor.AutoCloseOutputStream(writeSide)) {
-          // If the blob data is larger than pipe capacity (64 KB), a synchronous write call
-          // would fill up the whole buffer and block until the bytes are read (i.e. never).
-          // Writing from a separate thread allows us to return the read side descriptor
-          // immediately so that the reader can start reading.
-          outputStream.write(data);
-        } catch (IOException exception) {
-          // no-op
-        }
-      }
-    };
+    Thread writer =
+        new Thread() {
+          public void run() {
+            try (OutputStream outputStream =
+                new ParcelFileDescriptor.AutoCloseOutputStream(writeSide)) {
+              // If the blob data is larger than pipe capacity (64 KB), a synchronous write call
+              // would fill up the whole buffer and block until the bytes are read (i.e. never).
+              // Writing from a separate thread allows us to return the read side descriptor
+              // immediately so that the reader can start reading.
+              outputStream.write(data);
+            } catch (IOException exception) {
+              // no-op
+            }
+          }
+        };
     writer.start();
 
     return readSide;

--- a/packages/rn-tester/android/app/src/main/AndroidManifest.xml
+++ b/packages/rn-tester/android/app/src/main/AndroidManifest.xml
@@ -52,6 +52,11 @@
       </intent-filter>
     </activity>
     <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
+    <provider
+      android:name="com.facebook.react.modules.blob.BlobProvider"
+      android:authorities="@string/blob_provider_authority"
+      android:exported="false"
+    />
   </application>
 
 </manifest>

--- a/packages/rn-tester/android/app/src/main/res/values/strings.xml
+++ b/packages/rn-tester/android/app/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name">RNTester App</string>
+    <string name="blob_provider_authority">com.facebook.react.uiapp.blobs</string>
 </resources>

--- a/packages/rn-tester/js/examples/Image/ImageExample.js
+++ b/packages/rn-tester/js/examples/Image/ImageExample.js
@@ -48,7 +48,7 @@ class BlobImageExample extends React.Component<
     objectURL: null,
   };
 
-  componentDidMount() {
+  UNSAFE_componentWillMount() {
     (async () => {
       const result = await fetch(this.props.url);
       const blob = await result.blob();
@@ -58,7 +58,7 @@ class BlobImageExample extends React.Component<
   }
 
   render() {
-    return this.state.objectURL ? (
+    return this.state.objectURL !== null ? (
       <Image source={{uri: this.state.objectURL}} style={styles.base} />
     ) : (
       <Text>Object URL not created yet</Text>
@@ -647,7 +647,9 @@ exports.examples = [
     description: ('If the `source` prop `uri` property is an object URL, ' +
       'then it will be resolved using `BlobProvider` (Android) or `RCTBlobManager` (iOS).': string),
     render: function(): React.Node {
-      return <BlobImageExample url={fullImage.uri} />;
+      return (
+        <BlobImageExample url="https://www.facebook.com/ads/pics/successstories.png" />
+      );
     },
   },
   {

--- a/packages/rn-tester/js/examples/Image/ImageExample.js
+++ b/packages/rn-tester/js/examples/Image/ImageExample.js
@@ -32,18 +32,15 @@ type ImageSource = $ReadOnly<{|
   uri: string,
 |}>;
 
-type BlobImageExampleState = {|
+type BlobImageState = {|
   objectURL: ?string,
 |};
 
-type BlobImageExampleProps = $ReadOnly<{|
+type BlobImageProps = $ReadOnly<{|
   url: string,
 |}>;
 
-class BlobImageExample extends React.Component<
-  BlobImageExampleProps,
-  BlobImageExampleState,
-> {
+class BlobImage extends React.Component<BlobImageProps, BlobImageState> {
   state = {
     objectURL: null,
   };
@@ -62,6 +59,27 @@ class BlobImageExample extends React.Component<
       <Image source={{uri: this.state.objectURL}} style={styles.base} />
     ) : (
       <Text>Object URL not created yet</Text>
+    );
+  }
+}
+
+type BlobImageExampleState = {||};
+
+type BlobImageExampleProps = $ReadOnly<{|
+  urls: string[],
+|}>;
+
+class BlobImageExample extends React.Component<
+  BlobImageExampleProps,
+  BlobImageExampleState,
+> {
+  render() {
+    return (
+      <View style={styles.horizontal}>
+        {this.props.urls.map(url => (
+          <BlobImage key={url} url={url} />
+        ))}
+      </View>
     );
   }
 }
@@ -648,7 +666,12 @@ exports.examples = [
       'then it will be resolved using `BlobProvider` (Android) or `RCTBlobManager` (iOS).': string),
     render: function(): React.Node {
       return (
-        <BlobImageExample url="https://www.facebook.com/ads/pics/successstories.png" />
+        <BlobImageExample
+          urls={[
+            'https://www.facebook.com/favicon.ico',
+            'https://www.facebook.com/ads/pics/successstories.png',
+          ]}
+        />
       );
     },
   },

--- a/packages/rn-tester/js/examples/Image/ImageExample.js
+++ b/packages/rn-tester/js/examples/Image/ImageExample.js
@@ -32,6 +32,40 @@ type ImageSource = $ReadOnly<{|
   uri: string,
 |}>;
 
+type BlobImageExampleState = {|
+  objectURL: ?string,
+|};
+
+type BlobImageExampleProps = $ReadOnly<{|
+  url: string,
+|}>;
+
+class BlobImageExample extends React.Component<
+  BlobImageExampleProps,
+  BlobImageExampleState,
+> {
+  state = {
+    objectURL: null,
+  };
+
+  componentDidMount() {
+    (async () => {
+      const result = await fetch(this.props.url);
+      const blob = await result.blob();
+      const objectURL = URL.createObjectURL(blob);
+      this.setState({objectURL});
+    })();
+  }
+
+  render() {
+    return this.state.objectURL ? (
+      <Image source={{uri: this.state.objectURL}} style={styles.base} />
+    ) : (
+      <Text>Object URL not created yet</Text>
+    );
+  }
+}
+
 type NetworkImageCallbackExampleState = {|
   events: Array<string>,
   startLoadPrefetched: boolean,
@@ -606,6 +640,14 @@ exports.examples = [
       '"http", then it will be downloaded from the network.': string),
     render: function(): React.Node {
       return <Image source={fullImage} style={styles.base} />;
+    },
+  },
+  {
+    title: 'Plain Blob Image',
+    description: ('If the `source` prop `uri` property is an object URL, ' +
+      'then it will be resolved using `BlobProvider` (Android) or `RCTBlobManager` (iOS).': string),
+    render: function(): React.Node {
+      return <BlobImageExample url={fullImage.uri} />;
     },
   },
   {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Fixes #31774.

This pull request resolves a problem related to accessing blobs greater than 64 KB on Android. When an object URL for such blob is passed as source of `<Image />` component, the image does not load. 

This issue was related to the fact that pipe buffer has a limited capacity of 65536 bytes (https://man7.org/linux/man-pages/man7/pipe.7.html, section "Pipe capacity"). If there is more bytes to be written than free space in the buffer left, the write operation blocks and waits until the content is read from the pipe.

The current implementation of `BlobProvider.openFile` first creates a pipe, then writes the blob data to the pipe and finally returns the read side descriptor of the pipe. For blobs larger than 64 KB, the write operation will block forever, because there are no readers to empty the buffer.

https://github.com/facebook/react-native/blob/41ecccefcf16ac8bcf858dd955af709eb20f7e4a/ReactAndroid/src/main/java/com/facebook/react/modules/blob/BlobProvider.java#L86-L95

This pull request moves the write operation to a separate thread. The read side descriptor is returned immediately so that both writer and reader can work simultaneously. Reading from the pipe empties the buffer and allows the next chunks to be written.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Fixed] - Fix support for blobs larger than 64 KB

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

A new example has been added to RN Tester app to verify if the new implementation properly loads the image of size 455 KB from a blob via object URL passed as image source.

<img src="https://user-images.githubusercontent.com/20516055/123859163-9eba6d80-d924-11eb-8a09-2b1f353bb968.png" alt="Screenshot_1624996413" width="300" />
