### PR TITLE
Fix broken Android CI due to broken `BundleJsAndAssetsTask` override

### DIFF
--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/BundleJsAndAssetsTask.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/BundleJsAndAssetsTask.kt
@@ -34,10 +34,10 @@ abstract class BundleJsAndAssetsTask : Exec() {
   @get:OutputDirectory lateinit var jsSourceMapsDir: File
   @get:OutputFile lateinit var jsSourceMapsFile: File
 
-  @TaskAction
-  fun run() {
+  override fun exec() {
     cleanOutputDirectories()
-    executeBundleCommand()
+    configureBundleCommand()
+    super.exec()
   }
 
   private fun cleanOutputDirectories() {
@@ -47,7 +47,7 @@ abstract class BundleJsAndAssetsTask : Exec() {
     jsSourceMapsDir.recreateDir()
   }
 
-  private fun executeBundleCommand() {
+  private fun configureBundleCommand() {
     workingDir(reactRoot)
 
     @Suppress("SpreadOperator")
@@ -69,7 +69,5 @@ abstract class BundleJsAndAssetsTask : Exec() {
             "--sourcemap-output",
             jsSourceMapsFile,
             *extraArgs.toTypedArray()))
-
-    super.exec()
   }
 }


### PR DESCRIPTION
Summary:
This Diff fixes the `test_android` CircleCI that is currently broken due to a faulty `BundleJsAndAssetsTask`
(that's my fault sorry for this).

The CI is failing with a `execCommand == null!` error message. The message is happening as the aformentioned
task is not correctly overriding `exec()` but just declaring a `TaskAction`. I'm fixing it.

Changelog:
[Internal] [Changed] - Fix broken Android CI due to broken `BundleJsAndAssetsTask` override

Differential Revision: D30899742

