### PR TITLE
Add exported Kotlin stdlib for Kotlin module to enable OSS build

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/BUCK
@@ -27,9 +27,9 @@ rn_android_library(
         react_native_dep("third-party/android/androidx:annotation"),
         react_native_dep("third-party/java/infer-annotations:infer-annotations"),
         react_native_target("java/com/facebook/react/common:common"),
+        react_native_dep("third-party/java/jsr-305:jsr-305"),
         # dependencies used for systraces
         react_native_dep("java/com/facebook/systrace:systrace"),
         react_native_target("java/com/facebook/react/bridge:bridge"),
     ],
-    exported_deps = [],
 )

--- a/ReactAndroid/src/main/java/com/facebook/react/fabric/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/fabric/BUCK
@@ -1,4 +1,7 @@
-load("//tools/build_defs/oss:rn_defs.bzl", "YOGA_TARGET", "react_native_dep", "react_native_target", "rn_android_library")
+load("//tools/build_defs/oss:rn_defs.bzl", "IS_OSS_BUILD", "YOGA_TARGET", "react_native_android_toplevel_dep", "react_native_dep", "react_native_target", "rn_android_library")
+
+# TODO(T115916830): Remove when Kotlin files are used in this module
+KOTLIN_STDLIB_DEPS = [react_native_android_toplevel_dep("third-party/kotlin:kotlin-stdlib")] if IS_OSS_BUILD else []
 
 rn_android_library(
     name = "fabric",
@@ -47,7 +50,5 @@ rn_android_library(
         react_native_target("java/com/facebook/react/views/view:view"),
         react_native_target("java/com/facebook/react/views/text:text"),
         react_native_target("java/com/facebook/react/touch:touch"),
-    ],
-    exported_deps = [
-    ],
+    ] + KOTLIN_STDLIB_DEPS,
 )

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/BUCK
@@ -1,4 +1,7 @@
-load("//tools/build_defs/oss:rn_defs.bzl", "YOGA_TARGET", "react_native_dep", "react_native_target", "rn_android_library")
+load("//tools/build_defs/oss:rn_defs.bzl", "IS_OSS_BUILD", "YOGA_TARGET", "react_native_android_toplevel_dep", "react_native_dep", "react_native_target", "rn_android_library")
+
+# TODO(T115916830): Remove when Kotlin files are used in this module
+KOTLIN_STDLIB_DEPS = [react_native_android_toplevel_dep("third-party/kotlin:kotlin-stdlib")] if IS_OSS_BUILD else []
 
 rn_android_library(
     name = "text",
@@ -35,5 +38,5 @@ rn_android_library(
         react_native_target("java/com/facebook/react/uimanager/annotations:annotations"),
         react_native_target("java/com/facebook/react/views/view:view"),
         react_native_target("res:uimanager"),
-    ],
+    ] + KOTLIN_STDLIB_DEPS,
 )


### PR DESCRIPTION
Summary:
Adds Kotlin stdlib as exported dependency to make sure upstream targets include Kotlin jvm internal classes.

Changelog: [Internal]

Differential Revision: D35284430

