### PR TITLE
fix(jest): make assetFileTransformer return an object

### DIFF
--- a/jest/assetFileTransformer.js
+++ b/jest/assetFileTransformer.js
@@ -20,12 +20,13 @@ module.exports = {
   // the correct images are loaded for components. Essentially
   // require('img1.png') becomes `Object { "testUri": 'path/to/img1.png' }` in
   // the Jest snapshot.
-  process: (_, filename) =>
-    `module.exports = {
+  process: (_, filename) => ({
+    code: `module.exports = {
       testUri:
         ${JSON.stringify(
           path.relative(__dirname, filename).replace(/\\/g, '/'),
         )}
     };`,
+  }),
   getCacheKey: createCacheKeyFunction([__filename]),
 };


### PR DESCRIPTION
Fixes #33751 
Relates to #33576

## Summary

Jest 28 removed support for returning a string in the process method of a transformer (https://jestjs.io/docs/upgrading-to-jest28#transformer).

This PR changes assetFileTransformer to return an object instead of a string.

## Changelog

[Internal] [Fixed] - Return object from assetFileTransformer

## Test Plan

Tests pass with Jest 28 when this change is made.
