### PR TITLE
chore(LinkingExample): Update external URLs description

### DIFF
--- a/packages/rn-tester/js/examples/Linking/LinkingExample.js
+++ b/packages/rn-tester/js/examples/Linking/LinkingExample.js
@@ -33,7 +33,13 @@ class OpenURLButton extends React.Component<Props> {
       if (supported) {
         Linking.openURL(this.props.url);
       } else {
-        console.log("Don't know how to open URI: " + this.props.url);
+        console.log(
+          `Don't know how to open URI: ${
+            this.props.url
+          }, ensure you have an app installed that handles the "${
+            this.props.url.split(':')?.[0]
+          }" scheme`,
+        );
       }
     });
   };
@@ -134,6 +140,8 @@ exports.description = 'Shows how to use Linking to open URLs.';
 exports.examples = [
   {
     title: 'Open external URLs',
+    description:
+      'Custom schemes may require specific apps to be installed oo the device. Note: Phone app is not supported in the simulator.',
     render: function (): React.Element<typeof IntentAndroidExample> {
       return <IntentAndroidExample />;
     },

--- a/packages/rn-tester/js/examples/Linking/LinkingExample.js
+++ b/packages/rn-tester/js/examples/Linking/LinkingExample.js
@@ -141,7 +141,7 @@ exports.examples = [
   {
     title: 'Open external URLs',
     description:
-      'Custom schemes may require specific apps to be installed oo the device. Note: Phone app is not supported in the simulator.',
+      'Custom schemes may require specific apps to be installed on the device. Note: Phone app is not supported in the simulator.',
     render: function (): React.Element<typeof IntentAndroidExample> {
       return <IntentAndroidExample />;
     },


### PR DESCRIPTION
## Summary

Update LinkingExample "Open external URLs" description to mitigate confusion about opening custom schemes in the simulator when testing, as suggested by Luna here https://github.com/facebook/react-native/issues/32962#issuecomment-1026018822

## Changelog

[Internal] [Changed] - Update LinkingExample "Open external URLs" description

## Test Plan

1. Build RNTester iOS app
2. Head to the APIs example, Linking -> "Open external URLs"

https://user-images.githubusercontent.com/11707729/152087644-7e95692c-5180-465b-9fc8-2a637a091deb.mov


