### PR TITLE
Don’t hard-code CocoaPods’s sandbox path

### DIFF
--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -364,5 +364,5 @@ def __apply_Xcode_12_5_M1_post_install_workaround(installer)
   #   "Time.h:52:17: error: typedef redefinition with different types"
   # We need to make a patch to RCT-Folly - set `__IPHONE_10_0` to our iOS target + 1.
   # See https://github.com/facebook/flipper/issues/834 for more details.
-  `sed -i -e  $'s/__IPHONE_10_0/__IPHONE_12_0/' Pods/RCT-Folly/folly/portability/Time.h`
+  `sed -i -e  $'s/__IPHONE_10_0/__IPHONE_12_0/' #{installer.sandbox.root}/RCT-Folly/folly/portability/Time.h`
 end


### PR DESCRIPTION
## Summary

When running `scripts/react_native_pods.rb`, the `Pods` directory may not be in the current working directory, for example, when calling [`pod install`](https://guides.cocoapods.org/terminal/commands.html#pod_install) with `--project-directory=ios`. Therefore, `sed` fails and, ultimately, the build fails.

## Changelog

[iOS] [Fixed] - Fix build error after running `pod install` with `--project-directory=ios`

## Test Plan

1. `npx react-native init AwesomeProject --version 0.66.0-rc.3 --skip-install`
2. `cd AwesomeProject`
3. `yarn install`
4. `pod install --project-directory=ios`

This command prints “sed: Pods/RCT-Folly/folly/portability/Time.h: No such file or directory” but still exits with 0.

5. `npx react-native run-ios`

The build fails because of “typedef redefinition with different types” as described in https://github.com/facebook/flipper/issues/834.

6. Apply this patch using `(cd node_modules/react-native && curl https://github.com/kontist/react-native/commit/ec330f756e477e53dde891fe02fd74916d9faef0.patch | patch -p1)`
7. Re-run `pod install --project-directory=ios`
8. Re-run `npx react-native run-ios`

The iOS app should now run successfully.