### PR TITLE
[iOS] Fix Websockets Memory leaks

### DIFF
--- a/Libraries/WebSocket/RCTSRWebSocket.m
+++ b/Libraries/WebSocket/RCTSRWebSocket.m
@@ -1462,6 +1462,7 @@ static const size_t RCTSRFrameHeaderOverhead = 32;
   dispatch_async(_workQueue, ^{
     self->_selfRetain = nil;
   });
+  _cleanupScheduled = NO;
 }
 
 @end


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

While testing WebSockets connections against a server that was having problems (returning 403 errors) on the Rainbow Wallet iOS app  we detected that our connection retry logic was triggering a huge memory leak, making the app run out of memory after a few minutes and crash.

After looking at the implementation of RCTWebSocket.m I realized that the `_cleanupScheduled` flag was never reset after completing the clean up operations:
- Remove the streams from the networkRunLoop
- Unschedule from RunLoop
- Nuke NSStream's delegate
- Cleanup selfRetain in the same GCD queue

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [Fixed] - Fix memory leak in Websockets module

## Test Plan

Here you can see how the memory consumption before and after the fix while having the app running over 2 minutes.

BEFORE:

<img width="813" alt="Screen Shot 2021-07-28 at 12 00 29 PM" src="https://user-images.githubusercontent.com/1247834/127375924-6204339d-3b0a-4172-9756-e458c99ac0ea.png">

AFTER: 

<img width="971" alt="Screen Shot 2021-07-28 at 11 54 06 AM" src="https://user-images.githubusercontent.com/1247834/127375958-a6fbd967-4e50-4c81-9dec-8f56fbca4304.png">

xCode instruments show the same results.


This fix it's not that easy to test since you'll need a server returning a >= 400 error code and having the app side trying to reconnect after receiving the `onclose` event, however the fix itself is very clear and straight forward so I hope you consider it.

