### PR TITLE
Include folly fabric headers in source files

### DIFF
--- a/third-party-podspecs/RCT-Folly.podspec
+++ b/third-party-podspecs/RCT-Folly.podspec
@@ -91,7 +91,11 @@ Pod::Spec.new do |spec|
                           'folly/concurrency/CacheLocality.cpp',
                           'folly/detail/Futex.cpp',
                           'folly/synchronization/ParkingLot.cpp',
-                          'folly/portability/Malloc.cpp'
+                          'folly/portability/Malloc.cpp',
+                          'folly/concurrency/CacheLocality.h',
+                          'folly/synchronization/ParkingLot.h',
+                          'folly/synchronization/SanitizeThread.h',
+                          'folly/system/ThreadId.h'
 
     fabric.preserve_paths = 'folly/concurrency/CacheLocality.h',
                             'folly/synchronization/ParkingLot.h',


### PR DESCRIPTION
## Summary

See the main spec preserve_paths, they are all also included as source_files. Without this, the folly fabric header files won't be available for other pods.

## Changelog

[iOS] [Fixed] - Include folly fabric headers in source files

## Test Plan

Include react-native-safe-area-context 4.0.1 with new architecture active. It will result in a xcode build error:

<img width="466" alt="Screenshot 2022-02-26 at 19 33 35" src="https://user-images.githubusercontent.com/996231/155855017-8ea5f473-42a0-4e56-8108-472e6224ae7e.png">

