### PR TITLE
feat: add Android 12 BLUETOOTH_ADVERTISE to PermissionsAndroid

### DIFF
--- a/Libraries/PermissionsAndroid/NativePermissionsAndroid.js
+++ b/Libraries/PermissionsAndroid/NativePermissionsAndroid.js
@@ -43,7 +43,8 @@ export type PermissionType =
   | 'android.permission.READ_EXTERNAL_STORAGE'
   | 'android.permission.WRITE_EXTERNAL_STORAGE'
   | 'android.permission.BLUETOOTH_CONNECT'
-  | 'android.permission.BLUETOOTH_SCAN';
+  | 'android.permission.BLUETOOTH_SCAN'
+  | 'android.permission.BLUETOOTH_ADVERTISE';
 */
 
 export interface Spec extends TurboModule {

--- a/Libraries/PermissionsAndroid/PermissionsAndroid.js
+++ b/Libraries/PermissionsAndroid/PermissionsAndroid.js
@@ -61,6 +61,7 @@ const PERMISSIONS = Object.freeze({
   WRITE_EXTERNAL_STORAGE: 'android.permission.WRITE_EXTERNAL_STORAGE',
   BLUETOOTH_CONNECT: 'android.permission.BLUETOOTH_CONNECT',
   BLUETOOTH_SCAN: 'android.permission.BLUETOOTH_SCAN',
+  BLUETOOTH_ADVERTISE: 'android.permission.BLUETOOTH_ADVERTISE',
 });
 
 /**
@@ -75,6 +76,7 @@ class PermissionsAndroid {
     ACCESS_COARSE_LOCATION: string,
     ACCESS_FINE_LOCATION: string,
     ADD_VOICEMAIL: string,
+    BLUETOOTH_ADVERTISE: string,
     BLUETOOTH_CONNECT: string,
     BLUETOOTH_SCAN: string,
     BODY_SENSORS: string,


### PR DESCRIPTION
## Summary

This PR adds BLUETOOTH_ADVERTISE, which showed up in the latest Android 12 Beta build as new `dangerous` permissions requiring approval for them.

https://developer.android.com/reference/android/Manifest.permission.html#BLUETOOTH_ADVERTISE

You can see the new set of `SCAN/ADVERTISE/CONNECT` added in this doc - https://developer.android.com/about/versions/12/features/bluetooth-permissions, previously SCAN/CONNECT were added in: https://github.com/facebook/react-native/pull/31488

## Changelog

[Android] [Changed] - Add BLUETOOTH_ADVERTISE to PermissionsAndroid

## Test Plan

```
PermissionsAndroid.BLUETOOTH_ADVERTISE === 'android.permission.BLUETOOTH_ADVERTISE'
```
