### PR TITLE
Expose react-native-codegen for android

### DIFF
--- a/packages/react-native-codegen/package.json
+++ b/packages/react-native-codegen/package.json
@@ -15,7 +15,8 @@
   },
   "license": "MIT",
   "files": [
-    "lib"
+    "lib",
+    "android"
   ],
   "dependencies": {
     "flow-parser": "^0.121.0",

--- a/packages/react-native-codegen/package.json
+++ b/packages/react-native-codegen/package.json
@@ -16,7 +16,8 @@
   "license": "MIT",
   "files": [
     "lib",
-    "android"
+    "android",
+    "scripts"
   ],
   "dependencies": {
     "flow-parser": "^0.121.0",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

This change will expose android part of react-native-codegen in node_modules when it's installed.

This will help users who needs to build ReactAndroid from source for RN 0.64+ (Related Issue: https://github.com/facebook/react-native/issues/31176 )

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Internal] [Changed] - Expose react-native-codegen for android

## Test Plan
- [ ] Building Android from source by making following change to `settings.gradle`

```
pluginManagement {
    repositories {
        gradlePluginPortal()
        mavenLocal()
        google()
    }
}

source
include ':ReactAndroid'
project(':ReactAndroid').projectDir = new File(
    rootProject.projectDir, '../node_modules/react-native/ReactAndroid')

include(":packages:react-native-codegen:android")
project(":packages:react-native-codegen:android").projectDir = new File(rootProject.projectDir, 
"../node_modules/react-native-codegen/android")

includeBuild("../node_modules/react-native-codegen/android")
```

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
