### PR TITLE
Update gradle-download-task to 5.0.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ buildscript {
     dependencies {
         val kotlin_version: String by project
         classpath("com.android.tools.build:gradle:7.0.4")
-        classpath("de.undercouch:gradle-download-task:4.1.2")
+        classpath("de.undercouch:gradle-download-task:5.0.1")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version")
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/template/android/build.gradle
+++ b/template/android/build.gradle
@@ -15,7 +15,7 @@ buildscript {
     dependencies {
         classpath("com.android.tools.build:gradle:7.0.4")
         classpath("com.facebook.react:react-native-gradle-plugin")
-        classpath("de.undercouch:gradle-download-task:4.1.2")
+        classpath("de.undercouch:gradle-download-task:5.0.1")
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }


### PR DESCRIPTION
## Summary

This enables concurrent task exection and parallel downloads

See also https://github.com/michel-kraemer/gradle-download-task/issues/138

## Changelog

[General] [Changed] - Update gradle-download-task to 5.0.1 to support concurrent downloads

## Test Plan

Build runs successfully.
