### PR TITLE
[RN][OSS]Fix edge case where prepare_hermes_workspace and build_hermes_macos where using different hermes commits

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ references:
     gradle_cache_key: &gradle_cache_key v1-gradle-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "ReactAndroid/gradle.properties" }}
     hermes_cache_key: &hermes_cache_key v2-hermes-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/hermes/hermesversion" }}
     hermes_windows_cache_key: &hermes_windows_cache_key v2-hermes-{{ .Environment.CIRCLE_JOB }}-{{ checksum "tmp/hermes/hermesversion" }}
-    hermes_tarball_cache_key: &hermes_tarball_cache_key v2-hermes-tarball-{{ checksum "/tmp/hermes/cache/.hermes-cache-key-file" }}
+    hermes_tarball_cache_key: &hermes_tarball_cache_key v2-hermes-tarball-{{ checksum "/tmp/hermes/hermesversion" }}
     pods_cache_key: &pods_cache_key v7-pods-{{ .Environment.CIRCLE_JOB }}-{{ checksum "packages/rn-tester/Podfile.lock.bak" }}-{{ checksum "packages/rn-tester/Podfile" }}
     windows_yarn_cache_key: &windows_yarn_cache_key v1-win-yarn-cache-{{ arch }}-{{ checksum "yarn.lock" }}
     yarn_cache_key: &yarn_cache_key v5-yarn-cache-{{ .Environment.CIRCLE_JOB }}
@@ -289,24 +289,6 @@ commands:
         type: boolean
         default: False
     steps:
-      - run:
-          name: Setup Hermes cache
-          command: |
-            HERMES_CACHE_KEY_FILE="/tmp/hermes/cache/.hermes-cache-key-file"
-            if [ ! -f "$HERMES_CACHE_KEY_FILE" ]; then
-              echo "File not found. Use the same version from the hermes workspace"
-
-              HERMES_VERSION="/tmp/hermes/hermesversion"
-              if [ ! -f "$HERMES_VERSION" ]; then
-                echo "No hermesversion file found. Failing due to possible inconsistencies in the build"
-                exit 1
-              fi
-
-              mkdir -p /tmp/hermes/cache
-              cat $HERMES_VERSION > $HERMES_CACHE_KEY_FILE
-            fi
-            echo "Hermes version: "$HERMES_VERSION
-            echo "Hermes cached tarball: "$HERMES_CACHE_KEY_FILE
       - restore_cache:
           keys:
             - *hermes_tarball_cache_key
@@ -482,8 +464,7 @@ jobs:
             cd scripts
             sh run_ruby_tests.sh
       - run_yarn
-      - attach_workspace:
-          at: /tmp/hermes/
+      - *attach_hermes_workspace
       - run: |
           cd packages/rn-tester
           bundle check || bundle install
@@ -764,6 +745,7 @@ jobs:
     steps:
       - checkout_code_with_cache
       - run_yarn
+      - *attach_hermes_workspace
 
       # The macOS machine can run out of storage if Hermes is enabled and built from source.
       # Since this job does not use the iOS Simulator, deleting it provides a quick way to
@@ -783,9 +765,6 @@ jobs:
 
       - brew_install:
           package: cmake
-
-      - attach_workspace:
-          at: /tmp/hermes
 
       - with_hermes_tarball_cache_span:
           set_tarball_path: True
@@ -1031,10 +1010,6 @@ jobs:
             brew install cmake
       - with_hermes_tarball_cache_span:
           steps:
-            - persist_to_workspace:
-                root: /tmp/hermes/
-                paths:
-                  - cache
             - run:
                 name: Build the Hermes iOS frameworks
                 command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,10 +51,10 @@ references:
     checkout_cache_key: &checkout_cache_key v1-checkout
     gems_cache_key: &gems_cache_key v1-gems-{{ checksum "Gemfile.lock" }}
     gradle_cache_key: &gradle_cache_key v1-gradle-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "ReactAndroid/gradle.properties" }}
-    hermes_cache_key: &hermes_cache_key v1-hermes-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/hermes/hermesversion" }}
-    hermes_windows_cache_key: &hermes_windows_cache_key v1-hermes-{{ .Environment.CIRCLE_JOB }}-{{ checksum "tmp/hermes/hermesversion" }}
-    hermes_tarball_cache_key: &hermes_tarball_cache_key v1-hermes-tarball-{{ checksum "/tmp/hermes/cache/.hermes-cache-key-file" }}
-    pods_cache_key: &pods_cache_key v6-pods-{{ .Environment.CIRCLE_JOB }}-{{ checksum "packages/rn-tester/Podfile.lock.bak" }}-{{ checksum "packages/rn-tester/Podfile" }}
+    hermes_cache_key: &hermes_cache_key v2-hermes-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/hermes/hermesversion" }}
+    hermes_windows_cache_key: &hermes_windows_cache_key v2-hermes-{{ .Environment.CIRCLE_JOB }}-{{ checksum "tmp/hermes/hermesversion" }}
+    hermes_tarball_cache_key: &hermes_tarball_cache_key v2-hermes-tarball-{{ checksum "/tmp/hermes/cache/.hermes-cache-key-file" }}
+    pods_cache_key: &pods_cache_key v7-pods-{{ .Environment.CIRCLE_JOB }}-{{ checksum "packages/rn-tester/Podfile.lock.bak" }}-{{ checksum "packages/rn-tester/Podfile" }}
     windows_yarn_cache_key: &windows_yarn_cache_key v1-win-yarn-cache-{{ arch }}-{{ checksum "yarn.lock" }}
     yarn_cache_key: &yarn_cache_key v5-yarn-cache-{{ .Environment.CIRCLE_JOB }}
 
