### PR TITLE
:fire: (FileReader) remove unused _subscriptions attribute

### DIFF
--- a/Libraries/Blob/FileReader.js
+++ b/Libraries/Blob/FileReader.js
@@ -46,7 +46,6 @@ class FileReader extends (EventTarget(...READER_EVENTS): any) {
   _error: ?Error;
   _result: ?ReaderResult;
   _aborted: boolean = false;
-  _subscriptions: Array<any> = [];
 
   constructor() {
     super();
@@ -57,11 +56,6 @@ class FileReader extends (EventTarget(...READER_EVENTS): any) {
     this._readyState = EMPTY;
     this._error = null;
     this._result = null;
-  }
-
-  _clearSubscriptions(): void {
-    this._subscriptions.forEach(sub => sub.remove());
-    this._subscriptions = [];
   }
 
   _setReadyState(newState: ReadyState) {


### PR DESCRIPTION
## Summary

I was reading source code, and I noticed the _subscriptions attribute (and the _clearSubscriptions method) of the FileReader is not used.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Internal] [Changed] - Remove unused _subscriptions attribute in FileReader

## Test Plan

I checked that flow and jest are still green as I can't think about another way.