### PR TITLE
Fix test_windows by specifying a cwd

### DIFF
--- a/scripts/__tests__/hermes-utils-test.js
+++ b/scripts/__tests__/hermes-utils-test.js
@@ -26,6 +26,8 @@ const hermesTagSha = '5244f819b2f3949ca94a3a1bf75d54a8ed59d94a';
 const ROOT_DIR = path.normalize(path.join(__dirname, '..', '..'));
 const SDKS_DIR = path.join(ROOT_DIR, 'sdks');
 
+const MemoryFs = require('metro-memory-fs');
+
 let execCalls;
 let fs;
 let shelljs;
@@ -103,7 +105,9 @@ describe('hermes-utils', () => {
   beforeEach(() => {
     jest.resetModules();
 
-    jest.mock('fs', () => new (require('metro-memory-fs'))());
+    jest.mock('fs', () => new MemoryFs({
+      platform: process.platform === 'win32' ? 'win32' : 'posix'
+    }));
     fs = require('fs');
     fs.reset();
 


### PR DESCRIPTION
## Summary

`test_windows` is currently broken due to a Jest test trying to resolve a path. On Windows we need to set the `.cwd` before any path can be resolved. This is an attempt to fix it (I wasn't able to verify it locally, will rely on CI).

## Changelog

[Internal] - Fix test_windows by specifying a cwd

## Test Plan

Test with `yarn test` on Mac and is green. Will wait for a CI result for windows.
