### PR TITLE
Fix/hermes in release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -937,8 +937,17 @@ jobs:
           name: Download Hermes tarball
           command: |
             node scripts/hermes/prepare-hermes-for-build
-            cp sdks/download/* $HERMES_WS_DIR/download/.
-            cp -r sdks/hermes/* $HERMES_WS_DIR/hermes/.
+
+            # If Hermes is not built from source, we don't have these folders.
+            DOWNLOAD_FOLDER=sdks/download/
+            if [[ -d $DOWNLOAD_FOLDER ]]; then
+              cp $DOWNLOAD_FOLDER* $HERMES_WS_DIR/download/.
+            fi
+
+            HERMES_FOLDER=sdks/hermes/
+            if [[ -d $HERMES_FOLDER ]]; then
+              cp -r $HERMES_FOLDER* $HERMES_WS_DIR/hermes/.
+            fi
       - save_cache:
           key: v1-hermes-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/hermes/hermesversion" }}
           paths:

--- a/scripts/hermes/hermes-utils.js
+++ b/scripts/hermes/hermes-utils.js
@@ -192,6 +192,7 @@ function isOnAReleaseTag() {
 
 function shouldBuildHermesFromSource() {
   const hermesTag = readHermesTag();
+
   return (
     isOnAReleaseBranch() ||
     isOnAReleaseTag() ||


### PR DESCRIPTION
## Summary

The `prepare_hermes_workspace` has a `Download Hermes Tarball` that downloads the tarball to build hermes from source only in some circumstances. When we have a PR that runs against X.YY-stable, the download does not happens. However, the CI expect to have a couple of folder and tries to move them. 
When the download does not happens, these folders are not there and therefore the CI fails.

This PR should fix the issue: when the download does not happen, we don't try to copy these folders.

## Changelog

Avoid copying the folders when they are not there.

[General] [Changed] - When preparing the Hermes workspace, we don't copy the folders that are not present.

## Test Plan
The CI should be green.
