### PR TITLE
Enable Generic Discontiguous Regions within VirtualizedList

### DIFF
--- a/Libraries/Lists/CellRenderMask.js
+++ b/Libraries/Lists/CellRenderMask.js
@@ -110,6 +110,10 @@ export class CellRenderMask {
     );
   }
 
+  numCells(): number {
+    return this._numCells;
+  }
+
   equals(other: CellRenderMask): boolean {
     return (
       this._numCells === other._numCells &&

--- a/Libraries/Lists/VirtualizeUtils.js
+++ b/Libraries/Lists/VirtualizeUtils.js
@@ -92,7 +92,6 @@ export function computeWindowedRenderLimits(
   prev: {
     first: number,
     last: number,
-    ...
   },
   getFrameMetricsApprox: (index: number) => {
     length: number,
@@ -109,7 +108,6 @@ export function computeWindowedRenderLimits(
 ): {
   first: number,
   last: number,
-  ...
 } {
   const itemCount = getItemCount(data);
   if (itemCount === 0) {

--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -767,7 +767,9 @@ class VirtualizedList extends React.PureComponent<Props, State> {
     const renderMask = new CellRenderMask(itemCount);
 
     if (itemCount > 0) {
-      renderMask.addCells(cellsAroundViewport);
+      if (cellsAroundViewport.last >= cellsAroundViewport.first) {
+        renderMask.addCells(cellsAroundViewport);
+      }
 
       // The initially rendered cells are retained as part of the
       // "scroll-to-top" optimization
@@ -958,7 +960,7 @@ class VirtualizedList extends React.PureComponent<Props, State> {
     );
 
     return {
-      cellsAroundViewport: prevState.cellsAroundViewport,
+      cellsAroundViewport: constrainedCells,
       renderMask: VirtualizedList._createRenderMask(newProps, constrainedCells),
     };
   }

--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -1822,7 +1822,7 @@ class VirtualizedList extends React.PureComponent<Props, State> {
     }
     // Mark as high priority if we're close to the end of the last item
     // But only if there are items after the last rendered item
-    if (last < itemCount - 1) {
+    if (last > 0 && last < itemCount - 1) {
       const distBottom =
         this._getFrameMetricsApprox(last).offset - (offset + visibleLength);
       hiPri =
@@ -1933,7 +1933,11 @@ class VirtualizedList extends React.PureComponent<Props, State> {
       // check for invalid frames due to row re-ordering
       return frame;
     } else {
-      const {getItemLayout} = this.props;
+      const {data, getItemCount, getItemLayout} = this.props;
+      invariant(
+        index >= 0 && index < getItemCount(data),
+        'Tried to get frame for out of range index ' + index,
+      );
       invariant(
         !getItemLayout,
         'Should not have to estimate frames when a measurement metrics function is provided',
@@ -1956,7 +1960,7 @@ class VirtualizedList extends React.PureComponent<Props, State> {
   } => {
     const {data, getItem, getItemCount, getItemLayout} = this.props;
     invariant(
-      getItemCount(data) > index,
+      index >= 0 && index < getItemCount(data),
       'Tried to get frame for out of range index ' + index,
     );
     const item = getItem(data, index);

--- a/Libraries/Lists/__tests__/VirtualizedList-test.js
+++ b/Libraries/Lists/__tests__/VirtualizedList-test.js
@@ -965,13 +965,12 @@ it('renders no spacers up to initialScrollIndex on first render when virtualizat
     );
   });
 
-  // There should be no spacers present in an offset initial render with
-  // virtualiztion disabled. Only initialNumToRender items starting at
-  // initialScrollIndex.
+  // We should render initialNumToRender items with no spacers on initial render
+  // when virtualization is disabled
   expect(component).toMatchSnapshot();
 });
 
-it('expands first in viewport to render up to maxToRenderPerBatch on initial render', () => {
+it('renders initialNumToRender when initialScrollIndex is offset', () => {
   const items = generateItems(10);
   const ITEM_HEIGHT = 10;
 
@@ -988,9 +987,7 @@ it('expands first in viewport to render up to maxToRenderPerBatch on initial ren
     );
   });
 
-  // When virtualization is disabled we may render items before initialItemIndex
-  // if initialItemIndex + initialNumToRender < maToRenderPerBatch. Expect cells
-  // 0-3 to be rendered in this example, even though initialScrollIndex is 4.
+  // We should render initialNumToRender items starting at initialScrollIndex.
   expect(component).toMatchSnapshot();
 });
 

--- a/Libraries/Lists/__tests__/__snapshots__/VirtualizedList-test.js.snap
+++ b/Libraries/Lists/__tests__/__snapshots__/VirtualizedList-test.js.snap
@@ -850,10 +850,8 @@ exports[`VirtualizedList keeps sticky headers above viewport visualized 1`] = `
     Array [
       0,
       2,
-      4,
-      7,
-      10,
-      13,
+      5,
+      8,
     ]
   }
   windowSize={1}
@@ -870,47 +868,10 @@ exports[`VirtualizedList keeps sticky headers above viewport visualized 1`] = `
     <View
       style={
         Object {
-          "height": 50,
+          "height": 110,
         }
       }
     />
-    <View
-      style={null}
-    >
-      <MockCellItem
-        sticky={true}
-        value={6}
-      />
-    </View>
-    <View
-      style={
-        Object {
-          "height": 20,
-        }
-      }
-    />
-    <View
-      style={null}
-    >
-      <MockCellItem
-        sticky={true}
-        value={9}
-      />
-    </View>
-    <View
-      style={null}
-    >
-      <MockCellItem
-        value={10}
-      />
-    </View>
-    <View
-      style={null}
-    >
-      <MockCellItem
-        value={11}
-      />
-    </View>
     <View
       style={null}
     >
@@ -920,12 +881,12 @@ exports[`VirtualizedList keeps sticky headers above viewport visualized 1`] = `
       />
     </View>
     <View
-      style={null}
-    >
-      <MockCellItem
-        value={13}
-      />
-    </View>
+      style={
+        Object {
+          "height": 10,
+        }
+      }
+    />
     <View
       style={null}
     >
@@ -1993,45 +1954,10 @@ exports[`discards intitial render if initialScrollIndex != 0 1`] = `
     <View
       style={
         Object {
-          "height": 90,
+          "height": 140,
         }
       }
     />
-    <View
-      style={null}
-    >
-      <MockCellItem
-        value={9}
-      />
-    </View>
-    <View
-      style={null}
-    >
-      <MockCellItem
-        value={10}
-      />
-    </View>
-    <View
-      style={null}
-    >
-      <MockCellItem
-        value={11}
-      />
-    </View>
-    <View
-      style={null}
-    >
-      <MockCellItem
-        value={12}
-      />
-    </View>
-    <View
-      style={null}
-    >
-      <MockCellItem
-        value={13}
-      />
-    </View>
     <View
       style={null}
     >
@@ -2399,33 +2325,12 @@ exports[`does not over-render when there is less than initialNumToRender cells 1
 >
   <View>
     <View
-      style={null}
-    >
-      <MockCellItem
-        value={0}
-      />
-    </View>
-    <View
-      style={null}
-    >
-      <MockCellItem
-        value={1}
-      />
-    </View>
-    <View
-      style={null}
-    >
-      <MockCellItem
-        value={2}
-      />
-    </View>
-    <View
-      style={null}
-    >
-      <MockCellItem
-        value={3}
-      />
-    </View>
+      style={
+        Object {
+          "height": 40,
+        }
+      }
+    />
     <View
       style={null}
     >
@@ -2598,113 +2503,6 @@ exports[`eventually renders all items when virtualization disabled 1`] = `
         value={9}
       />
     </View>
-  </View>
-</RCTScrollView>
-`;
-
-exports[`expands first in viewport to render up to maxToRenderPerBatch on initial render 1`] = `
-<RCTScrollView
-  data={
-    Array [
-      Object {
-        "key": 0,
-      },
-      Object {
-        "key": 1,
-      },
-      Object {
-        "key": 2,
-      },
-      Object {
-        "key": 3,
-      },
-      Object {
-        "key": 4,
-      },
-      Object {
-        "key": 5,
-      },
-      Object {
-        "key": 6,
-      },
-      Object {
-        "key": 7,
-      },
-      Object {
-        "key": 8,
-      },
-      Object {
-        "key": 9,
-      },
-    ]
-  }
-  getItem={[Function]}
-  getItemCount={[Function]}
-  getItemLayout={[Function]}
-  initialNumToRender={2}
-  initialScrollIndex={4}
-  maxToRenderPerBatch={10}
-  onContentSizeChange={[Function]}
-  onLayout={[Function]}
-  onMomentumScrollBegin={[Function]}
-  onMomentumScrollEnd={[Function]}
-  onScroll={[Function]}
-  onScrollBeginDrag={[Function]}
-  onScrollEndDrag={[Function]}
-  renderItem={[Function]}
-  scrollEventThrottle={50}
-  stickyHeaderIndices={Array []}
->
-  <View>
-    <View
-      style={null}
-    >
-      <MockCellItem
-        value={0}
-      />
-    </View>
-    <View
-      style={null}
-    >
-      <MockCellItem
-        value={1}
-      />
-    </View>
-    <View
-      style={null}
-    >
-      <MockCellItem
-        value={2}
-      />
-    </View>
-    <View
-      style={null}
-    >
-      <MockCellItem
-        value={3}
-      />
-    </View>
-    <View
-      style={null}
-    >
-      <MockCellItem
-        value={4}
-      />
-    </View>
-    <View
-      style={null}
-    >
-      <MockCellItem
-        value={5}
-      />
-    </View>
-    <View
-      style={
-        Object {
-          "height": 40,
-        }
-      }
-    />
   </View>
 </RCTScrollView>
 `;
@@ -3100,13 +2898,6 @@ exports[`renders initialNumToRender cells when virtualization disabled 1`] = `
       style={null}
     >
       <MockCellItem
-        value={0}
-      />
-    </View>
-    <View
-      style={null}
-    >
-      <MockCellItem
         value={1}
       />
     </View>
@@ -3138,6 +2929,92 @@ exports[`renders initialNumToRender cells when virtualization disabled 1`] = `
         value={5}
       />
     </View>
+  </View>
+</RCTScrollView>
+`;
+
+exports[`renders initialNumToRender when initialScrollIndex is offset 1`] = `
+<RCTScrollView
+  data={
+    Array [
+      Object {
+        "key": 0,
+      },
+      Object {
+        "key": 1,
+      },
+      Object {
+        "key": 2,
+      },
+      Object {
+        "key": 3,
+      },
+      Object {
+        "key": 4,
+      },
+      Object {
+        "key": 5,
+      },
+      Object {
+        "key": 6,
+      },
+      Object {
+        "key": 7,
+      },
+      Object {
+        "key": 8,
+      },
+      Object {
+        "key": 9,
+      },
+    ]
+  }
+  getItem={[Function]}
+  getItemCount={[Function]}
+  getItemLayout={[Function]}
+  initialNumToRender={2}
+  initialScrollIndex={4}
+  maxToRenderPerBatch={10}
+  onContentSizeChange={[Function]}
+  onLayout={[Function]}
+  onMomentumScrollBegin={[Function]}
+  onMomentumScrollEnd={[Function]}
+  onScroll={[Function]}
+  onScrollBeginDrag={[Function]}
+  onScrollEndDrag={[Function]}
+  renderItem={[Function]}
+  scrollEventThrottle={50}
+  stickyHeaderIndices={Array []}
+>
+  <View>
+    <View
+      style={
+        Object {
+          "height": 40,
+        }
+      }
+    />
+    <View
+      style={null}
+    >
+      <MockCellItem
+        value={4}
+      />
+    </View>
+    <View
+      style={null}
+    >
+      <MockCellItem
+        value={5}
+      />
+    </View>
+    <View
+      style={
+        Object {
+          "height": 40,
+        }
+      }
+    />
   </View>
 </RCTScrollView>
 `;
@@ -3377,33 +3254,12 @@ exports[`renders offset cells in initial render when initialScrollIndex set 1`] 
 >
   <View>
     <View
-      style={null}
-    >
-      <MockCellItem
-        value={0}
-      />
-    </View>
-    <View
-      style={null}
-    >
-      <MockCellItem
-        value={1}
-      />
-    </View>
-    <View
-      style={null}
-    >
-      <MockCellItem
-        value={2}
-      />
-    </View>
-    <View
-      style={null}
-    >
-      <MockCellItem
-        value={3}
-      />
-    </View>
+      style={
+        Object {
+          "height": 40,
+        }
+      }
+    />
     <View
       style={null}
     >
@@ -3635,7 +3491,7 @@ exports[`renders tail spacer up to last measured with irregular layout when getI
     <View
       style={
         Object {
-          "height": 18,
+          "height": 17,
         }
       }
     />
@@ -4405,45 +4261,10 @@ exports[`retains intitial render if initialScrollIndex == 0 1`] = `
     <View
       style={
         Object {
-          "height": 40,
+          "height": 90,
         }
       }
     />
-    <View
-      style={null}
-    >
-      <MockCellItem
-        value={9}
-      />
-    </View>
-    <View
-      style={null}
-    >
-      <MockCellItem
-        value={10}
-      />
-    </View>
-    <View
-      style={null}
-    >
-      <MockCellItem
-        value={11}
-      />
-    </View>
-    <View
-      style={null}
-    >
-      <MockCellItem
-        value={12}
-      />
-    </View>
-    <View
-      style={null}
-    >
-      <MockCellItem
-        value={13}
-      />
-    </View>
     <View
       style={null}
     >


### PR DESCRIPTION
## Summary

This builds upon the `CellRenderMask` data structure added with https://github.com/facebook/react-native/pull/31420, and VirtualizedList coverage added with https://github.com/facebook/react-native/pull/31401, to allow more discontinuous structures in VirtualizedList. This enables keyboard/a11y scenarios, where focus may be outside of a viewport-derived region.

VirtualizedList currently keeps a [first, last] range as state, tracking the region of cells to render. The render functions uses this as an input, along with a few special cases to render more (sticky headers, initial render region.)

This change moves to instead keep state which describes discontinuous render regions. This mask is continually updated as the viewport changes, batch renders expand the region, etc. Special cases are baked into the render mask, with a relatively simple transformation from the mask to render function.

MS/FB folks have a video discussion about VirtualizedList here: https://msit.microsoftstream.com/video/fe01a1ff-0400-94b1-d4f1-f1eb924b1809

## Changelog

[Internal] [Added] - Discontiguous VirtualizedList Regions

## Test Plan

facebook/react-native#31401 added quite a few snapshot tests, centering around the logic this change is touching. I manually validated RNTester FlatList examples (and there should be some upstream UI testing for them).

