### PR TITLE
Fix Hermes Android release build

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/hermes/reactexecutor/Android.mk
+++ b/ReactAndroid/src/main/java/com/facebook/hermes/reactexecutor/Android.mk
@@ -43,7 +43,7 @@ else
   LOCAL_SHARED_LIBRARIES := \
     libfb \
     libfbjni \
-    libfolly_json \
+    libfolly_runtime \
     libhermes \
     libjsi \
     libreactnativejni


### PR DESCRIPTION
Summary:
Hermes executor release dependency was incorrectly merged.

Changelog: [Internal]

Differential Revision: D34853948

