### PR TITLE
Remove iOS 11 availability check

### DIFF
--- a/React/Fabric/Mounting/ComponentViews/InputAccessory/RCTInputAccessoryContentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/InputAccessory/RCTInputAccessoryContentView.mm
@@ -24,21 +24,12 @@
     _heightConstraint = [_safeAreaContainer.heightAnchor constraintEqualToConstant:0];
     _heightConstraint.active = YES;
 
-    if (@available(iOS 11.0, *)) {
-      [NSLayoutConstraint activateConstraints:@[
-        [_safeAreaContainer.bottomAnchor constraintEqualToAnchor:self.safeAreaLayoutGuide.bottomAnchor],
-        [_safeAreaContainer.topAnchor constraintEqualToAnchor:self.safeAreaLayoutGuide.topAnchor],
-        [_safeAreaContainer.leadingAnchor constraintEqualToAnchor:self.safeAreaLayoutGuide.leadingAnchor],
-        [_safeAreaContainer.trailingAnchor constraintEqualToAnchor:self.safeAreaLayoutGuide.trailingAnchor]
-      ]];
-    } else {
-      [NSLayoutConstraint activateConstraints:@[
-        [_safeAreaContainer.bottomAnchor constraintEqualToAnchor:self.bottomAnchor],
-        [_safeAreaContainer.topAnchor constraintEqualToAnchor:self.topAnchor],
-        [_safeAreaContainer.leadingAnchor constraintEqualToAnchor:self.leadingAnchor],
-        [_safeAreaContainer.trailingAnchor constraintEqualToAnchor:self.trailingAnchor]
-      ]];
-    }
+    [NSLayoutConstraint activateConstraints:@[
+      [_safeAreaContainer.bottomAnchor constraintEqualToAnchor:self.safeAreaLayoutGuide.bottomAnchor],
+      [_safeAreaContainer.topAnchor constraintEqualToAnchor:self.safeAreaLayoutGuide.topAnchor],
+      [_safeAreaContainer.leadingAnchor constraintEqualToAnchor:self.safeAreaLayoutGuide.leadingAnchor],
+      [_safeAreaContainer.trailingAnchor constraintEqualToAnchor:self.safeAreaLayoutGuide.trailingAnchor]
+    ]];
   }
   return self;
 }

--- a/React/Fabric/Mounting/ComponentViews/ScrollView/RCTEnhancedScrollView.mm
+++ b/React/Fabric/Mounting/ComponentViews/ScrollView/RCTEnhancedScrollView.mm
@@ -30,12 +30,10 @@
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if (self = [super initWithFrame:frame]) {
-    if (@available(iOS 11.0, *)) {
-      // We set the default behavior to "never" so that iOS
-      // doesn't do weird things to UIScrollView insets automatically
-      // and keeps it as an opt-in behavior.
-      self.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
-    }
+    // We set the default behavior to "never" so that iOS
+    // doesn't do weird things to UIScrollView insets automatically
+    // and keeps it as an opt-in behavior.
+    self.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
 
     // We intentionally force `UIScrollView`s `semanticContentAttribute` to `LTR` here
     // because this attribute affects a position of vertical scrollbar; we don't want this

--- a/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -258,18 +258,16 @@ static void RCTSendPaperScrollEvent_DEPRECATED(UIScrollView *scrollView, NSInteg
     }
   }
 
-  if (@available(iOS 11.0, *)) {
-    if (oldScrollViewProps.contentInsetAdjustmentBehavior != newScrollViewProps.contentInsetAdjustmentBehavior) {
-      auto const contentInsetAdjustmentBehavior = newScrollViewProps.contentInsetAdjustmentBehavior;
-      if (contentInsetAdjustmentBehavior == ContentInsetAdjustmentBehavior::Never) {
-        scrollView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
-      } else if (contentInsetAdjustmentBehavior == ContentInsetAdjustmentBehavior::Automatic) {
-        scrollView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentAutomatic;
-      } else if (contentInsetAdjustmentBehavior == ContentInsetAdjustmentBehavior::ScrollableAxes) {
-        scrollView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentAutomatic;
-      } else if (contentInsetAdjustmentBehavior == ContentInsetAdjustmentBehavior::Always) {
-        scrollView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentAlways;
-      }
+  if (oldScrollViewProps.contentInsetAdjustmentBehavior != newScrollViewProps.contentInsetAdjustmentBehavior) {
+    auto const contentInsetAdjustmentBehavior = newScrollViewProps.contentInsetAdjustmentBehavior;
+    if (contentInsetAdjustmentBehavior == ContentInsetAdjustmentBehavior::Never) {
+      scrollView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
+    } else if (contentInsetAdjustmentBehavior == ContentInsetAdjustmentBehavior::Automatic) {
+      scrollView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentAutomatic;
+    } else if (contentInsetAdjustmentBehavior == ContentInsetAdjustmentBehavior::ScrollableAxes) {
+      scrollView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentAutomatic;
+    } else if (contentInsetAdjustmentBehavior == ContentInsetAdjustmentBehavior::Always) {
+      scrollView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentAlways;
     }
   }
 

--- a/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.mm
+++ b/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.mm
@@ -210,12 +210,9 @@ UITextContentType RCTUITextContentTypeFromString(std::string const &contentType)
       @"streetAddressLine2" : UITextContentTypeStreetAddressLine2,
       @"sublocality" : UITextContentTypeSublocality,
       @"telephoneNumber" : UITextContentTypeTelephoneNumber,
+      @"username" : UITextContentTypeUsername,
+      @"password" : UITextContentTypePassword,
     } mutableCopy];
