### PR TITLE
chore: make CLI error message more descriptive

### DIFF
--- a/react.gradle
+++ b/react.gradle
@@ -32,7 +32,7 @@ def detectCliPath(config) {
         return "${projectDir}/../../node_modules/react-native/cli.js"
     }
     throw new Exception("Couldn't determine CLI location. " +
-             "Please set `project.ext.react.cliPath` to the path of the react-native cli.js");
+             "Please set `project.ext.react.cliPath` to the path of the react-native cli.js file. This file typically resides in `node_modules/react-native/cli.js`");
 }
 
 def composeSourceMapsPath = config.composeSourceMapsPath ?: "node_modules/react-native/scripts/compose-source-maps.js"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

motivation: I have a custom setup and needed to provide `react.cliPath`. I mistakenly provided path to `@react-native-community/cli` which resulted into JS bundle not being generated. This error message provides a little more detail.


## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Changed] - Improved error message in react.gradle

## Test Plan

I guess it's not needed in this case
