### PR TITLE
Fixed Android cliPath Gradle configuration option for build.gradle

### DIFF
--- a/react.gradle
+++ b/react.gradle
@@ -26,7 +26,7 @@ def detectEntryFile(config) {
  */
 def detectCliPath(config) {
     if (config.cliPath) {
-        return config.cliPath
+        return "${projectDir}/${config.cliPath}"
     }
     if (new File("${projectDir}/../../node_modules/react-native/cli.js").exists()) {
         return "${projectDir}/../../node_modules/react-native/cli.js"


### PR DESCRIPTION
When using monorepo with react-native you need to provide `android/app/build.gradle` following params(`cliPath`):
```
project.ext.react = [
    root: "../../../../",
    cliPath: "../../../../node_modules/react-native/cli.js",
    entryFile: "...",
    hermesCommand: "../../../../node_modules/hermes-engine/%OS-BIN%/hermesc"
]
```

With latest react-native `0.64.2` version you will get:
```
* What went wrong:
Execution failed for task ':app:bundleReleaseJsAndAssets'.
> Process 'command 'node'' finished with non-zero exit value 1
```

Debugging this issue showed that providing `cliPath` options ends up building wrong path to cli:
```
> Task :app:bundleReleaseJsAndAssets FAILED
node:internal/modules/cjs/loader:944
  throw err;
  ^

Error: Cannot find module '/node_modules/react-native/cli.js'
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:941:15)
    at Function.Module._load (node:internal/modules/cjs/loader:774:27)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:76:12)
    at node:internal/main/run_main_module:17:47 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}
```

## Summary

Changed `react.gradle` for proper File creation for `cliPath` to support this configuration option.

## Changelog

[Android] [Fixed] - Changed `react.gradle` `detectCliPath` function logic for `cliPath` case

## Test Plan

Run `./gradlew assembleRelease` or `./gradlew assembleDebug`
