### PR TITLE
Re-enable bundling of hermesc inside the react-native NPM package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1085,15 +1085,16 @@ jobs:
             mkdir -p ~/.ssh
             echo '|1|If6MU203eXTaaWL678YEfWkVMrw=|kqLeIAyTy8pzpj8x8Ae4Fr8Mtlc= ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==' >> ~/.ssh/known_hosts
       - checkout
-      # TODO: (hramos) Filter out unnecessary files before adding Hermes Compiler to package
-      # - *attach_hermes_workspace
-      # - run:
-      #     name: Move hermesc binaries to sdks/hermesc
-      #     command: |
-      #       curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-      #       apt update && apt install -y jq
-      #       mkdir -p ./sdks/hermesc
-      #       cp -R $HERMES_WS_DIR/hermesc/* ./sdks/hermesc
+      - *attach_hermes_workspace
+      - run:
+          name: Move hermesc binaries to sdks/hermesc
+          command: |
+            mkdir -p ./sdks/hermesc/linux64-bin
+            mkdir -p ./sdks/hermesc/osx-bin
+            mkdir -p ./sdks/hermesc/win64-bin
+            cp $HERMES_WS_DIR/hermesc/linux/bin/hermesc ./sdks/hermesc/linux64-bin/hermesc
+            cp $HERMES_WS_DIR/hermesc/macos/bin/hermesc ./sdks/hermesc/osx-bin/hermesc
+            cp $HERMES_WS_DIR/hermesc/windows/bin/Release/hermesc.exe ./sdks/hermesc/win64-bin/hermesc.exe
 
       - run_yarn
       - install_buck_tooling
@@ -1227,9 +1228,8 @@ workflows:
       - build_npm_package:
           # Build a release package on every untagged commit, but do not publish to npm.
           publish_npm_args: --dry-run
-          # TODO: (hramos) Slim down Hermes Compiler files before adding to react-native npm
-          # requires:
-          #   - store_hermesc
+          requires:
+            - store_hermesc
       - test_js:
           run_disabled_tests: false
       - test_android:
@@ -1301,9 +1301,8 @@ workflows:
           context: react-native-bot
           publish_npm_args: --release
           filters: *only_release_tags
-          # TODO: (hramos) Slim down Hermes Compiler files before adding to react-native npm
-          # requires:
-          #   - store_hermesc
+          requires:
+            - store_hermesc
 
   analysis:
     unless: << pipeline.parameters.run_package_release_workflow_only >>
@@ -1350,6 +1349,5 @@ workflows:
 
       - build_npm_package:
           publish_npm_args: --nightly
-          # TODO: (hramos) Slim down Hermes Compiler files before adding to react-native npm
-          # requires:
-          #   - store_hermesc
+          requires:
+            - store_hermesc


### PR DESCRIPTION
## Summary

This PR re-enables bundling of the precompiled `hermesc` binary inside the react-native NPM package. To handle this I've stripped over all the unnecessary files and kept only the relevant binary. It now follows the same structure as the `hermes-engine` NPM package.

## Changelog

[Internal] - Re-enable bundling of hermesc inside the react-native NPM package

## Test Plan

Will wait for a successful CI job to produce a commitlies of RN.
