### PR TITLE
Add support `Promise.allSettled` out of box

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "mkdirp": "^0.5.1",
     "nullthrows": "^1.1.1",
     "pretty-format": "^26.5.2",
-    "promise": "^8.0.3",
+    "promise": "^8.2.0",
     "react-devtools-core": "4.24.0",
     "react-native-gradle-plugin": "^0.71.0",
     "react-refresh": "^0.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5841,10 +5841,10 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
   integrity sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==
 
-promise@^8.0.3:
-  version "8.0.3"
-  resolved "https://registry.yarnpkg.com/promise/-/promise-8.0.3.tgz#f592e099c6cddc000d538ee7283bb190452b0bf6"
-  integrity sha512-HeRDUL1RJiLhyA0/grn+PTShlBAcLuh/1BJGtrvjwbvRDCTLLMEz9rOGCV+R3vHY4MixIuoMEd9Yq/XvsTPcjw==
+promise@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/promise/-/promise-8.2.0.tgz#a1f6280ab67457fbfc8aad2b198c9497e9e5c806"
+  integrity sha512-+CMAlLHqwRYwBMXKCP+o8ns7DN+xHDUiI+0nArsiJ9y+kJVPLFxEaSw6Ha9s9H0tftxg2Yzl25wqj9G7m5wLZg==
   dependencies:
     asap "~2.0.6"
 


### PR DESCRIPTION
## Summary

`promise` diff: [`8.0.3...8.2.0`](https://npmfs.com/compare/promise/8.0.3/8.2.0/)
Issue: https://github.com/facebook/react-native/issues/30236
Proposal: https://github.com/react-native-community/discussions-and-proposals/issues/491

## Changelog

[General] [Added] - Added support `Promise.allSettled`

## Test Plan

Release notes [`promise@8.2.0`](https://github.com/then/promise/releases/tag/8.2.0)

```tsx
typeof Promise.allSettled // function
```
