### PR TITLE
Set CxxModule instance before retrieving Method vector

### DIFF
--- a/ReactCommon/cxxreact/CxxNativeModule.cpp
+++ b/ReactCommon/cxxreact/CxxNativeModule.cpp
@@ -244,8 +244,8 @@ void CxxNativeModule::lazyInit() {
   module_ = provider_();
   provider_ = nullptr;
   if (module_) {
-    methods_ = module_->getMethods();
     module_->setInstance(instance_);
+    methods_ = module_->getMethods();
   }
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Allows `CxxModule` objects to set their `instance_` member before `getMethods()` is invoked, allowing for the `Method` callbacks to capture a weak reference to `getInstance()` if needed.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Fixed] - Set CxxModules' Instance before retrieving their Method vector.

## Test Plan

Ensure this statement swap does not break any scenarios with existing CI validation.
