### PR TITLE
Fix React module build error with swift integration on new architecture mode

### DIFF
--- a/React/AppSetup/RCTAppSetupUtils.h
+++ b/React/AppSetup/RCTAppSetupUtils.h
@@ -9,6 +9,8 @@
 #import <React/RCTBridge.h>
 #import <React/RCTRootView.h>
 
+#ifdef __cplusplus
+
 #if RCT_NEW_ARCH_ENABLED
 
 #ifndef RCT_USE_HERMES
@@ -28,13 +30,6 @@
 #import <ReactCommon/RCTTurboModuleManager.h>
 #endif
 
-RCT_EXTERN_C_BEGIN
-
-void RCTAppSetupPrepareApp(UIApplication *application);
-UIView *RCTAppSetupDefaultRootView(RCTBridge *bridge, NSString *moduleName, NSDictionary *initialProperties);
-
-RCT_EXTERN_C_END
-
 #if RCT_NEW_ARCH_ENABLED
 RCT_EXTERN id<RCTTurboModule> RCTAppSetupDefaultModuleFromClass(Class moduleClass);
 
@@ -42,3 +37,12 @@ std::unique_ptr<facebook::react::JSExecutorFactory> RCTAppSetupDefaultJsExecutor
     RCTBridge *bridge,
     RCTTurboModuleManager *turboModuleManager);
 #endif
+
+#endif // __cplusplus
+
+RCT_EXTERN_C_BEGIN
+
+void RCTAppSetupPrepareApp(UIApplication *application);
+UIView *RCTAppSetupDefaultRootView(RCTBridge *bridge, NSString *moduleName, NSDictionary *initialProperties);
+
+RCT_EXTERN_C_END


### PR DESCRIPTION
## Summary

when integrates with swift, the compiler will build clang module based on the *React-Core-umbrella.h*.  however, the include chain reaches some c++ headers that are not available from swift. it will cause build error.
 
![Screen Shot 2022-08-29 at 8 25 08 PM](https://user-images.githubusercontent.com/46429/187200668-2a1f12c9-61e5-4d8b-9531-69ff5c1a5741.png)

this pr adds `#ifdef __cplusplus` guard for it.

## Changelog

[iOS] [Fixed] - Fix React module build error with swift integration on new architecture mode

## Test Plan

one thing we didn't figure out is that we require reanimated to repro the build error.

1.  `npx react-native init RN070 --version 0.70.0-rc.4`. # can also repro this issue on 0.69
2.  `cd RN070`
3. `yarn add react-native-reanimated@next`
4. `cd ios && rm -rf Pods build && RCT_NEW_ARCH_ENABLED=1 pod install` 
5. add `@import React;` in `main.m` for clang module generation

```diff
--- a/ios/RN070/main.m
+++ b/ios/RN070/main.m
@@ -1,5 +1,6 @@
 #import <UIKit/UIKit.h>

+@import React;
 #import "AppDelegate.h"

 int main(int argc, char *argv[])
```

6. `yarn ios`