### PR TITLE
Remove optional codegen config inside template

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -25,8 +25,5 @@
   },
   "jest": {
     "preset": "react-native"
-  },
-  "codegenConfig": {
-    "libraries": []
   }
 }


### PR DESCRIPTION
Summary:
The codegen config is optional and can be removed from the default package.json configuration in the template to simplify 0.68 upgrade for people who are not opted-in to the new arch.

Changelog: [Internal] - Remove optional codegenConfig field from template

Differential Revision: D34216988

