### PR TITLE
Use relative installation root instead of absolute to avoid embedding absolute paths in pods project

### DIFF
--- a/packages/rn-tester/NativeModuleExample/ScreenshotManager.podspec
+++ b/packages/rn-tester/NativeModuleExample/ScreenshotManager.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
   s.source_files    = "**/*.{h,m,mm,swift}"
   s.requires_arc    = true
 
-  s.dependency "React"
+  s.dependency "React-Core"
   s.dependency "RCT-Folly", folly_version
 
   # s.dependency "..."

--- a/packages/rn-tester/RNTesterPods.xcodeproj/xcshareddata/xcschemes/RNTester.xcscheme
+++ b/packages/rn-tester/RNTesterPods.xcodeproj/xcshareddata/xcschemes/RNTester.xcscheme
@@ -3,7 +3,7 @@
    LastUpgradeVersion = "1210"
    version = "1.3">
    <BuildAction
-      parallelizeBuildables = "NO"
+      parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry

--- a/packages/rn-tester/RNTesterPods.xcodeproj/xcshareddata/xcschemes/RNTesterIntegrationTests.xcscheme
+++ b/packages/rn-tester/RNTesterPods.xcodeproj/xcshareddata/xcschemes/RNTesterIntegrationTests.xcscheme
@@ -3,7 +3,7 @@
    LastUpgradeVersion = "1210"
    version = "1.3">
    <BuildAction
-      parallelizeBuildables = "NO"
+      parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry

--- a/packages/rn-tester/RNTesterPods.xcodeproj/xcshareddata/xcschemes/RNTesterUnitTests.xcscheme
+++ b/packages/rn-tester/RNTesterPods.xcodeproj/xcshareddata/xcschemes/RNTesterUnitTests.xcscheme
@@ -3,7 +3,7 @@
    LastUpgradeVersion = "1210"
    version = "1.3">
    <BuildAction
-      parallelizeBuildables = "NO"
+      parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry

--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -546,6 +546,7 @@ def use_react_native_codegen!(spec, options={})
   library_name = options[:library_name] ||= "#{spec.name.gsub('_','-').split('-').collect(&:capitalize).join}Spec"
   Pod::UI.puts "[Codegen] Found #{library_name}"
 
+  relative_installation_root = Pod::Config.instance.installation_root.relative_path_from(Pathname.pwd)
   output_dir = options[:output_dir] ||= $CODEGEN_OUTPUT_DIR
   output_dir_module = "#{output_dir}/#{$CODEGEN_MODULE_DIR}"
   output_dir_component = "#{output_dir}/#{$CODEGEN_COMPONENT_DIR}"
@@ -553,7 +554,7 @@ def use_react_native_codegen!(spec, options={})
   codegen_config = {
     "modules" => {
       :js_srcs_pattern => "Native*.js",
-      :generated_dir => "#{Pod::Config.instance.installation_root}/#{output_dir_module}/#{library_name}",
+      :generated_dir => "#{relative_installation_root}/#{output_dir_module}/#{library_name}",
       :generated_files => [
         "#{library_name}.h",
         "#{library_name}-generated.mm"
@@ -561,7 +562,7 @@ def use_react_native_codegen!(spec, options={})
     },
     "components" => {
       :js_srcs_pattern => "*NativeComponent.js",
-      :generated_dir => "#{Pod::Config.instance.installation_root}/#{output_dir_component}/#{library_name}",
+      :generated_dir => "#{relative_installation_root}/#{output_dir_component}/#{library_name}",
       :generated_files => [
         "ComponentDescriptors.h",
         "EventEmitters.cpp",
@@ -610,7 +611,7 @@ def use_react_native_codegen!(spec, options={})
   spec.script_phase = {
     :name => 'Generate Specs',
     :input_files => input_files, # This also needs to be relative to Xcode
-    :output_files => ["${DERIVED_FILE_DIR}/codegen-#{library_name}.log"].concat(generated_files.map { |filename| " ${PODS_TARGET_SRCROOT}/#{filename}"} ),
+    :output_files => ["${DERIVED_FILE_DIR}/codegen-#{library_name}.log"].concat(generated_files.map { |filename| "${PODS_TARGET_SRCROOT}/#{filename}"} ),
     # The final generated files will be created when this script is invoked at Xcode build time.
     :script => get_script_phases_no_codegen_discovery(
       react_native_path: react_native_path,


### PR DESCRIPTION
## Summary

Use relative installation root instead of absolute to avoid embedding absolute paths in pods project
Also removes a leading space from each path.

Before: 

<img width="799" alt="155846827-94c474b7-8a79-45fc-a900-8860a94fb318" src="https://user-images.githubusercontent.com/996231/155847731-de128759-bff5-4d1f-a59a-377298055d85.png">

After:

<img width="745" alt="Screenshot 2022-02-26 at 15 58 32" src="https://user-images.githubusercontent.com/996231/155847739-b783debc-a805-4ce7-a88a-33f764dc5985.png">

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [Fixed] - Remove absolute paths from pods project

## Test Plan

Pod install and view in Xcode FBReactNativeSpec -> Build Phases -> [CP-User] Generate Specs
