### PR TITLE
accessibilityLabelledBy use DynamicFromObject to parse String to Dynamic

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManagerDelegate.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManagerDelegate.java
@@ -11,6 +11,7 @@ import android.view.View;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ColorPropConverter;
 import com.facebook.react.bridge.Dynamic;
+import com.facebook.react.bridge.DynamicFromObject;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.yoga.YogaConstants;
@@ -92,7 +93,8 @@ public abstract class BaseViewManagerDelegate<T extends View, U extends BaseView
         mViewManager.setNativeId(view, (String) value);
         break;
       case ViewProps.ACCESSIBILITY_LABELLED_BY:
-        mViewManager.setAccessibilityLabelledBy(view, (Dynamic) value);
+        Dynamic dynamicFromObject = new DynamicFromObject(value);
+        mViewManager.setAccessibilityLabelledBy(view, dynamicFromObject);
         break;
       case ViewProps.OPACITY:
         mViewManager.setOpacity(view, value == null ? 1.0f : ((Double) value).floatValue());

--- a/packages/rn-tester/js/examples/Accessibility/AccessibilityExample.js
+++ b/packages/rn-tester/js/examples/Accessibility/AccessibilityExample.js
@@ -212,8 +212,10 @@ class AccessibilityExample extends React.Component<{}> {
               value="Foo"
             />
           </View>
+        </RNTesterBlock>
+        <RNTesterBlock title="Switch with accessibilityLabelledBy attribute">
           <View>
-            <Text nativeID="formLabel4">Enable Fielld</Text>
+            <Text nativeID="formLabel4">Enable Notifications</Text>
             <Switch
               value={true}
               accessibilityLabel="switch test1"

--- a/packages/rn-tester/js/examples/Accessibility/AccessibilityExample.js
+++ b/packages/rn-tester/js/examples/Accessibility/AccessibilityExample.js
@@ -26,6 +26,7 @@ const {
   StyleSheet,
   Slider,
   Platform,
+  Switch,
 } = require('react-native');
 import type {EventSubscription} from 'react-native/Libraries/vendor/emitter/EventEmitter';
 
@@ -209,6 +210,14 @@ class AccessibilityExample extends React.Component<{}> {
               accessibilityLabelledBy={['formLabel2', 'formLabel3']}
               style={styles.default}
               value="Foo"
+            />
+          </View>
+          <View>
+            <Text nativeID="formLabel4">Enable Fielld</Text>
+            <Switch
+              value={true}
+              accessibilityLabel="switch test1"
+              accessibilityLabelledBy="formLabel4"
             />
           </View>
         </RNTesterBlock>


### PR DESCRIPTION
## Summary

`accessibilityLabelledBy` accepts String or Array type.
- The JavaScript Array type corresponds to java [ReadableArray][3] ([HybridData][4])
- The JavaScript String type corresponds to the java String

Use [DynamicFromObject][5] to parse String to Dynamic. 

https://github.com/facebook/react-native/blob/e509f96baf5e523301a5c9567c416508ff20d175/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java#L222-L228

All credits to [grgr-dkrk][1] (PR https://github.com/facebook/react-native/pull/32470). fixes [#30846][2]

## Changelog

[Android] [Fixed] - accessibilityLabelledBy use DynamicFromObject to parse String to Dynamic

## Test Plan

<details><summary>testing accessibilityLabelledBy with TextInput</summary>
<p>

https://user-images.githubusercontent.com/24992535/183593138-7ced1974-6a06-4f0f-822a-1ade1edc7212.mp4

</p>
</details>

<details><summary>testing accessibilityLabelledBy with Switch</summary>
<p>

![Screen Shot 2022-08-09 at 15 53 37](https://user-images.githubusercontent.com/24992535/183596336-4b73186b-6d27-485e-a6ea-29a0f0b9ef50.png)

</p>
</details>

<details><summary>testing paper renderer after the fix</summary>
<p>

https://user-images.githubusercontent.com/24992535/183605619-01f1be64-788a-43bd-88b0-a7b2cad75148.mp4

</p>
</details>

[1]: https://github.com/grgr-dkrk
[2]: https://github.com/facebook/react-native/issues/30846
[3]: https://github.com/facebook/react-native/blob/e509f96baf5e523301a5c9567c416508ff20d175/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableArray.java#L1
[4]: https://github.com/facebookincubator/fbjni/blob/main/java/com/facebook/jni/HybridData.java
[5]: https://github.com/facebook/react-native/blob/e509f96baf5e523301a5c9567c416508ff20d175/ReactAndroid/src/main/java/com/facebook/react/bridge/DynamicFromObject.java#L74