### PR TITLE
Move mavenCentral repo below local paths

### DIFF
--- a/template/android/build.gradle
+++ b/template/android/build.gradle
@@ -21,7 +21,6 @@ buildscript {
 
 allprojects {
     repositories {
-        mavenCentral()
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
             url("$rootDir/../node_modules/react-native/android")
@@ -30,7 +29,7 @@ allprojects {
             // Android JSC is installed from npm
             url("$rootDir/../node_modules/jsc-android/dist")
         }
-
+        mavenCentral()
         google()
         maven { url 'https://www.jitpack.io' }
     }


### PR DESCRIPTION
## Summary

In #31609, the deprecated `jcenter()` was replaced with `mavenCentral()`. In the template build.gradle, it _also changed the order of repos_. I am not sure if this was done intentionally or not (@dulmandakh please confirm). Instead of appearing right _after_ `google()`, `mavenCentral()` was put **first** in the list, even before the local repos (that, for example, contain the `react-native` artifacts fetched by npm). Now, under normal circumstance, this _might_ not cause issues because of latency, but there is chance that Gradle could resolve incorrect versions (or at least look in the wrong repo first). The last version of `react-native` published to the public repo was [`0.20.1`](https://mvnrepository.com/artifact/com.facebook.react/react-native/0.20.1), uploaded in February 2016!

This PR changes the order of `mavenCentral()` so that is consistent with both the repo's current [root level build.gradle](https://github.com/facebook/react-native/blob/main/build.gradle.kts#L34), as well as other default Android templates. Putting the local repos first will ensure they have the highest priority when looking for artifacts. `react-native` should _always_ come from the locally downloaded `node_modules/` folder, not from a remote repo.

## Changelog

[Android] [Changed] - Move mavenCentral repo below local paths

## Test Plan

Create new app from template, ensure local repos appear before remote repos; `react-native` resolves to correct version.