### PR TITLE
Only find closest font if system font was not found

### DIFF
--- a/React/Views/RCTFont.mm
+++ b/React/Views/RCTFont.mm
@@ -355,16 +355,18 @@ RCT_ARRAY_CONVERTER(RCTFontVariantDescriptor)
     }
   }
 
-  // Get the closest font that matches the given weight for the fontFamily
-  CGFloat closestWeight = INFINITY;
   NSArray<NSString *> *names = fontNamesForFamilyName(familyName);
-  for (NSString *name in names) {
-    UIFont *match = [UIFont fontWithName:name size:fontSize];
-    if (isItalic == isItalicFont(match) && isCondensed == isCondensedFont(match)) {
-      CGFloat testWeight = weightOfFont(match);
-      if (ABS(testWeight - fontWeight) < ABS(closestWeight - fontWeight)) {
-        font = match;
-        closestWeight = testWeight;
+  if (!didFindFont) {
+    // Get the closest font that matches the given weight for the fontFamily
+    CGFloat closestWeight = INFINITY;
+    for (NSString *name in names) {
+      UIFont *match = [UIFont fontWithName:name size:fontSize];
+      if (isItalic == isItalicFont(match) && isCondensed == isCondensedFont(match)) {
+        CGFloat testWeight = weightOfFont(match);
+        if (ABS(testWeight - fontWeight) < ABS(closestWeight - fontWeight)) {
+          font = match;
+          closestWeight = testWeight;
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

Before https://github.com/facebook/react-native/commit/f951da912dd8b4dc2b0d674f8f37f9d982a03c48 finding a system font used to return early. In order to allow variants, the referenced patch removed the early return so that variants could be applied later. However, there is no need to find the closest font as we already selected the proper system font. This also fixes a bug with setting a custom font handler via RCTSetDefaultFontHandler whos return could get overwritten by the closest font search.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [Fixed] - Respect RCTSetDefaultFontHandler chosen font

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
