### PR TITLE
Run `setup_ruby` to unblock `test_ios_rntester`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -719,6 +719,7 @@ jobs:
     executor: reactnativeios
     steps:
       - checkout
+      - setup_ruby
       - run_yarn
 
       - run:


### PR DESCRIPTION
## Summary

iOS CI is currently red to a bump of Ruby (cc @danilobuerger #33485).
Seems like the `test_ios_rntester` is not currently accessing the Ruby cache. This should fix it.

## Changelog

[Internal] - Run `setup_ruby` to unblock `test_ios_rntester`

## Test Plan

Will wait for a CI result.