### PR TITLE
Fix hermes profiler

### DIFF
--- a/ReactCommon/hermes/executor/HermesExecutorFactory.cpp
+++ b/ReactCommon/hermes/executor/HermesExecutorFactory.cpp
@@ -164,7 +164,6 @@ class DecoratedRuntime : public jsi::WithRuntimeDecorator<ReentrancyCheck> {
         runtime_, hermesRuntime_, jsQueue);
     facebook::hermes::inspector::chrome::enableDebugging(
         std::move(adapter), "Hermes React Native");
-    hermesRuntime_.registerForProfiling();
 #else
     (void)hermesRuntime_;
 #endif
@@ -173,7 +172,6 @@ class DecoratedRuntime : public jsi::WithRuntimeDecorator<ReentrancyCheck> {
   ~DecoratedRuntime() {
 #ifdef HERMES_ENABLE_DEBUGGER
     facebook::hermes::inspector::chrome::disableDebugging(hermesRuntime_);
-    hermesRuntime_.unregisterForProfiling();
 #endif
   }
 
@@ -221,6 +219,12 @@ std::unique_ptr<JSExecutor> HermesExecutorFactory::createJSExecutor(
 
   return std::make_unique<HermesExecutor>(
       decoratedRuntime, delegate, jsQueue, timeoutInvoker_, runtimeInstaller_);
+}
+
+::hermes::vm::RuntimeConfig HermesExecutorFactory::defaultRuntimeConfig() {
+  return ::hermes::vm::RuntimeConfig::Builder()
+      .withEnableSampleProfiling(true)
+      .build();
 }
 
 HermesExecutor::HermesExecutor(

--- a/ReactCommon/hermes/executor/HermesExecutorFactory.cpp
+++ b/ReactCommon/hermes/executor/HermesExecutorFactory.cpp
@@ -164,6 +164,7 @@ class DecoratedRuntime : public jsi::WithRuntimeDecorator<ReentrancyCheck> {
         runtime_, hermesRuntime_, jsQueue);
     facebook::hermes::inspector::chrome::enableDebugging(
         std::move(adapter), "Hermes React Native");
+    hermesRuntime_.registerForProfiling();
 #else
     (void)hermesRuntime_;
 #endif
@@ -172,6 +173,7 @@ class DecoratedRuntime : public jsi::WithRuntimeDecorator<ReentrancyCheck> {
   ~DecoratedRuntime() {
 #ifdef HERMES_ENABLE_DEBUGGER
     facebook::hermes::inspector::chrome::disableDebugging(hermesRuntime_);
+    hermesRuntime_.unregisterForProfiling();
 #endif
   }
 

--- a/ReactCommon/hermes/executor/HermesExecutorFactory.h
+++ b/ReactCommon/hermes/executor/HermesExecutorFactory.h
@@ -21,7 +21,7 @@ class HermesExecutorFactory : public JSExecutorFactory {
       JSIExecutor::RuntimeInstaller runtimeInstaller,
       const JSIScopedTimeoutInvoker &timeoutInvoker =
           JSIExecutor::defaultTimeoutInvoker,
-      ::hermes::vm::RuntimeConfig runtimeConfig = ::hermes::vm::RuntimeConfig())
+      ::hermes::vm::RuntimeConfig runtimeConfig = defaultRuntimeConfig())
       : runtimeInstaller_(runtimeInstaller),
         timeoutInvoker_(timeoutInvoker),
         runtimeConfig_(std::move(runtimeConfig)) {
@@ -33,6 +33,8 @@ class HermesExecutorFactory : public JSExecutorFactory {
       std::shared_ptr<MessageQueueThread> jsQueue) override;
 
  private:
+  static ::hermes::vm::RuntimeConfig defaultRuntimeConfig();
+
   JSIExecutor::RuntimeInstaller runtimeInstaller_;
   JSIScopedTimeoutInvoker timeoutInvoker_;
   ::hermes::vm::RuntimeConfig runtimeConfig_;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

The hermes profiler doesn't work currently, I tracked down the problem to a couple of things.

- Need to call `registerForProfiling` to enable profiling for a specific runtime. I added the call at the same place where we enable the debugger.
- `runInExecutor` didn't work and call its callback. Not sure exactly why, but using `executor_->add` like we do in a lot of other places to run code on the executor works.
- `GetHeapUsageRequest` seems to cause some deadlocks. JS contexts were not detected reliably, I suspect this is related to deadlocks when trying to run on inspector executor. `GetHeapUsageRequest` doesn't actually need any data from the inspector so there is no need to run it on that queue. To fix it I moved the call to use `runInExecutor` instead.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Fixed] - Fix hermes profiler

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
