### PR TITLE
Update RN Version Expected Structure

### DIFF
--- a/Libraries/Core/ReactNativeVersionCheck.js
+++ b/Libraries/Core/ReactNativeVersionCheck.js
@@ -41,6 +41,7 @@ exports.checkVersions = function checkVersions(): void {
 function _formatVersion(
   version:
     | {major: number, minor: number, patch: number, prerelease: ?number}
+    | {major: number, minor: number, patch: number, prerelease: ?string}
     | $TEMPORARY$object<{
         major: number,
         minor: number,


### PR DESCRIPTION
## Summary

Current syntax options for RN version values break Windows. Following change to nightly build format to be 0.0.0-X-X-X, prerelease value is now a string (X-X-X).

https://github.com/microsoft/react-native-windows/issues/9223

## Changelog

[General] [Fixed] - Fix RN version syntax to match new nightly build structure.

## Test Plan

