### PR TITLE
Add Query String Parsing Logic to URL Constructor

### DIFF
--- a/Libraries/Blob/URL.js
+++ b/Libraries/Blob/URL.js
@@ -126,9 +126,10 @@ export class URL {
 
   constructor(url: string, base: string) {
     let baseUrl = null;
+    const queryStringStart = url.indexOf('?');
     if (!base || validateBaseUrl(url)) {
       this._url = url;
-      if (!this._url.endsWith('/') && url.indexOf('?') < 0) {
+      if (!this._url.endsWith('/') && queryStringStart < 0) {
         this._url += '/';
       }
     } else {
@@ -152,10 +153,10 @@ export class URL {
       this._url = `${baseUrl}${url}`;
     }
 
-    let queryStringStart = this._url.indexOf('?');
     if (queryStringStart < 0) {
       return;
     }
+
     let queryString = this._url.substring(queryStringStart + 1);
 
     this._url = this._url.substr(0, queryStringStart);

--- a/Libraries/Blob/URL.js
+++ b/Libraries/Blob/URL.js
@@ -126,10 +126,9 @@ export class URL {
 
   constructor(url: string, base: string) {
     let baseUrl = null;
-    const queryStringStart = url.indexOf('?');
     if (!base || validateBaseUrl(url)) {
       this._url = url;
-      if (!this._url.endsWith('/') && queryStringStart < 0) {
+      if (!this._url.endsWith('/') && url.indexOf('?') < 0) {
         this._url += '/';
       }
     } else {
@@ -153,16 +152,25 @@ export class URL {
       this._url = `${baseUrl}${url}`;
     }
 
+    let queryStringStart = this._url.indexOf('?');
     if (queryStringStart < 0) {
       return;
     }
 
-    let queryString = this._url.substring(queryStringStart + 1);
+    const queryString = this._url.substring(queryStringStart + 1);
 
     this._url = this._url.substr(0, queryStringStart);
     let searchParams = queryString.split('&').reduce((agg, pair) => {
-      let [key, value] = pair.split('=');
-      agg[key] = value;
+      if (!pair) { return agg; }
+      const seperatorIndex = pair.indexOf('=');
+      if (seperatorIndex < 0) {
+        agg[pair] = '';
+      } else {
+        const key = pair.substring(0, seperatorIndex);
+        const value = pair.substr(seperatorIndex + 1);
+        agg[key] = value;
+      }
+
       return agg;
     }, {});
 

--- a/Libraries/Blob/URL.js
+++ b/Libraries/Blob/URL.js
@@ -161,7 +161,9 @@ export class URL {
 
     this._url = this._url.substr(0, queryStringStart);
     let searchParams = queryString.split('&').reduce((agg, pair) => {
-      if (!pair) { return agg; }
+      if (!pair) {
+        return agg;
+      }
       const seperatorIndex = pair.indexOf('=');
       if (seperatorIndex < 0) {
         agg[pair] = '';

--- a/Libraries/Blob/URL.js
+++ b/Libraries/Blob/URL.js
@@ -128,7 +128,7 @@ export class URL {
     let baseUrl = null;
     if (!base || validateBaseUrl(url)) {
       this._url = url;
-      if (!this._url.endsWith('/')) {
+      if (!this._url.endsWith('/') && url.indexOf('?') < 0) {
         this._url += '/';
       }
     } else {
@@ -151,6 +151,19 @@ export class URL {
       }
       this._url = `${baseUrl}${url}`;
     }
+
+    let queryStringStart = this._url.indexOf('?');
+    if (queryStringStart < 0) { return; }
+    let queryString = this._url.substring(queryStringStart + 1);
+
+    this._url = this._url.substr(0, queryStringStart);
+    let searchParams = queryString.split('&').reduce((agg, pair) => {
+      let [key, value] = pair.split('=');
+      agg[key] = value;
+      return agg;
+    }, {});
+
+    this._searchParamsInstance = new URLSearchParams(searchParams);
   }
 
   get hash() {

--- a/Libraries/Blob/URL.js
+++ b/Libraries/Blob/URL.js
@@ -153,7 +153,9 @@ export class URL {
     }
 
     let queryStringStart = this._url.indexOf('?');
-    if (queryStringStart < 0) { return; }
+    if (queryStringStart < 0) {
+      return;
+    }
     let queryString = this._url.substring(queryStringStart + 1);
 
     this._url = this._url.substr(0, queryStringStart);

--- a/Libraries/Blob/__tests__/URL-test.js
+++ b/Libraries/Blob/__tests__/URL-test.js
@@ -56,5 +56,14 @@ describe('URL', function() {
     d.searchParams.append('utm', 'facebook');
     expect(d.href).toBe('https://google.com/search?q=test&utm=facebook');
     expect([...d.searchParams].length).toBe(2);
+    const e = new URL('https://google.com/search?q');
+    expect(e.href).toBe('https://google.com/search?q=');
+    expect([...e.searchParams].length).toBe(1);
+    const f = new URL('https://google.com/search?q=test&');
+    expect(f.href).toBe('https://google.com/search?q=test');
+    expect([...f.searchParams].length).toBe(1);
+    const g = new URL('https://google.com/search?q=test=again');
+    expect(g.href).toBe('https://google.com/search?q=test=again');
+    expect([...g.searchParams].length).toBe(1);
   });
 });

--- a/Libraries/Blob/__tests__/URL-test.js
+++ b/Libraries/Blob/__tests__/URL-test.js
@@ -41,4 +41,20 @@ describe('URL', function() {
     const k = new URL('en-US/docs', 'https://developer.mozilla.org');
     expect(k.href).toBe('https://developer.mozilla.org/en-US/docs');
   });
+
+  it('should properly parse query strings', () => {
+    const a = new URL('/search?q=test', 'https://google.com');
+    expect(a.href).toBe('https://google.com/search?q=test');
+    expect([...a.searchParams].length).toBe(1);
+    const b = new URL('https://google.com/search?q=test');
+    expect(b.href).toBe('https://google.com/search?q=test');
+    expect([...b.searchParams].length).toBe(1);
+    const c = new URL('https://google.com/search?q=test&utm=facebook');
+    expect(c.href).toBe('https://google.com/search?q=test&utm=facebook');
+    expect([...c.searchParams].length).toBe(2);
+    const d = new URL('https://google.com/search?q=test');
+    d.searchParams.append('utm', 'facebook');
+    expect(d.href).toBe('https://google.com/search?q=test&utm=facebook');
+    expect([...d.searchParams].length).toBe(2);
+  });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Currently, the `URL` library is broken when parsing URLs that include query strings. See #31956.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Fixed] - The URL Constructor now properly parses and stores Query String parameters if included.

## Test Plan

Included several permutations of different URL parsing tests to the `URL` test suite. Also tested using https://github.com/adzerk/adzerk-decision-sdk-js to request Ads from Kevel (which is currently broken because of URL parsing issues).
