### PR TITLE
Replaced windowsAwareYarn with windowsAwareCommandLine for node calls

### DIFF
--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/GenerateCodegenArtifactsTask.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/GenerateCodegenArtifactsTask.kt
@@ -8,7 +8,7 @@
 package com.facebook.react.tasks
 
 import com.facebook.react.codegen.generator.JavaGenerator
-import com.facebook.react.utils.windowsAwareYarn
+import com.facebook.react.utils.windowsAwareCommandLine
 import org.gradle.api.GradleException
 import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
@@ -93,7 +93,7 @@ abstract class GenerateCodegenArtifactsTask : Exec() {
 
   internal fun setupCommandLine() {
     commandLine(
-        windowsAwareYarn(
+        windowsAwareCommandLine(
             *nodeExecutableAndArgs.get().toTypedArray(),
             reactNativeDir.file("scripts/generate-specs-cli.js").get().asFile.absolutePath,
             "--platform",

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/GenerateCodegenSchemaTask.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/GenerateCodegenSchemaTask.kt
@@ -7,7 +7,7 @@
 
 package com.facebook.react.tasks
 
-import com.facebook.react.utils.windowsAwareYarn
+import com.facebook.react.utils.windowsAwareCommandLine
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.ListProperty
@@ -49,7 +49,7 @@ abstract class GenerateCodegenSchemaTask : Exec() {
 
   internal fun setupCommandLine() {
     commandLine(
-        windowsAwareYarn(
+        windowsAwareCommandLine(
             *nodeExecutableAndArgs.get().toTypedArray(),
             codegenDir
                 .file("lib/cli/combine/combine-js-to-schema-cli.js")

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/TaskUtils.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/TaskUtils.kt
@@ -14,13 +14,6 @@ internal fun windowsAwareCommandLine(vararg args: Any): List<Any> =
       args.toList()
     }
 
-internal fun windowsAwareYarn(vararg args: Any): List<Any> =
-    if (Os.isWindows()) {
-      listOf("yarn.cmd") + args
-    } else {
-      listOf("yarn") + args
-    }
-
 internal fun windowsAwareBashCommandLine(
     vararg args: String,
     bashWindowsHome: String? = null

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/TaskUtilsTest.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/TaskUtilsTest.kt
@@ -44,24 +44,6 @@ class TaskUtilsTest {
 
   @Test
   @WithOs(OS.MAC)
-  fun windowsAwareYarn_onMac_returnsTheList() {
-    assertEquals(listOf("yarn", "a", "b", "c"), windowsAwareYarn("a", "b", "c"))
-  }
-
-  @Test
-  @WithOs(OS.UNIX)
-  fun windowsAwareYarn_onLinux_returnsTheList() {
-    assertEquals(listOf("yarn", "a", "b", "c"), windowsAwareYarn("a", "b", "c"))
-  }
-
-  @Test
-  @WithOs(OS.WIN)
-  fun windowsAwareYarn_onWindows_prependsCmd() {
-    assertEquals(listOf("yarn.cmd", "a", "b", "c"), windowsAwareYarn("a", "b", "c"))
-  }
-
-  @Test
-  @WithOs(OS.MAC)
   fun windowsAwareBashCommandLine_onMac_returnsTheList() {
     assertEquals(
         listOf("a", "b", "c"), windowsAwareBashCommandLine("a", "b", "c", bashWindowsHome = "abc"))


### PR DESCRIPTION
## Summary

It is not necessary to call node via yarn. Instead with this commit node is called directly (windows aware). This enables builds on systems that don't have yarn installed.

Fixes #33525

## Changelog

[Android] [Fixed] - Don't require yarn for codegen tasks

## Test Plan

1. react-native init test
2. cd test
3. enable newArchEnabled=true (gradle.properties)
4. enable enableHermes: true (build.gradle)
5. react-native run-android (when the yarn is not installed on the system)

(I have not tested or verified if this works on windows build machines)
