### PR TITLE
fix(RCTBlobManager): Prevent RCTConvert error for allowed null blob types

### DIFF
--- a/Libraries/Blob/RCTBlobManager.mm
+++ b/Libraries/Blob/RCTBlobManager.mm
@@ -262,7 +262,7 @@ RCT_EXPORT_METHOD(release:(NSString *)blobId)
   NSDictionary *blob = [RCTConvert NSDictionary:data[@"blob"]];
 
   NSString *contentType = @"application/octet-stream";
-  NSString *blobType = [RCTConvert NSString:blob[@"type"]];
+  NSString *blobType = [RCTConvert NSString:RCTNilIfNull(blob[@"type"])];
   if (blobType != nil && blobType.length > 0) {
     contentType = blob[@"type"];
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

While reworking our media picker, I ended up replacing the RNFetchBlob library to use `fetch()`, leveraging React Native's file resolver (especially to interpret `photos://` URI paths).

The migration process was pretty straightforward, however I kept getting RCTConvert errors when calling `fetch` with a `PUT` method and a blob body:

```
JSON value '<null>' of type NSNull cannot be converted to NSString

+[RCTConvert NSString:]
    RCTConvert.m:59
-[RCTBlobManager handleNetworkingRequest:]
-[RCTNetworking processDataForHTTPQuery:callback:]
-[RCTNetworking buildRequest:completionBlock:]
-[RCTNetworking sendRequest:callback:]
__invoking___
-[NSInvocation invoke]
-[NSInvocation invokeWithTarget:]
-[RCTModuleMethod invokeWithBridge:module:arguments:]
facebook::react::invokeInner(RCTBridge*, RCTModuleData*, unsigned int, folly::dynamic const&, int, (anonymous namespace)::SchedulingContext)
facebook::react::RCTNativeModule::invoke(unsigned int, folly::dynamic&&, int)::$_0::operator()() const
invocation function for block in facebook::react::RCTNativeModule::invoke(unsigned int, folly::dynamic&&, int)
_dispatch_call_block_and_release
_dispatch_client_callout
_dispatch_lane_serial_drain
_dispatch_lane_invoke
_dispatch_workloop_worker_thread
_pthread_wqthread
start_wqthread
```

So I took a look here, and understood that there was a default content-type that could be updated from the blob's own `type`:
https://github.com/facebook/react-native/blob/8ba4a2f127ee5fd862f2bb573ded50abce70c048/Libraries/Blob/RCTBlobManager.mm#L265-L268

However in my case, it seems the blob did not have a type on the JS side, and while the code was working fine, RCTConvert was still logging an error. It is my understanding that in this specific case, since there is a fallback, `null` values should be allowed.

I got inspired from `RCTConvert.m` and added the same `RCTNilIfNull` macro:
https://github.com/facebook/react-native/blob/8ba4a2f127ee5fd862f2bb573ded50abce70c048/React/Base/RCTConvert.m#L79-L84

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [Fixed] - Prevent error logging for supported Blob `null` types

## Test Plan

I'll put my `fetch` snippet here. This is using a third-party library in order to get a signed URL, but it is otherwise pretty straightforward.

This snippet would trigger an error before the changes introduced by this PR.

```js
// Setup (specific to third-party lib)
const key = `file/path/in/bucket`
const params = {
  Key: key,
  Bucket: 'my.awesome.bucket',
}
const s3url = await s3.getSignedUrl('putObject', params)

// Letting RN handle how to retrieve a platform-specific resource URI
const localFetch = await fetch(localPath)
// Getting the blob to upload as octet-stream
const blob = await localFetch.blob()

// Actually uploading
await fetch(s3url, {
  method: 'PUT',
  headers: {
    'Accept': 'application/json',
    'Content-Type': 'application/octet-stream',
  },
  body: blob,
})
```

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
