### PR TITLE
Disable ESLint `no-undef` for TypeScript files

### DIFF
--- a/packages/eslint-config-react-native-community/index.js
+++ b/packages/eslint-config-react-native-community/index.js
@@ -56,6 +56,7 @@ module.exports = {
           {argsIgnorePattern: '^_'},
         ],
         'no-unused-vars': 'off',
+        'no-undef': 'off',
       },
     },
     {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

The `typescript-eslint` project [recommends that `no-undef` is disabled for TypeScript files](https://github.com/typescript-eslint/typescript-eslint/blob/6c3816b3831e6e683c1a7842196b34248803d69b/docs/linting/TROUBLESHOOTING.md#i-get-errors-from-the-no-undef-rule-about-global-variables-not-being-defined-even-though-there-are-no-typescript-errors), since TypeScript itself will perform this check. Disabling this config property has two benefits:

- Undefined variables and types will only be reported once, by the TypeScript compiler. Currently they are reported twice: once by TypeScript, and once by ESLint:

<img width="506" alt="Screenshot 2021-11-24 at 12 38 22" src="https://user-images.githubusercontent.com/820863/143239961-eb8ed709-60f9-490a-bda3-fc581673d56c.png">

- Types that are declared globally by React Native will no longer be erroneously reported as undefined - this is currently the case for some types, e.g. `Blob`:

<img width="419" alt="Screenshot 2021-11-24 at 12 40 04" src="https://user-images.githubusercontent.com/820863/143240213-06428b24-09c8-4f95-8e77-7f4fd160eed1.png">


## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Fixed] - ESLint no-undef rule clashing with TypeScript compiler for TS files

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

- Before: ESLint reporting on undefined variables in TypeScript files
- After: ESLint no longer reporting on undefined variables in TypeScript files
