### PR TITLE
Fix ViewManagersPropertyCache sync issue

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagersPropertyCache.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagersPropertyCache.java
@@ -23,6 +23,7 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * This class is responsible for holding view manager property setters and is used in a process of
@@ -30,7 +31,7 @@ import java.util.Map;
  */
 /*package*/ class ViewManagersPropertyCache {
 
-  private static final Map<Class, Map<String, PropSetter>> CLASS_PROPS_CACHE = new HashMap<>();
+  private static final Map<Class, Map<String, PropSetter>> CLASS_PROPS_CACHE = new ConcurrentHashMap<>();
   private static final Map<String, PropSetter> EMPTY_PROPS_MAP = new HashMap<>();
 
   public static void clear() {

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagersPropertyCache.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagersPropertyCache.java
@@ -31,11 +31,6 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 /*package*/ class ViewManagersPropertyCache {
 
-  /**
-   * When the user needs to pre create a reactnative environment, multiple reactnative environments may be initialized at the same time.
-   * At this time, multiple threads will operate viewmanagerspropertycache concurrently, with a probability of Java util.
-   * HashMap$Node cannot be cast to java. util. Problems with HashMap $TreeNode
-   */
   private static final Map<Class, Map<String, PropSetter>> CLASS_PROPS_CACHE = new ConcurrentHashMap<>();
   private static final Map<String, PropSetter> EMPTY_PROPS_MAP = new HashMap<>();
 

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagersPropertyCache.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagersPropertyCache.java
@@ -31,6 +31,11 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 /*package*/ class ViewManagersPropertyCache {
 
+  /**
+   * When the user needs to pre create a reactnative environment, multiple reactnative environments may be initialized at the same time.
+   * At this time, multiple threads will operate viewmanagerspropertycache concurrently, with a probability of Java util.
+   * HashMap$Node cannot be cast to java. util. Problems with HashMap $TreeNode
+   */
   private static final Map<Class, Map<String, PropSetter>> CLASS_PROPS_CACHE = new ConcurrentHashMap<>();
   private static final Map<String, PropSetter> EMPTY_PROPS_MAP = new HashMap<>();
 


### PR DESCRIPTION
## Summary

When the user needs to pre create a reactnative environment, multiple reactnative environments may be initialized at the same time. At this time, multiple threads will operate ViewManagersPropertyCache concurrently, with a probability of Java util. HashMap$Node cannot be cast to java. util. Problems with HashMap $TreeNode

58 app is a loyal user of react native, which is used in many business scenarios. Our application is a hybrid application. We have made some optimizations for react native on the upper layer. For example, every time we open the RN carrier page, we will create an RN environment in advance for the next RN carrier page.

Our tribe business is very complex, with a large number of UI elements. When two RN environments are initialized at the same time, the class of viewmanagerspropertycache_ PROPS_ Cache will have concurrency problems.

<img width="1169" src="https://user-images.githubusercontent.com/11549682/145779674-dc8ee472-2df1-41c7-8c4b-2853f3e24406.png">

<img width="80" src="https://user-images.githubusercontent.com/11549682/145780170-ecb83018-a676-48d1-9c49-c639d7a707d8.png">

<img width="350" src="https://user-images.githubusercontent.com/11549682/145781106-f4ede832-d05e-42d6-9b35-bc53bf07a722.jpg">


## Changelog

[Android] [Security] - ViewManagersPropertyCache.CLASS_PROPS_CACHE concurrent security issue

## Test Plan

This type of error is not reported in our new version.