### PR TITLE
Hermes: Use prepare-hermes-for-build in CocoaPods

### DIFF
--- a/scripts/hermes/bump-hermes-version.js
+++ b/scripts/hermes/bump-hermes-version.js
@@ -17,11 +17,7 @@
 const {exit} = require('shelljs');
 const yargs = require('yargs');
 const inquirer = require('inquirer');
-const fs = require('fs');
-const path = require('path');
-
-const HERMES_TAG_FILE_DIR = 'sdks';
-const HERMES_TAG_FILE_PATH = `${HERMES_TAG_FILE_DIR}/.hermesversion`;
+const {setHermesTag} = require('./hermes-utils');
 
 let argv = yargs.option('t', {
   alias: 'tag',
@@ -29,32 +25,6 @@ let argv = yargs.option('t', {
     'Hermes release tag to use for this React Native release, ex. hermes-2022-02-21-RNv0.68.0',
   required: true,
 }).argv;
-
-function readHermesTag() {
-  if (fs.existsSync(path)) {
-    const data = fs.readFileSync(HERMES_TAG_FILE_PATH, {
-      encoding: 'utf8',
-      flag: 'r',
-    });
-    return data.trim();
-  } else {
-    return '';
-  }
-}
-
-function setHermesTag(hermesTag) {
-  if (readHermesTag() === hermesTag) {
-    // No need to update.
-    return;
-  }
-
-  if (!fs.existsSync(HERMES_TAG_FILE_DIR)) {
-    fs.mkdirSync(HERMES_TAG_FILE_DIR, {recursive: true});
-  }
-
-  fs.writeFileSync(HERMES_TAG_FILE_PATH, hermesTag.trim());
-  console.log('Hermes tag has been updated. Please commit your changes.');
-}
 
 async function main() {
   const hermesTag = argv.tag;

--- a/scripts/hermes/hermes-utils.js
+++ b/scripts/hermes/hermes-utils.js
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+'use strict';
+
+const fs = require('graceful-fs');
+const path = require('path');
+const {echo, exec, exit} = require('shelljs');
+
+const SDKS_DIR = path.normalize(path.join(__dirname, '..', '..', 'sdks'));
+const HERMES_DIR = `${SDKS_DIR}/hermes`;
+const HERMES_TAG_FILE_PATH = `${SDKS_DIR}/.hermesversion`;
+const HERMES_TARBALL_BASE_URL = 'https://github.com/facebook/hermes/tarball/';
+const HERMES_TARBALL_DOWNLOAD_DIR = `${SDKS_DIR}/download`;
+
+function prepareFileSystem() {
+  if (!fs.existsSync(SDKS_DIR)) {
+    fs.mkdirSync(SDKS_DIR, {recursive: true});
+  }
+
+  if (!fs.existsSync(HERMES_DIR)) {
+    fs.mkdirSync(HERMES_DIR, {recursive: true});
+  }
+
+  if (!fs.existsSync(HERMES_TARBALL_DOWNLOAD_DIR)) {
+    fs.mkdirSync(HERMES_TARBALL_DOWNLOAD_DIR, {recursive: true});
+  }
+}
+
+function readHermesTag() {
+  if (fs.existsSync(HERMES_TAG_FILE_PATH)) {
+    const data = fs.readFileSync(HERMES_TAG_FILE_PATH, {
+      encoding: 'utf8',
+      flag: 'r',
+    });
+    return data.trim();
+  } else {
+    return 'main';
+  }
+}
+
+function setHermesTag(hermesTag) {
+  if (readHermesTag() === hermesTag) {
+    // No need to update.
+    return;
+  }
+
+  prepareFileSystem();
+
+  fs.writeFileSync(HERMES_TAG_FILE_PATH, hermesTag.trim());
+  console.log('Hermes tag has been updated. Please commit your changes.');
+}
+
+function getHermesTagSHA(hermesTag) {
+  return exec(
+    `git ls-remote https://github.com/facebook/hermes ${hermesTag} | cut -f 1`,
+    {silent: true},
+  ).trim();
+}
+
+function getHermesTarballDownloadPath(hermesTag) {
+  const hermesTagSHA = getHermesTagSHA(hermesTag);
+  return `${HERMES_TARBALL_DOWNLOAD_DIR}/hermes-${hermesTagSHA}.tgz`;
+}
+
+function downloadHermesTarball() {
+  const hermesTag = readHermesTag();
+  const hermesTagSHA = getHermesTagSHA(hermesTag);
+  const hermesTarballDownloadPath = getHermesTarballDownloadPath(hermesTag);
+  let hermesTarballUrl = HERMES_TARBALL_BASE_URL + hermesTag;
+
+  prepareFileSystem();
+
+  if (fs.existsSync(hermesTarballDownloadPath)) {
+    return;
+  }
+
+  echo(`[Hermes] Downloading Hermes source code for commit ${hermesTagSHA}`);
+  if (exec(`curl ${hermesTarballUrl} -Lo ${hermesTarballDownloadPath}`).code) {
+    echo('[Hermes] Failed to download Hermes tarball.');
+    exit(1);
+    return;
+  }
+}
+
+function expandHermesTarball() {
+  const hermesTag = readHermesTag();
+  const hermesTagSHA = getHermesTagSHA(hermesTag);
+  const hermesTarballDownloadPath = getHermesTarballDownloadPath(hermesTag);
+
+  prepareFileSystem();
+
+  if (!fs.existsSync(hermesTarballDownloadPath)) {
+    echo(
+      `[Hermes] Failed to expand Hermes tarball, no file found at ${hermesTarballDownloadPath}.`,
+    );
+    exit(1);
+    return;
+  }
+
+  echo(`[Hermes] Expanding Hermes tarball for commit ${hermesTagSHA}`);
+  if (
+    exec(
+      `tar -zxf ${hermesTarballDownloadPath} --strip-components=1 --directory ${HERMES_DIR}`,
+    ).code
+  ) {
+    echo('[Hermes] Failed to expand Hermes tarball.');
+    exit(1);
+    return;
+  }
+}
+
+function copyBuildScripts() {
+  fs.copyFileSync(
+    `${SDKS_DIR}/hermes-engine/hermes-engine.podspec`,
+    `${HERMES_DIR}/hermes-engine.podspec`,
+  );
+  fs.copyFileSync(
+    `${SDKS_DIR}/hermes-engine/utils/build-apple-framework.sh`,
+    `${HERMES_DIR}/utils/build-apple-framework.sh`,
+  );
+  fs.copyFileSync(
+    `${SDKS_DIR}/hermes-engine/utils/build-ios-framework.sh`,
+    `${HERMES_DIR}/utils/build-ios-framework.sh`,
+  );
+  fs.copyFileSync(
+    `${SDKS_DIR}/hermes-engine/utils/build-mac-framework.sh`,
+    `${HERMES_DIR}/utils/build-mac-framework.sh`,
+  );
+}
+
+module.exports = {
+  copyBuildScripts,
+  downloadHermesTarball,
+  expandHermesTarball,
+  getHermesTagSHA,
+  readHermesTag,
+  setHermesTag,
+};

--- a/scripts/hermes/prepare-hermes-for-build.js
+++ b/scripts/hermes/prepare-hermes-for-build.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+'use strict';
+
+/**
+ * This script prepares Hermes to be built as part of the
+ * iOS build pipeline on macOS.
+ */
+const {
+  copyBuildScripts,
+  downloadHermesTarball,
+  expandHermesTarball,
+} = require('./hermes-utils');
+
+downloadHermesTarball();
+expandHermesTarball();
+copyBuildScripts();

--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -102,9 +102,9 @@ def use_react_native! (options={})
   end
 
   if hermes_enabled
+    system("(cd #{prefix} && node scripts/hermes/prepare-hermes-for-build)")
     pod 'React-hermes', :path => "#{prefix}/ReactCommon/hermes"
-    hermes_source_path = downloadAndConfigureHermesSource(prefix)
-    pod 'hermes-engine', :path => "#{hermes_source_path}/hermes-engine.podspec"
+    pod 'hermes-engine', :path => "#{prefix}/sdks/hermes/hermes-engine.podspec"
     pod 'libevent', '~> 2.1.12'
   end
 
@@ -603,38 +603,6 @@ def use_react_native_codegen!(spec, options={})
     :execution_position => :before_compile,
     :show_env_vars_in_log => true
   }
-end
-
-def downloadAndConfigureHermesSource(react_native_path)
-  hermes_tarball_base_url = "https://github.com/facebook/hermes/tarball/"
-  sdks_dir = "#{react_native_path}/sdks"
-  download_dir = "#{sdks_dir}/download"
-  hermes_dir = "#{sdks_dir}/hermes"
-  hermes_tag_file = "#{sdks_dir}/.hermesversion"
-  system("mkdir -p #{hermes_dir} #{download_dir}")
-
-  if (File.exist?(hermes_tag_file))
-    hermes_tag = File.read(hermes_tag_file).strip
-  else
-    hermes_tag = "main"
-  end
-
-  hermes_tarball_url = hermes_tarball_base_url + hermes_tag
-  hermes_tag_sha = %x[git ls-remote https://github.com/facebook/hermes #{hermes_tag} | cut -f 1].strip
-  hermes_tarball_path = "#{download_dir}/hermes-#{hermes_tag_sha}.tar.gz"
-
-  if (!File.exist?(hermes_tarball_path))
-    Pod::UI.puts "[Hermes] Downloading Hermes source code..."
-    system("curl #{hermes_tarball_url} -Lo #{hermes_tarball_path}")
-  end
-  Pod::UI.puts "[Hermes] Extracting Hermes tarball (#{hermes_tag_sha.slice(0,6)})"
-  system("tar -zxf #{hermes_tarball_path} --strip-components=1 --directory #{hermes_dir}")
-
-  # Use React Native's own scripts to build Hermes
-  system("cp #{sdks_dir}/hermes-engine/hermes-engine.podspec #{hermes_dir}/hermes-engine.podspec")
-  system("cp #{sdks_dir}/hermes-engine/utils/* #{hermes_dir}/utils/.")
-
-  hermes_dir
 end
 
 # This provides a post_install workaround for build issues related Xcode 12.5 and Apple Silicon (M1) machines.


### PR DESCRIPTION
Summary:
Updates the CocoaPods build scripts to consume the prepare-hermes-for-build script, replacing the now redundant set of Ruby code that would previously set the filesystem up.

Changelog:

[iOS] [Changed] - When building Hermes from source, the filesystem will now be prepared using the new hermes-utils.js scripts, outside of CocoaPods

Reviewed By: cortinico

Differential Revision: D36336633

