### PR TITLE
fix: Removes interface only check from third party components GenerateThirdPartyFabricComponentsProvider

### DIFF
--- a/packages/react-native-codegen/src/generators/components/GenerateThirdPartyFabricComponentsProviderH.js
+++ b/packages/react-native-codegen/src/generators/components/GenerateThirdPartyFabricComponentsProviderH.js
@@ -87,9 +87,6 @@ module.exports = {
               })
               .map(componentName => {
                 const component = components[componentName];
-                if (component.interfaceOnly === true) {
-                  return;
-                }
 
                 return LookupFuncTemplate({
                   className: componentName,

--- a/packages/react-native-codegen/src/generators/components/GenerateThirdPartyFabricComponentsProviderObjCpp.js
+++ b/packages/react-native-codegen/src/generators/components/GenerateThirdPartyFabricComponentsProviderObjCpp.js
@@ -84,9 +84,6 @@ module.exports = {
                 );
               })
               .map(componentName => {
-                if (components[componentName].interfaceOnly === true) {
-                  return;
-                }
                 const replacedTemplate = LookupMapTemplate({
                   className: componentName,
                   libraryName,

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GenerateThirdPartyFabricComponentsProviderH-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GenerateThirdPartyFabricComponentsProviderH-test.js.snap
@@ -24,7 +24,7 @@ extern \\"C\\" {
 Class<RCTComponentViewProtocol> RCTThirdPartyFabricComponentsProvider(const char *name);
 
 Class<RCTComponentViewProtocol> NoPropsNoEventsComponentCls(void) __attribute__((used)); // NO_PROPS_NO_EVENTS
-
+Class<RCTComponentViewProtocol> InterfaceOnlyComponentCls(void) __attribute__((used)); // INTERFACE_ONLY
 Class<RCTComponentViewProtocol> BooleanPropNativeComponentCls(void) __attribute__((used)); // BOOLEAN_PROP
 Class<RCTComponentViewProtocol> StringPropComponentCls(void) __attribute__((used)); // STRING_PROP
 Class<RCTComponentViewProtocol> IntegerPropNativeComponentCls(void) __attribute__((used)); // INTEGER_PROPS
@@ -41,7 +41,7 @@ Class<RCTComponentViewProtocol> ImageColorPropNativeComponentCls(void) __attribu
 Class<RCTComponentViewProtocol> StringEnumPropsNativeComponentCls(void) __attribute__((used)); // STRING_ENUM_PROP
 Class<RCTComponentViewProtocol> Int32EnumPropsNativeComponentCls(void) __attribute__((used)); // INT32_ENUM_PROP
 Class<RCTComponentViewProtocol> EventsNativeComponentCls(void) __attribute__((used)); // EVENT_PROPS
-
+Class<RCTComponentViewProtocol> InterfaceOnlyComponentCls(void) __attribute__((used)); // EVENTS_WITH_PAPER_NAME
 Class<RCTComponentViewProtocol> EventsNestedObjectNativeComponentCls(void) __attribute__((used)); // EVENT_NESTED_OBJECT_PROPS
 Class<RCTComponentViewProtocol> MultiComponent1NativeComponentCls(void) __attribute__((used)); // TWO_COMPONENTS_SAME_FILE
 Class<RCTComponentViewProtocol> MultiComponent2NativeComponentCls(void) __attribute__((used)); // TWO_COMPONENTS_SAME_FILE

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GenerateThirdPartyFabricComponentsProviderObjCpp-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GenerateThirdPartyFabricComponentsProviderObjCpp-test.js.snap
@@ -24,6 +24,7 @@ Class<RCTComponentViewProtocol> RCTThirdPartyFabricComponentsProvider(const char
 
     {\\"NoPropsNoEventsComponent\\", NoPropsNoEventsComponentCls}, // NO_PROPS_NO_EVENTS
 
+    {\\"InterfaceOnlyComponent\\", InterfaceOnlyComponentCls}, // INTERFACE_ONLY
 
     {\\"BooleanPropNativeComponent\\", BooleanPropNativeComponentCls}, // BOOLEAN_PROP
 
@@ -57,6 +58,7 @@ Class<RCTComponentViewProtocol> RCTThirdPartyFabricComponentsProvider(const char
 
     {\\"EventsNativeComponent\\", EventsNativeComponentCls}, // EVENT_PROPS
 
+    {\\"InterfaceOnlyComponent\\", InterfaceOnlyComponentCls}, // EVENTS_WITH_PAPER_NAME
 
     {\\"EventsNestedObjectNativeComponent\\", EventsNestedObjectNativeComponentCls}, // EVENT_NESTED_OBJECT_PROPS
 


### PR DESCRIPTION
## Summary

Currently the codegen does not include component with field `interfaceOnly` set to `true` in the `ThirdPartyFabricComponentsProvider`. 

These components need to be added to this file, so that non-core components can be used in fabric.

## Changelog

[General [Fixed] - Fixes GenerateThirdPartyFabricComponentsProvider

## Test Plan

Run codegen with component outside of core on iOS. 

Check if components with and without `interfaceOnly` are added to `RCTThirdPartyFabricComponentsProvider`
