### PR TITLE
add eslint-plugin-react-native-a11y

### DIFF
--- a/IntegrationTests/IntegrationTestsApp.js
+++ b/IntegrationTests/IntegrationTestsApp.js
@@ -73,6 +73,7 @@ class IntegrationTestsApp extends React.Component<{...}, $FlowFixMeState> {
         <ScrollView>
           {TESTS.map(test => [
             <TouchableOpacity
+              accessibilityRole="button"
               onPress={() => this.setState({test})}
               /* $FlowFixMe[incompatible-type] (>=0.115.0 site=react_native_fb)
                * This comment suppresses an error found when Flow v0.115 was

--- a/IntegrationTests/RCTRootViewIntegrationTestApp.js
+++ b/IntegrationTests/RCTRootViewIntegrationTestApp.js
@@ -50,6 +50,7 @@ class RCTRootViewIntegrationTestApp extends React.Component {
         <ScrollView>
           {TESTS.map(test => [
             <TouchableOpacity
+              accessibilityRole="button"
               onPress={() => this.setState({test})}
               style={styles.row}>
               <Text style={styles.testName}>{test.displayName}</Text>

--- a/Libraries/Components/Pressable/__tests__/Pressable-test.js
+++ b/Libraries/Components/Pressable/__tests__/Pressable-test.js
@@ -20,7 +20,7 @@ describe('<Pressable />', () => {
     expectRendersMatchingSnapshot(
       'Pressable',
       () => (
-        <Pressable>
+        <Pressable accessibilityRole="button">
           <View />
         </Pressable>
       ),
@@ -36,7 +36,7 @@ describe('<Pressable disabled={true} />', () => {
     expectRendersMatchingSnapshot(
       'Pressable',
       () => (
-        <Pressable disabled={true}>
+        <Pressable accessibilityRole="button" disabled={true}>
           <View />
         </Pressable>
       ),
@@ -52,7 +52,10 @@ describe('<Pressable disabled={true} accessibilityState={{}} />', () => {
     expectRendersMatchingSnapshot(
       'Pressable',
       () => (
-        <Pressable disabled={true} accessibilityState={{}}>
+        <Pressable
+          accessibilityRole="button"
+          disabled={true}
+          accessibilityState={{}}>
           <View />
         </Pressable>
       ),
@@ -68,7 +71,10 @@ describe('<Pressable disabled={true} accessibilityState={{checked: true}} />', (
     expectRendersMatchingSnapshot(
       'Pressable',
       () => (
-        <Pressable disabled={true} accessibilityState={{checked: true}}>
+        <Pressable
+          accessibilityRole="button"
+          disabled={true}
+          accessibilityState={{checked: true}}>
           <View />
         </Pressable>
       ),
@@ -84,7 +90,10 @@ describe('<Pressable disabled={true} accessibilityState={{disabled: false}} />',
     expectRendersMatchingSnapshot(
       'Pressable',
       () => (
-        <Pressable disabled={true} accessibilityState={{disabled: false}}>
+        <Pressable
+          accessibilityRole="button"
+          disabled={true}
+          accessibilityState={{disabled: false}}>
           <View />
         </Pressable>
       ),

--- a/Libraries/Components/TextInput/__tests__/TextInput-test.js
+++ b/Libraries/Components/TextInput/__tests__/TextInput-test.js
@@ -37,6 +37,7 @@ describe('TextInput tests', () => {
       <Component initialState={{text: initialValue}}>
         {({setState, state}) => (
           <TextInput
+            accessibilityLabel="Text input field"
             ref={inputRef}
             value={state.text}
             onChangeText={text => {
@@ -81,7 +82,13 @@ describe('TextInput tests', () => {
 
   it('should have support being focused and unfocused', () => {
     const textInputRef = React.createRef(null);
-    ReactTestRenderer.create(<TextInput ref={textInputRef} value="value1" />);
+    ReactTestRenderer.create(
+      <TextInput
+        accessibilityLabel="Text input field"
+        ref={textInputRef}
+        value="value1"
+      />,
+    );
 
     expect(textInputRef.current.isFocused()).toBe(false);
     ReactNative.findNodeHandle = jest.fn().mockImplementation(ref => {
@@ -114,8 +121,16 @@ describe('TextInput tests', () => {
 
     ReactTestRenderer.create(
       <>
-        <TextInput ref={textInputRe1} value="value1" />
-        <TextInput ref={textInputRe2} value="value2" />
+        <TextInput
+          accessibilityLabel="Text input field"
+          ref={textInputRe1}
+          value="value1"
+        />
+        <TextInput
+          accessibilityLabel="Text input field"
+          ref={textInputRe2}
+          value="value2"
+        />
       </>,
     );
     ReactNative.findNodeHandle = jest.fn().mockImplementation(ref => {
@@ -155,7 +170,7 @@ describe('TextInput tests', () => {
   it('should render as expected', () => {
     expectRendersMatchingSnapshot(
       'TextInput',
-      () => <TextInput />,
+      () => <TextInput accessibilityLabel="Text input field" />,
       () => {
         jest.dontMock('../TextInput');
       },

--- a/Libraries/Components/Touchable/__tests__/TouchableHighlight-test.js
+++ b/Libraries/Components/Touchable/__tests__/TouchableHighlight-test.js
@@ -20,7 +20,7 @@ const render = require('../../../../jest/renderer');
 describe('TouchableHighlight', () => {
   it('renders correctly', () => {
     const instance = render.create(
-      <TouchableHighlight style={{}}>
+      <TouchableHighlight accessibilityRole="button" style={{}}>
         <Text>Touchable</Text>
       </TouchableHighlight>,
     );
@@ -37,7 +37,7 @@ describe('TouchableHighlight with disabled state', () => {
   it('should be disabled when disabled is true', () => {
     expect(
       render.create(
-        <TouchableHighlight disabled={true}>
+        <TouchableHighlight accessibilityRole="button" disabled={true}>
           <View />
         </TouchableHighlight>,
       ),
@@ -47,7 +47,10 @@ describe('TouchableHighlight with disabled state', () => {
   it('should be disabled when disabled is true and accessibilityState is empty', () => {
     expect(
       render.create(
-        <TouchableHighlight disabled={true} accessibilityState={{}}>
+        <TouchableHighlight
+          accessibilityRole="button"
+          disabled={true}
+          accessibilityState={{}}>
           <View />
         </TouchableHighlight>,
       ),
@@ -58,6 +61,7 @@ describe('TouchableHighlight with disabled state', () => {
     expect(
       render.create(
         <TouchableHighlight
+          accessibilityRole="button"
           disabled={true}
           accessibilityState={{checked: true}}>
           <View />
@@ -70,6 +74,7 @@ describe('TouchableHighlight with disabled state', () => {
     expect(
       render.create(
         <TouchableHighlight
+          accessibilityRole="button"
           disabled={true}
           accessibilityState={{disabled: false}}>
           <View />
@@ -81,7 +86,9 @@ describe('TouchableHighlight with disabled state', () => {
   it('should disable button when accessibilityState is disabled', () => {
     expect(
       render.create(
-        <TouchableHighlight accessibilityState={{disabled: true}}>
+        <TouchableHighlight
+          accessibilityRole="button"
+          accessibilityState={{disabled: true}}>
           <View />
         </TouchableHighlight>,
       ),

--- a/Libraries/Components/Touchable/__tests__/TouchableNativeFeedback-test.js
+++ b/Libraries/Components/Touchable/__tests__/TouchableNativeFeedback-test.js
@@ -21,7 +21,7 @@ const render = require('../../../../jest/renderer');
 describe('TouchableWithoutFeedback', () => {
   it('renders correctly', () => {
     const instance = render.create(
-      <TouchableNativeFeedback style={{}}>
+      <TouchableNativeFeedback accessibilityRole="button" style={{}}>
         <Text>Touchable</Text>
       </TouchableNativeFeedback>,
     );
@@ -39,7 +39,7 @@ describe('TouchableWithoutFeedback', () => {
 describe('<TouchableNativeFeedback />', () => {
   it('should render as expected', () => {
     const instance = ReactTestRenderer.create(
-      <TouchableNativeFeedback>
+      <TouchableNativeFeedback accessibilityRole="button">
         <View />
       </TouchableNativeFeedback>,
     );
@@ -52,7 +52,7 @@ describe('<TouchableNativeFeedback disabled={true}>', () => {
   it('should be disabled when disabled is true', () => {
     expect(
       ReactTestRenderer.create(
-        <TouchableNativeFeedback disabled={true}>
+        <TouchableNativeFeedback accessibilityRole="button" disabled={true}>
           <View />
         </TouchableNativeFeedback>,
       ),
@@ -64,7 +64,10 @@ describe('<TouchableNativeFeedback disabled={true} accessibilityState={{}}>', ()
   it('should be disabled when disabled is true and accessibilityState is empty', () => {
     expect(
       ReactTestRenderer.create(
-        <TouchableNativeFeedback disabled={true} accessibilityState={{}}>
+        <TouchableNativeFeedback
+          accessibilityRole="button"
+          disabled={true}
+          accessibilityState={{}}>
           <View />
         </TouchableNativeFeedback>,
       ),
@@ -77,6 +80,7 @@ describe('<TouchableNativeFeedback disabled={true} accessibilityState={{checked:
     expect(
       ReactTestRenderer.create(
         <TouchableNativeFeedback
+          accessibilityRole="button"
           disabled={true}
           accessibilityState={{checked: true}}>
           <View />
@@ -91,6 +95,7 @@ describe('<TouchableNativeFeedback disabled={true} accessibilityState={{disabled
     expect(
       ReactTestRenderer.create(
         <TouchableNativeFeedback
+          accessibilityRole="button"
           disabled={true}
           accessibilityState={{disabled: false}}>
           <View />
@@ -105,6 +110,7 @@ describe('<TouchableNativeFeedback disabled={false} accessibilityState={{disable
     expect(
       ReactTestRenderer.create(
         <TouchableNativeFeedback
+          accessibilityRole="button"
           disabled={false}
           accessibilityState={{disabled: true}}>
           <View />

--- a/Libraries/Components/Touchable/__tests__/TouchableOpacity-test.js
+++ b/Libraries/Components/Touchable/__tests__/TouchableOpacity-test.js
@@ -18,7 +18,7 @@ const TouchableOpacity = require('../TouchableOpacity');
 describe('TouchableOpacity', () => {
   it('renders correctly', () => {
     const instance = ReactTestRenderer.create(
-      <TouchableOpacity>
+      <TouchableOpacity accessibilityRole="button">
         <Text>Touchable</Text>
       </TouchableOpacity>,
     );
@@ -28,7 +28,7 @@ describe('TouchableOpacity', () => {
 
   it('renders in disabled state when a disabled prop is passed', () => {
     const instance = ReactTestRenderer.create(
-      <TouchableOpacity disabled={true}>
+      <TouchableOpacity accessibilityRole="button" disabled={true}>
         <Text>Touchable</Text>
       </TouchableOpacity>,
     );
@@ -38,7 +38,9 @@ describe('TouchableOpacity', () => {
 
   it('renders in disabled state when a key disabled in accessibilityState is passed', () => {
     const instance = ReactTestRenderer.create(
-      <TouchableOpacity accessibilityState={{disabled: true}}>
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessibilityState={{disabled: true}}>
         <Text>Touchable</Text>
       </TouchableOpacity>,
     );

--- a/Libraries/Components/Touchable/__tests__/TouchableWithoutFeedback-test.js
+++ b/Libraries/Components/Touchable/__tests__/TouchableWithoutFeedback-test.js
@@ -19,7 +19,7 @@ import TouchableWithoutFeedback from '../TouchableWithoutFeedback';
 describe('TouchableWithoutFeedback', () => {
   it('renders correctly', () => {
     const instance = ReactTestRenderer.create(
-      <TouchableWithoutFeedback style={{}}>
+      <TouchableWithoutFeedback accessibilityRole="button" style={{}}>
         <Text>Touchable</Text>
       </TouchableWithoutFeedback>,
     );
@@ -38,7 +38,7 @@ describe('TouchableWithoutFeedback with disabled state', () => {
   it('should be disabled when disabled is true', () => {
     expect(
       ReactTestRenderer.create(
-        <TouchableWithoutFeedback disabled={true}>
+        <TouchableWithoutFeedback accessibilityRole="button" disabled={true}>
           <View />
         </TouchableWithoutFeedback>,
       ),
@@ -48,7 +48,10 @@ describe('TouchableWithoutFeedback with disabled state', () => {
   it('should be disabled when disabled is true and accessibilityState is empty', () => {
     expect(
       ReactTestRenderer.create(
-        <TouchableWithoutFeedback disabled={true} accessibilityState={{}}>
+        <TouchableWithoutFeedback
+          accessibilityRole="button"
+          disabled={true}
+          accessibilityState={{}}>
           <View />
         </TouchableWithoutFeedback>,
       ),
@@ -59,6 +62,7 @@ describe('TouchableWithoutFeedback with disabled state', () => {
     expect(
       ReactTestRenderer.create(
         <TouchableWithoutFeedback
+          accessibilityRole="button"
           disabled={true}
           accessibilityState={{checked: true}}>
           <View />
@@ -71,6 +75,7 @@ describe('TouchableWithoutFeedback with disabled state', () => {
     expect(
       ReactTestRenderer.create(
         <TouchableWithoutFeedback
+          accessibilityRole="button"
           disabled={true}
           accessibilityState={{disabled: false}}>
           <View />
@@ -82,7 +87,9 @@ describe('TouchableWithoutFeedback with disabled state', () => {
   it('should disable button when accessibilityState is disabled', () => {
     expect(
       ReactTestRenderer.create(
-        <TouchableWithoutFeedback accessibilityState={{disabled: true}}>
+        <TouchableWithoutFeedback
+          accessibilityRole="button"
+          accessibilityState={{disabled: true}}>
           <View />
         </TouchableWithoutFeedback>,
       ),

--- a/Libraries/Inspector/ElementProperties.js
+++ b/Libraries/Inspector/ElementProperties.js
@@ -50,6 +50,7 @@ class ElementProperties extends React.Component<Props> {
       const fileNameShort = parts[parts.length - 1];
       openFileButton = (
         <TouchableHighlight
+          accessibilityRole="button"
           style={styles.openButton}
           onPress={openFileInEditor.bind(null, fileName, lineNumber)}>
           <Text style={styles.openButtonTitle} numberOfLines={1}>
@@ -61,13 +62,14 @@ class ElementProperties extends React.Component<Props> {
     // Without the `TouchableWithoutFeedback`, taps on this inspector pane
     // would change the inspected element to whatever is under the inspector
     return (
-      <TouchableWithoutFeedback>
+      <TouchableWithoutFeedback accessibilityRole="button">
         <View style={styles.info}>
           <View style={styles.breadcrumb}>
             {mapWithSeparator(
               this.props.hierarchy,
               (hierarchyItem, i) => (
                 <TouchableHighlight
+                  accessibilityRole="button"
                   key={'item-' + i}
                   style={[styles.breadItem, i === selection && styles.selected]}
                   // $FlowFixMe[not-a-function] found when converting React.createClass to ES6

--- a/Libraries/Inspector/InspectorPanel.js
+++ b/Libraries/Inspector/InspectorPanel.js
@@ -123,6 +123,7 @@ class InspectorPanelButton extends React.Component<InspectorPanelButtonProps> {
   render() {
     return (
       <TouchableHighlight
+        accessibilityRole="button"
         onPress={() => this.props.onClick(!this.props.pressed)}
         style={[styles.button, this.props.pressed && styles.buttonPressed]}>
         <Text style={styles.buttonText}>{this.props.title}</Text>

--- a/Libraries/Inspector/NetworkOverlay.js
+++ b/Libraries/Inspector/NetworkOverlay.js
@@ -337,6 +337,7 @@ class NetworkOverlay extends React.Component<Props, State> {
 
     return (
       <TouchableHighlight
+        accessibilityRole="button"
         onPress={() => {
           this._pressRow(index);
         }}>
@@ -379,6 +380,7 @@ class NetworkOverlay extends React.Component<Props, State> {
     return (
       <View>
         <TouchableHighlight
+          accessibilityRole="button"
           style={styles.closeButton}
           onPress={this._closeButtonClicked}>
           <View>

--- a/Libraries/LogBox/UI/LogBoxButton.js
+++ b/Libraries/LogBox/UI/LogBoxButton.js
@@ -57,6 +57,7 @@ function LogBoxButton(props: Props): React.Node {
     content
   ) : (
     <TouchableWithoutFeedback
+      accessibilityRole="button"
       hitSlop={props.hitSlop}
       onPress={props.onPress}
       onPressIn={() => setPressed(true)}

--- a/ReactAndroid/src/androidTest/js/AnimatedTransformTestModule.js
+++ b/ReactAndroid/src/androidTest/js/AnimatedTransformTestModule.js
@@ -63,6 +63,7 @@ class AnimatedTransformTestApp extends React.Component {
     return (
       <View style={StyleSheet.absoluteFill}>
         <TouchableOpacity
+          accessibilityRole="button"
           onPress={this.toggle}
           testID="TouchableOpacity"
           style={[styles.base, this.state.flag ? styles.transformed : null]}>

--- a/ReactAndroid/src/androidTest/js/NativeIdTestModule.js
+++ b/ReactAndroid/src/androidTest/js/NativeIdTestModule.js
@@ -43,17 +43,27 @@ class NativeIdTestApp extends React.Component<{...}> {
       <View>
         <Image nativeID="Image" source={{uri: uri}} style={styles.base} />
         <Text nativeID="Text">text</Text>
-        <TextInput nativeID="TextInput" value="Text input" />
-        <TouchableBounce nativeID="TouchableBounce">
+        <TextInput
+          accessibilityLabel="Text input field"
+          nativeID="TextInput"
+          value="Text input"
+        />
+        <TouchableBounce accessibilityRole="button" nativeID="TouchableBounce">
           <Text>TouchableBounce</Text>
         </TouchableBounce>
-        <TouchableHighlight nativeID="TouchableHighlight">
+        <TouchableHighlight
+          accessibilityRole="button"
+          nativeID="TouchableHighlight">
           <Text>TouchableHighlight</Text>
         </TouchableHighlight>
-        <TouchableOpacity nativeID="TouchableOpacity">
+        <TouchableOpacity
+          accessibilityRole="button"
+          nativeID="TouchableOpacity">
           <Text>TouchableOpacity</Text>
         </TouchableOpacity>
-        <TouchableWithoutFeedback nativeID="TouchableWithoutFeedback">
+        <TouchableWithoutFeedback
+          accessibilityRole="button"
+          nativeID="TouchableWithoutFeedback">
           <View>
             <Text>TouchableWithoutFeedback</Text>
           </View>

--- a/ReactAndroid/src/androidTest/js/ScrollViewTestModule.js
+++ b/ReactAndroid/src/androidTest/js/ScrollViewTestModule.js
@@ -42,7 +42,9 @@ type ItemState = {||};
 class Item extends React.Component<ItemProps, ItemState> {
   render() {
     return (
-      <TouchableWithoutFeedback onPress={this.props.onPress}>
+      <TouchableWithoutFeedback
+        accessibilityRole="button"
+        onPress={this.props.onPress}>
         <View style={styles.item_container}>
           <Text style={styles.item_text}>{this.props.text}</Text>
         </View>

--- a/ReactAndroid/src/androidTest/js/SwipeRefreshLayoutTestModule.js
+++ b/ReactAndroid/src/androidTest/js/SwipeRefreshLayoutTestModule.js
@@ -30,7 +30,9 @@ class Row extends React.Component {
 
   render() {
     return (
-      <TouchableWithoutFeedback onPress={this._onPress}>
+      <TouchableWithoutFeedback
+        accessibilityRole="button"
+        onPress={this._onPress}>
         <View>
           <Text>{this.state.clicks + ' clicks'}</Text>
         </View>

--- a/ReactAndroid/src/androidTest/js/TestIdTestModule.js
+++ b/ReactAndroid/src/androidTest/js/TestIdTestModule.js
@@ -48,21 +48,29 @@ class TestIdTestApp extends React.Component {
 
         <Text testID="Text">text</Text>
 
-        <TextInput testID="TextInput" value="Text input" />
+        <TextInput
+          accessibilityLabel="Text input field"
+          testID="TextInput"
+          value="Text input"
+        />
 
-        <TouchableBounce testID="TouchableBounce">
+        <TouchableBounce accessibilityRole="button" testID="TouchableBounce">
           <Text>TouchableBounce</Text>
         </TouchableBounce>
 
-        <TouchableHighlight testID="TouchableHighlight">
+        <TouchableHighlight
+          accessibilityRole="button"
+          testID="TouchableHighlight">
           <Text>TouchableHighlight</Text>
         </TouchableHighlight>
 
-        <TouchableOpacity testID="TouchableOpacity">
+        <TouchableOpacity accessibilityRole="button" testID="TouchableOpacity">
           <Text>TouchableOpacity</Text>
         </TouchableOpacity>
 
-        <TouchableWithoutFeedback testID="TouchableWithoutFeedback">
+        <TouchableWithoutFeedback
+          accessibilityRole="button"
+          testID="TouchableWithoutFeedback">
           <View>
             <Text>TouchableWithoutFeedback</Text>
           </View>

--- a/ReactAndroid/src/androidTest/js/TextInputTestModule.js
+++ b/ReactAndroid/src/androidTest/js/TextInputTestModule.js
@@ -70,6 +70,7 @@ class TokenizedTextExample extends React.Component {
     return (
       <View>
         <TextInput
+          accessibilityLabel="Text input field"
           testID="tokenizedInput"
           multiline={true}
           style={styles.multiline}
@@ -96,6 +97,7 @@ class TextInputTestApp extends React.Component {
     return (
       <View style={styles.container}>
         <TextInput
+          accessibilityLabel="Text input field"
           style={styles.textInputHeight}
           autoCorrect={true}
           autoFocus={true}
@@ -106,6 +108,7 @@ class TextInputTestApp extends React.Component {
           testID="textInput1"
         />
         <TextInput
+          accessibilityLabel="Text input field"
           style={styles.textInput}
           autoCapitalize="sentences"
           autoCorrect={false}
@@ -117,25 +120,30 @@ class TextInputTestApp extends React.Component {
           testID="textInput2"
         />
         <TextInput
+          accessibilityLabel="Text input field"
           style={styles.textInput}
           defaultValue="Hello, World"
           testID="textInput3"
         />
         <TextInput
+          accessibilityLabel="Text input field"
           style={[styles.textInput, styles.textInputColor]}
           testID="textInput4"
         />
         <TextInput
+          accessibilityLabel="Text input field"
           style={[styles.textInput, styles.textInputColor]}
           defaultValue=""
           testID="textInput5"
         />
         <TextInput
+          accessibilityLabel="Text input field"
           style={[styles.textInput, styles.textInputColor]}
           defaultValue="Text"
           testID="textInput6"
         />
         <TextInput
+          accessibilityLabel="Text input field"
           onSubmitEditing={this.handleOnSubmitEditing.bind(this, 'onSubmit')}
           defaultValue=""
           testID="onSubmitTextInput"

--- a/ReactAndroid/src/androidTest/js/TouchBubblingTestAppModule.js
+++ b/ReactAndroid/src/androidTest/js/TouchBubblingTestAppModule.js
@@ -28,10 +28,12 @@ class TouchBubblingTestApp extends React.Component {
     return (
       <View style={styles.container}>
         <TouchableWithoutFeedback
+          accessibilityRole="button"
           onPress={this.handlePress.bind(this, 'outer')}
           testID="D">
           <View style={styles.outer}>
             <TouchableWithoutFeedback
+              accessibilityRole="button"
               onPress={this.handlePress.bind(this, 'inner')}
               testID="B">
               <View style={styles.inner}>
@@ -42,6 +44,7 @@ class TouchBubblingTestApp extends React.Component {
           </View>
         </TouchableWithoutFeedback>
         <TouchableWithoutFeedback
+          accessibilityRole="button"
           onPress={this.handlePress.bind(this, 'outsider')}
           testID="E">
           <View style={styles.element} />

--- a/packages/eslint-config-react-native-community/index.js
+++ b/packages/eslint-config-react-native-community/index.js
@@ -16,7 +16,7 @@ module.exports = {
     sourceType: 'module',
   },
 
-  extends: ['plugin:prettier/recommended'],
+  extends: ['plugin:prettier/recommended', 'plugin:react-native-a11y/basic'],
 
   plugins: [
     'eslint-comments',
@@ -321,5 +321,8 @@ module.exports = {
     'jest/no-focused-tests': 1,
     'jest/no-identical-title': 1,
     'jest/valid-expect': 1,
+
+    // React-Native A11y
+    'react-native-a11y/has-accessibility-hint': 'warn', // if Touchables have accessibilityLabel but no accessibilityHint
   },
 };

--- a/packages/eslint-config-react-native-community/package.json
+++ b/packages/eslint-config-react-native-community/package.json
@@ -23,6 +23,7 @@
     "eslint-plugin-react": "^7.26.1",
     "eslint-plugin-react-hooks": "^4.2.0",
     "eslint-plugin-react-native": "^3.11.0",
+    "eslint-plugin-react-native-a11y": "^3.2.1",
     "prettier": "^2.4.1"
   },
   "peerDependencies": {

--- a/packages/eslint-config-react-native-community/yarn.lock
+++ b/packages/eslint-config-react-native-community/yarn.lock
@@ -67,6 +67,13 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.10.tgz#824600d59e96aea26a5a2af5a9d812af05c3ae81"
   integrity sha512-PJdRPwyoOqFAWfLytxrWwGrAxghCgh/yTNCYciOz8QgjflA7aZhECPZAa2VUedKg2+QMWkI0L9lynh2SNmNEgA==
 
+"@babel/runtime@^7.15.4":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.7.tgz#03ff99f64106588c9c403c6ecb8c3bafbbdff1fa"
+  integrity sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.10.4":
   version "7.12.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.12.7.tgz#c817233696018e39fbb6c491d2fb684e05ed43bc"
@@ -390,6 +397,11 @@ array.prototype.flatmap@^1.2.4:
     define-properties "^1.1.3"
     es-abstract "^1.19.0"
 
+ast-types-flow@^0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
+  integrity sha1-9wtzXGvKGlycItmCw+Oef+ujva0=
+
 astral-regex@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
@@ -638,6 +650,15 @@ eslint-plugin-react-hooks@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz#8c229c268d468956334c943bb45fc860280f5556"
   integrity sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==
+
+eslint-plugin-react-native-a11y@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-native-a11y/-/eslint-plugin-react-native-a11y-3.2.1.tgz#6c3296f7c689ab2f8f89ad5bf6c0c8dafe029193"
+  integrity sha512-DNOCp2uKvW0I86CoEAOEljq7qe4MiZLlToSPiwu0X+Bgst0+d30sERvhIu5kyzY7XM3HD2xoJma7FW5XYGxRBA==
+  dependencies:
+    "@babel/runtime" "^7.15.4"
+    ast-types-flow "^0.0.7"
+    jsx-ast-utils "^3.2.1"
 
 eslint-plugin-react-native-globals@^0.1.1:
   version "0.1.2"
@@ -1216,7 +1237,7 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
 
-"jsx-ast-utils@^2.4.1 || ^3.0.0":
+"jsx-ast-utils@^2.4.1 || ^3.0.0", jsx-ast-utils@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-3.2.1.tgz#720b97bfe7d901b927d87c3773637ae8ea48781b"
   integrity sha512-uP5vu8xfy2F9A6LGC22KO7e2/vGTS1MhP+18f++ZNlf0Ohaxbc9nIEwHAsejlJKyzfZzU5UIhe5ItYkitcZnZA==
@@ -1457,6 +1478,11 @@ react-is@^16.8.1:
   version "16.8.4"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.4.tgz#90f336a68c3a29a096a3d648ab80e87ec61482a2"
   integrity sha512-PVadd+WaUDOAciICm/J1waJaSvgq+4rHE/K70j0PFqKhkTBsPv/82UGQJNXAngz1fOQLLxI6z1sEDmJDQhCTAA==
+
+regenerator-runtime@^0.13.4:
+  version "0.13.9"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52"
+  integrity sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==
 
 regexp.prototype.flags@^1.3.1:
   version "1.3.1"

--- a/packages/rn-tester/js/components/ListExampleShared.js
+++ b/packages/rn-tester/js/components/ListExampleShared.js
@@ -69,6 +69,7 @@ class ItemComponent extends React.PureComponent<{
     const imgSource = THUMB_URLS[itemHash % THUMB_URLS.length];
     return (
       <TouchableHighlight
+        accessibilityRole="button"
         onPress={this._onPress}
         onShowUnderlay={this.props.onShowUnderlay}
         onHideUnderlay={this.props.onHideUnderlay}

--- a/packages/rn-tester/js/components/RNTOption.js
+++ b/packages/rn-tester/js/components/RNTOption.js
@@ -35,6 +35,7 @@ export default function RNTOption(props: Props): React.Node {
 
   return (
     <Pressable
+      accessibilityRole="button"
       accessibilityState={{selected: !!props.selected}}
       disabled={
         props.disabled === false || props.multiSelect === true

--- a/packages/rn-tester/js/components/RNTesterBookmarkButton.js
+++ b/packages/rn-tester/js/components/RNTesterBookmarkButton.js
@@ -27,6 +27,7 @@ class RNTesterBookmarkButton extends React.Component<Props> {
     const {size, onPress, isActive} = this.props;
     return (
       <TouchableOpacity
+        accessibilityRole="button"
         style={[
           styles.imageViewStyle,
           {

--- a/packages/rn-tester/js/components/RNTesterButton.js
+++ b/packages/rn-tester/js/components/RNTesterButton.js
@@ -26,6 +26,7 @@ class RNTesterButton extends React.Component<Props> {
   render(): React.Node {
     return (
       <TouchableHighlight
+        accessibilityRole="button"
         testID={this.props.testID}
         onPress={this.props.onPress}
         style={styles.button}

--- a/packages/rn-tester/js/components/RNTesterDocumentationURL.js
+++ b/packages/rn-tester/js/components/RNTesterDocumentationURL.js
@@ -18,6 +18,7 @@ type Props = $ReadOnly<{|
 
 const RNTesterDocumentationURL = ({documentationURL}: Props): React.Node => (
   <TouchableOpacity
+    accessibilityRole="button"
     style={styles.container}
     onPress={() => openURLInBrowser(documentationURL)}>
     <Image

--- a/packages/rn-tester/js/components/RNTesterExampleFilter.js
+++ b/packages/rn-tester/js/components/RNTesterExampleFilter.js
@@ -126,6 +126,7 @@ class RNTesterExampleFilter<T> extends React.Component<Props<T>, State> {
                   style={styles.searchIcon}
                 />
                 <TextInput
+                  accessibilityLabel="Text input field"
                   autoCapitalize="none"
                   autoCorrect={false}
                   clearButtonMode="always"

--- a/packages/rn-tester/js/components/RNTesterListFilters.js
+++ b/packages/rn-tester/js/components/RNTesterListFilters.js
@@ -47,6 +47,7 @@ class RNTesterListFilters extends React.Component<
         {filters.map(filterLabel => {
           return (
             <TouchableOpacity
+              accessibilityRole="button"
               key={filterLabel}
               style={[
                 styles.pillStyle,

--- a/packages/rn-tester/js/components/RNTesterModuleList.js
+++ b/packages/rn-tester/js/components/RNTesterModuleList.js
@@ -37,6 +37,7 @@ const ExampleModuleRow = ({
   const onAndroid = !platform || platform === 'android';
   const rightAddOn = (
     <TouchableHighlight
+      accessibilityRole="button"
       style={styles.imageViewStyle}
       onPress={() =>
         toggleBookmark({

--- a/packages/rn-tester/js/components/RNTesterNavbar.js
+++ b/packages/rn-tester/js/components/RNTesterNavbar.js
@@ -33,6 +33,7 @@ const BookmarkTab = ({
     />
     <View style={styles.floatContainer}>
       <Pressable
+        accessibilityRole="button"
         testID="bookmarks-tab"
         onPress={() => handleNavBarPress({screen: 'bookmarks'})}>
         <View
@@ -62,6 +63,7 @@ const NavbarButton = ({
   iconStyle,
 }) => (
   <Pressable
+    accessibilityRole="button"
     testID={testID}
     onPress={handlePress}
     style={[styles.navButton, {backgroundColor: theme.BackgroundColor}]}>

--- a/packages/rn-tester/js/components/TextInlineView.js
+++ b/packages/rn-tester/js/components/TextInlineView.js
@@ -116,6 +116,7 @@ class ChangeImageSize extends React.Component<mixed, ChangeSizeState> {
     return (
       <View>
         <TouchableHighlight
+          accessibilityRole="button"
           onPress={() => {
             this.setState({width: this.state.width === 50 ? 100 : 50});
           }}>
@@ -152,6 +153,7 @@ class ChangeViewSize extends React.Component<mixed, ChangeSizeState> {
     return (
       <View>
         <TouchableHighlight
+          accessibilityRole="button"
           onPress={() => {
             this.setState({width: this.state.width === 50 ? 100 : 50});
           }}>
@@ -184,6 +186,7 @@ class ChangeInnerViewSize extends React.Component<mixed, ChangeSizeState> {
     return (
       <View>
         <TouchableHighlight
+          accessibilityRole="button"
           onPress={() => {
             this.setState({width: this.state.width === 50 ? 100 : 50});
           }}>

--- a/packages/rn-tester/js/examples/Accessibility/AccessibilityAndroidExample.android.js
+++ b/packages/rn-tester/js/examples/Accessibility/AccessibilityAndroidExample.android.js
@@ -60,7 +60,9 @@ class AccessibilityAndroidExample extends React.Component<
     return (
       <RNTesterPage title={'Accessibility Android APIs'}>
         <RNTesterBlock title="LiveRegion">
-          <TouchableWithoutFeedback onPress={this._addOne}>
+          <TouchableWithoutFeedback
+            accessibilityRole="button"
+            onPress={this._addOne}>
             <View style={styles.embedded}>
               <Text>Click me</Text>
             </View>
@@ -107,6 +109,7 @@ class AccessibilityAndroidExample extends React.Component<
             </View>
           </View>
           <TouchableWithoutFeedback
+            accessibilityRole="button"
             onPress={this._changeBackgroundImportantForAcc}>
             <View style={styles.embedded}>
               <Text>
@@ -125,6 +128,7 @@ class AccessibilityAndroidExample extends React.Component<
             </Text>
           </View>
           <TouchableWithoutFeedback
+            accessibilityRole="button"
             onPress={this._changeForgroundImportantForAcc}>
             <View style={styles.embedded}>
               <Text>

--- a/packages/rn-tester/js/examples/Alert/AlertExample.js
+++ b/packages/rn-tester/js/examples/Alert/AlertExample.js
@@ -30,6 +30,7 @@ const AlertWithDefaultButton = () => {
   return (
     <View>
       <TouchableHighlight
+        accessibilityRole="button"
         testID="alert-with-default-button"
         style={styles.wrapper}
         onPress={() => Alert.alert('Alert', alertMessage)}>
@@ -49,6 +50,7 @@ const AlertWithTwoButtons = () => {
   return (
     <View>
       <TouchableHighlight
+        accessibilityRole="button"
         style={styles.wrapper}
         onPress={() =>
           Alert.alert('Action Required!', alertMessage, [
@@ -73,6 +75,7 @@ const AlertWithThreeButtons = () => {
   return (
     <View>
       <TouchableHighlight
+        accessibilityRole="button"
         testID="alert-with-three-buttons"
         style={styles.wrapper}
         onPress={() =>
@@ -101,6 +104,7 @@ const AlertWithManyButtons = () => {
   return (
     <View>
       <TouchableHighlight
+        accessibilityRole="button"
         style={styles.wrapper}
         onPress={() =>
           Alert.alert(
@@ -129,6 +133,7 @@ const AlertWithCancelableTrue = () => {
   return (
     <View>
       <TouchableHighlight
+        accessibilityRole="button"
         style={styles.wrapper}
         onPress={() =>
           Alert.alert(
@@ -161,6 +166,7 @@ const AlertWithStyles = () => {
   return (
     <View>
       <TouchableHighlight
+        accessibilityRole="button"
         style={styles.wrapper}
         onPress={() =>
           Alert.alert('Styled Buttons!', alertMessage, [

--- a/packages/rn-tester/js/examples/Alert/AlertIOSExample.js
+++ b/packages/rn-tester/js/examples/Alert/AlertIOSExample.js
@@ -62,6 +62,7 @@ class PromptOptions extends React.Component<Props, State> {
         </Text>
 
         <TouchableHighlight
+          accessibilityRole="button"
           style={styles.wrapper}
           // $FlowFixMe[method-unbinding] added when improving typing for this parameters
           // $FlowFixMe[incompatible-call]
@@ -72,6 +73,7 @@ class PromptOptions extends React.Component<Props, State> {
         </TouchableHighlight>
 
         <TouchableHighlight
+          accessibilityRole="button"
           style={styles.wrapper}
           onPress={() =>
             Alert.prompt('Type a value', null, this.customButtons)
@@ -82,6 +84,7 @@ class PromptOptions extends React.Component<Props, State> {
         </TouchableHighlight>
 
         <TouchableHighlight
+          accessibilityRole="button"
           style={styles.wrapper}
           onPress={() =>
             Alert.prompt(
@@ -99,6 +102,7 @@ class PromptOptions extends React.Component<Props, State> {
         </TouchableHighlight>
 
         <TouchableHighlight
+          accessibilityRole="button"
           style={styles.wrapper}
           onPress={() =>
             Alert.prompt(
@@ -117,6 +121,7 @@ class PromptOptions extends React.Component<Props, State> {
         </TouchableHighlight>
 
         <TouchableHighlight
+          accessibilityRole="button"
           style={styles.wrapper}
           onPress={() =>
             Alert.prompt(
@@ -177,6 +182,7 @@ exports.examples = ([
       return (
         <View>
           <TouchableHighlight
+            accessibilityRole="button"
             style={styles.wrapper}
             onPress={() => Alert.prompt('Plain Text Entry')}>
             <View style={styles.button}>
@@ -184,6 +190,7 @@ exports.examples = ([
             </View>
           </TouchableHighlight>
           <TouchableHighlight
+            accessibilityRole="button"
             style={styles.wrapper}
             onPress={() =>
               Alert.prompt('Secure Text', null, null, 'secure-text')
@@ -193,6 +200,7 @@ exports.examples = ([
             </View>
           </TouchableHighlight>
           <TouchableHighlight
+            accessibilityRole="button"
             style={styles.wrapper}
             onPress={() =>
               Alert.prompt('Login & Password', null, null, 'login-password')

--- a/packages/rn-tester/js/examples/FlatList/BaseFlatListExample.js
+++ b/packages/rn-tester/js/examples/FlatList/BaseFlatListExample.js
@@ -37,6 +37,7 @@ const DATA = [
 const Item = ({item, separators}: RenderItemProps<string>) => {
   return (
     <Pressable
+      accessibilityRole="button"
       onPressIn={() => {
         separators.highlight();
       }}

--- a/packages/rn-tester/js/examples/FlatList/FlatList-basic.js
+++ b/packages/rn-tester/js/examples/FlatList/FlatList-basic.js
@@ -185,6 +185,7 @@ class FlatListExample extends React.PureComponent<Props, State> {
               {Platform.OS === 'android' && (
                 <View>
                   <TextInput
+                    accessibilityLabel="Text input field"
                     placeholder="Fading edge length"
                     underlineColorAndroid="black"
                     keyboardType={'numeric'}

--- a/packages/rn-tester/js/examples/InputAccessoryView/InputAccessoryViewExample.js
+++ b/packages/rn-tester/js/examples/InputAccessoryView/InputAccessoryViewExample.js
@@ -42,6 +42,7 @@ class TextInputBar extends React.PureComponent<TextInputProps, TextInputState> {
     return (
       <View style={styles.textInputContainer}>
         <TextInput
+          accessibilityLabel="Text input field"
           style={styles.textInput}
           onChangeText={text => {
             this.setState({text});

--- a/packages/rn-tester/js/examples/KeyboardAvoidingView/KeyboardAvoidingViewExample.js
+++ b/packages/rn-tester/js/examples/KeyboardAvoidingView/KeyboardAvoidingViewExample.js
@@ -33,10 +33,26 @@ const onButtonPress = () => {
 const TextInputForm = () => {
   return (
     <View>
-      <TextInput placeholder="Email" style={styles.textInput} />
-      <TextInput placeholder="Username" style={styles.textInput} />
-      <TextInput placeholder="Password" style={styles.textInput} />
-      <TextInput placeholder="Confirm Password" style={styles.textInput} />
+      <TextInput
+        accessibilityLabel="Text input field"
+        placeholder="Email"
+        style={styles.textInput}
+      />
+      <TextInput
+        accessibilityLabel="Text input field"
+        placeholder="Username"
+        style={styles.textInput}
+      />
+      <TextInput
+        accessibilityLabel="Text input field"
+        placeholder="Password"
+        style={styles.textInput}
+      />
+      <TextInput
+        accessibilityLabel="Text input field"
+        placeholder="Confirm Password"
+        style={styles.textInput}
+      />
       <Button title="Register" onPress={onButtonPress} />
     </View>
   );
@@ -50,6 +66,7 @@ const CloseButton = props => {
         {marginHorizontal: props.behavior === 'position' ? 0 : 25},
       ]}>
       <Pressable
+        accessibilityRole="button"
         onPress={() => props.setModalOpen(false)}
         style={styles.closeButton}>
         <Text>Close</Text>
@@ -71,6 +88,7 @@ const KeyboardAvoidingViewBehaviour = () => {
               justifyContent: 'center',
             }}>
             <TouchableOpacity
+              accessibilityRole="button"
               onPress={() => setBehavior('padding')}
               style={[
                 styles.pillStyle,
@@ -81,6 +99,7 @@ const KeyboardAvoidingViewBehaviour = () => {
               </Text>
             </TouchableOpacity>
             <TouchableOpacity
+              accessibilityRole="button"
               onPress={() => setBehavior('position')}
               style={[
                 styles.pillStyle,
@@ -91,6 +110,7 @@ const KeyboardAvoidingViewBehaviour = () => {
               </Text>
             </TouchableOpacity>
             <TouchableOpacity
+              accessibilityRole="button"
               onPress={() => setBehavior('height')}
               style={[
                 styles.pillStyle,
@@ -109,7 +129,9 @@ const KeyboardAvoidingViewBehaviour = () => {
         </KeyboardAvoidingView>
       </Modal>
       <View>
-        <Pressable onPress={() => setModalOpen(true)}>
+        <Pressable
+          accessibilityRole="button"
+          onPress={() => setModalOpen(true)}>
           <Text>Open Example</Text>
         </Pressable>
       </View>
@@ -131,7 +153,9 @@ const KeyboardAvoidingDisabled = () => {
         </KeyboardAvoidingView>
       </Modal>
       <View>
-        <Pressable onPress={() => setModalOpen(true)}>
+        <Pressable
+          accessibilityRole="button"
+          onPress={() => setModalOpen(true)}>
           <Text>Open Example</Text>
         </Pressable>
       </View>
@@ -153,7 +177,9 @@ const KeyboardAvoidingVerticalOffset = () => {
         </KeyboardAvoidingView>
       </Modal>
       <View>
-        <Pressable onPress={() => setModalOpen(true)}>
+        <Pressable
+          accessibilityRole="button"
+          onPress={() => setModalOpen(true)}>
           <Text>Open Example</Text>
         </Pressable>
       </View>
@@ -176,7 +202,9 @@ const KeyboardAvoidingContentContainerStyle = () => {
         </KeyboardAvoidingView>
       </Modal>
       <View>
-        <Pressable onPress={() => setModalOpen(true)}>
+        <Pressable
+          accessibilityRole="button"
+          onPress={() => setModalOpen(true)}>
           <Text>Open Example</Text>
         </Pressable>
       </View>

--- a/packages/rn-tester/js/examples/Layout/LayoutAnimationExample.js
+++ b/packages/rn-tester/js/examples/Layout/LayoutAnimationExample.js
@@ -107,32 +107,44 @@ class AddRemoveExample extends React.Component<{...}, AddRemoveExampleState> {
     ));
     return (
       <View style={styles.container}>
-        <TouchableOpacity onPress={this._onPressAddViewAnimated}>
+        <TouchableOpacity
+          accessibilityRole="button"
+          onPress={this._onPressAddViewAnimated}>
           <View style={styles.button}>
             <Text>Add view</Text>
           </View>
         </TouchableOpacity>
-        <TouchableOpacity onPress={this._onPressRemoveViewAnimated}>
+        <TouchableOpacity
+          accessibilityRole="button"
+          onPress={this._onPressRemoveViewAnimated}>
           <View style={styles.button}>
             <Text>Remove view</Text>
           </View>
         </TouchableOpacity>
-        <TouchableOpacity onPress={this._onPressReorderViewsAnimated}>
+        <TouchableOpacity
+          accessibilityRole="button"
+          onPress={this._onPressReorderViewsAnimated}>
           <View style={styles.button}>
             <Text>Reorder Views</Text>
           </View>
         </TouchableOpacity>
-        <TouchableOpacity onPress={this._onPressAddView}>
+        <TouchableOpacity
+          accessibilityRole="button"
+          onPress={this._onPressAddView}>
           <View style={styles.button}>
             <Text>Add view (no animation)</Text>
           </View>
         </TouchableOpacity>
-        <TouchableOpacity onPress={this._onPressRemoveView}>
+        <TouchableOpacity
+          accessibilityRole="button"
+          onPress={this._onPressRemoveView}>
           <View style={styles.button}>
             <Text>Remove view (no animation)</Text>
           </View>
         </TouchableOpacity>
-        <TouchableOpacity onPress={this._onPressReorderViews}>
+        <TouchableOpacity
+          accessibilityRole="button"
+          onPress={this._onPressReorderViews}>
           <View style={styles.button}>
             <Text>Reorder Views (no animation)</Text>
           </View>
@@ -179,12 +191,16 @@ class ReparentingExample extends React.Component<
 
     return (
       <View style={styles.container}>
-        <TouchableOpacity onPress={this._onPressToggleAnimated}>
+        <TouchableOpacity
+          accessibilityRole="button"
+          onPress={this._onPressToggleAnimated}>
           <View style={styles.button}>
             <Text>Toggle</Text>
           </View>
         </TouchableOpacity>
-        <TouchableOpacity onPress={this._onPressToggle}>
+        <TouchableOpacity
+          accessibilityRole="button"
+          onPress={this._onPressToggle}>
           <View style={styles.button}>
             <Text>Toggle (no animation)</Text>
           </View>
@@ -228,7 +244,9 @@ class CrossFadeExample extends React.Component<{...}, CrossFadeExampleState> {
   render() {
     return (
       <View style={styles.container}>
-        <TouchableOpacity onPress={this._onPressToggle}>
+        <TouchableOpacity
+          accessibilityRole="button"
+          onPress={this._onPressToggle}>
           <View style={styles.button}>
             <Text>Toggle</Text>
           </View>
@@ -290,7 +308,9 @@ class LayoutUpdateExample extends React.Component<
 
     return (
       <View style={styles.container}>
-        <TouchableOpacity onPress={this._onPressToggle}>
+        <TouchableOpacity
+          accessibilityRole="button"
+          onPress={this._onPressToggle}>
           <View style={styles.button}>
             <Text>Make box square</Text>
           </View>

--- a/packages/rn-tester/js/examples/Linking/LinkingExample.js
+++ b/packages/rn-tester/js/examples/Linking/LinkingExample.js
@@ -40,7 +40,7 @@ class OpenURLButton extends React.Component<Props> {
 
   render() {
     return (
-      <TouchableOpacity onPress={this.handleClick}>
+      <TouchableOpacity accessibilityRole="button" onPress={this.handleClick}>
         <View style={styles.button}>
           <Text style={styles.text}>Open {this.props.url}</Text>
         </View>
@@ -70,7 +70,7 @@ class SendIntentButton extends React.Component<Props> {
 
   render() {
     return (
-      <TouchableOpacity onPress={this.handleIntent}>
+      <TouchableOpacity accessibilityRole="button" onPress={this.handleIntent}>
         <View style={[styles.button, styles.buttonIntent]}>
           <Text style={styles.text}>{this.props.action}</Text>
         </View>

--- a/packages/rn-tester/js/examples/Modal/ModalOnShow.js
+++ b/packages/rn-tester/js/examples/Modal/ModalOnShow.js
@@ -43,6 +43,7 @@ function ModalOnShowOnDismiss(): React.Node {
                 onDismiss is called {onDismissCount} times
               </Text>
               <Pressable
+                accessibilityRole="button"
                 style={[styles.button, styles.buttonClose]}
                 onPress={() => setModalVisible(false)}>
                 <Text testID="dismiss-modal" style={styles.textStyle}>
@@ -50,6 +51,7 @@ function ModalOnShowOnDismiss(): React.Node {
                 </Text>
               </Pressable>
               <Pressable
+                accessibilityRole="button"
                 style={[styles.button, styles.buttonClose]}
                 onPress={() => setModalShowComponent(false)}>
                 <Text
@@ -67,6 +69,7 @@ function ModalOnShowOnDismiss(): React.Node {
         onDismiss is called {onDismissCount} times
       </Text>
       <Pressable
+        accessibilityRole="button"
         style={[styles.button, styles.buttonOpen]}
         onPress={() => {
           setModalShowComponent(true);

--- a/packages/rn-tester/js/examples/NativeAnimation/NativeAnimationsExample.js
+++ b/packages/rn-tester/js/examples/NativeAnimation/NativeAnimationsExample.js
@@ -54,7 +54,9 @@ class Tester extends React.Component<$FlowFixMeProps, $FlowFixMeState> {
 
   render() {
     return (
-      <TouchableWithoutFeedback onPress={this.onPress}>
+      <TouchableWithoutFeedback
+        accessibilityRole="button"
+        onPress={this.onPress}>
         <View>
           <View>
             <Text>Native:</Text>
@@ -102,7 +104,9 @@ class ValueListenerExample extends React.Component<{...}, $FlowFixMeState> {
 
   render() {
     return (
-      <TouchableWithoutFeedback onPress={this._onPress}>
+      <TouchableWithoutFeedback
+        accessibilityRole="button"
+        onPress={this._onPress}>
         <View>
           <View style={styles.row}>
             <Animated.View
@@ -332,7 +336,9 @@ class TrackingExample extends React.Component<
 
   render() {
     return (
-      <TouchableWithoutFeedback onPress={this.onPress}>
+      <TouchableWithoutFeedback
+        accessibilityRole="button"
+        onPress={this.onPress}>
         <View>
           <View>
             <Text>Native:</Text>

--- a/packages/rn-tester/js/examples/Pressable/PressableExample.js
+++ b/packages/rn-tester/js/examples/Pressable/PressableExample.js
@@ -38,6 +38,7 @@ function ContentPress() {
     <>
       <View style={styles.row}>
         <Pressable
+          accessibilityRole="button"
           onPress={() => {
             setTimesPressed(current => current + 1);
           }}>
@@ -130,6 +131,7 @@ function PressableDelayEvents() {
     <View testID="pressable_delay_events">
       <View style={[styles.row, styles.centered]}>
         <Pressable
+          accessibilityRole="button"
           style={styles.wrapper}
           testID="pressable_delay_events_button"
           onPress={() => appendEvent('press')}
@@ -189,6 +191,7 @@ function PressableHitSlop() {
     <View testID="pressable_hit_slop">
       <View style={[styles.row, styles.centered]}>
         <Pressable
+          accessibilityRole="button"
           onPress={() => setTimesPressed(num => num + 1)}
           style={styles.hitSlopWrapper}
           hitSlop={{top: 30, bottom: 30, left: 60, right: 60}}
@@ -214,7 +217,7 @@ function PressableNativeMethods() {
   return (
     <>
       <View style={[styles.row, styles.block]}>
-        <Pressable ref={ref}>
+        <Pressable accessibilityRole="button" ref={ref}>
           <View />
         </Pressable>
         <Text>
@@ -232,11 +235,15 @@ function PressableNativeMethods() {
 function PressableDisabled() {
   return (
     <>
-      <Pressable disabled={true} style={[styles.row, styles.block]}>
+      <Pressable
+        accessibilityRole="button"
+        disabled={true}
+        style={[styles.row, styles.block]}>
         <Text style={styles.disabledButton}>Disabled Pressable</Text>
       </Pressable>
 
       <Pressable
+        accessibilityRole="button"
         disabled={false}
         style={({pressed}) => [
           {opacity: pressed ? 0.5 : 1},
@@ -335,6 +342,7 @@ exports.examples = [
       return (
         <View style={styles.row}>
           <Pressable
+            accessibilityRole="button"
             style={({pressed}) => [
               {
                 backgroundColor: pressed ? 'rgb(210, 230, 255)' : 'white',
@@ -375,7 +383,9 @@ exports.examples = [
       };
       return (
         <View style={styles.row}>
-          <Pressable android_ripple={{color: 'green'}}>
+          <Pressable
+            accessibilityRole="button"
+            android_ripple={{color: 'green'}}>
             <Animated.View style={style} />
           </Pressable>
         </View>
@@ -400,6 +410,7 @@ exports.examples = [
               {justifyContent: 'space-around', alignItems: 'center'},
             ]}>
             <Pressable
+              accessibilityRole="button"
               android_ripple={{color: 'orange', borderless: true, radius: 30}}>
               <View>
                 <Text style={[styles.button, nativeFeedbackButton]}>
@@ -408,7 +419,9 @@ exports.examples = [
               </View>
             </Pressable>
 
-            <Pressable android_ripple={{borderless: true, radius: 150}}>
+            <Pressable
+              accessibilityRole="button"
+              android_ripple={{borderless: true, radius: 150}}>
               <View>
                 <Text style={[styles.button, nativeFeedbackButton]}>
                   radius 150
@@ -416,7 +429,9 @@ exports.examples = [
               </View>
             </Pressable>
 
-            <Pressable android_ripple={{borderless: false, radius: 70}}>
+            <Pressable
+              accessibilityRole="button"
+              android_ripple={{borderless: false, radius: 70}}>
               <View style={styles.block}>
                 <Text style={[styles.button, nativeFeedbackButton]}>
                   radius 70, with border
@@ -425,7 +440,9 @@ exports.examples = [
             </Pressable>
           </View>
 
-          <Pressable android_ripple={{borderless: false}}>
+          <Pressable
+            accessibilityRole="button"
+            android_ripple={{borderless: false}}>
             <View style={styles.block}>
               <Text style={[styles.button, nativeFeedbackButton]}>
                 with border, default color and radius
@@ -435,6 +452,7 @@ exports.examples = [
 
           <View style={{alignItems: 'center'}}>
             <Pressable
+              accessibilityRole="button"
               android_ripple={{
                 borderless: false,
                 foreground: true,

--- a/packages/rn-tester/js/examples/RTL/RTLExample.js
+++ b/packages/rn-tester/js/examples/RTL/RTLExample.js
@@ -93,7 +93,7 @@ const TextInputExample = withRTLState(({isRTL, setRTL, ...props}) => {
       <RTLToggler setRTL={setRTL} isRTL={isRTL} />
       <View style={directionStyle(isRTL)}>
         <Text style={props.style}>LRT or RTL TextInput.</Text>
-        <TextInput style={props.style} />
+        <TextInput accessibilityLabel="Text input field" style={props.style} />
       </View>
     </View>
   );
@@ -130,7 +130,9 @@ const IconsExample = withRTLState(({isRTL, setRTL}) => {
 function AnimationBlock(props) {
   return (
     <View style={styles.block}>
-      <TouchableWithoutFeedback onPress={props.onPress}>
+      <TouchableWithoutFeedback
+        accessibilityRole="button"
+        onPress={props.onPress}>
         <Animated.Image
           style={[styles.img, props.imgStyle]}
           source={require('../../assets/poke.png')}

--- a/packages/rn-tester/js/examples/RefreshControl/RefreshControlExample.js
+++ b/packages/rn-tester/js/examples/RefreshControl/RefreshControlExample.js
@@ -43,7 +43,9 @@ class Row extends React.Component {
 
   render() {
     return (
-      <TouchableWithoutFeedback onPress={this._onClick}>
+      <TouchableWithoutFeedback
+        accessibilityRole="button"
+        onPress={this._onClick}>
         <View style={styles.row}>
           <Text style={styles.text}>
             {this.props.data.text + ' (' + this.props.data.clicks + ' clicks)'}

--- a/packages/rn-tester/js/examples/RootViewSizeFlexibilityExample/RootViewSizeFlexibilityExampleApp.js
+++ b/packages/rn-tester/js/examples/RootViewSizeFlexibilityExample/RootViewSizeFlexibilityExampleApp.js
@@ -34,7 +34,9 @@ class RootViewSizeFlexibilityExampleApp extends React.Component<
 
     return (
       // $FlowFixMe[method-unbinding] added when improving typing for this parameters
-      <TouchableHighlight onPress={this._onPressButton.bind(this)}>
+      <TouchableHighlight
+        accessibilityRole="button"
+        onPress={this._onPressButton.bind(this)}>
         <View style={viewStyle}>
           <View style={styles.center}>
             <Text style={styles.whiteText}>React Native Button</Text>

--- a/packages/rn-tester/js/examples/ScrollView/ScrollViewAnimatedExample.js
+++ b/packages/rn-tester/js/examples/ScrollView/ScrollViewAnimatedExample.js
@@ -62,7 +62,9 @@ class ScrollViewAnimatedExample extends Component<{...}> {
             [{nativeEvent: {contentOffset: {x: this._scrollViewPos}}}],
             {useNativeDriver: true},
           )}>
-          <TouchableOpacity onPress={this.startAnimation}>
+          <TouchableOpacity
+            accessibilityRole="button"
+            onPress={this.startAnimation}>
             <View style={styles.button}>
               <Text>Scroll me horizontally</Text>
             </View>

--- a/packages/rn-tester/js/examples/ScrollView/ScrollViewExample.js
+++ b/packages/rn-tester/js/examples/ScrollView/ScrollViewExample.js
@@ -852,6 +852,7 @@ const MaxMinZoomScale = () => {
       </ScrollView>
       <Text style={styles.rowTitle}>Set Maximum Zoom Scale</Text>
       <TextInput
+        accessibilityLabel="Text input field"
         style={styles.textInput}
         value={maxZoomScale}
         onChangeText={val => setMaxZoomScale(val)}
@@ -859,6 +860,7 @@ const MaxMinZoomScale = () => {
       />
       <Text style={styles.rowTitle}>Set Minimum Zoom Scale</Text>
       <TextInput
+        accessibilityLabel="Text input field"
         style={styles.textInput}
         value={minZoomScale.toString()}
         onChangeText={val => setMinZoomScale(val)}
@@ -868,6 +870,7 @@ const MaxMinZoomScale = () => {
         <>
           <Text style={styles.rowTitle}>Set Zoom Scale</Text>
           <TextInput
+            accessibilityLabel="Text input field"
             style={styles.textInput}
             value={zoomScale.toString()}
             onChangeText={val => setZoomScale(val)}
@@ -892,6 +895,7 @@ const KeyboardExample = () => {
   return (
     <View>
       <TextInput
+        accessibilityLabel="Text input field"
         style={styles.textInput}
         value={textInputValue}
         onChangeText={val => setTextInputValue(val)}
@@ -1267,6 +1271,7 @@ const Button = (props: {
   testID?: string,
 }) => (
   <TouchableOpacity
+    accessibilityRole="button"
     style={StyleSheet.compose(
       styles.button,
       props.active === true ? styles.activeButton : null,

--- a/packages/rn-tester/js/examples/ScrollView/ScrollViewPressableStickyHeaderExample.js
+++ b/packages/rn-tester/js/examples/ScrollView/ScrollViewPressableStickyHeaderExample.js
@@ -30,6 +30,7 @@ function StickyHeader() {
         height: 100,
       }}>
       <Pressable
+        accessibilityRole="button"
         style={{flex: 1}}
         onPress={() => {
           setBackgroundColor(backgroundColor === 'blue' ? 'yellow' : 'blue');

--- a/packages/rn-tester/js/examples/ScrollView/ScrollViewSimpleExample.js
+++ b/packages/rn-tester/js/examples/ScrollView/ScrollViewSimpleExample.js
@@ -29,7 +29,7 @@ class ScrollViewSimpleExample extends React.Component<{...}> {
     const items = [];
     for (let i = 0; i < nItems; i++) {
       items[i] = (
-        <TouchableOpacity key={i} style={styles}>
+        <TouchableOpacity accessibilityRole="button" key={i} style={styles}>
           <Text>{'Item ' + i}</Text>
         </TouchableOpacity>
       );

--- a/packages/rn-tester/js/examples/SectionList/SectionListBaseExample.js
+++ b/packages/rn-tester/js/examples/SectionList/SectionListBaseExample.js
@@ -41,6 +41,7 @@ const DATA = [
 const Item = ({item, section, separators}) => {
   return (
     <Pressable
+      accessibilityRole="button"
       onPressIn={() => {
         separators.highlight();
       }}

--- a/packages/rn-tester/js/examples/StatusBar/StatusBarExample.js
+++ b/packages/rn-tester/js/examples/StatusBar/StatusBarExample.js
@@ -67,6 +67,7 @@ class StatusBarHiddenExample extends React.Component<{...}, $FlowFixMeState> {
           animated={this.state.animated}
         />
         <TouchableHighlight
+          accessibilityRole="button"
           style={styles.wrapper}
           onPress={this._onChangeHidden}>
           <View style={styles.button}>
@@ -74,6 +75,7 @@ class StatusBarHiddenExample extends React.Component<{...}, $FlowFixMeState> {
           </View>
         </TouchableHighlight>
         <TouchableHighlight
+          accessibilityRole="button"
           style={styles.wrapper}
           onPress={this._onChangeAnimated}>
           <View style={styles.button}>
@@ -83,6 +85,7 @@ class StatusBarHiddenExample extends React.Component<{...}, $FlowFixMeState> {
           </View>
         </TouchableHighlight>
         <TouchableHighlight
+          accessibilityRole="button"
           style={styles.wrapper}
           onPress={this._onChangeTransition}>
           <View style={styles.button}>
@@ -123,6 +126,7 @@ class StatusBarStyleExample extends React.Component<{...}, $FlowFixMeState> {
           barStyle={this.state.barStyle}
         />
         <TouchableHighlight
+          accessibilityRole="button"
           style={styles.wrapper}
           onPress={this._onChangeBarStyle}>
           <View style={styles.button}>
@@ -130,6 +134,7 @@ class StatusBarStyleExample extends React.Component<{...}, $FlowFixMeState> {
           </View>
         </TouchableHighlight>
         <TouchableHighlight
+          accessibilityRole="button"
           style={styles.wrapper}
           onPress={this._onChangeAnimated}>
           <View style={styles.button}>
@@ -165,6 +170,7 @@ class StatusBarNetworkActivityExample extends React.Component<
           }
         />
         <TouchableHighlight
+          accessibilityRole="button"
           style={styles.wrapper}
           onPress={this._onChangeNetworkIndicatorVisible}>
           <View style={styles.button}>
@@ -207,6 +213,7 @@ class StatusBarBackgroundColorExample extends React.Component<
           animated={this.state.animated}
         />
         <TouchableHighlight
+          accessibilityRole="button"
           style={styles.wrapper}
           onPress={this._onChangeBackgroundColor}>
           <View style={styles.button}>
@@ -214,6 +221,7 @@ class StatusBarBackgroundColorExample extends React.Component<
           </View>
         </TouchableHighlight>
         <TouchableHighlight
+          accessibilityRole="button"
           style={styles.wrapper}
           onPress={this._onChangeAnimated}>
           <View style={styles.button}>
@@ -244,6 +252,7 @@ class StatusBarTranslucentExample extends React.Component<
       <View>
         <StatusBar translucent={this.state.translucent} />
         <TouchableHighlight
+          accessibilityRole="button"
           style={styles.wrapper}
           onPress={this._onChangeTranslucent}>
           <View style={styles.button}>
@@ -262,6 +271,7 @@ class StatusBarStaticIOSExample extends React.Component<{...}> {
     return (
       <View>
         <TouchableHighlight
+          accessibilityRole="button"
           style={styles.wrapper}
           onPress={() => {
             StatusBar.setHidden(true, 'slide');
@@ -271,6 +281,7 @@ class StatusBarStaticIOSExample extends React.Component<{...}> {
           </View>
         </TouchableHighlight>
         <TouchableHighlight
+          accessibilityRole="button"
           style={styles.wrapper}
           onPress={() => {
             StatusBar.setHidden(false, 'fade');
@@ -280,6 +291,7 @@ class StatusBarStaticIOSExample extends React.Component<{...}> {
           </View>
         </TouchableHighlight>
         <TouchableHighlight
+          accessibilityRole="button"
           style={styles.wrapper}
           onPress={() => {
             StatusBar.setBarStyle('default', true);
@@ -289,6 +301,7 @@ class StatusBarStaticIOSExample extends React.Component<{...}> {
           </View>
         </TouchableHighlight>
         <TouchableHighlight
+          accessibilityRole="button"
           style={styles.wrapper}
           onPress={() => {
             StatusBar.setBarStyle('light-content', true);
@@ -298,6 +311,7 @@ class StatusBarStaticIOSExample extends React.Component<{...}> {
           </View>
         </TouchableHighlight>
         <TouchableHighlight
+          accessibilityRole="button"
           style={styles.wrapper}
           onPress={() => {
             StatusBar.setNetworkActivityIndicatorVisible(true);
@@ -307,6 +321,7 @@ class StatusBarStaticIOSExample extends React.Component<{...}> {
           </View>
         </TouchableHighlight>
         <TouchableHighlight
+          accessibilityRole="button"
           style={styles.wrapper}
           onPress={() => {
             StatusBar.setNetworkActivityIndicatorVisible(false);
@@ -325,6 +340,7 @@ class StatusBarStaticAndroidExample extends React.Component<{...}> {
     return (
       <View>
         <TouchableHighlight
+          accessibilityRole="button"
           style={styles.wrapper}
           onPress={() => {
             StatusBar.setHidden(true);
@@ -334,6 +350,7 @@ class StatusBarStaticAndroidExample extends React.Component<{...}> {
           </View>
         </TouchableHighlight>
         <TouchableHighlight
+          accessibilityRole="button"
           style={styles.wrapper}
           onPress={() => {
             StatusBar.setHidden(false);
@@ -343,6 +360,7 @@ class StatusBarStaticAndroidExample extends React.Component<{...}> {
           </View>
         </TouchableHighlight>
         <TouchableHighlight
+          accessibilityRole="button"
           style={styles.wrapper}
           onPress={() => {
             StatusBar.setBackgroundColor('#ff00ff', true);
@@ -352,6 +370,7 @@ class StatusBarStaticAndroidExample extends React.Component<{...}> {
           </View>
         </TouchableHighlight>
         <TouchableHighlight
+          accessibilityRole="button"
           style={styles.wrapper}
           onPress={() => {
             StatusBar.setBackgroundColor('#00ff00', true);
@@ -361,6 +380,7 @@ class StatusBarStaticAndroidExample extends React.Component<{...}> {
           </View>
         </TouchableHighlight>
         <TouchableHighlight
+          accessibilityRole="button"
           style={styles.wrapper}
           onPress={() => {
             StatusBar.setTranslucent(true);
@@ -374,6 +394,7 @@ class StatusBarStaticAndroidExample extends React.Component<{...}> {
           </View>
         </TouchableHighlight>
         <TouchableHighlight
+          accessibilityRole="button"
           style={styles.wrapper}
           onPress={() => {
             StatusBar.setTranslucent(false);
@@ -403,6 +424,7 @@ class ModalExample extends React.Component<{...}, $FlowFixMeState> {
     return (
       <View>
         <TouchableHighlight
+          accessibilityRole="button"
           style={styles.wrapper}
           onPress={this._onChangeModalVisible}>
           <View style={styles.button}>
@@ -417,6 +439,7 @@ class ModalExample extends React.Component<{...}, $FlowFixMeState> {
             <View style={[styles.innerContainer]}>
               <Text>This modal was presented!</Text>
               <TouchableHighlight
+                accessibilityRole="button"
                 onPress={this._onChangeModalVisible}
                 style={styles.modalButton}>
                 <View style={styles.button}>

--- a/packages/rn-tester/js/examples/Text/TextExample.ios.js
+++ b/packages/rn-tester/js/examples/Text/TextExample.ios.js
@@ -341,14 +341,21 @@ class TextBaseLineLayoutExample extends React.Component<{}, mixed> {
         <Text style={subtitleStyle}>{'<TextInput/>:'}</Text>
         <View style={{flexDirection: 'row', alignItems: 'baseline'}}>
           {marker}
-          <TextInput style={{margin: 0, padding: 0}}>{texts}</TextInput>
+          <TextInput
+            accessibilityLabel="Text input field"
+            style={{margin: 0, padding: 0}}>
+            {texts}
+          </TextInput>
           {marker}
         </View>
 
         <Text style={subtitleStyle}>{'<TextInput multiline/>:'}</Text>
         <View style={{flexDirection: 'row', alignItems: 'baseline'}}>
           {marker}
-          <TextInput multiline={true} style={{margin: 0, padding: 0}}>
+          <TextInput
+            accessibilityLabel="Text input field"
+            multiline={true}
+            style={{margin: 0, padding: 0}}>
             {texts}
           </TextInput>
           {marker}

--- a/packages/rn-tester/js/examples/TextInput/TextInputExample.android.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputExample.android.js
@@ -36,7 +36,10 @@ class ToggleDefaultPaddingExample extends React.Component<
   render() {
     return (
       <View>
-        <TextInput style={this.state.hasPadding ? {padding: 0} : null} />
+        <TextInput
+          accessibilityLabel="Text input field"
+          style={this.state.hasPadding ? {padding: 0} : null}
+        />
         <Text
           onPress={() => this.setState({hasPadding: !this.state.hasPadding})}>
           Toggle padding
@@ -156,32 +159,39 @@ exports.examples = ([
       return (
         <View>
           <TextInput
+            accessibilityLabel="Text input field"
             style={[styles.singleLine]}
             defaultValue="Default color text"
           />
           <TextInput
+            accessibilityLabel="Text input field"
             style={[styles.singleLine, {color: 'green'}]}
             defaultValue="Green Text"
           />
           <TextInput
+            accessibilityLabel="Text input field"
             placeholder="Default placeholder text color"
             style={styles.singleLine}
           />
           <TextInput
+            accessibilityLabel="Text input field"
             placeholder="Red placeholder text color"
             placeholderTextColor="red"
             style={styles.singleLine}
           />
           <TextInput
+            accessibilityLabel="Text input field"
             placeholder="Default underline color"
             style={styles.singleLine}
           />
           <TextInput
+            accessibilityLabel="Text input field"
             placeholder="Blue underline color"
             style={styles.singleLine}
             underlineColorAndroid="blue"
           />
           <TextInput
+            accessibilityLabel="Text input field"
             defaultValue="Same BackgroundColor as View "
             style={[
               styles.singleLine,
@@ -192,6 +202,7 @@ exports.examples = ([
             </Text>
           </TextInput>
           <TextInput
+            accessibilityLabel="Text input field"
             defaultValue="Highlight Color is red"
             selectionColor={'red'}
             style={styles.singleLine}
@@ -206,6 +217,7 @@ exports.examples = ([
       return (
         <View>
           <TextInput
+            accessibilityLabel="Text input field"
             defaultValue="Font Weight (default)"
             style={[styles.singleLine]}
           />
@@ -223,6 +235,7 @@ exports.examples = ([
             '100',
           ].map(fontWeight => (
             <TextInput
+              accessibilityLabel="Text input field"
               defaultValue={`Font Weight (${fontWeight})`}
               key={fontWeight}
               style={[styles.singleLine, {fontWeight}]}
@@ -237,6 +250,7 @@ exports.examples = ([
     render: function (): React.Node {
       return (
         <TextInput
+          accessibilityLabel="Text input field"
           placeholder="If you set height, beware of padding set from themes"
           style={[styles.singleLineWithHeightTextInput]}
         />
@@ -249,18 +263,22 @@ exports.examples = ([
       return (
         <View>
           <TextInput
+            accessibilityLabel="Text input field"
             style={[styles.singleLine, {letterSpacing: 0}]}
             placeholder="letterSpacing = 0"
           />
           <TextInput
+            accessibilityLabel="Text input field"
             style={[styles.singleLine, {letterSpacing: 2}]}
             placeholder="letterSpacing = 2"
           />
           <TextInput
+            accessibilityLabel="Text input field"
             style={[styles.singleLine, {letterSpacing: 9}]}
             placeholder="letterSpacing = 9"
           />
           <TextInput
+            accessibilityLabel="Text input field"
             style={[styles.singleLine, {letterSpacing: -1}]}
             placeholder="letterSpacing = -1"
           />
@@ -274,11 +292,13 @@ exports.examples = ([
       return (
         <View>
           <TextInput
+            accessibilityLabel="Text input field"
             defaultValue="iloveturtles"
             secureTextEntry={true}
             style={styles.singleLine}
           />
           <TextInput
+            accessibilityLabel="Text input field"
             secureTextEntry={true}
             style={[styles.singleLine, {color: 'red'}]}
             placeholder="color is supported too"
@@ -293,6 +313,7 @@ exports.examples = ([
     render: function (): React.Node {
       return (
         <TextInput
+          accessibilityLabel="Text input field"
           defaultValue="Can't touch this! (>'-')> ^(' - ')^ <('-'<) (>'-')> ^(' - ')^"
           editable={false}
           style={styles.singleLine}
@@ -306,6 +327,7 @@ exports.examples = ([
       return (
         <View>
           <TextInput
+            accessibilityLabel="Text input field"
             autoCorrect={true}
             placeholder="multiline, aligned top-left"
             placeholderTextColor="red"
@@ -316,6 +338,7 @@ exports.examples = ([
             ]}
           />
           <TextInput
+            accessibilityLabel="Text input field"
             autoCorrect={true}
             placeholder="multiline, aligned center"
             placeholderTextColor="green"
@@ -326,6 +349,7 @@ exports.examples = ([
             ]}
           />
           <TextInput
+            accessibilityLabel="Text input field"
             autoCorrect={true}
             multiline={true}
             style={[
@@ -348,11 +372,13 @@ exports.examples = ([
       return (
         <View>
           <TextInput
+            accessibilityLabel="Text input field"
             numberOfLines={2}
             multiline={true}
             placeholder="Two line input"
           />
           <TextInput
+            accessibilityLabel="Text input field"
             numberOfLines={5}
             multiline={true}
             placeholder="Five line input"
@@ -401,6 +427,7 @@ exports.examples = ([
       const examples = returnKeyTypes.map(type => {
         return (
           <TextInput
+            accessibilityLabel="Text input field"
             key={type}
             returnKeyType={type}
             placeholder={'returnKeyType: ' + type}
@@ -411,6 +438,7 @@ exports.examples = ([
       const types = returnKeyLabels.map(type => {
         return (
           <TextInput
+            accessibilityLabel="Text input field"
             key={type}
             returnKeyLabel={type}
             placeholder={'returnKeyLabel: ' + type}
@@ -432,17 +460,20 @@ exports.examples = ([
       return (
         <View>
           <TextInput
+            accessibilityLabel="Text input field"
             inlineImageLeft="ic_menu_black_24dp"
             placeholder="This has drawableLeft set"
             style={styles.singleLine}
           />
           <TextInput
+            accessibilityLabel="Text input field"
             inlineImageLeft="ic_menu_black_24dp"
             inlineImagePadding={30}
             placeholder="This has drawableLeft and drawablePadding set"
             style={styles.singleLine}
           />
           <TextInput
+            accessibilityLabel="Text input field"
             placeholder="This does not have drawable props set"
             style={styles.singleLine}
           />

--- a/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
@@ -57,6 +57,7 @@ class TextInputAccessoryViewChangeTextExample extends React.Component<
       <View>
         <Text>Set InputAccessoryView with ID & reset text:</Text>
         <TextInput
+          accessibilityLabel="Text input field"
           style={styles.default}
           inputAccessoryViewID={inputAccessoryViewID}
           onChangeText={text => this.setState({text})}
@@ -97,6 +98,7 @@ class TextInputAccessoryViewChangeKeyboardExample extends React.Component<
       <View>
         <Text>Set InputAccessoryView with ID & switch keyboard:</Text>
         <TextInput
+          accessibilityLabel="Text input field"
           style={styles.default}
           inputAccessoryViewID={inputAccessoryViewID}
           onChangeText={text => this.setState({text})}
@@ -129,6 +131,7 @@ class TextInputAccessoryViewDefaultDoneButtonExample extends React.Component<
   render() {
     return (
       <TextInput
+        accessibilityLabel="Text input field"
         style={styles.default}
         onChangeText={text => this.setState({text})}
         value={this.state.text}
@@ -148,6 +151,7 @@ class RewriteExampleKana extends React.Component<$FlowFixMeProps, any> {
     return (
       <View style={styles.rewriteContainer}>
         <TextInput
+          accessibilityLabel="Text input field"
           multiline={false}
           onChangeText={text => {
             this.setState({text: text.replace(/ひ/g, '日')});
@@ -173,6 +177,7 @@ class SecureEntryExample extends React.Component<$FlowFixMeProps, any> {
     return (
       <View>
         <TextInput
+          accessibilityLabel="Text input field"
           secureTextEntry={true}
           style={styles.default}
           defaultValue="abc"
@@ -186,6 +191,7 @@ class SecureEntryExample extends React.Component<$FlowFixMeProps, any> {
             flexDirection: 'row',
           }}>
           <TextInput
+            accessibilityLabel="Text input field"
             style={styles.default}
             defaultValue="cde"
             onChangeText={text => this.setState({password: text})}
@@ -375,7 +381,10 @@ exports.examples = ([
       return (
         <View>
           <WithLabel label="singleline">
-            <TextInput style={styles.default} value="(value property)">
+            <TextInput
+              accessibilityLabel="Text input field"
+              style={styles.default}
+              value="(value property)">
               (first raw text node)
               <Text style={{color: 'red'}}>(internal raw text node)</Text>
               (last raw text node)
@@ -383,6 +392,7 @@ exports.examples = ([
           </WithLabel>
           <WithLabel label="multiline">
             <TextInput
+              accessibilityLabel="Text input field"
               style={styles.default}
               multiline={true}
               value="(value property)">
@@ -402,7 +412,11 @@ exports.examples = ([
       const examples = keyboardAppearance.map(type => {
         return (
           <WithLabel key={type} label={type}>
-            <TextInput keyboardAppearance={type} style={styles.default} />
+            <TextInput
+              accessibilityLabel="Text input field"
+              keyboardAppearance={type}
+              style={styles.default}
+            />
           </WithLabel>
         );
       });
@@ -428,7 +442,11 @@ exports.examples = ([
       const examples = returnKeyTypes.map(type => {
         return (
           <WithLabel key={type} label={type}>
-            <TextInput returnKeyType={type} style={styles.default} />
+            <TextInput
+              accessibilityLabel="Text input field"
+              returnKeyType={type}
+              style={styles.default}
+            />
           </WithLabel>
         );
       });
@@ -442,6 +460,7 @@ exports.examples = ([
         <View>
           <WithLabel label="true">
             <TextInput
+              accessibilityLabel="Text input field"
               enablesReturnKeyAutomatically={true}
               style={styles.default}
             />
@@ -462,10 +481,12 @@ exports.examples = ([
       return (
         <View>
           <TextInput
+            accessibilityLabel="Text input field"
             style={[styles.default, {color: 'blue'}]}
             defaultValue="Blue"
           />
           <TextInput
+            accessibilityLabel="Text input field"
             style={[styles.default, {color: 'green'}]}
             defaultValue="Green"
           />
@@ -479,11 +500,13 @@ exports.examples = ([
       return (
         <View>
           <TextInput
+            accessibilityLabel="Text input field"
             style={styles.default}
             selectionColor={'green'}
             defaultValue="Highlight me"
           />
           <TextInput
+            accessibilityLabel="Text input field"
             style={styles.default}
             selectionColor={'rgba(86, 76, 205, 1)'}
             defaultValue="Highlight me"
@@ -505,6 +528,7 @@ exports.examples = ([
         return (
           <WithLabel key={mode} label={mode}>
             <TextInput
+              accessibilityLabel="Text input field"
               style={styles.default}
               clearButtonMode={mode}
               defaultValue={mode}
@@ -522,6 +546,7 @@ exports.examples = ([
         <View>
           <WithLabel label="clearTextOnFocus">
             <TextInput
+              accessibilityLabel="Text input field"
               placeholder="text is cleared on focus"
               defaultValue="text is cleared on focus"
               style={styles.default}
@@ -530,6 +555,7 @@ exports.examples = ([
           </WithLabel>
           <WithLabel label="selectTextOnFocus">
             <TextInput
+              accessibilityLabel="Text input field"
               placeholder="text is selected on focus"
               defaultValue="text is selected on focus"
               style={styles.default}
@@ -538,6 +564,7 @@ exports.examples = ([
           </WithLabel>
           <WithLabel label="clearTextOnFocus (multiline)">
             <TextInput
+              accessibilityLabel="Text input field"
               placeholder="text is cleared on focus"
               defaultValue="text is cleared on focus"
               style={styles.default}
@@ -547,6 +574,7 @@ exports.examples = ([
           </WithLabel>
           <WithLabel label="selectTextOnFocus (multiline)">
             <TextInput
+              accessibilityLabel="Text input field"
               placeholder="text is selected on focus"
               defaultValue="text is selected on focus"
               style={styles.default}
@@ -564,6 +592,7 @@ exports.examples = ([
       return (
         <View>
           <TextInput
+            accessibilityLabel="Text input field"
             style={styles.multiline}
             placeholder="blurOnSubmit = true"
             returnKeyType="next"
@@ -583,11 +612,13 @@ exports.examples = ([
       return (
         <View>
           <TextInput
+            accessibilityLabel="Text input field"
             placeholder="multiline text input"
             multiline={true}
             style={styles.multiline}
           />
           <TextInput
+            accessibilityLabel="Text input field"
             placeholder="multiline text input with font styles and placeholder"
             multiline={true}
             clearTextOnFocus={true}
@@ -598,18 +629,21 @@ exports.examples = ([
             style={[styles.multiline, styles.multilineWithFontStyles]}
           />
           <TextInput
+            accessibilityLabel="Text input field"
             placeholder="multiline text input with max length"
             maxLength={5}
             multiline={true}
             style={styles.multiline}
           />
           <TextInput
+            accessibilityLabel="Text input field"
             placeholder="uneditable multiline text input"
             editable={false}
             multiline={true}
             style={styles.multiline}
           />
           <TextInput
+            accessibilityLabel="Text input field"
             defaultValue="uneditable multiline text input with phone number detection: 88888888."
             editable={false}
             multiline={true}
@@ -628,6 +662,7 @@ exports.examples = ([
           <Text>Singleline TextInput</Text>
           <View style={{height: 80}}>
             <TextInput
+              accessibilityLabel="Text input field"
               style={{
                 position: 'absolute',
                 fontSize: 16,
@@ -647,6 +682,7 @@ exports.examples = ([
           <Text>Multiline TextInput</Text>
           <View style={{height: 130}}>
             <TextInput
+              accessibilityLabel="Text input field"
               style={{
                 position: 'absolute',
                 fontSize: 16,
@@ -667,6 +703,7 @@ exports.examples = ([
           </View>
           <View>
             <TextInput
+              accessibilityLabel="Text input field"
               style={{
                 fontSize: 16,
                 backgroundColor: '#eeeeee',
@@ -693,6 +730,7 @@ exports.examples = ([
       return (
         <View>
           <TextInput
+            accessibilityLabel="Text input field"
             placeholder="height increases with content"
             defaultValue="React Native enables you to build world-class application experiences on native platforms using a consistent developer experience based on JavaScript and React. The focus of React Native is on developer efficiency across all the platforms you care about - learn once, write anywhere. Facebook uses React Native in multiple production apps and will continue investing in React Native."
             multiline={true}
@@ -741,10 +779,15 @@ exports.examples = ([
       return (
         <View>
           <WithLabel label="maxLength: 5">
-            <TextInput maxLength={5} style={styles.default} />
+            <TextInput
+              accessibilityLabel="Text input field"
+              maxLength={5}
+              style={styles.default}
+            />
           </WithLabel>
           <WithLabel label="maxLength: 5 with placeholder">
             <TextInput
+              accessibilityLabel="Text input field"
               maxLength={5}
               placeholder="ZIP code entry"
               style={styles.default}
@@ -752,6 +795,7 @@ exports.examples = ([
           </WithLabel>
           <WithLabel label="maxLength: 5 with default value already set">
             <TextInput
+              accessibilityLabel="Text input field"
               maxLength={5}
               defaultValue="94025"
               style={styles.default}
@@ -759,6 +803,7 @@ exports.examples = ([
           </WithLabel>
           <WithLabel label="maxLength: 5 with very long default value already set">
             <TextInput
+              accessibilityLabel="Text input field"
               maxLength={5}
               defaultValue="9402512345"
               style={styles.default}
@@ -774,10 +819,18 @@ exports.examples = ([
       return (
         <View>
           <WithLabel label="emailAddress">
-            <TextInput textContentType="emailAddress" style={styles.default} />
+            <TextInput
+              accessibilityLabel="Text input field"
+              textContentType="emailAddress"
+              style={styles.default}
+            />
           </WithLabel>
           <WithLabel label="name">
-            <TextInput textContentType="name" style={styles.default} />
+            <TextInput
+              accessibilityLabel="Text input field"
+              textContentType="name"
+              style={styles.default}
+            />
           </WithLabel>
         </View>
       );
@@ -790,6 +843,7 @@ exports.examples = ([
         <View>
           <WithLabel label="letterSpacing: 10 lineHeight: 20 textAlign: 'center'">
             <TextInput
+              accessibilityLabel="Text input field"
               placeholder="multiline text input"
               multiline={true}
               style={[styles.multiline, styles.multilinePlaceholderStyles]}
@@ -797,6 +851,7 @@ exports.examples = ([
           </WithLabel>
           <WithLabel label="letterSpacing: 10 textAlign: 'center'">
             <TextInput
+              accessibilityLabel="Text input field"
               placeholder="singleline"
               style={[styles.default, styles.singlelinePlaceholderStyles]}
             />
@@ -811,7 +866,11 @@ exports.examples = ([
       return (
         <View>
           <WithLabel label="showSoftInputOnFocus: false">
-            <TextInput showSoftInputOnFocus={false} style={[styles.default]} />
+            <TextInput
+              accessibilityLabel="Text input field"
+              showSoftInputOnFocus={false}
+              style={[styles.default]}
+            />
           </WithLabel>
         </View>
       );

--- a/packages/rn-tester/js/examples/TextInput/TextInputKeyProp.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputKeyProp.js
@@ -28,6 +28,7 @@ function TextInputKeyProp() {
     console.log('Adding a TextInput with key ' + key);
     textInputs.push(
       <TextInput
+        accessibilityLabel="Text input field"
         style={{height: 40, borderColor: 'gray', borderWidth: 1}}
         key={key}
       />,

--- a/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
@@ -99,6 +99,7 @@ class RewriteExample extends React.Component<$FlowFixMeProps, any> {
     return (
       <View style={styles.rewriteContainer}>
         <TextInput
+          accessibilityLabel="Text input field"
           testID="rewrite_sp_underscore_input"
           autoCorrect={false}
           multiline={false}
@@ -130,6 +131,7 @@ class RewriteExampleInvalidCharacters extends React.Component<
     return (
       <View style={styles.rewriteContainer}>
         <TextInput
+          accessibilityLabel="Text input field"
           testID="rewrite_no_sp_input"
           autoCorrect={false}
           multiline={false}
@@ -158,6 +160,7 @@ class RewriteInvalidCharactersAndClearExample extends React.Component<
     return (
       <View style={styles.rewriteContainer}>
         <TextInput
+          accessibilityLabel="Text input field"
           testID="rewrite_clear_input"
           autoCorrect={false}
           ref={ref => {
@@ -195,6 +198,7 @@ class BlurOnSubmitExample extends React.Component<{...}> {
     return (
       <View>
         <TextInput
+          accessibilityLabel="Text input field"
           ref={this.ref1}
           style={styles.singleLine}
           placeholder="blurOnSubmit = false"
@@ -203,6 +207,7 @@ class BlurOnSubmitExample extends React.Component<{...}> {
           onSubmitEditing={() => this.ref2.current?.focus()}
         />
         <TextInput
+          accessibilityLabel="Text input field"
           ref={this.ref2}
           style={styles.singleLine}
           keyboardType="email-address"
@@ -212,6 +217,7 @@ class BlurOnSubmitExample extends React.Component<{...}> {
           onSubmitEditing={() => this.ref3.current?.focus()}
         />
         <TextInput
+          accessibilityLabel="Text input field"
           ref={this.ref3}
           style={styles.singleLine}
           keyboardType="url"
@@ -221,6 +227,7 @@ class BlurOnSubmitExample extends React.Component<{...}> {
           onSubmitEditing={() => this.ref4.current?.focus()}
         />
         <TextInput
+          accessibilityLabel="Text input field"
           ref={this.ref4}
           style={styles.singleLine}
           keyboardType="numeric"
@@ -229,6 +236,7 @@ class BlurOnSubmitExample extends React.Component<{...}> {
           onSubmitEditing={() => this.ref5.current?.focus()}
         />
         <TextInput
+          accessibilityLabel="Text input field"
           ref={this.ref5}
           style={styles.singleLine}
           keyboardType="numbers-and-punctuation"
@@ -263,6 +271,7 @@ class TextEventsExample extends React.Component<{...}, $FlowFixMeState> {
     return (
       <View>
         <TextInput
+          accessibilityLabel="Text input field"
           autoCapitalize="none"
           placeholder="Enter text to see events"
           autoCorrect={false}
@@ -351,6 +360,7 @@ class TokenizedTextExample extends React.Component<
     return (
       <View style={{flexDirection: 'row'}}>
         <TextInput
+          accessibilityLabel="Text input field"
           testID="text-input"
           multiline={true}
           style={styles.multiline}
@@ -427,6 +437,7 @@ class SelectionExample extends React.Component<
       <View>
         <View style={{flexDirection: 'row'}}>
           <TextInput
+            accessibilityLabel="Text input field"
             testID={`${this.props.testID}-text-input`}
             multiline={this.props.multiline}
             onChangeText={value => this.setState({value})}
@@ -514,6 +525,7 @@ module.exports = ([
         <View>
           <WithLabel label="none">
             <TextInput
+              accessibilityLabel="Text input field"
               testID="capitalize-none"
               autoCapitalize="none"
               style={styles.default}
@@ -521,6 +533,7 @@ module.exports = ([
           </WithLabel>
           <WithLabel label="sentences">
             <TextInput
+              accessibilityLabel="Text input field"
               testID="capitalize-sentences"
               autoCapitalize="sentences"
               style={styles.default}
@@ -528,6 +541,7 @@ module.exports = ([
           </WithLabel>
           <WithLabel label="words">
             <TextInput
+              accessibilityLabel="Text input field"
               testID="capitalize-words"
               autoCapitalize="words"
               style={styles.default}
@@ -535,6 +549,7 @@ module.exports = ([
           </WithLabel>
           <WithLabel label="characters">
             <TextInput
+              accessibilityLabel="Text input field"
               testID="capitalize-characters"
               autoCapitalize="characters"
               style={styles.default}
@@ -550,10 +565,18 @@ module.exports = ([
       return (
         <View>
           <WithLabel label="true">
-            <TextInput autoCorrect={true} style={styles.default} />
+            <TextInput
+              accessibilityLabel="Text input field"
+              autoCorrect={true}
+              style={styles.default}
+            />
           </WithLabel>
           <WithLabel label="false">
-            <TextInput autoCorrect={false} style={styles.default} />
+            <TextInput
+              accessibilityLabel="Text input field"
+              autoCorrect={false}
+              style={styles.default}
+            />
           </WithLabel>
         </View>
       );
@@ -581,7 +604,11 @@ module.exports = ([
       const examples = keyboardTypes.map(type => {
         return (
           <WithLabel key={type} label={type}>
-            <TextInput keyboardType={type} style={styles.default} />
+            <TextInput
+              accessibilityLabel="Text input field"
+              keyboardType={type}
+              style={styles.default}
+            />
           </WithLabel>
         );
       });
@@ -609,10 +636,12 @@ module.exports = ([
       return (
         <View>
           <TextInput
+            accessibilityLabel="Text input field"
             style={[styles.singleLine, {fontFamily: fontFamilyA}]}
             placeholder={`Custom fonts like ${fontFamilyA} are supported`}
           />
           <TextInput
+            accessibilityLabel="Text input field"
             style={[
               styles.singleLine,
               {fontFamily: fontFamilyA, fontWeight: 'bold'},
@@ -620,6 +649,7 @@ module.exports = ([
             placeholder={`${fontFamilyA} bold`}
           />
           <TextInput
+            accessibilityLabel="Text input field"
             style={[
               styles.singleLine,
               {fontFamily: fontFamilyA, fontWeight: '500'},
@@ -627,6 +657,7 @@ module.exports = ([
             placeholder={`${fontFamilyA} 500`}
           />
           <TextInput
+            accessibilityLabel="Text input field"
             style={[
               styles.singleLine,
               {fontFamily: fontFamilyA, fontStyle: 'italic'},
@@ -634,6 +665,7 @@ module.exports = ([
             placeholder={`${fontFamilyA} italic`}
           />
           <TextInput
+            accessibilityLabel="Text input field"
             style={[styles.singleLine, {fontFamily: fontFamilyB}]}
             placeholder={fontFamilyB}
           />

--- a/packages/rn-tester/js/examples/ToastAndroid/ToastAndroidExample.android.js
+++ b/packages/rn-tester/js/examples/ToastAndroid/ToastAndroidExample.android.js
@@ -17,6 +17,7 @@ const {StyleSheet, Text, ToastAndroid, Pressable} = require('react-native');
 const ToastWithShortDuration = () => {
   return (
     <Pressable
+      accessibilityRole="button"
       onPress={() =>
         ToastAndroid.show('Copied to clipboard!', ToastAndroid.SHORT)
       }>
@@ -28,6 +29,7 @@ const ToastWithShortDuration = () => {
 const ToastWithLongDuration = () => {
   return (
     <Pressable
+      accessibilityRole="button"
       onPress={() => ToastAndroid.show('Sending message..', ToastAndroid.LONG)}>
       <Text style={styles.text}>Tap to view toast</Text>
     </Pressable>
@@ -37,6 +39,7 @@ const ToastWithLongDuration = () => {
 const ToastWithTopGravity = () => {
   return (
     <Pressable
+      accessibilityRole="button"
       onPress={() =>
         ToastAndroid.showWithGravity(
           'Download Started..',
@@ -52,6 +55,7 @@ const ToastWithTopGravity = () => {
 const ToastWithCenterGravity = () => {
   return (
     <Pressable
+      accessibilityRole="button"
       onPress={() =>
         ToastAndroid.showWithGravity(
           'A problem has been occured while submitting your data.',
@@ -67,6 +71,7 @@ const ToastWithCenterGravity = () => {
 const ToastWithBottomGravity = () => {
   return (
     <Pressable
+      accessibilityRole="button"
       onPress={() =>
         ToastAndroid.showWithGravity(
           'Please read the contents carefully.',
@@ -82,6 +87,7 @@ const ToastWithBottomGravity = () => {
 const ToastWithXOffset = () => {
   return (
     <Pressable
+      accessibilityRole="button"
       onPress={() =>
         ToastAndroid.showWithGravityAndOffset(
           'Alex sent you a friend request',
@@ -99,6 +105,7 @@ const ToastWithXOffset = () => {
 const ToastWithYOffset = () => {
   return (
     <Pressable
+      accessibilityRole="button"
       onPress={() =>
         ToastAndroid.showWithGravityAndOffset(
           'There was a problem with your internet connection',

--- a/packages/rn-tester/js/examples/Touchable/TouchableExample.js
+++ b/packages/rn-tester/js/examples/Touchable/TouchableExample.js
@@ -51,12 +51,14 @@ class TouchableHighlightBox extends React.Component<{...}, $FlowFixMeState> {
       <View>
         <View style={styles.row}>
           <TouchableHighlight
+            accessibilityRole="button"
             style={styles.wrapper}
             testID="touchable_highlight_image_button"
             onPress={this.touchableOnPress}>
             <Image source={remoteImage} style={styles.image} />
           </TouchableHighlight>
           <TouchableHighlight
+            accessibilityRole="button"
             style={styles.wrapper}
             testID="touchable_highlight_text_button"
             activeOpacity={1}
@@ -100,6 +102,7 @@ class TouchableWithoutFeedbackBox extends React.Component<
     return (
       <View>
         <TouchableWithoutFeedback
+          accessibilityRole="button"
           onPress={this.textOnPress}
           testID="touchable_without_feedback_button">
           <View style={styles.wrapperCustom}>
@@ -199,6 +202,7 @@ class TouchableDelayEvents extends React.Component<{...}, $FlowFixMeState> {
       <View testID="touchable_delay_events">
         <View style={[styles.row, styles.centered]}>
           <TouchableOpacity
+            accessibilityRole="button"
             style={styles.wrapper}
             testID="touchable_delay_events_button"
             onPress={() => this._appendEvent('press')}
@@ -287,6 +291,7 @@ class TouchableHitSlop extends React.Component<{...}, $FlowFixMeState> {
       <View testID="touchable_hit_slop">
         <View style={[styles.row, styles.centered]}>
           <TouchableOpacity
+            accessibilityRole="button"
             onPress={this.onPress}
             style={styles.hitSlopWrapper}
             hitSlop={{top: 30, bottom: 30, left: 60, right: 60}}
@@ -348,15 +353,22 @@ class TouchableDisabled extends React.Component<{...}> {
   render() {
     return (
       <View>
-        <TouchableOpacity disabled={true} style={[styles.row, styles.block]}>
+        <TouchableOpacity
+          accessibilityRole="button"
+          disabled={true}
+          style={[styles.row, styles.block]}>
           <Text style={styles.disabledButton}>Disabled TouchableOpacity</Text>
         </TouchableOpacity>
 
-        <TouchableOpacity disabled={false} style={[styles.row, styles.block]}>
+        <TouchableOpacity
+          accessibilityRole="button"
+          disabled={false}
+          style={[styles.row, styles.block]}>
           <Text style={styles.button}>Enabled TouchableOpacity</Text>
         </TouchableOpacity>
 
         <TouchableHighlight
+          accessibilityRole="button"
           activeOpacity={1}
           disabled={true}
           underlayColor="rgb(210, 230, 255)"
@@ -366,6 +378,7 @@ class TouchableDisabled extends React.Component<{...}> {
         </TouchableHighlight>
 
         <TouchableHighlight
+          accessibilityRole="button"
           activeOpacity={1}
           underlayColor="rgb(210, 230, 255)"
           style={[styles.row, styles.block]}
@@ -374,6 +387,7 @@ class TouchableDisabled extends React.Component<{...}> {
         </TouchableHighlight>
 
         <TouchableWithoutFeedback
+          accessibilityRole="button"
           onPress={() => console.log('TWOF has been clicked')}
           disabled={true}>
           <View style={styles.wrapperCustom}>
@@ -389,6 +403,7 @@ class TouchableDisabled extends React.Component<{...}> {
         </TouchableWithoutFeedback>
 
         <TouchableWithoutFeedback
+          accessibilityRole="button"
           onPress={() => console.log('TWOF has been clicked')}
           disabled={false}>
           <View style={styles.wrapperCustom}>
@@ -401,6 +416,7 @@ class TouchableDisabled extends React.Component<{...}> {
         {Platform.OS === 'android' && (
           <>
             <TouchableNativeFeedback
+              accessibilityRole="button"
               onPress={() => console.log('custom TNF has been clicked')}
               background={TouchableNativeFeedback.SelectableBackground()}>
               <View style={[styles.row, styles.block]}>
@@ -411,6 +427,7 @@ class TouchableDisabled extends React.Component<{...}> {
             </TouchableNativeFeedback>
 
             <TouchableNativeFeedback
+              accessibilityRole="button"
               disabled={true}
               onPress={() => console.log('custom TNF has been clicked')}
               background={TouchableNativeFeedback.SelectableBackground()}>
@@ -439,6 +456,7 @@ function CustomRippleRadius() {
         {justifyContent: 'space-around', alignItems: 'center'},
       ]}>
       <TouchableNativeFeedback
+        accessibilityRole="button"
         onPress={() => console.log('custom TNF has been clicked')}
         background={TouchableNativeFeedback.Ripple('orange', true, 30)}>
         <View>
@@ -449,6 +467,7 @@ function CustomRippleRadius() {
       </TouchableNativeFeedback>
 
       <TouchableNativeFeedback
+        accessibilityRole="button"
         onPress={() => console.log('custom TNF has been clicked')}
         background={TouchableNativeFeedback.SelectableBackgroundBorderless(
           150,
@@ -461,6 +480,7 @@ function CustomRippleRadius() {
       </TouchableNativeFeedback>
 
       <TouchableNativeFeedback
+        accessibilityRole="button"
         onPress={() => console.log('custom TNF has been clicked')}
         background={TouchableNativeFeedback.SelectableBackground(70)}>
         <View style={styles.block}>
@@ -491,6 +511,7 @@ const TouchableHighlightUnderlayMethods = () => {
   };
   return (
     <TouchableHighlight
+      accessibilityRole="button"
       style={styles.logBox}
       underlayColor={'#eee'}
       onShowUnderlay={shownUnderlay}
@@ -513,6 +534,7 @@ const TouchableTouchSoundDisabled = () => {
       {Platform.OS === 'android' ? (
         <>
           <TouchableWithoutFeedback
+            accessibilityRole="button"
             touchSoundDisabled={soundEnabled}
             onPress={() => console.log('touchSoundDisabled pressed!')}>
             <Text
@@ -523,6 +545,7 @@ const TouchableTouchSoundDisabled = () => {
             </Text>
           </TouchableWithoutFeedback>
           <TouchableOpacity
+            accessibilityRole="button"
             style={{
               padding: 10,
             }}
@@ -564,6 +587,7 @@ function TouchableOnFocus<T: React.AbstractComponent<any, any>>() {
 
   return (
     <TouchableHighlight
+      accessibilityRole="button"
       ref={ref}
       onFocus={toggleFocus}
       onPress={focusTouchable}>
@@ -692,7 +716,7 @@ exports.examples = [
       return (
         <View>
           <View style={styles.row}>
-            <TouchableNativeFeedback>
+            <TouchableNativeFeedback accessibilityRole="button">
               <Animated.View style={style} />
             </TouchableNativeFeedback>
           </View>

--- a/packages/rn-tester/js/examples/TransparentHitTest/TransparentHitTestExample.js
+++ b/packages/rn-tester/js/examples/TransparentHitTest/TransparentHitTestExample.js
@@ -17,7 +17,9 @@ class TransparentHitTestExample extends React.Component<{...}> {
   render() {
     return (
       <View style={{flex: 1}}>
-        <TouchableOpacity onPress={() => Alert.alert('Alert', 'Hi!')}>
+        <TouchableOpacity
+          accessibilityRole="button"
+          onPress={() => Alert.alert('Alert', 'Hi!')}>
           <Text>HELLO!</Text>
         </TouchableOpacity>
 

--- a/packages/rn-tester/js/examples/TurboModule/SampleTurboModuleExample.js
+++ b/packages/rn-tester/js/examples/TurboModule/SampleTurboModuleExample.js
@@ -117,6 +117,7 @@ class SampleTurboModuleExample extends React.Component<{||}, State> {
       <View style={styles.container}>
         <View style={styles.item}>
           <TouchableOpacity
+            accessibilityRole="button"
             style={[styles.column, styles.button]}
             onPress={() =>
               Object.keys(this._tests).forEach(item =>
@@ -126,6 +127,7 @@ class SampleTurboModuleExample extends React.Component<{||}, State> {
             <Text style={styles.buttonTextLarge}>Run all tests</Text>
           </TouchableOpacity>
           <TouchableOpacity
+            accessibilityRole="button"
             onPress={() => this.setState({testResults: {}})}
             style={[styles.column, styles.button]}>
             <Text style={styles.buttonTextLarge}>Clear results</Text>
@@ -137,6 +139,7 @@ class SampleTurboModuleExample extends React.Component<{||}, State> {
           renderItem={({item}) => (
             <View style={styles.item}>
               <TouchableOpacity
+                accessibilityRole="button"
                 style={[styles.column, styles.button]}
                 onPress={e => this._setResult(item, this._tests[item]())}>
                 <Text style={styles.buttonText}>{item}</Text>

--- a/packages/rn-tester/js/examples/Vibration/VibrationExample.js
+++ b/packages/rn-tester/js/examples/Vibration/VibrationExample.js
@@ -64,6 +64,7 @@ exports.examples = [
     render(): React.Node {
       return (
         <TouchableHighlight
+          accessibilityRole="button"
           style={styles.wrapper}
           onPress={() => Vibration.vibrate()}>
           <View style={styles.button}>
@@ -78,6 +79,7 @@ exports.examples = [
     render(): React.Node {
       return (
         <TouchableHighlight
+          accessibilityRole="button"
           style={styles.wrapper}
           onPress={() => Vibration.vibrate(pattern)}>
           <View style={styles.button}>
@@ -92,6 +94,7 @@ exports.examples = [
     render(): React.Node {
       return (
         <TouchableHighlight
+          accessibilityRole="button"
           style={styles.wrapper}
           onPress={() => Vibration.vibrate(pattern, true)}>
           <View style={styles.button}>
@@ -106,6 +109,7 @@ exports.examples = [
     render(): React.Node {
       return (
         <TouchableHighlight
+          accessibilityRole="button"
           style={styles.wrapper}
           onPress={() => Vibration.cancel()}>
           <View style={styles.button}>

--- a/packages/rn-tester/js/examples/View/ViewExample.js
+++ b/packages/rn-tester/js/examples/View/ViewExample.js
@@ -105,7 +105,9 @@ exports.examples = [
 
         render() {
           return (
-            <TouchableWithoutFeedback onPress={this._handlePress}>
+            <TouchableWithoutFeedback
+              accessibilityRole="button"
+              onPress={this._handlePress}>
               <View>
                 <View
                   style={[
@@ -294,7 +296,9 @@ exports.examples = [
 
         render() {
           return (
-            <TouchableWithoutFeedback onPress={this._handlePress}>
+            <TouchableWithoutFeedback
+              accessibilityRole="button"
+              onPress={this._handlePress}>
               <View>
                 <Text style={{paddingBottom: 10}}>Blobs</Text>
                 <View
@@ -383,7 +387,9 @@ exports.examples = [
         render() {
           const indices = this.state.flipped ? [-1, 0, 1, 2] : [2, 1, 0, -1];
           return (
-            <TouchableWithoutFeedback onPress={this._handlePress}>
+            <TouchableWithoutFeedback
+              accessibilityRole="button"
+              onPress={this._handlePress}>
               <View>
                 <Text style={{paddingBottom: 10}}>
                   Tap to flip sorting order
@@ -459,7 +465,9 @@ exports.examples = [
 
         render() {
           return (
-            <TouchableWithoutFeedback onPress={this._handlePress}>
+            <TouchableWithoutFeedback
+              accessibilityRole="button"
+              onPress={this._handlePress}>
               <View>
                 <Text style={{paddingBottom: 10}}>
                   Press to toggle `display: none`

--- a/packages/rn-tester/js/examples/WebSocket/WebSocketExample.js
+++ b/packages/rn-tester/js/examples/WebSocket/WebSocketExample.js
@@ -42,7 +42,10 @@ class Button extends React.Component {
       );
     }
     return (
-      <TouchableOpacity onPress={this.props.onPress} style={styles.button}>
+      <TouchableOpacity
+        accessibilityRole="button"
+        onPress={this.props.onPress}
+        style={styles.button}>
         {label}
       </TouchableOpacity>
     );
@@ -227,6 +230,7 @@ class WebSocketExample extends React.Component<any, any, State> {
           {canSend ? <WebSocketImage url={this.state.url} /> : null}
         </Row>
         <TextInput
+          accessibilityLabel="Text input field"
           style={styles.textInput}
           autoCorrect={false}
           placeholder="Server URL..."
@@ -246,6 +250,7 @@ class WebSocketExample extends React.Component<any, any, State> {
           />
         </View>
         <TextInput
+          accessibilityLabel="Text input field"
           style={styles.textInput}
           autoCorrect={false}
           placeholder="Type message here..."
@@ -271,6 +276,7 @@ class WebSocketExample extends React.Component<any, any, State> {
           </Text>
         </View>
         <TextInput
+          accessibilityLabel="Text input field"
           style={styles.textInput}
           autoCorrect={false}
           placeholder="HTTP URL..."

--- a/packages/rn-tester/js/examples/XHR/XHRExampleBinaryUpload.js
+++ b/packages/rn-tester/js/examples/XHR/XHRExampleBinaryUpload.js
@@ -125,7 +125,7 @@ class XHRExampleBinaryUpload extends React.Component<{...}, $FlowFixMeState> {
           </View>
         </View>
         <View style={styles.uploadButton}>
-          <TouchableHighlight onPress={this._upload}>
+          <TouchableHighlight accessibilityRole="button" onPress={this._upload}>
             <View style={styles.uploadButtonBox}>
               <Text style={styles.uploadButtonLabel}>Upload</Text>
             </View>

--- a/packages/rn-tester/js/examples/XHR/XHRExampleDownload.js
+++ b/packages/rn-tester/js/examples/XHR/XHRExampleDownload.js
@@ -132,7 +132,10 @@ class XHRExampleDownload extends React.Component<{...}, Object> {
         </View>
       </View>
     ) : (
-      <TouchableHighlight style={styles.wrapper} onPress={this._download}>
+      <TouchableHighlight
+        accessibilityRole="button"
+        style={styles.wrapper}
+        onPress={this._download}>
         <View style={styles.button}>
           <Text>Download 7MB Text File</Text>
         </View>

--- a/packages/rn-tester/js/examples/XHR/XHRExampleFetch.js
+++ b/packages/rn-tester/js/examples/XHR/XHRExampleFetch.js
@@ -77,6 +77,7 @@ class XHRExampleFetch extends React.Component<any, any> {
       <View style={{marginTop: 10}}>
         <Text style={styles.label}>Server response:</Text>
         <TextInput
+          accessibilityLabel="Text input field"
           editable={false}
           multiline={true}
           defaultValue={this.state.responseText}
@@ -89,6 +90,7 @@ class XHRExampleFetch extends React.Component<any, any> {
       <View>
         <Text style={styles.label}>Edit URL to submit:</Text>
         <TextInput
+          accessibilityLabel="Text input field"
           returnKeyType="go"
           defaultValue="http://www.posttestserver.com/post.php"
           onSubmitEditing={event => {

--- a/packages/rn-tester/js/examples/XHR/XHRExampleHeaders.js
+++ b/packages/rn-tester/js/examples/XHR/XHRExampleHeaders.js
@@ -83,6 +83,7 @@ class XHRExampleHeaders extends React.Component {
         </View>
       ) : (
         <TouchableHighlight
+          accessibilityRole="button"
           style={styles.wrapper}
           onPress={this.download.bind(this)}>
           <View style={styles.button}>

--- a/packages/rn-tester/js/examples/XHR/XHRExampleOnTimeOut.js
+++ b/packages/rn-tester/js/examples/XHR/XHRExampleOnTimeOut.js
@@ -68,6 +68,7 @@ class XHRExampleOnTimeOut extends React.Component<any, any> {
       </View>
     ) : (
       <TouchableHighlight
+        accessibilityRole="button"
         style={styles.wrapper}
         // $FlowFixMe[method-unbinding] added when improving typing for this parameters
         onPress={this.loadTimeOutRequest.bind(this)}>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

- this adds [`eslint-plugin-react-native-a11y`](https://github.com/formidablelabs/eslint-plugin-react-native-a11y) to the `eslint-config-react-native-community` package
- as a result, any project using the community config (including the default template) would then additionally get linted for a11y issues
- `eslint-plugin-react-native-a11y` includes several recommended configs. This PR uses the `basic` config which only contains common a11y linting rules that apply across both iOS + Android.
- Additional rules (e.g. checking for `accessibilityIgnoresInvertColors` which is iOS-only) may be optionally enabled by users as with any other ESLint plugin.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Added] - `eslint-plugin-react-native-a11y` in default ESLint config

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

- verified that this works correctly in a new project by including it alongside `eslint-config-react-native-community` (see [installation instructions](https://github.com/FormidableLabs/eslint-plugin-react-native-a11y#configuration))

### Examples
<img width="1684" alt="Screen Shot 2021-12-21 at 12 09 03 PM" src="https://user-images.githubusercontent.com/2393035/146992656-82304caa-fcde-42fb-8285-5097c037a639.png">
<img width="1264" alt="Screen Shot 2021-12-21 at 12 12 36 PM" src="https://user-images.githubusercontent.com/2393035/146992665-4f24743a-9580-4aa6-8265-f7ccd20269af.png">

> n.b. second example used
> ```
>module.exports = {
>  root: true,
>  extends: ['@react-native-community', 'plugin:react-native-a11y/basic'],
>  rules: {
>    'react-native-a11y/has-valid-accessibility-ignores-invert-colors': 2,
>  },
>};
>```
>this is an additional rule that would not be included with only the `basic` config