### PR TITLE
Add `ACCESS_MEDIA_LOCATION` permission

### DIFF
--- a/Libraries/PermissionsAndroid/NativePermissionsAndroid.js
+++ b/Libraries/PermissionsAndroid/NativePermissionsAndroid.js
@@ -44,7 +44,8 @@ export type PermissionType =
   | 'android.permission.WRITE_EXTERNAL_STORAGE'
   | 'android.permission.BLUETOOTH_CONNECT'
   | 'android.permission.BLUETOOTH_SCAN'
-  | 'android.permission.BLUETOOTH_ADVERTISE';
+  | 'android.permission.BLUETOOTH_ADVERTISE'
+  | 'android.permission.ACCESS_MEDIA_LOCATION';
 */
 
 export interface Spec extends TurboModule {

--- a/Libraries/PermissionsAndroid/PermissionsAndroid.js
+++ b/Libraries/PermissionsAndroid/PermissionsAndroid.js
@@ -62,6 +62,7 @@ const PERMISSIONS = Object.freeze({
   BLUETOOTH_CONNECT: 'android.permission.BLUETOOTH_CONNECT',
   BLUETOOTH_SCAN: 'android.permission.BLUETOOTH_SCAN',
   BLUETOOTH_ADVERTISE: 'android.permission.BLUETOOTH_ADVERTISE',
+  ACCESS_MEDIA_LOCATION: 'android.permission.ACCESS_MEDIA_LOCATION',
 });
 
 /**
@@ -75,6 +76,7 @@ class PermissionsAndroid {
     ACCESS_BACKGROUND_LOCATION: string,
     ACCESS_COARSE_LOCATION: string,
     ACCESS_FINE_LOCATION: string,
+    ACCESS_MEDIA_LOCATION: string,
     ADD_VOICEMAIL: string,
     BLUETOOTH_ADVERTISE: string,
     BLUETOOTH_CONNECT: string,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

This PR adds `ACCESS_MEDIA_LOCATION` permission to the PermissionsAndroid library. It fixes #31953

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Added] - Add ACCESS_MEDIA_LOCATION permission to PermisionsAndroid library.

## Test Plan

Haven't tested it yet but the code follows the general pattern which is used for other permissions.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
