### PR TITLE
Remove unused and incorrect type declarations

### DIFF
--- a/Libraries/WebSocket/WebSocketInterceptor.js
+++ b/Libraries/WebSocket/WebSocketInterceptor.js
@@ -17,8 +17,8 @@ const originalRCTWebSocketSend = NativeWebSocketModule.send;
 const originalRCTWebSocketSendBinary = NativeWebSocketModule.sendBinary;
 const originalRCTWebSocketClose = NativeWebSocketModule.close;
 
-let eventEmitter: NativeEventEmitter;
-let subscriptions: Array<EventSubscription>;
+let eventEmitter;
+let subscriptions;
 
 let closeCallback;
 let sendCallback;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

See https://github.com/facebook/react-native/pull/32566

This file doesn't have a `@flow` comment, and the types that I removed here are incorrect anyway (missing a generic type parameter) because Flow didn't check them.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Fixed] - Remove unused and incorrect type declarations in WebSocketInterceptor

## Test Plan

See https://github.com/facebook/react-native/pull/32566
