### PR TITLE
fix(preprocessor): return object, not just code

### DIFF
--- a/jest/preprocessor_DO_NOT_USE.js
+++ b/jest/preprocessor_DO_NOT_USE.js
@@ -38,7 +38,7 @@ module.exports = {
         sourceType: 'script',
         ...nodeOptions,
         ast: false,
-      }).code;
+      });
     }
 
     const {ast} = transformer.transform({

--- a/jest/preprocessor_DO_NOT_USE.js
+++ b/jest/preprocessor_DO_NOT_USE.js
@@ -111,7 +111,7 @@ module.exports = {
         sourceMaps: true,
       },
       src,
-    ).code;
+    );
   },
 
   getCacheKey: (createCacheKeyFunction([

--- a/jest/preprocessor_DO_NOT_USE.js
+++ b/jest/preprocessor_DO_NOT_USE.js
@@ -30,7 +30,7 @@ babelRegisterOnly([]);
 
 const transformer = require('metro-react-native-babel-transformer');
 module.exports = {
-  process(src /*: string */, file /*: string */) /*: string */ {
+  process(src /*: string */, file /*: string */) /*: {code: string, ...} */ {
     if (nodeFiles.test(file)) {
       // node specific transforms only
       return babelTransformSync(src, {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Jest 28 will error if only a string is returned from a transfomer, it needs to be an object of `{code: string, map?: object}`. Returning an object has been supported since https://github.com/facebook/jest/pull/2290, released in Jest v20.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Internal] [Fixed] - Return object from Jest preprocessor

## Test Plan

Green CI?

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
