### PR TITLE
Add turbo module support in the default app template

### DIFF
--- a/React-Core.podspec
+++ b/React-Core.podspec
@@ -47,7 +47,7 @@ Pod::Spec.new do |s|
   s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
   s.header_dir             = "React"
   s.framework              = "JavaScriptCore"
-  s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/RCT-Folly\" \"${PODS_ROOT}/Headers/Public/React-hermes\" \"${PODS_ROOT}/Headers/Public/hermes-engine\"", "DEFINES_MODULE" => "YES" }
+  s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/RCT-Folly\" \"${PODS_ROOT}/Headers/Public/React-hermes\" \"${PODS_ROOT}/Headers/Public/hermes-engine\" \"${PODS_ROOT}/Headers/Public/FlipperKit\"", "DEFINES_MODULE" => "YES" }
   s.user_target_xcconfig   = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/Headers/Private/React-Core\""}
   s.default_subspec        = "Default"
 

--- a/React-Core.podspec
+++ b/React-Core.podspec
@@ -47,7 +47,7 @@ Pod::Spec.new do |s|
   s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
   s.header_dir             = "React"
   s.framework              = "JavaScriptCore"
-  s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/RCT-Folly\" \"${PODS_ROOT}/Headers/Public/React-hermes\" \"${PODS_ROOT}/Headers/Public/hermes-engine\" \"${PODS_ROOT}/Headers/Public/FlipperKit\"", "DEFINES_MODULE" => "YES" }
+  s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/RCT-Folly\" \"${PODS_ROOT}/Headers/Public/React-hermes\" \"${PODS_ROOT}/Headers/Public/hermes-engine\" \"${PODS_ROOT}/Headers/Public/FlipperKit\" \"$(PODS_ROOT)/Headers/Public/ReactCommon\"", "DEFINES_MODULE" => "YES" }
   s.user_target_xcconfig   = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/Headers/Private/React-Core\""}
   s.default_subspec        = "Default"
 

--- a/React/AppSetup/RCTAppSetupUtils.h
+++ b/React/AppSetup/RCTAppSetupUtils.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <Foundation/Foundation.h>
+#import <React/RCTBridge.h>
+#import <React/RCTRootView.h>
+
+@interface RCTAppSetupUtils : NSObject
++ (void)prepareApp:(UIApplication *_Nonnull)application;
++ (RCTRootView *_Nonnull)defaultRootViewWithBridge:(RCTBridge *_Nonnull)bridge
+                                        moduleName:(NSString *_Nonnull)moduleName
+                                 initialProperties:(nullable NSDictionary *)initialProperties;
+@end

--- a/React/AppSetup/RCTAppSetupUtils.h
+++ b/React/AppSetup/RCTAppSetupUtils.h
@@ -9,9 +9,35 @@
 #import <React/RCTBridge.h>
 #import <React/RCTRootView.h>
 
+#if RCT_TM_FABRIC_ENABLED
+
+#ifndef RCT_USE_HERMES
+#if __has_include(<reacthermes/HermesExecutorFactory.h>)
+#define RCT_USE_HERMES 1
+#else
+#define RCT_USE_HERMES 0
+#endif
+#endif
+
+#if RCT_USE_HERMES
+#import <reacthermes/HermesExecutorFactory.h>
+#else
+#import <React/JSCExecutorFactory.h>
+#endif
+
+#import <ReactCommon/RCTTurboModuleManager.h>
+#endif
+
 @interface RCTAppSetupUtils : NSObject
 + (void)prepareApp:(UIApplication *_Nonnull)application;
 + (RCTRootView *_Nonnull)defaultRootViewWithBridge:(RCTBridge *_Nonnull)bridge
                                         moduleName:(NSString *_Nonnull)moduleName
                                  initialProperties:(nullable NSDictionary *)initialProperties;
+
+#if RCT_TM_FABRIC_ENABLED
++ (id<RCTTurboModule> _Nonnull)defaultModuleInstanceFromClass:(Class _Nonnull)moduleClass;
++ (std::unique_ptr<facebook::react::JSExecutorFactory>)
+    defaultJsExecutorFactoryForBridge:(RCTBridge *_Nonnull)bridge
+               withTurboModuleManager:(RCTTurboModuleManager *_Nonnull)turboModuleManager;
+#endif
 @end

