### PR TITLE
Fix RetryableMountingException from Switch causing stuck ui operation

### DIFF
--- a/Libraries/Components/Switch/Switch.js
+++ b/Libraries/Components/Switch/Switch.js
@@ -165,7 +165,7 @@ const SwitchWithForwardedRef: React.AbstractComponent<
     setNative({value: event.nativeEvent.value});
   };
 
-  React.useLayoutEffect(() => {
+  React.useEffect(() => {
     // This is necessary in case native updates the switch and JS decides
     // that the update should be ignored and we should stick with the value
     // that we have in JS.


### PR DESCRIPTION
Summary:
Changelog:
[Android][Fixed] - Change useLayoutEffect to useEffect to fix #32594 - stuck operation in mViewCommandOperations list in Android Release on initial layout of a screen with Switch component.

## Summary
This PR fixes the RetryableMountingException that was generated by Switch on Android Release during initial layout - #32594 

## Changelog
Changed useLayoutEffect to useEffect

## Test Plan
To reproduce, put a log in UIViewOperationQueue in dispatchViewUpdates you can see that the RetryableMountingException is no longer thrown. As a result, mViewCommandOperations no longer has a stuck operation on initial layout.
