### PR TITLE
feat: Add tabIndex prop to View component

### DIFF
--- a/Libraries/Components/View/View.js
+++ b/Libraries/Components/View/View.js
@@ -26,13 +26,19 @@ export type Props = ViewProps;
 const View: React.AbstractComponent<
   ViewProps,
   React.ElementRef<typeof ViewNativeComponent>,
-> = React.forwardRef((props: ViewProps, forwardedRef) => {
-  return (
-    <TextAncestor.Provider value={false}>
-      <ViewNativeComponent {...props} ref={forwardedRef} />
-    </TextAncestor.Provider>
-  );
-});
+> = React.forwardRef(
+  ({tabIndex, focusable, ...otherProps}: ViewProps, forwardedRef) => {
+    return (
+      <TextAncestor.Provider value={false}>
+        <ViewNativeComponent
+          focusable={tabIndex !== undefined ? !tabIndex : focusable}
+          {...otherProps}
+          ref={forwardedRef}
+        />
+      </TextAncestor.Provider>
+    );
+  },
+);
 
 View.displayName = 'View';
 

--- a/Libraries/Components/View/ViewPropTypes.js
+++ b/Libraries/Components/View/ViewPropTypes.js
@@ -358,8 +358,8 @@ type AndroidViewProps = $ReadOnly<{|
    * for more details.
    *
    * Supports the following values:
-   * - -1 (View is focusable)
-   * - 0 (View is not focusable)
+   * -  0 (View is focusable)
+   * - -1 (View is not focusable)
    *
    * @platform android
    */

--- a/Libraries/Components/View/ViewPropTypes.js
+++ b/Libraries/Components/View/ViewPropTypes.js
@@ -353,6 +353,19 @@ type AndroidViewProps = $ReadOnly<{|
   focusable?: boolean,
 
   /**
+   * Indicates whether this `View` should be focusable with a non-touch input device, eg. receive focus with a hardware keyboard.
+   * See https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex
+   * for more details.
+   *
+   * Supports the following values:
+   * - -1 (View is focusable)
+   * - 0 (View is not focusable)
+   *
+   * @platform android
+   */
+  tabIndex?: 0 | -1,
+
+  /**
    * The action to perform when this `View` is clicked on by a non-touch click, eg. enter key on a hardware keyboard.
    *
    * @platform android


### PR DESCRIPTION
## Summary

This adds the `tabIndex` Android only prop to View as requested on https://github.com/facebook/react-native/issues/34424 mapping the existing `focusable` prop to `tabIndex` so that `tabIndex={0}` maps to `focusable={true}` and `tabIndex={-1}` represents ` focusable={false}`.  

## Changelog

[Android] [Added] - Add tabIndex prop to View component

## Test Plan

I'm still investigating the best way to test this but we're are just mapping this to an existing prop 