### PR TITLE
[LogBox] Add `LogBox.isIgnoredLog()` for expo remote logging integration

### DIFF
--- a/Libraries/LogBox/LogBox.js
+++ b/Libraries/LogBox/LogBox.js
@@ -24,6 +24,7 @@ interface ILogBox {
   isInstalled(): boolean;
   ignoreLogs($ReadOnlyArray<IgnorePattern>): void;
   ignoreAllLogs(?boolean): void;
+  isIgnoredLog(...args: Array<mixed>): boolean;
   clearAllLogs(): void;
   addLog(log: LogData): void;
   addException(error: ExtendedExceptionData): void;
@@ -109,6 +110,18 @@ if (__DEV__) {
 
     ignoreAllLogs(value?: ?boolean): void {
       LogBoxData.setDisabled(value == null ? true : value);
+    },
+
+    isIgnoredLog(...args: Array<mixed>): boolean {
+      if (LogBoxData.isDisabled()) {
+        return true;
+      }
+
+      try {
+        const {message} = parseLogBoxLog(args);
+        return LogBoxData.isMessageIgnored(message.content);
+      } catch (err) {}
+      return false;
     },
 
     clearAllLogs(): void {
@@ -242,6 +255,10 @@ if (__DEV__) {
 
     ignoreAllLogs(value?: ?boolean): void {
       // Do nothing.
+    },
+
+    isIgnoredLog(...args: Array<mixed>): boolean {
+      return false;
     },
 
     clearAllLogs(): void {

--- a/Libraries/LogBox/__tests__/LogBox-test.js
+++ b/Libraries/LogBox/__tests__/LogBox-test.js
@@ -388,7 +388,9 @@ describe('LogBox', () => {
   it('`isIgnoredLog` returns true for ignored log', () => {
     jest.unmock('../Data/LogBoxData');
     LogBox.ignoreLogs(['ignoreMe']);
-    expect(LogBox.isIgnoredLog('ignoreMe: message', 'another argument')).toBe(true);
+    expect(LogBox.isIgnoredLog('ignoreMe: message', 'another argument')).toBe(
+      true,
+    );
   });
 
   it('`isIgnoredLog` returns true for regexp based ignored log', () => {
@@ -397,7 +399,6 @@ describe('LogBox', () => {
     expect(LogBox.isIgnoredLog('ignoreMe')).toBe(true);
     expect(LogBox.isIgnoredLog('ignore123Me')).toBe(true);
   });
-
 
   it('`isIgnoredLog` returns true for any messages when `ignoreAllLogs` was called', () => {
     jest.unmock('../Data/LogBoxData');
@@ -408,7 +409,9 @@ describe('LogBox', () => {
   it('`isIgnoredLog` returns false for non-matched ignored log', () => {
     jest.unmock('../Data/LogBoxData');
     LogBox.ignoreLogs(['ignoreMe']);
-    expect(LogBox.isIgnoredLog('showMe: message', 'another argument')).toBe(false);
+    expect(LogBox.isIgnoredLog('showMe: message', 'another argument')).toBe(
+      false,
+    );
   });
 
   it('`isIgnoredLog` returns false when throwing exception from log parser.', () => {

--- a/Libraries/LogBox/__tests__/LogBox-test.js
+++ b/Libraries/LogBox/__tests__/LogBox-test.js
@@ -384,4 +384,43 @@ describe('LogBox', () => {
       'Custom: after installing for the second time',
     );
   });
+
+  it('`isIgnoredLog` returns true for ignored log', () => {
+    jest.unmock('../Data/LogBoxData');
+    LogBox.ignoreLogs(['ignoreMe']);
+    expect(LogBox.isIgnoredLog('ignoreMe: message', 'another argument')).toBe(true);
+  });
+
+  it('`isIgnoredLog` returns true for regexp based ignored log', () => {
+    jest.unmock('../Data/LogBoxData');
+    LogBox.ignoreLogs([/ignore\d*Me/]);
+    expect(LogBox.isIgnoredLog('ignoreMe')).toBe(true);
+    expect(LogBox.isIgnoredLog('ignore123Me')).toBe(true);
+  });
+
+
+  it('`isIgnoredLog` returns true for any messages when `ignoreAllLogs` was called', () => {
+    jest.unmock('../Data/LogBoxData');
+    LogBox.ignoreAllLogs();
+    expect(LogBox.isIgnoredLog('any messsages')).toBe(true);
+  });
+
+  it('`isIgnoredLog` returns false for non-matched ignored log', () => {
+    jest.unmock('../Data/LogBoxData');
+    LogBox.ignoreLogs(['ignoreMe']);
+    expect(LogBox.isIgnoredLog('showMe: message', 'another argument')).toBe(false);
+  });
+
+  it('`isIgnoredLog` returns false when throwing exception from log parser.', () => {
+    jest.mock('../Data/LogBoxData');
+    const mockError = new Error('Simulated error');
+
+    // Picking a random implemention detail to simulate throwing.
+    (LogBoxData.isMessageIgnored: any).mockImplementation(() => {
+      throw mockError;
+    });
+
+    LogBox.ignoreLogs(['ignoreMe']);
+    expect(LogBox.isIgnoredLog('ignoreMe')).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

In Expo environment, we overwrite console log handlers and send logs to CLI terminal or Snack remote console. If users use `LogBox.ignoreLogs()` to suppress some logs, the log will suppress from LogBox but still send to CLI terminal. Toward this problem, the PR introduces a `LogBox.isIgnoredLog()` function for us to check whether we should ignore the log entry.

This PR will help us to unblock and fix the problem mentioned in https://github.com/facebook/react-native/issues/33557#issuecomment-1137706990. (with example included)

## Changelog

[General] [Added] - Add `LogBox.isIgnoredLog()` function to indicate whether a log is ignored

## Test Plan

Unit Test

```
 PASS  Libraries/LogBox/__tests__/LogBox-test.js
  LogBox
    ✓ `isIgnoredLog` returns true for ignored log (4 ms)
    ✓ `isIgnoredLog` returns true for regexp based ignored log (3 ms)
    ✓ `isIgnoredLog` returns true for any messages when `ignoreAllLogs` was called (3 ms)
    ✓ `isIgnoredLog` returns false for non-matched ignored log (4 ms)
    ✓ `isIgnoredLog` returns false when throwing exception from log parser. (1 ms)
```
