### PR TITLE
fix //xplat/js/react-native-github:codegen_rn_components_schema_rncore

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -58,6 +58,7 @@ fb_native.genrule(
     ) + [
         react_native_root_target("packages/rn-tester:nativecomponent-srcs"),
     ],
+    labels = ["uses_hg"],
     cmd = "$(exe {}) $OUT $SRCS".format(react_native_root_target("packages/react-native-codegen:write_to_json")),
     out = "schema-rncore.json",
 )

--- a/packages/react-native-codegen/DEFS.bzl
+++ b/packages/react-native-codegen/DEFS.bzl
@@ -41,6 +41,7 @@ def rn_codegen_cli():
                 "src/cli/combine/combine_js_to_schema.sh",
                 ":yarn-workspace",
                 "//xplat/js:setup_env",
+                "//xplat/js:setup_env_vars",
             ],
             visibility = ["PUBLIC"],
         )

--- a/packages/react-native-codegen/src/cli/combine/combine_js_to_schema.sh
+++ b/packages/react-native-codegen/src/cli/combine/combine_js_to_schema.sh
@@ -9,8 +9,15 @@ set -u
 
 THIS_DIR=$(cd -P "$(dirname "$(realpath "${BASH_SOURCE[0]}" || echo "${BASH_SOURCE[0]}")")" && pwd)
 
+SETUP_ENV_VARS_PATH="$BUCK_PROJECT_ROOT/env-utils/setup_env_vars.sh"
+
+# Somehow this path this doesn't work in BUCK1, so falling back to the exisiting path that we use in BUCK1.
+if [ ! -f "${SETUP_ENV_VARS_PATH}" ]; then
+  SETUP_ENV_VARS_PATH="$BUCK_PROJECT_ROOT/xplat/js/env-utils/setup_env_vars.sh"
+fi
+
 # shellcheck source=xplat/js/env-utils/setup_env_vars.sh
-source "$THIS_DIR/../../../../../../env-utils/setup_env_vars.sh"
+source "${SETUP_ENV_VARS_PATH}"
 
 pushd "$JS_DIR" >/dev/null
   "$INSTALL_NODE_MODULES"


### PR DESCRIPTION
Summary:
Changelog: [Internal]

When building with buck2, `setup_env_vars.sh` cannot be found. exporting setup_env_vars.sh and adding it as a dep to `write_to_json` fixes it.

Reviewed By: d16r

Differential Revision: D35188154

