### PR TITLE
(AppState) fix removeEventListener adding another listener when type is blur or focus

### DIFF
--- a/Libraries/AppState/AppState.js
+++ b/Libraries/AppState/AppState.js
@@ -154,7 +154,7 @@ class AppState {
       case 'focus':
         // $FlowIssue[invalid-tuple-arity] Flow cannot refine handler based on the event type
         // $FlowIssue[incompatible-call]
-        emitter.addListener('appStateFocusChange', listener);
+        emitter.removeListener('appStateFocusChange', listener);
         return;
     }
     throw new Error('Trying to unsubscribe from unknown event: ' + type);


### PR DESCRIPTION
## Summary

I noticed the `AppState.removeEventListener` was in fact calling `addListener` instead of `removeListener` when type is blur or focus.

I know this method is deprecated but it can't hurt to fix it.

## Changelog

[General] [Fixed] - AppState.removeEventListener correctly removes listener for blur and focus events

## Test Plan

I've thought about adding a unit test, but it isn't that easy since AppState is mocked and the method is deprecated so I don't think it is worth investing too much for it.
