### PR TITLE
Attempt to fix test_android by specifying source 8

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/fabric/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/fabric/BUCK
@@ -30,6 +30,8 @@ rn_android_library(
     visibility = [
         "PUBLIC",
     ],
+    target = "8",
+    source = "8",
     deps = [
         YOGA_TARGET,
         react_native_dep("third-party/java/infer-annotations:infer-annotations"),


### PR DESCRIPTION
## Summary

`test_android` is currently broken as it tries to build with `source = "7"` (the default).
This is a best guess fix to try to fix this issue.

## Changelog

[Internal] - Attempt to fix test_android by specifying source 8

## Test Plan

Will rely on CI