### PR TITLE
Circle CI: enable BUILD_HERMES_SOURCE for test_ios_rntester job 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -727,6 +727,10 @@ jobs:
           name: Set USE_HERMES=1
           command: echo "export USE_HERMES=1" >> $BASH_ENV
 
+      - run:
+          name: Set BUILD_HERMES_SOURCE=1
+          command: echo "export BUILD_HERMES_SOURCE=1" >> $BASH_ENV
+
       - with_brew_cache_span:
           steps:
             - brew_install:

--- a/packages/rn-tester/Podfile
+++ b/packages/rn-tester/Podfile
@@ -36,7 +36,6 @@ def pods(options = {})
     config_file_dir: "#{Dir.pwd}/node_modules",
   )
   pod 'ReactCommon/turbomodule/samples', :path => "#{prefix_path}/ReactCommon"
-  pod 'hermes-engine', :path => "../sdks/hermes-engine"
 
   # Additional Pods which aren't included in the default Podfile
   pod 'React-RCTPushNotification', :path => "#{prefix_path}/Libraries/PushNotificationIOS"

--- a/packages/rn-tester/Podfile
+++ b/packages/rn-tester/Podfile
@@ -36,6 +36,7 @@ def pods(options = {})
     config_file_dir: "#{Dir.pwd}/node_modules",
   )
   pod 'ReactCommon/turbomodule/samples', :path => "#{prefix_path}/ReactCommon"
+  pod 'hermes-engine', :path => "../sdks/hermes-engine"
 
   # Additional Pods which aren't included in the default Podfile
   pod 'React-RCTPushNotification', :path => "#{prefix_path}/Libraries/PushNotificationIOS"

--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -673,8 +673,9 @@ def downloadAndConfigureHermesSource(react_native_path)
     Pod::UI.puts "[Hermes] Downloading Hermes source code (#{hermes_tarball_url})"
     system("curl #{hermes_tarball_url} -Lo #{hermes_tarball_path}")
   end
+  Pod::UI.puts "[Hermes] Extracting Hermes (#{hermes_tag_sha})"
+  system("tar -zxf #{hermes_tarball_path} --strip-components=1 --directory #{hermes_dir}")
 
-  
   hermesc_macos_path = "#{sdks_dir}/hermesc/macos/build_host_hermesc"
   hermesc_macos_link = "#{hermes_dir}/utils/build_host_hermesc"
   if (File.exist?(hermesc_macos_path))
@@ -682,9 +683,9 @@ def downloadAndConfigureHermesSource(react_native_path)
     Pod::UI.puts "[Hermes] Using pre-compiled Hermes Compiler from #{hermesc_macos_path}"
     system("ln -s #{hermesc_macos_path} #{hermesc_macos_link}")
   end
-  
-  Pod::UI.puts "[Hermes] Extracting Hermes (#{hermes_tag_sha})"
-  system("tar -zxf #{hermes_tarball_path} --strip-components=1 --directory #{hermes_dir}")
+
+  # TODO: Integrate this temporary hermes-engine.podspec into the actual one located in facebook/hermes
+  system("cp #{sdks_dir}/hermes-engine.podspec #{hermes_dir}/hermes-engine.podspec")
 
   hermes_dir
 end

--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -656,7 +656,6 @@ def downloadAndConfigureHermesSource(react_native_path)
   sdks_dir = "#{react_native_path}/sdks"
   download_dir = "#{sdks_dir}/download"
   hermes_dir = "#{sdks_dir}/hermes"
-  utils_dir = "#{sdks_dir}/hermes/utils"
   hermes_tag_file = "#{sdks_dir}/.hermesversion"
   system("mkdir -p #{hermes_dir} #{download_dir}")
 

--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -656,6 +656,7 @@ def downloadAndConfigureHermesSource(react_native_path)
   sdks_dir = "#{react_native_path}/sdks"
   download_dir = "#{sdks_dir}/download"
   hermes_dir = "#{sdks_dir}/hermes"
+  utils_dir = "#{sdks_dir}/hermes/utils"
   hermes_tag_file = "#{sdks_dir}/.hermesversion"
   system("mkdir -p #{hermes_dir} #{download_dir}")
 
@@ -673,8 +674,8 @@ def downloadAndConfigureHermesSource(react_native_path)
     Pod::UI.puts "[Hermes] Downloading Hermes source code (#{hermes_tarball_url})"
     system("curl #{hermes_tarball_url} -Lo #{hermes_tarball_path}")
   end
-  Pod::UI.puts "[Hermes] Extracting Hermes (#{hermes_tag_sha})"
 
+  
   hermesc_macos_path = "#{sdks_dir}/hermesc/macos/build_host_hermesc"
   hermesc_macos_link = "#{hermes_dir}/utils/build_host_hermesc"
   if (File.exist?(hermesc_macos_path))
@@ -682,9 +683,9 @@ def downloadAndConfigureHermesSource(react_native_path)
     Pod::UI.puts "[Hermes] Using pre-compiled Hermes Compiler from #{hermesc_macos_path}"
     system("ln -s #{hermesc_macos_path} #{hermesc_macos_link}")
   end
-
-  # TODO: Integrate this temporary hermes-engine.podspec into the actual one located in facebook/hermes
-  system("cp #{sdks_dir}/hermes-engine.podspec #{hermes_dir}/hermes-engine.podspec")
+  
+  Pod::UI.puts "[Hermes] Extracting Hermes (#{hermes_tag_sha})"
+  system("tar -zxf #{hermes_tarball_path} --strip-components=1 --directory #{hermes_dir}")
 
   hermes_dir
 end


### PR DESCRIPTION
## Summary

Fix CircleCI build for test_ios_rntester.

Broken due to [this commit](https://github.com/facebook/react-native/commit/fefa7b6ac8a1e0e33fa7a1070936c5c83c873c0a) after adding dev tools profiler.

## Changelog

[Internal] [Fixed] - Fix rn tester app CI

## Test Plan
CI should be green.