### PR TITLE
Update usages of default ReactNativeConfig

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/fabric/ReactNativeConfig.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/fabric/ReactNativeConfig.java
@@ -23,7 +23,7 @@ import com.facebook.proguard.annotations.DoNotStrip;
 @DoNotStrip
 public interface ReactNativeConfig {
 
-  public final ReactNativeConfig DefaultValuesReactNativeConfig = new EmptyReactNativeConfig();
+  ReactNativeConfig DEFAULT_CONFIG = new EmptyReactNativeConfig();
 
   /**
    * Get a boolean param by string name. Default should be false.

--- a/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.java
+++ b/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.java
@@ -171,7 +171,7 @@ public class RNTesterApplication extends Application implements ReactApplication
                         return new FabricJSIModuleProvider(
                             reactApplicationContext,
                             componentFactory,
-                            ReactNativeConfig.DefaultValuesReactNativeConfig,
+                            ReactNativeConfig.DEFAULT_CONFIG,
                             viewManagerRegistry);
                       }
                     });

--- a/template/android/app/src/main/java/com/helloworld/newarchitecture/MainApplicationReactNativeHost.java
+++ b/template/android/app/src/main/java/com/helloworld/newarchitecture/MainApplicationReactNativeHost.java
@@ -17,6 +17,7 @@ import com.facebook.react.bridge.UIManager;
 import com.facebook.react.fabric.ComponentFactory;
 import com.facebook.react.fabric.CoreComponentsRegistry;
 import com.facebook.react.fabric.FabricJSIModuleProvider;
+import com.facebook.react.fabric.ReactNativeConfig;
 import com.facebook.react.uimanager.ViewManagerRegistry;
 import com.helloworld.BuildConfig;
 import com.helloworld.newarchitecture.components.MainComponentsRegistry;
@@ -104,7 +105,7 @@ public class MainApplicationReactNativeHost extends ReactNativeHost {
                 return new FabricJSIModuleProvider(
                     reactApplicationContext,
                     componentFactory,
-                    ReactNativeConfig.DefaultValuesReactNativeConfig,
+                    ReactNativeConfig.DEFAULT_CONFIG,
                     viewManagerRegistry);
               }
             });


### PR DESCRIPTION
Summary:
Fixes compilation of Android template and renames the field according to Java guidelines.

Changelog: [Android][Changed] - Rename field with default values for ReactConfig to DEFAULT_CONFIG

Differential Revision: D34523356

