### PR TITLE
fix: pass filename to babelTransformFromAstSync

### DIFF
--- a/jest/preprocessor.js
+++ b/jest/preprocessor.js
@@ -147,6 +147,7 @@ module.exports = {
     const babelTransformResult = babelTransformFromAstSync(ast, src, {
       ast: true,
       retainLines: true,
+      filename: file,
       plugins: [
         [
           require('metro-transform-plugins').importExportPlugin,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Since we upgrade `react-native` from `0.65.2`  to `0.66.2` re are facing problems with the Jest preprocessor, you can check more infos [here](https://github.com/reactwg/react-native-releases/discussions/5#discussioncomment-1594605) and [here](https://github.com/facebook/react-native/issues/32372).

I'm just passing `fileName` using the file prop and looks like it solves the problem.

Before:

![Screen Shot 2021-11-05 at 11 00 35](https://user-images.githubusercontent.com/11574033/140797657-f377361f-5a4a-43cf-a95c-d51824cbbce0.png)


After:


![Screen Shot 2021-11-08 at 15 25 08](https://user-images.githubusercontent.com/11574033/140797666-10108c1e-90c4-4ae0-bed8-8169e7b6a0de.png)
## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Internal] [Fixed] - Passing filename to `babelTransformFromAstSync` to avoid babel error:  `Error: [BABEL] unknown: Preset /* your preset */ requires a filename to be set when babel is called directly,`

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
