### PR TITLE
fix: Link incompatible target in debug mode (#32595)

### DIFF
--- a/ReactCommon/react/debug/Android.mk
+++ b/ReactCommon/react/debug/Android.mk
@@ -24,8 +24,6 @@ LOCAL_CFLAGS := \
 
 LOCAL_CFLAGS += -fexceptions -frtti -std=c++17 -Wall -llog
 
-LOCAL_LDLIBS := -L$(SYSROOT)/usr/lib -llog
-
 include $(BUILD_SHARED_LIBRARY)
 
 $(call import-module,folly)


### PR DESCRIPTION
## Summary
Build from source crash in debug mode on other linux distribution except ubuntu.  ld will link from /usr/lib because of SYSROOT



## Changelog
DEBUG mode link incompatible target (#32595)