### PR TITLE
chore: update Dimensions API Flow types

### DIFF
--- a/Libraries/Utilities/Dimensions.js
+++ b/Libraries/Utilities/Dimensions.js
@@ -46,9 +46,9 @@ class Dimensions {
    * Example: `const {height, width} = Dimensions.get('window');`
    *
    * @param {string} dim Name of dimension as defined when calling `set`.
-   * @returns {Object?} Value for the dimension.
+   * @returns {DisplayMetrics?} Value for the dimension.
    */
-  static get(dim: string): Object {
+  static get(dim: string): DisplayMetrics {
     invariant(dimensions[dim], 'No dimension set for key ' + dim);
     return dimensions[dim];
   }
@@ -59,7 +59,7 @@ class Dimensions {
    *
    * @param {object} dims Simple string-keyed object of dimensions to set
    */
-  static set(dims: $ReadOnly<{[key: string]: any, ...}>): void {
+  static set(dims: $ReadOnly<DimensionsPayload>): void {
     // We calculate the window dimensions in JS so that we don't encounter loss of
     // precision in transferring the dimensions (which could be non-integers) over
     // the bridge.
@@ -128,7 +128,7 @@ class Dimensions {
   }
 }
 
-let initialDims: ?$ReadOnly<{[key: string]: any, ...}> =
+let initialDims: ?$ReadOnly<DimensionsPayload> =
   global.nativeExtensions &&
   global.nativeExtensions.DeviceInfo &&
   global.nativeExtensions.DeviceInfo.Dimensions;

--- a/Libraries/Utilities/Dimensions.js
+++ b/Libraries/Utilities/Dimensions.js
@@ -57,7 +57,7 @@ class Dimensions {
    * This should only be called from native code by sending the
    * didUpdateDimensions event.
    *
-   * @param {object} dims Simple string-keyed object of dimensions to set
+   * @param {DimensionsPayload} dims Simple string-keyed object of dimensions to set
    */
   static set(dims: $ReadOnly<DimensionsPayload>): void {
     // We calculate the window dimensions in JS so that we don't encounter loss of

--- a/Libraries/Utilities/Dimensions.js
+++ b/Libraries/Utilities/Dimensions.js
@@ -14,6 +14,7 @@ import EventEmitter, {
 import RCTDeviceEventEmitter from '../EventEmitter/RCTDeviceEventEmitter';
 import NativeDeviceInfo, {
   type DisplayMetrics,
+  type DisplayMetricsAndroid,
   type DimensionsPayload,
 } from './NativeDeviceInfo';
 import invariant from 'invariant';
@@ -48,7 +49,7 @@ class Dimensions {
    * @param {string} dim Name of dimension as defined when calling `set`.
    * @returns {DisplayMetrics?} Value for the dimension.
    */
-  static get(dim: string): DisplayMetrics {
+  static get(dim: string): DisplayMetrics | DisplayMetricsAndroid {
     invariant(dimensions[dim], 'No dimension set for key ' + dim);
     return dimensions[dim];
   }

--- a/Libraries/Utilities/Dimensions.js
+++ b/Libraries/Utilities/Dimensions.js
@@ -19,17 +19,11 @@ import NativeDeviceInfo, {
 } from './NativeDeviceInfo';
 import invariant from 'invariant';
 
-type DimensionsValue = {
-  window?: DisplayMetrics,
-  screen?: DisplayMetrics,
-  ...
-};
-
 const eventEmitter = new EventEmitter<{
-  change: [DimensionsValue],
+  change: [DimensionsPayload],
 }>();
 let dimensionsInitialized = false;
-let dimensions: DimensionsValue;
+let dimensions: DimensionsPayload;
 
 class Dimensions {
   /**

--- a/Libraries/Utilities/Dimensions.js
+++ b/Libraries/Utilities/Dimensions.js
@@ -41,7 +41,7 @@ class Dimensions {
    * Example: `const {height, width} = Dimensions.get('window');`
    *
    * @param {string} dim Name of dimension as defined when calling `set`.
-   * @returns {DisplayMetrics?} Value for the dimension.
+   * @returns {DisplayMetrics? | DisplayMetricsAndroid?} Value for the dimension.
    */
   static get(dim: string): DisplayMetrics | DisplayMetricsAndroid {
     invariant(dimensions[dim], 'No dimension set for key ' + dim);

--- a/Libraries/Utilities/NativeDeviceInfo.js
+++ b/Libraries/Utilities/NativeDeviceInfo.js
@@ -11,7 +11,7 @@
 import type {TurboModule} from '../TurboModule/RCTExport';
 import * as TurboModuleRegistry from '../TurboModule/TurboModuleRegistry';
 
-type DisplayMetricsAndroid = {|
+export type DisplayMetricsAndroid = {|
   width: number,
   height: number,
   scale: number,

--- a/Libraries/Utilities/NativeDeviceInfo.js
+++ b/Libraries/Utilities/NativeDeviceInfo.js
@@ -12,10 +12,7 @@ import type {TurboModule} from '../TurboModule/RCTExport';
 import * as TurboModuleRegistry from '../TurboModule/TurboModuleRegistry';
 
 type DisplayMetricsAndroid = {|
-  width: number,
-  height: number,
-  scale: number,
-  fontScale: number,
+  ...DisplayMetrics,
   densityDpi: number,
 |};
 

--- a/Libraries/Utilities/NativeDeviceInfo.js
+++ b/Libraries/Utilities/NativeDeviceInfo.js
@@ -11,7 +11,11 @@
 import type {TurboModule} from '../TurboModule/RCTExport';
 import * as TurboModuleRegistry from '../TurboModule/TurboModuleRegistry';
 
-type DisplayMetricsAndroid = DisplayMetrics & {|
+type DisplayMetricsAndroid = {|
+  width: number,
+  height: number,
+  scale: number,
+  fontScale: number,
   densityDpi: number,
 |};
 

--- a/Libraries/Utilities/NativeDeviceInfo.js
+++ b/Libraries/Utilities/NativeDeviceInfo.js
@@ -11,8 +11,7 @@
 import type {TurboModule} from '../TurboModule/RCTExport';
 import * as TurboModuleRegistry from '../TurboModule/TurboModuleRegistry';
 
-type DisplayMetricsAndroid = {|
-  ...DisplayMetrics,
+type DisplayMetricsAndroid = DisplayMetrics & {|
   densityDpi: number,
 |};
 

--- a/Libraries/Utilities/useWindowDimensions.js
+++ b/Libraries/Utilities/useWindowDimensions.js
@@ -9,10 +9,13 @@
  */
 
 import Dimensions from './Dimensions';
-import {type DisplayMetrics} from './NativeDeviceInfo';
+import {
+  type DisplayMetrics,
+  type DisplayMetricsAndroid
+} from './NativeDeviceInfo';
 import {useEffect, useState} from 'react';
 
-export default function useWindowDimensions(): DisplayMetrics {
+export default function useWindowDimensions(): DisplayMetrics | DisplayMetricsAndroid {
   const [dimensions, setDimensions] = useState(() => Dimensions.get('window'));
   useEffect(() => {
     function handleChange({window}) {

--- a/Libraries/Utilities/useWindowDimensions.js
+++ b/Libraries/Utilities/useWindowDimensions.js
@@ -11,11 +11,13 @@
 import Dimensions from './Dimensions';
 import {
   type DisplayMetrics,
-  type DisplayMetricsAndroid
+  type DisplayMetricsAndroid,
 } from './NativeDeviceInfo';
 import {useEffect, useState} from 'react';
 
-export default function useWindowDimensions(): DisplayMetrics | DisplayMetricsAndroid {
+export default function useWindowDimensions():
+  | DisplayMetrics
+  | DisplayMetricsAndroid {
   const [dimensions, setDimensions] = useState(() => Dimensions.get('window'));
   useEffect(() => {
     function handleChange({window}) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

This small PR updates the Flow types used in Dimensions. The following changes has been made:
* generic types has been replaced with types from `NativeDeviceInfo` (which already were used in event subscription update)
* ~simplification of `DisplayMetricsAndroid` by spreading via intersection with `DisplayMetrics` type and removing shared properties~ 
  > I have tried both notations, but according to the lint, it looks like a Native Modules typing limitation which requires redundancy / code duplication in cases like this.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Internal] [Changed] - update Dimensions API Flow types

## Test Plan

Running `yarn flow` in the workspace yields no errors.
