### PR TITLE
Change Wrapper of InspectorPanel from View to SafeAreaView

### DIFF
--- a/Libraries/Inspector/InspectorPanel.js
+++ b/Libraries/Inspector/InspectorPanel.js
@@ -19,7 +19,7 @@ const StyleSheet = require('../StyleSheet/StyleSheet');
 const Text = require('../Text/Text');
 const TouchableHighlight = require('../Components/Touchable/TouchableHighlight');
 const View = require('../Components/View/View');
-const SafeAreaView = require('../Components/SafeAreaView/SafeAreaView').default;
+import SafeAreaView from '../Components/SafeAreaView/SafeAreaView';
 
 import type {ViewStyleProp} from '../StyleSheet/StyleSheet';
 

--- a/Libraries/Inspector/InspectorPanel.js
+++ b/Libraries/Inspector/InspectorPanel.js
@@ -19,6 +19,7 @@ const StyleSheet = require('../StyleSheet/StyleSheet');
 const Text = require('../Text/Text');
 const TouchableHighlight = require('../Components/Touchable/TouchableHighlight');
 const View = require('../Components/View/View');
+const SafeAreaView = require('../Components/SafeAreaView/SafeAreaView').default;
 
 import type {ViewStyleProp} from '../StyleSheet/StyleSheet';
 
@@ -84,7 +85,7 @@ class InspectorPanel extends React.Component<Props> {
       contents = <View style={styles.waiting}>{this.renderWaiting()}</View>;
     }
     return (
-      <View style={styles.container}>
+      <SafeAreaView style={styles.container}>
         {!this.props.devtoolsIsOpen && contents}
         <View style={styles.buttonRow}>
           <InspectorPanelButton
@@ -108,7 +109,7 @@ class InspectorPanel extends React.Component<Props> {
             onClick={this.props.setTouchTargeting}
           />
         </View>
-      </View>
+      </SafeAreaView>
     );
   }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Currently, the `InspectorPanel` component is wrapped in `View`, which is a little difficult to click the panel button when in a device with a notch screen.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[General] [Fixed] - Change Wrapper of `InspectorPanel` from `View` to `SafeAreaView`

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

**From:**

<img alt="" height="500" src="https://user-images.githubusercontent.com/3097366/186088404-32cb2707-a4f1-45d6-9f83-f0992d5ba64d.png"> <img alt="" height="500" src="https://user-images.githubusercontent.com/3097366/186088438-863fd7da-b827-4cc1-b873-f0bf38764e83.png">


**To:**

<img alt="" height="500" src="https://user-images.githubusercontent.com/3097366/186088518-6e131a8e-27ae-4eed-b97d-ee6f6ab5e669.png"> <img alt="" height="500" src="https://user-images.githubusercontent.com/3097366/186088550-35ce0512-ac4f-4ef1-b5db-f2a3ec434b24.png"> <img alt="" height="500" src="https://user-images.githubusercontent.com/3097366/186088579-ff42ee60-6b1c-4179-aae8-764f4d04e680.png">

