### PR TITLE
Fix `HBC_SOURCEMAP_FILE` in `scripts/react-native-xcode.sh`

### DIFF
--- a/scripts/react-native-xcode.sh
+++ b/scripts/react-native-xcode.sh
@@ -168,7 +168,7 @@ else
   fi
   "$HERMES_CLI_PATH" -emit-binary $EXTRA_COMPILER_ARGS -out "$DEST/main.jsbundle" "$BUNDLE_FILE"
   if [[ $EMIT_SOURCEMAP == true ]]; then
-    HBC_SOURCEMAP_FILE="$BUNDLE_FILE.map"
+    HBC_SOURCEMAP_FILE="$DEST/main.jsbundle.map"
     "$NODE_BINARY" "$COMPOSE_SOURCEMAP_PATH" "$PACKAGER_SOURCEMAP_FILE" "$HBC_SOURCEMAP_FILE" -o "$SOURCEMAP_FILE"
   fi
   BUNDLE_FILE="$DEST/main.jsbundle"


### PR DESCRIPTION
## Summary 

Fixes #32497
Fixes #34212

The assigned HBC_SOURCEMAP_FILE path is incorrect as it does not reference the hermes bundle source map file

See: https://github.com/facebook/react-native/issues/32497#issuecomment-1171379674

## Changelog
[General] [Fixed] - using SOURCEMAP_FILE during xcode build phase with Hermes enabled

## Test Plan
1. In a blank react-native project
1. Enable Hermes
1. Go to xCode -> Project -> Build Phases -> Bundle React Native code and images
3. Add `export SOURCEMAP_FILE="$(pwd)/../ios.jsbundle.map"` before `react-native-xcode.sh` 
   e.g. 
   ```sh
   export NODE_BINARY=node
   export SOURCEMAP_FILE="$(pwd)/../ios.jsbundle.map"

   ../node_modules/react-native/scripts/react-native-xcode.sh
   ```
4. Make a release build `npx react-native run-ios --configuration Release` or `CMD + I` in xCode
5. Verify the build is successful 
6. Verify the `.map` file is outputted at the specified path (`ios.jsbundle.map` in project root for the example above)