### PR TITLE
Fix VirtualizedList jumping on Android keyboard open with wrong getItemLayout

### DIFF
--- a/packages/rn-tester/android/app/src/main/AndroidManifest.xml
+++ b/packages/rn-tester/android/app/src/main/AndroidManifest.xml
@@ -43,8 +43,11 @@
         android:label="@string/app_name"
         android:screenOrientation="fullSensor"
         android:launchMode="singleTask"
+        android:windowSoftInputMode="adjustResize"
         android:configChanges="orientation|screenSize|uiMode"
         android:exported="true">
+      <!-- windowSoftInputMode: adjustResize is the default for React Native Android -->
+      <!-- See https://github.com/facebook/react-native/blob/main/template/android/app/src/main/AndroidManifest.xml#L18 -->
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />
         <category android:name="android.intent.category.LAUNCHER" />

--- a/packages/rn-tester/js/examples/FlatList/FlatList-withTextInputs.js
+++ b/packages/rn-tester/js/examples/FlatList/FlatList-withTextInputs.js
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+'use strict';
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+import BaseFlatListExample from './BaseFlatListExample';
+import {View, TextInput, FlatList} from 'react-native';
+import type {RenderItemProps} from '@react-native/virtualized-lists';
+import * as React from 'react';
+
+const textInputsItemHeight = 50;
+
+const foodItems = [
+  'Pizza',
+  'Burger',
+  'Risotto',
+  'French Fries',
+  'Onion Rings',
+  'Fried Shrimps',
+  'Water',
+  'Coke',
+  'Beer',
+  'Cheesecake',
+  'Ice Cream',
+];
+
+export function FlatList_withTextInputs(): React.Node {
+  const renderItem = React.useCallback(
+    ({item, index}: RenderItemProps<string>) => {
+      return (
+        // Make each item have slightly incorrect height
+        <View style={{height: textInputsItemHeight + 3}}>
+          <TextInput defaultValue={item} />
+        </View>
+      );
+    },
+    [],
+  );
+
+  const getItemLayout = React.useCallback(
+    (data: ?(string[]), index: number) => {
+      return {
+        index,
+        offset: index * textInputsItemHeight,
+        length: textInputsItemHeight + index,
+      };
+    },
+    [],
+  );
+
+  const data = React.useMemo(() => {
+    const allData: string[] = [];
+    for (let i = 0; i < 10; i++) {
+      allData.push(...foodItems);
+    }
+    return allData;
+  }, []);
+
+  const exampleProps = {
+    renderItem,
+    getItemLayout,
+    windowSize: 5,
+    data,
+  };
+
+  const ref = React.useRef<FlatList<string> | null>(null);
+  return <BaseFlatListExample ref={ref} exampleProps={exampleProps} />;
+}
+
+export default ({
+  title: 'withTextInputs',
+  name: 'withTextInputs',
+  description:
+    "Test TextInputs and ensure they don't shift on keyboard open on Android when the estimated heights are incorrect.",
+  render: () => <FlatList_withTextInputs />,
+}: RNTesterModuleExample);

--- a/packages/rn-tester/js/examples/FlatList/FlatListExampleIndex.js
+++ b/packages/rn-tester/js/examples/FlatList/FlatListExampleIndex.js
@@ -19,6 +19,7 @@ import WithSeparatorsExample from './FlatList-withSeparators';
 import MultiColumnExample from './FlatList-multiColumn';
 import StickyHeadersExample from './FlatList-stickyHeaders';
 import NestedExample from './FlatList-nested';
+import WithTextInputsExample from './FlatList-withTextInputs';
 
 export default ({
   framework: 'React',
@@ -38,5 +39,6 @@ export default ({
     MultiColumnExample,
     StickyHeadersExample,
     NestedExample,
+    WithTextInputsExample,
   ],
 }: RNTesterModule);


### PR DESCRIPTION
## Summary

While working on a SectionList where the estimated heights from `getItemLayout` don't always match the actual heights, I noticed that opening/closing the Android keyboard will cause the list to jump around. This fix avoids that by special-casing the VirtualizedList to not adjust how its subitems are rendered on list open.

### Detailed explanation

1. When the Android keyboard shows up with `softInputMode="adjustResize"` (the default), the whole Android activity shrinks
2. This causes the `visibleLength` to change to be much smaller, which in turn affects the calculation of which items to be actually rendered (based on `windowSize`). Because the `visibleLength` will be smaller, much fewer items will be actually rendered when the keyboard is open
3. If the no-longer-rendered items don't have the correct height from `getItemLayout`, the keyboard can jump

While the user of the list components should fix `getItemLayout` to return the correct heights, this fix makes the lists more resilient against incorrect heights from `getItemLayout`.

### Fix

1. On Android, when we detect the keyboard opening, we record the length this list might shrink to
2. Whenever we detect that we're trying to set `visibleLength` to the height that it would have with the keyboard, we return the previous `visibleLength` instead
3. This also adds a new test to RNTesterApp for verifying this more easily

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Fixed] - Fix VirtualizedList jumping on Android keyboard open with wrong getItemLayout

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

I added a new test-case to the RNTesterApp. On Android, you can very easily see the difference in rendering with and without this fix.

1. Open RNTesterApp and go to the withTextInputs FlatList example
2. Scroll about 2/3 of the way down the list
3. Tap on a TextInput and wait for the keyboard to show up
4. Close the keyboard using the "Enter" key

| Before | After |
| --- | --- |
| https://user-images.githubusercontent.com/2937410/134803441-aec5029b-42ce-45ff-b190-42d18a8f3e94.mp4 | https://user-images.githubusercontent.com/2937410/134803448-0cebf25f-1b10-412f-a634-c8221360faa9.mp4 |

I also added some `console.log`s to ensure the logic is calling in the right order:

#### Added console.logs

```js
      if (isCloseToKeyboardOpenVisibleLength) {
        console.log('adjusted visible length');
        return this._scrollMetrics.visibleLength;
      }
```

```js
    if (Platform.OS === 'android' && this._onLayoutHasRunOnce) {
      console.log('_onLayout start delay');
```

```js
      this._pendingAndroidOnLayoutTimeout = setTimeout(
        () => {
          console.log('_onLayout run after timeout');
          this._runDelayedAndroidOnLayout();
        },
```

```js
    } else {
      console.log('_onLayout immediate');
      this._onLayoutImmediately(e);
    }
```

```js
      this._androidKeyboardListener = Keyboard.addListener(
        'keyboardDidShow',
        event => {
          this._androidKeyboardOpenVisibleLength =
            this._scrollMetrics.visibleLength - event.endCoordinates.height;
          console.log('_onLayout run from keyboard listener');
          this._runDelayedAndroidOnLayout();
        },
      );
```

#### Log output

```
 BUNDLE  packages/rn-tester/js/RNTesterApp.android.js

 WARN  Slider has been extracted from react-native core and will be removed in a future release. It can now be installed and imported from '@react-native-community/slider' instead of 'react-native'. See https://github.com/callstack/react-native-slider
 LOG  Running "RNTesterApp" with {"fabric":true,"initialProps":{"concurrentRoot":true},"rootTag":1}
 LOG  _onLayout immediate
 -- I tapped on a TextInput here --
 LOG  _onLayout start delay
 LOG  _onLayout run from keyboard listener
````