### PR TITLE
[android] add back hermes inspector support

### DIFF
--- a/ReactAndroid/src/main/jni/react/jni/CMakeLists.txt
+++ b/ReactAndroid/src/main/jni/react/jni/CMakeLists.txt
@@ -14,7 +14,8 @@ add_compile_options(
         -fexceptions
         -frtti
         -Wno-unused-lambda-capture
-        -std=c++17)
+        -std=c++17
+        -DWITH_INSPECTOR=1)
 
 ##########################
 ### React Native Utils ###


### PR DESCRIPTION
## Summary

the `WITH_INSPECTOR` build flag is missing from cmake migration. original we had it in [Application.mk](https://github.com/facebook/react-native/blob/ed46ea2058b909a2dd401347d68956324961ec2c/ReactAndroid/src/main/jni/Application.mk#L29)

this pr adds back the build flag and make hermes inspector (or debugging hermes in flipper) work again.

## Changelog

[Android] [Fixed] - add back hermes inspector support

## Test Plan

test on rn-tester hermes variant