### PR TITLE
Blacklist sdks/hermes from Metro resolution

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -19,7 +19,7 @@ const getPolyfills = require('./rn-get-polyfills');
 module.exports = {
   resolver: {
     // $FlowFixMe[signature-verification-failure] Can't infer RegExp type.
-    blockList: /buck-out/,
+    blockList: [/buck-out/, /sdks\/hermes/],
     extraNodeModules: {
       'react-native': __dirname,
     },

--- a/packages/rn-tester/android/app/build.gradle
+++ b/packages/rn-tester/android/app/build.gradle
@@ -293,4 +293,9 @@ afterEvaluate {
     configureCMakeDebug.dependsOn(packageReactDebugNdkLibs)
     preHermesDebugBuild.dependsOn(packageReactDebugNdkLibs)
     preJscDebugBuild.dependsOn(packageReactDebugNdkLibs)
+
+    // As we're consuming Hermes from source, we want to make sure
+    // `hermesc` is built before we actually invoke the `emit*HermesResource` task
+    emitHermesDebugHermesResources.dependsOn(":ReactAndroid:hermes-engine:buildHermes")
+    emitHermesReleaseHermesResources.dependsOn(":ReactAndroid:hermes-engine:buildHermes")
 }


### PR DESCRIPTION
Summary:
This will unblock the RN `test_android` CI Job as currently two versions
of `hermes-parser` are picked up during package resolution.

Changelog:
[Internal] [Fixed] - Blacklist sdks/hermes from Metro resolution

Differential Revision: D38856931

