### PR TITLE
Setup a toplevel downloadAll task

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,7 +210,7 @@ commands:
             - *gradle_cache_key
       - run:
           name: Download Dependencies Using Gradle
-          command: ./scripts/circleci/gradle_download_deps.sh
+          command: ./gradlew downloadAll
       - save_cache:
           paths:
             - ~/.gradle

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,3 +66,13 @@ tasks.register("buildAll") {
     // This builds RN Tester for Hermes/JSC for debug only
     dependsOn(":packages:rn-tester:android:app:assembleDebug")
 }
+
+tasks.register("downloadAll") {
+    description = "Download all the depedencies needed locally so they can be cached on CI."
+    dependsOn(gradle.includedBuild("react-native-gradle-plugin").task(":dependencies"))
+    dependsOn(":ReactAndroid:downloadNdkBuildDependencies")
+    dependsOn(":ReactAndroid:dependencies")
+    dependsOn(":ReactAndroid:androidDependencies")
+    dependsOn(":ReactAndroid:hermes-engine:dependencies")
+    dependsOn(":ReactAndroid:hermes-engine:androidDependencies")
+}

--- a/scripts/circleci/gradle_download_deps.sh
+++ b/scripts/circleci/gradle_download_deps.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-#
-# This source code is licensed under the MIT license found in the
-# LICENSE file in the root directory of this source tree.
-
-set -e
-
-./gradlew :ReactAndroid:downloadNdkBuildDependencies


### PR DESCRIPTION
Summary:
Similarly to buildAll and cleanAll, I'm creating a downloadlAll task
which is aligning the behavior of the download task we're doing on CIs.

I've also updated the Offline Cache as we're now storing a bigger set of dependencies.

Changelog:
[Internal] [Changed] - Setup a toplevel downloadAll task

allow-large-files

Reviewed By: cipolleschi

Differential Revision: D36441728

