### PR TITLE
Fix contextMenuHidden not woking on android

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -25,6 +25,9 @@ import android.text.SpannableStringBuilder;
 import android.text.TextWatcher;
 import android.view.Gravity;
 import android.view.KeyEvent;
+import android.view.ActionMode;
+import android.view.Menu;
+import android.view.MenuItem;
 import android.view.View;
 import android.view.inputmethod.EditorInfo;
 import android.widget.EditText;
@@ -571,12 +574,31 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
   @ReactProp(name = "contextMenuHidden", defaultBoolean = false)
   public void setContextMenuHidden(ReactEditText view, boolean contextMenuHidden) {
     final boolean _contextMenuHidden = contextMenuHidden;
-    view.setOnLongClickListener(
-        new View.OnLongClickListener() {
-          public boolean onLongClick(View v) {
-            return _contextMenuHidden;
-          };
-        });
+    if(_contextMenuHidden){
+      view.setCustomSelectionActionModeCallback(new ActionMode.Callback() {
+        @Override
+        public boolean onPrepareActionMode(ActionMode mode, Menu menu) {
+          menu.clear();
+          return false;
+        }
+
+        @Override
+        public boolean onActionItemClicked(ActionMode actionMode, MenuItem menuItem) {
+          return false;
+        }
+
+        @Override
+        public boolean onCreateActionMode(ActionMode actionMode, Menu menu) {
+          return false;
+        }
+
+        @Override
+        public void onDestroyActionMode(ActionMode mode) { return; }
+
+      });
+    }
+
+    view.setOnLongClickListener( v -> _contextMenuHidden);
   }
 
   @ReactProp(name = "selectTextOnFocus", defaultBoolean = false)

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -574,6 +574,12 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
   @ReactProp(name = "contextMenuHidden", defaultBoolean = false)
   public void setContextMenuHidden(ReactEditText view, boolean contextMenuHidden) {
     final boolean _contextMenuHidden = contextMenuHidden;
+    view.setOnLongClickListener(
+        new View.OnLongClickListener() {
+          public boolean onLongClick(View v) {
+            return _contextMenuHidden;
+          };
+        });
     if(_contextMenuHidden){
       view.setCustomSelectionActionModeCallback(new ActionMode.Callback() {
         @Override
@@ -597,8 +603,6 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
 
       });
     }
-
-    view.setOnLongClickListener( v -> _contextMenuHidden);
   }
 
   @ReactProp(name = "selectTextOnFocus", defaultBoolean = false)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
Fix **contextMenuHidden={true}** of TextInput not working on android, iOS works fine. The issue related to issue [27595](https://github.com/facebook/react-native/issues/27595)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Fixed] - Fix contextMenuHidden in ReactTextInputManager.java

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
