### PR TITLE
Simplify TurboModule setup

### DIFF
--- a/React/AppSetup/RCTAppDelegate.h
+++ b/React/AppSetup/RCTAppDelegate.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <UIKit/UIKit.h>
+
+#if RCT_NEW_ARCH_ENABLED
+// When the new architecture is enabled, the RCTAppDelegate imports some additional headers
+#import <React/RCTCxxBridgeDelegate.h>
+#import <ReactCommon/RCTTurboModuleManager.h>
+#endif
+
+/**
+ * The RCTAppDelegate is an utility class that implements some base configurations for all the React Native apps.
+ * It is not mandatory to use it, but it could simplify your AppDelegate code.
+ *
+ * To use it, you just need to make your AppDelegate a subclass of RCTAppDelegate:
+ *
+ * ```objc
+ * #import <React/RCTAppDelegate.h>
+ * @interface AppDelegate: RCTAppDelegate
+ * @end
+ * ```
+ *
+ * All the methods implemented by the RCTAppDelegate can be overriden by your AppDelegate if you need to provide a
+ custom implementation.
+ * If you need to customize the default implementation, you can invoke `[super <method_name>]` and use the returned
+ object.
+ *
+ * Overridable methods (New Architecture):
+ *   - (Class)getModuleClassFromName:(const char *)name
+ *   - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const std::string &)name
+                                                      jsInvoker:(std::shared_ptr<facebook::react::CallInvoker>)jsInvoker
+ *   - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const std::string &)name
+                                                     initParams:
+                                                         (const facebook::react::ObjCTurboModule::InitParams &)params
+ *   - (id<RCTTurboModule>)getModuleInstanceFromClass:(Class)moduleClass
+ */
+@interface RCTAppDelegate : UIResponder <UIApplicationDelegate>
+
+/// The window object, used to render the UViewControllers
+@property (nonatomic, strong) UIWindow *window;
+
+@end
+
+#if RCT_NEW_ARCH_ENABLED
+/// Extension that makes the RCTAppDelegate conform to New Architecture delegates
+@interface RCTAppDelegate () <RCTCxxBridgeDelegate, RCTTurboModuleManagerDelegate>
+
+/// The TurboModule manager
+@property (nonatomic, strong) RCTTurboModuleManager *turboModuleManager;
+
+@end
+#endif

--- a/React/AppSetup/RCTAppDelegate.mm
+++ b/React/AppSetup/RCTAppDelegate.mm
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RCTAppDelegate.h"
+#import <React/RCTAppSetupUtils.h>
+
+#if RCT_NEW_ARCH_ENABLED
+#import <React/CoreModulesPlugins.h>
+#endif
+
+@implementation RCTAppDelegate
+
+#if RCT_NEW_ARCH_ENABLED
+#pragma mark - RCTCxxBridgeDelegate
+
+- (std::unique_ptr<facebook::react::JSExecutorFactory>)jsExecutorFactoryForBridge:(RCTBridge *)bridge
+{
+  self.turboModuleManager = [[RCTTurboModuleManager alloc] initWithBridge:bridge
+                                                                 delegate:self
+                                                                jsInvoker:bridge.jsCallInvoker];
+  return RCTAppSetupDefaultJsExecutorFactory(bridge, _turboModuleManager);
+}
+
+#pragma mark RCTTurboModuleManagerDelegate
+
+- (Class)getModuleClassFromName:(const char *)name
+{
+  return RCTCoreModulesClassProvider(name);
+}
+
+- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const std::string &)name
+                                                      jsInvoker:(std::shared_ptr<facebook::react::CallInvoker>)jsInvoker
+{
+  return nullptr;
+}
+
+- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const std::string &)name
+                                                     initParams:
+                                                         (const facebook::react::ObjCTurboModule::InitParams &)params
+{
+  return nullptr;
+}
+
+- (id<RCTTurboModule>)getModuleInstanceFromClass:(Class)moduleClass
+{
+  return RCTAppSetupDefaultModuleFromClass(moduleClass);
+}
+
+#endif
+
+@end

--- a/template/ios/HelloWorld/AppDelegate.h
+++ b/template/ios/HelloWorld/AppDelegate.h
@@ -1,8 +1,7 @@
+#import <React/RCTAppDelegate.h>
 #import <React/RCTBridgeDelegate.h>
 #import <UIKit/UIKit.h>
 
-@interface AppDelegate : UIResponder <UIApplicationDelegate, RCTBridgeDelegate>
-
-@property (nonatomic, strong) UIWindow *window;
+@interface AppDelegate : RCTAppDelegate <RCTBridgeDelegate>
 
 @end

--- a/template/ios/HelloWorld/AppDelegate.mm
+++ b/template/ios/HelloWorld/AppDelegate.mm
@@ -1,25 +1,21 @@
 #import "AppDelegate.h"
 
+#import <React/RCTAppSetupUtils.h>
 #import <React/RCTBridge.h>
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTRootView.h>
 
-#import <React/RCTAppSetupUtils.h>
-
 #if RCT_NEW_ARCH_ENABLED
 #import <React/CoreModulesPlugins.h>
-#import <React/RCTCxxBridgeDelegate.h>
 #import <React/RCTFabricSurfaceHostingProxyRootView.h>
 #import <React/RCTSurfacePresenter.h>
 #import <React/RCTSurfacePresenterBridgeAdapter.h>
-#import <ReactCommon/RCTTurboModuleManager.h>
 
 #import <react/config/ReactNativeConfig.h>
 
 static NSString *const kRNConcurrentRoot = @"concurrentRoot";
 
-@interface AppDelegate () <RCTCxxBridgeDelegate, RCTTurboModuleManagerDelegate> {
-  RCTTurboModuleManager *_turboModuleManager;
+@interface AppDelegate () {
   RCTSurfacePresenterBridgeAdapter *_bridgeAdapter;
   std::shared_ptr<const facebook::react::ReactNativeConfig> _reactNativeConfig;
   facebook::react::ContextContainer::Shared _contextContainer;
@@ -90,44 +86,5 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
   return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
 #endif
 }
-
-#if RCT_NEW_ARCH_ENABLED
-
-#pragma mark - RCTCxxBridgeDelegate
-
-- (std::unique_ptr<facebook::react::JSExecutorFactory>)jsExecutorFactoryForBridge:(RCTBridge *)bridge
-{
-  _turboModuleManager = [[RCTTurboModuleManager alloc] initWithBridge:bridge
-                                                             delegate:self
-                                                            jsInvoker:bridge.jsCallInvoker];
-  return RCTAppSetupDefaultJsExecutorFactory(bridge, _turboModuleManager);
-}
-
-#pragma mark RCTTurboModuleManagerDelegate
-
-- (Class)getModuleClassFromName:(const char *)name
-{
-  return RCTCoreModulesClassProvider(name);
-}
-
-- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const std::string &)name
-                                                      jsInvoker:(std::shared_ptr<facebook::react::CallInvoker>)jsInvoker
-{
-  return nullptr;
-}
-
-- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const std::string &)name
-                                                     initParams:
-                                                         (const facebook::react::ObjCTurboModule::InitParams &)params
-{
-  return nullptr;
-}
-
-- (id<RCTTurboModule>)getModuleInstanceFromClass:(Class)moduleClass
-{
-  return RCTAppSetupDefaultModuleFromClass(moduleClass);
-}
-
-#endif
 
 @end


### PR DESCRIPTION
Summary:
By introducing a RCTAppDelegate base class, we can simplify the migration step to supports TM

## Changelog
[iOS][Changed] - Simplified migration steps for TM

Differential Revision: D38509891

