### PR TITLE
[WIP] Shallow clone instead of checkout whole repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,7 @@ commands:
           command: |
             mkdir ~/.ssh -p
             ssh-keyscan -H github.com >> ~/.ssh/known_hosts
-      - run: git clone --depth << parameters.checkout_depth >> "$CIRCLE_REPOSITORY_URL" --branch "$CIRCLE_BRANCH"
+      - run: git clone --depth << parameters.checkout_depth >> "$CIRCLE_REPOSITORY_URL" --branch "$CIRCLE_BRANCH" .
       - run:
           name: Test
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -818,9 +818,7 @@ jobs:
       - ANDROID_TOOLS_VERSION: 31.0.0
       - GRADLE_OPTS: -Dorg.gradle.daemon=false
     steps:
-      - checkout_code_with_cache:
-          shallow_checkout: true
-
+      - checkout_code_with_cache
       - run:
           name: Install Node
           # Note: Version set separately for non-Windows builds, see above.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -897,7 +897,7 @@ jobs:
       - CI_BUILD_NUMBER: $CIRCLE_BUILD_NUM
       - CI_BUILD_URL: $CIRCLE_BUILD_URL
     steps:
-      - checkout
+      - shallow_checkout
       - setup_artifacts
       - run_yarn
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,9 @@ commands:
     steps:
       - run:
           name: Add shhkey for github
-          command: ssh-keyscan -H github.com >> ~/.ssh/known_hosts
+          command: |
+          mkdir ~/.ssh/known_hosts -p
+          ssh-keyscan -H github.com >> ~/.ssh/known_hosts
       - run: git clone --depth << parameters.checkout_depth >> "$CIRCLE_REPOSITORY_URL" --branch "$CIRCLE_BRANCH"
 
   # Checkout with cache, on machines that are using Docker the cache is ignored

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,8 +129,8 @@ commands:
       - run:
           name: Add shhkey for github
           command: |
-            mkdir ~/.ssh/known_hosts -p
-            ssh-keyscan -H github.com >> ~/.ssh
+            mkdir ~/.ssh -p
+            ssh-keyscan -H github.com >> ~/.ssh/known_hosts
       - run: git clone --depth << parameters.checkout_depth >> "$CIRCLE_REPOSITORY_URL" --branch "$CIRCLE_BRANCH"
 
   # Checkout with cache, on machines that are using Docker the cache is ignored

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,6 +126,9 @@ commands:
         default: *shallow_checkout_depth
         type: integer
     steps:
+      - run: echo "$CIRCLE_REPOSITORY_URL" 
+      - run: echo "$CIRCLE_BRANCH"
+      - run: ls
       - run: git checkout --depth << parameters.checkout_depth >> "$CIRCLE_REPOSITORY_URL" --branch "$CIRCLE_BRANCH"
 
   # Checkout with cache, on machines that are using Docker the cache is ignored

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,8 +129,8 @@ commands:
       - run:
           name: Add shhkey for github
           command: |
-          mkdir ~/.ssh/known_hosts -p
-          ssh-keyscan -H github.com >> ~/.ssh/known_hosts
+            mkdir ~/.ssh/known_hosts -p
+            ssh-keyscan -H github.com >> ~/.ssh/known_hosts
       - run: git clone --depth << parameters.checkout_depth >> "$CIRCLE_REPOSITORY_URL" --branch "$CIRCLE_BRANCH"
 
   # Checkout with cache, on machines that are using Docker the cache is ignored

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -898,7 +898,7 @@ jobs:
       - CI_BUILD_URL: $CIRCLE_BUILD_URL
     steps:
       - shallow_checkout:
-        checkout_depth: 12
+          checkout_depth: 12
       - setup_artifacts
       - run_yarn
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,16 +153,13 @@ commands:
               - << parameters.checkout_base_cache_key >>
       # Logic to decide whether to shallow copy with cache
       - when:
-          condition:
-            and:
-              - equal: [ true, << parameters.shallow_checkout >> ]
+          condition: << parameters.shallow_checkout >> 
           steps:
             - checkout_shallow:
                 checkout_depth: << parameters.shallow_checkout_depth >>
       - when:
           condition:
-            and:
-              - not: << parameters.shallow_checkout >>
+              not: << parameters.shallow_checkout >>
           steps:
             - checkout
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ references:
   #        Single Use Environmental Variables
   # -------------------------
   envs:
