### PR TITLE
Fix for iOS displaying a RedBox for LogBox handled errors

### DIFF
--- a/React/CoreModules/RCTExceptionsManager.mm
+++ b/React/CoreModules/RCTExceptionsManager.mm
@@ -91,7 +91,7 @@ RCT_EXPORT_METHOD(updateExceptionMessage
                   : (double)exceptionId)
 {
   RCTRedBox *redbox = [_moduleRegistry moduleForName:"RedBox"];
-  [redbox showErrorMessage:message withStack:stack errorCookie:(int)exceptionId];
+  [redbox updateErrorMessage:message withStack:stack errorCookie:(int)exceptionId];
 
   if (_delegate && [_delegate respondsToSelector:@selector(updateJSExceptionWithMessage:stack:exceptionId:)]) {
     [_delegate updateJSExceptionWithMessage:message stack:stack exceptionId:[NSNumber numberWithDouble:exceptionId]];


### PR DESCRIPTION
## Summary

Fix for iOS displaying a RedBox for LogBox handled errors, this has been happening since RN 0.65 (in 64.2 and earlier, if it was handled by LogBox then it wouldn't trigger RedBox)

Fixes #32106

## Changelog

[iOS] [Fixed] - Stop RedBox from appearing for LogBox handled errors

## Test Plan

Manually tested. Seems to fix things (and RedBox still displays for things like 'Could not connect to development server') but I would appreciate @RSNara or someone else who is more familiar with the code to confirm that the original switch was a mistake and not something deliberately changed.