### PR TITLE
Update ruby codegen to cleanup build folder.

### DIFF
--- a/scripts/cocoapods/__tests__/test_utils/FileUtilsMock.rb
+++ b/scripts/cocoapods/__tests__/test_utils/FileUtilsMock.rb
@@ -1,0 +1,39 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+module FileUtils
+
+
+    class FileUtilsStorage
+        @@RMRF_INVOCATION_COUNT = 0
+        @@RMRF_PATHS = []
+
+        def self.rmrf_invocation_count
+            return @@RMRF_INVOCATION_COUNT
+        end
+
+        def self.increase_rmrfi_invocation_count
+            @@RMRF_INVOCATION_COUNT += 1
+        end
+
+        def self.rmrf_paths
+            return @@RMRF_PATHS
+        end
+
+        def self.push_rmrf_path(path)
+            @@RMRF_PATHS.push(path)
+        end
+
+        def self.reset
+            @@RMRF_INVOCATION_COUNT = 0
+            @@RMRF_PATHS = []
+        end
+    end
+
+    def self.rm_rf(path)
+        FileUtilsStorage.push_rmrf_path(path)
+        FileUtilsStorage.increase_rmrfi_invocation_count
+    end
+end

--- a/scripts/cocoapods/codegen.rb
+++ b/scripts/cocoapods/codegen.rb
@@ -79,6 +79,7 @@ def run_codegen!(
   folly_version: '2021.07.22.00',
   codegen_utils: CodegenUtils.new()
   )
+
   if new_arch_enabled
     codegen_utils.use_react_native_codegen_discovery!(
       disable_codegen,

--- a/scripts/cocoapods/codegen_utils.rb
+++ b/scripts/cocoapods/codegen_utils.rb
@@ -280,4 +280,25 @@ class CodegenUtils
 
       CodegenUtils.set_react_codegen_discovery_done(true)
     end
+
+    @@CLEANUP_DONE = false
+
+    def self.set_cleanup_done(newValue)
+      @@CLEANUP_DONE = newValue
+    end
+
+    def self.cleanup_done
+      return @@CLEANUP_DONE
+    end
+
+    def self.clean_up_build_folder(app_path, codegen_dir)
+      return if CodegenUtils.cleanup_done()
+      CodegenUtils.set_cleanup_done(true)
+
+      codegen_path = File.join(app_path, codegen_dir)
+      return if !Dir.exist?(codegen_path)
+
+      FileUtils.rm_rf(Dir.glob("#{codegen_path}/*"))
+      CodegenUtils.set_cleanup_done(true)
+    end
 end

--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -43,6 +43,8 @@ def use_react_native! (
   app_path: '..',
   config_file_dir: '')
 
+  CodegenUtils.clean_up_build_folder(app_path, $CODEGEN_OUTPUT_DIR)
+
   prefix = path
 
   # The version of folly that must be used


### PR DESCRIPTION
Summary:
This Diff cleans up the codegen folder for iOS when we install the pods. This is useful to start from a clean situation. The codegen runs after this step and we make sure that the file system is clean

## Changelog
[iOS][Changed] - Cleanup codegen build folder before installing the pods

Differential Revision: D38657027

