### PR TITLE
Response headers to image - iOS

### DIFF
--- a/Libraries/Image/RCTImageLoader.mm
+++ b/Libraries/Image/RCTImageLoader.mm
@@ -533,10 +533,8 @@ static UIImage *RCTResizeImageIfNeeded(UIImage *image,
       });
     } else if (!std::atomic_load(cancelled.get())) {
         if (response && error && [response isKindOfClass: [NSHTTPURLResponse class]]) {
-            if ([response isKindOfClass: [NSHTTPURLResponse class]]) {
-                NSHTTPURLResponse* _httpResp = (NSHTTPURLResponse*)response;
-                error = addResponseHeadersToError(error, _httpResp);
-            }
+            NSHTTPURLResponse* _httpResp = (NSHTTPURLResponse*)response;
+            error = addResponseHeadersToError(error, _httpResp);
         }
       completionBlock(error, imageOrData, imageMetadata, cacheResult, response);
     }

--- a/Libraries/Image/RCTImageLoader.mm
+++ b/Libraries/Image/RCTImageLoader.mm
@@ -56,6 +56,15 @@ static uint64_t monotonicTimeGetCurrentNanoseconds(void)
   return (mach_absolute_time() * tb_info.numer) / tb_info.denom;
 }
 
+static NSError* addResponseHeadersToError(NSError* originalError, NSHTTPURLResponse* response) {
+    NSMutableDictionary<NSString*, id>* _userInfo =  (NSMutableDictionary<NSString*, id>*)originalError.userInfo.mutableCopy;
+    _userInfo[@"httpStatusCode"] = [NSNumber numberWithInt:response.statusCode];
+    _userInfo[@"httpResponseHeaders"] = response.allHeaderFields;
+    NSError *error = [NSError errorWithDomain:originalError.domain code:originalError.code userInfo:_userInfo];
+    
+    return error;
+}
+
 @interface RCTImageLoader() <NativeImageLoaderIOSSpec, RCTImageLoaderWithAttributionProtocol>
 
 @end
@@ -523,6 +532,12 @@ static UIImage *RCTResizeImageIfNeeded(UIImage *image,
         }
       });
     } else if (!std::atomic_load(cancelled.get())) {
+        if (response && error && [response isKindOfClass: [NSHTTPURLResponse class]]) {
+            if ([response isKindOfClass: [NSHTTPURLResponse class]]) {
+                NSHTTPURLResponse* _httpResp = (NSHTTPURLResponse*)response;
+                error = addResponseHeadersToError(error, _httpResp);
+            }
+        }
       completionBlock(error, imageOrData, imageMetadata, cacheResult, response);
     }
   };

--- a/Libraries/Image/RCTImageView.mm
+++ b/Libraries/Image/RCTImageView.mm
@@ -378,7 +378,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
     });
 
     if (_onError) {
-      _onError(@{ @"error": error.localizedDescription });
+      _onError(@{ @"error": error.localizedDescription, @"responseCode": (error.userInfo[@"httpStatusCode"]?: [NSNull null]), @"httpResponseHeaders": (error.userInfo[@"httpResponseHeaders"] ?: [NSNull null]) });
     }
     if (_onLoadEnd) {
       _onLoadEnd(nil);


### PR DESCRIPTION
## Summary

Please see this issue https://github.com/facebook/react-native/issues/33034 for details on the problem solved by this PR.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[CATEGORY] [TYPE] - Message
[ios] [changed] - HTTP Response headers added to the error object passed to JS code.

## Test Plan

Tested:
(All tests done on images in rn-tester app, which is a part of this repo)
1. onError method in case image has an HTTP Error
2. onError method in case of non http error (DNS error)
3. Successful image load
