### PR TITLE
Android: Fix crash when WindowInsets is null on ReactRootView

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -27,6 +27,7 @@ import android.view.Surface;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewTreeObserver;
+import android.view.WindowInsets;
 import android.view.WindowManager;
 import android.widget.FrameLayout;
 import androidx.annotation.Nullable;
@@ -826,9 +827,12 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
       getRootView().getWindowVisibleDisplayFrame(mVisibleViewArea);
       int notchHeight = 0;
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-        DisplayCutout displayCutout = getRootView().getRootWindowInsets().getDisplayCutout();
+        WindowInsets insets = getRootView().getRootWindowInsets();
+        if (insets != null) {
+        DisplayCutout displayCutout = insets.getDisplayCutout();
         if (displayCutout != null) {
           notchHeight = displayCutout.getSafeInsetTop();
+        }
         }
       }
       final int heightDiff =

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -829,10 +829,10 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
         WindowInsets insets = getRootView().getRootWindowInsets();
         if (insets != null) {
-        DisplayCutout displayCutout = insets.getDisplayCutout();
-        if (displayCutout != null) {
-          notchHeight = displayCutout.getSafeInsetTop();
-        }
+          DisplayCutout displayCutout = insets.getDisplayCutout();
+          if (displayCutout != null) {
+            notchHeight = displayCutout.getSafeInsetTop();
+          }
         }
       }
       final int heightDiff =


### PR DESCRIPTION
## Summary

Fixes a potential crash was introduced by #30919 that aimed to get the keyboard height on devices with a Notch. The problem is that it considers that any ReactRootView will have an insets available.

When using [react-native-navigation](https://github.com/wix/react-native-navigation) and assigning a Navigation button to the TopBar as a component, the component gets registered as a RootView but won't have any insets attach to the view. 

[getRootWindowInsets()](https://developer.android.com/reference/android/view/View#getRootWindowInsets()) in fact return a `WindowInset` only available if the view is attached, so when executing `checkForKeyboardEvents` method from ReactRootView, is trying to access the `DisplayCutout` of a null object, leading to a crash.

## Changelog

[Android] [Fixed] - Fix potential crash if ReactRootView does not have insets attached.

## Test Plan

Without the code change: Notice how the second screen being push contains a React Component on the top right of the navigation bar, and when component is unmounted (going back) the app crashes.

https://user-images.githubusercontent.com/6757047/151558235-39b9a8b5-be73-4c31-8053-02ce188637b8.mp4

crash log
```
2022-01-28 10:27:52.902 15600-15600/com.mattermost.rnbeta E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.mattermost.rnbeta, PID: 15600
    java.lang.NullPointerException: Attempt to invoke virtual method 'android.view.DisplayCutout android.view.WindowInsets.getDisplayCutout()' on a null object reference
        at com.facebook.react.ReactRootView$CustomGlobalLayoutListener.checkForKeyboardEvents(ReactRootView.java:778)
        at com.facebook.react.ReactRootView$CustomGlobalLayoutListener.onGlobalLayout(ReactRootView.java:769)
        at android.view.ViewTreeObserver.dispatchOnGlobalLayout(ViewTreeObserver.java:1061)
        at android.view.ViewRootImpl.performTraversals(ViewRootImpl.java:3214)
        at android.view.ViewRootImpl.doTraversal(ViewRootImpl.java:2143)
        at android.view.ViewRootImpl$TraversalRunnable.run(ViewRootImpl.java:8665)
        at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1037)
        at android.view.Choreographer.doCallbacks(Choreographer.java:845)
        at android.view.Choreographer.doFrame(Choreographer.java:780)
        at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:1022)
        at android.os.Handler.handleCallback(Handler.java:938)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at android.os.Looper.loopOnce(Looper.java:201)
        at android.os.Looper.loop(Looper.java:288)
        at android.app.ActivityThread.main(ActivityThread.java:7839)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003)
```

After applying the patch which is only a null check validation and does not change any previous behavior


https://user-images.githubusercontent.com/6757047/151558429-9ff1a608-abb6-4168-8db9-df0c3c71d79e.mp4