-    shallow_checkout_depth: &shallow_checkout_depth 16
+    shallow_checkout_depth: &shallow_checkout_depth 8
 
   # -------------------------
   #        Cache Key Anchors
@@ -132,12 +132,6 @@ commands:
             mkdir ~/.ssh -p
             ssh-keyscan -H github.com >> ~/.ssh/known_hosts
       - run: git clone --depth << parameters.checkout_depth >> "$CIRCLE_REPOSITORY_URL" --branch "$CIRCLE_BRANCH" .
-      - run:
-          name: Test
-          command: |
-            ls
-            git status
-            git branch
 
   # Checkout with cache, on machines that are using Docker the cache is ignored
   checkout_code_with_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -465,7 +465,8 @@ jobs:
     environment:
       - REPORTS_DIR: "./reports/junit"
     steps:
-      - checkout_code_with_cache
+      - checkout_code_with_cache:
+          checkout_shallow: true
       - setup_artifacts
       - setup_ruby
       - run:
@@ -695,7 +696,8 @@ jobs:
     environment:
       - PROJECT_NAME: "AndroidTemplateProject"
     steps:
-      - checkout_code_with_cache
+      - checkout_code_with_cache:
+          checkout_shallow: true
       - run_yarn
       - attach_workspace:
           at: .
@@ -723,7 +725,8 @@ jobs:
       - HERMES_WS_DIR: *hermes_workspace_root
 
     steps:
-      - checkout_code_with_cache
+      - checkout_code_with_cache:
+          checkout_shallow: true
       - run_yarn
       - attach_workspace:
           at: .
@@ -757,7 +760,8 @@ jobs:
   test_ios_rntester:
     executor: reactnativeios
     steps:
-      - checkout_code_with_cache
+      - checkout_code_with_cache:
+          checkout_shallow: true
       - run_yarn
       - *attach_hermes_workspace
 
@@ -814,7 +818,8 @@ jobs:
       - ANDROID_TOOLS_VERSION: 31.0.0
       - GRADLE_OPTS: -Dorg.gradle.daemon=false
     steps:
-      - checkout_code_with_cache
+      - checkout_code_with_cache:
+          checkout_shallow: true
 
       - run:
           name: Install Node
@@ -1008,7 +1013,8 @@ jobs:
     environment:
       - HERMES_WS_DIR: *hermes_workspace_root
     steps:
-      - checkout_code_with_cache
+      - checkout_code_with_cache:
+          checkout_shallow: true
       - *attach_hermes_workspace
       - restore_cache:
           key: *hermes_cache_key
@@ -1156,7 +1162,8 @@ jobs:
         default: false
     executor: reactnativeios
     steps:
-      - checkout_code_with_cache
+      - checkout_code_with_cache:
+          checkout_shallow: true
       - run_yarn
       - add_ssh_keys:
           fingerprints:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,6 +131,12 @@ commands:
           command: |
             mkdir ~/.ssh -p
             ssh-keyscan -H github.com >> ~/.ssh/known_hosts
+      - run:
+          name: Test
+          command: |
+            ls
+             git status
+             git branch
       - run: git clone --depth << parameters.checkout_depth >> "$CIRCLE_REPOSITORY_URL" --branch "$CIRCLE_BRANCH"
 
   # Checkout with cache, on machines that are using Docker the cache is ignored

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,8 +127,8 @@ commands:
         type: integer
     steps:
       - run:
-        name: Add shhkey for github
-        command: ssh-keyscan -H github.com >> ~/.ssh/known_hosts
+          name: Add shhkey for github
+          command: ssh-keyscan -H github.com >> ~/.ssh/known_hosts
       - run: git clone --depth << parameters.checkout_depth >> "$CIRCLE_REPOSITORY_URL" --branch "$CIRCLE_BRANCH"
 
   # Checkout with cache, on machines that are using Docker the cache is ignored

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,12 @@ references:
     nodeprevlts_image: &nodeprevlts_image "cimg/node:14.19"
 
   # -------------------------
+  #        Single Use Environmental Variables
+  # -------------------------
+  envs:
+    shallow_checkout_depth: &shallow_checkout_depth 2
+
+  # -------------------------
   #        Cache Key Anchors
   # -------------------------
   # Anchors for the cache keys
@@ -113,19 +119,47 @@ executors:
 #        COMMANDS
 # -------------------------
 commands:
