### PR TITLE
iOS Ruby Updates

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,7 +56,7 @@ GEM
     colored2 (3.1.2)
     concurrent-ruby (1.1.9)
     escape (0.0.4)
-    ethon (0.14.0)
+    ethon (0.15.0)
       ffi (>= 1.15.0)
     ffi (1.15.4)
     fourflusher (2.3.1)
@@ -65,7 +65,7 @@ GEM
     httpclient (2.8.3)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
-    json (2.5.1)
+    json (2.6.0)
     minitest (5.14.4)
     molinillo (0.8.0)
     nanaimo (0.3.0)
@@ -85,7 +85,7 @@ GEM
       colored2 (~> 3.1)
       nanaimo (~> 0.3.0)
       rexml (~> 3.2.4)
-    zeitwerk (2.4.2)
+    zeitwerk (2.5.1)
 
 PLATFORMS
   ruby
@@ -97,4 +97,4 @@ RUBY VERSION
    ruby 2.7.4p191
 
 BUNDLED WITH
-   2.2.28
+   2.2.29

--- a/scripts/update-ruby.sh
+++ b/scripts/update-ruby.sh
@@ -55,6 +55,9 @@ sed_i -e "s/^\(ruby '\)[^']*\('.*\)$/\1$VERSION\2/" template/Gemfile
 
 rm -f Gemfile.lock template/Gemfile.lock
 
+export BUNDLE_APP_CONFIG="$ROOT/.bundle"
+cp "$BUNDLE_APP_CONFIG/"* template/_bundle # sync!
+
 bundle lock
 (cd template && bundle lock)
 

--- a/template/Gemfile.lock
+++ b/template/Gemfile.lock
@@ -56,7 +56,7 @@ GEM
     colored2 (3.1.2)
     concurrent-ruby (1.1.9)
     escape (0.0.4)
-    ethon (0.14.0)
+    ethon (0.15.0)
       ffi (>= 1.15.0)
     ffi (1.15.4)
     fourflusher (2.3.1)
@@ -65,7 +65,7 @@ GEM
     httpclient (2.8.3)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
-    json (2.5.1)
+    json (2.6.0)
     minitest (5.14.4)
     molinillo (0.8.0)
     nanaimo (0.3.0)
@@ -85,10 +85,10 @@ GEM
       colored2 (~> 3.1)
       nanaimo (~> 0.3.0)
       rexml (~> 3.2.4)
-    zeitwerk (2.4.2)
+    zeitwerk (2.5.1)
 
 PLATFORMS
-  arm64-darwin-20
+  ruby
 
 DEPENDENCIES
   cocoapods (~> 1.11, >= 1.11.2)
@@ -97,4 +97,4 @@ RUBY VERSION
    ruby 2.7.4p191
 
 BUNDLED WITH
-   2.2.28
+   2.2.29


### PR DESCRIPTION
## Summary

Fix the `scripts/update-ruby.sh` so it always use the correct [bundle config](https://bundler.io/man/bundle-config.1.html#DESCRIPTION). In the current version it wasn't using the correct configuration inside the `template/` directory, resulting in incorrect platform for `template/Gemfile.lock`.

While at that, update the gems to their latest version:
- ethon 0.14.0 -> 0.15.0
- json 0.5.1 -> 0.6.0
- zeitwerk 2.4.2 -> 2.5.1
- bundler 2.2.28 -> 2.2.29

## Changelog

No changelog

## Test Plan

Run `bump-oss-version.js` and see `template/Gemfile.lock` lists `ruby` as the `PLATFORM` (no diff in that line).

## References
 - https://github.com/facebook/react-native/commit/e18cf90d71d0bef2e2a0caf30a89e53129152965#r58230816
