### PR TITLE
Modularlize RCTBridgeModule.h 2/n - Move RCTTurboModuleRegistry.h to its own file in ReactInternal target

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -338,6 +338,7 @@ REACT_PUBLIC_HEADERS = {
     "React/RCTSurfaceView.h": RCTBASE_PATH + "Surface/RCTSurfaceView.h",
     "React/RCTTextDecorationLineType.h": RCTVIEWS_PATH + "RCTTextDecorationLineType.h",
     "React/RCTTouchHandler.h": RCTBASE_PATH + "RCTTouchHandler.h",
+    "React/RCTTurboModuleRegistry.h": RCTBASE_PATH + "Modules/RCTTurboModuleRegistry.h",
     "React/RCTUIManager.h": RCTMODULES_PATH + "RCTUIManager.h",
     "React/RCTUIManagerObserverCoordinator.h": RCTMODULES_PATH + "RCTUIManagerObserverCoordinator.h",
     "React/RCTUIManagerUtils.h": RCTMODULES_PATH + "RCTUIManagerUtils.h",

--- a/React/Base/Modules/RCTTurboModuleRegistry.h
+++ b/React/Base/Modules/RCTTurboModuleRegistry.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * A protocol that allows TurboModules to do lookup on other TurboModules.
+ * Calling these methods may cause a module to be synchronously instantiated.
+ */
+@protocol RCTTurboModuleRegistry <NSObject>
+- (id)moduleForName:(const char *)moduleName;
+
+/**
+ * Rationale:
+ * When TurboModules lookup other modules by name, we first check the TurboModule
+ * registry to see if a TurboModule exists with the respective name. In this case,
+ * we don't want a RedBox to be raised if the TurboModule isn't found.
+ *
+ * This method is deprecated and will be deleted after the migration from
+ * TurboModules to TurboModules is complete.
+ */
+- (id)moduleForName:(const char *)moduleName warnOnLookupFailure:(BOOL)warnOnLookupFailure;
+- (BOOL)moduleIsInitialized:(const char *)moduleName;
+
+- (NSArray<NSString *> *)eagerInitModuleNames;
+- (NSArray<NSString *> *)eagerInitMainQueueModuleNames;
+@end

--- a/React/Base/RCTBridgeModule.h
+++ b/React/Base/RCTBridgeModule.h
@@ -13,6 +13,7 @@
 
 @class RCTBridge;
 @protocol RCTBridgeMethod;
+@protocol RCTTurboModuleRegistry;
 @class RCTModuleRegistry;
 @class RCTViewRegistry;
 @class RCTCallableJSModules;
@@ -377,29 +378,6 @@ RCT_EXTERN_C_END
  */
 - (void)partialBatchDidFlush;
 
-@end
-
-/**
- * A protocol that allows TurboModules to do lookup on other TurboModules.
- * Calling these methods may cause a module to be synchronously instantiated.
- */
-@protocol RCTTurboModuleRegistry <NSObject>
-- (id)moduleForName:(const char *)moduleName;
-
-/**
- * Rationale:
- * When TurboModules lookup other modules by name, we first check the TurboModule
- * registry to see if a TurboModule exists with the respective name. In this case,
- * we don't want a RedBox to be raised if the TurboModule isn't found.
- *
- * This method is deprecated and will be deleted after the migration from
- * TurboModules to TurboModules is complete.
- */
-- (id)moduleForName:(const char *)moduleName warnOnLookupFailure:(BOOL)warnOnLookupFailure;
-- (BOOL)moduleIsInitialized:(const char *)moduleName;
-
-- (NSArray<NSString *> *)eagerInitModuleNames;
-- (NSArray<NSString *> *)eagerInitMainQueueModuleNames;
 @end
 
 /**

--- a/React/Base/RCTModuleRegistry.m
+++ b/React/Base/RCTModuleRegistry.m
@@ -6,7 +6,9 @@
  */
 
 #import "RCTBridge.h"
-#import "RCTBridgeModule.h"
+#import "RCTTurboModuleRegistry.h"
+
+@class RCTBridgeModule;
 
 @implementation RCTModuleRegistry {
   __weak id<RCTTurboModuleRegistry> _turboModuleRegistry;

--- a/React/CxxBridge/RCTCxxBridge.mm
+++ b/React/CxxBridge/RCTCxxBridge.mm
@@ -29,6 +29,7 @@
 #import <React/RCTProfile.h>
 #import <React/RCTRedBox.h>
 #import <React/RCTReloadCommand.h>
+#import <React/RCTTurboModuleRegistry.h>
 #import <React/RCTUtils.h>
 #import <cxxreact/CxxNativeModule.h>
 #import <cxxreact/Instance.h>

--- a/ReactCommon/react/nativemodule/core/platform/ios/RCTTurboModuleManager.h
+++ b/ReactCommon/react/nativemodule/core/platform/ios/RCTTurboModuleManager.h
@@ -9,9 +9,9 @@
 
 #import <memory>
 
-#import "RCTTurboModule.h"
-
+#import <React/RCTTurboModuleRegistry.h>
 #import <ReactCommon/RuntimeExecutor.h>
+#import "RCTTurboModule.h"
 
 @protocol RCTTurboModuleManagerDelegate <NSObject>
 


### PR DESCRIPTION
Summary:
Changelog: [Internal][iOS] Modularlize RCTBridgeModule.h 1/n -  Move RCTTurboModuleRegistry.h to its own file in ReactInternal target

# Why clean up RCTBridgeModule.h?
Clean up one unnecessary import of RCTBridgeModule.h.

RCTBridgeModule includes a lot of header files, and this header is imported everywhere. The ultimate goal is that files (especially React Native infra files) should only import only what they need and not import the entirely of RCTBridgeModule.h whenever possible.

This way, certain headers that are Bridge-only can be compiled out of the new architecture with a flag.

Differential Revision: D38971168