-
-    if (@available(iOS 11.0, *)) {
-      [mutableContentTypeMap
-          addEntriesFromDictionary:@{@"username" : UITextContentTypeUsername, @"password" : UITextContentTypePassword}];
-    }
 
     if (@available(iOS 12.0, *)) {
       [mutableContentTypeMap addEntriesFromDictionary:@{

--- a/React/Views/ScrollView/RCTScrollView.m
+++ b/React/Views/ScrollView/RCTScrollView.m
@@ -289,9 +289,7 @@
     // We set the default behavior to "never" so that iOS
     // doesn't do weird things to UIScrollView insets automatically
     // and keeps it as an opt-in behavior.
-    if ([_scrollView respondsToSelector:@selector(setContentInsetAdjustmentBehavior:)]) {
-      _scrollView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
-    }
+    _scrollView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
 
     _automaticallyAdjustContentInsets = YES;
     _contentInset = UIEdgeInsetsZero;
@@ -937,11 +935,9 @@ RCT_SET_AND_PRESERVE_OFFSET(setScrollIndicatorInsets, scrollIndicatorInsets, UIE
 - (void)setContentInsetAdjustmentBehavior:(UIScrollViewContentInsetAdjustmentBehavior)behavior
 {
   // `contentInsetAdjustmentBehavior` is available since iOS 11.
-  if ([_scrollView respondsToSelector:@selector(setContentInsetAdjustmentBehavior:)]) {
-    CGPoint contentOffset = _scrollView.contentOffset;
-    _scrollView.contentInsetAdjustmentBehavior = behavior;
-    _scrollView.contentOffset = contentOffset;
-  }
+  CGPoint contentOffset = _scrollView.contentOffset;
+  _scrollView.contentInsetAdjustmentBehavior = behavior;
+  _scrollView.contentOffset = contentOffset;
 }
 
 - (void)sendScrollEventWithName:(NSString *)eventName

--- a/ReactCommon/react/renderer/graphics/platform/ios/RCTPlatformColorUtils.mm
+++ b/ReactCommon/react/renderer/graphics/platform/ios/RCTPlatformColorUtils.mm
@@ -187,16 +187,14 @@ static inline facebook::react::ColorComponents _ColorComponentsFromUIColor(UICol
 facebook::react::ColorComponents RCTPlatformColorComponentsFromSemanticItems(std::vector<std::string> &semanticItems)
 {
   for (const auto &semanticCString : semanticItems) {
-    if (@available(iOS 11.0, *)) {
-      NSString *semanticNSString = _NSStringFromCString(semanticCString);
-      UIColor *uiColor = [UIColor colorNamed:semanticNSString];
-      if (uiColor != nil) {
-        return _ColorComponentsFromUIColor(uiColor);
-      }
-      uiColor = _UIColorFromSemanticString(semanticNSString);
-      if (uiColor != nil) {
-        return _ColorComponentsFromUIColor(uiColor);
-      }
+    NSString *semanticNSString = _NSStringFromCString(semanticCString);
+    UIColor *uiColor = [UIColor colorNamed:semanticNSString];
+    if (uiColor != nil) {
+      return _ColorComponentsFromUIColor(uiColor);
+    }
+    uiColor = _UIColorFromSemanticString(semanticNSString);
+    if (uiColor != nil) {
+      return _ColorComponentsFromUIColor(uiColor);
     }
   }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This pull request aims to remove iOS 11 availability check which is no longer needed.

The minimum iOS deployment target for React Native is iOS 11 but we still have iOS 11 version check like below.

```
if (@available(iOS 11.0, *)) {
```

This is a continuation pull request of https://github.com/facebook/react-native/pull/32151

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [Changed] - Remove iOS 11 availability check

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