+  # Shallow checkout
+  checkout_shallow:
+    parameters:
+      checkout_depth:
+        default: *shallow_checkout_depth
+        type: integer
+    steps:
+      - run: git checkout --depth << parameters.checkout_depth >>
+
   # Checkout with cache, on machines that are using Docker the cache is ignored
   checkout_code_with_cache:
     parameters:
       checkout_base_cache_key:
         default: *checkout_cache_key
         type: string
+      shallow_checkout:
+        default: False
+        type: boolean
+      shallow_checkout_depth:
+        default: *shallow_checkout_depth
+        type: integer
     steps:
       - restore_cache:
             keys:
               - << parameters.checkout_base_cache_key >>-{{ .Branch }}-{{ .Revision }}
               - << parameters.checkout_base_cache_key >>-{{ .Branch }}-
               - << parameters.checkout_base_cache_key >>
-      - checkout
+      # Logic to decide whether to shallow copy with cache
+      - when:
+          condition:
+            and:
+              - equal: [ true, << parameters.shallow_checkout >> ]
+          steps:
+            - checkout_shallow:
+                checkout_depth: << parameters.shallow_checkout_depth >>
+      - when:
+          condition:
+            and:
+              - not: << parameters.shallow_checkout >>
+          steps:
+            - checkout
       - save_cache:
           key: << parameters.checkout_base_cache_key >>-{{ .Branch }}-{{ .Revision }}
           paths:
@@ -304,7 +338,7 @@ jobs:
   analyze_pr:
     executor: reactnativeandroid
     steps:
-      - checkout
+      - checkout_shallow
       - run_yarn
 
       - install_github_bot_deps
@@ -332,7 +366,7 @@ jobs:
   analyze_code:
     executor: reactnativeandroid
     steps:
-      - checkout
+      - checkout_shallow
       - setup_artifacts
       - run_yarn
 
@@ -384,7 +418,7 @@ jobs:
         default: false
     executor: << parameters.executor >>
     steps:
-      - checkout
+      - checkout_shallow
       - setup_artifacts
       - run_yarn
       - run:
@@ -542,7 +576,7 @@ jobs:
     environment:
       KOTLIN_HOME=third-party/kotlin
     steps:
-      - checkout
+      - checkout_shallow
       - setup_artifacts
       - run_yarn
 
@@ -601,7 +635,7 @@ jobs:
         type: boolean
         default: false
     steps:
-      - checkout
+      - checkout_shallow
       - setup_artifacts
       - run_yarn
 
@@ -856,7 +890,7 @@ jobs:
       - CI_BUILD_NUMBER: $CIRCLE_BUILD_NUM
       - CI_BUILD_URL: $CIRCLE_BUILD_URL
     steps:
-      - checkout
+      - checkout_shallow
       - setup_artifacts
       - run_yarn
       - run:
@@ -887,7 +921,7 @@ jobs:
             curl -sL https://deb.nodesource.com/setup_16.x | bash -
             apt install -y nodejs
             npm install --global yarn
-      - checkout
+      - checkout_shallow
       - run_yarn
       - run:
           name: Set up Hermes workspace and caching
@@ -1144,7 +1178,7 @@ jobs:
           command: |
             mkdir -p ~/.ssh
             echo '|1|If6MU203eXTaaWL678YEfWkVMrw=|kqLeIAyTy8pzpj8x8Ae4Fr8Mtlc= ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==' >> ~/.ssh/known_hosts
-      - checkout
+      - checkout_shallow
       - *attach_hermes_workspace
       - run:
           name: Copy HermesC binaries

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -897,8 +897,7 @@ jobs:
       - CI_BUILD_NUMBER: $CIRCLE_BUILD_NUM
       - CI_BUILD_URL: $CIRCLE_BUILD_URL
     steps:
-      - shallow_checkout:
-          checkout_depth: 12
+      - checkout
       - setup_artifacts
       - run_yarn
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,7 @@ commands:
         default: *shallow_checkout_depth
         type: integer
     steps:
-      - run: git checkout --depth << parameters.checkout_depth >>
+      - run: git checkout --depth << parameters.checkout_depth >> "$CIRCLE_REPOSITORY_URL" --branch "$CIRCLE_BRANCH"
 
   # Checkout with cache, on machines that are using Docker the cache is ignored
   checkout_code_with_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,7 +130,7 @@ commands:
           name: Add shhkey for github
           command: |
             mkdir ~/.ssh/known_hosts -p
