### PR TITLE
fix(LogBox): remove invisible char from LogBoxInspectorReactFrames

### DIFF
--- a/Libraries/LogBox/UI/LogBoxInspectorReactFrames.js
+++ b/Libraries/LogBox/UI/LogBoxInspectorReactFrames.js
@@ -40,7 +40,7 @@ function getPrettyFileName(path: string) {
         // Note the below string contains a zero width space after the "/" character.
         // This is to prevent browsers like Chrome from formatting the file name as a link.
         // (Since this is a source link, it would not work to open the source file anyway.)
-        fileName = folderName + '/​' + fileName;
+        fileName = folderName + '/' + fileName;
       }
     }
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

This is a very tiny-tiny fix to the `'/'` section of L43: there was an invisible char in it - I'm not sure it was intentional; if so, please @rickhanlonii do let me know and I'll just close this off.

This was picked up by [socket.dev](https://socket.dev/npm/package/react-native), which is why I decided to spend a few mins just addressing it.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Fixed] - remove invisible char from LogBoxInspectorReactFrames

## Test Plan

I tried to test via the local E2E test script, with a fresh RNTestProject but it was failing for unrelated reasons 😅 So hopefully CI will be enough, it's a very small change after all.
