### PR TITLE
Silence deprecation warning for react-native dependency.

### DIFF
--- a/scripts/cocoapods/__tests__/codegen_utils-test.rb
+++ b/scripts/cocoapods/__tests__/codegen_utils-test.rb
@@ -125,7 +125,7 @@ class CodegenUtilsTests < Test::Unit::TestCase
         codegen = CodegenUtils.new().get_codegen_config_from_file('package.json', 'codegenConfig')
 
         # Assert
-        assert_equal(codegen, {'libraries' => []})
+        assert_equal(codegen, {})
     end
 
     def testGetCodegenConfigFromFile_whenFileExistsButHasNoKey_returnEmpty
@@ -137,7 +137,7 @@ class CodegenUtilsTests < Test::Unit::TestCase
         codegen = CodegenUtils.new().get_codegen_config_from_file('package.json', 'codegen')
 
         # Assert
-        assert_equal(codegen, {'libraries' => []})
+        assert_equal(codegen, {})
     end
 
     def testGetCodegenConfigFromFile_whenFileExistsAndHasKey_returnObject
@@ -211,19 +211,6 @@ class CodegenUtilsTests < Test::Unit::TestCase
             "${PODS_ROOT}/../MyFabricComponent1NativeComponent.js",
             "${PODS_ROOT}/../NativeModule1.js",
         ])
-    end
-
-    def testGetListOfJSSpecs_whenMisconfigured_aborts
-        # Arrange
-        app_codegen_config = {}
-        app_path = "~/MyApp/"
-        # Act
-        assert_raises() {
-           files = CodegenUtils.new().get_list_of_js_specs(app_codegen_config, app_path)
-        }
-        # Assert
-        assert_equal(Pod::UI.collected_warns , ["[Error] Codegen not properly configured. Please add the `codegenConfig` entry to your `package.json`"])
-
     end
 
     # ================================== #

--- a/scripts/cocoapods/codegen_utils.rb
+++ b/scripts/cocoapods/codegen_utils.rb
@@ -131,7 +131,7 @@ class CodegenUtils
     #
     # Returns: the list of dependencies as extracted from the package.json
     def get_codegen_config_from_file(config_path, config_key)
-      empty = {'libraries' => []}
+      empty = {}
       if !File.exist?(config_path)
         return empty
       end
@@ -159,9 +159,6 @@ class CodegenUtils
       elsif app_codegen_config['jsSrcsDir'] then
         codegen_dir = File.join(app_path, app_codegen_config['jsSrcsDir'])
         file_list.concat (Finder.find_codegen_file(codegen_dir))
-      else
-        Pod::UI.warn '[Error] Codegen not properly configured. Please add the `codegenConfig` entry to your `package.json`'
-        abort
       end
 
       input_files = file_list.map { |filename| "${PODS_ROOT}/../#{Pathname.new(filename).realpath().relative_path_from(Pod::Config.instance.installation_root)}" }

--- a/scripts/codegen/generate-artifacts-executor.js
+++ b/scripts/codegen/generate-artifacts-executor.js
@@ -51,6 +51,44 @@ function readPackageJSON(appRootDir) {
   return JSON.parse(fs.readFileSync(path.join(appRootDir, 'package.json')));
 }
 
+function printDeprecationWarningIfNeeded(dependency) {
+  if (dependency === REACT_NATIVE_DEPENDENCY_NAME) {
+    return;
+  }
+  console.log(`[Codegen] CodegenConfig Deprecated Setup for ${dependency}.
+    The configuration file still contains the codegen in the libraries array.
+    If possible, replace it with a single object.
+  `);
+  console.debug(`BEFORE:
+    {
+      // ...
+      "codegenConfig": {
+        "libraries": [
+          {
+            "name": "libName1",
+            "type": "all|components|modules",
+            "jsSrcsRoot": "libName1/js"
+          },
+          {
+            "name": "libName2",
+            "type": "all|components|modules",
+            "jsSrcsRoot": "libName2/src"
+          }
+        ]
+      }
+    }
+
+    AFTER:
+    {
+      "codegenConfig": {
+        "name": "libraries",
+        "type": "all",
+        "jsSrcsRoot": "."
+      }
+    }
+  `);
+}
+
 // Reading Libraries
 function extractLibrariesFromConfigurationArray(
   configFile,
@@ -102,38 +140,7 @@ function extractLibrariesFromJSON(
       libraryPath: dependencyPath,
     });
   } else {
-    console.log(`[Codegen] CodegenConfig Deprecated Setup for ${dependency}.
-      The configuration file still contains the codegen in the libraries array.
-      If possible, replace it with a single object.
-    `);
-    console.debug(`BEFORE:
-      {
-        // ...
-        "codegenConfig": {
-          "libraries": [
-            {
-              "name": "libName1",
-              "type": "all|components|modules",
-              "jsSrcsRoot": "libName1/js"
-            },
-            {
-              "name": "libName2",
-              "type": "all|components|modules",
-              "jsSrcsRoot": "libName2/src"
-            }
-          ]
-        }
-      }
-
-      AFTER:
-      {
-        "codegenConfig": {
-          "name": "libraries",
-          "type": "all",
-          "jsSrcsRoot": "."
-        }
-      }
-    `);
+    printDeprecationWarningIfNeeded(dependency);
     extractLibrariesFromConfigurationArray(
       configFile,
       codegenConfigKey,


### PR DESCRIPTION
Summary:
When a user runs `RCT_NEW_ARCH_ENABLED=1 pod install` to install the dependencies for the New Architecture, Cocoapods prints a warning because of React Native is still set up with a legacy configuration.

This diff silences these warnings because they can confuse the final user.

**Note:** We need to keep this legacy configuration to support both the legacy and the New Architecture.

## Changelog

[iOS][Changed] - Silence warning due to react-native internal details.

Differential Revision: D38503405

