### PR TITLE
Fix: Android react.gradle VmCleanup when packaging as library

### DIFF
--- a/react.gradle
+++ b/react.gradle
@@ -395,8 +395,10 @@ afterEvaluate {
 
         if (enableVmCleanup) {
             def task = tasks.findByName("package${targetName}")
-            def transformsLibDir = "$buildDir/intermediates/transforms/"
-            task.doFirst { vmSelectionAction(transformsLibDir) }
+            if (task != null) {
+                def transformsLibDir = "$buildDir/intermediates/transforms/"
+                task.doFirst { vmSelectionAction(transformsLibDir) }
+            }
 
             def sTask = tasks.findByName("strip${targetName}DebugSymbols")
             if (sTask != null) {


### PR DESCRIPTION
## Summary

When packaging a react app as an android library with the enableVmCleanup flag not set to false, an error occurs since the "package${targetName}" task can not be found. This PR adds a simple null check, similar to what is being done for the sTask and mTask just below it to prevent the error.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Fixed] - Fixes android build error when compiling as library

## Test Plan

Compile project as library (com.android.library), and should not trigger and error with these changes.

Would also like to have this fix cherry-pick'd to release 0.67 after merging.
