### PR TITLE
Update ImageBackground.js

### DIFF
--- a/Libraries/Image/ImageBackground.js
+++ b/Libraries/Image/ImageBackground.js
@@ -74,8 +74,8 @@ class ImageBackground extends React.Component<$FlowFixMeProps> {
               // So, we have to proxy/reapply these styles explicitly for actual <Image> component.
               // This workaround should be removed after implementing proper support of
               // intrinsic content size of the <Image>.
-              width: style.width,
-              height: style.height,
+              width: style?.width,
+              height: style?.height,
             },
             imageStyle,
           ]}


### PR DESCRIPTION

## Summary

Currently ImageBackGround component has optional style props, but if you don't pass it as prop, it still "thinks" you pass style and crushes.
In this pr, I made width and height inside component to be optional so it won't crush.

## Changelog

[General] [Fix] - Changed ImageBackground's style so it won't crush. 

[Screen Shot 2021-08-20 at 15 05 45](https://user-images.githubusercontent.com/62840630/130230568-be02b1a2-52ec-4f9d-b3d3-212552d3882b.png)

As you can see in this component, I tried to use ImageBackground without any style props, and my app crushes. Then I added style with empty object and the app didn't crush anymore, as you can see here:
![Screen Shot 2021-08-20 at 15 09 23](https://user-images.githubusercontent.com/62840630/130230932-a576c397-a910-4e40-a202-56482d83dd9c.png).

In conclusion, if we make width and height styles optionals inside ImageBackground component, it won't crush anymore.

Thoughts:
Maybe consider to make style props for this component none-optional because it isn't make any sense that image won't have any style at all.

Thanks ahead, that was my first pr, Eden Binyamin.


