### PR TITLE
ci: ignore bundle size reporter failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,7 +210,7 @@ commands:
       - install_github_bot_deps
       - run:
           name: Report size of RNTester.app (analysis-bot)
-          command: GITHUB_TOKEN="$PUBLIC_ANALYSISBOT_GITHUB_TOKEN_A""$PUBLIC_ANALYSISBOT_GITHUB_TOKEN_B" scripts/circleci/report-bundle-size.sh << parameters.platform >>
+          command: GITHUB_TOKEN="$PUBLIC_ANALYSISBOT_GITHUB_TOKEN_A""$PUBLIC_ANALYSISBOT_GITHUB_TOKEN_B" scripts/circleci/report-bundle-size.sh << parameters.platform >> || true
 
 # -------------------------
 #          JOBS

--- a/bots/make-comment.js
+++ b/bots/make-comment.js
@@ -80,6 +80,60 @@ async function createOrUpdateComment(
   });
 }
 
+/**
+ * Validates that required environment variables are set.
+ * @returns {boolean} `true` if everything is in order; `false` otherwise.
+ */
+function validateEnvironment() {
+  const {
+    GITHUB_TOKEN,
+    GITHUB_OWNER,
+    GITHUB_REPO,
+    GITHUB_PR_NUMBER,
+    GITHUB_REF,
+  } = process.env;
+
+  // We need the following variables to post a comment on a PR
+  if (
+    !GITHUB_TOKEN ||
+    !GITHUB_OWNER ||
+    !GITHUB_REPO ||
+    !GITHUB_PR_NUMBER ||
+    !GITHUB_REF
+  ) {
+    if (!GITHUB_TOKEN) {
+      console.error(
+        'Missing GITHUB_TOKEN. Example: ghp_5fd88b964fa214c4be2b144dc5af5d486a2. PR feedback cannot be provided on GitHub without a valid token.',
+      );
+    }
+    if (!GITHUB_OWNER) {
+      console.error('Missing GITHUB_OWNER. Example: facebook');
+    }
+    if (!GITHUB_REPO) {
+      console.error('Missing GITHUB_REPO. Example: react-native');
+    }
+    if (!GITHUB_PR_NUMBER) {
+      console.error(
+        'Missing GITHUB_PR_NUMBER. Example: 4687. PR feedback cannot be provided on GitHub without a valid pull request number.',
+      );
+    }
+    if (!GITHUB_REF) {
+      console.error("Missing GITHUB_REF. This should've been set by the CI.");
+    }
+
+    return false;
+  }
+
+  console.log(`  GITHUB_TOKEN=${GITHUB_TOKEN}`);
+  console.log(`  GITHUB_OWNER=${GITHUB_OWNER}`);
+  console.log(`  GITHUB_REPO=${GITHUB_REPO}`);
+  console.log(`  GITHUB_PR_NUMBER=${GITHUB_PR_NUMBER}`);
+  console.log(`  GITHUB_REF=${GITHUB_REF}`);
+
+  return true;
+}
+
 module.exports = {
   createOrUpdateComment,
+  validateEnvironment,
 };

