### PR TITLE
Disable prefab publishing if REACT_NATIVE_HERMES_SKIP_PREFAB is set.

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -249,7 +249,6 @@ final def extractNativeDependencies = tasks.register('extractNativeDependencies'
 
 task installArchives {
     dependsOn("publishReleasePublicationToNpmRepository")
-    dependsOn(":ReactAndroid:hermes-engine:installArchives")
 }
 
 // Creating sources with comments
@@ -374,12 +373,7 @@ dependencies {
 
     // It's up to the consumer to decide if hermes should be included or not.
     // Therefore hermes-engine is a compileOnly dependency.
-    // Moreover, you can toggle where to get the dependency with `buildHermesFromSource`.
-    if (project.getProperties().getOrDefault("buildHermesFromSource", "false").toBoolean()) {
-        compileOnly(project(":ReactAndroid:hermes-engine"))
-    } else {
-        compileOnly("com.facebook.react:hermes-engine:${VERSION_NAME}")
-    }
+    compileOnly(project(":ReactAndroid:hermes-engine"))
 
     javadocDeps("com.squareup:javapoet:1.13.0")
 

--- a/ReactAndroid/hermes-engine/build.gradle
+++ b/ReactAndroid/hermes-engine/build.gradle
@@ -29,6 +29,10 @@ if (hermesVersionFile.exists()) {
 def ndkBuildJobs = Runtime.runtime.availableProcessors().toString()
 def prefabHeadersDir = new File("$buildDir/prefab-headers")
 
+// By setting REACT_NATIVE_HERMES_SKIP_PREFAB you can skip prefab publishing, to
+// reduce the size of the Hermes published .AAR.
+def skipPrefabPublishing = System.getenv("REACT_NATIVE_HERMES_SKIP_PREFAB") != null
+
 // We inject the JSI directory used inside the Hermes build with the -DJSI_DIR config.
 def jsiDir = rootProject.file("ReactCommon/jsi")
 
@@ -171,6 +175,7 @@ android {
 
     buildFeatures {
         prefab true
+        prefabPublishing !skipPrefabPublishing
     }
 
     dependencies {
@@ -192,10 +197,6 @@ android {
             withJavadocJar()
             allVariants()
         }
-    }
-
-    buildFeatures {
-        prefabPublishing true
     }
 
     prefab {

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,8 +11,3 @@ kotlin_version=1.6.10
 # You can also override it from the CLI using
 # ./gradlew <task> -PreactNativeArchitectures=x86_64
 reactNativeArchitectures=armeabi-v7a,arm64-v8a,x86,x86_64
-
-# Use this property if hermes should be built from source or not.
-# If set to true, ReactAndroid will depend on :packages:hermes-engine and will build it from source.
-# If set to false, ReactAndroid will depend a hermes .aar which should be placed inside ./android folder.
-buildHermesFromSource=true

--- a/scripts/publish-npm.js
+++ b/scripts/publish-npm.js
@@ -31,7 +31,7 @@
  *     * or otherwise `{major}.{minor}-stable`
  */
 
-const {exec, echo, exit, test} = require('shelljs');
+const {exec, echo, exit, test, env} = require('shelljs');
 const {parseVersion, isTaggedLatest} = require('./version-utils');
 const fs = require('fs');
 const os = require('os');
@@ -172,6 +172,13 @@ if (isCommitly) {
 
 // -------- Generating Android Artifacts with JavaDoc
 if (exec('./gradlew :ReactAndroid:installArchives').code) {
+  echo('Could not generate artifacts');
+  exit(1);
+}
+
+// -------- Generating the Hermes Engine Artifacts
+env.REACT_NATIVE_HERMES_SKIP_PREFAB = true;
+if (exec('./gradlew :ReactAndroid:hermes-engine:installArchives').code) {
   echo('Could not generate artifacts');
   exit(1);
 }


### PR DESCRIPTION
Summary:
This allows us to toggle the publishing of prefab if the `REACT_NATIVE_HERMES_SKIP_PREFAB`
env variable is set. With this we can control how big is the .aar of hermes-engine, reducing
the size from ~200Mb right now to 8Mb.

Changelog:
[Internal] [Changed] - Disable prefab publishing if REACT_NATIVE_HERMES_SKIP_PREFAB is set

Differential Revision: D34929265

