### PR TITLE
Support Android flavors in new architecture

### DIFF
--- a/template/android/app/build.gradle
+++ b/template/android/app/build.gradle
@@ -190,20 +190,25 @@ android {
             // If you wish to add a custom TurboModule or component locally,
             // you should uncomment this line.
             // preBuild.dependsOn("generateCodegenArtifactsFromSchema")
-            preDebugBuild.dependsOn(packageReactNdkDebugLibs)
-            preReleaseBuild.dependsOn(packageReactNdkReleaseLibs)
+            android.applicationVariants.all { def variant ->
+                def targetName = variant.name.capitalize()
+                def preVariantBuildTask = tasks.findByName("pre${targetName}")
 
-            // Due to a bug inside AGP, we have to explicitly set a dependency
-            // between configureNdkBuild* tasks and the preBuild tasks.
-            // This can be removed once this is solved: https://issuetracker.google.com/issues/207403732
-            configureNdkBuildRelease.dependsOn(preReleaseBuild)
-            configureNdkBuildDebug.dependsOn(preDebugBuild)
-            reactNativeArchitectures().each { architecture ->
-                tasks.findByName("configureNdkBuildDebug[${architecture}]")?.configure {
-                    dependsOn("preDebugBuild")
+                // Due to a bug inside AGP, we have to explicitly set a dependency
+                // between configureNdkBuild* tasks and the preBuild tasks.
+                // This can be removed once this is solved: https://issuetracker.google.com/issues/207403732
+                if (targetName.endsWith("DebugBuild")) {
+                    preVariantBuildTask.dependsOn(packageReactNdkDebugLibs)
+                    configureNdkBuildDebug.dependsOn(preVariantBuildTask)
                 }
-                tasks.findByName("configureNdkBuildRelease[${architecture}]")?.configure {
-                    dependsOn("preReleaseBuild")
+                if (targetName.endsWith("ReleaseBuild")) {
+                    preVariantBuildTask.dependsOn(packageReactNdkReleaseLibs)
+                    configureNdkBuildRelease.dependsOn(preVariantBuildTask)
+                }
+                reactNativeArchitectures().each { architecture ->
+                    tasks.findByName("configureNdk${targetName}[${architecture}]")?.configure {
+                        dependsOn(preVariantBuildTask.name)
+                    }
                 }
             }
         }

--- a/template/android/app/build.gradle
+++ b/template/android/app/build.gradle
@@ -191,23 +191,28 @@ android {
             // you should uncomment this line.
             // preBuild.dependsOn("generateCodegenArtifactsFromSchema")
             android.applicationVariants.all { def variant ->
-                def targetName = variant.name.capitalize()
-                def preVariantBuildTask = tasks.findByName("pre${targetName}")
+                def variantName = variant.name.capitalize()
+                def preVariantBuildTask = tasks.findByName("pre${variantName}Build")
 
                 // Due to a bug inside AGP, we have to explicitly set a dependency
                 // between configureNdkBuild* tasks and the preBuild tasks.
                 // This can be removed once this is solved: https://issuetracker.google.com/issues/207403732
-                if (targetName.endsWith("DebugBuild")) {
+                if (variantName.endsWith("Debug")) {
                     preVariantBuildTask.dependsOn(packageReactNdkDebugLibs)
                     configureNdkBuildDebug.dependsOn(preVariantBuildTask)
+                    reactNativeArchitectures().each { architecture ->
+                        tasks.findByName("configureNdkBuildDebug[${architecture}]")?.configure {
+                            dependsOn(preVariantBuildTask.name)
+                        }
+                    }
                 }
-                if (targetName.endsWith("ReleaseBuild")) {
+                if (variantName.endsWith("Release")) {
                     preVariantBuildTask.dependsOn(packageReactNdkReleaseLibs)
                     configureNdkBuildRelease.dependsOn(preVariantBuildTask)
-                }
-                reactNativeArchitectures().each { architecture ->
-                    tasks.findByName("configureNdk${targetName}[${architecture}]")?.configure {
-                        dependsOn(preVariantBuildTask.name)
+                    reactNativeArchitectures().each { architecture ->
+                        tasks.findByName("configureNdkBuildRelease[${architecture}]")?.configure {
+                            dependsOn(preVariantBuildTask.name)
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary

When enabling the new architecture on Android apps using flavors the build fails with `Could not get unknown property 'preDebugBuild'` as reported in https://github.com/facebook/react-native/issues/33596. 

This PR fixes this by iterating over variants instead and dynamically applying the necessary dependencies. 

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Fixed] - Support Android flavors in new architecture

## Test Plan

Applied these changes to our Android project with multiple flavors and new architecture flag enabled. 