-            ssh-keyscan -H github.com >> ~/.ssh/known_hosts
+            ssh-keyscan -H github.com >> ~/.ssh
       - run: git clone --depth << parameters.checkout_depth >> "$CIRCLE_REPOSITORY_URL" --branch "$CIRCLE_BRANCH"
 
   # Checkout with cache, on machines that are using Docker the cache is ignored

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,10 @@ commands:
         default: *shallow_checkout_depth
         type: integer
     steps:
-      - run: git clone --depth << parameters.checkout_depth >> "$CIRCLE_REPOSITORY_URL" --branch "$CIRCLE_BRANCH" -y
+      - run:
+        name: Add shhkey for github
+        command: ssh-keyscan -H github.com >> ~/.ssh/known_hosts
+      - run: git clone --depth << parameters.checkout_depth >> "$CIRCLE_REPOSITORY_URL" --branch "$CIRCLE_BRANCH"
 
   # Checkout with cache, on machines that are using Docker the cache is ignored
   checkout_code_with_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,10 +126,7 @@ commands:
         default: *shallow_checkout_depth
         type: integer
     steps:
-      - run: echo "$CIRCLE_REPOSITORY_URL" 
-      - run: echo "$CIRCLE_BRANCH"
-      - run: ls
-      - run: git checkout --depth << parameters.checkout_depth >> "$CIRCLE_REPOSITORY_URL" --branch "$CIRCLE_BRANCH"
+      - run: git clone --depth << parameters.checkout_depth >> "$CIRCLE_REPOSITORY_URL" --branch "$CIRCLE_BRANCH"
 
   # Checkout with cache, on machines that are using Docker the cache is ignored
   checkout_code_with_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,7 @@ commands:
         default: *shallow_checkout_depth
         type: integer
     steps:
-      - run: git clone --depth << parameters.checkout_depth >> "$CIRCLE_REPOSITORY_URL" --branch "$CIRCLE_BRANCH"
+      - run: git clone --depth << parameters.checkout_depth >> "$CIRCLE_REPOSITORY_URL" --branch "$CIRCLE_BRANCH" -y
 
   # Checkout with cache, on machines that are using Docker the cache is ignored
   checkout_code_with_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ executors:
 # -------------------------
 commands:
   # Shallow checkout
-  checkout_shallow:
+  shallow_checkout:
     parameters:
       checkout_depth:
         default: *shallow_checkout_depth
@@ -155,7 +155,7 @@ commands:
       - when:
           condition: << parameters.shallow_checkout >> 
           steps:
-            - checkout_shallow:
+            - shallow_checkout:
                 checkout_depth: << parameters.shallow_checkout_depth >>
       - when:
           condition:
@@ -340,7 +340,7 @@ jobs:
   analyze_pr:
     executor: reactnativeandroid
     steps:
-      - checkout_shallow
+      - shallow_checkout
       - run_yarn
 
       - install_github_bot_deps
@@ -368,7 +368,7 @@ jobs:
   analyze_code:
     executor: reactnativeandroid
     steps:
-      - checkout_shallow
+      - shallow_checkout
       - setup_artifacts
       - run_yarn
 
@@ -420,7 +420,7 @@ jobs:
         default: false
     executor: << parameters.executor >>
     steps:
-      - checkout_shallow
+      - shallow_checkout
       - setup_artifacts
       - run_yarn
       - run:
@@ -466,7 +466,7 @@ jobs:
       - REPORTS_DIR: "./reports/junit"
     steps:
       - checkout_code_with_cache:
-          checkout_shallow: true
+          shallow_checkout: true
       - setup_artifacts
       - setup_ruby
       - run:
@@ -579,7 +579,7 @@ jobs:
     environment:
       KOTLIN_HOME=third-party/kotlin
     steps:
-      - checkout_shallow
+      - shallow_checkout
       - setup_artifacts
       - run_yarn
 
@@ -638,7 +638,7 @@ jobs:
         type: boolean
         default: false
     steps:
-      - checkout_shallow
+      - shallow_checkout
       - setup_artifacts
       - run_yarn
 
@@ -697,7 +697,7 @@ jobs:
       - PROJECT_NAME: "AndroidTemplateProject"
     steps:
       - checkout_code_with_cache:
-          checkout_shallow: true
+          shallow_checkout: true
       - run_yarn
       - attach_workspace:
           at: .
