### PR TITLE
Fix broken CI with a run of prettier

### DIFF
--- a/flow/HermesInternalType.js
+++ b/flow/HermesInternalType.js
@@ -58,7 +58,7 @@ declare type $HermesInternalType = {
    */
   +getRuntimeProperties?: () => {
     'OSS Release Version': string,
-    'Build': string,
+    Build: string,
     [string]: mixed,
   },
 


### PR DESCRIPTION
Summary:

This Diff is fixing a broken CircleCI on OSS due to
not properly formatted .js files. See https://app.circleci.com/pipelines/github/facebook/react-native/10040/workflows/923cb408-b09c-4425-87c1-2677a7af9681/jobs/213822

The offending diff was D29986749 (https://github.com/facebook/react-native/commit/ff4b33672a6a27d2ed68ae6602e9d29d9b7c3eb1)

Changelog:
[Internal] - Fix broken CI due to not formatted js files

Reviewed By: ShikaSD

Differential Revision: D30515439

