### PR TITLE
Implement Runtime.getHeapUsage for hermes chrome inspector

### DIFF
--- a/ReactCommon/hermes/inspector/chrome/MessageTypes.cpp
+++ b/ReactCommon/hermes/inspector/chrome/MessageTypes.cpp
@@ -505,8 +505,11 @@ debugger::ResumeRequest::ResumeRequest(const dynamic &obj)
   assign(id, obj, "id");
   assign(method, obj, "method");
 
-  dynamic params = obj.at("params");
-  assign(terminateOnResume, params, "terminateOnResume");
+  auto it = obj.find("params");
+  if (it != obj.items().end()) {
+    dynamic params = it->second;
+    assign(terminateOnResume, params, "terminateOnResume");
+  }
 }
 
 dynamic debugger::ResumeRequest::toDynamic() const {
@@ -825,8 +828,11 @@ heapProfiler::StartSamplingRequest::StartSamplingRequest(const dynamic &obj)
   assign(id, obj, "id");
   assign(method, obj, "method");
 
-  dynamic params = obj.at("params");
-  assign(samplingInterval, params, "samplingInterval");
+  auto it = obj.find("params");
+  if (it != obj.items().end()) {
+    dynamic params = it->second;
+    assign(samplingInterval, params, "samplingInterval");
+  }
 }
 
 dynamic heapProfiler::StartSamplingRequest::toDynamic() const {
@@ -853,8 +859,11 @@ heapProfiler::StartTrackingHeapObjectsRequest::StartTrackingHeapObjectsRequest(
   assign(id, obj, "id");
   assign(method, obj, "method");
 
-  dynamic params = obj.at("params");
-  assign(trackAllocations, params, "trackAllocations");
+  auto it = obj.find("params");
+  if (it != obj.items().end()) {
+    dynamic params = it->second;
+    assign(trackAllocations, params, "trackAllocations");
+  }
 }
 
 dynamic heapProfiler::StartTrackingHeapObjectsRequest::toDynamic() const {
@@ -902,10 +911,13 @@ heapProfiler::StopTrackingHeapObjectsRequest::StopTrackingHeapObjectsRequest(
   assign(id, obj, "id");
   assign(method, obj, "method");
 
-  dynamic params = obj.at("params");
-  assign(reportProgress, params, "reportProgress");
-  assign(treatGlobalObjectsAsRoots, params, "treatGlobalObjectsAsRoots");
-  assign(captureNumericValue, params, "captureNumericValue");
+  auto it = obj.find("params");
+  if (it != obj.items().end()) {
+    dynamic params = it->second;
+    assign(reportProgress, params, "reportProgress");
+    assign(treatGlobalObjectsAsRoots, params, "treatGlobalObjectsAsRoots");
+    assign(captureNumericValue, params, "captureNumericValue");
+  }
 }
 
 dynamic heapProfiler::StopTrackingHeapObjectsRequest::toDynamic() const {
@@ -935,10 +947,13 @@ heapProfiler::TakeHeapSnapshotRequest::TakeHeapSnapshotRequest(
   assign(id, obj, "id");
   assign(method, obj, "method");
 
-  dynamic params = obj.at("params");
-  assign(reportProgress, params, "reportProgress");
-  assign(treatGlobalObjectsAsRoots, params, "treatGlobalObjectsAsRoots");
-  assign(captureNumericValue, params, "captureNumericValue");
+  auto it = obj.find("params");
+  if (it != obj.items().end()) {
+    dynamic params = it->second;
+    assign(reportProgress, params, "reportProgress");
+    assign(treatGlobalObjectsAsRoots, params, "treatGlobalObjectsAsRoots");
+    assign(captureNumericValue, params, "captureNumericValue");
+  }
 }
 
 dynamic heapProfiler::TakeHeapSnapshotRequest::toDynamic() const {

--- a/ReactCommon/hermes/inspector/chrome/tests/MessageTests.cpp
+++ b/ReactCommon/hermes/inspector/chrome/tests/MessageTests.cpp
@@ -692,7 +692,10 @@ TEST(MessageTests, testResumeRequest) {
   std::string message = R"(
     {
       "id": 10,
-      "method": "Debugger.resume"
+      "method": "Debugger.resume",
+      "params": {
+        "terminateOnResume": false
+      }
     }
   )";
 

--- a/ReactCommon/hermes/inspector/tools/message_types.txt
+++ b/ReactCommon/hermes/inspector/tools/message_types.txt
@@ -32,5 +32,6 @@ Runtime.callFunctionOn
 Runtime.consoleAPICalled
 Runtime.evaluate
 Runtime.executionContextCreated
+Runtime.getHeapUsage
 Runtime.getProperties
 Runtime.runIfWaitingForDebugger

--- a/ReactCommon/hermes/inspector/tools/msggen/package.json
+++ b/ReactCommon/hermes/inspector/tools/msggen/package.json
@@ -12,7 +12,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "devtools-protocol": "0.0.730699",
+    "devtools-protocol": "0.0.959523",
     "yargs": "^14.2.0"
   },
   "devDependencies": {

--- a/ReactCommon/hermes/inspector/tools/msggen/src/ImplementationWriter.js
+++ b/ReactCommon/hermes/inspector/tools/msggen/src/ImplementationWriter.js
@@ -266,12 +266,25 @@ export function emitRequestDef(stream: Writable, command: Command) {
     assign(method, obj, "method");\n\n`);
 
   if (props.length > 0) {
-    stream.write('dynamic params = obj.at("params");\n');
+    const optionalParams = props.every(p => p.optional);
+    if (optionalParams) {
+      stream.write(`
+        auto it = obj.find("params");
+        if (it != obj.items().end()) {
+          dynamic params = it->second;
+      `);
+    } else {
+      stream.write('dynamic params = obj.at("params");\n');
+    }
 
     for (const prop of props) {
       const id = prop.getCppIdentifier();
       const name = prop.name;
       stream.write(`assign(${id}, params, "${name}");\n`);
+    }
+
+    if (optionalParams) {
+      stream.write('}');
     }
   }
 

--- a/ReactCommon/hermes/inspector/tools/msggen/src/index.js
+++ b/ReactCommon/hermes/inspector/tools/msggen/src/index.js
@@ -41,6 +41,7 @@ const proto = mergeDomains(standard, custom);
 function parseDomains(
   domainObjs: Array<any>,
   ignoreExperimental: boolean,
+  includeExperimental: Set<string>,
 ): Descriptor {
   const desc = {
     types: [],
@@ -59,7 +60,12 @@ function parseDomains(
     }
 
     for (const commandObj of obj.commands || []) {
-      const command = Command.create(domain, commandObj, ignoreExperimental);
+      const command = Command.create(
+        domain,
+        commandObj,
+        !includeExperimental.has(`${domain}.${commandObj.name}`) &&
+          ignoreExperimental,
+      );
       if (command) {
         desc.commands.push(command);
       }
@@ -199,18 +205,27 @@ function main() {
     .boolean('e')
     .alias('e', 'ignore-experimental')
     .describe('e', 'ignore experimental commands, props, and types')
+    .alias('i', 'include-experimental')
+    .describe('i', 'experimental commands to include')
     .alias('r', 'roots')
     .describe('r', 'path to a file listing root types, events, and commands')
     .nargs('r', 1)
     .demandCommand(2, 2).argv;
 
   const ignoreExperimental = !!args.e;
+  const includeExperimental = new Set(
+    typeof args.i === 'string' ? args.i.split(',') : [],
+  );
   const [headerPath, implPath] = args._;
 
   const headerStream = fs.createWriteStream(headerPath);
   const implStream = fs.createWriteStream(implPath);
 
-  const desc = parseDomains(proto.domains, ignoreExperimental);
+  const desc = parseDomains(
+    proto.domains,
+    ignoreExperimental,
+    includeExperimental,
+  );
   const graph = buildGraph(desc);
   const roots = parseRoots(desc, String(args.roots));
 

--- a/ReactCommon/hermes/inspector/tools/msggen/yarn.lock
+++ b/ReactCommon/hermes/inspector/tools/msggen/yarn.lock
@@ -2434,10 +2434,10 @@ detect-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
-devtools-protocol@0.0.730699:
-  version "0.0.730699"
-  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.730699.tgz#4d18f6a9b7fb7cf3f1ffe73bfe14aad66cf3b2ef"
-  integrity sha512-dprBpuPzVIIXXL6GevzhvWe2wg836h3d5hY+n6IzzHbKLsUh6QlVmcIy15za0J3MhDFbmEH60s6uYsrw/tgBbw==
+devtools-protocol@0.0.959523:
+  version "0.0.959523"
+  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.959523.tgz#a7ce62c6b88876081fe5bec866f70e467bc021ba"
+  integrity sha512-taOcAND/oJA5FhJD2I3RA+I8RPdrpPJWwvMBPzTq7Sugev1xTOG3lgtlSfkh5xkjTYw0Ti2CRQq016goFHMoPQ==
 
 diff-sequences@^26.6.2:
   version "26.6.2"

--- a/ReactCommon/hermes/inspector/tools/run_msggen
+++ b/ReactCommon/hermes/inspector/tools/run_msggen
@@ -2,24 +2,25 @@
 
 set -e
 
-DIR=$(dirname "${BASH_SOURCE[0]}")
+DIR=$(cd -P "$(dirname "$(readlink "${BASH_SOURCE[0]}" || echo "${BASH_SOURCE[0]}")")" && pwd)
 cd "${DIR}/msggen"
 
 yarn install
 yarn build
 
-FBSOURCE=$(hg root)
-MSGTYPES_PATH="${FBSOURCE}/xplat/js/react-native-github/ReactCommon/hermes/inspector/tools/message_types.txt"
-HEADER_PATH="${FBSOURCE}/xplat/js/react-native-github/ReactCommon/hermes/inspector/chrome/MessageTypes.h"
-CPP_PATH="${FBSOURCE}/xplat/js/react-native-github/ReactCommon/hermes/inspector/chrome/MessageTypes.cpp"
+MSGTYPES_PATH="${DIR}/message_types.txt"
+HEADER_PATH="${DIR}/../chrome/MessageTypes.h"
+CPP_PATH="${DIR}/../chrome/MessageTypes.cpp"
 
 node bin/index.js \
   --ignore-experimental \
+  --include-experimental=Runtime.getHeapUsage \
   --roots "$MSGTYPES_PATH" \
   "$HEADER_PATH" "$CPP_PATH"
 
 clang-format -i --style=file "$HEADER_PATH"
 clang-format -i --style=file "$CPP_PATH"
 
+FBSOURCE=$(hg root)
 "${FBSOURCE}/tools/signedsource" sign "$HEADER_PATH"
 "${FBSOURCE}/tools/signedsource" sign "$CPP_PATH"


### PR DESCRIPTION
## Summary

Reland of #32895 with fix for optional params object.

Original description:

I was looking at the hermes chrome devtools integration and noticed requests to `Runtime.getHeapUsage` which was not implemented. When implemented it will show a summary of memory usage of the javascript instance in devtools.

<img width="325" alt="image" src="https://user-images.githubusercontent.com/2677334/149637113-e1d95d26-9e26-46c2-9be6-47d22284f15f.png">

## Changelog

[General] [Added] - Implement Runtime.getHeapUsage for hermes chrome inspector

## Test Plan

I was able to reproduce the issue that caused the initial PR to be reverted using the resume request in Flipper. Pausing JS execution then resuming it will cause it to crash before this change, and works fine after.

Before

<img width="912" alt="image" src="https://user-images.githubusercontent.com/2677334/149637073-15f4e1fa-8183-42dc-8673-d4371731415c.png">

After

<img width="1076" alt="image" src="https://user-images.githubusercontent.com/2677334/149637085-579dee8f-5efb-4658-b0a8-2400bd119924.png">
