### PR TITLE
fix: jvm 11 error message from ReactPlugin.kt and react.gradle 

### DIFF
--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
@@ -18,12 +18,30 @@ import java.io.File
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.internal.jvm.Jvm
+import kotlin.system.exitProcess
 
 class ReactPlugin : Plugin<Project> {
   override fun apply(project: Project) {
+    checkJvmVersion()
     val extension = project.extensions.create("react", ReactExtension::class.java, project)
     applyAppPlugin(project, extension)
     applyCodegenPlugin(project, extension)
+  }
+
+  private fun checkJvmVersion(){
+    val jvmVersion = Jvm.current()?.javaVersion?.majorVersion
+    if ((jvmVersion?.toIntOrNull() ?: 0) <= 8) {
+      println("\n\n\n")
+      println("**************************************************************************************************************")
+      println("\n\n")
+      println("ERROR: requires JDK11 or higher.")
+      println("Incompatible major version detected: '" + jvmVersion + "'")
+      println("\n\n")
+      println("**************************************************************************************************************")
+      println("\n\n\n")
+      exitProcess(1)
+    }
   }
 
   private fun applyAppPlugin(project: Project, config: ReactExtension) {

--- a/react.gradle
+++ b/react.gradle
@@ -6,6 +6,7 @@
  */
 
 import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.internal.jvm.Jvm
 
 def config = project.hasProperty("react") ? project.react : [:];
 
@@ -127,6 +128,19 @@ android {
         resValue "integer", "react_native_dev_server_port", reactNativeDevServerPort()
         resValue "integer", "react_native_inspector_proxy_port", reactNativeInspectorProxyPort()
     }
+}
+
+def jvmVersion = Jvm.current().javaVersion.majorVersion
+if (jvmVersion.toInteger() <= 8) {
+    println "\n\n\n"
+    println "**************************************************************************************************************"
+    println "\n\n"
+    println "ERROR: requires JDK11 or higher."
+    println "Incompatible major version detected: '" + jvmVersion + "'"
+    println "\n\n"
+    println "**************************************************************************************************************"
+    println "\n\n\n"
+    System.exit(1)
 }
 
 afterEvaluate {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
you can see discussion here: https://github.com/reactwg/react-native-releases/discussions/13#discussioncomment-2069527
we were getting this error message when we build Gradle with other than 11 JVM
```
> Task :react-native-gradle-plugin:compileJava FAILED
2 actionable tasks: 2 executed

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':react-native-gradle-plugin:compileJava'.
> invalid source release: 11
```
this solution is suggested by @mikehardy

after this PR, now the error is like this
```
**************************************************************************************************************



ERROR: requires JDK11 or higher.
Incompatible major version detected: '8'



**************************************************************************************************************
```

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Fixed] - jvm 11 error message

## Test Plan
install other than 11 java version and just run `./scripts/test-manual-e2e.sh` this command at the root of RN repo than this error will appair `invalid source release: 11`

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
