### PR TITLE
Export REACT_NATIVE_PATH and fix find-node-for-xcode.sh fallback behavior

### DIFF
--- a/packages/rn-tester/Podfile
+++ b/packages/rn-tester/Podfile
@@ -8,6 +8,7 @@ platform :ios, '12.4'
 install! 'cocoapods', :deterministic_uuids => false
 
 USE_FRAMEWORKS = ENV['USE_FRAMEWORKS'] == '1'
+@prefix_path = "../.."
 
 if USE_FRAMEWORKS
   puts "Installing pods with use_frameworks!"
@@ -21,25 +22,23 @@ def pods(options = {})
   hermes_enabled = ENV['USE_HERMES'] == '1'
   puts "Building RNTester with Fabric #{fabric_enabled ? "enabled" : "disabled"}.#{hermes_enabled ? " Using Hermes engine." : ""}"
 
-  prefix_path = "../.."
-
   if ENV['USE_CODEGEN_DISCOVERY'] == '1'
     # Custom fabric component is only supported when using codegen discovery.
     pod 'MyNativeView', :path => "NativeComponentExample"
   end
 
   use_react_native!(
-    path: prefix_path,
+    path: @prefix_path,
     fabric_enabled: fabric_enabled,
     hermes_enabled: hermes_enabled,
     app_path: "#{Dir.pwd}",
     config_file_dir: "#{Dir.pwd}/node_modules",
   )
-  pod 'ReactCommon/turbomodule/samples', :path => "#{prefix_path}/ReactCommon"
+  pod 'ReactCommon/turbomodule/samples', :path => "#{@prefix_path}/ReactCommon"
 
   # Additional Pods which aren't included in the default Podfile
-  pod 'React-RCTPushNotification', :path => "#{prefix_path}/Libraries/PushNotificationIOS"
-  pod 'Yoga', :path => "#{prefix_path}/ReactCommon/yoga", :modular_headers => true
+  pod 'React-RCTPushNotification', :path => "#{@prefix_path}/Libraries/PushNotificationIOS"
+  pod 'Yoga', :path => "#{@prefix_path}/ReactCommon/yoga", :modular_headers => true
   # Additional Pods which are classed as unstable
 
   # RNTester native modules and components
@@ -64,6 +63,6 @@ target 'RNTesterIntegrationTests' do
 end
 
 post_install do |installer|
-  react_native_post_install(installer)
+  react_native_post_install(installer, @prefix_path)
   __apply_Xcode_12_5_M1_post_install_workaround(installer)
 end

--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -258,7 +258,23 @@ def fix_library_search_paths(installer)
   end
 end
 
-def react_native_post_install(installer)
+def set_node_modules_user_settings(installer, react_native_path)
+  puts "Setting REACT_NATIVE build settings"
+  projects = installer.aggregate_targets
+    .map{ |t| t.user_project }
+    .uniq{ |p| p.path }
+    .push(installer.pods_project)
+
+  projects.each do |project|
+    project.build_configurations.each do |config|
+      config.build_settings["REACT_NATIVE_PATH"] = File.join(Dir.pwd, react_native_path)
+    end
+
+    project.save()
+  end
+end
+
+def react_native_post_install(installer, react_native_path = "../node_modules/react-native")
   if has_pod(installer, 'Flipper')
     flipper_post_install(installer)
   end
@@ -272,6 +288,7 @@ def react_native_post_install(installer)
   end
   modify_flags_for_new_architecture(installer, cpp_flags)
 
+  set_node_modules_user_settings(installer, react_native_path)
 end
 
 def modify_flags_for_new_architecture(installer, cpp_flags)

--- a/scripts/xcode/with-environment.sh
+++ b/scripts/xcode/with-environment.sh
@@ -38,7 +38,7 @@ else
        "in the ios folder. This is needed by React Native to work correctly. " \
        "We fallback to the DEPRECATED behavior of finding `node`. This will be REMOVED in a future version. " \
        "You can read more about this here: https://reactnative.dev/docs/environment-setup#optional-configuring-your-environment" >&2
-    source "../find-node-for-xcode.sh"
+    source "${REACT_NATIVE_PATH}/scripts/find-node-for-xcode.sh"
 fi
 
 # Execute argument, if present


### PR DESCRIPTION
## Issue
In D35317070 (https://github.com/facebook/react-native/commit/0480f56c5b5478b6ebe5ad88e347cad2810bfb17) we introduced a way to configuring the Xcode environment via he `.xcode.env`, falling back to the old `find-node-for-xcode.sh` behavior in case of a misconfiguration.

Unfortunately, there were an issue with the new architecture for which the pods were not able to locate the `find-node-for-xcode.sh`, crashing while building the new architecture.

## Solution
This Diff solves the issue in two steps:
1. it exposes to the project the REACT_NATIVE_PATH like Android does here: D35451821 (https://github.com/facebook/react-native/commit/f8d7e0a968ea12606fd8cce03470fd374f732aad)
2. it leverages this new variables to reach the script

## NOTE
This pr depends on [this](https://github.com/facebook/react-native/pull/33671) and [this](https://github.com/facebook/react-native/pull/33672)

## Changelog
[iOS][Changed] - Fixed the fallback behavior when the `.xcode.env` file is missing, actually using the old `find-node-for-xcode.sh` script

Differential Revision: D35779165

