### PR TITLE
test(AnimatedMock): make mocks .start callback async + implemented on all animations

### DIFF
--- a/Libraries/Animated/AnimatedMock.js
+++ b/Libraries/Animated/AnimatedMock.js
@@ -39,7 +39,10 @@ export type CompositeAnimation = {
 };
 
 const emptyAnimation = {
-  start: () => {},
+  start: (callback?: ?EndCallback) => {
+    // we use setTimeout here so that the callbacks are async
+    if (callback) setTimeout(callback, 0);
+  },
   stop: () => {},
   reset: () => {},
   _startNativeLoop: () => {},
@@ -57,7 +60,7 @@ const spring = function(
     ...emptyAnimation,
     start: (callback?: ?EndCallback): void => {
       anyValue.setValue(config.toValue);
-      callback && callback({finished: true});
+      emptyAnimation.start(callback);
     },
   };
 };
@@ -71,7 +74,7 @@ const timing = function(
     ...emptyAnimation,
     start: (callback?: ?EndCallback): void => {
       anyValue.setValue(config.toValue);
-      callback && callback({finished: true});
+      emptyAnimation.start(callback);
     },
   };
 };

--- a/Libraries/Animated/AnimatedMock.js
+++ b/Libraries/Animated/AnimatedMock.js
@@ -41,7 +41,9 @@ export type CompositeAnimation = {
 const emptyAnimation = {
   start: (callback?: ?EndCallback) => {
     // we use setTimeout here so that the callbacks are async
-    if (callback) setTimeout(callback, 0);
+    if (callback) {
+      setTimeout(() => callback({finished: true}), 0);
+    }
   },
   stop: () => {},
   reset: () => {},

--- a/Libraries/Animated/__tests__/AnimatedMock-test.js
+++ b/Libraries/Animated/__tests__/AnimatedMock-test.js
@@ -14,6 +14,13 @@ const AnimatedMock = require('../AnimatedMock');
 const AnimatedImplementation = require('../AnimatedImplementation');
 
 describe('Animated Mock', () => {
+  const mockStartCallback = jest.fn();
+  jest.useFakeTimers();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('matches implementation keys', () => {
     expect(Object.keys(AnimatedMock)).toEqual(
       Object.keys(AnimatedImplementation),
@@ -48,13 +55,6 @@ describe('Animated Mock', () => {
       }
     });
     done();
-  });
-
-  const mockStartCallback = jest.fn();
-  jest.useFakeTimers();
-
-  beforeEach(() => {
-    jest.clearAllMocks();
   });
 
   const itCallsStartCallback = () => {

--- a/Libraries/Animated/__tests__/AnimatedMock-test.js
+++ b/Libraries/Animated/__tests__/AnimatedMock-test.js
@@ -49,4 +49,83 @@ describe('Animated Mock', () => {
     });
     done();
   });
+
+  const mockStartCallback = jest.fn();
+  jest.useFakeTimers();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const itCallsStartCallback = () => {
+    jest.runAllTimers();
+
+    expect(mockStartCallback).toHaveBeenCalledTimes(1);
+  };
+
+  describe('Animated.parallel', () => {
+    it('calls the start callback', () => {
+      AnimatedMock.parallel([]).start(mockStartCallback);
+
+      jest.runAllTimers();
+
+      itCallsStartCallback();
+    });
+  });
+
+  describe('Animated.sequence', () => {
+    it('calls the start callback', () => {
+      AnimatedMock.sequence([]).start(mockStartCallback);
+
+      jest.runAllTimers();
+
+      itCallsStartCallback();
+    });
+  });
+
+  describe('Animated.loop', () => {
+    it('calls the start callback', () => {
+      AnimatedMock.loop(AnimatedMock.timing(new AnimatedMock.Value(0))).start(
+        mockStartCallback,
+      );
+
+      itCallsStartCallback();
+    });
+  });
+
+  describe('Animated.delay', () => {
+    it('calls the start callback', () => {
+      AnimatedMock.decay(new AnimatedMock.Value(0)).start(mockStartCallback);
+
+      itCallsStartCallback();
+    });
+  });
+
+  describe('Animated.stagger', () => {
+    it('calls the start callback', () => {
+      AnimatedMock.stagger(50, []).start(mockStartCallback);
+
+      itCallsStartCallback();
+    });
+  });
+
+  describe('Animated.timing', () => {
+    it('calls the start callback', () => {
+      AnimatedMock.timing(new AnimatedMock.Value(0), {toValue: 20}).start(
+        mockStartCallback,
+      );
+
+      itCallsStartCallback();
+    });
+  });
+
+  describe('Animated.spring', () => {
+    it('calls the start callback', () => {
+      AnimatedMock.spring(new AnimatedMock.Value(0), {toValue: 20}).start(
+        mockStartCallback,
+      );
+
+      itCallsStartCallback();
+    });
+  });
 });


### PR DESCRIPTION
## Summary
When mocked `Animated` using the `AnimatedMock`, I noticed a few things that were off with the mocks that weren't happening with real code:

1. The mocks call the callback from `.start()` synchronously. I've changed this to make it async so that it's more like the real `Animated` behaviour
2. The mocks for `.parallel`, `.decay`, `.stagger`, `.sequence`, and `.loop` all used the `emptyAnimation` object which doesn't implement the `.start(cb)` callback like timing/spring do.

This should also fix #25615

## Changelog
<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Fixed] - AnimatedMock `.parallel`, `.stagger`, `.sequence`, `.loop` now correctly call the callback passed to `.start`
[General] [Fixed] - All AnimatedMock .start callback methods are now called async instead of synchronously to better simulate the production environment 

## Test Plan
- Added new tests to assert that they work as expected
- Also ran these changes against our own codebase and fixed a few issues 🎉 
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
