### PR TITLE
Setup a top level buildAll Gradle task

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -613,14 +613,23 @@ jobs:
 
       # Build and compile
       - run:
-          name: Build Android App
+          name: Build & Test React Native using Buck
           command: |
             buck build ReactAndroid/src/main/java/com/facebook/react
             buck build ReactAndroid/src/main/java/com/facebook/react/shell
+
+      - run:
+          name: Build & Test React Native using Gradle
+          command: ./gradlew buildAll
+
       - run:
           name: Compile Native Libs for Unit and Integration Tests
           command: ./gradlew :ReactAndroid:packageReactNdkLibsForBuck -Pjobs=$BUILD_THREADS
           no_output_timeout: 30m
+
+      - run:
+          name: Build RN Tester for Release using Gradle
+          command: ./gradlew packages:rn-tester:android:app:assembleRelease
 
       # Build JavaScript Bundle for instrumentation tests
       - run:
@@ -632,17 +641,13 @@ jobs:
           name: Wait for Android Virtual Device
           command: source scripts/android-setup.sh && waitForAVD
 
-      - run:
-          name: Assemble RNTester App
-          command: ./gradlew packages:rn-tester:android:app:assembleRelease
-
       # -------------------------
       # Run Android tests
       - run:
-          name: "Run Tests: Android Unit Tests"
+          name: Run Tests - Android Unit Tests with Buck
           command: buck test ReactAndroid/src/test/... --config build.threads=$BUILD_THREADS --xml ./reports/buck/all-results-raw.xml
       - run:
-          name: "Build Tests: Android Instrumentation Tests"
+          name: Build Tests - Android Instrumentation Tests with Buck
           # Here, just build the instrumentation tests. There is a known issue with installing the APK to android-21+ emulator.
           command: |
             if [[ ! -e ReactAndroid/src/androidTest/assets/AndroidTestBundle.js ]]; then
@@ -700,23 +705,6 @@ jobs:
       - run:
           name: Build the template application
           command: cd template/android/ && ./gradlew assembleDebug
-
-  # -------------------------
-  #    JOBS: Test Android RNTester
-  # -------------------------
-  test_android_rntester:
-    executor: reactnativeandroid
-    steps:
-      - checkout
-      - run_yarn
-
-      - run:
-          name: Generate artifacts for Maven
-          command: ./gradlew :ReactAndroid:installArchives
-
-      - run:
-          name: Assemble RNTester
-          command: ./gradlew :packages:rn-tester:android:app:assembleDebug
 
   # -------------------------
   #    JOBS: Test iOS Template
@@ -1304,7 +1292,6 @@ workflows:
       - test_android_template:
           requires:
             - build_npm_package
-      - test_android_rntester
       - test_ios_template:
           requires:
             - build_npm_package

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,3 +55,14 @@ tasks.register("cleanAll", Delete::class.java) {
     delete(rootProject.file("./packages/react-native-codegen/lib"))
     delete(rootProject.file("./packages/rn-tester/android/app/.cxx"))
 }
+
+tasks.register("buildAll") {
+    description = "Build and test all the React Native relevant projects."
+    dependsOn(gradle.includedBuild("react-native-gradle-plugin").task(":build"))
+    // This builds both the React Native framework for both debug and release
+    dependsOn(":ReactAndroid:assemble")
+    // This creates all the Maven artifacts and makes them available in the /android folder
+    dependsOn(":ReactAndroid:installArchives")
+    // This builds RN Tester for Hermes/JSC for debug only
+    dependsOn(":packages:rn-tester:android:app:assembleDebug")
+}

--- a/packages/react-native-gradle-plugin/build.gradle.kts
+++ b/packages/react-native-gradle-plugin/build.gradle.kts
@@ -6,6 +6,7 @@
  */
 
 import org.gradle.api.internal.classpath.ModuleRegistry
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.configurationcache.extensions.serviceOf
 
 plugins {
@@ -53,5 +54,14 @@ java {
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_11.majorVersion
+    }
+}
+
+tasks.withType<Test>().configureEach {
+    testLogging {
+        exceptionFormat = TestExceptionFormat.FULL
+        showExceptions = true
+        showCauses = true
+        showStackTraces = true
     }
 }

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/GenerateCodegenArtifactsTaskTest.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/GenerateCodegenArtifactsTaskTest.kt
@@ -61,17 +61,14 @@ class GenerateCodegenArtifactsTaskTest {
     val task =
         createTestTask<GenerateCodegenArtifactsTask> {
           it.nodeExecutableAndArgs.set(listOf("npm", "help"))
-          it.useJavaGenerator.set(true)
           it.codegenJavaPackageName.set("com.example.test")
           it.libraryName.set("example-test")
         }
 
     assertEquals(listOf("npm", "help"), task.nodeExecutableAndArgs.get())
-    assertEquals(true, task.useJavaGenerator.get())
     assertEquals("com.example.test", task.codegenJavaPackageName.get())
     assertEquals("example-test", task.libraryName.get())
     assertTrue(task.inputs.properties.containsKey("nodeExecutableAndArgs"))
-    assertTrue(task.inputs.properties.containsKey("useJavaGenerator"))
     assertTrue(task.inputs.properties.containsKey("codegenJavaPackageName"))
     assertTrue(task.inputs.properties.containsKey("libraryName"))
   }

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/PathUtilsTest.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/PathUtilsTest.kt
@@ -14,6 +14,7 @@ import com.facebook.react.tests.WithOs
 import java.io.File
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Assert.*
+import org.junit.Assume.assumeTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -170,6 +171,10 @@ class PathUtilsTest {
 
   @Test
   fun detectOSAwareHermesCommand_withHermescBuiltLocally() {
+    // As we can't mock env variables, we skip this test if an override of the Hermes
+    // path has been provided.
+    assumeTrue(System.getenv("REACT_NATIVE_OVERRIDE_HERMES_DIR") == null)
+
     tempFolder.newFolder("node_modules/react-native/ReactAndroid/hermes-engine/build/hermes/bin/")
     val expected =
         tempFolder.newFile(
@@ -208,6 +213,10 @@ class PathUtilsTest {
   @Test
   @WithOs(OS.MAC)
   fun detectOSAwareHermesCommand_withoutProvidedCommand_builtHermescTakesPrecedence() {
+    // As we can't mock env variables, we skip this test if an override of the Hermes
+    // path has been provided.
+    assumeTrue(System.getenv("REACT_NATIVE_OVERRIDE_HERMES_DIR") == null)
+
     tempFolder.newFolder("node_modules/react-native/ReactAndroid/hermes-engine/build/hermes/bin/")
     val expected =
         tempFolder.newFile(


### PR DESCRIPTION
Summary:
The idea behind this diff is to set a top level `buildAll` task that will be responsible
of invoking all the tasks we want to verify both in the internal and in the external CI.

This should ideally remove the breakages of the External CI happening from internal changes.

Changelog:
[Internal] [Changed] - Setup a top level buildAll Gradle task

Differential Revision: D36376384

