### PR TITLE
Let's not build reactnativeutilsjni shared library

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/fabric/jni/Android.mk
+++ b/ReactAndroid/src/main/java/com/facebook/react/fabric/jni/Android.mk
@@ -40,7 +40,7 @@ LOCAL_SHARED_LIBRARIES := \
   libreact_render_uimanager \
   libreact_utils \
   libreact_config \
-  libreactnativeutilsjni \
+  libreactnativejni \
   librrc_image \
   librrc_root \
   librrc_unimplementedview \

--- a/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/jni/Android.mk
+++ b/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/jni/Android.mk
@@ -19,7 +19,7 @@ LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)
 
 LOCAL_CFLAGS += -fexceptions -frtti -std=c++17 -Wall
 
-LOCAL_SHARED_LIBRARIES = libfb libfbjni libreactnativeutilsjni libruntimeexecutor
+LOCAL_SHARED_LIBRARIES = libfb libfbjni libreactnativejni libruntimeexecutor
 
 LOCAL_STATIC_LIBRARIES = libcallinvoker libreactperfloggerjni
 

--- a/ReactAndroid/src/main/jni/react/jni/Android.mk
+++ b/ReactAndroid/src/main/jni/react/jni/Android.mk
@@ -3,66 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-
-##########################
-### React Native Utils ###
-##########################
-
 LOCAL_PATH := $(call my-dir)
-
-include $(CLEAR_VARS)
-
-# Include . in the header search path for all source files in this module.
-LOCAL_C_INCLUDES := $(LOCAL_PATH)
-
-# Include ./../../ in the header search path for modules that depend on
-# reactnativejni. This will allow external modules to require this module's
-# headers using #include <react/jni/<header>.h>, assuming:
-#   .     == jni
-#   ./../ == react
-LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)/../..
-
-LOCAL_CFLAGS += -fexceptions -frtti -Wno-unused-lambda-capture
-
-LOCAL_LDLIBS += -landroid
-
-# The dynamic libraries (.so files) that this module depends on.
-LOCAL_SHARED_LIBRARIES := \
-  libfb \
-  libfbjni \
-  libfolly_json \
-  libglog_init \
-  libreact_render_runtimescheduler \
-  libruntimeexecutor \
-  libyoga
-
-# The static libraries (.a files) that this module depends on.
-LOCAL_STATIC_LIBRARIES := libreactnative libcallinvokerholder
-
-# Name of this module.
-#
-# Other modules can depend on this one by adding libreactnativejni to their
-# LOCAL_SHARED_LIBRARIES variable.
-LOCAL_MODULE := reactnativeutilsjni
-
-# Compile all local c++ files.
-LOCAL_SRC_FILES := $(wildcard $(LOCAL_PATH)/*.cpp)
-LOCAL_SRC_FILES := $(subst $(LOCAL_PATH)/,,$(LOCAL_SRC_FILES))
-
-ifeq ($(APP_OPTIM),debug)
-  # Keep symbols by overriding the strip command invoked by ndk-build.
-  # Note that this will apply to all shared libraries,
-  # i.e. shared libraries will NOT be stripped
-  # even though we override it in this Android.mk
-  cmd-strip :=
-endif
-
-# Build the files in this directory as a shared library
-include $(BUILD_SHARED_LIBRARY)
-
-
-
-
 
 ######################
 ### reactnativejni ###
@@ -91,7 +32,6 @@ LOCAL_SHARED_LIBRARIES := \
   libfolly_json \
   libglog_init \
   libreact_render_runtimescheduler \
-  libreactnativeutilsjni \
   libruntimeexecutor \
   libyoga \
   logger

--- a/ReactCommon/react/renderer/components/progressbar/Android.mk
+++ b/ReactCommon/react/renderer/components/progressbar/Android.mk
@@ -35,7 +35,7 @@ LOCAL_SHARED_LIBRARIES := \
   libreact_render_debug \
   libreact_render_graphics \
   libreact_render_uimanager \
-  libreactnativeutilsjni \
+  libreactnativejni \
   librrc_view \
   libyoga
 

--- a/ReactCommon/react/renderer/components/slider/Android.mk
+++ b/ReactCommon/react/renderer/components/slider/Android.mk
@@ -37,7 +37,7 @@ LOCAL_SHARED_LIBRARIES := \
   libreact_render_imagemanager \
   libreact_render_mapbuffer \
   libreact_render_uimanager \
-  libreactnativeutilsjni \
+  libreactnativejni \
   librrc_image \
   librrc_view \
   libyoga

--- a/ReactCommon/react/renderer/components/switch/Android.mk
+++ b/ReactCommon/react/renderer/components/switch/Android.mk
@@ -35,7 +35,7 @@ LOCAL_SHARED_LIBRARIES := \
   libreact_render_debug \
   libreact_render_graphics \
   libreact_render_uimanager \
-  libreactnativeutilsjni \
+  libreactnativejni \
   librrc_view \
   libyoga
 

--- a/ReactCommon/react/renderer/textlayoutmanager/Android.mk
+++ b/ReactCommon/react/renderer/textlayoutmanager/Android.mk
@@ -31,7 +31,7 @@ LOCAL_SHARED_LIBRARIES := \
   libreact_render_telemetry \
   libreact_render_uimanager \
   libreact_utils \
-  libreactnativeutilsjni \
+  libreactnativejni \
   libyoga
 
 LOCAL_STATIC_LIBRARIES :=


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

We will not build the shared library named reactnativeutilsjni as it is built from the same sources as reactnativejni. It makes sense to remove the duplicate copy. This change should help reduce the `apk` size for android apps.

This is similar to a recently merged PR in main:
https://github.com/facebook/react-native/pull/34339


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

[Android][Changed] - Replaced reactnativeutilsjni with reactnativejni in the build process to reduce size

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan

Built react-native 0.68 from source and it builds the `.aar` successfully.

It has to be tested against:
1. New Architecture
2. Old Architecture

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
