### PR TITLE
Do not use `kotlin-dsl` inside `react-native-gradle-plugin`

### DIFF
--- a/packages/react-native-gradle-plugin/build.gradle.kts
+++ b/packages/react-native-gradle-plugin/build.gradle.kts
@@ -6,8 +6,8 @@
  */
 
 plugins {
-  `java-gradle-plugin`
-  `kotlin-dsl`
+  kotlin("jvm") version "1.4.21"
+  id("java-gradle-plugin")
 }
 
 repositories {
@@ -25,5 +25,6 @@ gradlePlugin {
 }
 
 dependencies {
+  implementation(gradleApi())
   implementation("com.android.tools.build:gradle:4.2.2")
 }

--- a/packages/react-native-gradle-plugin/settings.gradle.kts
+++ b/packages/react-native-gradle-plugin/settings.gradle.kts
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+    }
+}

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/AndroidConfiguration.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/AndroidConfiguration.kt
@@ -16,7 +16,7 @@ fun Project.configureDevPorts(androidExt: BaseExtension) {
       project.properties["reactNativeInspectorProxyPort"]?.toString() ?: devServerPort
 
   androidExt.buildTypes.all {
-    resValue("integer", "react_native_dev_server_port", devServerPort)
-    resValue("integer", "react_native_inspector_proxy_port", inspectorProxyPort)
+    it.resValue("integer", "react_native_dev_server_port", devServerPort)
+    it.resValue("integer", "react_native_inspector_proxy_port", inspectorProxyPort)
   }
 }

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactAppPlugin.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactAppPlugin.kt
@@ -12,25 +12,23 @@ import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.LibraryExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.kotlin.dsl.create
-import org.gradle.kotlin.dsl.getByType
 
 class ReactAppPlugin : Plugin<Project> {
   override fun apply(project: Project) {
-    val config = project.extensions.create<ReactAppExtension>("reactApp", project)
+    val config = project.extensions.create("reactApp", ReactAppExtension::class.java, project)
 
     project.afterEvaluate {
-      val androidConfiguration = extensions.getByType<BaseExtension>()
-      configureDevPorts(androidConfiguration)
+      val androidConfiguration = project.extensions.getByType(BaseExtension::class.java)
+      project.configureDevPorts(androidConfiguration)
 
-      val isAndroidLibrary = plugins.hasPlugin("com.android.library")
+      val isAndroidLibrary = project.plugins.hasPlugin("com.android.library")
       val variants =
           if (isAndroidLibrary) {
-            extensions.getByType<LibraryExtension>().libraryVariants
+            project.extensions.getByType(LibraryExtension::class.java).libraryVariants
           } else {
-            extensions.getByType<AppExtension>().applicationVariants
+            project.extensions.getByType(AppExtension::class.java).applicationVariants
           }
-      variants.all { configureReactTasks(variant = this, config = config) }
+      variants.all { project.configureReactTasks(variant = it, config = config) }
     }
   }
 }

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/BundleJsAndAssetsTask.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/BundleJsAndAssetsTask.kt
@@ -53,10 +53,10 @@ open class BundleJsAndAssetsTask : DefaultTask() {
 
   private fun executeBundleCommand() {
     project.exec {
-      workingDir(reactRoot)
+      it.workingDir(reactRoot)
 
       @Suppress("SpreadOperator")
-      windowsAwareCommandLine(
+      it.windowsAwareCommandLine(
           *execCommand.toTypedArray(),
           bundleCommand,
           "--platform",

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/HermesBinaryTask.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/HermesBinaryTask.kt
@@ -45,7 +45,7 @@ open class HermesBinaryTask : DefaultTask() {
   private fun emitHermesBinary(outputFile: File) {
     project.exec {
       @Suppress("SpreadOperator")
-      windowsAwareCommandLine(
+      it.windowsAwareCommandLine(
           hermesCommand,
           "-emit-binary",
           "-out",
@@ -57,10 +57,10 @@ open class HermesBinaryTask : DefaultTask() {
 
   private fun composeSourceMaps() {
     project.exec {
-      workingDir(reactRoot)
+      it.workingDir(reactRoot)
 
       @Suppress("SpreadOperator")
-      windowsAwareCommandLine(
+      it.windowsAwareCommandLine(
           *composeSourceMapsCommand.toTypedArray(),
           jsPackagerSourceMapFile,
           jsCompilerSourceMapFile,


### PR DESCRIPTION
Summary:
Currently RN Gradle Plugin is using `kotlin-dsl` that comes will all sorts of side effects on Gradle plugins projects.
Specifically we can't specify the Kotlin version, plus it makes harder to include Java source code in a single
project.

I'm removing it in favor of Kotlin-JVM plugin. I've adapted the code to use the correct APIs.
Specifically most of the lambdas are changing the scope of the parameter (from `this` to `it`) so I had to adapt
those as well.

Changelog:
[Internal] [Changed] - Do not use `kotlin-dsl` for `react-native-gradle-plugin`

Differential Revision: D30726977

