### PR TITLE
Add bundleForVariant option

### DIFF
--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactExtension.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactExtension.kt
@@ -130,6 +130,16 @@ abstract class ReactExtension @Inject constructor(project: Project) {
   val bundleIn: MapProperty<String, Boolean> =
       objects.mapProperty(String::class.java, Boolean::class.java).convention(emptyMap())
 
+  /**
+   * Functional interface to toggle the bundle command only on specific [BaseVariant] Default: will check
+   * [bundleIn] or return True for Release variants and False for Debug variants.
+   */
+  var bundleForVariant: (BaseVariant) -> Boolean = { variant ->
+    if (bundleIn.getting(variant.name).isPresent) bundleIn.getting(variant.name).get()
+    else if (bundleIn.getting(variant.buildType.name).isPresent) bundleIn.getting(variant.buildType.name).get()
+    else variant.isRelease
+  }
+
   /** Hermes Config */
 
   /** The command to use to invoke hermes. Default is `hermesc` for the correct OS. */

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/TaskConfiguration.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/TaskConfiguration.kt
@@ -28,7 +28,6 @@ private const val REACT_GROUP = "react"
 @Suppress("SpreadOperator")
 internal fun Project.configureReactTasks(variant: BaseVariant, config: ReactExtension) {
   val targetName = variant.name.capitalize(Locale.ROOT)
-  val isRelease = variant.isRelease
   val targetPath = variant.dirName
 
   // React js bundle directories
@@ -50,7 +49,7 @@ internal fun Project.configureReactTasks(variant: BaseVariant, config: ReactExte
   val execCommand = nodeExecutableAndArgs + cliPath
   val enableHermes = config.enableHermesForVariant(variant)
   val cleanup = config.deleteDebugFilesForVariant(variant)
-  val bundleEnabled = variant.checkBundleEnabled(config)
+  val bundleEnabled = config.bundleForVariant(variant)
 
   val bundleTask =
       tasks.register("createBundle${targetName}JsAndAssets", BundleJsAndAssetsTask::class.java) {
@@ -256,18 +255,6 @@ private fun Project.cleanupVMFiles(
           visit.file.delete()
         }
       }
-}
-
-private fun BaseVariant.checkBundleEnabled(config: ReactExtension): Boolean {
-  if (config.bundleIn.getting(name).isPresent) {
-    return config.bundleIn.getting(name).get()
-  }
-
-  if (config.bundleIn.getting(buildType.name).isPresent) {
-    return config.bundleIn.getting(buildType.name).get()
-  }
-
-  return isRelease
 }
 
 internal val BaseVariant.isRelease: Boolean

--- a/react.gradle
+++ b/react.gradle
@@ -102,7 +102,18 @@ def hermesFlagsForVariant = config.hermesFlagsForVariant ?: {
 // Set disableDevForVariant to a function to configure per variant,
 // defaults to `devDisabledIn${targetName}` or True for Release variants and False for debug variants
 def disableDevForVariant = config.disableDevForVariant ?: {
-    def variant -> config."devDisabledIn${variant.name.capitalize()}" || variant.name.toLowerCase().contains("release")
+    def variant ->
+      config."devDisabledIn${variant.name.capitalize()}" ||
+      variant.name.toLowerCase().contains("release")
+}
+
+// Set bundleForVariant to a function to configure per variant,
+// defaults to `bundleIn${targetName}` or True for Release variants and False for debug variants
+def bundleForVariant = config.bundleForVariant ?: {
+    def variant ->
+      config."bundleIn${variant.name.capitalize()}" ||
+      config."bundleIn${variant.buildType.name.capitalize()}" ||
+      variant.name.toLowerCase().contains("release")
 }
 
 // Set deleteDebugFilesForVariant to a function to configure per variant,
@@ -238,11 +249,7 @@ afterEvaluate {
                 }
             }
 
-            enabled config."bundleIn${targetName}" != null
-                ? config."bundleIn${targetName}"
-                : config."bundleIn${variant.buildType.name.capitalize()}" != null
-                    ? config."bundleIn${variant.buildType.name.capitalize()}"
-                    : targetName.toLowerCase().contains("release")
+            enabled bundleForVariant(variant)
         }
 
         // Expose a minimal interface on the application variant and the task itself:


### PR DESCRIPTION
## Summary

Ref https://github.com/facebook/react-native/pull/30606#issuecomment-948458552

## Changelog

[Android] [Added] - Add bundleForVariant option

## Test Plan

I added the following log into react.gradle and ran the Android build for my app:

```
println("bundleEnabled: ${targetName}, ${bundleForVariant(variant)}")
```

```
# build.gradle

project.ext.react = [
    entryFile: "index.android.js",
    enableHermes: true,  // clean and rebuild if changing
    bundleForVariant: {
         def variant -> variant.name.toLowerCase().contains('release') || variant.name.toLowerCase().contains('live')
    },
]

...

flavorDimensions 'branding'
productFlavors {
    cve {
        dimension 'branding'
    }
    whce {
        dimension 'branding'
    }
}
```

Console output:

```
Reading env from: env/cve/live
bundleEnabled: CveDebug, false
bundleEnabled: CveRelease, true
bundleEnabled: CveLive, true
bundleEnabled: WhceDebug, false
bundleEnabled: WhceRelease, true
bundleEnabled: WhceLive, true
```