### PR TITLE
feat: Add dismissActionSheet method to ActionSheetIOS

### DIFF
--- a/Libraries/ActionSheetIOS/ActionSheetIOS.js
+++ b/Libraries/ActionSheetIOS/ActionSheetIOS.js
@@ -146,7 +146,9 @@ const ActionSheetIOS = {
 
   dismissActionSheet: () => {
     invariant(RCTActionSheetManager, "ActionSheetManager doesn't exist");
-    RCTActionSheetManager.dismissActionSheet();
+    if (typeof RCTActionSheetManager.dismissActionSheet === 'function') {
+      RCTActionSheetManager.dismissActionSheet();
+    }
   },
 };
 

--- a/Libraries/ActionSheetIOS/ActionSheetIOS.js
+++ b/Libraries/ActionSheetIOS/ActionSheetIOS.js
@@ -143,6 +143,11 @@ const ActionSheetIOS = {
       successCallback,
     );
   },
+
+  dismissActionSheet: () => {
+    invariant(RCTActionSheetManager, "ActionSheetManager doesn't exist");
+    RCTActionSheetManager.dismissActionSheet();
+  },
 };
 
 module.exports = ActionSheetIOS;

--- a/Libraries/ActionSheetIOS/NativeActionSheetManager.js
+++ b/Libraries/ActionSheetIOS/NativeActionSheetManager.js
@@ -47,7 +47,7 @@ export interface Spec extends TurboModule {
     |}) => void,
     successCallback: (completed: boolean, activityType: ?string) => void,
   ) => void;
-  +dismissActionSheet: () => void;
+  +dismissActionSheet?: () => void;
 }
 
 export default (TurboModuleRegistry.get<Spec>('ActionSheetManager'): ?Spec);

--- a/Libraries/ActionSheetIOS/NativeActionSheetManager.js
+++ b/Libraries/ActionSheetIOS/NativeActionSheetManager.js
@@ -47,6 +47,7 @@ export interface Spec extends TurboModule {
     |}) => void,
     successCallback: (completed: boolean, activityType: ?string) => void,
   ) => void;
+  +dismissActionSheet: () => void;
 }
 
 export default (TurboModuleRegistry.get<Spec>('ActionSheetManager'): ?Spec);

--- a/React/CoreModules/RCTActionSheetManager.mm
+++ b/React/CoreModules/RCTActionSheetManager.mm
@@ -21,14 +21,30 @@
 using namespace facebook::react;
 
 @interface RCTActionSheetManager () <UIActionSheetDelegate, NativeActionSheetManagerSpec>
+
+@property (nonatomic, strong) NSMutableArray<UIAlertController *> *alertControllers;
+
 @end
 
 @implementation RCTActionSheetManager
 
+- (instancetype)init
+{
+  self = [super init];
+  if (self) {
+    _alertControllers = [NSMutableArray new];
+  }
+  return self;
+}
+
++ (BOOL)requiresMainQueueSetup
+{
+  return NO;
+}
+
 RCT_EXPORT_MODULE()
 
 @synthesize viewRegistry_DEPRECATED = _viewRegistry_DEPRECATED;
