### PR TITLE
Fix typo and grammar

### DIFF
--- a/packages/rn-tester/js/examples/Modal/ModalOnShow.js
+++ b/packages/rn-tester/js/examples/Modal/ModalOnShow.js
@@ -132,6 +132,6 @@ export default ({
   title: "Modal's onShow/onDismiss",
   name: 'onShow',
   description:
-    'onShow and onDismiss (iOS only) callbacks are called when modals is shown/dissmissed',
+    'onShow and onDismiss (iOS only) callbacks are called when a modal is shown/dismissed',
   render: (): React.Node => <ModalOnShowOnDismiss />,
 }: RNTesterModuleExample);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

> Always leave the campground cleaner than you found it.

Fixing:
* typo in _dismissed_
* make the subject agree with the verb

## Changelog

[Internal] [Fixed] - A typo in a comment

## Test Plan

Grammarly says it's better now.
