### PR TITLE
fix: deadlock when sending events

### DIFF
--- a/React/CoreModules/RCTEventDispatcher.mm
+++ b/React/CoreModules/RCTEventDispatcher.mm
@@ -37,7 +37,7 @@ static uint16_t RCTUniqueCoalescingKeyGenerator = 0;
   NSMutableArray<NSNumber *> *_eventQueue;
   BOOL _eventsDispatchScheduled;
   NSHashTable<id<RCTEventDispatcherObserver>> *_observers;
-  NSLock *_observersLock;
+  NSRecursiveLock *_observersLock;
 }
 
 @synthesize bridge = _bridge;
@@ -53,7 +53,7 @@ RCT_EXPORT_MODULE()
   _eventQueueLock = [NSLock new];
   _eventsDispatchScheduled = NO;
   _observers = [NSHashTable weakObjectsHashTable];
-  _observersLock = [NSLock new];
+  _observersLock = [NSRecursiveLock new];
 }
 
 - (void)sendViewEventWithName:(NSString *)name reactTag:(NSNumber *)reactTag


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
In short, if an RCTEventDispatcher observer sends an event on the same thread that the observer was initially on, there will be a deadlock due to `sendEvent` already having the lock active on the `_observers` NSHashTable. An example where this occurred was when we had react-native-gesture-handler trigger an animated event, which then triggered an event on the underlying component being animated as a result of it being an observer on the animation event. Since this all occurred on the main thread, we ended up with a deadlock and the app froze.

To prevent this scenario, I used a `NSRecursiveLock` for _observersLock to be able to dispatch events on the same thread from observers.

@joebernard
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [Fix] - Prevent deadlock when dispatching events from observers on the same thread.

## Test Plan
Not sure if there are any tests present for sending events with RCTEventDispatcher already in place, but In regular app usage this solution has proved to be a viable and stable option so far and has prevented the deadlock from occurring.

This would still be thread-safe since we are now allowing the event to be sent through observers on the same thread the initial event was dispatched on. The only issue I could see here is the behavior of sending an event could be changed.


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
