### PR TITLE
ci: Add GitHub token permissions for workflows

### DIFF
--- a/.github/workflows/apply-version-label-issue.yml
+++ b/.github/workflows/apply-version-label-issue.yml
@@ -4,8 +4,13 @@ on:
   issues:
     types: [opened, edited]
 
+permissions:
+  contents: read
+
 jobs:
   add-version-label-issue:
+    permissions:
+      issues: write  # for react-native-community/actions-apply-version-label to label issues
     runs-on: ubuntu-latest
     continue-on-error: true
 

--- a/.github/workflows/danger_pr.yml
+++ b/.github/workflows/danger_pr.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   danger:
     runs-on: ubuntu-latest

--- a/.github/workflows/needs-attention.yml
+++ b/.github/workflows/needs-attention.yml
@@ -4,8 +4,14 @@ on:
   issue_comment:
     types: created
 
+permissions:
+  contents: read
+
 jobs:
   applyNeedsAttentionLabel:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      issues: write  # for hramos/needs-attention to label issues
     name: Apply Needs Attention Label
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/on-issue-labeled.yml
+++ b/.github/workflows/on-issue-labeled.yml
@@ -4,8 +4,14 @@ on:
   issues:
     types: labeled
 
+permissions:
+  contents: read
+
 jobs:
   respondToIssueBasedOnLabel:
+    permissions:
+      contents: read  # for hramos/respond-to-issue-based-on-label to fetch config file
+      issues: write  # for hramos/respond-to-issue-based-on-label to update issues
     name: Respond to Issue Based on Label
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test-docker-android.yml
+++ b/.github/workflows/test-docker-android.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test-docker-android:
     name: Test Docker


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

This PR adds minimum token permissions for the GITHUB_TOKEN using https://github.com/step-security/secure-workflows.

GitHub recommends defining minimum GITHUB_TOKEN permissions for securing GitHub Actions workflows 
- https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/  
- https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
- The Open Source Security Foundation (OpenSSF) [Scorecards](https://github.com/ossf/scorecard) treats not setting token permissions as a high-risk issue 

This project is part of the top 100 critical projects as per OpenSSF (https://github.com/ossf/wg-securing-critical-projects), so fixing the token permissions to improve security.

Signed-off-by: Varun Sharma <varunsh@stepsecurity.io>
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog
[General] [Security] - Add GitHub token permissions for workflows
<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

N/A