### PR TITLE
[ios] Support enabling new architecture from use_react_native!

### DIFF
--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -18,6 +18,32 @@ def use_react_native! (options={})
   # The prefix to react-native
   prefix = options[:path] ||= "../node_modules/react-native"
 
+  # Other than environment variables, setup new architecture features from options is also supported.
+  unless options[:new_arch_enabled].nil?
+    # new_arch_enabled implicitly enables fabric_enabled / hermes_enabled / codegen_discovery_enabled
+    options[:fabric_enabled] = options[:new_arch_enabled] if options[:fabric_enabled].nil?
+    options[:hermes_enabled] = options[:new_arch_enabled] if options[:hermes_enabled].nil?
+    options[:codegen_discovery_enabled] = options[:new_arch_enabled] if options[:codegen_discovery_enabled].nil?
+
+    if options[:fabric_enabled] != nil && options[:new_arch_enabled] != options[:fabric_enabled]
+      Pod::UI.warn '"new_arch_enabled" and "fabric_enabled" options are exclusive.'
+      Pod::UI.warn 'Will set "fabric_enabled" value same as "new_arch_enabled".'
+      options[:fabric_enabled] = options[:new_arch_enabled]
+    end
+
+    ENV['RCT_NEW_ARCH_ENABLED'] = options[:new_arch_enabled] == true ? '1' : nil
+  end
+
+  unless options[:codegen_discovery_enabled].nil?
+    if options[:new_arch_enabled] != nil && options[:new_arch_enabled] != options[:codegen_discovery_enabled]
+      Pod::UI.warn '"new_arch_enabled" and "codegen_discovery_enabled" options are exclusive.'
+      Pod::UI.warn 'Will set "codegen_discovery_enabled" value same as "new_arch_enabled".'
+      options[:codegen_discovery_enabled] = options[:new_arch_enabled]
+    end
+
+    ENV['USE_CODEGEN_DISCOVERY'] = options[:codegen_discovery_enabled] == true ? '1' : nil
+  end
+
   # Include Fabric dependencies
   fabric_enabled = options[:fabric_enabled] ||= false
 
@@ -132,8 +158,8 @@ end
 
 def get_default_flags()
   flags = {
-    :fabric_enabled => false,
-    :hermes_enabled => false,
+    :fabric_enabled => nil,
+    :hermes_enabled => nil,
   }
 
   if ENV['RCT_NEW_ARCH_ENABLED'] == '1'

