### PR TITLE
Add getter function for native modules

### DIFF
--- a/Libraries/BatchedBridge/NativeModules.js
+++ b/Libraries/BatchedBridge/NativeModules.js
@@ -195,6 +195,7 @@ if (global.nativeModuleProxy) {
 
       if (info.module) {
         NativeModules[info.name] = info.module;
+        NativeModules[`get${info.name}`] = () => info.module;
       }
       // If there's no module config, define a lazy getter
       else {

--- a/Libraries/BatchedBridge/__tests__/NativeModules-test.js
+++ b/Libraries/BatchedBridge/__tests__/NativeModules-test.js
@@ -55,6 +55,12 @@ describe('MessageQueue', function() {
     assertQueue(flushedQueue, 0, 0, 0, ['foo']);
   });
 
+  it('should generate getter for native modules', () => {
+    NativeModules.getRemoteModule1().remoteMethod('foo');
+    const flushedQueue = BatchedBridge.flushedQueue();
+    assertQueue(flushedQueue, 0, 0, 0, ['foo']);
+  });
+
   it('should make round trip and clear memory', function() {
     const onFail = jest.fn();
     const onSucc = jest.fn();


### PR DESCRIPTION
## Summary

Each native module currently gets assigned to the `NativeModules` object
using the module name, effectively resulting in the following object:

```js
NativeModules = {
  SomeModule: { ... },
  SomeOtherModule: { ... },
}
```

Writing unit tests for components that interact with native modules can
quickly become tricky, especially when testing scenarios involving
module constants. Writing the necessary code to properly override a
module constant without causing any side effects quickly becomes
cumbersome:

```js
// this causes subsequent tests to also have access to `FOO = 'foo'`
it('some test', () => {
  NativeModules.SomeModule.FOO = 'foo';
});

// so we need a `beforeEach()` block that resets `NativeModules` to _something_
let NativeModules;

beforeEach(() => {
  // some code that ensures the original implementation is not overridden
  // possibly even an `afterEach()` block to restore it afterwards
  NativeModules = ...
});

it('some test', () => {
  NativeModules.SomeModule.FOO = 'foo';
});
```
The above solution (i.e. save original + restore afterwards) needs to be
repeated in every test file that has to do with `NativeModules` since
we can't take advantage of jest's ability to restore mocks.

By adding a wrapper function that returns the module, we can easily just
mock the wrapper function and easily return mocked values:

```js
// during jest setup, only once
jest.mock('react-native', () => {
  const RN = jest.requireActual('react-native');
  RN.NativeModules.getSomeModule = jest.fn();
  return RN;
});

// then tests become as simple as:
it('some test', () => {
  NativeModules.getSomeModule.mockReturnValue({FOO: 'foo'});
});
```

This commit adds an extra attribute called `get<module-name>` (and does
not remove the existing attribute) so that the code is still backwards
compatible. Projects already referencing `NativeModules.<module-name>`
can continue to do so.

## Changelog

[General] [Added] - Add wrapper function to get native modules

## Test Plan

An extra test was added to ensure the new getter method works in the same way as the module attributes.