### PR TITLE
Mac Catalyst patches

### DIFF
--- a/packages/rn-tester/Podfile
+++ b/packages/rn-tester/Podfile
@@ -21,6 +21,7 @@ def pods(options = {}, use_flipper: false)
   project 'RNTesterPods.xcodeproj'
 
   fabric_enabled = true
+  mac_catalyst_enabled = false
   hermes_enabled = ENV['USE_HERMES'] == '1'
   puts "Building RNTester with Fabric #{fabric_enabled ? "enabled" : "disabled"}.#{hermes_enabled ? " Using Hermes engine." : ""}"
 
@@ -64,6 +65,6 @@ target 'RNTesterIntegrationTests' do
 end
 
 post_install do |installer|
-  react_native_post_install(installer, @prefix_path)
+  react_native_post_install(installer, mac_catalyst_enabled, @prefix_path)
   __apply_Xcode_12_5_M1_post_install_workaround(installer)
 end

--- a/scripts/cocoapods/__tests__/test_utils/InstallerMock.rb
+++ b/scripts/cocoapods/__tests__/test_utils/InstallerMock.rb
@@ -138,12 +138,16 @@ ReceivedCommonResolvedBuildSettings = Struct.new(:key, :resolve_against_xcconfig
 class TargetMock
     attr_reader :name
     attr_reader :build_configurations
+    attr_reader :product_type
 
     attr_reader :received_resolved_build_setting_parameters
 
-    def initialize(name, build_configurations = [])
+    def initialize(name, build_configurations = [], product_type = nil)
         @name = name
         @build_configurations = build_configurations
+        unless product_type.nil?
+          @product_type = product_type
+        end
         @received_resolved_build_setting_parameters = []
     end
 

--- a/scripts/cocoapods/__tests__/utils-test.rb
+++ b/scripts/cocoapods/__tests__/utils-test.rb
@@ -250,20 +250,20 @@ class UtilsTests < Test::Unit::TestCase
     # ============================== #
 
     def test_fixLibrarySearchPaths_correctlySetsTheSearchPathsForAllProjects
-        firstTarget = prepare_target("FirstTarget")
-        secondTarget = prepare_target("SecondTarget")
-        thirdTarget = prepare_target("ThirdTarget")
+        first_target = prepare_target("FirstTarget")
+        second_target = prepare_target("SecondTarget")
+        third_target = prepare_target("ThirdTarget")
         user_project_mock = UserProjectMock.new("a/path", [
                 prepare_config("Debug"),
                 prepare_config("Release"),
             ],
             :native_targets => [
-                firstTarget,
-                secondTarget
+                first_target,
+                second_target
             ]
         )
         pods_projects_mock = PodsProjectMock.new([], {"hermes-engine" => {}}, :native_targets => [
-            thirdTarget
+            third_target
         ])
         installer = InstallerMock.new(pods_projects_mock, [
             AggregatedProjectMock.new(user_project_mock)
@@ -304,21 +304,19 @@ class UtilsTests < Test::Unit::TestCase
     # ================================= #
 
     def test_applyMacCatalystPatches_correctlyAppliesNecessaryPatches
-        firstTarget = prepare_target("FirstTarget")
-        secondTarget = prepare_target("SecondTarget")
-        thirdTarget = prepare_target("ThirdTarget")
+        first_target = prepare_target("FirstTarget")
+        second_target = prepare_target("SecondTarget")
+        third_target = prepare_target("ThirdTarget", "com.apple.product-type.bundle")
         user_project_mock = UserProjectMock.new("a/path", [
                 prepare_config("Debug"),
                 prepare_config("Release"),
             ],
             :native_targets => [
-                firstTarget,
-                secondTarget
+                first_target,
+                second_target
             ]
         )
-        pods_projects_mock = PodsProjectMock.new([], {"hermes-engine" => {}}, :native_targets => [
-            thirdTarget
-        ])
+        pods_projects_mock = PodsProjectMock.new([third_target], {"hermes-engine" => {}}, :native_targets => [])
         installer = InstallerMock.new(pods_projects_mock, [
             AggregatedProjectMock.new(user_project_mock)
         ])
@@ -344,7 +342,7 @@ class UtilsTests < Test::Unit::TestCase
         end
 
         assert_equal(user_project_mock.save_invocation_count, 1)
-    end    
+    end
 
     # ==================================== #
     # Test - Set Node_Modules User Setting #
@@ -388,9 +386,9 @@ def prepare_config(config_name)
     ]})
 end
 