@@ -294,11 +294,19 @@ commands:
           command: |
             HERMES_CACHE_KEY_FILE="/tmp/hermes/cache/.hermes-cache-key-file"
             if [ ! -f "$HERMES_CACHE_KEY_FILE" ]; then
-              echo "File not found. Creating it using latest commit from main"
+              echo "File not found. Use the same version from the hermes workspace"
+
+              HERMES_VERSION="/tmp/hermes/hermesversion"
+              if [ ! -f "$HERMES_VERSION" ]; then
+                echo "No hermesversion file found. Failing due to possible inconsistencies in the build"
+                exit 1
+              fi
+
               mkdir -p /tmp/hermes/cache
-              git ls-remote https://github.com/facebook/hermes main | cut -f 1 > $HERMES_CACHE_KEY_FILE
+              cat $HERMES_VERSION > $HERMES_CACHE_KEY_FILE
             fi
-            cat $HERMES_CACHE_KEY_FILE
+            echo "Hermes version: "$HERMES_VERSION
+            echo "Hermes cached tarball: "$HERMES_CACHE_KEY_FILE
       - restore_cache:
           keys:
             - *hermes_tarball_cache_key
@@ -535,6 +543,16 @@ jobs:
             - run:
                 name: "Run Tests: iOS Unit and Integration Tests"
                 command: yarn test-ios
+            - run:
+                name: Zip Derived data folder
+                when: always
+                command: |
+                  echo "zipping tests results"
+                  cd /Users/distiller/Library/Developer/Xcode
+                  XCRESULT_PATH=$(find . -name '*.xcresult')
+                  tar -zcvf xcresults.tar.gz $XCRESULT_PATH
+            - store_artifacts:
+                path: /Users/distiller/Library/Developer/Xcode/xcresults.tar.gz
 
       # Optionally, run disabled tests
       - when:
@@ -560,6 +578,7 @@ jobs:
           platform: ios
       - store_test_results:
           path: ./reports/junit
+
 
   # -------------------------
   #    JOBS: Test Android
@@ -924,6 +943,7 @@ jobs:
               HERMES_TAG_SHA=$(git ls-remote https://github.com/facebook/hermes main | cut -f 1 | tr -d '[:space:]')
               echo $HERMES_TAG_SHA > /tmp/hermes/hermesversion
             fi
+            cat /tmp/hermes/hermesversion
       - restore_cache:
           key: *hermes_cache_key
       - run:
@@ -932,6 +952,8 @@ jobs:
             node scripts/hermes/prepare-hermes-for-build $CIRCLE_PULL_REQUEST
             cp sdks/download/* $HERMES_WS_DIR/download/.
             cp -r sdks/hermes/* $HERMES_WS_DIR/hermes/.
+
+            cat /tmp/hermes/hermesversion
       - save_cache:
           key: *hermes_cache_key
           paths:


### PR DESCRIPTION
## Summary

This PR fixes an edge case where `prepare_hermes_workspace` job was using a commit to build hermes but `build_hermes_macos` was using a different one. This resulted in cache poisoning where subsequent jobs thoughts to be using a version of Hermes while the restored cache was loading a different one.

<img width="1440" alt="Screenshot 2022-08-03 at 06 26 14" src="https://user-images.githubusercontent.com/11162307/182570809-5c6d9323-c3fb-4834-952f-7d07b99c4880.png">

This PR simplifies the flow, creating a single `.hermesversion` file in the `prepare_hermes_workspace` workspace and using that file as key for all the caches.

This whole investigation started with some failing tests, the PR also adds the `xcresult` archive as artifact for future failures.

## Changelog

[iOS] [Changed] - Simplified the cache code for Hermes and added the test `xcresult` archive as artifact, if we need to explore the tests in the future.  

## Test Plan

CircleCI is now green and all the caches are using the same file to create the checksum. 

We can verify that by looking at the `Save cache`/`Restore cache` commands related to Hermes. (In the workflow, their hash is always `B1NEL0P0OKhQYtk8DE150bXSoGrdWUweedHKmqNqnjo`)

Also, we removed completely the code that could create a version misalignment.

Verified that the `xcresult` artifact is [uploaded correctly](https://app.circleci.com/pipelines/github/facebook/react-native/14592/workflows/719df3df-8abf-4749-9d92-917db86bc37d/jobs/271261/artifacts).

