### PR TITLE
fix: compare the LogBoxData ignorePatterns with the right code

### DIFF
--- a/Libraries/LogBox/Data/LogBoxData.js
+++ b/Libraries/LogBox/Data/LogBoxData.js
@@ -330,7 +330,7 @@ export function addIgnorePatterns(
   // The same pattern may be added multiple times, but adding a new pattern
   // can be expensive so let's find only the ones that are new.
   patterns.forEach((pattern: IgnorePattern) => {
-    if (pattern instanceof RegExp) { 
+    if (pattern instanceof RegExp) {
       for (const existingPattern of ignorePatterns) {
         if (
           existingPattern instanceof RegExp &&

--- a/Libraries/LogBox/Data/LogBoxData.js
+++ b/Libraries/LogBox/Data/LogBoxData.js
@@ -329,8 +329,8 @@ export function addIgnorePatterns(
     if (pattern instanceof RegExp) {
       for (const existingPattern of ignorePatterns.entries()) {
         if (
-          existingPattern instanceof RegExp &&
-          existingPattern.toString() === pattern.toString()
+          existingPattern[0] instanceof RegExp &&
+          existingPattern[0].toString() === pattern.toString()
         ) {
           return false;
         }

--- a/Libraries/LogBox/Data/LogBoxData.js
+++ b/Libraries/LogBox/Data/LogBoxData.js
@@ -320,40 +320,36 @@ export function checkWarningFilter(format: string): WarningInfo {
   return warningFilter(format);
 }
 
+export function getIgnorePatterns(): $ReadOnlyArray<IgnorePattern> {
+  return Array.from(ignorePatterns);
+}
+
 export function addIgnorePatterns(
   patterns: $ReadOnlyArray<IgnorePattern>,
 ): void {
   // The same pattern may be added multiple times, but adding a new pattern
   // can be expensive so let's find only the ones that are new.
-  const newPatterns = patterns.filter((pattern: IgnorePattern) => {
-    if (pattern instanceof RegExp) {
-      for (const existingPattern of ignorePatterns.entries()) {
+  patterns.forEach((pattern: IgnorePattern) => {
+    if (pattern instanceof RegExp) { 
+      for (const existingPattern of ignorePatterns) {
         if (
-          existingPattern[0] instanceof RegExp &&
-          existingPattern[0].toString() === pattern.toString()
+          existingPattern instanceof RegExp &&
+          existingPattern.toString() === pattern.toString()
         ) {
-          return false;
+          return;
         }
       }
-      return true;
+      ignorePatterns.add(pattern);
     }
-    return !ignorePatterns.has(pattern);
-  });
-
-  if (newPatterns.length === 0) {
-    return;
-  }
-  for (const pattern of newPatterns) {
     ignorePatterns.add(pattern);
-
-    // We need to recheck all of the existing logs.
-    // This allows adding an ignore pattern anywhere in the codebase.
-    // Without this, if you ignore a pattern after the a log is created,
-    // then we would keep showing the log.
-    logs = new Set(
-      Array.from(logs).filter(log => !isMessageIgnored(log.message.content)),
-    );
-  }
+  });
+  // We need to recheck all of the existing logs.
+  // This allows adding an ignore pattern anywhere in the codebase.
+  // Without this, if you ignore a pattern after the a log is created,
+  // then we would keep showing the log.
+  logs = new Set(
+    Array.from(logs).filter(log => !isMessageIgnored(log.message.content)),
+  );
   handleUpdate();
 }
 

--- a/Libraries/LogBox/Data/LogBoxData.js
+++ b/Libraries/LogBox/Data/LogBoxData.js
@@ -327,6 +327,7 @@ export function getIgnorePatterns(): $ReadOnlyArray<IgnorePattern> {
 export function addIgnorePatterns(
   patterns: $ReadOnlyArray<IgnorePattern>,
 ): void {
+  const existingSize = ignorePatterns.size;
   // The same pattern may be added multiple times, but adding a new pattern
   // can be expensive so let's find only the ones that are new.
   patterns.forEach((pattern: IgnorePattern) => {
@@ -343,6 +344,9 @@ export function addIgnorePatterns(
     }
     ignorePatterns.add(pattern);
   });
+  if (ignorePatterns.size === existingSize) {
+    return;
+  }
   // We need to recheck all of the existing logs.
   // This allows adding an ignore pattern anywhere in the codebase.
   // Without this, if you ignore a pattern after the a log is created,

--- a/Libraries/LogBox/Data/__tests__/LogBoxData-test.js
+++ b/Libraries/LogBox/Data/__tests__/LogBoxData-test.js
@@ -418,6 +418,26 @@ describe('LogBoxData', () => {
     expect(logs[0].count).toBe(2);
   });
 
+  it('adding same pattern multiple times', () => {
+    expect(LogBoxData.getIgnorePatterns().length).toBe(0);
+    LogBoxData.addIgnorePatterns(['abc']);
+    expect(LogBoxData.getIgnorePatterns().length).toBe(1);
+    LogBoxData.addIgnorePatterns([/abc/]);
+    expect(LogBoxData.getIgnorePatterns().length).toBe(2);
+    LogBoxData.addIgnorePatterns(['abc']);
+    expect(LogBoxData.getIgnorePatterns().length).toBe(2);
+    LogBoxData.addIgnorePatterns([/abc/]);
+    expect(LogBoxData.getIgnorePatterns().length).toBe(2);
+  });
+
+  it('adding duplicated patterns', () => {
+    expect(LogBoxData.getIgnorePatterns().length).toBe(0);
+    LogBoxData.addIgnorePatterns(['abc', /ab/, /abc/, /abc/, 'abc']);
+    expect(LogBoxData.getIgnorePatterns().length).toBe(3);
+    LogBoxData.addIgnorePatterns([/ab/, /abc/]);
+    expect(LogBoxData.getIgnorePatterns().length).toBe(3);
+  });
+
   it('ignores logs matching patterns (logs)', () => {
     addLogs(['A!', 'B?', 'C!']);
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

the `LogBoxData.addIgnorePatterns` function shows the wrong code to get a item in `Set`. because every item in `set.entries` looks like `[value, value]`, but not `value`.

while the `addIgnorePatterns` function evalutes two itertaions that is not necessary. So I refacted this function.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Fixed] - for LogBox checking existingPattern in a wrong way.
[General] [Changed] - addIgnorePatterns runs in one iteration.
[General] [Added] - add a function `getIgnorePatterns` in `LogBoxData.js` for tests or other usecases.

## Test Plan

test codes in `LogBoxData-test.js`:
````js
it('adding same pattern multiple times', () => {
    expect(LogBoxData.getIgnorePatterns().length).toBe(0);
    LogBoxData.addIgnorePatterns(['abc']);
    expect(LogBoxData.getIgnorePatterns().length).toBe(1);
    LogBoxData.addIgnorePatterns([/abc/]);
    expect(LogBoxData.getIgnorePatterns().length).toBe(2);
    LogBoxData.addIgnorePatterns(['abc']);
    expect(LogBoxData.getIgnorePatterns().length).toBe(2);
    LogBoxData.addIgnorePatterns([/abc/]);
    expect(LogBoxData.getIgnorePatterns().length).toBe(2);
  });

  it('adding duplicated patterns', () => {
    expect(LogBoxData.getIgnorePatterns().length).toBe(0);
    LogBoxData.addIgnorePatterns(['abc', /ab/, /abc/, /abc/, 'abc']);
    expect(LogBoxData.getIgnorePatterns().length).toBe(3);
    LogBoxData.addIgnorePatterns([/ab/, /abc/]);
    expect(LogBoxData.getIgnorePatterns().length).toBe(3);
  });
````

and they have passed
