### PR TITLE
Feat/ios m1 improvements

### DIFF
--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -16,6 +16,13 @@ def use_react_native! (options={})
   # Include Hermes dependencies
   hermes_enabled = options[:hermes_enabled] ||= false
 
+  if `/usr/sbin/sysctl -n hw.optional.arm64 2>&1`.to_i == 1 && !RUBY_PLATFORM.start_with?('arm64')
+    Pod::UI.warn 'Do not use "pod install" from inside Rosetta2 (x86_64 emulation on arm64).'
+    Pod::UI.warn ' - Emulated x86_64 is slower than native arm64'
+    Pod::UI.warn ' - May result in mixed architectures in rubygems (eg: ffi_c.bundle files may be x86_64 with an arm64 interpreter)'
+    Pod::UI.warn 'Run "env /usr/bin/arch -arm64 /bin/bash --login" then try again.'
+  end
+
   # The Pods which should be included in all projects
   pod 'FBLazyVector', :path => "#{prefix}/Libraries/FBLazyVector"
   pod 'FBReactNativeSpec', :path => "#{prefix}/React/FBReactNativeSpec"

--- a/template/ios/Podfile
+++ b/template/ios/Podfile
@@ -25,6 +25,5 @@ target 'HelloWorld' do
 
   post_install do |installer|
     react_native_post_install(installer)
-    __apply_Xcode_12_5_M1_post_install_workaround(installer)
   end
 end


### PR DESCRIPTION
## Summary

* Remove left over from https://github.com/facebook/react-native/commit/a1c445a39c580037ada4a5d194a0d2daef15a25a#commitcomment-57240925
* Add a warning if running with Rosetta2 as per https://github.com/facebook/react-native/pull/32284#issuecomment-929680784

## Changelog

[iOS] [Fixed] - Removed __apply_Xcode_12_5_M1_post_install_workaround
[iOS] [Changed] - Warn if Rosetta2 is being used (x86_64 on arm64)

## Test Plan

Build on macOS Apple devices without any warnings during `pod install`