### PR TITLE
Fix OSS native Android build

### DIFF
--- a/ReactCommon/react/renderer/components/view/Android.mk
+++ b/ReactCommon/react/renderer/components/view/Android.mk
@@ -24,6 +24,7 @@ LOCAL_STATIC_LIBRARIES :=
 LOCAL_SHARED_LIBRARIES := \
   glog \
   libfolly_json \
+  libfolly_futures \
   libglog_init \
   libjsi \
   libreact_debug \

--- a/tools/build_defs/oss/rn_defs.bzl
+++ b/tools/build_defs/oss/rn_defs.bzl
@@ -177,6 +177,7 @@ def _unique(li):
 def rn_android_library(name, deps = [], plugins = [], *args, **kwargs):
     _ = kwargs.pop("autoglob", False)
     _ = kwargs.pop("is_androidx", False)
+    _ = kwargs.pop("pure_kotlin", False)
     if react_native_target(
         "java/com/facebook/react/uimanager/annotations:annotations",
     ) in deps and name != "processing":


### PR DESCRIPTION
Summary:
The build is failing with:

```
error: undefined reference to 'folly::SharedMutexImpl<false, void, std::__ndk1::atomic, folly::SharedMutexPolicyDefault>::unlock_shared()'
```

Indicating missing link to `folly_futures`.

Changelog: [Internal]

Differential Revision: D34419236

