### PR TITLE
Introduce findPackageJsonFile to address issue with GenerateCodegenArtifactsTaskTest

### DIFF
--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
@@ -15,6 +15,7 @@ import com.facebook.react.tasks.BuildCodegenCLITask
 import com.facebook.react.tasks.GenerateCodegenArtifactsTask
 import com.facebook.react.tasks.GenerateCodegenSchemaTask
 import com.facebook.react.utils.JsonUtils
+import com.facebook.react.utils.findPackageJsonFile
 import java.io.File
 import kotlin.system.exitProcess
 import org.gradle.api.Plugin
@@ -93,15 +94,7 @@ class ReactPlugin : Plugin<Project> {
           // We're reading the package.json at configuration time to properly feed
           // the `jsRootDir` @Input property of this task. Therefore, the
           // parsePackageJson should be invoked inside this lambda.
-          // We look for `package.json` in the parent folder of this Gradle module
-          // (generally the case for library projects) or we fallback to looking into the `root`
-          // folder of a React Native project (generally the case for app projects).
-          val packageJson =
-              if (project.file("../package.json").exists()) {
-                project.file("../package.json")
-              } else {
-                extension.root.file("package.json").orNull?.asFile
-              }
+          val packageJson = findPackageJsonFile(project, extension)
           val parsedPackageJson = packageJson?.let { JsonUtils.fromCodegenJson(it) }
 
           val jsSrcsDirInPackageJson = parsedPackageJson?.codegenConfig?.jsSrcsDir
@@ -122,7 +115,7 @@ class ReactPlugin : Plugin<Project> {
           it.nodeExecutableAndArgs.set(extension.nodeExecutableAndArgs)
           it.codegenDir.set(extension.codegenDir)
           it.generatedSrcDir.set(generatedSrcDir)
-          it.packageJsonFile.set(extension.root.file("package.json"))
+          it.packageJsonFile.set(findPackageJsonFile(project, extension))
           it.codegenJavaPackageName.set(extension.codegenJavaPackageName)
           it.libraryName.set(extension.libraryName)
         }

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/PathUtils.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/PathUtils.kt
@@ -10,6 +10,7 @@
 package com.facebook.react.utils
 
 import com.facebook.react.ReactExtension
+import org.gradle.api.Project
 import java.io.File
 
 /**
@@ -189,6 +190,18 @@ internal fun projectPathToLibraryName(projectPath: String): String =
         .split(':', '-', '_', '.')
         .joinToString("") { token -> token.replaceFirstChar { it.uppercase() } }
         .plus("Spec")
+
+/**
+ * Function to look for the relevant `package.json`. We first look in the parent folder
+ * of this Gradle module (generally the case for library projects) or we fallback to
+ * looking into the `root` folder of a React Native project (generally the case for app projects).
+ */
+internal fun findPackageJsonFile(project: Project, extension: ReactExtension) : File? =
+    if (project.file("../package.json").exists()) {
+        project.file("../package.json")
+    } else {
+        extension.root.file("package.json").orNull?.asFile
+    }
 
 private const val HERMESC_IN_REACT_NATIVE_PATH =
     "node_modules/react-native/sdks/hermesc/%OS-BIN%/hermesc"

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/PathUtilsTest.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/PathUtilsTest.kt
@@ -7,6 +7,7 @@
 
 package com.facebook.react.utils
 
+import com.facebook.react.ReactExtension
 import com.facebook.react.TestReactExtension
 import com.facebook.react.tests.OS
 import com.facebook.react.tests.OsRule
@@ -242,4 +243,30 @@ class PathUtilsTest {
         File("/home/circleci/hermes/build/bin/hermesc"),
         getBuiltHermescFile(tempFolder.root, "/home/circleci/hermes"))
   }
+
+    @Test
+    fun findPackageJsonFile_withFileInParentFolder_picksItUp() {
+        tempFolder.newFile("package.json")
+        val moduleFolder = tempFolder.newFolder("awesome-module")
+
+        val project = ProjectBuilder.builder().withProjectDir(moduleFolder).build()
+        project.plugins.apply("com.facebook.react")
+        val extension = project.extensions.getByType(ReactExtension::class.java)
+
+        assertEquals(project.file("../package.json"), findPackageJsonFile(project, extension))
+    }
+
+    @Test
+    fun findPackageJsonFile_withFileConfiguredInExtension_picksItUp() {
+        val moduleFolder = tempFolder.newFolder("awesome-module")
+        val localFile = File(moduleFolder, "package.json").apply { writeText("{}") }
+
+        val project = ProjectBuilder.builder().withProjectDir(moduleFolder).build()
+        project.plugins.apply("com.facebook.react")
+        val extension = project.extensions.getByType(ReactExtension::class.java).apply {
+          root.set(moduleFolder)
+        }
+
+        assertEquals(localFile, findPackageJsonFile(project, extension))
+    }
 }


### PR DESCRIPTION
## Summary

While doing some testing with @cipolleschi on React Native 0.70.0 we realized that custom Java Package is not properly propagated when invoking codegen for external libraries. 

This PR fixes it.

## Changelog

[Internal] - Introduce findPackageJsonFile to address issue with GenerateCodegenArtifactsTaskTest

## Test Plan

Added JUnit tests + Tested locally with @cipolleschi 