### PR TITLE
Encapsulate all the CMake build logic inside a `ReactNative-application.cmake` file for RN Tester

### DIFF
--- a/ReactAndroid/cmake-utils/ReactNative-application.cmake
+++ b/ReactAndroid/cmake-utils/ReactNative-application.cmake
@@ -1,0 +1,43 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# This CMake file takes care of creating everything you need to build and link
+# your C++ source code in a React Native Application for Android.
+# You just need to call `project(<my_project_name>)` and import this file.
+# Specifically this file will:
+# - Take care of creating a shared library called as your project
+# - Take care of setting the correct compile options
+# - Include all the pre-built libraries in your build graph
+# - Link your library against those prebuilt libraries so you can access JSI, Fabric, etc.
+
+cmake_minimum_required(VERSION 3.13)
+set(CMAKE_VERBOSE_MAKEFILE on)
+
+include(${REACT_ANDROID_DIR}/cmake-utils/Android-prebuilt.cmake)
+
+file(GLOB input_SRC CONFIGURE_DEPENDS *.cpp)
+add_library(${CMAKE_PROJECT_NAME} SHARED ${input_SRC})
+
+target_include_directories(${CMAKE_PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+target_compile_options(${CMAKE_PROJECT_NAME} PRIVATE -Wall -Werror -fexceptions -frtti -std=c++17 -DWITH_INSPECTOR=1 -DLOG_TAG=\"ReactNative\")
+
+target_link_libraries(${CMAKE_PROJECT_NAME}
+        fabricjni
+        fbjni
+        folly_runtime
+        glog
+        jsi
+        react_codegen_rncore
+        react_debug
+        react_nativemodule_core
+        react_render_componentregistry
+        react_render_core
+        react_render_debug
+        react_render_graphics
+        rrc_view
+        runtimeexecutor
+        turbomodulejsijni
+        yoga)

--- a/packages/rn-tester/android/app/src/main/jni/CMakeLists.txt
+++ b/packages/rn-tester/android/app/src/main/jni/CMakeLists.txt
@@ -4,37 +4,16 @@
 # LICENSE file in the root directory of this source tree.
 
 cmake_minimum_required(VERSION 3.13)
-set(CMAKE_VERBOSE_MAKEFILE on)
 
 # Define the library name here.
 project(rntester_appmodules)
 
-include(${REACT_ANDROID_DIR}/cmake-utils/Android-prebuilt.cmake)
+include(${REACT_ANDROID_DIR}/cmake-utils/ReactNative-application.cmake)
+
 add_subdirectory(${PROJECT_BUILD_DIR}/generated/source/codegen/jni/ codegen_build)
 add_subdirectory(${REACT_COMMON_DIR}/react/nativemodule/samples/platform/android/ sampleturbomodule_build)
 
-file(GLOB input_SRC CONFIGURE_DEPENDS *.cpp)
-add_library(${CMAKE_PROJECT_NAME} SHARED ${input_SRC})
-
-target_include_directories(${CMAKE_PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-target_compile_options(${CMAKE_PROJECT_NAME} PRIVATE -Wall -Werror -fexceptions -frtti -std=c++17 -DWITH_INSPECTOR=1 -DLOG_TAG=\"ReactNative\")
-
+# RN Tester needs to link against the local codegen-ned library and a sample turbomobule
 target_link_libraries(${CMAKE_PROJECT_NAME}
-        fabricjni
-        fbjni
-        folly_runtime
-        glog
-        jsi
         react_codegen_AppSpecs
-        react_codegen_rncore
-        react_debug
-        react_nativemodule_core
-        react_render_componentregistry
-        react_render_core
-        react_render_debug
-        react_render_graphics
-        rrc_view
-        runtimeexecutor
-        sampleturbomodule
-        turbomodulejsijni
-        yoga)
+        sampleturbomodule)


### PR DESCRIPTION
## Summary

The idea behind this is to encapsulate as much build logic as possible inside a `.cmake` file which is contained inside React Native.

This reduces the API surface for the users, once we apply this change to the `template` project, and makes easier for us to evolve native library dependencies on Android, without having to worry about asking users to replicate those changes.

Currently the change is only on RN Tester, will replicate to the template afterwards

## Changelog

[Internal] [Changed] - Encapsulate all the CMake build logic inside a `ReactNative-application.cmake` file for RN Tester

## Test Plan

Circle CI