### PR TITLE
[iOS] Restore ability to change JS bundle port via CLI

### DIFF
--- a/React-Core.podspec
+++ b/React-Core.podspec
@@ -47,7 +47,7 @@ Pod::Spec.new do |s|
   s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
   s.header_dir             = "React"
   s.framework              = "JavaScriptCore"
-  s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/RCT-Folly\" \"${PODS_ROOT}/Headers/Public/React-hermes\" \"${PODS_ROOT}/Headers/Public/hermes-engine\" \"${PODS_ROOT}/Headers/Public/FlipperKit\" \"$(PODS_ROOT)/Headers/Public/ReactCommon\" \"$(PODS_ROOT)/Headers/Public/React-RCTFabric\"", "DEFINES_MODULE" => "YES" }
+  s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/RCT-Folly\" \"${PODS_ROOT}/Headers/Public/React-hermes\" \"${PODS_ROOT}/Headers/Public/hermes-engine\" \"${PODS_ROOT}/Headers/Public/FlipperKit\" \"$(PODS_ROOT)/Headers/Public/ReactCommon\" \"$(PODS_ROOT)/Headers/Public/React-RCTFabric\"", "DEFINES_MODULE" => "YES", "GCC_PREPROCESSOR_DEFINITIONS" => "RCT_METRO_PORT=${RCT_METRO_PORT}" }
   s.user_target_xcconfig   = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/Headers/Private/React-Core\""}
   s.default_subspec        = "Default"
 


### PR DESCRIPTION
## Summary

Fixes #30708.

When given the `--port` option to the `npx react-native run-ios` command, [the React Native CLI passes the `RCT_METRO_PORT` variable when calling `xcodebuild`](https://github.com/react-native-community/cli/blob/ada951606e52ad98346cd72beeb15b56ceda8b7c/packages/platform-ios/src/commands/runIOS/index.ts#L552).

This used to adjust the port used when building on iOS, but this appears to have stopped working when the xcodeproj configuration was removed in favor of CocoaPods ([link, load the diff for React.xcodeproj](https://github.com/facebook/react-native/commit/79a7828b91b405de7399cd8cdc1aaaf610ce9d75#diff-43a2b2682727878049c3283b9361d9ad94964b63105fda6a834ba23baa5b471bL5199-L5205)).

This change re-adds the preprocessor definition that was used to pull the environment variable in, and now the `--port` flag works again.

## Changelog

[iOS] [Fixed] - Fixed the ability to pass the port to use for Metro when running `react-native run-ios --port <port>`.

## Test Plan

1. Using an example project generated from the 0.68.1 template, I modified `node_modules/react-native/React-Core.podspec` to have the same changes.
2. Deleted my project's `ios/Pods` folder and re-ran `bundle exec pod install`
3. Ran `yarn ios --port=9900` and verified that the app is connected to Metro, and check again with a refresh of the app.
4. Verified that I saw traffic on port 9900 when refreshing the app with `sudo lsof -i :9900`
5. Stopped the app and tested `yarn ios` without a port, and used `lsof` again to ensure it was using the default port `8081` again

I also ran the iOS tests locally and they passed.