### PR TITLE
Update "robolectric4-sandbox.jar" SHA to unblock broken Docker CI test

### DIFF
--- a/ReactAndroid/src/main/third-party/java/robolectric/BUCK
+++ b/ReactAndroid/src/main/third-party/java/robolectric/BUCK
@@ -147,7 +147,7 @@ rn_prebuilt_jar(
 
 fb_native.remote_file(
     name = "robolectric4-sandbox.jar",
-    sha1 = "03cedd73c5aedaf79fb9a593552816c9fb3282f2",
+    sha1 = "da39a3ee5e6b4b0d3255bfef95601890afd80709",
     url = "mvn:org.robolectric:sandbox:jar:4.4",
 )
 


### PR DESCRIPTION
Summary:
As the commit message says, the test_docker CI job started to fail with
```
Unable to download mvn:org.robolectric:sandbox:jar:4.4 (hashes do not match. Expected 03cedd73c5aedaf79fb9a593552816c9fb3282f2, saw da39a3ee5e6b4b0d3255bfef95601890afd80709)
```
I'm updating the stored hash to fix it.

Changelog:
[Internal] [Changed] - Update "robolectric4-sandbox.jar" SHA to unblock broken Docker CI test

Differential Revision: D32063444

