### PR TITLE
Unbreak analyze_pr

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,7 +236,7 @@ jobs:
           command: |
             curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
             apt update && apt install -y shellcheck jq
-            apt-get install openssl ca-certificates
+            apt-get -y install openssl ca-certificates
             update-ca-certificates
             curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
             apt update && apt install -y shellcheck jq


### PR DESCRIPTION
Summary:
Changelog: [internal] Fix analyze_pr which was getting stuck at apt-get install openssl ca-certificates

Added -y so that it will install openssl without asking Y/n question.

```
The following packages will be upgraded:
  openssl
1 upgraded, 0 newly installed, 0 to remove and 8 not upgraded.
Need to get 620 kB of archives.
After this operation, 1024 B disk space will be freed.
Do you want to continue? [Y/n]
```

Differential Revision: D32977991

