### PR TITLE
[eslint-config] Remove prettier from dependencies

### DIFF
--- a/packages/eslint-config-react-native-community/package.json
+++ b/packages/eslint-config-react-native-community/package.json
@@ -22,8 +22,7 @@
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-react": "^7.26.1",
     "eslint-plugin-react-hooks": "^4.2.0",
-    "eslint-plugin-react-native": "^3.11.0",
-    "prettier": "^2.4.1"
+    "eslint-plugin-react-native": "^3.11.0"
   },
   "peerDependencies": {
     "eslint": ">=7",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

`prettier` should not be declared in dependencies in the ESLint config because it can trigger issues when a different version is installed on the client app.

`prettier` is already declared as `peerDependencies` and in the [README](https://github.com/facebook/react-native/blob/main/packages/eslint-config-react-native-community/README.md), it's explicitly asked to install it:

```
yarn add --dev eslint prettier @react-native-community/eslint-config
```

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Fixed] - Remove prettier from dependencies in eslint-config

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

- Install the package `@react-native-community/eslint-config` and ensure everything works the same as before
