### PR TITLE
[IOS] Fixed Textinput not properly handling padding and paddingVertical in style props

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -1225,7 +1225,7 @@ function InternalTextInput(props: Props): React.Node {
 
     const style =
       props.multiline === true
-        ? [styles.multilineInput, props.style]
+        ? StyleSheet.flatten([styles.multilineInput, props.style])
         : props.style;
 
     const useOnChangeSync =


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

Fixes #33562 #21720. Earlier this [`paddingTop`](https://github.com/facebook/react-native/blob/d5da70e17e8c8210cd79a4d7b09c6a5ded4b5607/Libraries/Components/TextInput/TextInput.js#L1367) used to override the  `paddingTop` of `padding` and `paddingVertical` of the style props. Using `Stylesheet.flatten` will solve this problem.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [Fixed] - Fixed paddingTop not being applied when using padding and paddingVertical in multiline textinput

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
