### PR TITLE
Fix hermes executor not available when use_frameworks is enabled

### DIFF
--- a/React-Core.podspec
+++ b/React-Core.podspec
@@ -47,7 +47,13 @@ Pod::Spec.new do |s|
   s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
   s.header_dir             = "React"
   s.framework              = "JavaScriptCore"
-  s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/RCT-Folly\" \"${PODS_ROOT}/Headers/Public/React-hermes\" \"${PODS_ROOT}/Headers/Public/hermes-engine\" \"${PODS_ROOT}/Headers/Public/FlipperKit\" \"$(PODS_ROOT)/Headers/Public/ReactCommon\" \"$(PODS_ROOT)/Headers/Public/React-RCTFabric\"", "DEFINES_MODULE" => "YES", "GCC_PREPROCESSOR_DEFINITIONS" => "RCT_METRO_PORT=${RCT_METRO_PORT}", "CLANG_CXX_LANGUAGE_STANDARD" => "c++17" }
+  s.pod_target_xcconfig    = {
+    "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/RCT-Folly\" \"${PODS_ROOT}/Headers/Public/React-hermes\" \"${PODS_ROOT}/Headers/Public/hermes-engine\" \"${PODS_ROOT}/Headers/Public/FlipperKit\" \"$(PODS_ROOT)/Headers/Public/ReactCommon\" \"$(PODS_ROOT)/Headers/Public/React-RCTFabric\"",
+    "FRAMEWORK_SEARCH_PATHS" => "\"${PODS_CONFIGURATION_BUILD_DIR}/React-hermes\"",
+    "DEFINES_MODULE" => "YES",
+    "GCC_PREPROCESSOR_DEFINITIONS" => "RCT_METRO_PORT=${RCT_METRO_PORT}",
+    "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",
+  }
   s.user_target_xcconfig   = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/Headers/Private/React-Core\""}
   s.default_subspec        = "Default"
 


### PR DESCRIPTION
## Summary

When in `use_frameworks!` + `hermes_enabled` mode, the React podspecs have not dependency to the `React-hermes` podspec. the `HermesExecutorFactory.h` is not available [here](https://github.com/facebook/react-native/blob/1d997ce6d67242b9f667b01365c5e719c3d3f8d7/React/AppSetup/RCTAppSetupUtils.h#L15) and [here](https://github.com/facebook/react-native/blob/1d997ce6d67242b9f667b01365c5e719c3d3f8d7/React/CxxBridge/RCTCxxBridge.mm#L44). The app will fallback to JSCRuntime and crash in release build because the JSCRuntime cannot evaluate Hermes bundles.

The pr tries to add `React-hermes` to Framework Search Paths and make the `HermesExecutorFactory.h` reachable when in use_frameworks mode.

This pr should fix the problem mentioned in [0.70 release discussion](https://github.com/reactwg/react-native-releases/discussions/26#discussioncomment-3166350).

## Changelog

[iOS] [Fixed] - Fix Hermes executor not available when `use_frameworks` is enabled

## Test Plan

use patch-package to apply the change to a RN 0.69.1 project with the following test cases:

- old architecture + jsc
- new architecture + hermes
- old architecture + `use_frameworks! :linkage => :static` + hermes
- old architecture +`use_frameworks! :linkage => :static` + hermes + release build