### PR TITLE
draft: bump AGP to 7

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -400,6 +400,12 @@ react {
 }
 
 afterEvaluate {
+
+    // Needed as some of the native sources needs to be downloaded
+    // before configureNdkBuildDebug could be executed.
+    configureNdkBuildDebug.dependsOn(preBuild)
+    configureNdkBuildRelease.dependsOn(preBuild)
+
     publishing {
         publications {
             release(MavenPublication) {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ buildscript {
     }
     dependencies {
         val kotlin_version: String by project
-        classpath("com.android.tools.build:gradle:4.2.2")
+        classpath("com.android.tools.build:gradle:7.0.1")
         classpath("de.undercouch:gradle-download-task:4.1.1")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version")
         // NOTE: Do not place your application dependencies here; they belong

--- a/packages/react-native-gradle-plugin/build.gradle.kts
+++ b/packages/react-native-gradle-plugin/build.gradle.kts
@@ -29,7 +29,7 @@ gradlePlugin {
 
 dependencies {
   implementation(gradleApi())
-  implementation("com.android.tools.build:gradle:4.2.2")
+  implementation("com.android.tools.build:gradle:7.0.1")
 
   testImplementation("junit:junit:4.13.2")
 

--- a/packages/react-native-gradle-plugin/build.gradle.kts
+++ b/packages/react-native-gradle-plugin/build.gradle.kts
@@ -29,7 +29,7 @@ gradlePlugin {
 
 dependencies {
   implementation(gradleApi())
-  implementation("com.android.tools.build:gradle:7.0.1")
+  implementation("com.android.tools.build:gradle:4.2.2")
 
   testImplementation("junit:junit:4.13.2")
 

--- a/packages/rn-tester/android/app/build.gradle
+++ b/packages/rn-tester/android/app/build.gradle
@@ -149,9 +149,6 @@ android {
         ndkPath project.property("ANDROID_NDK_PATH")
     }
 
-    dexOptions {
-        javaMaxHeapSize "4g"
-    }
     flavorDimensions "vm"
     productFlavors {
         hermes {

--- a/packages/rn-tester/android/app/build.gradle
+++ b/packages/rn-tester/android/app/build.gradle
@@ -313,6 +313,8 @@ if (enableCodegen) {
     }
 
     afterEvaluate {
+        configureNdkBuildDebug.dependsOn(packageReactReleaseNdkLibs)
+        configureNdkBuildRelease.dependsOn(packageReactReleaseNdkLibs)
         preHermesReleaseBuild.dependsOn(packageReactReleaseNdkLibs)
         preJscReleaseBuild.dependsOn(packageReactReleaseNdkLibs)
         preHermesDebugBuild.dependsOn(packageReactDebugNdkLibs)

--- a/template/android/build.gradle
+++ b/template/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:4.2.2")
+        classpath("com.android.tools.build:gradle:7.0.1")
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }


### PR DESCRIPTION
## Summary

Bump Android Gradle Plugin to 7.

## Changelog

[Android] [Changed] - Bump Android Gradle Plugin to 7.

This will make Java 11 a requirement for users that are either:
* Cloning react-native to contribute
* Using react-native while building from source.
* Creating new project from the template.


## Test Plan

CI is green