### PR TITLE
change ios sandbox image load method

### DIFF
--- a/Libraries/Image/RCTLocalAssetImageLoader.mm
+++ b/Libraries/Image/RCTLocalAssetImageLoader.mm
@@ -24,7 +24,7 @@ RCT_EXPORT_MODULE()
 
 - (BOOL)canLoadImageURL:(NSURL *)requestURL
 {
-  return RCTIsLocalAssetURL(requestURL);
+  return RCTIsBundleAssetURL(requestURL);
 }
 
 - (BOOL)requiresScheduling

--- a/React/Base/RCTUtils.m
+++ b/React/Base/RCTUtils.m
@@ -820,18 +820,6 @@ UIImage *__nullable RCTImageFromLocalAssetURL(NSURL *imageURL)
     }
   }
 
-  if (!image) {
-    // Attempt to load from the file system
-    const char *fileSystemCString = [imageURL fileSystemRepresentation];
-    if (fileSystemCString != NULL) {
-      NSString *filePath = [NSString stringWithUTF8String:fileSystemCString];
-      if (filePath.pathExtension.length == 0) {
-        filePath = [filePath stringByAppendingPathExtension:@"png"];
-      }
-      image = [UIImage imageWithContentsOfFile:filePath];
-    }
-  }
-
   if (!image && !bundle) {
     // We did not find the image in the mainBundle, check in other shipped frameworks.
     NSArray<NSURL *> *possibleFrameworks =


### PR DESCRIPTION
## Summary

- `imageWithName` read data from memory, it can call on main thread
- `imageWithContentsOfFile` read data from disk, so it can't call on main thread
- replace imageWithContentsOfFile to NSURLRequest

1. if image in ipa
	- we can load image use imageWithName, don't need imageWithContentsOfFile
2. if image in disk/sandbox, need background thread async
	- we should replace imageWithContentsOfFile to NSURLFileRequest
3. if image in disk/sandbox, don't need cache
	- addImageToCache only handler NSHTTPURLResponse and it will ignore NSURLFileResponse
4. if image in disk/sandbox, we use NSURLFileRequest
	- it can work fine just like display a not sandbox's image in disk/system/photo

## Changelog

[iOS] [Changed] - Fix load sandbox image that will create main thread block

```objective-c
- (BOOL)canLoadImageURL:(NSURL *)requestURL {
  return (url in ipa || url in disk/sandbox)
}

if (canLoadImageURL) {
  image = [UIImage imageWithName];
  if (!image) {
	image = [UIImage imageWithContentsOfFile];
  }
} else {
  dispatch_async(background_queue) {
	// load image from network
  }
}
```

change to

```objective-c
- (BOOL)canLoadImageURL:(NSURL *)requestURL {
  return (url in ipa)
}

if (canLoadImageURL) {
  image = [UIImage imageWithName];
} else {
  dispatch_async(background_queue) {
	// load image from disk and network
  }
}
```

## Test Plan

1. I passed test-ios

2. I tested image in ipa
	- <Image source={require('happy.png')} />
	- [RCTConvert UIImage:[[[NSBundle mainBundle] bundleURL] URLByAppendingPathComponent:@"assets/app/happy.png"]]
3. I tested image in sandbox by codepush and shotview
	- <Image source={{ uri: 'file://../sandbox/codepush/happy.png' }} />
	- <Image source={{ uri: 'file://../sandbox/shotview/shot.png' }} />
4. I tested image on disk not sandbox by image picker
	- <Image source={{ uri: 'file://../system/photo/happy.png' }} />
