### PR TITLE
Updated borderColor view property to UIColor

### DIFF
--- a/React/Views/RCTViewManager.m
+++ b/React/Views/RCTViewManager.m
@@ -270,7 +270,7 @@ RCT_CUSTOM_VIEW_PROPERTY(borderRadius, CGFloat, RCTView)
     view.layer.cornerRadius = json ? [RCTConvert CGFloat:json] : defaultView.layer.cornerRadius;
   }
 }
-RCT_CUSTOM_VIEW_PROPERTY(borderColor, CGColor, RCTView)
+RCT_CUSTOM_VIEW_PROPERTY(borderColor, UIColor, RCTView)
 {
   if ([view respondsToSelector:@selector(setBorderColor:)]) {
     view.borderColor = json ? [RCTConvert UIColor:json] : defaultView.borderColor;


### PR DESCRIPTION
## Summary

In https://github.com/facebook/react-native/commit/c974cbff04a8d90ac0f856dbada3fc5a75c75b49 I changed the borderColor from CGColor to UIColor. I missed this view property which should also be updated to reflect the original change.

## Changelog

[iOS] [Fixed] - Set RCTView borderColor to UIColor

## Test Plan

Nothing to test. See PR https://github.com/facebook/react-native/pull/29728
