### PR TITLE
[fix] backport FlipperConfiguration from main

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "scripts/react_native_pods_utils/script_phases.rb",
     "scripts/react_native_pods_utils/script_phases.sh",
     "scripts/react_native_pods.rb",
+    "scripts/cocoapods",
     "scripts/react-native-xcode.sh",
     "sdks/.hermesversion",
     "sdks/hermes-engine",

--- a/packages/rn-tester/Podfile
+++ b/packages/rn-tester/Podfile
@@ -8,6 +8,8 @@ platform :ios, '12.4'
 install! 'cocoapods', :deterministic_uuids => false
 
 USE_FRAMEWORKS = ENV['USE_FRAMEWORKS'] == '1'
+IN_CI = ENV['CI'] == 'true'
+
 @prefix_path = "../.."
 
 if USE_FRAMEWORKS
@@ -15,7 +17,7 @@ if USE_FRAMEWORKS
   use_frameworks!
 end
 
-def pods(options = {})
+def pods(options = {}, use_flipper: false)
   project 'RNTesterPods.xcodeproj'
 
   fabric_enabled = true
@@ -31,6 +33,7 @@ def pods(options = {})
     path: @prefix_path,
     fabric_enabled: fabric_enabled,
     hermes_enabled: hermes_enabled,
+    flipper_configuration: use_flipper ? FlipperConfiguration.enabled : FlipperConfiguration.disabled,
     app_path: "#{Dir.pwd}",
     config_file_dir: "#{Dir.pwd}/node_modules",
   )
@@ -46,10 +49,7 @@ def pods(options = {})
 end
 
 target 'RNTester' do
-  pods()
-  if !USE_FRAMEWORKS
-    use_flipper!
-  end
+  pods({}, :use_flipper => !IN_CI && !USE_FRAMEWORKS)
 end
 
 target 'RNTesterUnitTests' do

--- a/scripts/cocoapods/FlipperConfiguration.rb
+++ b/scripts/cocoapods/FlipperConfiguration.rb
@@ -1,0 +1,31 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Helper class to configure flipper
+class FlipperConfiguration
+    attr_reader :flipper_enabled
+    attr_reader :configurations
+    attr_reader :versions
+
+    def initialize(flipper_enabled, configurations, versions)
+        @flipper_enabled = flipper_enabled
+        @configurations = configurations
+        @versions = versions
+    end
+
+    def self.enabled(configurations = ["Debug"], versions = {})
+        FlipperConfiguration.new(true, configurations, versions)
+    end
+
+    def self.disabled
+        FlipperConfiguration.new(false, [], {})
+    end
+
+    def == (other)
+        return @flipper_enabled == other.flipper_enabled &&
+            @configurations == other.configurations &&
+            @versions == other.versions
+    end
+  end

--- a/template/ios/Podfile
+++ b/template/ios/Podfile
@@ -4,6 +4,8 @@ require_relative '../node_modules/@react-native-community/cli-platform-ios/nativ
 platform :ios, '12.4'
 install! 'cocoapods', :deterministic_uuids => false
 
+production = ENV["PRODUCTION"] == "1"
+
 target 'HelloWorld' do
   config = use_native_modules!
 
@@ -13,8 +15,10 @@ target 'HelloWorld' do
   use_react_native!(
     :path => config[:reactNativePath],
     # to enable hermes on iOS, change `false` to `true` and then install pods
+    :production => production,
     :hermes_enabled => flags[:hermes_enabled],
     :fabric_enabled => flags[:fabric_enabled],
+    :flipper_configuration => FlipperConfiguration.enabled,
     # An absolute path to your application root.
     :app_path => "#{Pod::Config.instance.installation_root}/.."
   )
@@ -23,12 +27,6 @@ target 'HelloWorld' do
     inherit! :complete
     # Pods for testing
   end
-
-  # Enables Flipper.
-  #
-  # Note that if you have use_frameworks! enabled, Flipper will not work and
-  # you should disable the next line.
-  use_flipper!()
 
   post_install do |installer|
     react_native_post_install(installer)


### PR DESCRIPTION
## Summary

This PR backports FlipperConfiguration and the changes to the template Podfile so that apps created with React Native does not install Flipper pods when the dependencies are installed with `PRODUCTION=1 bundle exec pod install`.

When dependencies are installed using that command, Flipper won't be added as a dependency to the project and we can build the app using the Release schema. 

## Changelog

[iOS] [Fix] - Make sure that Flipper pods are not installed when creating a release build.

## Test Plan

CircleCI passes
