### PR TITLE
Building new architecture sources on Windows (NDK Bump)

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -287,6 +287,10 @@ android {
         ndkVersion System.getenv("LOCAL_ANDROID_NDK_VERSION")
     }
 
+    if (ndkVersion == null && ndkPath == null && rootProject.ext.ndkVersion != null) {
+        ndkVersion rootProject.ext.ndkVersion
+    }
+
     defaultConfig {
         minSdkVersion(21)
         targetSdkVersion(31)
@@ -321,15 +325,9 @@ android {
 
                 // Note: On Windows there are limits on number of character in file paths and in command lines
                 // Ref: https://android.googlesource.com/platform/ndk/+/master/docs/BuildSystemMaintainers.md#Path-Length-Limits
-                // NDK allows circumventing command line limits using response(RSP) files as inputs using NDK_APP_SHORT_COMMANDS flag.
-                // 
-                // Windows can support long file paths if configured through registry or by prefixing all file paths with a special character sequence 
-                // The latter requires changes in NDK. And there are tools in NDK (AR) which is not able to handle long paths (>256) even after setting the registry key.
-                // The new architecutre source tree is too deep, and the object file naming conventions in NDK makes the matters worse, by producing incredibly long file paths.
-                // Other solutions such as symlinking source code etc. didn't work as expected, and makes the build scripts complicated and hard to manage.
-                // This change temporarily works around the issue by placing the temporary build outputs as short a path as possible within the project path.
+                // NDK r23+ can handle long file paths. But we are still limited by the command line limit on Windows.           
                 if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                    arguments "NDK_OUT=${rootProject.projectDir.getParent()}\\.cxx",
+                    arguments "NDK_OUT=${rootProject.projectDir}\\.cxx",
                               "NDK_APP_SHORT_COMMANDS=true"
                 }
             }

--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -318,6 +318,20 @@ android {
                     // This flag will suppress "fcntl(): Bad file descriptor" warnings on local builds.
                     arguments "--output-sync=none"
                 }
+
+                // Note: On Windows there are limits on number of character in file paths and in command lines
+                // Ref: https://android.googlesource.com/platform/ndk/+/master/docs/BuildSystemMaintainers.md#Path-Length-Limits
+                // NDK allows circumventing command line limits using response(RSP) files as inputs using NDK_APP_SHORT_COMMANDS flag.
+                // 
+                // Windows can support long file paths if configured through registry or by prefixing all file paths with a special character sequence 
+                // The latter requires changes in NDK. And there are tools in NDK (AR) which is not able to handle long paths (>256) even after setting the registry key.
+                // The new architecutre source tree is too deep, and the object file naming conventions in NDK makes the matters worse, by producing incredibly long file paths.
+                // Other solutions such as symlinking source code etc. didn't work as expected, and makes the build scripts complicated and hard to manage.
+                // This change temporarily works around the issue by placing the temporary build outputs as short a path as possible within the project path.
+                if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                    arguments "NDK_OUT=${rootProject.projectDir.getParent()}\\.cxx",
+                              "NDK_APP_SHORT_COMMANDS=true"
+                }
             }
         }
         ndk {

--- a/template/android/app/build.gradle
+++ b/template/android/app/build.gradle
@@ -161,7 +161,7 @@ android {
 
                     // Fix for windows limit on number of character in file paths and in command lines
                     if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                        arguments "NDK_OUT=${rootProject.projectDir.getParent()}\\.cxx",
+                        arguments "NDK_OUT=${rootProject.projectDir}\\.cxx",
                             "NDK_APP_SHORT_COMMANDS=true"
                     }
                 }

--- a/template/android/app/build.gradle
+++ b/template/android/app/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: "com.android.application"
 
 import com.android.build.OutputFile
