### PR TITLE
[FIX] Build hermes from source on PR against stable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -936,18 +936,9 @@ jobs:
       - run:
           name: Download Hermes tarball
           command: |
-            node scripts/hermes/prepare-hermes-for-build
-
-            # If Hermes is not built from source, we don't have these folders.
-            DOWNLOAD_FOLDER=sdks/download/
-            if [[ -d $DOWNLOAD_FOLDER ]]; then
-              cp $DOWNLOAD_FOLDER* $HERMES_WS_DIR/download/.
-            fi
-
-            HERMES_FOLDER=sdks/hermes/
-            if [[ -d $HERMES_FOLDER ]]; then
-              cp -r $HERMES_FOLDER* $HERMES_WS_DIR/hermes/.
-            fi
+            node scripts/hermes/prepare-hermes-for-build $CIRCLE_PULL_REQUEST
+            cp sdks/download/* $HERMES_WS_DIR/download/.
+            cp -r sdks/hermes/* $HERMES_WS_DIR/hermes/.
       - save_cache:
           key: v1-hermes-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/hermes/hermesversion" }}
           paths:

--- a/scripts/hermes/hermes-utils.js
+++ b/scripts/hermes/hermes-utils.js
@@ -190,12 +190,27 @@ function isOnAReleaseTag() {
   return currentRemote.endsWith('facebook/react-native.git');
 }
 
-function shouldBuildHermesFromSource() {
+function isPRAgainstStable(pullRequest) {
+  if (pullRequest == null) {
+    return false;
+  }
+
+  const prComponents = pullRequest.split('/');
+  const prNumber = prComponents[prComponents.length - 1];
+  const apiURL = `https://api.github.com/repos/facebook/react-native/pulls/${prNumber}`;
+  const prJson = JSON.parse(execSync(`curl ${apiURL}`).toString());
+  const baseBranch = prJson.base.label;
+
+  return baseBranch.endsWith('-stable');
+}
+
+function shouldBuildHermesFromSource(pullRequest) {
   const hermesTag = readHermesTag();
 
   return (
     isOnAReleaseBranch() ||
     isOnAReleaseTag() ||
+    isPRAgainstStable(pullRequest) ||
     hermesTag === DEFAULT_HERMES_TAG
   );
 }

--- a/scripts/hermes/prepare-hermes-for-build.js
+++ b/scripts/hermes/prepare-hermes-for-build.js
@@ -23,8 +23,8 @@ const {
   shouldBuildHermesFromSource,
 } = require('./hermes-utils');
 
-async function main() {
-  if (!shouldBuildHermesFromSource()) {
+async function main(pullRequest) {
+  if (!shouldBuildHermesFromSource(pullRequest)) {
     copyPodSpec();
     return;
   }
@@ -40,6 +40,8 @@ async function main() {
   }
 }
 
-main().then(() => {
+const pullRequest = process.argv.length > 2 ? process.argv[2] : null;
+console.log(`Pull request detected: ${pullRequest}`);
+main(pullRequest).then(() => {
   process.exit(0);
 });


### PR DESCRIPTION
## Summary

This PR ensures that we can build Hermes from source also when we are creating prs against stable branches.
It also revert the changes of #34223 because they did not fix the issue.

## Changelog

[General] [Changed] - Make sure we can build Hermes from source when PR are opened agains `-stable`

## Test Plan

Tested locally + CircleCI is green (a part from `test_ios_unit`)
