### PR TITLE
chore(dangerfile): Auto-label pull requests opened against release branches

### DIFF
--- a/bots/dangerfile.js
+++ b/bots/dangerfile.js
@@ -89,11 +89,26 @@ if (!includesChangelog) {
 
 // Warns if the PR is opened against stable, as commits need to be cherry picked and tagged by a release maintainer.
 // Fails if the PR is opened against anything other than `main` or `-stable`.
-const isMergeRefMaster = danger.github.pr.base.ref === 'main';
+const isMergeRefMain = danger.github.pr.base.ref === 'main';
 const isMergeRefStable = danger.github.pr.base.ref.indexOf('-stable') !== -1;
-if (!isMergeRefMaster && !isMergeRefStable) {
+if (!isMergeRefMain && !isMergeRefStable) {
   const title = ':exclamation: Base Branch';
   const idea =
     'The base branch for this PR is something other than `main` or a `-stable` branch. [Are you sure you want to target something other than the `main` branch?](https://reactnative.dev/docs/contributing#pull-requests)';
   fail(`${title} - <i>${idea}</i>`);
+}
+
+// If the PR is opened against stable should add `Pick Request` label
+if (isMergeRefStable) {
+  const {owner, repo, number: issueNumber} = danger.github.thisPR;
+
+  danger.github.api.request(
+    'POST /repos/{owner}/{repo}/issues/{issueNumber}/labels',
+    {
+      owner,
+      repo,
+      issueNumber,
+      labels: ['Pick Request'],
+    },
+  );
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary 

Update dangerfile in order auto-label pull requests opened against release branches

Closes https://github.com/facebook/react-native/issues/32692

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Internal] [Added] -  Auto-label pull requests opened against release branches

## Test Plan

As I don't have admin rights to this repo I tested this script on [a PR in my fork](https://github.com/gabrieldonadel/react-native/pull/1) by running 

```
 yarn danger pr https://github.com/gabrieldonadel/react-native/pull/1
```

https://user-images.githubusercontent.com/11707729/150026370-4cce7831-c4ee-4269-b6a8-646f965826c5.mov

As you can see in the video once I run the script it automatically adds the label
