### PR TITLE
Updating Yarn Cache path to fix broken CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ commands:
       - save_cache:
           paths:
             - /tmp/yarn
-          key: v5-yarn-cache-{{ arch }}-{{ checksum "yarn.lock" }}
+          key: v6-yarn-cache-{{ arch }}-{{ checksum "yarn.lock" }}
 
   install_buck_tooling:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,10 +78,10 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - v5-yarn-cache-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "yarn.lock" }}
-            - v5-yarn-cache-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-
-            - v5-yarn-cache-{{ arch }}-
-            - v5-yarn-cache-
+            - v6-yarn-cache-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "yarn.lock" }}
+            - v6-yarn-cache-{{ .Environment.CIRCLE_JOB }}-{{ arch }}
+            - v6-yarn-cache-{{ .Environment.CIRCLE_JOB }}
+            - v6-yarn-cache-
       - run:
           name: "Yarn: Install Dependencies"
           command: |
@@ -93,7 +93,7 @@ commands:
       - save_cache:
           paths:
             - /tmp/yarn
-          key: v5-yarn-cache-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "yarn.lock" }}
+          key: v6-yarn-cache-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "yarn.lock" }}
 
   install_buck_tooling:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,10 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - v6-yarn-cache-{{ arch }}-{{ checksum "yarn.lock" }}
+            - v5-yarn-cache-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "yarn.lock" }}
+            - v5-yarn-cache-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-
+            - v5-yarn-cache-{{ arch }}-
+            - v5-yarn-cache-
       - run:
           name: "Yarn: Install Dependencies"
           command: |
@@ -90,7 +93,7 @@ commands:
       - save_cache:
           paths:
             - /tmp/yarn
-          key: v6-yarn-cache-{{ arch }}-{{ checksum "yarn.lock" }}
+          key: v5-yarn-cache-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "yarn.lock" }}
 
   install_buck_tooling:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,11 +85,11 @@ commands:
             # Skip yarn install on metro bump commits as the package is not yet
             # available on npm
             if [[ $(echo "$GIT_COMMIT_DESC" | grep -c "Bump metro@") -eq 0 ]]; then
-              yarn install --non-interactive --cache-folder ~/.cache/yarn
+              yarn install --non-interactive --cache-folder /tmp/yarn
             fi
       - save_cache:
           paths:
-            - ~/.cache/yarn
+            - /tmp/yarn
           key: v5-yarn-cache-{{ arch }}-{{ checksum "yarn.lock" }}
 
   install_buck_tooling:
@@ -115,7 +115,7 @@ commands:
     steps:
       - run:
           name: "Yarn: Install dependencies (GitHub bots)"
-          command: cd bots && yarn install --non-interactive --cache-folder ~/.cache/yarn
+          command: cd bots && yarn install --non-interactive --cache-folder /tmp/yarn
 
   brew_install:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,11 +87,11 @@ commands:
             # Skip yarn install on metro bump commits as the package is not yet
             # available on npm
             if [[ $(echo "$GIT_COMMIT_DESC" | grep -c "Bump metro@") -eq 0 ]]; then
-              yarn install --non-interactive --cache-folder /tmp/yarn
+              yarn install --non-interactive --cache-folder ~/.cache/yarn
             fi
       - save_cache:
           paths:
-            - /tmp/yarn
+            - ~/.cache/yarn
           key: v6-yarn-cache-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "yarn.lock" }}
 
   install_buck_tooling:
@@ -117,7 +117,7 @@ commands:
     steps:
       - run:
           name: "Yarn: Install dependencies (GitHub bots)"
-          command: cd bots && yarn install --non-interactive --cache-folder /tmp/yarn
+          command: cd bots && yarn install --non-interactive --cache-folder ~/.cache/yarn
 
   brew_install:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,9 +78,9 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - v6-yarn-cache-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "yarn.lock" }}
-            - v6-yarn-cache-{{ .Environment.CIRCLE_JOB }}-{{ arch }}
-            - v6-yarn-cache-{{ .Environment.CIRCLE_JOB }}
+            - v5-yarn-cache-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "yarn.lock" }}
+            - v5-yarn-cache-{{ .Environment.CIRCLE_JOB }}-{{ arch }}
+            - v5-yarn-cache-{{ .Environment.CIRCLE_JOB }}
       - run:
           name: "Yarn: Install Dependencies"
           command: |
@@ -92,7 +92,7 @@ commands:
       - save_cache:
           paths:
             - ~/.cache/yarn
