### PR TITLE
Use CircleCI API to trigger releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -733,6 +733,12 @@ jobs:
   #      JOBS: Releases
   # -------------------------
   prepare_package_for_release:
+    parameters:
+      version:
+        type: string
+      latest:
+        type: boolean
+        default: false
     executor: reactnativeios
     steps:
       - checkout
@@ -743,7 +749,7 @@ jobs:
       - run:
           name: "Set new react-native version and commit changes"
           command: |
-            node ./scripts/prepare-package-for-release.js
+            node ./scripts/prepare-package-for-release.js -v << parameters.version >> -l << parameters.latest >>
 
   build_npm_package:
     parameters:
@@ -827,13 +833,35 @@ jobs:
           command: |
             echo "Nightly build run"
 
+
+# -------------------------
+#        PIPELINE PARAMETERS
+# -------------------------
+parameters:
+  run_package_release_workflow_only:
+    default: false
+    type: boolean
+
+  release_latest:
+    default: false
+    type: boolean
+
+  release_version:
+    default: "9999"
+    type: string
+
 # -------------------------
 #        WORK FLOWS
+#
+#  When creating a new workflow, make sure to include condition `unless: << pipeline.parameters.run_package_release_workflow_only >>`
+#  It's setup this way so we can trigger a release via a POST
+#  See limitations: https://support.circleci.com/hc/en-us/articles/360050351292-How-to-trigger-a-workflow-via-CircleCI-API-v2
 # -------------------------
 workflows:
   version: 2
 
   tests:
+    unless: << pipeline.parameters.run_package_release_workflow_only >>
     jobs:
       - build_npm_package:
           # Build a release package on every untagged commit, but do not publish to npm.
@@ -899,20 +927,20 @@ workflows:
               ignore: gh-pages
           run_disabled_tests: false
 
-  releases:
+  # This workflow should only be triggered by release script
+  package_release:
+    when: << pipeline.parameters.run_package_release_workflow_only >>
     jobs:
-      # This job will trigger on relevant release branch pushes.
-      # It prepares the package and triggers `build_npm_package` for release
+      # This job will trigger publish_release workflow
       - prepare_package_for_release:
           name: prepare_package_for_release
-          # Since CircleCI does not support branch AND tag filters, we manually check in job
-          # and no-op if there is no `publish-v{version}` tag set.
-          filters:
-            branches:
-              only:
-                - /^(\d+)\.(\d+)-stable$/
+          version: << pipeline.parameters.release_version >>
+          latest : << pipeline.parameters.release_latest >>
 
-      # This job will trigger when a version tag is pushed (by prepare_package_for_release)
+  publish_release:
+    unless: << pipeline.parameters.run_package_release_workflow_only >>
+    jobs:
+      # This job will trigger when a version tag is pushed (by package_release)
       - build_npm_package:
           name: build_and_publish_npm_package
           context: react-native-bot
@@ -930,6 +958,7 @@ workflows:
               only: /v[0-9]+(\.[0-9]+)*(\-rc(\.[0-9]+)?)?/
 
   analysis:
+    unless: << pipeline.parameters.run_package_release_workflow_only >>
     jobs:
       # Run lints on every commit other than those to the gh-pages branch
       - analyze_code:
@@ -950,6 +979,7 @@ workflows:
               ignore: gh-pages
 
   nightly:
+    unless: << pipeline.parameters.run_package_release_workflow_only >>
     triggers:
       - schedule:
           cron: "0 20 * * *"

--- a/scripts/__tests__/version-utils-test.js
+++ b/scripts/__tests__/version-utils-test.js
@@ -10,9 +10,7 @@
 const {
   parseVersion,
   isTaggedLatest,
-  getPublishVersion,
   isReleaseBranch,
-  getPublishTag,
 } = require('../version-utils');
 
 let execResult = null;
@@ -46,42 +44,6 @@ describe('version-utils', () => {
     it('it should not identify commit as tagged `latest`', () => {
       execResult = '6c19dc3266b84f47a076b647a1c93b3c3b69d2c5\n';
       expect(isTaggedLatest('6c19dc3266b8')).toBe(false);
-    });
-  });
-
-  describe('getPublishTag', () => {
-    it('Should return null no tags are returned', () => {
-      execResult = '\n';
-      expect(getPublishTag()).toBe(null);
-    });
-    it('Should return tag', () => {
-      execResult = 'publish-v999.0.0-rc.0\n';
-      expect(getPublishTag()).toBe('publish-v999.0.0-rc.0');
-    });
-  });
-
-  describe('getPublishVersion', () => {
-    it('Should return null if invalid tag provided', () => {
-      expect(getPublishVersion('')).toBe(null);
-      expect(getPublishVersion('something')).toBe(null);
-    });
-    it('should throw error if invalid tag version provided', () => {
-      function testInvalidVersion() {
-        getPublishVersion('publish-<invalid-version>');
-      }
-      expect(testInvalidVersion).toThrowErrorMatchingInlineSnapshot(
-        `"You must pass a correctly formatted version; couldn't parse <invalid-version>"`,
-      );
-    });
-    it('Should return version for tag', () => {
-      const {version, major, minor, patch, prerelease} = getPublishVersion(
-        'publish-v0.67.0-rc.6',
-      );
-      expect(version).toBe('0.67.0-rc.6');
-      expect(major).toBe('0');
-      expect(minor).toBe('67');
-      expect(patch).toBe('0');
-      expect(prerelease).toBe('rc.6');
     });
   });
 

--- a/scripts/version-utils.js
+++ b/scripts/version-utils.js
@@ -38,15 +38,6 @@ function getBranchName() {
   }).stdout.trim();
 }
 
-function getPublishVersion(tag) {
-  if (!tag.startsWith('publish-')) {
-    return null;
-  }
-
-  const versionStr = tag.replace('publish-', '');
-  return parseVersion(versionStr);
-}
-
 function isTaggedLatest(commitSha) {
   return (
     exec(`git rev-list -1 latest | grep ${commitSha}`, {
@@ -55,19 +46,9 @@ function isTaggedLatest(commitSha) {
   );
 }
 
-function getPublishTag() {
-  // Assumes we only ever have one tag with the prefix `publish-v`
-  const tag = exec("git tag --points-at HEAD | grep 'publish-v'", {
-    silent: true,
-  }).stdout.trim();
-  return tag ? tag : null;
-}
-
 module.exports = {
   getBranchName,
   isTaggedLatest,
-  getPublishTag,
-  getPublishVersion,
   parseVersion,
   isReleaseBranch,
 };


### PR DESCRIPTION
Set it up so that we don't rely on intermediate tags to trigger release work on CircleCI.
This does have the con of needing to give CircleCI project permission for whoever wants to run a release.

See related discussion: https://github.com/reactwg/react-native-releases/discussions/7#discussioncomment-1836420

* changes to config.yml allow us to use our POST data to trigger a certain workflow. There is no direct API to trigger a workflow, CircleCI only has an API to trigger pipelines, so the suggestion is to leverage conditionals: https://support.circleci.com/hc/en-us/articles/360050351292-How-to-trigger-a-workflow-via-CircleCI-API-v2
* Update `bump-oss-version` to make the api call -- the instructions for running a release are still the same: https://github.com/facebook/react-native/wiki/Release-Process#creating-0minor0-rc0 
   * Would be good to make this a yarn script as @tido64 mentioned 
* Remove unused utilities now that we don't use intermediate tags like `publish-...`