### PR TITLE
Fix React-bridging header not found for third party modules

### DIFF
--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -268,6 +268,18 @@ def fix_library_search_paths(installer)
   end
 end
 
+def fix_react_bridging_header_search_paths(installer)
+  installer.target_installation_results.pod_target_installation_results
+    .each do |pod_name, target_installation_result|
+      target_installation_result.native_target.build_configurations.each do |config|
+        # For third party modules who have React-bridging dependency to search correct headers
+        config.build_settings['HEADER_SEARCH_PATHS'] ||= '$(inherited) '
+        config.build_settings['HEADER_SEARCH_PATHS'] << '"$(PODS_ROOT)/Headers/Private/React-bridging/react/bridging" '
+        config.build_settings['HEADER_SEARCH_PATHS'] << '"$(PODS_CONFIGURATION_BUILD_DIR)/React-bridging/react_bridging.framework/Headers" '
+      end
+  end
+end
+
 def set_node_modules_user_settings(installer, react_native_path)
   puts "Setting REACT_NATIVE build settings"
   projects = installer.aggregate_targets
@@ -291,6 +303,7 @@ def react_native_post_install(installer, react_native_path = "../node_modules/re
 
   exclude_architectures(installer)
   fix_library_search_paths(installer)
+  fix_react_bridging_header_search_paths(installer)
 
   cpp_flags = DEFAULT_OTHER_CPLUSPLUSFLAGS
   if ENV['RCT_NEW_ARCH_ENABLED'] == '1'


### PR DESCRIPTION
## Summary

Some third party modules will have build errors on react-native 0.69.1 if they have dependency to `React-bridging` (or `ReactCommon/turbomodule/core` from transitive dependency). We setup correct header search paths in [ReactCommon.podspec](https://github.com/facebook/react-native/blob/f3db6cc52792e3006a16408df4ae40f3aee19a86/ReactCommon/ReactCommon.podspec#L35). We should also apply the change to third party modules. This PR is a workaround for the migration without introducing breaking changes to third party modules.

Note that is pr is based on 0.69-stable. Because on main branch, the react_native_pods.rb has much refactoring. I'll probably create a new pr based on main branch after this one landed.

Fix #34102 

## Changelog

[iOS] [Fixed] - Fix React-bridging headers import not found

## Test Plan

```
$ npx react-native init TestApp --version 0.69
$ cd TestApp
$ yarn add react-native-vision-camera
$ yarn ios
```

