### PR TITLE
build: Bump AGP to 7.1.1 and fix bundle inclusion in release mode

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -418,6 +418,10 @@ afterEvaluate {
 
     // Needed as some of the native sources needs to be downloaded
     // before configureNdkBuildDebug could be executed.
+    reactNativeArchitectures().each { architecture ->
+        tasks.named("configureNdkBuildDebug[${architecture}]") { dependsOn(preBuild) }
+        tasks.named("configureNdkBuildRelease[${architecture}]") { dependsOn(preBuild) }
+    }
     configureNdkBuildDebug.dependsOn(preBuild)
     configureNdkBuildRelease.dependsOn(preBuild)
 

--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -279,6 +279,7 @@ task androidSourcesJar(type: Jar) {
 }
 
 android {
+    buildToolsVersion = "31.0.0"
     compileSdkVersion 31
 
     // Used to override the NDK path & version on internal CI

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ buildscript {
     }
     dependencies {
         val kotlin_version: String by project
-        classpath("com.android.tools.build:gradle:7.0.4")
+        classpath("com.android.tools.build:gradle:7.1.0")
         classpath("de.undercouch:gradle-download-task:5.0.1")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version")
         // NOTE: Do not place your application dependencies here; they belong

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ buildscript {
     }
     dependencies {
         val kotlin_version: String by project
-        classpath("com.android.tools.build:gradle:7.1.0")
+        classpath("com.android.tools.build:gradle:7.1.1")
         classpath("de.undercouch:gradle-download-task:5.0.1")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version")
         // NOTE: Do not place your application dependencies here; they belong

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/TaskConfiguration.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/TaskConfiguration.kt
@@ -194,6 +194,8 @@ internal fun Project.configureReactTasks(variant: BaseVariant, config: ReactExte
           it.into(jsBundleDirConfigValue.get())
         } else {
           it.into(mergeAssetsTask.map { mergeFoldersTask -> mergeFoldersTask.outputDir.get() })
+          // Workaround for Android Gradle Plugin 7.1 asset directory
+          it.into("$buildDir/intermediates/assets/${variant.name}/merge${targetName}Assets")
         }
 
         it.dependsOn(mergeAssetsTask)

--- a/packages/rn-tester/android/app/build.gradle
+++ b/packages/rn-tester/android/app/build.gradle
@@ -143,6 +143,7 @@ def reactNativeArchitectures() {
 }
 
 android {
+    buildToolsVersion = "31.0.0"
     compileSdkVersion 31
 
     // Used to override the NDK path & version on internal CI

--- a/packages/rn-tester/android/app/build.gradle
+++ b/packages/rn-tester/android/app/build.gradle
@@ -298,6 +298,16 @@ if (enableCodegen) {
     }
 
     afterEvaluate {
+        reactNativeArchitectures().each { architecture ->
+            tasks.named("configureNdkBuildDebug[${architecture}]") {
+                dependsOn("preHermesDebugBuild")
+                dependsOn("preJscDebugBuild")
+            }
+            tasks.named("configureNdkBuildRelease[${architecture}]") {
+                dependsOn("preHermesReleaseBuild")
+                dependsOn("preJscReleaseBuild")
+            }
+        }
         configureNdkBuildRelease.dependsOn(packageReactReleaseNdkLibs)
         preHermesReleaseBuild.dependsOn(packageReactReleaseNdkLibs)
         preJscReleaseBuild.dependsOn(packageReactReleaseNdkLibs)

--- a/react.gradle
+++ b/react.gradle
@@ -326,18 +326,16 @@ afterEvaluate {
                 if (isAndroidLibrary) {
                     into ("library_assets/${variant.name}/out")
                 } else {
+                    into ("assets/${targetPath}")
+
+                    // Workaround for Android Gradle Plugin 3.2+ new asset directory
+                    into ("merged_assets/${variant.name}/merge${targetName}Assets/out")
+
+                    // Workaround for Android Gradle Plugin 3.4+ new asset directory
+                    into ("merged_assets/${variant.name}/out")
+
                     // Workaround for Android Gradle Plugin 7.1 asset directory
-                    if (androidComponents.pluginVersion.major == 7 && androidComponents.pluginVersion.minor == 1) {
-                        into("$buildDir/intermediates/assets/${variant.name}/merge${targetName}Assets")
-                    }else{
-                        into ("assets/${targetPath}")
-
-                        // Workaround for Android Gradle Plugin 3.2+ new asset directory
-                        into ("merged_assets/${variant.name}/merge${targetName}Assets/out")
-
-                        // Workaround for Android Gradle Plugin 3.4+ new asset directory
-                        into ("merged_assets/${variant.name}/out")
-                    }
+                    into("$buildDir/intermediates/assets/${variant.name}/merge${targetName}Assets")
                 }
             }
 

--- a/react.gradle
+++ b/react.gradle
@@ -328,18 +328,24 @@ afterEvaluate {
                         from(jsBundleDir)
                     }
                 } else {
-                    into ("assets/${targetPath}") {
+                    // Workaround for Android Gradle Plugin 7.1 asset directory
+                    if (androidComponents.pluginVersion.major == 7 && androidComponents.pluginVersion.minor == 1) {
                         from(jsBundleDir)
-                    }
+                        into("$buildDir/intermediates/assets/${variant.name}/merge${targetName}Assets")
+                    }else{
+                        into ("assets/${targetPath}") {
+                            from(jsBundleDir)
+                        }
 
-                    // Workaround for Android Gradle Plugin 3.2+ new asset directory
-                    into ("merged_assets/${variant.name}/merge${targetName}Assets/out") {
-                        from(jsBundleDir)
-                    }
+                        // Workaround for Android Gradle Plugin 3.2+ new asset directory
+                        into ("merged_assets/${variant.name}/merge${targetName}Assets/out") {
+                            from(jsBundleDir)
+                        }
 
-                    // Workaround for Android Gradle Plugin 3.4+ new asset directory
-                    into ("merged_assets/${variant.name}/out") {
-                        from(jsBundleDir)
+                        // Workaround for Android Gradle Plugin 3.4+ new asset directory
+                        into ("merged_assets/${variant.name}/out") {
+                            from(jsBundleDir)
+                        }
                     }
                 }
             }

--- a/react.gradle
+++ b/react.gradle
@@ -318,34 +318,25 @@ afterEvaluate {
             group = "react"
             description = "copy bundled JS into ${targetName}."
 
+            from(jsBundleDir)
             if (config."jsBundleDir${targetName}") {
-                from(jsBundleDir)
                 into(file(config."jsBundleDir${targetName}"))
             } else {
                 into ("$buildDir/intermediates")
                 if (isAndroidLibrary) {
-                    into ("library_assets/${variant.name}/out") {
-                        from(jsBundleDir)
-                    }
+                    into ("library_assets/${variant.name}/out")
                 } else {
                     // Workaround for Android Gradle Plugin 7.1 asset directory
                     if (androidComponents.pluginVersion.major == 7 && androidComponents.pluginVersion.minor == 1) {
-                        from(jsBundleDir)
                         into("$buildDir/intermediates/assets/${variant.name}/merge${targetName}Assets")
                     }else{
-                        into ("assets/${targetPath}") {
-                            from(jsBundleDir)
-                        }
+                        into ("assets/${targetPath}")
 
                         // Workaround for Android Gradle Plugin 3.2+ new asset directory
-                        into ("merged_assets/${variant.name}/merge${targetName}Assets/out") {
-                            from(jsBundleDir)
-                        }
+                        into ("merged_assets/${variant.name}/merge${targetName}Assets/out")
 
                         // Workaround for Android Gradle Plugin 3.4+ new asset directory
-                        into ("merged_assets/${variant.name}/out") {
-                            from(jsBundleDir)
-                        }
+                        into ("merged_assets/${variant.name}/out")
                     }
                 }
             }

--- a/template/android/build.gradle
+++ b/template/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:7.0.4")
+        classpath("com.android.tools.build:gradle:7.1.0")
         classpath("com.facebook.react:react-native-gradle-plugin")
         classpath("de.undercouch:gradle-download-task:5.0.1")
         // NOTE: Do not place your application dependencies here; they belong

--- a/template/android/build.gradle
+++ b/template/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:7.1.0")
+        classpath("com.android.tools.build:gradle:7.1.1")
         classpath("com.facebook.react:react-native-gradle-plugin")
         classpath("de.undercouch:gradle-download-task:5.0.1")
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
## Summary

Upgrade Android Gradle to 7.1.0 on template and fix a bug where the bundle was not getting included when building the app in release mode

Closes https://github.com/facebook/react-native/issues/33002
Closes https://github.com/facebook/react-native/issues/33018
Closes #33046
Potentially fixes https://github.com/facebook/react-native/issues/33029

## Changelog

[Android] [Changed] - Bump AGP to 7.1.0 and fix bundle inclusion in release mode

## Test Plan

1. Run `./scripts/test-manual-e2e.sh`
2. Select `A new RN app using the template` and `Android`
3. Test app on the emulator
4. Open Android studio build the app using release variant
4. Check the release apk using Android studio "Analyze APK" tool and ensure the bundle is included

![image](https://user-images.githubusercontent.com/11707729/152700410-3bcb80b0-35b6-4bdc-bf57-98a42a29e5a6.png)

