### PR TITLE
🚧  importantForAccessibility="no" does not allow screenreader focus on nested Text Components with accessibilityRole="link" or inline Images 🚧 

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAccessibilityDelegate.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAccessibilityDelegate.java
@@ -341,52 +341,10 @@ public class ReactAccessibilityDelegate extends ExploreByTouchHelper {
 
   @Override
   public boolean performAccessibilityAction(View host, int action, Bundle args) {
-    /*
-    if (mAccessibilityActionsMap.containsKey(action)) {
-      final WritableMap event = Arguments.createMap();
-      event.putString("actionName", mAccessibilityActionsMap.get(action));
-      ReactContext reactContext = (ReactContext) host.getContext();
-      if (reactContext.hasActiveReactInstance()) {
-        final int reactTag = host.getId();
-        final int surfaceId = UIManagerHelper.getSurfaceId(reactContext);
-        UIManager uiManager = UIManagerHelper.getUIManager(reactContext, reactTag);
-        if (uiManager != null) {
-          uiManager
-              .<EventDispatcher>getEventDispatcher()
-              .dispatchEvent(
-                  new Event(surfaceId, reactTag) {
-                    @Override
-                    public String getEventName() {
-                      return TOP_ACCESSIBILITY_ACTION_EVENT;
-                    }
-
-                    @Override
-                    protected WritableMap getEventData() {
-                      return event;
-                    }
-                  });
-        }
-      } else {
-        ReactSoftExceptionLogger.logSoftException(
-            TAG, new ReactNoCrashSoftException("Cannot get RCTEventEmitter, no CatalystInstance"));
-      }
-
-      // In order to make Talkback announce the change of the adjustable's value,
-      // schedule to send a TYPE_VIEW_SELECTED event after performing the scroll actions.
-      final AccessibilityRole accessibilityRole =
-          (AccessibilityRole) host.getTag(R.id.accessibility_role);
-      final ReadableMap accessibilityValue = (ReadableMap) host.getTag(R.id.accessibility_value);
-      if (accessibilityRole == AccessibilityRole.ADJUSTABLE
-          && (action == AccessibilityActionCompat.ACTION_SCROLL_FORWARD.getId()
-              || action == AccessibilityActionCompat.ACTION_SCROLL_BACKWARD.getId())) {
-        if (accessibilityValue != null && !accessibilityValue.hasKey("text")) {
-          scheduleAccessibilityEventSender(host);
-        }
-        return super.performAccessibilityAction(host, action, args);
-      }
-      return true;
-    }
-    */
+    Integer x = 225;
+    Integer y = 116;
+    Integer virtualViewId = getVirtualViewAt(x, y);
+    sendEventForVirtualView(virtualViewId, AccessibilityEvent.TYPE_VIEW_ACCESSIBILITY_FOCUSED);
     return true;
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAccessibilityDelegate.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAccessibilityDelegate.java
@@ -18,6 +18,7 @@ import android.text.Spannable;
 import android.text.Spanned;
 import android.text.style.AbsoluteSizeSpan;
 import android.text.style.ClickableSpan;
+import android.util.Log;
 import android.view.View;
 import android.view.accessibility.AccessibilityEvent;
 import android.widget.TextView;
@@ -30,19 +31,11 @@ import androidx.core.view.accessibility.AccessibilityNodeInfoCompat.RangeInfoCom
 import androidx.core.view.accessibility.AccessibilityNodeProviderCompat;
 import androidx.customview.widget.ExploreByTouchHelper;
 import com.facebook.react.R;
-import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Dynamic;
-import com.facebook.react.bridge.ReactContext;
-import com.facebook.react.bridge.ReactNoCrashSoftException;
-import com.facebook.react.bridge.ReactSoftExceptionLogger;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableMapKeySetIterator;
 import com.facebook.react.bridge.ReadableType;
-import com.facebook.react.bridge.UIManager;
-import com.facebook.react.bridge.WritableMap;
-import com.facebook.react.uimanager.events.Event;
-import com.facebook.react.uimanager.events.EventDispatcher;
 import com.facebook.react.uimanager.util.ReactFindViewUtil;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -348,6 +341,7 @@ public class ReactAccessibilityDelegate extends ExploreByTouchHelper {
 
   @Override
   public boolean performAccessibilityAction(View host, int action, Bundle args) {
+    /*
     if (mAccessibilityActionsMap.containsKey(action)) {
       final WritableMap event = Arguments.createMap();
       event.putString("actionName", mAccessibilityActionsMap.get(action));
@@ -392,7 +386,8 @@ public class ReactAccessibilityDelegate extends ExploreByTouchHelper {
       }
       return true;
     }
-    return super.performAccessibilityAction(host, action, args);
+    */
+    return true;
   }
 
   private static void setState(
@@ -503,41 +498,15 @@ public class ReactAccessibilityDelegate extends ExploreByTouchHelper {
 
   @Override
   protected int getVirtualViewAt(float x, float y) {
-    if (mAccessibilityLinks == null
-        || mAccessibilityLinks.size() == 0
-        || !(mView instanceof TextView)) {
-      return INVALID_ID;
-    }
-
+    Log.w("TESTING::ReactAccessibilityDelegate", "getVirtualViewAt");
+    Log.w("TESTING::ReactAccessibilityDelegate", "x: " + (x));
+    Log.w("TESTING::ReactAccessibilityDelegate", "y: " + (y));
     TextView textView = (TextView) mView;
-    if (!(textView.getText() instanceof Spanned)) {
-      return INVALID_ID;
+    if (mAccessibilityLinks != null || mAccessibilityLinks.size() > 0) {
+      Integer firstLinkId = mAccessibilityLinks.mLinks.get(mAccessibilityLinks.size() - 1).id;
+      return firstLinkId;
     }
-
-    Layout layout = textView.getLayout();
-    if (layout == null) {
-      return INVALID_ID;
-    }
-
-    x -= textView.getTotalPaddingLeft();
-    y -= textView.getTotalPaddingTop();
-    x += textView.getScrollX();
-    y += textView.getScrollY();
-
-    int line = layout.getLineForVertical((int) y);
-    int charOffset = layout.getOffsetForHorizontal(line, x);
-
-    ClickableSpan clickableSpan = getFirstSpan(charOffset, charOffset, ClickableSpan.class);
-    if (clickableSpan == null) {
-      return INVALID_ID;
-    }
-
-    Spanned spanned = (Spanned) textView.getText();
-    int start = spanned.getSpanStart(clickableSpan);
-    int end = spanned.getSpanEnd(clickableSpan);
-
-    final AccessibilityLinks.AccessibleLink link = mAccessibilityLinks.getLinkBySpanPos(start, end);
-    return link != null ? link.id : INVALID_ID;
+    return INVALID_ID;
   }
 
   @Override

--- a/packages/rn-tester/js/examples/Accessibility/AccessibilityExample.js
+++ b/packages/rn-tester/js/examples/Accessibility/AccessibilityExample.js
@@ -74,9 +74,11 @@ class AccessibilityExample extends React.Component<{}> {
     return (
       <View>
         <RNTesterBlock title="TextView without label">
-          <Text>
+          <Text importantForAccessibility="yes">
             Text's accessibilityLabel is the raw text itself unless it is set
             explicitly.
+            <Text accessibilityRole="link"> Link One </Text>
+            <Text accessibilityRole="link"> Link Two </Text>
           </Text>
         </RNTesterBlock>
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

fixes https://github.com/facebook/react-native/issues/30850#issuecomment-1192286477
TODOs https://github.com/facebook/react-native/issues/30850#issuecomment-1197763943

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[Android] [Fix] - importantForAccessibility="no" does not allow screenreader focus on nested Text Components with accessibilityRole="link" or inline Images

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Test Cases https://github.com/facebook/react-native/issues/30850#issuecomment-1192286477
