### PR TITLE
Added additional builder method receiving arguments for using jsc or hermes to correctly decide which DSO to load at app startup.

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -212,6 +212,12 @@ public class ReactInstanceManager {
     return new ReactInstanceManagerBuilder();
   }
 
+  /** Creates a builder that is capable of creating an instance of {@link ReactInstanceManager}.
+   with argument determining which one of hermes or jsc to use */
+  public static ReactInstanceManagerBuilder builder(Boolean hermesEnabled) {
+    return new ReactInstanceManagerBuilder(hermesEnabled);
+  }
+
   /* package */ ReactInstanceManager(
       Context applicationContext,
       @Nullable Activity currentActivity,


### PR DESCRIPTION
## Summary

The current implementation of **getDefaultJSExecutorFactory** relies solely on try catch to load the correct .so file for jsc or hermes based on the project configuration.
Relying solely on try catch block and loading jsc even when project is using hermes can lead to launch time crashes especially in monorepo architectures and hybrid apps using both native android and react native.
So we can make use of an additional **ReactInstanceManager :: builder** method that accepts an argument while building ReactInstanceManager which can tell which library to load at startup in **ReactInstanceManagerBuilder** which will now have an enhanced getDefaultJSExecutorFactory method that will combine the old logic with the new one to load the dso files.
The code snippet in **ReactInstanceManager** for adding a new builder method: 

```
  /** Creates a builder that is capable of creating an instance of {@link ReactInstanceManager}. */
  public static ReactInstanceManagerBuilder builder() {
    return new ReactInstanceManagerBuilder();
  }

  /** Creates a builder that is capable of creating an instance of {@link ReactInstanceManager}.
   with argument determining which one of hermes or jsc to use */
  public static ReactInstanceManagerBuilder builder(Boolean hermesEnabled) {
    return new ReactInstanceManagerBuilder(hermesEnabled);
  }
```

The code snippet for the new logic in **ReactInstanceManagerBuilder**:

1) Setting up the new logic:

```
private String jscOrHermes = "";

  /* package protected */ ReactInstanceManagerBuilder() {}

  /* package protected (can switch between hermes {hermesEnabled: true} and jsc {hermesEnabled: false}) */
  ReactInstanceManagerBuilder(Boolean hermesEnabled) {
    // if the builder is called with arguments, set the current js engine based on the value
    if(hermesEnabled){
      jscOrHermes = "hermes";
    }
    else
      jscOrHermes = "jsc";
  }
```

2) Modifying the getDefaultJSExecutorFactory method to incorporate the new logic with the old one:

```
 private JavaScriptExecutorFactory getDefaultJSExecutorFactory(
      String appName, String deviceName, Context applicationContext) {
    // if the app uses old way of building ReactInstanceManager,
    // use the old buggy code

    // Relying solely on try catch block and loading jsc even when
    // project is using hermes can lead to launchtime crashes expecially in
    // monorepo architectures and hybrid apps using both native android
    // and react native.
    // So we can use the value of enableHermes receved by the constructor
    // to decide which library to load at launch
    if(jscOrHermes.isEmpty()) {
      try {
        // If JSC is included, use it as normal
        initializeSoLoaderIfNecessary(applicationContext);
        JSCExecutor.loadLibrary();
        return new JSCExecutorFactory(appName, deviceName);
      } catch (UnsatisfiedLinkError jscE) {
        // https://github.com/facebook/hermes/issues/78 shows that
        // people who aren't trying to use Hermes are having issues.
        // https://github.com/facebook/react-native/issues/25923#issuecomment-554295179
        // includes the actual JSC error in at least one case.
        //
        // So, if "__cxa_bad_typeid" shows up in the jscE exception
        // message, then we will assume that's the failure and just
        // throw now.

        if (jscE.getMessage().contains("__cxa_bad_typeid")) {
          throw jscE;
        }

        // Otherwise use Hermes
        try {
          HermesExecutor.loadLibrary();
          return new HermesExecutorFactory();
        } catch (UnsatisfiedLinkError hermesE) {
          // If we get here, either this is a JSC build, and of course
          // Hermes failed (since it's not in the APK), or it's a Hermes
          // build, and Hermes had a problem.

          // We suspect this is a JSC issue (it's the default), so we
          // will throw that exception, but we will print hermesE first,
          // since it could be a Hermes issue and we don't want to
          // swallow that.
          hermesE.printStackTrace();
          throw jscE;
        }
      }
    }
    // if the app explicitly specifies which engine to use, directly load
    // that library
    else{
      try {
        initializeSoLoaderIfNecessary(applicationContext);
        if(jscOrHermes.equals("hermes")){
          HermesExecutor.loadLibrary();
          return new HermesExecutorFactory();
        }
        else{
          JSCExecutor.loadLibrary();
          return new JSCExecutorFactory(appName, deviceName);
        }
      } catch (UnsatisfiedLinkError e) {
        // linking library failed, so we print its stacktrace and
        // throw the exception
        e.printStackTrace();
        throw e;
      }
    }
  }
```

