### PR TITLE
Make Hermes the default engine on Android.

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,6 @@
     "anser": "^1.4.9",
     "base64-js": "^1.1.2",
     "event-target-shim": "^5.0.1",
-    "hermes-engine": "~0.11.0",
     "invariant": "^2.2.4",
     "jsc-android": "^250230.2.1",
     "memoize-one": "^5.0.0",

--- a/template/android/app/build.gradle
+++ b/template/android/app/build.gradle
@@ -78,7 +78,7 @@ import com.android.build.OutputFile
  */
 
 project.ext.react = [
-    enableHermes: false,  // clean and rebuild if changing
+    enableHermes: true,  // clean and rebuild if changing
 ]
 
 apply from: "../../node_modules/react-native/react.gradle"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3495,11 +3495,6 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
-hermes-engine@~0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/hermes-engine/-/hermes-engine-0.11.0.tgz#bb224730d230a02a5af02c4e090d1f52d57dd3db"
-  integrity sha512-7aMUlZja2IyLYAcZ69NBnwJAR5ZOYlSllj0oMpx08a8HzxHOys0eKCzfphrf6D0vX1JGO1QQvVsQKe6TkYherw==
-
 hermes-eslint@0.8.0:
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/hermes-eslint/-/hermes-eslint-0.8.0.tgz#e0a892d3f63f25d0966aa558ed40e373e2d0a065"


### PR DESCRIPTION
Summary:
This just flips the switch for having Hermes on by default
on new projects for React Native.

Changelog:
[Android] [Changed] - Make Hermes the default engine on Android

Differential Revision: D37354079

