### PR TITLE
Fix applyAppPlugin being accessed too early in the React App Gradle Plugin

### DIFF
--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
@@ -27,8 +27,8 @@ class ReactPlugin : Plugin<Project> {
   }
 
   private fun applyAppPlugin(project: Project, config: ReactExtension) {
-    if (config.applyAppPlugin.getOrElse(false)) {
-      project.afterEvaluate {
+    project.afterEvaluate {
+      if (config.applyAppPlugin.getOrElse(false)) {
         val androidConfiguration = project.extensions.getByType(BaseExtension::class.java)
         project.configureDevPorts(androidConfiguration)
 

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/ReactPluginTest.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/ReactPluginTest.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react
+
+import com.android.build.gradle.AppExtension
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ReactPluginTest {
+
+  @Test
+  fun reactPlugin_withApplyAppPluginSetToTrue_addsARelevantTask() {
+    val project = ProjectBuilder.builder().build()
+    project.plugins.apply("com.android.application")
+    project.plugins.apply("com.facebook.react")
+
+    project.extensions.getByType(AppExtension::class.java).apply { compileSdkVersion(30) }
+    project.extensions.getByType(ReactExtension::class.java).apply {
+      applyAppPlugin.set(true)
+      cliPath.set(".")
+    }
+
+    // We check if the App Plugin si applied by finding one of the added task.
+    assertTrue(project.getTasksByName("bundleDebugJsAndAssets", false).isNotEmpty())
+  }
+
+  @Test
+  fun reactPlugin_withApplyAppPluginSetToFalse_doesNotApplyTheAppPlugin() {
+    val project = ProjectBuilder.builder().build()
+    project.plugins.apply("com.android.application")
+    project.plugins.apply("com.facebook.react")
+
+    project.extensions.getByType(AppExtension::class.java).apply { compileSdkVersion(30) }
+    project.extensions.getByType(ReactExtension::class.java).apply { applyAppPlugin.set(false) }
+
+    assertTrue(project.getTasksByName("bundleDebugJsAndAssets", false).isEmpty())
+  }
+
+  @Test
+  fun reactPlugin_withApplyAppPluginSetToFalse_codegenPluginIsApplied() {
+    val project = ProjectBuilder.builder().build()
+    project.plugins.apply("com.android.application")
+    project.plugins.apply("com.facebook.react")
+
+    project.extensions.getByType(AppExtension::class.java).apply { compileSdkVersion(30) }
+    project.extensions.getByType(ReactExtension::class.java).apply { applyAppPlugin.set(false) }
+
+    assertTrue(project.getTasksByName("buildCodegenCLI", false).isNotEmpty())
+  }
+}


### PR DESCRIPTION
Summary:
While working on the NDK AGP Apis, I realized the the `applyAppPlugin` is accessed
too early inside the Gradle plugin. Specifically is accessed once the plugin is applied,
and the extension is not configured afterwards. This means that the extension is always set
the default values.

I'm fixing it moving it inside the `project.afterEvaluate` that was already need to access
the variant informations.

Changelog:
[Internal] [Changed] - Fix applyAppPlugin being accessed too early in the React App Gradle Plugin

Reviewed By: ShikaSD

Differential Revision: D31652984

