### PR TITLE
Fix Alert leaving behind a window and view controller (issue 32304)

### DIFF
--- a/React/CoreModules/RCTAlertController.m
+++ b/React/CoreModules/RCTAlertController.m
@@ -35,9 +35,7 @@
 
 - (void)hide
 {
-  [_alertWindow resignKeyWindow];
   [_alertWindow setHidden: YES];
-  _alertWindow.rootViewController = nil;
   _alertWindow = nil;
 }
 

--- a/React/CoreModules/RCTAlertController.m
+++ b/React/CoreModules/RCTAlertController.m
@@ -35,6 +35,9 @@
 
 - (void)hide
 {
+  [_alertWindow resignKeyWindow];
+  [_alertWindow setHidden: YES];
+  _alertWindow.rootViewController = nil;
   _alertWindow = nil;
 }
 


### PR DESCRIPTION
In hide, the window is explicitly removed from the screen and hidden and the root view controller is set to nil to prevent any possible retain cycle between them

This fixes issue 32304 https://github.com/facebook/react-native/issues/32304

## Summary

Restores ability to display an alert, even on iOS 15, without the user losing all ability to interact with the screen.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [Fixed] - Fix Alert.alert causing user interaction to be blocked on iOS 15 (issues/32304)

## Test Plan

Build and run a react-native app on iOS 15. Display an alert and dismiss it.

Now try to interact with the app some more.

Expected: Buttons, scrollbars, etc.. in the main view of the app still function.

Wiithout this fix: It's not possible to interact with those components, as an invisible window is covering the entire screen, blocking all user interaction.