--- a/scripts/spec/react_native_pods_spec.rb
+++ b/scripts/spec/react_native_pods_spec.rb
@@ -1,0 +1,171 @@
+require_relative "../react_native_pods"
+
+
+# Inject dependencies for CocoaPods because rspec doesn't run by CocoaPods.
+module Pod
+  class UI
+    def self.warn(message)
+      Kernel::puts(message)
+    end
+    def self.puts(message)
+    end
+  end # class UI
+
+  class Lockfile
+  end # class Lockfile
+end # module Pod
+
+def pod(*args)
+end
+
+# Inject dependencies non critical functions for `use_react_native!` target
+def get_react_codegen_spec(options={})
+end
+
+def generate_react_codegen_podspec!(spec)
+end
+
+def use_react_native_codegen_discovery!(options={})
+end
+
+def checkAndGenerateEmptyThirdPartyProvider!(react_native_path)
+end
+
+
+describe use_react_native! do
+  before(:each) do
+    @options = {}
+    allow(LocalPodspecPatch).to receive(:pods_to_update) do |options|
+      @options = options
+    end
+    .and_return('')
+
+    ENV.delete("RCT_NEW_ARCH_ENABLED")
+    ENV.delete("USE_CODEGEN_DISCOVERY")
+  end
+
+  context "with get_default_flags" do
+    it "should return false values for old architecture" do
+      flags = get_default_flags()
+      use_react_native!(
+        :fabric_enabled => flags[:fabric_enabled],
+        :hermes_enabled => flags[:hermes_enabled],
+      )
+      expect(@options[:fabric_enabled]).to be false
+      expect(@options[:hermes_enabled]).to be false
+      expect(ENV['RCT_NEW_ARCH_ENABLED']).not_to eq('1')
+      expect(ENV['USE_CODEGEN_DISCOVERY']).not_to eq('1')
+    end
+
+    it "should return true values when RCT_NEW_ARCH_ENABLED=1" do
+      ENV['RCT_NEW_ARCH_ENABLED'] = '1'
+      flags = get_default_flags()
+      use_react_native!(
+        :fabric_enabled => flags[:fabric_enabled],
+        :hermes_enabled => flags[:hermes_enabled],
+      )
+      expect(@options[:fabric_enabled]).to be true
+      expect(@options[:hermes_enabled]).to be true
+      expect(ENV['RCT_NEW_ARCH_ENABLED']).to eq('1')
+      expect(ENV['USE_CODEGEN_DISCOVERY']).to eq('1')
+    end
+
+    it "should return hermes_enabled=true when specified explicitly" do
+      flags = get_default_flags()
+      use_react_native!(
+        :fabric_enabled => flags[:fabric_enabled],
+        :hermes_enabled => true,
+      )
+      expect(@options[:fabric_enabled]).to be false
+      expect(@options[:hermes_enabled]).to be true
+      expect(ENV['RCT_NEW_ARCH_ENABLED']).not_to eq('1')
+      expect(ENV['USE_CODEGEN_DISCOVERY']).not_to eq('1')
+    end
+  end
+
+  context "new_arch_enabled tests" do
+    it "should return true values when new_arch_enabled=true" do
+      use_react_native!(
+        :new_arch_enabled => true,
+      )
+      expect(@options[:fabric_enabled]).to be true
+      expect(@options[:hermes_enabled]).to be true
+      expect(ENV['RCT_NEW_ARCH_ENABLED']).to eq('1')
+      expect(ENV['USE_CODEGEN_DISCOVERY']).to eq('1')
+    end
+
+    it "should support non-hermes in new architecture mode" do
+      use_react_native!(
+        :hermes_enabled => false,
+        :new_arch_enabled => true,
+      )
+      expect(@options[:fabric_enabled]).to be true
+      expect(@options[:hermes_enabled]).to be false
+      expect(ENV['RCT_NEW_ARCH_ENABLED']).to eq('1')
+      expect(ENV['USE_CODEGEN_DISCOVERY']).to eq('1')
+    end
+
+    it "should show a warning when new_arch_enabled=true and fabric_enabled=false" do
+      expect(Pod::UI).to receive(:warn).at_least(:once)
+
+      use_react_native!(
+        :fabric_enabled => false,
+        :new_arch_enabled => true,
+      )
+      expect(@options[:fabric_enabled]).to be true
+      expect(@options[:hermes_enabled]).to be true
+      expect(ENV['RCT_NEW_ARCH_ENABLED']).to eq('1')
+      expect(ENV['USE_CODEGEN_DISCOVERY']).to eq('1')
+    end
+
+    it "should show a warning when new_arch_enabled=false and fabric_enabled=true" do
+      expect(Pod::UI).to receive(:warn).at_least(:once)
+
+      use_react_native!(
+        :fabric_enabled => true,
+        :new_arch_enabled => false,
+      )
+      expect(@options[:fabric_enabled]).to be false
+      expect(@options[:hermes_enabled]).to be false
+      expect(ENV['RCT_NEW_ARCH_ENABLED']).not_to eq('1')
+      expect(ENV['USE_CODEGEN_DISCOVERY']).not_to eq('1')
+    end
+
+    it "should show a warning when new_arch_enabled=true and codegen_discovery_enabled=false" do
+      expect(Pod::UI).to receive(:warn).at_least(:once)
+
+      use_react_native!(
+        :new_arch_enabled => true,
+        :codegen_discovery_enabled => false,
+      )
+      expect(@options[:codegen_discovery_enabled]).to be true
+      expect(ENV['RCT_NEW_ARCH_ENABLED']).to eq('1')
+      expect(ENV['USE_CODEGEN_DISCOVERY']).to eq('1')
+    end
+
+    it "should show a warning when new_arch_enabled=false and codegen_discovery_enabled=true" do
+      expect(Pod::UI).to receive(:warn).at_least(:once)
+
+      use_react_native!(
+        :new_arch_enabled => false,
+        :codegen_discovery_enabled => true,
+      )
+      expect(@options[:codegen_discovery_enabled]).to be false
+      expect(ENV['RCT_NEW_ARCH_ENABLED']).not_to eq('1')
+      expect(ENV['USE_CODEGEN_DISCOVERY']).not_to eq('1')
+    end
+
+
+    it "should support classic codegen" do
+      use_react_native!(
+        :fabric_enabled => true,
+        :hermes_enabled => true,
+      )
+      expect(@options[:fabric_enabled]).to be true
+      expect(@options[:hermes_enabled]).to be true
+      expect(ENV['RCT_NEW_ARCH_ENABLED']).not_to eq('1')
+      expect(ENV['USE_CODEGEN_DISCOVERY']).not_to eq('1')
+    end
+  end
+
+end


### PR DESCRIPTION
## Summary

currently we can only enable new architecture through environment variables: `RCT_NEW_ARCH_ENABLED=1 pod install`. that's not ideal for expo managed apps setup. this pr introduces two new options, `new_arch_enabled` and `codegen_discovery_enabled` in the `use_react_native!()` method. so we can also enable new architecture without environment variables.

## Changelog

[iOS] [Added] - Support enabling new architecture from the `use_react_native!` options

## Test Plan

that is complicated for different option combinations. even for original code, what if someone set `fabric_enabled=false` and run with `RCT_NEW_ARCH_ENABLED=1 pod install`. i have added a unit test in `scripts/spec/react_native_pods_spec.rb`

that is the steps to run the unit test:

```
$ gem install rspec
$ cd scripts
$ rspec -f d
```

so far the test cases are:

```
  with get_default_flags
    should return false values for old architecture
    should return true values when RCT_NEW_ARCH_ENABLED=1
    should return hermes_enabled=true when specified explicitly
  new_arch_enabled tests
    should return true values when new_arch_enabled=true
    should support non-hermes in new architecture mode
    should show a warning when new_arch_enabled=true and fabric_enabled=false
    should show a warning when new_arch_enabled=false and fabric_enabled=true
    should show a warning when new_arch_enabled=true and codegen_discovery_enabled=false
    should show a warning when new_arch_enabled=false and codegen_discovery_enabled=true
    should support classic codegen
```