### PR TITLE
Make sure *.ts files are considered for task avoidance in the Gradle Plugin

### DIFF
--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/GenerateCodegenSchemaTask.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/GenerateCodegenSchemaTask.kt
@@ -33,6 +33,7 @@ abstract class GenerateCodegenSchemaTask : Exec() {
   val jsInputFiles =
       project.fileTree(jsRootDir) {
         it.include("**/*.js")
+        it.include("**/*.ts")
         it.exclude("**/generated/source/codegen/**/*")
       }
 

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/GenerateCodegenSchemaTaskTest.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/GenerateCodegenSchemaTaskTest.kt
@@ -29,15 +29,16 @@ class GenerateCodegenSchemaTaskTest {
     val jsRootDir =
         tempFolder.newFolder("js").apply {
           File(this, "file.js").createNewFile()
+          File(this, "file.ts").createNewFile()
           File(this, "ignore.txt").createNewFile()
         }
 
     val task = createTestTask<GenerateCodegenSchemaTask> { it.jsRootDir.set(jsRootDir) }
 
     assertEquals(jsRootDir, task.jsInputFiles.dir)
-    assertEquals(setOf("**/*.js"), task.jsInputFiles.includes)
-    assertEquals(1, task.jsInputFiles.files.size)
-    assertEquals(setOf(File(jsRootDir, "file.js")), task.jsInputFiles.files)
+    assertEquals(setOf("**/*.js", "**/*.ts"), task.jsInputFiles.includes)
+    assertEquals(2, task.jsInputFiles.files.size)
+    assertEquals(setOf(File(jsRootDir, "file.js"), File(jsRootDir, "file.ts")), task.jsInputFiles.files)
   }
 
   @Test


### PR DESCRIPTION
## Summary

I've realized that the gradle plugin is currently looking at `.js` files for task re-execution. This means that, while the *.ts would still be considered when the codegen is invoked, an edit on one of those file, won't retrigger the codegen on Android.

This change fixes it so that we consider both `*.ts` and `*.js` files.

## Changelog

[Android] [Fixed] - Make sure *.ts files are considered for task avoidance in the Gradle Plugin

## Test Plan

Tests are attached.