### PR TITLE
Remove unused variable `NODE_MODULES_DIR` from `build.gradle` in app template

### DIFF
--- a/template/android/app/build.gradle
+++ b/template/android/app/build.gradle
@@ -157,7 +157,6 @@ android {
                     arguments "-DPROJECT_BUILD_DIR=$buildDir",
                         "-DREACT_ANDROID_DIR=$rootDir/../node_modules/react-native/ReactAndroid",
                         "-DREACT_ANDROID_BUILD_DIR=$rootDir/../node_modules/react-native/ReactAndroid/build",
-                        "-DNODE_MODULES_DIR=$rootDir/../node_modules",
                         "-DTARGET_NAME=$dynamicLibraryName",
                         "-DANDROID_STL=c++_shared"
                 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

This PR removes unused variable `NODE_MODULES_DIR` passed from `build.gradle` to `CMakeLists.txt` which causes the following CMake warnings to appear in the logs:

```
> Task :app:configureCMakeDebug[arm64-v8a]
C/C++: debug|arm64-v8a :CMake Warning:
C/C++: debug|arm64-v8a :  Manually-specified variables were not used by the project:
C/C++: debug|arm64-v8a :    NODE_MODULES_DIR
```

First I changed the value of `NODE_MODULES_DIR` to some non-existent path (i.e. `-DNODE_MODULES_DIR=/foo/bar`) to confirm that the variable is indeed unused. Then I completely removed it from `arguments` and the CMake warning disappeared.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[Android] [Fixed] - Removed unused variable `NODE_MODULES_DIR` from `build.gradle` in app template

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

1. Create a new RN 0.70.0-rc.3 app from template with `npx react-native@next init RN070RC3 --version 0.70.0-rc.3`
2. Set `newArchEnabled=true` in `settings.gradle`
3. Open `android` directory in Android Studio
4. Run Gradle Sync
5. Build the app
6. Search for `NODE_MODULES_DIR` in the logs 
7. Notice the CMake warning
8. Remove the line from this PR
9. Build the app again
10. Search for `NODE_MODULES_DIR` in the logs
11. Confirm there are no occurrences
