### PR TITLE
chore: prefer the local react-native-codegen package

### DIFF
--- a/scripts/generate-specs-cli.js
+++ b/scripts/generate-specs-cli.js
@@ -11,9 +11,9 @@
 
 let RNCodegen;
 try {
-  RNCodegen = require('react-native-codegen/lib/generators/RNCodegen.js');
-} catch (e) {
   RNCodegen = require('../packages/react-native-codegen/lib/generators/RNCodegen.js');
+} catch (e) {
+  RNCodegen = require('react-native-codegen/lib/generators/RNCodegen.js');
   if (!RNCodegen) {
     throw 'RNCodegen not found.';
   }


### PR DESCRIPTION
## Summary

Currently, the build breaks if we move `react-native-codegen` from the template's dependencies to root. This is due to `scripts/generate-specs-cli.js` using the one installed under `node_modules` instead of the local one.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Internal] [Fixed] - `scripts/generate-specs-cli.js` should prefer the local `react-native-codegen` package

## Test Plan

1. Make the following changes
   ```diff
   diff --git a/package.json b/package.json
   index 847c726a69b..78da8232988 100644
   --- a/package.json
   +++ b/package.json
   @@ -107,6 +107,7 @@
        "promise": "^8.0.3",
        "prop-types": "^15.7.2",
        "react-devtools-core": "^4.13.0",
   +    "react-native-codegen": "^0.0.7",
        "react-refresh": "^0.4.0",
        "regenerator-runtime": "^0.13.2",
        "scheduler": "^0.20.2",
   diff --git a/template/package.json b/template/package.json
   index 715614112ac..5e0762b1b25 100644
   --- a/template/package.json
   +++ b/template/package.json
   @@ -21,7 +21,6 @@
        "eslint": "7.14.0",
        "jest": "^26.6.3",
        "metro-react-native-babel-preset": "^0.66.2",
   -    "react-native-codegen": "^0.0.7",
        "react-test-renderer": "17.0.2"
      },
      "jest": {
   ```
2. Run `scripts/test-manual-e2e.sh`


## Expected Behavior

Task `:ReactAndroid:buildReactNdkLib` succeeds.

## Actual Behavior

```
> Task :ReactAndroid:buildReactNdkLib FAILED
make: Entering directory '~/Source/react-native/ReactAndroid/src/main/jni/react/jni'
fcntl(): Bad file descriptor
make: Leaving directory '~/Source/react-native/ReactAndroid/src/main/jni/react/jni'
~/Library/Android/sdk/ndk/21.4.7075529/build/core/build-binary.mk:651: Android NDK: Module react_codegen_rncore depends on undefined modules: react_render_components_view
~/Library/Android/sdk/ndk/21.4.7075529/build/core/build-binary.mk:664: *** Android NDK: Note that old versions of ndk-build silently ignored this error case. If your project worked on those versions, the missing libraries were not needed and you can remove those dependencies from the module to fix your build. Alternatively, set APP_ALLOW_MISSING_DEPS=true to allow missing dependencies.    .  Stop.

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':ReactAndroid:buildReactNdkLib'.
> Process 'command '~/Library/Android/sdk/ndk/21.4.7075529/ndk-build'' finished with non-zero exit value 2

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.9/userguide/command_line_interface.html#sec:command_line_warnings

BUILD FAILED in 19s
20 actionable tasks: 20 executed
Couldn't generate artifacts
```