### PR TITLE
nullable annotations RCTURLRequestDelegate, RCTURLRequestHandler

### DIFF
--- a/React/Base/RCTURLRequestDelegate.h
+++ b/React/Base/RCTURLRequestDelegate.h
@@ -17,24 +17,24 @@
  * Call this when you send request data to the server. This is used to track
  * upload progress, so should be called multiple times for large request bodies.
  */
-- (void)URLRequest:(id)requestToken didSendDataWithProgress:(int64_t)bytesSent;
+- (void)URLRequest:(nonnull id)requestToken didSendDataWithProgress:(int64_t)bytesSent;
 
 /**
  * Call this when you first receives a response from the server. This should
  * include response headers, etc.
  */
-- (void)URLRequest:(id)requestToken didReceiveResponse:(NSURLResponse *)response;
+- (void)URLRequest:(nonnull id)requestToken didReceiveResponse:(nonnull NSURLResponse *)response;
 
 /**
  * Call this when you receive data from the server. This can be called multiple
  * times with partial data chunks, or just once with the full data packet.
  */
-- (void)URLRequest:(id)requestToken didReceiveData:(NSData *)data;
+- (void)URLRequest:(nonnull id)requestToken didReceiveData:(nonnull NSData *)data;
 
 /**
  * Call this when the request is complete and/or if an error is encountered.
  * For a successful request, the error parameter should be nil.
  */
-- (void)URLRequest:(id)requestToken didCompleteWithError:(NSError *)error;
+- (void)URLRequest:(nonnull id)requestToken didCompleteWithError:(nullable NSError *)error;
 
 @end

--- a/React/Base/RCTURLRequestHandler.h
+++ b/React/Base/RCTURLRequestHandler.h
@@ -19,7 +19,7 @@
  * request. Typically the handler would examine the scheme/protocol of the
  * request URL (and possibly the HTTP method and/or headers) to determine this.
  */
-- (BOOL)canHandleRequest:(NSURLRequest *)request;
+- (BOOL)canHandleRequest:(nonnull NSURLRequest *)request;
 
 /**
  * Send a network request and call the delegate with the response data. The
@@ -29,7 +29,7 @@
  * delegate methods, or the delegate won't recognize the token.
  * Following common Objective-C pattern, `delegate` will not be retained.
  */
-- (id)sendRequest:(NSURLRequest *)request withDelegate:(id<RCTURLRequestDelegate>)delegate;
+- (nonnull id)sendRequest:(nonnull NSURLRequest *)request withDelegate:(nonnull id<RCTURLRequestDelegate>)delegate;
 
 @optional
 
@@ -38,7 +38,7 @@
  * for ones that can. It should be used to free up any resources on ongoing
  * processes associated with the request.
  */
-- (void)cancelRequest:(id)requestToken;
+- (void)cancelRequest:(nonnull id)requestToken;
 
 /**
  * If more than one RCTURLRequestHandler responds YES to `canHandleRequest:`


### PR DESCRIPTION
## Summary

I'm working on my own custom networking module for React Native, and found that we can improve DX with nullability annotations, especially on Swift.

## Changelog

[Internal] [Changed] - nullable annotations RCTURLRequestDelegate, RCTURLRequestHandler

## Test Plan

No behavior changed, but Objective-C nullability annotations