### PR TITLE
Bump Gradle to 7.5.0

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/packages/react-native-gradle-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/react-native-gradle-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/template/android/gradle/wrapper/gradle-wrapper.properties
+++ b/template/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary

### Follow-up
- https://github.com/facebook/react-native/issues/34103
- https://github.com/facebook/react-native/pull/33823

#### Debug/Release further tested on RN 0.70.0-rc.0-1
- https://github.com/leotm/react-native-template-new-architecture/pull/775
- builds/runtime: locally on `macos-13` b2
- builds: in CI `ubuntu-20.04` latest (not yet beta `ubuntu-22.04`)

cc @cortinico @dulmandakh

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[Android] [Changed] - Bump Gradle to 7.5.0

## Test Plan

Everything builds and runs as expected.
