### PR TITLE
Simplify the Android.mk file in the App Template

### DIFF
--- a/template/android/app/src/main/jni/Android.mk
+++ b/template/android/app/src/main/jni/Android.mk
@@ -16,22 +16,10 @@ LOCAL_PATH := $(THIS_DIR)
 # You can customize the name of your application .so file here.
 LOCAL_MODULE := helloworld_appmodules
 
-LOCAL_C_INCLUDES := $(LOCAL_PATH)
-LOCAL_SRC_FILES := $(wildcard $(LOCAL_PATH)/*.cpp)
-LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)
-
-# Autolinked TurboModules and Fabric components
-LOCAL_C_INCLUDES += $(PROJECT_BUILD_DIR)/generated/rncli/src/main/jni
-LOCAL_SRC_FILES += $(wildcard $(PROJECT_BUILD_DIR)/generated/rncli/src/main/jni/*.cpp)
-LOCAL_EXPORT_C_INCLUDES += $(PROJECT_BUILD_DIR)/generated/rncli/src/main/jni
-
-# If you wish to add a custom TurboModule or Fabric component in your app you
-# will have to uncomment those lines to include the generated source
-# files from the codegen (placed in $(GENERATED_SRC_DIR)/codegen/jni)
-#
-# LOCAL_C_INCLUDES += $(GENERATED_SRC_DIR)/codegen/jni
-# LOCAL_SRC_FILES += $(wildcard $(GENERATED_SRC_DIR)/codegen/jni/*.cpp)
-# LOCAL_EXPORT_C_INCLUDES += $(GENERATED_SRC_DIR)/codegen/jni
+# The generated/rncli/src/main/jni folder contains Autolinking support files.
+LOCAL_C_INCLUDES := $(LOCAL_PATH) $(PROJECT_BUILD_DIR)/generated/rncli/src/main/jni
+LOCAL_SRC_FILES := $(wildcard $(LOCAL_PATH)/*.cpp) $(wildcard $(PROJECT_BUILD_DIR)/generated/rncli/src/main/jni/*.cpp)
+LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH) $(PROJECT_BUILD_DIR)/generated/rncli/src/main/jni
 
 # Here you should add any native library you wish to depend on.
 LOCAL_SHARED_LIBRARIES := \
@@ -54,6 +42,11 @@ LOCAL_SHARED_LIBRARIES := \
 
 # Autolinked libraries
 LOCAL_SHARED_LIBRARIES += $(call import-codegen-modules) 
+
+# If you wish to add a custom TurboModule or Fabric component in your app you
+# will have to link against it here:
+# LOCAL_SHARED_LIBRARIES += \
+#   libreact_codegen_<your library name>
 
 LOCAL_CFLAGS := -DLOG_TAG=\"ReactNative\" -fexceptions -frtti -std=c++17 -Wall
 


### PR DESCRIPTION
## Summary

I'm simplifying the `Android.mk` file inside the template as it was confusing. There are two ways to include the generated code from the codegen:
1. Importing the generated Android.mk file
2. Include the generate source files in the `_appmodules` source files.

Those two approaches are mutually exclusive (as doing both will lead to duplicate symbols). Our template comments were confusing and were suggesting a combination of both.

I'm simplifying the comments here by removing the one suggesting to go with option `1` instead.

## Changelog

[Android][Changed] - Simplify the Android.mk file in the App Template

## Test Plan

Nothing to test here as it's a comments only change