### PR TITLE
Added missing constructor to WritableNativeArray

### DIFF
--- a/ReactAndroid/src/main/jni/react/jni/WritableNativeArray.cpp
+++ b/ReactAndroid/src/main/jni/react/jni/WritableNativeArray.cpp
@@ -17,6 +17,13 @@ namespace react {
 WritableNativeArray::WritableNativeArray()
     : HybridBase(folly::dynamic::array()) {}
 
+WritableNativeArray::WritableNativeArray(folly::dynamic &&val)
+    : HybridBase(std::move(val)) {
+  if (!array_.isArray()) {
+    throw std::runtime_error("WritableNativeArray value must be an array.");
+  }
+}
+
 local_ref<WritableNativeArray::jhybriddata> WritableNativeArray::initHybrid(
     alias_ref<jclass>) {
   return makeCxxInstance();

--- a/ReactAndroid/src/main/jni/react/jni/WritableNativeArray.h
+++ b/ReactAndroid/src/main/jni/react/jni/WritableNativeArray.h
@@ -29,6 +29,8 @@ struct WritableNativeArray
       "Lcom/facebook/react/bridge/WritableNativeArray;";
 
   WritableNativeArray();
+  WritableNativeArray(folly::dynamic &&val);
+
   static jni::local_ref<jhybriddata> initHybrid(jni::alias_ref<jclass>);
 
   void pushNull();


### PR DESCRIPTION
## Summary

`WritableNativeMap` has two constructors:
```c++
WritableNativeMap();
WritableNativeMap(folly::dynamic &&val);
```
but `WritableNativeArray` has only one constructor:
```c++
WritableNativeArray();
```
Without a second constructor, I am not able to create `WritableNativeArray` from the existing array. I added this second constructor because I need it for `react-native-reanimated`.

## Changelog

[Android] [Added] - Added missing constructor to WritableNativeArray

## Test Plan

```c++
std::shared_ptr<jsi::Runtime> rt = facebook::hermes::makeHermesRuntime();
jsi::Value value;
WritableNativeArray::newObjectCxxArgs(jsi::dynamicFromValue(*rt.get(), value));
```
