### PR TITLE
feat: prevent removing globalEvalWithSourceUrl in RELEASE builds

### DIFF
--- a/ReactCommon/jsiexecutor/jsireact/JSIExecutor.cpp
+++ b/ReactCommon/jsiexecutor/jsireact/JSIExecutor.cpp
@@ -525,7 +525,6 @@ Value JSIExecutor::nativeCallSyncHook(const Value *args, size_t count) {
   return returnValue;
 }
 
-#if DEBUG
 Value JSIExecutor::globalEvalWithSourceUrl(const Value *args, size_t count) {
   if (count != 1 && count != 2) {
     throw std::invalid_argument(
@@ -541,7 +540,6 @@ Value JSIExecutor::globalEvalWithSourceUrl(const Value *args, size_t count) {
   return runtime_->evaluateJavaScript(
       std::make_unique<StringBuffer>(std::move(code)), url);
 }
-#endif
 
 void bindNativeLogger(Runtime &runtime, Logger logger) {
   runtime.global().setProperty(

--- a/ReactCommon/jsiexecutor/jsireact/JSIExecutor.cpp
+++ b/ReactCommon/jsiexecutor/jsireact/JSIExecutor.cpp
@@ -121,7 +121,6 @@ void JSIExecutor::initializeRuntime() {
               const jsi::Value *args,
               size_t count) { return nativeCallSyncHook(args, count); }));
 
-#if DEBUG
   runtime_->global().setProperty(
       *runtime_,
       "globalEvalWithSourceUrl",
@@ -134,7 +133,6 @@ void JSIExecutor::initializeRuntime() {
               const jsi::Value &,
               const jsi::Value *args,
               size_t count) { return globalEvalWithSourceUrl(args, count); }));
-#endif
 
   if (runtimeInstaller_) {
     runtimeInstaller_(*runtime_);

--- a/ReactCommon/jsiexecutor/jsireact/JSIExecutor.h
+++ b/ReactCommon/jsiexecutor/jsireact/JSIExecutor.h
@@ -116,9 +116,7 @@ class JSIExecutor : public JSExecutor {
   void callNativeModules(const jsi::Value &queue, bool isEndOfBatch);
   jsi::Value nativeCallSyncHook(const jsi::Value *args, size_t count);
   jsi::Value nativeRequire(const jsi::Value *args, size_t count);
-#ifdef DEBUG
   jsi::Value globalEvalWithSourceUrl(const jsi::Value *args, size_t count);
-#endif
 
   std::shared_ptr<jsi::Runtime> runtime_;
   std::shared_ptr<ExecutorDelegate> delegate_;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Expo Go was using `nativeInjectHMRUpdate` for [snack](https://snack.expo.io/) to provide stack traces to OTA errors. `nativeInjectHMRUpdate` was replaced with `globalEvalWithSourceUrl` [here](https://github.com/facebook/react-native/commit/71c84cf6bebba701bb23b135e079aa68c05f4441). The issue with `globalEvalWithSourceUrl` is that it is stripped in RELEASE builds, and Expo Go is installed via the App Store, making it a release build.

I propose we keep the method, `eval` is still exposed in production so there's no increase in security risk, simply provides a better DX for multipurpose development clients. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[Android] [Added] - Expose `globalEvalWithSourceUrl` in production builds.
[iOS] [Added] - Expose `globalEvalWithSourceUrl` in production builds.

## Test Plan

- Function should be available as `global.globalEvalWithSourceUrl` in a production build.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
