### PR TITLE
feat: Add support for Modal on iOS when Fabric is enabled

### DIFF
--- a/React/Fabric/Mounting/ComponentViews/RCTFabricComponentsPlugins.h
+++ b/React/Fabric/Mounting/ComponentViews/RCTFabricComponentsPlugins.h
@@ -42,6 +42,7 @@ Class<RCTComponentViewProtocol> RCTTextInputCls(void) __attribute__((used));
 Class<RCTComponentViewProtocol> RCTInputAccessoryCls(void) __attribute__((used));
 Class<RCTComponentViewProtocol> RCTViewCls(void) __attribute__((used));
 Class<RCTComponentViewProtocol> RCTImageCls(void) __attribute__((used));
+Class<RCTComponentViewProtocol> RCTModalHostViewCls(void) __attribute__((used));
 
 #ifdef __cplusplus
 }

--- a/React/Fabric/Mounting/ComponentViews/RCTFabricComponentsPlugins.mm
+++ b/React/Fabric/Mounting/ComponentViews/RCTFabricComponentsPlugins.mm
@@ -30,6 +30,7 @@ Class<RCTComponentViewProtocol> RCTFabricComponentsProvider(const char *name) {
     {"InputAccessoryView", RCTInputAccessoryCls},
     {"View", RCTViewCls},
     {"Image", RCTImageCls},
+    {"ModalHostView", RCTModalHostViewCls}
   };
 
   auto p = sFabricComponentsClassMap.find(name);


### PR DESCRIPTION
## Summary
 
While working on a fix for https://github.com/facebook/react-native/issues/29974 (I have a draft for that already (https://github.com/gabrieldonadel/react-native/pull/16), just waiting for https://github.com/facebook/react-native/pull/34406 to get merged) I noticed that the `KeyboardAvoidingView` tests on RNTester on iOS were not working with Fabric enabled because the `ModalHostView` component was still not implemented. Upon some more investigation, I found this code suggestion from Milker90 (https://github.com/facebook/react-native/issues/33652#issuecomment-1214675790) that enables the Modal component on iOS when Fabric is enabled. 

Closes https://github.com/facebook/react-native/issues/33652

## Changelog

[iOS] [Added] - Add support for Modal on iOS when Fabric is enabled

## Test Plan

1. With Fabric enabled open the RNTester app and navigate to the Modal page
2. Test the `Modal` component through the sections changing props

https://user-images.githubusercontent.com/11707729/186289099-5223907d-b300-46bf-bfde-73259c29d544.mov



