### PR TITLE
Fix Broken RN-Tester due to wrong `cliPath`

### DIFF
--- a/packages/rn-tester/android/app/build.gradle
+++ b/packages/rn-tester/android/app/build.gradle
@@ -77,7 +77,7 @@ plugins {
  */
 
 reactApp {
-    cliPath = "$rootDir/cli.js"
+    cliPath = "../../../../cli.js"
     bundleAssetName = "RNTesterApp.android.bundle"
     entryFile = file("../../js/RNTesterApp.android.js")
     reactRoot = rootDir


### PR DESCRIPTION
Summary:
After we backported the cliPath fix, I forgot to update the `cliPath` specified for RN-Tester.
See D30899057 (https://github.com/facebook/react-native/commit/8d4fe826c3370c8c41203a9710fc6b0d3bd83a98). This Diff is fixing it.

Changelog:
[Internal] [Fixed] - Fix Broken RN-Tester due to wrong `cliPath`

Differential Revision: D30929640

