### PR TITLE
Add support for "preferred" AlertButton

### DIFF
--- a/Libraries/Alert/Alert.js
+++ b/Libraries/Alert/Alert.js
@@ -17,7 +17,11 @@ export type AlertType =
   | 'plain-text'
   | 'secure-text'
   | 'login-password';
-export type AlertButtonStyle = 'default' | 'cancel' | 'destructive';
+export type AlertButtonStyle =
+  | 'default'
+  | 'cancel'
+  | 'destructive'
+  | 'preferred';
 export type Buttons = Array<{
   text?: string,
   onPress?: ?Function,
@@ -113,6 +117,7 @@ class Alert {
       const buttons = [];
       let cancelButtonKey;
       let destructiveButtonKey;
+      let preferredButtonKey;
       if (typeof callbackOrButtons === 'function') {
         callbacks = [callbackOrButtons];
       } else if (Array.isArray(callbackOrButtons)) {
@@ -122,6 +127,8 @@ class Alert {
             cancelButtonKey = String(index);
           } else if (btn.style === 'destructive') {
             destructiveButtonKey = String(index);
+          } else if (btn.style === 'preferred') {
+            preferredButtonKey = String(index);
           }
           if (btn.text || index < (callbackOrButtons || []).length - 1) {
             const btnDef = {};
@@ -140,6 +147,7 @@ class Alert {
           defaultValue,
           cancelButtonKey,
           destructiveButtonKey,
+          preferredButtonKey,
           keyboardType,
         },
         (id, value) => {

--- a/Libraries/Alert/Alert.js
+++ b/Libraries/Alert/Alert.js
@@ -17,14 +17,11 @@ export type AlertType =
   | 'plain-text'
   | 'secure-text'
   | 'login-password';
-export type AlertButtonStyle =
-  | 'default'
-  | 'cancel'
-  | 'destructive'
-  | 'preferred';
+export type AlertButtonStyle = 'default' | 'cancel' | 'destructive';
 export type Buttons = Array<{
   text?: string,
   onPress?: ?Function,
+  isPreferred?: boolean,
   style?: AlertButtonStyle,
   ...
 }>;
@@ -127,7 +124,7 @@ class Alert {
             cancelButtonKey = String(index);
           } else if (btn.style === 'destructive') {
             destructiveButtonKey = String(index);
-          } else if (btn.style === 'preferred') {
+          } else if (btn.isPreferred) {
             preferredButtonKey = String(index);
           }
           if (btn.text || index < (callbackOrButtons || []).length - 1) {

--- a/Libraries/Alert/NativeAlertManager.js
+++ b/Libraries/Alert/NativeAlertManager.js
@@ -19,6 +19,7 @@ export type Args = {|
   defaultValue?: string,
   cancelButtonKey?: string,
   destructiveButtonKey?: string,
+  preferredButtonKey?: string,
   keyboardType?: string,
 |};
 

--- a/packages/rn-tester/js/examples/Alert/AlertExample.js
+++ b/packages/rn-tester/js/examples/Alert/AlertExample.js
@@ -204,7 +204,7 @@ const AlertWithStylesPreferred = () => {
           Alert.alert('Foo Title', alertMessage, [
             {
               text: 'OK',
-              style: 'preferred',
+              isPreferred: 'preferred',
               onPress: () => setMessage('OK Pressed!'),
             },
             {
@@ -290,7 +290,7 @@ exports.examples = [
     title: 'Alert with styles',
     platform: 'ios',
     description:
-      "Alert buttons can be styled. Three button button styles are shown here - 'default' | 'cancel' | 'destructive'.",
+      "Alert buttons can be styled. There are three button styles - 'default' | 'cancel' | 'destructive'.",
     render(): React.Node {
       return <AlertWithStyles />;
     },
@@ -299,7 +299,7 @@ exports.examples = [
     title: 'Alert with styles + preferred',
     platform: 'ios',
     description:
-      "Alert buttons can be styled. Setting the style of a button as 'preferred' will give it emphasis over cancel buttons",
+      "Alert buttons with 'isPreferred' will be emphasized, even over cancel buttons",
     render(): React.Node {
       return <AlertWithStylesPreferred />;
     },

--- a/packages/rn-tester/js/examples/Alert/AlertExample.js
+++ b/packages/rn-tester/js/examples/Alert/AlertExample.js
@@ -190,6 +190,39 @@ const AlertWithStyles = () => {
   );
 };
 
+const AlertWithStylesPreferred = () => {
+  const [message, setMessage] = useState('');
+
+  const alertMessage =
+    "The OK button is styled with 'preferred', so it is emphasized over the cancel button.";
+
+  return (
+    <View>
+      <TouchableHighlight
+        style={styles.wrapper}
+        onPress={() =>
+          Alert.alert('Foo Title', alertMessage, [
+            {
+              text: 'OK',
+              style: 'preferred',
+              onPress: () => setMessage('OK Pressed!'),
+            },
+            {
+              text: 'Cancel',
+              style: 'cancel',
+              onPress: () => setMessage('Cancel Pressed!'),
+            },
+          ])
+        }>
+        <View style={styles.button}>
+          <Text>Tap to view alert</Text>
+        </View>
+      </TouchableHighlight>
+      <Log message={message} />
+    </View>
+  );
+};
+
 const styles = StyleSheet.create({
   wrapper: {
     borderRadius: 5,
@@ -257,9 +290,18 @@ exports.examples = [
     title: 'Alert with styles',
     platform: 'ios',
     description:
-      "Alert buttons can be styled. There are three button styles - 'default' | 'cancel' | 'destructive'.",
+      "Alert buttons can be styled. Three button button styles are shown here - 'default' | 'cancel' | 'destructive'.",
     render(): React.Node {
       return <AlertWithStyles />;
+    },
+  },
+  {
+    title: 'Alert with styles + preferred',
+    platform: 'ios',
+    description:
+      "Alert buttons can be styled. Setting the style of a button as 'preferred' will give it emphasis over cancel buttons",
+    render(): React.Node {
+      return <AlertWithStylesPreferred />;
     },
   },
 ];


### PR DESCRIPTION
## Summary

Currently, with the Alert API on iOS, the only way to bold one of the buttons is by setting the style to "cancel". This has the side-effect of moving it to the left. The underlying UIKit API has a way of setting a "preferred" button, which does not have this negative side-effect, so this PR wires this up.

See preferredAction on UIAlertController https://developer.apple.com/documentation/uikit/uialertcontroller/

Docs PR: https://github.com/facebook/react-native-website/pull/2839

## Changelog

[iOS] [Added] - Support setting an Alert button as "preferred", to emphasize it without needing to set it as a "cancel" button.

## Test Plan

I ran the RNTesterPods app and added an example. It has a button styled with "preferred" and another with "cancel", to demonstrate that the "preferred" button takes emphasis over the "cancel" button.

![Simulator Screen Shot - iPhone 11 - 2021-11-04 at 09 48 35](https://user-images.githubusercontent.com/2056078/140292801-df880c43-c330-40df-b8e4-c1476c1645d6.png)

