### PR TITLE
Fix NPE on RN-Tester due to null mFabricViewStateManager

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -747,7 +747,7 @@ public class ReactEditText extends AppCompatEditText
     // view, we don't need to construct one or apply it at all - it provides no use in Fabric.
     ReactContext reactContext = getReactContext(this);
 
-    if (!mFabricViewStateManager.hasStateWrapper() && !reactContext.isBridgeless()) {
+    if (mFabricViewStateManager != null && !mFabricViewStateManager.hasStateWrapper() && !reactContext.isBridgeless()) {
       final ReactTextInputLocalData localData = new ReactTextInputLocalData(this);
       UIManagerModule uiManager = reactContext.getNativeModule(UIManagerModule.class);
       if (uiManager != null) {
@@ -983,7 +983,7 @@ public class ReactEditText extends AppCompatEditText
    */
   private void updateCachedSpannable(boolean resetStyles) {
     // Noops in non-Fabric
-    if (!mFabricViewStateManager.hasStateWrapper()) {
+    if (mFabricViewStateManager == null || !mFabricViewStateManager.hasStateWrapper()) {
       return;
     }
     // If this view doesn't have an ID yet, we don't have a cache key, so bail here


### PR DESCRIPTION
## Summary

RN-Tester is currently crashing at startup time due to an NPE.
This PR fixes it.

## Changelog

[Android] [Fixed] - Fix NPE on `ReactEditText` due to null mFabricViewStateManager

## Test Plan

Tested locally that RN Tester runs both in Debug and in Release