### PR TITLE
Make `TurboModuleRegistry.get(...)` enforcing by default, add `getOrNull(..)`

### DIFF
--- a/Libraries/ActionSheetIOS/NativeActionSheetManager.js
+++ b/Libraries/ActionSheetIOS/NativeActionSheetManager.js
@@ -50,4 +50,4 @@ export interface Spec extends TurboModule {
   +dismissActionSheet?: () => void;
 }
 
-export default (TurboModuleRegistry.get<Spec>('ActionSheetManager'): ?Spec);
+export default (TurboModuleRegistry.getOrNull<Spec>('ActionSheetManager'): ?Spec);

--- a/Libraries/Alert/NativeAlertManager.js
+++ b/Libraries/Alert/NativeAlertManager.js
@@ -29,4 +29,4 @@ export interface Spec extends TurboModule {
   ) => void;
 }
 
-export default (TurboModuleRegistry.get<Spec>('AlertManager'): ?Spec);
+export default (TurboModuleRegistry.getOrNull<Spec>('AlertManager'): ?Spec);

--- a/Libraries/Animated/NativeAnimatedModule.js
+++ b/Libraries/Animated/NativeAnimatedModule.js
@@ -66,4 +66,4 @@ export interface Spec extends TurboModule {
   +removeListeners: (count: number) => void;
 }
 
-export default (TurboModuleRegistry.get<Spec>('NativeAnimatedModule'): ?Spec);
+export default (TurboModuleRegistry.getOrNull<Spec>('NativeAnimatedModule'): ?Spec);

--- a/Libraries/Animated/NativeAnimatedTurboModule.js
+++ b/Libraries/Animated/NativeAnimatedTurboModule.js
@@ -66,6 +66,6 @@ export interface Spec extends TurboModule {
   +removeListeners: (count: number) => void;
 }
 
