### PR TITLE
Add workflow to create version labels on new releases

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -25,7 +25,7 @@ body:
     id: react-native-info
     attributes:
       label: Output of `react-native info`
-      description: Run `react-native info` in your terminal and copy the results here.
+      description: Run `react-native info` in your terminal, copy and paste the results here.
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/release_blocker_form.yml
+++ b/.github/ISSUE_TEMPLATE/release_blocker_form.yml
@@ -23,10 +23,10 @@ body:
     validations:
       required: true
   - type: textarea
-    id: environment
+    id: react-native-info
     attributes:
-      label: Developer Environment
-      description: Please list relevant versions of system, tooling. Ex. OS, processor, Xcode, etc.
+      label: Output of `react-native info`
+      description: Run `react-native info` in your terminal, copy and paste the results here.
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/upgrade-regression-form.yml
+++ b/.github/ISSUE_TEMPLATE/upgrade-regression-form.yml
@@ -31,10 +31,10 @@ body:
     validations:
       required: true
   - type: textarea
-    id: environment
+    id: react-native-info
     attributes:
-      label: Developer Environment
-      description: Please list relevant versions of system, tooling. Ex. OS, processor, Xcode, etc.
+      label: Output of `react-native info`
+      description: Run `react-native info` in your terminal, copy and paste the results here.
     validations:
       required: true
   - type: textarea

--- a/.github/workflows/apply-version-label-issue.yml
+++ b/.github/workflows/apply-version-label-issue.yml
@@ -1,0 +1,16 @@
+name: Apply version label to issue
+
+on:
+  issues:
+    types: [opened, edited]
+
+jobs:
+  add-version-label-issue:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - uses: lucasbento/core-workflow-apply-version-label@v0.0.3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/apply-version-label-issue.yml
+++ b/.github/workflows/apply-version-label-issue.yml
@@ -11,6 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - uses: lucasbento/core-workflow-apply-version-label@v0.0.3
+      - uses: lucasbento/core-workflow-apply-version-label@v0.0.4
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create-new-tag-version-label.yml
+++ b/.github/workflows/create-new-tag-version-label.yml
@@ -1,0 +1,18 @@
+name: Create new tag as version label
+
+on:
+  release:
+    types:
+      - created
+      - edited
+
+jobs:
+  add-new-tag-version-label:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - uses: lucasbento/core-workflow-create-version-label@v0.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

This PR adds the following GitHub actions:

- https://github.com/lucasbento/core-workflow-create-version-label - Create version labels (such as `Version: 0.65.1`) whenever there's a new release;
- https://github.com/lucasbento/core-workflow-apply-version-label - Apply a version label to opened/edited issues based on the version mentioned on the issue body.

## Changelog

N/A.

## Few things to keep in mind

- A label named "Version: unspecified" must be created;
- The GitHub action to create labels will only run when there's a new release or if one is edited, it will then create all the other labels bases on the previous releases until it encounters one that already exists.

---

Example of issue with version label: https://github.com/lucasbento/test-issue-forms/issues/4
