### PR TITLE
fix AGP 7 compatibility

### DIFF
--- a/template/android/app/build.gradle
+++ b/template/android/app/build.gradle
@@ -220,7 +220,7 @@ dependencies {
 // Run this once to be able to run the application with BUCK
 // puts all compile dependencies into folder libs for BUCK to use
 task copyDownloadableDepsToLibs(type: Copy) {
-    from configurations.compile
+    from configurations.implementation
     into 'libs'
 }
 


### PR DESCRIPTION
## Summary

Android Gradle Plugin 7 removed dependency configurations, and it includes compile. Below is a snipped from release notes https://developer.android.com/studio/releases/gradle-plugin

I can confirm that RN 0.65.0 app is running as expected on Android with the patch.

> **compile**
Depending on use case, this has been replaced by api or implementation.
Also applies to *Compile variants, for example: debugCompile.


## Changelog

[Android] [Changed] - Android Gradle Plugin 7 compatibility

## Test Plan

Create a project with RN 0.65.0 and upgrade Android Gradle Plugin to 7.0.0, and Gradle to 7.0.2. It'll fail to sync. Then apply the change, and it'll sync as normal, and build the app.