### PR TITLE
Reduce flakyness of `configureNdkBuild*` tasks by setting an

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -423,6 +423,10 @@ afterEvaluate {
     // This can be safely removed once we move to CMake or once AGP supports C++ references on ndk-build.
     configureNdkBuildDebug.dependsOn(":ReactAndroid:hermes-engine:prefabDebugPackage")
     configureNdkBuildRelease.dependsOn(":ReactAndroid:hermes-engine:prefabReleasePackage")
+    reactNativeArchitectures().each { architecture ->
+        tasks.named("configureNdkBuildDebug[${architecture}]") { dependsOn(":ReactAndroid:hermes-engine:prefabDebugPackage") }
+        tasks.named("configureNdkBuildRelease[${architecture}]") { dependsOn(":ReactAndroid:hermes-engine:prefabReleasePackage") }
+    }
 
     publishing {
         publications {


### PR DESCRIPTION
Summary:
This is a follow up to
https://github.com/facebook/react-native/commit/21dd646ecaf4f17cc62f18a4abf2f9cb88a72881
The ABI specific tasks were not involved in this patch, and they're still
failing. I'm fixing them.

Changelog:
[Internal] [Changed] - Reduce flakyness of `configureNdkBuild*` tasks by setting an
explicit dependency on prefab - part 2

Differential Revision: D34960946

