### PR TITLE
feat: Add support for "Prefer Cross-Fade Transitions" into AccessibilityInfo

### DIFF
--- a/Libraries/Components/AccessibilityInfo/AccessibilityInfo.js
+++ b/Libraries/Components/AccessibilityInfo/AccessibilityInfo.js
@@ -180,6 +180,31 @@ const AccessibilityInfo = {
   },
 
   /**
+   * Query whether reduce motion and prefer cross-fade transitions settings are currently enabled.
+   *
+   * Returns a promise which resolves to a boolean.
+   * The result is `true` when  prefer cross-fade transitions is enabled and `false` otherwise.
+   *
+   * See https://reactnative.dev/docs/accessibilityinfo#prefersCrossFadeTransitions
+   */
+  prefersCrossFadeTransitions(): Promise<boolean> {
+    return new Promise((resolve, reject) => {
+      if (Platform.OS === 'android') {
+        return Promise.resolve(false);
+      } else {
+        if (NativeAccessibilityManagerIOS != null) {
+          NativeAccessibilityManagerIOS.getCurrentPrefersCrossFadeTransitionsState(
+            resolve,
+            reject,
+          );
+        } else {
+          reject(null);
+        }
+      }
+    });
+  },
+
+  /**
    * Query whether reduced transparency is currently enabled.
    *
    * Returns a promise which resolves to a boolean.

--- a/Libraries/Components/AccessibilityInfo/NativeAccessibilityManager.js
+++ b/Libraries/Components/AccessibilityInfo/NativeAccessibilityManager.js
@@ -28,6 +28,10 @@ export interface Spec extends TurboModule {
     onSuccess: (isReduceMotionEnabled: boolean) => void,
     onError: (error: Object) => void,
   ) => void;
+  +getCurrentPrefersCrossFadeTransitionsState: (
+    onSuccess: (prefersCrossFadeTransitions: boolean) => void,
+    onError: (error: Object) => void,
+  ) => void;
   +getCurrentReduceTransparencyState: (
     onSuccess: (isReduceTransparencyEnabled: boolean) => void,
     onError: (error: Object) => void,

--- a/React/CoreModules/RCTAccessibilityManager.h
+++ b/React/CoreModules/RCTAccessibilityManager.h
@@ -23,6 +23,7 @@ extern NSString *const RCTAccessibilityManagerDidUpdateMultiplierNotification; /
 @property (nonatomic, assign) BOOL isGrayscaleEnabled;
 @property (nonatomic, assign) BOOL isInvertColorsEnabled;
 @property (nonatomic, assign) BOOL isReduceMotionEnabled;
+@property (nonatomic, assign) BOOL prefersCrossFadeTransitions;
 @property (nonatomic, assign) BOOL isReduceTransparencyEnabled;
 @property (nonatomic, assign) BOOL isVoiceOverEnabled;
 

--- a/React/CoreModules/RCTAccessibilityManager.mm
+++ b/React/CoreModules/RCTAccessibilityManager.mm
@@ -76,6 +76,13 @@ RCT_EXPORT_MODULE()
                                                  name:UIAccessibilityReduceMotionStatusDidChangeNotification
                                                object:nil];
 
+      if (@available(iOS 14.0, *)) {
+          [[NSNotificationCenter defaultCenter] addObserver:self
+                                                   selector:@selector(prefersCrossFadeTransitionsStatusDidChange:)
+                                                       name:UIAccessibilityPrefersCrossFadeTransitionsStatusDidChangeNotification
+                                                     object:nil];
+      }
+
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(reduceTransparencyStatusDidChange:)
                                                  name:UIAccessibilityReduceTransparencyStatusDidChangeNotification
@@ -91,6 +98,7 @@ RCT_EXPORT_MODULE()
     _isGrayscaleEnabled = UIAccessibilityIsGrayscaleEnabled();
     _isInvertColorsEnabled = UIAccessibilityIsInvertColorsEnabled();
     _isReduceMotionEnabled = UIAccessibilityIsReduceMotionEnabled();
+    _prefersCrossFadeTransitions = UIAccessibilityPrefersCrossFadeTransitions();
     _isReduceTransparencyEnabled = UIAccessibilityIsReduceTransparencyEnabled();
     _isVoiceOverEnabled = UIAccessibilityIsVoiceOverRunning();
   }
@@ -165,6 +173,19 @@ RCT_EXPORT_MODULE()
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [[_moduleRegistry moduleForName:"EventDispatcher"] sendDeviceEventWithName:@"reduceMotionChanged"
                                                                           body:@(_isReduceMotionEnabled)];
+#pragma clang diagnostic pop
+  }
+}
+
+- (void)prefersCrossFadeTransitionsStatusDidChange:(__unused NSNotification *)notification
+{
+  BOOL newPrefersCrossFadeTransitionsEnabled = UIAccessibilityPrefersCrossFadeTransitions();
+  if (_prefersCrossFadeTransitions != newPrefersCrossFadeTransitionsEnabled) {
+    _prefersCrossFadeTransitions = newPrefersCrossFadeTransitionsEnabled;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    [[_moduleRegistry moduleForName:"EventDispatcher"] sendDeviceEventWithName:@"prefersCrossFadeTransitionsChanged"
+                                                                          body:@(_prefersCrossFadeTransitions)];
 #pragma clang diagnostic pop
   }
 }
@@ -356,6 +377,13 @@ RCT_EXPORT_METHOD(getCurrentReduceMotionState
                   : (__unused RCTResponseSenderBlock)onError)
 {
   onSuccess(@[ @(_isReduceMotionEnabled) ]);
+}
+
+RCT_EXPORT_METHOD(getCurrentPrefersCrossFadeTransitionsState
+                  : (RCTResponseSenderBlock)onSuccess onError
+                  : (__unused RCTResponseSenderBlock)onError)
+{
+  onSuccess(@[ @(_prefersCrossFadeTransitions) ]);
 }
 
 RCT_EXPORT_METHOD(getCurrentReduceTransparencyState

--- a/React/CoreModules/RCTAccessibilityManager.mm
+++ b/React/CoreModules/RCTAccessibilityManager.mm
@@ -76,13 +76,6 @@ RCT_EXPORT_MODULE()
                                                  name:UIAccessibilityReduceMotionStatusDidChangeNotification
                                                object:nil];
 
-      if (@available(iOS 14.0, *)) {
-          [[NSNotificationCenter defaultCenter] addObserver:self
-                                                   selector:@selector(prefersCrossFadeTransitionsStatusDidChange:)
-                                                       name:UIAccessibilityPrefersCrossFadeTransitionsStatusDidChangeNotification
-                                                     object:nil];
-      }
-
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(reduceTransparencyStatusDidChange:)
                                                  name:UIAccessibilityReduceTransparencyStatusDidChangeNotification
@@ -98,7 +91,6 @@ RCT_EXPORT_MODULE()
     _isGrayscaleEnabled = UIAccessibilityIsGrayscaleEnabled();
     _isInvertColorsEnabled = UIAccessibilityIsInvertColorsEnabled();
     _isReduceMotionEnabled = UIAccessibilityIsReduceMotionEnabled();
-    _prefersCrossFadeTransitions = UIAccessibilityPrefersCrossFadeTransitions();
     _isReduceTransparencyEnabled = UIAccessibilityIsReduceTransparencyEnabled();
     _isVoiceOverEnabled = UIAccessibilityIsVoiceOverRunning();
   }
@@ -173,19 +165,6 @@ RCT_EXPORT_MODULE()
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [[_moduleRegistry moduleForName:"EventDispatcher"] sendDeviceEventWithName:@"reduceMotionChanged"
                                                                           body:@(_isReduceMotionEnabled)];
-#pragma clang diagnostic pop
-  }
-}
-
-- (void)prefersCrossFadeTransitionsStatusDidChange:(__unused NSNotification *)notification
-{
-  BOOL newPrefersCrossFadeTransitionsEnabled = UIAccessibilityPrefersCrossFadeTransitions();
-  if (_prefersCrossFadeTransitions != newPrefersCrossFadeTransitionsEnabled) {
-    _prefersCrossFadeTransitions = newPrefersCrossFadeTransitionsEnabled;
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    [[_moduleRegistry moduleForName:"EventDispatcher"] sendDeviceEventWithName:@"prefersCrossFadeTransitionsChanged"
-                                                                          body:@(_prefersCrossFadeTransitions)];
 #pragma clang diagnostic pop
   }
 }
@@ -383,7 +362,12 @@ RCT_EXPORT_METHOD(getCurrentPrefersCrossFadeTransitionsState
                   : (RCTResponseSenderBlock)onSuccess onError
                   : (__unused RCTResponseSenderBlock)onError)
 {
-  onSuccess(@[ @(_prefersCrossFadeTransitions) ]);
+
+    if (@available(iOS 14.0, *)) {
+        onSuccess(@[ @(UIAccessibilityPrefersCrossFadeTransitions()) ]);
+    } else {
+        onSuccess(@[ @(false) ]);
+    }
 }
 
 RCT_EXPORT_METHOD(getCurrentReduceTransparencyState

--- a/jest/setup.js
+++ b/jest/setup.js
@@ -128,6 +128,7 @@ jest
       isGrayscaleEnabled: jest.fn(),
       isInvertColorsEnabled: jest.fn(),
       isReduceMotionEnabled: jest.fn(),
+      prefersCrossFadeTransitions: jest.fn(),
       isReduceTransparencyEnabled: jest.fn(),
       isScreenReaderEnabled: jest.fn(() => Promise.resolve(false)),
       removeEventListener: jest.fn(),

--- a/packages/rn-tester/js/examples/Accessibility/AccessibilityExample.js
+++ b/packages/rn-tester/js/examples/Accessibility/AccessibilityExample.js
@@ -1128,6 +1128,11 @@ class DisplayOptionsStatusExample extends React.Component<{}> {
           notification={'reduceMotionChanged'}
         />
         <DisplayOptionStatusExample
+          optionName={'Prefer Cross-Fade Transitions'}
+          optionChecker={AccessibilityInfo.prefersCrossFadeTransitions}
+          notification={'prefersCrossFadeTransitionsChanged'}
+        />
+        <DisplayOptionStatusExample
           optionName={'Screen Reader'}
           optionChecker={AccessibilityInfo.isScreenReaderEnabled}
           notification={'screenReaderChanged'}


### PR DESCRIPTION
## Summary

This PR adds `prefersCrossFadeTransitions()` to AccessibilityInfo in order to add support for "Prefer Cross-Fade Transitions", exposing the iOS settings option as proposed here https://github.com/react-native-community/discussions-and-proposals/issues/452. 
I believe this would be especially helpful for solving https://github.com/facebook/react-native/issues/31484

#### TODO
- [ ]  Submit react-native-web PR updating AccessibilityInfo documentation. 

## Changelog 

[iOS] [Added] - Add support for "Prefer Cross-Fade Transitions" into AccessibilityInfo

## Test Plan

**On iOS 14+** 

1.  Access Settings > "General" > "Accessibility" > "Reduce Motion", enable "Reduce Motion" then enable "Prefer Cross-Fade Transitions".
2. Open the RNTester app and navigate to the Accessibility page


https://user-images.githubusercontent.com/11707729/154588402-7d050858-3c2d-4d86-9585-928b8c66941b.mov


