### PR TITLE
Add ability to pass ItemSeparatorComponent as React Element

### DIFF
--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -2097,9 +2097,11 @@ class CellRenderer extends React.Component<
         : this._onLayout;
     // NOTE: that when this is a sticky header, `onLayout` will get automatically extracted and
     // called explicitly by `ScrollViewStickyHeader`.
-    const itemSeparator = ItemSeparatorComponent && (
-      <ItemSeparatorComponent {...this.state.separatorProps} />
-    );
+    const itemSeparator = React.isValidElement(ItemSeparatorComponent)
+      ? ItemSeparatorComponent
+      : ItemSeparatorComponent && (
+          <ItemSeparatorComponent {...this.state.separatorProps} />
+        );
     const cellStyle = inversionStyle
       ? horizontal
         ? [styles.rowReverse, inversionStyle]


### PR DESCRIPTION
## Summary

Currently `ListHeaderComponent` & `ListFooterComponent` allow to use React Componetn & Elemelen

```tsx
<FlatList
  ListHeaderComponent={<View />} // valid
  ListHeaderComponent={View}     // valid
/>
```

But when you try to pass `ItemSeparatorComponent` as React Element it will throw an error

```tsx
<FlatList
  ItemSeparatorComponent={View}     // ok
  ItemSeparatorComponent={<View />} /* not valid: 
    Error: Element type is invalid: expected a string (for built-in components) or a class/function 
    (for composite components) but got: object.
    Check the render method of `CellRenderer`.
  */
/>
```

So, this PR adds this ability

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Changed] - Add ability to pass `ItemSeparatorComponent` as React Element

## Test Plan

...
