### PR TITLE
Fix windowed rendering when scrolling to index 0 in a VirtualizedList with non-zero initialScrollIndex

### DIFF
--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -1749,6 +1749,7 @@ class VirtualizedList extends React.PureComponent<Props, State> {
           if (
             (this._hasDoneFirstRenderPass &&
               this.props.initialScrollIndex != null) ||
+            !this.props.initialScrollIndex ||
             offset
           ) {
             newState = computeWindowedRenderLimits(

--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -1187,6 +1187,7 @@ class VirtualizedList extends React.PureComponent<Props, State> {
   _fillRateHelper: FillRateHelper;
   _frames = {};
   _footerLength = 0;
+  _hasDoneFirstRenderPass = false;
   _hasDoneInitialScroll = false;
   _hasInteracted = false;
   _hasMore = false;
@@ -1745,7 +1746,11 @@ class VirtualizedList extends React.PureComponent<Props, State> {
           // we'll wipe out the initialNumToRender rendered elements starting at initialScrollIndex.
           // So let's wait until we've scrolled the view to the right place. And until then,
           // we will trust the initialScrollIndex suggestion.
-          if (!this.props.initialScrollIndex || this._scrollMetrics.offset) {
+          if (
+            (this._hasDoneFirstRenderPass &&
+              this.props.initialScrollIndex != null) ||
+            offset
+          ) {
             newState = computeWindowedRenderLimits(
               this.props.data,
               this.props.getItemCount,
@@ -1756,6 +1761,7 @@ class VirtualizedList extends React.PureComponent<Props, State> {
               this._scrollMetrics,
             );
           }
+          this._hasDoneFirstRenderPass = true;
         }
       } else {
         const distanceFromEnd = contentLength - visibleLength - offset;

--- a/Libraries/Lists/__tests__/VirtualizedList-test.js
+++ b/Libraries/Lists/__tests__/VirtualizedList-test.js
@@ -890,11 +890,6 @@ it('renders items at start of list after scrolling to index 0 with a non-zero in
 
   const instance = component.getInstance();
   instance.scrollToIndex({index: 0});
-
-  // Layout information from before the time we scroll to initial index may not
-  // correspond to the area "initialScrollIndex" points to. Expect only the 5
-  // initial items (starting at initialScrollIndex) to be rendered after
-  // processing all batch work, even though the windowSize allows for more.
   expect(component).toMatchSnapshot();
 });
 

--- a/Libraries/Lists/__tests__/VirtualizedList-test.js
+++ b/Libraries/Lists/__tests__/VirtualizedList-test.js
@@ -862,18 +862,18 @@ it('does not adjust render area until content area layed out', () => {
   expect(component).toMatchSnapshot();
 });
 
-it('does not adjust render area with non-zero initialScrollIndex until scrolled', () => {
-  const items = generateItems(20);
-  const ITEM_HEIGHT = 10;
+it('renders items at start of list after scrolling to index 0 with a non-zero initialScrollIndex', () => {
+  const items = generateItems(10);
+  const ITEM_HEIGHT = 50;
 
   let component;
   ReactTestRenderer.act(() => {
     component = ReactTestRenderer.create(
       <VirtualizedList
-        initialNumToRender={5}
-        initialScrollIndex={1}
-        windowSize={10}
-        maxToRenderPerBatch={10}
+        initialNumToRender={3}
+        initialScrollIndex={7}
+        windowSize={3}
+        maxToRenderPerBatch={3}
         {...baseItemProps(items)}
         {...fixedHeightItemLayoutProps(ITEM_HEIGHT)}
       />,
@@ -883,10 +883,13 @@ it('does not adjust render area with non-zero initialScrollIndex until scrolled'
   ReactTestRenderer.act(() => {
     simulateLayout(component, {
       viewport: {width: 10, height: 50},
-      content: {width: 10, height: 200},
+      content: {width: 10, height: 50},
     });
     performAllBatches();
   });
+
+  const instance = component.getInstance();
+  instance.scrollToIndex({index: 0});
 
   // Layout information from before the time we scroll to initial index may not
   // correspond to the area "initialScrollIndex" points to. Expect only the 5

--- a/Libraries/Lists/__tests__/__snapshots__/VirtualizedList-test.js.snap
+++ b/Libraries/Lists/__tests__/__snapshots__/VirtualizedList-test.js.snap
@@ -2207,144 +2207,6 @@ exports[`does not adjust render area until content area layed out 1`] = `
 </RCTScrollView>
 `;
 
-exports[`does not adjust render area with non-zero initialScrollIndex until scrolled 1`] = `
-<RCTScrollView
-  data={
-    Array [
-      Object {
-        "key": 0,
-      },
-      Object {
-        "key": 1,
-      },
-      Object {
-        "key": 2,
-      },
-      Object {
-        "key": 3,
-      },
-      Object {
-        "key": 4,
-      },
-      Object {
-        "key": 5,
-      },
-      Object {
-        "key": 6,
-      },
-      Object {
-        "key": 7,
-      },
-      Object {
-        "key": 8,
-      },
-      Object {
-        "key": 9,
-      },
-      Object {
-        "key": 10,
-      },
-      Object {
-        "key": 11,
-      },
-      Object {
-        "key": 12,
-      },
-      Object {
-        "key": 13,
-      },
-      Object {
-        "key": 14,
-      },
-      Object {
-        "key": 15,
-      },
-      Object {
-        "key": 16,
-      },
-      Object {
-        "key": 17,
-      },
-      Object {
-        "key": 18,
-      },
-      Object {
-        "key": 19,
-      },
-    ]
-  }
-  getItem={[Function]}
-  getItemCount={[Function]}
-  getItemLayout={[Function]}
-  initialNumToRender={5}
-  initialScrollIndex={1}
-  maxToRenderPerBatch={10}
-  onContentSizeChange={[Function]}
-  onLayout={[Function]}
-  onMomentumScrollBegin={[Function]}
-  onMomentumScrollEnd={[Function]}
-  onScroll={[Function]}
-  onScrollBeginDrag={[Function]}
-  onScrollEndDrag={[Function]}
-  renderItem={[Function]}
-  scrollEventThrottle={50}
-  stickyHeaderIndices={Array []}
-  windowSize={10}
->
-  <View>
-    <View
-      style={
-        Object {
-          "height": 10,
-        }
-      }
-    />
-    <View
-      style={null}
-    >
-      <MockCellItem
-        value={1}
-      />
-    </View>
-    <View
-      style={null}
-    >
-      <MockCellItem
-        value={2}
-      />
-    </View>
-    <View
-      style={null}
-    >
-      <MockCellItem
-        value={3}
-      />
-    </View>
-    <View
-      style={null}
-    >
-      <MockCellItem
-        value={4}
-      />
-    </View>
-    <View
-      style={null}
-    >
-      <MockCellItem
-        value={5}
-      />
-    </View>
-    <View
-      style={
-        Object {
-          "height": 140,
-        }
-      }
-    />
-  </View>
-</RCTScrollView>
-`;
-
 exports[`does not over-render when there is less than initialNumToRender cells 1`] = `
 <RCTScrollView
   data={
@@ -3138,6 +3000,86 @@ exports[`renders initialNumToRender cells when virtualization disabled 1`] = `
         value={5}
       />
     </View>
+  </View>
+</RCTScrollView>
+`;
+
+exports[`renders items at start of list after scrolling to index 0 with a non-zero initialScrollIndex 1`] = `
+<RCTScrollView
+  data={
+    Array [
+      Object {
+        "key": 0,
+      },
+      Object {
+        "key": 1,
+      },
+      Object {
+        "key": 2,
+      },
+      Object {
+        "key": 3,
+      },
+      Object {
+        "key": 4,
+      },
+      Object {
+        "key": 5,
+      },
+      Object {
+        "key": 6,
+      },
+      Object {
+        "key": 7,
+      },
+      Object {
+        "key": 8,
+      },
+      Object {
+        "key": 9,
+      },
+    ]
+  }
+  getItem={[Function]}
+  getItemCount={[Function]}
+  getItemLayout={[Function]}
+  initialNumToRender={3}
+  initialScrollIndex={7}
+  maxToRenderPerBatch={3}
+  onContentSizeChange={[Function]}
+  onLayout={[Function]}
+  onMomentumScrollBegin={[Function]}
+  onMomentumScrollEnd={[Function]}
+  onScroll={[Function]}
+  onScrollBeginDrag={[Function]}
+  onScrollEndDrag={[Function]}
+  renderItem={[Function]}
+  scrollEventThrottle={50}
+  stickyHeaderIndices={Array []}
+  windowSize={3}
+>
+  <View>
+    <View
+      style={null}
+    >
+      <MockCellItem
+        value={0}
+      />
+    </View>
+    <View
+      style={null}
+    >
+      <MockCellItem
+        value={1}
+      />
+    </View>
+    <View
+      style={
+        Object {
+          "height": 400,
+        }
+      }
+    />
   </View>
 </RCTScrollView>
 `;


### PR DESCRIPTION
## Summary

Currently the following behaviour exists:

If
1. A `VirtualizedList` is rendered with a non-zero `initialScrollIndex` value and
2. The element at index 0 is not in the rendered window and 
3. The `scrollToIndex` or `scrollToOffset` methods are used to navigate to index 0

Then the windowed rendering will not recompute correctly and the elements in the window of index 0 will not get rendered (with blank cells shown instead) until the user starts scrolling the list manually.

This PR fixes this edge case without interfering with any other behaviour of `VirtualizedList`. 

## Changelog

[General] [Fixed] - Fix windowed rendering when scrolling to index 0 in a VirtualizedList with non-zero initialScrollIndex

## Test Plan

Tested this change heavily in my private code base and have been using it in production for months beneath a number of VirtualizedLists and FlatLists. Problem can be reproduced and then fix confirmed by rendering a large VirtualizedList with an initialScrollIndex that puts index 0 outside the render window and then calling `listRef.current.scrollToIndex({animated: false, index: 0, viewPosition: 0})`.

The following videos are taken from my app and demonstrate a large horizontal VirtualizedList with each item having the same fixed layout with width matching the width of the screen. In each video, the list has been rendered with a window size of 3 and an initial scroll index of 563. I use a menu in the app to navigate to page 1 (index 0). Before this change, the page (item) is not rendered until I start to manually scroll the list. After this change, the item at index 0 is rendered correctly without any manual intervention.

Before:

https://user-images.githubusercontent.com/9062287/159818718-e19c2610-1fea-46a1-ab70-4958b7635085.mov

After:

https://user-images.githubusercontent.com/9062287/159818049-24e77544-4b7c-4ebe-9dc0-a5e6ca101c67.mov
