### PR TITLE
Bump iOS from 11.0 to 12.4 in Hermes eng podspec

### DIFF
--- a/sdks/hermes-engine/hermes-engine.podspec
+++ b/sdks/hermes-engine/hermes-engine.podspec
@@ -38,7 +38,7 @@ Pod::Spec.new do |spec|
   spec.license     = package["license"]
   spec.author      = "Facebook"
   spec.source      = source
-  spec.platforms   = { :osx => "10.13", :ios => "11.0" }
+  spec.platforms   = { :osx => "10.13", :ios => "12.4" }
 
   spec.preserve_paths      = ["destroot/bin/*"].concat(HermesHelper::BUILD_TYPE == :debug ? ["**/*.{h,c,cpp}"] : [])
   spec.source_files        = "destroot/include/**/*.h"


### PR DESCRIPTION
## Summary

Deprecate iOS/tvOS SDK 11.0 support now that 12.4+ is required

Context: https://github.com/facebook/react-native/pull/33935#issuecomment-1142253352

## Changelog

[iOS] [Fixed] - Deprecate iOS/tvOS SDK 11.0 support now that 12.4+ is required
