### PR TITLE
[fix] Hermes pod: change logic to use the hermes tag to set the pod source correctly

### DIFF
--- a/sdks/hermes-engine/hermes-engine.podspec
+++ b/sdks/hermes-engine/hermes-engine.podspec
@@ -32,9 +32,9 @@ elsif version == '1000.0.0'
 elsif currentremote.strip.end_with?("facebook/react-native.git") and currentbranch.strip.end_with?("-stable")
   Pod::UI.puts '[Hermes] Detected that you are on a React Native release branch, building Hermes from source...'.yellow if Object.const_defined?("Pod::UI")
   hermestag_file = File.join(__dir__, "..", ".hermesversion")
-  hermestag = File.read(hermestag_file)
+  hermestag = File.read(hermestag_file).strip
   source[:git] = git
-  source[:tag] = hermestag.to_s
+  source[:tag] = hermestag
 else
   source[:http] = "https://github.com/facebook/react-native/releases/download/v#{version}/hermes-runtime-darwin-v#{version}.tar.gz"
 end

--- a/sdks/hermes-engine/hermes-engine.podspec
+++ b/sdks/hermes-engine/hermes-engine.podspec
@@ -34,7 +34,8 @@ elsif currentremote.strip.end_with?("facebook/react-native.git") and currentbran
   hermestag_file = File.join(__dir__, "..", ".hermesversion")
   hermestag = File.read(hermestag_file)
   source[:git] = git
-  source[:commit] = `git ls-remote https://github.com/facebook/hermes #{hermestag} | cut -f 1`.strip
+  source[:tag] = hermestag.to_s
+  puts "TAG! #{source [:tag]}"
 else
   source[:http] = "https://github.com/facebook/react-native/releases/download/v#{version}/hermes-runtime-darwin-v#{version}.tar.gz"
 end

--- a/sdks/hermes-engine/hermes-engine.podspec
+++ b/sdks/hermes-engine/hermes-engine.podspec
@@ -31,8 +31,10 @@ elsif version == '1000.0.0'
   source[:commit] = `git ls-remote https://github.com/facebook/hermes main | cut -f 1`.strip
 elsif currentremote.strip.end_with?("facebook/react-native.git") and currentbranch.strip.end_with?("-stable")
   Pod::UI.puts '[Hermes] Detected that you are on a React Native release branch, building Hermes from source...'.yellow if Object.const_defined?("Pod::UI")
+  hermestag_file = File.join(__dir__, "..", ".hermesversion")
+  hermestag = File.read(hermestag_file)
   source[:git] = git
-  source[:commit] = `git ls-remote https://github.com/facebook/hermes main | cut -f 1`.strip
+  source[:commit] = `git ls-remote https://github.com/facebook/hermes #{hermestag} | cut -f 1`.strip
 else
   source[:http] = "https://github.com/facebook/react-native/releases/download/v#{version}/hermes-runtime-darwin-v#{version}.tar.gz"
 end

--- a/sdks/hermes-engine/hermes-engine.podspec
+++ b/sdks/hermes-engine/hermes-engine.podspec
@@ -35,7 +35,6 @@ elsif currentremote.strip.end_with?("facebook/react-native.git") and currentbran
   hermestag = File.read(hermestag_file)
   source[:git] = git
   source[:tag] = hermestag.to_s
-  puts "TAG! #{source [:tag]}"
 else
   source[:http] = "https://github.com/facebook/react-native/releases/download/v#{version}/hermes-runtime-darwin-v#{version}.tar.gz"
 end


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

This fix is necessarly to ensure that when working on the codebase in the `0.XX-stable` branches (ex. when you are working on a release) the Hermes podfile is correctly set against the right commit for that branch, and not latest commit from main branch of Hermes repo.

I didn't add a check to verify that the file `.hermesversion` exists because I think it's safe to assume that the file and the tag correctly exists when this step (doing a pod install on the `0.XX-stable` branch).

Once this is merged, we need to cherry pick it on both the 0.69 and 0.70 branches

## Changelog

[iOS] [Fixed] - Hermes pod: change logic to use the hermes tag to set the pod source correctly

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

* git clone the repo
* checkout 0.69-stable branch
* follow https://reactnative.dev/contributing/release-testing
* without this commit, when testing RNTester + iOS + Hermes the app will insta-crash on opening
* with it, the app gets build successfully