### PR TITLE
fix(android): Append `.exe` to hermesc binary path for Windows users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,7 +122,6 @@ package-lock.json
 # Visual studio
 .vscode
 .vs
-bin/
 
 # Android memory profiler files
 *.hprof

--- a/.gitignore
+++ b/.gitignore
@@ -122,6 +122,7 @@ package-lock.json
 # Visual studio
 .vscode
 .vs
+bin/
 
 # Android memory profiler files
 *.hprof

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/PathUtils.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/PathUtils.kt
@@ -170,7 +170,7 @@ internal fun detectOSAwareHermesCommand(projectRoot: File, hermesCommand: String
  */
 internal fun getBuiltHermescFile(projectRoot: File, pathOverride: String?) =
     if (!pathOverride.isNullOrBlank()) {
-      File(pathOverride, "build/bin/hermesc")
+      File(pathOverride, "build/bin/${HERMESC_BIN}")
     } else {
       File(projectRoot, HERMESC_BUILT_FROM_SOURCE_PATH)
     }
@@ -190,7 +190,9 @@ internal fun projectPathToLibraryName(projectPath: String): String =
         .joinToString("") { token -> token.replaceFirstChar { it.uppercase() } }
         .plus("Spec")
 
+private const val HERMESC_BIN = Os.isWindows() ? "hermesc.exe" : "hermesc"
+
 private const val HERMESC_IN_REACT_NATIVE_PATH =
-    "node_modules/react-native/sdks/hermesc/%OS-BIN%/hermesc"
+    "node_modules/react-native/sdks/hermesc/%OS-BIN%/${HERMESC_BIN}"
 private const val HERMESC_BUILT_FROM_SOURCE_PATH =
-    "node_modules/react-native/ReactAndroid/hermes-engine/build/hermes/bin/hermesc"
+    "node_modules/react-native/ReactAndroid/hermes-engine/build/hermes/bin/${HERMESC_BIN}"

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/PathUtils.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/PathUtils.kt
@@ -145,7 +145,8 @@ internal fun detectOSAwareHermesCommand(projectRoot: File, hermesCommand: String
 
   // 3. If the react-native contains a pre-built hermesc, use it.
   val prebuiltHermesPath =
-      HERMESC_IN_REACT_NATIVE_PATH.replace("%OS-BIN%", getHermesOSBin())
+      HERMESC_IN_REACT_NATIVE_DIR.plus(getHermesCBin())
+          .replace("%OS-BIN%", getHermesOSBin())
           // Execution on Windows fails with / as separator
           .replace('/', File.separatorChar)
 
@@ -162,7 +163,7 @@ internal fun detectOSAwareHermesCommand(projectRoot: File, hermesCommand: String
 
 /**
  * Gets the location where Hermesc should be. If nothing is specified, built hermesc is assumed to
- * be inside [HERMESC_BUILT_FROM_SOURCE_PATH]. Otherwise user can specify an override with
+ * be inside [HERMESC_BUILT_FROM_SOURCE_DIR]. Otherwise user can specify an override with
  * [pathOverride], which is assumed to be an absolute path where Hermes source code is
  * provided/built.
  *
@@ -170,10 +171,12 @@ internal fun detectOSAwareHermesCommand(projectRoot: File, hermesCommand: String
  */
 internal fun getBuiltHermescFile(projectRoot: File, pathOverride: String?) =
     if (!pathOverride.isNullOrBlank()) {
-      File(pathOverride, "build/bin/${HERMESC_BIN}")
+      File(pathOverride, "build/bin/${getHermesCBin()}")
     } else {
-      File(projectRoot, HERMESC_BUILT_FROM_SOURCE_PATH)
+      File(projectRoot, HERMESC_BUILT_FROM_SOURCE_DIR.plus(getHermesCBin()))
     }
+
+internal fun getHermesCBin() = if (Os.isWindows()) "hermesc.exe" else "hermesc"
 
 internal fun getHermesOSBin(): String {
   if (Os.isWindows()) return "win64-bin"
@@ -190,9 +193,7 @@ internal fun projectPathToLibraryName(projectPath: String): String =
         .joinToString("") { token -> token.replaceFirstChar { it.uppercase() } }
         .plus("Spec")
 
-private const val HERMESC_BIN = Os.isWindows() ? "hermesc.exe" : "hermesc"
-
-private const val HERMESC_IN_REACT_NATIVE_PATH =
-    "node_modules/react-native/sdks/hermesc/%OS-BIN%/${HERMESC_BIN}"
-private const val HERMESC_BUILT_FROM_SOURCE_PATH =
-    "node_modules/react-native/ReactAndroid/hermes-engine/build/hermes/bin/${HERMESC_BIN}"
+private const val HERMESC_IN_REACT_NATIVE_DIR =
+    "node_modules/react-native/sdks/hermesc/%OS-BIN%/"
+private const val HERMESC_BUILT_FROM_SOURCE_DIR =
+    "node_modules/react-native/ReactAndroid/hermes-engine/build/hermes/bin/"

--- a/react.gradle
+++ b/react.gradle
@@ -102,20 +102,22 @@ def getHermesCommand = {
         }
     }
 
+    def hermescBin = Os.isFamily(Os.FAMILY_WINDOWS) ? 'hermesc.exe' : 'hermesc'
+
     // 2. If the project is building hermes-engine from source, use hermesc from there
     // Also note that user can override the hermes source location with
     // the `REACT_NATIVE_OVERRIDE_HERMES_DIR` env variable.
     def hermesOverrideDir = System.getenv("REACT_NATIVE_OVERRIDE_HERMES_DIR")
     def builtHermesc = hermesOverrideDir ?
-        new File(hermesOverrideDir, "build/bin/hermesc") :
-        new File(reactRoot, "node_modules/react-native/ReactAndroid/hermes-engine/build/hermes/bin/hermesc")
+        new File(hermesOverrideDir, "build/bin/$hermescBin") :
+        new File(reactRoot, "node_modules/react-native/ReactAndroid/hermes-engine/build/hermes/bin/$hermescBin")
 
     if (builtHermesc.exists()) {
         return builtHermesc.getAbsolutePath()
     }
 
     // 3. If the react-native contains a pre-built hermesc, use it.
-    def prebuiltHermesPath = "node_modules/react-native/sdks/hermesc/%OS-BIN%/hermesc"
+    def prebuiltHermesPath = "node_modules/react-native/sdks/hermesc/%OS-BIN%/$hermescBin"
         .replaceAll("%OS-BIN%", getHermesOSBin())
         .replace('/' as char, File.separatorChar);
     def prebuiltHermes = new File(reactRoot, prebuiltHermesPath)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Resolves #34116.

In a nutshell, the problem was a missing `.exe` extension on the `hermesc` binary path when running on Windows OS. The missing extension causes the method `.exists()` of the File instance to always return false, so none of the conditions ever met and an error was thrown whenever a release build with Hermes enabled was run on Windows. More details can be found in the comments on the above issues.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[Android] [Fixed] - Fix error of release builds with Hermes enabled for Windows users

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

### Reproduce

Changes on Gradle scrips are better tested on an actual application. To reproduce the issue you can:
1. Create or reuse a React Native application with version `v0.69.1` on a Windows machine
2. Enable Hermes on Android following the steps on the [documentation](https://reactnative.dev/docs/hermes#enabling-hermes)
3. Clean the build folder: `cd android && ./gradlew clean`
4. Bundle the JS and assets for a release version: `./gradlew bundleReleaseJsAndAssets`
5. The build fails with the following error:
```shell
Execution failed for task ':app:bundleReleaseJsAndAssets'.
> java.lang.Exception: Couldn't determine Hermesc location. Please set `project.ext.react.hermesCommand` to the path of the hermesc binary file. node_modules/react-native/sdks/hermesc/%OS-BIN%/hermesc
```

### Test the changes

Follow the same steps above using the fix on this PR and the error should disappear 🙂
