### PR TITLE
ci: Add github action to apply version label to pre-release issues

### DIFF
--- a/.github/workflows/apply-version-label-issue.yml
+++ b/.github/workflows/apply-version-label-issue.yml
@@ -10,6 +10,6 @@ jobs:
     continue-on-error: true
 
     steps:
-      - uses: gabrieldonadel/core-workflow-apply-version-label@v0.0.1
+      - uses: gabrieldonadel/actions-apply-version-label@v0.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/apply-version-label-issue.yml
+++ b/.github/workflows/apply-version-label-issue.yml
@@ -10,6 +10,7 @@ jobs:
     continue-on-error: true
 
     steps:
-      - uses: gabrieldonadel/actions-apply-version-label@v0.0.1
+      - uses: gabrieldonadel/actions-apply-version-label@v0.0.2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          required-label: "Type: Upgrade Issue"

--- a/.github/workflows/apply-version-label-issue.yml
+++ b/.github/workflows/apply-version-label-issue.yml
@@ -1,0 +1,15 @@
+name: Apply version label to issue
+
+on:
+  issues:
+    types: [opened, edited]
+
+jobs:
+  add-version-label-issue:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+      - uses: gabrieldonadel/core-workflow-apply-version-label@v0.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Add workflow to automatically label issues with the `Type: Upgrade Issue` label as `Version: XX` using [actions-apply-version-label](https://github.com/marketplace/actions/apply-version-label-to-issue-with-specific-label) github action.

Closes https://github.com/facebook/react-native/issues/32691

## Changelog

[Internal] [Added] - Add github action to apply version label to pre-release issues

## Test Plan

As I don't have admin rights to this repo I merged these same changes  in my fork (https://github.com/gabrieldonadel/react-native/pull/3) and tested this action by opening [an issue](https://github.com/gabrieldonadel/react-native/issues/5) tagged as `pre-release` 

https://user-images.githubusercontent.com/11707729/150696182-82381f86-78af-4ba0-a94c-e5780ee54316.mov


## Next steps 

Transfer [core-workflow-apply-version-label](https://github.com/gabrieldonadel/core-workflow-apply-version-label) to [react-native-community](https://github.com/react-native-community) 
