### PR TITLE
Fix JSInspector build error on windows

### DIFF
--- a/ReactCommon/jsinspector/BUCK
+++ b/ReactCommon/jsinspector/BUCK
@@ -32,4 +32,5 @@ rn_xplat_cxx_library(
     visibility = [
         "PUBLIC",
     ],
+    windows_compiler_flags = ["/WX-"],  # Do not treat all warnings as errors
 )


### PR DESCRIPTION
Summary: D31631766 (https://github.com/facebook/react-native/commit/b60e229d7f57f9ba79d984b85925f979290d31bf) unified compiler flags for all RN targets, which also enabled `-Werror`  for this target. This causes issues on Windows where some warnings are extremely noisy and unhelpful and causes our Hermes+JSInspector build to fail

Reviewed By: rshest

Differential Revision: D32244577

