### PR TITLE
Support PlatformColor in borderColor on Android

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewProps.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewProps.java
@@ -276,14 +276,16 @@ public class ViewProps {
         }
         return true;
       case BORDER_LEFT_COLOR:
-        return !map.isNull(BORDER_LEFT_COLOR) && map.getInt(BORDER_LEFT_COLOR) == Color.TRANSPARENT;
+        return map.getType(BORDER_LEFT_COLOR) == ReadableType.Number 
+            && map.getInt(BORDER_LEFT_COLOR) == Color.TRANSPARENT;
       case BORDER_RIGHT_COLOR:
-        return !map.isNull(BORDER_RIGHT_COLOR)
+        return map.getType(BORDER_RIGHT_COLOR) == ReadableType.Number 
             && map.getInt(BORDER_RIGHT_COLOR) == Color.TRANSPARENT;
       case BORDER_TOP_COLOR:
-        return !map.isNull(BORDER_TOP_COLOR) && map.getInt(BORDER_TOP_COLOR) == Color.TRANSPARENT;
+        return map.getType(BORDER_TOP_COLOR) == ReadableType.Number 
+            && map.getInt(BORDER_TOP_COLOR) == Color.TRANSPARENT;
       case BORDER_BOTTOM_COLOR:
-        return !map.isNull(BORDER_BOTTOM_COLOR)
+        return map.getType(BORDER_BOTTOM_COLOR) == ReadableType.Number 
             && map.getInt(BORDER_BOTTOM_COLOR) == Color.TRANSPARENT;
       case BORDER_WIDTH:
         return map.isNull(BORDER_WIDTH) || map.getDouble(BORDER_WIDTH) == 0d;

--- a/packages/rn-tester/js/examples/PlatformColor/PlatformColorExample.js
+++ b/packages/rn-tester/js/examples/PlatformColor/PlatformColorExample.js
@@ -214,6 +214,7 @@ function FallbackColorsExample() {
           style={{
             ...styles.colorCell,
             backgroundColor: color.color,
+            borderColor: color.color,
           }}
         />
       </View>


### PR DESCRIPTION
## Summary

PlatformColor should work on all *color style attributes on all platform.

Partially fixes #32942

## Changelog

[Android] [Fixed] - Support PlatformColor in borderColor

## Test Plan

Open rn tester (USE_FABRIC=false) platform color api examples. Without the changes to ViewProps.java, it will error out.
