### PR TITLE
Fix babel-plugin-codegen crash when export init is null

### DIFF
--- a/packages/babel-plugin-codegen/index.js
+++ b/packages/babel-plugin-codegen/index.js
@@ -86,6 +86,7 @@ module.exports = function ({parse, types: t}) {
 
           if (firstDeclaration.type === 'VariableDeclarator') {
             if (
+              firstDeclaration.init &&
               firstDeclaration.init.type === 'CallExpression' &&
               firstDeclaration.init.callee.type === 'Identifier' &&
               firstDeclaration.init.callee.name === 'codegenNativeCommands'


### PR DESCRIPTION
## Summary

It is possible that `init` is null when using the following code.

```js
export var a;
```

The typescript compiler actually generates something like this for enums so a lot of third party libraries triggered this issue.

For example in expo-apple-authentication/build/AppleAuthentication.types.js

```js
export var AppleAuthenticationScope;
(function (AppleAuthenticationScope) {
    AppleAuthenticationScope[AppleAuthenticationScope["FULL_NAME"] = 0] = "FULL_NAME";
    AppleAuthenticationScope[AppleAuthenticationScope["EMAIL"] = 1] = "EMAIL";
})(AppleAuthenticationScope || (AppleAuthenticationScope = {}));
```

This simply adds a null check.

## Changelog

[General] [Fixed] - Fix babel-plugin-codegen crash when export init is null

## Test Plan

Tested that this fixed the crash in an app.
