### PR TITLE
Fix/flat list not calling render items for nullish values when numColumns > 1

### DIFF
--- a/Libraries/Lists/FlatList.js
+++ b/Libraries/Lists/FlatList.js
@@ -499,8 +499,9 @@ class FlatList<ItemT> extends React.PureComponent<Props<ItemT>, void> {
     if (numColumns > 1) {
       const ret = [];
       for (let kk = 0; kk < numColumns; kk++) {
-        const item = data[index * numColumns + kk];
-        if (item != null) {
+        const itemIndex = index * numColumns + kk;
+        if (itemIndex < data.length) {
+          const item = data[itemIndex];
           ret.push(item);
         }
       }

--- a/Libraries/Lists/__tests__/FlatList-test.js
+++ b/Libraries/Lists/__tests__/FlatList-test.js
@@ -152,4 +152,36 @@ describe('FlatList', () => {
     expect(scrollRef.measureLayout).toBeInstanceOf(jest.fn().constructor);
     expect(scrollRef.measureInWindow).toBeInstanceOf(jest.fn().constructor);
   });
+
+  it('calls renderItem for all data items', () => {
+    const data = [
+      {key: 'i1'},
+      null,
+      undefined,
+      {key: 'i2'},
+      null,
+      undefined,
+      {key: 'i3'},
+    ];
+
+    const renderItemInOneColumn = jest.fn();
+    ReactTestRenderer.create(
+      <FlatList data={data} renderItem={renderItemInOneColumn} />,
+    );
+
+    expect(renderItemInOneColumn).toHaveBeenCalledTimes(7);
+
+    const renderItemInThreeColumns = jest.fn();
+
+    ReactTestRenderer.create(
+      <FlatList
+        data={data}
+        renderItem={renderItemInThreeColumns}
+        numColumns={3}
+      />,
+    );
+
+    // This test fails (renderItemInThreeColumnss is called only 3 times)
+    expect(renderItemInThreeColumns).toHaveBeenCalledTimes(7);
+  });
 });

--- a/Libraries/Lists/__tests__/FlatList-test.js
+++ b/Libraries/Lists/__tests__/FlatList-test.js
@@ -181,7 +181,6 @@ describe('FlatList', () => {
       />,
     );
 
-    // This test fails (renderItemInThreeColumnss is called only 3 times)
     expect(renderItemInThreeColumns).toHaveBeenCalledTimes(7);
   });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Fixes #34034.

The FlatList doesn't call renderItem on nullish values when numColumns > 1, but it does when numColumns is not set (or equals 1).
I think the behavior should be consistent, so I updated the code so renderItems is called for every items.

I believe the condition `item != null` was here to make sure renderItem isn't called for index outside of data range, so I replaced it with `itemIndex < data.length`.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Fixed] - Fix FlatList not calling render items for nullish values when numColumns > 1

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

- I added a failing test corresponding to the issue, and the test now succeeds.
- I used the same code as in the test on a newly initialized app on RN 0.69 and made sure renderItem was called for every items as expected.
