### PR TITLE
Add missing `hermes-executor-debug` from the bundled version of React Native

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -289,35 +289,19 @@ android {
                         "-DANDROID_TOOLCHAIN=clang",
                         "-DANDROID_PLATFORM=android-21"
 
-                targets "reactnativejni",
+                targets "fabricjni",
+                    "hermes-executor-debug",
+                    "hermes-executor-release",
                     "jscexecutor",
                     "jsijniprofiler",
                     "reactnativeblob",
+                    "reactnativejni",
                     "reactperfloggerjni",
-                    "turbomodulejsijni",
-                    "fabricjni"
+                    "turbomodulejsijni"
             }
         }
         ndk {
             abiFilters (*reactNativeArchitectures())
-        }
-    }
-
-    buildTypes {
-        debug {
-            externalNativeBuild {
-                cmake {
-                    targets "hermes-executor-debug"
-                }
-            }
-        }
-
-        release {
-            externalNativeBuild {
-                cmake {
-                    targets "hermes-executor-release"
-                }
-            }
         }
     }
 

--- a/ReactAndroid/src/main/java/com/facebook/hermes/reactexecutor/Android.mk
+++ b/ReactAndroid/src/main/java/com/facebook/hermes/reactexecutor/Android.mk
@@ -6,47 +6,53 @@
 LOCAL_PATH := $(call my-dir)
 REACT_NATIVE := $(LOCAL_PATH)/../../../../../../../..
 
-ifeq ($(APP_OPTIM),debug)
-  include $(CLEAR_VARS)
+#########################
+# hermes-executor-debug #
+#########################
 
-  LOCAL_MODULE := hermes-executor-debug
-  LOCAL_CFLAGS := -DHERMES_ENABLE_DEBUGGER=1
+include $(CLEAR_VARS)
 
