### PR TITLE
Fix codegen trying to parse `.d.ts` files

### DIFF
--- a/packages/react-native-codegen/src/cli/combine/combine-js-to-schema-cli.js
+++ b/packages/react-native-codegen/src/cli/combine/combine-js-to-schema-cli.js
@@ -27,7 +27,9 @@ function filterJSFile(file: string) {
     // NativeSampleTurboModule is for demo purpose. It should be added manually to the
     // app for now.
     !file.endsWith('NativeSampleTurboModule.js') &&
-    !file.includes('__tests')
+    !file.includes('__tests') &&
+    // Ignore TypeScript type declaration files.
+    !file.endsWith('.d.ts')
   );
 }
 


### PR DESCRIPTION
## Summary

With react-native 0.70-rc.3 and new arch, codegen may fail if it encounters `.d.ts` files because specs may appear to be unused.

## Changelog

[General] [Fixed] - Codegen should ignore `.d.ts` files

## Test Plan

See repro in https://github.com/microsoft/react-native-test-app/pull/1052. The build will fail without manually patching this in.

If you prefer to use your own test app, try adding [react-native-safe-area-context](https://github.com/th3rdwave/react-native-safe-area-context) as a dependency.