### PR TITLE
Let danger run on `pull_request_target`

### DIFF
--- a/.github/workflows/danger_pr.yml
+++ b/.github/workflows/danger_pr.yml
@@ -1,24 +1,28 @@
 name: Run Danger on PR
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, reopened, synchronize]
 
 permissions:
-  contents: read
+  actions: write
+  checks: write
+  contents: write
+  issues: write
+  pull-requests: write
+  statuses: write
 
 jobs:
   danger:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: yarn install
+      - name: Run Yarn Install on Root
+        run: yarn install
         working-directory: .
-      - run: yarn install
+      - name: Run Yarn Install inside Bots
+        run: yarn install
         working-directory: bots
       - name: Danger
-        run: DANGER_GITHUB_API_TOKEN="$PUBLIC_PULLBOT_GITHUB_TOKEN_A""$PUBLIC_PULLBOT_GITHUB_TOKEN_B" yarn danger ci --use-github-checks --failOnErrors --id danger_pr
+        run: yarn danger ci --use-github-checks --failOnErrors
         working-directory: bots
-        env:
-          PUBLIC_PULLBOT_GITHUB_TOKEN_A: a6edf8e8d40ce4e8b11a
-          PUBLIC_PULLBOT_GITHUB_TOKEN_B: 150e1341f4dd9c944d2a

--- a/bots/README.md
+++ b/bots/README.md
@@ -1,13 +1,15 @@
 ## Danger
 
-[Danger](http://danger.systems/js/) is a JavaScript runtime which helps you provide continuous feedback inside GitHub. It's used by @pull-bot to analyze the contents of a GitHub pull request.
+[Danger](http://danger.systems/js/) is a JavaScript runtime which helps you provide continuous feedback inside GitHub. 
+It's used inside Github Actions to analyze the contents of a GitHub pull request.
 
 If you want to test changes to Danger, I'd recommend checking out an existing PR and then running the `danger pr` command.
-You'll need a GitHub token. You can re-use this one: `a6edf8e8d40ce4e8b11a 150e1341f4dd9c944d2a` (just remove the space).
+You'll need a GitHub Public Access Token (PAT). It will look like `ghp_<REDACTED>`.
+
 So, for example:
 
 ```
-DANGER_GITHUB_API_TOKEN=[ENV_ABOVE] yarn danger pr https://github.com/facebook/react-native/pull/1234
+DANGER_GITHUB_API_TOKEN=ghp_<REDACTED> yarn danger pr https://github.com/facebook/react-native/pull/1234
 ```
 
 ## Code Analysis Bot

--- a/bots/dangerfile.js
+++ b/bots/dangerfile.js
@@ -91,7 +91,7 @@ if (!includesChangelog) {
 // Warns if the PR is opened against stable, as commits need to be cherry picked and tagged by a release maintainer.
 // Fails if the PR is opened against anything other than `main` or `-stable`.
 const isMergeRefMain = danger.github.pr.base.ref === 'main';
-const isMergeRefStable = danger.github.pr.base.ref.indexOf('-stable') !== -1;
+const isMergeRefStable = danger.github.pr.base.ref.endsWith('-stable');
 if (!isMergeRefMain && !isMergeRefStable) {
   const title = ':exclamation: Base Branch';
   const idea =
@@ -101,17 +101,12 @@ if (!isMergeRefMain && !isMergeRefStable) {
 
 // If the PR is opened against stable should add `Pick Request` label
 if (isMergeRefStable) {
-  const {owner, repo, number: issueNumber} = danger.github.thisPR;
-
-  danger.github.api.request(
-    'POST /repos/{owner}/{repo}/issues/{issueNumber}/labels',
-    {
-      owner,
-      repo,
-      issueNumber,
-      labels: ['Pick Request'],
-    },
-  );
+  danger.github.api.issues.addLabels({
+    owner: danger.github.pr.base.repo.owner.login,
+    repo: danger.github.pr.base.repo.name,
+    issue_number: danger.github.pr.number,
+    labels: ['Pick Request'],
+  });
 }
 
 eslint.default();


### PR DESCRIPTION
## Summary

This is a nit. Did some cleanups on our Danger setup.
The most substantial work is:
- Moved over danger to run on `pull_request_target`. This allow us to re-use the Github Action access token without having to provide one.
- Fixed an issue with the `Pick Request` label which was not applied correctly.
- Removed the danger_id as we were not passing it correctly.

## Changelog

[Internal] - Let danger run on `pull_request_target`

## Test Plan

Tested locally with `yarn danger pr https://github.com/facebook/react-native/pull/34197`