### PR TITLE
General Logging Util (stab) class for native errors

### DIFF
--- a/ReactCommon/react/renderer/components/view/Android.mk
+++ b/ReactCommon/react/renderer/components/view/Android.mk
@@ -21,7 +21,7 @@ LOCAL_CFLAGS += -fexceptions -frtti -std=c++17 -Wall
 
 LOCAL_STATIC_LIBRARIES :=
 
-LOCAL_SHARED_LIBRARIES := libyoga glog libfolly_json libglog_init libreact_render_core libreact_render_debug libreact_render_graphics libreact_debug
+LOCAL_SHARED_LIBRARIES := libyoga glog libfolly_json libglog_init libreact_render_core libreact_render_debug libreact_render_graphics libreact_debug libreact_utils
 
 include $(BUILD_SHARED_LIBRARY)
 
@@ -31,5 +31,6 @@ $(call import-module,fbgloginit)
 $(call import-module,react/renderer/core)
 $(call import-module,react/renderer/debug)
 $(call import-module,react/renderer/graphics)
+$(call import-module,react/utils)
 $(call import-module,yogajni)
 $(call import-module,react/debug)

--- a/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
+++ b/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
@@ -14,6 +14,7 @@
 #include <react/renderer/core/LayoutContext.h>
 #include <react/renderer/debug/DebugStringConvertibleItem.h>
 #include <react/renderer/debug/SystraceSection.h>
+#include <react/utils/ReactNativeLogger.h>
 #include <yoga/Yoga.h>
 #include <algorithm>
 #include <limits>
@@ -226,7 +227,8 @@ void YogaLayoutableShadowNode::appendChild(
 
     ensureConsistency();
   } else {
-    LOG(ERROR) << "Text strings must be rendered within a <Text> component.";
+    ReactNativeLogger::error(
+        "Text strings must be rendered within a <Text> component.");
   }
 }
 

--- a/ReactCommon/react/utils/Android.mk
+++ b/ReactCommon/react/utils/Android.mk
@@ -20,9 +20,11 @@ LOCAL_CFLAGS := \
 LOCAL_CFLAGS += -fexceptions -frtti -std=c++17 -Wall
 
 LOCAL_STATIC_LIBRARIES :=
-LOCAL_SHARED_LIBRARIES := libreact_debug libreact_render_mapbuffer
+LOCAL_SHARED_LIBRARIES := libreact_debug libreact_render_mapbuffer libglog libglog_init
 
 include $(BUILD_SHARED_LIBRARY)
 
 $(call import-module,react/debug)
+$(call import-module,fbgloginit)
+$(call import-module,glog)
 $(call import-module,react/renderer/mapbuffer)

--- a/ReactCommon/react/utils/BUCK
+++ b/ReactCommon/react/utils/BUCK
@@ -58,6 +58,7 @@ rn_xplat_cxx_library(
     tests = [],
     visibility = ["PUBLIC"],
     deps = [
+        "//third-party/glog:glog",
         "//xplat/folly:container_evicting_cache_map",
         "//xplat/folly:headers_only",
         "//xplat/folly:memory",

--- a/ReactCommon/react/utils/ReactNativeLogger.cpp
+++ b/ReactCommon/react/utils/ReactNativeLogger.cpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "ReactNativeLogger.h"
+#include <glog/logging.h>
+
+namespace facebook {
+namespace react {
+namespace ReactNativeLogger {
+
+void info(std::string const &text) {
+  LOG(INFO) << text;
+}
+
+void warning(std::string const &text) {
+  LOG(WARNING) << text;
+}
+
+void error(std::string const &text) {
+  LOG(ERROR) << text;
+}
+
+} // namespace ReactNativeLogger
+} // namespace react
+} // namespace facebook

--- a/ReactCommon/react/utils/ReactNativeLogger.h
+++ b/ReactCommon/react/utils/ReactNativeLogger.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+namespace facebook {
+namespace react {
+namespace ReactNativeLogger {
+
+void info(std::string const &text);
+void warning(std::string const &text);
+void error(std::string const &text);
+
+} // namespace ReactNativeLogger
+} // namespace react
+} // namespace facebook


### PR DESCRIPTION
Summary:
Overall Context: We want to add a way to log errors (e.g. mustfix, warn, etc on the server with stack trace) without crashing the app (e.g. react_native_assert crashes the app).

This diff: I am writing very simple logger functions which will get resolved at build time depending on the platforms/apps.

Changelog: [internal]

Reviewed By: JoshuaGross

Differential Revision: D30174404

