### PR TITLE
fix: Use same implementation for `performance.now()` on iOS and Android

### DIFF
--- a/React/CxxBridge/RCTJSIExecutorRuntimeInstaller.mm
+++ b/React/CxxBridge/RCTJSIExecutorRuntimeInstaller.mm
@@ -8,6 +8,7 @@
 #include "RCTJSIExecutorRuntimeInstaller.h"
 
 #import <React/RCTLog.h>
+#include <chrono>
 
 namespace facebook {
 namespace react {
@@ -21,8 +22,7 @@ JSIExecutor::RuntimeInstaller RCTJSIExecutorRuntimeInstaller(JSIExecutor::Runtim
     bindNativeLogger(runtime, iosLoggingBinder);
 
     PerformanceNow iosPerformanceNowBinder = []() {
-      // CACurrentMediaTime() returns the current absolute time, in seconds
-      return CACurrentMediaTime() * 1000;
+      return std::chrono::system_clock::now().time_since_epoch() / std::chrono::milliseconds(1);
     };
     bindNativePerformanceNow(runtime, iosPerformanceNowBinder);
 

--- a/ReactAndroid/src/main/jni/react/jni/NativeTime.cpp
+++ b/ReactAndroid/src/main/jni/react/jni/NativeTime.cpp
@@ -12,14 +12,7 @@ namespace facebook {
 namespace react {
 
 double reactAndroidNativePerformanceNowHook() {
-  auto time = std::chrono::steady_clock::now();
-  auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(
-                      time.time_since_epoch())
-                      .count();
-
-  constexpr double NANOSECONDS_IN_MILLISECOND = 1000000.0;
-
-  return duration / NANOSECONDS_IN_MILLISECOND;
+  return std::chrono::system_clock::now().time_since_epoch() / std::chrono::milliseconds(1);
 }
 
 } // namespace react


### PR DESCRIPTION

## Summary

I've noticed that the `performance.now()` implementations differ on iOS and Android.

iOS:
```objc
PerformanceNow iosPerformanceNowBinder = []() {
  // CACurrentMediaTime() returns the current absolute time, in seconds
  return CACurrentMediaTime() * 1000;
};
```
Android:
```c++
double reactAndroidNativePerformanceNowHook() {
  auto time = std::chrono::steady_clock::now();
  auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(
                      time.time_since_epoch())
                      .count();

  constexpr double NANOSECONDS_IN_MILLISECOND = 1000000.0;

  return duration / NANOSECONDS_IN_MILLISECOND;
}
```

For consistency, I thought why not just use the same implementation on both iOS and Android.

It also seems more logical to use Chrono on iOS, since it has nanosecond precision and we just multiply it to milliseconds, whereas `CACurrentMediaTime` multiplies to seconds, and we divide it down to milliseconds again.

## Changelog

(internal change only)

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Run on iOS and Android:

```ts
const now = global.performance.now()
console.log(`${Platform.OS}: ${now}`)
```
