### PR TITLE
Add AlertKeyboardType type definition to Alert.prompt

### DIFF
--- a/Libraries/Alert/Alert.js
+++ b/Libraries/Alert/Alert.js
@@ -24,6 +24,23 @@ export type Buttons = Array<{
   style?: AlertButtonStyle,
   ...
 }>;
+export type AlertKeyboardType =
+  // Cross Platform
+  | 'default'
+  | 'email-address'
+  | 'numeric'
+  | 'phone-pad'
+  | 'number-pad'
+  | 'decimal-pad'
+  | 'url'
+  // iOS-only
+  | 'ascii-capable'
+  | 'numbers-and-punctuation'
+  | 'name-phone-pad'
+  | 'twitter'
+  | 'web-search'
+  // Android-only
+  | 'visible-password';
 
 type Options = {
   cancelable?: ?boolean,
@@ -106,7 +123,7 @@ class Alert {
     callbackOrButtons?: ?(((text: string) => void) | Buttons),
     type?: ?AlertType = 'plain-text',
     defaultValue?: string,
-    keyboardType?: string,
+    keyboardType?: AlertKeyboardType,
   ): void {
     if (Platform.OS === 'ios') {
       let callbacks = [];


### PR DESCRIPTION
## Summary

Hi. When using `Alert.prompt` there's no type definition for the keyboard type parameter. Currently only accepts a string. This pull request adds in `AlertKeyboardType` that would help anyone using the function to discover the various options available for the  keyboard type.

## Changelog

[General] [Added] - Add AlertKeyboardType type definition to Alert.prompt

## Test Plan

`npm test` - all tests pass.
