### PR TITLE
Setup Automatic Rebase given a /rebase comment

### DIFF
--- a/.github/workflows/autorebase.yml
+++ b/.github/workflows/autorebase.yml
@@ -1,0 +1,19 @@
+name: Automatic Rebase
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  rebase:
+    name: Rebase
+    if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/rebase') && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the latest code
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
+      - name: Automatic Rebase
+        uses: cirrus-actions/rebase@1.7
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

This is a nit, but at least will help us reduce requests to rebase for PRs which maybe have a broken CI due to a stale base commit.

I've limited the scope to members and owners. A `/rebase` will trigger a rebase authored by Github Action bot.

We can play a bit around with it, and remove it if it doesn't really work well for us.

## Changelog

[Internal] - Setup Automatic Rebase given a /rebase comment

## Test Plan

Nothing to test here.