### PR TITLE
Unsolicited refactor of FlatList.getItem

### DIFF
--- a/Libraries/Lists/FlatList.js
+++ b/Libraries/Lists/FlatList.js
@@ -492,14 +492,9 @@ class FlatList<ItemT> extends React.PureComponent<Props<ItemT>, void> {
   _getItem = (data: Array<ItemT>, index: number) => {
     const numColumns = numColumnsOrDefault(this.props.numColumns);
     if (numColumns > 1) {
-      const ret = [];
-      for (let kk = 0; kk < numColumns; kk++) {
-        const item = data[index * numColumns + kk];
-        if (item != null) {
-          ret.push(item);
-        }
-      }
-      return ret;
+      return data
+        .slice(index * numColumns, (index + 1) * numColumns)
+        .filter(item => item != null);
     } else {
       return data[index];
     }


### PR DESCRIPTION
## Summary

This should be the same, but I think it is prettier.

`.filter(item => item != null)` might be simply `.filter(item => item)`, but this looks to be intentional for handling when the item is the empty string `''` from a90d0e3614c467c33cf85bcbe65be71903d5aecc

## Changelog

[Internal][Changed] - Refactored FlatList getItem.

## Test Plan

* Existing test cases still pass
* Benchmarked performance characteristics with Node 16.13.2 on an M1/arm64 (https://gist.github.com/philihp/1c821a7f1bd3056c0256e055a60967b1)
```bash
testFiltery x 4,707,602 ops/sec ±0.13% (99 runs sampled)
testControl x 4,707,246 ops/sec ±0.10% (95 runs sampled)
```

<sub>notice me, senpai</sub>