### PR TITLE
Hide the logbox window explicitly. New behavior in iOS SDK appears to…

### DIFF
--- a/React/CoreModules/RCTLogBox.mm
+++ b/React/CoreModules/RCTLogBox.mm
@@ -72,6 +72,7 @@ RCT_EXPORT_METHOD(hide)
       if (!strongSelf) {
         return;
       }
+      [strongSelf->_view setHidden: YES];
       strongSelf->_view = nil;
     });
   }


### PR DESCRIPTION
… retain UIWindow while visible.


## Summary

Fixes  #32434: RCTLogBox window is orphaned, covering entire screen.

After this change, the logbox window once again is removed from the screen.

## Changelog

New behavior in iOS SDK is that UIWindow is retained by the system while shown.  Thus it's not enough to let ARC release the window to cause it to leave the screen.  Hiding it is also necessary.

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [Fixed] - 32434

## Test Plan


1.     Use console.warn to generate a yellow warning message in log box
2.     click the log
3.     tap "dismiss"
4.     try to tap anywhere
5. Use Xcode view debugger to inspect the UI state

## Expected

The app still responds to the touch.
In Xcode, there is not an extra UIWindow covering the screen

