### PR TITLE
Add `unset npm_config_prefix` to the top of find-node.sh

### DIFF
--- a/scripts/find-node.sh
+++ b/scripts/find-node.sh
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+unset npm_config_prefix
+
 set -e
 
 # Support Homebrew on M1


### PR DESCRIPTION
## Summary

A lot of people are encountering [this issue](https://github.com/react-native-community/upgrade-support/issues/138). This patch fixes the issue using a suggestion from [here](https://github.com/react-native-community/upgrade-support/issues/138#issuecomment-798788120).

## Changelog

[Internal] [Fixed] - Fix nvm node resolution

## Test Plan

Build fails with the following error without the patch:

```
nvm is not compatible with the "npm_config_prefix" environment variable: currently set to "/Users/jenny/.nvm/versions/node/v12.22.6"

Run `unset npm_config_prefix` to unset it.

nvm is not compatible with the "npm_config_prefix" environment variable: currently set to "/Users/jenny/.nvm/versions/node/v12.22.6"

Run `unset npm_config_prefix` to unset it.

Command PhaseScriptExecution failed with a nonzero exit code
```

Build succeeds with no errors after applying the patch.