### PR TITLE
Complete missing Flow declarations in URL

### DIFF
--- a/Libraries/Blob/URL.js
+++ b/Libraries/Blob/URL.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @flow
  */
 
 const Blob = require('./Blob');
@@ -18,6 +19,7 @@ if (
   typeof NativeBlobModule.getConstants().BLOB_URI_SCHEME === 'string'
 ) {
   const constants = NativeBlobModule.getConstants();
+  // $FlowFixMe[incompatible-type] asserted above
   BLOB_URL_PREFIX = constants.BLOB_URI_SCHEME + ':';
   if (typeof constants.BLOB_URI_HOST === 'string') {
     BLOB_URL_PREFIX += `//${constants.BLOB_URI_HOST}/`;
@@ -64,23 +66,23 @@ export class URLSearchParams {
     this._searchParams.push([key, value]);
   }
 
-  delete(name) {
+  delete(name: string) {
     throw new Error('URLSearchParams.delete is not implemented');
   }
 
-  get(name) {
+  get(name: string) {
     throw new Error('URLSearchParams.get is not implemented');
   }
 
-  getAll(name) {
+  getAll(name: string) {
     throw new Error('URLSearchParams.getAll is not implemented');
   }
 
-  has(name) {
+  has(name: string) {
     throw new Error('URLSearchParams.has is not implemented');
   }
 
-  set(name, value) {
+  set(name: string, value: string) {
     throw new Error('URLSearchParams.set is not implemented');
   }
 
@@ -88,11 +90,12 @@ export class URLSearchParams {
     throw new Error('URLSearchParams.sort is not implemented');
   }
 
+  // $FlowFixMe[unsupported-syntax]
   [Symbol.iterator]() {
     return this._searchParams[Symbol.iterator]();
   }
 
-  toString() {
+  toString(): string {
     if (this._searchParams.length === 0) {
       return '';
     }
@@ -111,9 +114,10 @@ function validateBaseUrl(url: string) {
 }
 
 export class URL {
+  _url: string;
   _searchParamsInstance = null;
 
-  static createObjectURL(blob: Blob) {
+  static createObjectURL(blob: Blob): string {
     if (BLOB_URL_PREFIX === null) {
       throw new Error('Cannot create URL for blob!');
     }
@@ -124,7 +128,7 @@ export class URL {
     // Do nothing.
   }
 
-  constructor(url: string, base: string) {
+  constructor(url: string, base: string | URL) {
     let baseUrl = null;
     if (!base || validateBaseUrl(url)) {
       this._url = url;
@@ -137,7 +141,7 @@ export class URL {
         if (!validateBaseUrl(baseUrl)) {
           throw new TypeError(`Invalid base URL: ${baseUrl}`);
         }
-      } else if (typeof base === 'object') {
+      } else {
         baseUrl = base.toString();
       }
       if (baseUrl.endsWith('/')) {
@@ -153,15 +157,15 @@ export class URL {
     }
   }
 
-  get hash() {
+  get hash(): string {
     throw new Error('URL.hash is not implemented');
   }
 
-  get host() {
+  get host(): string {
     throw new Error('URL.host is not implemented');
   }
 
-  get hostname() {
+  get hostname(): string {
     throw new Error('URL.hostname is not implemented');
   }
 
@@ -169,27 +173,27 @@ export class URL {
     return this.toString();
   }
 
-  get origin() {
+  get origin(): string {
     throw new Error('URL.origin is not implemented');
   }
 
-  get password() {
+  get password(): string {
     throw new Error('URL.password is not implemented');
   }
 
-  get pathname() {
+  get pathname(): string {
     throw new Error('URL.pathname not implemented');
   }
 
-  get port() {
+  get port(): string {
     throw new Error('URL.port is not implemented');
   }
 
-  get protocol() {
+  get protocol(): string {
     throw new Error('URL.protocol is not implemented');
   }
 
-  get search() {
+  get search(): string {
     throw new Error('URL.search is not implemented');
   }
 
@@ -208,11 +212,12 @@ export class URL {
     if (this._searchParamsInstance === null) {
       return this._url;
     }
+    const instanceString = this._searchParamsInstance.toString();
     const separator = this._url.indexOf('?') > -1 ? '&' : '?';
-    return this._url + separator + this._searchParamsInstance.toString();
+    return this._url + separator + instanceString;
   }
 
-  get username() {
+  get username(): string {
     throw new Error('URL.username is not implemented');
   }
 }


### PR DESCRIPTION
## Summary

When transpiling flow with a Babel config like
```
{
	plugins:  [['@babel/plugin-transform-flow-strip-types', {requireDirective: true}]]
}
```
all files containing Flow syntax need to have `@flow` at the top of the file.
```
node_modules/react-native/Libraries/Blob/URL.js: A @flow directive is required when using Flow annotations with the `requireDirective` option.
  55 |   _searchParams = [];
  56 |
> 57 |   constructor(params: any) {
     |                     ^^^^^
  58 |     if (typeof params === 'object') {
  59 |       Object.keys(params).forEach(key => this.append(key, params[key]));
  60 |     }
```

In URL, it was removed (mistakenly I think) by https://github.com/facebook/react-native/commit/63038500a23d2dc10798cc116bb70c03064db8bc#diff-552f9731d5c9bc329105a5f4224319966395e59b5bb23202b756c5d152e0f007. Only the `strict-local´ part should have been removed, not the whole line.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Fixed] - Complete missing Flow declarations in URL

## Test Plan

See above