### PR TITLE
Fix `pod install --project-directory=ios` failing when Hermes is enabled

### DIFF
--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -666,11 +666,14 @@ end
 
 def downloadAndConfigureHermesSource(react_native_path)
   hermes_tarball_base_url = "https://github.com/facebook/hermes/tarball/"
-  sdks_dir = "#{react_native_path}/sdks"
-  download_dir = "#{sdks_dir}/download"
-  hermes_dir = "#{sdks_dir}/hermes"
-  hermes_tag_file = "#{sdks_dir}/.hermesversion"
-  system("mkdir -p #{hermes_dir} #{download_dir}")
+
+  sdks_dir = Pod::Config.instance.installation_root.join(react_native_path, "sdks")
+  download_dir = sdks_dir.join("download")
+  hermes_dir = sdks_dir.join("hermes")
+  hermes_tag_file = sdks_dir.join(".hermesversion")
+
+  hermes_dir.mkpath
+  download_dir.mkpath
 
   if (File.exist?(hermes_tag_file))
     hermes_tag = File.read(hermes_tag_file).strip
@@ -680,19 +683,19 @@ def downloadAndConfigureHermesSource(react_native_path)
 
   hermes_tarball_url = hermes_tarball_base_url + hermes_tag
   hermes_tag_sha = %x[git ls-remote https://github.com/facebook/hermes #{hermes_tag} | cut -f 1].strip
-  hermes_tarball_path = "#{download_dir}/hermes-#{hermes_tag_sha}.tar.gz"
+  hermes_tarball_path = download_dir.join("hermes-#{hermes_tag_sha}.tar.gz")
 
   if (!File.exist?(hermes_tarball_path))
     Pod::UI.puts "[Hermes] Downloading Hermes source code..."
-    system("curl #{hermes_tarball_url} -Lo #{hermes_tarball_path}")
+    system("curl #{hermes_tarball_url} -Lo #{hermes_tarball_path.to_s}")
   end
   Pod::UI.puts "[Hermes] Extracting Hermes tarball (#{hermes_tag_sha.slice(0,6)})"
-  system("tar -zxf #{hermes_tarball_path} --strip-components=1 --directory #{hermes_dir}")
+  system("tar -zxf #{hermes_tarball_path.to_s} --strip-components=1 --directory #{hermes_dir.to_s}")
 
   # TODO: Integrate this temporary hermes-engine.podspec into the actual one located in facebook/hermes
-  system("cp #{sdks_dir}/hermes-engine.podspec #{hermes_dir}/hermes-engine.podspec")
+  FileUtils.cp(sdks_dir.join("hermes-engine.podspec"), hermes_dir.join("hermes-engine.podspec"))
 
-  hermes_dir
+  hermes_dir.relative_path_from(Pod::Config.instance.installation_root).to_s
 end
 
 # This provides a post_install workaround for build issues related Xcode 12.5 and Apple Silicon (M1) machines.


### PR DESCRIPTION
## Summary

`pod install --project-directory=ios` fails when Hermes is enabled:

```
% pod install --project-directory=ios
[Codegen] Generating ios/build/generated/ios/React-Codegen.podspec.json
[Hermes] Extracting Hermes tarball (5244f8)

[DEBUG] pwd: /~/example
[DEBUG] cp: cp ../node_modules/react-native/sdks/hermes-engine.podspec ../node_modules/react-native/sdks/hermes/hermes-engine.podspec

warn Multiple Podfiles were found: ios/Podfile,macos/Podfile. Choosing ios/Podfile automatically. If you would like to select a different one, you can configure it via "project.ios.sourceDir". You can learn more about it here: https://github.com/react-native-community/cli/blob/master/docs/configuration.md
Auto-linking React Native module for target `ReactTestApp`: ReactTestApp-DevSupport
Analyzing dependencies
Fetching podspec for `DoubleConversion` from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`
[Codegen] Found FBReactNativeSpec
Fetching podspec for `RCT-Folly` from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`
Fetching podspec for `boost` from `../node_modules/react-native/third-party-podspecs/boost.podspec`
Fetching podspec for `glog` from `../node_modules/react-native/third-party-podspecs/glog.podspec`
[!] No podspec found for `hermes-engine` in `../node_modules/react-native/sdks/hermes/hermes-engine.podspec`
```

## Changelog

[iOS] [Fixed] - `pod install --project-directory=ios` fails when Hermes is enabled

## Test Plan

Running `pod install --project-directory=ios` is enough to trigger this issue.