### PR TITLE
Fix TextInput selectionColor on Mac Catalyst

### DIFF
--- a/Libraries/Text/TextInput/RCTBaseTextInputViewManager.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputViewManager.m
@@ -42,7 +42,11 @@ RCT_REMAP_VIEW_PROPERTY(keyboardAppearance, backedTextInputView.keyboardAppearan
 RCT_REMAP_VIEW_PROPERTY(placeholder, backedTextInputView.placeholder, NSString)
 RCT_REMAP_VIEW_PROPERTY(placeholderTextColor, backedTextInputView.placeholderColor, UIColor)
 RCT_REMAP_VIEW_PROPERTY(returnKeyType, backedTextInputView.returnKeyType, UIReturnKeyType)
+#if TARGET_OS_MACCATALYST
+RCT_REMAP_VIEW_PROPERTY(selectionColor, backedTextInputView.textInputTraits.insertionPointColor, UIColor)
+#else
 RCT_REMAP_VIEW_PROPERTY(selectionColor, backedTextInputView.tintColor, UIColor)
+#endif
 RCT_REMAP_VIEW_PROPERTY(spellCheck, backedTextInputView.spellCheckingType, UITextSpellCheckingType)
 RCT_REMAP_VIEW_PROPERTY(caretHidden, backedTextInputView.caretHidden, BOOL)
 RCT_REMAP_VIEW_PROPERTY(clearButtonMode, backedTextInputView.clearButtonMode, UITextFieldViewMode)


### PR DESCRIPTION
## Summary

React Native's selectionColor property has no effect on the cursor color because tintColor is not recognized by Catalyst when mapping UITextField to NSTextField. Setting the input's textInputTraits insertionPointColor does work though.

## Changelog

[iOS] [Fixed] - Fix TextInput selectionColor on Mac Catalyst

## Test Plan

* Run a react-native app with a TextInput component on Mac using Catalyst with "Optimize Interface for Mac" selected and TextInput's selectionColor prop set
* TextInput's selectionColor prop should work
