### PR TITLE
Fix typo jsi to libjsi

### DIFF
--- a/ReactCommon/cxxreact/Android.mk
+++ b/ReactCommon/cxxreact/Android.mk
@@ -23,13 +23,13 @@ LOCAL_CFLAGS += -fexceptions -frtti -Wno-unused-lambda-capture
 LOCAL_STATIC_LIBRARIES := \
   boost \
   callinvoker \
-  jsi \
   reactperflogger
 
 LOCAL_SHARED_LIBRARIES := \
   glog \
   jsinspector \
   libfolly_json \
+  libjsi \
   libruntimeexecutor \
   logger
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

https://github.com/facebook/react-native/commit/094f221 created `jsi` static module and made `reactnative` statically depend on it

https://github.com/facebook/react-native/commit/1bc885b made `jsi` shared module but forgot to change `reactnative`'s dependency


## Changelog

[General] [Fixed] - Fix typo jsi to libjsi

## Test Plan

None
