### PR TITLE
[Android] Updated logic for loading correct jsc or hermes engine .so files at app startup.

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -44,6 +44,10 @@ def boostPath = dependenciesPath ?: System.getenv("REACT_NATIVE_BOOST_PATH")
 // Setup build type for NDK, supported values: {debug, release}
 def nativeBuildType = System.getenv("NATIVE_BUILD_TYPE") ?: "release"
 
+def config = project.hasProperty("react") ? project.react : [:]
+
+def enableHermes = config.enableHermes ?: false
+
 task createNativeDepsDirectories {
     downloadsDir.mkdirs()
     thirdPartyNdkDir.mkdirs()
@@ -298,6 +302,13 @@ android {
         buildConfigField("boolean", "IS_INTERNAL_BUILD", "false")
         buildConfigField("int", "EXOPACKAGE_FLAGS", "0")
         buildConfigField("int", "HERMES_BYTECODE_VERSION", "0")
+        // setting buildConfigField to check for hermes or jsc
+        if(enableHermes){
+            buildConfigField("boolean", "HERMES_ENABLED", "true")
+        }
+        else{
+            buildConfigField("boolean", "HERMES_ENABLED", "false")
+        }
 
         resValue "integer", "react_native_dev_server_port", reactNativeDevServerPort()
         resValue "integer", "react_native_inspector_proxy_port", reactNativeInspectorProxyPort()

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManagerBuilder.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManagerBuilder.java
@@ -34,6 +34,7 @@ import com.facebook.react.jscexecutor.JSCExecutorFactory;
 import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
 import com.facebook.react.packagerconnection.RequestHandler;
 import com.facebook.react.uimanager.UIImplementationProvider;
+import com.facebook.react.BuildConfig;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -66,8 +67,11 @@ public class ReactInstanceManagerBuilder {
   private @Nullable Map<String, RequestHandler> mCustomPackagerCommandHandlers;
   private @Nullable ReactPackageTurboModuleManagerDelegate.Builder mTMMDelegateBuilder;
   private @Nullable SurfaceDelegateFactory mSurfaceDelegateFactory;
+  private boolean enableHermes = false;
 
-  /* package protected */ ReactInstanceManagerBuilder() {}
+  /* package protected */ ReactInstanceManagerBuilder() {
+    enableHermes = BuildConfig.HERMES_ENABLED;
+  }
 
   /** Sets a provider of {@link UIImplementation}. Uses default provider if null is passed. */
   public ReactInstanceManagerBuilder setUIImplementationProvider(
@@ -348,38 +352,32 @@ public class ReactInstanceManagerBuilder {
     try {
       // If JSC is included, use it as normal
       initializeSoLoaderIfNecessary(applicationContext);
-      JSCExecutor.loadLibrary();
-      return new JSCExecutorFactory(appName, deviceName);
-    } catch (UnsatisfiedLinkError jscE) {
-      // https://github.com/facebook/hermes/issues/78 shows that
-      // people who aren't trying to use Hermes are having issues.
-      // https://github.com/facebook/react-native/issues/25923#issuecomment-554295179
-      // includes the actual JSC error in at least one case.
-      //
-      // So, if "__cxa_bad_typeid" shows up in the jscE exception
-      // message, then we will assume that's the failure and just
-      // throw now.
-
-      if (jscE.getMessage().contains("__cxa_bad_typeid")) {
-        throw jscE;
-      }
-
-      // Otherwise use Hermes
-      try {
+      // Relying solely on try catch block and loading jsc even when
+      // project is suing hermes can lead to launchtime crashes expecially in
+      // monorepo architectures and hybrid apps using both native android
+      // and react native.
+      // So we use the value of enableHermes from build.gradle to decide which
+      // library to load at launch
+      if(enableHermes){
         HermesExecutor.loadLibrary();
         return new HermesExecutorFactory();
-      } catch (UnsatisfiedLinkError hermesE) {
-        // If we get here, either this is a JSC build, and of course
-        // Hermes failed (since it's not in the APK), or it's a Hermes
-        // build, and Hermes had a problem.
-
-        // We suspect this is a JSC issue (it's the default), so we
-        // will throw that exception, but we will print hermesE first,
-        // since it could be a Hermes issue and we don't want to
-        // swallow that.
-        hermesE.printStackTrace();
-        throw jscE;
       }
+      else{
+        JSCExecutor.loadLibrary();
+        return new JSCExecutorFactory(appName, deviceName);
+      }
+    } catch (UnsatisfiedLinkError e) {
+      // Any library failed to load, we
+      // will throw that exception, but we will print it first,
+      // since it could be a Hermes issue and we don't want to
+      // swallow that.
+      // The case  
+      // if (jscE.getMessage().contains("__cxa_bad_typeid")) {
+      //   throw jscE;
+      // }
+      // would be covered in this catch block only
+      e.printStackTrace();
+      throw e;
     }
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManagerBuilder.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManagerBuilder.java
@@ -24,6 +24,7 @@ import com.facebook.react.bridge.NativeModuleCallExceptionHandler;
 import com.facebook.react.bridge.NotThreadSafeBridgeIdleDebugListener;
 import com.facebook.react.common.LifecycleState;
 import com.facebook.react.common.SurfaceDelegateFactory;
+import com.facebook.react.common.build.ReactBuildConfig;
 import com.facebook.react.devsupport.DefaultDevSupportManagerFactory;
 import com.facebook.react.devsupport.DevSupportManagerFactory;
 import com.facebook.react.devsupport.interfaces.DevBundleDownloadListener;
@@ -34,7 +35,6 @@ import com.facebook.react.jscexecutor.JSCExecutorFactory;
 import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
 import com.facebook.react.packagerconnection.RequestHandler;
 import com.facebook.react.uimanager.UIImplementationProvider;
-import com.facebook.react.BuildConfig;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -70,7 +70,7 @@ public class ReactInstanceManagerBuilder {
   private boolean enableHermes = false;
 
   /* package protected */ ReactInstanceManagerBuilder() {
-    enableHermes = BuildConfig.HERMES_ENABLED;
+    enableHermes = ReactBuildConfig.HERMES_ENABLED;
   }
 
   /** Sets a provider of {@link UIImplementation}. Uses default provider if null is passed. */

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManagerBuilder.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManagerBuilder.java
@@ -353,10 +353,10 @@ public class ReactInstanceManagerBuilder {
       // If JSC is included, use it as normal
       initializeSoLoaderIfNecessary(applicationContext);
       // Relying solely on try catch block and loading jsc even when
-      // project is suing hermes can lead to launchtime crashes expecially in
+      // project is using hermes can lead to launch-time crashes especially in
       // monorepo architectures and hybrid apps using both native android
       // and react native.
-      // So we use the value of enableHermes from build.gradle to decide which
+      // So we can use the value of enableHermes from build.gradle to decide which
       // library to load at launch
       if(enableHermes){
         HermesExecutor.loadLibrary();

--- a/ReactAndroid/src/main/java/com/facebook/react/common/build/ReactBuildConfig.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/common/build/ReactBuildConfig.java
@@ -21,4 +21,5 @@ public class ReactBuildConfig {
   public static final boolean IS_INTERNAL_BUILD = BuildConfig.IS_INTERNAL_BUILD;
   public static final int EXOPACKAGE_FLAGS = BuildConfig.EXOPACKAGE_FLAGS;
   public static final int HERMES_BYTECODE_VERSION = BuildConfig.HERMES_BYTECODE_VERSION;
+  public static final boolean HERMES_ENABLED = BuildConfig.HERMES_ENABLED;
 }


### PR DESCRIPTION
## Summary

The current implementation of **getDefaultJSExecutorFactory** relies solely on try catch to load the correct .so file for jsc or hermes based on the project configuration.
Relying solely on try catch block and loading jsc even when project is using hermes can lead to launch-time crashes especially in monorepo architectures and hybrid apps using both native androidand react native.
So we can use the value of enableHermes from build.gradle to decide which library to load at launch-time by adding a **buildConfigField** and fetching it in **ReactInstanceManagerBuilder** with a modified logic to load the dso files.

The code snippet for the new logic in **ReactInstanceManagerBuilder**:

```
private JavaScriptExecutorFactory getDefaultJSExecutorFactory(
      String appName, String deviceName, Context applicationContext) {
    try {
      // If JSC is included, use it as normal
      initializeSoLoaderIfNecessary(applicationContext);
      // Relying solely on try catch block and loading jsc even when
      // project is using hermes can lead to launchtime crashes expecially in
      // monorepo architectures and hybrid apps using both native android
      // and react native.
      // So we can use the value of enableHermes from build.gradle to decide which
      // library to load at launch
      if(enableHermes){
        HermesExecutor.loadLibrary();
        return new HermesExecutorFactory();
      }
      else{
        JSCExecutor.loadLibrary();
        return new JSCExecutorFactory(appName, deviceName);
      }
    } catch (UnsatisfiedLinkError e) {
      // Any library failed to load, we
      // will throw that exception, but we will print it first,
      // since it could be a Hermes issue and we don't want to
      // swallow that.
      // The case  
      // if (jscE.getMessage().contains("__cxa_bad_typeid")) {
      //   throw jscE;
      // }
      // would be covered in this catch block only
      e.printStackTrace();
      throw e;
    }
  }
```
Our app was facing a similar issue as listed in this list:  **https://github.com/facebook/react-native/issues?q=is%3Aissue+is%3Aopen+DSO**. Which was react-native trying to load jsc even when our project used hermes when a debug build was deployed on a device using android studio play button.

This change can possibly solve many of the issues listed in the list as it solved ours.

## Changelog

[GENERAL] [ADDED] - declaration of config and enableHermes in ReactAndroid/build.gradle
```
def config = project.hasProperty("react") ? project.react : [:]

def enableHermes = config.enableHermes ?: false
```

[GENERAL] [ADDED] - setting up buildConfigField based on value of enableHermes

```
if(enableHermes){
            buildConfigField("boolean", "HERMES_ENABLED", "true")
        }
        else{
            buildConfigField("boolean", "HERMES_ENABLED", "false")
        }
```

[GENERAL] [ADDED] - declaration of enableHermes in ReactInstanceManagerBuilder:
`  private boolean enableHermes = false;
`

[GENERAL] [ADDED] - buildConfig value in ReactBuildConfig:
`  public static final boolean HERMES_ENABLED = BuildConfig.HERMES_ENABLED;
`

[GENERAL] [ADDED] - initialisation of enableHermes in ReactInstanceManagerBuilder constructor:
```
  /* package protected */ ReactInstanceManagerBuilder() {
    enableHermes = ReactBuildConfig.HERMES_ENABLED;
  }
```

[GENERAL] [ADDED] - new logic for loading libraries based on the boolean

```
  private JavaScriptExecutorFactory getDefaultJSExecutorFactory(
      String appName, String deviceName, Context applicationContext) {
    try {
      // If JSC is included, use it as normal
      initializeSoLoaderIfNecessary(applicationContext);
      // Relying solely on try catch block and loading jsc even when
      // project is suing hermes can lead to launchtime crashes expecially in
      // monorepo architectures and hybrid apps using both native android
      // and react native.
      // So we use the value of enableHermes from build.gradle to decide which
      // library to load at launch
      if(enableHermes){
        HermesExecutor.loadLibrary();
        return new HermesExecutorFactory();
      }
      else{
        JSCExecutor.loadLibrary();
        return new JSCExecutorFactory(appName, deviceName);
      }
    } catch (UnsatisfiedLinkError e) {
      // Any library failed to load, we
      // will throw that exception, but we will print it first,
      // since it could be a Hermes issue and we don't want to
      // swallow that.
      // The case  
      // if (jscE.getMessage().contains("__cxa_bad_typeid")) {
      //   throw jscE;
      // }
      // would be covered in this catch block only
      e.printStackTrace();
      throw e;
    }
  }
```

[GENERAL] [REMOVED] - Old logic of loading libraries

 ```
 private JavaScriptExecutorFactory getDefaultJSExecutorFactory(
      String appName, String deviceName, Context applicationContext) {
    try {
      // If JSC is included, use it as normal
      initializeSoLoaderIfNecessary(applicationContext);
      JSCExecutor.loadLibrary();
      return new JSCExecutorFactory(appName, deviceName);
    } catch (UnsatisfiedLinkError jscE) {
      // https://github.com/facebook/hermes/issues/78 shows that
      // people who aren't trying to use Hermes are having issues.
      // https://github.com/facebook/react-native/issues/25923#issuecomment-554295179
      // includes the actual JSC error in at least one case.
      //
      // So, if "__cxa_bad_typeid" shows up in the jscE exception
      // message, then we will assume that's the failure and just
      // throw now.

      if (jscE.getMessage().contains("__cxa_bad_typeid")) {
        throw jscE;
      }

      // Otherwise use Hermes
      try {
        HermesExecutor.loadLibrary();
        return new HermesExecutorFactory();
      } catch (UnsatisfiedLinkError hermesE) {
        // If we get here, either this is a JSC build, and of course
        // Hermes failed (since it's not in the APK), or it's a Hermes
        // build, and Hermes had a problem.

        // We suspect this is a JSC issue (it's the default), so we
        // will throw that exception, but we will print hermesE first,
        // since it could be a Hermes issue and we don't want to
        // swallow that.
        hermesE.printStackTrace();
        throw jscE;
      }
    }
  }

```
## Test Plan

The testing for this change might be tricky but can be done by following the reproduction steps in the issues related to DSO loading here: https://github.com/facebook/react-native/issues?q=is%3Aissue+is%3Aopen+DSO

Generally, the app will not crash anymore on deploying debug using android studio if we are removing libjsc and its related libraries in **packagingOptions** in build.gradle and using hermes in the project.
It can be like:
```
packagingOptions {
        if (enableHermes) {
            exclude "**/libjsc*.so"
        }
    }
```
