### PR TITLE
Modify the judgment condition for shouldEmitEvent

### DIFF
--- a/React/Modules/RCTEventEmitter.m
+++ b/React/Modules/RCTEventEmitter.m
@@ -65,7 +65,7 @@
         [[self supportedEvents] componentsJoinedByString:@"`, `"]);
   }
 
-  BOOL shouldEmitEvent = (_observationDisabled || _listenerCount > 0);
+  BOOL shouldEmitEvent = (!_observationDisabled && _listenerCount > 0);
 
   if (shouldEmitEvent && _callableJSModules) {
     [_callableJSModules invokeModule:@"RCTDeviceEventEmitter"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

@RSNara 

When `_observationDisabled` is `YES`, `shouldEmitEvent` should be `NO`.

Before: 

```objectivec
BOOL shouldEmitEvent = (_observationDisabled || _listenerCount > 0);
```

After:

```objectivec
BOOL shouldEmitEvent = (!_observationDisabled && _listenerCount > 0);
```

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [Fixed] - Correct the judgment condition for `shouldEmitEvent`
