### PR TITLE
Do not fail if -javadoc.jar are missing in the final NPM package

### DIFF
--- a/scripts/publish-npm.js
+++ b/scripts/publish-npm.js
@@ -170,7 +170,7 @@ if (isCommitly) {
   }
 }
 
-// -------- Generating Android Artifacts with JavaDoc
+// -------- Generating Android Artifacts
 if (exec('./gradlew :ReactAndroid:installArchives').code) {
   echo('Could not generate artifacts');
   exit(1);
@@ -195,8 +195,6 @@ let artifacts = [
   '-release.aar',
   '-debug-sources.jar',
   '-release-sources.jar',
-  '-debug-javadoc.jar',
-  '-release-javadoc.jar',
 ].map(suffix => {
   return `react-native-${releaseVersion}${suffix}`;
 });


### PR DESCRIPTION
Summary:
When I disabled the Javadoc pubblication as it was failing on CI,
I forgot to turn off the verification that the -javadoc artifact is included
inside the NPM package. This caused `build_npm_package-1` to fail on main.
I'm fixing it here.

Changelog:
[Internal] [Fixed] - Do not fail if -javadoc.jar are missing in the final NPM package

Differential Revision: D36507320

