### PR TITLE
Update template/android and RN Tester to use `hermes-engine` from the `react-native` NPM package.

### DIFF
--- a/packages/rn-tester/android/app/build.gradle
+++ b/packages/rn-tester/android/app/build.gradle
@@ -226,11 +226,12 @@ dependencies {
     // Build React Native from source
     implementation project(':ReactAndroid')
 
-    implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
+    // Consume Hermes as built from source only for the Hermes variant.
+    hermesImplementation(project(":ReactAndroid:hermes-engine")) {
+        exclude group:'com.facebook.fbjni'
+    }
 
-    def hermesPath = '$projectDir/../../../../../node_modules/hermes-engine/android/'
-    hermesDebugImplementation files(hermesPath + "hermes-debug.aar")
-    hermesReleaseImplementation files(hermesPath + "hermes-release.aar")
+    implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
 
     debugImplementation("com.facebook.flipper:flipper:${FLIPPER_VERSION}") {
         exclude group:'com.facebook.fbjni'

--- a/template/android/app/build.gradle
+++ b/template/android/app/build.gradle
@@ -271,9 +271,10 @@ dependencies {
     }
 
     if (enableHermes) {
-        def hermesPath = "../../node_modules/hermes-engine/android/";
-        debugImplementation files(hermesPath + "hermes-debug.aar")
-        releaseImplementation files(hermesPath + "hermes-release.aar")
+        //noinspection GradleDynamicVersion
+        implementation("com.facebook.react:hermes-engine:+") { // From node_modules
+            exclude group:'com.facebook.fbjni'
+        }
     } else {
         implementation jscFlavor
     }
@@ -286,7 +287,11 @@ if (isNewArchitectureEnabled()) {
     configurations.all {
         resolutionStrategy.dependencySubstitution {
             substitute(module("com.facebook.react:react-native"))
-                    .using(project(":ReactAndroid")).because("On New Architecture we're building React Native from source")
+                    .using(project(":ReactAndroid"))
+                    .because("On New Architecture we're building React Native from source")
+            substitute(module("com.facebook.react:hermes-engine"))
+                    .using(project(":ReactAndroid:hermes-engine"))
+                    .because("On New Architecture we're building Hermes from source")
         }
     }
 }

--- a/template/android/settings.gradle
+++ b/template/android/settings.gradle
@@ -6,4 +6,6 @@ includeBuild('../node_modules/react-native-gradle-plugin')
 if (settings.hasProperty("newArchEnabled") && settings.newArchEnabled == "true") {
     include(":ReactAndroid")
     project(":ReactAndroid").projectDir = file('../node_modules/react-native/ReactAndroid')
+    include(":ReactAndroid:hermes-engine")
+    project(":ReactAndroid:hermes-engine").projectDir = file('../node_modules/react-native/ReactAndroid/hermes-engine')
 }


### PR DESCRIPTION
Summary:
We can now change the `hermes-engine` dependency to be consumed by the `react-native` NPM package
and not anymore from the standalone `hermes-engine`. This will allow for a better stability
as the `hermes-engine` and the `react-native` were built from source at the same instant in time.

Changelog:
[Android] [Changed] - Update template/android and RN Tester to use `hermes-engine` from the `react-native` NPM package.

Reviewed By: hramos

Differential Revision: D34213795

