### PR TITLE
fix(ios): `pod install --project-directory=ios` fails

### DIFF
--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -274,7 +274,7 @@ def generate_temp_pod_spec_for_codegen!(fabric_enabled)
 
   return {
     "spec" => spec,
-    "path" => output_dir,
+    "path" => $CODEGEN_OUTPUT_DIR,  # Path needs to be relative to `Podfile`
   }
 end
 


### PR DESCRIPTION
## Summary

Running `pod install` from outside the `ios` folder fails because the
path to `React-Codegen` is wrong:

```
% pod install --project-directory=ios
[Codegen] Generating ios/build/generated/ios/React-Codegen.podspec.json
Auto-linking React Native module for target `ReactTestApp`: ReactTestApp-DevSupport
Analyzing dependencies
Fetching podspec for `DoubleConversion` from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`
Fetching podspec for `RCT-Folly` from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`
[!] No podspec found for `React-Codegen` in `ios/build/generated/ios`
```

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [Fixed] - `pod install --project-directory=ios` fails due to wrong path to `React-Codegen`

## Test Plan

1. Verify that `pod install` still works in `/packages/rn-tester`
2. Verify that `pod install --project-directory=ios` also works:
   ```
   git clone https://github.com/microsoft/react-native-test-app.git
   cd react-native-test-app
   npm run set-react-version main
   yarn
   cd example
   pod install --project-directory=ios
   ```