### PR TITLE
Expose an API to enable Concurrent Root on Android

### DIFF
--- a/ReactAndroid/src/test/java/com/facebook/react/ReactActivityDelegateTest.kt
+++ b/ReactAndroid/src/test/java/com/facebook/react/ReactActivityDelegateTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react
+
+import android.os.Bundle
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ReactActivityDelegateTest {
+
+  @Test
+  fun delegateWithConcurrentRoot_populatesInitialPropsCorrectly() {
+    val delegate =
+        object : ReactActivityDelegate(null, "test-delegate") {
+          override fun isConcurrentRootEnabled() = true
+          public val inspectLaunchOptions: Bundle?
+            get() = getLaunchOptions()
+        }
+
+    assertNotNull(delegate.inspectLaunchOptions)
+    assertTrue(delegate.inspectLaunchOptions!!.containsKey("concurrentRoot"))
+    assertTrue(delegate.inspectLaunchOptions!!.getBoolean("concurrentRoot"))
+  }
+
+  @Test
+  fun delegateWithoutConcurrentRoot_hasNullInitialProperties() {
+    val delegate =
+        object : ReactActivityDelegate(null, "test-delegate") {
+          override fun isConcurrentRootEnabled() = false
+          public val inspectLaunchOptions: Bundle?
+            get() = getLaunchOptions()
+        }
+
+    assertNull(delegate.inspectLaunchOptions)
+  }
+
+  @Test
+  fun delegateWithConcurrentRoot_composesInitialPropertiesCorrectly() {
+    val delegate =
+        object : ReactActivityDelegate(null, "test-delegate") {
+          override fun isConcurrentRootEnabled() = true
+          override fun getLaunchOptions(): Bundle =
+              Bundle().apply { putString("test-property", "test-value") }
+          public val inspectLaunchOptions: Bundle?
+            get() = getLaunchOptions()
+        }
+
+    assertNotNull(delegate.inspectLaunchOptions)
+    assertTrue(delegate.inspectLaunchOptions!!.containsKey("concurrentRoot"))
+    assertTrue(delegate.inspectLaunchOptions!!.getBoolean("concurrentRoot"))
+    assertTrue(delegate.inspectLaunchOptions!!.containsKey("test-property"))
+    assertEquals("test-value", delegate.inspectLaunchOptions!!.getString("test-property"))
+  }
+}

--- a/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterActivity.java
+++ b/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterActivity.java
@@ -51,6 +51,11 @@ public class RNTesterActivity extends ReactActivity {
     protected Bundle getLaunchOptions() {
       return mInitialProps;
     }
+
+    @Override
+    protected boolean isConcurrentRootEnabled() {
+      return true;
+    }
   }
 
   @Override

--- a/template/android/app/src/main/java/com/helloworld/MainActivity.java
+++ b/template/android/app/src/main/java/com/helloworld/MainActivity.java
@@ -37,5 +37,12 @@ public class MainActivity extends ReactActivity {
       reactRootView.setIsFabric(BuildConfig.IS_NEW_ARCHITECTURE_ENABLED);
       return reactRootView;
     }
+
+    @Override
+    protected boolean isConcurrentRootEnabled() {
+      // If you opted-in for the New Architecture, we enable Concurrent Root (i.e. React 18).
+      // More on this on https://reactjs.org/blog/2022/03/29/react-v18.html
+      return BuildConfig.IS_NEW_ARCHITECTURE_ENABLED;
+    }
   }
 }


### PR DESCRIPTION
Summary:
With React 18, we now need to allow users on Fabric to opt-in for Concurrent Root.

This commit adds a new method that can be called on the ReactActivityDelegate
that can be used to set the `concurrentRoot` flag on the `initialProps` on the Render.

Changelog:
[Android] [Added] - Expose an API to enable Concurrent Root on Android

Reviewed By: mdvacca

Differential Revision: D35614879

