### PR TITLE
feat: support queuing accessibility announcements on ios

### DIFF
--- a/Libraries/Components/AccessibilityInfo/AccessibilityInfo.js
+++ b/Libraries/Components/AccessibilityInfo/AccessibilityInfo.js
@@ -333,11 +333,17 @@ const AccessibilityInfo = {
    *
    * See https://reactnative.dev/docs/accessibilityinfo#announceforaccessibility
    */
-  announceForAccessibility(announcement: string): void {
+  announceForAccessibility(
+    announcement: string,
+    queue?: boolean = false,
+  ): void {
     if (Platform.OS === 'android') {
       NativeAccessibilityInfoAndroid?.announceForAccessibility(announcement);
     } else {
-      NativeAccessibilityManagerIOS?.announceForAccessibility(announcement);
+      NativeAccessibilityManagerIOS?.announceForAccessibility(
+        announcement,
+        queue,
+      );
     }
   },
 

--- a/Libraries/Components/AccessibilityInfo/NativeAccessibilityManager.js
+++ b/Libraries/Components/AccessibilityInfo/NativeAccessibilityManager.js
@@ -51,7 +51,7 @@ export interface Spec extends TurboModule {
     +accessibilityExtraExtraExtraLarge?: ?number,
   |}) => void;
   +setAccessibilityFocus: (reactTag: number) => void;
-  +announceForAccessibility: (announcement: string) => void;
+  +announceForAccessibility: (announcement: string, queue: boolean) => void;
 }
 
 export default (TurboModuleRegistry.get<Spec>('AccessibilityManager'): ?Spec);

--- a/React/CoreModules/RCTAccessibilityManager.mm
+++ b/React/CoreModules/RCTAccessibilityManager.mm
@@ -296,9 +296,17 @@ RCT_EXPORT_METHOD(setAccessibilityFocus : (double)reactTag)
   });
 }
 
-RCT_EXPORT_METHOD(announceForAccessibility : (NSString *)announcement)
+RCT_EXPORT_METHOD(announceForAccessibility : (NSString *)announcement queue : (BOOL)queue)
 {
-  UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, announcement);
+  if (@available(iOS 11.0, *)) {
+    NSDictionary *attrsDictionary = [NSDictionary dictionaryWithObject:@(queue)
+                                                                forKey:UIAccessibilitySpeechAttributeQueueAnnouncement];
+    NSAttributedString *announcementWithAttrs = [[NSAttributedString alloc] initWithString:announcement
+                                                                                attributes:attrsDictionary];
+    UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, announcementWithAttrs);
+  } else {
+    UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, announcement);
+  }
 }
 
 RCT_EXPORT_METHOD(getMultiplier : (RCTResponseSenderBlock)callback)

--- a/packages/rn-tester/js/examples/Accessibility/AccessibilityExample.js
+++ b/packages/rn-tester/js/examples/Accessibility/AccessibilityExample.js
@@ -864,10 +864,65 @@ class FakeSliderExample extends React.Component<{}, FakeSliderExampleState> {
 
 class AnnounceForAccessibility extends React.Component<{}> {
   _handleOnPress = () =>
-    AccessibilityInfo.announceForAccessibility('Announcement Test');
+    setTimeout(
+      () => AccessibilityInfo.announceForAccessibility('Announcement Test'),
+      1000,
+    );
+
+  _handleOnPressQueued = () =>
+    setTimeout(
+      () =>
+        AccessibilityInfo.announceForAccessibility(
+          'Queued Announcement Test',
+          true,
+        ),
+      1000,
+    );
+
+  _handleOnPressQueueMultiple = () => {
+    setTimeout(
+      () =>
+        AccessibilityInfo.announceForAccessibility(
+          'First Queued Announcement Test',
+          true,
+        ),
+      1000,
+    );
+    setTimeout(
+      () =>
+        AccessibilityInfo.announceForAccessibility(
+          'Second Queued Announcement Test',
+          true,
+        ),
+      1100,
+    );
+    setTimeout(
+      () =>
+        AccessibilityInfo.announceForAccessibility(
+          'Third Queued Announcement Test',
+          true,
+        ),
+      1200,
+    );
+  };
 
   render(): React.Node {
-    return (
+    return Platform.OS === 'ios' ? (
+      <View>
+        <Button
+          onPress={this._handleOnPress}
+          title="Announce for Accessibility Immediately"
+        />
+        <Button
+          onPress={this._handleOnPressQueued}
+          title="Announce for Accessibility Queued"
+        />
+        <Button
+          onPress={this._handleOnPressQueueMultiple}
+          title="Announce for Accessibility Queue Multiple"
+        />
+      </View>
+    ) : (
       <View>
         <Button
           onPress={this._handleOnPress}


### PR DESCRIPTION
## Summary

The current implementation of `AccessibilityInfo.announceForAccessibility` will immediately interrupt any existing in progress speech with the announcement. Sometimes this is desirable behaviour, but often you will want to wait until existing speech is finished before reading the new announcement. This change gives us that option.

My personal use case for this feature is a custom text input. When typing on iOS with voiceover enabled, each character is read out after being selected. I wanted to add some additional information after each character to help with the context of what has changed in the input, but I didn't want to override the reading of the character itself.

This feature is supported natively on iOS by constructing an `NSAttributedString` with the property [`accessibilitySpeechQueueAnnouncement`](https://developer.apple.com/documentation/foundation/nsattributedstring/key/2865770-accessibilityspeechqueueannounce), so this change just adds an extra parameter to `AccessibilityInfo.announceForAccessibility` which controls the value of that property on the native side. Adding this as an extra optional parameter with false as the default ensures that existing uses of the function won't be affected.

Unfortunately, this feature doesn't appear to be supported on Android, so the new second property will be iOS only.

## Changelog

[iOS] [Added] - add new argument to announceForAccessibility to allow queueing on iOS

## Test Plan

I've updated the `announceForAccessibility` section in RNTester with multiple buttons to demonstrate the difference between `queue: false` (default) and `queue: true` and show they work as intended.

Here's the expectation for each button:

- "Announce for Accessibility Immediately": on press, should start reading the button label, then be interrupted by the announcement
- "Announce for Accessibility Queued": on press, should read the button label then read the announcement afterwards
- "Announce for Accessibility Queue Multiple": on press, should read the button label, then read three announcements sequentially, no interruptions

You can see the realisation of those expectations in the following video recorded on an iPhone 12 running iOS 15.0.2:

https://user-images.githubusercontent.com/14826539/142770536-d57bfd69-eba5-444d-9c89-4bf4851ea062.mov

I've also tested the same way on an iPhone 8 running iOS 13.4 and it works exactly the same.
