### PR TITLE
Hermes: Do not build Hermes for catalyst

### DIFF
--- a/sdks/hermes-engine/utils/build-ios-framework.sh
+++ b/sdks/hermes-engine/utils/build-ios-framework.sh
@@ -12,9 +12,8 @@ if [ ! -d destroot/Library/Frameworks/universal/hermes.xcframework ]; then
 
     build_apple_framework "iphoneos" "arm64" "$ios_deployment_target"
     build_apple_framework "iphonesimulator" "x86_64;arm64" "$ios_deployment_target"
-    build_apple_framework "catalyst" "x86_64;arm64" "$ios_deployment_target"
 
-    create_universal_framework "iphoneos" "iphonesimulator" "catalyst"
+    create_universal_framework "iphoneos" "iphonesimulator"
 else
     echo "Skipping; Clean \"destroot\" to rebuild".
 fi


### PR DESCRIPTION
Summary:
Only build iOS Simulator and iOS device architectures.

Changelog: [Internal]

Differential Revision: D36363984

