### PR TITLE
Allow modifying iOS image cache limits

### DIFF
--- a/Libraries/Image/RCTImageCache.h
+++ b/Libraries/Image/RCTImageCache.h
@@ -39,4 +39,7 @@
 @end
 
 @interface RCTImageCache : NSObject <RCTImageCache>
+
+RCT_EXTERN void RCTSetImageCacheLimits(NSUInteger maxCachableDecodedImageSizeInBytes, NSUInteger imageCacheTotalCostLimit);
+
 @end

--- a/Libraries/Image/RCTImageCache.m
+++ b/Libraries/Image/RCTImageCache.m
@@ -18,7 +18,13 @@
 
 #import <React/RCTImageUtils.h>
 
-static const NSUInteger RCTMaxCachableDecodedImageSizeInBytes = 2097152; // 2 MB
+static NSUInteger RCTMaxCachableDecodedImageSizeInBytes = 2*1024*1024;
+static NSUInteger RCTImageCacheTotalCostLimit = 20*1024*1024;
+
+void RCTSetImageCacheLimits(NSUInteger maxCachableDecodedImageSizeInBytes, NSUInteger imageCacheTotalCostLimit) {
+  RCTMaxCachableDecodedImageSizeInBytes = maxCachableDecodedImageSizeInBytes;
+  RCTImageCacheTotalCostLimit = imageCacheTotalCostLimit;
+}
 
 static NSString *RCTCacheKeyForImage(NSString *imageTag, CGSize size, CGFloat scale,
                                      RCTResizeMode resizeMode)
@@ -38,7 +44,7 @@ static NSString *RCTCacheKeyForImage(NSString *imageTag, CGSize size, CGFloat sc
 {
   if (self = [super init]) {
     _decodedImageCache = [NSCache new];
-    _decodedImageCache.totalCostLimit = 20 * 1024 * 1024; // 20 MB
+    _decodedImageCache.totalCostLimit = RCTImageCacheTotalCostLimit;
     _cacheStaleTimes = [NSMutableDictionary new];
 
     [[NSNotificationCenter defaultCenter] addObserver:self


### PR DESCRIPTION
## Summary

Allow modifying iOS image cache limits. Currently the image cache imposes some strict limits:

[NSCache.totalCostLimit](https://developer.apple.com/documentation/foundation/nscache/1407672-totalcostlimit?language=objc) of 20MB.
Single Image Size Limit of 2MB (bitmap size).

This may not be enough for applications that make heavy use of images. With this commit it is possible to fine tune them to the applications need.

This can be set for example in the App Delegate with:

```objc
RCTSetImageCacheLimits(4*1024*1024, 200*1024*1024);
```
This would increase the single image size limit to 4 MB and the total cost limit to 200 MB.

## Changelog

[iOS] [Added] - Allow modifying iOS image cache limits

## Test Plan

There is no easy way to test this except adding the above snippet and checking via break points that the new limits are used.
