### PR TITLE
Move fabric setup to a seprata file

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "scripts/react_native_pods_utils/script_phases.sh",
     "scripts/react_native_pods.rb",
     "scripts/cocoapods/flipper.rb",
+    "scripts/cocoapods/fabric.rb",
     "scripts/react-native-xcode.sh",
     "sdks/hermes-engine",
     "sdks/hermesc",

--- a/scripts/cocoapods/__tests__/fabric-test.rb
+++ b/scripts/cocoapods/__tests__/fabric-test.rb
@@ -1,0 +1,189 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+require "test/unit"
+require_relative "../fabric.rb"
+require_relative "./test_utils/podSpy.rb"
+require_relative "./test_utils/PodMock.rb"
+require_relative "./test_utils/PathnameMock.rb"
+require_relative "./test_utils/FileMock.rb"
+require_relative "./test_utils/DirMock.rb"
+require_relative "./test_utils/systemUtils.rb"
+
+class FabricTests < Test::Unit::TestCase
+    :third_party_provider_header
+    :third_party_provider_implementation
+    :base_path
+    :prefix
+
+    def setup
+        File.is_testing!
+        Dir.is_testing!
+        Pod::Config.reset()
+
+        @prefix = "../.."
+        @third_party_provider_header = "RCTThirdPartyFabricComponentsProvider.h"
+        @third_party_provider_implementation = "RCTThirdPartyFabricComponentsProvider.cpp"
+        @base_path = "~/app/ios"
+        Pathname.pwd!(@base_path)
+        Pod::Config.instance.installation_root.relative_path_from = @base_path
+    end
+
+    def teardown
+        system_reset_commands()
+        podSpy_cleanUp()
+        Pod::UI.reset()
+        Pod::Executable.reset()
+        Pathname.reset()
+        File.reset()
+        Dir.reset()
+    end
+
+    # ============================================== #
+    # Test - setup_fabric #
+    # ============================================== #
+    def testSetupFabric_whenFileAlreadyExists_doNothing()
+
+        # Arrange
+        File.mocked_existing_files([
+            @base_path + "/build/" + @third_party_provider_header,
+            @base_path + "/build/" + @third_party_provider_implementation,
+        ])
+
+        # Act
+        setup_fabric!(@prefix, false, 'build')
+
+        # Assert
+        assert_equal(Pathname.pwd_invocation_count, 1)
+        assert_equal(Pod::Config.instance.installation_root.relative_path_from_invocation_count, 1)
+        assert_equal(File.exist_invocation_count, 2)
+        assert_equal(Dir.exist_invocation_count, 0)
+        assert_equal(Pod::UI.collected_messages, [])
+        assert_equal($collected_commands, [])
+        assert_equal(File.open_files.length, 0)
+        assert_equal(Pod::Executable.executed_commands.length, 0)
+        check_installed_pods(@prefix)
+    end
+
+    def testSetupFabric_whenHeaderMissingAndCodegenMissing_raiseError()
+
+        # Arrange
+        File.mocked_existing_files([
+            @base_path + "/build/" + @third_party_provider_implementation,
+        ])
+
+        # Act
+        assert_raise {
+            setup_fabric!(@prefix, false, 'build')
+        }
+
+        # Assert
+        assert_equal(Pathname.pwd_invocation_count, 1)
+        assert_equal(Pod::Config.instance.installation_root.relative_path_from_invocation_count, 1)
+        assert_equal(File.exist_invocation_count, 1)
+        assert_equal(Dir.exist_invocation_count, 2)
+        assert_equal(Pod::UI.collected_messages, [])
+        assert_equal($collected_commands, [])
+        assert_equal(File.open_files.length, 0)
+        assert_equal(Pod::Executable.executed_commands.length, 0)
+        assert_equal($podInvocationCount, 0)
+    end
+
+    def testSetupFabric_whenImplementationMissingAndCodegenrepoExists_dontBuildCodegen()
+
+        # Arrange
+        File.mocked_existing_files([
+            @base_path + "/build/" + @third_party_provider_header,
+            @base_path + "/build/tmpSchemaList.txt"
+        ])
+
+        Dir.mocked_existing_dirs([
+            @base_path + "/"+ @prefix + "/packages/react-native-codegen",
+            @base_path + "/"+ @prefix + "/packages/react-native-codegen/lib"
+        ])
+
+        # Act
+        setup_fabric!(@prefix, false, 'build')
+
+        # Assert
+        assert_equal(Pathname.pwd_invocation_count, 1)
+        assert_equal(Pod::Config.instance.installation_root.relative_path_from_invocation_count, 1)
+        assert_equal(File.exist_invocation_count, 3)
+        assert_equal(Dir.exist_invocation_count, 2)
+        assert_equal(Pod::UI.collected_messages, ["[Codegen] generating an empty RCTThirdPartyFabricComponentsProvider"])
+        assert_equal($collected_commands, [])
+        assert_equal(File.open_invocation_count, 1)
+        assert_equal(File.open_files_with_mode[@base_path + "/build/tmpSchemaList.txt"], 'w')
+        assert_equal(File.open_files[0].collected_write, ["[]"])
+        assert_equal(File.open_files[0].fsync_invocation_count, 1)
+        assert_equal(Pod::Executable.executed_commands[0], {
+            "command" => "node",
+            "arguments" => [
+                @base_path + "/" + @prefix + "/scripts/generate-provider-cli.js",
+                "--platform", 'ios',
+                "--schemaListPath", @base_path + "/build/tmpSchemaList.txt",
+                "--outputDir", @base_path + "/build"
+            ]
+        })
+        assert_equal(File.delete_invocation_count, 1)
+        assert_equal(File.deleted_files, [@base_path + "/build/tmpSchemaList.txt"])
+        check_installed_pods(@prefix)
+    end
+
+    def testSetupFabric_whenBothMissing_buildCodegen()
+        # Arrange
+        codegen_cli_path = @base_path + "/" + @prefix + "/../react-native-codegen"
+        Dir.mocked_existing_dirs([
+            codegen_cli_path,
+        ])
+        # Act
+        setup_fabric!(@prefix, false, 'build')
+
+        # Assert
+        assert_equal(Pathname.pwd_invocation_count, 1)
+        assert_equal(Pod::Config.instance.installation_root.relative_path_from_invocation_count, 1)
+        assert_equal(File.exist_invocation_count, 2)
+        assert_equal(Dir.exist_invocation_count, 3)
+        assert_equal(Pod::UI.collected_messages, [
+            "[Codegen] building #{codegen_cli_path}.",
+            "[Codegen] generating an empty RCTThirdPartyFabricComponentsProvider"
+        ])
+        assert_equal($collected_commands, ["~/app/ios/../../../react-native-codegen/scripts/oss/build.sh"])
+        assert_equal(File.open_files[0].collected_write, ["[]"])
+        assert_equal(File.open_files[0].fsync_invocation_count, 1)
+        assert_equal(Pod::Executable.executed_commands[0], {
+            "command" => "node",
+            "arguments" => [
+                @base_path + "/" + @prefix + "/scripts/generate-provider-cli.js",
+                "--platform", 'ios',
+                "--schemaListPath", @base_path + "/build/tmpSchemaList.txt",
+                "--outputDir", @base_path + "/build"
+            ]
+        })
+        check_installed_pods(@prefix)
+    end
+
+    def check_installed_pods(prefix)
+        assert_equal($podInvocationCount, 6)
+
+        check_pod("React-Fabric", :path => "#{prefix}/ReactCommon")
+        check_pod("React-rncore", :path => "#{prefix}/ReactCommon")
+        check_pod("React-graphics", :path => "#{prefix}/ReactCommon/react/renderer/graphics")
+        check_pod("React-jsi/Fabric", :path => "#{prefix}/ReactCommon/jsi")
+        check_pod("React-RCTFabric", :path => "#{prefix}/React", :modular_headers => true)
+        check_pod("RCT-Folly/Fabric", :podspec => "#{prefix}/third-party-podspecs/RCT-Folly.podspec")
+    end
+
+    def check_pod(name, path: nil, modular_headers: nil, podspec: nil)
+        params = $podInvocation[name]
+        expected_params = {}
+
+        if path != nil then expected_params[:path] = path end
+        if modular_headers != nil then expected_params[:modular_headers] = modular_headers end
+        if podspec != nil then expected_params[:podspec] = podspec end
+
+        assert_equal(params, expected_params)
+    end
+end