--- a/bots/make-comment.js
+++ b/bots/make-comment.js
@@ -52,44 +52,21 @@ async function updateComment(octokit, issueParams, body, replacePattern) {
 
 /**
  * Creates or updates a comment with specified pattern.
+ * @param {{ auth: string; owner: string; repo: string; issue_number: string; }} params
  * @param {string} body Comment body
  * @param {string} replacePattern Pattern for finding the comment to update
  */
-async function createOrUpdateComment(body, replacePattern) {
-  const {GITHUB_TOKEN, GITHUB_OWNER, GITHUB_REPO, GITHUB_PR_NUMBER} =
-    process.env;
-  if (!GITHUB_TOKEN || !GITHUB_OWNER || !GITHUB_REPO || !GITHUB_PR_NUMBER) {
-    if (!GITHUB_TOKEN) {
-      console.error(
-        'Missing GITHUB_TOKEN. Example: 5fd88b964fa214c4be2b144dc5af5d486a2f8c1e. PR feedback cannot be provided on GitHub without a valid token.',
-      );
-    }
-    if (!GITHUB_OWNER) {
-      console.error('Missing GITHUB_OWNER. Example: facebook');
-    }
-    if (!GITHUB_REPO) {
-      console.error('Missing GITHUB_REPO. Example: react-native');
-    }
-    if (!GITHUB_PR_NUMBER) {
-      console.error(
-        'Missing GITHUB_PR_NUMBER. Example: 4687. PR feedback cannot be provided on GitHub without a valid pull request number.',
-      );
-    }
-    process.exit(1);
-  }
-
+async function createOrUpdateComment(
+  {auth, ...issueParams},
+  body,
+  replacePattern,
+) {
   if (!body) {
     return;
   }
 
   const {Octokit} = require('@octokit/rest');
-  const octokit = new Octokit({auth: GITHUB_TOKEN});
-
-  const issueParams = {
-    owner: GITHUB_OWNER,
-    repo: GITHUB_REPO,
-    issue_number: GITHUB_PR_NUMBER,
-  };
+  const octokit = new Octokit({auth});
 
   if (await updateComment(octokit, issueParams, body, replacePattern)) {
     return;

--- a/bots/post-artifacts-link.js
+++ b/bots/post-artifacts-link.js
@@ -9,27 +9,27 @@
 
 'use strict';
 
-const {GITHUB_TOKEN, CIRCLE_BUILD_URL, GITHUB_SHA} = process.env;
-if (!GITHUB_TOKEN || !CIRCLE_BUILD_URL) {
-  if (!GITHUB_TOKEN) {
-    console.error("Missing GITHUB_TOKEN. This should've been set by the CI.");
-  }
-  if (!CIRCLE_BUILD_URL) {
-    console.error(
-      "Missing CIRCLE_BUILD_URL. This should've been set by the CI.",
-    );
-  }
-  process.exit(1);
-}
+const {
+  CIRCLE_BUILD_URL,
+  GITHUB_OWNER,
+  GITHUB_PR_NUMBER,
+  GITHUB_REPO,
+  GITHUB_SHA,
+  GITHUB_TOKEN,
+} = process.env;
 
-const {createOrUpdateComment} = require('./make-comment');
+const {
+  createOrUpdateComment,
+  validateEnvironment: validateEnvironmentForMakeComment,
+} = require('./make-comment');
 
 /**
  * Creates or updates a comment with specified pattern.
+ * @param {{ auth: string; owner: string; repo: string; issue_number: string; }} params
  * @param {string} buildURL link to circleCI build
  * @param {string} commitSha github sha of PR
  */
-function postArtifactLink(buildUrl, commitSha) {
+function postArtifactLink(params, buildUrl, commitSha) {
   // build url link is redirected by CircleCI so appending `/artifacts` doesn't work
   const artifactLink = buildUrl;
   const comment = [
@@ -38,11 +38,48 @@ function postArtifactLink(buildUrl, commitSha) {
     } is ready.`,
     `To use, download tarball from "Artifacts" tab in [this CircleCI job](${artifactLink}) then run \`yarn add <path to tarball>\` in your React Native project.`,
   ].join('\n');
-  createOrUpdateComment(comment);
+  createOrUpdateComment(params, comment);
+}
+
+/**
+ * Validates that required environment variables are set.
+ * @returns {boolean} `true` if everything is in order; `false` otherwise.
+ */
+function validateEnvironment() {
+  if (
+    !validateEnvironmentForMakeComment() ||
+    !CIRCLE_BUILD_URL ||
+    !GITHUB_SHA
+  ) {
+    if (!GITHUB_SHA) {
+      console.error("Missing GITHUB_SHA. This should've been set by the CI.");
+    }
+    if (!CIRCLE_BUILD_URL) {
+      console.error(
+        "Missing CIRCLE_BUILD_URL. This should've been set by the CI.",
+      );
+    }
+    return false;
+  }
+
+  console.log(`  GITHUB_SHA=${GITHUB_SHA}`);
+  console.log(`  CIRCLE_BUILD_URL=${CIRCLE_BUILD_URL}`);
+
+  return true;
+}
+
+if (!validateEnvironment()) {
+  process.exit(1);
 }
 
 try {
-  postArtifactLink(CIRCLE_BUILD_URL, GITHUB_SHA);
+  const params = {
+    auth: GITHUB_TOKEN,
+    owner: GITHUB_OWNER,
+    repo: GITHUB_REPO,
+    issue_number: GITHUB_PR_NUMBER,
+  };
+  postArtifactLink(params, CIRCLE_BUILD_URL, GITHUB_SHA);
 } catch (error) {
   console.error(error);
   process.exitCode = 1;

--- a/bots/report-bundle-size.js
+++ b/bots/report-bundle-size.js
@@ -211,6 +211,13 @@ function validateEnvironment() {
     return false;
   }
 
+  console.log(`  GITHUB_TOKEN=${GITHUB_TOKEN}`);
+  console.log(`  GITHUB_OWNER=${GITHUB_OWNER}`);
+  console.log(`  GITHUB_REPO=${GITHUB_REPO}`);
+  console.log(`  GITHUB_PR_NUMBER=${GITHUB_PR_NUMBER}`);
+  console.log(`  GITHUB_REF=${GITHUB_REF}`);
+  console.log(`  GITHUB_SHA=${GITHUB_SHA}`);
+
   return true;
 }
 

--- a/bots/report-bundle-size.js
+++ b/bots/report-bundle-size.js
@@ -20,7 +20,10 @@ const {
 
 const fs = require('fs');
 const datastore = require('./datastore');
-const {createOrUpdateComment} = require('./make-comment');
+const {
+  createOrUpdateComment,
+  validateEnvironment: validateEnvironmentForMakeComment,
+} = require('./make-comment');
 
 /**
  * Generates and submits a comment. If this is run on the main or release branch, data is
@@ -176,7 +179,7 @@ function isPullRequest(ref) {
 
 /**
  * Validates that required environment variables are set.
- * @returns `true` if everything is in order; `false` otherwise.
+ * @returns {boolean} `true` if everything is in order; `false` otherwise.
  */
 function validateEnvironment() {
   if (!GITHUB_REF) {
@@ -185,24 +188,7 @@ function validateEnvironment() {
   }
 
   if (isPullRequest(GITHUB_REF)) {
-    // We need the following variables to post a comment on a PR
-    if (!GITHUB_TOKEN || !GITHUB_OWNER || !GITHUB_REPO || !GITHUB_PR_NUMBER) {
-      if (!GITHUB_TOKEN) {
-        console.error(
-          'Missing GITHUB_TOKEN. Example: ghp_5fd88b964fa214c4be2b144dc5af5d486a2. PR feedback cannot be provided on GitHub without a valid token.',
-        );
-      }
-      if (!GITHUB_OWNER) {
-        console.error('Missing GITHUB_OWNER. Example: facebook');
-      }
-      if (!GITHUB_REPO) {
-        console.error('Missing GITHUB_REPO. Example: react-native');
-      }
-      if (!GITHUB_PR_NUMBER) {
-        console.error(
-          'Missing GITHUB_PR_NUMBER. Example: 4687. PR feedback cannot be provided on GitHub without a valid pull request number.',
-        );
-      }
+    if (!validateEnvironmentForMakeComment()) {
       return false;
     }
   } else if (!GITHUB_SHA) {
@@ -211,11 +197,6 @@ function validateEnvironment() {
     return false;
   }
 
-  console.log(`  GITHUB_TOKEN=${GITHUB_TOKEN}`);
-  console.log(`  GITHUB_OWNER=${GITHUB_OWNER}`);
-  console.log(`  GITHUB_REPO=${GITHUB_REPO}`);
-  console.log(`  GITHUB_PR_NUMBER=${GITHUB_PR_NUMBER}`);
-  console.log(`  GITHUB_REF=${GITHUB_REF}`);
   console.log(`  GITHUB_SHA=${GITHUB_SHA}`);
 
   return true;

--- a/bots/report-bundle-size.js
+++ b/bots/report-bundle-size.js
@@ -83,7 +83,7 @@ async function reportSizeStats(stats, replacePattern) {
     const document =
       (await datastore.getLatestDocument(collection, 'main')) || {};
     const comment = formatBundleStats(document, stats);
-    createOrUpdateComment(comment, replacePattern);
+    createOrUpdateComment(params, comment, replacePattern);
   }
 
   await datastore.terminateStore(store);

--- a/bots/report-bundle-size.js
+++ b/bots/report-bundle-size.js
@@ -45,7 +45,7 @@ async function reportSizeStats(stats, replacePattern) {
   );
   const collection = datastore.getBinarySizesCollection(store);
 
-  if (isPullRequest(GITHUB_REF)) {
+  if (!isPullRequest(GITHUB_REF)) {
     // Ensure we only store numbers greater than zero.
     const validatedStats = Object.keys(stats).reduce((validated, key) => {
       const value = stats[key];


### PR DESCRIPTION
## Summary

CircleCI stopped populating `CIRCLE_PULL_REQUEST` without providing an
alternative, so now it's impossible to get the PR number unless it comes
from a forked repo.

## Changelog

[Internal] [Fixed] - ignore bundle size reporter failures

## Test Plan

CI should ignore bundle size reporter failures.