### PR TITLE
fix: Accessibility example typos

### DIFF
--- a/packages/rn-tester/js/examples/Accessibility/AccessibilityAndroidExample.android.js
+++ b/packages/rn-tester/js/examples/Accessibility/AccessibilityAndroidExample.android.js
@@ -153,7 +153,7 @@ class AccessibilityAndroidExample extends React.Component<
           <Text style={styles.paragraph}>
             In the following example, the words "test", "inline links", "another
             link", and "link that spans multiple lines because the text is so
-            long", should each be independantly focusable elements, announced as
+            long", should each be independently focusable elements, announced as
             their content followed by ", Link".
           </Text>
           <Text style={styles.paragraph}>
@@ -162,7 +162,7 @@ class AccessibilityAndroidExample extends React.Component<
           </Text>
           <Text style={styles.paragraph}>
             Focusing on the paragraph itself should also announce that there are
-            "links avaialable", and opening Talkback's links menu should show
+            "links available", and opening Talkback's links menu should show
             these same links.
           </Text>
           <Text style={styles.paragraph}>

--- a/packages/rn-tester/js/examples/Accessibility/AccessibilityExample.js
+++ b/packages/rn-tester/js/examples/Accessibility/AccessibilityExample.js
@@ -110,7 +110,7 @@ class AccessibilityExample extends React.Component<{}> {
           </View>
         </RNTesterBlock>
 
-        <RNTesterBlock title="Accessible view with TextViews wihout label">
+        <RNTesterBlock title="Accessible view with TextViews without label">
           <View accessible={true}>
             <Text style={{color: 'green'}}>This is text one.</Text>
             <Text style={{color: 'blue'}}>This is text two.</Text>
@@ -754,7 +754,7 @@ class AccessibilityActionsExample extends React.Component<{}> {
             onAccessibilityAction={event => {
               switch (event.nativeEvent.actionName) {
                 case 'activate':
-                  Alert.alert('Alert', 'Activate accessiblity action');
+                  Alert.alert('Alert', 'Activate accessibility action');
                   break;
                 case 'copy':
                   Alert.alert('Alert', 'copy action success');
@@ -762,7 +762,7 @@ class AccessibilityActionsExample extends React.Component<{}> {
               }
             }}
             onPress={() => Alert.alert('Button has been pressed!')}
-            title="Button with accessiblity action"
+            title="Button with accessibility action"
           />
         </RNTesterBlock>
 
@@ -776,7 +776,7 @@ class AccessibilityActionsExample extends React.Component<{}> {
             onAccessibilityAction={event => {
               switch (event.nativeEvent.actionName) {
                 case 'activate':
-                  Alert.alert('Alert', 'Activate accessiblity action');
+                  Alert.alert('Alert', 'Activate accessibility action');
                   break;
                 case 'copy':
                   Alert.alert('Alert', 'copy action success');
@@ -800,7 +800,7 @@ function SliderAccessibilityExample(): React.Node {
         <Slider value={25} maximumValue={100} minimumValue={0} disabled />
       </RNTesterBlock>
       <RNTesterBlock
-        title="Disabled Slider via accessibiltyState"
+        title="Disabled Slider via accessibilityState"
         description="Verify with TalkBack/VoiceOver announces Slider as disabled">
         <Slider
           value={75}


### PR DESCRIPTION
## Summary

While working on https://github.com/facebook/react-native/pull/34552 I noticed that a couple of words inside the Accessibility example files were misspelled.

## Changelog
 
[Internal] [Fixed] - Fix accessibility example typos

## Test Plan

Shouldn't require much testing as this is just fixing some typos inside Accessibility example 
