### PR TITLE
feat: Add newly intrdouced permission introduced in Android 13

### DIFF
--- a/Libraries/PermissionsAndroid/NativePermissionsAndroid.js
+++ b/Libraries/PermissionsAndroid/NativePermissionsAndroid.js
@@ -51,7 +51,8 @@ export type PermissionType =
   | 'android.permission.ANSWER_PHONE_CALLS'
   | 'android.permission.READ_PHONE_NUMBERS'
   | 'android.permission.UWB_RANGING'
-  | 'android.permission.POST_NOTIFICATIONS';
+  | 'android.permission.POST_NOTIFICATIONS'
+  | 'android.permission.NEARBY_WIFI_DEVICES';
 */
 
 export interface Spec extends TurboModule {

--- a/Libraries/PermissionsAndroid/NativePermissionsAndroid.js
+++ b/Libraries/PermissionsAndroid/NativePermissionsAndroid.js
@@ -50,7 +50,8 @@ export type PermissionType =
   | 'android.permission.ACTIVITY_RECOGNITION'
   | 'android.permission.ANSWER_PHONE_CALLS'
   | 'android.permission.READ_PHONE_NUMBERS'
-  | 'android.permission.UWB_RANGING';
+  | 'android.permission.UWB_RANGING'
+  | 'android.permission.POST_NOTIFICATIONS';
 */
 
 export interface Spec extends TurboModule {

--- a/Libraries/PermissionsAndroid/PermissionsAndroid.js
+++ b/Libraries/PermissionsAndroid/PermissionsAndroid.js
@@ -69,6 +69,7 @@ const PERMISSIONS = Object.freeze({
   READ_PHONE_NUMBERS: 'android.permission.READ_PHONE_NUMBERS',
   UWB_RANGING: 'android.permission.UWB_RANGING',
   POST_NOTIFICATION: 'android.permission.POST_NOTIFICATIONS ',
+  NEARBY_WIFI_DEVICES: 'android.permission.NEARBY_WIFI_DEVICES',
 });
 
 /**
@@ -94,6 +95,7 @@ class PermissionsAndroid {
     CALL_PHONE: string,
     CAMERA: string,
     GET_ACCOUNTS: string,
+    NEARBY_WIFI_DEVICES: string,
     POST_NOTIFICATION: string,
     PROCESS_OUTGOING_CALLS: string,
     READ_CALENDAR: string,

--- a/Libraries/PermissionsAndroid/PermissionsAndroid.js
+++ b/Libraries/PermissionsAndroid/PermissionsAndroid.js
@@ -68,6 +68,7 @@ const PERMISSIONS = Object.freeze({
   ANSWER_PHONE_CALLS: 'android.permission.ANSWER_PHONE_CALLS',
   READ_PHONE_NUMBERS: 'android.permission.READ_PHONE_NUMBERS',
   UWB_RANGING: 'android.permission.UWB_RANGING',
+  POST_NOTIFICATION: 'android.permission.POST_NOTIFICATIONS ',
 });
 
 /**
@@ -93,6 +94,7 @@ class PermissionsAndroid {
     CALL_PHONE: string,
     CAMERA: string,
     GET_ACCOUNTS: string,
+    POST_NOTIFICATION: string,
     PROCESS_OUTGOING_CALLS: string,
     READ_CALENDAR: string,
     READ_CALL_LOG: string,


### PR DESCRIPTION
## Summary

Android 13 introduces two new permission,
- [NEARBY_WIFI_DEVICES](https://developer.android.com/about/versions/13/features/nearby-wifi-devices-permission) for scanning nearby wifi devices.
- [POST_NOTIFICATIONS](https://developer.android.com/about/versions/13/changes/notification-permission) for posting notifications.

This PR adds all the new permission (as of this PR creation) in Android 13.

## Changelog

[Android] [Added] - Add POST_NOTIFICATIONS, NEARBY_WIFI_DEVICES permission

## Test Plan

```
PermissionsAndroid.POST_NOTIFICATIONS === 'android.permission.POST_NOTIFICATIONS'
PermissionsAndroid.NEARBY_WIFI_DEVICES === 'android.permission.NEARBY_WIFI_DEVICES'
```
