### PR TITLE
Fix: find-node.sh location in react-native-xcode.sh script

### DIFF
--- a/scripts/react-native-xcode.sh
+++ b/scripts/react-native-xcode.sh
@@ -81,7 +81,7 @@ fi
 
 # Find path to Node
 # shellcheck source=/dev/null
-source "$RN_DIR/scripts/find-node.sh"
+source "$REACT_NATIVE_DIR/scripts/find-node.sh"
 
 # check and assign NODE_BINARY env
 # shellcheck source=/dev/null


### PR DESCRIPTION
## Summary

Fix the `find-node.sh` call in `react-native-xcode.sh` script

## Related issue
https://github.com/facebook/react-native/issues/32168

## Changelog

[iOS] [Fixed] - Fix for unable to find `find-node.sh` in `react-native-xcode.sh` script

## Test Plan

• Run an Xcode build which uses the `scripts/react-native-xcode.sh` in the JS Bundle build phase.
