### PR TITLE
fix(ios): fix `Time.h` patch not being applied

### DIFF
--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -646,5 +646,6 @@ def __apply_Xcode_12_5_M1_post_install_workaround(installer)
   #   "Time.h:52:17: error: typedef redefinition with different types"
   # We need to make a patch to RCT-Folly - remove the `__IPHONE_OS_VERSION_MIN_REQUIRED` check.
   # See https://github.com/facebook/flipper/issues/834 for more details.
-  `sed -i -e  $'s/ && (__IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_10_0)//' Pods/RCT-Folly/folly/portability/Time.h`
+  time_header = "#{Pod::Config.instance.installation_root.to_s}/Pods/RCT-Folly/folly/portability/Time.h"
+  `sed -i -e  $'s/ && (__IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_10_0)//' #{time_header}`
 end


### PR DESCRIPTION
## Summary

The path to `Time.h` is currently hard-coded and does not take into
consideration the `--project-directory` flag when running `pod install`.

## Changelog

[iOS] [Fixed] - Fix `Time.h` patch not being applied when running `pod install --project-directory=ios`

## Test Plan

```
git clone https://github.com/microsoft/react-native-test-app.git
cd react-native-test-app
npm run set-react-version main
yarn
cd example
pod install --project-directory=ios
../scripts/xcodebuild.sh ios/Example.xcworkspace build
```