### PR TITLE
Backport the cliPath fix to the Gradle Plugin

### DIFF
--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/PathUtils.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/PathUtils.kt
@@ -35,7 +35,9 @@ internal fun detectedCliPath(
     config: ReactAppExtension,
 ): String =
     detectCliPath(
-        projectDir = projectDir, reactRoot = config.reactRoot, preconfuredCliPath = config.cliPath)
+        projectDir = projectDir,
+        reactRoot = config.reactRoot,
+        preconfiguredCliPath = config.cliPath)
 
 /**
  * Computes the `hermesc` command location. The Algo follows this order:
@@ -55,9 +57,15 @@ private fun detectEntryFile(entryFile: File?, reactRoot: File): File =
       else -> File(reactRoot, "index.js")
     }
 
-private fun detectCliPath(projectDir: File, reactRoot: File, preconfuredCliPath: String?): String {
+private fun detectCliPath(
+    projectDir: File,
+    reactRoot: File,
+    preconfiguredCliPath: String?
+): String {
   // 1. preconfigured path
-  if (preconfuredCliPath != null) return preconfuredCliPath
+  if (preconfiguredCliPath != null) {
+    return File(projectDir, preconfiguredCliPath).toString()
+  }
 
   // 2. node module path
   val nodeProcess =

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tests/PathUtilsTest.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tests/PathUtilsTest.kt
@@ -58,12 +58,25 @@ class PathUtilsTest {
   fun detectedCliPath_withCliPathFromExtension() {
     val project = ProjectBuilder.builder().build()
     val extension = ReactAppExtension(project)
-    val expected = tempFolder.newFile("fake-cli.sh")
-    extension.cliPath = expected.toString()
+    val expected = File(project.projectDir, "fake-cli.sh").apply { writeText("#!/bin/bash") }
+    extension.cliPath = "./fake-cli.sh"
 
     val actual = detectedCliPath(project.projectDir, extension)
 
-    assertEquals(expected.toString(), actual)
+    assertEquals(expected.canonicalPath, File(actual).canonicalPath)
+  }
+
+  @Test
+  fun detectedCliPath_withCliPathFromExtensionInParentFolder() {
+    val rootProject = ProjectBuilder.builder().build()
+    val project = ProjectBuilder.builder().withParent(rootProject).build()
+    val extension = ReactAppExtension(project)
+    val expected = File(rootProject.projectDir, "cli-in-root.sh").apply { writeText("#!/bin/bash") }
+    extension.cliPath = "../cli-in-root.sh"
+
+    val actual = detectedCliPath(project.projectDir, extension)
+
+    assertEquals(expected.canonicalPath, File(actual).canonicalPath)
   }
 
   @Test


### PR DESCRIPTION
Summary:
This Diff is backporting the change in https://github.com/facebook/react-native/pull/31839/
applied to `react.gradle` also to the React Gradle Plugin. Ideally we would like to two
logic to be in sync as much as possible.

Changelog:
[Internal] [Changed] - Backport the cliPath fix to the Gradle Plugin

Differential Revision: D30899057

