### PR TITLE
Use monotonic clock for performance.now()

### DIFF
--- a/React/CxxBridge/RCTJSIExecutorRuntimeInstaller.mm
+++ b/React/CxxBridge/RCTJSIExecutorRuntimeInstaller.mm
@@ -22,8 +22,14 @@ JSIExecutor::RuntimeInstaller RCTJSIExecutorRuntimeInstaller(JSIExecutor::Runtim
     bindNativeLogger(runtime, iosLoggingBinder);
 
     PerformanceNow iosPerformanceNowBinder = []() {
-      auto time = std::chrono::system_clock::now().time_since_epoch();
-      return std::chrono::duration_cast<std::chrono::milliseconds>(time).count();
+      auto time = std::chrono::steady_clock::now();
+      auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                          time.time_since_epoch())
+                          .count();
+
+      constexpr double NANOSECONDS_IN_MILLISECOND = 1000000.0;
+
+      return duration / NANOSECONDS_IN_MILLISECOND;
     };
     bindNativePerformanceNow(runtime, iosPerformanceNowBinder);
 

--- a/ReactAndroid/src/main/jni/react/jni/NativeTime.cpp
+++ b/ReactAndroid/src/main/jni/react/jni/NativeTime.cpp
@@ -12,8 +12,14 @@ namespace facebook {
 namespace react {
 
 double reactAndroidNativePerformanceNowHook() {
-  auto time = std::chrono::system_clock::now().time_since_epoch();
-  return std::chrono::duration_cast<std::chrono::milliseconds>(time).count();
+  auto time = std::chrono::steady_clock::now();
+  auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                      time.time_since_epoch())
+                      .count();
+
+  constexpr double NANOSECONDS_IN_MILLISECOND = 1000000.0;
+
+  return duration / NANOSECONDS_IN_MILLISECOND;
 }
 
 } // namespace react


### PR DESCRIPTION
## Summary

This is a cherry-pick of https://github.com/facebook/react-native/pull/33983 on the 0.69 branch.

## Changelog

[General] [Fixed] - Use monotonic clock for performance.now()

## Test Plan
Run on iOS and Android:
```
const now = global.performance.now()
console.log(`${Platform.OS}: ${now}`)
```