### PR TITLE
Do not use kwargs which are not known in Buck OSS

### DIFF
--- a/tools/build_defs/oss/rn_defs.bzl
+++ b/tools/build_defs/oss/rn_defs.bzl
@@ -113,8 +113,6 @@ def rn_xplat_cxx_library(
     # OSS builds cannot have platform-specific flags here, so these are the same
     # for all platforms.
     kwargs["compiler_flags"] = kwargs.get("compiler_flags", [])
-    kwargs["fbobjc_compiler_flags"] = kwargs.get("fbobjc_compiler_flags", [])
-    kwargs["fbandroid_compiler_flags"] = kwargs.get("fbandroid_compiler_flags", [])
 
     kwargs["compiler_flags"] = ["-std=c++17"] + kwargs["compiler_flags"]
     kwargs["compiler_flags"] = ["-Wall"] + kwargs["compiler_flags"]
@@ -124,10 +122,6 @@ def rn_xplat_cxx_library(
     # be supported by other compilers (e.g. MSVC)
     if compiler_flags_pedantic:
         kwargs["compiler_flags"] = ["-Wpedantic"] + kwargs["compiler_flags"]
-
-        # Do not enable the flag for Apple in targets which also build Objective C++
-        if any([file.endswith(".mm") for file in (kwargs.get("srcs", []) + kwargs.get("ios_srcs", []))]):
-            kwargs["fbobjc_compiler_flags"] = ["-Wno-pedantic"] + kwargs["fbobjc_compiler_flags"]
     else:
         kwargs["compiler_flags"] = ["-Wno-pedantic"] + kwargs["compiler_flags"]
 


### PR DESCRIPTION
## Summary

This is an attempt to fix the `test_buck` CI after the land of https://github.com/facebook/react-native/commit/063c2b4668b279ccbca639f98f7a0a5c4d7c5690

There were references to internal args that are causing Buck OSS to fail. I'm removing them all.

## Changelog

[Internal] - Do not use kwargs which are not known in Buck OSS

## Test Plan

If CI is green, we can merge this 👍 