### PR TITLE
Enable SonarKit and Flipper in React-Core

### DIFF
--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -191,6 +191,15 @@ def flipper_post_install(installer)
         config.build_settings['SWIFT_VERSION'] = '4.1'
       end
     end
+
+    # Enable flipper for React-Core Debug configuration
+    if target.name == 'React-Core'
+      target.build_configurations.each do |config|
+        if config.name == 'Debug'
+          config.build_settings['OTHER_CFLAGS'] = "$(inherited) -DFB_SONARKIT_ENABLED=1"
+        end
+      end
+    end
   end
 end
 


### PR DESCRIPTION
Summary:
This DIFF turns on the `FB_SONARKIT_ENABLED` flag when installing Flipper ina RN app. The flag is enabled only in Debug config, given that Flipper is installed only in this configuration.

This PR also fixes this issue: https://github.com/facebook/react-native/issues/33497

## Changelog
[iOS][Changed] - Enable SonarKit in React-Core when the configuration is `'Debug'`

Differential Revision: D35141506

