### PR TITLE
Only show warning when overwrite existing preprocessor

### DIFF
--- a/Libraries/StyleSheet/StyleSheet.js
+++ b/Libraries/StyleSheet/StyleSheet.js
@@ -347,7 +347,12 @@ module.exports = {
       return;
     }
 
-    if (__DEV__ && typeof value.process === 'function') {
+    if (
+      __DEV__ &&
+      typeof value.process === 'function' &&
+      typeof ReactNativeStyleAttributes[property]?.process === 'function' &&
+      value.process !== ReactNativeStyleAttributes[property]?.process
+    ) {
       console.warn(`Overwriting ${property} style attribute preprocessor`);
     }
 

--- a/Libraries/StyleSheet/__tests__/StyleSheet-test.js
+++ b/Libraries/StyleSheet/__tests__/StyleSheet-test.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails oncall+react_native
+ * @format
+ * @flow
+ */
+
+import {setStyleAttributePreprocessor} from '../StyleSheet';
+
+describe(setStyleAttributePreprocessor, () => {
+  const originalConsoleWarn = console.warn;
+
+  beforeEach(() => {
+    jest.resetModules();
+    console.warn = jest.fn();
+  });
+
+  afterEach(() => {
+    console.warn = originalConsoleWarn;
+  });
+
+  it('should not show warning when set preprocessor first time', () => {
+    const spyConsole = jest.spyOn(global.console, 'warn');
+    setStyleAttributePreprocessor(
+      'fontFamily',
+      (fontFamily: string) => fontFamily,
+    );
+    expect(spyConsole).not.toHaveBeenCalled();
+  });
+
+  it('should show warning when overwrite the preprocessor', () => {
+    const spyConsole = jest.spyOn(global.console, 'warn');
+    setStyleAttributePreprocessor(
+      'fontFamily',
+      (fontFamily: string) => fontFamily,
+    );
+    setStyleAttributePreprocessor(
+      'fontFamily',
+      (fontFamily: string) => `Scoped-${fontFamily}`,
+    );
+    expect(spyConsole).toHaveBeenCalledWith(
+      'Overwriting fontFamily style attribute preprocessor',
+    );
+  });
+});

--- a/Libraries/StyleSheet/__tests__/StyleSheet-test.js
+++ b/Libraries/StyleSheet/__tests__/StyleSheet-test.js
@@ -6,7 +6,6 @@
  *
  * @emails oncall+react_native
  * @format
- * @flow
  */
 
 import {setStyleAttributePreprocessor} from '../StyleSheet';


### PR DESCRIPTION
## Summary

from the original design of `StyleSheet.setStyleAttributePreprocessor()` in #11138, the overwriting warning shows when the existing preprocess is be overwritten.  the behavior changes from https://github.com/facebook/react-native/commit/33b385825c72. This PR revises the logic back to original design.

## Changelog

[Internal] [Fixed] - Show warning only when overwriting existing preprocessor in `StyleSheet.setStyleAttributePreprocessor()`

## Test Plan

Unit Test

```
 PASS  Libraries/StyleSheet/__tests__/StyleSheet-test.js
  setStyleAttributePreprocessor
    ✓ should not show warning when set preprocessor first time (2 ms)
    ✓ should show warning when overwrite the preprocessor (1 ms)
```