### PR TITLE
fix: Make WebSocketTests work in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -432,7 +432,7 @@ jobs:
   # -------------------------
   #     JOBS: iOS Unit Tests
   # -------------------------
-  test_ios_unit:
+  test_ios:
     executor: reactnativeios
     parameters:
       use_frameworks:
@@ -1237,7 +1237,7 @@ workflows:
             - build_npm_package
       - test_ios_rntester
       - build_ios
-      - test_ios_unit:
+      - test_ios:
           run_unit_tests: true
           requires:
             - build_ios
@@ -1245,8 +1245,8 @@ workflows:
       # - build_ios:
       #     name: build_ios_frameworks
       #     use_frameworks: true
-      # - test_ios_unit:
-      #     name: test_ios_unit_frameworks
+      # - test_ios:
+      #     name: test_ios_frameworks
       #     use_frameworks: true
       #     run_unit_tests: true
       #     requires:

--- a/IntegrationTests/launchWebSocketServer.sh
+++ b/IntegrationTests/launchWebSocketServer.sh
@@ -1,18 +1,12 @@
 #!/bin/bash
-
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-# Set terminal title
-echo -en "\033]0;Web Socket Test Server\a"
-clear
-
 THIS_DIR=$(cd -P "$(dirname "$(readlink "${BASH_SOURCE[0]}" || echo "${BASH_SOURCE[0]}")")" && pwd)
-pushd "$THIS_DIR"
+pushd "$THIS_DIR" || exit
 ./websocket_integration_test_server.js
-popd
+popd || exit
 
-echo "Process terminated. Press <enter> to close the window"
-read
+echo "Process terminated."

--- a/scripts/objc-test.sh
+++ b/scripts/objc-test.sh
@@ -55,6 +55,24 @@ waitForPackager() {
   echo "Packager is ready!"
 }
 
+waitForWebSocketServer() {
+  local -i max_attempts=60
+  local -i attempt_num=1
+
+  until curl -s http://localhost:5555 | grep "Upgrade Required" -q; do
+    if (( attempt_num == max_attempts )); then
+      echo "WebSocket Server did not respond in time. No more attempts left."
+      exit 1
+    else
+      (( attempt_num++ ))
+      echo "WebSocket Server did not respond. Retrying for attempt number $attempt_num..."
+      sleep 1
+    fi
+  done
+
+  echo "WebSocket Server is ready!"
+}
+
 runTests() {
   # shellcheck disable=SC1091
   source "./scripts/.tests.env"
@@ -102,11 +120,13 @@ main() {
   # Otherwise, just build RNTester and exit
   if [ "$1" = "test" ]; then
 
+    # Start the WebSocket test server
+    echo "Launch WebSocket Server"
+    sh "./IntegrationTests/launchWebSocketServer.sh" &
+    waitForWebSocketServer
+
     # Start the packager
     yarn start --max-workers=1 || echo "Can't start packager automatically" &
-    # Start the WebSocket test server
-    open "./IntegrationTests/launchWebSocketServer.command" || echo "Can't start web socket server automatically"
-
     waitForPackager
     preloadBundles
 


### PR DESCRIPTION
## Summary

This PR reestablish the WebSocketTest in CI which is making the `test_ios_unit` fail.

**Note:** the test_ios_unit is actually running integration tests...

## Changelog

[iOS] [Changed] - Fix the test_ios_unit test

## Test Plan

The CI of this PR is green. 😬 
