### PR TITLE
fix/linking-get-initial-urlw

### DIFF
--- a/Libraries/Linking/Linking.js
+++ b/Libraries/Linking/Linking.js
@@ -105,11 +105,11 @@ class Linking extends NativeEventEmitter<LinkingEventDefinitions> {
    * See https://reactnative.dev/docs/linking.html#getinitialurl
    */
   getInitialURL(): Promise<?string> {
-    return Platform.OS === 'android'
-      ? InteractionManager.runAfterInteractions().then(() =>
-          nullthrows(NativeIntentAndroid).getInitialURL(),
-        )
-      : nullthrows(NativeLinkingManager).getInitialURL();
+    if (Platform.OS === 'android') {
+      return nullthrows(NativeIntentAndroid).getInitialURL();
+    } else {
+      return nullthrows(NativeLinkingManager).getInitialURL();
+    }
   }
 
   /*


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

As discussed on this #25675 GitHub issue, Linking.getInitialURL isn't working properly. After some tests, I found out that `InteractionManager.runAfterInteractions` was never being resolved. Removing it from the code solves the issue.

More details at: https://github.com/facebook/react-native/issues/25675#issuecomment-909219479

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Fixed] - Fix Linking.getInitialURL() on Android

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
In a demo app I've used both:

```js
// Works
NativeIntentAndroid.getInitialURL().then(url => console.log(url))

// Doesn't Work
InteractionManager.runAfterInteractions().then(() => {
    NativeIntentAndroid.getInitialURL().then(url => console.log(url))
})
```

If there are other test cases, please let me know!