### PR TITLE
[jsi] align pointer casting

### DIFF
--- a/ReactCommon/jsi/jsi/jsi-inl.h
+++ b/ReactCommon/jsi/jsi/jsi-inl.h
@@ -167,7 +167,7 @@ inline Function Object::getFunction(Runtime& runtime) && {
 template <typename T>
 inline bool Object::isHostObject(Runtime& runtime) const {
   return runtime.isHostObject(*this) &&
-      std::dynamic_pointer_cast<T>(runtime.getHostObject(*this));
+      std::static_pointer_cast<T>(runtime.getHostObject(*this));
 }
 
 template <>


### PR DESCRIPTION
## Summary

there's an inconsistency for pointer casting between `isHostObject` and `getHostObject / asHostObject`. is it intentionally? by some chances i came across an issue where dynamic_pointer_cast returns null, maybe we can align the pointer casting implementation.

## Changelog

[General] [Changed] - Align JSI `isHostObject` pointer casting as `getHostObject` and `asHostObject`

## Test Plan

ci passed
