### PR TITLE
Move react peerDependency/devDependency to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,9 +99,6 @@
     "packages/!(eslint-config-react-native-community)",
     "repo-config"
   ],
-  "peerDependencies": {
-    "react": "18.1.0"
-  },
   "dependencies": {
     "@jest/create-cache-key-function": "^27.0.1",
     "@react-native-community/cli": "^9.0.0-alpha.9",
@@ -124,6 +121,7 @@
     "nullthrows": "^1.1.1",
     "pretty-format": "^26.5.2",
     "promise": "^8.0.3",
+    "react": "18.1.0",
     "react-devtools-core": "4.24.0",
     "react-native-gradle-plugin": "^0.71.0",
     "react-refresh": "^0.4.0",
@@ -138,7 +136,6 @@
   "devDependencies": {
     "flow-bin": "^0.184.0",
     "hermes-eslint": "0.8.0",
-    "react": "18.1.0",
     "react-test-renderer": "^18.1.0"
   },
   "codegenConfig": {


### PR DESCRIPTION
## Summary

Hi 👋 , will be possible to move the react dependency from the peerDependencies/devDependencies to dependencies field.

I was searching about why is in peerDependencies and seems that was added due a react Haste Module system:

https://github.com/facebook/react-native/commit/9f01f9677096117da8be721913a09db870505c2f

that was deprecated on React v16+ and start using ES Module system:

https://reactjs.org/blog/2017/12/15/improving-the-repository-infrastructure.html#removing-the-custom-module-system

That was the only reason? I was reading about peerDependencies (https://nodejs.org/es/blog/npm/peer-dependencies/#using-peer-dependencies) and seems like with the ES6 modules RN should use always the good version.

## Changelog

[General] [Added] - Move React from peerDependencies to dependencies


## Test Plan

Sorry i dont know how to test it well. Is the same version of react and mi apps works fine when install with the "legacy-peer-deps" flag .