-export default (TurboModuleRegistry.get<Spec>(
+export default (TurboModuleRegistry.getOrNull<Spec>(
   'NativeAnimatedTurboModule',
 ): ?Spec);

--- a/Libraries/AppState/NativeAppState.js
+++ b/Libraries/AppState/NativeAppState.js
@@ -25,4 +25,4 @@ export interface Spec extends TurboModule {
   +removeListeners: (count: number) => void;
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>('AppState'): Spec);
+export default (TurboModuleRegistry.get<<Spec>('AppState'): Spec);

--- a/Libraries/AppState/NativeAppState.js
+++ b/Libraries/AppState/NativeAppState.js
@@ -25,4 +25,4 @@ export interface Spec extends TurboModule {
   +removeListeners: (count: number) => void;
 }
 
-export default (TurboModuleRegistry.get<<Spec>('AppState'): Spec);
+export default (TurboModuleRegistry.get<Spec>('AppState'): Spec);

--- a/Libraries/Blob/NativeBlobModule.js
+++ b/Libraries/Blob/NativeBlobModule.js
@@ -21,7 +21,7 @@ export interface Spec extends TurboModule {
   +release: (blobId: string) => void;
 }
 
-const NativeModule = TurboModuleRegistry.get<Spec>('BlobModule');
+const NativeModule = TurboModuleRegistry.getOrNull<Spec>('BlobModule');
 
 let constants = null;
 let NativeBlobModule = null;

--- a/Libraries/Blob/NativeFileReaderModule.js
+++ b/Libraries/Blob/NativeFileReaderModule.js
@@ -16,6 +16,6 @@ export interface Spec extends TurboModule {
   +readAsText: (data: Object, encoding: string) => Promise<string>;
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>(
+export default (TurboModuleRegistry.get<<Spec>(
   'FileReaderModule',
 ): Spec);

--- a/Libraries/Blob/NativeFileReaderModule.js
+++ b/Libraries/Blob/NativeFileReaderModule.js
@@ -16,6 +16,6 @@ export interface Spec extends TurboModule {
   +readAsText: (data: Object, encoding: string) => Promise<string>;
 }
 
-export default (TurboModuleRegistry.get<<Spec>(
+export default (TurboModuleRegistry.get<Spec>(
   'FileReaderModule',
 ): Spec);

--- a/Libraries/BugReporting/NativeBugReporting.js
+++ b/Libraries/BugReporting/NativeBugReporting.js
@@ -17,4 +17,4 @@ export interface Spec extends TurboModule {
   +setCategoryID: (categoryID: string) => void;
 }
 
-export default (TurboModuleRegistry.get<Spec>('BugReporting'): ?Spec);
+export default (TurboModuleRegistry.getOrNull<Spec>('BugReporting'): ?Spec);

--- a/Libraries/Components/AccessibilityInfo/NativeAccessibilityInfo.js
+++ b/Libraries/Components/AccessibilityInfo/NativeAccessibilityInfo.js
@@ -29,4 +29,4 @@ export interface Spec extends TurboModule {
   ) => void;
 }
 
-export default (TurboModuleRegistry.get<Spec>('AccessibilityInfo'): ?Spec);
+export default (TurboModuleRegistry.getOrNull<Spec>('AccessibilityInfo'): ?Spec);

--- a/Libraries/Components/AccessibilityInfo/NativeAccessibilityManager.js
+++ b/Libraries/Components/AccessibilityInfo/NativeAccessibilityManager.js
@@ -58,4 +58,4 @@ export interface Spec extends TurboModule {
   ) => void;
 }
 
-export default (TurboModuleRegistry.get<Spec>('AccessibilityManager'): ?Spec);
+export default (TurboModuleRegistry.getOrNull<Spec>('AccessibilityManager'): ?Spec);

--- a/Libraries/Components/Clipboard/NativeClipboard.js
+++ b/Libraries/Components/Clipboard/NativeClipboard.js
@@ -17,4 +17,4 @@ export interface Spec extends TurboModule {
   +setString: (content: string) => void;
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>('Clipboard'): Spec);
+export default (TurboModuleRegistry.get<<Spec>('Clipboard'): Spec);

--- a/Libraries/Components/Clipboard/NativeClipboard.js
+++ b/Libraries/Components/Clipboard/NativeClipboard.js
@@ -17,4 +17,4 @@ export interface Spec extends TurboModule {
   +setString: (content: string) => void;
 }
 
-export default (TurboModuleRegistry.get<<Spec>('Clipboard'): Spec);
+export default (TurboModuleRegistry.get<Spec>('Clipboard'): Spec);

--- a/Libraries/Components/DatePickerAndroid/NativeDatePickerAndroid.js
+++ b/Libraries/Components/DatePickerAndroid/NativeDatePickerAndroid.js
@@ -20,6 +20,6 @@ export interface Spec extends TurboModule {
   +open: (options: Object) => Promise<Object>;
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>(
+export default (TurboModuleRegistry.get<<Spec>(
   'DatePickerAndroid',
 ): Spec);

--- a/Libraries/Components/DatePickerAndroid/NativeDatePickerAndroid.js
+++ b/Libraries/Components/DatePickerAndroid/NativeDatePickerAndroid.js
@@ -20,6 +20,6 @@ export interface Spec extends TurboModule {
   +open: (options: Object) => Promise<Object>;
 }
 
-export default (TurboModuleRegistry.get<<Spec>(
+export default (TurboModuleRegistry.get<Spec>(
   'DatePickerAndroid',
 ): Spec);

--- a/Libraries/Components/Keyboard/NativeKeyboardObserver.js
+++ b/Libraries/Components/Keyboard/NativeKeyboardObserver.js
@@ -16,4 +16,4 @@ export interface Spec extends TurboModule {
   +removeListeners: (count: number) => void;
 }
 
-export default (TurboModuleRegistry.get<Spec>('KeyboardObserver'): ?Spec);
+export default (TurboModuleRegistry.getOrNull<Spec>('KeyboardObserver'): ?Spec);

--- a/Libraries/Components/Sound/NativeSoundManager.js
+++ b/Libraries/Components/Sound/NativeSoundManager.js
@@ -18,4 +18,4 @@ export interface Spec extends TurboModule {
   +playTouchSound: () => void;
 }
 
-export default (TurboModuleRegistry.get<Spec>('SoundManager'): ?Spec);
+export default (TurboModuleRegistry.getOrNull<Spec>('SoundManager'): ?Spec);

--- a/Libraries/Components/StatusBar/NativeStatusBarManagerAndroid.js
+++ b/Libraries/Components/StatusBar/NativeStatusBarManagerAndroid.js
@@ -28,7 +28,7 @@ export interface Spec extends TurboModule {
   +setHidden: (hidden: boolean) => void;
 }
 
-const NativeModule = TurboModuleRegistry.get<<Spec>('StatusBarManager');
+const NativeModule = TurboModuleRegistry.get<Spec>('StatusBarManager');
 let constants = null;
 
 const NativeStatusBarManager = {

--- a/Libraries/Components/StatusBar/NativeStatusBarManagerAndroid.js
+++ b/Libraries/Components/StatusBar/NativeStatusBarManagerAndroid.js
@@ -28,7 +28,7 @@ export interface Spec extends TurboModule {
   +setHidden: (hidden: boolean) => void;
 }
 
-const NativeModule = TurboModuleRegistry.getEnforcing<Spec>('StatusBarManager');
+const NativeModule = TurboModuleRegistry.get<<Spec>('StatusBarManager');
 let constants = null;
 
 const NativeStatusBarManager = {

--- a/Libraries/Components/StatusBar/NativeStatusBarManagerIOS.js
+++ b/Libraries/Components/StatusBar/NativeStatusBarManagerIOS.js
@@ -36,7 +36,7 @@ export interface Spec extends TurboModule {
   +setHidden: (hidden: boolean, withAnimation: string) => void;
 }
 
-const NativeModule = TurboModuleRegistry.get<<Spec>('StatusBarManager');
+const NativeModule = TurboModuleRegistry.get<Spec>('StatusBarManager');
 let constants = null;
 
 const NativeStatusBarManager = {

--- a/Libraries/Components/StatusBar/NativeStatusBarManagerIOS.js
+++ b/Libraries/Components/StatusBar/NativeStatusBarManagerIOS.js
@@ -36,7 +36,7 @@ export interface Spec extends TurboModule {
   +setHidden: (hidden: boolean, withAnimation: string) => void;
 }
 
-const NativeModule = TurboModuleRegistry.getEnforcing<Spec>('StatusBarManager');
+const NativeModule = TurboModuleRegistry.get<<Spec>('StatusBarManager');
 let constants = null;
 
 const NativeStatusBarManager = {

--- a/Libraries/Components/ToastAndroid/NativeToastAndroid.js
+++ b/Libraries/Components/ToastAndroid/NativeToastAndroid.js
@@ -34,4 +34,4 @@ export interface Spec extends TurboModule {
   ) => void;
 }
 
-export default (TurboModuleRegistry.get<<Spec>('ToastAndroid'): Spec);
+export default (TurboModuleRegistry.get<Spec>('ToastAndroid'): Spec);

--- a/Libraries/Components/ToastAndroid/NativeToastAndroid.js
+++ b/Libraries/Components/ToastAndroid/NativeToastAndroid.js
@@ -34,4 +34,4 @@ export interface Spec extends TurboModule {
   ) => void;
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>('ToastAndroid'): Spec);
+export default (TurboModuleRegistry.get<<Spec>('ToastAndroid'): Spec);

--- a/Libraries/Core/NativeExceptionsManager.js
+++ b/Libraries/Core/NativeExceptionsManager.js
@@ -58,7 +58,7 @@ export interface Spec extends TurboModule {
 const Platform = require('../Utilities/Platform');
 
 const NativeModule =
-  TurboModuleRegistry.get<<Spec>('ExceptionsManager');
+  TurboModuleRegistry.get<Spec>('ExceptionsManager');
 
 const ExceptionsManager = {
   reportFatalException(

--- a/Libraries/Core/NativeExceptionsManager.js
+++ b/Libraries/Core/NativeExceptionsManager.js
@@ -58,7 +58,7 @@ export interface Spec extends TurboModule {
 const Platform = require('../Utilities/Platform');
 
 const NativeModule =
-  TurboModuleRegistry.getEnforcing<Spec>('ExceptionsManager');
+  TurboModuleRegistry.get<<Spec>('ExceptionsManager');
 
 const ExceptionsManager = {
   reportFatalException(

--- a/Libraries/Core/SegmentFetcher/NativeSegmentFetcher.js
+++ b/Libraries/Core/SegmentFetcher/NativeSegmentFetcher.js
@@ -24,4 +24,4 @@ export interface Spec extends TurboModule {
   ) => void;
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>('SegmentFetcher'): Spec);
+export default (TurboModuleRegistry.get<<Spec>('SegmentFetcher'): Spec);

--- a/Libraries/Core/SegmentFetcher/NativeSegmentFetcher.js
+++ b/Libraries/Core/SegmentFetcher/NativeSegmentFetcher.js
@@ -24,4 +24,4 @@ export interface Spec extends TurboModule {
   ) => void;
 }
 
-export default (TurboModuleRegistry.get<<Spec>('SegmentFetcher'): Spec);
+export default (TurboModuleRegistry.get<Spec>('SegmentFetcher'): Spec);

--- a/Libraries/Core/Timers/NativeTiming.js
+++ b/Libraries/Core/Timers/NativeTiming.js
@@ -22,4 +22,4 @@ export interface Spec extends TurboModule {
   +setSendIdleEvents: (sendIdleEvents: boolean) => void;
 }
 
-export default (TurboModuleRegistry.get<Spec>('Timing'): ?Spec);
+export default (TurboModuleRegistry.getOrNull<Spec>('Timing'): ?Spec);

--- a/Libraries/HeapCapture/NativeJSCHeapCapture.js
+++ b/Libraries/HeapCapture/NativeJSCHeapCapture.js
@@ -15,4 +15,4 @@ export interface Spec extends TurboModule {
   +captureComplete: (path: string, error: ?string) => void;
 }
 
-export default (TurboModuleRegistry.get<Spec>('JSCHeapCapture'): ?Spec);
+export default (TurboModuleRegistry.getOrNull<Spec>('JSCHeapCapture'): ?Spec);

--- a/Libraries/Image/NativeImageEditor.js
+++ b/Libraries/Image/NativeImageEditor.js
@@ -46,6 +46,6 @@ export interface Spec extends TurboModule {
   ) => void;
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>(
+export default (TurboModuleRegistry.get<<Spec>(
   'ImageEditingManager',
 ): Spec);

--- a/Libraries/Image/NativeImageEditor.js
+++ b/Libraries/Image/NativeImageEditor.js
@@ -46,6 +46,6 @@ export interface Spec extends TurboModule {
   ) => void;
 }
 
-export default (TurboModuleRegistry.get<<Spec>(
+export default (TurboModuleRegistry.get<Spec>(
   'ImageEditingManager',
 ): Spec);

--- a/Libraries/Image/NativeImageLoaderAndroid.js
+++ b/Libraries/Image/NativeImageLoaderAndroid.js
@@ -33,4 +33,4 @@ export interface Spec extends TurboModule {
   +queryCache: (uris: Array<string>) => Promise<Object>;
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>('ImageLoader'): Spec);
+export default (TurboModuleRegistry.get<<Spec>('ImageLoader'): Spec);

--- a/Libraries/Image/NativeImageLoaderAndroid.js
+++ b/Libraries/Image/NativeImageLoaderAndroid.js
@@ -33,4 +33,4 @@ export interface Spec extends TurboModule {
   +queryCache: (uris: Array<string>) => Promise<Object>;
 }
 
-export default (TurboModuleRegistry.get<<Spec>('ImageLoader'): Spec);
+export default (TurboModuleRegistry.get<Spec>('ImageLoader'): Spec);

--- a/Libraries/Image/NativeImageLoaderIOS.js
+++ b/Libraries/Image/NativeImageLoaderIOS.js
@@ -33,4 +33,4 @@ export interface Spec extends TurboModule {
   +queryCache: (uris: Array<string>) => Promise<Object>;
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>('ImageLoader'): Spec);
+export default (TurboModuleRegistry.get<<Spec>('ImageLoader'): Spec);

--- a/Libraries/Image/NativeImageLoaderIOS.js
+++ b/Libraries/Image/NativeImageLoaderIOS.js
@@ -33,4 +33,4 @@ export interface Spec extends TurboModule {
   +queryCache: (uris: Array<string>) => Promise<Object>;
 }
 
-export default (TurboModuleRegistry.get<<Spec>('ImageLoader'): Spec);
+export default (TurboModuleRegistry.get<Spec>('ImageLoader'): Spec);

--- a/Libraries/Image/NativeImagePickerIOS.js
+++ b/Libraries/Image/NativeImagePickerIOS.js
@@ -35,4 +35,4 @@ export interface Spec extends TurboModule {
   +removePendingVideo: (url: string) => void;
 }
 
-export default (TurboModuleRegistry.get<Spec>('ImagePickerIOS'): ?Spec);
+export default (TurboModuleRegistry.getOrNull<Spec>('ImagePickerIOS'): ?Spec);

--- a/Libraries/Image/NativeImageStoreAndroid.js
+++ b/Libraries/Image/NativeImageStoreAndroid.js
@@ -20,6 +20,6 @@ export interface Spec extends TurboModule {
   ) => void;
 }
 
-export default (TurboModuleRegistry.get<<Spec>(
+export default (TurboModuleRegistry.get<Spec>(
   'ImageStoreManager',
 ): Spec);

--- a/Libraries/Image/NativeImageStoreAndroid.js
+++ b/Libraries/Image/NativeImageStoreAndroid.js
@@ -20,6 +20,6 @@ export interface Spec extends TurboModule {
   ) => void;
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>(
+export default (TurboModuleRegistry.get<<Spec>(
   'ImageStoreManager',
 ): Spec);

--- a/Libraries/Image/NativeImageStoreIOS.js
+++ b/Libraries/Image/NativeImageStoreIOS.js
@@ -27,6 +27,6 @@ export interface Spec extends TurboModule {
   ) => void;
 }
 
-export default (TurboModuleRegistry.get<<Spec>(
+export default (TurboModuleRegistry.get<Spec>(
   'ImageStoreManager',
 ): Spec);

--- a/Libraries/Image/NativeImageStoreIOS.js
+++ b/Libraries/Image/NativeImageStoreIOS.js
@@ -27,6 +27,6 @@ export interface Spec extends TurboModule {
   ) => void;
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>(
+export default (TurboModuleRegistry.get<<Spec>(
   'ImageStoreManager',
 ): Spec);

--- a/Libraries/Interaction/NativeFrameRateLogger.js
+++ b/Libraries/Interaction/NativeFrameRateLogger.js
@@ -21,4 +21,4 @@ export interface Spec extends TurboModule {
   +endScroll: () => void;
 }
 
-export default (TurboModuleRegistry.get<Spec>('FrameRateLogger'): ?Spec);
+export default (TurboModuleRegistry.getOrNull<Spec>('FrameRateLogger'): ?Spec);

--- a/Libraries/Linking/NativeIntentAndroid.js
+++ b/Libraries/Linking/NativeIntentAndroid.js
@@ -26,4 +26,4 @@ export interface Spec extends TurboModule {
   ) => Promise<void>;
 }
 
-export default (TurboModuleRegistry.get<Spec>('IntentAndroid'): ?Spec);
+export default (TurboModuleRegistry.getOrNull<Spec>('IntentAndroid'): ?Spec);

--- a/Libraries/Linking/NativeLinkingManager.js
+++ b/Libraries/Linking/NativeLinkingManager.js
@@ -23,4 +23,4 @@ export interface Spec extends TurboModule {
   +removeListeners: (count: number) => void;
 }
 
-export default (TurboModuleRegistry.get<Spec>('LinkingManager'): ?Spec);
+export default (TurboModuleRegistry.getOrNull<Spec>('LinkingManager'): ?Spec);

--- a/Libraries/Modal/NativeModalManager.js
+++ b/Libraries/Modal/NativeModalManager.js
@@ -17,4 +17,4 @@ export interface Spec extends TurboModule {
   +removeListeners: (count: number) => void;
 }
 
-export default (TurboModuleRegistry.get<Spec>('ModalManager'): ?Spec);
+export default (TurboModuleRegistry.getOrNull<Spec>('ModalManager'): ?Spec);

--- a/Libraries/NativeModules/specs/NativeAnimationsDebugModule.js
+++ b/Libraries/NativeModules/specs/NativeAnimationsDebugModule.js
@@ -16,4 +16,4 @@ export interface Spec extends TurboModule {
   +stopRecordingFps: (animationStopTimeMs: number) => void;
 }
 
-export default (TurboModuleRegistry.get<Spec>('AnimationsDebugModule'): ?Spec);
+export default (TurboModuleRegistry.getOrNull<Spec>('AnimationsDebugModule'): ?Spec);

--- a/Libraries/NativeModules/specs/NativeDevMenu.js
+++ b/Libraries/NativeModules/specs/NativeDevMenu.js
@@ -19,4 +19,4 @@ export interface Spec extends TurboModule {
   +setHotLoadingEnabled: (enabled: boolean) => void;
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>('DevMenu'): Spec);
+export default (TurboModuleRegistry.get<<Spec>('DevMenu'): Spec);

--- a/Libraries/NativeModules/specs/NativeDevMenu.js
+++ b/Libraries/NativeModules/specs/NativeDevMenu.js
@@ -19,4 +19,4 @@ export interface Spec extends TurboModule {
   +setHotLoadingEnabled: (enabled: boolean) => void;
 }
 
-export default (TurboModuleRegistry.get<<Spec>('DevMenu'): Spec);
+export default (TurboModuleRegistry.get<Spec>('DevMenu'): Spec);

--- a/Libraries/NativeModules/specs/NativeDevSettings.js
+++ b/Libraries/NativeModules/specs/NativeDevSettings.js
@@ -29,4 +29,4 @@ export interface Spec extends TurboModule {
   +setIsShakeToShowDevMenuEnabled: (enabled: boolean) => void;
 }
 
-export default (TurboModuleRegistry.get<<Spec>('DevSettings'): Spec);
+export default (TurboModuleRegistry.get<Spec>('DevSettings'): Spec);

--- a/Libraries/NativeModules/specs/NativeDevSettings.js
+++ b/Libraries/NativeModules/specs/NativeDevSettings.js
@@ -29,4 +29,4 @@ export interface Spec extends TurboModule {
   +setIsShakeToShowDevMenuEnabled: (enabled: boolean) => void;
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>('DevSettings'): Spec);
+export default (TurboModuleRegistry.get<<Spec>('DevSettings'): Spec);

--- a/Libraries/NativeModules/specs/NativeDeviceEventManager.js
+++ b/Libraries/NativeModules/specs/NativeDeviceEventManager.js
@@ -15,4 +15,4 @@ export interface Spec extends TurboModule {
   +invokeDefaultBackPressHandler: () => void;
 }
 
-export default (TurboModuleRegistry.get<Spec>('DeviceEventManager'): ?Spec);
+export default (TurboModuleRegistry.getOrNull<Spec>('DeviceEventManager'): ?Spec);

--- a/Libraries/NativeModules/specs/NativeDialogManagerAndroid.js
+++ b/Libraries/NativeModules/specs/NativeDialogManagerAndroid.js
@@ -44,4 +44,4 @@ export interface Spec extends TurboModule {
   ) => void;
 }
 
-export default (TurboModuleRegistry.get<Spec>('DialogManagerAndroid'): ?Spec);
+export default (TurboModuleRegistry.getOrNull<Spec>('DialogManagerAndroid'): ?Spec);

--- a/Libraries/NativeModules/specs/NativeLogBox.js
+++ b/Libraries/NativeModules/specs/NativeLogBox.js
@@ -16,4 +16,4 @@ export interface Spec extends TurboModule {
   +hide: () => void;
 }
 
-export default (TurboModuleRegistry.get<Spec>('LogBox'): ?Spec);
+export default (TurboModuleRegistry.getOrNull<Spec>('LogBox'): ?Spec);

--- a/Libraries/NativeModules/specs/NativeRedBox.js
+++ b/Libraries/NativeModules/specs/NativeRedBox.js
@@ -16,4 +16,4 @@ export interface Spec extends TurboModule {
   +dismiss: () => void;
 }
 
-export default (TurboModuleRegistry.get<Spec>('RedBox'): ?Spec);
+export default (TurboModuleRegistry.getOrNull<Spec>('RedBox'): ?Spec);

--- a/Libraries/NativeModules/specs/NativeSourceCode.js
+++ b/Libraries/NativeModules/specs/NativeSourceCode.js
@@ -17,7 +17,7 @@ export interface Spec extends TurboModule {
   |};
 }
 
-const NativeModule = TurboModuleRegistry.get<<Spec>('SourceCode');
+const NativeModule = TurboModuleRegistry.get<Spec>('SourceCode');
 let constants = null;
 
 const NativeSourceCode = {

--- a/Libraries/NativeModules/specs/NativeSourceCode.js
+++ b/Libraries/NativeModules/specs/NativeSourceCode.js
@@ -17,7 +17,7 @@ export interface Spec extends TurboModule {
   |};
 }
 
-const NativeModule = TurboModuleRegistry.getEnforcing<Spec>('SourceCode');
+const NativeModule = TurboModuleRegistry.get<<Spec>('SourceCode');
 let constants = null;
 
 const NativeSourceCode = {

--- a/Libraries/Network/NativeNetworkingAndroid.js
+++ b/Libraries/Network/NativeNetworkingAndroid.js
@@ -33,4 +33,4 @@ export interface Spec extends TurboModule {
   +removeListeners: (count: number) => void;
 }
 
-export default (TurboModuleRegistry.get<<Spec>('Networking'): Spec);
+export default (TurboModuleRegistry.get<Spec>('Networking'): Spec);

--- a/Libraries/Network/NativeNetworkingAndroid.js
+++ b/Libraries/Network/NativeNetworkingAndroid.js
@@ -33,4 +33,4 @@ export interface Spec extends TurboModule {
   +removeListeners: (count: number) => void;
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>('Networking'): Spec);
+export default (TurboModuleRegistry.get<<Spec>('Networking'): Spec);

--- a/Libraries/Network/NativeNetworkingIOS.js
+++ b/Libraries/Network/NativeNetworkingIOS.js
@@ -33,4 +33,4 @@ export interface Spec extends TurboModule {
   +removeListeners: (count: number) => void;
 }
 
-export default (TurboModuleRegistry.get<<Spec>('Networking'): Spec);
+export default (TurboModuleRegistry.get<Spec>('Networking'): Spec);

--- a/Libraries/Network/NativeNetworkingIOS.js
+++ b/Libraries/Network/NativeNetworkingIOS.js
@@ -33,4 +33,4 @@ export interface Spec extends TurboModule {
   +removeListeners: (count: number) => void;
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>('Networking'): Spec);
+export default (TurboModuleRegistry.get<<Spec>('Networking'): Spec);

--- a/Libraries/Performance/NativeJSCSamplingProfiler.js
+++ b/Libraries/Performance/NativeJSCSamplingProfiler.js
@@ -15,4 +15,4 @@ export interface Spec extends TurboModule {
   +operationComplete: (token: number, result: ?string, error: ?string) => void;
 }
 
-export default (TurboModuleRegistry.get<Spec>('JSCSamplingProfiler'): ?Spec);
+export default (TurboModuleRegistry.getOrNull<Spec>('JSCSamplingProfiler'): ?Spec);

--- a/Libraries/PermissionsAndroid/NativePermissionsAndroid.js
+++ b/Libraries/PermissionsAndroid/NativePermissionsAndroid.js
@@ -64,4 +64,4 @@ export interface Spec extends TurboModule {
   ) => Promise<{[permission: PermissionType]: PermissionStatus, ...}>;
 }
 
-export default (TurboModuleRegistry.get<Spec>('PermissionsAndroid'): ?Spec);
+export default (TurboModuleRegistry.getOrNull<Spec>('PermissionsAndroid'): ?Spec);

--- a/Libraries/PushNotificationIOS/NativePushNotificationManagerIOS.js
+++ b/Libraries/PushNotificationIOS/NativePushNotificationManagerIOS.js
@@ -73,6 +73,6 @@ export interface Spec extends TurboModule {
   +removeListeners: (count: number) => void;
 }
 
-export default (TurboModuleRegistry.get<Spec>(
+export default (TurboModuleRegistry.getOrNull<Spec>(
   'PushNotificationManager',
 ): ?Spec);

--- a/Libraries/ReactNative/NativeHeadlessJsTaskSupport.js
+++ b/Libraries/ReactNative/NativeHeadlessJsTaskSupport.js
@@ -16,4 +16,4 @@ export interface Spec extends TurboModule {
   +notifyTaskRetry: (taskId: number) => Promise<boolean>;
 }
 
-export default (TurboModuleRegistry.get<Spec>('HeadlessJsTaskSupport'): ?Spec);
+export default (TurboModuleRegistry.getOrNull<Spec>('HeadlessJsTaskSupport'): ?Spec);

--- a/Libraries/ReactNative/NativeI18nManager.js
+++ b/Libraries/ReactNative/NativeI18nManager.js
@@ -22,4 +22,4 @@ export interface Spec extends TurboModule {
   swapLeftAndRightInRTL: (flipStyles: boolean) => void;
 }
 
-export default (TurboModuleRegistry.get<Spec>('I18nManager'): ?Spec);
+export default (TurboModuleRegistry.getOrNull<Spec>('I18nManager'): ?Spec);

--- a/Libraries/ReactNative/NativeUIManager.js
+++ b/Libraries/ReactNative/NativeUIManager.js
@@ -117,4 +117,4 @@ export interface Spec extends TurboModule {
   +dismissPopupMenu: () => void;
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>('UIManager'): Spec);
+export default (TurboModuleRegistry.get<<Spec>('UIManager'): Spec);

--- a/Libraries/ReactNative/NativeUIManager.js
+++ b/Libraries/ReactNative/NativeUIManager.js
@@ -117,4 +117,4 @@ export interface Spec extends TurboModule {
   +dismissPopupMenu: () => void;
 }
 
-export default (TurboModuleRegistry.get<<Spec>('UIManager'): Spec);
+export default (TurboModuleRegistry.get<Spec>('UIManager'): Spec);

--- a/Libraries/Settings/NativeSettingsManager.js
+++ b/Libraries/Settings/NativeSettingsManager.js
@@ -19,6 +19,6 @@ export interface Spec extends TurboModule {
   +deleteValues: (values: Array<string>) => void;
 }
 
-export default (TurboModuleRegistry.get<<Spec>(
+export default (TurboModuleRegistry.get<Spec>(
   'SettingsManager',
 ): Spec);

--- a/Libraries/Settings/NativeSettingsManager.js
+++ b/Libraries/Settings/NativeSettingsManager.js
@@ -19,6 +19,6 @@ export interface Spec extends TurboModule {
   +deleteValues: (values: Array<string>) => void;
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>(
+export default (TurboModuleRegistry.get<<Spec>(
   'SettingsManager',
 ): Spec);

--- a/Libraries/Share/NativeShareModule.js
+++ b/Libraries/Share/NativeShareModule.js
@@ -19,4 +19,4 @@ export interface Spec extends TurboModule {
   ) => Promise<{|action: string|}>;
 }
 
-export default (TurboModuleRegistry.get<Spec>('ShareModule'): ?Spec);
+export default (TurboModuleRegistry.getOrNull<Spec>('ShareModule'): ?Spec);

--- a/Libraries/Storage/NativeAsyncLocalStorage.js
+++ b/Libraries/Storage/NativeAsyncLocalStorage.js
@@ -41,4 +41,4 @@ export interface Spec extends TurboModule {
   ) => void;
 }
 
-export default (TurboModuleRegistry.get<Spec>('AsyncLocalStorage'): ?Spec);
+export default (TurboModuleRegistry.getOrNull<Spec>('AsyncLocalStorage'): ?Spec);

--- a/Libraries/Storage/NativeAsyncSQLiteDBStorage.js
+++ b/Libraries/Storage/NativeAsyncSQLiteDBStorage.js
@@ -41,4 +41,4 @@ export interface Spec extends TurboModule {
   ) => void;
 }
 
-export default (TurboModuleRegistry.get<Spec>('AsyncSQLiteDBStorage'): ?Spec);
+export default (TurboModuleRegistry.getOrNull<Spec>('AsyncSQLiteDBStorage'): ?Spec);

--- a/Libraries/TurboModule/TurboModuleRegistry.js
+++ b/Libraries/TurboModule/TurboModuleRegistry.js
@@ -32,16 +32,16 @@ function requireModule<T: TurboModule>(name: string): ?T {
   return null;
 }
 
-export function get<T: TurboModule>(name: string): ?T {
-  return requireModule<T>(name);
-}
-
-export function getEnforcing<T: TurboModule>(name: string): T {
+export function get<T: TurboModule>(name: string): T {
   const module = requireModule<T>(name);
   invariant(
     module != null,
-    `TurboModuleRegistry.getEnforcing(...): '${name}' could not be found. ` +
+    `TurboModuleRegistry.get(...): '${name}' could not be found. ` +
       'Verify that a module by this name is registered in the native binary.',
   );
   return module;
+}
+
+export function getOrNull<T: TurboModule>(name: string): ?T {
+  return requireModule<T>(name);
 }

--- a/Libraries/TurboModule/samples/NativeSampleTurboModule.js
+++ b/Libraries/TurboModule/samples/NativeSampleTurboModule.js
@@ -32,6 +32,6 @@ export interface Spec extends TurboModule {
   +getValueWithPromise: (error: boolean) => Promise<string>;
 }
 
-export default (TurboModuleRegistry.get<<Spec>(
+export default (TurboModuleRegistry.get<Spec>(
   'SampleTurboModule',
 ): Spec);

--- a/Libraries/TurboModule/samples/NativeSampleTurboModule.js
+++ b/Libraries/TurboModule/samples/NativeSampleTurboModule.js
@@ -32,6 +32,6 @@ export interface Spec extends TurboModule {
   +getValueWithPromise: (error: boolean) => Promise<string>;
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>(
+export default (TurboModuleRegistry.get<<Spec>(
   'SampleTurboModule',
 ): Spec);

--- a/Libraries/Utilities/NativeAppearance.js
+++ b/Libraries/Utilities/NativeAppearance.js
@@ -31,4 +31,4 @@ export interface Spec extends TurboModule {
   +removeListeners: (count: number) => void;
 }
 
-export default (TurboModuleRegistry.get<Spec>('Appearance'): ?Spec);
+export default (TurboModuleRegistry.getOrNull<Spec>('Appearance'): ?Spec);

--- a/Libraries/Utilities/NativeDevLoadingView.js
+++ b/Libraries/Utilities/NativeDevLoadingView.js
@@ -20,4 +20,4 @@ export interface Spec extends TurboModule {
   +hide: () => void;
 }
 
-export default (TurboModuleRegistry.get<Spec>('DevLoadingView'): ?Spec);
+export default (TurboModuleRegistry.getOrNull<Spec>('DevLoadingView'): ?Spec);

--- a/Libraries/Utilities/NativeDevSplitBundleLoader.js
+++ b/Libraries/Utilities/NativeDevSplitBundleLoader.js
@@ -15,4 +15,4 @@ export interface Spec extends TurboModule {
   +loadBundle: (bundlePath: string) => Promise<void>;
 }
 
-export default (TurboModuleRegistry.get<Spec>('DevSplitBundleLoader'): ?Spec);
+export default (TurboModuleRegistry.getOrNull<Spec>('DevSplitBundleLoader'): ?Spec);

--- a/Libraries/Utilities/NativeDeviceInfo.js
+++ b/Libraries/Utilities/NativeDeviceInfo.js
@@ -40,7 +40,7 @@ export interface Spec extends TurboModule {
   |};
 }
 
-const NativeModule: Spec = TurboModuleRegistry.get<<Spec>('DeviceInfo');
+const NativeModule: Spec = TurboModuleRegistry.get<Spec>('DeviceInfo');
 let constants = null;
 
 const NativeDeviceInfo = {

--- a/Libraries/Utilities/NativeDeviceInfo.js
+++ b/Libraries/Utilities/NativeDeviceInfo.js
@@ -40,7 +40,7 @@ export interface Spec extends TurboModule {
   |};
 }
 
-const NativeModule: Spec = TurboModuleRegistry.getEnforcing<Spec>('DeviceInfo');
+const NativeModule: Spec = TurboModuleRegistry.get<<Spec>('DeviceInfo');
 let constants = null;
 
 const NativeDeviceInfo = {

--- a/Libraries/Utilities/NativeJSDevSupport.js
+++ b/Libraries/Utilities/NativeJSDevSupport.js
@@ -20,4 +20,4 @@ export interface Spec extends TurboModule {
   +onFailure: (errorCode: number, error: string) => void;
 }
 
-export default (TurboModuleRegistry.get<Spec>('JSDevSupport'): ?Spec);
+export default (TurboModuleRegistry.getOrNull<Spec>('JSDevSupport'): ?Spec);

--- a/Libraries/Utilities/NativePlatformConstantsAndroid.js
+++ b/Libraries/Utilities/NativePlatformConstantsAndroid.js
@@ -33,6 +33,6 @@ export interface Spec extends TurboModule {
   +getAndroidID: () => string;
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>(
+export default (TurboModuleRegistry.get<<Spec>(
   'PlatformConstants',
 ): Spec);

--- a/Libraries/Utilities/NativePlatformConstantsAndroid.js
+++ b/Libraries/Utilities/NativePlatformConstantsAndroid.js
@@ -33,6 +33,6 @@ export interface Spec extends TurboModule {
   +getAndroidID: () => string;
 }
 
-export default (TurboModuleRegistry.get<<Spec>(
+export default (TurboModuleRegistry.get<Spec>(
   'PlatformConstants',
 ): Spec);

--- a/Libraries/Utilities/NativePlatformConstantsIOS.js
+++ b/Libraries/Utilities/NativePlatformConstantsIOS.js
@@ -27,6 +27,6 @@ export interface Spec extends TurboModule {
   |};
 }
 
-export default (TurboModuleRegistry.get<<Spec>(
+export default (TurboModuleRegistry.get<Spec>(
   'PlatformConstants',
 ): Spec);

--- a/Libraries/Utilities/NativePlatformConstantsIOS.js
+++ b/Libraries/Utilities/NativePlatformConstantsIOS.js
@@ -27,6 +27,6 @@ export interface Spec extends TurboModule {
   |};
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>(
+export default (TurboModuleRegistry.get<<Spec>(
   'PlatformConstants',
 ): Spec);

--- a/Libraries/Vibration/NativeVibration.js
+++ b/Libraries/Vibration/NativeVibration.js
@@ -20,4 +20,4 @@ export interface Spec extends TurboModule {
   +cancel: () => void;
 }
 
-export default (TurboModuleRegistry.get<<Spec>('Vibration'): Spec);
+export default (TurboModuleRegistry.get<Spec>('Vibration'): Spec);

--- a/Libraries/Vibration/NativeVibration.js
+++ b/Libraries/Vibration/NativeVibration.js
@@ -20,4 +20,4 @@ export interface Spec extends TurboModule {
   +cancel: () => void;
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>('Vibration'): Spec);
+export default (TurboModuleRegistry.get<<Spec>('Vibration'): Spec);

--- a/Libraries/WebSocket/NativeWebSocketModule.js
+++ b/Libraries/WebSocket/NativeWebSocketModule.js
@@ -28,6 +28,6 @@ export interface Spec extends TurboModule {
   +removeListeners: (count: number) => void;
 }
 
-export default (TurboModuleRegistry.get<<Spec>(
+export default (TurboModuleRegistry.get<Spec>(
   'WebSocketModule',
 ): Spec);

--- a/Libraries/WebSocket/NativeWebSocketModule.js
+++ b/Libraries/WebSocket/NativeWebSocketModule.js
@@ -28,6 +28,6 @@ export interface Spec extends TurboModule {
   +removeListeners: (count: number) => void;
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>(
+export default (TurboModuleRegistry.get<<Spec>(
   'WebSocketModule',
 ): Spec);

--- a/packages/eslint-plugin-specs/__tests__/react-native-modules-test.js
+++ b/packages/eslint-plugin-specs/__tests__/react-native-modules-test.js
@@ -27,7 +27,7 @@ import type {UnsafeObject} from 'react-native/Libraries/Types/CodegenTypes';
 export interface Spec extends TurboModule {
   func1(a: string): UnsafeObject,
 }
-export default TurboModuleRegistry.get<Spec>('XYZ');
+export default TurboModuleRegistry.getOrNull<Spec>('XYZ');
     `,
     filename: `${NATIVE_MODULES_DIR}/NativeXYZ.js`,
   },
@@ -41,7 +41,7 @@ import {TurboModuleRegistry, type TurboModule} from 'react-native';
 export interface Spec extends TurboModule {
   func1(a: string): {||},
 }
-export default TurboModuleRegistry.get<Spec>('XYZ');
+export default TurboModuleRegistry.getOrNull<Spec>('XYZ');
       `,
     filename: `${NATIVE_MODULES_DIR}/XYZ.js`,
     errors: [

--- a/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeArrayTurboModule.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeArrayTurboModule.js
@@ -20,6 +20,6 @@ export interface Spec extends TurboModule {
   +getArrayWithAlias: (a: AnotherArray, b: Array<ArrayType>) => AnotherArray;
 }
 
-export default (TurboModuleRegistry.get<<Spec>(
+export default (TurboModuleRegistry.get<Spec>(
   'SampleTurboModule',
 ): Spec);

--- a/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeArrayTurboModule.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeArrayTurboModule.js
@@ -20,6 +20,6 @@ export interface Spec extends TurboModule {
   +getArrayWithAlias: (a: AnotherArray, b: Array<ArrayType>) => AnotherArray;
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>(
+export default (TurboModuleRegistry.get<<Spec>(
   'SampleTurboModule',
 ): Spec);

--- a/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeBooleanTurboModule.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeBooleanTurboModule.js
@@ -19,6 +19,6 @@ export interface Spec extends TurboModule {
   +getBooleanWithAlias: (arg: Boolean) => AnotherBoolean;
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>(
+export default (TurboModuleRegistry.get<<Spec>(
   'SampleTurboModule',
 ): Spec);

--- a/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeBooleanTurboModule.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeBooleanTurboModule.js
@@ -19,6 +19,6 @@ export interface Spec extends TurboModule {
   +getBooleanWithAlias: (arg: Boolean) => AnotherBoolean;
 }
 
-export default (TurboModuleRegistry.get<<Spec>(
+export default (TurboModuleRegistry.get<Spec>(
   'SampleTurboModule',
 ): Spec);

--- a/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeCallbackTurboModule.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeCallbackTurboModule.js
@@ -19,6 +19,6 @@ export interface Spec extends TurboModule {
   +getValueWithCallbackWithAlias: (c: CB) => void;
 }
 
-export default (TurboModuleRegistry.get<<Spec>(
+export default (TurboModuleRegistry.get<Spec>(
   'SampleTurboModule',
 ): Spec);

--- a/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeCallbackTurboModule.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeCallbackTurboModule.js
@@ -19,6 +19,6 @@ export interface Spec extends TurboModule {
   +getValueWithCallbackWithAlias: (c: CB) => void;
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>(
+export default (TurboModuleRegistry.get<<Spec>(
   'SampleTurboModule',
 ): Spec);

--- a/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeNullableTurboModule.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeNullableTurboModule.js
@@ -20,6 +20,6 @@ export interface Spec extends TurboModule {
   +getValueWithPromise: () => ?Promise<string>;
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>(
+export default (TurboModuleRegistry.get<<Spec>(
   'SampleTurboModule',
 ): Spec);

--- a/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeNullableTurboModule.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeNullableTurboModule.js
@@ -20,6 +20,6 @@ export interface Spec extends TurboModule {
   +getValueWithPromise: () => ?Promise<string>;
 }
 
-export default (TurboModuleRegistry.get<<Spec>(
+export default (TurboModuleRegistry.get<Spec>(
   'SampleTurboModule',
 ): Spec);

--- a/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeNumberTurboModule.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeNumberTurboModule.js
@@ -19,6 +19,6 @@ export interface Spec extends TurboModule {
   +getNumberWithAlias: (arg: Number) => AnotherNumber;
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>(
+export default (TurboModuleRegistry.get<<Spec>(
   'SampleTurboModule',
 ): Spec);

--- a/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeNumberTurboModule.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeNumberTurboModule.js
@@ -19,6 +19,6 @@ export interface Spec extends TurboModule {
   +getNumberWithAlias: (arg: Number) => AnotherNumber;
 }
 
-export default (TurboModuleRegistry.get<<Spec>(
+export default (TurboModuleRegistry.get<Spec>(
   'SampleTurboModule',
 ): Spec);

--- a/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeObjectTurboModule.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeObjectTurboModule.js
@@ -58,6 +58,6 @@ export interface Spec extends TurboModule {
   |};
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>(
+export default (TurboModuleRegistry.get<<Spec>(
   'SampleTurboModule',
 ): Spec);

--- a/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeObjectTurboModule.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeObjectTurboModule.js
@@ -58,6 +58,6 @@ export interface Spec extends TurboModule {
   |};
 }
 
-export default (TurboModuleRegistry.get<<Spec>(
+export default (TurboModuleRegistry.get<Spec>(
   'SampleTurboModule',
 ): Spec);

--- a/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeOptionalObjectTurboModule.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeOptionalObjectTurboModule.js
@@ -32,6 +32,6 @@ export interface Spec extends TurboModule {
   |};
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>(
+export default (TurboModuleRegistry.get<<Spec>(
   'SampleTurboModule',
 ): Spec);

--- a/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeOptionalObjectTurboModule.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeOptionalObjectTurboModule.js
@@ -32,6 +32,6 @@ export interface Spec extends TurboModule {
   |};
 }
 
-export default (TurboModuleRegistry.get<<Spec>(
+export default (TurboModuleRegistry.get<Spec>(
   'SampleTurboModule',
 ): Spec);

--- a/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativePromiseTurboModule.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativePromiseTurboModule.js
@@ -19,6 +19,6 @@ export interface Spec extends TurboModule {
   +getValueWithPromiseWithAlias: (arg: String) => AnotherPromise;
 }
 
-export default (TurboModuleRegistry.get<<Spec>(
+export default (TurboModuleRegistry.get<Spec>(
   'SampleTurboModule',
 ): Spec);

--- a/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativePromiseTurboModule.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativePromiseTurboModule.js
@@ -19,6 +19,6 @@ export interface Spec extends TurboModule {
   +getValueWithPromiseWithAlias: (arg: String) => AnotherPromise;
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>(
+export default (TurboModuleRegistry.get<<Spec>(
   'SampleTurboModule',
 ): Spec);

--- a/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeSampleTurboModule.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeSampleTurboModule.js
@@ -43,6 +43,6 @@ export interface Spec extends TurboModule {
   +getValueWithPromise: (error: boolean) => Promise<string>;
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>(
+export default (TurboModuleRegistry.get<<Spec>(
   'SampleTurboModule',
 ): Spec);

--- a/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeSampleTurboModule.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeSampleTurboModule.js
@@ -43,6 +43,6 @@ export interface Spec extends TurboModule {
   +getValueWithPromise: (error: boolean) => Promise<string>;
 }
 
-export default (TurboModuleRegistry.get<<Spec>(
+export default (TurboModuleRegistry.get<Spec>(
   'SampleTurboModule',
 ): Spec);

--- a/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeSampleTurboModuleArrays.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeSampleTurboModuleArrays.js
@@ -44,6 +44,6 @@ export interface Spec extends TurboModule {
   +getValueWithPromise: (error: Array<boolean>) => Promise<Array<string>>;
 }
 
-export default (TurboModuleRegistry.get<<Spec>(
+export default (TurboModuleRegistry.get<Spec>(
   'SampleTurboModuleArrays',
 ): Spec);

--- a/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeSampleTurboModuleArrays.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeSampleTurboModuleArrays.js
@@ -44,6 +44,6 @@ export interface Spec extends TurboModule {
   +getValueWithPromise: (error: Array<boolean>) => Promise<Array<string>>;
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>(
+export default (TurboModuleRegistry.get<<Spec>(
   'SampleTurboModuleArrays',
 ): Spec);

--- a/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeSampleTurboModuleNullable.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeSampleTurboModuleNullable.js
@@ -39,6 +39,6 @@ export interface Spec extends TurboModule {
   +getValueWithPromise: (error: ?boolean) => ?Promise<string>;
 }
 
-export default (TurboModuleRegistry.get<<Spec>(
+export default (TurboModuleRegistry.get<Spec>(
   'SampleTurboModuleNullable',
 ): Spec);

--- a/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeSampleTurboModuleNullable.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeSampleTurboModuleNullable.js
@@ -39,6 +39,6 @@ export interface Spec extends TurboModule {
   +getValueWithPromise: (error: ?boolean) => ?Promise<string>;
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>(
+export default (TurboModuleRegistry.get<<Spec>(
   'SampleTurboModuleNullable',
 ): Spec);

--- a/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeSampleTurboModuleNullableAndOptional.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeSampleTurboModuleNullableAndOptional.js
@@ -39,6 +39,6 @@ export interface Spec extends TurboModule {
   +getValueWithPromise?: (error?: ?boolean) => ?Promise<string>;
 }
 
-export default (TurboModuleRegistry.get<<Spec>(
+export default (TurboModuleRegistry.get<Spec>(
   'SampleTurboModuleNullableAndOptional',
 ): Spec);

--- a/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeSampleTurboModuleNullableAndOptional.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeSampleTurboModuleNullableAndOptional.js
@@ -39,6 +39,6 @@ export interface Spec extends TurboModule {
   +getValueWithPromise?: (error?: ?boolean) => ?Promise<string>;
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>(
+export default (TurboModuleRegistry.get<<Spec>(
   'SampleTurboModuleNullableAndOptional',
 ): Spec);

--- a/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeSampleTurboModuleOptional.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeSampleTurboModuleOptional.js
@@ -39,6 +39,6 @@ export interface Spec extends TurboModule {
   +getValueWithPromise?: (error?: boolean) => Promise<string>;
 }
 
-export default (TurboModuleRegistry.get<<Spec>(
+export default (TurboModuleRegistry.get<Spec>(
   'SampleTurboModuleOptional',
 ): Spec);

--- a/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeSampleTurboModuleOptional.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeSampleTurboModuleOptional.js
@@ -39,6 +39,6 @@ export interface Spec extends TurboModule {
   +getValueWithPromise?: (error?: boolean) => Promise<string>;
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>(
+export default (TurboModuleRegistry.get<<Spec>(
   'SampleTurboModuleOptional',
 ): Spec);

--- a/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeStringTurboModule.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeStringTurboModule.js
@@ -19,6 +19,6 @@ export interface Spec extends TurboModule {
   +getStringWithAlias: (arg: String) => AnotherString;
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>(
+export default (TurboModuleRegistry.get<<Spec>(
   'SampleTurboModule',
 ): Spec);

--- a/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeStringTurboModule.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeStringTurboModule.js
@@ -19,6 +19,6 @@ export interface Spec extends TurboModule {
   +getStringWithAlias: (arg: String) => AnotherString;
 }
 
-export default (TurboModuleRegistry.get<<Spec>(
+export default (TurboModuleRegistry.get<Spec>(
   'SampleTurboModule',
 ): Spec);

--- a/packages/react-native-codegen/src/parsers/flow/modules/__test_fixtures__/failures.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__test_fixtures__/failures.js
@@ -32,7 +32,7 @@ export interface Spec extends TurboModule {
   getString: (arg: string) => Array;
 }
 
-export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<Spec>('SampleTurboModule');
 
 `;
 
@@ -56,7 +56,7 @@ export interface Spec extends TurboModule {
   getString: (arg : Array) => string;
 }
 
-export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<Spec>('SampleTurboModule');
 
 `;
 
@@ -80,7 +80,7 @@ export interface Spec extends TurboModule {
   getString: (arg : $ReadOnly<>) => string;
 }
 
-export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<Spec>('SampleTurboModule');
 
 `;
 
@@ -108,7 +108,7 @@ export interface Spec extends TurboModule {
 
 }
 
-export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<Spec>('SampleTurboModule');
 
 `;
 
@@ -133,7 +133,7 @@ export interface Spec extends TurboModule {
 
 }
 
-export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<Spec>('SampleTurboModule');
 
 `;
 
@@ -158,7 +158,7 @@ export interface Spec extends TurboModule {
 
 }
 
-export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<Spec>('SampleTurboModule');
 
 `;
 
@@ -179,8 +179,8 @@ import type {TurboModule} from '../RCTExport';
 import * as TurboModuleRegistry from '../TurboModuleRegistry';
 
 
-export default TurboModuleRegistry.get<<Spec1>('SampleTurboModule1');
-export default TurboModuleRegistry.get<<Spec2>('SampleTurboModule2');
+export default TurboModuleRegistry.get<Spec1>('SampleTurboModule1');
+export default TurboModuleRegistry.get<Spec2>('SampleTurboModule2');
 
 `;
 

--- a/packages/react-native-codegen/src/parsers/flow/modules/__test_fixtures__/failures.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__test_fixtures__/failures.js
@@ -32,7 +32,7 @@ export interface Spec extends TurboModule {
   getString: (arg: string) => Array;
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
 
 `;
 
@@ -56,7 +56,7 @@ export interface Spec extends TurboModule {
   getString: (arg : Array) => string;
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
 
 `;
 
@@ -80,7 +80,7 @@ export interface Spec extends TurboModule {
   getString: (arg : $ReadOnly<>) => string;
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
 
 `;
 
@@ -108,7 +108,7 @@ export interface Spec extends TurboModule {
 
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
 
 `;
 
@@ -133,7 +133,7 @@ export interface Spec extends TurboModule {
 
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
 
 `;
 
@@ -158,7 +158,7 @@ export interface Spec extends TurboModule {
 
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
 
 `;
 
@@ -179,8 +179,8 @@ import type {TurboModule} from '../RCTExport';
 import * as TurboModuleRegistry from '../TurboModuleRegistry';
 
 
-export default TurboModuleRegistry.getEnforcing<Spec1>('SampleTurboModule1');
-export default TurboModuleRegistry.getEnforcing<Spec2>('SampleTurboModule2');
+export default TurboModuleRegistry.get<<Spec1>('SampleTurboModule1');
+export default TurboModuleRegistry.get<<Spec2>('SampleTurboModule2');
 
 `;
 

--- a/packages/react-native-codegen/src/parsers/flow/modules/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__test_fixtures__/fixtures.js
@@ -32,7 +32,7 @@ export interface Spec extends TurboModule {
   // no methods
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
 
 `;
 
@@ -67,7 +67,7 @@ export interface Spec extends TurboModule {
     const1: {const1: boolean},
   |}>;
 }
-export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
 
 `;
 
@@ -103,7 +103,7 @@ export interface Spec extends TurboModule {
   |};
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
 
 `;
 
@@ -130,7 +130,7 @@ export interface Spec extends TurboModule {
   +passStringish: (arg: Stringish) => void;
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
 
 `;
 
@@ -171,7 +171,7 @@ export interface Spec extends TurboModule {
   +getStringFromAlias: (a: ObjectAlias) => string;
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
 
 `;
 
@@ -206,7 +206,7 @@ export interface Spec extends TurboModule {
   foo2: (x: Foo) => void;
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
 
 `;
 
@@ -232,7 +232,7 @@ export interface Spec extends TurboModule {
   +getFloat: (arg: Float) => Float;
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
 `;
 
 const NATIVE_MODULE_WITH_SIMPLE_OBJECT = `
@@ -255,7 +255,7 @@ export interface Spec extends TurboModule {
   +getObject: (o: Object) => Object,
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
 
 `;
 
@@ -280,7 +280,7 @@ export interface Spec extends TurboModule {
   +getUnsafeObject: (o: UnsafeObject) => UnsafeObject,
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
 
 `;
 
@@ -304,7 +304,7 @@ export interface Spec extends TurboModule {
   +getRootTag: (rootTag: RootTag) => RootTag,
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
 
 `;
 
@@ -329,7 +329,7 @@ export interface Spec extends TurboModule {
   +voidFunc: (arg: ?string) => void;
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
 
 `;
 
@@ -354,7 +354,7 @@ export interface Spec extends TurboModule {
   +getArray: (arg: $ReadOnlyArray<string>) => $ReadOnlyArray<string>;
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
 
 `;
 
@@ -391,7 +391,7 @@ export interface Spec extends TurboModule {
   |}>;
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
 
 `;
 
@@ -415,7 +415,7 @@ export interface Spec extends TurboModule {
   +getArray: (arg: Array<[string, string]>) => Array<string | number | boolean>;
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
 
 `;
 
@@ -441,7 +441,7 @@ export interface Spec extends TurboModule {
   +getArray: (arg: Array<SomeString>) => Array<string>;
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
 
 `;
 
@@ -465,7 +465,7 @@ export interface Spec extends TurboModule {
   +getArray: (arg: Array<Array<Array<Array<Array<string>>>>>) => Array<Array<Array<string>>>;
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
 
 `;
 
@@ -494,7 +494,7 @@ export interface Spec extends TurboModule {
   +getValueWithPromiseObjDefinedSomewhereElse: () => Promise<SomeObj>;
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
 
 `;
 
@@ -521,7 +521,7 @@ export interface Spec extends TurboModule {
   ) => void;
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
 
 `;
 
@@ -545,7 +545,7 @@ export interface Spec extends TurboModule {
   // no methods
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModuleAndroid');
+export default TurboModuleRegistry.get<<Spec>('SampleTurboModuleAndroid');
 
 `;
 
@@ -569,7 +569,7 @@ export interface Spec extends TurboModule {
   // no methods
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModuleIOS');
+export default TurboModuleRegistry.get<<Spec>('SampleTurboModuleIOS');
 
 `;
 
@@ -593,7 +593,7 @@ export interface Spec extends TurboModule {
   +getCallback: () => () => void;
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModuleCxx');
+export default TurboModuleRegistry.get<<Spec>('SampleTurboModuleCxx');
 
 `;
 

--- a/packages/react-native-codegen/src/parsers/flow/modules/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__test_fixtures__/fixtures.js
@@ -32,7 +32,7 @@ export interface Spec extends TurboModule {
   // no methods
 }
 
-export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<Spec>('SampleTurboModule');
 
 `;
 
@@ -67,7 +67,7 @@ export interface Spec extends TurboModule {
     const1: {const1: boolean},
   |}>;
 }
-export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<Spec>('SampleTurboModule');
 
 `;
 
@@ -103,7 +103,7 @@ export interface Spec extends TurboModule {
   |};
 }
 
-export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<Spec>('SampleTurboModule');
 
 `;
 
@@ -130,7 +130,7 @@ export interface Spec extends TurboModule {
   +passStringish: (arg: Stringish) => void;
 }
 
-export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<Spec>('SampleTurboModule');
 
 `;
 
@@ -171,7 +171,7 @@ export interface Spec extends TurboModule {
   +getStringFromAlias: (a: ObjectAlias) => string;
 }
 
-export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<Spec>('SampleTurboModule');
 
 `;
 
@@ -206,7 +206,7 @@ export interface Spec extends TurboModule {
   foo2: (x: Foo) => void;
 }
 
-export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<Spec>('SampleTurboModule');
 
 `;
 
@@ -232,7 +232,7 @@ export interface Spec extends TurboModule {
   +getFloat: (arg: Float) => Float;
 }
 
-export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<Spec>('SampleTurboModule');
 `;
 
 const NATIVE_MODULE_WITH_SIMPLE_OBJECT = `
@@ -255,7 +255,7 @@ export interface Spec extends TurboModule {
   +getObject: (o: Object) => Object,
 }
 
-export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<Spec>('SampleTurboModule');
 
 `;
 
@@ -280,7 +280,7 @@ export interface Spec extends TurboModule {
   +getUnsafeObject: (o: UnsafeObject) => UnsafeObject,
 }
 
-export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<Spec>('SampleTurboModule');
 
 `;
 
@@ -304,7 +304,7 @@ export interface Spec extends TurboModule {
   +getRootTag: (rootTag: RootTag) => RootTag,
 }
 
-export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<Spec>('SampleTurboModule');
 
 `;
 
@@ -329,7 +329,7 @@ export interface Spec extends TurboModule {
   +voidFunc: (arg: ?string) => void;
 }
 
-export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<Spec>('SampleTurboModule');
 
 `;
 
@@ -354,7 +354,7 @@ export interface Spec extends TurboModule {
   +getArray: (arg: $ReadOnlyArray<string>) => $ReadOnlyArray<string>;
 }
 
-export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<Spec>('SampleTurboModule');
 
 `;
 
@@ -391,7 +391,7 @@ export interface Spec extends TurboModule {
   |}>;
 }
 
-export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<Spec>('SampleTurboModule');
 
 `;
 
@@ -415,7 +415,7 @@ export interface Spec extends TurboModule {
   +getArray: (arg: Array<[string, string]>) => Array<string | number | boolean>;
 }
 
-export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<Spec>('SampleTurboModule');
 
 `;
 
@@ -441,7 +441,7 @@ export interface Spec extends TurboModule {
   +getArray: (arg: Array<SomeString>) => Array<string>;
 }
 
-export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<Spec>('SampleTurboModule');
 
 `;
 
@@ -465,7 +465,7 @@ export interface Spec extends TurboModule {
   +getArray: (arg: Array<Array<Array<Array<Array<string>>>>>) => Array<Array<Array<string>>>;
 }
 
-export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<Spec>('SampleTurboModule');
 
 `;
 
@@ -494,7 +494,7 @@ export interface Spec extends TurboModule {
   +getValueWithPromiseObjDefinedSomewhereElse: () => Promise<SomeObj>;
 }
 
-export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<Spec>('SampleTurboModule');
 
 `;
 
@@ -521,7 +521,7 @@ export interface Spec extends TurboModule {
   ) => void;
 }
 
-export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<Spec>('SampleTurboModule');
 
 `;
 
@@ -545,7 +545,7 @@ export interface Spec extends TurboModule {
   // no methods
 }
 
-export default TurboModuleRegistry.get<<Spec>('SampleTurboModuleAndroid');
+export default TurboModuleRegistry.get<Spec>('SampleTurboModuleAndroid');
 
 `;
 
@@ -569,7 +569,7 @@ export interface Spec extends TurboModule {
   // no methods
 }
 
-export default TurboModuleRegistry.get<<Spec>('SampleTurboModuleIOS');
+export default TurboModuleRegistry.get<Spec>('SampleTurboModuleIOS');
 
 `;
 
@@ -593,7 +593,7 @@ export interface Spec extends TurboModule {
   +getCallback: () => () => void;
 }
 
-export default TurboModuleRegistry.get<<Spec>('SampleTurboModuleCxx');
+export default TurboModuleRegistry.get<Spec>('SampleTurboModuleCxx');
 
 `;
 

--- a/packages/react-native-codegen/src/parsers/flow/modules/__tests__/module-parser-e2e-test.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__tests__/module-parser-e2e-test.js
@@ -84,7 +84,7 @@ describe('Flow Module Parser', () => {
           export interface Spec extends TurboModule {
             +useArg(arg: any): void;
           }
-          export default TurboModuleRegistry.get<Spec>('Foo');
+          export default TurboModuleRegistry.getOrNull<Spec>('Foo');
         `);
 
       expect(parser).toThrow(UnsupportedFlowTypeAnnotationParserError);
@@ -98,7 +98,7 @@ describe('Flow Module Parser', () => {
           export interface Spec extends TurboModule {
             +useArg(boolean): void;
           }
-          export default TurboModuleRegistry.get<Spec>('Foo');
+          export default TurboModuleRegistry.getOrNull<Spec>('Foo');
         `);
 
       expect(parser).toThrow(UnnamedFunctionParamParserError);
@@ -145,7 +145,7 @@ describe('Flow Module Parser', () => {
           export interface Spec extends TurboModule {
             +useArg(${annotateArg(paramName, paramType)}): void;
           }
-          export default TurboModuleRegistry.get<Spec>('Foo');
+          export default TurboModuleRegistry.getOrNull<Spec>('Foo');
         `);
 
         expect(module.spec.properties[0]).not.toBe(null);
@@ -356,7 +356,7 @@ describe('Flow Module Parser', () => {
               export interface Spec extends TurboModule {
                 +useArg(${annotateArg('arg', 'AnimalPointer')}): void;
               }
-              export default TurboModuleRegistry.get<Spec>('Foo');
+              export default TurboModuleRegistry.getOrNull<Spec>('Foo');
             `);
 
             expect(module.spec.properties[0]).not.toBe(null);
@@ -693,7 +693,7 @@ describe('Flow Module Parser', () => {
         export interface Spec extends TurboModule {
           +useArg(): void;
         }
-        export default TurboModuleRegistry.get<Spec>('Foo');
+        export default TurboModuleRegistry.getOrNull<Spec>('Foo');
       `);
 
       expect(module.spec.properties[0]).not.toBe(null);
@@ -727,7 +727,7 @@ describe('Flow Module Parser', () => {
           export interface Spec extends TurboModule {
             +useArg(): ${annotateRet(flowType)};
           }
-          export default TurboModuleRegistry.get<Spec>('Foo');
+          export default TurboModuleRegistry.getOrNull<Spec>('Foo');
         `);
 
         expect(module.spec.properties[0]).not.toBe(null);

--- a/packages/react-native-codegen/src/parsers/flow/modules/errors.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/errors.js
@@ -232,7 +232,7 @@ class UnusedModuleFlowInterfaceParserError extends ParserError {
     super(
       hasteModuleName,
       flowInterface,
-      "Unused NativeModule spec. Please load the NativeModule by calling TurboModuleRegistry.get<Spec>('<moduleName>').",
+      "Unused NativeModule spec. Please load the NativeModule by calling TurboModuleRegistry.getOrNull<Spec>('<moduleName>').",
     );
   }
 }

--- a/packages/react-native-codegen/src/parsers/typescript/modules/__test_fixtures__/failures.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/__test_fixtures__/failures.js
@@ -27,7 +27,7 @@ export interface Spec extends TurboModule {
   getString: (arg: string) => Array;
 }
 
-export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<Spec>('SampleTurboModule');
 `;
 
 const NATIVE_MODULES_WITH_ARRAY_WITH_NO_TYPE_FOR_CONTENT_AS_PARAM = `
@@ -47,7 +47,7 @@ export interface Spec extends TurboModule {
   getString: (arg: Array) => string;
 }
 
-export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<Spec>('SampleTurboModule');
 `;
 
 const NATIVE_MODULES_WITH_NOT_ONLY_METHODS = `
@@ -71,7 +71,7 @@ export interface Spec extends TurboModule {
 
 }
 
-export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<Spec>('SampleTurboModule');
 
 `;
 
@@ -92,7 +92,7 @@ export interface Spec extends TurboModule {
   readonly getBool: (boolean) => boolean;
 }
 
-export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<Spec>('SampleTurboModule');
 `;
 
 const NATIVE_MODULES_WITH_PROMISE_WITHOUT_TYPE = `
@@ -113,7 +113,7 @@ export interface Spec extends TurboModule {
 
 }
 
-export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<Spec>('SampleTurboModule');
 
 `;
 
@@ -130,8 +130,8 @@ const TWO_NATIVE_MODULES_EXPORTED_WITH_DEFAULT = `
 import type {TurboModule} from '../RCTExport';
 import * as TurboModuleRegistry from '../TurboModuleRegistry';
 
-export default TurboModuleRegistry.get<<Spec1>('SampleTurboModule1');
-export default TurboModuleRegistry.get<<Spec2>('SampleTurboModule2');
+export default TurboModuleRegistry.get<Spec1>('SampleTurboModule1');
+export default TurboModuleRegistry.get<Spec2>('SampleTurboModule2');
 `;
 
 const TWO_NATIVE_EXTENDING_TURBO_MODULE = `

--- a/packages/react-native-codegen/src/parsers/typescript/modules/__test_fixtures__/failures.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/__test_fixtures__/failures.js
@@ -27,7 +27,7 @@ export interface Spec extends TurboModule {
   getString: (arg: string) => Array;
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
 `;
 
 const NATIVE_MODULES_WITH_ARRAY_WITH_NO_TYPE_FOR_CONTENT_AS_PARAM = `
@@ -47,7 +47,7 @@ export interface Spec extends TurboModule {
   getString: (arg: Array) => string;
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
 `;
 
 const NATIVE_MODULES_WITH_NOT_ONLY_METHODS = `
@@ -71,7 +71,7 @@ export interface Spec extends TurboModule {
 
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
 
 `;
 
@@ -92,7 +92,7 @@ export interface Spec extends TurboModule {
   readonly getBool: (boolean) => boolean;
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
 `;
 
 const NATIVE_MODULES_WITH_PROMISE_WITHOUT_TYPE = `
@@ -113,7 +113,7 @@ export interface Spec extends TurboModule {
 
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
 
 `;
 
@@ -130,8 +130,8 @@ const TWO_NATIVE_MODULES_EXPORTED_WITH_DEFAULT = `
 import type {TurboModule} from '../RCTExport';
 import * as TurboModuleRegistry from '../TurboModuleRegistry';
 
-export default TurboModuleRegistry.getEnforcing<Spec1>('SampleTurboModule1');
-export default TurboModuleRegistry.getEnforcing<Spec2>('SampleTurboModule2');
+export default TurboModuleRegistry.get<<Spec1>('SampleTurboModule1');
+export default TurboModuleRegistry.get<<Spec2>('SampleTurboModule2');
 `;
 
 const TWO_NATIVE_EXTENDING_TURBO_MODULE = `

--- a/packages/react-native-codegen/src/parsers/typescript/modules/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/__test_fixtures__/fixtures.js
@@ -27,7 +27,7 @@ export interface Spec extends TurboModule {
 
 }
 
-export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<Spec>('SampleTurboModule');
 `;
 
 const NATIVE_MODULE_WITH_COMPLEX_OBJECTS = `
@@ -59,7 +59,7 @@ export interface Spec extends TurboModule {
   }>;
 }
 
-export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<Spec>('SampleTurboModule');
 `;
 
 const NATIVE_MODULE_WITH_COMPLEX_OBJECTS_WITH_NULLABLE_KEY = `
@@ -93,7 +93,7 @@ export interface Spec extends TurboModule {
   };
 }
 
-export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<Spec>('SampleTurboModule');
 `;
 
 const NATIVE_MODULE_WITH_BASIC_PARAM_TYPES = `
@@ -117,7 +117,7 @@ export interface Spec extends TurboModule {
   readonly passStringish: (arg: Stringish) => void;
 }
 
-export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<Spec>('SampleTurboModule');
 
 `;
 
@@ -155,7 +155,7 @@ export interface Spec extends TurboModule {
   readonly getStringFromAlias: (a: ObjectAlias) => string;
 }
 
-export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<Spec>('SampleTurboModule');
 `;
 
 const NATIVE_MODULE_WITH_NESTED_ALIASES = `
@@ -187,7 +187,7 @@ export interface Spec extends TurboModule {
   foo2: (x: Foo) => void;
 }
 
-export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<Spec>('SampleTurboModule');
 
 `;
 
@@ -210,7 +210,7 @@ export interface Spec extends TurboModule {
   readonly getFloat: (arg: Float) => Float;
 }
 
-export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<Spec>('SampleTurboModule');
 `;
 
 const NATIVE_MODULE_WITH_SIMPLE_OBJECT = `
@@ -230,7 +230,7 @@ export interface Spec extends TurboModule {
   readonly getObject: (o: Object) => Object,
 }
 
-export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<Spec>('SampleTurboModule');
 `;
 
 const NATIVE_MODULE_WITH_UNSAFE_OBJECT = `
@@ -251,7 +251,7 @@ export interface Spec extends TurboModule {
   readonly getUnsafeObject: (o: UnsafeObject) => UnsafeObject;
 }
 
-export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<Spec>('SampleTurboModule');
 `;
 
 const NATIVE_MODULE_WITH_ROOT_TAG = `
@@ -274,7 +274,7 @@ export interface Spec extends TurboModule {
   readonly getRootTag: (rootTag: RootTag) => RootTag;
 }
 
-export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<Spec>('SampleTurboModule');
 `;
 
 const NATIVE_MODULE_WITH_NULLABLE_PARAM = `
@@ -294,7 +294,7 @@ export interface Spec extends TurboModule {
   readonly voidFunc: (arg: string | null | void) => void;
 }
 
-export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<Spec>('SampleTurboModule');
 `;
 
 const NATIVE_MODULE_WITH_BASIC_ARRAY = `
@@ -315,7 +315,7 @@ export interface Spec extends TurboModule {
   readonly getArray: (arg: ReadonlyArray<string>) => ReadonlyArray<string>;
 }
 
-export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<Spec>('SampleTurboModule');
 `;
 
 const NATIVE_MODULE_WITH_OBJECT_WITH_OBJECT_DEFINED_IN_FILE_AS_PROPERTY = `
@@ -348,7 +348,7 @@ export interface Spec extends TurboModule {
   }>;
 }
 
-export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<Spec>('SampleTurboModule');
 `;
 
 const NATIVE_MODULE_WITH_ARRAY_WITH_UNION_AND_TOUPLE = `
@@ -370,7 +370,7 @@ export interface Spec extends TurboModule {
   ) => Array<string | number | boolean>;
 }
 
-export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<Spec>('SampleTurboModule');
 `;
 
 const NATIVE_MODULE_WITH_ARRAY_WITH_ALIAS = `
@@ -392,7 +392,7 @@ export interface Spec extends TurboModule {
   readonly getArray: (arg: Array<SomeString>) => Array<string>;
 }
 
-export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<Spec>('SampleTurboModule');
 `;
 
 const NATIVE_MODULE_WITH_COMPLEX_ARRAY = `
@@ -414,7 +414,7 @@ export interface Spec extends TurboModule {
   ) => Array<Array<Array<string>>>;
 }
 
-export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<Spec>('SampleTurboModule');
 `;
 
 const NATIVE_MODULE_WITH_PROMISE = `
@@ -439,7 +439,7 @@ export interface Spec extends TurboModule {
   readonly getValueWithPromiseObjDefinedSomewhereElse: () => Promise<SomeObj>;
 }
 
-export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<Spec>('SampleTurboModule');
 `;
 
 const NATIVE_MODULE_WITH_CALLBACK = `
@@ -461,7 +461,7 @@ export interface Spec extends TurboModule {
   ) => void;
 }
 
-export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<Spec>('SampleTurboModule');
 `;
 
 const ANDROID_ONLY_NATIVE_MODULE = `
@@ -479,7 +479,7 @@ import * as TurboModuleRegistry from 'react-native/Libraries/TurboModule/TurboMo
 
 export interface Spec extends TurboModule {}
 
-export default TurboModuleRegistry.get<<Spec>(
+export default TurboModuleRegistry.get<Spec>(
   'SampleTurboModuleAndroid',
 );
 `;
@@ -499,7 +499,7 @@ import * as TurboModuleRegistry from 'react-native/Libraries/TurboModule/TurboMo
 
 export interface Spec extends TurboModule {}
 
-export default TurboModuleRegistry.get<<Spec>(
+export default TurboModuleRegistry.get<Spec>(
   'SampleTurboModuleIOS',
 );
 `;
@@ -521,7 +521,7 @@ export interface Spec extends TurboModule {
   readonly getCallback: () => () => void;
 }
 
-export default TurboModuleRegistry.get<<Spec>(
+export default TurboModuleRegistry.get<Spec>(
   'SampleTurboModuleCxx',
 );
 `;

--- a/packages/react-native-codegen/src/parsers/typescript/modules/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/__test_fixtures__/fixtures.js
@@ -27,7 +27,7 @@ export interface Spec extends TurboModule {
 
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
 `;
 
 const NATIVE_MODULE_WITH_COMPLEX_OBJECTS = `
@@ -59,7 +59,7 @@ export interface Spec extends TurboModule {
   }>;
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
 `;
 
 const NATIVE_MODULE_WITH_COMPLEX_OBJECTS_WITH_NULLABLE_KEY = `
@@ -93,7 +93,7 @@ export interface Spec extends TurboModule {
   };
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
 `;
 
 const NATIVE_MODULE_WITH_BASIC_PARAM_TYPES = `
@@ -117,7 +117,7 @@ export interface Spec extends TurboModule {
   readonly passStringish: (arg: Stringish) => void;
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
 
 `;
 
@@ -155,7 +155,7 @@ export interface Spec extends TurboModule {
   readonly getStringFromAlias: (a: ObjectAlias) => string;
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
 `;
 
 const NATIVE_MODULE_WITH_NESTED_ALIASES = `
@@ -187,7 +187,7 @@ export interface Spec extends TurboModule {
   foo2: (x: Foo) => void;
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
 
 `;
 
@@ -210,7 +210,7 @@ export interface Spec extends TurboModule {
   readonly getFloat: (arg: Float) => Float;
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
 `;
 
 const NATIVE_MODULE_WITH_SIMPLE_OBJECT = `
@@ -230,7 +230,7 @@ export interface Spec extends TurboModule {
   readonly getObject: (o: Object) => Object,
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
 `;
 
 const NATIVE_MODULE_WITH_UNSAFE_OBJECT = `
@@ -251,7 +251,7 @@ export interface Spec extends TurboModule {
   readonly getUnsafeObject: (o: UnsafeObject) => UnsafeObject;
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
 `;
 
 const NATIVE_MODULE_WITH_ROOT_TAG = `
@@ -274,7 +274,7 @@ export interface Spec extends TurboModule {
   readonly getRootTag: (rootTag: RootTag) => RootTag;
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
 `;
 
 const NATIVE_MODULE_WITH_NULLABLE_PARAM = `
@@ -294,7 +294,7 @@ export interface Spec extends TurboModule {
   readonly voidFunc: (arg: string | null | void) => void;
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
 `;
 
 const NATIVE_MODULE_WITH_BASIC_ARRAY = `
@@ -315,7 +315,7 @@ export interface Spec extends TurboModule {
   readonly getArray: (arg: ReadonlyArray<string>) => ReadonlyArray<string>;
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
 `;
 
 const NATIVE_MODULE_WITH_OBJECT_WITH_OBJECT_DEFINED_IN_FILE_AS_PROPERTY = `
@@ -348,7 +348,7 @@ export interface Spec extends TurboModule {
   }>;
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
 `;
 
 const NATIVE_MODULE_WITH_ARRAY_WITH_UNION_AND_TOUPLE = `
@@ -370,7 +370,7 @@ export interface Spec extends TurboModule {
   ) => Array<string | number | boolean>;
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
 `;
 
 const NATIVE_MODULE_WITH_ARRAY_WITH_ALIAS = `
@@ -392,7 +392,7 @@ export interface Spec extends TurboModule {
   readonly getArray: (arg: Array<SomeString>) => Array<string>;
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
 `;
 
 const NATIVE_MODULE_WITH_COMPLEX_ARRAY = `
@@ -414,7 +414,7 @@ export interface Spec extends TurboModule {
   ) => Array<Array<Array<string>>>;
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
 `;
 
 const NATIVE_MODULE_WITH_PROMISE = `
@@ -439,7 +439,7 @@ export interface Spec extends TurboModule {
   readonly getValueWithPromiseObjDefinedSomewhereElse: () => Promise<SomeObj>;
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
 `;
 
 const NATIVE_MODULE_WITH_CALLBACK = `
@@ -461,7 +461,7 @@ export interface Spec extends TurboModule {
   ) => void;
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+export default TurboModuleRegistry.get<<Spec>('SampleTurboModule');
 `;
 
 const ANDROID_ONLY_NATIVE_MODULE = `
@@ -479,7 +479,7 @@ import * as TurboModuleRegistry from 'react-native/Libraries/TurboModule/TurboMo
 
 export interface Spec extends TurboModule {}
 
-export default TurboModuleRegistry.getEnforcing<Spec>(
+export default TurboModuleRegistry.get<<Spec>(
   'SampleTurboModuleAndroid',
 );
 `;
@@ -499,7 +499,7 @@ import * as TurboModuleRegistry from 'react-native/Libraries/TurboModule/TurboMo
 
 export interface Spec extends TurboModule {}
 
-export default TurboModuleRegistry.getEnforcing<Spec>(
+export default TurboModuleRegistry.get<<Spec>(
   'SampleTurboModuleIOS',
 );
 `;
@@ -521,7 +521,7 @@ export interface Spec extends TurboModule {
   readonly getCallback: () => () => void;
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>(
+export default TurboModuleRegistry.get<<Spec>(
   'SampleTurboModuleCxx',
 );
 `;

--- a/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/typescript-module-parser-e2e-test.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/typescript-module-parser-e2e-test.js
@@ -84,7 +84,7 @@ describe('TypeScript Module Parser', () => {
           export interface Spec extends TurboModule {
             useArg(arg: any): void;
           }
-          export default TurboModuleRegistry.get<Spec>('Foo');
+          export default TurboModuleRegistry.getOrNull<Spec>('Foo');
         `);
 
       expect(parser).toThrow(UnsupportedTypeScriptTypeAnnotationParserError);
@@ -98,7 +98,7 @@ describe('TypeScript Module Parser', () => {
           export interface Spec extends TurboModule {
             useArg(boolean): void;
           }
-          export default TurboModuleRegistry.get<Spec>('Foo');
+          export default TurboModuleRegistry.getOrNull<Spec>('Foo');
         `);
 
       expect(parser).toThrow(UnnamedFunctionParamParserError);
@@ -145,7 +145,7 @@ describe('TypeScript Module Parser', () => {
           export interface Spec extends TurboModule {
             useArg(${annotateArg(paramName, paramType)}): void;
           }
-          export default TurboModuleRegistry.get<Spec>('Foo');
+          export default TurboModuleRegistry.getOrNull<Spec>('Foo');
         `);
 
         expect(module.spec.properties[0]).not.toBe(null);
@@ -356,7 +356,7 @@ describe('TypeScript Module Parser', () => {
               export interface Spec extends TurboModule {
                 useArg(${annotateArg('arg', 'AnimalPointer')}): void;
               }
-              export default TurboModuleRegistry.get<Spec>('Foo');
+              export default TurboModuleRegistry.getOrNull<Spec>('Foo');
             `);
 
             expect(module.spec.properties[0]).not.toBe(null);
@@ -695,7 +695,7 @@ describe('TypeScript Module Parser', () => {
         export interface Spec extends TurboModule {
           useArg(): void;
         }
-        export default TurboModuleRegistry.get<Spec>('Foo');
+        export default TurboModuleRegistry.getOrNull<Spec>('Foo');
       `);
 
       expect(module.spec.properties[0]).not.toBe(null);
@@ -729,7 +729,7 @@ describe('TypeScript Module Parser', () => {
           export interface Spec extends TurboModule {
             useArg(): ${annotateRet(flowType)};
           }
-          export default TurboModuleRegistry.get<Spec>('Foo');
+          export default TurboModuleRegistry.getOrNull<Spec>('Foo');
         `);
 
         expect(module.spec.properties[0]).not.toBe(null);

--- a/packages/react-native-codegen/src/parsers/typescript/modules/errors.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/errors.js
@@ -228,7 +228,7 @@ class UnusedModuleTypeScriptInterfaceParserError extends ParserError {
     super(
       hasteModuleName,
       flowInterface,
-      "Unused NativeModule spec. Please load the NativeModule by calling TurboModuleRegistry.get<Spec>('<moduleName>').",
+      "Unused NativeModule spec. Please load the NativeModule by calling TurboModuleRegistry.getOrNull<Spec>('<moduleName>').",
     );
   }
 }

--- a/packages/rn-tester/NativeModuleExample/NativeScreenshotManager.js
+++ b/packages/rn-tester/NativeModuleExample/NativeScreenshotManager.js
@@ -22,7 +22,7 @@ export interface Spec extends TurboModule {
   ): Promise<string>;
 }
 
-const NativeModule = TurboModuleRegistry.get<Spec>('ScreenshotManager');
+const NativeModule = TurboModuleRegistry.getOrNull<Spec>('ScreenshotManager');
 export function takeScreenshot(
   id: string,
   options: ScreenshotManagerOptions,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

The Turbo Module guides often encourage the use of `TurboModuleRegistry.get(...)` and directly exporting that, however this will be cumbersome to use for any library users since they have to check for null **before every call** to that Turbo Module. 

Example:


* TurboModule exports itself:
    ```ts
    export default TurboModuleRegistry.get<Spec>('ExampleModule')
    ```
* Library users use it:
    ```ts
    import Module from './ExampleTurboModuleSpec'
    
    // instead of 
    const x = Module.add(5, 4)

    // ...they now have to write
    let x = 0
    if (Module != null) x = Module.add(5, 4)
    else // what else?
    ```

In my opinion, `get(...)` should return the module and throwing if it could not be loaded, whereas `getOrNull(...)` (or `getOrUndefined(...)` or `tryGet(...)`) can be used when fallback behaviour is okay (e.g. when falling back to a JS-based module for react-native-web.

But that should be explicit behaviour, not implied and overseen, such as in this example: https://github.com/talknagish/react-native-turbo-starter/blob/aaba7d8613a4bb943876718bd31d3bdd84805f5d/src/NativeTurboStarter.ts#L34-L35

This PR changes this behaviour:

### Before

```ts
TurboModuleRegistry.get<Spec>('ExampleModule') // <-- returns Spec | undefined
TurboModuleRegistry.getEnforcing<Spec>('ExampleModule') // <-- returns Spec, throws if not found
```

### After

```ts
TurboModuleRegistry.get<Spec>('ExampleModule') // <-- returns Spec, throws if not found
TurboModuleRegistry.getOrNull<Spec>('ExampleModule') // <-- returns Spec | undefined
```

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Changed] - **Breaking change**: Make `TurboModuleRegistry.get(...)` enforcing by default, add `getOrNull(...)`

## Test Plan

### A

1. Try to `get` a Turbo Module that doesn't exist
2. See if `get(..)` throws and `getOrNull(...)` doesn't.

### B

1. See if RN still starts correctly with all changes updated