### PR TITLE
Pass node executable to codegen

### DIFF
--- a/scripts/generate-artifacts.js
+++ b/scripts/generate-artifacts.js
@@ -54,6 +54,11 @@ const argv = yargs
     description:
       'Path where codegen config files are located (e.g. node_modules dir).',
   })
+  .option('n', {
+    alias: 'nodeBinary',
+    default: 'node',
+    description: 'Path to the node executable.',
+  })
   .usage('Usage: $0 -p [path to app]')
   .demandOption(['p']).argv;
 
@@ -62,6 +67,7 @@ const CODEGEN_CONFIG_FILENAME = argv.f;
 const CODEGEN_CONFIG_FILE_DIR = argv.c;
 const CODEGEN_CONFIG_KEY = argv.k;
 const CODEGEN_FABRIC_ENABLED = argv.e;
+const NODE = argv.n;
 const CODEGEN_REPO_PATH = `${RN_ROOT}/packages/react-native-codegen`;
 const CODEGEN_NPM_PATH = `${RN_ROOT}/../react-native-codegen`;
 const CORE_LIBRARIES = new Set(['rncore', 'FBReactNativeSpec']);
@@ -69,6 +75,10 @@ const REACT_NATIVE_DEPENDENCY_NAME = 'react-native';
 
 function isReactNativeCoreLibrary(libraryName) {
   return CORE_LIBRARIES.has(libraryName);
+}
+
+function executeNodeScript(script) {
+  execSync(`${NODE} ${script}`);
 }
 
 function main(appRootDir, outputPath) {
@@ -234,8 +244,8 @@ function main(appRootDir, outputPath) {
 
       console.log(`\n\n[Codegen] >>>>> Processing ${library.config.name}`);
       // Generate one schema for the entire library...
-      execSync(
-        `node ${path.join(
+      executeNodeScript(
+        `${path.join(
           codegenCliPath,
           'lib',
           'cli',
@@ -250,8 +260,8 @@ function main(appRootDir, outputPath) {
         ? `--libraryType ${library.config.type}`
         : '';
       fs.mkdirSync(pathToTempOutputDir, {recursive: true});
-      execSync(
-        `node ${path.join(
+      executeNodeScript(
+        `${path.join(
           RN_ROOT,
           'scripts',
           'generate-specs-cli.js',
@@ -284,8 +294,8 @@ function main(appRootDir, outputPath) {
 
       // Generate FabricComponentProvider.
       // Only for iOS at this moment.
-      execSync(
-        `node ${path.join(
+      executeNodeScript(
+        `${path.join(
           RN_ROOT,
           'scripts',
           'generate-provider-cli.js',

--- a/scripts/react_native_pods_utils/script_phases.sh
+++ b/scripts/react_native_pods_utils/script_phases.sh
@@ -100,7 +100,7 @@ generateCodegenArtifactsFromSchema () {
 generateArtifacts () {
     describe "Generating codegen artifacts"
     pushd "$RCT_SCRIPT_RN_DIR" >/dev/null || exit 1
-        "$NODE_BINARY" "scripts/generate-artifacts.js" --path "$RCT_SCRIPT_APP_PATH" --outputPath "$TEMP_OUTPUT_DIR" --fabricEnabled "$RCT_SCRIPT_FABRIC_ENABLED" --configFileDir "$RCT_SCRIPT_CONFIG_FILE_DIR"
+        "$NODE_BINARY" "scripts/generate-artifacts.js" --path "$RCT_SCRIPT_APP_PATH" --outputPath "$TEMP_OUTPUT_DIR" --fabricEnabled "$RCT_SCRIPT_FABRIC_ENABLED" --configFileDir "$RCT_SCRIPT_CONFIG_FILE_DIR" --nodeBinary "$NODE_BINARY"
     popd >/dev/null || exit 1
 }
 


### PR DESCRIPTION
Summary:
This pr adds a parameter to the `create-artifacts.js` script to accept the path to a node executable, falling back to `node` in case the parameter has not been passed.
Then, it passes the NODE_BINARY to the script in the `script_phases.sh` script.

This PR decouples the `node` environment from the system one and fixes a build issue in the new architecture when the environment has no `node`

## Changelog

[iOS][Changed] - Update CodeGen scripts to accept custom node executable

Differential Revision: D35748497

