### PR TITLE
Update Android Dockerfile to include root BUCK file

### DIFF
--- a/.circleci/Dockerfiles/Dockerfile.android
+++ b/.circleci/Dockerfiles/Dockerfile.android
@@ -25,6 +25,7 @@ ENV JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
 
 ADD .buckconfig /app/.buckconfig
 ADD .buckjavaargs /app/.buckjavaargs
+ADD BUCK /app/BUCK
 ADD Libraries /app/Libraries
 ADD ReactAndroid /app/ReactAndroid
 ADD ReactCommon /app/ReactCommon


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Adds the root BUCK file to the Docker image we use to test RNTester on CircleCI. See https://github.com/facebook/react-native/commit/df9cd05621f58fe5c67f889b741bfff20c780b0e

Differential Revision: D30099261

