### PR TITLE
Export `script/cocoapods/flipper.rb` to fix the CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "scripts/react_native_pods_utils/script_phases.rb",
     "scripts/react_native_pods_utils/script_phases.sh",
     "scripts/react_native_pods.rb",
+    "scripts/cocoapods/flipper.rb",
     "scripts/react-native-xcode.sh",
     "sdks/hermesc",
     "sdks/hermes-engine.podspec",


### PR DESCRIPTION
Summary:
This Diff exports the `flipper.rb` file in the `package.json` to fix the OSS CI

## Changelog
[iOS][Changed] - Export `flipper.rb` script file

Differential Revision: D36244721

