### PR TITLE
feat: add package.json version to process.version

### DIFF
--- a/Libraries/Core/setUpGlobals.js
+++ b/Libraries/Core/setUpGlobals.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+const packageJson = require('../../package.json');
+
 /**
  * Sets up global variables for React Native.
  * You can use this module directly, or just require InitializeCore.
@@ -27,6 +29,7 @@ if (global.self === undefined) {
 // Set up process
 global.process = global.process || {};
 global.process.env = global.process.env || {};
+global.process.version = packageJson.version || global.process.version || undefined;
 if (!global.process.env.NODE_ENV) {
   global.process.env.NODE_ENV = __DEV__ ? 'development' : 'production';
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Expose the current react native version to the process. This came about from an issue with [aws-chime-sdk-js](https://github.com/aws/amazon-chime-sdk-js/issues/1856) and [detect-browser](https://github.com/DamonOehlman/detect-browser/pull/172) which hindered web sockets in chime working correctly. I figured the simple fix would be to use process.version for react-native in detect browser, but there is nowhere where that gets set and I couldn't find out how to get the current react-native version in the runtime.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Added] - Add polyfill for version to global.process.version

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

assert that react-native/package.json === global.process.version