--- a/scripts/cocoapods/__tests__/test_utils/DirMock.rb
+++ b/scripts/cocoapods/__tests__/test_utils/DirMock.rb
@@ -1,0 +1,47 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+class Dir
+
+    @@is_testing = false
+    @@exist_invocation_count = 0
+    @@mocked_existing_dirs = []
+
+    # Monkey patched exists? method.
+    # It is used also by the test runner, so it can't start monkey patched
+    # To use this, invoke the `is_testing` method before starting your test.
+    # Remember to invoke `reset` after the test.
+    def self.exist?(path)
+        if !@@is_testing
+            return exists?(path)
+        end
+
+        @@exist_invocation_count += 1
+        return @@mocked_existing_dirs.include?(path)
+    end
+
+    # Getter for the exist_invocation_count to check that the exist method
+    # is invoked the right number of times
+    def self.exist_invocation_count()
+        return @@exist_invocation_count
+    end
+
+    # Set the list of dirs the test must return as existing
+    def self.mocked_existing_dirs(dirs)
+        @@mocked_existing_dirs = dirs
+    end
+
+    # Turn on the mocking features of the File mock
+    def self.is_testing!()
+        @@is_testing = true
+    end
+
+    # Resets all the settings for the File mock
+    def self.reset()
+        @@mocked_existing_dirs = []
+        @@is_testing = false
+        @@exist_invocation_count = 0
+    end
+end

