### PR TITLE
feat/build ios and macos in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1039,18 +1039,29 @@ jobs:
           steps:
             - run:
                 name: Build the Hermes iOS frameworks
+                #background: true
                 command: |
                   cd ~/react-native/sdks/hermes
-                  ./utils/build-ios-framework.sh
+                  ./utils/build-ios-framework.sh #> /tmp/hermes-ios.log
+
+                  #cd ~/react-native/scripts/circleci
+                  #./write-completion-file.sh iOS
             - run:
                 name: Build the Hermes Mac frameworks
+                #background: true
                 command: |
                   cd ~/react-native/sdks/hermes
-                  ./utils/build-mac-framework.sh
+                  ./utils/build-mac-framework.sh #> /tmp/hermes-macos.log
                   cp build_macosx/bin/hermesc /tmp/hermes/osx-bin/.
+
+                  #cd ~/react-native/scripts/circleci
+                  #./write-completion-file.sh MacOS
             - run:
                 name: Package the Hermes Apple frameworks
                 command: |
+                  #cd ~/react-native/scripts/circleci
+                  #./wait-for-completion.sh iOS MacOS
+
                   cd ~/react-native/sdks/hermes
                   . ./utils/build-apple-framework.sh
 

--- a/scripts/circleci/wait-for-completion.sh
+++ b/scripts/circleci/wait-for-completion.sh
@@ -1,0 +1,25 @@
+SECONDS=0
+
+MAX_WAIT=1800 # 30 mins
+
+function waitFor {
+  echo "Waiting for $1 to complete"
+  sleep 1
+  SECONDS=$(($SECONDS + 1))
+
+  if [[ SECONDS -ge MAX_WAIT ]]; then
+    echo "Build for $1 took too long to run"
+    exit 1
+  fi
+}
+
+
+while [[ ! -f "/tmp/build-completed-$1" ]];
+do
+  waitFor $1
+done
+SECONDS=0
+while [[ ! -f "/tmp/build-completed-$2" ]];
+do
+  waitFor $2
+done

--- a/scripts/circleci/write-completion-file.sh
+++ b/scripts/circleci/write-completion-file.sh
@@ -1,0 +1,1 @@
+touch /tmp/build-completed-$1


### PR DESCRIPTION
## Summary

Hermes iOS and Hermes MacOS are built sequentially and it could take up to 1 hour to build them both.
However, they may be built in parallel. This PR tries to run the two commands in background, running some code to wait for them to finish. This should halves the build time for Hermes.

## Changelog

[General] [Changed] - Run Hermes for iOS and Hermes for MacOS in parallel

## Test Plan

Hermes should build successfully and the CI should not get stuck.