### PR TITLE
Fixing crash on launch when built on Windows with new architecture

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -321,20 +321,6 @@ android {
                     // This flag will suppress "fcntl(): Bad file descriptor" warnings on local builds.
                     arguments "--output-sync=none"
                 }
-
-                // Note: On Windows there are limits on number of character in file paths and in command lines
-                // Ref: https://android.googlesource.com/platform/ndk/+/master/docs/BuildSystemMaintainers.md#Path-Length-Limits
-                // NDK allows circumventing command line limits using response(RSP) files as inputs using NDK_APP_SHORT_COMMANDS flag.
-                // 
-                // Windows can support long file paths if configured through registry or by prefixing all file paths with a special character sequence 
-                // The latter requires changes in NDK. And there are tools in NDK (AR) which is not able to handle long paths (>256) even after setting the registry key.
-                // The new architecutre source tree is too deep, and the object file naming conventions in NDK makes the matters worse, by producing incredibly long file paths.
-                // Other solutions such as symlinking source code etc. didn't work as expected, and makes the build scripts complicated and hard to manage.
-                // This change temporarily works around the issue by placing the temporary build outputs as short a path as possible within the project path.
-                if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                    arguments "NDK_OUT=${rootProject.projectDir.getParent()}\\.cxx",
-                              "NDK_APP_SHORT_COMMANDS=true"
-                }
             }
         }
         ndk {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,8 +5,16 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import org.apache.tools.ant.taskdefs.condition.Os
+
 val ndkPath by extra(System.getenv("ANDROID_NDK"))
-val ndkVersion by extra(System.getenv("ANDROID_NDK_VERSION"))
+var ndkVersion by extra(System.getenv("ANDROID_NDK_VERSION"))
+
+if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+    // For Windows Users, we need to use NDK 23, otherwise the build will
+    // fail due to paths longer than the OS limit
+    ndkVersion = "23.1.7779620"
+}
 
 buildscript {
     repositories {

--- a/packages/rn-tester/android/app/build.gradle
+++ b/packages/rn-tester/android/app/build.gradle
@@ -10,6 +10,8 @@ plugins {
     id("com.facebook.react")
 }
 
+import org.apache.tools.ant.taskdefs.condition.Os
+
 /**
  * The react.gradle file registers a task for each build variant (e.g. bundleDebugJsAndAssets
  * and bundleReleaseJsAndAssets).
@@ -152,6 +154,12 @@ android {
     }
     if (rootProject.hasProperty("ndkVersion")) {
         ndkVersion rootProject.ext.ndkVersion
+    }
+
+    if (!project["ndkVersion"] && Os.isFamily(Os.FAMILY_WINDOWS)) {
+        // For Windows Users, we need to use NDK 23, otherwise the build will
+        // fail due to paths longer than the OS limit
+        project.ext.ndkVersion = "23.1.7779620"
     }
 
     flavorDimensions "vm"

--- a/template/android/app/build.gradle
+++ b/template/android/app/build.gradle
@@ -158,12 +158,6 @@ android {
                     // Make sure this target name is the same you specify inside the
                     // src/main/jni/Android.mk file for the `LOCAL_MODULE` variable.
                     targets "helloworld_appmodules"
-
-                    // Fix for windows limit on number of character in file paths and in command lines
-                    if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                        arguments "NDK_OUT=${rootProject.projectDir.getParent()}\\.cxx",
-                            "NDK_APP_SHORT_COMMANDS=true"
-                    }
                 }
             }
             if (!enableSeparateBuildPerCPUArchitecture) {

--- a/template/android/build.gradle
+++ b/template/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
             // For M1 Users we need to use the NDK 24 which added support for aarch64
             ndkVersion = "24.0.8215888"
         } else if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-            // For Android Users, we need to use NDK 23, otherwise the build will
+            // For Windows Users, we need to use NDK 23, otherwise the build will
             // fail due to paths longer than the OS limit
             ndkVersion = "23.1.7779620"
         } else {


### PR DESCRIPTION
## Summary
Last week, we made a fix to build on Windows with new architecture enabled. But, it turns out the built application is not launching as the apk doesn't contain all libraries. 

This PR is reverting a change made in last commit to override the output path. It turns out, we can't safely override NDK_OUT when using 'externalNativeBuild' DSL command, unlike the earlier custom task. Gradle Android plugin makes some strong assumptions and we don't have much control over from build scripts.

It turned out that we don't need overriding the output paths when using ndk22+ and windows powershell. ndk22+ handles long file paths, and powershell handles very long command lines. 

We need to update documentation to support only powershell.

## Changelog
This PR is reverting a change made in last commit to override the output path. It turned out that we don't need overriding the output paths when using ndk22+ and windows powershell. ndk22+ handles long file paths, and powershell handles very long command lines. 

[Android] [Fixed] - Fixing crash on launch when built on Windows with new architecture

## Test Plan
Verified rntester builds and launches.