### PR TITLE
Simplify logic to choose if we need to build hermes from source or not.

### DIFF
--- a/scripts/hermes/prepare-hermes-for-build.js
+++ b/scripts/hermes/prepare-hermes-for-build.js
@@ -23,12 +23,11 @@ const {
   shouldBuildHermesFromSource,
 } = require('./hermes-utils');
 
-async function main(pullRequest) {
-  if (!shouldBuildHermesFromSource(pullRequest)) {
+async function main(isInCI) {
+  if (!shouldBuildHermesFromSource(isInCI)) {
     copyPodSpec();
     return;
   }
-
   downloadHermesTarball();
   expandHermesTarball();
   copyPodSpec();
@@ -40,8 +39,8 @@ async function main(pullRequest) {
   }
 }
 
-const pullRequest = process.argv.length > 2 ? process.argv[2] : null;
-console.log(`Pull request detected: ${pullRequest}`);
-main(pullRequest).then(() => {
+const isInCI = process.env.CI === 'true';
+
+main(isInCI).then(() => {
   process.exit(0);
 });


### PR DESCRIPTION
Summary:
This diff simplify the logic to decide whether we want to build hermes from source or not.

The requirement we have is that we don't want our users to build hermes.
So, we don't want to build hermes when there is a precompiled tarball available, while we want to build hermes in CI.

## Changelog

[General][Changed] - Build hermes when in CI and not when there is a tarball

Differential Revision: D37999748

