### PR TITLE
Fix Fabric debug message when we set `fabric_enabled = false` in `rn-tester`

### DIFF
--- a/packages/rn-tester/Podfile
+++ b/packages/rn-tester/Podfile
@@ -17,8 +17,8 @@ end
 def pods()
   project 'RNTesterPods.xcodeproj'
 
-  puts "Building RNTester with Fabric enabled."
   fabric_enabled = true
+  puts "Building RNTester with Fabric #{fabric_enabled ? "enabled" : "disabled"}."
 
   prefix_path = "../.."
   use_react_native!(path: prefix_path, fabric_enabled: fabric_enabled, hermes_enabled: ENV['USE_HERMES'] == '1')


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

The debug message stays `Building RNTester with Fabric enabled.` even if we set `fabric_enabled = false`

This pull request changes the message like below when `fabric_enabled = false`

`Building RNTester with Fabric disabled.`

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [Fixed] - Fix the debug message for Fabric in rn-tester

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
