### PR TITLE
Expose private node management methods in UIManager

### DIFF
--- a/React/Fabric/RCTScheduler.h
+++ b/React/Fabric/RCTScheduler.h
@@ -10,6 +10,7 @@
 
 #import <react/renderer/componentregistry/ComponentDescriptorFactory.h>
 #import <react/renderer/core/ComponentDescriptor.h>
+#import <react/renderer/core/EventListener.h>
 #import <react/renderer/core/LayoutConstraints.h>
 #import <react/renderer/core/LayoutContext.h>
 #import <react/renderer/mounting/MountingCoordinator.h>
@@ -63,6 +64,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)onAllAnimationsComplete;
 
 - (void)animationTick;
+
+- (void)addEventListener:(std::shared_ptr<facebook::react::EventListener> const &)listener;
+
+- (void)removeEventListener:(std::shared_ptr<facebook::react::EventListener> const &)listener;
 
 @end
 

--- a/React/Fabric/RCTScheduler.h
+++ b/React/Fabric/RCTScheduler.h
@@ -16,6 +16,7 @@
 #import <react/renderer/mounting/MountingCoordinator.h>
 #import <react/renderer/scheduler/SchedulerToolbox.h>
 #import <react/renderer/scheduler/SurfaceHandler.h>
+#import <react/renderer/uimanager/UIManager.h>
 #import <react/utils/ContextContainer.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -48,6 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface RCTScheduler : NSObject
 
 @property (atomic, weak, nullable) id<RCTSchedulerDelegate> delegate;
+@property (readonly) std::shared_ptr<facebook::react::UIManager> const uiManager;
 
 - (instancetype)initWithToolbox:(facebook::react::SchedulerToolbox)toolbox;
 

--- a/React/Fabric/RCTScheduler.mm
+++ b/React/Fabric/RCTScheduler.mm
@@ -193,4 +193,14 @@ class LayoutAnimationDelegateProxy : public LayoutAnimationStatusDelegate, publi
   }
 }
 
+- (void)addEventListener:(std::shared_ptr<EventListener> const &)listener
+{
+  return _scheduler->addEventListener(listener);
+}
+
+- (void)removeEventListener:(std::shared_ptr<EventListener> const &)listener
+{
+  return _scheduler->removeEventListener(listener);
+}
+
 @end

--- a/React/Fabric/RCTScheduler.mm
+++ b/React/Fabric/RCTScheduler.mm
@@ -203,4 +203,9 @@ class LayoutAnimationDelegateProxy : public LayoutAnimationStatusDelegate, publi
   return _scheduler->removeEventListener(listener);
 }
 
+- (std::shared_ptr<facebook::react::UIManager> const)uiManager
+{
+  return _scheduler->getUIManager();
+}
+
 @end

--- a/React/Fabric/RCTSurfacePresenter.h
+++ b/React/Fabric/RCTSurfacePresenter.h
@@ -19,6 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class RCTFabricSurface;
 @class RCTImageLoader;
 @class RCTMountingManager;
