### PR TITLE
Avoid copying folders that are not present in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -898,7 +898,7 @@ jobs:
       - run:
           name: Download Hermes tarball
           command: |
-            node scripts/hermes/prepare-hermes-for-build
+            node scripts/hermes/prepare-hermes-for-build $CIRCLE_PULL_REQUEST
             cp sdks/download/* $HERMES_WS_DIR/download/.
             cp -r sdks/hermes/* $HERMES_WS_DIR/hermes/.
       - save_cache:

--- a/scripts/hermes/hermes-utils.js
+++ b/scripts/hermes/hermes-utils.js
@@ -199,11 +199,26 @@ function isRequestingLatestCommitFromHermesMainBranch() {
   return hermesTag === DEFAULT_HERMES_TAG;
 }
 
-function shouldBuildHermesFromSource() {
+function isPRAgainstStable(pullRequest) {
+  if (pullRequest == null) {
+    return false;
+  }
+
+  const prComponents = pullRequest.split('/');
+  const prNumber = prComponents[prComponents.length - 1];
+  const apiURL = `https://api.github.com/repos/facebook/react-native/pulls/${prNumber}`;
+  const prJson = JSON.parse(execSync(`curl ${apiURL}`).toString());
+  const baseBranch = prJson.base.label;
+
+  return baseBranch.endsWith('-stable');
+}
+
+function shouldBuildHermesFromSource(pullRequest) {
   return (
     !isTestingAgainstLocalHermesTarball() &&
     (isOnAReactNativeReleaseBranch() ||
       isOnAReactNativeReleaseTag() ||
+      isPRAgainstStable(pullRequest) ||
       isRequestingLatestCommitFromHermesMainBranch())
   );
 }

--- a/scripts/hermes/prepare-hermes-for-build.js
+++ b/scripts/hermes/prepare-hermes-for-build.js
@@ -23,8 +23,8 @@ const {
   shouldBuildHermesFromSource,
 } = require('./hermes-utils');
 
-async function main() {
-  if (!shouldBuildHermesFromSource()) {
+async function main(pullRequest) {
+  if (!shouldBuildHermesFromSource(pullRequest)) {
     copyPodSpec();
     return;
   }
@@ -40,6 +40,8 @@ async function main() {
   }
 }
 
-main().then(() => {
+const pullRequest = process.argv.length > 2 ? process.argv[2] : null;
+console.log(`Pull request detected: ${pullRequest}`);
+main(pullRequest).then(() => {
   process.exit(0);
 });


### PR DESCRIPTION
Summary:
This Diff is a copy of this [PR](https://github.com/facebook/react-native/pull/34223) that we have against 0.69-stable.

This Diff introduces some checks to prevent that we try to copy folders that are not present.

## Changelog

Avoid copying the folders when they are not there.

[General] [Changed] - When preparing the Hermes workspace, we don't copy the folders that are not present.

Differential Revision: D37961092