### **Suggested changes in any Android App's MainApplication that extends ReactApplication to take advantage of this fix**
```
builder = ReactInstanceManager.builder(BuildConfig.HERMES_ENABLED)
                .setApplication(this)
                .setBundleAssetName("index.android.bundle")
                .setJSMainModulePath("index")
```

where HERMES_ENABLED is a buildConfigField based on the enableHermes flag in build.gradle:

`def enableHermes = project.ext.react.get("enableHermes", true)
`
and then

```
defaultConfig{
if(enableHermes) {
            buildConfigField("boolean", "HERMES_ENABLED", "true")
        }
        else{
            buildConfigField("boolean", "HERMES_ENABLED", "false")
        }
}
```

Our app was facing a similar issue as listed in this list:  **https://github.com/facebook/react-native/issues?q=is%3Aissue+is%3Aopen+DSO**. Which was react-native trying to load jsc even when our project used hermes when a debug build was deployed on a device using android studio play button.

This change can possibly solve many of the issues listed in the list as it solved ours.

## Changelog


[GENERAL] [ADDED] - A second builder method in ReactInstanceManager.java:
```
  /** Creates a builder that is capable of creating an instance of {@link ReactInstanceManager}.
   with argument determining which one of hermes or jsc to use */
  public static ReactInstanceManagerBuilder builder(Boolean hermesEnabled) {
    return new ReactInstanceManagerBuilder(hermesEnabled);
  }
```

[GENERAL] [ADDED] - A string varaible and a parametrized constructor  in ReactInstanceManagerBuilder.java:

```
private String jscOrHermes = "";

  /* package protected (can switch between hermes {hermesEnabled: true} and jsc {hermesEnabled: false}) */
  ReactInstanceManagerBuilder(Boolean hermesEnabled) {
    // if the builder is called with arguments, set the current js engine based on the value
    if(hermesEnabled){
      jscOrHermes = "hermes";
    }
    else
      jscOrHermes = "jsc";
  }
```
[GENERAL] [ADDED] - Modified **getDefaultJSExecutorFactory** method

```
private JavaScriptExecutorFactory getDefaultJSExecutorFactory(
      String appName, String deviceName, Context applicationContext) {
    // if the app uses old way of building ReactInstanceManager,
    // use the old buggy code

    // Relying solely on try catch block and loading jsc even when
    // project is using hermes can lead to launchtime crashes expecially in
    // monorepo architectures and hybrid apps using both native android
    // and react native.
    // So we can use the value of enableHermes receved by the constructor
    // to decide which library to load at launch
    if(jscOrHermes.isEmpty()) {
      try {
        // If JSC is included, use it as normal
        initializeSoLoaderIfNecessary(applicationContext);
        JSCExecutor.loadLibrary();
        return new JSCExecutorFactory(appName, deviceName);
      } catch (UnsatisfiedLinkError jscE) {
        // https://github.com/facebook/hermes/issues/78 shows that
        // people who aren't trying to use Hermes are having issues.
        // https://github.com/facebook/react-native/issues/25923#issuecomment-554295179
        // includes the actual JSC error in at least one case.
        //
        // So, if "__cxa_bad_typeid" shows up in the jscE exception
        // message, then we will assume that's the failure and just
        // throw now.

        if (jscE.getMessage().contains("__cxa_bad_typeid")) {
          throw jscE;
        }

        // Otherwise use Hermes
        try {
          HermesExecutor.loadLibrary();
          return new HermesExecutorFactory();
        } catch (UnsatisfiedLinkError hermesE) {
          // If we get here, either this is a JSC build, and of course
          // Hermes failed (since it's not in the APK), or it's a Hermes
          // build, and Hermes had a problem.

          // We suspect this is a JSC issue (it's the default), so we
          // will throw that exception, but we will print hermesE first,
          // since it could be a Hermes issue and we don't want to
          // swallow that.
          hermesE.printStackTrace();
          throw jscE;
        }
      }
    }
    // if the app explicitly specifies which engine to use, directly load
    // that library
    else{
      try {
        initializeSoLoaderIfNecessary(applicationContext);
        if(jscOrHermes.equals("hermes")){
          HermesExecutor.loadLibrary();
          return new HermesExecutorFactory();
        }
        else{
          JSCExecutor.loadLibrary();
          return new JSCExecutorFactory(appName, deviceName);
        }
      } catch (UnsatisfiedLinkError e) {
        // linking library failed, so we print its stacktrace and
        // throw the exception
        e.printStackTrace();
        throw e;
      }
    }
  }
```

## Test Plan

The testing for this change might be tricky but can be done by following the reproduction steps in the issues related to DSO loading here: https://github.com/facebook/react-native/issues?q=is%3Aissue+is%3Aopen+DSO

Generally, the app will not crash anymore on deploying debug using android studio if we are removing libjsc and its related libraries in **packagingOptions** in build.gradle and using hermes in the project.
It can be like:
```
packagingOptions {
        if (enableHermes) {
            exclude "**/libjsc*.so"
        }
    }
```
