### PR TITLE
Fix missing import on New Architecture build script in template

### DIFF
--- a/template/android/app/build.gradle
+++ b/template/android/app/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: "com.android.application"
 
 import com.android.build.OutputFile
+import org.apache.tools.ant.taskdefs.condition.Os
 
 /**
  * The react.gradle file registers a task for each build variant (e.g. bundleDebugJsAndAssets

--- a/template/android/build.gradle
+++ b/template/android/build.gradle
@@ -1,5 +1,3 @@
-import org.apache.tools.ant.taskdefs.condition.Os
-
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {


### PR DESCRIPTION
Summary:
The OS static class is accessed inside app/build.gradle but the import is on
the top level Gradle file. This is causing an app created from template to fail
building.

This is needed to be cherry-picked on the 0.70-stable branch.

Changelog:
[Android] [Fixed] - Fix missing import on New Architecture build script in template

Differential Revision: D37995897

