### PR TITLE
Bump react-native-codegen before 0.70 branch cut

### DIFF
--- a/packages/react-native-codegen/package.json
+++ b/packages/react-native-codegen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-codegen",
-  "version": "0.70.1",
+  "version": "0.70.2",
   "description": "⚛️ Code generation tools for React Native",
   "homepage": "https://github.com/facebook/react-native/tree/HEAD/packages/react-native-codegen",
   "repository": {

--- a/repo-config/package.json
+++ b/repo-config/package.json
@@ -44,7 +44,7 @@
     "mkdirp": "^0.5.1",
     "prettier": "^2.4.1",
     "react": "18.1.0",
-    "react-native-codegen": "^0.70.1",
+    "react-native-codegen": "^0.70.2",
     "react-test-renderer": "18.1.0",
     "shelljs": "^0.8.5",
     "signedsource": "^1.0.0",


### PR DESCRIPTION
Summary:
Bumping React Native Codegen to prepare for the release of React Native 0.70

Changelog:
[General] [Changed] - Bump react-native-codegen before 0.70 branch cut

Reviewed By: cortinico

Differential Revision: D37849972

