### PR TITLE
Use arbitrary hermes-engine.podspec during build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -732,6 +732,13 @@ jobs:
             rm -rf packages/rn-tester/Pods
             cd packages/rn-tester && bundle exec pod install
 
+      # The macOS machine can run out of storage if Hermes is enabled and built from source.
+      # Since this job does not use the iOS Simulator, deleting it provides a quick way to
+      # free up space.
+      - run:
+          name: Delete iOS Simulators
+          command: sudo rm -rf /Library/Developer/CoreSimulator/Profiles/Runtimes/
+
       - run:
           name: Build RNTester
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -368,7 +368,60 @@ jobs:
           path: ./reports/junit
 
   # -------------------------
-  #     JOBS: Test iOS
+  #     JOBS: Build iOS
+  # -------------------------
+  build_ios:
+    executor: reactnativeios
+    parameters:
+      use_frameworks:
+        type: boolean
+        default: false
+    steps:
+      - checkout
+      - setup_ruby
+      - run_yarn
+
+      - run: |
+          cd packages/rn-tester
+          bundle check || bundle install
+
+      - run:
+          name: Configure Environment Variables
+          command: |
+            echo 'export PATH=/usr/local/opt/node@16/bin:$PATH' >> $BASH_ENV
+            source $BASH_ENV
+
+      - run:
+          name: Configure Watchman
+          command: echo "{}" > .watchmanconfig
+
+      - when:
+          condition: << parameters.use_frameworks >>
+          steps:
+            - run:
+                name: Set USE_FRAMEWORKS=1
+                command: echo "export USE_FRAMEWORKS=1" >> $BASH_ENV
+
+      - run:
+          name: Set USE_HERMES=1
+          command: echo "export USE_HERMES=1" >> $BASH_ENV
+      - with_brew_cache_span:
+          steps:
+            - brew_install:
+                package: cmake ninja
+
+      - run:
+          name: Setup the CocoaPods environment
+          command: bundle exec pod setup
+
+      - with_rntester_pods_cache_span:
+          steps:
+            - run:
+                name: Generate RNTesterPods Workspace
+                command: cd packages/rn-tester && bundle exec pod install --verbose
+
+  # -------------------------
+  #     JOBS: iOS Unit Tests
   # -------------------------
   test_ios_unit:
     executor: reactnativeios
@@ -1174,16 +1227,24 @@ workflows:
           requires:
             - build_npm_package
       - test_ios_rntester
+      - build_ios
       - test_ios_unit:
           # TODO(ncor, neildhar) Integration tests for iOS + Hermes are currently
           # disabled due to an ABI incompatibility introduced by D33830544.
           # They can be re-enabled as soon as Hermes 0.12.0 is released.
           run_unit_tests: false
+          requires:
+            - build_ios
       # DISABLED: USE_FRAMEWORKS=1 not supported by Flipper
+      # - build_ios:
+      #     name: build_ios_frameworks
+      #     use_frameworks: true
       # - test_ios_unit:
       #     name: test_ios_unit_frameworks
       #     use_frameworks: true
       #     run_unit_tests: true
+      #     requires:
+      #       - build_ios_frameworks
       - test_js:
           name: test_js_prev_lts
           executor: nodeprevlts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,14 +184,14 @@ commands:
           command: cp packages/rn-tester/Podfile.lock packages/rn-tester/Podfile.lock.bak
       - restore_cache:
           keys:
-            # The committed lockfile is generated using USE_FRAMEWORKS=0 and USE_HERMES=0 so it could load an outdated cache if a change
+            # The committed lockfile is generated using USE_FRAMEWORKS=0 and USE_HERMES=1 so it could load an outdated cache if a change
             # only affects the frameworks or hermes config. To help prevent this also cache based on the content of Podfile.
-            - v3-pods-{{ .Environment.CIRCLE_JOB }}-{{ checksum "packages/rn-tester/Podfile.lock.bak" }}-{{ checksum "packages/rn-tester/Podfile" }}
+            - v6-pods-{{ .Environment.CIRCLE_JOB }}-{{ checksum "packages/rn-tester/Podfile.lock.bak" }}-{{ checksum "packages/rn-tester/Podfile" }}
       - steps: << parameters.steps >>
       - save_cache:
           paths:
             - packages/rn-tester/Pods
-          key: v3-pods-{{ .Environment.CIRCLE_JOB }}-{{ checksum "packages/rn-tester/Podfile.lock.bak" }}-{{ checksum "packages/rn-tester/Podfile" }}
+          key: v6-pods-{{ .Environment.CIRCLE_JOB }}-{{ checksum "packages/rn-tester/Podfile.lock.bak" }}-{{ checksum "packages/rn-tester/Podfile" }}
 
   download_gradle_dependencies:
     steps:
@@ -370,13 +370,10 @@ jobs:
   # -------------------------
   #     JOBS: Test iOS
   # -------------------------
-  test_ios:
+  test_ios_unit:
     executor: reactnativeios
     parameters:
       use_frameworks:
-        type: boolean
-        default: false
-      use_hermes:
         type: boolean
         default: false
       run_unit_tests:
@@ -411,7 +408,7 @@ jobs:
       - with_brew_cache_span:
           steps:
             - brew_install:
-                package: watchman
+                package: watchman cmake ninja
             - run:
                 name: "Brew: Tap wix/brew"
                 command: brew tap wix/brew >/dev/null
@@ -429,16 +426,9 @@ jobs:
                 name: Set USE_FRAMEWORKS=1
                 command: echo "export USE_FRAMEWORKS=1" >> $BASH_ENV
 
-      - when:
-          condition: << parameters.use_hermes >>
-          steps:
-            - run:
-                name: Set USE_HERMES=1
-                command: echo "export USE_HERMES=1" >> $BASH_ENV
-            - with_brew_cache_span:
-                steps:
-                  - brew_install:
-                      package: cmake ninja
+      - run:
+          name: Set USE_HERMES=1
+          command: echo "export USE_HERMES=1" >> $BASH_ENV
 
       - run:
           name: Setup the CocoaPods environment
@@ -670,24 +660,18 @@ jobs:
   # -------------------------
   test_ios_rntester:
     executor: reactnativeios
-    parameters:
-      use_hermes:
-          type: boolean
-          default: false
     steps:
       - checkout
       - run_yarn
 
-      - when:
-          condition: << parameters.use_hermes >>
+      - run:
+          name: Set USE_HERMES=1
+          command: echo "export USE_HERMES=1" >> $BASH_ENV
+
+      - with_brew_cache_span:
           steps:
-            - run:
-                name: Set USE_HERMES=1
-                command: echo "export USE_HERMES=1" >> $BASH_ENV
-            - with_brew_cache_span:
-                steps:
-                  - brew_install:
-                      package: cmake ninja
+            - brew_install:
+                package: cmake ninja
 
       - run:
           name: Install CocoaPods dependencies
@@ -1189,30 +1173,15 @@ workflows:
       - test_ios_template:
           requires:
             - build_npm_package
-      - test_ios_rntester:
-          name: test_ios_rntester_hermes
-          use_hermes: true
-      - test_ios_rntester:
-          name: test_ios_rntester_jsc
-      - test_ios:
-          name: test_ios_unit_jsc
-          run_unit_tests: true
-      # DISABLED: USE_FRAMEWORKS=1 not supported by Flipper
-      # - test_ios:
-      #     name: test_ios_unit_frameworks_jsc
-      #     use_frameworks: true
-      #     run_unit_tests: true
-      - test_ios:
-          name: test_ios_unit_hermes
-          use_hermes: true
+      - test_ios_rntester
+      - test_ios_unit:
           # TODO(ncor, neildhar) Integration tests for iOS + Hermes are currently
           # disabled due to an ABI incompatibility introduced by D33830544.
           # They can be re-enabled as soon as Hermes 0.12.0 is released.
           run_unit_tests: false
       # DISABLED: USE_FRAMEWORKS=1 not supported by Flipper
-      # - test_ios:
-      #     name: test_ios_unit_frameworks_hermes
-      #     use_hermes: true
+      # - test_ios_unit:
+      #     name: test_ios_unit_frameworks
       #     use_frameworks: true
       #     run_unit_tests: true
       - test_js:

--- a/packages/rn-tester/Podfile
+++ b/packages/rn-tester/Podfile
@@ -14,15 +14,12 @@ if USE_FRAMEWORKS
   use_frameworks!
 end
 
-if ENV['USE_HERMES'] == '1'
-  puts "Using Hermes engine"
-end
-
 def pods(options = {})
   project 'RNTesterPods.xcodeproj'
 
   fabric_enabled = true
-  puts "Building RNTester with Fabric #{fabric_enabled ? "enabled" : "disabled"}."
+  hermes_enabled = ENV['USE_HERMES'] == '1'
+  puts "Building RNTester with Fabric #{fabric_enabled ? "enabled" : "disabled"}.#{hermes_enabled ? " Using Hermes engine." : ""}"
 
   prefix_path = "../.."
 
