### PR TITLE
ci: Bump actions-apply-version-label to 0.0.3

### DIFF
--- a/.github/workflows/apply-version-label-issue.yml
+++ b/.github/workflows/apply-version-label-issue.yml
@@ -10,7 +10,7 @@ jobs:
     continue-on-error: true
 
     steps:
-      - uses: gabrieldonadel/actions-apply-version-label@v0.0.2
+      - uses: gabrieldonadel/actions-apply-version-label@v0.0.3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           required-label: "Type: Upgrade Issue"

--- a/.github/workflows/apply-version-label-issue.yml
+++ b/.github/workflows/apply-version-label-issue.yml
@@ -10,7 +10,7 @@ jobs:
     continue-on-error: true
 
     steps:
-      - uses: gabrieldonadel/actions-apply-version-label@v0.0.3
+      - uses: react-native-community/actions-apply-version-label@v0.0.3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           required-label: "Type: Upgrade Issue"


### PR DESCRIPTION
## Summary

This PR  bumps the `actions-apply-version-label`  version to 0.0.3 in order to fix an issue where we were throwing an error when the identified label does not exist, instead we should just report a warning. This also updates `apply-version-label-issue.yml` to use `actions-apply-version-label` from `react-native-community` as it has been recently transferred to the community

## Changelog

[Internal] [Fixed] - Fix `actions-apply-version-label` error when version label is missing

## Test Plan

Open an issue with a missing version label and ran the new action version

https://github.com/gabrieldonadel/actions-apply-version-label/actions/runs/1756805059
