### PR TITLE
Backports fixes on the 0.69 release branch to main

### DIFF
--- a/scripts/hermes/hermes-utils.js
+++ b/scripts/hermes/hermes-utils.js
@@ -171,9 +171,27 @@ function isOnAReleaseBranch() {
   );
 }
 
+function isOnAReleaseTag() {
+  try {
+    // If on a named tag, this method will return the tag name.
+    // If not, it will throw as the return code is not 0.
+    execSync('git describe --exact-match HEAD', {stdio: 'ignore'});
+  } catch (error) {
+    return false;
+  }
+  let currentRemote = execSync('git config --get remote.origin.url')
+    .toString()
+    .trim();
+  return currentRemote.endsWith('facebook/react-native.git');
+}
+
 function shouldBuildHermesFromSource() {
   const hermesTag = readHermesTag();
-  return isOnAReleaseBranch() || hermesTag === DEFAULT_HERMES_TAG;
+  return (
+    isOnAReleaseBranch() ||
+    isOnAReleaseTag() ||
+    hermesTag === DEFAULT_HERMES_TAG
+  );
 }
 
 function shouldUsePrebuiltHermesC(os) {

--- a/scripts/hermes/hermes-utils.js
+++ b/scripts/hermes/hermes-utils.js
@@ -159,9 +159,16 @@ function copyPodSpec() {
 }
 
 function isOnAReleaseBranch() {
-  let currentBranch = execSync(`git rev-parse --abbrev-ref HEAD`).toString().trim();
-  let currentRemote = execSync(`git config --get remote.origin.url`).toString().trim();
-  return currentBranch.endsWith('-stable') && currentRemote.endsWith('facebook/react-native.git');
+  let currentBranch = execSync('git rev-parse --abbrev-ref HEAD')
+    .toString()
+    .trim();
+  let currentRemote = execSync('git config --get remote.origin.url')
+    .toString()
+    .trim();
+  return (
+    currentBranch.endsWith('-stable') &&
+    currentRemote.endsWith('facebook/react-native.git')
+  );
 }
 
 function shouldBuildHermesFromSource() {

--- a/scripts/hermes/hermes-utils.js
+++ b/scripts/hermes/hermes-utils.js
@@ -159,16 +159,21 @@ function copyPodSpec() {
 }
 
 function isOnAReleaseBranch() {
-  let currentBranch = execSync('git rev-parse --abbrev-ref HEAD')
-    .toString()
-    .trim();
-  let currentRemote = execSync('git config --get remote.origin.url')
-    .toString()
-    .trim();
-  return (
-    currentBranch.endsWith('-stable') &&
-    currentRemote.endsWith('facebook/react-native.git')
-  );
+  try {
+    let currentBranch = execSync('git rev-parse --abbrev-ref HEAD')
+      .toString()
+      .trim();
+    let currentRemote = execSync('git config --get remote.origin.url')
+      .toString()
+      .trim();
+    return (
+      currentBranch.endsWith('-stable') &&
+      currentRemote.endsWith('facebook/react-native.git')
+    );
+  } catch (error) {
+    // If not inside a git repo, we're going to fail here and return.
+    return false;
+  }
 }
 
 function isOnAReleaseTag() {

--- a/scripts/hermes/hermes-utils.js
+++ b/scripts/hermes/hermes-utils.js
@@ -158,9 +158,15 @@ function copyPodSpec() {
   );
 }
 
+function isOnAReleaseBranch() {
+  let currentBranch = execSync(`git rev-parse --abbrev-ref HEAD`).toString().trim();
+  let currentRemote = execSync(`git config --get remote.origin.url`).toString().trim();
+  return currentBranch.endsWith('-stable') && currentRemote.endsWith('facebook/react-native.git');
+}
+
 function shouldBuildHermesFromSource() {
   const hermesTag = readHermesTag();
-  return hermesTag === DEFAULT_HERMES_TAG;
+  return isOnAReleaseBranch() || hermesTag === DEFAULT_HERMES_TAG;
 }
 
 function shouldUsePrebuiltHermesC(os) {

--- a/sdks/hermes-engine/hermes-engine.podspec
+++ b/sdks/hermes-engine/hermes-engine.podspec
@@ -13,11 +13,18 @@ package_file = File.join(__dir__, "..", "..", "package.json")
 package = JSON.parse(File.read(package_file))
 version = package['version']
 
+currentbranch = `git rev-parse --abbrev-ref HEAD`.strip
+currentremote = `git config --get remote.origin.url`.strip
+
 source = {}
 git = "https://github.com/facebook/hermes.git"
 
 if version == '1000.0.0'
   Pod::UI.puts '[Hermes] Hermes needs to be compiled, installing hermes-engine may take a while...'.yellow if Object.const_defined?("Pod::UI")
+  source[:git] = git
+  source[:commit] = `git ls-remote https://github.com/facebook/hermes main | cut -f 1`.strip
+elsif currentremote.end_with?("facebook/react-native.git") and currentbranch.end_with?("-stable")
+  Pod::UI.puts '[Hermes] Detected that you are on a React Native release branch, building Hermes from source...'.yellow if Object.const_defined?("Pod::UI")
   source[:git] = git
   source[:commit] = `git ls-remote https://github.com/facebook/hermes main | cut -f 1`.strip
 else

--- a/sdks/hermes-engine/hermes-engine.podspec
+++ b/sdks/hermes-engine/hermes-engine.podspec
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 require "json"
+require "open3"
 
 # sdks/hermesc/osx-bin/ImportHermesc.cmake
 import_hermesc_file=File.join(__dir__, "..", "hermesc", "osx-bin", "ImportHermesc.cmake")
@@ -13,8 +14,10 @@ package_file = File.join(__dir__, "..", "..", "package.json")
 package = JSON.parse(File.read(package_file))
 version = package['version']
 
-currentbranch = `git rev-parse --abbrev-ref HEAD`.strip
-currentremote = `git config --get remote.origin.url`.strip
+# We need to check the current git branch/remote to verify if
+# we're on a React Native release branch to actually build Hermes.
+currentbranch, err = Open3.capture3("git rev-parse --abbrev-ref HEAD")
+currentremote, err = Open3.capture3("git config --get remote.origin.url")
 
 source = {}
 git = "https://github.com/facebook/hermes.git"
@@ -23,7 +26,7 @@ if version == '1000.0.0'
   Pod::UI.puts '[Hermes] Hermes needs to be compiled, installing hermes-engine may take a while...'.yellow if Object.const_defined?("Pod::UI")
   source[:git] = git
   source[:commit] = `git ls-remote https://github.com/facebook/hermes main | cut -f 1`.strip
-elsif currentremote.end_with?("facebook/react-native.git") and currentbranch.end_with?("-stable")
+elsif currentremote.strip.end_with?("facebook/react-native.git") and currentbranch.strip.end_with?("-stable")
   Pod::UI.puts '[Hermes] Detected that you are on a React Native release branch, building Hermes from source...'.yellow if Object.const_defined?("Pod::UI")
   source[:git] = git
   source[:commit] = `git ls-remote https://github.com/facebook/hermes main | cut -f 1`.strip


### PR DESCRIPTION
## Summary

This PR includes a set of changes that landed only on the 0.69-stable release branch and need to be backported to main:

- https://github.com/facebook/react-native/commit/a72d1960ff39b7902ffdf6753d29734c7e3d7758
- https://github.com/facebook/react-native/commit/659b693fcdadf8d3df0f8ac4f35d7cb97250a413
- https://github.com/facebook/react-native/commit/2a6832a7e3d34710d7307742604c2ade0ae3445c
- https://github.com/facebook/react-native/commit/0ca6e410595aaaa3cfc299e8bcf330ef0e31d5fe
- https://github.com/facebook/react-native/commit/f50936bef2a990dfcd0632c710851021aee83290

Most of the fixes are working around the assumption that 
`version != 1000.0.0 => Build Hermes From Source`.

That is not true in the release branch as the version is named (e.g. 0.69.0-rc4) and we need to build Hermes there.

## Changelog

[Internal] - Backports fixes on the 0.69 release branch to main

## Test Plan

Tested that those commits are working fine on the release branch.