### PR TITLE
Add missing scripts/packager-reporter.js file in npm published files

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "scripts/launchPackager.command",
     "scripts/node-binary.sh",
     "scripts/packager.sh",
+    "scripts/packager-reporter.js",
     "scripts/react_native_pods.rb",
     "scripts/react-native-xcode.sh",
     "template.config.js",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

When using the nightly builds, metro fails with an error because of missing scripts/packager-reporter.js. The file is not included in the published files so this is why.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Internal] [Fixed] - Add missing scripts/packager-reporter.js file in npm published files

## Test Plan

Test that nightly builds work when adding the missing file.
