### PR TITLE
Fix action sheet callback invoked more than once on iPad

### DIFF
--- a/React/CoreModules/RCTActionSheetManager.mm
+++ b/React/CoreModules/RCTActionSheetManager.mm
@@ -126,6 +126,10 @@ RCT_EXPORT_METHOD(showActionSheetWithOptions
 
   NSInteger index = 0;
   bool isCancelButtonIndex = false;
+  // The handler for a button might get called more than once when tapping outside
+  // the action sheet on iPad. RCTResponseSenderBlock can only be called once so
+  // keep track of callback invocation here.
+  __block bool callbackInvoked = false;
   for (NSString *option in buttons) {
     UIAlertActionStyle style = UIAlertActionStyleDefault;
     if ([destructiveButtonIndices containsObject:@(index)]) {
@@ -139,7 +143,9 @@ RCT_EXPORT_METHOD(showActionSheetWithOptions
     UIAlertAction *actionButton = [UIAlertAction actionWithTitle:option
                                                            style:style
                                                          handler:^(__unused UIAlertAction *action) {
-                                                           callback(@[ @(localIndex) ]);
+                                                           if (!callbackInvoked) {
+                                                             callback(@[ @(localIndex) ]);
+                                                           }
                                                          }];
     if (isCancelButtonIndex) {
       [actionButton setValue:cancelButtonTintColor forKey:@"titleTextColor"];

--- a/React/CoreModules/RCTActionSheetManager.mm
+++ b/React/CoreModules/RCTActionSheetManager.mm
@@ -144,6 +144,7 @@ RCT_EXPORT_METHOD(showActionSheetWithOptions
                                                            style:style
                                                          handler:^(__unused UIAlertAction *action) {
                                                            if (!callbackInvoked) {
+                                                             callbackInvoked = true;
                                                              callback(@[ @(localIndex) ]);
                                                            }
                                                          }];


### PR DESCRIPTION
## Summary

iOS will sometimes invoke the UIAlertAction handler for the cancel button more than once on iPad. This can be reproduced relatively easily by having a button that opens an action sheet and spam tapping outside the action sheet while it is opening. Since native module callbacks can only be invoked once this causes the app to crash here https://github.com/facebook/react-native/blob/main/ReactCommon/react/nativemodule/core/platform/ios/RCTTurboModule.mm#L206.

## Changelog

[iOS] [Fixed] - Fix action sheet callback invoked more than once on iPad

## Test Plan

Tested on iPad simulator to reproduce the crash and verified that this fixes it.
