### PR TITLE
feat: add getAll function to formdata

### DIFF
--- a/Libraries/Network/FormData.js
+++ b/Libraries/Network/FormData.js
@@ -64,6 +64,12 @@ class FormData {
     this._parts.push([key, value]);
   }
 
+  getAll(key: string): Array<FormDataValue> {
+    return this._parts
+      .filter(([name]) => name === key)
+      .map(([, value]) => value);
+  }
+
   getParts(): Array<FormDataPart> {
     return this._parts.map(([name, value]) => {
       const contentDisposition = 'form-data; name="' + name + '"';

--- a/Libraries/Network/__tests__/FormData-test.js
+++ b/Libraries/Network/__tests__/FormData-test.js
@@ -77,4 +77,35 @@ describe('FormData', function () {
     };
     expect(formData.getParts()[0]).toMatchObject(expectedPart);
   });
+
+  it('should return values based on the given key', function () {
+    formData.append('username', 'Chris');
+    formData.append('username', 'Bob');
+
+    expect(formData.getAll('username').length).toBe(2);
+
+    expect(formData.getAll('username')).toMatchObject(['Chris', 'Bob']);
+
+    formData.append('photo', {
+      uri: 'arbitrary/path',
+      type: 'image/jpeg',
+      name: 'photo3.jpg',
+    });
+
+    formData.append('photo', {
+      uri: 'arbitrary/path',
+      type: 'image/jpeg',
+      name: 'photo2.jpg',
+    });
+
+    const expectedPart = {
+      uri: 'arbitrary/path',
+      type: 'image/jpeg',
+      name: 'photo2.jpg',
+    };
+
+    expect(formData.getAll('photo')[1]).toMatchObject(expectedPart);
+
+    expect(formData.getAll('file').length).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary
The getAll() method of the [FormData](https://developer.mozilla.org/en-US/docs/Web/API/FormData) interface returns all the values associated with a given key from within a FormData object.

## Changelog

[General] [Added] - Add getAll function to FormData class for getting all parts containing that key. This is also available in web API.

## Test Plan

New test added in FormData-test.js
