### PR TITLE
Fix issues with `-rc` version not being labeled properly

### DIFF
--- a/.github/workflows/apply-version-label-issue.yml
+++ b/.github/workflows/apply-version-label-issue.yml
@@ -9,6 +9,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: lucasbento/core-workflow-apply-version-label@v0.0.4
+      - uses: lucasbento/core-workflow-apply-version-label@v0.0.5
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/apply-version-label-issue.yml
+++ b/.github/workflows/apply-version-label-issue.yml
@@ -9,8 +9,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
-
       - uses: lucasbento/core-workflow-apply-version-label@v0.0.4
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create-new-tag-version-label.yml
+++ b/.github/workflows/create-new-tag-version-label.yml
@@ -11,8 +11,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
-
       - uses: lucasbento/core-workflow-create-version-label@v0.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

This PR bumps https://github.com/lucasbento/core-workflow-apply-version-label which fixes the issue with versions having `-rc` not working.

## Changelog

N/A.
