### PR TITLE
chore: add headers.Content-type to openFileInEditor call

### DIFF
--- a/Libraries/Core/Devtools/openFileInEditor.js
+++ b/Libraries/Core/Devtools/openFileInEditor.js
@@ -15,6 +15,9 @@ const getDevServer = require('./getDevServer');
 function openFileInEditor(file: string, lineNumber: number) {
   fetch(getDevServer().url + 'open-stack-frame', {
     method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
     body: JSON.stringify({file, lineNumber}),
   });
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Currently the `Content-type` is not defined and defaults to `text/plain`. This makes it more accurate.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[internal] [Changed] - add `headers.Content-type` to `openFileInEditor` call

## Test Plan

- [x] in development trigger `openFileInEditor`, e.g. by pressing on a line in a stack trace -> code editor opens
