### PR TITLE
Use compose to render Switch in Fabric

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -10,6 +10,7 @@ plugins {
     id("com.facebook.react")
     id("maven-publish")
     id("de.undercouch.download")
+    id("kotlin-android")
 }
 
 import com.facebook.react.tasks.internal.*
@@ -336,6 +337,7 @@ android {
             exclude("com/facebook/react/processing")
             exclude("com/facebook/react/module/processing")
         }
+//        kotlin.srcDirs += 'src/main/java/com/facebook/react/kotlin'
     }
 
     lintOptions {
@@ -351,6 +353,24 @@ android {
         extractHeaders
         extractJNI
         javadocDeps.extendsFrom api
+    }
+
+    buildFeatures {
+        compose true
+    }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion '1.0.1'
+        kotlinCompilerVersion "1.5.10"
+        kotlinCompilerExtensionVersion "1.0.0-beta08"
+    }
+
+    kotlinOptions {
+        jvmTarget = "1.8"
     }
 }
 
@@ -387,6 +407,24 @@ dependencies {
     androidTestImplementation("androidx.test:runner:${ANDROIDX_TEST_VERSION}")
     androidTestImplementation("androidx.test:rules:${ANDROIDX_TEST_VERSION}")
     androidTestImplementation("org.mockito:mockito-core:${MOCKITO_CORE_VERSION}")
+
+    implementation("androidx.core:core-ktx:1.3.2")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib:1.5.21")
+
+    implementation "androidx.compose.compiler:compiler:1.0.0-beta08"
+
+    // Integration with activities
+    implementation 'androidx.activity:activity-compose:1.3.1'
+    // Compose Material Design
+    implementation 'androidx.compose.material:material:1.0.1'
+    // Animations
+    implementation 'androidx.compose.animation:animation:1.0.1'
+    // Tooling support (Previews, etc.)
+    implementation 'androidx.compose.ui:ui-tooling:1.0.1'
+    // Integration with ViewModels
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-compose:1.0.0-alpha07'
+    // UI Tests
+    androidTestImplementation 'androidx.compose.ui:ui-test-junit4:1.0.1'
 }
 
 react {

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
@@ -15,6 +15,10 @@ import android.content.res.Configuration;
 import android.os.Build;
 import android.os.Bundle;
 import android.view.KeyEvent;
+import android.view.View;
+import android.widget.FrameLayout;
+import android.widget.LinearLayout;
+import android.widget.TextView;
 import androidx.annotation.Nullable;
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.bridge.Callback;
@@ -89,7 +93,22 @@ public class ReactActivityDelegate {
 
   protected void loadApp(String appKey) {
     mReactDelegate.loadApp(appKey);
-    getPlainActivity().setContentView(mReactDelegate.getReactRootView());
+    Context context = getContext();
+    LinearLayout linearLayout = new LinearLayout(context);
+    linearLayout.setLayoutParams(
+        new FrameLayout.LayoutParams(
+            FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.MATCH_PARENT));
+
+    linearLayout.setOrientation(LinearLayout.VERTICAL);
+    View composeView = com.facebook.react.kotlin.TestComposableKt.getComposeView(context);
+
+    TextView text = new TextView(context);
+    text.setText("This is a text");
+    linearLayout.addView(text);
+    linearLayout.addView(composeView);
+    linearLayout.addView(mReactDelegate.getReactRootView());
+
+    getPlainActivity().setContentView(linearLayout);
   }
 
   protected void onPause() {

--- a/ReactAndroid/src/main/java/com/facebook/react/kotlin/BackgroundMeasure.kt
+++ b/ReactAndroid/src/main/java/com/facebook/react/kotlin/BackgroundMeasure.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.kotlin
+
+import android.content.Context
+import android.widget.FrameLayout
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Composition
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.MonotonicFrameClock
+import androidx.compose.runtime.Recomposer
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.focus.FocusDirection
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.layout.Measurable
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalFontLoader
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.platform.LocalViewConfiguration
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.IntSize
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+class BackgroundMeasure(private val context: Context) {
+  private val view = FrameLayout(context)
+  private val owner =
+      object : ComposeShims.BackgroundMeasureOwner(context) {
+        // These methods use inline classes, so we have to override them here
+        override fun calculateLocalPosition(positionInWindow: Offset): Offset = positionInWindow
+        override fun calculatePositionInWindow(localPosition: Offset): Offset = localPosition
+        override fun getFocusDirection(keyEvent: KeyEvent): FocusDirection? = null
+        override fun requestRectangleOnScreen(rect: Rect) {}
+      }
+  private val root = owner.root
+  private val applier = ComposeShims.createApplier(root)
+
+  val clock =
+      object : MonotonicFrameClock {
+        override suspend fun <R> withFrameNanos(onFrame: (frameTimeNanos: Long) -> R): R =
+            onFrame(System.nanoTime())
+      }
+  val coroutineContext = Dispatchers.Unconfined + clock
+  val recomposer = Recomposer(coroutineContext)
+  val composition = Composition(applier, recomposer)
+
+  /** Synchronously (I hope?) measures Composable on a current thread (at least seems like so?) */
+  fun measureComposable(constraints: Constraints, content: @Composable () -> Unit): IntSize {
+    composition.setContent {
+      CompositionLocalProvider(
+          // See ProvideCommonCompositionLocals or ProvideAndroidCompositionLocals for a full list
+          // Here I only added things until Text composable stopped crashing
+          LocalDensity.provides(owner.density),
+          LocalFontLoader.provides(owner.fontLoader),
+          LocalContext.provides(context),
+          LocalLayoutDirection.provides(owner.layoutDirection),
+          LocalViewConfiguration.provides(owner.viewConfiguration),
+          LocalView.provides(view),
+          content = content)
+    }
+
+    val runRecomposeJob =
+        CoroutineScope(coroutineContext).launch(start = CoroutineStart.UNDISPATCHED) {
+          recomposer.runRecomposeAndApplyChanges()
+        }
+
+    ComposeShims.attachOwner(root, owner)
+    owner.nodes.forEach { ComposeShims.setLayoutRequired(it) }
+    (root as Measurable).measure(constraints)
+
+    runRecomposeJob.cancel()
+
+    return IntSize(ComposeShims.getNodeWidth(root), ComposeShims.getNodeHeight(root))
+  }
+}

--- a/ReactAndroid/src/main/java/com/facebook/react/kotlin/ComposeShims.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/kotlin/ComposeShims.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.kotlin;
+
+import static androidx.compose.ui.platform.AndroidComposeView_androidKt.getLocaleLayoutDirection;
+import static androidx.compose.ui.unit.AndroidDensity_androidKt.Density;
+
+import android.content.Context;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.compose.runtime.Applier;
+import androidx.compose.ui.autofill.Autofill;
+import androidx.compose.ui.autofill.AutofillTree;
+import androidx.compose.ui.focus.FocusManager;
+import androidx.compose.ui.graphics.Canvas;
+import androidx.compose.ui.hapticfeedback.HapticFeedback;
+import androidx.compose.ui.layout.RootMeasurePolicy;
+import androidx.compose.ui.node.LayoutNode;
+import androidx.compose.ui.node.OwnedLayer;
+import androidx.compose.ui.node.Owner;
+import androidx.compose.ui.node.OwnerSnapshotObserver;
+import androidx.compose.ui.node.RootForTest;
+import androidx.compose.ui.node.UiApplier;
+import androidx.compose.ui.platform.AccessibilityManager;
+import androidx.compose.ui.platform.AndroidFontResourceLoader;
+import androidx.compose.ui.platform.AndroidViewConfiguration;
+import androidx.compose.ui.platform.ClipboardManager;
+import androidx.compose.ui.platform.TextToolbar;
+import androidx.compose.ui.platform.ViewConfiguration;
+import androidx.compose.ui.platform.WindowInfo;
+import androidx.compose.ui.text.font.Font;
+import androidx.compose.ui.text.input.TextInputService;
+import androidx.compose.ui.unit.Density;
+import androidx.compose.ui.unit.LayoutDirection;
+import java.util.ArrayList;
+import java.util.List;
+import kotlin.Unit;
+import kotlin.jvm.functions.Function0;
+import kotlin.jvm.functions.Function1;
+
+/**
+ * A lot of Compose API is internal and Kotlin compiler won't let us to access it
+ *
+ * <p>Thankfully, Java doesn't believe in internal, so we can do restricted things as long as we
+ * don't touch inline functions/classes
+ */
+@SuppressWarnings("KotlinInternalInJava")
+public class ComposeShims {
+  public static Applier<LayoutNode> createApplier(LayoutNode root) {
+    return new UiApplier(root);
+  }
+
+  public static void setLayoutRequired(LayoutNode root) {
+    root.setLayoutState$ui_release(LayoutNode.LayoutState.NeedsRemeasure);
+  }
+
+  public static void attachOwner(LayoutNode root, Owner owner) {
+    root.attach$ui_release(owner);
+  }
+
+  public static int getNodeWidth(LayoutNode node) {
+    return node.getWidth();
+  }
+
+  public static int getNodeHeight(LayoutNode node) {
+    return node.getHeight();
+  }
+
+  /**
+   * Normally, Owner is a view, but it doesn't have to be! Below is minimal owner implementation to
+   * measure Text composable.
+   */
+  public abstract static class BackgroundMeasureOwner implements Owner {
+    private final LayoutNode mRoot;
+    private final List<LayoutNode> mNodes;
+    private final Context mContext;
+
+    public BackgroundMeasureOwner(Context context) {
+      mRoot = new LayoutNode();
+      mRoot.setMeasurePolicy(RootMeasurePolicy.INSTANCE);
+
+      mNodes = new ArrayList<>();
+      mContext = context;
+    }
+
+    public List<LayoutNode> getNodes() {
+      return mNodes;
+    }
+
+    @NonNull
+    @Override
+    public LayoutNode getRoot() {
+      return mRoot;
+    }
+
+    @NonNull
+    @Override
+    public RootForTest getRootForTest() {
+      // FIXME: don't need for poc
+      return null;
+    }
+
+    @NonNull
+    @Override
+    public HapticFeedback getHapticFeedBack() {
+      // FIXME: don't need for poc
+      return null;
+    }
+
+    @NonNull
+    @Override
+    public ClipboardManager getClipboardManager() {
+      // FIXME: don't need for poc
+      return null;
+    }
+
+    @NonNull
+    @Override
+    public AccessibilityManager getAccessibilityManager() {
+      // FIXME: don't need for poc
+      return null;
+    }
+
+    @NonNull
+    @Override
+    public TextToolbar getTextToolbar() {
+      // FIXME: don't need for poc
+      return null;
+    }
+
+    @NonNull
+    @Override
+    public AutofillTree getAutofillTree() {
+      // FIXME: don't need for poc
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public Autofill getAutofill() {
+      // FIXME: don't need for poc
+      return null;
+    }
+
+    @NonNull
+    @Override
+    public Density getDensity() {
+      return Density(mContext);
+    }
+
+    @NonNull
+    @Override
+    public TextInputService getTextInputService() {
+      // FIXME: don't need for poc
+      return null;
+    }
+
+    @NonNull
+    @Override
+    public FocusManager getFocusManager() {
+      // FIXME: don't need for poc
+      return null;
+    }
+
+    @NonNull
+    @Override
+    public WindowInfo getWindowInfo() {
+      // FIXME: don't need for poc
+      return null;
+    }
+
+    @NonNull
+    @Override
+    public Font.ResourceLoader getFontLoader() {
+      return new AndroidFontResourceLoader(mContext);
+    }
+
+    @NonNull
+    @Override
+    public LayoutDirection getLayoutDirection() {
+      return getLocaleLayoutDirection(mContext.getResources().getConfiguration());
+    }
+
+    @Override
+    public boolean getShowLayoutBounds() {
+      // FIXME: don't need for poc
+      return false;
+    }
+
+    @Override
+    public void setShowLayoutBounds(boolean showLayoutBounds) {
+      // FIXME: don't need for poc
+    }
+
+    @Override
+    public void onRequestMeasure(@NonNull LayoutNode layoutNode) {
+      // FIXME: don't need for poc
+    }
+
+    @Override
+    public void onRequestRelayout(@NonNull LayoutNode layoutNode) {
+      // FIXME: don't need for poc
+    }
+
+    @Override
+    public void onAttach(@NonNull LayoutNode node) {
+      mNodes.add(node);
+    }
+
+    @Override
+    public void onDetach(@NonNull LayoutNode node) {
+      mNodes.remove(node);
+    }
+
+    @Override
+    public boolean requestFocus() {
+      // FIXME: don't need for poc
+      return false;
+    }
+
+    @Override
+    public void measureAndLayout() {
+      // FIXME: don't need for poc
+    }
+
+    @NonNull
+    @Override
+    public OwnedLayer createLayer(
+        @NonNull Function1<? super Canvas, Unit> drawBlock,
+        @NonNull Function0<Unit> invalidateParentLayer) {
+      // FIXME: don't need for poc
+      return null;
+    }
+
+    @Override
+    public void onSemanticsChange() {
+      // FIXME: don't need for poc
+    }
+
+    @Override
+    public void onLayoutChange(@NonNull LayoutNode layoutNode) {
+      // FIXME: don't need for poc
+    }
+
+    @Override
+    public long getMeasureIteration() {
+      return 0;
+    }
+
+    @NonNull
+    @Override
+    public ViewConfiguration getViewConfiguration() {
+      return new AndroidViewConfiguration(android.view.ViewConfiguration.get(mContext));
+    }
+
+    @NonNull
+    @Override
+    public OwnerSnapshotObserver getSnapshotObserver() {
+      return new OwnerSnapshotObserver(Function0::invoke);
+    }
+  }
+}

--- a/ReactAndroid/src/main/java/com/facebook/react/kotlin/TestComposable.kt
+++ b/ReactAndroid/src/main/java/com/facebook/react/kotlin/TestComposable.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.kotlin
+
+import android.content.Context
+import android.util.Log
+import android.view.View
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.ComposeView
+
+@Composable
+fun TestComposable() {
+  Text("Hello world from Compose!")
+}
+
+fun getComposeView(context: Context): View {
+  Log.e("TAG", "DAVIDDAVIDDAVIDDAVIDDAVIDDAVIDDAVIDDAVIDDAVID")
+
+  return ComposeView(context).apply { setContent { TestComposable() } }
+}

--- a/ReactAndroid/src/main/java/com/facebook/react/views/ReactComposeView.kt
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/ReactComposeView.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.views
+
+import android.content.Context
+import android.util.AttributeSet
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.platform.AbstractComposeView
+
+open class ReactComposeView
+@JvmOverloads
+constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0) :
+    AbstractComposeView(context, attrs, defStyleAttr) {
+
+  private val content = mutableStateOf<(@Composable () -> Unit)?>(null)
+
+  @Suppress("RedundantVisibilityModifier")
+  protected override var shouldCreateCompositionOnAttachedToWindow: Boolean = false
+  // private set
+
+  @Composable
+  override fun Content() {
+    content.value?.invoke()
+  }
+
+  override fun getAccessibilityClassName(): CharSequence {
+    return javaClass.name
+  }
+
+  /**
+   * Set the Jetpack Compose UI content for this view. Initial composition will occur when the view
+   * becomes attached to a window or when [createComposition] is called, whichever comes first.
+   */
+  fun setContent(content: @Composable () -> Unit) {
+    shouldCreateCompositionOnAttachedToWindow = true
+    this.content.value = content
+    if (isAttachedToWindow) {
+      createComposition()
+    }
+  }
+}

--- a/ReactAndroid/src/main/java/com/facebook/react/views/switchview/ReactComposeSwitch.kt
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/switchview/ReactComposeSwitch.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.views.switchview
+
+import android.content.Context
+import androidx.compose.material.Switch
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.unit.Constraints
+import com.facebook.react.kotlin.BackgroundMeasure
+import com.facebook.react.uimanager.PixelUtil
+import com.facebook.react.views.ReactComposeView
+import com.facebook.yoga.YogaMeasureOutput
+
+@Composable
+fun ComposeSwitch(
+    checked: Boolean,
+    enabled: Boolean,
+    onCheckedChange: (isChecked: Boolean) -> Unit
+) {
+  val checkedState = remember { mutableStateOf(checked) }
+  Switch(
+      checked = checkedState.value,
+      onCheckedChange = {
+        checkedState.value = it
+        onCheckedChange(it)
+      },
+      enabled = enabled)
+}
+
+fun measureInBackground(
+    context: Context,
+): Long {
+  val backgroundMeasure = BackgroundMeasure(context)
+  val size = backgroundMeasure.measureComposable(Constraints()) { ComposeSwitch(false, false, {}) }
+  println("Compose switch measured to $size")
+
+  return YogaMeasureOutput.make(
+      PixelUtil.toDIPFromPixel(size.width.toFloat()),
+      PixelUtil.toDIPFromPixel(size.height.toFloat()))
+}
+
+class ReactComposeSwitchView : ReactComposeView {
+  constructor(ctx: Context) : super(ctx)
+
+  var switchEnabled: Boolean = true
+  var switchChecked: Boolean = true
+  var onCheckedChangeListener: (ReactComposeSwitchView, Boolean) -> Unit = { _, _ -> }
+
+  fun updateView(): ReactComposeSwitchView {
+    return this.apply {
+      setContent {
+        ComposeSwitch(switchChecked, switchEnabled) { onCheckedChangeListener(this, it) }
+      }
+    }
+  }
+}

--- a/ReactAndroid/src/main/java/com/facebook/react/views/switchview/ReactSwitch.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/switchview/ReactSwitch.java
@@ -22,6 +22,7 @@ import androidx.appcompat.widget.SwitchCompat;
  * allow any other changes to that switch until JS sets a value explicitly. This stops the Switch
  * from changing its value multiple times, when those changes have not been processed by JS first.
  */
+// TODO: use Switch
 /*package*/ class ReactSwitch extends SwitchCompat {
 
   private boolean mAllowChange;


### PR DESCRIPTION
Summary:
This change is a proof of concept to try Compose integration with RN component on Android by measuring and drawing Switch component through a Composable function.

To interface Composable nodes with the view system, we use a "classic" view interoperability layer to plug Compose-based Switch into existing ViewManager and propagate props and events as we do with “classic” views.

Fabric also requires initial measure during layout, which was implemented through custom background `Recomposer` and `LayoutNode` hacks to avoid creating full-blown view.

Differential Revision: D31657259

