### PR TITLE
Store Hermes Debug Symbols inside CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1166,6 +1166,11 @@ jobs:
       # END: Stables and nightlies
 
       - run: node ./scripts/publish-npm.js << parameters.publish_npm_args >>
+      - run:
+          name: Zip Hermes Native Symbols
+          command: zip -r /tmp/hermes-native-symbols.zip ~/react-native/ReactAndroid/hermes-engine/build/intermediates/cmake/
+      - store_artifacts:
+          path: /tmp/hermes-native-symbols.zip
 
       # START: Commitlies
       # Provide a react-native package for this commit as a Circle CI release artifact.


### PR DESCRIPTION
Summary:
This diff adds a `store_artifacts` to CircleCI so the Hermes debug symbols are retained and can be used to symbolicate native crashes for Hermes.

Changelog:
[Internal] [Changed] - Store Hermes Debug Symbols inside CircleCI

Reviewed By: cipolleschi

Differential Revision: D36201978