+@class RCTScheduler;
 
 /**
  * Coordinates presenting of React Native Surfaces and represents application
@@ -53,6 +54,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)unregisterSurface:(RCTFabricSurface *)surface;
 
 @property (readonly) RCTMountingManager *mountingManager;
+@property (readonly, nullable) RCTScheduler *scheduler;
 
 /*
  * Allow callers to initialize a new fabric surface without adding Fabric as a Buck dependency.

--- a/React/Fabric/RCTSurfacePresenter.mm
+++ b/React/Fabric/RCTSurfacePresenter.mm
@@ -115,7 +115,7 @@ static BackgroundExecutor RCTGetBackgroundExecutor()
   return _mountingManager;
 }
 
-- (RCTScheduler *_Nullable)_scheduler
+- (RCTScheduler *_Nullable)scheduler
 {
   std::lock_guard<std::mutex> lock(_schedulerAccessMutex);
   return _scheduler;
@@ -151,7 +151,7 @@ static BackgroundExecutor RCTGetBackgroundExecutor()
 - (void)registerSurface:(RCTFabricSurface *)surface
 {
   [_surfaceRegistry registerSurface:surface];
-  RCTScheduler *scheduler = [self _scheduler];
+  RCTScheduler *scheduler = [self scheduler];
   if (scheduler) {
     [scheduler registerSurface:surface.surfaceHandler];
   }
@@ -159,7 +159,7 @@ static BackgroundExecutor RCTGetBackgroundExecutor()
 
 - (void)unregisterSurface:(RCTFabricSurface *)surface
 {
-  RCTScheduler *scheduler = [self _scheduler];
+  RCTScheduler *scheduler = [self scheduler];
   if (scheduler) {
     [scheduler unregisterSurface:surface.surfaceHandler];
   }
@@ -188,7 +188,7 @@ static BackgroundExecutor RCTGetBackgroundExecutor()
 
 - (BOOL)synchronouslyUpdateViewOnUIThread:(NSNumber *)reactTag props:(NSDictionary *)props
 {
-  RCTScheduler *scheduler = [self _scheduler];
+  RCTScheduler *scheduler = [self scheduler];
   if (!scheduler) {
     return NO;
   }
@@ -212,7 +212,7 @@ static BackgroundExecutor RCTGetBackgroundExecutor()
 
 - (void)setupAnimationDriverWithSurfaceHandler:(facebook::react::SurfaceHandler const &)surfaceHandler
 {
-  [[self _scheduler] setupAnimationDriver:surfaceHandler];
+  [[self scheduler] setupAnimationDriver:surfaceHandler];
 }
 
 - (BOOL)suspend

--- a/ReactAndroid/src/main/java/com/facebook/react/fabric/jni/Binding.h
+++ b/ReactAndroid/src/main/java/com/facebook/react/fabric/jni/Binding.h
@@ -43,6 +43,8 @@ class Binding : public jni::HybridClass<Binding>,
 
   static void registerNatives();
 
+  std::shared_ptr<Scheduler> getScheduler();
+
  private:
   void setConstraints(
       jint surfaceId,
@@ -133,7 +135,6 @@ class Binding : public jni::HybridClass<Binding>,
   std::shared_ptr<FabricMountingManager> mountingManager_;
   std::shared_ptr<Scheduler> scheduler_;
 
-  std::shared_ptr<Scheduler> getScheduler();
   std::shared_ptr<FabricMountingManager> verifyMountingManager(
       std::string const &locationHint);
 

--- a/ReactAndroid/src/main/java/com/facebook/react/fabric/jni/JFabricUIManager.cpp
+++ b/ReactAndroid/src/main/java/com/facebook/react/fabric/jni/JFabricUIManager.cpp
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "JFabricUIManager.h"
+
+namespace facebook::react {
+
+Binding *JFabricUIManager::getBinding() {
+  static const auto bindingField =
+      javaClassStatic()->getField<Binding::javaobject>("mBinding");
+
+  return getFieldValue(bindingField)->cthis();
+}
+} // namespace facebook::react

--- a/ReactAndroid/src/main/java/com/facebook/react/fabric/jni/JFabricUIManager.h
+++ b/ReactAndroid/src/main/java/com/facebook/react/fabric/jni/JFabricUIManager.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <fbjni/fbjni.h>
+#include "Binding.h"
+
+using namespace facebook::jni;
+
+namespace facebook::react {
+
+class JFabricUIManager : public JavaClass<JFabricUIManager> {
+ public:
+  static constexpr auto kJavaDescriptor =
+      "Lcom/facebook/react/fabric/FabricUIManager;";
+
+  Binding *getBinding();
+};
+
+} // namespace facebook::react

--- a/ReactCommon/react/renderer/core/EventDispatcher.cpp
+++ b/ReactCommon/react/renderer/core/EventDispatcher.cpp
@@ -36,6 +36,10 @@ EventDispatcher::EventDispatcher(
 
 void EventDispatcher::dispatchEvent(RawEvent &&rawEvent, EventPriority priority)
     const {
+  // Allows the event listener to interrupt default event dispatch
+  if (eventListeners_.willDispatchEvent(rawEvent)) {
+    return;
+  }
   getEventQueue(priority).enqueueEvent(std::move(rawEvent));
 }
 
@@ -46,6 +50,10 @@ void EventDispatcher::dispatchStateUpdate(
 }
 
 void EventDispatcher::dispatchUniqueEvent(RawEvent &&rawEvent) const {
+  // Allows the event listener to interrupt default event dispatch
+  if (eventListeners_.willDispatchEvent(rawEvent)) {
+    return;
+  }
   asynchronousBatchedQueue_->enqueueUniqueEvent(std::move(rawEvent));
 }
 
@@ -60,6 +68,19 @@ const EventQueue &EventDispatcher::getEventQueue(EventPriority priority) const {
     case EventPriority::AsynchronousBatched:
       return *asynchronousBatchedQueue_;
   }
+}
+
+void EventDispatcher::addListener(
+    const std::shared_ptr<EventListener const> &listener) const {
+  eventListeners_.addListener(listener);
+}
+
+/*
+ * Removes provided event listener to the event dispatcher.
+ */
+void EventDispatcher::removeListener(
+    const std::shared_ptr<EventListener const> &listener) const {
+  eventListeners_.removeListener(listener);
 }
 
 } // namespace react

