### PR TITLE
Fix hermes compilation in the `react-native` package 

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,8 @@
     "scripts/cocoapods/flipper.rb",
     "scripts/cocoapods/new_architecture.rb",
     "scripts/react-native-xcode.sh",
+    "scripts/hermes/hermes-utils.js",
+    "scripts/hermes/prepare-hermes-for-build.js",
     "sdks/hermes-engine",
     "sdks/hermesc",
     "template.config.js",

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "react-shallow-renderer": "16.14.1",
     "regenerator-runtime": "^0.13.2",
     "scheduler": "^0.21.0",
+    "shelljs": "^0.8.5",
     "stacktrace-parser": "^0.1.3",
     "use-sync-external-store": "^1.0.0",
     "whatwg-fetch": "^3.0.0",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

When releasing the latest RC, we have noticed `pod install` is broken since the downloaded `react-native` package is missing hermes scripts and `shelljs` dependency (needed by `hermes-utils.js`).

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Internal] - Fix compiling hermes in the release version.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
- Run `test-manual-e2e.sh` with template and Hermes on iOS