### PR TITLE
Refactor script_phases script out of react_native_pods.rb

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
     "scripts/node-binary.sh",
     "scripts/packager.sh",
     "scripts/packager-reporter.js",
+    "scripts/react_native_pods_utils/script_phases.rb",
+    "scripts/react_native_pods_utils/script_phases.sh",
     "scripts/react_native_pods.rb",
     "scripts/react-native-xcode.sh",
     "template.config.js",

--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -881,7 +881,7 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
   FBLazyVector: b81a2b70c72d8b0aefb652cea22c11e9ffd02949
-  FBReactNativeSpec: 140e95aa3cc1f6084938f6b8123bb0c4398325d1
+  FBReactNativeSpec: a9c75a44813c347e748342bc4ce0789e162d22e6
   Flipper: 30e8eeeed6abdc98edaf32af0cda2f198be4b733
   Flipper-Boost-iOSX: fd1e2b8cbef7e662a122412d7ac5f5bea715403c
   Flipper-DoubleConversion: 57ffbe81ef95306cc9e69c4aa3aeeeeb58a6a28c
@@ -923,10 +923,10 @@ SPEC CHECKSUMS:
   React-RCTTest: 12bbd7fc2e72bd9920dc7286c5b8ef96639582b6
   React-RCTText: e9146b2c0550a83d1335bfe2553760070a2d75c7
   React-RCTVibration: 50be9c390f2da76045ef0dfdefa18b9cf9f35cfa
-  React-rncore: 90798d1c013f1c62d0066c5618ddf8681c7a7c22
+  React-rncore: 419b6945917d7eb76b304b76acbb49f79fb7e7e0
   React-runtimeexecutor: 4b0c6eb341c7d3ceb5e2385cb0fdb9bf701024f3
   ReactCommon: 7a2714d1128f965392b6f99a8b390e3aa38c9569
-  ScreenshotManager: ccf2b410b3c59385b26b8460a58cca8a8aca5e85
+  ScreenshotManager: 025a85e18687aff80bca262c3a7065ff54e636ae
   Yoga: c0d06f5380d34e939f55420669a60fe08b79bd75
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 

--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 require 'pathname'
+require_relative './react_native_pods_utils/script_phases.rb'
 
 $CODEGEN_OUTPUT_DIR = 'build/generated/ios'
 $CODEGEN_COMPONENT_DIR = 'react/renderer/components'
@@ -392,96 +393,12 @@ def get_react_codegen_script_phases(options={})
     'input_files' => input_files,
     'show_env_vars_in_log': true,
     'output_files': ["${DERIVED_FILE_DIR}/react-codegen.log"],
