### PR TITLE
Add INFO, and MENU key event support to Android TV

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/ReactAndroidHWInputDeviceHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactAndroidHWInputDeviceHelper.java
@@ -36,6 +36,8 @@ public class ReactAndroidHWInputDeviceHelper {
           .put(KeyEvent.KEYCODE_DPAD_RIGHT, "right")
           .put(KeyEvent.KEYCODE_DPAD_DOWN, "down")
           .put(KeyEvent.KEYCODE_DPAD_LEFT, "left")
+          .put(KeyEvent.KEYCODE_INFO, "info")
+          .put(KeyEvent.KEYCODE_MENU, "menu")
           .build();
 
   /**


### PR DESCRIPTION
## Summary

Add INFO, and MENU key event support to Android TV

## Changelog

[Android] [Added] - Add INFO, and MENU key event support to Android TV

## Test Plan

We develop application that utilizes aforementioned events, we've made a build against react-native fork with these changes and it was working as expected. These changes just add 2 more button mappings, so I don't think it requires some extensive testing.
