### PR TITLE
Fix RefreshControl not showing in some cases when set true programmatically

### DIFF
--- a/React/Views/RefreshControl/RCTRefreshControl.m
+++ b/React/Views/RefreshControl/RCTRefreshControl.m
@@ -72,18 +72,20 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)aDecoder)
 
     // `beginRefreshing` must be called after the animation is done. This is why it is impossible
     // to use `setContentOffset` with `animated:YES`.
-    [UIView animateWithDuration:0.25
-        delay:0
-        options:UIViewAnimationOptionBeginFromCurrentState
-        animations:^(void) {
-          [scrollView setContentOffset:offset];
-        }
-        completion:^(__unused BOOL finished) {
-          if (beginRefreshingTimestamp == self->_currentRefreshingStateTimestamp) {
-            [super beginRefreshing];
-            [self setCurrentRefreshingState:super.refreshing];
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [UIView animateWithDuration:0.25
+          delay:0
+          options:UIViewAnimationOptionBeginFromCurrentState
+          animations:^(void) {
+            [scrollView setContentOffset:offset];
           }
-        }];
+          completion:^(__unused BOOL finished) {
+            if (beginRefreshingTimestamp == self->_currentRefreshingStateTimestamp) {
+              [super beginRefreshing];
+              [self setCurrentRefreshingState:super.refreshing];
+            }
+          }];
+    });
   } else if (beginRefreshingTimestamp == self->_currentRefreshingStateTimestamp) {
     [super beginRefreshing];
     [self setCurrentRefreshingState:super.refreshing];
@@ -98,18 +100,20 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)aDecoder)
   if (scrollView && _refreshingProgrammatically && scrollView.contentOffset.y < -scrollView.contentInset.top) {
     UInt64 endRefreshingTimestamp = _currentRefreshingStateTimestamp;
     CGPoint offset = {scrollView.contentOffset.x, -scrollView.contentInset.top};
-    [UIView animateWithDuration:0.25
-        delay:0
-        options:UIViewAnimationOptionBeginFromCurrentState
-        animations:^(void) {
-          [scrollView setContentOffset:offset];
-        }
-        completion:^(__unused BOOL finished) {
-          if (endRefreshingTimestamp == self->_currentRefreshingStateTimestamp) {
-            [super endRefreshing];
-            [self setCurrentRefreshingState:super.refreshing];
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [UIView animateWithDuration:0.25
+          delay:0
+          options:UIViewAnimationOptionBeginFromCurrentState
+          animations:^(void) {
+            [scrollView setContentOffset:offset];
           }
-        }];
+          completion:^(__unused BOOL finished) {
+            if (endRefreshingTimestamp == self->_currentRefreshingStateTimestamp) {
+              [super endRefreshing];
+              [self setCurrentRefreshingState:super.refreshing];
+            }
+          }];
+    });
   } else {
     [super endRefreshing];
   }


### PR DESCRIPTION
## Summary
RefreshControl is not showing when set true together with emptying the FlatList data #32688.

## Changelog
[iOS] [Fixed] - Fix RefreshControl not showing in some cases when set true programmatically, fixes #32688.

## Test Plan
There is no logic change, I am just running the animation in dispatch_get_main_queue.
Tested in my application, now the RefreshControl is showing properly.
