### PR TITLE
fix: KeyboardAvoidingView _updateBottomIfNecessary typo

### DIFF
--- a/Libraries/Components/Keyboard/KeyboardAvoidingView.js
+++ b/Libraries/Components/Keyboard/KeyboardAvoidingView.js
@@ -87,7 +87,7 @@ class KeyboardAvoidingView extends React.Component<Props, State> {
 
   _onKeyboardChange = (event: ?KeyboardEvent) => {
     this._keyboardEvent = event;
-    this._updateBottomIfNecesarry();
+    this._updateBottomIfNecessary();
   };
 
   _onLayout = (event: ViewLayoutEvent) => {
@@ -99,7 +99,7 @@ class KeyboardAvoidingView extends React.Component<Props, State> {
     }
 
     if (wasFrameNull) {
-      this._updateBottomIfNecesarry();
+      this._updateBottomIfNecessary();
     }
 
     if (this.props.onLayout) {
@@ -107,7 +107,7 @@ class KeyboardAvoidingView extends React.Component<Props, State> {
     }
   };
 
-  _updateBottomIfNecesarry = () => {
+  _updateBottomIfNecessary = () => {
     if (this._keyboardEvent == null) {
       this.setState({bottom: 0});
       return;


### PR DESCRIPTION
## Summary

While working on a fix for https://github.com/facebook/react-native/issues/29974 I notice that the `_updateBottomIfNecessary` function inside `KeyboardAvoidingView` was misspelled, so I decided to open a PR fixing it.

## Changelog


[General] [Fixed] - Fix typo in _updateBottomIfNecessary function on KeyboardAvoidingView component

## Test Plan

Shouldn't require much testing as this is just renaming a private function of `KeyboardAvoidingView`
