### PR TITLE
Fix FlexDirection not working on sticky components inside ScrollView

### DIFF
--- a/Libraries/Components/ScrollView/ScrollViewStickyHeader.js
+++ b/Libraries/Components/ScrollView/ScrollViewStickyHeader.js
@@ -310,7 +310,10 @@ class ScrollViewStickyHeader extends React.Component<Props, State> {
           passthroughAnimatedPropExplicitValues
         }>
         {React.cloneElement(child, {
-          style: styles.fill, // We transfer the child style to the wrapper.
+          style: [
+            styles.fill,
+            {flexDirection: child.props.style.flexDirection},
+          ], // We transfer the child style to the wrapper but still need to apply the flexDirection
           onLayout: undefined, // we call this manually through our this._onLayout
         })}
       </AnimatedView>


### PR DESCRIPTION
## Summary

There is an issue with the way the style is applied in ScrollViewStickyHeader component (see https://github.com/facebook/react-native/issues/32252).
The style is applied to the wrapper. It is fine for most of style properties, but not for flexDirection, because the cloned child always has the default column direction.

## Changelog

[General] [Fixed] - Fix FlexDirection not working on sticky components inside ScrollView

## Test Plan

I used the following code to test:

<details>
<summary>Code</summary>

```
import * as React from 'react';
import {View, StyleSheet, ScrollView} from 'react-native';

export default function App() {
  return (
    <ScrollView style={styles.container} stickyHeaderIndices={[0]}>
      <View style={styles.header}>
        <View style={[styles.box, {backgroundColor: 'blue'}]} />
        <View style={[styles.box, {backgroundColor: 'red'}]} />
        <View style={[styles.box, {backgroundColor: 'green'}]} />
      </View>
      <View style={styles.square} />
    </ScrollView>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    paddingTop: 50,
    backgroundColor: '#ecf0f1',
    padding: 8,
  },
  box: {
    height: 50,
    width: 50,
  },
  header: {
    flex: 1,
    flexDirection: 'row',
  },
  square: {
    backgroundColor: 'orange',
    flex: 1,
    height: 400,
    width: '100%',
  },
});
```

</details>

And here is the result:

Before, the boxes are in column even though `flexDirection: row` is applied:
<img src="https://user-images.githubusercontent.com/17070498/138347638-7a3fdef5-b577-4637-8321-e92e6d2395e8.png" width="400" />

After, the boxes are in row as expected:
<img src="https://user-images.githubusercontent.com/17070498/138347674-16bb8f6e-866d-4ba2-8901-4b1f2f8ad786.png" width="400" />
