### PR TITLE
#34214 for main

### DIFF
--- a/scripts/cocoapods/__tests__/new_architecture-test.rb
+++ b/scripts/cocoapods/__tests__/new_architecture-test.rb
@@ -208,10 +208,8 @@ def prepare_CXX_Flags_build_configuration(name)
 end
 
 def prepare_pod_target_installation_results_mock(name, configs)
-    return PodTargetInstallationResultsMock.new(
-        :name => name,
-        :native_target => TargetMock.new(name, configs)
-    )
+    target = TargetMock.new(name, configs)
+    return TargetInstallationResultMock.new(target, target)
 end
 
 def prepare_installer_for_cpp_flags(xcconfigs, build_configs)
@@ -232,8 +230,6 @@ def prepare_installer_for_cpp_flags(xcconfigs, build_configs)
         [
             AggregatedProjectMock.new(:xcconfigs => xcconfigs_map, :base_path => "a/path/")
         ],
-        :target_installation_results => TargetInstallationResultsMock.new(
-            :pod_target_installation_results => pod_target_installation_results_map
-        )
+        :pod_target_installation_results => pod_target_installation_results_map
     )
 end

--- a/scripts/cocoapods/__tests__/test_utils/InstallerMock.rb
+++ b/scripts/cocoapods/__tests__/test_utils/InstallerMock.rb
@@ -41,10 +41,23 @@ class InstallerMock
     attr_reader :aggregate_targets
     attr_reader :target_installation_results
 
-    def initialize(pods_project = PodsProjectMock.new, aggregate_targets = [AggregatedProjectMock.new], target_installation_results: [])
+    InstallationResults = Struct.new(:pod_target_installation_results, :aggregate_target_installation_results)
+
+    def initialize(pods_project = PodsProjectMock.new, aggregate_targets = [AggregatedProjectMock.new],
+                   pod_target_installation_results = {},
+                   aggregate_target_installation_results = {})
         @pods_project = pods_project
         @aggregate_targets = aggregate_targets
-        @target_installation_results = target_installation_results
+
+        @target_installation_results = InstallationResults.new(pod_target_installation_results, aggregate_target_installation_results)
+        aggregate_targets.each do |aggregate_target|
+            aggregate_target.user_project.native_targets.each do |target|
+                @target_installation_results.pod_target_installation_results[target.name] = TargetInstallationResultMock.new(target, target)
+            end
+        end
+        pods_project.native_targets.each do |target|
+            @target_installation_results.pod_target_installation_results[target.name] = TargetInstallationResultMock.new(target, target)
+        end
     end
 
     def target_with_name(name)
@@ -168,20 +181,27 @@ class BuildConfigurationMock
     end
 end
 
-class TargetInstallationResultsMock
-    attr_reader :pod_target_installation_results
-
-    def initialize(pod_target_installation_results: {})
-        @pod_target_installation_results = pod_target_installation_results
-    end
-end
-
-class PodTargetInstallationResultsMock
-    attr_reader :name
+class TargetInstallationResultMock
+    attr_reader :target
     attr_reader :native_target
+    attr_reader :resource_bundle_targets
+    attr_reader :test_native_targets
+    attr_reader :test_resource_bundle_targets
+    attr_reader :test_app_host_targets
+    attr_reader :app_native_targets
+    attr_reader :app_resource_bundle_targets
 
-    def initialize(name: "", native_target: TargetMock.new())
-        @name = name
+    def initialize(target = TargetMock, native_target = TargetMock,
+                   resource_bundle_targets = [], test_native_targets = [],
+                   test_resource_bundle_targets = {}, test_app_host_targets = [],
+                   app_native_targets = {}, app_resource_bundle_targets = {})
+        @target = target
         @native_target = native_target
+        @resource_bundle_targets = resource_bundle_targets
+        @test_native_targets = test_native_targets
+        @test_resource_bundle_targets = test_resource_bundle_targets
+        @test_app_host_targets = test_app_host_targets
+        @app_native_targets = app_native_targets
+        @app_resource_bundle_targets = app_resource_bundle_targets
     end
 end

--- a/scripts/cocoapods/__tests__/test_utils/InstallerMock.rb
+++ b/scripts/cocoapods/__tests__/test_utils/InstallerMock.rb
@@ -44,8 +44,8 @@ class InstallerMock
     InstallationResults = Struct.new(:pod_target_installation_results, :aggregate_target_installation_results)
 
     def initialize(pods_project = PodsProjectMock.new, aggregate_targets = [AggregatedProjectMock.new],
-                   pod_target_installation_results = {},
-                   aggregate_target_installation_results = {})
+                   pod_target_installation_results: {},
+                   aggregate_target_installation_results: {})
         @pods_project = pods_project
         @aggregate_targets = aggregate_targets
 

--- a/scripts/cocoapods/utils.rb
+++ b/scripts/cocoapods/utils.rb
@@ -93,6 +93,18 @@ class ReactNativePodsUtils
         end
     end
 
+    def self.fix_react_bridging_header_search_paths(installer)
+        installer.target_installation_results.pod_target_installation_results
+            .each do |pod_name, target_installation_result|
+                target_installation_result.native_target.build_configurations.each do |config|
+                    # For third party modules who have React-bridging dependency to search correct headers
+                    config.build_settings['HEADER_SEARCH_PATHS'] ||= '$(inherited) '
+                    config.build_settings['HEADER_SEARCH_PATHS'] << '"$(PODS_ROOT)/Headers/Private/React-bridging/react/bridging" '
+                    config.build_settings['HEADER_SEARCH_PATHS'] << '"$(PODS_CONFIGURATION_BUILD_DIR)/React-bridging/react_bridging.framework/Headers" '
+            end
+        end
+    end
+
     def self.apply_mac_catalyst_patches(installer)
         # Fix bundle signing issues
         installer.pods_project.targets.each do |target|

--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -156,6 +156,7 @@ def react_native_post_install(installer, react_native_path = "../node_modules/re
 
   ReactNativePodsUtils.exclude_i386_architecture_while_using_hermes(installer)
   ReactNativePodsUtils.fix_library_search_paths(installer)
+  ReactNativePodsUtils.fix_react_bridging_header_search_paths(installer)
   ReactNativePodsUtils.set_node_modules_user_settings(installer, react_native_path)
 
   NewArchitectureHelper.set_clang_cxx_language_standard_if_needed(installer)


### PR DESCRIPTION
## Summary

cherry-pick changes from #34214 to main. because the `react_native_pods.rb` on main is quite different from 0.69, i have separated pr for the change.

## Changelog

[iOS] [Fixed] - Fix React-bridging headers import not found

## Test Plan

RNTester + pod install and verify pod targets to have `React-bridging` in header search paths.
