### PR TITLE
fix: Crash if WebView is disabled

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/network/ForwardingCookieHandler.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/network/ForwardingCookieHandler.java
@@ -152,7 +152,9 @@ public class ForwardingCookieHandler extends CookieHandler {
             || (message != null
                 && (message.contains("WebView provider")
                     || message.contains("No WebView installed")
-                    || message.contains("Cannot load WebView")))) {
+                    || message.contains("Cannot load WebView")
+                    || message.contains("disableWebView")
+                    || message.contains("WebView is disabled")))) {
           return null;
         } else {
           throw exception;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
When the webview is updated by play store, all apps that has loaded webview gets killed. For background see https://issuetracker.google.com/issues/228611949?pli=1

We have a long-running app and don't want this to happen and while we are not using webview anywhere, we are using websockets that loads it for reading cookies, however we are not using cookies to authenticate the websocket and thus want to disable the webview to avoid loading it unnecessarily and then getting killed unnecessarily.

The webview has support for beeing disabled https://developer.android.com/reference/android/webkit/WebView#disableWebView() however as-is this crashes React Native. It seems to me like this case is very similar to not having web view installed and should be handled in the same way.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[Android] [Fixed] - Avoid crash in ForwardingCookieHandler if webview is disabled 

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Add `WebView.disableWebView();` as the first line in `MainActivity.onCreate`.