### PR TITLE
fix(deps): react-shallow-renderer v16.15.0 for react v18 compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "react-devtools-core": "4.24.0",
     "react-native-gradle-plugin": "^0.0.7",
     "react-refresh": "^0.4.0",
-    "react-shallow-renderer": "16.14.1",
+    "react-shallow-renderer": "16.15.0",
     "regenerator-runtime": "^0.13.2",
     "scheduler": "^0.21.0",
     "stacktrace-parser": "^0.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5996,6 +5996,11 @@ react-devtools-core@4.24.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
+"react-is@^16.12.0 || ^17.0.0 || ^18.0.0":
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
+  integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
+
 react-is@^16.8.1, react-is@^16.8.4:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -6036,7 +6041,15 @@ react-refresh@^0.4.0:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.4.0.tgz#d421f9bd65e0e4b9822a399f14ac56bda9c92292"
   integrity sha512-bacjSio8GOtzNZKZZM6EWqbhlbb6pr28JWJWFTLwEBKvPIBRo6/Ob68D2EWZA2VyTdQxAh+TRnCYOPNKsQiXTA==
 
-react-shallow-renderer@16.14.1, react-shallow-renderer@^16.13.1:
+react-shallow-renderer@16.15.0:
+  version "16.15.0"
+  resolved "https://registry.yarnpkg.com/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz#48fb2cf9b23d23cde96708fe5273a7d3446f4457"
+  integrity sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==
+  dependencies:
+    object-assign "^4.1.1"
+    react-is "^16.12.0 || ^17.0.0 || ^18.0.0"
+
+react-shallow-renderer@^16.13.1:
   version "16.14.1"
   resolved "https://registry.yarnpkg.com/react-shallow-renderer/-/react-shallow-renderer-16.14.1.tgz#bf0d02df8a519a558fd9b8215442efa5c840e124"
   integrity sha512-rkIMcQi01/+kxiTE9D3fdS959U1g7gs+/rborw++42m1O9FAQiNI/UNRZExVUoAOprn4umcXf+pFRou8i4zuBg==


### PR DESCRIPTION
## Summary

It improves the developer experience a lot to have all your dependencies use react v18, this one still wanted v17 causing `npm` and `npx` et al a great deal of resolution stress (warnings, some errors in certain conditions)

See https://github.com/reactwg/react-native-releases/discussions/23#discussioncomment-3013506

This bumps the dependency from 16.14.x to 16.15.0 in order to pull in their first react v18 compatible release.
It mirrors part of a change that already landed on react-native#main

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
-->

[General] [Fixed] - use react-v18-compatible version of react-shallow-renderer

## Test Plan

CI ran it on main already, CI should run against the branch. You can also modify it locally and see it works in `<yourapp>/node_modules/react-native/package.json`
