### PR TITLE
Fix keyboard staying as email when switching between default and email

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -148,6 +148,13 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
       InputType.TYPE_TEXT_FLAG_CAP_SENTENCES
           | InputType.TYPE_TEXT_FLAG_CAP_WORDS
           | InputType.TYPE_TEXT_FLAG_CAP_CHARACTERS;
+  private static final int INPUT_TYPE_CLEAR =
+      InputType.TYPE_MASK_CLASS
+          | InputType.TYPE_NUMBER_FLAG_SIGNED
+          | InputType.TYPE_NUMBER_FLAG_DECIMAL
+          | InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS
+          | InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD
+          | InputType.TYPE_TEXT_VARIATION_URI;
 
   private static final String KEYBOARD_TYPE_EMAIL_ADDRESS = "email-address";
   private static final String KEYBOARD_TYPE_NUMERIC = "numeric";
@@ -855,7 +862,7 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
       flagsToSet = InputType.TYPE_TEXT_VARIATION_URI;
     }
 
-    updateStagedInputTypeFlag(view, InputType.TYPE_MASK_CLASS, flagsToSet);
+    updateStagedInputTypeFlag(view, INPUT_TYPE_CLEAR, flagsToSet);
     checkPasswordType(view);
   }
 


### PR DESCRIPTION
## Summary
Right now, when we change the keyboardType on android between between default and email, the value keyboard type stays as email (specially noticeable with the key next to the spacebar, that changes between the comma (`,`) to the at sign (`@`)).

This is because the mask we are using when updating the input is only taking into account the class, and not the flags nor the variations.

We don't apply all masks because it may interfere with flags assigned by other props, like multiline or secure text entry. Therefore, we have created our own mask, taking into account all the variations and flags that the keyboardType prop may set. This may be hard to maintain, since whenever we add any other keyboard type, we have to take these flags into mind.

The error I was trying to fix was in particular regarding going back and forward from email, but this fix may solve other similar issues with other keyboard styles.

## Changelog

[Android] [Fixed] - Fix a bug where the keyboard, once set as email, won't change back to default.

## Test Plan

In order to test this PR, any test code with a TextInput, and a way to change the value of the keyboardType should work. We should be able to see how the keyboard changes to the correct type without staying, for example, on the email state.
