### PR TITLE
Add RCT_EXTERN_REMAP_METHOD

### DIFF
--- a/React/Base/RCTBridgeModule.h
+++ b/React/Base/RCTBridgeModule.h
@@ -331,6 +331,11 @@ RCT_EXTERN_C_END
 #define RCT_EXTERN__BLOCKING_SYNCHRONOUS_METHOD(method) _RCT_EXTERN_REMAP_METHOD(, method, YES)
 
 /**
+ * Like RCT_EXTERN_METHOD, but allows setting a custom JavaScript name.
+ */
+#define RCT_EXTERN_REMAP_METHOD(js_name, method) _RCT_EXTERN_REMAP_METHOD(js_name, method, NO)
+
+/**
  * Like RCT_EXTERN_REMAP_METHOD, but allows setting a custom JavaScript name
  * and also whether this method is synchronous.
  */


### PR DESCRIPTION
## Summary

The macro _RCT_EXTERN_REMAP_METHOD stated that RCT_EXTERN_REMAP_METHOD exists, but it does not.
This adds in the macro that allows for externing a method but choosing a custom JavaScript name.
We write all of our modules in Swift, so this is useful so we don't have to set all
of the argument labels properly to match up the Swift signature with the ObjC one.

## Changelog

[iOS] [Added] - Added RCT_EXTERN_REMAP_METHOD macro for externing a method with a custom JavaScript  name.

## Test Plan

My iOS app has already switched to calling `_RCT_EXTERN_REMAP_METHOD` with this signature, and it's a trivial change. However, I am happy to add a unit test somewhere if it's useful, but a point in the right place of where to add such a test would be appreciated.
