### PR TITLE
Remove with_brew_cache_span from Circle's config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,21 +183,6 @@ commands:
           name: "Brew: Install << parameters.package >>"
           command: brew install << parameters.package >> >/dev/null
 
-  with_brew_cache_span:
-    parameters:
-      steps:
-        type: steps
-    steps:
-      - restore_cache:
-          keys:
-            - *brew_cache_key
-      - steps: << parameters.steps >>
-      - save_cache:
-          paths:
-            - /usr/local/Homebrew
-            - ~/Library/Caches/Homebrew
-          key: *brew_cache_key
-
   with_rntester_pods_cache_span:
     parameters:
       steps:
@@ -435,10 +420,8 @@ jobs:
           name: Set BUILD_HERMES_SOURCE=1
           command: echo "export BUILD_HERMES_SOURCE=1" >> $BASH_ENV
 
-      - with_brew_cache_span:
-          steps:
-            - brew_install:
-                package: cmake
+      - brew_install:
+          package: cmake
 
       - run:
           name: Setup the CocoaPods environment
@@ -492,15 +475,13 @@ jobs:
             echo 'export PATH=/usr/local/opt/node@16/bin:$PATH' >> $BASH_ENV
             source $BASH_ENV
 
-      - with_brew_cache_span:
-          steps:
-            - brew_install:
-                package: watchman cmake
-            - run:
-                name: "Brew: Tap wix/brew"
-                command: brew tap wix/brew >/dev/null
-            - brew_install:
-                package: applesimutils
+      - brew_install:
+          package: watchman cmake
+      - run:
+          name: "Brew: Tap wix/brew"
+          command: brew tap wix/brew >/dev/null
+      - brew_install:
+          package: applesimutils
 
       - run:
           name: Configure Watchman
@@ -763,10 +744,8 @@ jobs:
           name: Set BUILD_HERMES_SOURCE=1
           command: echo "export BUILD_HERMES_SOURCE=1" >> $BASH_ENV
 
-      - with_brew_cache_span:
-          steps:
-            - brew_install:
-                package: cmake
+      - brew_install:
+          package: cmake
 
       - run:
           name: Install CocoaPods dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,6 @@ references:
   # Anchors for the cache keys
 
   cache_keys:
-    brew_cache_key: &brew_cache_key v4-brew
     buck_cache_key: &buck_cache_key v3-buck-v2019.01.10.01-{{ checksum "scripts/circleci/buck_fetch.sh" }}}
     gems_cache_key: &gems_cache_key v1-gems-{{ checksum "Gemfile.lock" }}
     gradle_cache_key: &gradle_cache_key v1-gradle-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "ReactAndroid/gradle.properties" }}
@@ -475,13 +474,11 @@ jobs:
             echo 'export PATH=/usr/local/opt/node@16/bin:$PATH' >> $BASH_ENV
             source $BASH_ENV
 
-      - brew_install:
-          package: watchman cmake
       - run:
           name: "Brew: Tap wix/brew"
           command: brew tap wix/brew >/dev/null
       - brew_install:
-          package: applesimutils
+          package: applesimutils watchman cmake
 
       - run:
           name: Configure Watchman


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

The machines have on their env `HOMEBREW_NO_AUTO_UPDATE=1`, hence I believe that `with_brew_cache_span` is not needed anymore.

If this works it should save the cache downloading and unarchiving time

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Internal] - Remove with_brew_cache_span from Circle's config
