### PR TITLE
Allow preferred Alert button regardless of the style

### DIFF
--- a/Libraries/Alert/Alert.js
+++ b/Libraries/Alert/Alert.js
@@ -137,7 +137,8 @@ class Alert {
             cancelButtonKey = String(index);
           } else if (btn.style === 'destructive') {
             destructiveButtonKey = String(index);
-          } else if (btn.isPreferred) {
+          }
+          if (btn.isPreferred) {
             preferredButtonKey = String(index);
           }
           if (btn.text || index < (callbackOrButtons || []).length - 1) {


### PR DESCRIPTION
## Summary

See https://github.com/facebook/react-native/pull/32538 for the discussion

cc @robbie-c 

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[iOS] [Fixed] - Allow preferred Alert button regardless of the style

## Test Plan

Same test plan as PR mentioned above
