### PR TITLE
[Android] Reset ReactInstanceManager state on failure to allow retries

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -1103,14 +1103,22 @@ public class ReactInstanceManager {
                 // create
                 mHasStartedCreatingInitialContext = true;
 
+                final ReactApplicationContext reactApplicationContext;
                 try {
                   Process.setThreadPriority(Process.THREAD_PRIORITY_DISPLAY);
                   ReactMarker.logMarker(VM_INIT);
-                  final ReactApplicationContext reactApplicationContext =
-                      createReactContext(
-                          initParams.getJsExecutorFactory().create(),
-                          initParams.getJsBundleLoader());
-
+                  reactApplicationContext =
+                    createReactContext(
+                      initParams.getJsExecutorFactory().create(),
+                      initParams.getJsBundleLoader());
+                } catch (Exception e) {
+                    // Reset state and bail out. This lets us try again later.
+                    mHasStartedCreatingInitialContext = false;
+                    mCreateReactContextThread = null;
+                    mDevSupportManager.handleException(e);
+                    return;
+                }
+                try {
                   mCreateReactContextThread = null;
                   ReactMarker.logMarker(PRE_SETUP_REACT_CONTEXT_START);
                   final Runnable maybeRecreateReactContextRunnable =


### PR DESCRIPTION
## Summary

This fixes https://github.com/facebook/react-native/issues/32898 by reseting ReactInstanceManager state when `createReactContext` throws. By resetting the state, we allow future attempts at creating the React context.

## Changelog

[Android] [Fixed] - Fixed empty screen after retrying a BundleDownloader failure in dev mode

## Test Plan

Go through the steps to reproduce listed in https://github.com/facebook/react-native/issues/32898 and see that the React Native application starts.
