### PR TITLE
Attempt to fix CircleCI by bumping CMake to 3.18.1

### DIFF
--- a/ReactAndroid/hermes-engine/build.gradle
+++ b/ReactAndroid/hermes-engine/build.gradle
@@ -120,7 +120,7 @@ android {
 
     externalNativeBuild {
         cmake {
-            version "3.10.2"
+            version "3.18.1"
             path "$hermesDir/CMakeLists.txt"
         }
     }


### PR DESCRIPTION
## Summary

I accidentally broke CircleCI. This PR attempts to fix it by setting the requested CMake version to `3.18.1`.

We might have to bump the Docker image to fix this instead.

## Changelog

[Internal] - Attempt to fix CircleCI by bumping CMake to 3.18.1

## Test Plan

Will rely on Green CircleCI