### PR TITLE
Fix unexpected ScrollView fling behavior due to Android P bug workaround

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -20,6 +20,7 @@ import android.graphics.Color;
 import android.graphics.Rect;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
+import android.os.Build;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.View;
@@ -479,18 +480,7 @@ public class ReactScrollView extends ScrollView
 
   @Override
   public void fling(int velocityY) {
-    // Workaround.
-    // On Android P if a ScrollView is inverted, we will get a wrong sign for
-    // velocityY (see https://issuetracker.google.com/issues/112385925).
-    // At the same time, mOnScrollDispatchHelper tracks the correct velocity direction.
-    //
-    // Hence, we can use the absolute value from whatever the OS gives
-    // us and use the sign of what mOnScrollDispatchHelper has tracked.
-    float signum = Math.signum(mOnScrollDispatchHelper.getYFlingVelocity());
-    if (signum == 0) {
-      signum = Math.signum(velocityY);
-    }
-    final int correctedVelocityY = (int) (Math.abs(velocityY) * signum);
+    final int correctedVelocityY = correctFlingVelocityY(velocityY);
 
     if (mPagingEnabled) {
       flingAndSnap(correctedVelocityY);
@@ -528,6 +518,25 @@ public class ReactScrollView extends ScrollView
     }
     handlePostTouchScrolling(0, correctedVelocityY);
   }
+
+  private int correctFlingVelocityY(int velocityY) {
+     if (Build.VERSION.SDK_INT != Build.VERSION_CODES.P) {
+       return velocityY;
+     }
+
+     // Workaround.
+     // On Android P if a ScrollView is inverted, we will get a wrong sign for
+     // velocityY (see https://issuetracker.google.com/issues/112385925).
+     // At the same time, mOnScrollDispatchHelper tracks the correct velocity direction.
+     //
+     // Hence, we can use the absolute value from whatever the OS gives
+     // us and use the sign of what mOnScrollDispatchHelper has tracked.
+     float signum = Math.signum(mOnScrollDispatchHelper.getYFlingVelocity());
+     if (signum == 0) {
+       signum = Math.signum(velocityY);
+     }
+     return (int) (Math.abs(velocityY) * signum);
+   }
 
   private void enableFpsListener() {
     if (isScrollPerfLoggingEnabled()) {


### PR DESCRIPTION
## Summary

Some custom logic is applied to workaround a platform bug where velocity may be incorrect on Android P. [The bug in question](https://issuetracker.google.com/issues/112385925) appears to have been fixed before Android `Q` was released, so we shouldn't *need* to apply the workaround on other versions.

As described in https://github.com/facebook/react-native/issues/34226 the workaround can adversely affect certain scroll behaviors, which can easily be reproduced when you briefly scroll one direction then quickly fling the opposite direction (see the video in the linked ticket).

This PR changes the workaround to *only* be applied on Android P, in order to avoid causing weird scroll behavior on versions that are not actually affected by the bug the workaround is working around.

## Changelog

```
[Android] [Fixed] - Fix occasionally incorrect ScrollView fling behavior
```

## Test Plan

- Repro the strange fling behavior in the current version (See video attached in https://github.com/facebook/react-native/issues/34226)
- Verify that the string fling behavior is fixed with this patch
- Verify that fling behavior still works as expected on Android versions affected by the [original bug](https://issuetracker.google.com/issues/112385925), and those immediately following it (to verify that the bug being worked around was, in fact, fixed as expected).