### PR TITLE
Add support for Android intent urls in Linking library

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/intent/IntentModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/intent/IntentModule.java
@@ -23,7 +23,6 @@ import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableType;
 import com.facebook.react.module.annotations.ReactModule;
-import java.net.URISyntaxException;
 
 /** Intent module. Launch other activities or open URLs. */
 @ReactModule(name = IntentModule.NAME)
@@ -100,8 +99,7 @@ public class IntentModule extends NativeIntentAndroidSpec {
         String fallback = intent.getStringExtra(EXTRA_BROWSER_FALLBACK_URL);
         if (fallback != null) {
           intent = Intent.parseUri(fallback, 0);
-          componentName =
-            intent.resolveActivity(getReactApplicationContext().getPackageManager());
+          componentName = intent.resolveActivity(getReactApplicationContext().getPackageManager());
         }
       }
 
@@ -154,7 +152,7 @@ public class IntentModule extends NativeIntentAndroidSpec {
         if (fallback != null) {
           intent = Intent.parseUri(fallback, 0);
           canOpen =
-            intent.resolveActivity(getReactApplicationContext().getPackageManager()) != null;
+              intent.resolveActivity(getReactApplicationContext().getPackageManager()) != null;
         }
       }
 

--- a/packages/rn-tester/js/examples/Linking/LinkingExample.js
+++ b/packages/rn-tester/js/examples/Linking/LinkingExample.js
@@ -18,6 +18,7 @@ const {
   TouchableOpacity,
   ToastAndroid,
   View,
+  ScrollView,
 } = require('react-native');
 
 const RNTesterBlock = require('../../components/RNTesterBlock');
@@ -71,7 +72,7 @@ class SendIntentButton extends React.Component<Props> {
 class IntentAndroidExample extends React.Component {
   render() {
     return (
-      <View>
+      <ScrollView>
         <RNTesterBlock title="Open external URLs">
           <OpenURLButton url={'https://www.facebook.com'} />
           <OpenURLButton url={'http://www.facebook.com'} />
@@ -79,6 +80,13 @@ class IntentAndroidExample extends React.Component {
           <OpenURLButton url={'fb://notifications'} />
           <OpenURLButton url={'geo:37.484847,-122.148386'} />
           <OpenURLButton url={'tel:9876543210'} />
+          {Platform.OS === 'android' && (
+            <OpenURLButton
+              url={
+                'intent://notifications#Intent;scheme=fb;S.browser_fallback_url=https%3A%2F%2Ffacebook.com;end'
+              }
+            />
+          )}
         </RNTesterBlock>
         {Platform.OS === 'android' && (
           <RNTesterBlock title="Send intents">
@@ -94,7 +102,7 @@ class IntentAndroidExample extends React.Component {
             />
           </RNTesterBlock>
         )}
-      </View>
+      </ScrollView>
     );
   }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Changed the way urls are parsed in the Linking library from `Uri.parse()` to `Intent.parseUri()`. If the url does not use the ["intent:" scheme](https://developer.chrome.com/docs/multidevice/android/intents/) it falls back to the original method so it does not break any functionality. If it does use that scheme it is now handled correctly including opening fallback url when there is no app to handle the intent.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Changed] - Change the way Linking library parses urls on Android to support urls using "intent:" scheme.

## Test Plan

Videos demonstrating the change:
[Clicking on link with the app installed](https://imgur.com/a/Rfbdnr4)
[Clicking on link without the app installed](https://imgur.com/a/5afoR8v)
[Testing other urls to check if they still work](https://imgur.com/a/IHEVPcb)
