### PR TITLE
fix: bump flipper pods to get arm64 catalyst slice

### DIFF
--- a/scripts/cocoapods/flipper.rb
+++ b/scripts/cocoapods/flipper.rb
@@ -8,10 +8,10 @@
 $flipper_default_versions = {
     'Flipper' => '0.125.0',
     'Flipper-Boost-iOSX' => '1.76.0.1.11',
-    'Flipper-DoubleConversion' => '3.2.0',
+    'Flipper-DoubleConversion' => '3.2.0.1',
     'Flipper-Fmt' => '7.1.7',
     'Flipper-Folly' => '2.6.10',
-    'Flipper-Glog' => '0.5.0.4',
+    'Flipper-Glog' => '0.5.0.5',
     'Flipper-PeerTalk' => '0.0.4',
     'Flipper-RSocket' => '1.4.3',
     'OpenSSL-Universal' => '1.1.1100',


### PR DESCRIPTION
## Summary

Patch release bumps that just change arm64 slice packaging
See https://github.com/facebook/flipper/issues/3117#issuecomment-1123759397

These pods were just released by @lblasa and this PR integrates them - I personally confirm success on an arm64 doing a macCatalyst build for the first time since react-native 0.64, and users report intel works fine as well - no regression


## Changelog

[Catalyst][Fix] - use pods with arm64 macCatalyst slices

## Test Plan

Run a macCatalyst build on intel machine and m1 machine, I use this harness as part of release-testers facebook group, and it exercises macCatalyst build if you pass in a valid development team (for signing) https://github.com/mikehardy/rnfbdemo/blob/main/make-demo.sh

(the test harness is locally modified to no longer exclude M1 builds and with a patch-package that implements this PR, pending this merge+release...)
