### PR TITLE
feat: Add inputMode prop to TextInput component

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -155,6 +155,15 @@ export type KeyboardType =
   // Android-only
   | 'visible-password';
 
+export type InputMode =
+  | 'text'
+  | 'decimal'
+  | 'numeric'
+  | 'tel'
+  | 'search'
+  | 'email'
+  | 'url';
+
 export type ReturnKeyType =
   // Cross Platform
   | 'done'
@@ -566,6 +575,22 @@ export type Props = $ReadOnly<{|
    * - `send`
    */
   enterKeyHint?: ?enterKeyHintType,
+
+  /**
+   * `inputMode` works like the `inputmode` attribute in HTML, it determines which
+   * keyboard to open, e.g.`numeric` and has precedence over keyboardType
+   *
+   * Support the following values:
+   *
+   * - `text`
+   * - `decimal`
+   * - `numeric`
+   * - `tel`
+   * - `search`
+   * - `email`
+   * - `url`
+   */
+  inputMode?: ?InputMode,
 
   /**
    * Determines which keyboard to open, e.g.`numeric`.
@@ -1422,6 +1447,16 @@ const enterKeyHintToReturnTypeMap = {
   send: 'send',
 };
 
+const inputModeToKeyboardTypeMap = {
+  text: 'default',
+  decimal: 'decimal-pad',
+  numeric: 'number-pad',
+  tel: 'phone-pad',
+  search: Platform.OS === 'ios' ? 'web-search' : 'default',
+  email: 'email-address',
+  url: 'url',
+};
+
 const ExportedForwardRef: React.AbstractComponent<
   React.ElementConfig<typeof InternalTextInput>,
   React.ElementRef<HostComponent<mixed>> & ImperativeMethods,
@@ -1434,6 +1469,8 @@ const ExportedForwardRef: React.AbstractComponent<
     editable,
     enterKeyHint,
     returnKeyType,
+    inputMode,
+    keyboardType,
     ...restProps
   },
   forwardedRef: ReactRefSetter<
@@ -1448,6 +1485,9 @@ const ExportedForwardRef: React.AbstractComponent<
       editable={readOnly !== undefined ? !readOnly : editable}
       returnKeyType={
         enterKeyHint ? enterKeyHintToReturnTypeMap[enterKeyHint] : returnKeyType
+      }
+      keyboardType={
+        inputMode ? inputModeToKeyboardTypeMap[inputMode] : keyboardType
       }
       {...restProps}
       forwardedRef={forwardedRef}

--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -156,6 +156,7 @@ export type KeyboardType =
   | 'visible-password';
 
 export type InputMode =
+  | 'none'
   | 'text'
   | 'decimal'
   | 'numeric'
@@ -582,6 +583,7 @@ export type Props = $ReadOnly<{|
    *
    * Support the following values:
    *
+   * - `none`
    * - `text`
    * - `decimal`
    * - `numeric`
@@ -1448,6 +1450,7 @@ const enterKeyHintToReturnTypeMap = {
 };
 
 const inputModeToKeyboardTypeMap = {
+  none: 'default',
   text: 'default',
   decimal: 'decimal-pad',
   numeric: 'number-pad',

--- a/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
@@ -726,6 +726,7 @@ module.exports = ([
     name: 'inputModes',
     render: function (): React.Node {
       const inputMode = [
+        'none',
         'text',
         'decimal',
         'numeric',

--- a/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
@@ -722,6 +722,29 @@ module.exports = ([
     },
   },
   {
+    title: 'Input modes',
+    name: 'inputModes',
+    render: function (): React.Node {
+      const inputMode = [
+        'text',
+        'decimal',
+        'numeric',
+        'tel',
+        'search',
+        'email',
+        'url',
+      ];
+      const examples = inputMode.map(mode => {
+        return (
+          <WithLabel key={mode} label={mode}>
+            <TextInput inputMode={mode} style={styles.default} />
+          </WithLabel>
+        );
+      });
+      return <View>{examples}</View>;
+    },
+  },
+  {
     title: 'Blur on submit',
     render: function (): React.Element<any> {
       return <BlurOnSubmitExample />;


### PR DESCRIPTION
## Summary

This adds the `inputMode` prop to the TextInput component as requested on https://github.com/facebook/react-native/issues/34424, mapping web [inputMode types](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode) to equivalent [keyboardType](https://reactnative.dev/docs/textinput#keyboardtype) values.  This PR also updates RNTester TextInputExample in order to facilitate the manual QA.

### Caveats

~~This only adds support to `text`, `decimal`, `numeric`, `tel`, `search`, `email`, and `url` types.~~

#### `inputMode="none"`

**Currently mapped to `default` keyboard type.**
  
The main problem with this input mode is that it's not supported natively neither on Android or iOS. Android `TextView` does accept `none` as `android:inputType` but that makes the text not editable, which wouldn't really solve our problem. `UITextInput` on iOS on the other hand doesn't even have something similar to avoid displaying the virtual keyboard.

If we really want to add the support for `inputMode="none"` one interesting approach we could take is to do something similar to what WebKit has done (https://github.com/WebKit/WebKit/commit/3b5f0c8ecf9de23f79524ed02e290837ab8334cd). In order to achieve this behavior, they had to return a `UIView` with a bounds of `CGRectZero` as the inputView of the `WKContentView` when inputmode=none is present. 
~~I guess the real question here should be, do we really want to add this? Or perhaps should we just map `inputMode="none"` to `keyboardType="default"`~~

Android docs: https://developer.android.com/reference/android/widget/TextView#attr_android:inputType
iOS docs: https://developer.apple.com/documentation/uikit/uikeyboardtype?language=objc


#### `inputMode="search"` on Android

**Currently mapped to `default` keyboard type.**

 Android `TextView` does not offers any options like `UIKeyboardTypeWebSearch` on iOS to be used  as `search` with `android:inputType` and that's probably the reason why `keyboardType="web-search"` is iOS only. I checked how this is handled on the browser on my Android device and it seems that Chrome just uses the default keyboard, maybe we should do the same?

### Open questions

- ~~What should be done about `inputMode="none"`?~~ Add it and map it to `default` keyboard type.
- ~~Which keyboard should we show on Android when `inputMode="search"`?~~ Use the `default` keyboard the same way Chrome does

## Changelog


[General] [Added] - Add inputMode prop to TextInput component

## Test Plan 


1. Open the RNTester app and navigate to the TextInput page
2. Test the `TextInput` component through the `Input modes` section


https://user-images.githubusercontent.com/11707729/185691224-3042e828-a008-4bd0-bb3d-010a6a18dfd5.mov