+import org.apache.tools.ant.taskdefs.condition.Os
 
 /**
  * The react.gradle file registers a task for each build variant (e.g. bundleDebugJsAndAssets
@@ -157,6 +158,12 @@ android {
                     // Make sure this target name is the same you specify inside the
                     // src/main/jni/Android.mk file for the `LOCAL_MODULE` variable.
                     targets "helloworld_appmodules"
+
+                    // Fix for windows limit on number of character in file paths and in command lines
+                    if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                        arguments "NDK_OUT=${rootProject.projectDir.getParent()}\\.cxx",
+                            "NDK_APP_SHORT_COMMANDS=true"
+                    }
                 }
             }
         }

--- a/template/android/build.gradle
+++ b/template/android/build.gradle
@@ -1,3 +1,5 @@
+import org.apache.tools.ant.taskdefs.condition.Os
+
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
@@ -6,7 +8,15 @@ buildscript {
         minSdkVersion = 21
         compileSdkVersion = 31
         targetSdkVersion = 31
-        ndkVersion = "21.4.7075529"
+        
+        if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+            // Note: On Windows there are limits on number of character in file paths and command lines
+            // Ref: https://android.googlesource.com/platform/ndk/+/master/docs/BuildSystemMaintainers.md#Path-Length-Limits
+            // NDK r23+ can handle long file paths. But we are still limited by the command line limit on Windows. 
+            ndkVersion = "23.1.7779620"
+        } else {
+            ndkVersion = "21.4.7075529"
+        }
     }
     repositories {
         google()


### PR DESCRIPTION
On Windows there are limits on number of character in file paths and in command lines
Ref: https://android.googlesource.com/platform/ndk/+/master/docs/BuildSystemMaintainers.md#Path-Length-Limits

The new architecutre source tree is too deep, and the object file naming conventions in NDK makes the matters worse, by producing incredibly long file paths.

Windows can support long file paths if configured through registry or by prefixing all file paths with a special character sequence. LLVM tools can work with long paths if user configured it but NDK23- uses binutils tools which don't.
This PR bumps NDK when building on Windows

Even with NDKr23, we are hitting the command line limits of 8191 characters !
NDK_APP_LOCAL_COMMANDS should come to rescue, but gradle android plugin has hardcoded the flag to false
Ref: Line#165 in https://android.googlesource.com/platform/tools/base/+/gradle_2.3.0/build-system/gradle-core/src/main/java/com/android/build/gradle/tasks/NdkBuildExternalNativeJsonGenerator.java#165

Hence, we can't use the default build directory. But, we can support much longer paths than without the NDK bump.

Changelog:
[Android] [Fixed] - Fix for building new architecture sources on Windows

On Windows there are limits on number of character in file paths and in command lines
Ref: https://android.googlesource.com/platform/ndk/+/master/docs/BuildSystemMaintainers.md#Path-Length-Limits

The new architecutre source tree is too deep, and the object file naming conventions in NDK makes the matters worse, by producing incredibly long file paths.

Windows can support long file paths if configured through registry or by prefixing all file paths with a special character sequence. LLVM tools can work with long paths if user configured it but NDK23- uses binutils tools which don't.
This PR bumps NDK when building on Windows

Even with NDKr23, we are hitting the command line limits of 8191 characters !
NDK_APP_LOCAL_COMMANDS should come to rescue, but gradle android plugin has hardcoded the flag to false
Ref: Line#165 in https://android.googlesource.com/platform/tools/base/+/gradle_2.3.0/build-system/gradle-core/src/main/java/com/android/build/gradle/tasks/NdkBuildExternalNativeJsonGenerator.java#165

Hence, we can't use the default build directory. But, we can support much longer paths than without the NDK bump.

## Summary

Make sure react native apps can be build on windows machines.

## Changelog

On Windows there are limits on number of character in file paths and in command lines
Ref: https://android.googlesource.com/platform/ndk/+/master/docs/BuildSystemMaintainers.md#Path-Length-Limits

The new architecutre source tree is too deep, and the object file naming conventions in NDK makes the matters worse, by producing incredibly long file paths.

Windows can support long file paths if configured through registry or by prefixing all file paths with a special character sequence. LLVM tools can work with long paths if user configured it but NDK23- uses binutils tools which don't.
This PR bumps NDK when building on Windows

Even with NDKr23, we are hitting the command line limits of 8191 characters !
NDK_APP_LOCAL_COMMANDS should come to rescue, but gradle android plugin has hardcoded the flag to false
Ref: Line#165 in https://android.googlesource.com/platform/tools/base/+/gradle_2.3.0/build-system/gradle-core/src/main/java/com/android/build/gradle/tasks/NdkBuildExternalNativeJsonGenerator.java#165

Hence, we can't use the default build directory. But, we can support much longer paths than without the NDK bump.

[CATEGORY] [TYPE] - Message

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
