### PR TITLE
Fix BorderExample Crash on Out of Tree Platforms

### DIFF
--- a/packages/rn-tester/js/examples/Border/BorderExample.js
+++ b/packages/rn-tester/js/examples/Border/BorderExample.js
@@ -183,10 +183,12 @@ const styles = StyleSheet.create({
   },
   border15: {
     borderWidth: 10,
-    borderColor: PlatformColor(
-      'systemGray4',
-      '@android:color/holo_orange_dark',
-    ),
+    borderColor: Platform.select({
+      ios: PlatformColor('systemGray4'),
+      android: PlatformColor('@android:color/holo_orange_dark'),
+      windows: PlatformColor('SystemAccentColorDark1'),
+      default: 'black',
+    }),
   },
   border16: {
     borderWidth: 10,


### PR DESCRIPTION
## Summary

https://github.com/facebook/react-native/commit/9b4f8e01442356f820e135fae3849063b2b8c92c#diff-ee44452e2deeb3a607e863852bb720518875b88c4e78ea7dc76805488bfb1818 added examples to the border test page using PlatformColor. An iOS specific instance was later conditioned to only iOS in https://github.com/facebook/react-native/commit/f6d0f9deaccdc53114d47b8a69c49fda7cb1f8e1#diff-ee44452e2deeb3a607e863852bb720518875b88c4e78ea7dc76805488bfb1818 but one example remains that has values for Android, and iOS only. This causes a crash on at least RNW, since none of the PlatformColors are valid.

This change addsa a fallback to black for unsupported platforms, and also adds a Windows PlatformColor for kicks (and marginal extra usefuleness).

## Changelog

[Internal] [Fixed] - Fix BorderExample Crash on Out of Tree Platforms

## Test Plan

Validated on RNTester on Windows.

