### PR TITLE
fix(AccessibilityInfo): correctly unsubscribe events in AccessibilityInfo.removeEventListener

### DIFF
--- a/Libraries/Components/AccessibilityInfo/AccessibilityInfo.js
+++ b/Libraries/Components/AccessibilityInfo/AccessibilityInfo.js
@@ -377,7 +377,7 @@ const AccessibilityInfo = {
     if (deviceEventName != null) {
       // $FlowIgnore[incompatible-cast]
       (RCTDeviceEventEmitter: EventEmitter<$FlowFixMe>).removeListener(
-        'deviceEventName',
+        deviceEventName,
         // $FlowFixMe[invalid-tuple-arity]
         handler,
       );

--- a/packages/rn-tester/js/examples/Accessibility/AccessibilityExample.js
+++ b/packages/rn-tester/js/examples/Accessibility/AccessibilityExample.js
@@ -1164,7 +1164,10 @@ class DisplayOptionsStatusExample extends React.Component<{}> {
 function DisplayOptionStatusExample({optionName, optionChecker, notification}) {
   const [statusEnabled, setStatusEnabled] = React.useState(false);
   React.useEffect(() => {
-    const subscription = AccessibilityInfo.addEventListener(notification, setStatusEnabled);
+    const subscription = AccessibilityInfo.addEventListener(
+      notification,
+      setStatusEnabled,
+    );
     optionChecker().then(isEnabled => {
       setStatusEnabled(isEnabled);
     });

--- a/packages/rn-tester/js/examples/Accessibility/AccessibilityExample.js
+++ b/packages/rn-tester/js/examples/Accessibility/AccessibilityExample.js
@@ -1164,12 +1164,12 @@ class DisplayOptionsStatusExample extends React.Component<{}> {
 function DisplayOptionStatusExample({optionName, optionChecker, notification}) {
   const [statusEnabled, setStatusEnabled] = React.useState(false);
   React.useEffect(() => {
-    AccessibilityInfo.addEventListener(notification, setStatusEnabled);
+    const subscription = AccessibilityInfo.addEventListener(notification, setStatusEnabled);
     optionChecker().then(isEnabled => {
       setStatusEnabled(isEnabled);
     });
     return function cleanup() {
-      AccessibilityInfo.removeEventListener(notification, setStatusEnabled);
+      subscription.remove();
     };
   }, [optionChecker, notification]);
   return (


### PR DESCRIPTION
## Summary

Previously, calling the (deprecated) `AccessibilityInfo.removeEventListener` function will not remove any event subscriptions, because it removes an event with the literal name of _"deviceEventName"_ instead of the value of the variable `deviceEventName`

I've also updated the subscription removal logic in RNTester to use the preferred `subscription.remove` method rather than the deprecated `AccessibilityInfo.removeEventListener` function, which produces a LogBox warning

## Changelog

[General] [Fixed] - correctly unsubscribe events in AccessibilityInfo.removeEventListener

## Test Plan

```javascript
it('should unsubscribe event listeners with removeEventListener', () => {
  const handler = jest.fn();

  AccessibilityInfo.addEventListener('screenReaderChanged', handler);
  AccessibilityInfo.removeEventListener('screenReaderChanged', handler);
  DeviceEventEmitter.emit('screenReaderChanged');

  expect(handler).not.toBeCalled(); // would currently fail
});
```
(note- the React Native setup file mocks `AccessibilityInfo` by default - https://github.com/facebook/react-native/blob/main/jest/setup.js#L121-L138 - so you need to disable that for the above test to work) 