### PR TITLE
fix: RNtester DynamicColorIOS import error on Android

### DIFF
--- a/packages/rn-tester/js/examples/Border/BorderExample.js
+++ b/packages/rn-tester/js/examples/Border/BorderExample.js
@@ -15,6 +15,7 @@ const {
   View,
   PlatformColor,
   DynamicColorIOS,
+  Platform,
 } = require('react-native');
 
 const styles = StyleSheet.create({
@@ -186,7 +187,10 @@ const styles = StyleSheet.create({
   },
   border16: {
     borderWidth: 10,
-    borderColor: DynamicColorIOS({light: 'magenta', dark: 'cyan'}),
+    borderColor:
+      Platform.OS === 'ios'
+        ? DynamicColorIOS({light: 'magenta', dark: 'cyan'})
+        : undefined,
   },
 });
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
This PR fixes an import error on rn tester app. I tried taking a pull from the latest main branch and got this error on running the rn-tester app on Android
<img width="1278" alt="Screenshot 2021-08-11 at 2 36 34 PM" src="https://user-images.githubusercontent.com/23293248/129001897-e22ad961-867c-4b48-a416-26bede05a863.png">


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Fixed] [Android] - DynamicColorIOS import error in RNTester example app.

## Test Plan
Example app should run on android. Without the iOS platform conditional, it'll throw the above error.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
