### PR TITLE
Update eslint rules according react 17

### DIFF
--- a/packages/eslint-config-react-native-community/index.js
+++ b/packages/eslint-config-react-native-community/index.js
@@ -293,7 +293,7 @@ module.exports = {
     'react/jsx-no-duplicate-props': 2,
     'react/jsx-no-undef': 2,
     'react/jsx-sort-props': 0,
-    'react/jsx-uses-react': 1,
+    'react/jsx-uses-react': 0,
     'react/jsx-uses-vars': 1,
     'react/no-did-mount-set-state': 1,
     'react/no-did-update-set-state': 1,
@@ -301,7 +301,7 @@ module.exports = {
     'react/no-string-refs': 1,
     'react/no-unknown-property': 0,
     'react/prop-types': 0,
-    'react/react-in-jsx-scope': 1,
+    'react/react-in-jsx-scope': 0,
     'react/self-closing-comp': 1,
     'react/wrap-multilines': 0,
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

According React 17 the import from React is not required, them I've disabled the rules `react-in-jsx-scope` and `jsx-uses-react` before I change this rules I search this topic in [stackoverflow](https://stackoverflow.com/questions/64646248/eslintrc-js-for-react-17-and-jsx-without-import-react) that suggest this changes

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[GENERAL] [FIXED] - Update eslint rules according react 17

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Remove the import of React when it's no necessary and the warning `'React' must be in scope when using JSXeslintreact/react-in-jsx-scope` should not appear in the editor