### PR TITLE
add Codegen generated `gradlePlugin-build` directory to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,7 @@ package-lock.json
 
 # react-native-codegen
 /React/FBReactNativeSpec/FBReactNativeSpec
+/packages/react-native-codegen/android/gradlePlugin-build
 /packages/react-native-codegen/lib
 /ReactCommon/react/renderer/components/rncore/
 /packages/rn-tester/NativeModuleExample/ScreenshotManagerSpec*


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Currently, after setting up repository, there is a list of around 60 unversioned files reported by Git. 

<img width="928" alt="Screenshot 2022-04-08 at 12 01 05" src="https://user-images.githubusercontent.com/719641/162413835-9528b71c-941e-4e69-9294-2cc39cbf5445.png">

It looks like those files are generated by the Codegen, so I assumed that they should not be a part of repository, please correct me, if I'm wrong about this.

## Changelog

N/A

## Test Plan

After adding the `gradlePlugin-build` directory to `.gitignore`, there are no unversioned files reported by Git.
