### PR TITLE
CLI: export packager environment variables

### DIFF
--- a/scripts/launchPackager.command
+++ b/scripts/launchPackager.command
@@ -10,6 +10,9 @@ clear
 
 THIS_DIR=$(cd -P "$(dirname "$(readlink "${BASH_SOURCE[0]}" || echo "${BASH_SOURCE[0]}")")" && pwd)
 
+# export packager environment variables
+source "$THIS_DIR/.packager.env"
+
 if [ -n "${RCT_PACKAGER_LOGS_DIR}" ] ; then
   echo "Writing logs to $RCT_PACKAGER_LOGS_DIR"
   # shellcheck source=/dev/null


### PR DESCRIPTION
## Summary

Custom metro port not working without exporting variables from `.packager.env`

## Changelog

[General] [Fixed] - Fix support for custom port

## Test Plan

run `react-native run-android --port=8082` and `react-native run-ios --port=8082`
