### PR TITLE
Bump NDK version to 23.0.7599858 (LTS)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -634,7 +634,7 @@ jobs:
       - ANDROID_BUILD_VERSION: 30
       - ANDROID_TOOLS_VERSION: 30.0.2
       - GRADLE_OPTS: -Dorg.gradle.daemon=false
-      - NDK_VERSION: 21.4.7075529
+      - NDK_VERSION: 23.0.7599858
     steps:
       - checkout
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,6 @@ org.gradle.daemon=true
 org.gradle.jvmargs=-Xmx4g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 org.gradle.parallel=true
 
-ANDROID_NDK_VERSION=21.4.7075529
+ANDROID_NDK_VERSION=23.0.7599858
 android.useAndroidX=true
 kotlin_version=1.4.32

--- a/template/android/build.gradle
+++ b/template/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         minSdkVersion = 21
         compileSdkVersion = 30
         targetSdkVersion = 30
-        ndkVersion = "21.4.7075529"
+        ndkVersion = "23.0.7599858"
     }
     repositories {
         google()


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Bump NKD version to 23.0.7599858 (LTS) which:
- Includes Android 12 APIs
- Updates LLVM

And has very short list of known bugs

## Changelog

[Android] [Changed] - Bump NKD version to 23.0.7599858 (LTS)