### PR TITLE
fix: border width top/bottom not matching the border radius

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewBackgroundDrawable.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewBackgroundDrawable.java
@@ -791,7 +791,7 @@ public class ReactViewBackgroundDrawable extends Drawable {
 
     /** Compute mInnerTopLeftCorner */
     mInnerTopLeftCorner.x = mInnerClipTempRectForBorderRadius.left;
-    mInnerTopLeftCorner.y = mInnerClipTempRectForBorderRadius.top;
+    mInnerTopLeftCorner.y = mInnerClipTempRectForBorderRadius.top * 2;
 
     getEllipseIntersectionWithLine(
         // Ellipse Bounds
@@ -817,7 +817,7 @@ public class ReactViewBackgroundDrawable extends Drawable {
     }
 
     mInnerBottomLeftCorner.x = mInnerClipTempRectForBorderRadius.left;
-    mInnerBottomLeftCorner.y = mInnerClipTempRectForBorderRadius.bottom;
+    mInnerBottomLeftCorner.y = mInnerClipTempRectForBorderRadius.bottom * -2;
 
     getEllipseIntersectionWithLine(
         // Ellipse Bounds
@@ -843,7 +843,7 @@ public class ReactViewBackgroundDrawable extends Drawable {
     }
 
     mInnerTopRightCorner.x = mInnerClipTempRectForBorderRadius.right;
-    mInnerTopRightCorner.y = mInnerClipTempRectForBorderRadius.top;
+    mInnerTopRightCorner.y = mInnerClipTempRectForBorderRadius.top * 2;
 
     getEllipseIntersectionWithLine(
         // Ellipse Bounds
@@ -869,7 +869,7 @@ public class ReactViewBackgroundDrawable extends Drawable {
     }
 
     mInnerBottomRightCorner.x = mInnerClipTempRectForBorderRadius.right;
-    mInnerBottomRightCorner.y = mInnerClipTempRectForBorderRadius.bottom;
+    mInnerBottomRightCorner.y = mInnerClipTempRectForBorderRadius.bottom * -2;
 
     getEllipseIntersectionWithLine(
         // Ellipse Bounds


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Fixes #33950 

After analysing the values used for drawing the border specifically the top and bottom values of `mInnerClipTempRectForBorderRadius` weren't matching the needs when it comes to the case of borderTopWidth and borderBottomWidth, when the borderRadius is applied.

Asking for reviews @cortinico 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[Android] [Fixed] - Border width top/bottom not matching the border radius

## Test Plan

Tested in a local project, following are the outputs(Details are in the issue attached):

Before:
<img src="https://user-images.githubusercontent.com/47336142/183289227-96b20f86-1507-46f5-a79d-f61457624e8b.png" height="550">

After:
<img src="https://user-images.githubusercontent.com/47336142/183289177-6148df29-f0de-4b99-bdf0-c28a9c7d3ac7.png" height="550">

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
