### PR TITLE
Connect Ruby tests with CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -452,8 +452,12 @@ jobs:
       - checkout
       - setup_artifacts
       - setup_ruby
+      - run:
+          name: Run Ruby Tests
+          command: |
+            cd scripts/cocoapods
+            sh run_tests.sh
       - run_yarn
-
       - run: |
           cd packages/rn-tester
           bundle check || bundle install

--- a/scripts/cocoapods/__tests__/dummy_test-test.rb
+++ b/scripts/cocoapods/__tests__/dummy_test-test.rb
@@ -1,0 +1,12 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+require "test/unit"
+
+class DummyTest < Test::Unit::TestCase
+    def test_add
+        assert_equal(5, 2+3)
+    end
+end

--- a/scripts/cocoapods/__tests__/dummy_test2-test.rb
+++ b/scripts/cocoapods/__tests__/dummy_test2-test.rb
@@ -1,0 +1,12 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+require "test/unit"
+
+class DummyTest2 < Test::Unit::TestCase
+    def test_sub
+        assert_equal(5, 11-6)
+    end
+end

--- a/scripts/cocoapods/__tests__/subfolder/dummy_test3-test.rb
+++ b/scripts/cocoapods/__tests__/subfolder/dummy_test3-test.rb
@@ -1,0 +1,12 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+require "test/unit"
+
+class DummyTest3 < Test::Unit::TestCase
+    def test_mul
+        assert_equal(12, 3*4)
+    end
+end

--- a/scripts/cocoapods/run_tests.sh
+++ b/scripts/cocoapods/run_tests.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -f
+
+basepath=$(dirname "${0}")
+files=( $(find . -name '*-test.rb') )
+
+test_suite="${basepath}/all_tests.rb"
+touch "${test_suite}"
+
+echo "require \"test/unit\"" > "${test_suite}"
+echo "discovered the following files:"
+for i in "${files[@]}"
+do
+    filename="${i#"${basepath}/"}"
+    echo "${filename}"
+    echo "require_relative \"${filename}\"" >> "${test_suite}"
+done
+
+ruby "${test_suite}"
+
+rm "${test_suite}"

--- a/scripts/cocoapods/run_tests.sh
+++ b/scripts/cocoapods/run_tests.sh
@@ -21,6 +21,7 @@ do
     echo "require_relative \"${filename}\"" >> "${test_suite}"
 done
 
-ruby "${test_suite}"
-
+ruby -Itest "${test_suite}"
+RES=$?
 rm "${test_suite}"
+exit $RES

--- a/scripts/cocoapods/submodule/__tests__/dummy_test4-test.rb
+++ b/scripts/cocoapods/submodule/__tests__/dummy_test4-test.rb
@@ -1,0 +1,12 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+require "test/unit"
+
+class DummyTest4 < Test::Unit::TestCase
+    def test_div
+        assert_equal(5, 10/2)
+    end
+end


### PR DESCRIPTION
Summary:
This Diff connects the ruby tests setup with CircleCI, making sure that we are executing the same script in Sandcastle and CircleCI.

At the moment, the scripts runs somedummy tests to make sure that everything works.

## Changelog
[iOS][Changed] - Add ruby tests to circleci

Differential Revision: D36091716

