### PR TITLE
Avoid full copy of large folly::dynamic objects by switching to std::move semantics

### DIFF
--- a/ReactCommon/cxxreact/ModuleRegistry.cpp
+++ b/ReactCommon/cxxreact/ModuleRegistry.cpp
@@ -189,7 +189,7 @@ folly::Optional<ModuleConfig> ModuleRegistry::getConfig(
     // no constants or methods
     return folly::none;
   } else {
-    return ModuleConfig{index, config};
+    return ModuleConfig{index, std::move(config)};
   }
 }
 


### PR DESCRIPTION
## Summary

Problem:
Current creation of ModuleConfig does a full copy of folly::dynamic object, which for large objects can cause 1000's of memory allocations, and thus increasing app's memory footprint and speed.

Fix:
Use std::move semantics to avoid copy of folly::dynamic, thus avoiding memory allocations.

## Changelog

[General] [Fixed] - Avoid full copy of large folly::dynamic objects by switching to std::move semantics

## Test Plan

Compiled React Native for Windows
Consumed into Microsoft Excel App
Tested functionality through Microsoft Office Excel App
Viewed Memory Allocations in Debugger
