### PR TITLE
fix race condition in iOS websocket implementation

### DIFF
--- a/Libraries/WebSocket/RCTSRWebSocket.m
+++ b/Libraries/WebSocket/RCTSRWebSocket.m
@@ -782,6 +782,10 @@ static inline BOOL closeCodeIsValid(int closeCode)
 
 - (void)_handleFrameWithData:(NSData *)frameData opCode:(NSInteger)opcode
 {
+  // copy frameData before handling,
+  // to avoid concurrent updates to the value at the pointer
+  frameData = [frameData copy];
+
   // Check that the current data is valid UTF8
 
   BOOL isControlFrame = (opcode == RCTSROpCodePing || opcode == RCTSROpCodePong || opcode == RCTSROpCodeConnectionClose);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

The iOS WebSocket implementation has a race condition that causes WebSocket frame payloads to be processed incorrectly.
This can cause errors on RFC6455 compliant WebSocket servers:
- the server sends a ping frame with no payload
- the server sends a text frame with a payload longer than 125 bytes
- the client answers the ping with a pong frame echoing back the contents of the text frame

This is caused by concurrent modification of the current frame contents, that is passed by reference to the handlers. The concurrent modification happens [here](https://github.com/facebook/react-native/blob/main/Libraries/WebSocket/RCTSRWebSocket.m#L1162).

The bug was detected and fixed in the original SocketRocket repository in [this PR](https://github.com/facebookincubator/SocketRocket/pull/371). The relevant part of the fix is applied in this PR.

Resolves #30020.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [Fixed] - Fix WebSocket control frames having payloads longer than 125 bytes

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

The bug is not easily and consistently reproduced, being a race condition.
We were able to reproduce it by connecting a react native app to a websocket server that sent ~100 pings per second and ~100 text frames per second. After a couple of seconds, the server receives an invalid pong message, with a payload equal to the payload of the text frame. The following is a node server that can replicate the problem on a react-native app running on iOS.

<details>

```
const { WebSocketServer } = require('ws');

const wss = new WebSocketServer({ port: 8080 });

wss.on('connection', function connection(ws) {
  const pingInterval = setInterval(() => {
    ws.ping();
  }, 10);

  const sendInterval = setInterval(() => {
    const arr = new Array(100);
    for (let i = 0; i < arr.length; i++) {
      arr[i] = Math.random();
    }
    ws.send('message with payload longer than 125 bytes: ' + arr.join(','));
  }, 10);

  ws.on('close', () => {
    clearInterval(pingInterval);
    clearInterval(sendInterval);
  });

  ws.on('error', (err) => {
    console.error(err);
    process.exit(1);
  });
});
```

</details>