### PR TITLE
Add control of dark/light theming of Share menu

### DIFF
--- a/Libraries/Share/Share.js
+++ b/Libraries/Share/Share.js
@@ -32,6 +32,7 @@ type Options = {
   excludedActivityTypes?: Array<string>,
   tintColor?: string,
   subject?: string,
+  userInterfaceStyle?: string,
   ...
 };
 
@@ -133,6 +134,7 @@ class Share {
             subject: options.subject,
             tintColor: typeof tintColor === 'number' ? tintColor : undefined,
             excludedActivityTypes: options.excludedActivityTypes,
+            userInterfaceStyle: typeof options.userInterfaceStyle === 'string' ? options.userInterfaceStyle : undefined,
           },
           error => reject(error),
           (success, activityType) => {


### PR DESCRIPTION
## Summary

Added userInterfaceStyle to Share options and pass to native module. Makes it possible to control light/dark theme of the native Share menu.

## Changelog

[iOS] [Added] - Added userInterfaceStyle to Share options and pass forward to native module

## Test Plan
