### PR TITLE
Remove platform specific behavior for fb_xplat_platform_specific_rule where rule = android_x_prebuilt_aar

### DIFF
--- a/tools/build_defs/oss/rn_defs.bzl
+++ b/tools/build_defs/oss/rn_defs.bzl
@@ -211,6 +211,11 @@ def rn_android_resource(*args, **kwargs):
     native.android_resource(*args, **kwargs)
 
 def rn_android_prebuilt_aar(*args, **kwargs):
+    native.alias(
+        name = kwargs["name"] + "Android",
+        actual = ":" + kwargs["name"],
+        visibility = kwargs.get("visibility") or ["PUBLIC"],
+    )
     native.android_prebuilt_aar(*args, **kwargs)
 
 def rn_apple_library(*args, **kwargs):


### PR DESCRIPTION
Summary:
Same as title

Changelog:
[Android][Deprecating] - Removing suffixing, adding aliasing

Reviewed By: aniketmathur

Differential Revision: D34214323

