### PR TITLE
OSS CircleCI: pinned Linux machines to ubuntu-2004:202010-01

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -585,7 +585,8 @@ jobs:
   #    JOBS: Test Docker
   # -------------------------
   test_docker_android:
-    machine: true
+    machine:
+      image: ubuntu-2004:202010-01
     steps:
       - checkout
       - run:
@@ -762,7 +763,8 @@ jobs:
   #    JOBS: Nightly
   # -------------------------
   nightly_job:
-    machine: true
+    machine:
+      image: ubuntu-2004:202010-01
     steps:
       - run:
           name: Nightly


### PR DESCRIPTION
Summary:
Some tests were running old Ubuntu with old Node.js etc, causing failures like this:
https://app.circleci.com/pipelines/github/facebook/react-native/10557/workflows/ddd94f8a-7200-40ab-9439-19683d691c67/jobs/220000

In this case, `node` in the machine was really old:

```
node -v
v6.1.0
```

So let's use the latest recommended one per: https://circleci.com/docs/2.0/executor-intro/#machine

Changelog: [Internal]

Differential Revision: D31351763

