### PR TITLE
fix: Add missing intents to RNTester AndroidManifest

### DIFF
--- a/packages/rn-tester/android/app/src/main/AndroidManifest.xml
+++ b/packages/rn-tester/android/app/src/main/AndroidManifest.xml
@@ -59,5 +59,23 @@
       android:exported="false"
     />
   </application>
+  <queries>
+    <package android:name="com.facebook.katana" />
+    <package android:name="com.facebook.lite" />
+    <package android:name="com.facebook.android" />
+    <intent>
+      <action android:name="android.intent.action.VIEW" />
+      <category android:name="android.intent.category.BROWSABLE" />
+      <data android:scheme="https" />
+    </intent>
+    <intent>
+      <action android:name="android.intent.action.VIEW" />
+      <data android:scheme="geo" />
+    </intent>
+    <intent>
+      <action android:name="android.intent.action.DIAL" />
+      <data android:scheme="tel" />
+    </intent>
+  </queries>
 
 </manifest>


### PR DESCRIPTION
## Summary

Partially resolves https://github.com/facebook/react-native/issues/32962 by adding required intents to RNTester AndroidManifest. 

As [we're now using SDK 31](https://github.com/facebook/react-native/blob/d3a0c4129d6a5a7beced4e9aa62b2da4e3f4fed4/packages/rn-tester/android/app/build.gradle#L166-L166) as the `targetSdkVersion` for `RNTester` we must manually specify the intents for the schemes we want to handle due to changes in Package visibility on Android 11. 

This PR updates RNTester `AndroidManifest` in order to support `canOpenURL` with the url types:
 - http/https urls
 - phone numbers
 - geolocation
 - facebook app uri

 
## Changelog


[Internal] [Fixed] - Add missing intents to RNTester AndroidManifest

## Test Plan

1. Run `./scripts/test-manual-e2e.sh`, choose Android and then Hermes  
2. Head to the APIs example, Linking -> "Open external URLs" 


https://user-images.githubusercontent.com/11707729/151486852-1a2d571d-da9f-4cb5-999a-b111eb9bca29.mov