@@ -726,7 +726,7 @@ jobs:
 
     steps:
       - checkout_code_with_cache:
-          checkout_shallow: true
+          shallow_checkout: true
       - run_yarn
       - attach_workspace:
           at: .
@@ -761,7 +761,7 @@ jobs:
     executor: reactnativeios
     steps:
       - checkout_code_with_cache:
-          checkout_shallow: true
+          shallow_checkout: true
       - run_yarn
       - *attach_hermes_workspace
 
@@ -819,7 +819,7 @@ jobs:
       - GRADLE_OPTS: -Dorg.gradle.daemon=false
     steps:
       - checkout_code_with_cache:
-          checkout_shallow: true
+          shallow_checkout: true
 
       - run:
           name: Install Node
@@ -897,7 +897,7 @@ jobs:
       - CI_BUILD_NUMBER: $CIRCLE_BUILD_NUM
       - CI_BUILD_URL: $CIRCLE_BUILD_URL
     steps:
-      - checkout_shallow
+      - shallow_checkout
       - setup_artifacts
       - run_yarn
       - run:
@@ -928,7 +928,7 @@ jobs:
             curl -sL https://deb.nodesource.com/setup_16.x | bash -
             apt install -y nodejs
             npm install --global yarn
-      - checkout_shallow
+      - shallow_checkout
       - run_yarn
       - run:
           name: Set up Hermes workspace and caching
@@ -1014,7 +1014,7 @@ jobs:
       - HERMES_WS_DIR: *hermes_workspace_root
     steps:
       - checkout_code_with_cache:
-          checkout_shallow: true
+          shallow_checkout: true
       - *attach_hermes_workspace
       - restore_cache:
           key: *hermes_cache_key
@@ -1163,7 +1163,7 @@ jobs:
     executor: reactnativeios
     steps:
       - checkout_code_with_cache:
-          checkout_shallow: true
+          shallow_checkout: true
       - run_yarn
       - add_ssh_keys:
           fingerprints:
@@ -1187,7 +1187,7 @@ jobs:
           command: |
             mkdir -p ~/.ssh
             echo '|1|If6MU203eXTaaWL678YEfWkVMrw=|kqLeIAyTy8pzpj8x8Ae4Fr8Mtlc= ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==' >> ~/.ssh/known_hosts
-      - checkout_shallow
+      - shallow_checkout
       - *attach_hermes_workspace
       - run:
           name: Copy HermesC binaries

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ references:
   #        Single Use Environmental Variables
   # -------------------------
   envs:
-    shallow_checkout_depth: &shallow_checkout_depth 2
+    shallow_checkout_depth: &shallow_checkout_depth 16
 
   # -------------------------
   #        Cache Key Anchors

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,13 +131,13 @@ commands:
           command: |
             mkdir ~/.ssh -p
             ssh-keyscan -H github.com >> ~/.ssh/known_hosts
+      - run: git clone --depth << parameters.checkout_depth >> "$CIRCLE_REPOSITORY_URL" --branch "$CIRCLE_BRANCH"
       - run:
           name: Test
           command: |
             ls
-             git status
-             git branch
-      - run: git clone --depth << parameters.checkout_depth >> "$CIRCLE_REPOSITORY_URL" --branch "$CIRCLE_BRANCH"
+            git status
+            git branch
 
   # Checkout with cache, on machines that are using Docker the cache is ignored
   checkout_code_with_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ references:
   #        Single Use Environmental Variables
   # -------------------------
   envs:
-    shallow_checkout_depth: &shallow_checkout_depth 8
+    shallow_checkout_depth: &shallow_checkout_depth 4
 
   # -------------------------
   #        Cache Key Anchors
@@ -897,7 +897,8 @@ jobs:
       - CI_BUILD_NUMBER: $CIRCLE_BUILD_NUM
       - CI_BUILD_URL: $CIRCLE_BUILD_URL
     steps:
-      - shallow_checkout
+      - shallow_checkout:
+        checkout_depth: 12
       - setup_artifacts
       - run_yarn
       - run:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

There's no need to checkout the whole repo, shallow cloning should work fine enough to reduce build time.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

- Add command `checkout_shallow` with the default depth of 2.
- Modified `checkout_code_with_cache` to enable shallow cloning, defaults to full clone.
<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[CATEGORY] [TYPE] - Message

## Test Plan

Runs tests by replacing all `checkout` with `checkout_shallow`.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
