### PR TITLE
Add support code for experimental dev-mode bundle splitting

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -698,6 +698,7 @@ rn_library(
         "//xplat/js:node_modules__pretty_19format",
         "//xplat/js:node_modules__promise",
         "//xplat/js:node_modules__prop_19types",
+        "//xplat/js:node_modules__qs",
         "//xplat/js:node_modules__react_19devtools_19core",
         "//xplat/js:node_modules__react_19refresh",
         "//xplat/js:node_modules__react_19shallow_19renderer",

--- a/Libraries/DevBundleLoading/__tests__/asyncRequireForMetro-test.js
+++ b/Libraries/DevBundleLoading/__tests__/asyncRequireForMetro-test.js
@@ -1,0 +1,171 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails oncall+react_native
+ * @format
+ * @flow strict-local
+ */
+
+'use strict';
+
+jest.mock('react-native/Libraries/Utilities/HMRClient');
+
+const getDevServer = jest.fn(() => ({
+  url: 'localhost:8042/',
+  fullBundleUrl:
+    'http://localhost:8042/EntryPoint.bundle?platform=' +
+    jest.requireActual('react-native').Platform.OS +
+    '&dev=true&minify=false&unusedExtraParam=42',
+  bundleLoadedFromServer: true,
+}));
+
+jest.mock(
+  'react-native/Libraries/Core/Devtools/getDevServer',
+  () => getDevServer,
+);
+
+const sendRequest = jest.fn(
+  (
+    method,
+    trackingName,
+    url,
+    headers,
+    data,
+    responseType,
+    incrementalUpdates,
+    timeout,
+    callback,
+    withCredentials,
+  ) => {
+    callback(1);
+  },
+);
+
+jest.mock('react-native/Libraries/Network/RCTNetworking', () => ({
+  sendRequest,
+  addListener: jest.fn((name, fn) => {
+    if (name === 'didReceiveNetworkData') {
+      setImmediate(() => fn([1, mockDataResponse]));
+    } else if (name === 'didCompleteNetworkResponse') {
+      setImmediate(() => fn([1, null]));
+    } else if (name === 'didReceiveNetworkResponse') {
+      setImmediate(() => fn([1, null, mockHeaders]));
+    }
+    return {remove: () => {}};
+  }),
+}));
+
+jest.mock(
+  '12',
+  () => ({
+    isLoaded: true,
+  }),
+  {virtual: true},
+);
+
+jest.mock(
+  '482018',
+  () => ({
+    exists: true,
+  }),
+  {virtual: true},
+);
+
+jest.mock(
+  '555',
+  () => ({
+    exists: true,
+  }),
+  {virtual: true},
+);
+
+const asyncRequireForMetro = require('../asyncRequireForMetro');
+let mockHeaders;
+let mockDataResponse;
+
+test('asyncRequireForMetro will throw for JSON responses', async () => {
+  mockHeaders = {'Content-Type': 'application/json'};
+  mockDataResponse = JSON.stringify({message: 'Error thrown from Metro'});
+
+  asyncRequireForMetro.addImportBundleNames({
+    '555': 'Fail',
+  });
+
+  await expect(asyncRequireForMetro(555, '**')).rejects.toThrow(
+    'Error thrown from Metro',
+  );
+});
+
+test('asyncRequireForMetro will request a bundle if import bundles are available', async () => {
+  mockDataResponse = '"code";';
+  mockHeaders = {'Content-Type:': 'application/javascript'};
+
+  asyncRequireForMetro.addImportBundleNames({
+    '12': 'Banana',
+    '482018': 'Tiny/Apple',
+  });
+
+  const module12 = await asyncRequireForMetro(12, '**');
+  expect(module12).toEqual({isLoaded: true});
+
+  const module482018 = await asyncRequireForMetro(482018, '**');
+  expect(module482018).toEqual({exists: true});
+
+  // Assert on the actual URLs fetched.
+  // NOTE: The cache isn't cleared between tests, so we can't do
+  // sendRequest.clearMock() and test this in isolation. Instead, we do this
+  // here, where we know the bundles must have been fetched at least once.
+  expect(sendRequest.mock.calls).toContainEqual([
+    'GET',
+    expect.anything(),
+    'localhost:8042/Banana.bundle?platform=ios&dev=true&minify=false&unusedExtraParam=42&modulesOnly=true&runModule=false&runtimeBytecodeVersion=',
+    expect.anything(),
+    expect.anything(),
+    expect.anything(),
+    expect.anything(),
+    expect.anything(),
+    expect.anything(),
+    expect.anything(),
+  ]);
+
+  expect(sendRequest.mock.calls).toContainEqual([
+    'GET',
+    expect.anything(),
+    'localhost:8042/Tiny/Apple.bundle?platform=ios&dev=true&minify=false&unusedExtraParam=42&modulesOnly=true&runModule=false&runtimeBytecodeVersion=',
+    expect.anything(),
+    expect.anything(),
+    expect.anything(),
+    expect.anything(),
+    expect.anything(),
+    expect.anything(),
+    expect.anything(),
+  ]);
+});
+
+it('asyncRequireForMetro throws if not connected to a Metro server', async () => {
+  getDevServer.mockImplementationOnce(() => ({
+    url: 'localhost:8042/',
+    fullBundleUrl:
+      'http://localhost:8042/EntryPoint.bundle?platform=' +
+      jest.requireActual('react-native').Platform.OS +
+      '&dev=true&minify=false&unusedExtraParam=42',
+    bundleLoadedFromServer: false,
+  }));
+  asyncRequireForMetro.addImportBundleNames({
+    '99': 'Banana',
+  });
+
+  const promise = asyncRequireForMetro(99, '**');
+  await expect(promise).rejects.toThrow(
+    'This bundle was compiled with transformer.experimentalImportBundleSupport and can only be used when connected to a Metro server.',
+  );
+});
+
+describe('asyncRequireForMetro.resource', () => {
+  it('should throw', async () => {
+    expect(() => asyncRequireForMetro.resource(482018, 'MyModule')).toThrow();
+  });
+});

--- a/Libraries/DevBundleLoading/asyncRequireForMetro.js
+++ b/Libraries/DevBundleLoading/asyncRequireForMetro.js
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+'use strict';
+
+import loadBundle from './loadBundle';
+
+type Options = {isPrefetchOnly: boolean, ...};
+
+type ImportBundleNames = {
+  [string]: string,
+  __proto__: null,
+  ...
+};
+
+type MetroRequire = {
+  (number): mixed,
+  importAll: number => mixed,
+  ...
+};
+
+declare var global: {globalEvalWithSourceUrl?: (string, string) => mixed, ...};
+
+const dynamicRequire: MetroRequire = (require: $FlowFixMe);
+
+const DEFAULT_OPTIONS = {isPrefetchOnly: false};
+const IMPORT_BUNDLE_NAMES: ImportBundleNames = Object.create(null);
+const importBundlePromises: {
+  [string]: Promise<mixed>,
+  __proto__: null,
+  ...
+} = Object.create(null);
+
+async function asyncRequire(
+  moduleID: number,
+  moduleName: string,
+  options?: Options = DEFAULT_OPTIONS,
+): Promise<mixed> {
+  if (options.isPrefetchOnly) {
+    return Promise.resolve();
+  }
+
+  const stringModuleID = String(moduleID);
+  const bundlePath = IMPORT_BUNDLE_NAMES[stringModuleID];
+  if (bundlePath) {
+    if (!importBundlePromises[stringModuleID]) {
+      importBundlePromises[stringModuleID] = loadBundle(bundlePath).then(() =>
+        dynamicRequire(moduleID),
+      );
+    }
+    return importBundlePromises[stringModuleID];
+  }
+
+  return dynamicRequire.importAll(moduleID);
+}
+asyncRequire.prefetch = function(moduleID: number, moduleName: string): void {
+  asyncRequire(moduleID, moduleName, {isPrefetchOnly: true}).then(
+    () => {},
+    () => {},
+  );
+};
+
+asyncRequire.resource = function(moduleID: number, moduleName: string): empty {
+  throw new Error('Not implemented');
+};
+
+asyncRequire.addImportBundleNames = function(
+  importBundleNames: ImportBundleNames,
+): void {
+  Object.assign(IMPORT_BUNDLE_NAMES, importBundleNames);
+};
+
+module.exports = asyncRequire;

--- a/Libraries/DevBundleLoading/loadBundle.js
+++ b/Libraries/DevBundleLoading/loadBundle.js
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import HMRClient from '../Utilities/HMRClient';
+import LoadingView from '../Utilities/LoadingView';
+import getDevServer from '../Core/Devtools/getDevServer';
+import qs from 'qs';
+import NativeDevSplitBundleLoader from '../Utilities/NativeDevSplitBundleLoader.js';
+import Networking from '../Network/RCTNetworking';
+
+declare var global: {globalEvalWithSourceUrl?: (string, string) => mixed, ...};
+
+let pendingRequests = 0;
+
+function asyncRequest(
+  url: string,
+): Promise<{body: string, headers: {[string]: string}}> {
+  let id = null;
+  let responseText = null;
+  let headers = null;
+  let dataListener;
+  let completeListener;
+  let responseListener;
+  return new Promise((resolve, reject) => {
+    dataListener = Networking.addListener(
+      'didReceiveNetworkData',
+      ([requestId, response]) => {
+        if (requestId === id) {
+          responseText = response;
+        }
+      },
+    );
+    responseListener = Networking.addListener(
+      'didReceiveNetworkResponse',
+      ([requestId, status, responseHeaders]) => {
+        if (requestId === id) {
+          headers = responseHeaders;
+        }
+      },
+    );
+    completeListener = Networking.addListener(
+      'didCompleteNetworkResponse',
+      ([requestId, error]) => {
+        if (requestId === id) {
+          if (error) {
+            reject(error);
+          } else {
+            resolve({body: responseText, headers});
+          }
+        }
+      },
+    );
+    Networking.sendRequest(
+      'GET',
+      'asyncRequest',
+      url,
+      {},
+      '',
+      'text',
+      false,
+      0,
+      requestId => {
+        id = requestId;
+      },
+      true,
+    );
+    //$FlowFixMe[incompatible-return]
+  }).finally(() => {
+    dataListener && dataListener.remove();
+    completeListener && completeListener.remove();
+    responseListener && responseListener.remove();
+  });
+}
+
+function buildUrlForBundle(bundlePath, params) {
+  const {fullBundleUrl, url: serverUrl} = getDevServer();
+  let query = {};
+  if (fullBundleUrl != null) {
+    const queryStart = fullBundleUrl.indexOf('?');
+    if (queryStart !== -1) {
+      query = qs.parse(fullBundleUrl.substring(queryStart + 1));
+    }
+  }
+  Object.assign(query, params);
+  return serverUrl + bundlePath + '.bundle?' + qs.stringify(query);
+}
+
+module.exports = function(bundlePath: string): Promise<mixed> {
+  if (NativeDevSplitBundleLoader && NativeDevSplitBundleLoader.loadBundle) {
+    return NativeDevSplitBundleLoader.loadBundle(bundlePath).catch(e => {
+      // On Android 'e' is not an instance of Error, which seems to be a bug.
+      // As a workaround, re-throw an Error to not break the error handling code.
+      throw new Error(e.message);
+    });
+  }
+
+  const requestUrl = buildUrlForBundle(bundlePath, {
+    modulesOnly: 'true',
+    runModule: 'false',
+    // The JavaScript loader does not support bytecode.
+    runtimeBytecodeVersion: null,
+  });
+
+  LoadingView.showMessage('Downloading...', 'load');
+  return asyncRequest(requestUrl)
+    .then(({body, headers}) => {
+      if (
+        headers['Content-Type'] != null &&
+        headers['Content-Type'].indexOf('application/json') >= 0
+      ) {
+        // Errors are returned as JSON.
+        throw new Error(
+          JSON.parse(body).message || `Unknown error fetching '${bundlePath}'`,
+        );
+      }
+
+      HMRClient.registerBundle(requestUrl);
+
+      // Some engines do not support `sourceURL` as a comment. We expose a
+      // `globalEvalWithSourceUrl` function to handle updates in that case.
+      if (global.globalEvalWithSourceUrl) {
+        global.globalEvalWithSourceUrl(body, requestUrl);
+      } else {
+        // eslint-disable-next-line no-eval
+        eval(body);
+      }
+    })
+    .finally(() => {
+      if (!--pendingRequests) {
+        LoadingView.hide();
+      }
+    });
+};

--- a/Libraries/DevBundleLoading/loadBundle.js
+++ b/Libraries/DevBundleLoading/loadBundle.js
@@ -80,7 +80,16 @@ function asyncRequest(
 }
 
 function buildUrlForBundle(bundlePath, params) {
-  const {fullBundleUrl, url: serverUrl} = getDevServer();
+  const {
+    fullBundleUrl,
+    url: serverUrl,
+    bundleLoadedFromServer,
+  } = getDevServer();
+  if (!bundleLoadedFromServer) {
+    throw new Error(
+      'This bundle was compiled with transformer.experimentalImportBundleSupport and can only be used when connected to a Metro server.',
+    );
+  }
   let query = {};
   if (fullBundleUrl != null) {
     const queryStart = fullBundleUrl.indexOf('?');

--- a/flow-typed/npm/qs_v6.5.x.js
+++ b/flow-typed/npm/qs_v6.5.x.js
@@ -1,0 +1,60 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+// flow-typed signature: 715c2f8b80fc0049acaff07253098596
+// flow-typed version: a7cda84c32/qs_v6.5.x/flow_>=v0.45.x
+
+declare module 'qs' {
+  declare type ParseOptions = {
+    allowPrototypes?: boolean,
+    arrayLimit?: number,
+    decoder?: Function,
+    delimiter?: string,
+    depth?: number,
+    parameterLimit?: number,
+    plainObjects?: boolean,
+    strictNullHandling?: boolean,
+    ignoreQueryPrefix?: boolean,
+    parseArrays?: boolean,
+    allowDots?: boolean,
+  ...};
+
+  declare type ArrayFormat = "brackets" | "indices" | "repeat";
+
+  declare type FilterFunction = (prefix: string, value: any) => any;
+  declare type FilterArray = Array<string | number>;
+  declare type Filter = FilterArray | FilterFunction;
+
+  declare type StringifyOptions = {
+    encoder?: Function,
+    delimiter?: string,
+    strictNullHandling?: boolean,
+    skipNulls?: boolean,
+    encode?: boolean,
+    sort?: Function,
+    allowDots?: boolean,
+    serializeDate?: Function,
+    encodeValuesOnly?: boolean,
+    format?: string,
+    addQueryPrefix?: boolean,
+    arrayFormat?: ArrayFormat,
+    filter?: Filter,
+  ...};
+
+  declare type Formatter = (any) => string;
+
+  declare type Formats = {
+    RFC1738: string,
+    RFC3986: string,
+    "default": string,
+    formatters: {
+      RFC1738: Formatter,
+      RFC3986: Formatter,
+    ...},
+  ...};
+
+  declare module.exports: {
+    parse(str: string, opts?: ParseOptions): Object,
+    stringify(obj: Object | Array<any>, opts?: StringifyOptions): string,
+    formats: Formats,
+  ...};
+}

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "pretty-format": "^26.5.2",
     "promise": "^8.0.3",
     "prop-types": "^15.7.2",
+    "qs": "^6.5.1",
     "react-devtools-core": "^4.13.0",
     "react-refresh": "^0.4.0",
     "regenerator-runtime": "^0.13.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1850,6 +1850,14 @@ cache-base@^1.0.1:
     union-value "^1.0.0"
     unset-value "^1.0.0"
 
+call-bind@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.2.tgz#b1d4e89e688119c3c9a903ad30abb2f6a919be3c"
+  integrity sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==
+  dependencies:
+    function-bind "^1.1.1"
+    get-intrinsic "^1.0.2"
+
 caller-callsite@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/caller-callsite/-/caller-callsite-2.0.0.tgz#847e0fce0a223750a9a027c54b33731ad3154134"
@@ -3130,6 +3138,15 @@ get-caller-file@^2.0.1:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
+
+get-intrinsic@^1.0.2:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.1.tgz#15f59f376f855c446963948f0d24cd3637b4abc6"
+  integrity sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==
+  dependencies:
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.1"
 
 get-port@^2.1.0:
   version "2.1.0"
@@ -5105,6 +5122,11 @@ object-inspect@^1.8.0:
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.8.0.tgz#df807e5ecf53a609cc6bfe93eac3cc7be5b3a9d0"
   integrity sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==
 
+object-inspect@^1.9.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.11.0.tgz#9dceb146cedd4148a0d9e51ab88d34cf509922b1"
+  integrity sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==
+
 object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
@@ -5554,6 +5576,13 @@ punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
+qs@^6.5.1:
+  version "6.10.1"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.1.tgz#4931482fa8d647a5aab799c5271d2133b981fb6a"
+  integrity sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==
+  dependencies:
+    side-channel "^1.0.4"
 
 qs@~6.5.2:
   version "6.5.2"
@@ -6102,6 +6131,15 @@ side-channel@^1.0.2:
   dependencies:
     es-abstract "^1.18.0-next.0"
     object-inspect "^1.8.0"
+
+side-channel@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
+  integrity sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==
+  dependencies:
+    call-bind "^1.0.0"
+    get-intrinsic "^1.0.2"
+    object-inspect "^1.9.0"
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Moves `asyncRequireForMetro.js` into React Native. This code can be used together with `experimentalImportBundleSupport: true` in Metro to load split bundles in development from a Metro server. This is still an experimental, undocumented workflow - proper documentation will follow when it's stable.

The minimal Metro config required for this to work is:

```
// metro.config.js
module.exports = {
  transformer: {
    asyncRequireModulePath: 'react-native/Libraries/DevBundleLoading/asyncRequireForMetro.js',
    experimentalImportBundleSupport: true,
  },
};
```

Differential Revision: D30580274

