### PR TITLE
Fix error when pod has no IPHONEOS_DEPLOYMENT_TARGET (0.66-stable)

### DIFF
--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -238,7 +238,7 @@ def __apply_Xcode_12_5_M1_post_install_workaround(installer)
   installer.pods_project.targets.each do |target|
     target.build_configurations.each do |config|
       # ensure IPHONEOS_DEPLOYMENT_TARGET is at least 11.0
-      should_upgrade = config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'].split('.')[0].to_i < 11
+      should_upgrade = config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'].to_f < 11.0 && config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'].to_f != 0.0
       if should_upgrade
         config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '11.0'
       end


### PR DESCRIPTION
Co-Authored-By: William Bell <williambell9708@outlook.com>

**ℹ️ This is a cherry-pick of #32746 to 0.66-stable**

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

If one of the pods has no IPHONEOS_DEPLOYMENT_TARGET, the M1 postinstall workaround script fails. This commit updates the code to handle this special case.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [Fixed] - __apply_Xcode_12_5_M1_post_install_workaround failing when one of the Pods has no IPHONEOS_DEPLOYMENT_TARGET set

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

https://github.com/reactwg/react-native-releases/discussions/6#discussioncomment-1791520