### PR TITLE
[Android] Add headers support when passing source array

### DIFF
--- a/Libraries/Image/Image.android.js
+++ b/Libraries/Image/Image.android.js
@@ -159,26 +159,24 @@ let Image = (props: ImagePropsType, forwardedRef) => {
     source = null;
   }
 
-  let style;
-  let sources;
-  if (source?.uri != null) {
-    const {width, height} = source;
-    style = flattenStyle([{width, height}, styles.base, props.style]);
-    sources = [{uri: source.uri}];
-  } else {
-    style = flattenStyle([styles.base, props.style]);
-    sources = source;
-  }
+  const sourceIsSingleImage = !Array.isArray(source) && source != null;
+  const style = flattenStyle(
+    sourceIsSingleImage && {
+      width: source.width,
+      height: source.height,
+    },
+    styles.base,
+    props.style,
+  );
 
   const {onLoadStart, onLoad, onLoadEnd, onError} = props;
   const nativeProps = {
     ...props,
     style,
     shouldNotifyLoadEvents: !!(onLoadStart || onLoad || onLoadEnd || onError),
-    src: sources,
+    src: sourceIsSingleImage ? [source] : source,
     /* $FlowFixMe(>=0.78.0 site=react_native_android_fb) This issue was found
      * when making Flow check .android.js files. */
-    headers: source?.headers,
     defaultSrc: defaultSource ? defaultSource.uri : null,
     loadingIndicatorSrc: loadingIndicatorSource
       ? loadingIndicatorSource.uri

--- a/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageManager.java
@@ -239,11 +239,6 @@ public class ReactImageManager extends SimpleViewManager<ReactImageView> {
     view.setShouldNotifyLoadEvents(shouldNotifyLoadEvents);
   }
 
-  @ReactProp(name = "headers")
-  public void setHeaders(ReactImageView view, ReadableMap headers) {
-    view.setHeaders(headers);
-  }
-
   @Override
   public @Nullable Map getExportedCustomDirectEventTypeConstants() {
     @Nullable

--- a/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.java
@@ -207,7 +207,6 @@ public class ReactImageView extends GenericDraweeView {
   private @Nullable Object mCallerContext;
   private int mFadeDurationMs = -1;
   private boolean mProgressiveRenderingEnabled;
-  private ReadableMap mHeaders;
 
   // We can't specify rounding in XML, so have to do so here
   private static GenericDraweeHierarchy buildHierarchy(Context context) {
@@ -392,7 +391,8 @@ public class ReactImageView extends GenericDraweeView {
       if (sources.size() == 1) {
         ReadableMap source = sources.getMap(0);
         String uri = source.getString("uri");
-        ImageSource imageSource = new ImageSource(getContext(), uri);
+        ReadableMap headers = source.getMap("headers");
+        ImageSource imageSource = new ImageSource(getContext(), uri, headers);
         tmpSources.add(imageSource);
         if (Uri.EMPTY.equals(imageSource.getUri())) {
           warnImageSource(uri);
@@ -401,9 +401,10 @@ public class ReactImageView extends GenericDraweeView {
         for (int idx = 0; idx < sources.size(); idx++) {
           ReadableMap source = sources.getMap(idx);
           String uri = source.getString("uri");
+          ReadableMap headers = source.getMap("headers");
           ImageSource imageSource =
               new ImageSource(
-                  getContext(), uri, source.getDouble("width"), source.getDouble("height"));
+                  getContext(), uri, headers, source.getDouble("width"), source.getDouble("height"));
           tmpSources.add(imageSource);
           if (Uri.EMPTY.equals(imageSource.getUri())) {
             warnImageSource(uri);
@@ -473,10 +474,6 @@ public class ReactImageView extends GenericDraweeView {
         mBorderCornerRadii != null && !YogaConstants.isUndefined(mBorderCornerRadii[3])
             ? mBorderCornerRadii[3]
             : defaultBorderRadius;
-  }
-
-  public void setHeaders(ReadableMap headers) {
-    mHeaders = headers;
   }
 
   public void maybeUpdateView() {
@@ -568,7 +565,7 @@ public class ReactImageView extends GenericDraweeView {
             .setProgressiveRenderingEnabled(mProgressiveRenderingEnabled);
 
     ImageRequest imageRequest =
-        ReactNetworkImageRequest.fromBuilderWithHeaders(imageRequestBuilder, mHeaders);
+        ReactNetworkImageRequest.fromBuilderWithHeaders(imageRequestBuilder, mImageSource.getHeaders());
 
     if (mGlobalImageLoadListener != null) {
       mGlobalImageLoadListener.onLoadAttempt(mImageSource.getUri());

--- a/ReactAndroid/src/main/java/com/facebook/react/views/imagehelper/ImageSource.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/imagehelper/ImageSource.java
@@ -11,18 +11,21 @@ import android.content.Context;
 import android.net.Uri;
 import androidx.annotation.Nullable;
 import com.facebook.infer.annotation.Assertions;
+import com.facebook.react.bridge.ReadableMap;
 import java.util.Objects;
 
 /** Class describing an image source (network URI or resource) and size. */
 public class ImageSource {
 
   private @Nullable Uri mUri;
+  private ReadableMap mHeaders;
   private String mSource;
   private double mSize;
   private boolean isResource;
 
-  public ImageSource(Context context, String source, double width, double height) {
+  public ImageSource(Context context, String source, ReadableMap headers, double width, double height) {
     mSource = source;
+    mHeaders = headers;
     mSize = width * height;
 
     // Important: we compute the URI here so that we don't need to hold a reference to the context,
@@ -46,8 +49,8 @@ public class ImageSource {
     return Objects.hash(mUri, mSource, mSize, isResource);
   }
 
-  public ImageSource(Context context, String source) {
-    this(context, source, 0.0d, 0.0d);
+  public ImageSource(Context context, String source, ReadableMap headers) {
+    this(context, source, headers, 0.0d, 0.0d);
   }
 
   /** Get the source of this image, as it was passed to the constructor. */
@@ -58,6 +61,11 @@ public class ImageSource {
   /** Get the URI for this image - can be either a parsed network URI or a resource URI. */
   public Uri getUri() {
     return Assertions.assertNotNull(mUri);
+  }
+
+  /** Get the headers for this image. */
+  public ReadableMap getHeaders() {
+    return mHeaders;
   }
 
   /** Get the area of this image. */


### PR DESCRIPTION
## Summary

Currently passing headers in the `source` array of an `<ImageView />` is not supported on android because
- headers are passed to native via one `ReadableMap` prop, passed as-is to the `ReactNetworkImageRequest.fromBuilderWithHeaders`. This means different headers per array entry are simply not possible
- currently those headers are passed to native via `source?.headers` which clearly will not work when putting the headers into the source array (e.g. `[ { headers: { Test: '123' }, uri: '...' } ]` - this also showcases a workaround, just set the `headers` property on your source array and you are good to go as long as you always need the same headers)

## Changelog

- Simplified android `<Image />` code flow
- Moved android native image view `headers` property into the `src` property
- Added `headers` property to `ImageSource` class

FIX Android - Fixed headers for `<Image />` source arrays

## Test Plan

CI tests should cover these changes.