### PR TITLE
fix(jest/setup): fix circular dependencies in mockModal

### DIFF
--- a/jest/mockModal.js
+++ b/jest/mockModal.js
@@ -13,11 +13,11 @@
 'use strict';
 
 const React = require('react');
-const Modal = require('../Libraries/Modal/Modal');
+import typeof Modal from '../Libraries/Modal/Modal';
 
 function mockModal(BaseComponent: $FlowFixMe) {
   class ModalMock extends BaseComponent {
-    render(): React.Element<typeof Modal> {
+    render(): React.Element<Modal> {
       return (
         <BaseComponent {...this.props}>
           {this.props.visible !== true ? null : this.props.children}


### PR DESCRIPTION
## Summary

Fixes https://github.com/facebook/react-native/issues/32939
It appears there is circular dependencies on the Modal component that causes the modalMock function to be an empty object. Removing the import fixes the issue.
I don't know yet why this is not happening when executing the test suite inside `Modal-test.js` but I will investigate this later.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Fixed] - Fix error "mockModal is not a function"

## Test Plan

On a newly initiated project using react-native 0.67.1 I created a ModalComponent:
```
import React from 'react';
import {Modal, Text} from 'react-native';

export const ModalComponent = () => {
  return (
    <Modal visible>
      <Text>Test</Text>
    </Modal>
  );
};
```
and a ModalComponent.test.tsx:
```
import 'react-native';
import React from 'react';
import {ModalComponent} from '../ModalComponent';

// Note: test renderer must be required after react-native.
import renderer from 'react-test-renderer';

it('renders correctly', () => {
  renderer.create(<ModalComponent />);
});
```

Running the test throws the error "TypeError: mockModal is not a function".

After modifying the mockModal inside node_modules/react-native/jest/mockModal.js it works correctly.