### PR TITLE
Fix `Alert` not showing in an app using `UIScene`

### DIFF
--- a/React/CoreModules/RCTAlertController.h
+++ b/React/CoreModules/RCTAlertController.h
@@ -10,6 +10,5 @@
 @interface RCTAlertController : UIAlertController
 
 - (void)show:(BOOL)animated completion:(void (^)(void))completion;
-- (void)hide;
 
 @end

--- a/React/CoreModules/RCTAlertController.m
+++ b/React/CoreModules/RCTAlertController.m
@@ -9,23 +9,7 @@
 
 #import <React/RCTAlertController.h>
 
-@interface RCTAlertController ()
-
-@property (nonatomic, strong) UIWindow *alertWindow;
-
-@end
-
 @implementation RCTAlertController
-
-- (UIWindow *)alertWindow
-{
-  if (_alertWindow == nil) {
-    _alertWindow = [[UIWindow alloc] initWithFrame:RCTSharedApplication().keyWindow.bounds];
-    _alertWindow.rootViewController = [UIViewController new];
-    _alertWindow.windowLevel = UIWindowLevelAlert + 1;
-  }
-  return _alertWindow;
-}
 
 - (void)show:(BOOL)animated completion:(void (^)(void))completion
 {
@@ -34,19 +18,7 @@
         RCTSharedApplication().delegate.window.overrideUserInterfaceStyle ?: UIUserInterfaceStyleUnspecified;
     self.overrideUserInterfaceStyle = style;
   }
-  [self.alertWindow makeKeyAndVisible];
-  [self.alertWindow.rootViewController presentViewController:self animated:animated completion:completion];
-}
-
-- (void)hide
-{
-  [_alertWindow setHidden:YES];
-
-  if (@available(iOS 13, *)) {
-    _alertWindow.windowScene = nil;
-  }
-
-  _alertWindow = nil;
+  [[RCTKeyWindow() rootViewController] presentViewController:self animated:animated completion:completion];
 }
 
 @end

--- a/React/CoreModules/RCTAlertManager.mm
+++ b/React/CoreModules/RCTAlertManager.mm
@@ -185,7 +185,6 @@ RCT_EXPORT_METHOD(alertWithArgs : (JS::NativeAlertManager::Args &)args callback 
                                    case RCTAlertViewStylePlainTextInput:
                                    case RCTAlertViewStyleSecureTextInput:
                                      callback(@[ buttonKey, [weakAlertController.textFields.firstObject text] ]);
-                                     [weakAlertController hide];
                                      break;
                                    case RCTAlertViewStyleLoginAndPasswordInput: {
                                      NSDictionary<NSString *, NSString *> *loginCredentials = @{
@@ -193,12 +192,10 @@ RCT_EXPORT_METHOD(alertWithArgs : (JS::NativeAlertManager::Args &)args callback 
                                        @"password" : [weakAlertController.textFields.lastObject text]
                                      };
                                      callback(@[ buttonKey, loginCredentials ]);
-                                     [weakAlertController hide];
                                      break;
                                    }
                                    case RCTAlertViewStyleDefault:
                                      callback(@[ buttonKey ]);
-                                     [weakAlertController hide];
                                      break;
                                  }
                                }];


### PR DESCRIPTION
## Summary

In an app using `UIScene`, `Alert` no longer pops up because the window
that gets created are not attached to a scene.

## Changelog

[iOS] [Fixed] - Fix `Alert` not showing in an app using `UIScene`

## Test Plan

Use the test plan in #29295. This should not regress that fix.