### PR TITLE
[0.70] Fix Macro Errors for Windows

### DIFF
--- a/ReactCommon/react/renderer/components/text/BaseTextProps.cpp
+++ b/ReactCommon/react/renderer/components/text/BaseTextProps.cpp
@@ -12,20 +12,17 @@
 #include <react/renderer/debug/DebugStringConvertibleItem.h>
 #include <react/renderer/graphics/conversions.h>
 
-#define GET_FIELD_VALUE(field, fieldName, defaultValue, rawValue) \
-  (rawValue.hasValue() ? ([&rawValue, &context]{                  \
-    decltype(defaultValue) res;                                   \
-    fromRawValue(context, rawValue, res);                         \
-    return res;                                                   \
-  }())                                                            \
-                       : defaultValue);
-
-#define REBUILD_FIELD_SWITCH_CASE(                                   \
-    defaults, rawValue, property, field, fieldName)                  \
-  case CONSTEXPR_RAW_PROPS_KEY_HASH(fieldName): {                    \
-    property.field =                                                 \
-        GET_FIELD_VALUE(field, fieldName, defaults.field, rawValue); \
-    return;                                                          \
+#define REBUILD_FIELD_SWITCH_CASE(                  \
+    defaults, rawValue, property, field, fieldName) \
+  case CONSTEXPR_RAW_PROPS_KEY_HASH(fieldName): {   \
+    if (rawValue.hasValue()) {                      \
+      decltype(defaults.field) res;                 \
+      fromRawValue(context, rawValue, res);         \
+      property.field = res;                         \
+    } else {                                        \
+      property.field = defaults.field;              \
+    }                                               \
+    return;                                         \
   }
 
 namespace facebook {

--- a/ReactCommon/react/renderer/components/text/BaseTextProps.cpp
+++ b/ReactCommon/react/renderer/components/text/BaseTextProps.cpp
@@ -13,12 +13,12 @@
 #include <react/renderer/graphics/conversions.h>
 
 #define GET_FIELD_VALUE(field, fieldName, defaultValue, rawValue) \
-  (rawValue.hasValue() ? ({                                       \
+  (rawValue.hasValue() ? ([&rawValue, &context]{                  \
     decltype(defaultValue) res;                                   \
     fromRawValue(context, rawValue, res);                         \
-    res;                                                          \
-  })                                                              \
-                       : defaultValue)
+    return res;                                                   \
+  }())                                                            \
+                       : defaultValue);
 
 #define REBUILD_FIELD_SWITCH_CASE(                                   \
     defaults, rawValue, property, field, fieldName)                  \

