### PR TITLE
feat: add missing Android dangerous permissions

### DIFF
--- a/Libraries/PermissionsAndroid/NativePermissionsAndroid.js
+++ b/Libraries/PermissionsAndroid/NativePermissionsAndroid.js
@@ -45,7 +45,12 @@ export type PermissionType =
   | 'android.permission.BLUETOOTH_CONNECT'
   | 'android.permission.BLUETOOTH_SCAN'
   | 'android.permission.BLUETOOTH_ADVERTISE'
-  | 'android.permission.ACCESS_MEDIA_LOCATION';
+  | 'android.permission.ACCESS_MEDIA_LOCATION'
+  | 'android.permission.ACCEPT_HANDOVER'
+  | 'android.permission.ACTIVITY_RECOGNITION'
+  | 'android.permission.ANSWER_PHONE_CALLS'
+  | 'android.permission.READ_PHONE_NUMBERS'
+  | 'android.permission.UWB_RANGING';
 */
 
 export interface Spec extends TurboModule {

--- a/Libraries/PermissionsAndroid/PermissionsAndroid.js
+++ b/Libraries/PermissionsAndroid/PermissionsAndroid.js
@@ -63,6 +63,11 @@ const PERMISSIONS = Object.freeze({
   BLUETOOTH_SCAN: 'android.permission.BLUETOOTH_SCAN',
   BLUETOOTH_ADVERTISE: 'android.permission.BLUETOOTH_ADVERTISE',
   ACCESS_MEDIA_LOCATION: 'android.permission.ACCESS_MEDIA_LOCATION',
+  ACCEPT_HANDOVER: 'android.permission.ACCEPT_HANDOVER',
+  ACTIVITY_RECOGNITION: 'android.permission.ACTIVITY_RECOGNITION',
+  ANSWER_PHONE_CALLS: 'android.permission.ANSWER_PHONE_CALLS',
+  READ_PHONE_NUMBERS: 'android.permission.READ_PHONE_NUMBERS',
+  UWB_RANGING: 'android.permission.UWB_RANGING',
 });
 
 /**
@@ -73,11 +78,14 @@ const PERMISSIONS = Object.freeze({
 
 class PermissionsAndroid {
   PERMISSIONS: {|
+    ACCEPT_HANDOVER: string,
     ACCESS_BACKGROUND_LOCATION: string,
     ACCESS_COARSE_LOCATION: string,
     ACCESS_FINE_LOCATION: string,
     ACCESS_MEDIA_LOCATION: string,
+    ACTIVITY_RECOGNITION: string,
     ADD_VOICEMAIL: string,
+    ANSWER_PHONE_CALLS: string,
     BLUETOOTH_ADVERTISE: string,
     BLUETOOTH_CONNECT: string,
     BLUETOOTH_SCAN: string,
@@ -90,6 +98,7 @@ class PermissionsAndroid {
     READ_CALL_LOG: string,
     READ_CONTACTS: string,
     READ_EXTERNAL_STORAGE: string,
+    READ_PHONE_NUMBERS: string,
     READ_PHONE_STATE: string,
     READ_SMS: string,
     RECEIVE_MMS: string,
@@ -98,6 +107,7 @@ class PermissionsAndroid {
     RECORD_AUDIO: string,
     SEND_SMS: string,
     USE_SIP: string,
+    UWB_RANGING: string,
     WRITE_CALENDAR: string,
     WRITE_CALL_LOG: string,
     WRITE_CONTACTS: string,


### PR DESCRIPTION
## Summary

This PR adds all missing `dangerous` permissions in Android. I recently updated these for Android 12 and found many more missing dating all the way back to API 26. After this PR, it will be in sync with ALL dangerous permissions as of the recently released Android 12.

https://developer.android.com/reference/android/Manifest.permission.html#ACCEPT_HANDOVER - 28
https://developer.android.com/reference/android/Manifest.permission.html#ACTIVITY_RECOGNITION - 29
https://developer.android.com/reference/android/Manifest.permission.html#ANSWER_PHONE_CALLS - 26
https://developer.android.com/reference/android/Manifest.permission.html#READ_PHONE_NUMBERS - 26
https://developer.android.com/reference/android/Manifest.permission.html#UWB_RANGING - 31

## Changelog

[Android] [Changed] - Add ACCEPT_HANDOVER, ACTIVITY_RECOGNITION, ANSWER_PHONE_CALLS, READ_PHONE_NUMBERS & UWB_RANGING to PermissionsAndroid

## Test Plan

```
PermissionsAndroid.ACCEPT_HANDOVER === 'android.permission.ACCEPT_HANDOVER'
PermissionsAndroid.ACTIVITY_RECOGNITION === 'android.permission.ACTIVITY_RECOGNITION'
PermissionsAndroid.ANSWER_PHONE_CALLS === 'android.permission.ANSWER_PHONE_CALLS'
PermissionsAndroid.READ_PHONE_NUMBERS === 'android.permission.READ_PHONE_NUMBERS'
PermissionsAndroid.UWB_RANGING === 'android.permission.UWB_RANGING'
```
