### PR TITLE
chore: Add menu to test-manual-e2e script

### DIFF
--- a/scripts/test-manual-e2e.sh
+++ b/scripts/test-manual-e2e.sh
@@ -171,20 +171,20 @@ test_template_app(){
 
 show_menu(){
     echo "Which app do you want to test?
-1 - RNTester
-2 - A new RN app using the template"
-    read selected_app
+  1 - RNTester
+  2 - A new RN app using the template"
+    read -p "> " selected_app
 
     echo "What platform do you want to test?
-1 - Android
-2 - iOS"
-    read selected_platform
+  1 - Android
+  2 - iOS"
+    read -p "> " selected_platform
 
     if [ "$selected_app" == "1" ]; then
         echo "What VM are you testing?
-1 - Hermes
-2 - JSC"
-        read selected_vm
+  1 - Hermes
+  2 - JSC"
+        read -p "> " selected_vm
     fi
 
 }
@@ -197,9 +197,9 @@ handle_menu_input(){
         read -r -n 1
 
         if [ "$selected_platform" == "1" ]; then
-            test_android selected_vm
+            test_android "$selected_vm"
         elif [ "$selected_platform" == "2" ]; then
-            test_ios selected_vm
+            test_ios "$selected_vm"
         fi
     elif [ "$selected_app" == "2" ]; then
         test_template_app

--- a/scripts/test-manual-e2e.sh
+++ b/scripts/test-manual-e2e.sh
@@ -23,132 +23,205 @@ info() {
 }
 
 repo_root=$(pwd)
+selected_platform=""
+selected_vm=""
+PACKAGE_VERSION=""
 
-rm -rf android
-./gradlew :ReactAndroid:installArchives || error "Couldn't generate artifacts"
+test_android(){
+    generate_maven_artifacts
+    if [ "$1" == "1" ]; then
+        test_android_hermes
+    elif [ "$1" == "2" ]; then
+        test_android_jsc
+    fi
+}
 
-success "Generated artifacts for Maven"
+generate_maven_artifacts(){
+    rm -rf android
+    ./gradlew :ReactAndroid:installArchives || error "Couldn't generate artifacts"
 
-yarn
+    success "Generated artifacts for Maven"
+}
 
-success "Killing any running packagers"
-lsof -i :8081 | grep LISTEN
-lsof -i :8081 | grep LISTEN | /usr/bin/awk '{print $2}' | xargs kill
+test_android_hermes(){
+    ./gradlew :packages:rn-tester:android:app:installHermesDebug || error "Couldn't build RNTester Android"
 
-info "Start the packager in another terminal by running 'npm start' from the root"
-info "and then press any key."
-info ""
-read -r -n 1
+    info "Press any key to run RNTester on Android with Hermes enabled"
+    info ""
+    read -r -n 1
+    adb shell am start -n com.facebook.react.uiapp/.RNTesterActivity
+}
 
-./gradlew :packages:rn-tester:android:app:installJscDebug || error "Couldn't build RNTester Android"
+test_android_jsc(){
+    ./gradlew :packages:rn-tester:android:app:installJscDebug || error "Couldn't build RNTester Android"
 
-info "Press any key to run RNTester in an already running Android emulator/device"
-info ""
-read -r -n 1
-adb shell am start -n com.facebook.react.uiapp/.RNTesterActivity
+    info "Press any key to run RNTester in an already running Android emulator/device"
+    info ""
+    read -r -n 1
+    adb shell am start -n com.facebook.react.uiapp/.RNTesterActivity
+}
+
+test_ios(){
+    if [ "$1" == "1" ]; then
+        test_ios_hermes
+    elif [ "$1" == "2" ]; then
+        test_ios_jsc
+    fi
+}
+
+test_ios_hermes(){
+    success "About to test iOS Hermes... "
+    success "Installing CocoaPods dependencies..."
+    rm -rf packages/rn-tester/Pods
+    (cd packages/rn-tester && USE_HERMES=1 bundle exec pod install)
+
+    info "Press any key to open the workspace in Xcode, then build and test manually."
+    info ""
+    read -r -n 1
+
+    open "packages/rn-tester/RNTesterPods.xcworkspace"
+}
+
+test_ios_jsc(){
+    success "About to test iOS JSC... "
+    success "Installing CocoaPods dependencies..."
+    rm -rf packages/rn-tester/Pods
+    (cd packages/rn-tester && bundle exec pod install)
+
+    info "Press any key to open the workspace in Xcode, then build and test manually."
+    info ""
+    read -r -n 1
+
+    open "packages/rn-tester/RNTesterPods.xcworkspace"
+}
+
+kill_packagers(){
+    success "Killing any running packagers"
+    lsof -i :8081 | grep LISTEN
+    lsof -i :8081 | grep LISTEN | /usr/bin/awk '{print $2}' | xargs kill
+}
+
+init_template_app(){
+    kill_packagers
+
+    PACKAGE_VERSION=$(cat package.json \
+    | grep version \
+    | head -1 \
+    | awk -F: '{ print $2 }' \
+    | sed 's/[",]//g' \
+    | tr -d '[[:space:]]')
+
+    success "Preparing version $PACKAGE_VERSION"
+
+    npm pack
+
+    TIMESTAMP=$(date +%s)
+    PACKAGE=$(pwd)/react-native-$PACKAGE_VERSION-$TIMESTAMP.tgz
+    success "Package bundled ($PACKAGE)"
+
+    mv "$(pwd)/react-native-$PACKAGE_VERSION.tgz" "$PACKAGE"
+
+    node scripts/set-rn-template-version.js "file:$PACKAGE"
+    success "React Native version changed in the template"
+
+    project_name="RNTestProject"
+
+    cd /tmp/ || exit
+    rm -rf "$project_name"
+    node "$repo_root/cli.js" init "$project_name" --template "$repo_root"
+
+    info "Double checking the versions in package.json are correct:"
+    grep "\"react-native\": \".*react-native-$PACKAGE_VERSION-$TIMESTAMP.tgz\"" "/tmp/${project_name}/package.json" || error "Incorrect version number in /tmp/${project_name}/package.json"
+    grep -E "com.facebook.react:react-native:\\+" "${project_name}/android/app/build.gradle" || error "Dependency in /tmp/${project_name}/android/app/build.gradle must be com.facebook.react:react-native:+"
+
+    success "New sample project generated at /tmp/${project_name}"
+}
+
+test_template_app(){
+    if [ "$PACKAGE_VERSION" == "" ]; then
+        init_template_app
+    fi
+
+    if [ "$selected_platform" == "1" ]; then
+        info "Test the following on Android:"
+        info "   - Disable Fast Refresh. It might be enabled from last time (the setting is stored on the device)"
+        info "   - Verify 'Reload JS' works"
+        info ""
+        info "Press any key to run the sample in Android emulator/device"
+        info ""
+        read -r -n 1
+        cd "/tmp/${project_name}" && npx react-native run-android
+    elif [ "$selected_platform" == "2" ]; then
+        info "Test the following on iOS:"
+        info "   - Disable Fast Refresh. It might be enabled from last time (the setting is stored on the device)"
+        info "   - Verify 'Reload JS' works"
+        info "   - Test Chrome debugger by adding breakpoints and reloading JS. We don't have tests for Chrome debugging."
+        info "   - Disable Chrome debugging."
+        info "   - Enable Fast Refresh, change a file (index.js) and save. The UI should refresh."
+        info "   - Disable Fast Refresh."
+        info ""
+        info "Press any key to open the project in Xcode"
+        info ""
+        read -r -n 1
+        open "/tmp/${project_name}/ios/${project_name}.xcworkspace"
+    fi
+    cd "$repo_root" || exit
+}
 
 
-info "Once done testing, keep emulator running"
-info "Press any key to run RNTester on Android with Hermes enabled"
-read -r -n 1
+show_menu(){
+    echo "Which app do you want to test?
+1 - RNTester
+2 - A new RN app using the template"
+    read selected_app
 
-./gradlew :packages:rn-tester:android:app:installHermesDebug || error "Couldn't build RNTester Android"
-adb shell am start -n com.facebook.react.uiapp/.RNTesterActivity
+    echo "What platform do you want to test?
+1 - Android
+2 - iOS"
+    read selected_platform
 
-info "When done testing RNTester on Android,"
-info "Press any key to start testing RNTester in iOS"
-read -r -n 1
+    if [ "$selected_app" == "1" ]; then
+        echo "What VM are you testing?
+1 - Hermes
+2 - JSC"
+        read selected_vm
+    fi
 
-success "About to test iOS JSC... "
-success "Installing CocoaPods dependencies..."
-rm -rf packages/rn-tester/Pods
-(cd packages/rn-tester && bundle exec pod install)
+}
 
-info "Press any key to open the workspace in Xcode, then build and test manually."
-info ""
-read -r -n 1
+handle_menu_input(){
+    if [ "$selected_app" == "1" ]; then
+        info "Start the packager in another terminal by running 'npm start' from the root"
+        info "and then press any key."
+        info ""
+        read -r -n 1
 
-open "packages/rn-tester/RNTesterPods.xcworkspace"
+        if [ "$selected_platform" == "1" ]; then
+            test_android selected_vm
+        elif [ "$selected_platform" == "2" ]; then
+            test_ios selected_vm
+        fi
+    elif [ "$selected_app" == "2" ]; then
+        test_template_app
+    fi
 
-info "When done testing iOS JSC, press any key to test iOS Hermes"
-read -r -n 1
+    read -p "Would you like to test something else? (Y/N)" confirm
+    if [ "$confirm" == "${confirm#[Yy]}" ]; then
+        info "Next steps:"
+        info "https://github.com/facebook/react-native/wiki/Release-Process"
+        exit 1
+    else
+        show_menu
+        handle_menu_input
+    fi
+}
 
-success "About to test iOS Hermes... "
-success "Installing CocoaPods dependencies..."
-rm -rf packages/rn-tester/Pods
-(cd packages/rn-tester && USE_HERMES=1 bundle exec pod install)
+init(){
+    show_menu
+    yarn
+    kill_packagers
+    handle_menu_input
+}
 
-info "Press any key to open the workspace in Xcode, then build and test manually."
-info ""
-read -r -n 1
+init
 
-open "packages/rn-tester/RNTesterPods.xcworkspace"
-
-info "When done testing RNTester app on iOS and Android press any key to continue."
-info ""
-read -r -n 1
-
-success "Killing packager"
-lsof -i :8081 | grep LISTEN
-lsof -i :8081 | grep LISTEN | /usr/bin/awk '{print $2}' | xargs kill
-
-# Testing the template app
-
-PACKAGE_VERSION=$(cat package.json \
-  | grep version \
-  | head -1 \
-  | awk -F: '{ print $2 }' \
-  | sed 's/[",]//g' \
-  | tr -d '[[:space:]]')
-
-success "Preparing version $PACKAGE_VERSION"
-
-npm pack
-
-TIMESTAMP=$(date +%s)
-PACKAGE=$(pwd)/react-native-$PACKAGE_VERSION-$TIMESTAMP.tgz
-success "Package bundled ($PACKAGE)"
-
-mv "$(pwd)/react-native-$PACKAGE_VERSION.tgz" "$PACKAGE"
-
-node scripts/set-rn-template-version.js "file:$PACKAGE"
-success "React Native version changed in the template"
-
-project_name="RNTestProject"
-
-cd /tmp/ || exit
-rm -rf "$project_name"
-node "$repo_root/cli.js" init "$project_name" --template "$repo_root"
-
-info "Double checking the versions in package.json are correct:"
-grep "\"react-native\": \".*react-native-$PACKAGE_VERSION-$TIMESTAMP.tgz\"" "/tmp/${project_name}/package.json" || error "Incorrect version number in /tmp/${project_name}/package.json"
-grep -E "com.facebook.react:react-native:\\+" "${project_name}/android/app/build.gradle" || error "Dependency in /tmp/${project_name}/android/app/build.gradle must be com.facebook.react:react-native:+"
-
-success "New sample project generated at /tmp/${project_name}"
-
-info "Test the following on Android:"
-info "   - Disable Fast Refresh. It might be enabled from last time (the setting is stored on the device)"
-info "   - Verify 'Reload JS' works"
-info ""
-info "Press any key to run the sample in Android emulator/device"
-info ""
-read -r -n 1
-cd "/tmp/${project_name}" && npx react-native run-android
-
-info "Test the following on iOS:"
-info "   - Disable Fast Refresh. It might be enabled from last time (the setting is stored on the device)"
-info "   - Verify 'Reload JS' works"
-info "   - Test Chrome debugger by adding breakpoints and reloading JS. We don't have tests for Chrome debugging."
-info "   - Disable Chrome debugging."
-info "   - Enable Fast Refresh, change a file (index.js) and save. The UI should refresh."
-info "   - Disable Fast Refresh."
-info ""
-info "Press any key to open the project in Xcode"
-info ""
-read -r -n 1
-open "/tmp/${project_name}/ios/${project_name}.xcworkspace"
-
-cd "$repo_root" || exit
-
-info "Next steps:"
-info "https://github.com/facebook/react-native/wiki/Release-Process"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Add a menu to the test-manual-e2e script in order to allow a user to select which scenario they want to test rather than having to run them all in order.

Closes https://github.com/facebook/react-native/issues/32679

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Internal] [Added] - Add menu to test-manual-e2e.sh in order to accept configurations

## Test Plan

Manually run `./scripts/test-manual-e2e.sh` and test all menu options 

https://user-images.githubusercontent.com/11707729/149861072-211c78d3-0b0a-4854-b252-d81a019957f1.mov
 