### PR TITLE
Bump React Native Gradle plugin to 0.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "pretty-format": "^26.5.2",
     "promise": "^8.0.3",
     "react-devtools-core": "4.24.0",
-    "react-native-gradle-plugin": "^0.0.5",
+    "react-native-gradle-plugin": "^0.0.6",
     "react-refresh": "^0.4.0",
     "react-shallow-renderer": "16.14.1",
     "regenerator-runtime": "^0.13.2",

--- a/packages/react-native-gradle-plugin/package.json
+++ b/packages/react-native-gradle-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-gradle-plugin",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "⚛️ Gradle Plugin for React Native",
   "homepage": "https://github.com/facebook/react-native/tree/HEAD/packages/react-native-gradle-plugin",
   "repository": {


### PR DESCRIPTION
Summary:
We currently have some code on the RN Gradle Plugin that we need to ship.
There are both bugfixes needed for RN 0.68.1 and for the current nightly
(therefore needed for RN 0.69).

I've verified that this works on a fresh RN 0.68.0 install with `npm pack`
and triggering a build on a fresh setup from app template, with newArchEnabled set to true.

Changelog:
[Android] [Changed] - Bump React Native Gradle plugin to 0.0.6

Differential Revision: D35439444

