### PR TITLE
Bump OSS Android build to SDK 31

### DIFF
--- a/.circleci/Dockerfiles/Dockerfile.android
+++ b/.circleci/Dockerfiles/Dockerfile.android
@@ -14,7 +14,7 @@
 # and build a Android application that can be used to run the
 # tests specified in the scripts/ directory.
 #
-FROM reactnativecommunity/react-native-android:5.1
+FROM reactnativecommunity/react-native-android:5.2
 
 LABEL Description="React Native Android Test Image"
 LABEL maintainer="Héctor Ramos <hector@fb.com>"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ executors:
   reactnativeandroid:
     <<: *defaults
     docker:
-      - image: reactnativecommunity/react-native-android:5.1
+      - image: reactnativecommunity/react-native-android:5.2
     resource_class: "large"
     environment:
       - TERM: "dumb"
@@ -649,8 +649,8 @@ jobs:
     environment:
       - ANDROID_HOME: "C:\\Android\\android-sdk"
       - ANDROID_NDK: "C:\\Android\\android-sdk\\ndk\\20.1.5948944"
-      - ANDROID_BUILD_VERSION: 30
-      - ANDROID_TOOLS_VERSION: 30.0.2
+      - ANDROID_BUILD_VERSION: 31
+      - ANDROID_TOOLS_VERSION: 31.0.0
       - GRADLE_OPTS: -Dorg.gradle.daemon=false
       - NDK_VERSION: 21.4.7075529
     steps:

--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -281,7 +281,7 @@ task installArchives {
 }
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
     if (project.hasProperty("ANDROID_NDK_VERSION")) {
         ndkVersion project.property("ANDROID_NDK_VERSION")
     }
