### PR TITLE
Add missing sources jar into published android artifacts

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -272,6 +272,12 @@ task installArchives {
     dependsOn("publishReleasePublicationToNpmRepository")
 }
 
+// Creating sources with comments
+task androidSourcesJar(type: Jar) {
+  classifier = 'sources'
+  from android.sourceSets.main.java.srcDirs
+}
+
 android {
     compileSdkVersion 31
 
@@ -413,6 +419,9 @@ afterEvaluate {
             release(MavenPublication) {
                 // Applies the component for the release build variant.
                 from components.release
+
+                // Add additional sourcesJar to artifacts
+                artifact(androidSourcesJar)
 
                 // You can then customize attributes of the publication as shown below.
                 artifactId = POM_ARTIFACT_ID


### PR DESCRIPTION
## Summary

when migrated to `maven-publish` in #31611, the sources jar is not included by default from `maven-publish`. so react-native 0.66 / 0.67 doesn't include sources jar in npm published artifacts. it's not ideal for debug or tracing code.

this pr added the sources jar into the published artifact.

## Changelog

[Android] [Fixed] - Add missing sources jar into published android artifacts

## Test Plan

make sure sources jar is included in artifact.

```
$ ./gradlew :ReactAndroid:installArchives
$ find android -name '*sources.jar*'
```