### PR TITLE
build: Fix error rootProject path when integrating reactnative as the…

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -45,6 +45,8 @@ def boostPath = dependenciesPath ?: System.getenv("REACT_NATIVE_BOOST_PATH")
 // Setup build type for NDK, supported values: {debug, release}
 def nativeBuildType = System.getenv("NATIVE_BUILD_TYPE") ?: "release"
 
+def reactCommonDir = new File("$projectDir/../ReactCommon")
+
 // We put the publishing version from gradle.properties inside ext. so other
 // subprojects can access it as well.
 ext.publishing_version = VERSION_NAME
@@ -283,7 +285,7 @@ android {
 
         externalNativeBuild {
             cmake {
-                arguments "-DREACT_COMMON_DIR=${rootProject.projectDir}/ReactCommon",
+                arguments "-DREACT_COMMON_DIR=${reactCommonDir.absolutePath}",
                         "-DREACT_ANDROID_DIR=$projectDir",
                         "-DANDROID_STL=c++_shared",
                         "-DANDROID_TOOLCHAIN=clang",

--- a/ReactAndroid/hermes-engine/build.gradle
+++ b/ReactAndroid/hermes-engine/build.gradle
@@ -14,15 +14,15 @@ plugins {
 }
 
 def customDownloadDir = System.getenv("REACT_NATIVE_DOWNLOADS_DIR")
-def downloadsDir = customDownloadDir ? new File(customDownloadDir) : rootProject.file("sdks/download")
+def downloadsDir = customDownloadDir ? new File(customDownloadDir) : new File("$projectDir/../../sdks/download")
 
 // By default we are going to download and unzip hermes inside the /sdks/hermes folder
 // but you can provide an override for where the hermes source code is located.
 def overrideHermesDir = System.getenv("REACT_NATIVE_OVERRIDE_HERMES_DIR") != null
-def hermesDir = System.getenv("REACT_NATIVE_OVERRIDE_HERMES_DIR") ?: rootProject.file("sdks/hermes")
+def hermesDir = System.getenv("REACT_NATIVE_OVERRIDE_HERMES_DIR") ?: new File("$projectDir/../../sdks/hermes")
 
 def hermesVersion = "main"
-def hermesVersionFile = rootProject.file("sdks/.hermesversion")
+def hermesVersionFile = new File("$projectDir/../../sdks/.hermesversion")
 if (hermesVersionFile.exists()) {
     hermesVersion = hermesVersionFile.text
 }
@@ -34,7 +34,7 @@ def prefabHeadersDir = new File("$buildDir/prefab-headers")
 def skipPrefabPublishing = System.getenv("REACT_NATIVE_HERMES_SKIP_PREFAB") != null
 
 // We inject the JSI directory used inside the Hermes build with the -DJSI_DIR config.
-def jsiDir = rootProject.file("ReactCommon/jsi")
+def jsiDir = new File("$projectDir/../../ReactCommon/jsi")
 
 // The .aar is placed inside the ./android folder at the top level.
 // There it will be placed alongside the React Android .aar


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
hermes-engine rootProject will cause error path when manually building

The scene
```
MY_PROJECT
├─android
└─third_party
│      └─react-native
│ build.gradle.kts
│ setting.gradle.kts
```
`hermes-engine` will regard `MY_PROJECT` as rootPrject

```
val REACT_NATIVE_DIR = "$rootDir/third_party/react-native"

include(":MY_ANDROID_PROJECT")
project(":MY_ANDROID_PROJECT").projectDir = File("$rootDir/packages/embedded/android")

include(":ReactAndroid")
project(":ReactAndroid").projectDir = File("$REACT_NATIVE_DIR/ReactAndroid")

include(":ReactAndroid:hermes-engine")
project(":ReactAndroid:hermes-engine").projectDir = File("$REACT_NATIVE_DIR/ReactAndroid/hermes-engine")

include(":packages:react-native-codegen:android")
project(":packages:react-native-codegen:android").projectDir = File("$REACT_NATIVE_DIR/packages/react-native-codegen/android")

includeBuild("$REACT_NATIVE_DIR/packages/react-native-gradle-plugin")

// React Native
//includeBuild(REACT_NATIVE_DIR)

```






## Test Plan
No test plan, it just modified the path with the same result and pass the ci 