### PR TITLE
Use readlink instead of realpath in packager.sh

### DIFF
--- a/scripts/packager.sh
+++ b/scripts/packager.sh
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 # scripts directory
-THIS_DIR=$(cd -P "$(dirname "$(realpath "${BASH_SOURCE[0]}" || echo "${BASH_SOURCE[0]}")")" && pwd)
+THIS_DIR=$(cd -P "$(dirname "$(readlink "${BASH_SOURCE[0]}" || echo "${BASH_SOURCE[0]}")")" && pwd)
 REACT_NATIVE_ROOT="$THIS_DIR/.."
 # Application root directory - General use case: react-native is a dependency
 PROJECT_ROOT="$THIS_DIR/../../.."


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

`realpath` is not available on macOS 12.2 and 12.4. Because of this, the following error is shown when launching an RN app with XCode (which calls `packager.sh` via `launchPackage.command`):

<img width="1123" alt="Screen Shot 2022-07-06 at 1 26 08 PM" src="https://user-images.githubusercontent.com/218725/177608681-0cf4dc5a-b71c-4ddc-8fbe-4d37b2d3e2cb.png">

I am running Bash 5 but realpath is also not available with zsh. 

This issue was introduced in https://github.com/facebook/react-native/commit/bb8ddd6c1247fde230a60c662a318422df52516e#diff-6ca7c99209bdf630550bb9e2946ce8611948c5a23b32ffb25028792ef5d48b8d, which interestingly did not change `launchPackage.command`. There's a recent comment on that commit that confirms this issue:

https://github.com/facebook/react-native/commit/bb8ddd6c1247fde230a60c662a318422df52516e#commitcomment-77818917

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [Fixed] - Use readlink instead of realpath in packager.sh

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
