### PR TITLE
Fixed iOS 14 large title header being collapsed initially

### DIFF
--- a/React/Views/ScrollView/RCTScrollContentView.m
+++ b/React/Views/ScrollView/RCTScrollContentView.m
@@ -14,13 +14,20 @@
 
 @implementation RCTScrollContentView
 
+- (void)didMoveToWindow
+{
+  [super didMoveToWindow];
+  RCTScrollView *scrollView = (RCTScrollView *)self.superview.superview;
+  [scrollView updateContentSizeIfNeeded];
+}
+
 - (void)reactSetFrame:(CGRect)frame
 {
   [super reactSetFrame:frame];
 
   RCTScrollView *scrollView = (RCTScrollView *)self.superview.superview;
 
-  if (!scrollView) {
+  if (!scrollView || !self.window) {
     return;
   }
 

--- a/React/Views/ScrollView/RCTScrollContentView.m
+++ b/React/Views/ScrollView/RCTScrollContentView.m
@@ -17,17 +17,30 @@
 - (void)didMoveToWindow
 {
   [super didMoveToWindow];
-  RCTScrollView *scrollView = (RCTScrollView *)self.superview.superview;
-  [scrollView updateContentSizeIfNeeded];
+  if (@available(iOS 14.0, *)) {
+    if (@available(iOS 15.0, *)) {
+    } else {
+      RCTScrollView *scrollView = (RCTScrollView *)self.superview.superview;
+      [scrollView updateContentSizeIfNeeded];
+    }
+  }
 }
 
 - (void)reactSetFrame:(CGRect)frame
 {
   [super reactSetFrame:frame];
+  if (@available(iOS 14.0, *)) {
+    if (@available(iOS 15.0, *)) {
+    } else {
+      if (!self.window) {
+        return;
+      }
+    }
+  }
 
   RCTScrollView *scrollView = (RCTScrollView *)self.superview.superview;
 
-  if (!scrollView || !self.window) {
+  if (!scrollView) {
     return;
   }
 


### PR DESCRIPTION
## Summary

The `largeTitle` option for scrollview/flatlist headers on iOS by [React Native Screens](https://github.com/software-mansion/react-native-screens) was initially rendering in its collapsed "small" state when the screen first opens. See: [#649](https://github.com/software-mansion/react-native-screens/issues/649) [#484](https://github.com/grahammendick/navigation/issues/484) [#645](https://github.com/software-mansion/react-native-screens/issues/645)

We must ensure that updateContentOffsetIfNeeded first runs after the ScrollView is moved to the window. So we prevent it running inside reactSetFrame if there’s no window yet and get it to run from didMoveToWindow instead. The problem is we need to stop the updateContentOffsetIfNeeded running in reactSetFrame because that's too early. You can see what that means by commenting out the !self.windowcheck in the fix and seeing it won't work anymore. 

This fix is only needed on iOS 14.

Expected behavior: The title should begin in large form and collapse only when the user scrolls down, to match the behavior of native iOS.

The following gif illustrates the problematic behavior. Notice how the "Items" header starts off in its collapsed form instead of large text.

![problematic large title gif](https://user-images.githubusercontent.com/54056632/131758021-f59338ec-f9a2-45b8-a50e-2179458b3750.gif)

This pull request fixes the issue by causing the title to start off in its fully expanded form.

## Changelog

[iOS] [Fixed] - Fix scrollview large title starting off collapsed on iOS 14.

## Test Plan

This is the behavior of the header after implementing the pull request. Notice that upon opening the second screen, the header starts off in its expanded form, which is expected behavior. This fix is only needed on iOS 14.

![working large title gif](https://user-images.githubusercontent.com/54056632/131758730-3f19e9c5-8c2a-448d-8c01-7162065e2316.gif)