### PR TITLE
fix: Access to relative paths when invoking test-manual-e2e

### DIFF
--- a/scripts/test-manual-e2e.sh
+++ b/scripts/test-manual-e2e.sh
@@ -11,7 +11,7 @@ ENDCOLOR="\033[0m"
 
 error() {
     echo -e "$RED""$*""$ENDCOLOR"
-    popd >/dev/null
+    popd >/dev/null || exit
     exit 1
 }
 
@@ -24,8 +24,8 @@ info() {
 }
 
 # Ensures commands are executed from the repo root folder
-dir_absolute_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
-pushd "$dir_absolute_path/../" >/dev/null
+dir_absolute_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" || exit ; pwd -P )
+pushd "$dir_absolute_path/../" >/dev/null || exit
 
 repo_root=$(pwd)
 selected_platform=""
@@ -140,7 +140,7 @@ init_template_app(){
     grep -E "com.facebook.react:react-native:\\+" "${project_name}/android/app/build.gradle" || error "Dependency in /tmp/${project_name}/android/app/build.gradle must be com.facebook.react:react-native:+"
 
     success "New sample project generated at /tmp/${project_name}"
-    popd >/dev/null
+    popd >/dev/null || exit
 }
 
 test_template_app(){
@@ -148,7 +148,7 @@ test_template_app(){
         init_template_app
     fi
 
-    pushd "/tmp/${project_name}" >/dev/null
+    pushd "/tmp/${project_name}" >/dev/null || exit
     if [ "$selected_platform" == "1" ]; then
         info "Test the following on Android:"
         info "   - Disable Fast Refresh. It might be enabled from last time (the setting is stored on the device)"
@@ -216,7 +216,7 @@ handle_menu_input(){
     if [ "$confirm" == "${confirm#[Yy]}" ]; then
         info "Next steps:"
         info "https://github.com/facebook/react-native/wiki/Release-Process"
-        popd >/dev/null
+        popd >/dev/null || exit
         exit 1
     else
         show_menu

--- a/scripts/test-manual-e2e.sh
+++ b/scripts/test-manual-e2e.sh
@@ -22,6 +22,10 @@ info() {
     echo -e "$BLUE""$*""$ENDCOLOR"
 }
 
+# Ensures commands are executed from the repo root folder
+dir_absolute_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
+cd "$dir_absolute_path/../"
+
 repo_root=$(pwd)
 selected_platform=""
 selected_vm=""

--- a/scripts/test-manual-e2e.sh
+++ b/scripts/test-manual-e2e.sh
@@ -11,6 +11,7 @@ ENDCOLOR="\033[0m"
 
 error() {
     echo -e "$RED""$*""$ENDCOLOR"
+    popd >/dev/null
     exit 1
 }
 
@@ -24,7 +25,7 @@ info() {
 
 # Ensures commands are executed from the repo root folder
 dir_absolute_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
-cd "$dir_absolute_path/../"
+pushd "$dir_absolute_path/../" >/dev/null
 
 repo_root=$(pwd)
 selected_platform=""
@@ -130,7 +131,7 @@ init_template_app(){
 
     project_name="RNTestProject"
 
-    cd /tmp/ || exit
+    pushd /tmp/ >/dev/null || exit
     rm -rf "$project_name"
     node "$repo_root/cli.js" init "$project_name" --template "$repo_root"
 
@@ -139,6 +140,7 @@ init_template_app(){
     grep -E "com.facebook.react:react-native:\\+" "${project_name}/android/app/build.gradle" || error "Dependency in /tmp/${project_name}/android/app/build.gradle must be com.facebook.react:react-native:+"
 
     success "New sample project generated at /tmp/${project_name}"
+    popd >/dev/null
 }
 
 test_template_app(){
@@ -146,6 +148,7 @@ test_template_app(){
         init_template_app
     fi
 
+    pushd "/tmp/${project_name}" >/dev/null
     if [ "$selected_platform" == "1" ]; then
         info "Test the following on Android:"
         info "   - Disable Fast Refresh. It might be enabled from last time (the setting is stored on the device)"
@@ -154,7 +157,7 @@ test_template_app(){
         info "Press any key to run the sample in Android emulator/device"
         info ""
         read -r -n 1
-        cd "/tmp/${project_name}" && npx react-native run-android
+        npx react-native run-android
     elif [ "$selected_platform" == "2" ]; then
         info "Test the following on iOS:"
         info "   - Disable Fast Refresh. It might be enabled from last time (the setting is stored on the device)"
@@ -167,9 +170,9 @@ test_template_app(){
         info "Press any key to open the project in Xcode"
         info ""
         read -r -n 1
-        open "/tmp/${project_name}/ios/${project_name}.xcworkspace"
+        open "ios/${project_name}.xcworkspace"
     fi
-    cd "$repo_root" || exit
+    popd >/dev/null || exit
 }
 
 
@@ -213,6 +216,7 @@ handle_menu_input(){
     if [ "$confirm" == "${confirm#[Yy]}" ]; then
         info "Next steps:"
         info "https://github.com/facebook/react-native/wiki/Release-Process"
+        popd >/dev/null
         exit 1
     else
         show_menu


### PR DESCRIPTION
## Summary

Running `test-manual-e2e.sh` from any folder other than the repo root results in errors regarding files not existing, that's because we're not taking into consideration the path from where the script is invoked. This PR updates it so that we get the absolute path of the script and then use it to get the parent directory and `cd` to the repo root folder.

Closes https://github.com/facebook/react-native/issues/32999

## Changelog 

[Internal] [Fixed] - fix access to relative paths when invoking `test-manual-e2e.sh` from folders other than the repo root

## Test Plan

1. Clone this repo
2. Navigate to the rn-tester folder `cd packages/rn-tester/`
3. Run `../../scripts/test-manual-e2e.sh`
4. Select RNTester, Android and Hermes

https://user-images.githubusercontent.com/11707729/151730441-18bc37de-0224-4f5e-a2fe-408e3ace5c1f.mov
