### PR TITLE
Use `GCC_PREPROCESSOR_DEFINITIONS` to set `FB_SONARKIT_ENABLED`

### DIFF
--- a/scripts/cocoapods/__tests__/flipper-test.rb
+++ b/scripts/cocoapods/__tests__/flipper-test.rb
@@ -86,7 +86,7 @@ class FlipperTests < Test::Unit::TestCase
         reactCore_target = installer.target_with_name("React-Core")
         reactCore_target.build_configurations.each do |config|
             if config.name == 'Debug' then
-                assert_equal(config.build_settings['OTHER_CFLAGS'], "$(inherited) -DFB_SONARKIT_ENABLED=1")
+                assert_equal(config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'], ['$(inherited)', 'FB_SONARKIT_ENABLED=1'])
             else
                 assert_true(config.build_settings.empty?)
             end

--- a/scripts/cocoapods/flipper.rb
+++ b/scripts/cocoapods/flipper.rb
@@ -84,7 +84,7 @@ def flipper_post_install(installer)
         if target.name == 'React-Core'
             target.build_configurations.each do |config|
                 if config.name == 'Debug'
-                    config.build_settings['OTHER_CFLAGS'] = "$(inherited) -DFB_SONARKIT_ENABLED=1"
+                    config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] = ['$(inherited)', 'FB_SONARKIT_ENABLED=1']
                 end
             end
         end


### PR DESCRIPTION
## Summary

`OTHER_CFLAGS` doesn't seem to work when the file is imported from Objc++. This causes flipper to not be included.

## Changelog

[iOS] [Fixed] - Use `GCC_PREPROCESSOR_DEFINITIONS` to set `FB_SONARKIT_ENABLED`

## Test Plan

Tested the change in an app. Used a breakpoint to see that flipper code is not executed before this change, and is after. Also made sure other `GCC_PREPROCESSOR_DEFINITIONS` set by cocoapods are still properly inherited.