### PR TITLE
Pin use-subscription to < 1.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "regenerator-runtime": "^0.13.2",
     "scheduler": "^0.20.2",
     "stacktrace-parser": "^0.1.3",
-    "use-subscription": "^1.0.0",
+    "use-subscription": ">=1.0.0 <1.6.0",
     "whatwg-fetch": "^3.0.0",
     "ws": "^6.1.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7245,10 +7245,12 @@ urix@^0.1.0:
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
 
-use-subscription@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/use-subscription/-/use-subscription-1.0.0.tgz#25ed2161f75e9f6bd8c5c4acfe6087bfebfbfef4"
-  integrity sha512-PkDL9KSMN01nJYfa5c8O7Qbs7lmpzirfRWhWfIQN053hbIj5s1o5L7hrTzCfCCO2FsN2bKrU7ciRxxRcinmxAA==
+"use-subscription@>=1.0.0 <1.6.0":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/use-subscription/-/use-subscription-1.5.1.tgz#73501107f02fad84c6dd57965beb0b75c68c42d1"
+  integrity sha512-Xv2a1P/yReAjAbhylMfFplFKj9GssgTwN7RlcTxBujFQcloStWNDQdc4g4NRWH9xS4i/FDk04vQBptAXoF3VcA==
+  dependencies:
+    object-assign "^4.1.1"
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
## Summary

Starting with 1.6.0 this package relies on react 18 which is currently not supported by rn

See https://github.com/facebook/react/blob/main/packages/use-subscription/package.json#L18

Fixes #33540

## Changelog

[General] [Fixed] - Pin use-subscription to < 1.6.0

## Test Plan

no test plan