### PR TITLE
Move cocoapods cli native_modules require from template to rn scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "scripts/xcode/with-environment.sh",
     "scripts/launchPackager.bat",
     "scripts/launchPackager.command",
+    "scripts/native_modules.rb",
     "scripts/node-binary.sh",
     "scripts/packager.sh",
     "scripts/packager-reporter.js",

--- a/scripts/native_modules.rb
+++ b/scripts/native_modules.rb
@@ -1,0 +1,6 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+require_relative '../../@react-native-community/cli-platform-ios/native_modules'

--- a/template/ios/Podfile
+++ b/template/ios/Podfile
@@ -1,5 +1,5 @@
 require_relative '../node_modules/react-native/scripts/react_native_pods'
-require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
+require_relative '../node_modules/react-native/scripts/native_modules'
 
 platform :ios, '12.4'
 install! 'cocoapods', :deterministic_uuids => false


### PR DESCRIPTION
## Summary

This resolves issues where the node_modules structure is not hoisted (like with pnpm). Since the template does not directly depend on the cli, it doesn't exist in the pnpm node_modules root. Moving it to the rn scripts makes sure that the relative require starts in the correct directory for both hoisted and pnpm structures.

## Changelog

[iOS] [Fixed] - Fix cocoapods cli native_modules require for pnpm node_modules

## Test Plan

1. react-native init 
2. rm -rf node_modules
3. pnpm i
4. bundle install
5. bundle exec pod install --project-directory=ios

This should succeed. Without the patch, it will fail with 

```
[!] Invalid `Podfile` file: cannot load such file -- /.../node_modules/@react-native-community/cli-platform-ios/native_modules.

 #  from /.../ios/Podfile:2
 #  -------------------------------------------
 #  require_relative '../node_modules/react-native/scripts/react_native_pods'
 >  require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
 #  
 #  -------------------------------------------
```
