### PR TITLE
Setup multi-variant publishing for React Native Android

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -244,13 +244,7 @@ final def extractNativeDependencies = tasks.register('extractNativeDependencies'
 }
 
 task installArchives {
-    dependsOn("publishReleasePublicationToNpmRepository")
-}
-
-// Creating sources with comments
-task androidSourcesJar(type: Jar) {
-  classifier = 'sources'
-  from android.sourceSets.main.java.srcDirs
+    dependsOn("publishAllPublicationsToNpmRepository")
 }
 
 android {
@@ -358,11 +352,18 @@ android {
     configurations {
         extractHeaders
         extractJNI
-        javadocDeps.extendsFrom api
     }
 
     buildFeatures {
         prefab true
+    }
+
+    publishing {
+        multipleVariants {
+            withSourcesJar()
+            withJavadocJar()
+            allVariants()
+        }
     }
 }
 
@@ -389,8 +390,6 @@ dependencies {
     // It's up to the consumer to decide if hermes should be included or not.
     // Therefore hermes-engine is a compileOnly dependency.
     compileOnly(project(":ReactAndroid:hermes-engine"))
-
-    javadocDeps("com.squareup:javapoet:1.13.0")
 
     testImplementation("junit:junit:${JUNIT_VERSION}")
     testImplementation("org.powermock:powermock-api-mockito2:${POWERMOCK_VERSION}")
@@ -431,11 +430,8 @@ afterEvaluate {
     publishing {
         publications {
             release(MavenPublication) {
-                // Applies the component for the release build variant.
-                from components.release
-
-                // Add additional sourcesJar to artifacts
-                artifact(androidSourcesJar)
+                // We do a multi variant release
+                from components.default
 
                 // You can then customize attributes of the publication as shown below.
                 artifactId = POM_ARTIFACT_ID

--- a/scripts/publish-npm.js
+++ b/scripts/publish-npm.js
@@ -188,7 +188,16 @@ exec('git checkout ReactAndroid/gradle.properties');
 
 echo('Generated artifacts for Maven');
 
-let artifacts = ['.aar', '.pom'].map(suffix => {
+let artifacts = [
+  '.module',
+  '.pom',
+  '-debug.aar',
+  '-release.aar',
+  '-debug-sources.jar',
+  '-release-sources.jar',
+  '-debug-javadoc.jar',
+  '-release-javadoc.jar',
+].map(suffix => {
   return `react-native-${releaseVersion}${suffix}`;
 });
 
@@ -199,7 +208,7 @@ artifacts.forEach(name => {
       `./android/com/facebook/react/react-native/${releaseVersion}/${name}`,
     )
   ) {
-    echo(`file ${name} was not generated`);
+    echo(`Failing as expected file: ${name} was not correctly generated.`);
     exit(1);
   }
 });


### PR DESCRIPTION
Summary:
As we now provide `hermes-executor-debug` OR `hermes-executor-release` based on which version of RN we're building, we need to provide a variant aware AAR.

Changelog:
[Internal] [Changed] - Setup multi-variant publishing for React Native Android

Differential Revision: D35289444

