### PR TITLE
[Android] [Fixed] - com.facebook.infer.annotation.Assertions.assertNotNull(Assertions.java:28) 

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -737,7 +737,7 @@ public class ReactInstanceManager {
     int size = 0;
     for (int i = 0; i < fragments.size(); i++) {
       Fragment fragment = fragments.get(i);
-      if (!fragment.isDetached()) {
+      if (!fragment.isDetached() && fragment.getHost() != null) {
         if (fragment instanceof ReactFragment) {
           size++;
         } else {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
The usage scenario is when an Activity corresponds to loading multiple fragments.
fix like this:
```xml
com.facebook.infer.annotation.Assertions.assertNotNull(Assertions.java:28)
com.facebook.react.ReactInstanceManager.onHostPause(ReactInstanceManager.java:552)
com.facebook.react.ReactDelegate.onHostPause(ReactDelegate.java:63)
com.facebook.react.ReactFragment.onPause(ReactFragment.java:98)
com.hycan.rn.fragment.HycanReactFragment.onPause(HycanReactFragment.kt:69)
androidx.fragment.app.Fragment.performPause(Fragment.java:3168)
androidx.fragment.app.FragmentStateManager.pause(FragmentStateManager.java:632)
androidx.fragment.app.FragmentStateManager.moveToExpectedState(FragmentStateManager.java:314)
androidx.fragment.app.FragmentStore.moveToExpectedState(FragmentStore.java:112)
androidx.fragment.app.FragmentManager.moveToState(FragmentManager.java:1647)
androidx.fragment.app.FragmentManager.dispatchStateChange(FragmentManager.java:3128)
androidx.fragment.app.FragmentManager.dispatchPause(FragmentManager.java:3090)
...
```

## Changelog

`com.facebook.react.ReactInstanceManager.onHostDestroy(Activity activity)`
Both ReactFragment and ReactActivity onDestory will call `com.facebook.react.ReactInstanceManager.onHostDestroy`.

Need to determine if FragmentManager has ReactFragment that has not been `Detached`.



## Test Plan

before:
<img width="1339" alt="wecom-temp-ffa7f5d7642879e5a003959bc6294cc0" src="https://user-images.githubusercontent.com/18374613/159401826-4dd61087-7dad-4133-ad18-fac7db261c2b.png">
after:
<img width="1166" alt="wecom-temp-ae78a54e61d266e46fca79d05325da47" src="https://user-images.githubusercontent.com/18374613/159401855-7b1d29ee-08d5-4f24-ac76-d6e9165b5339.png">