### PR TITLE
Use NDK 23 only for Windows users.

### DIFF
--- a/template/android/build.gradle
+++ b/template/android/build.gradle
@@ -1,3 +1,5 @@
+import org.apache.tools.ant.taskdefs.condition.Os
+
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
@@ -6,11 +8,16 @@ buildscript {
         minSdkVersion = 21
         compileSdkVersion = 31
         targetSdkVersion = 31
-        // For M1 Users we need to use the NDK 24, otherwise we default to the
-        // side-by-side NDK version from AGP.
+
         if (System.properties['os.arch'] == "aarch64") {
+            // For M1 Users we need to use the NDK 24 which added support for aarch64
             ndkVersion = "24.0.8215888"
+        } else if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+            // For Android Users, we need to use NDK 23, otherwise the build will
+            // fail due to paths longer than the OS limit
+            ndkVersion = "23.1.7779620"
         } else {
+            // Otherwise we default to the side-by-side NDK version from AGP.
             ndkVersion = "21.4.7075529"
         }
     }


### PR DESCRIPTION
Summary:
Bumping the NDK to 23 to prevent build failures due to the NDK
using longer paths.

Changelog:
[Android] [Fixed] - Use NDK 23 only for Windows users.

Differential Revision: D35547459

