### PR TITLE
Update template to gitignore `android/app/.cxx`

### DIFF
--- a/template/_gitignore
+++ b/template/_gitignore
@@ -30,6 +30,7 @@ build/
 local.properties
 *.iml
 *.hprof
+android/app/.cxx
 
 # node.js
 #

--- a/template/_gitignore
+++ b/template/_gitignore
@@ -30,7 +30,7 @@ build/
 local.properties
 *.iml
 *.hprof
-.cxx
+.cxx/
 
 # node.js
 #

--- a/template/_gitignore
+++ b/template/_gitignore
@@ -30,7 +30,7 @@ build/
 local.properties
 *.iml
 *.hprof
-android/app/.cxx
+.cxx
 
 # node.js
 #


### PR DESCRIPTION
## Summary

CMake gens running debug
- `android/app/.cxx/Debug/*`
- `android/app/.cxx/RelWithDebInfo/*`

Neither/nothing during release.

So probably want the 87 debug files untracked.

Follow-up: https://github.com/facebook/react-native/pull/34354

_macOS 13b, RN 0.70.0-rc.3_

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[Android] [Added] - Update template to gitignore `android/app/.cxx`

## Test Plan

Everything builds and runs as expected
