### PR TITLE
Delete simulators in background on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -734,6 +734,14 @@ jobs:
       - checkout
       - run_yarn
 
+      # The macOS machine can run out of storage if Hermes is enabled and built from source.
+      # Since this job does not use the iOS Simulator, deleting it provides a quick way to
+      # free up space.
+      - run:
+          name: Delete iOS Simulators
+          background: true
+          command: sudo rm -rf /Library/Developer/CoreSimulator/Profiles/Runtimes/
+
       - run:
           name: Set USE_HERMES=1
           command: echo "export USE_HERMES=1" >> $BASH_ENV
@@ -752,13 +760,6 @@ jobs:
           command: |
             rm -rf packages/rn-tester/Pods
             cd packages/rn-tester && bundle exec pod install
-
-      # The macOS machine can run out of storage if Hermes is enabled and built from source.
-      # Since this job does not use the iOS Simulator, deleting it provides a quick way to
-      # free up space.
-      - run:
-          name: Delete iOS Simulators
-          command: sudo rm -rf /Library/Developer/CoreSimulator/Profiles/Runtimes/
 
       - run:
           name: Build RNTester


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Instead of wait for Circle to delete the simulators, we can do it in background and save 40 seconds