### PR TITLE
Fix a bug for which is impossible to disable Hermes

### DIFF
--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -36,7 +36,7 @@ def use_react_native! (options={})
   production = options[:production] ||= false
 
   # Include Hermes dependencies
-  hermes_enabled = options[:hermes_enabled] ||= true
+  hermes_enabled = options[:hermes_enabled] != nil ? options[:hermes_enabled] : true
 
   flipper_configuration = options[:flipper_configuration] ||= FlipperConfiguration.disabled
 


### PR DESCRIPTION
Summary:
The `||=` operator in an expression like `x = a ||= b` works in a way that:
- if a is null, it assigns b to x
- if a is `falsy`, it assigns b to x
- otherwise, it assigns a to x.

In our setup, if the user set `hermes_enabled` to `false` in the Podfile (one of the suggested way to disabled Hermes), the `options[:hermes_enabled]` part will evaluate to false and, therefore, `hermes_enabled` will obtain the value of `true`.

## Changelog

[iOS][Changed] - Use the correct operator to decide whether Hermes is enabled or not.

Differential Revision: D37643845

