### PR TITLE
Improve support for Android users on M1 machine

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -252,10 +252,13 @@ android {
     buildToolsVersion = "31.0.0"
     compileSdkVersion 31
 
-    // Used to override the NDK path & version on internal CI
-    if (System.getenv("ANDROID_NDK") != null && System.getenv("LOCAL_ANDROID_NDK_VERSION") != null) {
-        ndkPath System.getenv("ANDROID_NDK")
-        ndkVersion System.getenv("LOCAL_ANDROID_NDK_VERSION")
+    // Used to override the NDK path/version on internal CI or by allowing
+    // users to customize the NDK path/version from their root project (e.g. for M1 support)
+    if (rootProject.hasProperty("ndkPath")) {
+        ndkPath rootProject.ext.ndkPath
+    }
+    if (rootProject.hasProperty("ndkVersion")) {
+        ndkVersion rootProject.ext.ndkVersion
     }
 
     defaultConfig {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+val ndkPath by extra(System.getenv("ANDROID_NDK"))
+val ndkVersion by extra(System.getenv("ANDROID_NDK_VERSION"))
+
 buildscript {
     repositories {
         google()

--- a/packages/rn-tester/android/app/build.gradle
+++ b/packages/rn-tester/android/app/build.gradle
@@ -146,10 +146,13 @@ android {
     buildToolsVersion = "31.0.0"
     compileSdkVersion 31
 
-    // Used to override the NDK path & version on internal CI
-    if (System.getenv("ANDROID_NDK") != null && System.getenv("LOCAL_ANDROID_NDK_VERSION") != null) {
-        ndkPath System.getenv("ANDROID_NDK")
-        ndkVersion System.getenv("LOCAL_ANDROID_NDK_VERSION")
+    // Used to override the NDK path/version on internal CI or by allowing
+    // users to customize the NDK path/version from their root project (e.g. for M1 support)
+    if (rootProject.hasProperty("ndkPath")) {
+        ndkPath rootProject.ext.ndkPath
+    }
+    if (rootProject.hasProperty("ndkVersion")) {
+        ndkVersion rootProject.ext.ndkVersion
     }
 
     flavorDimensions "vm"

--- a/template/android/build.gradle
+++ b/template/android/build.gradle
@@ -6,7 +6,13 @@ buildscript {
         minSdkVersion = 21
         compileSdkVersion = 31
         targetSdkVersion = 31
-        ndkVersion = "21.4.7075529"
+        // For M1 Users we need to use the NDK 24, otherwise we default to the
+        // side-by-side NDK version from AGP.
+        if (System.properties['os.arch'] == "aarch64") {
+            ndkVersion = "24.0.8215888"
+        } else {
+            ndkVersion = "21.4.7075529"
+        }
     }
     repositories {
         google()


### PR DESCRIPTION
Summary:
Currently users on M1 machine can't use the New Architecture correctly as they will get build failures when building the native code.

This Diff fixes it by automatically recognizing the host architecture and switching to NDK 24 if user is runnign on `aarch64`

Changelog:
[Android] [Fixed] - Improve support for Android users on M1 machine

Differential Revision: D35468252

