### PR TITLE
Bake prod env var into `react_native_pods.rb` for iOS Release build

### DIFF
--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -37,7 +37,7 @@ def use_react_native! (
   path: "../node_modules/react-native",
   fabric_enabled: false,
   new_arch_enabled: ENV['RCT_NEW_ARCH_ENABLED'] == '1',
-  production: ENV['PRODUCTION'] == false,
+  production: ENV['PRODUCTION'] == '1',
   hermes_enabled: true,
   flipper_configuration: FlipperConfiguration.disabled,
   app_path: '..',

--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -37,7 +37,7 @@ def use_react_native! (
   path: "../node_modules/react-native",
   fabric_enabled: false,
   new_arch_enabled: ENV['RCT_NEW_ARCH_ENABLED'] == '1',
-  production: false,
+  production: ENV['PRODUCTION'] == false,
   hermes_enabled: true,
   flipper_configuration: FlipperConfiguration.disabled,
   app_path: '..',

--- a/template/ios/Podfile
+++ b/template/ios/Podfile
@@ -4,8 +4,6 @@ require_relative '../node_modules/react-native/scripts/native_modules'
 platform :ios, '12.4'
 install! 'cocoapods', :deterministic_uuids => false
 
-production = ENV["PRODUCTION"] == "1"
-
 target 'HelloWorld' do
   config = use_native_modules!
 
@@ -14,7 +12,6 @@ target 'HelloWorld' do
 
   use_react_native!(
     :path => config[:reactNativePath],
-    :production => production,
     # Hermes is now enabled by default. Disable by setting this flag to false.
     # Upcoming versions of React Native may rely on get_default_flags(), but
     # we make it explicit here to aid in the React Native upgrade process.

--- a/template/ios/Podfile
+++ b/template/ios/Podfile
@@ -4,6 +4,8 @@ require_relative '../node_modules/react-native/scripts/native_modules'
 platform :ios, '12.4'
 install! 'cocoapods', :deterministic_uuids => false
 
+production = ENV["PRODUCTION"] == "1"
+
 target 'HelloWorld' do
   config = use_native_modules!
 
@@ -12,6 +14,7 @@ target 'HelloWorld' do
 
   use_react_native!(
     :path => config[:reactNativePath],
+    :production => production,
     # Hermes is now enabled by default. Disable by setting this flag to false.
     # Upcoming versions of React Native may rely on get_default_flags(), but
     # we make it explicit here to aid in the React Native upgrade process.


### PR DESCRIPTION
## Summary

### Mentioned
- pr[main]: https://github.com/facebook/react-native/pull/33882
- discussion: https://github.com/reactwg/react-native-releases/discussions/21#discussioncomment-2945972
- pr[0.69-stable]: https://github.com/facebook/react-native/pull/34098

Close: https://github.com/facebook/react-native/issues/33764

Saw the issue ago couple wks too: https://github.com/leotm/react-native-template-new-architecture/issues/757
Fixed similarly: https://github.com/leotm/react-native-template-new-architecture/pull/791

## Changelog

[iOS] [Changed] - Update Podfile to allow `PRODUCTION=1 pod install`

## Test Plan

Everything builds and runs as expected