--- a/scripts/cocoapods/__tests__/test_utils/FileMock.rb
+++ b/scripts/cocoapods/__tests__/test_utils/FileMock.rb
@@ -1,0 +1,115 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+class File
+
+    @@is_testing = false
+    @@exist_invocation_count = 0
+    @@mocked_existing_files = []
+
+    @@delete_invocation_count = 0
+    @@deleted_files = []
+
+    @@open_files_with_mode = {}
+    @@open_invocation_count = 0
+
+    @@open_files = []
+    attr_reader :collected_write
+    attr_reader :fsync_invocation_count
+
+    def initialize()
+        @collected_write = []
+        @fsync_invocation_count = 0
+    end
+
+    # Monkey patched exists? method.
+    # It is used also by the test runner, so it can't start monkey patched
+    # To use this, invoke the `is_testing` method before starting your test.
+    # Remember to invoke `reset` after the test.
+    def self.exist?(path)
+        if !@@is_testing
+            return exists?(path)
+        end
+
+        @@exist_invocation_count += 1
+        return @@mocked_existing_files.include?(path)
+    end
+
+    def self.delete(path)
+        if !@@is_testing
+            delete(path)
+            return
+        end
+
+        @@delete_invocation_count += 1
+        @@deleted_files.push(path)
+    end
+
+    def self.delete_invocation_count
+        return @@delete_invocation_count
+    end
+
+    def self.deleted_files
+        return @@deleted_files
+    end
+
+    # Getter for the exist_invocation_count to check that the exist method
+    # is invoked the right number of times
+    def self.exist_invocation_count()
+        return @@exist_invocation_count
+    end
+
+    # Set the list of files the test must return as existing
+    def self.mocked_existing_files(files)
+        @@mocked_existing_files = files
+    end
+
+    # Turn on the mocking features of the File mock
+    def self.is_testing!()
+        @@is_testing = true
+    end
+
+    def self.open(path, mode, &block)
+        @@open_files_with_mode[path] = mode
+        @@open_invocation_count += 1
+        file = File.new()
+        @@open_files.push(file)
+        yield(file)
+    end
+
+    def self.open_files_with_mode
+        return @@open_files_with_mode
+    end
+
+    def self.open_invocation_count
+        return @@open_invocation_count
+    end
+
+    def self.open_files
+        return @@open_files
+    end
+
+    def write(text)
+        @collected_write.push(text.to_s)
+    end
+
+    def fsync()
+        @fsync_invocation_count += 1
+    end
+
+    # Resets all the settings for the File mock
+    def self.reset()
+        @@delete_invocation_count = 0
+        @@deleted_files = []
+        @@open_files = []
+        @@open_files_with_mode = {}
+        @@open_invocation_count = 0
+        @@mocked_existing_files = []
+        @@is_testing = false
+        @@exist_invocation_count = 0
+    end
+
+
+end

