### PR TITLE
Fix import path breakage

### DIFF
--- a/ReactAndroid/src/test/resources/BUCK
+++ b/ReactAndroid/src/test/resources/BUCK
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-load("@fbsource//tools/build_defs:fb_native_wrapper.bzl", "fb_native")
+load("//tools/build_defs:fb_native_wrapper.bzl", "fb_native")
 
 fb_native.java_library(
     name = "robolectric",


### PR DESCRIPTION
Summary:
https://github.com/facebook/react-native/runs/6262282188?check_suite_focus=true

Cell imports aren't compatible with open source buck builds.

Differential Revision: D36073197

