### PR TITLE
Circle CI: switch to next-gen images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,12 +54,12 @@ executors:
     <<: *defaults
     docker:
       # Note: Version set separately for Windows builds, see below.
-      - image: circleci/node:16
+      - image: cimg/node:16.14
     resource_class: "xlarge"
   nodeprevlts:
     <<: *defaults
     docker:
-      - image: circleci/node:14
+      - image: cimg/node:14.19
     resource_class: "xlarge"
   reactnativeandroid:
     <<: *defaults


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<img width="819" alt="Screenshot 2022-04-07 at 20 42 30" src="https://user-images.githubusercontent.com/719641/162288224-1f360edd-3d9f-4f82-aac9-341d97480dfc.png">

This PR switches the Circle CI images to the next-gen ones, according to the migration guide. 

With new images, specifying the minor version is required, and I have selected the latest version for each major release.

References:
* https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034
* https://circleci.com/developer/images/image/cimg/node

---

Orbs are still using the full `circleci` name, however during the update I have spotted that used Windows Orb is quite outdated. I will push another PR and try the Orb bump in there, unless there is a reason, why the specific Orb version is used.

## Changelog

N/A

## Test Plan

Run the CI.
