### PR TITLE
Revert "Fix Deadlock in RCTi18nUtil (iOS) (#31032)" (#32574)

### DIFF
--- a/React/Modules/RCTI18nUtil.h
+++ b/React/Modules/RCTI18nUtil.h
@@ -18,19 +18,11 @@
 + (instancetype)sharedInstance;
 
 - (BOOL)isRTL;
-
-/**
- * Should be used very early during app start up
- * Before the bridge is initialized
- */
-@property (atomic, setter=allowRTL:) BOOL isRTLAllowed;
-
-/**
- * Could be used to test RTL layout with English
- * Used for development and testing purpose
- */
-@property (atomic, setter=forceRTL:) BOOL isRTLForced;
-
-@property (atomic, setter=swapLeftAndRightInRTL:) BOOL doLeftAndRightSwapInRTL;
+- (BOOL)isRTLAllowed;
+- (void)allowRTL:(BOOL)value;
+- (BOOL)isRTLForced;
+- (void)forceRTL:(BOOL)value;
+- (BOOL)doLeftAndRightSwapInRTL;
+- (void)swapLeftAndRightInRTL:(BOOL)value;
 
 @end

--- a/React/Modules/RCTI18nUtil.m
+++ b/React/Modules/RCTI18nUtil.m
@@ -18,7 +18,6 @@
   dispatch_once(&onceToken, ^{
     sharedInstance = [self new];
     [sharedInstance swapLeftAndRightInRTL:true];
-    [sharedInstance allowRTL:true];
   });
 
   return sharedInstance;
@@ -39,6 +38,53 @@
     return YES;
   }
   return NO;
+}
+
+/**
+ * Should be used very early during app start up
+ * Before the bridge is initialized
+ * @return whether the app allows RTL layout, default is true
+ */
+- (BOOL)isRTLAllowed
+{
+  NSNumber *value = [[NSUserDefaults standardUserDefaults] objectForKey:@"RCTI18nUtil_allowRTL"];
+  if (value == nil) {
+    return YES;
+  }
+  return [value boolValue];
+}
+
+- (void)allowRTL:(BOOL)rtlStatus
+{
+  [[NSUserDefaults standardUserDefaults] setBool:rtlStatus forKey:@"RCTI18nUtil_allowRTL"];
+  [[NSUserDefaults standardUserDefaults] synchronize];
+}
+
+/**
+ * Could be used to test RTL layout with English
+ * Used for development and testing purpose
+ */
+- (BOOL)isRTLForced
+{
+  BOOL rtlStatus = [[NSUserDefaults standardUserDefaults] boolForKey:@"RCTI18nUtil_forceRTL"];
+  return rtlStatus;
+}
+
+- (void)forceRTL:(BOOL)rtlStatus
+{
+  [[NSUserDefaults standardUserDefaults] setBool:rtlStatus forKey:@"RCTI18nUtil_forceRTL"];
+  [[NSUserDefaults standardUserDefaults] synchronize];
+}
+
+- (BOOL)doLeftAndRightSwapInRTL
+{
+  return [[NSUserDefaults standardUserDefaults] boolForKey:@"RCTI18nUtil_makeRTLFlipLeftAndRightStyles"];
+}
+
+- (void)swapLeftAndRightInRTL:(BOOL)value
+{
+  [[NSUserDefaults standardUserDefaults] setBool:value forKey:@"RCTI18nUtil_makeRTLFlipLeftAndRightStyles"];
+  [[NSUserDefaults standardUserDefaults] synchronize];
 }
 
 // Check if the current device language is RTL


### PR DESCRIPTION
## Summary
This reverts commit fcead14b0effe2176a5d08ad50ee71e48528ddbd.

This should close https://github.com/facebook/react-native/issues/32509 . There was a bug where il8nManager.forceRTL() wouldn't work on app launch, and required an app restart. That was caused by an earlier change (https://github.com/facebook/react-native/pull/31032) which should not be necessary (the deadlock it was attempting to fix was actually caused by separate code).

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [Fixed] - Fixed bug where forceRTL did not work on app launch

Pull Request resolved: https://github.com/facebook/react-native/pull/32574

Test Plan: Simple revert back to previously working code.

Reviewed By: RSNara

Differential Revision: D32315034

Pulled By: GijsWeterings

fbshipit-source-id: dae6c1f0a2481e53f2f1e80f1ac083947681ef99

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

[CATEGORY] [TYPE] - Message

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
