### PR TITLE
fix animated value synchronization on detach

### DIFF
--- a/Libraries/Animated/NativeAnimatedHelper.js
+++ b/Libraries/Animated/NativeAnimatedHelper.js
@@ -53,7 +53,7 @@ const API = {
   },
   getState: function(
     tag: number,
-    callback: (state: { offset: number, value: number }) => void,
+    callback: (state: {offset: number, value: number}) => void,
   ): void {
     invariant(NativeAnimatedModule, 'Native animated module is not available');
     if (NativeAnimatedModule.getState) {

--- a/Libraries/Animated/NativeAnimatedHelper.js
+++ b/Libraries/Animated/NativeAnimatedHelper.js
@@ -51,6 +51,15 @@ const API = {
       NativeAnimatedModule.getValue(tag, saveValueCallback);
     }
   },
+  getState: function(
+    tag: number,
+    callback: (state: { offset: number, value: number }) => void,
+  ): void {
+    invariant(NativeAnimatedModule, 'Native animated module is not available');
+    if (NativeAnimatedModule.getState) {
+      NativeAnimatedModule.getState(tag, callback);
+    }
+  },
   setWaitingForIdentifier: function(id: string): void {
     waitingForQueuedOperations.add(id);
     queueOperations = true;

--- a/Libraries/Animated/NativeAnimatedModule.js
+++ b/Libraries/Animated/NativeAnimatedModule.js
@@ -13,6 +13,7 @@ import * as TurboModuleRegistry from '../TurboModule/TurboModuleRegistry';
 
 type EndResult = {finished: boolean, ...};
 type EndCallback = (result: EndResult) => void;
+type GetStateCallback = (state: { offset: number, value: number }) => void;
 type SaveValueCallback = (value: number) => void;
 
 export type EventMapping = {|
@@ -30,6 +31,7 @@ export interface Spec extends TurboModule {
   +finishOperationBatch: () => void;
   +createAnimatedNode: (tag: number, config: AnimatedNodeConfig) => void;
   +getValue: (tag: number, saveValueCallback: SaveValueCallback) => void;
+  +getState: (tag: number, callback: GetStateCallback) => void;
   +startListeningToAnimatedNodeValue: (tag: number) => void;
   +stopListeningToAnimatedNodeValue: (tag: number) => void;
   +connectAnimatedNodes: (parentTag: number, childTag: number) => void;

--- a/Libraries/Animated/nodes/AnimatedValue.js
+++ b/Libraries/Animated/nodes/AnimatedValue.js
@@ -98,7 +98,7 @@ class AnimatedValue extends AnimatedWithChildren {
 
   __detach() {
     if (this.__isNative) {
-      NativeAnimatedAPI.getValue(this.__getNativeTag(), value => {
+      NativeAnimatedAPI.getState(this.__getNativeTag(), ({ value }) => {
         this._value = value;
       });
     }

--- a/Libraries/Animated/nodes/AnimatedValue.js
+++ b/Libraries/Animated/nodes/AnimatedValue.js
@@ -98,7 +98,7 @@ class AnimatedValue extends AnimatedWithChildren {
 
   __detach() {
     if (this.__isNative) {
-      NativeAnimatedAPI.getState(this.__getNativeTag(), ({ value }) => {
+      NativeAnimatedAPI.getState(this.__getNativeTag(), ({value}) => {
         this._value = value;
       });
     }

--- a/Libraries/NativeAnimation/Nodes/RCTValueAnimatedNode.h
+++ b/Libraries/NativeAnimation/Nodes/RCTValueAnimatedNode.h
@@ -9,6 +9,11 @@
 
 #import "RCTAnimatedNode.h"
 
+typedef struct {
+  CGFloat offset;
+  CGFloat value;
+} State;
+
 @class RCTValueAnimatedNode;
 
 @protocol RCTValueAnimatedNodeObserver <NSObject>
@@ -22,6 +27,7 @@
 - (void)setOffset:(CGFloat)offset;
 - (void)flattenOffset;
 - (void)extractOffset;
+- (State)getState;
 
 @property (nonatomic, assign) CGFloat value;
 @property (nonatomic, strong) id animatedObject;

--- a/Libraries/NativeAnimation/Nodes/RCTValueAnimatedNode.m
+++ b/Libraries/NativeAnimation/Nodes/RCTValueAnimatedNode.m
@@ -53,4 +53,9 @@
   }
 }
 
+- (State)getState
+{
+  return (State){.offset = _offset, .value = _value};
+}
+
 @end

--- a/Libraries/NativeAnimation/RCTNativeAnimatedNodesManager.h
+++ b/Libraries/NativeAnimation/RCTNativeAnimatedNodesManager.h
@@ -27,6 +27,9 @@
 - (void)getValue:(nonnull NSNumber *)nodeTag
         saveCallback:(nullable RCTResponseSenderBlock)saveCallback;
 
+- (void)getState:(nonnull NSNumber *)nodeTag
+        callback:(nullable RCTResponseSenderBlock)callback;
+
 // graph
 
 - (void)createAnimatedNode:(nonnull NSNumber *)tag

--- a/Libraries/NativeAnimation/RCTNativeAnimatedNodesManager.m
+++ b/Libraries/NativeAnimation/RCTNativeAnimatedNodesManager.m
@@ -258,6 +258,18 @@ static NSString *RCTNormalizeAnimatedEventName(NSString *eventName)
     saveCallback(@[@(valueNode.value)]);
 }
 
+- (void)getState:(NSNumber *)nodeTag callback:(RCTResponseSenderBlock)callback
+{
+     RCTAnimatedNode *node = _animationNodes[nodeTag];
+     if (![node isKindOfClass:[RCTValueAnimatedNode class]]) {
+       RCTLogError(@"Not a value node.");
+       return;
+     }
+    RCTValueAnimatedNode *valueNode = (RCTValueAnimatedNode *)node;
+    State state = [valueNode getState];
+    callback(@[@{@"offset": @(state.offset), @"value": @(state.value)}]);
+}
+
 #pragma mark -- Drivers
 
 - (void)startAnimatingNode:(nonnull NSNumber *)animationId

--- a/Libraries/NativeAnimation/RCTNativeAnimatedTurboModule.mm
+++ b/Libraries/NativeAnimation/RCTNativeAnimatedTurboModule.mm
@@ -260,6 +260,12 @@ RCT_EXPORT_METHOD(getValue:(double)nodeTag saveValueCallback:(RCTResponseSenderB
   }];
 }
 
+RCT_EXPORT_METHOD(getState:(double)nodeTag callback:(RCTResponseSenderBlock)callback) {
+  [self addOperationBlock:^(RCTNativeAnimatedNodesManager *nodesManager) {
+      [nodesManager getState:[NSNumber numberWithDouble:nodeTag] callback:callback];
+  }];
+}
+
 #pragma mark -- Batch handling
 
 - (void)addOperationBlock:(AnimatedOperation)operation

--- a/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedModule.java
@@ -899,4 +899,16 @@ public class NativeAnimatedModule extends NativeAnimatedModuleSpec
       context.removeLifecycleEventListener(this);
     }
   }
+
+  @Override
+  public void getState(final double animatedValueNodeTagDouble, final Callback callback) {
+    final int animatedValueNodeTag = (int) animatedValueNodeTagDouble;
+    addOperation(
+        new UIThreadOperation() {
+          @Override
+          public void execute(NativeAnimatedNodesManager animatedNodesManager) {
+            animatedNodesManager.getState(animatedValueNodeTag, callback);
+          }
+        });
+  }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedNodesManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedNodesManager.java
@@ -23,6 +23,7 @@ import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.UIManager;
 import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.bridge.WritableNativeMap;
 import com.facebook.react.uimanager.UIManagerHelper;
 import com.facebook.react.uimanager.common.UIManagerType;
 import com.facebook.react.uimanager.events.Event;
@@ -432,6 +433,20 @@ import java.util.Queue;
           "getValue: Animated node with tag [" + tag + "] does not exist or is not a 'value' node");
     }
     callback.invoke(((ValueAnimatedNode) node).getValue());
+  }
+
+  @UiThread
+  public void getState(int tag, Callback callback) {
+    AnimatedNode node = mAnimatedNodes.get(tag);
+    if (node == null || !(node instanceof ValueAnimatedNode)) {
+      throw new JSApplicationIllegalArgumentException(
+          "Animated node with tag " + tag + " does not exists or is not a 'value' node");
+    }
+    State state = ((ValueAnimatedNode) node).getState();
+    WritableNativeMap map = new WritableNativeMap();
+    map.putDouble("offset", state.offset);
+    map.putDouble("value", state.value);
+    callback.invoke(map);
   }
 
   @UiThread

--- a/ReactAndroid/src/main/java/com/facebook/react/animated/ValueAnimatedNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/animated/ValueAnimatedNode.java
@@ -10,6 +10,16 @@ package com.facebook.react.animated;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ReadableMap;
 
+class State {
+  public final double offset;
+  public final double value;
+
+  State(double value, double offset) {
+    this.offset = offset;
+    this.value = value;
+  }
+}
+
 /**
  * Basic type of animated node that maps directly from {@code Animated.Value(x)} of Animated.js
  * library.
@@ -34,6 +44,14 @@ import com.facebook.react.bridge.ReadableMap;
       this.update();
     }
     return mOffset + mValue;
+  }
+
+  public State getState() {
+    if (Double.isNaN(mOffset + mValue)) {
+      this.update();
+    }
+
+    return new State(mValue, mOffset);
   }
 
   public Object getAnimatedObject() {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

When an animated value node is detached, and native animations are enabled, the value is synchronized with the native state. However, this incorrectly includes the offset in the value.

The problem was introduced with this commit https://github.com/facebook/react-native/commit/d92284216f4b079079f7ee479f35c94c900bc701. This PR adds a new method called `getState` that returns both the raw value and offset of the animated value. I added a new method to avoid breaking changes.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Fixed] - Fix synchronization of animation state when animation completes when using native animations.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
