### PR TITLE
Fix test_buck by providing exported deps for textinput target

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/BUCK
@@ -1,4 +1,7 @@
-load("//tools/build_defs/oss:rn_defs.bzl", "YOGA_TARGET", "react_native_dep", "react_native_target", "rn_android_library")
+load("//tools/build_defs/oss:rn_defs.bzl", "IS_OSS_BUILD", "YOGA_TARGET", "react_native_android_toplevel_dep", "react_native_dep", "react_native_target", "rn_android_library",)
+
+# TODO(T115916830): Remove when Kotlin files are used in this module
+KOTLIN_STDLIB_DEPS = [react_native_android_toplevel_dep("third-party/kotlin:kotlin-stdlib")] if IS_OSS_BUILD else []
 
 rn_android_library(
     name = "textinput",
@@ -33,7 +36,7 @@ rn_android_library(
         react_native_target("java/com/facebook/react/common/mapbuffer:mapbuffer"),
         react_native_target("java/com/facebook/react/views/view:view"),
         react_native_target("java/com/facebook/react/config:config"),
-    ],
+    ] + KOTLIN_STDLIB_DEPS,
     exported_deps = [
         react_native_dep("third-party/android/androidx:appcompat"),
     ],


### PR DESCRIPTION
## Summary

This is an attempt to fix the broken `test_buck` as the `/textinput` target now needs to access the Kotlin stdlib dependencies

## Changelog

[Internal] - Fix test_buck by providing exported deps for textinput target

## Test Plan

Will wait for a CircleCI result