### PR TITLE
fix: image cache did not take into account request cache policy

### DIFF
--- a/Libraries/Image/RCTImageLoader.mm
+++ b/Libraries/Image/RCTImageLoader.mm
@@ -501,6 +501,10 @@ static UIImage *RCTResizeImageIfNeeded(UIImage *image,
   BOOL cacheResult = [loadHandler respondsToSelector:@selector(shouldCacheLoadedImages)] ?
   [loadHandler shouldCacheLoadedImages] : YES;
 
+  if (request.cachePolicy == NSURLRequestReloadIgnoringLocalCacheData) {
+    cacheResult = NO;
+  }
+
   if (cacheResult && partialLoadHandler) {
     UIImage *image = [[self imageCache] imageForUrl:request.URL.absoluteString
                                                size:size


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
Image Component cache = 'reload' prop not worked correct because inner Image cache did not take into account request cache (cache property convert in RCTConvert into request.cachePolicy).

Fixes #9195

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[IOS] [Fixed] - Image Component will not update correctly when passing in new url

## Test Plan

Reproduce code: https://snack.expo.dev/@rundbom/image-should-update


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