--- a/scripts/cocoapods/__tests__/test_utils/PathnameMock.rb
+++ b/scripts/cocoapods/__tests__/test_utils/PathnameMock.rb
@@ -1,0 +1,28 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+class Pathname
+    @@pwd = ""
+    @@pwd_invocation_count = 0
+
+    def self.pwd!(pwd)
+        @@pwd = pwd
+    end
+
+    def self.pwd()
+        @@pwd_invocation_count += 1
+        return @@pwd
+    end
+
+    def self.pwd_invocation_count
+        return @@pwd_invocation_count
+    end
+
+
+    def self.reset()
+        @@pwd = ""
+        @@pwd_invocation_count = 0
+    end
+end

--- a/scripts/cocoapods/__tests__/test_utils/PodMock.rb
+++ b/scripts/cocoapods/__tests__/test_utils/PodMock.rb
@@ -1,0 +1,76 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+module Pod
+    class Config
+        @@instance = Config.new()
+
+        attr_reader :installation_root
+
+        def initialize()
+            @installation_root = InstallationRootMock.new()
+        end
+
+        def self.instance()
+            return @@instance
+        end
+
+        def self.reset()
+            @@instance = Config.new()
+        end
+    end
+
+    class InstallationRootMock
+
+        attr_accessor :relative_path_from
+        attr_reader :relative_path_from_invocation_count
+
+        def initialize()
+            @relative_path_from = ""
+            @relative_path_from_invocation_count = 0
+        end
+
+        def relative_path_from(path)
+            @relative_path_from_invocation_count += 1
+            return @relative_path_from
+        end
+    end
+
+    class UI
+
+        @@collected_messages = []
+
+        def self.puts(message)
+            @@collected_messages.push(message)
+        end
+
+        def self.collected_messages()
+            return @@collected_messages
+        end
+
+        def self.reset()
+            @@collected_messages = []
+        end
+    end
+
+    class Executable
+        @@executed_commands = []
+
+        def self.execute_command(command, arguments)
+            @@executed_commands.push({
+                "command" => command,
+                "arguments" => arguments
+            })
+        end
+
+        def self.executed_commands
+            return @@executed_commands
+        end
+
+        def self.reset()
+            @@executed_commands = []
+        end
+    end
+end

--- a/scripts/cocoapods/__tests__/test_utils/podSpy.rb
+++ b/scripts/cocoapods/__tests__/test_utils/podSpy.rb
@@ -26,11 +26,13 @@ def podSpy_cleanUp
     $podInvocationCount = 0
 end
 
-def pod(name, version = nil, path: nil, configurations: nil)
+def pod(name, version = nil, path: nil, configurations: nil, modular_headers: nil, podspec: nil)
     $podInvocationCount += 1
     params = {}
     if version != nil then params[:version] = version end
     if path != nil then params[:path] = path end
     if configurations != nil then params[:configurations] = configurations end
+    if modular_headers != nil then params[:modular_headers] = modular_headers end
+    if podspec != nil then params[:podspec] = podspec end
     $podInvocation[name] = params
 end

--- a/scripts/cocoapods/__tests__/test_utils/systemUtils.rb
+++ b/scripts/cocoapods/__tests__/test_utils/systemUtils.rb
@@ -1,0 +1,14 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+$collected_commands = []
+
+def system(command)
+    $collected_commands.push(command)
+end
+
+def system_reset_commands()
+    $collected_commands = []
+end

