### PR TITLE
Make sure the template project name is `helloworld_appmodules`

### DIFF
--- a/template/android/app/src/main/jni/CMakeLists.txt
+++ b/template/android/app/src/main/jni/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.13)
 
 # Define the library name here.
-project(rntester_appmodules)
+project(helloworld_appmodules)
 
 # This file includes all the necessary to let you build your application with the New Architecture.
 include(${REACT_ANDROID_DIR}/cmake-utils/ReactNative-application.cmake)


### PR DESCRIPTION
## Summary

Make sure the new app template uses the correct project CMake project name: `helloworld_appmodules`, otherwise the app will fail to load the dynamic library.

This was a copy-n-paste error from RNTester.

## Changelog

[Internal] - Make sure the template project name is `helloworld_appmodules`

## Test Plan

Will test an app created with the New App template