### PR TITLE
Update StatusBar for Android 11+

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/statusbar/StatusBarModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/statusbar/StatusBarModule.java
@@ -15,6 +15,7 @@ import android.content.Context;
 import android.os.Build;
 import android.view.View;
 import android.view.WindowInsets;
+import android.view.WindowInsetsController;
 import android.view.WindowManager;
 import androidx.annotation.Nullable;
 import androidx.core.view.ViewCompat;
@@ -184,7 +185,28 @@ public class StatusBarModule extends NativeStatusBarManagerAndroidSpec {
       return;
     }
 
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+      UiThreadUtil.runOnUiThread(
+        new Runnable() {
+          @TargetApi(Build.VERSION_CODES.R)
+          @Override
+          public void run() {
+            WindowInsetsController insetsController = activity.getWindow().getInsetsController();
+            if ("light-content".equals(style)) {
+              // light-content means white icons on a dark status bar
+              insetsController.setSystemBarsAppearance(
+                0,
+                WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS
+              );
+            } else {
+              insetsController.setSystemBarsAppearance(
+                WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS,
+                WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS
+              );
+            }
+          }
+        });
+    } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
       UiThreadUtil.runOnUiThread(
           new Runnable() {
             @TargetApi(Build.VERSION_CODES.M)

--- a/packages/rn-tester/js/examples/StatusBar/StatusBarExample.js
+++ b/packages/rn-tester/js/examples/StatusBar/StatusBarExample.js
@@ -23,7 +23,7 @@ const {
 
 const colors = ['#ff0000', '#00ff00', '#0000ff', 'rgba(0, 0, 0, 0.4)'];
 
-const barStyles = ['default', 'light-content'];
+const barStyles = ['default', 'light-content', 'dark-content'];
 
 const showHideTransitions = ['fade', 'slide'];
 
@@ -129,11 +129,16 @@ class StatusBarStyleExample extends React.Component<{...}, $FlowFixMeState> {
             <Text>style: '{getValue(barStyles, this._barStyleIndex)}'</Text>
           </View>
         </TouchableHighlight>
+        <View style={styles.wrapper}>
+          <Text>(default is dark for iOS, light for Android)</Text>
+        </View>
         <TouchableHighlight
           style={styles.wrapper}
           onPress={this._onChangeAnimated}>
           <View style={styles.button}>
-            <Text>animated: {this.state.animated ? 'true' : 'false'}</Text>
+            <Text>
+              animated (ios only): {this.state.animated ? 'true' : 'false'}
+            </Text>
           </View>
         </TouchableHighlight>
       </View>
@@ -288,6 +293,9 @@ class StatusBarStaticIOSExample extends React.Component<{...}> {
             <Text>setBarStyle('default', true)</Text>
           </View>
         </TouchableHighlight>
+        <View style={styles.wrapper}>
+          <Text>(default is dark for iOS, light for Android)</Text>
+        </View>
         <TouchableHighlight
           style={styles.wrapper}
           onPress={() => {
@@ -342,6 +350,36 @@ class StatusBarStaticAndroidExample extends React.Component<{...}> {
             <Text>setHidden(false)</Text>
           </View>
         </TouchableHighlight>
+        <TouchableHighlight
+          style={styles.wrapper}
+          onPress={() => {
+            StatusBar.setBarStyle('light-content');
+          }}>
+          <View style={styles.button}>
+            <Text>setBarStyle('light-content')</Text>
+          </View>
+        </TouchableHighlight>
+        <TouchableHighlight
+          style={styles.wrapper}
+          onPress={() => {
+            StatusBar.setBarStyle('dark-content');
+          }}>
+          <View style={styles.button}>
+            <Text>setBarStyle('dark-content')</Text>
+          </View>
+        </TouchableHighlight>
+        <TouchableHighlight
+          style={styles.wrapper}
+          onPress={() => {
+            StatusBar.setBarStyle('default');
+          }}>
+          <View style={styles.button}>
+            <Text>setBarStyle('default')</Text>
+          </View>
+        </TouchableHighlight>
+        <View style={styles.wrapper}>
+          <Text>(default is dark for iOS, light for Android)</Text>
+        </View>
         <TouchableHighlight
           style={styles.wrapper}
           onPress={() => {
@@ -448,7 +486,6 @@ exports.examples = [
     render(): React.Node {
       return <StatusBarStyleExample />;
     },
-    platform: 'ios',
   },
   {
     title: 'StatusBar network activity indicator',


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Android 11 (API 30) introduced a new interface for changing the appearance of the status bars with [WindowInsetsController#setSystemBarsAppearance](https://developer.android.com/reference/kotlin/android/view/WindowInsetsController#setsystembarsappearance) and deprecated using the WindowManager#systemUiVisibility properties.

Apparently, once you call `setSystemBarsAppearance` Android will no longer respect `systemUiVisibility` and if anyone, such as the Android 12 Splash Screen library, happens to call it, it will break status bars.

This PR augments the RN StatusBarModule to use the new interface on Android 11+.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Added] - Use new StatusBar API on Android 11 (API 30)+

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
