### PR TITLE
Make `test_android_template` work regardless of the version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -585,7 +585,8 @@ jobs:
           name: Setup the Android Template
           command: |
             cd template
-            sed -i 's/1000\.0\.0/file\:\.\./g' package.json
+            # We replace the "react-native" dependency version with file:.. so we use it from source.
+            sed -i 's/\"react-native\"\:.*/\"react-native\"\: \"file\:\.\.\"/g' package.json
             npm install
             # react-native-community/cli is needed as the Android template is referencing a .gradle file inside it.
             npm i @react-native-community/cli


### PR DESCRIPTION
## Summary

Fixes #32835

## Changelog

[Internal] - Make `test_android_template` work regardless of the version

## Test Plan

Tested locally. Will wait for `test_android_template` to be green.