### PR TITLE
fix: fix the race condition when calling readAsDataURL after new Blob(blobs)

### DIFF
--- a/Libraries/Blob/RCTFileReaderModule.mm
+++ b/Libraries/Blob/RCTFileReaderModule.mm
@@ -31,24 +31,26 @@ RCT_EXPORT_METHOD(readAsText:(NSDictionary<NSString *, id> *)blob
                   reject:(RCTPromiseRejectBlock)reject)
 {
   RCTBlobManager *blobManager = [_moduleRegistry moduleForName:"BlobModule"];
-  NSData *data = [blobManager resolve:blob];
+  dispatch_async(blobManager.methodQueue, ^{
+    NSData *data = [blobManager resolve:blob];
 
-  if (data == nil) {
-    reject(RCTErrorUnspecified,
-           [NSString stringWithFormat:@"Unable to resolve data for blob: %@", [RCTConvert NSString:blob[@"blobId"]]], nil);
-  } else {
-    NSStringEncoding stringEncoding;
-
-    if (encoding == nil) {
-      stringEncoding = NSUTF8StringEncoding;
+    if (data == nil) {
+      reject(RCTErrorUnspecified,
+             [NSString stringWithFormat:@"Unable to resolve data for blob: %@", [RCTConvert NSString:blob[@"blobId"]]], nil);
     } else {
-      stringEncoding = CFStringConvertEncodingToNSStringEncoding(CFStringConvertIANACharSetNameToEncoding((CFStringRef) encoding));
+      NSStringEncoding stringEncoding;
+
+      if (encoding == nil) {
+        stringEncoding = NSUTF8StringEncoding;
+      } else {
+        stringEncoding = CFStringConvertEncodingToNSStringEncoding(CFStringConvertIANACharSetNameToEncoding((CFStringRef) encoding));
+      }
+
+      NSString *text = [[NSString alloc] initWithData:data encoding:stringEncoding];
+
+      resolve(text);
     }
-
-    NSString *text = [[NSString alloc] initWithData:data encoding:stringEncoding];
-
-    resolve(text);
-  }
+  });
 }
 
 RCT_EXPORT_METHOD(readAsDataURL:(NSDictionary<NSString *, id> *)blob
@@ -56,19 +58,21 @@ RCT_EXPORT_METHOD(readAsDataURL:(NSDictionary<NSString *, id> *)blob
                   reject:(RCTPromiseRejectBlock)reject)
 {
   RCTBlobManager *blobManager = [_moduleRegistry moduleForName:"BlobModule"];
-  NSData *data = [blobManager resolve:blob];
+  dispatch_async(blobManager.methodQueue, ^{
+    NSData *data = [blobManager resolve:blob];
 
-  if (data == nil) {
-    reject(RCTErrorUnspecified,
-           [NSString stringWithFormat:@"Unable to resolve data for blob: %@", [RCTConvert NSString:blob[@"blobId"]]], nil);
-  } else {
-    NSString *type = [RCTConvert NSString:blob[@"type"]];
-    NSString *text = [NSString stringWithFormat:@"data:%@;base64,%@",
-                      type != nil && [type length] > 0 ? type : @"application/octet-stream",
-                      [data base64EncodedStringWithOptions:0]];
+    if (data == nil) {
+      reject(RCTErrorUnspecified,
+             [NSString stringWithFormat:@"Unable to resolve data for blob: %@", [RCTConvert NSString:blob[@"blobId"]]], nil);
+    } else {
+      NSString *type = [RCTConvert NSString:blob[@"type"]];
+      NSString *text = [NSString stringWithFormat:@"data:%@;base64,%@",
+                        type != nil && [type length] > 0 ? type : @"application/octet-stream",
+                        [data base64EncodedStringWithOptions:0]];
 
-    resolve(text);
-  }
+      resolve(text);
+    }
+  });
 }
 
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const facebook::react::ObjCTurboModule::InitParams &)params


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

```js
async () => {
  let blobs = [];
  for (let i = 0; i < 4; i++) {
    const res = await fetch();
    blobs = [...blobs, await res.blob()] 
  }
  const blob = new Blob(blobs); // <<<<<<<<<<<<<<< a
  return await new Promise((resolve, reject) => {
    const fileReader = new FileReader();
    fileReader.onload = async () => {
      await RNFS.writeFile(destPath, (fileReader.result as string).split(',')[1], 'base64');
      resolve(destPath);
    };
    fileReader.onabort = () => {
      reject('');
    };
    fileReader.onerror = (event) => {
      reject('');
    };
    fileReader.readAsDataURL(blob); // <<<<<<<<<<<<<<< b
  });
}
```

Sometime `fileReader.readAsDataURL` is unable to get blob from the dictionary after `new Blob(blobs)` and then reject with `Unable to resolve data for blob: blobId` in iOS or `The specified blob is invalid` in android. Because line `a` and `b` can be run in different thread. `new Blob([])` is in progress and `fileReader.readAsDataURL` accesses the blob dictionary ahead of the blob creation.

The expected behaviour is it should finish new Blob([]) first and then readAsDataURL(blob)

To fix that, there should be a lock inside the method `createFromParts`. For iOS, It needs to be a recursive_mutex to allow same thread to acquire lock

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [Fixed] - fix the race condition when calling readAsDataURL after new Blob(blobs)

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->


