### PR TITLE
Add issue templates for New Architecture

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,6 +6,9 @@ contact_links:
     - name: 🤔 Questions and Help
       url: https://reactnative.dev/help
       about: Looking for help with your app? Please refer to the React Native community's support resources.
+    - name: 💫 [New Architecture] Questions & Technical Deep dive insights
+      url: https://github.com/reactwg/react-native-new-architecture
+      about: Questions and doubts related to technical questions for the New Architecture should be directed to the Working Group. Instructions on how to join are available in the README. 
     - name: 🚀 Discussions and Proposals
       url: https://github.com/react-native-community/discussions-and-proposals
       about: Discuss the future of React Native in the React Native community's discussions and proposals repository.

--- a/.github/ISSUE_TEMPLATE/new_architecture_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/new_architecture_bug_report.yml
@@ -1,0 +1,52 @@
+name: 💫 [New Architecture] Bug Report
+description: Report a reproducible bug or a build issue when using the New Architecture (Fabric & TurboModules) in React Native.
+labels: ["Needs: Triage :mag:", "Type: New Architecture"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please provide all the information requested. Issues that do not follow this format are going to be closed.
+        This issue report is reserved to bug & build issues for users on the New Architecture. If you're not using
+        the New Architecture, please don't open issues on this category.
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: |
+        Please provide a clear and concise description of what the bug or issue is. Include screenshots if needed. 
+        Please make sure you check the New Architecture documentation first, as your issue might
+        already be answered there - https://reactnative.dev/docs/next/new-architecture-intro
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: What react-native version does this appear on? Please test against the latest stable version. Bug reports against older versions are more likely to stall.
+      placeholder: ex. 0.68.0
+    validations:
+      required: true
+  - type: textarea
+    id: react-native-info
+    attributes:
+      label: Output of `npx react-native info`
+      description: Run `npx react-native info` in your terminal, copy and paste the results here.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Provide a detailed list of steps that reproduce the issue.
+    validations:
+      required: true
+  - type: textarea
+    id: extra
+    attributes:
+      label: Snack, code example, screenshot, or link to a repository
+      description: |
+        Please provide a Snack (https://snack.expo.io/), a link to a repository on GitHub, or provide a minimal code example that reproduces the problem.
+        You may provide a screenshot of the application if you think it is relevant to your bug report.
+        Here are some tips for providing a minimal example: https://stackoverflow.com/help/mcve
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/upgrade-regression-form.yml
+++ b/.github/ISSUE_TEMPLATE/upgrade-regression-form.yml
@@ -1,4 +1,4 @@
-name: Upgrade - Build Regression
+name: ⬆️ Upgrade - Build Regression
 description: If you are upgrading to a new React Native version (stable or pre-release) and encounter a build regression.
 labels: ["Needs: Triage :mag:", "Type: Upgrade Issue"]
 body:


### PR DESCRIPTION
## Summary

I'm adding a new Issue Template for New Architecture issues + I've added a contact entry for the Working Group.

## Changelog

[Internal] - Add issue templates for New Architecture

## Test Plan

Tested this here
https://github.com/cortinico/react-native/issues/new/choose