### PR TITLE
Bump @react-native/polyfills version

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@react-native-community/cli-platform-ios": "^6.0.0",
     "@react-native/assets": "1.0.0",
     "@react-native/normalize-color": "1.0.0",
-    "@react-native/polyfills": "1.0.0",
+    "@react-native/polyfills": "2.0.0",
     "abort-controller": "^3.0.0",
     "anser": "^1.4.9",
     "base64-js": "^1.1.2",

--- a/packages/polyfills/package.json
+++ b/packages/polyfills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native/polyfills",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Polyfills for React Native.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

https://github.com/facebook/react-native/commit/8a62583f794875e6dc5d1e4a24889b3b702d9f86 did some renaming inside of the @react-native/polyfills project, with the jest preset updated to use the new name. The new package for polyfills has not yet been published, so the jest preset in the main branch will be looking for the new name, while the old name is provided by the currently published @react-native/polyfills@1.0.0. This is not hit inside the repo, since the dependency is linked instead of using the published one.

Bump @react-native/polyfills to 2.0 (breaking change), in preparation for publish.

## Changelog

[Internal][Fixed] - Bump @react-native/polyfills version