-def prepare_target(name)
-    return TargetMock.new(name, [
-        prepare_config("Debug"),
-        prepare_config("Release")
-    ])
+def prepare_target(name, product_type = nil)
+  return TargetMock.new(name, [
+      prepare_config("Debug"),
+      prepare_config("Release")
+  ], product_type)
 end

--- a/scripts/cocoapods/utils.rb
+++ b/scripts/cocoapods/utils.rb
@@ -111,9 +111,9 @@ class ReactNativePodsUtils
                     config.build_settings['PRESERVE_DEAD_CODE_INITS_AND_TERMS'] = 'YES'
                     # Modify library search paths
                     config.build_settings['LIBRARY_SEARCH_PATHS'] = ['$(SDKROOT)/usr/lib/swift', '$(SDKROOT)/System/iOSSupport/usr/lib/swift', '$(inherited)']
-                end  
+                end
             end
-            aggregate_target.user_project.save  
+            aggregate_target.user_project.save()
         end
     end
 

--- a/scripts/cocoapods/utils.rb
+++ b/scripts/cocoapods/utils.rb
@@ -93,6 +93,30 @@ class ReactNativePodsUtils
         end
     end
 
+    def self.apply_mac_catalyst_patches(installer)
+        # Fix bundle signing issues
+        installer.pods_project.targets.each do |target|
+            if target.respond_to?(:product_type) and target.product_type == "com.apple.product-type.bundle"
+                target.build_configurations.each do |config|
+                    config.build_settings['CODE_SIGN_IDENTITY[sdk=macosx*]'] = '-'
+                end
+            end
+        end
+
+        installer.aggregate_targets.each do |aggregate_target|
+            aggregate_target.user_project.native_targets.each do |target|
+                target.build_configurations.each do |config|
+                    # Explicitly set dead code stripping flags
+                    config.build_settings['DEAD_CODE_STRIPPING'] = 'YES'
+                    config.build_settings['PRESERVE_DEAD_CODE_INITS_AND_TERMS'] = 'YES'
+                    # Modify library search paths
+                    config.build_settings['LIBRARY_SEARCH_PATHS'] = ['$(SDKROOT)/usr/lib/swift', '$(SDKROOT)/System/iOSSupport/usr/lib/swift', '$(inherited)']
+                end  
+            end
+            aggregate_target.user_project.save  
+        end
+    end
+
     private
 
     def self.fix_library_search_path(config)

--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -140,7 +140,11 @@ def use_flipper!(versions = {}, configurations: ['Debug'])
   use_flipper_pods(versions, :configurations => configurations)
 end
 
-def react_native_post_install(installer, react_native_path = "../node_modules/react-native")
+def react_native_post_install(installer, mac_catalyst_enabled, react_native_path = "../node_modules/react-native")
+  if mac_catalyst_enabled
+    ReactNativePodsUtils.apply_mac_catalyst_patches(installer)
+  end
+
   if ReactNativePodsUtils.has_pod(installer, 'Flipper')
     flipper_post_install(installer)
   end
@@ -496,11 +500,6 @@ def __apply_Xcode_12_5_M1_post_install_workaround(installer)
   # See https://github.com/facebook/flipper/issues/834 for more details.
   time_header = "#{Pod::Config.instance.installation_root.to_s}/Pods/RCT-Folly/folly/portability/Time.h"
   `sed -i -e  $'s/ && (__IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_10_0)//' #{time_header}`
-end
-
-# Apply three patches necessary for successful building and archiving RN on Mac Catalyst targets
-def __apply_mac_catalyst_patches(installer)
-  ReactNativePodsUtils.apply_mac_catalyst_patches(installer)
 end
 
 # Monkeypatch of `Pod::Lockfile` to ensure automatic update of dependencies integrated with a local podspec when their version changed.

--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -498,6 +498,30 @@ def __apply_Xcode_12_5_M1_post_install_workaround(installer)
   `sed -i -e  $'s/ && (__IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_10_0)//' #{time_header}`
 end
 
