### PR TITLE
fix: make getConstants() get constants from native side

### DIFF
--- a/Libraries/ReactNative/I18nManager.js
+++ b/Libraries/ReactNative/I18nManager.js
@@ -10,13 +10,11 @@
 
 import NativeI18nManager from './NativeI18nManager';
 
-const i18nConstants: {|
+function getI18nManagerConstants(): {|
   doLeftAndRightSwapInRTL: boolean,
   isRTL: boolean,
-  localeIdentifier?: ?string,
-|} = getI18nManagerConstants();
-
-function getI18nManagerConstants() {
+  localeIdentifier: ?string,
+|} {
   if (NativeI18nManager) {
     const {isRTL, doLeftAndRightSwapInRTL, localeIdentifier} =
       NativeI18nManager.getConstants();
@@ -26,6 +24,7 @@ function getI18nManagerConstants() {
   return {
     isRTL: false,
     doLeftAndRightSwapInRTL: true,
+    localeIdentifier: undefined,
   };
 }
 
@@ -35,7 +34,7 @@ module.exports = {
     isRTL: boolean,
     localeIdentifier: ?string,
   |} => {
-    return i18nConstants;
+    return getI18nManagerConstants();
   },
 
   allowRTL: (shouldAllow: boolean) => {
@@ -61,7 +60,4 @@ module.exports = {
 
     NativeI18nManager.swapLeftAndRightInRTL(flipStyles);
   },
-
-  isRTL: i18nConstants.isRTL,
-  doLeftAndRightSwapInRTL: i18nConstants.doLeftAndRightSwapInRTL,
 };

--- a/Libraries/ReactNative/I18nManager.js
+++ b/Libraries/ReactNative/I18nManager.js
@@ -10,6 +10,12 @@
 
 import NativeI18nManager from './NativeI18nManager';
 
+const initialI18nConstants: {|
+  doLeftAndRightSwapInRTL: boolean,
+  isRTL: boolean,
+  localeIdentifier?: ?string,
+|} = getI18nManagerConstants();
+
 function getI18nManagerConstants(): {|
   doLeftAndRightSwapInRTL: boolean,
   isRTL: boolean,
@@ -60,4 +66,7 @@ module.exports = {
 
     NativeI18nManager.swapLeftAndRightInRTL(flipStyles);
   },
+
+  isRTL: initialI18nConstants.isRTL,
+  doLeftAndRightSwapInRTL: initialI18nConstants.doLeftAndRightSwapInRTL,
 };

--- a/packages/rn-tester/js/examples/FlatList/FlatList-basic.js
+++ b/packages/rn-tester/js/examples/FlatList/FlatList-basic.js
@@ -67,7 +67,7 @@ type State = {|
   isRTL: boolean,
 |};
 
-const IS_RTL = I18nManager.isRTL;
+const IS_RTL = I18nManager.getConstants().isRTL;
 
 class FlatListExample extends React.PureComponent<Props, State> {
   state: State = {

--- a/packages/rn-tester/js/examples/RTL/RTLExample.js
+++ b/packages/rn-tester/js/examples/RTL/RTLExample.js
@@ -41,7 +41,7 @@ const SCALE = PixelRatio.get();
 const IMAGE_DIMENSION = 100 * SCALE;
 const IMAGE_SIZE = [IMAGE_DIMENSION, IMAGE_DIMENSION];
 
-const IS_RTL = I18nManager.isRTL;
+const IS_RTL = I18nManager.getConstants().isRTL;
 
 function ListItem(props) {
   return (


### PR DESCRIPTION
~~BREAKING CHANGES:
exported `isRTL` and `doLeftAndRightSwapInRTL` props are removed. I wanted to replace them with a getter that gets constants but it was not allowed inside the flow config.~~

**EDIT**: I brought back the `isRTL` and `doLeftAndRightSwapInRTL` props to not make it a breaking change for apps that rely on them. they behave in the same way they did before. only `getConstants` is fixed now.

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

fixes #33923 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Fixed] - `I18nManager.getConstants()` now actually gets the updated constants from the native side

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
