### PR TITLE
Install Fabric dependencies when the New Architecture is enabled

### DIFF
--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -45,6 +45,8 @@ def use_react_native! (
 
   CodegenUtils.clean_up_build_folder(app_path, $CODEGEN_OUTPUT_DIR)
 
+  fabric_enabled = fabric_enabled || new_arch_enabled
+
   prefix = path
 
   # The version of folly that must be used


### PR DESCRIPTION
Summary:
While testing some recent changes on a nightly, I realized that if we install the dependencies using RCT_NEW_ARCH_ENABLED=1 and we forget to change the flag in the Podfile, Fabric dependencies won't be installed.

However, Fabric is required by the New Architecture. This fix makes sure that we install Fabric dependencies when the New Architecture is enabled.

## Changelog
[iOS][Changed] Install Fabric dependencies when RCT_NEW_ARCH_ENABLED=1

Differential Revision: D38786978