--- a/React/AppSetup/RCTAppSetupUtils.mm
+++ b/React/AppSetup/RCTAppSetupUtils.mm
@@ -7,6 +7,18 @@
 
 #import "RCTAppSetupUtils.h"
 
+#if RCT_TM_FABRIC_ENABLED
+#import <React/CoreModulesPlugins.h>
+#import <React/RCTDataRequestHandler.h>
+#import <React/RCTFileRequestHandler.h>
+#import <React/RCTGIFImageDecoder.h>
+#import <React/RCTHTTPRequestHandler.h>
+#import <React/RCTImageLoader.h>
+#import <React/RCTJSIExecutorRuntimeInstaller.h>
+#import <React/RCTLocalAssetImageLoader.h>
+#import <React/RCTNetworking.h>
+#endif
+
 #ifdef FB_SONARKIT_ENABLED
 #import <FlipperKit/FlipperClient.h>
 #import <FlipperKitLayoutPlugin/FlipperKitLayoutPlugin.h>
@@ -35,6 +47,10 @@ static void InitializeFlipper(UIApplication *application)
 #ifdef FB_SONARKIT_ENABLED
   InitializeFlipper(application);
 #endif
+
+#if RCT_TM_FABRIC_ENABLED
+  RCTEnableTurboModule(YES);
+#endif
 }
 
 + (RCTRootView *)defaultRootViewWithBridge:(RCTBridge *)bridge
@@ -43,5 +59,67 @@ static void InitializeFlipper(UIApplication *application)
 {
   return [[RCTRootView alloc] initWithBridge:bridge moduleName:moduleName initialProperties:initialProperties];
 }
