### PR TITLE
fix(android): make template / rn-tester Android 12 compatible

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/BridgeDevSupportManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/BridgeDevSupportManager.java
@@ -58,7 +58,7 @@ import java.util.concurrent.TimeoutException;
  *
  * IMPORTANT: In order for developer support to work correctly it is required that the
  * manifest of your application contain the following entries:
- * {@code <activity android:name="com.facebook.react.devsupport.DevSettingsActivity"/>}
+ * {@code <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" android:exported="true"/>}
  * {@code <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>}
  */
 public final class BridgeDevSupportManager extends DevSupportManagerBase {

--- a/packages/rn-tester/android/app/build.gradle
+++ b/packages/rn-tester/android/app/build.gradle
@@ -140,7 +140,7 @@ def nativeArchitectures = project.getProperties().get("reactNativeArchitectures"
                           : ["armeabi-v7a", "x86", "x86_64", "arm64-v8a"]
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 31
     if (project.hasProperty("ANDROID_NDK_VERSION")) {
         ndkVersion project.property("ANDROID_NDK_VERSION")
     }
@@ -164,7 +164,7 @@ android {
     defaultConfig {
         applicationId "com.facebook.react.uiapp"
         minSdkVersion 21
-        targetSdkVersion 29
+        targetSdkVersion 31
         versionCode 1
         versionName "1.0"
         testBuildType System.getProperty('testBuildType', 'debug')  // This will later be used to control the test apk build type

--- a/packages/rn-tester/android/app/src/main/AndroidManifest.xml
+++ b/packages/rn-tester/android/app/src/main/AndroidManifest.xml
@@ -35,6 +35,7 @@
         android:name=".RNTesterActivity"
         android:label="@string/app_name"
         android:screenOrientation="fullSensor"
+        android:exported="true"
         android:launchMode="singleTask"
         android:configChanges="orientation|screenSize|uiMode" >
       <intent-filter>
@@ -51,7 +52,10 @@
         <data android:scheme="rntester" android:host="example" />
       </intent-filter>
     </activity>
-    <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
+    <activity
+        android:name="com.facebook.react.devsupport.DevSettingsActivity"
+        android:exported="true"
+    />
     <provider
       android:name="com.facebook.react.modules.blob.BlobProvider"
       android:authorities="@string/blob_provider_authority"

--- a/template/android/app/src/debug/AndroidManifest.xml
+++ b/template/android/app/src/debug/AndroidManifest.xml
@@ -8,6 +8,9 @@
         android:usesCleartextTraffic="true"
         tools:targetApi="28"
         tools:ignore="GoogleAppIndexingWarning">
-        <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
+        <activity
+            android:name="com.facebook.react.devsupport.DevSettingsActivity"
+            android:exported="false"
+        />
     </application>
 </manifest>

--- a/template/android/app/src/main/AndroidManifest.xml
+++ b/template/android/app/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:name=".MainActivity"
         android:label="@string/app_name"
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
+        android:exported="true"
         android:launchMode="singleTask"
         android:windowSoftInputMode="adjustResize">
         <intent-filter>

--- a/template/android/build.gradle
+++ b/template/android/build.gradle
@@ -4,8 +4,8 @@ buildscript {
     ext {
         buildToolsVersion = "30.0.2"
         minSdkVersion = 21
-        compileSdkVersion = 30
-        targetSdkVersion = 30
+        compileSdkVersion = 31
+        targetSdkVersion = 31
         ndkVersion = "21.4.7075529"
     }
     repositories {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

The stock new app template is not Android-12 compatible, and I did not notice any issues or PRs opened for it when I searched, though I may have missed it? So I'm proposing what I think are the necessary changes so new apps work on Android 12 out of the box

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Fixed] - updated new app template and rn-tester for Android 12 support

## Test Plan

1. Check out my branch
2. Make a temporary edit to `template/package.json` to replace react-native version `1000.0.0` with `0.67.0-rc.2`
3. Make a temporary edit to `template/android/app/src/debug/.../ReactNativeFlipper.java` to revert this change which makes ReactNativeFlipper incompatible with the react-native 0.67-0-rc.2 release (https://github.com/facebook/react-native/commit/ce74aa4ed335d4c36ce722d47937b582045e05c4#diff-1e429281c560d83c035cbe6f50683ada72292f7860de108d420fb55185ababad)
3. `npx react-native init Android12Test --template git@github.com:mikehardy/react-native.git#android12`
4. `cd Android12Test && npx react-native run-android`

Those test steps worked for me

I assume rn-tester is tested in CI? If not it will clearly work or clearly blow up when run, but I did check locally:

1. Check out my branch
2. `yarn install`
3. `./gradlew :packages:rn-tester:android:app:installJscDebug` (this is where it would fail if there was a problem)
4. `./scripts/packager.sh`
5. start the app on the device - it all seems to work

Note that I am able to pop up the android debug settings (the DevSupportActivity) with `ctrl-M` on linux but I am simply not able to get the emulator shake to bring it up with exported:true or exported:false. Just in case, and since it is debug only I labeled that activity exported:true to make sure it could be called if needed.

If someone with more knowledge of how and when DevSupportActivity is used in the ecosystem it may be possible to have this as exported:false safely.