### PR TITLE
Update RCTModalHostViewManager to export the currect propery type

### DIFF
--- a/React/Views/RCTModalHostView.h
+++ b/React/Views/RCTModalHostView.h
@@ -33,7 +33,7 @@
 @property (nonatomic, copy) RCTDirectEventBlock onOrientationChange;
 
 // Fabric only
-@property (nonatomic, copy) RCTBubblingEventBlock onDismiss;
+@property (nonatomic, copy) RCTDirectEventBlock onDismiss;
 
 - (instancetype)initWithBridge:(RCTBridge *)bridge NS_DESIGNATED_INITIALIZER;
 

--- a/React/Views/RCTModalHostViewManager.m
+++ b/React/Views/RCTModalHostViewManager.m
@@ -124,6 +124,6 @@ RCT_EXPORT_VIEW_PROPERTY(visible, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(onRequestClose, RCTDirectEventBlock)
 
 // Fabric only
-RCT_EXPORT_VIEW_PROPERTY(onDismiss, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onDismiss, RCTBubblingEventBlock)
 
 @end

--- a/React/Views/RCTModalHostViewManager.m
+++ b/React/Views/RCTModalHostViewManager.m
@@ -124,6 +124,6 @@ RCT_EXPORT_VIEW_PROPERTY(visible, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(onRequestClose, RCTDirectEventBlock)
 
 // Fabric only
-RCT_EXPORT_VIEW_PROPERTY(onDismiss, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onDismiss, RCTDirectEventBlock)
 
 @end


### PR DESCRIPTION
## Summary

Fix the issue `Component 'RCTModalHostView' re-registered bubbling event 'topDismiss' as a direct event`
the export type `onDismiss` of `RCTModalHostView` does not match the property type,

Property:
`@property (nonatomic, copy) RCTBubblingEventBlock onDismiss;`

Export:
`RCT_EXPORT_VIEW_PROPERTY(onDismiss, RCTDirectEventBlock)`

## Changelog

[General] [Fixed] - Update RCTModalHostViewManager to export the currect propery type

## Test Plan

Build with RN 0.66 with no warning
