### PR TITLE
Do not specify a Kotlin version in the RN rootProject

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -8,7 +8,7 @@
 plugins {
     id("com.android.library")
     id("com.facebook.react")
-    id("org.jetbrains.kotlin.android")
+    id("org.jetbrains.kotlin.android") version "1.6.10"
     id("maven-publish")
     id("de.undercouch.download")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,10 +14,8 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        val kotlin_version: String by project
         classpath("com.android.tools.build:gradle:7.1.1")
         classpath("de.undercouch:gradle-download-task:5.0.1")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version")
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,6 @@ org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8
 org.gradle.parallel=true
 
 android.useAndroidX=true
-kotlin_version=1.6.10
 
 # Use this property to specify which architecture you want to build.
 # You can also override it from the CLI using


### PR DESCRIPTION
## Summary

As we introduced KGP inside `ReactAndroid` (cc @ShikaSD), we now need to specify a version for it (as users will consume that build on Android New Architecture.

Currently, the version is loaded in the RN `rootProject` which is not available on user's project. I'm cleaning this up.

## Changelog

[Internal] - Do not specify a Kotlin version in the RN rootProject

## Test Plan

Tested on a nightly version with

```
npx react-native init RNNightly --version nightly
```