--- a/scripts/cocoapods/fabric.rb
+++ b/scripts/cocoapods/fabric.rb
@@ -1,0 +1,74 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# TODO: Move this to codegen.rb when we refactor that part
+def build_codegen!(react_native_path, relative_installation_root)
+    codegen_repo_path = "#{relative_installation_root}/#{react_native_path}/packages/react-native-codegen";
+    codegen_npm_path = "#{relative_installation_root}/#{react_native_path}/../react-native-codegen";
+    codegen_cli_path = ""
+
+    if Dir.exist?(codegen_repo_path)
+      codegen_cli_path = codegen_repo_path
+    elsif Dir.exist?(codegen_npm_path)
+      codegen_cli_path = codegen_npm_path
+    else
+      raise "[codegen] Couldn't not find react-native-codegen."
+    end
+
+    if !Dir.exist?("#{codegen_cli_path}/lib")
+      Pod::UI.puts "[Codegen] building #{codegen_cli_path}."
+      system("#{codegen_cli_path}/scripts/oss/build.sh")
+    end
+  end
+
+# This is a temporary supporting function until we enable use_react_native_codegen_discovery by default.
+def checkAndGenerateEmptyThirdPartyProvider!(react_native_path, new_arch_enabled, codegen_output_dir)
+    return if new_arch_enabled
+
+    relative_installation_root = Pod::Config.instance.installation_root.relative_path_from(Pathname.pwd)
+
+    output_dir = "#{relative_installation_root}/#{codegen_output_dir}"
+
+    provider_h_path = "#{output_dir}/RCTThirdPartyFabricComponentsProvider.h"
+    provider_cpp_path ="#{output_dir}/RCTThirdPartyFabricComponentsProvider.cpp"
+
+    if(!File.exist?(provider_h_path) || !File.exist?(provider_cpp_path))
+        # build codegen
+        build_codegen!(react_native_path, relative_installation_root)
+
+        # Just use a temp empty schema list.
+        temp_schema_list_path = "#{output_dir}/tmpSchemaList.txt"
+        File.open(temp_schema_list_path, 'w') do |f|
+            f.write('[]')
+            f.fsync
+        end
+
+        Pod::UI.puts '[Codegen] generating an empty RCTThirdPartyFabricComponentsProvider'
+        Pod::Executable.execute_command(
+        'node',
+        [
+            "#{relative_installation_root}/#{react_native_path}/scripts/generate-provider-cli.js",
+            "--platform", 'ios',
+            "--schemaListPath", temp_schema_list_path,
+            "--outputDir", "#{output_dir}"
+        ])
+        File.delete(temp_schema_list_path) if File.exist?(temp_schema_list_path)
+    end
+end
+
+# It sets up the faric dependencies and it create the an EmptyThirdPartyProvider, if needed.
+#
+# @parameter prefix: prefix to use to reach react-native
+# @parameter new_arch_enabled: whether the new arch is enabled or not
+# @parameter codegen_output_dir: the directory where the code is generated
+def setup_fabric!(prefix, new_arch_enabled, codegen_output_dir)
+    checkAndGenerateEmptyThirdPartyProvider!(prefix, new_arch_enabled, codegen_output_dir)
+    pod 'React-Fabric', :path => "#{prefix}/ReactCommon"
+    pod 'React-rncore', :path => "#{prefix}/ReactCommon"
+    pod 'React-graphics', :path => "#{prefix}/ReactCommon/react/renderer/graphics"
+    pod 'React-jsi/Fabric', :path => "#{prefix}/ReactCommon/jsi"
+    pod 'React-RCTFabric', :path => "#{prefix}/React", :modular_headers => true
+    pod 'RCT-Folly/Fabric', :podspec => "#{prefix}/third-party-podspecs/RCT-Folly.podspec"
+end


### PR DESCRIPTION
Summary:
This Diff moves the fabric setup from the `react_native_pods` script to its own `fabric` file.

It also introduces tests for the file and some test utilities.

## Changelog
[iOS][Changed] - Move fabric setup to its own file

Differential Revision: D36344911

