### PR TITLE
[Feat] Avoid installing Flipper in CI

### DIFF
--- a/packages/rn-tester/Podfile
+++ b/packages/rn-tester/Podfile
@@ -9,6 +9,8 @@ platform :ios, '12.4'
 install! 'cocoapods', :deterministic_uuids => false
 
 USE_FRAMEWORKS = ENV['USE_FRAMEWORKS'] == '1'
+IN_CI = ENV['CI'] == 'true'
+
 @prefix_path = "../.."
 
 if USE_FRAMEWORKS
@@ -16,7 +18,7 @@ if USE_FRAMEWORKS
   use_frameworks!
 end
 
-def pods(options = {})
+def pods(options = {}, use_flipper: false)
   project 'RNTesterPods.xcodeproj'
 
   fabric_enabled = true
@@ -27,12 +29,12 @@ def pods(options = {})
     # Custom fabric component is only supported when using codegen discovery.
     pod 'MyNativeView', :path => "NativeComponentExample"
   end
-
+  
   use_react_native!(
     path: @prefix_path,
     fabric_enabled: fabric_enabled,
     hermes_enabled: hermes_enabled,
-    flipper_configuration: USE_FRAMEWORKS ? FlipperConfiguration.disabled : FlipperConfiguration.enabled,
+    flipper_configuration: use_flipper ? FlipperConfiguration.enabled : FlipperConfiguration.disabled,
     app_path: "#{Dir.pwd}",
     config_file_dir: "#{Dir.pwd}/node_modules",
     production: !ENV['PRODUCTION'].nil?
@@ -49,7 +51,7 @@ def pods(options = {})
 end
 
 target 'RNTester' do
-  pods()
+  pods({}, :use_flipper => !IN_CI && !USE_FRAMEWORKS)
 end
 
 target 'RNTesterUnitTests' do


### PR DESCRIPTION
## Summary

This PR speeds up the build in CircleCI by avoiding adding Flipper dependency when running in CI.

The savings are:
* ~ 13/15% for `test_ios`
* ~ 30/40% for `test_rntester`
* ~50% for `test_ios_template`~

**Edit after review**: We do actually want to have Flipper in the `test_ios_template` to check that it builds correctly.

## Changelog
[iOS] [Changed] - Do not add Flipper when running in CI.

## Test Plan

CircleCI passing with these stats:

| BEFORE | AFTER |
| ---- | ---- |
| <img width="663" alt="FlipperCI-Before" src="https://user-images.githubusercontent.com/11162307/170006493-2651b000-0421-47c3-90e9-153474c15a95.png"> | <img width="652" alt="FlipperCI-After" src="https://user-images.githubusercontent.com/11162307/170006557-34e53601-66b4-4054-a156-0e2349f48dc2.png"> |

 