### PR TITLE
Lazily query for git branch & remote

### DIFF
--- a/scripts/hermes/hermes-utils.js
+++ b/scripts/hermes/hermes-utils.js
@@ -159,16 +159,21 @@ function copyPodSpec() {
 }
 
 function isOnAReleaseBranch() {
-  let currentBranch = execSync('git rev-parse --abbrev-ref HEAD')
-    .toString()
-    .trim();
-  let currentRemote = execSync('git config --get remote.origin.url')
-    .toString()
-    .trim();
-  return (
-    currentBranch.endsWith('-stable') &&
-    currentRemote.endsWith('facebook/react-native.git')
-  );
+  try {
+    let currentBranch = execSync('git rev-parse --abbrev-ref HEAD')
+      .toString()
+      .trim();
+    let currentRemote = execSync('git config --get remote.origin.url')
+      .toString()
+      .trim();
+    return (
+      currentBranch.endsWith('-stable') &&
+      currentRemote.endsWith('facebook/react-native.git')
+    );
+  } catch (error) {
+    // If not inside a git repo, we're going to fail here and return.
+    return false;
+  }
 }
 
 function isOnAReleaseTag() {

--- a/sdks/hermes-engine/hermes-engine.podspec
+++ b/sdks/hermes-engine/hermes-engine.podspec
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 require "json"
+require "open3"
 
 # sdks/hermesc/osx-bin/ImportHermesc.cmake
 import_hermesc_file=File.join(__dir__, "..", "hermesc", "osx-bin", "ImportHermesc.cmake")
@@ -13,8 +14,10 @@ package_file = File.join(__dir__, "..", "..", "package.json")
 package = JSON.parse(File.read(package_file))
 version = package['version']
 
-currentbranch = `git rev-parse --abbrev-ref HEAD`.strip
-currentremote = `git config --get remote.origin.url`.strip
+# We need to check the current git branch/remote to verify if
+# we're on a React Native release branch to actually build Hermes.
+currentbranch, err = Open3.capture3("git rev-parse --abbrev-ref HEAD")
+currentremote, err = Open3.capture3("git config --get remote.origin.url")
 
 source = {}
 git = "https://github.com/facebook/hermes.git"
@@ -23,7 +26,7 @@ if version == '1000.0.0'
   Pod::UI.puts '[Hermes] Hermes needs to be compiled, installing hermes-engine may take a while...'.yellow if Object.const_defined?("Pod::UI")
   source[:git] = git
   source[:commit] = `git ls-remote https://github.com/facebook/hermes main | cut -f 1`.strip
-elsif currentremote.end_with?("facebook/react-native.git") and currentbranch.end_with?("-stable")
+elsif currentremote.strip.end_with?("facebook/react-native.git") and currentbranch.strip.end_with?("-stable")
   Pod::UI.puts '[Hermes] Detected that you are on a React Native release branch, building Hermes from source...'.yellow if Object.const_defined?("Pod::UI")
   source[:git] = git
   source[:commit] = `git ls-remote https://github.com/facebook/hermes main | cut -f 1`.strip


### PR DESCRIPTION
## Summary

On RN 0.69, we added a check for current branch/remote/tag.
As they execute eagerly, users which are not inside a git repo will experience a failure. This is addressing it.

## Changelog

[Internal] - Lazily query for git branch & remote

## Test Plan

I've tested those changes on a newly created project with RC4 and verified that they work correctly.