### PR TITLE
Prevent duplicate accessibilityLabel on parent views

### DIFF
--- a/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -641,8 +641,14 @@ static RCTBorderStyle RCTBorderStyleFromBorderStyle(BorderStyle borderStyle)
 
 static NSString *RCTRecursiveAccessibilityLabel(UIView *view)
 {
-  NSMutableString *result = [NSMutableString stringWithString:@""];
+  NSMutableString *result = [NSMutableString string];
   for (UIView *subview in view.subviews) {
+    // Ignore non-text subviews that are accessible themselves because we don't want
+    // to create ambiguity with multiple views having the same label.
+    // (e.g. <View> that contains a <TouchableHighlight>)
+    if (subview.isAccessibilityElement && [subview isKindOfClass:[RCTViewComponentView class]]) {
+      continue;
+    }
     NSString *label = subview.accessibilityLabel;
     if (!label) {
       label = RCTRecursiveAccessibilityLabel(subview);

--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -82,8 +82,14 @@ UIAccessibilityTraits const SwitchAccessibilityTrait = 0x20000000000001;
 
 static NSString *RCTRecursiveAccessibilityLabel(UIView *view)
 {
-  NSMutableString *str = [NSMutableString stringWithString:@""];
+  NSMutableString *str = [NSMutableString string];
   for (UIView *subview in view.subviews) {
+    // Ignore non-text subviews that are accessible themselves because we don't want
+    // to create ambiguity with multiple views having the same label.
+    // (e.g. <View> that contains a <TouchableHighlight>)
+    if (subview.isAccessibilityElement && [subview isKindOfClass:[RCTView class]]) {
+      continue;
+    }
     NSString *label = subview.accessibilityLabel;
     if (!label) {
       label = RCTRecursiveAccessibilityLabel(subview);

--- a/packages/rn-tester/js/examples/Accessibility/AccessibilityIOSExample.js
+++ b/packages/rn-tester/js/examples/Accessibility/AccessibilityIOSExample.js
@@ -55,6 +55,26 @@ class AccessibilityIOSExample extends React.Component<Props> {
             This view's children are hidden from the accessibility tree
           </Text>
         </View>
+        <View>
+          <Text>
+            Nested accessibility elements do not have recursive text content
+          </Text>
+          <View accessible>
+            <Text>The label is View 1</Text>
+            <View accessible>
+              <Text>This text is not in the label</Text>
+            </View>
+          </View>
+          <View accessible>
+            <Text>The label is View 2</Text>
+            <View accessible>
+              <Text>This text is not in the label</Text>
+            </View>
+            <View>
+              <Text>and this text is in the label</Text>
+            </View>
+          </View>
+        </View>
       </RNTesterBlock>
     );
   }


### PR DESCRIPTION
## Summary

In testing React Native apps using Appium, the `accessibilityLabel` is an important prop which provides an additional means to lookup elements in addition to the `testID`. More importantly, the `accessibilityLabel` provides detail to screen readers and other accessibility helpers. React Native on iOS has custom logic (compared to Android), whereby it concatenates the accessibility labels of children. This is useful in a case such as this:

```
<TouchableHighlight accessibilityRole="button" onPress={...}>
  <Text>This button</Text>
  <Text>Does something useful</Text>
</TouchableHighlight>
```
The above creates the following accessibility view:
```
<UIView accessibilityLabel="This button Does something useful" />
```
and when viewed in Appium Studio
```
<XCUIElementTypeButton name="This button Does something useful" />
```

However, if the above is in one or more views, such as:
```
<View>
  <View>
    <TouchableHighlight accessibilityRole="button" onPress={...}>
      <Text>This button</Text>
      <Text>Does something useful</Text>
    </TouchableHighlight>
  </View>
  <FlatList ... />
</View>
```
You can get the following from XCUITest and Appium:
```
<XCUIElementTypeOther name="This button Does something useful">
  <XCUIElementTypeOther name="This button Does something useful">
    <XCUIElementTypeButton name="This button Does something useful" />
  </XCUIElementTypeOther>
</XCUIElementTypeOther>
```
This happens because the parent Views are using `RCTRecursiveAccessibilityLabel()` to populate the label from the child Touchable. This doesn't make sense semantically because the TouchableHighlight is an accessible element. It benefits from the concatenation to create its label from the two Text elements, but the container views are not part of that label. They should not include it.

This PR should fix #21830, and it represents a possibly lower impact alternative to #24113, #24118, #29801, and #31222. It's not clear what functionality is relying on the string concatenation as it is currently implemented.

## Changelog

Change the recursion algorithm to include labels from accessible elements _only if_ they are not other types of `RCTView` instances. For example, `RCTTextView` should be included. This helps to minimize the impact of this change on other developers of custom views.

[iOS] [Changed] - When iterating over subviews, ignore subviews that are accessible elements (e.g. Touchable).

## Test Plan

Verified that accessibility labels on `<Touchable>` elements maintain existing behavior with nested Text elements.
Verified that accessibility labels on non-accessible views do not include all child labels.

I added an example to `AccessibilityIOSExample.js` which can be used with VoiceOver to see the new behavior. In the example, text nested inside accessible subviews is not part of the spoken label.
