### PR TITLE
Use Debian Buster for linux jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -810,7 +810,7 @@ jobs:
   # -------------------------
   prepare-hermes-ws:
     docker:
-      - image: debian:stretch
+      - image: debian:buster
     environment:
       - HERMES_WS_DIR: *hermes_workspace_root
     steps:
@@ -834,7 +834,7 @@ jobs:
 
   build-hermesc-linux:
     docker:
-      - image: debian:stretch
+      - image: debian:buster
     environment:
       - HERMES_WS_DIR: *hermes_workspace_root
       - TERM: dumb
@@ -955,7 +955,7 @@ jobs:
 
   inject-hermesc:
     docker:
-      - image: debian:stretch
+      - image: debian:buster
     environment:
       - HERMES_WS_DIR: *hermes_workspace_root
     steps:


### PR DESCRIPTION
## Summary

Linux tests are failing because the default version of CMake in Debian stretch, upgrade to Buster.
That's similar to https://github.com/facebook/hermes/commit/1838d6f2ce660fc0f63a4aa00ccab283e254d570

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

[Internal] - Use Debian Buster for linux jobs

## Test Plan

Will rely on CI results