### PR TITLE
Allow passing ReadableNativeMap/Array to push/put methods

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/WritableNativeArray.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/WritableNativeArray.java
@@ -45,21 +45,21 @@ public class WritableNativeArray extends ReadableNativeArray implements Writable
   @Override
   public void pushArray(@Nullable ReadableArray array) {
     Assertions.assertCondition(
-        array == null || array instanceof WritableNativeArray, "Illegal type provided");
-    pushNativeArray((WritableNativeArray) array);
+        array == null || array instanceof ReadableNativeArray, "Illegal type provided");
+    pushNativeArray((ReadableNativeArray) array);
   }
 
   // Note: this consumes the map so do not reuse it.
   @Override
   public void pushMap(@Nullable ReadableMap map) {
     Assertions.assertCondition(
-        map == null || map instanceof WritableNativeMap, "Illegal type provided");
-    pushNativeMap((WritableNativeMap) map);
+        map == null || map instanceof ReadableNativeMap, "Illegal type provided");
+    pushNativeMap((ReadableNativeMap) map);
   }
 
   private static native HybridData initHybrid();
 
-  private native void pushNativeArray(WritableNativeArray array);
+  private native void pushNativeArray(ReadableNativeArray array);
 
-  private native void pushNativeMap(WritableNativeMap map);
+  private native void pushNativeMap(ReadableNativeMap map);
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/WritableNativeMap.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/WritableNativeMap.java
@@ -41,16 +41,16 @@ public class WritableNativeMap extends ReadableNativeMap implements WritableMap 
   @Override
   public void putMap(@NonNull String key, @Nullable ReadableMap value) {
     Assertions.assertCondition(
-        value == null || value instanceof WritableNativeMap, "Illegal type provided");
-    putNativeMap(key, (WritableNativeMap) value);
+        value == null || value instanceof ReadableNativeMap, "Illegal type provided");
+    putNativeMap(key, (ReadableNativeMap) value);
   }
 
   // Note: this consumes the map so do not reuse it.
   @Override
   public void putArray(@NonNull String key, @Nullable ReadableArray value) {
     Assertions.assertCondition(
-        value == null || value instanceof WritableNativeArray, "Illegal type provided");
-    putNativeArray(key, (WritableNativeArray) value);
+        value == null || value instanceof ReadableNativeArray, "Illegal type provided");
+    putNativeArray(key, (ReadableNativeArray) value);
   }
 
   // Note: this **DOES NOT** consume the source map
@@ -73,9 +73,9 @@ public class WritableNativeMap extends ReadableNativeMap implements WritableMap 
 
   private static native HybridData initHybrid();
 
-  private native void putNativeMap(String key, WritableNativeMap value);
+  private native void putNativeMap(String key, ReadableNativeMap value);
 
-  private native void putNativeArray(String key, WritableNativeArray value);
+  private native void putNativeArray(String key, ReadableNativeArray value);
 
   private native void mergeNativeMap(ReadableNativeMap source);
 }

--- a/ReactAndroid/src/main/jni/react/jni/WritableNativeArray.cpp
+++ b/ReactAndroid/src/main/jni/react/jni/WritableNativeArray.cpp
@@ -7,7 +7,7 @@
 
 #include "WritableNativeArray.h"
 
-#include "WritableNativeMap.h"
+#include "ReadableNativeMap.h"
 
 using namespace facebook::jni;
 
@@ -58,7 +58,7 @@ void WritableNativeArray::pushString(jstring value) {
   array_.push_back(wrap_alias(value)->toStdString());
 }
 
-void WritableNativeArray::pushNativeArray(WritableNativeArray *otherArray) {
+void WritableNativeArray::pushNativeArray(ReadableNativeArray *otherArray) {
   if (otherArray == NULL) {
     pushNull();
     return;
@@ -67,7 +67,7 @@ void WritableNativeArray::pushNativeArray(WritableNativeArray *otherArray) {
   array_.push_back(otherArray->consume());
 }
 
-void WritableNativeArray::pushNativeMap(WritableNativeMap *map) {
+void WritableNativeArray::pushNativeMap(ReadableNativeMap *map) {
   if (map == NULL) {
     pushNull();
     return;

--- a/ReactAndroid/src/main/jni/react/jni/WritableNativeArray.h
+++ b/ReactAndroid/src/main/jni/react/jni/WritableNativeArray.h
@@ -16,7 +16,7 @@
 namespace facebook {
 namespace react {
 
-struct WritableNativeMap;
+struct ReadableNativeMap;
 
 struct WritableArray : jni::JavaClass<WritableArray> {
   static auto constexpr kJavaDescriptor =
@@ -38,8 +38,8 @@ struct WritableNativeArray
   void pushDouble(jdouble value);
   void pushInt(jint value);
   void pushString(jstring value);
-  void pushNativeArray(WritableNativeArray *otherArray);
-  void pushNativeMap(WritableNativeMap *map);
+  void pushNativeArray(ReadableNativeArray *otherArray);
+  void pushNativeMap(ReadableNativeMap *map);
 
   static void registerNatives();
 };

--- a/ReactAndroid/src/main/jni/react/jni/WritableNativeMap.cpp
+++ b/ReactAndroid/src/main/jni/react/jni/WritableNativeMap.cpp
@@ -57,7 +57,7 @@ void WritableNativeMap::putString(std::string key, alias_ref<jstring> val) {
 
 void WritableNativeMap::putNativeArray(
     std::string key,
-    WritableNativeArray *otherArray) {
+    ReadableNativeArray *otherArray) {
   if (!otherArray) {
     putNull(std::move(key));
     return;
@@ -68,7 +68,7 @@ void WritableNativeMap::putNativeArray(
 
 void WritableNativeMap::putNativeMap(
     std::string key,
-    WritableNativeMap *otherMap) {
+    ReadableNativeMap *otherMap) {
   if (!otherMap) {
     putNull(std::move(key));
     return;

--- a/ReactAndroid/src/main/jni/react/jni/WritableNativeMap.h
+++ b/ReactAndroid/src/main/jni/react/jni/WritableNativeMap.h
@@ -12,7 +12,7 @@
 #include <folly/json.h>
 
 #include "ReadableNativeMap.h"
-#include "WritableNativeArray.h"
+#include "ReadableNativeArray.h"
 
 namespace facebook {
 namespace react {
@@ -37,8 +37,8 @@ struct WritableNativeMap
   void putDouble(std::string key, double val);
   void putInt(std::string key, int val);
   void putString(std::string key, jni::alias_ref<jstring> val);
-  void putNativeArray(std::string key, WritableNativeArray *val);
-  void putNativeMap(std::string key, WritableNativeMap *val);
+  void putNativeArray(std::string key, ReadableNativeArray *val);
+  void putNativeMap(std::string key, ReadableNativeMap *val);
   void mergeNativeMap(ReadableNativeMap *other);
 
   static void registerNatives();


### PR DESCRIPTION
## Summary

This allow adding ReadableNativeArray/Map to a WritableNativeArray/Map. There is no reason why this can't be allowed, the types were actually updated in https://github.com/facebook/react-native/commit/1a2937151b8d36e8741ef9d4fbe7d2ebf65cb775#diff-d1dc45892b3ba242aed9a1bf7219d2838fae8c7a654c402ba70bc4b100149624, but the assertion remains.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Internal] [Added] - Allow passing ReadableNativeMap/Array to push/put methods

## Test Plan

Tested that RN tester builds and run correctly on android.