### PR TITLE
Fix Switch causing RetryableMountingLayerException

### DIFF
--- a/Libraries/Components/Switch/Switch.js
+++ b/Libraries/Components/Switch/Switch.js
@@ -165,7 +165,7 @@ const SwitchWithForwardedRef: React.AbstractComponent<
     setNative({value: event.nativeEvent.value});
   };
 
-  React.useLayoutEffect(() => {
+  React.useEffect(() => {
     // This is necessary in case native updates the switch and JS decides
     // that the update should be ignored and we should stick with the value
     // that we have in JS.

--- a/Libraries/Components/Switch/Switch.js
+++ b/Libraries/Components/Switch/Switch.js
@@ -165,12 +165,13 @@ const SwitchWithForwardedRef: React.AbstractComponent<
     setNative({value: event.nativeEvent.value});
   };
 
-  React.useEffect(() => {
+  React.useLayoutEffect(() => {
     // This is necessary in case native updates the switch and JS decides
     // that the update should be ignored and we should stick with the value
     // that we have in JS.
     const jsValue = value === true;
-    const shouldUpdateNativeSwitch = native.value !== jsValue;
+    const shouldUpdateNativeSwitch =
+      native.value != null && native.value !== jsValue;
     if (
       shouldUpdateNativeSwitch &&
       nativeSwitchRef.current?.setNativeProps != null


### PR DESCRIPTION
## Summary
Added a null check to native.value in Switch to fix regression from RN 66 -> stuck operation in mViewCommandOperations list in Android Release on initial layout of a screen with Switch component. If approved, please incorporate this fix into an RN 66 release.

## Changelog
[Android][Fixed] - Added a null check to native.value in Switch to fix #32594

## Test Plan
To reproduce, put a log in UIViewOperationQueue in dispatchViewUpdates you can see that the RetryableMountingException is no longer thrown for a screen with the Switch component on Android Release. As a result, mViewCommandOperations no longer has a stuck operation on initial layout.