### PR TITLE
Start surface after setting the delegate

### DIFF
--- a/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingProxyRootView.mm
+++ b/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingProxyRootView.mm
@@ -73,13 +73,7 @@ static RCTRootViewSizeFlexibility convertToRootViewSizeFlexibility(RCTSurfaceSiz
   // `RCTRootViewSizeFlexibilityNone` is the RCTRootView's default.
   RCTSurfaceSizeMeasureMode sizeMeasureMode = convertToSurfaceSizeMeasureMode(RCTRootViewSizeFlexibilityNone);
 
-  id<RCTSurfaceProtocol> surface = [[self class] createSurfaceWithBridge:bridge
-                                                              moduleName:moduleName
-                                                       initialProperties:initialProperties];
-  [surface start];
-  if (self = [super initWithSurface:surface sizeMeasureMode:sizeMeasureMode]) {
-    // Nothing specific to do.
-  }
+  self = [super initWithBridge:bridge moduleName:moduleName initialProperties:initialProperties sizeMeasureMode:sizeMeasureMode];
 
   RCT_PROFILE_END_EVENT(RCTProfileTagAlways, @"");
 

--- a/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingView.mm
+++ b/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingView.mm
@@ -46,8 +46,10 @@ RCT_NOT_IMPLEMENTED(-(nullable instancetype)initWithCoder : (NSCoder *)coder)
   id<RCTSurfaceProtocol> surface = [[self class] createSurfaceWithBridge:bridge
                                                               moduleName:moduleName
                                                        initialProperties:initialProperties];
-  [surface start];
-  return [self initWithSurface:surface sizeMeasureMode:sizeMeasureMode];
+  if (self = [self initWithSurface:surface sizeMeasureMode:sizeMeasureMode]) {
+    [surface start];
+  }
+  return self;
 }
 
 - (instancetype)initWithSurface:(id<RCTSurfaceProtocol>)surface


### PR DESCRIPTION
## Summary

When starting the surface, _propagateStageChange is called. This checks the delegate to call surface:didChangeStage: on it.

When initWithSurface:sizeMeasureMode: is called after start, then the delegate will be nil and thus not be called.

This turns it around so a delegate is present for the surface to propagate its state to.

This fixes RCTContentDidAppearNotification not getting posted otherwise.

## Changelog

[iOS] [Fixed] - Post RCTContentDidAppearNotification with new arch

## Test Plan

I found it best to set a breakpoint in XCode to where RCTContentDidAppearNotification is being posted. 

Prior to the patch that breakpoint will not be called. After applying the patch, it will be called.
