### PR TITLE
use root locale when converting string case

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
@@ -197,7 +197,7 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
     final String bundleFile = subclassTag + "ReactNativeDevBundle.js";
     mJSBundleDownloadedFile = new File(applicationContext.getFilesDir(), bundleFile);
 
-    final String splitBundlesDir = subclassTag.toLowerCase() + "_dev_js_split_bundles";
+    final String splitBundlesDir = subclassTag.toLowerCase(Locale.ROOT) + "_dev_js_split_bundles";
     mJSSplitBundlesDir = mApplicationContext.getDir(splitBundlesDir, Context.MODE_PRIVATE);
 
     mDefaultNativeModuleCallExceptionHandler = new DefaultNativeModuleCallExceptionHandler();

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.java
@@ -30,6 +30,7 @@ import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import okhttp3.Call;
@@ -376,7 +377,7 @@ public final class NetworkingModule extends NativeNetworkingAndroidSpec {
     }
 
     RequestBody requestBody;
-    if (data == null || method.toLowerCase().equals("get") || method.toLowerCase().equals("head")) {
+    if (data == null || method.toLowerCase(Locale.ROOT).equals("get") || method.toLowerCase(Locale.ROOT).equals("head")) {
       requestBody = RequestBodyUtil.getEmptyBody(method);
     } else if (handler != null) {
       requestBody = handler.toRequestBody(data, contentType);

--- a/ReactAndroid/src/main/java/com/facebook/react/views/imagehelper/ResourceDrawableIdHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/imagehelper/ResourceDrawableIdHelper.java
@@ -12,6 +12,7 @@ import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import androidx.annotation.Nullable;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -47,7 +48,7 @@ public class ResourceDrawableIdHelper {
     if (name == null || name.isEmpty()) {
       return 0;
     }
-    name = name.toLowerCase().replace("-", "_");
+    name = name.toLowerCase(Locale.ROOT).replace("-", "_");
 
     // name could be a resource id.
     try {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -75,6 +75,7 @@ import com.facebook.yoga.YogaConstants;
 import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.LinkedList;
+import java.util.Locale;
 import java.util.Map;
 
 /** Manages instances of TextInput. */
@@ -569,7 +570,7 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
   }
 
   private static boolean shouldHideCursorForEmailTextInput() {
-    String manufacturer = Build.MANUFACTURER.toLowerCase();
+    String manufacturer = Build.MANUFACTURER.toLowerCase(Locale.ROOT);
     return (Build.VERSION.SDK_INT == Build.VERSION_CODES.Q && manufacturer.contains("xiaomi"));
   }
 


### PR DESCRIPTION
## Summary

Not setting locale for language/country neutral operation may cause bug depending on the default locale.
See https://docs.oracle.com/javase/7/docs/api/java/util/Locale.html#ROOT

Note: I am just searching for toLowerCase() and toUppercase() in my project's dependencies and send the same PR, in order to just be considered. Although I've seen the lack of explicit locale has caused issues for us, I am not sure if react-native is actually affected. I haven't checked for `String.format()` yet. 

Example related issue: joltup/rn-fetch-blob#573

## Changelog

[Android] [Fixed] - Use root locale when converting string case.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
