### PR TITLE
Do not remove libjscexecutor.so from release builds

### DIFF
--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/TaskConfiguration.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/TaskConfiguration.kt
@@ -240,10 +240,6 @@ private fun Project.cleanupVMFiles(
     } else {
       // For JSC, delete all the libhermes* files
       it.include("**/libhermes*.so")
-      // Delete the libjscexecutor from release build
-      if (cleanup) {
-        it.include("**/libjscexecutor.so")
-      }
     }
   }
       .visit { visit ->

--- a/react.gradle
+++ b/react.gradle
@@ -372,10 +372,6 @@ afterEvaluate {
                 } else {
                     // For JSC, delete all the libhermes* files
                     include "**/libhermes*.so"
-                    // Delete the libjscexecutor from release build
-                    if (cleanup) {
-                        include "**/libjscexecutor.so"
-                    }
                 }
             }.visit { details ->
                 def targetVariant1 = ".*/transforms/[^/]*/${variant.name}/.*"


### PR DESCRIPTION
Summary:
As the title says, we dont' want to remove `libjscexecutor.so` when
baking release builds and having JSC enable as this leads to instacrashes.

Fixes #32928
Fixes #32927

Changelog:
[Android] [Fixed] - Do not remove libjscexecutor.so from release builds

Differential Revision: D33681932

