### PR TITLE
Fix broken Circle CI due to missing BUCK rule for androidx:tests

### DIFF
--- a/ReactAndroid/src/androidTest/buck-runner/BUCK
+++ b/ReactAndroid/src/androidTest/buck-runner/BUCK
@@ -14,6 +14,7 @@ rn_android_binary(
     use_split_dex = True,
     deps = [
         react_native_dep("libraries/soloader/java/com/facebook/soloader:soloader"),
+        react_native_dep("third-party/java/testing-support-lib:exposed-instrumentation-api"),
         react_native_integration_tests_target("assets:assets"),
         react_native_integration_tests_target("java/com/facebook/react/tests:tests"),
         react_native_target("java/com/facebook/react/devsupport:devsupport"),

--- a/ReactAndroid/src/main/third-party/android/androidx/BUCK
+++ b/ReactAndroid/src/main/third-party/android/androidx/BUCK
@@ -300,6 +300,25 @@ fb_native.android_library(
 )
 
 fb_native.android_library(
+    name = "test-runner",
+    visibility = ["PUBLIC"],
+    exported_deps = [
+        ":annotation",
+        ":test-monitor",
+        ":test-runner-binary",
+    ],
+)
+
+fb_native.android_library(
+    name = "test-rules",
+    visibility = ["PUBLIC"],
+    exported_deps = [
+        ":test-rules-binary",
+        ":test-runner",
+    ],
+)
+
+fb_native.android_library(
     name = "vectordrawable",
     visibility = ["PUBLIC"],
     exported_deps = [
@@ -474,6 +493,16 @@ fb_native.android_prebuilt_aar(
 fb_native.android_prebuilt_aar(
     name = "test-monitor-binary",
     aar = ":test-monitor-binary-aar",
+)
+
+fb_native.android_prebuilt_aar(
+    name = "test-rules-binary",
+    aar = ":test-rules-binary-aar",
+)
+
+fb_native.android_prebuilt_aar(
+    name = "test-runner-binary",
+    aar = ":test-runner-binary-aar",
 )
 
 fb_native.android_prebuilt_aar(
@@ -663,6 +692,18 @@ fb_native.remote_file(
     name = "test-monitor-binary-aar",
     sha1 = "d2f75d117c055f35c8ebbd4f96fabc2137df9e4d",
     url = "mvn:androidx.test:monitor:aar:1.2.0",
+)
+
+fb_native.remote_file(
+    name = "test-rules-binary-aar",
+    sha1 = "91904046e724ac82d9b7fe698e5fe92b871c726e",
+    url = "mvn:androidx.test:rules:aar:1.2.0",
+)
+
+fb_native.remote_file(
+    name = "test-runner-binary-aar",
+    sha1 = "237b061c45b3b450f88dd8cde87375ab22b0496a",
+    url = "mvn:androidx.test:runner:aar:1.2.0",
 )
 
 fb_native.remote_file(

--- a/ReactAndroid/src/main/third-party/java/testing-support-lib/BUCK
+++ b/ReactAndroid/src/main/third-party/java/testing-support-lib/BUCK
@@ -1,36 +1,5 @@
 load("//tools/build_defs:fb_native_wrapper.bzl", "fb_native")
 
-fb_native.android_library(
-    name = "runner",
-    exported_deps = [
-        ":monitor-binary",
-        ":runner-binary",
-    ],
-    visibility = ["PUBLIC"],
-)
-
-fb_native.android_prebuilt_aar(
-    name = "monitor-binary",
-    aar = ":monitor-binary-aar",
-)
-
-fb_native.android_prebuilt_aar(
-    name = "runner-binary",
-    aar = ":runner-binary-aar",
-)
-
-fb_native.remote_file(
-    name = "monitor-binary-aar",
-    sha1 = "443c2f33d4e19f868cd4e4437909ec8dcf43f053",
-    url = "mvn:androidx.test:monitor:aar:1.1.1",
-)
-
-fb_native.remote_file(
-    name = "runner-binary-aar",
-    sha1 = "810a7aacb5106d92cdf648b2497694c4ebf73500",
-    url = "mvn:androidx.test:runner:aar:1.1.1",
-)
-
 fb_native.android_prebuilt_aar(
     name = "exposed-instrumentation-api",
     aar = ":testing-support-instrumentation",


### PR DESCRIPTION
Summary: Update the OSS React Native dependencies to match the internal dependency structure.

Differential Revision: D30397818

