### PR TITLE
Move use_react_native_codegen_discovery to use_react_native!

### DIFF
--- a/packages/rn-tester/Podfile
+++ b/packages/rn-tester/Podfile
@@ -26,21 +26,18 @@ def pods(options = {})
 
   prefix_path = "../.."
 
-  if options[:use_codegen_discovery]
-    Pod::UI.puts "[Codegen] Building target with codegen library discovery enabled."
-    pre_install do |installer|
-      use_react_native_codegen_discovery!({
-        react_native_path: prefix_path,
-        app_path: "#{Dir.pwd}",
-        fabric_enabled: fabric_enabled,
-        config_file_dir: "#{Dir.pwd}/node_modules",
-      })
-    end
+  if ENV['USE_CODEGEN_DISCOVERY'] == '1'
     # Custom fabric component is only supported when using codegen discovery.
     pod 'MyNativeView', :path => "NativeComponentExample"
   end
 
-  use_react_native!(path: prefix_path, fabric_enabled: fabric_enabled, hermes_enabled: ENV['USE_HERMES'] == '1')
+  use_react_native!(
+    path: prefix_path,
+    fabric_enabled: fabric_enabled,
+    hermes_enabled: ENV['USE_HERMES'] == '1',
+    app_path: "#{Dir.pwd}",
+    config_file_dir: "#{Dir.pwd}/node_modules",
+  )
   pod 'ReactCommon/turbomodule/samples', :path => "#{prefix_path}/ReactCommon"
 
   # Additional Pods which aren't included in the default Podfile
@@ -53,7 +50,7 @@ def pods(options = {})
 end
 
 target 'RNTester' do
-  pods({ :use_codegen_discovery => ENV['USE_CODEGEN_DISCOVERY'] == '1' })
+  pods()
   if !USE_FRAMEWORKS
     use_flipper!
   end

--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -68,6 +68,19 @@ def use_react_native! (options={})
   pod 'boost', :podspec => "#{prefix}/third-party-podspecs/boost.podspec"
   pod 'RCT-Folly', :podspec => "#{prefix}/third-party-podspecs/RCT-Folly.podspec"
 
+  if ENV['USE_CODEGEN_DISCOVERY'] == '1'
+    Pod::UI.puts "[Codegen] Building target with codegen library discovery enabled."
+    # TODO: Make sure this is run only once per execution.
+    app_path = options[:app_path]
+    config_file_dir = options[:config_file_dir]
+    use_react_native_codegen_discovery!({
+      react_native_path: prefix,
+      app_path: app_path,
+      fabric_enabled: fabric_enabled,
+      config_file_dir: config_file_dir,
+    })
+  end
+
   # Generate a podspec file for generated files.
   temp_podinfo = generate_temp_pod_spec_for_codegen!(fabric_enabled)
   pod temp_podinfo['spec']['name'], :path => temp_podinfo['path']
@@ -354,6 +367,7 @@ def use_react_native_codegen_discovery!(options={})
     Pod::UI.puts out;
   else
     Pod::UI.warn '[Codegen] error: no app_path was provided'
+    Pod::UI.warn '[Codegen] If you are calling use_react_native_codegen_discovery! in your Podfile, please remove the call and pass `app_path` and/or `config_file_dir` to `use_react_native!`.'
     exit 1
   end
 end


### PR DESCRIPTION
Summary:
Changelog: [Internal] Move the use_react_native_codegen_discovery call to use_react_native.

Found out that pre_install doesn't get invoked until all podspecs are read. This wouldn't work because I want use_react_native_codegen_discovery to generate React-Codgen podspecs.

I also think it's better to have less logic in Podfiles as it's hard to update once users set it up.

Reviewed By: cortinico

Differential Revision: D33054318

