### PR TITLE
Enabling ProMotion on iPhone 13 Pro & iPad Pro

### DIFF
--- a/template/ios/HelloWorld/AppDelegate.mm
+++ b/template/ios/HelloWorld/AppDelegate.mm
@@ -54,6 +54,12 @@
   rootViewController.view = rootView;
   self.window.rootViewController = rootViewController;
   [self.window makeKeyAndVisible];
+
+  CADisplayLink *displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(displayLinkTriggered)];
+  if (@available(iOS 15.0, *)) {
+    displayLink.preferredFrameRateRange = CAFrameRateRangeMake(60, 120, 60);
+  }
+
   return YES;
 }
 

--- a/template/ios/HelloWorld/Info.plist
+++ b/template/ios/HelloWorld/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+  <key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>

--- a/template/ios/HelloWorld/Info.plist
+++ b/template/ios/HelloWorld/Info.plist
@@ -2,7 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <key>CADisableMinimumFrameDurationOnPhone</key>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Enabling ProMotion on iPhone 13 Pro & iPad Pro by default
Refer to https://developer.apple.com/documentation/quartzcore/optimizing_promotion_refresh_rates_for_iphone_13_pro_and_ipad_pro?language=objc

https://github.com/facebook/react-native/issues/32703
https://github.com/facebook/react-native/issues/29333

## Changelog

[iOS] [Added] - Add `<key>CADisableMinimumFrameDurationOnPhone</key><true/>` to `Info.plist`
[iOS] [Added] - Set refresh rate range in `AppDelegate.mm`

## Test Plan

N/A
