### PR TITLE
[android] Propose to connect metro server programmatically

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/PackagerConnectionSettings.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/PackagerConnectionSettings.java
@@ -32,7 +32,7 @@ public class PackagerConnectionSettings {
 
   /**
    * Try to get debug server host in the order: 1. non-persistent host set by {@link
-   * #setDebugServerHostWithoutPersisting} programmatically 2. debug setting 3. default hostname for
+   * #setNonPersistentDebugServerHost} programmatically 2. debug setting 3. default hostname for
    * current device/emulator
    */
   public String getDebugServerHost() {
@@ -67,13 +67,13 @@ public class PackagerConnectionSettings {
     return mNonPersistentDebugServerHost;
   }
 
-  public synchronized void setDebugServerHostWithoutPersisting(String host) {
+  public synchronized void setNonPersistentDebugServerHost(String host) {
     mNonPersistentDebugServerHost = host;
   }
 
   /**
    * Try to get inspector server host in the order: 1. non-persistent host set by {@link
-   * #setDebugServerHostWithoutPersisting} programmatically 2. default hostname for current
+   * #setNonPersistentDebugServerHost} programmatically 2. default hostname for current
    * device/emulator
    */
   public String getInspectorServerHost() {

--- a/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/PackagerConnectionSettings.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/PackagerConnectionSettings.java
@@ -58,7 +58,7 @@ public class PackagerConnectionSettings {
     mPreferences.edit().putString(PREFS_DEBUG_SERVER_HOST_KEY, host).apply();
   }
 
-  public void setDebugServerHostWithoutPersisting(final String host, final boolean savePrefs) {
+  public void setDebugServerHostWithoutPersisting(final String host) {
     mDebugServerHost = host;
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/PackagerConnectionSettings.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/PackagerConnectionSettings.java
@@ -53,15 +53,13 @@ public class PackagerConnectionSettings {
     return host;
   }
 
-  public void setDebugServerHost(final String host) {
-    setDebugServerHost(host, true);
+  public void setDebugServerHost(String host) {
+    mDebugServerHost = host;
+    mPreferences.edit().putString(PREFS_DEBUG_SERVER_HOST_KEY, host).apply();
   }
 
-  public void setDebugServerHost(final String host, final boolean savePrefs) {
+  public void setDebugServerHostWithoutPersisting(final String host, final boolean savePrefs) {
     mDebugServerHost = host;
-    if (savePrefs) {
-      mPreferences.edit().putString(PREFS_DEBUG_SERVER_HOST_KEY, host).apply();
-    }
   }
 
   public String getInspectorServerHost() {

--- a/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/PackagerConnectionSettings.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/PackagerConnectionSettings.java
@@ -23,20 +23,20 @@ public class PackagerConnectionSettings {
   private final SharedPreferences mPreferences;
   private final String mPackageName;
   private final Context mAppContext;
+  private String mDebugServerHost;
 
   public PackagerConnectionSettings(Context applicationContext) {
     mPreferences = PreferenceManager.getDefaultSharedPreferences(applicationContext);
     mPackageName = applicationContext.getPackageName();
     mAppContext = applicationContext;
+    mDebugServerHost = mPreferences.getString(PREFS_DEBUG_SERVER_HOST_KEY, null);
   }
 
   public String getDebugServerHost() {
     // Check host setting first. If empty try to detect emulator type and use default
     // hostname for those
-    String hostFromSettings = mPreferences.getString(PREFS_DEBUG_SERVER_HOST_KEY, null);
-
-    if (!TextUtils.isEmpty(hostFromSettings)) {
-      return Assertions.assertNotNull(hostFromSettings);
+    if (!TextUtils.isEmpty(mDebugServerHost)) {
+      return Assertions.assertNotNull(mDebugServerHost);
     }
 
     String host = AndroidInfoHelpers.getServerHost(mAppContext);
@@ -53,11 +53,24 @@ public class PackagerConnectionSettings {
     return host;
   }
 
-  public void setDebugServerHost(String host) {
-    mPreferences.edit().putString(PREFS_DEBUG_SERVER_HOST_KEY, host).apply();
+  public void setDebugServerHost(final String host) {
+    setDebugServerHost(host, true);
+  }
+
+  public void setDebugServerHost(final String host, final boolean savePrefs) {
+    mDebugServerHost = host;
+    if (savePrefs) {
+      mPreferences.edit().putString(PREFS_DEBUG_SERVER_HOST_KEY, host).apply();
+    }
   }
 
   public String getInspectorServerHost() {
+    // Check host setting first. If empty try to detect emulator type and use default
+    // hostname for those
+    if (!TextUtils.isEmpty(mDebugServerHost)) {
+      return Assertions.assertNotNull(mDebugServerHost);
+    }
+
     return AndroidInfoHelpers.getInspectorProxyHost(mAppContext);
   }
 


### PR DESCRIPTION
## Summary

same as #31828 but for android. by calling `setNonPersistentDebugServerHost("192.168.123.123:12345")`, we could control the metro connection programmatically.

this pr also fix an issue for inspector connection does not honor custom packager setting. when user uses a custom metro server address in dev menu, hermes inspector cannot work in this case.

## Changelog

[Internal] [Android] [Added] - Propose to connect metro server programmatically
[Android] [Fixed] - Fix Hermes inspector does not work for custom metro server address.

## Test Plan

1. run metro server at 8082 port by `yarn start --port 8082`
2. chrome://inspect monitor `localhost:8082` port
3. launch rntester with hermes and see if chrome inspector can find rntester app.

