### PR TITLE
chore: Deprecate TextInput editable prop

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -22,6 +22,7 @@ import TextInputState from './TextInputState';
 import invariant from 'invariant';
 import nullthrows from 'nullthrows';
 import setAndForwardRef from '../../Utilities/setAndForwardRef';
+import warnOnce from '../../Utilities/warnOnce';
 
 import usePressability from '../../Pressability/usePressability';
 
@@ -528,6 +529,7 @@ export type Props = $ReadOnly<{|
   defaultValue?: ?Stringish,
 
   /**
+   * @deprecated - use readOnly instead
    * If `false`, text is not editable. The default value is `true`.
    */
   editable?: ?boolean,
@@ -1396,6 +1398,13 @@ const ExportedForwardRef: React.AbstractComponent<
     React.ElementRef<HostComponent<mixed>> & ImperativeMethods,
   >,
 ) {
+  if (__DEV__ && editable !== undefined) {
+    warnOnce(
+      'TextInput-editable-prop-deprecated',
+      'The editable prop from TextInput has been deprecated and will be removed in a future release. Please use the readOnly prop instead',
+    );
+  }
+
   return (
     <InternalTextInput
       allowFontScaling={allowFontScaling}


### PR DESCRIPTION
## Summary

This is a follow-up PR of https://github.com/facebook/react-native/pull/34444 and it adds a deprecation warning regarding the `TextInput` component `editable` prop as requested by @lunaleaps here -> https://github.com/facebook/react-native/pull/34444#discussion_r952952614

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[General] [Deprecated] -  Adds deprecation warning to TextInput editable prop

## Test Plan

1. Open the RNTester app and navigate to the TextInput page
2. Observe the warning

https://user-images.githubusercontent.com/11707729/186525140-5203c0c9-40ca-4c9d-8dbb-47388973c77c.mov