--- a/ReactCommon/react/renderer/core/EventDispatcher.h
+++ b/ReactCommon/react/renderer/core/EventDispatcher.h
@@ -9,6 +9,7 @@
 
 #include <react/renderer/core/BatchedEventQueue.h>
 #include <react/renderer/core/EventBeat.h>
+#include <react/renderer/core/EventListener.h>
 #include <react/renderer/core/EventPriority.h>
 #include <react/renderer/core/EventQueueProcessor.h>
 #include <react/renderer/core/StateUpdate.h>
@@ -52,6 +53,18 @@ class EventDispatcher {
   void dispatchStateUpdate(StateUpdate &&stateUpdate, EventPriority priority)
       const;
 
+#pragma mark - Event listeners
+  /*
+   * Adds provided event listener to the event dispatcher.
+   */
+  void addListener(const std::shared_ptr<EventListener const> &listener) const;
+
+  /*
+   * Removes provided event listener to the event dispatcher.
+   */
+  void removeListener(
+      const std::shared_ptr<EventListener const> &listener) const;
+
  private:
   EventQueue const &getEventQueue(EventPriority priority) const;
 
@@ -59,6 +72,8 @@ class EventDispatcher {
   std::unique_ptr<BatchedEventQueue> synchronousBatchedQueue_;
   std::unique_ptr<UnbatchedEventQueue> asynchronousUnbatchedQueue_;
   std::unique_ptr<BatchedEventQueue> asynchronousBatchedQueue_;
+
+  mutable EventListenerContainer eventListeners_;
 };
 
 } // namespace react

--- a/ReactCommon/react/renderer/core/EventListener.cpp
+++ b/ReactCommon/react/renderer/core/EventListener.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "EventListener.h"
+
+namespace facebook::react {
+
+bool EventListenerContainer::willDispatchEvent(const RawEvent &event) {
+  std::shared_lock<butter::shared_mutex> lock(mutex_);
+
+  bool handled = false;
+  for (auto const &listener : eventListeners_) {
+    handled = handled || listener->operator()(event);
+  }
+  return handled;
+}
+
+void EventListenerContainer::addListener(
+    const std::shared_ptr<EventListener const> &listener) {
+  std::unique_lock<butter::shared_mutex> lock(mutex_);
+
+  eventListeners_.push_back(listener);
+}
+
+void EventListenerContainer::removeListener(
+    const std::shared_ptr<EventListener const> &listener) {
+  std::unique_lock<butter::shared_mutex> lock(mutex_);
+
+  auto it = std::find(eventListeners_.begin(), eventListeners_.end(), listener);
+  if (it != eventListeners_.end()) {
+    eventListeners_.erase(it);
+  }
+}
+
+} // namespace facebook::react

--- a/ReactCommon/react/renderer/core/EventListener.h
+++ b/ReactCommon/react/renderer/core/EventListener.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <string>
+
+#include <react/renderer/core/RawEvent.h>
+
+#include <butter/mutex.h>
+
+namespace facebook {
+namespace react {
+
+/**
+ * Listener for events dispatched to JS runtime.
+ * Return `true` to interrupt default dispatch to JS event emitter, `false` to
+ * pass through to default handlers.
+ */
+using EventListener = std::function<bool(const RawEvent &event)>;
+
+class EventListenerContainer {
+ public:
+  /*
+   * Invoke listeners in this container with the event.
+   * Returns true if event was handled by the listener, false to continue
+   * default dispatch.
+   */
+  bool willDispatchEvent(const RawEvent &event);
+
+  void addListener(const std::shared_ptr<EventListener const> &listener);
+  void removeListener(const std::shared_ptr<EventListener const> &listener);
+
+ private:
+  butter::shared_mutex mutex_;
+  std::vector<std::shared_ptr<EventListener const>> eventListeners_;
+};
+
+} // namespace react
+} // namespace facebook

--- a/ReactCommon/react/renderer/scheduler/Scheduler.cpp
+++ b/ReactCommon/react/renderer/scheduler/Scheduler.cpp
@@ -368,5 +368,19 @@ ContextContainer::Shared Scheduler::getContextContainer() const {
   return contextContainer_;
 }
 
