### PR TITLE
Fix ESLint and Typescript-ESLint disagreeing about function spacing

### DIFF
--- a/packages/eslint-config-react-native-community/index.js
+++ b/packages/eslint-config-react-native-community/index.js
@@ -59,6 +59,8 @@ module.exports = {
         'no-shadow': 'off',
         '@typescript-eslint/no-shadow': 1,
         'no-undef': 'off',
+        'func-call-spacing': 'off',
+        '@typescript-eslint/func-call-spacing': 1,
       },
     },
     {
@@ -257,7 +259,7 @@ module.exports = {
     'no-empty-character-class': 1, // disallow the use of empty character classes in regular expressions
     'no-lonely-if': 0, // disallow if as the only statement in an else block (off by default)
     'no-new-object': 1, // disallow use of the Object constructor
-    'no-spaced-func': 1, // disallow space between function identifier and application
+    'func-call-spacing': 1, // disallow space between function identifier and application
     'no-ternary': 0, // disallow the use of ternary operators (off by default)
     'no-trailing-spaces': 1, // disallow trailing whitespace at the end of lines
     'no-underscore-dangle': 0, // disallow dangling underscores in identifiers


### PR DESCRIPTION
Summary:
Fixes #33452 by replacing deprecated no-spaced-func ESLint rule and adding related TypeScript.

Changelog: [General][Fixed] - Update function spacing linting rules

See #33452 - Existing function spacing linting should pass as expected.

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[CATEGORY] [TYPE] - Message

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
