### PR TITLE
Fix test-manual-e2e on Android/Hermes for New App Template

### DIFF
--- a/scripts/test-manual-e2e.sh
+++ b/scripts/test-manual-e2e.sh
@@ -33,7 +33,6 @@ selected_vm=""
 PACKAGE_VERSION=""
 
 test_android(){
-    generate_maven_artifacts
     if [ "$1" == "1" ]; then
         test_android_hermes
     elif [ "$1" == "2" ]; then
@@ -43,7 +42,9 @@ test_android(){
 
 generate_maven_artifacts(){
     rm -rf android
-    ./gradlew :ReactAndroid:installArchives || error "Couldn't generate artifacts"
+    
+    ./gradlew :ReactAndroid:installArchives || error "Couldn't generate React Native Maven artifacts"
+    ./gradlew :ReactAndroid:hermes-engine:installArchives || error "Couldn't generate Hermes Engine Maven artifacts"
 
     success "Generated artifacts for Maven"
 }
@@ -108,6 +109,10 @@ kill_packagers(){
 
 init_template_app(){
     kill_packagers
+
+    if [ "$selected_platform" == "1" ]; then
+        generate_maven_artifacts
+    fi
 
     PACKAGE_VERSION=$(cat package.json \
     | grep version \


### PR DESCRIPTION
## Summary

The current `test-manual-e2e.sh` script is broken on Android + Hermes + New App Template.

This commit fixes it. Specifically:
- There is no need to generate Maven Artifacts for RN Tester, as RN Tester consumes them from source.
- There is instead a need to generate Maven Artifacts for New App Template, as they need to be included inside the NPM package.
- The `:ReactAndroid:hermes-engine:installArchives` task needs to invoked to also generate the Hermes-engine .aar for bundling.

## Changelog

[Internal] - Fix test-manual-e2e on Android/Hermes for New App Template

## Test Plan

I've tested this against the `0.70-stable` branch and I was able to run an App from the New Template properly.