@@ -291,7 +291,7 @@ android {
 
     defaultConfig {
         minSdkVersion(21)
-        targetSdkVersion(28)
+        targetSdkVersion(31)
         versionCode(1)
         versionName("1.0")
 

--- a/ReactAndroid/src/androidTest/AndroidManifest.xml
+++ b/ReactAndroid/src/androidTest/AndroidManifest.xml
@@ -14,6 +14,7 @@
     <activity
       android:name="com.facebook.react.testing.ReactAppTestActivity"
       android:theme="@style/Theme.ReactNative.AppCompat.Light.NoActionBar.FullScreen"
+      android:exported="false"
     />
   </application>
 </manifest>

--- a/ReactAndroid/src/androidTest/buck-runner/AndroidManifest.xml
+++ b/ReactAndroid/src/androidTest/buck-runner/AndroidManifest.xml
@@ -15,7 +15,8 @@
     <uses-library android:name="android.test.runner" />
     <activity
       android:name="com.facebook.react.testing.ReactAppTestActivity"
-      android:theme="@style/Theme.ReactNative.AppCompat.Light.NoActionBar.FullScreen">
+      android:theme="@style/Theme.ReactNative.AppCompat.Light.NoActionBar.FullScreen"
+      android:exported="false">
     </activity>
   </application>
 

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/BridgeDevSupportManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/BridgeDevSupportManager.java
@@ -58,7 +58,7 @@ import java.util.concurrent.TimeoutException;
  *
  * IMPORTANT: In order for developer support to work correctly it is required that the
  * manifest of your application contain the following entries:
- * {@code <activity android:name="com.facebook.react.devsupport.DevSettingsActivity"/>}
+ * {@code <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" android:exported="false"/>}
  * {@code <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>}
  */
 public final class BridgeDevSupportManager extends DevSupportManagerBase {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "prettier": "prettier --write \"./**/*.{js,md,yml}\"",
     "format-check": "prettier --list-different \"./**/*.{js,md,yml}\"",
     "update-lock": "npx yarn-deduplicate",
-    "docker-setup-android": "docker pull reactnativecommunity/react-native-android:5.1",
+    "docker-setup-android": "docker pull reactnativecommunity/react-native-android:5.2",
     "docker-build-android": "docker build -t reactnativeci/android -f .circleci/Dockerfiles/Dockerfile.android .",
     "test-android-run-instrumentation": "docker run --cap-add=SYS_ADMIN -it reactnativeci/android bash .circleci/Dockerfiles/scripts/run-android-docker-instrumentation-tests.sh",
     "test-android-run-unit": "docker run --cap-add=SYS_ADMIN -it reactnativeci/android bash .circleci/Dockerfiles/scripts/run-android-docker-unit-tests.sh",

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/ReactPluginTest.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/ReactPluginTest.kt
@@ -20,7 +20,7 @@ class ReactPluginTest {
     project.plugins.apply("com.android.application")
     project.plugins.apply("com.facebook.react")
 
-    project.extensions.getByType(AppExtension::class.java).apply { compileSdkVersion(30) }
+    project.extensions.getByType(AppExtension::class.java).apply { compileSdkVersion(31) }
     project.extensions.getByType(ReactExtension::class.java).apply {
       applyAppPlugin.set(true)
       cliPath.set(".")
@@ -36,7 +36,7 @@ class ReactPluginTest {
     project.plugins.apply("com.android.application")
     project.plugins.apply("com.facebook.react")
 
-    project.extensions.getByType(AppExtension::class.java).apply { compileSdkVersion(30) }
+    project.extensions.getByType(AppExtension::class.java).apply { compileSdkVersion(31) }
     project.extensions.getByType(ReactExtension::class.java).apply { applyAppPlugin.set(false) }
 
     assertTrue(project.getTasksByName("bundleDebugJsAndAssets", false).isEmpty())
@@ -48,7 +48,7 @@ class ReactPluginTest {
     project.plugins.apply("com.android.application")
     project.plugins.apply("com.facebook.react")
 
-    project.extensions.getByType(AppExtension::class.java).apply { compileSdkVersion(30) }
+    project.extensions.getByType(AppExtension::class.java).apply { compileSdkVersion(31) }
     project.extensions.getByType(ReactExtension::class.java).apply { applyAppPlugin.set(false) }
 
     assertTrue(project.getTasksByName("buildCodegenCLI", false).isNotEmpty())

--- a/packages/rn-tester/android/app/build.gradle
+++ b/packages/rn-tester/android/app/build.gradle
@@ -142,7 +142,7 @@ def reactNativeArchitectures() {
 }
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 31
     if (project.hasProperty("ANDROID_NDK_VERSION")) {
         ndkVersion project.property("ANDROID_NDK_VERSION")
     }
@@ -166,7 +166,7 @@ android {
     defaultConfig {
         applicationId "com.facebook.react.uiapp"
         minSdkVersion 21
-        targetSdkVersion 29
+        targetSdkVersion 31
         versionCode 1
         versionName "1.0"
         testBuildType System.getProperty('testBuildType', 'debug')  // This will later be used to control the test apk build type

--- a/packages/rn-tester/android/app/src/main/AndroidManifest.xml
+++ b/packages/rn-tester/android/app/src/main/AndroidManifest.xml
@@ -36,7 +36,8 @@
         android:label="@string/app_name"
         android:screenOrientation="fullSensor"
         android:launchMode="singleTask"
-        android:configChanges="orientation|screenSize|uiMode" >
+        android:configChanges="orientation|screenSize|uiMode"
+        android:exported="true">
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />
         <category android:name="android.intent.category.LAUNCHER" />
@@ -51,7 +52,7 @@
         <data android:scheme="rntester" android:host="example" />
       </intent-filter>
     </activity>
-    <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
+    <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" android:exported="false"/>
     <provider
       android:name="com.facebook.react.modules.blob.BlobProvider"
       android:authorities="@string/blob_provider_authority"

--- a/scripts/.tests.env
+++ b/scripts/.tests.env
@@ -4,15 +4,15 @@
 
 ## ANDROID ##
 # Android SDK Build Tools revision
-export ANDROID_SDK_BUILD_TOOLS_REVISION=30.0.2
+export ANDROID_SDK_BUILD_TOOLS_REVISION=31.0.0
 # Android API Level we build with
-export ANDROID_SDK_BUILD_API_LEVEL="28"
+export ANDROID_SDK_BUILD_API_LEVEL="31"
 # Google APIs for Android level
 export ANDROID_GOOGLE_API_LEVEL="23"
 # Minimum Android API SDK Level we target
 export ANDROID_SDK_MINIMUM_API_LEVEL="21"
 # Target API SDK level to build for
-export ANDROID_SDK_TARGET_API_LEVEL="29"
+export ANDROID_SDK_TARGET_API_LEVEL="31"
 # Android Image SDK level to install on the emulator
 export ANDROID_SYSTEM_IMAGE_API_LEVEL="21"
 

--- a/template/android/app/src/debug/AndroidManifest.xml
+++ b/template/android/app/src/debug/AndroidManifest.xml
@@ -8,6 +8,6 @@
         android:usesCleartextTraffic="true"
         tools:targetApi="28"
         tools:ignore="GoogleAppIndexingWarning">
-        <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
+        <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" android:exported="false" />
     </application>
 </manifest>

--- a/template/android/app/src/main/AndroidManifest.xml
+++ b/template/android/app/src/main/AndroidManifest.xml
@@ -15,7 +15,8 @@
         android:label="@string/app_name"
         android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
         android:launchMode="singleTask"
-        android:windowSoftInputMode="adjustResize">
+        android:windowSoftInputMode="adjustResize"
+        android:exported="true">
         <intent-filter>
             <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.LAUNCHER" />

--- a/template/android/build.gradle
+++ b/template/android/build.gradle
@@ -2,10 +2,10 @@
 
 buildscript {
     ext {
-        buildToolsVersion = "30.0.2"
+        buildToolsVersion = "31.0.0"
         minSdkVersion = 21
-        compileSdkVersion = 30
-        targetSdkVersion = 30
+        compileSdkVersion = 31
+        targetSdkVersion = 31
         ndkVersion = "21.4.7075529"
     }
     repositories {


### PR DESCRIPTION
Summary:
Updates OSS builds for internals and template to target SDK 31, corresponding to Android 12.

Changelog:
[Updated][Android] - Bump Android compile and target SDK to 21

Differential Revision: D32107409

