### PR TITLE
chore: Add comments explaining the existence of NativeDatePickerAndroid

### DIFF
--- a/Libraries/Components/DatePickerAndroid/NativeDatePickerAndroid.js
+++ b/Libraries/Components/DatePickerAndroid/NativeDatePickerAndroid.js
@@ -11,6 +11,11 @@
 import type {TurboModule} from '../../TurboModule/RCTExport';
 import * as TurboModuleRegistry from '../../TurboModule/TurboModuleRegistry';
 
+/**
+ * This file backs native modules that are used internally at Meta
+ * and this JS spec was intentionally left here. In the meanwhile this
+ * file should not be deleted.
+ */
 export interface Spec extends TurboModule {
   +open: (options: Object) => Promise<Object>;
 }


### PR DESCRIPTION
## Summary

This PR adds comments explaining the reason why the `NativeDatePickerAndroid.js` file was kept when removing `DatePickerAndroid`(https://github.com/facebook/react-native/commit/7a770526c626e6659a12939f8c61057a688aa623 ) in order to prevent people from trying to delete it, as this file has no references in the Github repo

## Changelog 

[Internal] [Added] - Add comments explaining the existence of NativeDatePickerAndroid

## Test Plan

Ensure builds are still working correctly, although this just adds a comment
