### PR TITLE
feat: add aria-disabled aliasing for button

### DIFF
--- a/Libraries/Components/Button.js
+++ b/Libraries/Components/Button.js
@@ -145,6 +145,10 @@ type ButtonProps = $ReadOnly<{|
   accessibilityActions?: ?$ReadOnlyArray<AccessibilityActionInfo>,
   onAccessibilityAction?: ?(event: AccessibilityActionEvent) => mixed,
   accessibilityState?: ?AccessibilityState,
+  /**
+   * Indicates whether the element is disabled or not.
+   */
+  'aria-disabled'?: ?boolean,
 
   /**
    * [Android] Controlling if a view fires accessibility events and if it is reported to accessibility services.
@@ -300,9 +304,12 @@ class Button extends React.Component<ButtonProps> {
     const disabled =
       this.props.disabled != null
         ? this.props.disabled
+        : this.props['aria-disabled']
+        ? this.props['aria-disabled']
         : this.props.accessibilityState?.disabled;
 
     const accessibilityState =
+      disabled !== this.props['aria-disabled'] ||
       disabled !== this.props.accessibilityState?.disabled
         ? {...this.props.accessibilityState, disabled}
         : this.props.accessibilityState;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

This adds the aria-disabled prop to the Button component where it's used as requested on https://github.com/facebook/react-native/issues/34424, mapping web [aria-disabled](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-disabled) to equivalent [accessibilityState](https://reactnative.dev/docs/accessibility#accessibilitystate)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

[General] [Added] - Add aria-disabled prop to Button component

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[CATEGORY] [TYPE] - Message

## Test Plan

```
<Button
  aria-disabled={true}
  onPress={() => onButtonPress('submitted')}
  testID="accessibilityState_button"
  color={theme.LinkColor}
  title="Submit Application"
  accessibilityLabel="Press to submit your application!"
/>
```

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