-          key: v6-yarn-cache-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "yarn.lock" }}
+          key: v5-yarn-cache-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "yarn.lock" }}
 
   install_buck_tooling:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,6 @@ commands:
             - v6-yarn-cache-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "yarn.lock" }}
             - v6-yarn-cache-{{ .Environment.CIRCLE_JOB }}-{{ arch }}
             - v6-yarn-cache-{{ .Environment.CIRCLE_JOB }}
-            - v6-yarn-cache-
       - run:
           name: "Yarn: Install Dependencies"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - v5-yarn-cache-{{ arch }}-{{ checksum "yarn.lock" }}
+            - v6-yarn-cache-{{ arch }}-{{ checksum "yarn.lock" }}
       - run:
           name: "Yarn: Install Dependencies"
           command: |

--- a/scripts/run-ci-e2e-tests.js
+++ b/scripts/run-ci-e2e-tests.js
@@ -264,11 +264,13 @@ try {
       exitCode = 1;
       throw Error(exitCode);
     }
-    
     describe('Test: Flow check');
     // The resolve package included a test for a malformed package.json (see https://github.com/browserify/resolve/issues/89)
     // that is failing the flow check. We're removing it.
-    rm('-rf', `${ROOT}/node_modules/resolve/test/resolver/malformed_package_json`);
+    rm(
+      '-rf',
+      `${ROOT}/node_modules/resolve/test/resolver/malformed_package_json`,
+    );
     if (exec(`${ROOT}/node_modules/.bin/flow check`).code) {
       echo('Flow check failed.');
       exitCode = 1;

--- a/scripts/run-ci-e2e-tests.js
+++ b/scripts/run-ci-e2e-tests.js
@@ -269,7 +269,7 @@ try {
     // that is failing the flow check. We're removing it.
     rm(
       '-rf',
-      `${ROOT}/node_modules/resolve/test/resolver/malformed_package_json`,
+      './node_modules/resolve/test/resolver/malformed_package_json',
     );
     if (exec(`${ROOT}/node_modules/.bin/flow check`).code) {
       echo('Flow check failed.');

--- a/scripts/run-ci-e2e-tests.js
+++ b/scripts/run-ci-e2e-tests.js
@@ -19,7 +19,7 @@
  * --retries [num] - how many times to retry possible flaky commands: yarn add and running tests, default 1
  */
 
-const {cd, cp, echo, exec, exit, mv} = require('shelljs');
+const {cd, cp, echo, exec, exit, mv, rm} = require('shelljs');
 const spawn = require('child_process').spawn;
 const argv = require('yargs').argv;
 const path = require('path');
@@ -264,7 +264,11 @@ try {
       exitCode = 1;
       throw Error(exitCode);
     }
+    
     describe('Test: Flow check');
+    // The resolve package included a test for a malformed package.json (see https://github.com/browserify/resolve/issues/89)
+    // that is failing the flow check. We're removing it.
+    rm('-rf', `${ROOT}/node_modules/resolve/test/resolver/malformed_package_json`);
     if (exec(`${ROOT}/node_modules/.bin/flow check`).code) {
       echo('Flow check failed.');
       exitCode = 1;

--- a/scripts/run-ci-e2e-tests.js
+++ b/scripts/run-ci-e2e-tests.js
@@ -267,10 +267,7 @@ try {
     describe('Test: Flow check');
     // The resolve package included a test for a malformed package.json (see https://github.com/browserify/resolve/issues/89)
     // that is failing the flow check. We're removing it.
-    rm(
-      '-rf',
-      './node_modules/resolve/test/resolver/malformed_package_json',
-    );
+    rm('-rf', './node_modules/resolve/test/resolver/malformed_package_json');
     if (exec(`${ROOT}/node_modules/.bin/flow check`).code) {
       echo('Flow check failed.');
       exitCode = 1;


### PR DESCRIPTION
## Summary

The CI is currently failing with:
```
Error extracting tarball /tmp/cache1419328940 : tar: root/.cache/yarn: Cannot mkdir: Permission denied tar: root/.cache/yarn/v6
```
This PR attempts to fix it by changing the path of the Yarn cache to a folder that is always writable.
See https://github.com/react-native-community/react-native-circleci-orb/pull/59 for reference.

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Changelog

[Internal] - Updating Yarn Cache path to fix broken CI

## Test Plan
 
Will wait for CI output.