### PR TITLE
removed default props for drawerBackgroundColor and fixed lint issues

### DIFF
--- a/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android.js
+++ b/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android.js
@@ -56,7 +56,7 @@ type Props = $ReadOnly<{|
    * );
    * ```
    */
-  drawerBackgroundColor?: ColorValue,
+  drawerBackgroundColor?: ?ColorValue,
 
   /**
    * Specifies the side of the screen from which the drawer will slide in.

--- a/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android.js
+++ b/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android.js
@@ -46,19 +46,6 @@ type Props = $ReadOnly<{|
   keyboardDismissMode?: ?('none' | 'on-drag'),
 
   /**
-   * Specifies the background color of the drawer. The default value is white.
-   * If you want to set the opacity of the drawer, use rgba. Example:
-   *
-   * ```
-   * return (
-   *   <DrawerLayoutAndroid drawerBackgroundColor="rgba(0,0,0,0.5)">
-   *   </DrawerLayoutAndroid>
-   * );
-   * ```
-   */
-  drawerBackgroundColor: ColorValue,
-
-  /**
    * Specifies the side of the screen from which the drawer will slide in.
    */
   drawerPosition: ?('left' | 'right'),
@@ -161,11 +148,6 @@ class DrawerLayoutAndroid extends React.Component<Props, State> {
 
     return {Left: 'left', Right: 'right'};
   }
-  static defaultProps: {|
-    drawerBackgroundColor: 'white',
-  |} = {
-    drawerBackgroundColor: 'white',
-  };
 
   _nativeRef = React.createRef<
     React.ElementRef<typeof AndroidDrawerLayoutNativeComponent>,
@@ -175,6 +157,7 @@ class DrawerLayoutAndroid extends React.Component<Props, State> {
 
   render(): React.Node {
     const {
+      drawerBackgroundColor = 'white',
       onDrawerStateChanged,
       renderNavigationView,
       onDrawerOpen,
@@ -189,7 +172,7 @@ class DrawerLayoutAndroid extends React.Component<Props, State> {
           styles.drawerSubview,
           {
             width: this.props.drawerWidth,
-            backgroundColor: this.props.drawerBackgroundColor,
+            backgroundColor: drawerBackgroundColor,
           },
         ]}
         collapsable={false}>
@@ -220,6 +203,7 @@ class DrawerLayoutAndroid extends React.Component<Props, State> {
       <AndroidDrawerLayoutNativeComponent
         {...props}
         ref={this._nativeRef}
+        drawerBackgroundColor={drawerBackgroundColor}
         drawerWidth={this.props.drawerWidth}
         drawerPosition={this.props.drawerPosition}
         drawerLockMode={this.props.drawerLockMode}

--- a/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android.js
+++ b/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android.js
@@ -46,6 +46,19 @@ type Props = $ReadOnly<{|
   keyboardDismissMode?: ?('none' | 'on-drag'),
 
   /**
+   * Specifies the background color of the drawer. The default value is white.
+   * If you want to set the opacity of the drawer, use rgba. Example:
+   *
+   * ```
+   * return (
+   *   <DrawerLayoutAndroid drawerBackgroundColor="rgba(0,0,0,0.5)">
+   *   </DrawerLayoutAndroid>
+   * );
+   * ```
+   */
+  drawerBackgroundColor?: ColorValue,
+
+  /**
    * Specifies the side of the screen from which the drawer will slide in.
    */
   drawerPosition: ?('left' | 'right'),

--- a/Libraries/Components/DrawerAndroid/__tests__/__snapshots__/DrawerAndroid-test.js.snap
+++ b/Libraries/Components/DrawerAndroid/__tests__/__snapshots__/DrawerAndroid-test.js.snap
@@ -106,7 +106,6 @@ exports[`<DrawerLayoutAndroid /> should render as expected: should deep render w
 
 exports[`<DrawerLayoutAndroid /> should render as expected: should shallow render as <DrawerLayoutAndroid /> when mocked 1`] = `
 <DrawerLayoutAndroid
-  drawerBackgroundColor="white"
   drawerPosition="left"
   drawerWidth={300}
   renderNavigationView={[Function]}
@@ -115,7 +114,6 @@ exports[`<DrawerLayoutAndroid /> should render as expected: should shallow rende
 
 exports[`<DrawerLayoutAndroid /> should render as expected: should shallow render as <DrawerLayoutAndroid /> when not mocked 1`] = `
 <DrawerLayoutAndroid
-  drawerBackgroundColor="white"
   drawerPosition="left"
   drawerWidth={300}
   renderNavigationView={[Function]}


### PR DESCRIPTION
## Summary
Removed the deaultProps in the DrawerLayoutAndroid file and replaced it with a default value in case props are undefined.
## Changelog
[General] [Changed] - Remove defaultProps from the DrawerLayoutAndroid Component. @lunaleaps this is the fix for issue #31606
## Test Plan
Ran test suite
