### PR TITLE
Make CircleCI run shallow clones of the React Native repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,10 +135,10 @@ commands:
           command: |
             git clone --branch main --no-checkout "$CIRCLE_REPOSITORY_URL" --single-branch .
             # Fetch from fork if applicable
-            if [ -z $CIRCLE_PR_NUMBER ] ; then
+            if [ -n "$CIRCLE_PR_NUMBER" ] ; then
               git fetch --force --depth 1 origin +refs/pull/$CIRCLE_PR_NUMBER/head:refs/remotes/origin/pull/$CIRCLE_PR_NUMBER
             fi
-            if [ -z $CIRCLE_BRANCH ] ; then
+            if [ -n "$CIRCLE_BRANCH" ] ; then
               git checkout --force -B "$CIRCLE_BRANCH" "$CIRCLE_SHA1"
             else
               git checkout main


### PR DESCRIPTION
This PR tries to fix the CI considering three use cases:
- CI running on main
- CI running on a branch in the React Native repo
- CI running on a PR opened from a fork

## Changelog
[General][Fixed] - Fix shallow cloning break on main.

Introduced in [#34438](https://github.com/facebook/react-native/pull/34438)
Failed to fix in [#34453](https://github.com/facebook/react-native/pull/34453)

Differential Revision: D38859731

