### PR TITLE
Fix Macro Errors for Windows

### DIFF
--- a/ReactCommon/react/renderer/components/text/BaseTextProps.cpp
+++ b/ReactCommon/react/renderer/components/text/BaseTextProps.cpp
@@ -13,7 +13,7 @@
 #include <react/renderer/graphics/conversions.h>
 
 #define GET_FIELD_VALUE(field, fieldName, defaultValue, rawValue) \
-  (rawValue.hasValue() ? ([&rawValue, &context]{                   \
+  (rawValue.hasValue() ? ([&rawValue, &context]{                  \
     decltype(defaultValue) res;                                   \
     fromRawValue(context, rawValue, res);                         \
     return res;                                                   \

--- a/ReactCommon/react/renderer/components/text/BaseTextProps.cpp
+++ b/ReactCommon/react/renderer/components/text/BaseTextProps.cpp
@@ -13,7 +13,7 @@
 #include <react/renderer/graphics/conversions.h>
 
 #define GET_FIELD_VALUE(field, fieldName, defaultValue, rawValue) \
-  (rawValue.hasValue() ? ([&rawValue,&context]{                   \
+  (rawValue.hasValue() ? ([&rawValue, &context]{                   \
     decltype(defaultValue) res;                                   \
     fromRawValue(context, rawValue, res);                         \
     return res;                                                   \

--- a/ReactCommon/react/renderer/components/text/BaseTextProps.cpp
+++ b/ReactCommon/react/renderer/components/text/BaseTextProps.cpp
@@ -13,12 +13,12 @@
 #include <react/renderer/graphics/conversions.h>
 
 #define GET_FIELD_VALUE(field, fieldName, defaultValue, rawValue) \
-  (rawValue.hasValue() ? ({                                       \
+  (rawValue.hasValue() ? ([&rawValue,&context]{                   \
     decltype(defaultValue) res;                                   \
     fromRawValue(context, rawValue, res);                         \
-    res;                                                          \
-  })                                                              \
-                       : defaultValue)
+    return res;                                                   \
+  }())                                                            \
+                       : defaultValue);
 
 #define REBUILD_FIELD_SWITCH_CASE(                                   \
     defaults, rawValue, property, field, fieldName)                  \
@@ -27,6 +27,7 @@
         GET_FIELD_VALUE(field, fieldName, defaults.field, rawValue); \
     return;                                                          \
   }
+
 
 namespace facebook {
 namespace react {

--- a/ReactCommon/react/renderer/components/text/BaseTextProps.cpp
+++ b/ReactCommon/react/renderer/components/text/BaseTextProps.cpp
@@ -28,7 +28,6 @@
     return;                                                          \
   }
 
-
 namespace facebook {
 namespace react {
 

--- a/ReactCommon/react/renderer/components/view/ViewProps.cpp
+++ b/ReactCommon/react/renderer/components/view/ViewProps.cpp
@@ -262,11 +262,11 @@ ViewProps::ViewProps(
   case CONSTEXPR_RAW_PROPS_KEY_HASH(eventString): { \
     ViewEvents defaultViewEvents{};                 \
     events[eventType] = [defaultViewEvents, &value, &context]{    \
-        bool res = defaultViewEvents[eventType];    \
-        if (value.hasValue()) {                     \
-            fromRawValue(context, value, res);      \
-        }                                           \
-        return res;                                 \
+      bool res = defaultViewEvents[eventType];      \
+      if (value.hasValue()) {                       \
+        fromRawValue(context, value, res);          \
+      }                                             \
+      return res;                                   \
     }();                                            \
     return;                                         \
   }

--- a/ReactCommon/react/renderer/components/view/ViewProps.cpp
+++ b/ReactCommon/react/renderer/components/view/ViewProps.cpp
@@ -261,13 +261,13 @@ ViewProps::ViewProps(
 #define VIEW_EVENT_CASE(eventType, eventString)     \
   case CONSTEXPR_RAW_PROPS_KEY_HASH(eventString): { \
     ViewEvents defaultViewEvents{};                 \
-    events[eventType] = ({                          \
-      bool res = defaultViewEvents[eventType];      \
-      if (value.hasValue()) {                       \
-        fromRawValue(context, value, res);          \
-      }                                             \
-      res;                                          \
-    });                                             \
+    events[eventType] = [defaultViewEvents, &value, &context]{    \
+        bool res = defaultViewEvents[eventType];    \
+        if (value.hasValue()) {                     \
+            fromRawValue(context, value, res);      \
+        }                                           \
+        return res;                                 \
+    }();                                            \
     return;                                         \
   }
 

--- a/ReactCommon/react/renderer/core/ConcreteComponentDescriptor.h
+++ b/ReactCommon/react/renderer/core/ConcreteComponentDescriptor.h
@@ -119,7 +119,7 @@ class ConcreteComponentDescriptor : public ComponentDescriptor {
       rawProps.iterateOverValues([&](RawPropsPropNameHash hash,
                                      const char *propName,
                                      RawValue const &fn) {
-        shadowNodeProps.get()->setProp(context, hash, propName, fn);
+        shadowNodeProps.get()->Props::setProp(context, hash, propName, fn);
       });
     }
 

--- a/ReactCommon/react/renderer/core/PropsMacros.h
+++ b/ReactCommon/react/renderer/core/PropsMacros.h
@@ -19,14 +19,12 @@
 
 // Get hash at compile-time. sizeof(str) - 1 == strlen
 #define CONSTEXPR_RAW_PROPS_KEY_HASH(s)                   \
-  ({                                                      \
+  []{                                                     \
     CLANG_PRAGMA("clang diagnostic push")                 \
     CLANG_PRAGMA("clang diagnostic ignored \"-Wshadow\"") \
-    constexpr RawPropsPropNameHash propNameHash =         \
-        folly::hash::fnv32_buf(s, sizeof(s) - 1);         \
-    propNameHash;                                         \
+    return folly::hash::fnv32_buf(s, sizeof(s) - 1);      \
     CLANG_PRAGMA("clang diagnostic pop")                  \
-  })
+    }()
 
 #define RAW_PROPS_KEY_HASH(s) folly::hash::fnv32_buf(s, std::strlen(s))
 

--- a/ReactCommon/react/renderer/core/PropsMacros.h
+++ b/ReactCommon/react/renderer/core/PropsMacros.h
@@ -24,7 +24,7 @@
     CLANG_PRAGMA("clang diagnostic ignored \"-Wshadow\"") \
     return folly::hash::fnv32_buf(s, sizeof(s) - 1);      \
     CLANG_PRAGMA("clang diagnostic pop")                  \
-    }()
+  }()
 
 #define RAW_PROPS_KEY_HASH(s) folly::hash::fnv32_buf(s, std::strlen(s))
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Fix macro errors for Windows. Current syntax breaks the build of the React Common project on Windows because the ({...}) syntax is not supported; must be replaced with lambda expressions. 

Resolves #34090 

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[General] [Fixed] - Fix macro errors for Windows.

@lyahdav @JoshuaGross 

## Test Plan

Build on react-native-windows repo. Tested in RNW app.