### PR TITLE
Hermes: Use prepare-hermes-for-build in Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -911,8 +911,12 @@ jobs:
           name: Install dependencies
           command: |
             apt update
-            apt install -y wget git
+            apt install -y wget git curl
+            curl -sL https://deb.nodesource.com/setup_16.x | bash -
+            apt install -y nodejs
+            npm install --global yarn
       - checkout
+      - run_yarn
       - run:
           name: Set up Hermes workspace and caching
           command: |
@@ -929,24 +933,9 @@ jobs:
       - run:
           name: Download Hermes tarball
           command: |
-            HERMES_TARBALL_URL="https://github.com/facebook/hermes/archive/refs/heads/main.tar.gz"
-            HERMES_TARBALL_PATH="$HERMES_WS_DIR/download/hermes.tar.gz"
-
-            if [ -f "$HERMES_VERSION_FILE" ]; then
-              HERMES_TAG=$(cat $HERMES_VERSION_FILE | tr -d '[:space:]')
-              HERMES_TARBALL_URL="https://github.com/facebook/hermes/archive/refs/tags/$HERMES_TAG.tar.gz"
-              echo "Using Hermes version tagged $HERMES_TAG"
-            else
-              echo "Using Hermes latest version from trunk"
-            fi
-
-            if [ -f "$HERMES_TARBALL_PATH" ]; then
-              echo "Skipping download; $HERMES_TARBALL_PATH already present."
-            else
-              echo "Downloading Hermes tarball from $HERMES_TARBALL_URL"
-              wget -O "$HERMES_TARBALL_PATH" "$HERMES_TARBALL_URL"
-            fi
-            tar -xzf "$HERMES_WS_DIR/download/hermes.tar.gz" --strip-components=1 -C "$HERMES_WS_DIR/hermes"
+            node scripts/hermes/prepare-hermes-for-build
+            cp sdks/download/* $HERMES_WS_DIR/download/.
+            cp -r sdks/hermes/* $HERMES_WS_DIR/hermes/.
       - save_cache:
           key: *hermes_cache_key
           paths:

--- a/sdks/hermes-engine/utils/build-apple-framework.sh
+++ b/sdks/hermes-engine/utils/build-apple-framework.sh
@@ -90,7 +90,8 @@ function create_universal_framework {
   done
 
   mkdir universal
-  xcodebuild -create-xcframework "$args" -output "universal/hermes.xcframework"
+  # shellcheck disable=SC2086
+  xcodebuild -create-xcframework $args -output "universal/hermes.xcframework"
 
   for platform in "$@"; do
     rm -r "$platform"


### PR DESCRIPTION
Summary:
Use `scripts/hermes/prepare-hermes-for-build.js` in Circle CI, eliminating redundant steps in the `prepare_hermes_workspace` Circle CI job.

Changelog: [Internal]

Differential Revision: D36335122

