### PR TITLE
fix: RCTAlertController's UserInterfaceStyle to follow root window

### DIFF
--- a/React/CoreModules/RCTAlertController.m
+++ b/React/CoreModules/RCTAlertController.m
@@ -30,7 +30,8 @@
 - (void)show:(BOOL)animated completion:(void (^)(void))completion
 {
   if (@available(iOS 13.0, *)) {
-    self.overrideUserInterfaceStyle = UIApplication.sharedApplication.delegate.window.overrideUserInterfaceStyle;
+    UIUserInterfaceStyle style = RCTSharedApplication().delegate.window.overrideUserInterfaceStyle ?: UIUserInterfaceStyleUnspecified;
+    self.overrideUserInterfaceStyle = style;
   }
   [self.alertWindow makeKeyAndVisible];
   [self.alertWindow.rootViewController presentViewController:self animated:animated completion:completion];

--- a/React/CoreModules/RCTAlertController.m
+++ b/React/CoreModules/RCTAlertController.m
@@ -29,6 +29,9 @@
 
 - (void)show:(BOOL)animated completion:(void (^)(void))completion
 {
+  if (@available(iOS 13.0, *)) {
+    self.overrideUserInterfaceStyle = UIApplication.sharedApplication.delegate.window.overrideUserInterfaceStyle;
+  }
   [self.alertWindow makeKeyAndVisible];
   [self.alertWindow.rootViewController presentViewController:self animated:animated completion:completion];
 }


### PR DESCRIPTION
## Summary

The motivation of this PR is for the Alert to follow the same style override (`overrideUserInterfaceStyle` being light/dark) as the one used by the root window (`UIApplication.sharedApplication.delegate.window`).


This is something that has worked previously because `RCTPResentedViewController()` was used to present the Alert (the behavior has changed in https://github.com/vonovak/react-native/commit/f319ff321c4b7c0929b99e3ebe7e1ce1fa50b34c). With the former approach, the alert would "inherit" the `userInterfaceStyle` of the view controller it was presented within (and that one, in turn, would "inherit" from `UIApplication.sharedApplication.delegate.window`).

With the current approach, the "style inheritance" does not work with the view controller being created [here](https://github.com/facebook/react-native/blob/f3db6cc52792e3006a16408df4ae40f3aee19a86/React/CoreModules/RCTAlertController.m#L24).

Because this viewcontroller instance does not have where to "inherit" the styling from, the styling might be different from the rest of the app. This PR fixes that.

## Changelog


[iOS] [Fixed] - fix: RCTAlertController's UserInterfaceStyle to follow root window


## Test Plan

Instead of 

```
self.overrideUserInterfaceStyle = UIApplication.sharedApplication.delegate.window.overrideUserInterfaceStyle;
```

you can do 

```
self.overrideUserInterfaceStyle = UIUserInterfaceStyleDark;
```

and observe the result. So if the override is set, it'll manifest itself. If it's not set, the value of `UIApplication.sharedApplication.delegate.window.overrideUserInterfaceStyle` will be `UIUserInterfaceStyleUnspecified`, and it'll have no effect.

<details>
  <summary>screenshot</summary>
  
![Simulator Screen Shot - iPhone 11 - 2022-07-18 at 21 40 06](https://user-images.githubusercontent.com/1566403/179616673-d0e48e07-50b5-41a1-afb7-0aa8f7ec37b5.png)
</details>



