### PR TITLE
Enable pedantic warnings in C++ podspecs

### DIFF
--- a/ReactCommon/React-Fabric.podspec
+++ b/ReactCommon/React-Fabric.podspec
@@ -16,7 +16,7 @@ else
   source[:tag] = "v#{version}"
 end
 
-folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
+folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32 -Wno-gnu-zero-variadic-macro-arguments'
 folly_version = '2021.07.22.00'
 folly_dep_name = 'RCT-Folly/Fabric'
 boost_compiler_flags = '-Wno-documentation'
@@ -315,7 +315,8 @@ Pod::Spec.new do |s|
     ss.source_files         = "react/renderer/leakchecker/**/*.{cpp,h}"
     ss.exclude_files        = "react/renderer/leakchecker/tests"
     ss.header_dir           = "react/renderer/leakchecker"
-    ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
+    ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"",
+                                "GCC_WARN_PEDANTIC" => "YES" }
   end
 
   s.subspec "runtimescheduler" do |ss|
@@ -324,13 +325,14 @@ Pod::Spec.new do |s|
     ss.source_files         = "react/renderer/runtimescheduler/**/*.{cpp,h}"
     ss.exclude_files        = "react/renderer/runtimescheduler/tests"
     ss.header_dir           = "react/renderer/runtimescheduler"
-    ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
+    ss.pod_target_xcconfig  = {"HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"",
+                               "GCC_WARN_PEDANTIC" => "YES" }
   end
 
   s.subspec "utils" do |ss|
     ss.source_files         = "react/utils/*.{m,mm,cpp,h}"
     ss.header_dir           = "react/utils"
-    ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
+    ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\""}
   end
 
 end

--- a/ReactCommon/React-bridging.podspec
+++ b/ReactCommon/React-bridging.podspec
@@ -35,7 +35,8 @@ Pod::Spec.new do |s|
   s.compiler_flags         = folly_compiler_flags
   s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/RCT-Folly\"",
                                "USE_HEADERMAP" => "YES",
-                               "CLANG_CXX_LANGUAGE_STANDARD" => "c++17" }
+                               "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",
+                               "GCC_WARN_PEDANTIC" => "YES" }
 
   s.dependency "RCT-Folly", folly_version
   s.dependency "React-jsi", version

--- a/ReactCommon/ReactCommon.podspec
+++ b/ReactCommon/ReactCommon.podspec
@@ -16,7 +16,7 @@ else
   source[:tag] = "v#{version}"
 end
 
-folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
+folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32 -Wno-gnu-zero-variadic-macro-arguments'
 folly_version = '2021.07.22.00'
 boost_compiler_flags = '-Wno-documentation'
 
@@ -34,7 +34,8 @@ Pod::Spec.new do |s|
   s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
   s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/Headers/Private/React-Core\" \"$(PODS_ROOT)/Headers/Private/React-bridging/react/bridging\" \"$(PODS_CONFIGURATION_BUILD_DIR)/React-bridging/react_bridging.framework/Headers\"",
                                "USE_HEADERMAP" => "YES",
-                               "CLANG_CXX_LANGUAGE_STANDARD" => "c++17" }
+                               "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",
+                               "GCC_WARN_PEDANTIC" => "YES" }
 
   # TODO (T48588859): Restructure this target to align with dir structure: "react/nativemodule/..."
   # Note: Update this only when ready to minimize breaking changes.

--- a/ReactCommon/butter/CMakeLists.txt
+++ b/ReactCommon/butter/CMakeLists.txt
@@ -11,7 +11,9 @@ add_compile_options(
         -fexceptions
         -frtti
         -std=c++17
-        -Wall)
+        -Wall
+        -Wpedantic
+        -Wno-gnu-zero-variadic-macro-arguments)
 
 add_library(butter INTERFACE)
 

--- a/ReactCommon/callinvoker/CMakeLists.txt
+++ b/ReactCommon/callinvoker/CMakeLists.txt
@@ -6,7 +6,13 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-fexceptions -frtti -std=c++17 -Wall)
+add_compile_options(
+        -fexceptions
+        -frtti
+        -std=c++17
+        -Wall
+        -Wpedantic
+        -Wno-gnu-zero-variadic-macro-arguments)
 
 add_library(callinvoker INTERFACE)
 

