### PR TITLE
Attempt to fix test_android by adding a react-native.config.js inside rn-tester

### DIFF
--- a/packages/rn-tester/react-native.config.js
+++ b/packages/rn-tester/react-native.config.js
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+'use strict';
+
+const ios = require('@react-native-community/cli-platform-ios');
+const android = require('@react-native-community/cli-platform-android');
+
+module.exports = {
+  commands: [...ios.commands, ...android.commands],
+  platforms: {
+    ios: {
+      projectConfig: ios.projectConfig,
+      dependencyConfig: ios.dependencyConfig,
+    },
+    android: {
+      projectConfig: android.projectConfig,
+      dependencyConfig: android.dependencyConfig,
+    },
+  },
+  reactNativePath: '../../',
+  project: {
+    ios: {
+      sourceDir: '.',
+    },
+    android: {
+      sourceDir: '.',
+    },
+  },
+};


### PR DESCRIPTION
## Summary

`test_android` is now red because I had to specify a root for RN tester.
The job is now failing as it fails to find the correct platforms for the bundler command.
This PR fixes it.

## Changelog

[Internal] - Attempt to fix test_android by moving react-native.config.js

## Test Plan

Tested locally + will wait for a CI result