### PR TITLE
Introduce focus logic for views for Android (and onFocusChange, JS side)

### DIFF
--- a/Libraries/NativeComponent/PlatformBaseViewConfig.js
+++ b/Libraries/NativeComponent/PlatformBaseViewConfig.js
@@ -170,6 +170,12 @@ const PlatformBaseViewConfig: PartialViewConfigWithoutName =
               bubbled: 'onPointerUp',
             },
           },
+          topOnFocusChange: {
+            phasedRegistrationNames: {
+              bubbled: 'onFocusChange',
+              captured: 'onFocusChangeCapture',
+            },
+          },
         },
         validAttributes: {
           // @ReactProps from BaseViewManager

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewFocusEvent.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewFocusEvent.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.views.view;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.uimanager.events.Event;
+import com.facebook.react.uimanager.events.RCTEventEmitter;
+
+/**
+ * Event emitted by native View when it receives focus.
+ */
+/* package */ class ReactViewFocusEvent extends Event<ReactViewFocusEvent> {
+
+  private static final String EVENT_NAME = "topOnFocusChange";
+  private boolean mHasFocus;
+
+  public ReactViewFocusEvent(int viewId, boolean hasFocus) {
+    super(viewId);
+    mHasFocus = hasFocus;
+  }
+
+  @Override
+  public String getEventName() {
+    return EVENT_NAME;
+  }
+
+  @Override
+  public boolean canCoalesce() {
+    return false;
+  }
+
+  @Override
+  public void dispatch(RCTEventEmitter rctEventEmitter) {
+    rctEventEmitter.receiveEvent(getViewTag(), getEventName(), serializeEventData());
+  }
+
+  private WritableMap serializeEventData() {
+    WritableMap eventData = Arguments.createMap();
+    eventData.putInt("target", getViewTag());
+    eventData.putBoolean("hasFocus", mHasFocus);
+    return eventData;
+  }
+}

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
@@ -26,6 +26,7 @@ import com.facebook.react.uimanager.PointerEvents;
 import com.facebook.react.uimanager.Spacing;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.UIManagerHelper;
+import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.ViewProps;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.annotations.ReactPropGroup;
@@ -48,8 +49,13 @@ public class ReactViewManager extends ReactClippingViewManager<ReactViewGroup> {
     Spacing.START,
     Spacing.END,
   };
-  private static final int CMD_HOTSPOT_UPDATE = 1;
-  private static final int CMD_SET_PRESSED = 2;
+  // Focus or blur call on native components (through NativeMethodsMixin) redirects to TextInputState.js
+  // which dispatches focusTextInput or blurTextInput commands. These commands are mapped to FOCUS_TEXT_INPUT=1
+  // and BLUR_TEXT_INPUT=2 in ReactTextInputManager, hence these constants value should be in sync with ReactTextInputManager.
+  private static final int FOCUS_TEXT_INPUT = 1;
+  private static final int BLUR_TEXT_INPUT = 2;
+  private static final int CMD_HOTSPOT_UPDATE = 3;
+  private static final int CMD_SET_PRESSED = 4;
   private static final String HOTSPOT_UPDATE_KEY = "hotspotUpdate";
 
   @ReactProp(name = "accessible")
@@ -119,6 +125,36 @@ public class ReactViewManager extends ReactClippingViewManager<ReactViewGroup> {
       view.setBorderRadius(borderRadius, index - 1);
     }
   }
+
+  @Nullable
+  @Override
+  public Map<String, Object> getExportedCustomBubblingEventTypeConstants() {
+    return MapBuilder.<String, Object>builder()
+      .put(
+        "topOnFocusChange",
+        MapBuilder.of(
+          "phasedRegistrationNames",
+          MapBuilder.of("bubbled", "onFocusChange","captured", "onFocusChangeCapture")))
+      .build();
+  }
+
+  @Override
+  protected void addEventEmitters(
+    final ThemedReactContext reactContext,
+    final ReactViewGroup reactViewGroup) {
+    reactViewGroup.setOnFocusChangeListener(
+      new View.OnFocusChangeListener() {
+        @Override
+        public void onFocusChange(View v, boolean hasFocus) {
+          EventDispatcher eventDispatcher =
+            reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher();
+            eventDispatcher.dispatchEvent(
+              new ReactViewFocusEvent(reactViewGroup.getId(), hasFocus));
+        }
+      }
+    );
+  }
+
 
   @ReactProp(name = "borderStyle")
   public void setBorderStyle(ReactViewGroup view, @Nullable String borderStyle) {
@@ -296,7 +332,7 @@ public class ReactViewManager extends ReactClippingViewManager<ReactViewGroup> {
 
   @Override
   public Map<String, Integer> getCommandsMap() {
-    return MapBuilder.of(HOTSPOT_UPDATE_KEY, CMD_HOTSPOT_UPDATE, "setPressed", CMD_SET_PRESSED);
+    return MapBuilder.of("focusTextInput", FOCUS_TEXT_INPUT, "blurTextInput", BLUR_TEXT_INPUT, HOTSPOT_UPDATE_KEY, CMD_HOTSPOT_UPDATE, "setPressed", CMD_SET_PRESSED);
   }
 
   @Override
@@ -310,6 +346,16 @@ public class ReactViewManager extends ReactClippingViewManager<ReactViewGroup> {
       case CMD_SET_PRESSED:
         {
           handleSetPressed(root, args);
+          break;
+        }
+      case FOCUS_TEXT_INPUT: 
+        {
+          root.requestFocus();
+          break;
+        }
+      case BLUR_TEXT_INPUT: 
+        {
+          root.clearFocus();
           break;
         }
     }
@@ -326,6 +372,16 @@ public class ReactViewManager extends ReactClippingViewManager<ReactViewGroup> {
       case "setPressed":
         {
           handleSetPressed(root, args);
+          break;
+        }
+      case "focusTextInput": 
+        {
+          root.requestFocus();
+          break;
+        }
+      case "blurTextInput": 
+        {
+          root.clearFocus();
           break;
         }
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

The reason why I'm working on this is to reduce the delta between this and the react-native-macos fork, in particular with the android patch folder "Focus": [https://github.com/microsoft/react-native-macos/tree/main/android-patches/patches/Focus](https://github.com/microsoft/react-native-macos/tree/main/android-patches/patches/Focus) (it's a long story)

If this PR gets merged, we can remove that patch (once react-native-macos catches up with upstream) and close off https://github.com/microsoft/react-native-macos/issues/289 (I think)

Sadly the documentation around this set of changes is a bit fuzzy, so I'm doing my best in figuring out how to best document and present a test plan (reason why the PR is still in draft mode). My current understanding is that it adds the extra logic needed to catch events emitted by native View when it receives focus, expose it via `onFocusChange` and also fix TextInput's to use `focusTextInput` and `blurTextInput` when used via keyboard (that's the part I'm a bit fuzzy about).

The one main change compared to the original patch is that I had to modify `PlatformBaseViewConfig` since this commit https://github.com/facebook/react-native/commit/7b9490b4b122183c34bd6228836ffb1d2f394f0a by @RSNara removes the old `ReactNativeViewViewConfigAndroid`.
Other relevant folks who might be a good fit for reviewing this (once it's not in draft anymore) are @javache and @lunaleaps, since they seem to have worked recently on this area of the code (refs https://github.com/facebook/react-native/commit/6e5cefe604786c1883ca09febee0792af7ce1b34, https://github.com/facebook/react-native/commit/c50e6b52fe3ff9e0ff3f8bfcd104c1a3d306c38c)

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[CATEGORY] [TYPE] - Message

(TBC)

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

(WIP)