-    'script': %{set -o pipefail
-set -e
-
-pushd "${PODS_ROOT}/../" > /dev/null
-POD_INSTALLATION_ROOT=$(pwd)
-popd >/dev/null
-RN_DIR=$(cd "$POD_INSTALLATION_ROOT/#{react_native_path}" && pwd)
-
-GENERATED_SRCS_DIR="$\{DERIVED_FILE_DIR\}/generated/source/codegen-discovery"
-TEMP_OUTPUT_DIR="$GENERATED_SRCS_DIR/out"
-
-APP_PATH="$POD_INSTALLATION_ROOT/#{$relative_app_root}"
-CONFIG_FILE_DIR="#{relative_config_file_dir ? "$POD_INSTALLATION_ROOT/#{relative_config_file_dir}" : ''}"
-OUTPUT_DIR="$POD_INSTALLATION_ROOT"
-FABRIC_ENABLED="#{fabric_enabled}"
-
-CODEGEN_REPO_PATH="$RN_DIR/packages/react-native-codegen"
-CODEGEN_NPM_PATH="$RN_DIR/../react-native-codegen"
-CODEGEN_CLI_PATH=""
-
-# Determine path to react-native-codegen
-if [ -d "$CODEGEN_REPO_PATH" ]; then
-  CODEGEN_CLI_PATH=$(cd "$CODEGEN_REPO_PATH" && pwd)
-elif [ -d "$CODEGEN_NPM_PATH" ]; then
-  CODEGEN_CLI_PATH=$(cd "$CODEGEN_NPM_PATH" && pwd)
-else
-  echo "error: Could not determine react-native-codegen location. Try running 'yarn install' or 'npm install' in your project root." >> "${SCRIPT_OUTPUT_FILE_0}" 2>&1
-  exit 1
-fi
-
-find_node () {
-  source "$RN_DIR/scripts/find-node.sh"
-
-  NODE_BINARY="${NODE_BINARY:-$(command -v node || true)}"
-  if [ -z "$NODE_BINARY" ]; then
-    echo "error: Could not find node. Make sure it is in bash PATH or set the NODE_BINARY environment variable." >> "${SCRIPT_OUTPUT_FILE_0}" 2>&1
-    exit 1
-  fi
-}
-
-setup_dirs () {
-  set +e
-  rm -rf "$GENERATED_SRCS_DIR"
-  set -e
-
-  mkdir -p "$GENERATED_SRCS_DIR" "$TEMP_OUTPUT_DIR"
-
-  # Clear output files
-  > "${SCRIPT_OUTPUT_FILE_0}"
-}
-
-describe () {
-  printf "\\n\\n>>>>> %s\\n\\n\\n" "$1" >> "${SCRIPT_OUTPUT_FILE_0}" 2>&1
-}
-
-buildCodegenCLI () {
-  if [ ! -d "$CODEGEN_CLI_PATH/lib" ]; then
-    describe "Building react-native-codegen package"
-    bash "$CODEGEN_CLI_PATH/scripts/oss/build.sh"
-  fi
-}
-
-generateArtifacts () {
-  describe "Generating codegen artifacts"
-  pushd "$RN_DIR" >/dev/null || exit 1
-CONFIG_FILE_DIR="$POD_INSTALLATION_ROOT/#{$relative_config_file_dir}"
-    "$NODE_BINARY" "scripts/generate-artifacts.js" --path "$APP_PATH" --outputPath "$OUTPUT_DIR" --fabricEnabled "$FABRIC_ENABLED" --configFileDir "$CONFIG_FILE_DIR"
-  popd >/dev/null || exit 1
-}
-
-moveOutputs () {
-  mkdir -p "$OUTPUT_DIR"
-
-  # Copy all output to output_dir
-  cp -R "$TEMP_OUTPUT_DIR/" "$OUTPUT_DIR" || exit 1
-  echo "Output has been written to $OUTPUT_DIR:" >> "${SCRIPT_OUTPUT_FILE_0}" 2>&1
-  ls -1 "$OUTPUT_DIR" >> "${SCRIPT_OUTPUT_FILE_0}" 2>&1
-}
-
-main () {
-  setup_dirs
-  find_node
-  buildCodegenCLI
-  generateArtifacts
-  moveOutputs
-}
-
-main "$@"
-echo 'Done.' >> "${SCRIPT_OUTPUT_FILE_0}" 2>&1
-    },
+    'script': get_script_phases_with_codegen_discovery(
+      react_native_path: react_native_path,
+      relative_app_root: relative_app_root,
+      relative_config_file_dir: relative_config_file_dir,
+      fabric_enabled: fabric_enabled
+    ),
   }
 
 end
@@ -566,7 +483,7 @@ def use_react_native_codegen!(spec, options={})
   # TODO: Once the new codegen approach is ready for use, we should output a warning here to let folks know to migrate.
 
   # The prefix to react-native
-  prefix = options[:react_native_path] ||= "../.."
+  react_native_path = options[:react_native_path] ||= "../.."
 
   # Library name (e.g. FBReactNativeSpec)
   library_name = options[:library_name] ||= "#{spec.name.gsub('_','-').split('-').collect(&:capitalize).join}Spec"
@@ -638,124 +555,17 @@ def use_react_native_codegen!(spec, options={})
     :input_files => input_files, # This also needs to be relative to Xcode
     :output_files => ["${DERIVED_FILE_DIR}/codegen-#{library_name}.log"].concat(generated_files.map { |filename| " ${PODS_TARGET_SRCROOT}/#{filename}"} ),
     # The final generated files will be created when this script is invoked at Xcode build time.