@@ -34,7 +31,7 @@ def pods(options = {})
   use_react_native!(
     path: prefix_path,
     fabric_enabled: fabric_enabled,
-    hermes_enabled: ENV['USE_HERMES'] == '1',
+    hermes_enabled: hermes_enabled,
     app_path: "#{Dir.pwd}",
     config_file_dir: "#{Dir.pwd}/node_modules",
   )

--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -683,6 +683,9 @@ def downloadAndConfigureHermesSource(react_native_path)
     system("ln -s #{hermesc_macos_path} #{hermesc_macos_link}")
   end
 
+  # TODO: Integrate this temporary hermes-engine.podspec into the actual one located in facebook/hermes
+  system("cp #{sdks_dir}/hermes-engine.podspec #{hermes_dir}/hermes-engine.podspec")
+
   hermes_dir
 end
 

--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -111,9 +111,11 @@ def use_react_native! (options={})
   if hermes_enabled
     pod 'React-hermes', :path => "#{prefix}/ReactCommon/hermes"
     if ENV['BUILD_HERMES_SOURCE'] == '1'
+      Pod::UI.puts "[Hermes] Building Hermes from source"
       hermes_source_path = downloadAndConfigureHermesSource(prefix)
       pod 'hermes-engine', :path => "#{hermes_source_path}/hermes-engine.podspec"
     else
+      Pod::UI.warn "[Hermes] Installing Hermes from CocoaPods. The `hermes-engine` pod has been deprecated and will not see future updates."
       pod 'hermes-engine', '~> 0.11.0'
     end
     pod 'libevent', '~> 2.1.12'

--- a/sdks/hermes-engine.podspec
+++ b/sdks/hermes-engine.podspec
@@ -1,0 +1,51 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+hermes_tag = 'main'
+hermes_tag_file = File.join(__dir__, ".hermesversion")
+if (File.exist?(hermes_tag_file))
+  hermes_tag = File.read(hermes_tag_file)
+end
+hermes_tag_sha = `git ls-remote https://github.com/facebook/hermes #{hermes_tag} | cut -f 1`.strip
+source = { :git => 'https://github.com/facebook/hermes.git', :commit => hermes_tag_sha }
+
+module HermesHelper
+  # BUILD_TYPE = :debug
+  BUILD_TYPE = :release
+end
+
+Pod::Spec.new do |spec|
+  spec.name        = "hermes-engine"
+  spec.version     = '1000.0.0'
+  spec.summary     = "Hermes is a small and lightweight JavaScript engine optimized for running React Native."
+  spec.description = "Hermes is a JavaScript engine optimized for fast start-up of React Native apps. It features ahead-of-time static optimization and compact bytecode."
+  spec.homepage    = "https://hermesengine.dev"
+  spec.license     = { type: "MIT", file: "LICENSE" }
+  spec.author      = "Facebook"
+  spec.source      = source
+  spec.platforms   = { :osx => "10.13", :ios => "11.0" }
+
+  spec.preserve_paths      = ["destroot/bin/*"].concat(HermesHelper::BUILD_TYPE == :debug ? ["**/*.{h,c,cpp}"] : [])
+  spec.source_files        = "destroot/include/**/*.h"
+  spec.header_mappings_dir = "destroot/include"
+
+  spec.ios.vendored_frameworks = "destroot/Library/Frameworks/universal/hermes.xcframework"
+  spec.osx.vendored_frameworks = "destroot/Library/Frameworks/macosx/hermes.framework"
+
+  spec.xcconfig            = { "CLANG_CXX_LANGUAGE_STANDARD" => "c++17", "CLANG_CXX_LIBRARY" => "compiler-default", "GCC_PREPROCESSOR_DEFINITIONS" => "HERMES_ENABLE_DEBUGGER=1" }
+
+  # TODO: Consider moving Hermes build scripts to react_native_pods.rb for greater control over when they're executed
+  spec.prepare_command = <<-EOS
+    # When true, debug build will be used.
+    # See `build-apple-framework.sh` for details
+    DEBUG=#{HermesHelper::BUILD_TYPE == :debug}
+
+    # Build iOS framework
+    ./utils/build-ios-framework.sh
+
+    # Build Mac framework
+    ./utils/build-mac-framework.sh
+  EOS
+end


### PR DESCRIPTION
Summary:
When building Hermes from source, use arbitrary hermes-engine.podspec to ensure correct Hermes tag is used by CocoaPods.

Without this change, CocoaPods will check out the `v0.11.0` git tag from the `facebook/hermes` git repository.

Ideally, this change should be done in the original `hermes-engine.podspec` in `facebook/hermes`. For now, use the arbitrary copy until the canonical Pod has been updated.

Changelog: [Internal]

Reviewed By: cortinico

Differential Revision: D35300595

