### PR TITLE
fix typos in comments

### DIFF
--- a/Libraries/Image/ImageSource.js
+++ b/Libraries/Image/ImageSource.js
@@ -13,7 +13,7 @@
 /**
  * Keep this in sync with `DeprecatedImageSourcePropType.js`.
  *
- * This type is intentinoally inexact in order to permit call sites that supply
+ * This type is intentionally inexact in order to permit call sites that supply
  * extra properties.
  */
 export interface ImageURISource {

--- a/Libraries/UTFSequence.js
+++ b/Libraries/UTFSequence.js
@@ -16,7 +16,7 @@ const deepFreezeAndThrowOnMutationInDev = require('./Utilities/deepFreezeAndThro
  * A collection of Unicode sequences for various characters and emoji.
  *
  *  - More explicit than using the sequences directly in code.
- *  - Source code should be limitted to ASCII.
+ *  - Source code should be limited to ASCII.
  *  - Less chance of typos.
  */
 const UTFSequence: {|

--- a/Libraries/Utilities/MatrixMath.js
+++ b/Libraries/Utilities/MatrixMath.js
@@ -71,7 +71,7 @@ const MatrixMath = {
    * This create a perspective projection towards negative z
    * Clipping the z range of [-near, -far]
    *
-   * @param fovInRadians - field of view in randians
+   * @param fovInRadians - field of view in radians
    */
   createPerspective: function(fovInRadians, aspect, near, far) {
     const h = 1 / Math.tan(fovInRadians / 2);

--- a/Libraries/vendor/emitter/_EventSubscriptionVendor.js
+++ b/Libraries/vendor/emitter/_EventSubscriptionVendor.js
@@ -58,7 +58,7 @@ class EventSubscriptionVendor<EventDefinitions: {...}> {
    * Removes a bulk set of the subscriptions.
    *
    * @param {?string} eventType - Optional name of the event type whose
-   *   registered supscriptions to remove, if null remove all subscriptions.
+   *   registered subscriptions to remove, if null remove all subscriptions.
    */
   removeAllSubscriptions<K: $Keys<EventDefinitions>>(eventType: ?K): void {
     if (eventType == null) {

--- a/React/Base/RCTCxxConvert.h
+++ b/React/Base/RCTCxxConvert.h
@@ -10,7 +10,7 @@
 /**
  * This class provides a collection of conversion functions for mapping
  * JSON objects to cxx types. Extensible via categories.
- * Convert methods are expected to return cxx objects wraped in RCTManagedPointer.
+ * Convert methods are expected to return cxx objects wrapped in RCTManagedPointer.
  */
 
 @interface RCTCxxConvert : NSObject

--- a/React/Fabric/RCTSurfacePresenterBridgeAdapter.h
+++ b/React/Fabric/RCTSurfacePresenterBridgeAdapter.h
@@ -34,7 +34,7 @@ facebook::react::RuntimeExecutor RCTRuntimeExecutorFromBridge(RCTBridge *bridge)
 
 /*
  * Controls a stored instance of the Bridge. A consumer can re-set the stored Bridge using that method; the class is
- * responsible to coordinate this change with a SurfacePresetner accordingly.
+ * responsible to coordinate this change with a SurfacePresenter accordingly.
  */
 @property (nonatomic, weak) RCTBridge *bridge;
 

--- a/React/Fabric/RCTSurfaceRegistry.h
+++ b/React/Fabric/RCTSurfaceRegistry.h
@@ -17,7 +17,7 @@ typedef void (^RCTSurfaceEnumeratorBlock)(NSEnumerator<RCTFabricSurface *> *enum
 
 /**
  * Registry of Surfaces.
- * Incapsulates storing Surface objects and querying them by root tag.
+ * Encapsulates storing Surface objects and querying them by root tag.
  * All methods of the registry are thread-safe.
  * The registry stores Surface objects as weak references.
  */

--- a/React/Profiler/RCTProfileTrampoline-arm.S
+++ b/React/Profiler/RCTProfileTrampoline-arm.S
@@ -89,7 +89,7 @@ SYMBOL_NAME(RCTProfileTrampoline):
 
   pop {lr} // pop the caller
   pop {r0} // pop the return value
-  bx lr // jump to the calleer
+  bx lr // jump to the caller
 
   trap
 

--- a/React/Profiler/RCTProfileTrampoline-arm64.S
+++ b/React/Profiler/RCTProfileTrampoline-arm64.S
@@ -41,7 +41,7 @@ SYMBOL_NAME(RCTProfileTrampoline):
   /**
    * Allocate 16-bytes for the values that have to be preserved across the call
    * to the actual function, since the stack has to be in the exact initial
-   * state. During its lifetimewe use it to store the initial value of the
+   * state. During its lifetime we use it to store the initial value of the
    * callee saved registers we use to point the memory, the actual address of
    * the implementation and the caller address.
    */
@@ -119,7 +119,7 @@ SYMBOL_NAME(RCTProfileTrampoline):
   // restore the stack pointer
   add sp, sp, #0x20
 
-  // jump to the calleer, without a link
+  // jump to the caller, without a link
   br lr
 
 #endif


### PR DESCRIPTION
## Summary

Fixed some typos in the code comments.

## Changelog

[Internal] [Fixed] - Fixed typo in the comments

## Test Plan

N/A
