### PR TITLE
Fix RawPropsParser for Windows

### DIFF
--- a/ReactCommon/react/renderer/core/RawPropsParser.cpp
+++ b/ReactCommon/react/renderer/core/RawPropsParser.cpp
@@ -97,7 +97,7 @@ void RawPropsParser::preparse(RawProps const &rawProps) const noexcept {
   rawProps.keyIndexToValueIndex_.resize(keyCount, kRawPropsValueIndexEmpty);
 
   // Resetting the cursor, the next increment will give `0`.
-  rawProps.keyIndexCursor_ = keyCount - 1;
+  rawProps.keyIndexCursor_ = static_cast<int>(keyCount - 1);
 
   switch (rawProps.mode_) {
     case RawProps::Mode::Empty:


### PR DESCRIPTION
## Summary

Changes in https://github.com/facebook/react-native/compare/7cece3423...189c2c895 broke build for Windows because of a conversion from size_t to int. Adds a static cast to int to fix the error and restore windows build

Error Message
```
##[error]node_modules\react-native\ReactCommon\react\renderer\core\RawPropsParser.cpp(100,42): Error C2220: the following warning is treated as an error
     3>D:\a\_work\1\s\node_modules\react-native\ReactCommon\react\renderer\core\RawPropsParser.cpp(100,42): error C2220: the following warning is treated as an error [D:\a\_work\1\s\vnext\Microsoft.ReactNative\Microsoft.ReactNative.vcxproj]
##[warning]node_modules\react-native\ReactCommon\react\renderer\core\RawPropsParser.cpp(100,42): **Warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data**
     3>D:\a\_work\1\s\node_modules\react-native\ReactCommon\react\renderer\core\RawPropsParser.cpp(100,42): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data [D:\a\_work\1\s\vnext\Microsoft.ReactNative\Microsoft.ReactNative.vcxproj]
```


## Changelog

[General] [Fixed] - Restore Windows build with RawPropsParser.cpp

## Test Plan

Tested locally and changes pass in the react-native-windows pipeline, change is being merged into the main branch of react-native-windows.