### PR TITLE
fix context creation error for blurring image

### DIFF
--- a/Libraries/Image/RCTImageBlurUtils.m
+++ b/Libraries/Image/RCTImageBlurUtils.m
@@ -79,9 +79,20 @@ UIImage *RCTBlurredImageWithRadius(UIImage *inputImage, CGFloat radius)
   free(tempBuffer);
 
   //create image context from buffer
+  CGBitmapInfo bitmapInfoMasked = CGImageGetBitmapInfo(imageRef);
+  CGBitmapInfo bitmapInfo = bitmapInfoMasked & kCGBitmapByteOrderMask;
+  CGImageAlphaInfo alphaInfo = CGImageGetAlphaInfo(imageRef);
+  if (alphaInfo == kCGImageAlphaNone || alphaInfo == kCGImageAlphaOnly) {
+      alphaInfo = kCGImageAlphaNoneSkipFirst;
+  } else if (alphaInfo == kCGImageAlphaFirst) {
+      alphaInfo = kCGImageAlphaPremultipliedFirst;
+  } else if (alphaInfo == kCGImageAlphaLast) {
+      alphaInfo = kCGImageAlphaPremultipliedLast;
+  }
+  bitmapInfo |= alphaInfo;
   CGContextRef ctx = CGBitmapContextCreate(buffer1.data, buffer1.width, buffer1.height,
                                            8, buffer1.rowBytes, CGImageGetColorSpace(imageRef),
-                                           CGImageGetBitmapInfo(imageRef));
+                                           bitmapInfo);
 
   //create image from context
   imageRef = CGBitmapContextCreateImage(ctx);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

I found an error on CGContext creation when try to blur an image
`
CGBitmapContextCreate: unsupported parameter combination:
 	8 bits/component; integer;
 	32 bits/pixel;
	RGB color space model; kCGImageAlphaLast;
	default byte order;
	5216 bytes/row.
Valid parameters for RGB color space model are:
	16  bits per pixel,		 5  bits per component,		 kCGImageAlphaNoneSkipFirst
	32  bits per pixel,		 8  bits per component,		 kCGImageAlphaNoneSkipFirst
	32  bits per pixel,		 8  bits per component,		 kCGImageAlphaNoneSkipLast
	32  bits per pixel,		 8  bits per component,		 kCGImageAlphaPremultipliedFirst
	32  bits per pixel,		 8  bits per component,		 kCGImageAlphaPremultipliedLast
	32  bits per pixel,		 10 bits per component,		 kCGImageAlphaNone|kCGImagePixelFormatRGBCIF10
	64  bits per pixel,		 16 bits per component,		 kCGImageAlphaPremultipliedLast
	64  bits per pixel,		 16 bits per component,		 kCGImageAlphaNoneSkipLast
	64  bits per pixel,		 16 bits per component,		 kCGImageAlphaPremultipliedLast|kCGBitmapFloatComponents|kCGImageByteOrder16Little
	64  bits per pixel,		 16 bits per component,		 kCGImageAlphaNoneSkipLast|kCGBitmapFloatComponents|kCGImageByteOrder16Little
	128 bits per pixel,		 32 bits per component,		 kCGImageAlphaPremultipliedLast|kCGBitmapFloatComponents
	128 bits per pixel,		 32 bits per component,		 kCGImageAlphaNoneSkipLast|kCGBitmapFloatComponents
 See Quartz 2D Programming Guide (available online) for more information.
`
It seems you have to modify CGImageAlphaInfo before masking it with bitmapInfo

## Changelog
[iOS] [Fixed] - fix context creation error for blurring image

## Test Plan
use a webp image to test it
