### PR TITLE
Fix downloading prebuilt hermes from the Github release

### DIFF
--- a/sdks/hermes-engine/hermes-engine.podspec
+++ b/sdks/hermes-engine/hermes-engine.podspec
@@ -21,7 +21,7 @@ if version == '1000.0.0'
   source[:git] = git
   source[:commit] = `git ls-remote https://github.com/facebook/hermes main | cut -f 1`.strip
 else
-  source[:http] = `https://github.com/facebook/react-native/releases/download/v#{version}/hermes-runtime-darwin-v#{version}.tar.gz`
+  source[:http] = "https://github.com/facebook/react-native/releases/download/v#{version}/hermes-runtime-darwin-v#{version}.tar.gz"
 end
 
 module HermesHelper


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This:
```ruby
source[:http] = `https://github.com/facebook/react-native/releases/download/v#{version}/hermes-runtime-darwin-v#{version}.tar.gz`
```
currently fails with the following error:
```
[!] Failed to load 'hermes-engine' podspec: 
[!] Invalid `hermes-engine.podspec` file: No such file or directory - https://github.com/facebook/react-native/releases/download/v0.69.0-rc.4/hermes-runtime-darwin-v0.69.0-rc.4.tar.gz.
```

For some reasons, the string with backticks is treated differently than with double quotes since this works:
```ruby
source[:http] = "https://github.com/facebook/react-native/releases/download/v#{version}/hermes-runtime-darwin-v#{version}.tar.gz"
```

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Internal] - Fix downloading prebuilt hermes from the Github release

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

- `npx react-native init RN069RC4 --version 0.69.0-rc.4`
- in the created project, run `pod install` with hermes enabled
- run `git init && git add . && git commit -m "Initial commit" && git remote add origin https://github.com/fortmarek/some-fake-repository` (this is necessary due to an unrelated bug in the RC4)
- observe error
- update `node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec` with the change from this commit
- run `pod install`
- 🎉 
