### PR TITLE
Build codegen package in pod install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,12 +92,6 @@ commands:
             - ~/.cache/yarn
           key: v4-yarn-cache-{{ arch }}-{{ checksum "yarn.lock" }}
 
-  build_codegen:
-    steps:
-      - run:
-          name: "Codegen: Build react-native-codegen package"
-          command: cd packages/react-native-codegen && yarn build
-
   install_buck_tooling:
     steps:
       - restore_cache:
@@ -373,7 +367,6 @@ jobs:
       - setup_artifacts
       - setup_ruby
       - run_yarn
-      - build_codegen
 
       - run: |
           cd packages/rn-tester

--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -881,7 +881,7 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
   FBLazyVector: b81a2b70c72d8b0aefb652cea22c11e9ffd02949
-  FBReactNativeSpec: 37e065c0cfc5da966014bf62b50edb066d8206cd
+  FBReactNativeSpec: 755b7fee1b08aefd74fb2fa9f7312b253719d536
   Flipper: 30e8eeeed6abdc98edaf32af0cda2f198be4b733
   Flipper-Boost-iOSX: fd1e2b8cbef7e662a122412d7ac5f5bea715403c
   Flipper-DoubleConversion: 57ffbe81ef95306cc9e69c4aa3aeeeeb58a6a28c
@@ -923,10 +923,10 @@ SPEC CHECKSUMS:
   React-RCTTest: 12bbd7fc2e72bd9920dc7286c5b8ef96639582b6
   React-RCTText: e9146b2c0550a83d1335bfe2553760070a2d75c7
   React-RCTVibration: 50be9c390f2da76045ef0dfdefa18b9cf9f35cfa
-  React-rncore: c57d93f56e2d385bdbda34eae2d20d4d3c0c8b4a
+  React-rncore: d09af3a25cbff0b484776785676c28f3729e07f5
   React-runtimeexecutor: 4b0c6eb341c7d3ceb5e2385cb0fdb9bf701024f3
   ReactCommon: 7a2714d1128f965392b6f99a8b390e3aa38c9569
-  ScreenshotManager: 9f69049876d8aafafa13a1a635baa8f7e168eee4
+  ScreenshotManager: e8a3fc9b2e24b81127b36cb4ebe0eed65090c949
   Yoga: c0d06f5380d34e939f55420669a60fe08b79bd75
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 


### PR DESCRIPTION
Summary:
In D32420306 (https://github.com/facebook/react-native/commit/3d8b5a35f9ef2a1c1c3c974917dbc9abc79ba522) (https://github.com/facebook/react-native/commit/3d8b5a35f9ef2a1c1c3c974917dbc9abc79ba522), I added a phase which uses a codegen, but it assumed that the codegen package has already been built. This diff fixes the issue where it checks and build the codegen packaage.

I also reverted the change that I made for the circle CI test since it now builds the codegen when running pod install.

Differential Revision: D32707588

