### PR TITLE
Do not load Flipper via reflection

### DIFF
--- a/template/android/app/src/debug/java/com/helloworld/ReactNativeFlipper.java
+++ b/template/android/app/src/debug/java/com/helloworld/ReactNativeFlipper.java
@@ -25,6 +25,11 @@ import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.modules.network.NetworkingModule;
 import okhttp3.OkHttpClient;
 
+/** 
+ * Class responsible of loading Flipper inside your React Native application.
+ * This is the debug flavor of it. Here you can add your own plugins and customize
+ * the Flipper setup.
+ */
 public class ReactNativeFlipper {
   public static void initializeFlipper(Context context, ReactInstanceManager reactInstanceManager) {
     if (FlipperUtils.shouldEnableFlipper(context)) {

--- a/template/android/app/src/main/java/com/helloworld/MainApplication.java
+++ b/template/android/app/src/main/java/com/helloworld/MainApplication.java
@@ -10,7 +10,6 @@ import com.facebook.react.ReactPackage;
 import com.facebook.react.config.ReactFeatureFlags;
 import com.facebook.soloader.SoLoader;
 import com.helloworld.newarchitecture.MainApplicationReactNativeHost;
-import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 
 public class MainApplication extends Application implements ReactApplication {
@@ -55,34 +54,7 @@ public class MainApplication extends Application implements ReactApplication {
     // If you opted-in for the New Architecture, we enable the TurboModule system
     ReactFeatureFlags.useTurboModules = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED;
     SoLoader.init(this, /* native exopackage */ false);
-    initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
+    ReactNativeFlipper.initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
   }
 
-  /**
-   * Loads Flipper in React Native templates. Call this in the onCreate method with something like
-   * initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
-   *
-   * @param context
-   * @param reactInstanceManager
-   */
-  private static void initializeFlipper(
-      Context context, ReactInstanceManager reactInstanceManager) {
-    if (BuildConfig.DEBUG) {
-      try {
-        /*
-         We use reflection here to pick up the class that initializes Flipper,
-        since Flipper library is not available in release mode
-        */
-        Class<?> aClass = Class.forName("com.helloworld.ReactNativeFlipper");
-        aClass
-            .getMethod("initializeFlipper", Context.class, ReactInstanceManager.class)
-            .invoke(null, context, reactInstanceManager);
-      } catch (ClassNotFoundException
-          | InvocationTargetException
-          | IllegalAccessException
-          | NoSuchMethodException e) {
-        e.printStackTrace();
-      }
-    }
-  }
 }

--- a/template/android/app/src/release/java/com/helloworld/ReactNativeFlipper.java
+++ b/template/android/app/src/release/java/com/helloworld/ReactNativeFlipper.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * <p>This source code is licensed under the MIT license found in the LICENSE file in the root
+ * directory of this source tree.
+ */
+package com.helloworld;
+
+import android.content.Context;
+import com.facebook.react.ReactInstanceManager;
+
+/** 
+ * Class responsible of loading Flipper inside your React Native application.
+ * This is the release flavor of it so it's empty as we don't want to load Flipper.
+ */
+public class ReactNativeFlipper {
+  public static void initializeFlipper(Context context, ReactInstanceManager reactInstanceManager) {
+    // Do nothing as we don't want to initialize Flipper on Release.
+  }
+}


### PR DESCRIPTION
## Summary

Followup to #34379 by @danilobuerger

Loading Flipper via reflection is type unsafe and requires extra code + exception handling that we can get rid of. The recommended way to use Flipper on Android is either via a `no-op` artifact or by using build flavors.

As we already had a setup for Flipper for `debug`, I'm creating the `release` equivalent which is just a stub. This allows us to get rid of some code inside `MainApplication.java`

## Changelog

[Android] [Changed] - Do not load Flipper via reflection

## Test Plan

Will wait for a CI result on this.