### PR TITLE
Update platform os value to constant

### DIFF
--- a/Libraries/Utilities/Platform.android.js
+++ b/Libraries/Utilities/Platform.android.js
@@ -19,7 +19,10 @@ export type PlatformSelectSpec<A, N, D> = {
 
 const Platform = {
   __constants: null,
-  OS: 'android',
+  // $FlowFixMe[unsafe-getters-setters]
+  get OS(): string {
+    return 'android';
+  },
   // $FlowFixMe[unsafe-getters-setters]
   get Version(): number {
     return this.constants.Version;

--- a/Libraries/Utilities/Platform.ios.js
+++ b/Libraries/Utilities/Platform.ios.js
@@ -19,7 +19,10 @@ export type PlatformSelectSpec<D, N, I> = {
 
 const Platform = {
   __constants: null,
-  OS: 'ios',
+  // $FlowFixMe[unsafe-getters-setters]
+  get OS(): string {
+    return 'ios';
+  },
   // $FlowFixMe[unsafe-getters-setters]
   get Version(): string {
     return this.constants.osVersion;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

now `Platform.OS` can be updated, like `Platform.OS = 'example'`.
But actually `Platform.OS` should be constant.

## Changelog

use `get` to access OS value instead of define a property in Platform object

## Test Plan

```
Platform.OS = 'example'
console.log(Platform.OS) // 'ios'/'android'/...
```
