### PR TITLE
update jscodeshift to 0.13.1

### DIFF
--- a/packages/react-native-codegen/package.json
+++ b/packages/react-native-codegen/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@babel/parser": "^7.14.0",
     "flow-parser": "^0.121.0",
-    "jscodeshift": "^0.11.0",
+    "jscodeshift": "^0.13.1",
     "nullthrows": "^1.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

So it seems that `react-native-codegen` at the version `^0.11.0`, but its problematic since versions bellow `0.13.1` still has the `colors` dependency which I want to remove from my project due to the latest problems 

## Changelog

[General] [Fixed] - Update `jscodeshift` to `0.13.1`
