### PR TITLE
Add missing BUCK dependency on javax-annotation-api for ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/BUCK
@@ -26,6 +26,7 @@ rn_android_library(
         react_native_dep("libraries/fbjni:java"),
         react_native_dep("third-party/android/androidx:annotation"),
         react_native_dep("third-party/java/infer-annotations:infer-annotations"),
+        react_native_dep("third-party/java/jsr-305:jsr-305"),
         react_native_target("java/com/facebook/react/common:common"),
         # dependencies used for systraces
         react_native_dep("java/com/facebook/systrace:systrace"),


### PR DESCRIPTION
Summary:
CircleCI is currently red as mapbuffer is missing a dependency on javax annotations.

Changelog:
[Internal] [Changed] - Add missing BUCK dependency on javax-annotation-api for ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer

Differential Revision: D35280223

