### PR TITLE
Static link for hermes-inspector

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/hermes/reactexecutor/Android.mk
+++ b/ReactAndroid/src/main/java/com/facebook/hermes/reactexecutor/Android.mk
@@ -40,7 +40,7 @@ LOCAL_C_INCLUDES := $(LOCAL_PATH) $(REACT_NATIVE)/ReactCommon/jsi $(call find-no
 
 LOCAL_CPP_FEATURES := exceptions
 
-LOCAL_STATIC_LIBRARIES := libjsireact libhermes-executor-common-debug libhermes-inspector
+LOCAL_STATIC_LIBRARIES := libjsireact libhermes-executor-common-debug
 LOCAL_SHARED_LIBRARIES := \
   libfb \
   libfbjni \

--- a/ReactCommon/hermes/inspector/Android.mk
+++ b/ReactCommon/hermes/inspector/Android.mk
@@ -31,4 +31,4 @@ LOCAL_SHARED_LIBRARIES := \
   libhermes \
   libjsi
 
-include $(BUILD_SHARED_LIBRARY)
+include $(BUILD_STATIC_LIBRARY)

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/TaskConfiguration.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/TaskConfiguration.kt
@@ -230,6 +230,7 @@ private fun Project.cleanupVMFiles(
       it.include("**/libjsc*.so")
 
       if (cleanup) {
+        // Reduce size by deleting the debugger/inspector
         it.include("**/libhermes-executor-debug.so")
       } else {
         // Release libs take precedence and must be removed

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/TaskConfiguration.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/TaskConfiguration.kt
@@ -230,8 +230,6 @@ private fun Project.cleanupVMFiles(
       it.include("**/libjsc*.so")
 
       if (cleanup) {
-        // Reduce size by deleting the debugger/inspector
-        it.include("**/libhermes-inspector.so")
         it.include("**/libhermes-executor-debug.so")
       } else {
         // Release libs take precedence and must be removed

--- a/react.gradle
+++ b/react.gradle
@@ -363,7 +363,6 @@ afterEvaluate {
 
                     if (cleanup) {
                         // Reduce size by deleting the debugger/inspector
-                        include '**/libhermes-inspector.so'
                         include '**/libhermes-executor-debug.so'
                     } else {
                         // Release libs take precedence and must be removed


### PR DESCRIPTION
## Summary

Follow up to #32683 to also link hermes-inspector statically.

## Changelog

[Android] [Fix] - Static link for hermes-inspector

## Test Plan

Tested a clean build and made sure hermes-inspector.so doesn't exist anymore.