### PR TITLE
Fix how KeyboardAvoidingView handles the onLayout prop.

### DIFF
--- a/Libraries/Components/Keyboard/KeyboardAvoidingView.js
+++ b/Libraries/Components/Keyboard/KeyboardAvoidingView.js
@@ -101,6 +101,10 @@ class KeyboardAvoidingView extends React.Component<Props, State> {
     if (wasFrameNull) {
       this._updateBottomIfNecesarry();
     }
+
+    if (this.props.onLayout) {
+      this.props.onLayout(event);
+    }
   };
 
   _updateBottomIfNecesarry = () => {
@@ -157,6 +161,8 @@ class KeyboardAvoidingView extends React.Component<Props, State> {
       // eslint-disable-next-line no-unused-vars
       keyboardVerticalOffset = 0,
       style,
+      // eslint-disable-next-line no-unused-vars
+      onLayout,
       ...props
     } = this.props;
     const bottomHeight = enabled === true ? this.state.bottom : 0;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Resolves #32608

This PR updates the `KeyboardAvoidingView` to correctly handle the `onLayout` prop.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Fixed] - `onLayout` prop is handled correctly in `<KeyboardAvoidingView>`

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

| Current Behavior with the `onLayout` prop specified | After applying fix |
|---|---|
| ![Simulator Screen Recording - iPhone 11 - 2021-11-17 at 14 44 09](https://user-images.githubusercontent.com/1406082/142287541-0dbcf137-4d72-4ab6-9367-ac42bdf5aed9.gif) | ![Simulator Screen Recording - iPhone 11 - 2021-11-17 at 14 44 28](https://user-images.githubusercontent.com/1406082/142287611-c7424a6c-b590-48f7-8d74-e96543eab41c.gif) |