+# Apply three patches necessary for successful building and archiving RN on Mac Catalyst targets
+def __apply_mac_catalyst_patches(installer)
+  # Fix bundle signing issues
+  installer.pods_project.targets.each do |target|
+    if target.respond_to?(:product_type) and target.product_type == "com.apple.product-type.bundle"
+      target.build_configurations.each do |config|
+        config.build_settings['CODE_SIGN_IDENTITY[sdk=macosx*]'] = '-'
+      end
+    end
+  end
+
+  installer.aggregate_targets.each do |aggregate_target|
+    aggregate_target.user_project.native_targets.each do |target|
+      target.build_configurations.each do |config|
+        # Explicitly set dead code stripping flag
+        config.build_settings['DEAD_CODE_STRIPPING'] = 'YES'
+        # Modify library search paths
+        config.build_settings['LIBRARY_SEARCH_PATHS'] = ['$(SDKROOT)/usr/lib/swift', '$(SDKROOT)/System/iOSSupport/usr/lib/swift', '$(inherited)']
+      end  
+    end
+    aggregate_target.user_project.save  
+  end
+end
+
 # Monkeypatch of `Pod::Lockfile` to ensure automatic update of dependencies integrated with a local podspec when their version changed.
 # This is necessary because local podspec dependencies must be otherwise manually updated.
 module LocalPodspecPatch

--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -500,26 +500,7 @@ end
 
 # Apply three patches necessary for successful building and archiving RN on Mac Catalyst targets
 def __apply_mac_catalyst_patches(installer)
-  # Fix bundle signing issues
-  installer.pods_project.targets.each do |target|
-    if target.respond_to?(:product_type) and target.product_type == "com.apple.product-type.bundle"
-      target.build_configurations.each do |config|
-        config.build_settings['CODE_SIGN_IDENTITY[sdk=macosx*]'] = '-'
-      end
-    end
-  end
-
-  installer.aggregate_targets.each do |aggregate_target|
-    aggregate_target.user_project.native_targets.each do |target|
-      target.build_configurations.each do |config|
-        # Explicitly set dead code stripping flag
-        config.build_settings['DEAD_CODE_STRIPPING'] = 'YES'
-        # Modify library search paths
-        config.build_settings['LIBRARY_SEARCH_PATHS'] = ['$(SDKROOT)/usr/lib/swift', '$(SDKROOT)/System/iOSSupport/usr/lib/swift', '$(inherited)']
-      end  
-    end
-    aggregate_target.user_project.save  
-  end
+  ReactNativePodsUtils.apply_mac_catalyst_patches(installer)
 end
 
 # Monkeypatch of `Pod::Lockfile` to ensure automatic update of dependencies integrated with a local podspec when their version changed.

--- a/template/ios/Podfile
+++ b/template/ios/Podfile
@@ -31,9 +31,11 @@ target 'HelloWorld' do
   end
 
   post_install do |installer|
-    react_native_post_install(installer)
+    # Set `mac_catalyst_enabled` to `true` in order to apply patches necessary for Mac Catalyst builds
+    mac_catalyst_enabled = false
+    
+    react_native_post_install(installer, mac_catalyst_enabled)
     __apply_Xcode_12_5_M1_post_install_workaround(installer)
-    # Enable the next line in order to apply patches necessary for Mac Catalyst builds
-    #__apply_mac_catalyst_patches(installer)
+    
   end
 end

--- a/template/ios/Podfile
+++ b/template/ios/Podfile
@@ -33,5 +33,7 @@ target 'HelloWorld' do
   post_install do |installer|
     react_native_post_install(installer)
     __apply_Xcode_12_5_M1_post_install_workaround(installer)
+    # Enable the next line in order to apply patches necessary for Mac Catalyst builds
+    #__apply_mac_catalyst_patches(installer)
   end
 end


### PR DESCRIPTION
## Summary

This PR adds a new method called **__apply_mac_catalyst_patches** to **scripts/react_native_pods.rb**. If it is enabled in the Podfile, it will apply three patches necessary for successful building not only for iOS and tvOS targets, but also for macOS using Apple's Mac Catalyst technology.

These 3 patches are:
- Fixing bundle signing issues by altering CODE_SIGN_IDENTITY
- Explicitly setting dead code stripping flag in project.pbxproj
- Modifying library search paths

The details were discussed here https://github.com/reactwg/react-native-releases/discussions/21#discussioncomment-2754289

## Changelog

[iOS] [Added] - Add Mac Catalyst compatibility (can be enabled in Podfile) 

## Test Plan

1. Go to project settings in Xcode, to General tab. Enable "iPad" and "Mac Catalyst" checkboxes
2. Go to "Signing & Capabilities" tab, ensure that a correct bundle id and development team are set
3. Edit Podfile, uncomment **__apply_mac_catalyst_patches(installer)** line
4. Run `pod install` in ios directory
5. Get back to Xcode, select "My Mac (Mac Catalyst)" as a target device
6. Build & run