### PR TITLE
Hermes: Use pre-built Hermes runtime in iOS Template tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -677,13 +677,24 @@ jobs:
     executor: reactnativeios
     environment:
       - PROJECT_NAME: "iOSTemplateProject"
+      - HERMES_WS_DIR: *hermes_workspace_root
 
     steps:
       - checkout_code_with_cache
       - run_yarn
       - attach_workspace:
           at: .
-
+      - *attach_hermes_workspace
+      - run:
+          name: Set USE_HERMES=1
+          command: echo "export USE_HERMES=1" >> $BASH_ENV
+      - run:
+          name: Set HERMES_ENGINE_TARBALL_PATH
+          command: |
+            echo "export HERMES_ENGINE_TARBALL_PATH=$(ls -AU $HERMES_WS_DIR/hermes-runtime-darwin/hermes-runtime-darwin-*.tar.gz | head -1)" >> $BASH_ENV
+      - run:
+          name: Set RCT_VERBOSE_POD_INSTALL=1
+          command: echo "export RCT_VERBOSE_POD_INSTALL=1" >> $BASH_ENV
       - run:
           name: Create iOS template project
           command: |
@@ -693,8 +704,7 @@ jobs:
             node ./scripts/set-rn-template-version.js "file:$PATH_TO_PACKAGE"
             mkdir -p ~/tmp
             cd ~/tmp
-            node "$REPO_ROOT/cli.js" init "$PROJECT_NAME" --template "$REPO_ROOT"
-
+            node "$REPO_ROOT/cli.js" init "$PROJECT_NAME" --template "$REPO_ROOT" --verbose
       - run:
           name: Build template project
           command: |
@@ -992,6 +1002,9 @@ jobs:
             cp LICENSE /tmp/cocoapods-package-root
 
             tar -C /tmp/cocoapods-package-root/ -czvf /tmp/hermes/output/hermes-runtime-darwin-v$(get_release_version).tar.gz .
+
+            mkdir -p /tmp/hermes/hermes-runtime-darwin
+            cp /tmp/hermes/output/hermes-runtime-darwin-v$(get_release_version).tar.gz /tmp/hermes/hermes-runtime-darwin/.
       - save_cache:
           key: *hermes_cache_key
           paths:
@@ -1002,12 +1015,13 @@ jobs:
             - ~/react-native/hermes/build_macosx
             - ~/react-native/hermes/destroot
       - store_artifacts:
-          path: /tmp/hermes/output/
+          path: /tmp/hermes/hermes-runtime-darwin/
       - store_artifacts:
           path: /tmp/hermes/osx-bin/
       - persist_to_workspace:
           root: /tmp/hermes/
           paths:
+            - hermes-runtime-darwin
             - osx-bin
 
   build_hermesc_windows:

--- a/scripts/hermes/hermes-utils.js
+++ b/scripts/hermes/hermes-utils.js
@@ -158,7 +158,11 @@ function copyPodSpec() {
   );
 }
 
-function isOnAReleaseBranch() {
+function isTestingAgainstLocalHermesTarball() {
+  return 'HERMES_ENGINE_TARBALL_PATH' in process.env;
+}
+
+function isOnAReactNativeReleaseBranch() {
   try {
     let currentBranch = execSync('git rev-parse --abbrev-ref HEAD')
       .toString()
@@ -176,7 +180,7 @@ function isOnAReleaseBranch() {
   }
 }
 
-function isOnAReleaseTag() {
+function isOnAReactNativeReleaseTag() {
   try {
     // If on a named tag, this method will return the tag name.
     // If not, it will throw as the return code is not 0.
@@ -190,12 +194,17 @@ function isOnAReleaseTag() {
   return currentRemote.endsWith('facebook/react-native.git');
 }
 
-function shouldBuildHermesFromSource() {
+function isRequestingLatestCommitFromHermesMainBranch() {
   const hermesTag = readHermesTag();
+  return hermesTag === DEFAULT_HERMES_TAG;
+}
+
+function shouldBuildHermesFromSource() {
   return (
-    isOnAReleaseBranch() ||
-    isOnAReleaseTag() ||
-    hermesTag === DEFAULT_HERMES_TAG
+    !isTestingAgainstLocalHermesTarball() &&
+    (isOnAReactNativeReleaseBranch() ||
+      isOnAReactNativeReleaseTag() ||
+      isRequestingLatestCommitFromHermesMainBranch())
   );
 }
 

--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -148,6 +148,10 @@ def get_default_flags()
     flags[:hermes_enabled] = true
   end
 
+  if ENV['USE_HERMES'] == '1'
+    flags[:hermes_enabled] = true
+  end
+
   return flags
 end
 

--- a/sdks/hermes-engine/hermes-engine.podspec
+++ b/sdks/hermes-engine/hermes-engine.podspec
@@ -22,7 +22,10 @@ currentremote, err = Open3.capture3("git config --get remote.origin.url")
 source = {}
 git = "https://github.com/facebook/hermes.git"
 
-if version == '1000.0.0'
+if ENV.has_key?('HERMES_ENGINE_TARBALL_PATH')
+  Pod::UI.puts '[Hermes] Using pre-built Hermes binaries from local path.' if Object.const_defined?("Pod::UI")
+  source[:http] = "file://#{ENV['HERMES_ENGINE_TARBALL_PATH']}"
+elsif version == '1000.0.0'
   Pod::UI.puts '[Hermes] Hermes needs to be compiled, installing hermes-engine may take a while...'.yellow if Object.const_defined?("Pod::UI")
   source[:git] = git
   source[:commit] = `git ls-remote https://github.com/facebook/hermes main | cut -f 1`.strip


### PR DESCRIPTION
Summary:
Enable Hermes in iOS Template tests and use pre-built Hermes binaries from Circle CI.

Changelog: [Internal]

Differential Revision: D36989241

