### PR TITLE
Remove platform specific behavior for fb_xplat_platform_specific_rule where rule = fb_native.prebuilt_native_library

### DIFF
--- a/tools/build_defs/oss/rn_defs.bzl
+++ b/tools/build_defs/oss/rn_defs.bzl
@@ -233,6 +233,11 @@ def rn_java_annotation_processor(*args, **kwargs):
     native.java_annotation_processor(*args, **kwargs)
 
 def rn_prebuilt_native_library(*args, **kwargs):
+    native.alias(
+        name = kwargs["name"] + "Android",
+        actual = ":" + kwargs["name"],
+        visibility = kwargs.get("visibility") or ["PUBLIC"],
+    )
     native.prebuilt_native_library(*args, **kwargs)
 
 def rn_prebuilt_jar(*args, **kwargs):

--- a/tools/build_defs/oss/rn_defs.bzl
+++ b/tools/build_defs/oss/rn_defs.bzl
@@ -211,6 +211,11 @@ def rn_android_resource(*args, **kwargs):
     native.android_resource(*args, **kwargs)
 
 def rn_android_prebuilt_aar(*args, **kwargs):
+    native.alias(
+        name = kwargs["name"] + "Android",
+        actual = ":" + kwargs["name"],
+        visibility = kwargs.get("visibility") or ["PUBLIC"],
+    )
     native.android_prebuilt_aar(*args, **kwargs)
 
 def rn_apple_library(*args, **kwargs):


### PR DESCRIPTION
Summary:
Same as the title and added aliasing

Changelog:
[Android][Deprecated] - Removing suffixing

Reviewed By: aniketmathur

Differential Revision: D34223571

