### PR TITLE
[FlatList] Pass into renderItem() function an extraData prop

### DIFF
--- a/Libraries/Lists/FlatList.js
+++ b/Libraries/Lists/FlatList.js
@@ -580,14 +580,21 @@ class FlatList<ItemT> extends React.PureComponent<Props<ItemT>, void> {
   }
 
   _renderer = () => {
-    const {ListItemComponent, renderItem, columnWrapperStyle} = this.props;
+    const {
+      ListItemComponent,
+      renderItem,
+      columnWrapperStyle,
+      extraData,
+    } = this.props;
     const numColumns = numColumnsOrDefault(this.props.numColumns);
 
     let virtualizedListRenderKey = ListItemComponent
       ? 'ListItemComponent'
       : 'renderItem';
 
-    const renderer = (props): React.Node => {
+    const renderer = (info): React.Node => {
+      const props = {...info, extraData};
+
       if (ListItemComponent) {
         // $FlowFixMe[not-a-component] Component isn't valid
         // $FlowFixMe[incompatible-type-arg] Component isn't valid

--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -55,6 +55,7 @@ export type RenderItemProps<ItemT> = {
   item: ItemT,
   index: number,
   separators: Separators,
+  extraData?: any,
   ...
 };
 

--- a/Libraries/Lists/__tests__/FlatList-test.js
+++ b/Libraries/Lists/__tests__/FlatList-test.js
@@ -93,6 +93,37 @@ describe('FlatList', () => {
     );
     expect(component).toMatchSnapshot();
   });
+  it('invoke renderItem with extraData param', () => {
+    const renderItem = jest.fn().mockReturnValue(null);
+    const selectedId = 2;
+    const ids = [1, 2, 3];
+
+    ReactTestRenderer.create(
+      <FlatList data={ids} renderItem={renderItem} extraData={selectedId} />,
+    );
+
+    expect(renderItem).toBeCalledWith(
+      expect.objectContaining({extraData: selectedId}),
+    );
+  });
+  it('render ListItemComponent with extraData prop', () => {
+    const ListItemComponent = jest.fn().mockReturnValue(null);
+    const selectedId = 2;
+    const ids = [1, 2, 3];
+
+    ReactTestRenderer.create(
+      <FlatList
+        data={ids}
+        ListItemComponent={ListItemComponent}
+        extraData={selectedId}
+      />,
+    );
+
+    expect(ListItemComponent).toBeCalledWith(
+      expect.objectContaining({extraData: selectedId}),
+      {},
+    );
+  });
   it('getNativeScrollRef for case where it returns a native view', () => {
     jest.resetModules();
     jest.unmock('../../Components/ScrollView/ScrollView');


### PR DESCRIPTION

## Summary

In function components to reduce a render count of List we have to memorize a `renderItem` function (because on each render in a new function), but if our a `renderItem` function depends on an `extraData` ("selected item" for example) we have to pass it as dependencies to `useCallback` hook

```tsx
const renderItem = useCallback(({ item }) => {...}, [selectedUserId]);
const renderItem = useCallback(({ item, extraData: selectedUserId }) => {...}, []);
```

So, if we will have the ability to get to `extraData` we can write more effective code (from my POV)

Real use-case:

```tsx
function MyUserList({ userIds }) {
  const [selectedId, setSelectedId] = useState(null);

  const renderItem = useCallback(
    ({ item: userId, extraData: selectedUserId }) => (
      <MyUserItem
        onSelect={setSelectedId}
        isSelected={selectedUserId === userId}
        userId={userId}
      />
    ),
    []
  );

  return (
    <FlatList
      // Pure component will re-rendered when `selectedId` or `users` was changed
      extraData={selectedId}
      data={userIds}
      // Never update because was memoized via useCallback with empty dependencies `useCallback(fn, [])`
      renderItem={renderItem}
    />
  );
}
```


## Changelog

[General] [Added] - Add `extraData` prop to renderItem function `<ScrollView renderItem={info => info.extraData} />

## Test Plan

See tests in PR, example  of usage see above
