### PR TITLE
Pass react build dir to cmake

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -283,6 +283,7 @@ android {
             cmake {
                 arguments "-DREACT_COMMON_DIR=${reactNativeRootDir}/ReactCommon",
                         "-DREACT_ANDROID_DIR=$projectDir",
+                        "-DREACT_BUILD_DIR=$buildDir",
                         "-DANDROID_STL=c++_shared",
                         "-DANDROID_TOOLCHAIN=clang",
                         "-DANDROID_PLATFORM=android-21"

--- a/ReactAndroid/src/main/jni/CMakeLists.txt
+++ b/ReactAndroid/src/main/jni/CMakeLists.txt
@@ -16,8 +16,12 @@ function(add_react_android_subdir relative_path)
   add_subdirectory(${REACT_ANDROID_DIR}/${relative_path} ReactAndroid/${relative_path})
 endfunction()
 
+function(add_react_build_subdir relative_path)
+  add_subdirectory(${REACT_BUILD_DIR}/${relative_path} build/${relative_path})
+endfunction()
+
 function(add_react_third_party_ndk_subdir relative_path)
-  add_react_android_subdir(build/third-party-ndk/${relative_path})
+  add_react_build_subdir(third-party-ndk/${relative_path})
 endfunction()
 
 function(add_react_common_subdir relative_path)
@@ -84,7 +88,7 @@ add_react_common_subdir(react/renderer/mapbuffer)
 add_react_common_subdir(react/nativemodule/core)
 
 # ReactAndroid JNI targets
-add_react_android_subdir(build/generated/source/codegen/jni)
+add_react_build_subdir(generated/source/codegen/jni)
 add_react_android_subdir(src/main/java/com/facebook/hermes/reactexecutor)
 add_react_android_subdir(src/main/jni/first-party/fbjni)
 add_react_android_subdir(src/main/jni/first-party/fb)


### PR DESCRIPTION
## Summary

The ReactAndroid cmake build assumes that the build directory is ReactAndroid/build, but this is not always the case if gradle is configured with a different build location. Instead of assuming the build location in cmake, pass it from gradle.

## Changelog

[Android] [Fixed] - Pass react build dir to cmake

## Test Plan

Tested in an app with a custom build dir that RN now builds properly after this change.

In build.gradle add:

```groovy
allprojects {
    buildDir = "${System.getProperty("user.home")}/.gradle/builds/${rootProject.name}/${project.name}"
}
```