### PR TITLE
fix(iOS): remove alert's window when call to `hide`.

### DIFF
--- a/React/CoreModules/RCTAlertController.m
+++ b/React/CoreModules/RCTAlertController.m
@@ -35,6 +35,12 @@
 
 - (void)hide
 {
+  [_alertWindow setHidden: YES];
+
+  if (@available(iOS 13, *)) {
+    _alertWindow.windowScene = nil;
+  }
+
   _alertWindow = nil;
 }
 


### PR DESCRIPTION
## Summary

Resolves this issue: #32304.
**NOTE:** This PR is based on a prior PR for this fix: https://github.com/facebook/react-native/pull/32305, I've co-authorized its creator for this change (@paddlefish).

Without this change, calling to hide an alert, leaves a `UIWindow` that blocks user interactions with the screen.

The correct way to remove a `UIWindow` in iOS is to set its hidden property to `YES`. Also, it is required to remove all references to the window (the associated `windowScene` for example) and ARC will automatically free this `UIWindow`.

The line after this change, set the `_alertWindow` reference to `nil`, but the window is already associated with a scene (see the screenshots from [this PR](https://github.com/facebook/react-native/pull/32305#discussion_r720521707)). So we also need to remove the `windowScene` from that window, as recommended by Apple: https://developer.apple.com/documentation/uikit/uiwindowscene/3198091-windows.
>To remove the window from the current scene, or move it to a different scene, change the value of the window's windowScene property.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [Fixed] - remove alert's window when call to `hide`.

## Test Plan

See https://github.com/facebook/react-native/pull/32305
