### PR TITLE
chore: upgrade RN CLI to v9.0.0-alpha.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
   },
   "dependencies": {
     "@jest/create-cache-key-function": "^27.0.1",
-    "@react-native-community/cli": "^9.0.0-alpha.5",
+    "@react-native-community/cli": "^9.0.0-alpha.9",
     "@react-native-community/cli-platform-android": "^9.0.0-alpha.5",
     "@react-native-community/cli-platform-ios": "^9.0.0-alpha.5",
     "@react-native/assets": "1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1080,22 +1080,22 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@react-native-community/cli-clean@^9.0.0-alpha.5":
-  version "9.0.0-alpha.5"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-clean/-/cli-clean-9.0.0-alpha.5.tgz#db101bdd5ff56e7c75797a385d51c5d1c0786dc4"
-  integrity sha512-ML/80mmSMi+x1r2nkGas19bk/956cNewSEmKSTv0L/dHTlzxuPdbrvrRw6st4MY7LtZtJ+duulPdD4+obyHuNg==
+"@react-native-community/cli-clean@^9.0.0-alpha.6":
+  version "9.0.0-alpha.6"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-clean/-/cli-clean-9.0.0-alpha.6.tgz#f505b8432cc31786f25db7a0747c172d18c0e7be"
+  integrity sha512-8CBctrx9uwiOIvxY0maDZS9i55JEpHdqwTh6exDfLDLRdilWot6fbIFqt4jXaFlzB1GhsTNGrxE/fZ7TmjMJsw==
   dependencies:
-    "@react-native-community/cli-tools" "^9.0.0-alpha.5"
+    "@react-native-community/cli-tools" "^9.0.0-alpha.6"
     chalk "^4.1.2"
     execa "^1.0.0"
     prompts "^2.4.0"
 
-"@react-native-community/cli-config@^9.0.0-alpha.5":
-  version "9.0.0-alpha.5"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-config/-/cli-config-9.0.0-alpha.5.tgz#7a8d48a493c44dd0e9b9d808de9914af4ffd4c90"
-  integrity sha512-6m4FGPfYsTeg9z+PZ7PBFBkQ2oHNDsyCdyvjO/jOC7QB2wboe39oRYOnGy+TqYMyT0jJEOceTcxUsG2q2b1vwQ==
+"@react-native-community/cli-config@^9.0.0-alpha.6":
+  version "9.0.0-alpha.6"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-config/-/cli-config-9.0.0-alpha.6.tgz#1d3271b18bbb6622e39cdd83c5d2960375cef29f"
+  integrity sha512-TtPOxh2/FDgtAoeWjE2Z2hu29Rj8e5aWUWUoYaUBcXftc2Ghu/s4xpKwtQRljGGMeJBnlJ1/gQhZWFnSbm8DYA==
   dependencies:
-    "@react-native-community/cli-tools" "^9.0.0-alpha.5"
+    "@react-native-community/cli-tools" "^9.0.0-alpha.6"
     cosmiconfig "^5.1.0"
     deepmerge "^3.2.0"
     glob "^7.1.3"
@@ -1108,14 +1108,14 @@
   dependencies:
     serve-static "^1.13.1"
 
-"@react-native-community/cli-doctor@^9.0.0-alpha.5":
-  version "9.0.0-alpha.5"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-doctor/-/cli-doctor-9.0.0-alpha.5.tgz#9be8217d9d9e9d437fd4705bcb1410ef5a4d2b75"
-  integrity sha512-IM9Rwc9cGjpE1haUY86AJ3gYPHkFhUwt0Oxk3XqP8bD+nhKKx6YOQx6J9Wl0EhpM5lnyoCj4mls2LVWPZ6lQpQ==
+"@react-native-community/cli-doctor@^9.0.0-alpha.8":
+  version "9.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-doctor/-/cli-doctor-9.0.0-alpha.8.tgz#ffec5590c167c70879e6fc868d1ece7e5dfd207f"
+  integrity sha512-sA0lR5svSKrhNkqqHE6NlxDr9SD4+sXnqU6fgM7K8KmRqbq8/Sn2vvS2T3wraLK5AwwdHhWgHIJdarxlvYJHcg==
   dependencies:
-    "@react-native-community/cli-config" "^9.0.0-alpha.5"
-    "@react-native-community/cli-platform-ios" "^9.0.0-alpha.5"
-    "@react-native-community/cli-tools" "^9.0.0-alpha.5"
+    "@react-native-community/cli-config" "^9.0.0-alpha.6"
+    "@react-native-community/cli-platform-ios" "^9.0.0-alpha.8"
+    "@react-native-community/cli-tools" "^9.0.0-alpha.6"
     chalk "^4.1.2"
     command-exists "^1.2.8"
     envinfo "^7.7.2"
@@ -1130,13 +1130,13 @@
     sudo-prompt "^9.0.0"
     wcwidth "^1.0.1"
 
-"@react-native-community/cli-hermes@^9.0.0-alpha.5":
-  version "9.0.0-alpha.5"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-hermes/-/cli-hermes-9.0.0-alpha.5.tgz#0675083be64348d0a10043b07ce8820336729e47"
-  integrity sha512-PKuT14qmjBm2YTDGyTp/pWk7azq5RzULCiGh0b0Q4FAFjMSTcV9I1AWu4pahn46H78G4H0cU4qSApV1z5hy/nw==
+"@react-native-community/cli-hermes@^9.0.0-alpha.7":
+  version "9.0.0-alpha.7"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-hermes/-/cli-hermes-9.0.0-alpha.7.tgz#4ef0cc3c9896dda05602981983a602fd209c4b94"
+  integrity sha512-Qa6bypTm+XMRDUwU6VfR2F63gpfdcV0TJ8NEW2tCOUMq7beonp23BCf2xAroHrVthDUqLmVawG9a+1aGCzg+Kg==
   dependencies:
-    "@react-native-community/cli-platform-android" "^9.0.0-alpha.5"
-    "@react-native-community/cli-tools" "^9.0.0-alpha.5"
+    "@react-native-community/cli-platform-android" "^9.0.0-alpha.7"
+    "@react-native-community/cli-tools" "^9.0.0-alpha.6"
     chalk "^4.1.2"
     hermes-profile-transformer "^0.0.6"
     ip "^1.1.5"
@@ -1156,6 +1156,19 @@
     logkitty "^0.7.1"
     slash "^3.0.0"
 
+"@react-native-community/cli-platform-android@^9.0.0-alpha.7":
+  version "9.0.0-alpha.7"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-android/-/cli-platform-android-9.0.0-alpha.7.tgz#08be394db17c071f09966634175c25a37af03ab6"
+  integrity sha512-T7KalF7vddNdJ5fnTz6ydJvb+UnycWmxMth6teQw0qp5VSY0RiU/M5p34xEPDIUyqU6Rw92Mp2qPWDATRNHkZw==
+  dependencies:
+    "@react-native-community/cli-tools" "^9.0.0-alpha.6"
+    chalk "^4.1.2"
+    execa "^1.0.0"
+    fs-extra "^8.1.0"
+    glob "^7.1.3"
+    logkitty "^0.7.1"
+    slash "^3.0.0"
+
 "@react-native-community/cli-platform-ios@^9.0.0-alpha.5":
   version "9.0.0-alpha.5"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-ios/-/cli-platform-ios-9.0.0-alpha.5.tgz#7b1fa6ac098c942e0aa0d167078f019d94e1cb42"
@@ -1170,29 +1183,40 @@
     ora "^5.4.1"
     plist "^3.0.2"
 
-"@react-native-community/cli-plugin-metro@^9.0.0-alpha.5":
-  version "9.0.0-alpha.5"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-plugin-metro/-/cli-plugin-metro-9.0.0-alpha.5.tgz#ab5ba5bd54d90298dd85c3a52b3935e5fea442eb"
-  integrity sha512-3/FnnK2/AePMZxnTWNFugfxfTq1mXznmp3XlCPZo7M3m1PTiV+0HU0f+zDOmh1D0agvIy5UUnx+i1qcpW2B83Q==
+"@react-native-community/cli-platform-ios@^9.0.0-alpha.8":
+  version "9.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-ios/-/cli-platform-ios-9.0.0-alpha.8.tgz#c31be8313dc022ac21470c5ed5f81bc2c5aaf093"
+  integrity sha512-6VVo/mIifCRFP6WmSj6EbxViurVrvpG6arWfn3+fMuO/0CjrmLEM3b7sC9vg/ha+fiVz66Gbxrg9GKInZ0x7zw==
   dependencies:
-    "@react-native-community/cli-server-api" "^9.0.0-alpha.5"
-    "@react-native-community/cli-tools" "^9.0.0-alpha.5"
+    "@react-native-community/cli-tools" "^9.0.0-alpha.6"
     chalk "^4.1.2"
-    metro "^0.71.3"
-    metro-config "^0.71.3"
-    metro-core "^0.71.3"
-    metro-react-native-babel-transformer "^0.71.3"
-    metro-resolver "^0.71.3"
-    metro-runtime "^0.71.3"
+    execa "^1.0.0"
+    glob "^7.1.3"
+    ora "^5.4.1"
+
+"@react-native-community/cli-plugin-metro@^9.0.0-alpha.9":
+  version "9.0.0-alpha.9"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-plugin-metro/-/cli-plugin-metro-9.0.0-alpha.9.tgz#ce940926bb23eb0fee253b84bc0cb59e589843e8"
+  integrity sha512-kd/5OYAOhvxTbdwCQ6HUr6ohXA/zDnnd0JpqpsqccNXiZAV8NBNHkG+7eYiBC9k1ugzmSmMc3cs6tdPgnr7BoQ==
+  dependencies:
+    "@react-native-community/cli-server-api" "^9.0.0-alpha.6"
+    "@react-native-community/cli-tools" "^9.0.0-alpha.6"
+    chalk "^4.1.2"
+    metro "^0.72.0"
+    metro-config "^0.72.0"
+    metro-core "^0.72.0"
+    metro-react-native-babel-transformer "^0.72.0"
+    metro-resolver "^0.72.0"
+    metro-runtime "^0.72.0"
     readline "^1.3.0"
 
-"@react-native-community/cli-server-api@^9.0.0-alpha.5":
-  version "9.0.0-alpha.5"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-server-api/-/cli-server-api-9.0.0-alpha.5.tgz#764dee34dd5ab5afb39406491412fb8d2b00d85d"
-  integrity sha512-74z9fkcnwrSSxNEKKlNdFJqDDytdzaNHq/9hPCuXi24cK5yyuL8E79Ku7sBva3tKEIVzWKdFsWJqzB7QIkBk1Q==
+"@react-native-community/cli-server-api@^9.0.0-alpha.6":
+  version "9.0.0-alpha.6"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-server-api/-/cli-server-api-9.0.0-alpha.6.tgz#3994edd88770e01bf8557d08ec73de7e7a0c2f06"
+  integrity sha512-Zka4hED2jcV/Eabuc4LB2AgJR5H2RZuH9GQ/IbuFgdT7zLNq9KbbkEfdNvY5ZhkuYPjJRmE9zf5jb3y6mwcW6g==
   dependencies:
     "@react-native-community/cli-debugger-ui" "^9.0.0-alpha.4"
-    "@react-native-community/cli-tools" "^9.0.0-alpha.5"
+    "@react-native-community/cli-tools" "^9.0.0-alpha.6"
     compression "^1.7.1"
     connect "^3.6.5"
     errorhandler "^1.5.0"
@@ -1217,6 +1241,22 @@
     semver "^6.3.0"
     shell-quote "^1.7.3"
 
+"@react-native-community/cli-tools@^9.0.0-alpha.6":
+  version "9.0.0-alpha.6"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-tools/-/cli-tools-9.0.0-alpha.6.tgz#97bbdf3ca12f2795029b4589f1d662a98895aedb"
+  integrity sha512-v1+FWhJJD50xaD4nx4wRWffLkDbSiurqplgMXvQyvE2VZbz57r6nKO6VgCsWDagRW/a5hBQ3oC8+lZKbOE/6YQ==
+  dependencies:
+    appdirsjs "^1.2.4"
+    chalk "^4.1.2"
+    find-up "^5.0.0"
+    lodash "^4.17.15"
+    mime "^2.4.1"
+    node-fetch "^2.6.0"
+    open "^6.2.0"
+    ora "^5.4.1"
+    semver "^6.3.0"
+    shell-quote "^1.7.3"
+
 "@react-native-community/cli-types@^9.0.0-alpha.0":
   version "9.0.0-alpha.0"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-types/-/cli-types-9.0.0-alpha.0.tgz#b0809b868e1a2a0c326a0f218abdbb8ff7744272"
@@ -1224,29 +1264,26 @@
   dependencies:
     joi "^17.2.1"
 
-"@react-native-community/cli@^9.0.0-alpha.5":
-  version "9.0.0-alpha.5"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli/-/cli-9.0.0-alpha.5.tgz#8410eb408d20da26fc9139171d4684f3d061fdb5"
-  integrity sha512-6ihMoYaGKjWJ/uyJLDDnckOAGJg2XVofnuG8WvOw1Sk3vnEaIQTF+PVZF2q2VSGmWLvzNZTVtY5+aBIJFvkApA==
+"@react-native-community/cli@^9.0.0-alpha.9":
+  version "9.0.0-alpha.9"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli/-/cli-9.0.0-alpha.9.tgz#7fdf136bd621f876938317e68dfe047fc365890c"
+  integrity sha512-kIee2jfh6SuZWiRaAnEDefsoezPLZTLVe3xDVd74q+1EPsANTcySR/Joks7dsz6nMi/FPLfVOfMKh7Pb7slyeg==
   dependencies:
-    "@react-native-community/cli-clean" "^9.0.0-alpha.5"
-    "@react-native-community/cli-config" "^9.0.0-alpha.5"
+    "@react-native-community/cli-clean" "^9.0.0-alpha.6"
+    "@react-native-community/cli-config" "^9.0.0-alpha.6"
     "@react-native-community/cli-debugger-ui" "^9.0.0-alpha.4"
-    "@react-native-community/cli-doctor" "^9.0.0-alpha.5"
-    "@react-native-community/cli-hermes" "^9.0.0-alpha.5"
-    "@react-native-community/cli-plugin-metro" "^9.0.0-alpha.5"
-    "@react-native-community/cli-server-api" "^9.0.0-alpha.5"
-    "@react-native-community/cli-tools" "^9.0.0-alpha.5"
+    "@react-native-community/cli-doctor" "^9.0.0-alpha.8"
+    "@react-native-community/cli-hermes" "^9.0.0-alpha.7"
+    "@react-native-community/cli-plugin-metro" "^9.0.0-alpha.9"
+    "@react-native-community/cli-server-api" "^9.0.0-alpha.6"
+    "@react-native-community/cli-tools" "^9.0.0-alpha.6"
     "@react-native-community/cli-types" "^9.0.0-alpha.0"
     chalk "^4.1.2"
-    commander "^2.19.0"
+    commander "^9.4.0"
     execa "^1.0.0"
     find-up "^4.1.0"
     fs-extra "^8.1.0"
     graceful-fs "^4.1.3"
-    leven "^3.1.0"
-    lodash "^4.17.15"
-    minimist "^1.2.0"
     prompts "^2.4.0"
     semver "^6.3.0"
 
@@ -2231,10 +2268,10 @@ command-exists@^1.2.8:
   resolved "https://registry.yarnpkg.com/command-exists/-/command-exists-1.2.8.tgz#715acefdd1223b9c9b37110a149c6392c2852291"
   integrity sha512-PM54PkseWbiiD/mMsbvW351/u+dafwTJ0ye2qB60G1aGQP9j3xK2gmMDc+R34L3nDtx4qMCitXT75mkbkGJDLw==
 
-commander@^2.19.0:
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
-  integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
+commander@^9.4.0:
+  version "9.4.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-9.4.0.tgz#bc4a40918fefe52e22450c111ecd6b7acce6f11c"
+  integrity sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw==
 
 commander@~2.13.0:
   version "2.13.0"
@@ -4874,16 +4911,6 @@ metro-babel-register@0.72.0:
     babel-plugin-replace-ts-export-assignment "^0.0.2"
     escape-string-regexp "^1.0.5"
 
-metro-babel-transformer@0.71.3:
-  version "0.71.3"
-  resolved "https://registry.yarnpkg.com/metro-babel-transformer/-/metro-babel-transformer-0.71.3.tgz#ca55850cc904178b740be123b77b58e81f156e4f"
-  integrity sha512-zsbD8MurKherTtwKY3To/dVNKCkPojX//apetyeVrAkJ7M9dw4+hqoglP3SraOlrL3jm/ufFPRZwC2Pr8V9ZQQ==
-  dependencies:
-    "@babel/core" "^7.14.0"
-    hermes-parser "0.8.0"
-    metro-source-map "0.71.3"
-    nullthrows "^1.1.1"
-
 metro-babel-transformer@0.72.0:
   version "0.72.0"
   resolved "https://registry.yarnpkg.com/metro-babel-transformer/-/metro-babel-transformer-0.72.0.tgz#18a425865fcdc817363e0982f6d1e3f6a1f8ee74"
@@ -4894,43 +4921,43 @@ metro-babel-transformer@0.72.0:
     metro-source-map "0.72.0"
     nullthrows "^1.1.1"
 
-metro-cache-key@0.71.3:
-  version "0.71.3"
-  resolved "https://registry.yarnpkg.com/metro-cache-key/-/metro-cache-key-0.71.3.tgz#1f9a22476ff9ba717b296e2bcf0920ab371fab71"
-  integrity sha512-V7ZJaQgzsgDBlr3AjEj10UE1rnIxkiLx5StZfwwoVZ2PBe2ZWgG0yGq2dvyRtpC/8FLc/cIFbUVteLrDs1V/mg==
+metro-cache-key@0.72.0:
+  version "0.72.0"
+  resolved "https://registry.yarnpkg.com/metro-cache-key/-/metro-cache-key-0.72.0.tgz#347eebbe5a7b806f675e52890722ab1b88c953d9"
+  integrity sha512-zoZ2SXzjJeXkwGikx2V97r7D/yo6rZOdM9iARKugj+Dk+9W+VdehiGNnmIwKmbIudCWulWOpWkJOeygeUkTfIw==
 
-metro-cache@0.71.3:
-  version "0.71.3"
-  resolved "https://registry.yarnpkg.com/metro-cache/-/metro-cache-0.71.3.tgz#992ce0c609306025e36a7d05ed7f8a04c1e517a9"
-  integrity sha512-B7rHnbRnwCFpNPp//zqCpDpbLeb7NSOdFlLYGyADFbU/Bu35GlAmdf4q/PNLeDdbcLkvZaWelKMDXYWeCAn6FQ==
+metro-cache@0.72.0:
+  version "0.72.0"
+  resolved "https://registry.yarnpkg.com/metro-cache/-/metro-cache-0.72.0.tgz#423e38d9c45b815ff1ef2800a60f5a3c1bc333b0"
+  integrity sha512-Ui7qilKLjDMdc+IlkyhQXQ0wVAz9ji6qAyUC6q6WUkEyo9fp3j1Bv2c7MogXeGoRLkfw0YGXa3DFqZG8vBNDbg==
   dependencies:
-    metro-core "0.71.3"
+    metro-core "0.72.0"
     rimraf "^2.5.4"
 
-metro-config@0.71.3, metro-config@^0.71.3:
-  version "0.71.3"
-  resolved "https://registry.yarnpkg.com/metro-config/-/metro-config-0.71.3.tgz#f876f96398fb8063a04adf68890c01f393d8b7b2"
-  integrity sha512-RLedw7x5GLSsDSkG2WQ59LDcna69C51/f086Ksr+Ey6fRZEjcdjzHs3dtZeJyiCylKwZL9ofr1OYrFixb/mHsg==
+metro-config@0.72.0, metro-config@^0.72.0:
+  version "0.72.0"
+  resolved "https://registry.yarnpkg.com/metro-config/-/metro-config-0.72.0.tgz#c027dc429d1750a6d44033fb2f5bf11c0cc4df4c"
+  integrity sha512-hdJUbASzO/zPo6Ip9s7FH+nnWhEqPc610xzQUBjP5PZlpfl4sOqTn+cpmy2fk1LdMV8x4Wr6y6lsEJI+pbVDKA==
   dependencies:
     cosmiconfig "^5.0.5"
     jest-validate "^26.5.2"
-    metro "0.71.3"
-    metro-cache "0.71.3"
-    metro-core "0.71.3"
-    metro-runtime "0.71.3"
+    metro "0.72.0"
+    metro-cache "0.72.0"
+    metro-core "0.72.0"
+    metro-runtime "0.72.0"
 
-metro-core@0.71.3, metro-core@^0.71.3:
-  version "0.71.3"
-  resolved "https://registry.yarnpkg.com/metro-core/-/metro-core-0.71.3.tgz#5ffe3c4ab20c6a40d12746a538ef34e6d7ba1046"
-  integrity sha512-/c1X4+jsr2uxqN1p87gcwyd073apsQAy76zeD5ihDTF05IHLN6z407JuFZWi+WKhReFmdipXTjAoqzd3GZ+PwA==
+metro-core@0.72.0, metro-core@^0.72.0:
+  version "0.72.0"
+  resolved "https://registry.yarnpkg.com/metro-core/-/metro-core-0.72.0.tgz#1eb6cdde21293a7bd7a188c419780180004e9925"
+  integrity sha512-MeEdRBl1OQxUukI2VBAOFjUl4hU2Ll9+I72WGX1mz9qqCrslJ7++4tEmnTplbLaYBSPb0PSH3+zC073aL1yeRg==
   dependencies:
     lodash.throttle "^4.1.1"
-    metro-resolver "0.71.3"
+    metro-resolver "0.72.0"
 
-metro-file-map@0.71.3:
-  version "0.71.3"
-  resolved "https://registry.yarnpkg.com/metro-file-map/-/metro-file-map-0.71.3.tgz#6ea153574f259e84ee426240897c3764502e6acd"
-  integrity sha512-a4DlTkCoQsPtzMMVxsrEt0DC3/Ga+NaXueHqdGuCsY5rzjSoWDiyAdscuWjFKLSPaoPacBQpZgSo4MhjBSPYng==
+metro-file-map@0.72.0:
+  version "0.72.0"
+  resolved "https://registry.yarnpkg.com/metro-file-map/-/metro-file-map-0.72.0.tgz#943f068f0cefe70d37d9fda13dd21ec94fdecf2e"
+  integrity sha512-bKkwgrrGOlGtdhuYqqdaiiNH7dRKLDgNNgVps9uOBqpJMX/d8/f+4uurRAFSZeRcJGZ1bu7ljvFg9+8xYZlKig==
   dependencies:
     abort-controller "^3.0.0"
     anymatch "^3.0.3"
@@ -4947,15 +4974,15 @@ metro-file-map@0.71.3:
   optionalDependencies:
     fsevents "^2.1.2"
 
-metro-hermes-compiler@0.71.3:
-  version "0.71.3"
-  resolved "https://registry.yarnpkg.com/metro-hermes-compiler/-/metro-hermes-compiler-0.71.3.tgz#1b4c6b84e46e346b0def829493468a7577e5ee01"
-  integrity sha512-gqZSdUfzwcftXNwCFf/HiZhMMM7pAWQ2jMnLzIEINAp5qPxnIONvqJd5/yTnVzDjAf3kG9k1Pzt6NEsKQzuYIA==
+metro-hermes-compiler@0.72.0:
+  version "0.72.0"
+  resolved "https://registry.yarnpkg.com/metro-hermes-compiler/-/metro-hermes-compiler-0.72.0.tgz#b754df502e48c02c9523b92ef1ed5e19b1d94921"
+  integrity sha512-QkY8rHFKhjVlrrxB2FEj8bGzYVHNTOx/IENSlKx3PxlchFMGCG8fxVgzB8u5VyIW610hKd5d+Ux2pXldtm/vSA==
 
-metro-inspector-proxy@0.71.3:
-  version "0.71.3"
-  resolved "https://registry.yarnpkg.com/metro-inspector-proxy/-/metro-inspector-proxy-0.71.3.tgz#616ba731719ac80400b9374c592b398a28af8e40"
-  integrity sha512-HbM2GBXcAWKtnysw8j+pK/hv20Gx6LT3lFkIr+hsIG+ejaGkOpUYAV3EBrfDuQ4bM4F8yvIT4ZWjD2Zvcm1f5Q==
+metro-inspector-proxy@0.72.0:
+  version "0.72.0"
+  resolved "https://registry.yarnpkg.com/metro-inspector-proxy/-/metro-inspector-proxy-0.72.0.tgz#a0cb144af9cce828731d2fccde143e0fd4e42286"
+  integrity sha512-GIToyQr9xkap/ayt1MVMCU7/ZecVsPrCqOjL58TgXfE/5L7wF87p+mPy8nqceHAqgajCukfQC4n5McwxFEp4KA==
   dependencies:
     connect "^3.6.5"
     debug "^2.2.0"
@@ -4967,57 +4994,12 @@ metro-memory-fs@0.72.0:
   resolved "https://registry.yarnpkg.com/metro-memory-fs/-/metro-memory-fs-0.72.0.tgz#ddf4d5c13d6eafb30bbfa2ae8282ad671adde351"
   integrity sha512-jp5G/N3iozgA1tRIzBZVJbd5p9GGHMo+WKpHp75n439qaZ7OG4uakTFp/WMVVEm0EEkOmZyKt00NxZvB5bxz2g==
 
-metro-minify-uglify@0.71.3:
-  version "0.71.3"
-  resolved "https://registry.yarnpkg.com/metro-minify-uglify/-/metro-minify-uglify-0.71.3.tgz#cb5cc716e98dcf7fa1e261de2a7232de25e377e9"
-  integrity sha512-sV5IVePaqJQ1Nypf5fCJOtUtYLtZCcfcOTZvbcD1lkDTw8jZnNsTWd9s61lYg2ppXoUQu+QXfirGJI917c7bUw==
+metro-minify-uglify@0.72.0:
+  version "0.72.0"
+  resolved "https://registry.yarnpkg.com/metro-minify-uglify/-/metro-minify-uglify-0.72.0.tgz#1a4a0f1734c841771f60aa5664b27d922dc69ba8"
+  integrity sha512-3NtBGA1w9+9524bTCvsRajq+YqEw/p/MQTeZ1746Qs8QjtrvXgxGlCeRvH/6yhQpss+LnXmiPO60Ql9YvT8yYw==
   dependencies:
     uglify-es "^3.1.9"
-
-metro-react-native-babel-preset@0.71.3:
-  version "0.71.3"
-  resolved "https://registry.yarnpkg.com/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.71.3.tgz#8e30b87c39342d9ffb4ccc619e7790ac60e16929"
-  integrity sha512-ym8xeoK/5fY/TsQPQXVnJN822NB9TZglxc2XVk+DM8kJO0XacWh2GtDRFeFHEehVsYWpIZeaDPF2XES+YU5mhA==
-  dependencies:
-    "@babel/core" "^7.14.0"
-    "@babel/plugin-proposal-async-generator-functions" "^7.0.0"
-    "@babel/plugin-proposal-class-properties" "^7.0.0"
-    "@babel/plugin-proposal-export-default-from" "^7.0.0"
-    "@babel/plugin-proposal-nullish-coalescing-operator" "^7.0.0"
-    "@babel/plugin-proposal-object-rest-spread" "^7.0.0"
-    "@babel/plugin-proposal-optional-catch-binding" "^7.0.0"
-    "@babel/plugin-proposal-optional-chaining" "^7.0.0"
-    "@babel/plugin-syntax-dynamic-import" "^7.0.0"
-    "@babel/plugin-syntax-export-default-from" "^7.0.0"
-    "@babel/plugin-syntax-flow" "^7.2.0"
-    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.0.0"
-    "@babel/plugin-syntax-optional-chaining" "^7.0.0"
-    "@babel/plugin-transform-arrow-functions" "^7.0.0"
-    "@babel/plugin-transform-async-to-generator" "^7.0.0"
-    "@babel/plugin-transform-block-scoping" "^7.0.0"
-    "@babel/plugin-transform-classes" "^7.0.0"
-    "@babel/plugin-transform-computed-properties" "^7.0.0"
-    "@babel/plugin-transform-destructuring" "^7.0.0"
-    "@babel/plugin-transform-exponentiation-operator" "^7.0.0"
-    "@babel/plugin-transform-flow-strip-types" "^7.0.0"
-    "@babel/plugin-transform-function-name" "^7.0.0"
-    "@babel/plugin-transform-literals" "^7.0.0"
-    "@babel/plugin-transform-modules-commonjs" "^7.0.0"
-    "@babel/plugin-transform-named-capturing-groups-regex" "^7.0.0"
-    "@babel/plugin-transform-parameters" "^7.0.0"
-    "@babel/plugin-transform-react-display-name" "^7.0.0"
-    "@babel/plugin-transform-react-jsx" "^7.0.0"
-    "@babel/plugin-transform-react-jsx-self" "^7.0.0"
-    "@babel/plugin-transform-react-jsx-source" "^7.0.0"
-    "@babel/plugin-transform-runtime" "^7.0.0"
-    "@babel/plugin-transform-shorthand-properties" "^7.0.0"
-    "@babel/plugin-transform-spread" "^7.0.0"
-    "@babel/plugin-transform-sticky-regex" "^7.0.0"
-    "@babel/plugin-transform-template-literals" "^7.0.0"
-    "@babel/plugin-transform-typescript" "^7.5.0"
-    "@babel/plugin-transform-unicode-regex" "^7.0.0"
-    "@babel/template" "^7.0.0"
-    react-refresh "^0.4.0"
 
 metro-react-native-babel-preset@0.72.0:
   version "0.72.0"
@@ -5064,7 +5046,7 @@ metro-react-native-babel-preset@0.72.0:
     "@babel/template" "^7.0.0"
     react-refresh "^0.4.0"
 
-metro-react-native-babel-transformer@0.72.0:
+metro-react-native-babel-transformer@0.72.0, metro-react-native-babel-transformer@^0.72.0:
   version "0.72.0"
   resolved "https://registry.yarnpkg.com/metro-react-native-babel-transformer/-/metro-react-native-babel-transformer-0.72.0.tgz#5f6ae8454646d735cda57ccd2dbb7b0d692d5234"
   integrity sha512-DsZPRgS/QOQDhAVzchGLa/luAiE2UDaIzVRLFfwT1zRUdryWqaaJO8JK+oGVDpdxoqi3qV7sHu/4WzkL7wvwbA==
@@ -5077,53 +5059,19 @@ metro-react-native-babel-transformer@0.72.0:
     metro-source-map "0.72.0"
     nullthrows "^1.1.1"
 
-metro-react-native-babel-transformer@^0.71.3:
-  version "0.71.3"
-  resolved "https://registry.yarnpkg.com/metro-react-native-babel-transformer/-/metro-react-native-babel-transformer-0.71.3.tgz#7725cecffedf542fdb379fe59c1e19cf1d0f97b8"
-  integrity sha512-DTRIldy5Dt4/+YN9DXg+9ltyk1VPZkT0d8XERQ6Ln4/uwmeEUpc1MeaA72Te9TkpznCQElAR0vhupdoaHkPcoQ==
-  dependencies:
-    "@babel/core" "^7.14.0"
-    babel-preset-fbjs "^3.4.0"
-    hermes-parser "0.8.0"
-    metro-babel-transformer "0.71.3"
-    metro-react-native-babel-preset "0.71.3"
-    metro-source-map "0.71.3"
-    nullthrows "^1.1.1"
-
-metro-resolver@0.71.3, metro-resolver@^0.71.3:
-  version "0.71.3"
-  resolved "https://registry.yarnpkg.com/metro-resolver/-/metro-resolver-0.71.3.tgz#af58030209ff6176816684124c18a9250116cdb1"
-  integrity sha512-VeNlDVUZAKejtpV9ruZ3ivydhC2UtL6ZffYxAn1G6sPsW+B/lTywYigx32pY0xBkfkDnzul6bKOiKNe9LKW1uQ==
+metro-resolver@0.72.0, metro-resolver@^0.72.0:
+  version "0.72.0"
+  resolved "https://registry.yarnpkg.com/metro-resolver/-/metro-resolver-0.72.0.tgz#a0877267a16ab3fdd730a5bcabde08c8f437e108"
+  integrity sha512-aQ3ILLFs6e7lju60WVhU3lxROJ+fZluiOncqLq0o0QECCnrEbWQTRVMQmDTpq5cI/w7k6tSbNMhlUzPPLFI5Uw==
   dependencies:
     absolute-path "^0.0.0"
 
-metro-runtime@0.71.3, metro-runtime@^0.71.3:
-  version "0.71.3"
-  resolved "https://registry.yarnpkg.com/metro-runtime/-/metro-runtime-0.71.3.tgz#e17a3100bb61e7ea66d38f1dcaa971357572b59d"
-  integrity sha512-1l7YYYY64wdphvPOUA3NDHVoYxuV6SEn8O6/WGGEqGj/M0focrue1ra3caoCPDUOJFWgHxh6FVaAXXTOltjNwg==
-  dependencies:
-    "@babel/runtime" "^7.0.0"
-
-metro-runtime@0.72.0:
+metro-runtime@0.72.0, metro-runtime@^0.72.0:
   version "0.72.0"
   resolved "https://registry.yarnpkg.com/metro-runtime/-/metro-runtime-0.72.0.tgz#f72b158fc5072a83b6274d6eae1db41fb065d77e"
   integrity sha512-ZY372filZa8KApndcC2MuuObUufW8A4UEYHaKv6onIT0maCX2mzNGaDIiOXs6i5gHjb801qaR0a3UqCVxhGgeQ==
   dependencies:
     "@babel/runtime" "^7.0.0"
-
-metro-source-map@0.71.3:
-  version "0.71.3"
-  resolved "https://registry.yarnpkg.com/metro-source-map/-/metro-source-map-0.71.3.tgz#ffbb21d3ab5a137234bcf225336283e7e669ee0b"
-  integrity sha512-rMwDrYWFSC/J71N0XT8c/hf0q1tfvwNi8Tqa7lCCxmF0HUoPZSocY2lp7IcdZaxckpm++Nrrdc+D/jsG1JD5oQ==
-  dependencies:
-    "@babel/traverse" "^7.14.0"
-    "@babel/types" "^7.0.0"
-    invariant "^2.2.4"
-    metro-symbolicate "0.71.3"
-    nullthrows "^1.1.1"
-    ob1 "0.71.3"
-    source-map "^0.5.6"
-    vlq "^1.0.0"
 
 metro-source-map@0.72.0:
   version "0.72.0"
@@ -5139,18 +5087,6 @@ metro-source-map@0.72.0:
     source-map "^0.5.6"
     vlq "^1.0.0"
 
-metro-symbolicate@0.71.3:
-  version "0.71.3"
-  resolved "https://registry.yarnpkg.com/metro-symbolicate/-/metro-symbolicate-0.71.3.tgz#ba02b87742d2bed8e9a5a4cc0146ca8f6645c20b"
-  integrity sha512-fvcI9/1aSRviWnEGSrEVFYDS26r38PwLwKWpSl1GqEtwE6fgwlMeZKQbj+BIGYRSHXU48pIA/kJZc88oB4pjJA==
-  dependencies:
-    invariant "^2.2.4"
-    metro-source-map "0.71.3"
-    nullthrows "^1.1.1"
-    source-map "^0.5.6"
-    through2 "^2.0.1"
-    vlq "^1.0.0"
-
 metro-symbolicate@0.72.0:
   version "0.72.0"
   resolved "https://registry.yarnpkg.com/metro-symbolicate/-/metro-symbolicate-0.72.0.tgz#ca46943d522cef8123735b71fb81b57cc867c48f"
@@ -5163,10 +5099,10 @@ metro-symbolicate@0.72.0:
     through2 "^2.0.1"
     vlq "^1.0.0"
 
-metro-transform-plugins@0.71.3:
-  version "0.71.3"
-  resolved "https://registry.yarnpkg.com/metro-transform-plugins/-/metro-transform-plugins-0.71.3.tgz#25798db10459533b497a66e3be0d01a0d6b731ff"
-  integrity sha512-Z4XeaGD0obC3dHIlLA4w7DW5enczLD1OfxUaCM92W+yYIhqn2SJDw6yzaj7CV0AWzeOxRF9itkvQHdy3X+/6Yg==
+metro-transform-plugins@0.72.0:
+  version "0.72.0"
+  resolved "https://registry.yarnpkg.com/metro-transform-plugins/-/metro-transform-plugins-0.72.0.tgz#d495c6a535da33d986430dc0ef6eee7549dbe47b"
+  integrity sha512-IV7znwPOKusmfRbZi/TLUrdJqQTZBaufNZJ+evW+yM7Vjy4mGHy1GDlgOkGiMjzjIqB8yFSNh1oVo3q7LJlxlA==
   dependencies:
     "@babel/core" "^7.14.0"
     "@babel/generator" "^7.14.0"
@@ -5174,29 +5110,29 @@ metro-transform-plugins@0.71.3:
     "@babel/traverse" "^7.14.0"
     nullthrows "^1.1.1"
 
-metro-transform-worker@0.71.3:
-  version "0.71.3"
-  resolved "https://registry.yarnpkg.com/metro-transform-worker/-/metro-transform-worker-0.71.3.tgz#474fa6f544891366f991a28b70d4f72f1de1cbd4"
-  integrity sha512-riaDvCfWRgkl0Cy2VUqGZOwzONQ7oqVg6UmgG1vhnTpGC3xJFXVV6np1pDLTHjlMFu4xjnb7zZxHm8emX6C4JQ==
+metro-transform-worker@0.72.0:
+  version "0.72.0"
+  resolved "https://registry.yarnpkg.com/metro-transform-worker/-/metro-transform-worker-0.72.0.tgz#3b9dd519b6383b32ea82e3deeb2229de2aa25fe5"
+  integrity sha512-QUFXeU4R4xgLkxczZUmI63XHbu418YlEh2km1c2vUwuDpEYvKndBi15tlwBkXU5uaWWqUVA59FnJdccExWtD8Q==
   dependencies:
     "@babel/core" "^7.14.0"
     "@babel/generator" "^7.14.0"
     "@babel/parser" "^7.14.0"
     "@babel/types" "^7.0.0"
     babel-preset-fbjs "^3.4.0"
-    metro "0.71.3"
-    metro-babel-transformer "0.71.3"
-    metro-cache "0.71.3"
-    metro-cache-key "0.71.3"
-    metro-hermes-compiler "0.71.3"
-    metro-source-map "0.71.3"
-    metro-transform-plugins "0.71.3"
+    metro "0.72.0"
+    metro-babel-transformer "0.72.0"
+    metro-cache "0.72.0"
+    metro-cache-key "0.72.0"
+    metro-hermes-compiler "0.72.0"
+    metro-source-map "0.72.0"
+    metro-transform-plugins "0.72.0"
     nullthrows "^1.1.1"
 
-metro@0.71.3, metro@^0.71.3:
-  version "0.71.3"
-  resolved "https://registry.yarnpkg.com/metro/-/metro-0.71.3.tgz#3e3c90d4e7d5b3f957df5fb7784d79a3b5a56c66"
-  integrity sha512-1Rig6w7othfDHAQXsGTpUTYdKhYBJDgmCWmdD1WVLv1DaW6tqxTM1DPPi1L5x6w33LdPUjAANT3nwJp5Ki81tg==
+metro@0.72.0, metro@^0.72.0:
+  version "0.72.0"
+  resolved "https://registry.yarnpkg.com/metro/-/metro-0.72.0.tgz#6b7d536b28a36422bffa4e815fd27224df0273c6"
+  integrity sha512-LyZfgtAHkxtXBU99SBeN06UfnZyE1pcmEw7fkslZvFS2DXe30WeRosPvy/5uVgeD9du2y62Q3T7H73qRepJggQ==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     "@babel/core" "^7.14.0"
@@ -5221,22 +5157,22 @@ metro@0.71.3, metro@^0.71.3:
     invariant "^2.2.4"
     jest-worker "^27.2.0"
     lodash.throttle "^4.1.1"
-    metro-babel-transformer "0.71.3"
-    metro-cache "0.71.3"
-    metro-cache-key "0.71.3"
-    metro-config "0.71.3"
-    metro-core "0.71.3"
-    metro-file-map "0.71.3"
-    metro-hermes-compiler "0.71.3"
-    metro-inspector-proxy "0.71.3"
-    metro-minify-uglify "0.71.3"
-    metro-react-native-babel-preset "0.71.3"
-    metro-resolver "0.71.3"
-    metro-runtime "0.71.3"
-    metro-source-map "0.71.3"
-    metro-symbolicate "0.71.3"
-    metro-transform-plugins "0.71.3"
-    metro-transform-worker "0.71.3"
+    metro-babel-transformer "0.72.0"
+    metro-cache "0.72.0"
+    metro-cache-key "0.72.0"
+    metro-config "0.72.0"
+    metro-core "0.72.0"
+    metro-file-map "0.72.0"
+    metro-hermes-compiler "0.72.0"
+    metro-inspector-proxy "0.72.0"
+    metro-minify-uglify "0.72.0"
+    metro-react-native-babel-preset "0.72.0"
+    metro-resolver "0.72.0"
+    metro-runtime "0.72.0"
+    metro-source-map "0.72.0"
+    metro-symbolicate "0.72.0"
+    metro-transform-plugins "0.72.0"
+    metro-transform-worker "0.72.0"
     mime-types "^2.1.27"
     node-fetch "^2.2.0"
     nullthrows "^1.1.1"
@@ -5486,11 +5422,6 @@ oauth-sign@~0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
-
-ob1@0.71.3:
-  version "0.71.3"
-  resolved "https://registry.yarnpkg.com/ob1/-/ob1-0.71.3.tgz#aa98b76e1038d016f4e0e42b5d1e7b009db3f0e0"
-  integrity sha512-SiCAg5YyrYyMvpgiri+B8DeUTTNdcvYNi+SR2ztH17Kv5X2moE+WPH7JI8UiLZrhlO5FQCUV5Dewzz0nXkF4Rg==
 
 ob1@0.72.0:
   version "0.72.0"


### PR DESCRIPTION
## Summary

Upgrades the React Native CLI to v9.0.0-alpha.9 with Metro 0.72 and package size improvements 

cc @kelset @cortinico @huntie 

## Changelog

[General] [Changed] - Upgrade RN CLI to v9.0.0-alpha.9

## Test Plan

CI