+void Scheduler::addEventListener(
+    const std::shared_ptr<EventListener const> &listener) {
+  if (eventDispatcher_->has_value()) {
+    eventDispatcher_->value().addListener(listener);
+  }
+}
+
+void Scheduler::removeEventListener(
+    const std::shared_ptr<EventListener const> &listener) {
+  if (eventDispatcher_->has_value()) {
+    eventDispatcher_->value().removeListener(listener);
+  }
+}
+
 } // namespace react
 } // namespace facebook

--- a/ReactCommon/react/renderer/scheduler/Scheduler.cpp
+++ b/ReactCommon/react/renderer/scheduler/Scheduler.cpp
@@ -368,6 +368,10 @@ ContextContainer::Shared Scheduler::getContextContainer() const {
   return contextContainer_;
 }
 
+std::shared_ptr<UIManager> Scheduler::getUIManager() const {
+  return uiManager_;
+}
+
 void Scheduler::addEventListener(
     const std::shared_ptr<EventListener const> &listener) {
   if (eventDispatcher_->has_value()) {

--- a/ReactCommon/react/renderer/scheduler/Scheduler.h
+++ b/ReactCommon/react/renderer/scheduler/Scheduler.h
@@ -108,6 +108,9 @@ class Scheduler final : public UIManagerDelegate {
 #pragma mark - ContextContainer
   ContextContainer::Shared getContextContainer() const;
 
+#pragma mark - UIManager
+  std::shared_ptr<UIManager> getUIManager() const;
+
 #pragma mark - Event listeners
   void addEventListener(const std::shared_ptr<EventListener const> &listener);
   void removeEventListener(

--- a/ReactCommon/react/renderer/scheduler/Scheduler.h
+++ b/ReactCommon/react/renderer/scheduler/Scheduler.h
@@ -16,6 +16,7 @@
 #include <react/renderer/components/root/RootComponentDescriptor.h>
 #include <react/renderer/core/ComponentDescriptor.h>
 #include <react/renderer/core/EventEmitter.h>
+#include <react/renderer/core/EventListener.h>
 #include <react/renderer/core/LayoutConstraints.h>
 #include <react/renderer/mounting/MountingOverrideDelegate.h>
 #include <react/renderer/scheduler/InspectorData.h>
@@ -106,6 +107,11 @@ class Scheduler final : public UIManagerDelegate {
 
 #pragma mark - ContextContainer
   ContextContainer::Shared getContextContainer() const;
+
+#pragma mark - Event listeners
+  void addEventListener(const std::shared_ptr<EventListener const> &listener);
+  void removeEventListener(
+      const std::shared_ptr<EventListener const> &listener);
 
  private:
   friend class SurfaceHandler;

--- a/ReactCommon/react/renderer/uimanager/UIManager.h
+++ b/ReactCommon/react/renderer/uimanager/UIManager.h
@@ -111,14 +111,6 @@ class UIManager final : public ShadowTreeDelegate {
       RootShadowNode::Shared const &oldRootShadowNode,
       RootShadowNode::Unshared const &newRootShadowNode) const override;
 
- private:
-  friend class UIManagerBinding;
-  friend class Scheduler;
-  friend class SurfaceHandler;
-
-  // `TimelineController` needs to call private `getShadowTreeRegistry()`.
-  friend class TimelineController;
-
   ShadowNode::Shared createNode(
       Tag tag,
       std::string const &componentName,
@@ -174,6 +166,13 @@ class UIManager final : public ShadowTreeDelegate {
       const ShadowNode::Shared &shadowNode,
       std::string const &eventType);
 
+  ShadowTreeRegistry const &getShadowTreeRegistry() const;
+
+ private:
+  friend class UIManagerBinding;
+  friend class Scheduler;
+  friend class SurfaceHandler;
+
   /**
    * Configure a LayoutAnimation to happen on the next commit.
    * This API configures a global LayoutAnimation starting from the root node.
@@ -183,8 +182,6 @@ class UIManager final : public ShadowTreeDelegate {
       RawValue const &config,
       jsi::Value const &successCallback,
       jsi::Value const &failureCallback) const;
-
-  ShadowTreeRegistry const &getShadowTreeRegistry() const;
 
   SharedComponentDescriptorRegistry componentDescriptorRegistry_;
   UIManagerDelegate *delegate_;


### PR DESCRIPTION
Summary:
These methods used to be public in the legacy implementation, and hiding them significantly reduces amount of customization available to other clients outside Fabric core.

Changelog: [Internal] Allow external callers to call UIManager methods

Differential Revision: D35818114

