### PR TITLE
Allow to setup a Gradle Enterprise Instance via env variable.

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,3 +22,20 @@ include(
 // Include this to enable codegen Gradle plugin.
 includeBuild("packages/react-native-gradle-plugin/")
 
+rootProject.name = "react-native-github"
+
+plugins {
+    id("com.gradle.enterprise").version("3.7.1")
+}
+
+if (System.getenv("GRADLE_ENTERPRISE_URL") != null) {
+    gradleEnterprise {
+        server = System.getenv("GRADLE_ENTERPRISE_URL")
+        buildScan {
+            publishAlways()
+            tag("ReactNative")
+            tag(if(System.getenv("CI") != null) "CI" else "Local")
+        }
+    }
+}
+


### PR DESCRIPTION
Summary:
This diff allows to setup a Gradle Enterprise instance
either locally or on CI via the `GRADLE_ENTERPRISE_URL`.

Moreover, it applies the `com.gradle.enterprise` Gradle
plugin by default. This has the positive side effect of
not invalidating build cache for the included build if
you happen to pass the `--scan` flag in OSS (as the
classpath isn't changed).

Changelog:
[Android] [Added] - Allow to setup a Gradle Enterprise Instance via env variable.

Reviewed By: mdvacca

Differential Revision: D33582388

