### PR TITLE
[CI] bump Node references from 12/14 to 14/16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,11 +28,11 @@ executors:
     <<: *defaults
     docker:
       # Note: Version set separately for Windows builds, see below.
-      - image: circleci/node:14
+      - image: circleci/node:16
   nodeprevlts:
     <<: *defaults
     docker:
-      - image: circleci/node:12
+      - image: circleci/node:14
   reactnativeandroid:
     <<: *defaults
     docker:
@@ -376,7 +376,7 @@ jobs:
       - run:
           name: Configure Environment Variables
           command: |
-            echo 'export PATH=/usr/local/opt/node@14/bin:$PATH' >> $BASH_ENV
+            echo 'export PATH=/usr/local/opt/node@16/bin:$PATH' >> $BASH_ENV
             source $BASH_ENV
 
       - with_brew_cache_span:
@@ -393,7 +393,7 @@ jobs:
           name: Configure Node
           # Sourcing find-node.sh will ensure nvm is set up.
           # It also helps future invocation of find-node.sh prevent permission issue with nvm.sh.
-          command: source scripts/find-node.sh && nvm install 14 && nvm alias default 14
+          command: source scripts/find-node.sh && nvm install 16 && nvm alias default 16
 
       - run:
           name: Configure Watchman
@@ -644,8 +644,8 @@ jobs:
           name: Install Node
           # Note: Version set separately for non-Windows builds, see above.
           command: |
-            nvm install 14.17.0
-            nvm use 14.17.0
+            nvm install 16
+            nvm use 16
 
       # Setup Dependencies
       - run:

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "repository": "github:facebook/react-native",
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "jest-junit": {
     "outputDirectory": "reports/junit",

--- a/scripts/validate-ios-test-env.sh
+++ b/scripts/validate-ios-test-env.sh
@@ -23,7 +23,7 @@ fi
 # Check that the correct version of node is installed
 NODE_VERSION="$(command node --version | sed 's/[-/a-zA-Z]//g' |sed 's/.\{2\}$//')"
 
-if (( $(echo "${NODE_VERSION} < 12.0" | bc -l) )); then
+if (( $(echo "${NODE_VERSION} < 14.0" | bc -l) )); then
   echo "Node ${NODE_VERSION} detected. This version of Node is not supported."
   echo "See https://reactnative.dev/docs/getting-started for instructions."
   exit 1


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Node 16 has been the LTS for quite some time now ([Oct 2021](https://nodejs.org/en/blog/release/v16.13.0/)), so this PR just wants to bring the RN OSS CI up to speed.

(I realized that this was needed while doing the same for macos https://github.com/microsoft/react-native-macos/pull/997)

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Changed] - Breaking: moving minimum version of Node expected to 14, and move CI to current LTS(16).

## Test Plan

CI itself is the test 🤣 locally no significant changes were experienced.
