### PR TITLE
Allow network requests to finish when app is sent to background

### DIFF
--- a/packages/react-native/Libraries/Network/RCTNetworking.mm
+++ b/packages/react-native/Libraries/Network/RCTNetworking.mm
@@ -573,6 +573,11 @@ RCT_EXPORT_MODULE()
   RCTAssertThread([self requestQueue], @"sendRequest: must be called on request queue");
   __weak __typeof(self) weakSelf = self;
   __block RCTNetworkTask *task;
+  __block UIBackgroundTaskIdentifier bgTaskIdentifier = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{
+      [task cancel];
+      [[UIApplication sharedApplication] endBackgroundTask:bgTaskIdentifier];
+  }];
+
   RCTURLRequestProgressBlock uploadProgressBlock = ^(int64_t progress, int64_t total) {
     NSArray *responseJSON = @[ task.requestID, @((double)progress), @((double)total) ];
     [weakSelf sendEventWithName:@"didSendNetworkData" body:responseJSON];
@@ -637,6 +642,7 @@ RCT_EXPORT_MODULE()
 
   RCTURLRequestCompletionBlock completionBlock = ^(NSURLResponse *response, NSData *data, NSError *error) {
     __typeof(self) strongSelf = weakSelf;
+    [[UIApplication sharedApplication] endBackgroundTask:bgTaskIdentifier];
     if (!strongSelf) {
       return;
     }


### PR DESCRIPTION
## Summary

This change allows network requests to be executed in background safely.

In certain conditions iOS HTTP requests are being terminated with this
error:

```
Error Domain=NSURLErrorDomain Code=-1005 "The network connection was lost."
```

While working on this issue I discovered this happens when app is
brought to background (sometimes several times).

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [Fixed] - Fix random network errors happening when application is in background

## Test Plan

1. Create sample express server:

    ```js
    const express = require('express');
    const app = express();
    const port = 9999;
    
    app.get('/', (req, res) => {
      setTimeout(() => {
        res.send('Hello World!');
      }, 20000);
    });
    
    app.listen(port, () => {
      console.log(`Example app listening at http://localhost:${port}`);
    });
    ```

2. Run the following code in react-native app:

    ```
    const App = () => {
      return (
        <View style={{margin: 30}}>
          <Button
            onPress={() => {
              console.log('sending a request');
              axios
                .get('http://192.168.0.110:9999')
                .then(r => {
                  console.log('response', r.data);
                })
                .catch(e => {
                  console.log('error', e);
                });
            }}
            title="REQUEST"
          />
        </View>
      );
    };
    ```

3. Hit "REQUEST" button and send app to background few times for a few seconds each. The request should succeed in the end.

