### PR TITLE
remove buildToolsVersion

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -249,7 +249,6 @@ task installArchives {
 }
 
 android {
-    buildToolsVersion = "31.0.0"
     compileSdkVersion 31
 
     // Used to override the NDK path/version on internal CI or by allowing

--- a/ReactAndroid/hermes-engine/build.gradle
+++ b/ReactAndroid/hermes-engine/build.gradle
@@ -118,7 +118,6 @@ def reactNativeArchitectures() {
 
 android {
     compileSdkVersion 31
-    buildToolsVersion = "31.0.0"
 
     // Used to override the NDK path/version on internal CI or by allowing
     // users to customize the NDK path/version from their root project (e.g. for M1 support)

--- a/packages/rn-tester/android/app/build.gradle
+++ b/packages/rn-tester/android/app/build.gradle
@@ -143,7 +143,6 @@ def reactNativeArchitectures() {
 }
 
 android {
-    buildToolsVersion = "31.0.0"
     compileSdkVersion 31
 
     // Used to override the NDK path/version on internal CI or by allowing

--- a/template/android/build.gradle
+++ b/template/android/build.gradle
@@ -4,7 +4,6 @@ import org.apache.tools.ant.taskdefs.condition.Os
 
 buildscript {
     ext {
-        buildToolsVersion = "31.0.0"
         minSdkVersion = 21
         compileSdkVersion = 31
         targetSdkVersion = 31


### PR DESCRIPTION
## Summary

Since Android Gradle Plugin 3.1.0 (March 2018), we no longer need to specify buildToolsVersion. Most React Native modules don't use this config (I removed for popular ones), or they have fallback value. We'll have one less version and compatibility to maintain.

Below is excerpt from AGP 3.1.0 release notes.

> Build Tools 27.0.3 or higher. Keep in mind, you no longer need to specify a version for the build tools using the android.buildToolsVersion property—the plugin uses the minimum required version by default


## Changelog

[Android] [Changed] - remove buildToolsVersion config

## Test Plan

Everything builds and runs as expected