### PR TITLE
fix: Correctly resolve classes with FindClass(..)

### DIFF
--- a/ReactAndroid/src/main/jni/first-party/yogajni/jni/YGJNIVanilla.cpp
+++ b/ReactAndroid/src/main/jni/first-party/yogajni/jni/YGJNIVanilla.cpp
@@ -147,7 +147,7 @@ static int YGJNILogFunc(
     if (*jloggerPtr) {
       JNIEnv* env = getCurrentEnv();
 
-      jclass cl = env->FindClass("Lcom/facebook/yoga/YogaLogLevel;");
+      jclass cl = env->FindClass("com/facebook/yoga/YogaLogLevel");
       static const jmethodID smethodId =
           facebook::yoga::vanillajni::getStaticMethodId(
               env, cl, "fromInt", "(I)Lcom/facebook/yoga/YogaLogLevel;");
@@ -386,7 +386,7 @@ static void jni_YGNodeCalculateLayoutJNI(
     }
   } catch (const std::logic_error& ex) {
     env->ExceptionClear();
-    jclass cl = env->FindClass("Ljava/lang/IllegalStateException;");
+    jclass cl = env->FindClass("java/lang/IllegalStateException");
     static const jmethodID methodId = facebook::yoga::vanillajni::getMethodId(
         env, cl, "<init>", "(Ljava/lang/String;)V");
     auto throwable = env->NewObject(cl, methodId, env->NewStringUTF(ex.what()));

--- a/ReactAndroid/src/main/jni/first-party/yogajni/jni/YogaJniException.cpp
+++ b/ReactAndroid/src/main/jni/first-party/yogajni/jni/YogaJniException.cpp
@@ -15,7 +15,7 @@ namespace yoga {
 namespace vanillajni {
 
 YogaJniException::YogaJniException() {
-  jclass cl = getCurrentEnv()->FindClass("Ljava/lang/RuntimeException;");
+  jclass cl = getCurrentEnv()->FindClass("java/lang/RuntimeException");
   static const jmethodID methodId = facebook::yoga::vanillajni::getMethodId(
       getCurrentEnv(), cl, "<init>", "()V");
   auto throwable = getCurrentEnv()->NewObject(cl, methodId);


### PR DESCRIPTION
## Summary

`JNIEnv`'s `FindClass(..)` function takes the classes in the standard
`foo/bar/Baz` class specification (unless they're special, like arrays).
Specifying them with `Lfoo/bar/Baz;` results in a
`ClassNotFoundException` being raised -- which is especially unhelpful
when intending to re-throw an exception.

The docs for `JNIEnv#FindClass(..)` can be found [here][jnienv].

[jnienv]:
  https://docs.oracle.com/javase/7/docs/technotes/guides/jni/spec/functions.html#:~:text=The%20name%20argument,java/lang/String%22

## Changelog

[Android] [Fixed] - Correctly resolve classes with FindClass(..)

## Test Plan

No exact test plan. However, if an exception is thrown during the
rendering process, a fatal `ClassNotFoundException` is raised, rather
than having the error be passed up to the `ReactNativeManager`.

Fixes: facebook/yoga#1120
