### PR TITLE
fix: find-node.sh now respects .nvmrc

### DIFF
--- a/scripts/find-node.sh
+++ b/scripts/find-node.sh
@@ -19,12 +19,16 @@ fi
 # Define NVM_DIR and source the nvm.sh setup script
 [ -z "$NVM_DIR" ] && export NVM_DIR="$HOME/.nvm"
 
+# Source nvm with '--no-use' and then `nvm use` to respect .nvmrc
+# See: https://github.com/nvm-sh/nvm/issues/2053
 if [[ -s "$HOME/.nvm/nvm.sh" ]]; then
   # shellcheck source=/dev/null
-  . "$HOME/.nvm/nvm.sh"
+  . "$HOME/.nvm/nvm.sh" --no-use
+  nvm use 2> /dev/null || nvm use default
 elif [[ -x "$(command -v brew)" && -s "$(brew --prefix nvm)/nvm.sh" ]]; then
   # shellcheck source=/dev/null
-  . "$(brew --prefix nvm)/nvm.sh"
+  . "$(brew --prefix nvm)/nvm.sh" --no-use
+  nvm use 2> /dev/null || nvm use default
 fi
 
 # Set up the nodenv node version manager if present


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

React-native Xcode build steps (such as "Build JS Bundle") rely on `find.node-sh` to find the correct node binary, using nvm if present. We do this because Xcode may run build steps in a fresh shell environment, presumably for repeatable builds.

This PR fixes `find-node.sh`, to respect any `.nvmrc` file that may be present in the build environment.

Today: `find-node.sh` will set the shell environment to the system node version, and ignores any `.nvmrc` the project may provide to pin node for repeatable builds. By ignoring `.nvmrc`, node versions may differ depending on system environment — between developer laptops, or between developer and CI environments. 😞

This problem has been been noticed before in https://github.com/facebook/react-native/issues/8887

### Should this fix happen upstream?

Unfortunately this nvm behavior [is intended](https://github.com/nvm-sh/nvm/issues/2053),  for backwards compatibility

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [Fixed] - find-node.sh now respects .nvmrc

## Test Plan

Before:
```bash
# nvm isn't loaded
$ which nvm

# we're on default system node
$ which node && node --version
/usr/local/bin/node
v17.0.1

$ echo v16.13.0 > .nvmrc
$ source ./scripts/find-node.sh

# Expected: v16.13.0
$ node --version
v17.0.1
```

After:
```bash
# we're on default system node
$ which node && node --version
/usr/local/bin/node
v17.0.1

$ echo v16.13.0 > .nvmrc
$ source ./scripts/find-node.sh

# Expected: v16.13.0
$ node --version
v16.13.0
```

After (no .nvmrc, should preserve previous behavior):
```bash
# we're on default system node
$ which node && node --version
/usr/local/bin/node
v17.0.1

$ source ./scripts/find-node.sh

$  nvm ls|grep default
default -> v14.17.1

# Expected: v14.17.1
$ node --version
v14.17.1
```
