### PR TITLE
RN: Upgrade `infer-annotation` to 0.18.0

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -496,7 +496,7 @@ android {
 }
 
 dependencies {
-    api("com.facebook.infer.annotation:infer-annotation:0.11.2")
+    api("com.facebook.infer.annotation:infer-annotation:0.18.0")
     api("com.facebook.yoga:proguard-annotations:1.19.0")
     api("javax.inject:javax.inject:1")
     api("androidx.appcompat:appcompat:1.0.2")

--- a/ReactAndroid/src/main/third-party/java/infer-annotations/BUCK
+++ b/ReactAndroid/src/main/third-party/java/infer-annotations/BUCK
@@ -9,6 +9,6 @@ rn_prebuilt_jar(
 
 fb_native.remote_file(
     name = "infer-annotations.jar",
-    sha1 = "f514ff4ca022a579d9cf7524846988b646ae4491",
-    url = "mvn:com.facebook.infer.annotation:infer-annotation:jar:0.11.2",
+    sha1 = "27539793fe93ed7d92b6376281c16cda8278ab2f",
+    url = "mvn:com.facebook.infer.annotation:infer-annotation:jar:0.18.0",
 )


### PR DESCRIPTION
Summary:
Upgrades `infer-annotation` to 0.18.0 so that we can use `Nullsafe` in Android Java.

I found this when looking at the "Bazel" steps on this page: https://search.maven.org/artifact/com.facebook.infer.annotation/infer-annotation/0.18.0/jar

Changelog:
[Android][Changed] - Upgraded `infer-annotation` to 0.18.0.

Reviewed By: mdvacca, ShikaSD

Differential Revision: D29685321

