### PR TITLE
[ios] Propose to connect metro server programmatically

### DIFF
--- a/React/DevSupport/RCTPackagerConnection.h
+++ b/React/DevSupport/RCTPackagerConnection.h
@@ -59,6 +59,9 @@ typedef void (^RCTConnectedHandler)(void);
 /** Disconnects and removes all handlers. */
 - (void)stop;
 
+/** Reconnect with given packager server. */
+- (void)reconnect:(NSString *)packagerServerHostPort;
+
 /**
  * Historically no distinction was made between notification and request
  * handlers. If you use this method, it will be registered as *both* a

--- a/React/DevSupport/RCTPackagerConnection.mm
+++ b/React/DevSupport/RCTPackagerConnection.mm
@@ -120,24 +120,28 @@ static RCTReconnectingWebSocket *socketForLocation(NSString *const serverHostPor
   _requestRegistrations.clear();
 }
 
-- (void)bundleURLSettingsChanged
+- (void)reconnect:(NSString *)packagerServerHostPort
 {
   std::lock_guard<std::mutex> l(_mutex);
   if (_socket == nil) {
     return; // already stopped
   }
 
-  NSString *const serverHostPort = [[RCTBundleURLProvider sharedSettings] packagerServerHostPort];
-  if ([serverHostPort isEqual:_serverHostPortForSocket]) {
+  if ([packagerServerHostPort isEqual:_serverHostPortForSocket]) {
     return; // unchanged
   }
 
   _socket.delegate = nil;
   [_socket stop];
-  _serverHostPortForSocket = serverHostPort;
-  _socket = socketForLocation(serverHostPort);
+  _serverHostPortForSocket = packagerServerHostPort;
+  _socket = socketForLocation(packagerServerHostPort);
   _socket.delegate = self;
   [_socket start];
+}
+
+- (void)bundleURLSettingsChanged
+{
+  [self reconnect:[[RCTBundleURLProvider sharedSettings] packagerServerHostPort]];
 }
 
 - (RCTHandlerToken)addNotificationHandler:(RCTNotificationHandler)handler


### PR DESCRIPTION
## Summary

nowadays, we could only specify metro server by either dev settings or building time ip.txt.
this pr adds a new way to specify metro server programmatically which makes rn launcher or testing more feasible.


## Changelog

[Internal] [iOS] [Added] - Propose to connect metro server programmatically

## Test Plan

just exposing a public interface for RCTPackagerConnection without much code change.
test to call this interface success locally.
