### PR TITLE
Bump dependencies before 0.70 branch cut

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "pretty-format": "^26.5.2",
     "promise": "^8.0.3",
     "react-devtools-core": "4.24.0",
-    "react-native-gradle-plugin": "^0.0.7",
+    "react-native-gradle-plugin": "^0.70.0",
     "react-refresh": "^0.4.0",
     "react-shallow-renderer": "^16.15.0",
     "regenerator-runtime": "^0.13.2",

--- a/packages/react-native-codegen/package.json
+++ b/packages/react-native-codegen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-codegen",
-  "version": "0.70.0",
+  "version": "0.70.1",
   "description": "⚛️ Code generation tools for React Native",
   "homepage": "https://github.com/facebook/react-native/tree/HEAD/packages/react-native-codegen",
   "repository": {

--- a/packages/react-native-gradle-plugin/package.json
+++ b/packages/react-native-gradle-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-gradle-plugin",
-  "version": "0.0.7",
+  "version": "0.70.0",
   "description": "⚛️ Gradle Plugin for React Native",
   "homepage": "https://github.com/facebook/react-native/tree/HEAD/packages/react-native-gradle-plugin",
   "repository": {

--- a/repo-config/package.json
+++ b/repo-config/package.json
@@ -44,7 +44,7 @@
     "mkdirp": "^0.5.1",
     "prettier": "^2.4.1",
     "react": "18.1.0",
-    "react-native-codegen": "^0.70.0",
+    "react-native-codegen": "^0.70.1",
     "react-test-renderer": "18.1.0",
     "shelljs": "^0.8.5",
     "signedsource": "^1.0.0",


### PR DESCRIPTION
Summary:
Bumping React Native Codegen & Gradle plugin to prepare for
the release of React Native 0.70

Changelog:
[General] [Changed] - Bump dependencies before 0.70 branch cut

Differential Revision: D37818496

