### PR TITLE
chore(typo): fix spacing typo in gradle plugin message

### DIFF
--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactExtension.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactExtension.kt
@@ -248,7 +248,7 @@ abstract class ReactExtension @Inject constructor(project: Project) {
    * Please also note that those are the default value and you most likely don't need those at all.
    */
   @Deprecated(
-      "reactRoot was confusing and has been replace with root" +
+      "reactRoot was confusing and has been replace with root " +
           "to point to your root project and reactNativeDir to point to " +
           "the folder of the react-native NPM package",
       replaceWith = ReplaceWith("reactNativeRoot"))


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

There is a simple typo - a missing space in to string concatenation in a deprecation message, the message pops up in a newly initialized RN68 project so seems worth fixing

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Fixed] - Fix typo in gradle plugin deprecation message

## Test Plan

Fixed via visual inspection (adding a single space character is luckily easy like that, yes that's perhaps over-confident but if you see the diff you will probably agree?)

@cortinico 
