### PR TITLE
Add Modal property overlay color

### DIFF
--- a/Libraries/Modal/Modal.js
+++ b/Libraries/Modal/Modal.js
@@ -88,6 +88,12 @@ export type Props = $ReadOnly<{|
   transparent?: ?boolean,
 
   /**
+   * The `overlayColor` prop determines the color that will be applied to
+   * the Modal's background when the `transparent` prop is false.
+   */
+  overlayColor?: ?string,
+
+  /**
    * The `statusBarTranslucent` prop determines whether your modal should go under
    * the system statusbar.
    *
@@ -225,7 +231,9 @@ class Modal extends React.Component<Props> {
 
     const containerStyles = {
       backgroundColor:
-        this.props.transparent === true ? 'transparent' : 'white',
+        this.props.transparent === true
+          ? 'transparent'
+          : this.props.overlayColor || 'white',
     };
 
     let animationType = this.props.animationType || 'none';
@@ -233,7 +241,7 @@ class Modal extends React.Component<Props> {
     let presentationStyle = this.props.presentationStyle;
     if (!presentationStyle) {
       presentationStyle = 'fullScreen';
-      if (this.props.transparent === true) {
+      if (this.props.transparent === true || this.props.overlayColor) {
         presentationStyle = 'overFullScreen';
       }
     }
@@ -249,6 +257,7 @@ class Modal extends React.Component<Props> {
         animationType={animationType}
         presentationStyle={presentationStyle}
         transparent={this.props.transparent}
+        overlayColor={this.props.overlayColor}
         hardwareAccelerated={this.props.hardwareAccelerated}
         onRequestClose={this.props.onRequestClose}
         onShow={this.props.onShow}

--- a/Libraries/Modal/Modal.js
+++ b/Libraries/Modal/Modal.js
@@ -90,7 +90,8 @@ export type Props = $ReadOnly<{|
 
   /**
    * The `overlayColor` prop determines the color that will be applied to
-   * the Modal's background when the `transparent` prop is false.
+   * the Modal's background when the `transparent` prop is false. If `overlayColor`
+   * is not used, the Modal's background color will default to white.
    */
   overlayColor?: ?string,
 
@@ -239,7 +240,9 @@ class Modal extends React.Component<Props> {
       backgroundColor:
         this.props.transparent === true
           ? 'transparent'
-          : overlayColor || 'white',
+          : this.props.overlayColor !== null
+          ? this.props.overlayColor
+          : 'white',
     };
 
     let animationType = this.props.animationType || 'none';
@@ -247,7 +250,7 @@ class Modal extends React.Component<Props> {
     let presentationStyle = this.props.presentationStyle;
     if (!presentationStyle) {
       presentationStyle = 'fullScreen';
-      if (this.props.transparent === true || overlayColor) {
+      if (this.props.transparent === true || this.props.overlayColor !== '') {
         presentationStyle = 'overFullScreen';
       }
     }

--- a/Libraries/Modal/Modal.js
+++ b/Libraries/Modal/Modal.js
@@ -27,6 +27,7 @@ import type {RootTag} from '../ReactNative/RootTag';
 import type {DirectEventHandler} from '../Types/CodegenTypes';
 import {type EventSubscription} from '../vendor/emitter/EventEmitter';
 import RCTModalHostView from './RCTModalHostViewNativeComponent';
+import processColor from '../StyleSheet/processColor';
 
 type ModalEventDefinitions = {
   modalDismissed: [{modalID: number}],
@@ -229,11 +230,16 @@ class Modal extends React.Component<Props> {
       return null;
     }
 
+    const overlayColor =
+      this.props.overlayColor == null
+        ? null
+        : processColor(this.props.overlayColor);
+
     const containerStyles = {
       backgroundColor:
         this.props.transparent === true
           ? 'transparent'
-          : this.props.overlayColor || 'white',
+          : overlayColor || 'white',
     };
 
     let animationType = this.props.animationType || 'none';
@@ -257,7 +263,7 @@ class Modal extends React.Component<Props> {
         animationType={animationType}
         presentationStyle={presentationStyle}
         transparent={this.props.transparent}
-        overlayColor={this.props.overlayColor}
+        overlayColor={overlayColor}
         hardwareAccelerated={this.props.hardwareAccelerated}
         onRequestClose={this.props.onRequestClose}
         onShow={this.props.onShow}

--- a/Libraries/Modal/Modal.js
+++ b/Libraries/Modal/Modal.js
@@ -247,7 +247,7 @@ class Modal extends React.Component<Props> {
     let presentationStyle = this.props.presentationStyle;
     if (!presentationStyle) {
       presentationStyle = 'fullScreen';
-      if (this.props.transparent === true || this.props.overlayColor) {
+      if (this.props.transparent === true || overlayColor) {
         presentationStyle = 'overFullScreen';
       }
     }

--- a/Libraries/Modal/Modal.js
+++ b/Libraries/Modal/Modal.js
@@ -240,7 +240,7 @@ class Modal extends React.Component<Props> {
       backgroundColor:
         this.props.transparent === true
           ? 'transparent'
-          : this.props.overlayColor !== null
+          : this.props.overlayColor
           ? this.props.overlayColor
           : 'white',
     };

--- a/Libraries/Modal/RCTModalHostViewNativeComponent.js
+++ b/Libraries/Modal/RCTModalHostViewNativeComponent.js
@@ -17,6 +17,7 @@ import type {
 } from '../Types/CodegenTypes';
 
 import type {ViewProps} from '../Components/View/ViewPropTypes';
+import {type ProcessedColorValue} from '../StyleSheet/processColor';
 
 type OrientationChangeEvent = $ReadOnly<{|
   orientation: 'portrait' | 'landscape',
@@ -49,6 +50,12 @@ type NativeProps = $ReadOnly<{|
    * See https://reactnative.dev/docs/modal#transparent
    */
   transparent?: WithDefault<boolean, false>,
+
+  /**
+   * The `overlayColor` prop determines the color that will be applied to
+   * the Modal's background when the `transparent` prop is false.
+   */
+  overlayColor?: ?ProcessedColorValue,
 
   /**
    * The `statusBarTranslucent` prop determines whether your modal should go under


### PR DESCRIPTION
Full disclosure: This feature was originally suggested [here](https://github.com/facebook/react-native/issues/18398) in 2018, but no pull request was made and the issue was closed. I can’t take credit for the idea originally, but since the original poster’s GitHub account no longer exists for me to ask permission, and the issue in question persists through today, I decided to take a shot at a fix. For reference, another attempt was made to fix this same issue [here](https://github.com/facebook/react-native/pull/24949), but the request was closed by the requester, rather than merged.

## Summary

Currently, when a developer sets the _transparency_ prop of a Modal component to false, a white page is rendered “behind” the modal. This effect is hardcoded. This small feature allows developers to utilize a new prop, called **overlayColor**, to change this background color to suit their needs. The value of **overlayColor** will be a string, and may include anything that could be entered as a valid _backgroundColor_ style. 

In order to facilitate possible use of transparency values in the **overlayColor** string (i.e. rgba values), the _presentationStyle_ prop logic has been modified to make “overFullScreen” the default value of that prop when **overlayColor** is utilized. Without making this change to the _presentationStyle_ prop, color values with transparency cannot be rendered properly on iOS.

## Changelog

[General] [Added] - Add overlayColor property to Modal component

## Test Plan

**npm test result**: When testing, I first ran the test on the main branch as a control group and received 196 failed tests of 2845 total. Not sure what causes those failures, but after implementing changes on the modal-overlayColor branch and running npm test again, the number of failed tests did not increase.

**npm run flow result**: The flow test showed that I hadn’t properly considered all the pieces of the Modal component. 

First, and in particular, checking for the value of **overlayColor** as a string returned a “sketchy-null-string” error. Investigation led me to the Text component, where a similarly-functioning feature, the _selectionColor_ prop, imports processColor from the StyleSheet component, and passes the input string through that function. Doing so in my code eliminated the sketchy-null-string error, but reveals a “sketchy-null-number” error. If possible, I’d appreciate some guidance on why this is happening, and how to resolve it, since I had never used flow before attempting these tests. In the end, I settled on a solution that works in my test code, but still gives me a couple "sketchy-null-string" error. I don’t feel like this is necessarily the most optimized solution, so if there’s a better way to approach this, I’d be eager to hear it.

Second, it showed that I needed to edit the RCTModalHostViewNativeComponent file to reflect changes made in Modal.js. Again, I relied on the TextNativeComponent file for usage of the _selectionColor_ prop as a guide.

## Usage Example
#### Default Behavior:
![React Native Modal - defaultBehavior](https://user-images.githubusercontent.com/87335128/159850360-78172585-469c-483f-93bf-61929c2fb0de.png)
#### With **overlayColor** Enabled:
![React Native Modal - overlayColor](https://user-images.githubusercontent.com/87335128/159850444-bb87d745-7d07-4601-9b20-c973de37fb62.png)

_**Note 1**_: Allowing the use of transparency values in the **overlayColor** prop when the _transparent_ prop is set to false may be a bit misleading. There's probably a better solution available to remove any possible confusion, but I've taken to considering _transparent_ to mean "true transparency", whereas the rgba value represented in the screenshot is only a partial transparency.

_**Note 2**_: Because of the behavior of the Modal component, setting the _transparent_ prop to false results in an unaesthetic animation in the background color if the _animationType_ property is set to "slide". This doesn't fall within the scope of this pull request, but it's probably worth noting for developers so they can expect that behavior.