### PR TITLE
Fix: change prop used on Image Background

### DIFF
--- a/Libraries/Image/ImageBackground.js
+++ b/Libraries/Image/ImageBackground.js
@@ -67,7 +67,7 @@ class ImageBackground extends React.Component<ImageBackgroundProps> {
 
   render(): React.Node {
     const {children, style, imageStyle, imageRef, ...props} = this.props;
-    const flattenedStyle = flattenStyle(style);
+    const flattenedStyle = flattenStyle(imageStyle);
     return (
       <View
         accessibilityIgnoresInvertColors={true}


### PR DESCRIPTION
## Summary

The same prop was being used in the View container and to the nested Image, so if you specify height/width using percentages it causes an unexpected behavior.

Issue: #33513 

## Changelog

[General] [Fixed] - Change style prop by imageStyle on flattened style given unexpected behaviors when use percentages

## Test Plan
Test ImageBackground components using fixed height/width and percentages.