### PR TITLE
Fix `pod install --project-directory=ios` failing when Hermes is enabled

### DIFF
--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 require 'json'
+require 'open3'
 require 'pathname'
 require_relative './react_native_pods_utils/script_phases.rb'
 require_relative './cocoapods/flipper.rb'
@@ -105,9 +106,14 @@ def use_react_native! (options={})
   end
 
   if hermes_enabled
+    prepare_hermes = 'node scripts/hermes/prepare-hermes-for-build'
+    react_native_dir = Pod::Config.instance.installation_root.join(prefix)
+    prep_output, prep_status = Open3.capture2e(prepare_hermes, :chdir => react_native_dir)
+    prep_output.split("\n").each { |line| Pod::UI.info line }
+    abort unless prep_status == 0
+
     pod 'React-hermes', :path => "#{prefix}/ReactCommon/hermes"
     pod 'libevent', '~> 2.1.12'
-    system("(cd #{prefix} && node scripts/hermes/prepare-hermes-for-build)")
     pod 'hermes-engine', :path => "#{prefix}/sdks/hermes/hermes-engine.podspec"
   end
 


### PR DESCRIPTION
## Summary

`pod install --project-directory=ios` silently fails to prep Hermes:

```
% pod install --project-directory=ios
[Codegen] Generating ios/build/generated/ios/React-Codegen.podspec.json
[Hermes] Downloading Hermes source code for commit 515e112edc267ad58d3c70991b3d9a721cc66b19
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 9478k    0 9478k    0     0  3939k      0 --:--:--  0:00:02 --:--:-- 5591k
[Hermes] Expanding Hermes tarball for commit 515e112edc267ad58d3c70991b3d9a721cc66b19
[Hermes] Using pre-built HermesC

[!] One or more resources were not found and will not be included in the project. If they are found later and you want to include them, run `pod install` again.
warn Multiple Podfiles were found: ios/Podfile,macos/Podfile. Choosing ios/Podfile automatically. If you would like to select a different one, you can configure it via "project.ios.sourceDir". You can learn more about it here: https://github.com/react-native-community/cli/blob/master/docs/configuration.md
Auto-linking React Native module for target `ReactTestApp`: ReactTestApp-DevSupport
Analyzing dependencies
Fetching podspec for `DoubleConversion` from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`
[Codegen] Found FBReactNativeSpec
Fetching podspec for `RCT-Folly` from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`
Fetching podspec for `boost` from `../node_modules/react-native/third-party-podspecs/boost.podspec`
Fetching podspec for `glog` from `../node_modules/react-native/third-party-podspecs/glog.podspec`
[!] No podspec found for `hermes-engine` in `../node_modules/react-native/sdks/hermes/hermes-engine.podspec`

% ls -l node_modules/react-native/sdks
total 0
hermes-engine
hermesc
```

## Changelog

[iOS] [Fixed] - `pod install --project-directory=ios` fails when Hermes is enabled

## Test Plan

Instead of running `pod install` inside `ios` folder, run `pod install --project-directory=ios`.