### PR TITLE
fix: remove unactionable warning when on 'Paper'

### DIFF
--- a/Libraries/Utilities/codegenNativeComponent.js
+++ b/Libraries/Utilities/codegenNativeComponent.js
@@ -34,15 +34,14 @@ function codegenNativeComponent<Props>(
   componentName: string,
   options?: Options,
 ): NativeComponentType<Props> {
-  const errorMessage =
-    "Native Component '" +
-    componentName +
-    "' that calls codegenNativeComponent was not code generated at build time. Please check its definition.";
   if (global.RN$Bridgeless === true) {
+    const errorMessage =
+      "Native Component '" +
+      componentName +
+      "' that calls codegenNativeComponent was not code generated at build time. Please check its definition.";
     console.error(errorMessage);
-  } else {
-    console.warn(errorMessage);
   }
+
   let componentNameInUse =
     options && options.paperComponentName != null
       ? options.paperComponentName


### PR DESCRIPTION
## Summary

We are currently seeing warning `Native Component 'X' that calls codegenNativeComponent was not code generated at build time. Please check its definition.` even though we have not opted into Fabric. This warning is not actionable and is just noisy.

See also discussion: https://github.com/reactwg/react-native-releases/discussions/21#discussioncomment-2657180

## Changelog

[General] [Fixed] - Remove unactionable warning about `codegenNativeComponent` when on 'Paper'

## Test Plan

n/a