### PR TITLE
chore: use npx to run react-native

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -24,8 +24,8 @@ body:
   - type: textarea
     id: react-native-info
     attributes:
-      label: Output of `react-native info`
-      description: Run `react-native info` in your terminal, copy and paste the results here.
+      label: Output of `npx react-native info`
+      description: Run `npx react-native info` in your terminal, copy and paste the results here.
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
## Summary

the docs mostly use npx to run react native (https://reactnative.dev/docs/environment-setup) and I do not have react native installed globally, so I think npx should be used here as well


<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [changed] - improved bug template

## Test Plan

not needed