--- a/ReactCommon/react/renderer/components/view/ViewProps.cpp
+++ b/ReactCommon/react/renderer/components/view/ViewProps.cpp
@@ -252,13 +252,11 @@ ViewProps::ViewProps(
 #define VIEW_EVENT_CASE(eventType, eventString)     \
   case CONSTEXPR_RAW_PROPS_KEY_HASH(eventString): { \
     ViewEvents defaultViewEvents{};                 \
-    events[eventType] = [defaultViewEvents, &value, &context]{    \
-      bool res = defaultViewEvents[eventType];      \
-      if (value.hasValue()) {                       \
-        fromRawValue(context, value, res);          \
-      }                                             \
-      return res;                                   \
-    }();                                            \
+    bool res = defaultViewEvents[eventType];        \
+    if (value.hasValue()) {                         \
+      fromRawValue(context, value, res);            \
+    }                                               \
+    events[eventType] = res;                        \
     return;                                         \
   }
 

--- a/ReactCommon/react/renderer/components/view/ViewProps.cpp
+++ b/ReactCommon/react/renderer/components/view/ViewProps.cpp
@@ -252,13 +252,13 @@ ViewProps::ViewProps(
 #define VIEW_EVENT_CASE(eventType, eventString)     \
   case CONSTEXPR_RAW_PROPS_KEY_HASH(eventString): { \
     ViewEvents defaultViewEvents{};                 \
-    events[eventType] = ({                          \
+    events[eventType] = [defaultViewEvents, &value, &context]{    \
       bool res = defaultViewEvents[eventType];      \
       if (value.hasValue()) {                       \
         fromRawValue(context, value, res);          \
       }                                             \
-      res;                                          \
-    });                                             \
+      return res;                                   \
+    }();                                            \
     return;                                         \
   }
 

--- a/ReactCommon/react/renderer/core/ConcreteComponentDescriptor.h
+++ b/ReactCommon/react/renderer/core/ConcreteComponentDescriptor.h
@@ -119,7 +119,7 @@ class ConcreteComponentDescriptor : public ComponentDescriptor {
       rawProps.iterateOverValues([&](RawPropsPropNameHash hash,
                                      const char *propName,
                                      RawValue const &fn) {
-        shadowNodeProps.get()->setProp(context, hash, propName, fn);
+        shadowNodeProps.get()->Props::setProp(context, hash, propName, fn);
       });
     }
 

--- a/ReactCommon/react/renderer/core/ConcreteComponentDescriptor.h
+++ b/ReactCommon/react/renderer/core/ConcreteComponentDescriptor.h
@@ -119,7 +119,7 @@ class ConcreteComponentDescriptor : public ComponentDescriptor {
       rawProps.iterateOverValues([&](RawPropsPropNameHash hash,
                                      const char *propName,
                                      RawValue const &fn) {
-        shadowNodeProps.get()->Props::setProp(context, hash, propName, fn);
+        shadowNodeProps.get()->setProp(context, hash, propName, fn);
       });
     }
 

--- a/ReactCommon/react/renderer/core/PropsMacros.h
+++ b/ReactCommon/react/renderer/core/PropsMacros.h
@@ -19,14 +19,12 @@
 
 // Get hash at compile-time. sizeof(str) - 1 == strlen
 #define CONSTEXPR_RAW_PROPS_KEY_HASH(s)                   \
-  ({                                                      \
+  []{                                                     \
     CLANG_PRAGMA("clang diagnostic push")                 \
     CLANG_PRAGMA("clang diagnostic ignored \"-Wshadow\"") \
-    constexpr RawPropsPropNameHash propNameHash =         \
-        folly::hash::fnv32_buf(s, sizeof(s) - 1);         \
-    propNameHash;                                         \
+    return folly::hash::fnv32_buf(s, sizeof(s) - 1);      \
     CLANG_PRAGMA("clang diagnostic pop")                  \
-  })
+  }()
 
 #define RAW_PROPS_KEY_HASH(s) folly::hash::fnv32_buf(s, std::strlen(s))
 

--- a/ReactCommon/react/renderer/core/PropsMacros.h
+++ b/ReactCommon/react/renderer/core/PropsMacros.h
@@ -19,12 +19,12 @@
 
 // Get hash at compile-time. sizeof(str) - 1 == strlen
 #define CONSTEXPR_RAW_PROPS_KEY_HASH(s)                   \
-  []{                                                     \
+  ([]() constexpr->RawPropsPropNameHash {                 \
     CLANG_PRAGMA("clang diagnostic push")                 \
     CLANG_PRAGMA("clang diagnostic ignored \"-Wshadow\"") \
     return folly::hash::fnv32_buf(s, sizeof(s) - 1);      \
     CLANG_PRAGMA("clang diagnostic pop")                  \
-  }()
+  }())
 
 #define RAW_PROPS_KEY_HASH(s) folly::hash::fnv32_buf(s, std::strlen(s))
 


### PR DESCRIPTION
## Summary

Fix macro errors for Windows. Current syntax breaks the build of the React Common project on Windows because the ({...}) syntax is not supported; must be replaced with lambda expressions.

Backport #34299 to 0.70.

## Changelog

[General] [Fixed] - Fix macro errors for Windows.

## Test Plan

Build on react-native-windows repo. Tested in RNW app.
