### PR TITLE
Fix broken `ISSUE_TEMPLATE` due to extra `:`

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,7 +6,7 @@ contact_links:
     - name: 🤔 Questions and Help
       url: https://reactnative.dev/help
       about: Looking for help with your app? Please refer to the React Native community's support resources.
-    - name: 💫 New Architecture: Questions & Technical Deep dive insights
+    - name: 💫 New Architecture - Questions & Technical Deep dive insights
       url: https://github.com/reactwg/react-native-new-architecture
       about: Questions and doubts related to technical questions for the New Architecture should be directed to the Working Group. Instructions on how to join are available in the README.
     - name: 🚀 Discussions and Proposals

--- a/.github/ISSUE_TEMPLATE/new_architecture_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/new_architecture_bug_report.yml
@@ -1,4 +1,4 @@
-name: 💫 New Architecture: Bug Report
+name: 💫 New Architecture - Bug Report
 description: Report a reproducible bug or a build issue when using the New Architecture (Fabric & TurboModules) in React Native.
 labels: ["Needs: Triage :mag:", "Type: New Architecture"]
 body:


### PR DESCRIPTION
## Summary

It seems that using `:` inside the `name` field of our Issue Template broke the parsing of them. I'm fixing it here.

## Changelog

[Internal] - Fix broken `ISSUE_TEMPLATE` due to extra `:`

## Test Plan

Tested on:
https://github.com/cortinico/react-native/issues/new/choose
