### PR TITLE
Use side-by-side NDK for Android

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -647,7 +647,6 @@ jobs:
       - ANDROID_BUILD_VERSION: 31
       - ANDROID_TOOLS_VERSION: 31.0.0
       - GRADLE_OPTS: -Dorg.gradle.daemon=false
-      - NDK_VERSION: 21.4.7075529
     steps:
       - checkout
 
@@ -693,7 +692,6 @@ jobs:
             sdkmanager "build-tools;%ANDROID_TOOLS_VERSION%"
             sdkmanager "add-ons;addon-google_apis-google-23"
             sdkmanager "extras;android;m2repository"
-            sdkmanager "ndk;%NDK_VERSION%"
 
       # -------------------------
       # Run Tests

--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -274,11 +274,11 @@ task installArchives {
 
 android {
     compileSdkVersion 31
-    if (project.hasProperty("ANDROID_NDK_VERSION")) {
-        ndkVersion project.property("ANDROID_NDK_VERSION")
-    }
-    if (project.hasProperty("ANDROID_NDK_PATH")) {
-        ndkPath project.property("ANDROID_NDK_PATH")
+
+    // Used to override the NDK path & version on internal CI
+    if (System.getenv("ANDROID_NDK") != null && System.getenv("LOCAL_ANDROID_NDK_VERSION") != null) {
+        ndkPath System.getenv("ANDROID_NDK")
+        ndkVersion System.getenv("LOCAL_ANDROID_NDK_VERSION")
     }
 
     defaultConfig {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,13 +39,6 @@ allprojects {
             }
         }
     }
-
-    // used to override ndk path/version from env variables on CI
-    ext["ANDROID_NDK_PATH"] = null
-    if (System.getenv("LOCAL_ANDROID_NDK_VERSION") != null) {
-        setProperty("ANDROID_NDK_VERSION", System.getenv("LOCAL_ANDROID_NDK_VERSION"))
-        ext["ANDROID_NDK_PATH"] =  System.getenv("ANDROID_NDK")
-    }
 }
 
 tasks.register("cleanAll", Delete::class.java) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,6 @@ org.gradle.daemon=true
 org.gradle.jvmargs=-Xmx4g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 org.gradle.parallel=true
 
-ANDROID_NDK_VERSION=21.4.7075529
 android.useAndroidX=true
 kotlin_version=1.5.31
 

--- a/packages/rn-tester/android/app/build.gradle
+++ b/packages/rn-tester/android/app/build.gradle
@@ -143,11 +143,11 @@ def reactNativeArchitectures() {
 
 android {
     compileSdkVersion 31
-    if (project.hasProperty("ANDROID_NDK_VERSION")) {
-        ndkVersion project.property("ANDROID_NDK_VERSION")
-    }
-    if (project.hasProperty("ANDROID_NDK_PATH")) {
-        ndkPath project.property("ANDROID_NDK_PATH")
+
+    // Used to override the NDK path & version on internal CI
+    if (System.getenv("ANDROID_NDK") != null && System.getenv("LOCAL_ANDROID_NDK_VERSION") != null) {
+        ndkPath System.getenv("ANDROID_NDK")
+        ndkVersion System.getenv("LOCAL_ANDROID_NDK_VERSION")
     }
 
     flavorDimensions "vm"


### PR DESCRIPTION
Summary:
If we leverage the side-by-side configuration of the NDK
(see https://developer.android.com/studio/projects/configure-agp-ndk#agp_version_41)
we will not have to specify the NDK Path or Version at all.

We will automatically pick the best NDK version selected by AGP.

Changelog:
[Android] [Changed] - Use side-by-side NDK for Android

Differential Revision: D33475818