+
+#if RCT_TM_FABRIC_ENABLED
++ (id<RCTTurboModule>)defaultModuleInstanceFromClass:(Class)moduleClass
+{
+  // Set up the default RCTImageLoader and RCTNetworking modules.
+  if (moduleClass == RCTImageLoader.class) {
+    return [[moduleClass alloc] initWithRedirectDelegate:nil
+        loadersProvider:^NSArray<id<RCTImageURLLoader>> *(RCTModuleRegistry *moduleRegistry) {
+          return @[ [RCTLocalAssetImageLoader new] ];
+        }
+        decodersProvider:^NSArray<id<RCTImageDataDecoder>> *(RCTModuleRegistry *moduleRegistry) {
+          return @[ [RCTGIFImageDecoder new] ];
+        }];
+  } else if (moduleClass == RCTNetworking.class) {
+    return [[moduleClass alloc]
+        initWithHandlersProvider:^NSArray<id<RCTURLRequestHandler>> *(RCTModuleRegistry *moduleRegistry) {
+          return @[
+            [RCTHTTPRequestHandler new],
+            [RCTDataRequestHandler new],
+            [RCTFileRequestHandler new],
+          ];
+        }];
+  }
+  // No custom initializer here.
+  return [moduleClass new];
+}
+
++ (std::unique_ptr<facebook::react::JSExecutorFactory>)defaultJsExecutorFactoryForBridge:(RCTBridge *)bridge
+                                                                  withTurboModuleManager:
+                                                                      (RCTTurboModuleManager *)turboModuleManager;
+{
+  // Necessary to allow NativeModules to lookup TurboModules
+  [bridge setRCTTurboModuleRegistry:turboModuleManager];
+
+#if RCT_DEV
+  if (!RCTTurboModuleEagerInitEnabled()) {
+    /**
+     * Instantiating DevMenu has the side-effect of registering
+     * shortcuts for CMD + d, CMD + i,  and CMD + n via RCTDevMenu.
+     * Therefore, when TurboModules are enabled, we must manually create this
+     * NativeModule.
+     */
+    [turboModuleManager moduleForName:"RCTDevMenu"];
+  }
+#endif
+
+#if RCT_USE_HERMES
+  return std::make_unique<facebook::react::HermesExecutorFactory>(
+#else
+  return std::make_unique<facebook::react::JSCExecutorFactory>(
+#endif
+      facebook::react::RCTJSIExecutorRuntimeInstaller([turboModuleManager, bridge](facebook::jsi::Runtime &runtime) {
+        if (!bridge || !turboModuleManager) {
+          return;
+        }
+        facebook::react::RuntimeExecutor syncRuntimeExecutor =
+            [&](std::function<void(facebook::jsi::Runtime & runtime_)> &&callback) { callback(runtime); };
+        [turboModuleManager installJSBindingWithRuntimeExecutor:syncRuntimeExecutor];
+      }));
+}
+
+#endif
 
 @end

--- a/React/AppSetup/RCTAppSetupUtils.mm
+++ b/React/AppSetup/RCTAppSetupUtils.mm
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RCTAppSetupUtils.h"
+
+#ifdef FB_SONARKIT_ENABLED
+#import <FlipperKit/FlipperClient.h>
+#import <FlipperKitLayoutPlugin/FlipperKitLayoutPlugin.h>
+#import <FlipperKitNetworkPlugin/FlipperKitNetworkPlugin.h>
+#import <FlipperKitReactPlugin/FlipperKitReactPlugin.h>
+#import <FlipperKitUserDefaultsPlugin/FKUserDefaultsPlugin.h>
+#import <SKIOSNetworkPlugin/SKIOSNetworkAdapter.h>
+
+static void InitializeFlipper(UIApplication *application)
+{
+  FlipperClient *client = [FlipperClient sharedClient];
+  SKDescriptorMapper *layoutDescriptorMapper = [[SKDescriptorMapper alloc] initWithDefaults];
+  [client addPlugin:[[FlipperKitLayoutPlugin alloc] initWithRootNode:application
+                                                withDescriptorMapper:layoutDescriptorMapper]];
+  [client addPlugin:[[FKUserDefaultsPlugin alloc] initWithSuiteName:nil]];
+  [client addPlugin:[FlipperKitReactPlugin new]];
+  [client addPlugin:[[FlipperKitNetworkPlugin alloc] initWithNetworkAdapter:[SKIOSNetworkAdapter new]]];
+  [client start];
+}
+#endif
+
+@implementation RCTAppSetupUtils
+
++ (void)prepareApp:(UIApplication *)application
+{
+#ifdef FB_SONARKIT_ENABLED
+  InitializeFlipper(application);
+#endif
+}
+
++ (RCTRootView *)defaultRootViewWithBridge:(RCTBridge *)bridge
+                                moduleName:(NSString *)moduleName
+                         initialProperties:(NSDictionary *)initialProperties
+{
+  return [[RCTRootView alloc] initWithBridge:bridge moduleName:moduleName initialProperties:initialProperties];
+}
+
+@end

--- a/template/ios/HelloWorld.xcodeproj/project.pbxproj
+++ b/template/ios/HelloWorld.xcodeproj/project.pbxproj
@@ -482,6 +482,7 @@
 			baseConfigurationReference = 3B4392A12AC88292D35C810B /* Pods-HelloWorld.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++17";
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_BITCODE = NO;
@@ -508,6 +509,7 @@
 			baseConfigurationReference = 5709B34CF0A7D63546082F79 /* Pods-HelloWorld.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++17";
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				INFOPLIST_FILE = HelloWorld/Info.plist;
@@ -588,6 +590,12 @@
 				);
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CPLUSPLUSFLAGS = (
+					"$(OTHER_CFLAGS)",
+					"-DFOLLY_NO_CONFIG",
+					"-DFOLLY_MOBILE=1",
+					"-DFOLLY_USE_LIBCPP=1",
+				);
 				SDKROOT = iphoneos;
 			};
 			name = Debug;
@@ -645,6 +653,12 @@
 					"\"$(inherited)\"",
 				);
 				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_CPLUSPLUSFLAGS = (
+					"$(OTHER_CFLAGS)",
+					"-DFOLLY_NO_CONFIG",
+					"-DFOLLY_MOBILE=1",
+					"-DFOLLY_USE_LIBCPP=1",
+				);
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;
 			};

--- a/template/ios/HelloWorld/AppDelegate.mm
+++ b/template/ios/HelloWorld/AppDelegate.mm
@@ -6,6 +6,17 @@
 
 #import <React/RCTAppSetupUtils.h>
 
+#if RCT_TM_FABRIC_ENABLED
+#import <React/CoreModulesPlugins.h>
+#import <React/RCTCxxBridgeDelegate.h>
+#import <ReactCommon/RCTTurboModuleManager.h>
+
+@interface AppDelegate () <RCTCxxBridgeDelegate, RCTTurboModuleManagerDelegate> {
+  RCTTurboModuleManager *_turboModuleManager;
+}
+@end
+#endif
+
 @implementation AppDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
@@ -39,5 +50,43 @@
   return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
 #endif
 }
+
+#if RCT_TM_FABRIC_ENABLED
+
+#pragma mark - RCTCxxBridgeDelegate
+
+- (std::unique_ptr<facebook::react::JSExecutorFactory>)jsExecutorFactoryForBridge:(RCTBridge *)bridge
+{
+  _turboModuleManager = [[RCTTurboModuleManager alloc] initWithBridge:bridge
+                                                             delegate:self
+                                                            jsInvoker:bridge.jsCallInvoker];
+  return [RCTAppSetupUtils defaultJsExecutorFactoryForBridge:bridge withTurboModuleManager:_turboModuleManager];
+}
+
+#pragma mark RCTTurboModuleManagerDelegate
+
+- (Class)getModuleClassFromName:(const char *)name
+{
+  return RCTCoreModulesClassProvider(name);
+}
+
+- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const std::string &)name
+                                                      jsInvoker:(std::shared_ptr<facebook::react::CallInvoker>)jsInvoker
+{
+  return nullptr;
+}
+
+- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const std::string &)name
+                                                     initParams:(const facebook::react::ObjCTurboModule::InitParams &)params
+{
+  return nullptr;
+}
+
+- (id<RCTTurboModule>)getModuleInstanceFromClass:(Class)moduleClass
+{
+  return [RCTAppSetupUtils defaultModuleInstanceFromClass: moduleClass];
+}
+
+#endif
 
 @end

--- a/template/ios/HelloWorld/AppDelegate.mm
+++ b/template/ios/HelloWorld/AppDelegate.mm
@@ -4,37 +4,18 @@
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTRootView.h>
 
-#ifdef FB_SONARKIT_ENABLED
-#import <FlipperKit/FlipperClient.h>
-#import <FlipperKitLayoutPlugin/FlipperKitLayoutPlugin.h>
-#import <FlipperKitUserDefaultsPlugin/FKUserDefaultsPlugin.h>
-#import <FlipperKitNetworkPlugin/FlipperKitNetworkPlugin.h>
-#import <SKIOSNetworkPlugin/SKIOSNetworkAdapter.h>
-#import <FlipperKitReactPlugin/FlipperKitReactPlugin.h>
-
-static void InitializeFlipper(UIApplication *application) {
-  FlipperClient *client = [FlipperClient sharedClient];
-  SKDescriptorMapper *layoutDescriptorMapper = [[SKDescriptorMapper alloc] initWithDefaults];
-  [client addPlugin:[[FlipperKitLayoutPlugin alloc] initWithRootNode:application withDescriptorMapper:layoutDescriptorMapper]];
-  [client addPlugin:[[FKUserDefaultsPlugin alloc] initWithSuiteName:nil]];
-  [client addPlugin:[FlipperKitReactPlugin new]];
-  [client addPlugin:[[FlipperKitNetworkPlugin alloc] initWithNetworkAdapter:[SKIOSNetworkAdapter new]]];
-  [client start];
-}
-#endif
+#import <React/RCTAppSetupUtils.h>
 
 @implementation AppDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
-#ifdef FB_SONARKIT_ENABLED
-  InitializeFlipper(application);
-#endif
+  [RCTAppSetupUtils prepareApp: application];
 
   RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
-  RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge
-                                                   moduleName:@"HelloWorld"
-                                            initialProperties:nil];
+  RCTRootView *rootView = [RCTAppSetupUtils defaultRootViewWithBridge:bridge
+                                   moduleName:@"HelloWorld"
+                           initialProperties:nil];
 
   if (@available(iOS 13.0, *)) {
       rootView.backgroundColor = [UIColor systemBackgroundColor];


### PR DESCRIPTION
Summary: Changelog: [internal] Add an optional support for Turbomodule. Define RCT_TM_FABRIC_ENABLED to enable the new architecture.

Reviewed By: philIip

Differential Revision: D33052777

