### PR TITLE
Fix Android border positioning regression

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewBackgroundDrawable.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewBackgroundDrawable.java
@@ -1106,8 +1106,8 @@ public class ReactViewBackgroundDrawable extends Drawable {
             int width = Math.round(borderWidth.left);
             updatePathEffect(width);
             mPaint.setStrokeWidth(width);
-            mPathForSingleBorder.moveTo(left, top - borderWidth.top / 2);
-            mPathForSingleBorder.lineTo(left, bottom + borderWidth.bottom / 2);
+            mPathForSingleBorder.moveTo(left + width / 2, top);
+            mPathForSingleBorder.lineTo(left + width / 2, bottom);
             canvas.drawPath(mPathForSingleBorder, mPaint);
           }
           if (borderTop > 0) {
@@ -1115,8 +1115,8 @@ public class ReactViewBackgroundDrawable extends Drawable {
             int width = Math.round(borderWidth.top);
             updatePathEffect(width);
             mPaint.setStrokeWidth(width);
-            mPathForSingleBorder.moveTo(left, top);
-            mPathForSingleBorder.lineTo(right, top);
+            mPathForSingleBorder.moveTo(left, top + width / 2);
+            mPathForSingleBorder.lineTo(right, top + width / 2);
             canvas.drawPath(mPathForSingleBorder, mPaint);
           }
           if (borderRight > 0) {
@@ -1124,8 +1124,8 @@ public class ReactViewBackgroundDrawable extends Drawable {
             int width = Math.round(borderWidth.right);
             updatePathEffect(width);
             mPaint.setStrokeWidth(width);
-            mPathForSingleBorder.moveTo(right, top - borderWidth.top / 2);
-            mPathForSingleBorder.lineTo(right, bottom + borderWidth.bottom / 2);
+            mPathForSingleBorder.moveTo(right - width / 2, top);
+            mPathForSingleBorder.lineTo(right - width / 2, bottom);
             canvas.drawPath(mPathForSingleBorder, mPaint);
           }
           if (borderBottom > 0) {
@@ -1133,8 +1133,8 @@ public class ReactViewBackgroundDrawable extends Drawable {
             int width = Math.round(borderWidth.bottom);
             updatePathEffect(width);
             mPaint.setStrokeWidth(width);
-            mPathForSingleBorder.moveTo(left, bottom);
-            mPathForSingleBorder.lineTo(right, bottom);
+            mPathForSingleBorder.moveTo(left, bottom - width / 2);
+            mPathForSingleBorder.lineTo(right, bottom - width / 2);
             canvas.drawPath(mPathForSingleBorder, mPaint);
           }
         }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

#29099 introduced a regression where non-rounded borders on Android would render partly outside of the bounds of the view as I reported in #32393. This PR addresses that by rendering the borders completely inside the view like it works on iOS, previous version of RN and for rounded corners. 

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Fixed] - Fix Android border positioning regression

## Test Plan

Rendering the following code (as reported in the issue) in the RN Tester app:

```jsx
<View
  style={{
    aspectRatio: 1,
    backgroundColor: 'green',
    borderWidth: 8,
    borderColor: 'black',
    borderStyle: 'dashed',
  }}
/>
```

|Before|After|
|--|--|
|![before](https://user-images.githubusercontent.com/378279/137178113-dd2fea7e-48c8-450b-be3a-92706ef93194.png)|![after](https://user-images.githubusercontent.com/378279/137178140-b5ce7b3d-d455-48a9-a57f-0f3194a65c9a.png)|