-    :script => %{set -o pipefail
-set -e
-
-pushd "${PODS_ROOT}/../" > /dev/null
-POD_INSTALLATION_ROOT=$(pwd)
-popd >/dev/null
-RN_DIR=$(cd "$\{PODS_TARGET_SRCROOT\}/#{prefix}" && pwd)
-
-GENERATED_SRCS_DIR="$\{DERIVED_FILE_DIR\}/generated/source/codegen"
-GENERATED_SCHEMA_FILE="$GENERATED_SRCS_DIR/schema.json"
-TEMP_OUTPUT_DIR="$GENERATED_SRCS_DIR/out"
-
-LIBRARY_NAME="#{library_name}"
-OUTPUT_DIR="$POD_INSTALLATION_ROOT/#{$CODEGEN_OUTPUT_DIR}"
-
-CODEGEN_REPO_PATH="$RN_DIR/packages/react-native-codegen"
-CODEGEN_NPM_PATH="$RN_DIR/../react-native-codegen"
-CODEGEN_CLI_PATH=""
-
-LIBRARY_TYPE="#{library_type ? library_type : 'all'}"
-
-# Determine path to react-native-codegen
-if [ -d "$CODEGEN_REPO_PATH" ]; then
-  CODEGEN_CLI_PATH=$(cd "$CODEGEN_REPO_PATH" && pwd)
-elif [ -d "$CODEGEN_NPM_PATH" ]; then
-  CODEGEN_CLI_PATH=$(cd "$CODEGEN_NPM_PATH" && pwd)
-else
-  echo "error: Could not determine react-native-codegen location. Try running 'yarn install' or 'npm install' in your project root." >> "${SCRIPT_OUTPUT_FILE_0}" 2>&1
-  exit 1
-fi
-
-find_node () {
-  source "$RN_DIR/scripts/find-node.sh"
-
-  NODE_BINARY="${NODE_BINARY:-$(command -v node || true)}"
-  if [ -z "$NODE_BINARY" ]; then
-    echo "error: Could not find node. Make sure it is in bash PATH or set the NODE_BINARY environment variable." >> "${SCRIPT_OUTPUT_FILE_0}" 2>&1
-    exit 1
-  fi
-}
-
-setup_dirs () {
-  set +e
-  rm -rf "$GENERATED_SRCS_DIR"
-  set -e
-
-  mkdir -p "$GENERATED_SRCS_DIR" "$TEMP_OUTPUT_DIR"
-
-  # Clear output files
-  > "${SCRIPT_OUTPUT_FILE_0}"
-}
-
-describe () {
-  printf "\\n\\n>>>>> %s\\n\\n\\n" "$1" >> "${SCRIPT_OUTPUT_FILE_0}" 2>&1
-}
-
-buildCodegenCLI () {
-  if [ ! -d "$CODEGEN_CLI_PATH/lib" ]; then
-    describe "Building react-native-codegen package"
-    bash "$CODEGEN_CLI_PATH/scripts/oss/build.sh"
-  fi
-}
-
-generateCodegenSchemaFromJavaScript () {
-  describe "Generating codegen schema from JavaScript"
-
-  SRCS_PATTERN="#{js_srcs_pattern}"
-  SRCS_DIR="#{js_srcs_dir}"
-  if [ $SRCS_PATTERN ]; then
-    JS_SRCS=$(find "$\{PODS_TARGET_SRCROOT\}"/$SRCS_DIR -type f -name "$SRCS_PATTERN" -print0 | xargs -0)
-    echo "#{file_list}" >> "${SCRIPT_OUTPUT_FILE_0}" 2>&1
-  else
-    JS_SRCS="$\{PODS_TARGET_SRCROOT\}/$SRCS_DIR"
-    echo "#{js_srcs_dir}" >> "${SCRIPT_OUTPUT_FILE_0}" 2>&1
-  fi
-
-  "$NODE_BINARY" "$CODEGEN_CLI_PATH/lib/cli/combine/combine-js-to-schema-cli.js" "$GENERATED_SCHEMA_FILE" $JS_SRCS
-}
-
-runSpecCodegen () {
-  "$NODE_BINARY" "scripts/generate-specs-cli.js" --platform ios --schemaPath "$GENERATED_SCHEMA_FILE" --outputDir "$1" --libraryName "$LIBRARY_NAME" --libraryType "$2"
-}
-
-generateCodegenArtifactsFromSchema () {
-  describe "Generating codegen artifacts from schema"
-  pushd "$RN_DIR" >/dev/null || exit 1
-    if [ "$LIBRARY_TYPE" = "all" ]; then
-      runSpecCodegen "$TEMP_OUTPUT_DIR/#{$CODEGEN_MODULE_DIR}/#{library_name}" "modules"
-      runSpecCodegen "$TEMP_OUTPUT_DIR/#{$CODEGEN_COMPONENT_DIR}/#{library_name}" "components"
-    elif [ "$LIBRARY_TYPE" = "components" ]; then
-      runSpecCodegen "$TEMP_OUTPUT_DIR/#{$CODEGEN_COMPONENT_DIR}/#{library_name}" "$LIBRARY_TYPE"
-    elif [ "$LIBRARY_TYPE" = "modules" ]; then
-      runSpecCodegen "$TEMP_OUTPUT_DIR/#{$CODEGEN_MODULE_DIR}/#{library_name}" "$LIBRARY_TYPE"
-    fi
-  popd >/dev/null || exit 1
-}
-
-moveOutputs () {
-  mkdir -p "$OUTPUT_DIR"
-
-  # Copy all output to output_dir
-  cp -R "$TEMP_OUTPUT_DIR/" "$OUTPUT_DIR" || exit 1
-  echo "$LIBRARY_NAME output has been written to $OUTPUT_DIR:" >> "${SCRIPT_OUTPUT_FILE_0}" 2>&1
-  ls -1 "$OUTPUT_DIR" >> "${SCRIPT_OUTPUT_FILE_0}" 2>&1
-}
-
-main () {
-  setup_dirs
-  find_node
-  buildCodegenCLI
-  generateCodegenSchemaFromJavaScript
-  generateCodegenArtifactsFromSchema
-  moveOutputs
-}
-
-main "$@"
-echo 'Done.' >> "${SCRIPT_OUTPUT_FILE_0}" 2>&1
-    },
+    :script => get_script_phases_no_codegen_discovery(
+      react_native_path: react_native_path,
+      codegen_output_dir: $CODEGEN_OUTPUT_DIR,
+      codegen_module_dir: $CODEGEN_MODULE_DIR,
+      codegen_component_dir: $CODEGEN_COMPONENT_DIR,
+      library_name: library_name,
+      library_type: library_type,
+      js_srcs_pattern: js_srcs_pattern,
+      js_srcs_dir: js_srcs_dir,
+      file_list: file_list
+    ),
     :execution_position => :before_compile,
     :show_env_vars_in_log => true
   }

