### PR TITLE
RN: Fix Prettier Formatting Errors

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+Libraries/Renderer/

--- a/Libraries/vendor/emitter/_EmitterSubscription.js
+++ b/Libraries/vendor/emitter/_EmitterSubscription.js
@@ -20,7 +20,8 @@ import {type EventSubscription} from './EventSubscription';
  */
 class EmitterSubscription<EventDefinitions: {...}, K: $Keys<EventDefinitions>>
   extends _EventSubscription<EventDefinitions, K>
-  implements EventSubscription {
+  implements EventSubscription
+{
   emitter: EventEmitter<EventDefinitions>;
   listener: ?(...$ElementType<EventDefinitions, K>) => mixed;
   context: ?$FlowFixMe;

--- a/Libraries/vendor/emitter/_EventEmitter.js
+++ b/Libraries/vendor/emitter/_EventEmitter.js
@@ -31,7 +31,8 @@ const sparseFilterPredicate = () => true;
  * more advanced emitter may use an EventHolder and EventFactory.
  */
 class EventEmitter<EventDefinitions: {...}> {
-  _subscriber: EventSubscriptionVendor<EventDefinitions> = new EventSubscriptionVendor<EventDefinitions>();
+  _subscriber: EventSubscriptionVendor<EventDefinitions> =
+    new EventSubscriptionVendor<EventDefinitions>();
 
   /**
    * @constructor

--- a/Libraries/vendor/emitter/_EventSubscription.js
+++ b/Libraries/vendor/emitter/_EventSubscription.js
@@ -18,7 +18,8 @@ import type EventSubscriptionVendor from './_EventSubscriptionVendor';
  * remove its own subscription.
  */
 class _EventSubscription<EventDefinitions: {...}, K: $Keys<EventDefinitions>>
-  implements EventSubscription {
+  implements EventSubscription
+{
   eventType: K;
   key: number;
   subscriber: EventSubscriptionVendor<EventDefinitions>;

--- a/Libraries/vendor/emitter/_EventSubscriptionVendor.js
+++ b/Libraries/vendor/emitter/_EventSubscriptionVendor.js
@@ -23,7 +23,7 @@ class EventSubscriptionVendor<EventDefinitions: {...}> {
     [type: $Keys<EventDefinitions>]: Array<
       EventSubscription<EventDefinitions, $FlowFixMe>,
     >,
-    ...,
+    ...
   };
 
   constructor() {


### PR DESCRIPTION
## Summary

Ignores the `Libraries/Renderer/` directory of files which are synchronized from React (and should not be modified).

Also, formats some EventEmitter modules that for some reason were missed when I upgraded to Prettier v2.x.

## Changelog

[Internal]

## Test Plan

```
yarn run format-check
```