-NSMutableArray<UIAlertController *> *_alertControllers = [NSMutableArray array];
 
 - (dispatch_queue_t)methodQueue
 {
@@ -138,7 +154,7 @@ RCT_EXPORT_METHOD(showActionSheetWithOptions
                                                          handler:^(__unused UIAlertAction *action) {
                                                            if (!callbackInvoked) {
                                                              callbackInvoked = true;
-                                                             [_alertControllers removeObject:alertController];
+                                                               [self->_alertControllers removeObject:alertController];
                                                              callback(@[ @(localIndex) ]);
                                                            }
                                                          }];

--- a/React/CoreModules/RCTActionSheetManager.mm
+++ b/React/CoreModules/RCTActionSheetManager.mm
@@ -28,6 +28,7 @@ using namespace facebook::react;
 RCT_EXPORT_MODULE()
 
 @synthesize viewRegistry_DEPRECATED = _viewRegistry_DEPRECATED;
+NSMutableArray<UIAlertController *> *_alertControllers = [NSMutableArray array];
 
 - (dispatch_queue_t)methodQueue
 {
@@ -137,6 +138,7 @@ RCT_EXPORT_METHOD(showActionSheetWithOptions
                                                          handler:^(__unused UIAlertAction *action) {
                                                            if (!callbackInvoked) {
                                                              callbackInvoked = true;
+                                                             [_alertControllers removeObject:alertController];
                                                              callback(@[ @(localIndex) ]);
                                                            }
                                                          }];
@@ -178,7 +180,19 @@ RCT_EXPORT_METHOD(showActionSheetWithOptions
   }
 #endif
 
+  [_alertControllers addObject:alertController];
   [self presentViewController:alertController onParentViewController:controller anchorViewTag:anchorViewTag];
+}
+
+RCT_EXPORT_METHOD(dismissActionSheet)
+{
+  if(_alertControllers.count == 0){
+    RCTLogWarn(@"Unable to dismiss action sheet");
+  }
+
+  id _alertController = [_alertControllers lastObject];
+  [_alertController dismissViewControllerAnimated:YES completion:nil];
+  [_alertControllers removeLastObject];
 }
 
 RCT_EXPORT_METHOD(showShareActionSheetWithOptions

--- a/packages/rn-tester/js/examples/ActionSheetIOS/ActionSheetIOSExample.js
+++ b/packages/rn-tester/js/examples/ActionSheetIOS/ActionSheetIOSExample.js
@@ -204,6 +204,34 @@ class ActionSheetDisabledExample extends React.Component<Props, State> {
   };
 }
 
+class ActionSheetDismissExample extends React.Component<{...}> {
+  render() {
+    return (
+      <View>
+        <Text onPress={this.showAndDismissActionSheet} style={style.button}>
+          Click to show and automatically dismiss the ActionSheet after 3
+          seconds
+        </Text>
+      </View>
+    );
+  }
+
+  showAndDismissActionSheet = () => {
+    ActionSheetIOS.showActionSheetWithOptions(
+      {
+        options: BUTTONS,
+        cancelButtonIndex: CANCEL_INDEX,
+        destructiveButtonIndex: DESTRUCTIVE_INDEX,
+      },
+      () => {},
+    );
+
+    setTimeout(() => {
+      ActionSheetIOS.dismissActionSheet();
+    }, 3000);
+  };
+}
+
 class ShareActionSheetExample extends React.Component<
   $FlowFixMeProps,
   $FlowFixMeState,
@@ -392,6 +420,12 @@ exports.examples = [
     title: 'Show Action Sheet with disabled buttons',
     render(): React.Element<any> {
       return <ActionSheetDisabledExample />;
+    },
+  },
+  {
+    title: 'Show Action Sheet and automatically dismiss it',
+    render(): React.Element<any> {
+      return <ActionSheetDismissExample />;
     },
   },
   {


### PR DESCRIPTION
## Summary

This PR adds a `dismissActionSheet` method to `ActionSheetIOS` in order to allow dismissing an ActionSheet programmatically. This is especially useful in apps where a user has the ability to open an ActionSheet and then open a push notification that will redirect them to another screen which usually leads to scenarios where the presented ActionSheet has no relation with the current screen.

#### TODO
- [ ]  Submit react-native-website PR updating ActionSheetIOS documentation. 

## Changelog

[iOS] [Added] - Add dismissActionSheet method to ActionSheetIOS

## Test Plan

1. Open the RNTester app and navigate to the ActionSheetIOS page
2. Test `dismissActionSheet` through the `Show Action Sheet and automatically dismiss it` example

https://user-images.githubusercontent.com/11707729/155867546-c6770a49-9b09-45e3-a6b1-4f7645d67dbf.mov


