### PR TITLE
fix: Resolve NODE_BINARY *after* finding the path to node

### DIFF
--- a/scripts/generate-specs.sh
+++ b/scripts/generate-specs.sh
@@ -27,12 +27,13 @@ set -e
 THIS_DIR=$(cd -P "$(dirname "$(readlink "${BASH_SOURCE[0]}" || echo "${BASH_SOURCE[0]}")")" && pwd)
 TEMP_DIR=$(mktemp -d /tmp/react-native-codegen-XXXXXXXX)
 RN_DIR=$(cd "$THIS_DIR/.." && pwd)
-NODE_BINARY="${NODE_BINARY:-$(command -v node || true)}"
 USE_FABRIC="${USE_FABRIC:-0}"
 
 # Find path to Node
 # shellcheck source=/dev/null
 source "$RN_DIR/scripts/find-node.sh"
+
+NODE_BINARY="${NODE_BINARY:-$(command -v node || true)}"
 
 cleanup () {
   set +e


### PR DESCRIPTION
## Summary

We want to resolve `NODE_BINARY` **after** `find-node.sh` runs and sets up any node version manager that we need to setup, otherwise `NODE_BINARY` is always undefined.

## Changelog

[Internal] [Fixed] - Resolve NODE_BINARY after finding the right path to node

## Test Plan
