### PR TITLE
chore(deps): Bump shelljs from 0.8.4 to 0.8.5

### DIFF
--- a/repo-config/package.json
+++ b/repo-config/package.json
@@ -44,7 +44,7 @@
     "react": "17.0.2",
     "react-native-codegen": "^0.0.13",
     "react-test-renderer": "17.0.2",
-    "shelljs": "^0.8.4",
+    "shelljs": "^0.8.5",
     "signedsource": "^1.0.0",
     "ws": "^6.1.4",
     "yargs": "^15.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6331,10 +6331,10 @@ shell-quote@^1.6.1:
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.3.tgz#aa40edac170445b9a431e17bb62c0b881b9c4123"
   integrity sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==
 
-shelljs@^0.8.4:
-  version "0.8.4"
-  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.4.tgz#de7684feeb767f8716b326078a8a00875890e3c2"
-  integrity sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==
+shelljs@^0.8.5:
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.5.tgz#de055408d8361bed66c669d2f000538ced8ee20c"
+  integrity sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==
   dependencies:
     glob "^7.0.0"
     interpret "^1.0.0"


### PR DESCRIPTION
## Summary

Running `yarn audit` shows a vulnerability in the `shelljs` version we're currently using

![image](https://user-images.githubusercontent.com/11707729/151735377-eb0ed224-59b6-443c-9127-1b72dd88ee80.png)

This PR upgrades `shelljs` from 0.8.4 to 0.8.5 in order to mitigate this vulnerability 

More info on https://github.com/advisories/GHSA-4rq4-32rv-6wp6 

## Changelog

[Internal] [Security] - Upgrade shelljs to v0.8.5 in order to fix Improper Privilege Management vulnerability 

## Test Plan

There are no API changes between versions 0.8.4 and 0.8.5, so just testing the scripts that use this lib should be enough.
