### PR TITLE
Automatic update of `RCT-Folly`

### DIFF
--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -586,8 +586,8 @@ def update_folly_if_needed(options={})
   prefix = options[:path] ||= "../node_modules/react-native"
   podspec_path = "#{prefix}/third-party-podspecs/RCT-Folly.podspec"
   folly = eval(File.read(podspec_path))
-  current_version = folly.version.to_s + "-v2"
 
+  current_version = folly.version.to_s
   # Update RCT-Folly if the versions are not equal
   if current_version != local_version
     $folly_update_is_running = true

--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -88,11 +88,12 @@ def use_react_native! (options={})
     pod 'libevent', '~> 2.1.12'
   end
 
-  if FollyPatch.folly_update_necessary?(options)
+  pods_to_update = LocalPodspecPatch.pods_to_update(options)
+  if !pods_to_update.empty?
     if Pod::Lockfile.public_instance_methods.include?(:detect_changes_with_podfile)
-      Pod::Lockfile.prepend(FollyPatch)
+      Pod::Lockfile.prepend(LocalPodspecPatch)
     else
-      Pod::UI.warn 'Automatically updating `RCT-Folly` has failed, please run `pod update RCT-Folly --no-repo-update` manually to fix the issue.'
+      Pod::UI.warn "Automatically updating #{pods_to_update.join(", ")} has failed, please run `pod update #{pods_to_update.join(" ")} --no-repo-update` manually to fix the issue."
     end
   end
 end
@@ -567,40 +568,45 @@ def __apply_Xcode_12_5_M1_post_install_workaround(installer)
   `sed -i -e  $'s/__IPHONE_10_0/__IPHONE_12_0/' Pods/RCT-Folly/folly/portability/Time.h`
 end
 
-# Monkeypatch of `Pod::Lockfile` to ensure automatic update of `RCT-Folly` when its version changed.
-# This is necessary because `RCT-Folly` is a local podspec which users need to manually update.
-module FollyPatch
-  # Returns true if the cached version of `RCT-Folly` podspec differs from the one in the `react-native` package.
-  def self.folly_update_necessary?(react_native_options)
-    # Read local podspec of `RCT-Folly` to determine the cached version
-    local_podspec_path = File.join(
-      Dir.pwd, "Pods/Local Podspecs/RCT-Folly.podspec.json"
-    )
-
-    # Local podspec cannot be outdated if it does not exist, yet
-    return false unless File.file?(local_podspec_path)
-
-    local_podspec = File.read(local_podspec_path)
-    local_podspec_json = JSON.parse(local_podspec)
-    local_version = local_podspec_json["version"]
-
-    # Read the version from a podspec from the `react-native` package
+# Monkeypatch of `Pod::Lockfile` to ensure automatic update of dependencies integrated with a local podspec when their version changed.
+# This is necessary because local podspec dependencies must be otherwise manually updated.
+module LocalPodspecPatch
+  # Returns local podspecs whose versions differ from the one in the `react-native` package.
+  def self.pods_to_update(react_native_options)
     prefix = react_native_options[:path] ||= "../node_modules/react-native"
-    podspec_path = "#{prefix}/third-party-podspecs/RCT-Folly.podspec"
-    folly = eval(File.read(podspec_path))
+    @@local_podspecs = Dir.glob("#{prefix}/third-party-podspecs/*").map { |file| File.basename(file, ".podspec") }
+    @@local_podspecs = @@local_podspecs.select do |podspec_name|
+      # Read local podspec to determine the cached version
+      local_podspec_path = File.join(
+        Dir.pwd, "Pods/Local Podspecs/#{podspec_name}.podspec.json"
+      )
 
-    current_version = folly.version.to_s
+      # Local podspec cannot be outdated if it does not exist, yet
+      next unless File.file?(local_podspec_path)
 
-    current_version != local_version
+      local_podspec = File.read(local_podspec_path)
+      local_podspec_json = JSON.parse(local_podspec)
+      local_version = local_podspec_json["version"]
+
+      # Read the version from a podspec from the `react-native` package
+      podspec_path = "#{prefix}/third-party-podspecs/#{podspec_name}.podspec"
+      current_podspec = Pod::Specification.from_file(podspec_path)
+
+      current_version = current_podspec.version.to_s
+      current_version != local_version
+    end
+    @@local_podspecs
   end
 
   # Patched `detect_changes_with_podfile` method
   def detect_changes_with_podfile(podfile)
     changes = super(podfile)
-    return changes unless changes[:unchanged].include?('RCT-Folly')
+    @@local_podspecs.each do |local_podspec|
+      next unless changes[:unchanged].include?(local_podspec)
 
-    changes[:unchanged].delete('RCT-Folly')
-    changes[:changed] << 'RCT-Folly'
+      changes[:unchanged].delete(local_podspec)
+      changes[:changed] << local_podspec
+    end
     changes
   end
 end


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

When upgrading `react-native`, the version `RCT-Folly` defined [here](https://github.com/facebook/react-native/blob/main/third-party-podspecs/RCT-Folly.podspec) can change. If that happens, if you run `pod install` after `yarn install`, you will get a similar error to this:
```
[!] CocoaPods could not find compatible versions for pod "RCT-Folly":
  In snapshot (Podfile.lock):
    RCT-Folly (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)

  In Podfile:
    RCT-Folly (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)

    React-RCTNetwork (from `../node_modules/react-native/Libraries/Network`) was resolved to 0.66.3, which depends on
      RCT-Folly (= 2021.06.28.00-v2)
```

This error occurs because `Cocoapods` does not update pods that point to a local podspec. Locally, you could resolve this issue by running `pod update RCT-Folly --no-repo-update`. On the CI, you have to do a clean checkout (in case you cache the `Pods` folder which we do). All of this makes upgrading `react-native` painful - for the whole community and for us @shopify

There are other users who have struggled with this, such as [here](https://github.com/facebook/react-native/issues/32423). The suggestion there is to delete `Podfile.lock` which is unnecessary - but it shows that users are confused what to do with this error and is something worth fixing.

To mitigate these issues, `react_native_pods.rb` automatically marks `RCT-Folly` as changed in the [detect_changes_with_podfile method](https://github.com/CocoaPods/Core/blob/master/lib/cocoapods-core/lockfile.rb#L289) from `Pod::Lockfile` if the version in `node_modules/react-native/third-party-podspecs/RCT-Folly.podspec` and `Pods/Local Podspecs/RCT-Folly.podspec.json` mismatch. 

Instead of automatically updating the local podspec (in `Pods/Local Podspecs` directory) we could also:
a) integrate `RCT-Folly` as a local pod (such as `React-Core` and others)
b) integrate `RCT-Folly` as an external dependency (going through Cocoapods' centralized repository)

I don't have enough context on why `RCT-Folly` is bundled the way it is, so I am open to suggestions here.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [Fixed] - Fix `pod install` when `RCT-Folly` version has been updated.

## Test Plan

I have created a [repository](https://github.com/fortmarek/react-native-upgrade-reproduction) where you can reproduce the issue. You can simply:
1) clone the repo (`git clone https://github.com/fortmarek/react-native-upgrade-reproduction`)
2) Run `yarn install && cd ios && pod install`
3) Change `react-native` version in `package.json` to `0.66.3`
4) Run again `yarn install && pod install`
5) Observe error

To test the fix, you can then:
1) copy-paste the `react_native_pods.rb` file from this branch to `react-native-upgrade-reproduction/node_modules/scripts/react_native_pods.rb`
2) run `pod install` again

This time, the `pod install` command should succeed.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
