### PR TITLE
(jest/setup) remove removeEventListener from AccessibilityInfo and Linking mocks

### DIFF
--- a/jest/setup.js
+++ b/jest/setup.js
@@ -130,7 +130,6 @@ jest
       isReduceMotionEnabled: jest.fn(),
       isReduceTransparencyEnabled: jest.fn(),
       isScreenReaderEnabled: jest.fn(() => Promise.resolve(false)),
-      removeEventListener: jest.fn(),
       setAccessibilityFocus: jest.fn(),
       sendAccessibilityEvent: jest.fn(),
       getRecommendedTimeoutMillis: jest.fn(),
@@ -177,7 +176,6 @@ jest
     openSettings: jest.fn(),
     addEventListener: jest.fn(),
     getInitialURL: jest.fn(() => Promise.resolve()),
-    removeEventListener: jest.fn(),
     sendIntent: jest.fn(),
   }))
   // Mock modules defined by the native layer (ex: Objective-C, Java)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

The removeEventListener method has been removed from AccessibilityInfo and Linking in this PR: #33580, so I believe we can remove it from the mocks.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[Internal] [Removed] - Remove removeEventListener from AccessibilityInfo and Linking mocks

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

I executed jest and everything is still green.