### PR TITLE
Setup a build matrix for test_android_template

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -732,7 +732,7 @@ jobs:
             PACKAGE=$(cat build/react-native-package-version)
             PATH_TO_PACKAGE="$(pwd)/build/$PACKAGE"
             node ./scripts/set-rn-template-version.js "file:$PATH_TO_PACKAGE"
-            node cli.js init $PROJECT_NAME --directory "/tmp/$PROJECT_NAME" --template $(pwd) --verbose --skip-install
+            node cli.js init $PROJECT_NAME --directory "/tmp/$PROJECT_NAME" --template $(pwd) --verbose
       - run:
           name: Build template project
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -737,7 +737,7 @@ jobs:
           name: Build template project
           command: |
             xcodebuild build \
-              -workspace ~/tmp/$PROJECT_NAME/ios/$PROJECT_NAME.xcworkspace \
+              -workspace /tmp/$PROJECT_NAME/ios/$PROJECT_NAME.xcworkspace \
               -scheme $PROJECT_NAME \
               -sdk iphonesimulator
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -677,8 +677,17 @@ jobs:
   # -------------------------
   test_android_template:
     executor: reactnativeandroid
+    parameters:
+      flavor:
+        type: string
+        default: "Debug"
+      newarchitecture:
+        type: boolean
+        default: false
+    environment:
+      - PROJECT_NAME: "AndroidTemplateProject"
     steps:
-      - checkout
+      - checkout_code_with_cache
       - run_yarn
       - attach_workspace:
           at: .
@@ -686,16 +695,14 @@ jobs:
       - run:
           name: Create Android template project
           command: |
-            REPO_ROOT=$(pwd)
-            PACKAGE=$(cat build/react-native-package-version)
-            PATH_TO_PACKAGE="$REPO_ROOT/build/$PACKAGE"
-            cd template
-            npm add $PATH_TO_PACKAGE
-            npm install
+            node ./scripts/set-rn-template-version.js "file:$(pwd)/build/$(cat build/react-native-package-version)"
+            node cli.js init $PROJECT_NAME --directory "/tmp/$PROJECT_NAME" --template $(pwd) --verbose --skip-install
+            cd /tmp/$PROJECT_NAME
+            yarn
 
       - run:
-          name: Build the template application
-          command: cd template/android/ && ./gradlew assembleDebug
+          name: Build the template application for << parameters.flavor >> with New Architecture set << parameters.newarchitecture >>
+          command: cd /tmp/$PROJECT_NAME/android/ && ./gradlew assemble<< parameters.flavor >> -PnewArchEnabled=<< parameters.newarchitecture >>
 
   # -------------------------
   #    JOBS: Test iOS Template
@@ -722,13 +729,10 @@ jobs:
       - run:
           name: Create iOS template project
           command: |
-            REPO_ROOT=$(pwd)
             PACKAGE=$(cat build/react-native-package-version)
-            PATH_TO_PACKAGE="$REPO_ROOT/build/$PACKAGE"
+            PATH_TO_PACKAGE="$(pwd)/build/$PACKAGE"
             node ./scripts/set-rn-template-version.js "file:$PATH_TO_PACKAGE"
-            mkdir -p ~/tmp
-            cd ~/tmp
-            node "$REPO_ROOT/cli.js" init "$PROJECT_NAME" --template "$REPO_ROOT" --verbose
+            node cli.js init $PROJECT_NAME --directory "/tmp/$PROJECT_NAME" --template $(pwd) --verbose --skip-install
       - run:
           name: Build template project
           command: |
@@ -1327,6 +1331,10 @@ workflows:
       - test_android_template:
           requires:
             - build_npm_package
+          matrix:
+            parameters:
+              newarchitecture: [true, false]
+              flavor: ["Debug", "Release"]
       - test_ios_template:
           requires:
             - build_npm_package


### PR DESCRIPTION
## Summary

I'm extending `test_android_template` to use a CI Matrix. This will allow us to make sure that we test a new app template against Debug/Release and against New/Old Arch.

This will make sure we catch a lot of bugs early on 👍 

## Changelog

[Internal] - Setup a build matrix for test_android_template

## Test Plan

Will wait for a green CI