--- a/ReactCommon/react/bridging/CMakeLists.txt
+++ b/ReactCommon/react/bridging/CMakeLists.txt
@@ -6,7 +6,14 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-fexceptions -frtti -std=c++17 -Wall -DLOG_TAG=\"ReactNative\")
+add_compile_options(
+        -fexceptions
+        -frtti
+        -std=c++17
+        -Wall
+        -Wpedantic
+        -Wno-gnu-zero-variadic-macro-arguments
+        -DLOG_TAG=\"ReactNative\")
 
 file(GLOB react_bridging_SRC CONFIGURE_DEPENDS *.cpp)
 

--- a/ReactCommon/react/config/CMakeLists.txt
+++ b/ReactCommon/react/config/CMakeLists.txt
@@ -11,6 +11,8 @@ add_compile_options(
         -frtti
         -std=c++17
         -Wall
+        -Wpedantic
+        -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 
 file(GLOB react_config_SRC CONFIGURE_DEPENDS *.cpp)

--- a/ReactCommon/react/debug/CMakeLists.txt
+++ b/ReactCommon/react/debug/CMakeLists.txt
@@ -11,6 +11,8 @@ add_compile_options(
         -frtti
         -std=c++17
         -Wall
+        -Wpedantic
+        -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 
 

--- a/ReactCommon/react/nativemodule/core/CMakeLists.txt
+++ b/ReactCommon/react/nativemodule/core/CMakeLists.txt
@@ -6,7 +6,14 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-fexceptions -frtti -std=c++17 -Wall -DLOG_TAG=\"ReactNative\")
+add_compile_options(
+        -fexceptions
+        -frtti
+        -std=c++17
+        -Wall
+        -Wpedantic
+        -Wno-gnu-zero-variadic-macro-arguments
+        -DLOG_TAG=\"ReactNative\")
 
 
 file(GLOB react_nativemodule_core_SRC CONFIGURE_DEPENDS

--- a/ReactCommon/react/nativemodule/samples/platform/android/CMakeLists.txt
+++ b/ReactCommon/react/nativemodule/samples/platform/android/CMakeLists.txt
@@ -6,7 +6,14 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-fexceptions -frtti -std=c++17 -Wall -DLOG_TAG=\"ReactNative\")
+add_compile_options(
+        -fexceptions
+        -frtti
+        -std=c++17
+        -Wall
+        -Wpedantic
+        -Wno-gnu-zero-variadic-macro-arguments
+        -DLOG_TAG=\"ReactNative\")
 
 file(GLOB sampleturbomodule_SRC CONFIGURE_DEPENDS ReactCommon/*.cpp)
 add_library(sampleturbomodule STATIC ${sampleturbomodule_SRC})

--- a/ReactCommon/react/renderer/animations/CMakeLists.txt
+++ b/ReactCommon/react/renderer/animations/CMakeLists.txt
@@ -6,7 +6,14 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-fexceptions -frtti -std=c++17 -Wall -DLOG_TAG=\"Fabric\")
+add_compile_options(
+        -fexceptions
+        -frtti
+        -std=c++17
+        -Wall
+        -Wpedantic
+        -Wno-gnu-zero-variadic-macro-arguments
+        -DLOG_TAG=\"Fabric\")
 
 file(GLOB react_render_animations_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(react_render_animations SHARED ${react_render_animations_SRC})

--- a/ReactCommon/react/renderer/attributedstring/CMakeLists.txt
+++ b/ReactCommon/react/renderer/attributedstring/CMakeLists.txt
@@ -6,7 +6,14 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-fexceptions -frtti -std=c++17 -Wall -DLOG_TAG=\"Fabric\")
+add_compile_options(
+        -fexceptions
+        -frtti
+        -std=c++17
+        -Wall
+        -Wpedantic
+        -Wno-gnu-zero-variadic-macro-arguments
+        -DLOG_TAG=\"Fabric\")
 
 file(GLOB react_render_attributedstring_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(react_render_attributedstring SHARED ${react_render_attributedstring_SRC})

--- a/ReactCommon/react/renderer/componentregistry/CMakeLists.txt
+++ b/ReactCommon/react/renderer/componentregistry/CMakeLists.txt
@@ -6,7 +6,14 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-fexceptions -frtti -std=c++17 -Wall -DLOG_TAG=\"Fabric\")
+add_compile_options(
+        -fexceptions
+        -frtti
+        -std=c++17
+        -Wall
+        -Wpedantic
+        -Wno-gnu-zero-variadic-macro-arguments
+        -DLOG_TAG=\"Fabric\")
 
 file(GLOB react_render_componentregistry_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(react_render_componentregistry SHARED ${react_render_componentregistry_SRC})

--- a/ReactCommon/react/renderer/componentregistry/native/CMakeLists.txt
+++ b/ReactCommon/react/renderer/componentregistry/native/CMakeLists.txt
@@ -6,7 +6,14 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-fexceptions -frtti -std=c++17 -Wall -DLOG_TAG=\"Fabric\")
+add_compile_options(
+        -fexceptions
+        -frtti
+        -std=c++17
+        -Wall
+        -Wpedantic
+        -Wno-gnu-zero-variadic-macro-arguments
+        -DLOG_TAG=\"Fabric\")
 
 file(GLOB rrc_native_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(rrc_native SHARED ${rrc_native_SRC})

--- a/ReactCommon/react/renderer/components/image/CMakeLists.txt
+++ b/ReactCommon/react/renderer/components/image/CMakeLists.txt
@@ -6,7 +6,14 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-fexceptions -frtti -std=c++17 -Wall -DLOG_TAG=\"Fabric\")
+add_compile_options(
+        -fexceptions
+        -frtti
+        -std=c++17
+        -Wall
+        -Wpedantic
+        -Wno-gnu-zero-variadic-macro-arguments
+        -DLOG_TAG=\"Fabric\")
 
 file(GLOB rrc_image_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(rrc_image SHARED ${rrc_image_SRC})

--- a/ReactCommon/react/renderer/components/modal/CMakeLists.txt
+++ b/ReactCommon/react/renderer/components/modal/CMakeLists.txt
@@ -6,7 +6,14 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-fexceptions -frtti -std=c++17 -Wall -DLOG_TAG=\"Fabric\")
+add_compile_options(
+        -fexceptions
+        -frtti
+        -std=c++17
+        -Wall
+        -Wpedantic
+        -Wno-gnu-zero-variadic-macro-arguments
+        -DLOG_TAG=\"Fabric\")
 
 file(GLOB rrc_modal_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(rrc_modal STATIC ${rrc_modal_SRC})

--- a/ReactCommon/react/renderer/components/progressbar/CMakeLists.txt
+++ b/ReactCommon/react/renderer/components/progressbar/CMakeLists.txt
@@ -6,7 +6,14 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-fexceptions -frtti -std=c++17 -Wall -DLOG_TAG=\"Fabric\")
+add_compile_options(
+        -fexceptions
+        -frtti
+        -std=c++17
+        -Wall
+        -Wpedantic
+        -Wno-gnu-zero-variadic-macro-arguments
+        -DLOG_TAG=\"Fabric\")
 
 file(GLOB rrc_progressbar_SRC CONFIGURE_DEPENDS android/react/renderer/components/progressbar/*.cpp)
 add_library(rrc_progressbar STATIC ${rrc_progressbar_SRC})

--- a/ReactCommon/react/renderer/components/root/CMakeLists.txt
+++ b/ReactCommon/react/renderer/components/root/CMakeLists.txt
@@ -6,7 +6,14 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-fexceptions -frtti -std=c++17 -Wall -DLOG_TAG=\"Fabric\")
+add_compile_options(
+        -fexceptions
+        -frtti
+        -std=c++17
+        -Wall
+        -Wpedantic
+        -Wno-gnu-zero-variadic-macro-arguments
+        -DLOG_TAG=\"Fabric\")
 
 file(GLOB rrc_root_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(rrc_root SHARED ${rrc_root_SRC})

--- a/ReactCommon/react/renderer/components/scrollview/CMakeLists.txt
+++ b/ReactCommon/react/renderer/components/scrollview/CMakeLists.txt
@@ -6,7 +6,14 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-fexceptions -frtti -std=c++17 -Wall -DLOG_TAG=\"Fabric\")
+add_compile_options(
+        -fexceptions
+        -frtti
+        -std=c++17
+        -Wall
+        -Wpedantic
+        -Wno-gnu-zero-variadic-macro-arguments
+        -DLOG_TAG=\"Fabric\")
 
 file(GLOB rrc_scrollview_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(rrc_scrollview SHARED ${rrc_scrollview_SRC})

--- a/ReactCommon/react/renderer/components/slider/CMakeLists.txt
+++ b/ReactCommon/react/renderer/components/slider/CMakeLists.txt
@@ -6,7 +6,14 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-fexceptions -frtti -std=c++17 -Wall -DLOG_TAG=\"Fabric\")
+add_compile_options(
+        -fexceptions
+        -frtti
+        -std=c++17
+        -Wall
+        -Wpedantic
+        -Wno-gnu-zero-variadic-macro-arguments
+        -DLOG_TAG=\"Fabric\")
 
 file(GLOB rrc_slider_SRC CONFIGURE_DEPENDS *.cpp platform/android/react/renderer/components/slider/*.cpp)
 add_library(rrc_slider STATIC ${rrc_slider_SRC})

--- a/ReactCommon/react/renderer/components/switch/CMakeLists.txt
+++ b/ReactCommon/react/renderer/components/switch/CMakeLists.txt
@@ -41,4 +41,6 @@ target_compile_options(
         -frtti
         -std=c++17
         -Wall
+        -Wpedantic
+        -Wno-gnu-zero-variadic-macro-arguments
 )

--- a/ReactCommon/react/renderer/components/text/CMakeLists.txt
+++ b/ReactCommon/react/renderer/components/text/CMakeLists.txt
@@ -6,7 +6,14 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-fexceptions -frtti -std=c++17 -Wall -DLOG_TAG=\"Fabric\")
+add_compile_options(
+        -fexceptions
+        -frtti
+        -std=c++17
+        -Wall
+        -Wpedantic
+        -Wno-gnu-zero-variadic-macro-arguments
+        -DLOG_TAG=\"Fabric\")
 
 file(GLOB rrc_text_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(rrc_text SHARED ${rrc_text_SRC})

--- a/ReactCommon/react/renderer/components/textinput/CMakeLists.txt
+++ b/ReactCommon/react/renderer/components/textinput/CMakeLists.txt
@@ -6,7 +6,14 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-fexceptions -frtti -std=c++17 -Wall -DLOG_TAG=\"Fabric\")
+add_compile_options(
+        -fexceptions
+        -frtti
+        -std=c++17
+        -Wall
+        -Wpedantic
+        -Wno-gnu-zero-variadic-macro-arguments
+        -DLOG_TAG=\"Fabric\")
 
 file(GLOB rrc_textinput_SRC CONFIGURE_DEPENDS androidtextinput/react/renderer/components/androidtextinput/*.cpp)
 add_library(rrc_textinput SHARED ${rrc_textinput_SRC})

--- a/ReactCommon/react/renderer/components/unimplementedview/CMakeLists.txt
+++ b/ReactCommon/react/renderer/components/unimplementedview/CMakeLists.txt
@@ -6,7 +6,14 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-fexceptions -frtti -std=c++17 -Wall -DLOG_TAG=\"Fabric\")
+add_compile_options(
+        -fexceptions
+        -frtti
+        -std=c++17
+        -Wall
+        -Wpedantic
+        -Wno-gnu-zero-variadic-macro-arguments
+        -DLOG_TAG=\"Fabric\")
 
 file(GLOB rrc_unimplementedview_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(rrc_unimplementedview SHARED ${rrc_unimplementedview_SRC})

--- a/ReactCommon/react/renderer/components/view/CMakeLists.txt
+++ b/ReactCommon/react/renderer/components/view/CMakeLists.txt
@@ -6,7 +6,14 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-fexceptions -frtti -std=c++17 -Wall -DLOG_TAG=\"Fabric\")
+add_compile_options(
+        -fexceptions
+        -frtti
+        -std=c++17
+        -Wall
+        -Wpedantic
+        -Wno-gnu-zero-variadic-macro-arguments
+        -DLOG_TAG=\"Fabric\")
 
 file(GLOB rrc_view_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(rrc_view SHARED ${rrc_view_SRC})

--- a/ReactCommon/react/renderer/core/CMakeLists.txt
+++ b/ReactCommon/react/renderer/core/CMakeLists.txt
@@ -6,7 +6,14 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-fexceptions -frtti -std=c++17 -Wall -DLOG_TAG=\"Fabric\")
+add_compile_options(
+        -fexceptions
+        -frtti
+        -std=c++17
+        -Wall
+        -Wpedantic
+        -Wno-gnu-zero-variadic-macro-arguments
+        -DLOG_TAG=\"Fabric\")
 
 file(GLOB react_render_core_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(react_render_core SHARED ${react_render_core_SRC})

--- a/ReactCommon/react/renderer/debug/CMakeLists.txt
+++ b/ReactCommon/react/renderer/debug/CMakeLists.txt
@@ -6,7 +6,14 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-fexceptions -frtti -std=c++17 -Wall -DLOG_TAG=\"Fabric\")
+add_compile_options(
+        -fexceptions
+        -frtti
+        -std=c++17
+        -Wall
+        -Wpedantic
+        -Wno-gnu-zero-variadic-macro-arguments
+        -DLOG_TAG=\"Fabric\")
 
 file(GLOB react_render_debug_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(react_render_debug SHARED ${react_render_debug_SRC})

--- a/ReactCommon/react/renderer/graphics/CMakeLists.txt
+++ b/ReactCommon/react/renderer/graphics/CMakeLists.txt
@@ -6,7 +6,14 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-fexceptions -frtti -std=c++17 -Wall -DLOG_TAG=\"Fabric\")
+add_compile_options(
+        -fexceptions
+        -frtti
+        -std=c++17
+        -Wall
+        -Wpedantic
+        -Wno-gnu-zero-variadic-macro-arguments
+        -DLOG_TAG=\"Fabric\")
 
 file(GLOB react_render_graphics_SRC CONFIGURE_DEPENDS
         *.cpp

--- a/ReactCommon/react/renderer/imagemanager/CMakeLists.txt
+++ b/ReactCommon/react/renderer/imagemanager/CMakeLists.txt
@@ -6,7 +6,14 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-fexceptions -frtti -std=c++17 -Wall -DLOG_TAG=\"Fabric\")
+add_compile_options(
+        -fexceptions
+        -frtti
+        -std=c++17
+        -Wall
+        -Wpedantic
+        -Wno-gnu-zero-variadic-macro-arguments
+        -DLOG_TAG=\"Fabric\")
 
 file(GLOB react_render_imagemanager_SRC CONFIGURE_DEPENDS
         *.cpp

--- a/ReactCommon/react/renderer/leakchecker/CMakeLists.txt
+++ b/ReactCommon/react/renderer/leakchecker/CMakeLists.txt
@@ -6,7 +6,14 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-fexceptions -frtti -std=c++17 -Wall -DLOG_TAG=\"Fabric\")
+add_compile_options(
+        -fexceptions
+        -frtti
+        -std=c++17
+        -Wall
+        -Wpedantic
+        -Wno-gnu-zero-variadic-macro-arguments
+        -DLOG_TAG=\"Fabric\")
 
 file(GLOB react_render_leakchecker_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(react_render_leakchecker SHARED ${react_render_leakchecker_SRC})

--- a/ReactCommon/react/renderer/mapbuffer/CMakeLists.txt
+++ b/ReactCommon/react/renderer/mapbuffer/CMakeLists.txt
@@ -6,7 +6,14 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-fexceptions -frtti -std=c++17 -Wall -DLOG_TAG=\"Fabric\")
+add_compile_options(
+        -fexceptions
+        -frtti
+        -std=c++17
+        -Wall
+        -Wpedantic
+        -Wno-gnu-zero-variadic-macro-arguments
+        -DLOG_TAG=\"Fabric\")
 
 file(GLOB react_render_mapbuffer_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(react_render_mapbuffer SHARED ${react_render_mapbuffer_SRC})

--- a/ReactCommon/react/renderer/mounting/CMakeLists.txt
+++ b/ReactCommon/react/renderer/mounting/CMakeLists.txt
@@ -6,7 +6,14 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-fexceptions -frtti -std=c++17 -Wall -DLOG_TAG=\"Fabric\")
+add_compile_options(
+        -fexceptions
+        -frtti
+        -std=c++17
+        -Wall
+        -Wpedantic
+        -Wno-gnu-zero-variadic-macro-arguments
+        -DLOG_TAG=\"Fabric\")
 
 file(GLOB react_render_mounting_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(react_render_mounting SHARED ${react_render_mounting_SRC})

--- a/ReactCommon/react/renderer/runtimescheduler/CMakeLists.txt
+++ b/ReactCommon/react/renderer/runtimescheduler/CMakeLists.txt
@@ -6,7 +6,14 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-fexceptions -frtti -std=c++17 -Wall -DLOG_TAG=\"Fabric\")
+add_compile_options(
+        -fexceptions
+        -frtti
+        -std=c++17
+        -Wall
+        -Wpedantic
+        -Wno-gnu-zero-variadic-macro-arguments
+        -DLOG_TAG=\"Fabric\")
 
 file(GLOB react_render_runtimescheduler_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(react_render_runtimescheduler SHARED ${react_render_runtimescheduler_SRC})

--- a/ReactCommon/react/renderer/scheduler/CMakeLists.txt
+++ b/ReactCommon/react/renderer/scheduler/CMakeLists.txt
@@ -6,7 +6,14 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-fexceptions -frtti -std=c++17 -Wall -DLOG_TAG=\"Fabric\")
+add_compile_options(
+        -fexceptions
+        -frtti
+        -std=c++17
+        -Wall
+        -Wpedantic
+        -Wno-gnu-zero-variadic-macro-arguments
+        -DLOG_TAG=\"Fabric\")
 
 file(GLOB react_render_scheduler_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(react_render_scheduler SHARED ${react_render_scheduler_SRC})

--- a/ReactCommon/react/renderer/telemetry/CMakeLists.txt
+++ b/ReactCommon/react/renderer/telemetry/CMakeLists.txt
@@ -6,7 +6,14 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-fexceptions -frtti -std=c++17 -Wall -DLOG_TAG=\"Fabric\")
+add_compile_options(
+        -fexceptions
+        -frtti
+        -std=c++17
+        -Wall
+        -Wpedantic
+        -Wno-gnu-zero-variadic-macro-arguments
+        -DLOG_TAG=\"Fabric\")
 
 file(GLOB react_render_telemetry_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(react_render_telemetry SHARED ${react_render_telemetry_SRC})

--- a/ReactCommon/react/renderer/templateprocessor/CMakeLists.txt
+++ b/ReactCommon/react/renderer/templateprocessor/CMakeLists.txt
@@ -6,7 +6,14 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-fexceptions -frtti -std=c++17 -Wall -DLOG_TAG=\"Fabric\")
+add_compile_options(
+        -fexceptions
+        -frtti
+        -std=c++17
+        -Wall
+        -Wpedantic
+        -Wno-gnu-zero-variadic-macro-arguments
+        -DLOG_TAG=\"Fabric\")
 
 file(GLOB react_render_templateprocessor_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(react_render_templateprocessor SHARED ${react_render_templateprocessor_SRC})

--- a/ReactCommon/react/renderer/textlayoutmanager/CMakeLists.txt
+++ b/ReactCommon/react/renderer/textlayoutmanager/CMakeLists.txt
@@ -6,7 +6,14 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-fexceptions -frtti -std=c++17 -Wall -DLOG_TAG=\"Fabric\")
+add_compile_options(
+        -fexceptions
+        -frtti
+        -std=c++17
+        -Wall
+        -Wpedantic
+        -Wno-gnu-zero-variadic-macro-arguments
+        -DLOG_TAG=\"Fabric\")
 
 file(GLOB react_render_textlayourmanager_SRC CONFIGURE_DEPENDS
         *.cpp

--- a/ReactCommon/react/renderer/uimanager/CMakeLists.txt
+++ b/ReactCommon/react/renderer/uimanager/CMakeLists.txt
@@ -6,7 +6,14 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-fexceptions -frtti -std=c++17 -Wall -DLOG_TAG=\"Fabric\")
+add_compile_options(
+        -fexceptions
+        -frtti
+        -std=c++17
+        -Wall
+        -Wpedantic
+        -Wno-gnu-zero-variadic-macro-arguments
+        -DLOG_TAG=\"Fabric\")
 
 file(GLOB react_render_uimanager_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(react_render_uimanager SHARED ${react_render_uimanager_SRC})

--- a/ReactCommon/react/utils/CMakeLists.txt
+++ b/ReactCommon/react/utils/CMakeLists.txt
@@ -11,6 +11,8 @@ add_compile_options(
         -frtti
         -std=c++17
         -Wall
+        -Wpedantic
+        -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 
 file(GLOB react_utils_SRC CONFIGURE_DEPENDS *.cpp *.mm)

--- a/ReactCommon/reactperflogger/CMakeLists.txt
+++ b/ReactCommon/reactperflogger/CMakeLists.txt
@@ -6,7 +6,13 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-fexceptions -frtti -std=c++17 -Wall)
+add_compile_options(
+        -fexceptions
+        -frtti
+        -std=c++17
+        -Wall
+        -Wpedantic
+        -Wno-gnu-zero-variadic-macro-arguments)
 
 file(GLOB reactperflogger_SRC CONFIGURE_DEPENDS reactperflogger/*.cpp)
 add_library(reactperflogger STATIC ${reactperflogger_SRC})

--- a/ReactCommon/runtimeexecutor/CMakeLists.txt
+++ b/ReactCommon/runtimeexecutor/CMakeLists.txt
@@ -6,7 +6,13 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-fexceptions -frtti -std=c++17 -Wall)
+add_compile_options(
+        -fexceptions
+        -frtti
+        -std=c++17
+        -Wall
+        -Wpedantic
+        -Wno-gnu-zero-variadic-macro-arguments)
 
 file(GLOB_RECURSE runtimeexecutor_SRC CONFIGURE_DEPENDS *.cpp *.h)
 

--- a/ReactCommon/yoga/CMakeLists.txt
+++ b/ReactCommon/yoga/CMakeLists.txt
@@ -6,7 +6,13 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-fexceptions -frtti -O3 -Wall)
+add_compile_options(
+        -fexceptions
+        -frtti
+        -O3
+        -Wall
+        -Wpedantic
+        -Wno-gnu-zero-variadic-macro-arguments)
 
 file(GLOB_RECURSE yogacore_SRC CONFIGURE_DEPENDS yoga/*.cpp)
 add_library(yogacore STATIC ${yogacore_SRC})


### PR DESCRIPTION
Summary:
Mirrors D38457812 (https://github.com/facebook/react-native/commit/063c2b4668b279ccbca639f98f7a0a5c4d7c5690) and D38632454, this enables pedantic warnings for iOS in OSS, so that the warning level matches the internal.

This is enabled through the `GCC_WARN_PEDANTIC` xcconfig flag (confusingly part of "Apple Clang - Warning Policies"), which controls whether "-pedantic" is passed.

Changelog:
[iOS][Changed] - Enable pedantic errors in C++ podspecs

Differential Revision: D38681644

