### PR TITLE
Support TypeScript array types for turbo module (module only)

### DIFF
--- a/packages/react-native-codegen/src/parsers/typescript/modules/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/__test_fixtures__/fixtures.js
@@ -322,6 +322,27 @@ export interface Spec extends TurboModule {
 export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
 `;
 
+const NATIVE_MODULE_WITH_BASIC_ARRAY2 = `
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+import type {TurboModule} from 'react-native/Libraries/TurboModule/RCTExport';
+import * as TurboModuleRegistry from 'react-native/Libraries/TurboModule/TurboModuleRegistry';
+
+export interface Spec extends TurboModule {
+  readonly getArray: (arg: string[]) => string[];
+  readonly getArray: (arg: readonly string[]) => readonly string[];
+}
+
+export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+`;
+
 const NATIVE_MODULE_WITH_OBJECT_WITH_OBJECT_DEFINED_IN_FILE_AS_PROPERTY = `
 /**
  * Copyright (c) Meta Platforms, Inc. and affiliates.
@@ -377,6 +398,28 @@ export interface Spec extends TurboModule {
 export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
 `;
 
+const NATIVE_MODULE_WITH_ARRAY2_WITH_UNION_AND_TOUPLE = `
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+import type {TurboModule} from 'react-native/Libraries/TurboModule/RCTExport';
+import * as TurboModuleRegistry from 'react-native/Libraries/TurboModule/TurboModuleRegistry';
+
+export interface Spec extends TurboModule {
+  readonly getArray: (
+    arg: [string, string][],
+  ) => (string | number | boolean)[];
+}
+
+export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+`;
+
 const NATIVE_MODULE_WITH_ARRAY_WITH_ALIAS = `
 /**
  * Copyright (c) Meta Platforms, Inc. and affiliates.
@@ -399,6 +442,28 @@ export interface Spec extends TurboModule {
 export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
 `;
 
+const NATIVE_MODULE_WITH_ARRAY2_WITH_ALIAS = `
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+import type {TurboModule} from 'react-native/Libraries/TurboModule/RCTExport';
+import * as TurboModuleRegistry from 'react-native/Libraries/TurboModule/TurboModuleRegistry';
+
+export type SomeString = string;
+
+export interface Spec extends TurboModule {
+  readonly getArray: (arg: SomeString[]) => string[];
+}
+
+export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+`;
+
 const NATIVE_MODULE_WITH_COMPLEX_ARRAY = `
 /**
  * Copyright (c) Meta Platforms, Inc. and affiliates.
@@ -416,6 +481,28 @@ export interface Spec extends TurboModule {
   readonly getArray: (
     arg: Array<Array<Array<Array<Array<string>>>>>,
   ) => Array<Array<Array<string>>>;
+}
+
+export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+`;
+
+const NATIVE_MODULE_WITH_COMPLEX_ARRAY2 = `
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+import type {TurboModule} from 'react-native/Libraries/TurboModule/RCTExport';
+import * as TurboModuleRegistry from 'react-native/Libraries/TurboModule/TurboModuleRegistry';
+
+export interface Spec extends TurboModule {
+  readonly getArray: (
+    arg: string[][][][][],
+  ) => string[][][];
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
@@ -534,6 +621,7 @@ export default TurboModuleRegistry.getEnforcing<Spec>(
 module.exports = {
   NATIVE_MODULE_WITH_OBJECT_WITH_OBJECT_DEFINED_IN_FILE_AS_PROPERTY,
   NATIVE_MODULE_WITH_ARRAY_WITH_UNION_AND_TOUPLE,
+  NATIVE_MODULE_WITH_ARRAY2_WITH_UNION_AND_TOUPLE,
   NATIVE_MODULE_WITH_FLOAT_AND_INT32,
   NATIVE_MODULE_WITH_ALIASES,
   NATIVE_MODULE_WITH_NESTED_ALIASES,
@@ -545,8 +633,11 @@ module.exports = {
   NATIVE_MODULE_WITH_ROOT_TAG,
   NATIVE_MODULE_WITH_NULLABLE_PARAM,
   NATIVE_MODULE_WITH_BASIC_ARRAY,
+  NATIVE_MODULE_WITH_BASIC_ARRAY2,
   NATIVE_MODULE_WITH_COMPLEX_ARRAY,
+  NATIVE_MODULE_WITH_COMPLEX_ARRAY2,
   NATIVE_MODULE_WITH_ARRAY_WITH_ALIAS,
+  NATIVE_MODULE_WITH_ARRAY2_WITH_ALIAS,
   NATIVE_MODULE_WITH_BASIC_PARAM_TYPES,
   NATIVE_MODULE_WITH_CALLBACK,
   EMPTY_NATIVE_MODULE,

--- a/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/__snapshots__/typescript-module-parser-snapshot-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/__snapshots__/typescript-module-parser-snapshot-test.js.snap
@@ -369,6 +369,49 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_AR
 }"
 `;
 
+exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_ARRAY2_WITH_ALIAS 1`] = `
+"{
+  'modules': {
+    'NativeSampleTurboModule': {
+      'type': 'NativeModule',
+      'aliases': {},
+      'spec': {
+        'properties': [
+          {
+            'name': 'getArray',
+            'optional': false,
+            'typeAnnotation': {
+              'type': 'FunctionTypeAnnotation',
+              'returnTypeAnnotation': {
+                'type': 'ArrayTypeAnnotation',
+                'elementType': {
+                  'type': 'StringTypeAnnotation'
+                }
+              },
+              'params': [
+                {
+                  'name': 'arg',
+                  'optional': false,
+                  'typeAnnotation': {
+                    'type': 'ArrayTypeAnnotation',
+                    'elementType': {
+                      'type': 'StringTypeAnnotation'
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      'moduleNames': [
+        'SampleTurboModule'
+      ]
+    }
+  }
+}"
+`;
+
 exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_ARRAY_WITH_UNION_AND_TOUPLE 1`] = `
 "{
   'modules': {
@@ -406,7 +449,112 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_AR
 }"
 `;
 
+exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_ARRAY2_WITH_UNION_AND_TOUPLE 1`] = `
+"{
+  'modules': {
+    'NativeSampleTurboModule': {
+      'type': 'NativeModule',
+      'aliases': {},
+      'spec': {
+        'properties': [
+          {
+            'name': 'getArray',
+            'optional': false,
+            'typeAnnotation': {
+              'type': 'FunctionTypeAnnotation',
+              'returnTypeAnnotation': {
+                'type': 'ArrayTypeAnnotation'
+              },
+              'params': [
+                {
+                  'name': 'arg',
+                  'optional': false,
+                  'typeAnnotation': {
+                    'type': 'ArrayTypeAnnotation'
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      'moduleNames': [
+        'SampleTurboModule'
+      ]
+    }
+  }
+}"
+`;
+
 exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_BASIC_ARRAY 1`] = `
+"{
+  'modules': {
+    'NativeSampleTurboModule': {
+      'type': 'NativeModule',
+      'aliases': {},
+      'spec': {
+        'properties': [
+          {
+            'name': 'getArray',
+            'optional': false,
+            'typeAnnotation': {
+              'type': 'FunctionTypeAnnotation',
+              'returnTypeAnnotation': {
+                'type': 'ArrayTypeAnnotation',
+                'elementType': {
+                  'type': 'StringTypeAnnotation'
+                }
+              },
+              'params': [
+                {
+                  'name': 'arg',
+                  'optional': false,
+                  'typeAnnotation': {
+                    'type': 'ArrayTypeAnnotation',
+                    'elementType': {
+                      'type': 'StringTypeAnnotation'
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          {
+            'name': 'getArray',
+            'optional': false,
+            'typeAnnotation': {
+              'type': 'FunctionTypeAnnotation',
+              'returnTypeAnnotation': {
+                'type': 'ArrayTypeAnnotation',
+                'elementType': {
+                  'type': 'StringTypeAnnotation'
+                }
+              },
+              'params': [
+                {
+                  'name': 'arg',
+                  'optional': false,
+                  'typeAnnotation': {
+                    'type': 'ArrayTypeAnnotation',
+                    'elementType': {
+                      'type': 'StringTypeAnnotation'
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      'moduleNames': [
+        'SampleTurboModule'
+      ]
+    }
+  }
+}"
+`;
+
+exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_BASIC_ARRAY2 1`] = `
 "{
   'modules': {
     'NativeSampleTurboModule': {
@@ -631,6 +779,67 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_CA
 `;
 
 exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_COMPLEX_ARRAY 1`] = `
+"{
+  'modules': {
+    'NativeSampleTurboModule': {
+      'type': 'NativeModule',
+      'aliases': {},
+      'spec': {
+        'properties': [
+          {
+            'name': 'getArray',
+            'optional': false,
+            'typeAnnotation': {
+              'type': 'FunctionTypeAnnotation',
+              'returnTypeAnnotation': {
+                'type': 'ArrayTypeAnnotation',
+                'elementType': {
+                  'type': 'ArrayTypeAnnotation',
+                  'elementType': {
+                    'type': 'ArrayTypeAnnotation',
+                    'elementType': {
+                      'type': 'StringTypeAnnotation'
+                    }
+                  }
+                }
+              },
+              'params': [
+                {
+                  'name': 'arg',
+                  'optional': false,
+                  'typeAnnotation': {
+                    'type': 'ArrayTypeAnnotation',
+                    'elementType': {
+                      'type': 'ArrayTypeAnnotation',
+                      'elementType': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'ArrayTypeAnnotation',
+                            'elementType': {
+                              'type': 'StringTypeAnnotation'
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      'moduleNames': [
+        'SampleTurboModule'
+      ]
+    }
+  }
+}"
+`;
+
+exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_COMPLEX_ARRAY2 1`] = `
 "{
   'modules': {
     'NativeSampleTurboModule': {

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -62,6 +62,10 @@ function nullGuard<T>(fn: () => T): ?T {
 }
 
 function translateArrayTypeAnnotation(
+  hasteModuleName: string,
+  types: TypeDeclarationMap,
+  aliasMap: {...NativeModuleAliasMap},
+  cxxOnly: boolean,
   tsArrayType: 'Array' | 'ReadonlyArray',
   tsElementType: $FlowFixMe,
   nullable: $FlowFixMe,
@@ -174,6 +178,10 @@ function translateTypeAnnotation(
           );
 
           return translateArrayTypeAnnotation(
+            hasteModuleName,
+            types,
+            aliasMap,
+            cxxOnly,
             typeAnnotation.type,
             typeAnnotation.typeParameters.params[0],
             nullable,

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -152,6 +152,35 @@ function translateTypeAnnotation(
     resolveTypeAnnotation(typeScriptTypeAnnotation, types);
 
   switch (typeAnnotation.type) {
+    case 'TSArrayType': {
+      return translateArrayTypeAnnotation(
+        hasteModuleName,
+        types,
+        aliasMap,
+        cxxOnly,
+        'Array',
+        typeAnnotation.elementType,
+        nullable,
+      );
+    }
+    case 'TSTypeOperator': {
+      if (typeAnnotation.operator === 'readonly' && typeAnnotation.typeAnnotation.type === 'TSArrayType') {
+        return translateArrayTypeAnnotation(
+          hasteModuleName,
+          types,
+          aliasMap,
+          cxxOnly,
+          'ReadonlyArray',
+          typeAnnotation.typeAnnotation.elementType,
+          nullable,
+        );
+      } else {
+        throw new UnsupportedTypeScriptGenericParserError(
+          hasteModuleName,
+          typeAnnotation,
+        );
+      }
+    }
     case 'TSTypeReference': {
       switch (typeAnnotation.typeName.name) {
         case 'RootTag': {

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -64,6 +64,7 @@ function nullGuard<T>(fn: () => T): ?T {
 function translateArrayTypeAnnotation(
   tsArrayType: 'Array' | 'ReadonlyArray',
   tsElementType: $FlowFixMe,
+  nullable: $FlowFixMe,
 ): Nullable<NativeModuleTypeAnnotation> {
   try {
     /**
@@ -174,7 +175,8 @@ function translateTypeAnnotation(
 
           return translateArrayTypeAnnotation(
             typeAnnotation.type,
-            typeAnnotation.typeParameters.params[0]
+            typeAnnotation.typeParameters.params[0],
+            nullable,
           );
         }
         case 'Readonly': {

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -164,7 +164,10 @@ function translateTypeAnnotation(
       );
     }
     case 'TSTypeOperator': {
-      if (typeAnnotation.operator === 'readonly' && typeAnnotation.typeAnnotation.type === 'TSArrayType') {
+      if (
+        typeAnnotation.operator === 'readonly' &&
+        typeAnnotation.typeAnnotation.type === 'TSArrayType'
+      ) {
         return translateArrayTypeAnnotation(
           hasteModuleName,
           types,


### PR DESCRIPTION
## Summary

Turbo module codegen supports arrays in both Flow and TypeScript, but it only recognize `Array<T>` and `ReadonlyArray<T>` in TypeScript.

In this change, `T[]` and `readonly T[]` are made recognizable in codegen.

## Changelog

[General] [Added] - Support TypeScript array types for turbo module (module only)

## Test Plan

`yarn jest` passed in `packages/react-native-codegen`