--- a/scripts/react_native_pods_utils/script_phases.rb
+++ b/scripts/react_native_pods_utils/script_phases.rb
@@ -1,0 +1,53 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Run test manually by running `ruby react-native/scripts/react_native_pods_utils/__test__/script_phases.test.rb`
+
+require "erb"
+
+def get_script_phases_with_codegen_discovery(options)
+    export_vars = {
+        'RCT_SCRIPT_RN_DIR' => "$RCT_SCRIPT_POD_INSTALLATION_ROOT/#{options[:react_native_path]}",
+        'RCT_SCRIPT_APP_PATH' => "$RCT_SCRIPT_POD_INSTALLATION_ROOT/#{options[:relative_app_root]}",
+        'RCT_SCRIPT_CONFIG_FILE_DIR' => "#{options[:relative_config_file_dir] ? "$RCT_SCRIPT_POD_INSTALLATION_ROOT/#{options[:relative_config_file_dir]}" : ''}",
+        'RCT_SCRIPT_OUTPUT_DIR' => "$RCT_SCRIPT_POD_INSTALLATION_ROOT",
+        'RCT_SCRIPT_FABRIC_ENABLED' => "#{options[:fabric_enabled]}",
+        'RCT_SCRIPT_TYPE' => "withCodegenDiscovery",
+    }
+    return get_script_template(options[:react_native_path], export_vars)
+end
+
+def get_script_phases_no_codegen_discovery(options)
+    export_vars = {
+        'RCT_SCRIPT_RN_DIR' => "${PODS_TARGET_SRCROOT}/#{options[:react_native_path]}",
+        'RCT_SCRIPT_LIBRARY_NAME' => "#{options[:library_name]}",
+        'RCT_SCRIPT_OUTPUT_DIR' => "$RCT_SCRIPT_POD_INSTALLATION_ROOT/#{options[:codegen_output_dir]}",
+        'RCT_SCRIPT_LIBRARY_TYPE' => "#{options[:library_type] ? options[:library_type] : 'all'}",
+        'RCT_SCRIPT_JS_SRCS_PATTERN' => "#{options[:js_srcs_pattern]}",
+        'RCT_SCRIPT_JS_SRCS_DIR' => "#{options[:js_srcs_dir]}",
+        'RCT_SCRIPT_CODEGEN_MODULE_DIR' => "#{options[:codegen_module_dir]}",
+        'RCT_SCRIPT_CODEGEN_COMPONENT_DIR' => "#{options[:codegen_component_dir]}",
+        'RCT_SCRIPT_FILE_LIST' => ("#{options[:file_list]}").dump,
+    }
+    return get_script_template(options[:react_native_path], export_vars)
+end
+
+
+def get_script_template(react_native_path, export_vars={})
+    template =<<~EOS
+        pushd "$PODS_ROOT/../" > /dev/null
+        RCT_SCRIPT_POD_INSTALLATION_ROOT=$(pwd)
+        popd >/dev/null
+        <% export_vars.each do |(varname, value)| %>
+        export <%= varname -%>=<%= value -%>
+        <% end %>
+
+        SCRIPT_PHASES_SCRIPT="$RCT_SCRIPT_RN_DIR/scripts/react_native_pods_utils/script_phases.sh"
+        /bin/sh -c "$SCRIPT_PHASES_SCRIPT"
+        EOS
+    result = ERB.new(template, 0, '->').result(binding)
+    # puts result
+    return result
+end


### PR DESCRIPTION
Summary:
Changelog: [Internal] This diff refactors react_native_pods.rb so that it's a bit more readable/maintainable.

With the intorduction of the codegen discovery script, we have two script phases that shares some code. I've factored it out of the main file and wrote a snapshot test so that it's easier to see the output script file.

Reviewed By: cortinico

Differential Revision: D33045541

