### PR TITLE
Remove build_ios and use only test_ios

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -464,7 +464,7 @@ jobs:
            - packages/rn-tester/RNTesterPods.xcodeproj
            - packages/rn-tester/RNTesterPods.xcworkspace
            - packages/rn-tester/build
-           - packages/rn-tester/sdks
+           - sdks
 
   # -------------------------
   #     JOBS: iOS Unit Tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -461,6 +461,8 @@ jobs:
           root: .
           paths:
            - packages/rn-tester/Pods
+           - RNTesterPods.xcodeproj
+           - RNTesterPods.xcworkspace
 
   # -------------------------
   #     JOBS: iOS Unit Tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -457,6 +457,11 @@ jobs:
                       name: Generate RNTesterPods Workspace
                       command: cd packages/rn-tester && bundle exec pod install --verbose
 
+      - persist_to_workspace:
+          root: .
+          paths:
+           - packages/rn-tester/Pods
+
   # -------------------------
   #     JOBS: iOS Unit Tests
   # -------------------------
@@ -478,6 +483,8 @@ jobs:
       - REPORTS_DIR: "./reports/junit"
     steps:
       - checkout
+      - attach_workspace:
+          at: .
       - setup_artifacts
       - setup_ruby
       - run:
@@ -524,17 +531,6 @@ jobs:
           name: Set BUILD_HERMES_SOURCE=1
           command: echo "export BUILD_HERMES_SOURCE=1" >> $BASH_ENV
 
-      - run:
-          name: Setup the CocoaPods environment
-          command: bundle exec pod setup
-
-      - with_hermes_sdk_cache_span:
-          steps:
-            - with_rntester_pods_cache_span:
-                steps:
-                  - run:
-                      name: Generate RNTesterPods Workspace
-                      command: cd packages/rn-tester && bundle exec pod install --verbose
 
       # -------------------------
       # Runs iOS unit tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -461,10 +461,12 @@ jobs:
           root: .
           paths:
            - packages/rn-tester/Pods
+           - packages/rn-tester/Podfile.lock
            - packages/rn-tester/RNTesterPods.xcodeproj
            - packages/rn-tester/RNTesterPods.xcworkspace
            - packages/rn-tester/build
-           - sdks
+           - sdks/hermesc
+           - sdks/hermes
 
   # -------------------------
   #     JOBS: iOS Unit Tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -464,6 +464,7 @@ jobs:
            - packages/rn-tester/RNTesterPods.xcodeproj
            - packages/rn-tester/RNTesterPods.xcworkspace
            - packages/rn-tester/build
+           - packages/rn-tester/sdks
 
   # -------------------------
   #     JOBS: iOS Unit Tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -400,75 +400,6 @@ jobs:
           path: ./reports/junit
 
   # -------------------------
-  #     JOBS: Build iOS
-  # -------------------------
-  build_ios:
-    executor: reactnativeios
-    parameters:
-      use_frameworks:
-        type: boolean
-        default: false
-    steps:
-      - checkout
-      - setup_ruby
-      - run_yarn
-
-      - run: |
-          cd packages/rn-tester
-          bundle check || bundle install
-
-      - run:
-          name: Configure Environment Variables
-          command: |
-            echo 'export PATH=/usr/local/opt/node@16/bin:$PATH' >> $BASH_ENV
-            source $BASH_ENV
-
-      - run:
-          name: Configure Watchman
-          command: echo "{}" > .watchmanconfig
-
-      - when:
-          condition: << parameters.use_frameworks >>
-          steps:
-            - run:
-                name: Set USE_FRAMEWORKS=1
-                command: echo "export USE_FRAMEWORKS=1" >> $BASH_ENV
-
-      - run:
-          name: Set USE_HERMES=1
-          command: echo "export USE_HERMES=1" >> $BASH_ENV
-
-      - run:
-          name: Set BUILD_HERMES_SOURCE=1
-          command: echo "export BUILD_HERMES_SOURCE=1" >> $BASH_ENV
-
-      - brew_install:
-          package: cmake
-
-      - run:
-          name: Setup the CocoaPods environment
-          command: bundle exec pod setup
-
-      - with_hermes_sdk_cache_span:
-          steps:
-            - with_rntester_pods_cache_span:
-                steps:
-                  - run:
-                      name: Generate RNTesterPods Workspace
-                      command: cd packages/rn-tester && bundle exec pod install --verbose
-
-      - persist_to_workspace:
-          root: .
-          paths:
-           - packages/rn-tester/Pods
-           - packages/rn-tester/Podfile.lock
-           - packages/rn-tester/RNTesterPods.xcodeproj
-           - packages/rn-tester/RNTesterPods.xcworkspace
-           - packages/rn-tester/build
-           - sdks/hermesc
-           - sdks/hermes
-
-  # -------------------------
   #     JOBS: iOS Unit Tests
   # -------------------------
   test_ios:
@@ -489,8 +420,6 @@ jobs:
       - REPORTS_DIR: "./reports/junit"
     steps:
       - checkout
-      - attach_workspace:
-          at: .
       - setup_artifacts
       - setup_ruby
       - run:
@@ -537,6 +466,17 @@ jobs:
           name: Set BUILD_HERMES_SOURCE=1
           command: echo "export BUILD_HERMES_SOURCE=1" >> $BASH_ENV
 
+      - run:
+          name: Setup the CocoaPods environment
+          command: bundle exec pod setup
+
+      - with_hermes_sdk_cache_span:
+          steps:
+            - with_rntester_pods_cache_span:
+                steps:
+                  - run:
+                      name: Generate RNTesterPods Workspace
+                      command: cd packages/rn-tester && bundle exec pod install --verbose
 
       # -------------------------
       # Runs iOS unit tests
@@ -1311,15 +1251,9 @@ workflows:
           requires:
             - build_npm_package
       - test_ios_rntester
-      - build_ios
       - test_ios:
           run_unit_tests: true
-          requires:
-            - build_ios
       # DISABLED: USE_FRAMEWORKS=1 not supported by Flipper
-      # - build_ios:
-      #     name: build_ios_frameworks
-      #     use_frameworks: true
       # - test_ios:
       #     name: test_ios_frameworks
       #     use_frameworks: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -461,8 +461,9 @@ jobs:
           root: .
           paths:
            - packages/rn-tester/Pods
-           - RNTesterPods.xcodeproj
-           - RNTesterPods.xcworkspace
+           - packages/rn-tester/RNTesterPods.xcodeproj
+           - packages/rn-tester/RNTesterPods.xcworkspace
+           - packages/rn-tester/build
 
   # -------------------------
   #     JOBS: iOS Unit Tests


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
build_ios is a subset of test_ios.
The Hermes cache takes 20-30 minutes to be downloaded and unarchived, that is the slowest part of both the jobs and that was duplicated.
This means that if we remove build_ios we save a lot of time, and the CI is still covering the build and the testing of the code.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Internal] - Remove build_ios and use only test_ios

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Checked on CircleCI
