### PR TITLE
Added Gemfile.lock to git add files when calling update-ruby.sh

### DIFF
--- a/scripts/update-ruby.sh
+++ b/scripts/update-ruby.sh
@@ -63,5 +63,6 @@ bundle lock
 git add \
     .ruby-version \
     Gemfile \
+    Gemfile.lock \
     template/_ruby-version \
     template/Gemfile


### PR DESCRIPTION
## Summary

In https://github.com/facebook/react-native/blob/main/scripts/update-ruby.sh#L61

```bash
bundle lock
```

is called which creates a Gemfile.lock in the rn root. This file should be in the git add files list along with the other files that get updated by that script.

## Changelog

[Internal] [Fixed] - Added Gemfile.lock to git add files when calling update-ruby.sh

## Test Plan

Call update-ruby.sh with or without this patch. Without this patch, the Gemfile.lock will not be staged, with this patch, the Gemfile.lock will be staged.