-  LOCAL_SRC_FILES := $(wildcard $(LOCAL_PATH)/*.cpp)
+LOCAL_MODULE := hermes-executor-debug
+LOCAL_CFLAGS := -DHERMES_ENABLE_DEBUGGER=1
 
-  LOCAL_C_INCLUDES := $(LOCAL_PATH) $(REACT_NATIVE)/ReactCommon/jsi
+LOCAL_SRC_FILES := $(wildcard $(LOCAL_PATH)/*.cpp)
 
-  LOCAL_CPP_FEATURES := exceptions
+LOCAL_C_INCLUDES := $(LOCAL_PATH) $(REACT_NATIVE)/ReactCommon/jsi
 
-  LOCAL_STATIC_LIBRARIES := libjsireact libhermes-executor-common-debug
-  LOCAL_SHARED_LIBRARIES := \
-    libfb \
-    libfbjni \
-    libfolly_runtime \
-    libhermes \
-    libjsi \
-    libreactnativejni
+LOCAL_CPP_FEATURES := exceptions
 
-  include $(BUILD_SHARED_LIBRARY)
-else
-  include $(CLEAR_VARS)
+LOCAL_STATIC_LIBRARIES := libjsireact libhermes-executor-common-debug
+LOCAL_SHARED_LIBRARIES := \
+  libfb \
+  libfbjni \
+  libfolly_runtime \
+  libhermes \
+  libjsi \
+  libreactnativejni
 
-  LOCAL_MODULE := hermes-executor-release
+include $(BUILD_SHARED_LIBRARY)
 
-  LOCAL_SRC_FILES := $(wildcard $(LOCAL_PATH)/*.cpp)
+###########################
+# hermes-executor-release #
+###########################
 
-  LOCAL_C_INCLUDES := $(LOCAL_PATH) $(REACT_NATIVE)/ReactCommon/jsi
+include $(CLEAR_VARS)
 
-  LOCAL_CPP_FEATURES := exceptions
+LOCAL_MODULE := hermes-executor-release
 
-  LOCAL_STATIC_LIBRARIES := libjsireact libhermes-executor-common-release
-  LOCAL_SHARED_LIBRARIES := \
-    libfb \
-    libfbjni \
-    libfolly_runtime \
-    libhermes \
-    libjsi \
-    libreactnativejni
+LOCAL_SRC_FILES := $(wildcard $(LOCAL_PATH)/*.cpp)
 
-  include $(BUILD_SHARED_LIBRARY)
-endif
+LOCAL_C_INCLUDES := $(LOCAL_PATH) $(REACT_NATIVE)/ReactCommon/jsi
+
+LOCAL_CPP_FEATURES := exceptions
+
+LOCAL_STATIC_LIBRARIES := libjsireact libhermes-executor-common-release
+LOCAL_SHARED_LIBRARIES := \
+  libfb \
+  libfbjni \
+  libfolly_runtime \
+  libhermes \
+  libjsi \
+  libreactnativejni
+
+include $(BUILD_SHARED_LIBRARY)

--- a/ReactCommon/hermes/executor/Android.mk
+++ b/ReactCommon/hermes/executor/Android.mk
@@ -6,33 +6,39 @@
 LOCAL_PATH := $(call my-dir)
 REACT_NATIVE := $(LOCAL_PATH)/../../..
 
-ifeq ($(APP_OPTIM),debug)
-  include $(CLEAR_VARS)
+################################
+# hermes-executor-common-debug #
+################################
 
-  LOCAL_MODULE := hermes-executor-common-debug
-  LOCAL_CFLAGS := -DHERMES_ENABLE_DEBUGGER=1
+include $(CLEAR_VARS)
 
-  LOCAL_SRC_FILES := $(wildcard $(LOCAL_PATH)/*.cpp)
+LOCAL_MODULE := hermes-executor-common-debug
+LOCAL_CFLAGS := -DHERMES_ENABLE_DEBUGGER=1
 
-  LOCAL_C_INCLUDES := $(LOCAL_PATH) $(REACT_NATIVE)/ReactCommon/jsi
-  LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)
+LOCAL_SRC_FILES := $(wildcard $(LOCAL_PATH)/*.cpp)
 
-  LOCAL_STATIC_LIBRARIES := libjsireact libhermes-inspector
-  LOCAL_SHARED_LIBRARIES := libhermes libjsi
+LOCAL_C_INCLUDES := $(LOCAL_PATH) $(REACT_NATIVE)/ReactCommon/jsi
+LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)
 
-  include $(BUILD_STATIC_LIBRARY)
-else
-  include $(CLEAR_VARS)
+LOCAL_STATIC_LIBRARIES := libjsireact libhermes-inspector
+LOCAL_SHARED_LIBRARIES := libhermes libjsi
 
-  LOCAL_MODULE := hermes-executor-common-release
+include $(BUILD_STATIC_LIBRARY)
 
-  LOCAL_SRC_FILES := $(wildcard $(LOCAL_PATH)/*.cpp)
+##################################
+# hermes-executor-common-release #
+##################################
 
-  LOCAL_C_INCLUDES := $(LOCAL_PATH) $(REACT_NATIVE)/ReactCommon/jsi
-  LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)
+include $(CLEAR_VARS)
 
-  LOCAL_STATIC_LIBRARIES := libjsireact
-  LOCAL_SHARED_LIBRARIES := libhermes libjsi
+LOCAL_MODULE := hermes-executor-common-release
 
-  include $(BUILD_STATIC_LIBRARY)
-endif
+LOCAL_SRC_FILES := $(wildcard $(LOCAL_PATH)/*.cpp)
+
+LOCAL_C_INCLUDES := $(LOCAL_PATH) $(REACT_NATIVE)/ReactCommon/jsi
+LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)
+
+LOCAL_STATIC_LIBRARIES := libjsireact
+LOCAL_SHARED_LIBRARIES := libhermes libjsi
+
+include $(BUILD_STATIC_LIBRARY)


### PR DESCRIPTION
Summary:
I've just realized that once we specified separate CMake target `hermes-executor-debug` and `hermes-executor-release` for the two RN build types, we actually missed that RN is distributed as a single .aar (the release one). So we're essentially skipping to distribute the -debug version of Hermes executor. This diff fixes it.

Changelog:
[Internal] [Changed] - Add missing `hermes-executor-debug` from the bundled version of React Native

Differential Revision: D35286345

