### PR TITLE
chore: remove git.io

### DIFF
--- a/ReactCommon/react/nativemodule/core/platform/ios/RCTTurboModule.mm
+++ b/ReactCommon/react/nativemodule/core/platform/ios/RCTTurboModule.mm
@@ -626,7 +626,7 @@ NSInvocation *ObjCTurboModule::getMethodInvocation(
       if ([objCArg isKindOfClass:[NSDictionary class]] && hasMethodArgConversionSelector(methodNameNSString, i)) {
         SEL methodArgConversionSelector = getMethodArgConversionSelector(methodNameNSString, i);
 
-        // Message dispatch logic from old infra (link: https://git.io/fjf3U)
+        // Message dispatch logic from old infra (link: https://github.com/facebook/react-native/commit/6783694158057662fd7b11fc123c339b2b21bfe6#diff-263fc157dfce55895cdc16495b55d190R350)
         RCTManagedPointer *(*convert)(id, SEL, id) = (__typeof__(convert))objc_msgSend;
         RCTManagedPointer *box = convert([RCTCxxConvert class], methodArgConversionSelector, objCArg);
 


### PR DESCRIPTION
## Summary

All links on git.io will stop redirecting after April 29, 2022. So I removed it.

- https://github.blog/changelog/2022-04-25-git-io-deprecation/
