### PR TITLE
OSS: install node via nvm on iOS image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -370,13 +370,17 @@ jobs:
           steps:
             - brew_install:
                 package: watchman
-            - brew_install:
-                package: node@12
             - run:
                 name: "Brew: Tap wix/brew"
                 command: HOMEBREW_NO_AUTO_UPDATE=1 brew tap wix/brew >/dev/null
             - brew_install:
                 package: applesimutils
+
+      - run:
+          name: Configure Node
+          # Sourcing find-node.sh will ensure nvm is set up.
+          # It also helps future invocation of find-node.sh prevent permission issue with nvm.sh.
+          command: source scripts/find-node.sh && nvm install 12 && nvm alias default 12
 
       - run:
           name: Configure Watchman


### PR DESCRIPTION
Summary:
With the iOS image using Xcode 13, the Circle CI guide mentioned to use `nvm` to manage node: https://circleci.com/docs/2.0/testing-ios/#images-using-xcode-13-and-later

Changelog: [Internal]

Differential Revision: D31331905

