### PR TITLE
Fix `RCTModalHostView` reappearing

### DIFF
--- a/React/Modules/RCTUIManager.m
+++ b/React/Modules/RCTUIManager.m
@@ -793,10 +793,10 @@ RCT_EXPORT_METHOD(removeSubviewsFromContainerWithID : (nonnull NSNumber *)contai
     // original `superview` (which can differ from `container`) and an index of removed view.
     UIView *originalSuperview = removedChild.superview;
     NSUInteger originalIndex = [originalSuperview.subviews indexOfObjectIdenticalTo:removedChild];
-    [container removeReactSubview:removedChild];
     // Disable user interaction while the view is animating
     // since the view is (conceptually) deleted and not supposed to be interactive.
     removedChild.userInteractionEnabled = NO;
+    [container removeReactSubview:removedChild];
     [originalSuperview insertSubview:removedChild atIndex:originalIndex];
 
     NSString *property = deletingLayoutAnimation.property;

--- a/React/Views/RCTModalHostView.m
+++ b/React/Views/RCTModalHostView.m
@@ -138,6 +138,13 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : coder)
 - (void)didMoveToSuperview
 {
   [super didMoveToSuperview];
+
+  // In the case where there is a LayoutAnimation, we will be reinserted into the view hierarchy but only for aesthetic
+  // purposes. In such a case, we should NOT represent the <Modal>.
+  if (!self.userInteractionEnabled && ![self.superview.reactSubviews containsObject:self]) {
+    return;
+  }
+
   [self ensurePresentedOnlyIfNeeded];
 }
 


### PR DESCRIPTION
## Summary

`RCTModalHostView` methods (`didMoveToWindow`, `didMoveToSuperview`) can be called during:
```obj-c
- (void)_removeChildren:(NSArray<UIView *> *)children
          fromContainer:(UIView *)container
          withAnimation:(RCTLayoutAnimationGroup *)animation
```
This happens if there's `_layoutAnimationGroup` and leads to reappearing of `Modal` with `userInteractionEnabled == NO`

## Changelog

[iOS] [Fixed] - Fix Modal false appearing after closing it

## Test Plan

There's no specific test plan, modal just should be closed as expected