### PR TITLE
Make hermes-executor-common a static lib

### DIFF
--- a/ReactCommon/hermes/executor/Android.mk
+++ b/ReactCommon/hermes/executor/Android.mk
@@ -19,7 +19,7 @@ LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)
 LOCAL_STATIC_LIBRARIES := libjsireact
 LOCAL_SHARED_LIBRARIES := libhermes libjsi
 
-include $(BUILD_SHARED_LIBRARY)
+include $(BUILD_STATIC_LIBRARY)
 
 include $(CLEAR_VARS)
 
@@ -34,4 +34,4 @@ LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)
 LOCAL_STATIC_LIBRARIES := libjsireact libhermes-inspector
 LOCAL_SHARED_LIBRARIES := libhermes libjsi
 
-include $(BUILD_SHARED_LIBRARY)
+include $(BUILD_STATIC_LIBRARY)

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/TaskConfiguration.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/TaskConfiguration.kt
@@ -233,12 +233,10 @@ private fun Project.cleanupVMFiles(
         // Reduce size by deleting the debugger/inspector
         it.include("**/libhermes-inspector.so")
         it.include("**/libhermes-executor-debug.so")
-        it.include("**/libhermes-executor-common-debug.so")
       } else {
         // Release libs take precedence and must be removed
         // to allow debugging
         it.include("**/libhermes-executor-release.so")
-        it.include("**/libhermes-executor-common-release.so")
       }
     } else {
       // For JSC, delete all the libhermes* files

--- a/react.gradle
+++ b/react.gradle
@@ -365,12 +365,10 @@ afterEvaluate {
                         // Reduce size by deleting the debugger/inspector
                         include '**/libhermes-inspector.so'
                         include '**/libhermes-executor-debug.so'
-                        include '**/libhermes-executor-common-debug.so'
                     } else {
                         // Release libs take precedence and must be removed
                         // to allow debugging
                         include '**/libhermes-executor-release.so'
-                        include '**/libhermes-executor-common-release.so'
                     }
                 } else {
                     // For JSC, delete all the libhermes* files


### PR DESCRIPTION
## Summary

I've been seeing a couple crashes related to missing hermes-executor-common.so, seems to happen on specific android versions, but can't repro. I investigated this so file more and noticed it is incorrectly linked as a static library here https://github.com/facebook/react-native/blob/b8f415eb6cdc0e0e7a7413b6f9defdcee304d9e8/ReactAndroid/src/main/java/com/facebook/hermes/reactexecutor/Android.mk#L20. There doesn't seem to be any reason for this to be a shared lib so I changed it to be compiled as a static lib.

## Changelog

[Android] [Fixed] - Make hermes-executor-common a static lib

## Test Plan

- Verify there is no more hermes-executor-common-{release,debug}.so
- Test locally in an app to make sure it build and run properly.
- Verify that the crash happening on play store pre-launch report doesn't happen anymore.
