### PR TITLE
Reintroduce `find-node.sh` as mitigation measure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -416,6 +416,12 @@ jobs:
                 package: applesimutils
 
       - run:
+          name: Configure Node
+          # Sourcing find-node.sh will ensure nvm is set up.
+          # It also helps future invocation of find-node.sh prevent permission issue with nvm.sh.
+          command: source scripts/find-node-for-xcode.sh && nvm install 16 && nvm alias default 16
+
+      - run:
           name: Configure Watchman
           command: echo "{}" > .watchmanconfig
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "README.md",
     "rn-get-polyfills.js",
     "scripts/compose-source-maps.js",
+    "scripts/find-node-for-xcode.sh",
     "scripts/generate-artifacts.js",
     "scripts/generate-provider-cli.js",
     "scripts/generate-specs-cli.js",

--- a/scripts/find-node-for-xcode.sh
+++ b/scripts/find-node-for-xcode.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -e
+
+# WHY WE NEED THIS:
+# This script is used to find a valid instance of `node` installed in the machine.
+# This script is sourced by other scripts to get access to node.
+# Specifically, it is used by the `react-native-xcode.sh` script, invoked by a
+# post-build phase in Xcode, to build the js files required by React Native.
+#
+# DEPRECATION NOTE:
+# React Native should not make assumptions on your current node environment.
+# This file is deprecated and will be removed in a future release in favor of something
+# node-agnostic and configurable by the developers.
+
+# remove global prefix if it's already set
+# the running shell process will choose a node binary and a global package directory breaks version managers
+unset PREFIX
+
+# Support Homebrew on M1
+HOMEBREW_M1_BIN=/opt/homebrew/bin
+if [[ -d $HOMEBREW_M1_BIN && ! $PATH =~ $HOMEBREW_M1_BIN ]]; then
+  export PATH="$HOMEBREW_M1_BIN:$PATH"
+fi
+
+# Define NVM_DIR and source the nvm.sh setup script
+[ -z "$NVM_DIR" ] && export NVM_DIR="$HOME/.nvm"
+
+# Source nvm with '--no-use' and then `nvm use` to respect .nvmrc
+# See: https://github.com/nvm-sh/nvm/issues/2053
+if [[ -s "$HOME/.nvm/nvm.sh" ]]; then
+  # shellcheck source=/dev/null
+  . "$HOME/.nvm/nvm.sh" --no-use
+  nvm use 2> /dev/null || nvm use default
+elif [[ -x "$(command -v brew)" && -s "$(brew --prefix nvm)/nvm.sh" ]]; then
+  # shellcheck source=/dev/null
+  . "$(brew --prefix nvm)/nvm.sh" --no-use
+  nvm use 2> /dev/null || nvm use default
+fi
+
+# Set up the nodenv node version manager if present
+if [[ -x "$HOME/.nodenv/bin/nodenv" ]]; then
+  eval "$("$HOME/.nodenv/bin/nodenv" init -)"
+elif [[ -x "$(command -v brew)" && -x "$(brew --prefix nodenv)/bin/nodenv" ]]; then
+  eval "$("$(brew --prefix nodenv)/bin/nodenv" init -)"
+fi
+
+# Set up the ndenv of anyenv if preset
+if [[ ! -x node && -d ${HOME}/.anyenv/bin ]]; then
+  export PATH=${HOME}/.anyenv/bin:${PATH}
+  if [[ "$(anyenv envs | grep -c ndenv )" -eq 1 ]]; then
+    eval "$(anyenv init -)"
+  fi
+fi
+
+# Set up asdf-vm if present
+if [[ -f "$HOME/.asdf/asdf.sh" ]]; then
+  # shellcheck source=/dev/null
+  . "$HOME/.asdf/asdf.sh"
+elif [[ -x "$(command -v brew)" && -f "$(brew --prefix asdf)/asdf.sh" ]]; then
+  # shellcheck source=/dev/null
+  . "$(brew --prefix asdf)/asdf.sh"
+fi
+
+# Set up volta if present
+if [[ -x "$HOME/.volta/bin/node" ]]; then
+  export VOLTA_HOME="$HOME/.volta"
+  export PATH="$VOLTA_HOME/bin:$PATH"
+fi
+
+# Set up the fnm node version manager if present
+if [[ -x "$HOME/.fnm/fnm" ]]; then
+  eval "$("$HOME/.fnm/fnm" env)"
+elif [[ -x "$(command -v brew)" && -x "$(brew --prefix fnm)/bin/fnm" ]]; then
+  eval "$("$(brew --prefix fnm)/bin/fnm" env)"
+fi

--- a/scripts/react-native-xcode.sh
+++ b/scripts/react-native-xcode.sh
@@ -79,7 +79,9 @@ if [[ $DEV != true && ! -f "$ENTRY_FILE" ]]; then
   exit 2
 fi
 
-NODE_BINARY="$(command -v node)"
+# Find path to Node
+# shellcheck source=/dev/null
+source "$REACT_NATIVE_DIR/scripts/find-node-for-xcode.sh"
 
 # check and assign NODE_BINARY env
 # shellcheck source=/dev/null

--- a/scripts/react_native_pods_utils/script_phases.sh
+++ b/scripts/react_native_pods_utils/script_phases.sh
@@ -33,6 +33,8 @@ else
 fi
 
 find_node () {
+    # shellcheck disable=SC1091
+    source "$RCT_SCRIPT_RN_DIR/scripts/find-node-for-xcode.sh"
 
     NODE_BINARY="${NODE_BINARY:-$(command -v node || true)}"
     if [ -z "$NODE_BINARY" ]; then


### PR DESCRIPTION
Summary:
This Diff is a revert of this other diff: D34352049 (https://github.com/facebook/react-native/commit/802b3f778b4d2ecd22882b371a84293421558b8a).

Following a discussion with the Open Source Community, the removal of `find-node.sh` script will break some configurations that leverages different node managers.

The landed diff will block the release of version 0.69, that's the reason why we are reverting it.

However, we still want to abstract RN from knowing which node manager the user is going to use. After discussing with the community, we will deprecate the usage of this script and we will move toward a configurable `.xcode.env` file that developers can configure on their own. The task for this is tracked here: T115868521.

## Changelog
[Internal][Removed] - Reintroduce the old `find-node.sh` script to prevent broken builds for some users

Differential Revision: D35280778

