### PR TITLE
Update Modal's mock to not render its children when it is not visible

### DIFF
--- a/Libraries/Modal/__tests__/Modal-test.js
+++ b/Libraries/Modal/__tests__/Modal-test.js
@@ -27,6 +27,15 @@ describe('<Modal />', () => {
     expect(instance).toMatchSnapshot();
   });
 
+  it('should not render its children when mocked with visible=false', () => {
+    const instance = render.create(
+      <Modal visible={false}>
+        <View />
+      </Modal>,
+    );
+    expect(instance).toMatchSnapshot();
+  });
+
   it('should shallow render as <Modal> when mocked', () => {
     const output = render.shallow(
       <Modal>

--- a/Libraries/Modal/__tests__/__snapshots__/Modal-test.js.snap
+++ b/Libraries/Modal/__tests__/__snapshots__/Modal-test.js.snap
@@ -4,9 +4,7 @@ exports[`<Modal /> should not render its children when mocked with visible=false
 <Modal
   hardwareAccelerated={false}
   visible={false}
->
-  <View />
-</Modal>
+/>
 `;
 
 exports[`<Modal /> should render as <Modal> when mocked 1`] = `
@@ -22,7 +20,7 @@ exports[`<Modal /> should render as <RCTModalHostView> when not mocked 1`] = `
 <RCTModalHostView
   animationType="none"
   hardwareAccelerated={false}
-  identifier={2}
+  identifier={4}
   onDismiss={[Function]}
   onStartShouldSetResponder={[Function]}
   presentationStyle="fullScreen"

--- a/Libraries/Modal/__tests__/__snapshots__/Modal-test.js.snap
+++ b/Libraries/Modal/__tests__/__snapshots__/Modal-test.js.snap
@@ -1,5 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<Modal /> should not render its children when mocked with visible=false 1`] = `
+<Modal
+  hardwareAccelerated={false}
+  visible={false}
+>
+  <View />
+</Modal>
+`;
+
 exports[`<Modal /> should render as <Modal> when mocked 1`] = `
 <Modal
   hardwareAccelerated={false}
@@ -13,7 +22,7 @@ exports[`<Modal /> should render as <RCTModalHostView> when not mocked 1`] = `
 <RCTModalHostView
   animationType="none"
   hardwareAccelerated={false}
-  identifier={1}
+  identifier={2}
   onDismiss={[Function]}
   onStartShouldSetResponder={[Function]}
   presentationStyle="fullScreen"

--- a/jest/mockModal.js
+++ b/jest/mockModal.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow strict-local
+ */
+
+/* eslint-env jest */
+
+'use strict';
+
+const React = require('react');
+const Modal = require('../Libraries/Modal/Modal');
+
+function mockModal(BaseComponent: $FlowFixMe) {
+  class ModalMock extends BaseComponent {
+    render(): React.Element<typeof Modal> {
+      return (
+        <BaseComponent
+          {...this.props}
+          children={this.props.visible !== true ? null : this.props.children}
+        />
+      );
+    }
+  }
+  return ModalMock;
+}
+
+module.exports = (mockModal: $FlowFixMe);

--- a/jest/setup.js
+++ b/jest/setup.js
@@ -110,9 +110,11 @@ jest
       getNativeRef: jest.fn(),
     }),
   )
-  .mock('../Libraries/Modal/Modal', () =>
-    mockComponent('../Libraries/Modal/Modal'),
-  )
+  .mock('../Libraries/Modal/Modal', () => {
+    const baseComponent = mockComponent('../Libraries/Modal/Modal');
+    const mockModal = jest.requireActual('./mockModal');
+    return mockModal(baseComponent);
+  })
   .mock('../Libraries/Components/View/View', () =>
     mockComponent('../Libraries/Components/View/View', MockNativeMethods),
   )


### PR DESCRIPTION
## Summary

The Modal's mock always render its children (whether it is visible or not), whereas in reality the Modal renders `null` when the Modal is not visible.
This causes troubles when trying to test whether the Modal is visible or not. Instead of testing if the children are rendered (using getByText from React Native Testing Library for instance), we are forced to test the value of the visible prop directly (see https://github.com/callstack/react-native-testing-library/issues/508 and https://github.com/callstack/react-native-testing-library/issues/659).
This is not ideal because we are forced to test implementation detail and can't test from the user perspective. I also believe the mock should be as close as possible from reality.

I had 2 options:
  1. Rendering the Modal without its children
  2. Not rendering the Modal at all
 
The latter has the advantage of being closer to the reality, but I chose the former to still be able to test the Modal through the visible prop, so there is no breaking change (only snapshots update will be required).


## Changelog

[General] [Changed] - Update Modal's mock to not render its children when it is not visible. ⚠️ Snapshots containing Modal with `visible={false}` will have to be updated.

## Test Plan

I added a test case when visible is false, then updated the mock so the children are not rendered. The before / after is here:
![image](https://user-images.githubusercontent.com/17070498/136256142-a351d002-8b77-490a-ba65-1e8ad0d6eb55.png)

