### PR TITLE
[HermesExecutorFactory] add debugging settings

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/hermes/reactexecutor/HermesExecutor.java
+++ b/ReactAndroid/src/main/java/com/facebook/hermes/reactexecutor/HermesExecutor.java
@@ -33,8 +33,11 @@ public class HermesExecutor extends JavaScriptExecutor {
     }
   }
 
-  HermesExecutor(@Nullable RuntimeConfig config) {
-    super(config == null ? initHybridDefaultConfig() : initHybrid(config.heapSizeMB));
+  HermesExecutor(@Nullable RuntimeConfig config, boolean enableDebugger, String debuggerName) {
+    super(
+        config == null
+            ? initHybridDefaultConfig(enableDebugger, debuggerName)
+            : initHybrid(enableDebugger, debuggerName, config.heapSizeMB));
   }
 
   @Override
@@ -51,7 +54,9 @@ public class HermesExecutor extends JavaScriptExecutor {
    */
   public static native boolean canLoadFile(String path);
 
-  private static native HybridData initHybridDefaultConfig();
+  private static native HybridData initHybridDefaultConfig(
+      boolean enableDebugger, String debuggerName);
 
-  private static native HybridData initHybrid(long heapSizeMB);
+  private static native HybridData initHybrid(
+      boolean enableDebugger, String debuggerName, long heapSizeMB);
 }

--- a/ReactAndroid/src/main/java/com/facebook/hermes/reactexecutor/HermesExecutorFactory.java
+++ b/ReactAndroid/src/main/java/com/facebook/hermes/reactexecutor/HermesExecutorFactory.java
@@ -15,6 +15,8 @@ public class HermesExecutorFactory implements JavaScriptExecutorFactory {
   private static final String TAG = "Hermes";
 
   private final RuntimeConfig mConfig;
+  private boolean mEnableDebugger = true;
+  private String mDebuggerName = "";
 
   public HermesExecutorFactory() {
     this(null);
@@ -24,9 +26,17 @@ public class HermesExecutorFactory implements JavaScriptExecutorFactory {
     mConfig = config;
   }
 
+  public void setEnableDebugger(boolean enableDebugger) {
+    mEnableDebugger = enableDebugger;
+  }
+
+  public void setDebuggerName(String debuggerName) {
+    mDebuggerName = debuggerName;
+  }
+
   @Override
   public JavaScriptExecutor create() {
-    return new HermesExecutor(mConfig);
+    return new HermesExecutor(mConfig, mEnableDebugger, mDebuggerName);
   }
 
   @Override

--- a/ReactAndroid/src/main/jni/react/hermes/reactexecutor/OnLoad.cpp
+++ b/ReactAndroid/src/main/jni/react/hermes/reactexecutor/OnLoad.cpp
@@ -69,26 +69,39 @@ class HermesExecutorHolder
       "Lcom/facebook/hermes/reactexecutor/HermesExecutor;";
 
   static jni::local_ref<jhybriddata> initHybridDefaultConfig(
-      jni::alias_ref<jclass>) {
+      jni::alias_ref<jclass>,
+      bool enableDebugger,
+      std::string debuggerName) {
     JReactMarker::setLogPerfMarkerIfNeeded();
 
     std::call_once(flag, []() {
       facebook::hermes::HermesRuntime::setFatalHandler(hermesFatalHandler);
     });
-    return makeCxxInstance(
-        std::make_unique<HermesExecutorFactory>(installBindings));
+    auto factory = std::make_unique<HermesExecutorFactory>(installBindings);
+    factory->setEnableDebugger(enableDebugger);
+    if (!debuggerName.empty()) {
+      factory->setDebuggerName(debuggerName);
+    }
+    return makeCxxInstance(std::move(factory));
   }
 
   static jni::local_ref<jhybriddata> initHybrid(
       jni::alias_ref<jclass>,
+      bool enableDebugger,
+      std::string debuggerName,
       jlong heapSizeMB) {
     JReactMarker::setLogPerfMarkerIfNeeded();
     auto runtimeConfig = makeRuntimeConfig(heapSizeMB);
     std::call_once(flag, []() {
       facebook::hermes::HermesRuntime::setFatalHandler(hermesFatalHandler);
     });
-    return makeCxxInstance(std::make_unique<HermesExecutorFactory>(
-        installBindings, JSIExecutor::defaultTimeoutInvoker, runtimeConfig));
+    auto factory = std::make_unique<HermesExecutorFactory>(
+        installBindings, JSIExecutor::defaultTimeoutInvoker, runtimeConfig);
+    factory->setEnableDebugger(enableDebugger);
+    if (!debuggerName.empty()) {
+      factory->setDebuggerName(debuggerName);
+    }
+    return makeCxxInstance(std::move(factory));
   }
 
   static bool canLoadFile(jni::alias_ref<jclass>, const std::string &path) {

--- a/ReactCommon/hermes/executor/HermesExecutorFactory.cpp
+++ b/ReactCommon/hermes/executor/HermesExecutorFactory.cpp
@@ -151,9 +151,9 @@ class DecoratedRuntime : public jsi::WithRuntimeDecorator<ReentrancyCheck> {
       bool enableDebugger,
       const std::string &debuggerName)
       : jsi::WithRuntimeDecorator<ReentrancyCheck>(*runtime, reentrancyCheck_),
-        runtime_(std::move(runtime)),
-        enableDebugger_(enableDebugger) {
+        runtime_(std::move(runtime)) {
 #ifdef HERMES_ENABLE_DEBUGGER
+    enableDebugger_ = enableDebugger;
     if (enableDebugger_) {
       std::shared_ptr<HermesRuntime> rt(runtime_, &hermesRuntime);
       auto adapter =
@@ -182,8 +182,8 @@ class DecoratedRuntime : public jsi::WithRuntimeDecorator<ReentrancyCheck> {
 
   std::shared_ptr<Runtime> runtime_;
   ReentrancyCheck reentrancyCheck_;
-  bool enableDebugger_;
 #ifdef HERMES_ENABLE_DEBUGGER
+  bool enableDebugger_;
   facebook::hermes::inspector::chrome::DebugSessionToken debugToken_;
 #endif
 };

--- a/ReactCommon/hermes/executor/HermesExecutorFactory.cpp
+++ b/ReactCommon/hermes/executor/HermesExecutorFactory.cpp
@@ -147,20 +147,28 @@ class DecoratedRuntime : public jsi::WithRuntimeDecorator<ReentrancyCheck> {
   DecoratedRuntime(
       std::unique_ptr<Runtime> runtime,
       HermesRuntime &hermesRuntime,
-      std::shared_ptr<MessageQueueThread> jsQueue)
+      std::shared_ptr<MessageQueueThread> jsQueue,
+      bool enableDebugger,
+      const std::string &debuggerName)
       : jsi::WithRuntimeDecorator<ReentrancyCheck>(*runtime, reentrancyCheck_),
-        runtime_(std::move(runtime)) {
+        runtime_(std::move(runtime)),
+        enableDebugger_(enableDebugger) {
 #ifdef HERMES_ENABLE_DEBUGGER
-    std::shared_ptr<HermesRuntime> rt(runtime_, &hermesRuntime);
-    auto adapter = std::make_unique<HermesExecutorRuntimeAdapter>(rt, jsQueue);
-    debugToken_ = facebook::hermes::inspector::chrome::enableDebugging(
-        std::move(adapter), "Hermes React Native");
+    if (enableDebugger_) {
+      std::shared_ptr<HermesRuntime> rt(runtime_, &hermesRuntime);
+      auto adapter =
+          std::make_unique<HermesExecutorRuntimeAdapter>(rt, jsQueue);
+      debugToken_ = facebook::hermes::inspector::chrome::enableDebugging(
+          std::move(adapter), debuggerName);
+    }
 #endif
   }
 
   ~DecoratedRuntime() {
 #ifdef HERMES_ENABLE_DEBUGGER
-    facebook::hermes::inspector::chrome::disableDebugging(debugToken_);
+    if (enableDebugger_) {
+      facebook::hermes::inspector::chrome::disableDebugging(debugToken_);
+    }
 #endif
   }
 
@@ -174,12 +182,21 @@ class DecoratedRuntime : public jsi::WithRuntimeDecorator<ReentrancyCheck> {
 
   std::shared_ptr<Runtime> runtime_;
   ReentrancyCheck reentrancyCheck_;
+  bool enableDebugger_;
 #ifdef HERMES_ENABLE_DEBUGGER
   facebook::hermes::inspector::chrome::DebugSessionToken debugToken_;
 #endif
 };
 
 } // namespace
+
+void HermesExecutorFactory::setEnableDebugger(bool enableDebugger) {
+  enableDebugger_ = enableDebugger;
+}
+
+void HermesExecutorFactory::setDebuggerName(const std::string &debuggerName) {
+  debuggerName_ = debuggerName;
+}
 
 std::unique_ptr<JSExecutor> HermesExecutorFactory::createJSExecutor(
     std::shared_ptr<ExecutorDelegate> delegate,
@@ -188,7 +205,11 @@ std::unique_ptr<JSExecutor> HermesExecutorFactory::createJSExecutor(
       makeHermesRuntimeSystraced(runtimeConfig_);
   HermesRuntime &hermesRuntimeRef = *hermesRuntime;
   auto decoratedRuntime = std::make_shared<DecoratedRuntime>(
-      std::move(hermesRuntime), hermesRuntimeRef, jsQueue);
+      std::move(hermesRuntime),
+      hermesRuntimeRef,
+      jsQueue,
+      enableDebugger_,
+      debuggerName_);
 
   // So what do we have now?
   // DecoratedRuntime -> HermesRuntime

--- a/ReactCommon/hermes/executor/HermesExecutorFactory.h
+++ b/ReactCommon/hermes/executor/HermesExecutorFactory.h
@@ -28,6 +28,10 @@ class HermesExecutorFactory : public JSExecutorFactory {
     assert(timeoutInvoker_ && "Should not have empty timeoutInvoker");
   }
 
+  void setEnableDebugger(bool enableDebugger);
+
+  void setDebuggerName(const std::string &debuggerName);
+
   std::unique_ptr<JSExecutor> createJSExecutor(
       std::shared_ptr<ExecutorDelegate> delegate,
       std::shared_ptr<MessageQueueThread> jsQueue) override;
@@ -36,6 +40,8 @@ class HermesExecutorFactory : public JSExecutorFactory {
   JSIExecutor::RuntimeInstaller runtimeInstaller_;
   JSIScopedTimeoutInvoker timeoutInvoker_;
   ::hermes::vm::RuntimeConfig runtimeConfig_;
+  bool enableDebugger_ = true;
+  std::string debuggerName_ = "Hermes React Native";
 };
 
 class HermesExecutor : public JSIExecutor {


### PR DESCRIPTION
## Summary

For brownfield apps, it is possible to have multiple hermes runtimes serving different JS bundles. Hermes inspector currently only supports single JS bundle. The latest loaded JS bundle will overwrite previous JS bundle. This is because we always use the ["Hermes React Native" as the inspector page name](https://github.com/facebook/react-native/blob/de75a7a22eebbe6b7106377bdd697a2d779b91b0/ReactCommon/hermes/executor/HermesExecutorFactory.cpp#L157) and [the latest page name will overwrite previous one](https://github.com/facebook/react-native/blob/de75a7a22eebbe6b7106377bdd697a2d779b91b0/ReactCommon/hermes/inspector/chrome/ConnectionDemux.cpp#L77-L86).

This PR adds more customization for HermesExecutorFactory:
- `setEnableDebugger`: provide a way to disable debugging features for the hermes runtime
- `setDebuggerName`: provide a way to customize inspector page name other than the default "Hermes React Native"

## Changelog

[General] [Added] - Add more debugging settings for *HermesExecutorFactory*

## Test Plan

Verify the features by RNTester.

1. `setEnableDebugger`

```diff
--- a/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.java
+++ b/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.java
@@ -10,10 +10,12 @@ package com.facebook.react.uiapp;
 import android.app.Application;
 import androidx.annotation.NonNull;
 import com.facebook.fbreact.specs.SampleTurboModule;
+import com.facebook.hermes.reactexecutor.HermesExecutorFactory;
 import com.facebook.react.ReactApplication;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.TurboReactPackage;
+import com.facebook.react.bridge.JavaScriptExecutorFactory;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.config.ReactFeatureFlags;
@@ -50,6 +52,13 @@ public class RNTesterApplication extends Application implements ReactApplication
           return BuildConfig.DEBUG;
         }

+        @Override
+        protected JavaScriptExecutorFactory getJavaScriptExecutorFactory() {
+          HermesExecutorFactory factory = new HermesExecutorFactory();
+          factory.setEnableDebugger(false);
+          return factory;
+        }
+
         @Override
         public List<ReactPackage> getPackages() {
           return Arrays.<ReactPackage>asList(
```

after app launched, the metro inspector should return empty array.
Run `curl http://localhost:8081/json` and returns `[]`

2. `setDebuggerName`

```diff
--- a/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.java
+++ b/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.java
@@ -10,10 +10,12 @@ package com.facebook.react.uiapp;
 import android.app.Application;
 import androidx.annotation.NonNull;
 import com.facebook.fbreact.specs.SampleTurboModule;
+import com.facebook.hermes.reactexecutor.HermesExecutorFactory;
 import com.facebook.react.ReactApplication;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.TurboReactPackage;
+import com.facebook.react.bridge.JavaScriptExecutorFactory;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.config.ReactFeatureFlags;
@@ -50,6 +52,13 @@ public class RNTesterApplication extends Application implements ReactApplication
           return BuildConfig.DEBUG;
         }

+        @Override
+        protected JavaScriptExecutorFactory getJavaScriptExecutorFactory() {
+          HermesExecutorFactory factory = new HermesExecutorFactory();
+          factory.setDebuggerName("Custom Hermes Debugger");
+          return factory;
+        }
+
         @Override
         public List<ReactPackage> getPackages() {
           return Arrays.<ReactPackage>asList(
```

after app launched, the metro inspector should return an entry with *Custom Hermes Debugger*
Run `curl http://localhost:8081/json` and returns

```json
[
  {
    "id": "2-1",
    "description": "com.facebook.react.uiapp",
    "title": "Custom Hermes Debugger",
    "faviconUrl": "https://reactjs.org/favicon.ico",
    "devtoolsFrontendUrl": "devtools://devtools/bundled/js_app.html?experiments=true&v8only=true&ws=%5B%3A%3A1%5D%3A8081%2Finspector%2Fdebug%3Fdevice%3D2%26page%3D1",
    "type": "node",
    "webSocketDebuggerUrl": "ws://[::1]:8081/inspector/debug?device=2&page=1",
    "vm": "Hermes"
  }
]
```