### PR TITLE
Fix eslint no-shadow issue with TypeScript enums

### DIFF
--- a/packages/eslint-config-react-native-community/index.js
+++ b/packages/eslint-config-react-native-community/index.js
@@ -56,8 +56,8 @@ module.exports = {
           {argsIgnorePattern: '^_'},
         ],
         'no-unused-vars': 'off',
-        "no-shadow": "off",
-        "@typescript-eslint/no-shadow": 1,
+        'no-shadow': 'off',
+        '@typescript-eslint/no-shadow': 1,
       },
     },
     {

--- a/packages/eslint-config-react-native-community/index.js
+++ b/packages/eslint-config-react-native-community/index.js
@@ -56,6 +56,8 @@ module.exports = {
           {argsIgnorePattern: '^_'},
         ],
         'no-unused-vars': 'off',
+        "no-shadow": "off",
+        "@typescript-eslint/no-shadow": 1,
       },
     },
     {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

The current ESLint config includes a rule for `no-shadow`. When authoring using TypeScript, the [typescript-eslint docs](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/no-shadow.md) mention that the base `no-shadow` rule should be disabled in favour of `@typescript-eslint/no-shadow`, otherwise false positives can be reported. In my case, I was experiencing the same symptoms as described in [this issue](https://github.com/typescript-eslint/typescript-eslint/issues/2552).

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Fixed] - ESLint `no-shadow` rule returning false positive for TypeScript enums

## Test Plan

Before config changes:

<img width="631" alt="Screenshot 2021-11-22 at 21 02 31" src="https://user-images.githubusercontent.com/820863/142934803-ef1343d6-46ab-4495-9ea5-957f7ec404fc.png">

After changes:

<img width="486" alt="Screenshot 2021-11-22 at 21 03 28" src="https://user-images.githubusercontent.com/820863/142934914-a151656a-a37e-4ffb-9db5-ed9fb93543c7.png">


