### PR TITLE
fix: node module resolution for react-native/normalize-color

### DIFF
--- a/packages/normalize-color/package.json
+++ b/packages/normalize-color/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@react-native/normalize-color",
   "version": "1.0.0",
+  "main": "./base",
   "description": "Color normalization code for React Native.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

I attempted to use this package in a node module but node module resolution will fail to resolve it properly.  A `package.json` without a `main` field will default to `./index.js`, but the default file here is `./base.js`. 

For future readers; even after this is merged it'll still not work with node tools because flow types are present in the file.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->


[General] [Fixed] - Added `main` field to `package.json` of `@react-native/normalize-color`

## Test Plan

- eyeball'd it