### PR TITLE
Fix Circle CI for CompositeReactPackageTurboModuleManagerDelegate

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/CompositeReactPackageTurboModuleManagerDelegate.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/CompositeReactPackageTurboModuleManagerDelegate.java
@@ -49,7 +49,7 @@ public class CompositeReactPackageTurboModuleManagerDelegate
         ReactApplicationContext context, List<ReactPackage> packages) {
       List<TurboModuleManagerDelegate> delegates = new ArrayList<>();
       for (ReactPackageTurboModuleManagerDelegate.Builder delegatesBuilder : mDelegatesBuilder) {
-        delegates.add(delegatesBuilder.build(context, Collections.emptyList()));
+        delegates.add(delegatesBuilder.build(context, Collections.<ReactPackage>emptyList()));
       }
       return new CompositeReactPackageTurboModuleManagerDelegate(context, packages, delegates);
     }


### PR DESCRIPTION
Summary:
This fails to compile in our CircleCI builds
```
/root/react-native/ReactAndroid/src/main/java/com/facebook/react/CompositeReactPackageTurboModuleManagerDelegate.java:52: error: incompatible types: java.util.List<java.lang.Object> cannot be converted to java.util.List<com.facebook.react.ReactPackage>
        delegates.add(delegatesBuilder.build(context, Collections.emptyList()));
```
Make the empty collection generic should solve the issue

Changelog:
[Internal] [Changed] - Fix Circle CI for CompositeReactPackageTurboModuleManagerDelegate

Reviewed By: cortinico, dmitryrykun

Differential Revision: D36130573

