### PR TITLE
Revert "iOS: Fix refreshControl layouting (#28236)"

### DIFF
--- a/React/Views/RefreshControl/RCTRefreshControl.h
+++ b/React/Views/RefreshControl/RCTRefreshControl.h
@@ -14,6 +14,5 @@
 
 @property (nonatomic, copy) NSString *title;
 @property (nonatomic, copy) RCTDirectEventBlock onRefresh;
-@property (nonatomic, weak) UIScrollView *scrollView;
 
 @end

--- a/React/Views/RefreshControl/RCTRefreshControl.m
+++ b/React/Views/RefreshControl/RCTRefreshControl.m
@@ -48,6 +48,12 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)aDecoder)
     self.backgroundColor = [UIColor clearColor];
   }
 
+  // Fix for bug #7976
+  // TODO: Remove when updating to use iOS 10 refreshControl UIScrollView prop.
+  if (self.backgroundColor == nil) {
+    self.backgroundColor = [UIColor clearColor];
+  }
+
   // If the control is refreshing when mounted we need to call
   // beginRefreshing in layoutSubview or it doesn't work.
   if (_currentRefreshingState && _isInitialRender) {
@@ -60,42 +66,34 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)aDecoder)
 {
   UInt64 beginRefreshingTimestamp = _currentRefreshingStateTimestamp;
   _refreshingProgrammatically = YES;
-
+  // When using begin refreshing we need to adjust the ScrollView content offset manually.
+  UIScrollView *scrollView = (UIScrollView *)self.superview;
   // Fix for bug #24855
   [self sizeToFit];
+  CGPoint offset = {scrollView.contentOffset.x, scrollView.contentOffset.y - self.frame.size.height};
 
-  if (self.scrollView) {
-    // When using begin refreshing we need to adjust the ScrollView content offset manually.
-    UIScrollView *scrollView = (UIScrollView *)self.scrollView;
-
-    CGPoint offset = {scrollView.contentOffset.x, scrollView.contentOffset.y - self.frame.size.height};
-
-    // `beginRefreshing` must be called after the animation is done. This is why it is impossible
-    // to use `setContentOffset` with `animated:YES`.
-    [UIView animateWithDuration:0.25
-        delay:0
-        options:UIViewAnimationOptionBeginFromCurrentState
-        animations:^(void) {
-          [scrollView setContentOffset:offset];
+  // `beginRefreshing` must be called after the animation is done. This is why it is impossible
+  // to use `setContentOffset` with `animated:YES`.
+  [UIView animateWithDuration:0.25
+      delay:0
+      options:UIViewAnimationOptionBeginFromCurrentState
+      animations:^(void) {
+        [scrollView setContentOffset:offset];
+      }
+      completion:^(__unused BOOL finished) {
+        if (beginRefreshingTimestamp == self->_currentRefreshingStateTimestamp) {
+          [super beginRefreshing];
+          [self setCurrentRefreshingState:super.refreshing];
         }
-        completion:^(__unused BOOL finished) {
-          if (beginRefreshingTimestamp == self->_currentRefreshingStateTimestamp) {
-            [super beginRefreshing];
-            [self setCurrentRefreshingState:super.refreshing];
-          }
-        }];
-  } else if (beginRefreshingTimestamp == self->_currentRefreshingStateTimestamp) {
-    [super beginRefreshing];
-    [self setCurrentRefreshingState:super.refreshing];
-  }
+      }];
 }
 
 - (void)endRefreshingProgrammatically
 {
   // The contentOffset of the scrollview MUST be greater than the contentInset before calling
   // endRefreshing otherwise the next pull to refresh will not work properly.
-  UIScrollView *scrollView = self.scrollView;
-  if (scrollView && _refreshingProgrammatically && scrollView.contentOffset.y < -scrollView.contentInset.top) {
+  UIScrollView *scrollView = (UIScrollView *)self.superview;
+  if (_refreshingProgrammatically && scrollView.contentOffset.y < -scrollView.contentInset.top) {
     UInt64 endRefreshingTimestamp = _currentRefreshingStateTimestamp;
     CGPoint offset = {scrollView.contentOffset.x, -scrollView.contentInset.top};
     [UIView animateWithDuration:0.25

--- a/React/Views/ScrollView/RCTScrollView.m
+++ b/React/Views/ScrollView/RCTScrollView.m
@@ -221,17 +221,7 @@
     [_customRefreshControl removeFromSuperview];
   }
   _customRefreshControl = refreshControl;
-  // We have to set this because we can't always guarantee the
-  // `RCTCustomRefreshContolProtocol`'s superview will always be of class
-  // `UIScrollView` like we were previously
-  if ([_customRefreshControl respondsToSelector:@selector(setScrollView:)]) {
-    _customRefreshControl.scrollView = self;
-  }
-  if ([refreshControl isKindOfClass:UIRefreshControl.class]) {
-    self.refreshControl = (UIRefreshControl *)refreshControl;
-  } else {
-    [self addSubview:_customRefreshControl];
-  }
+  [self addSubview:_customRefreshControl];
 }
 
 - (void)setPinchGestureEnabled:(BOOL)pinchGestureEnabled
@@ -407,7 +397,7 @@ static inline void RCTApplyTransformationAccordingLayoutDirection(
 #if !TARGET_OS_TV
   // Adjust the refresh control frame if the scrollview layout changes.
   UIView<RCTCustomRefreshContolProtocol> *refreshControl = _scrollView.customRefreshControl;
-  if (refreshControl && refreshControl.isRefreshing && ![refreshControl isKindOfClass:UIRefreshControl.class]) {
+  if (refreshControl && refreshControl.isRefreshing) {
     refreshControl.frame =
         (CGRect){_scrollView.contentOffset, {_scrollView.frame.size.width, refreshControl.frame.size.height}};
   }

--- a/React/Views/ScrollView/RCTScrollableProtocol.h
+++ b/React/Views/ScrollView/RCTScrollableProtocol.h
@@ -38,7 +38,4 @@
 @property (nonatomic, copy) RCTDirectEventBlock onRefresh;
 @property (nonatomic, readonly, getter=isRefreshing) BOOL refreshing;
 
-@optional
-@property (nonatomic, weak) UIScrollView *scrollView;
-
 @end


### PR DESCRIPTION
This reverts commit 1b0fb9bead4d158d14df5a994423d06716b5e377.

Related Discussion
https://github.com/facebook/react-native/pull/28236#issuecomment-891730388
https://github.com/facebook/react-native/issues/31461

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [Fixed] - RefreshControl causes an unwanted visual jump in the list content when the refreshing prop goes from true to false

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
