### PR TITLE
feat: add post notification Android  permission

### DIFF
--- a/Libraries/PermissionsAndroid/NativePermissionsAndroid.js
+++ b/Libraries/PermissionsAndroid/NativePermissionsAndroid.js
@@ -58,7 +58,8 @@ export type PermissionType =
   | 'android.permission.READ_PHONE_NUMBERS'
   | 'android.permission.UWB_RANGING'
   | 'android.permission.POST_NOTIFICATIONS'
-  | 'android.permission.NEARBY_WIFI_DEVICES';
+  | 'android.permission.NEARBY_WIFI_DEVICES'
+  | 'android.permission.POST_NOTIFICATIONS';
 */
 
 export interface Spec extends TurboModule {

--- a/Libraries/PermissionsAndroid/PermissionsAndroid.js
+++ b/Libraries/PermissionsAndroid/PermissionsAndroid.js
@@ -76,6 +76,7 @@ const PERMISSIONS = Object.freeze({
   UWB_RANGING: 'android.permission.UWB_RANGING',
   POST_NOTIFICATION: 'android.permission.POST_NOTIFICATIONS',
   NEARBY_WIFI_DEVICES: 'android.permission.NEARBY_WIFI_DEVICES',
+  POST_NOTIFICATIONS: 'android.permission.POST_NOTIFICATIONS',
 });
 
 /**
@@ -122,6 +123,7 @@ class PermissionsAndroid {
     RECEIVE_WAP_PUSH: string,
     RECORD_AUDIO: string,
     SEND_SMS: string,
+    POST_NOTIFICATIONS: string,
     USE_SIP: string,
     UWB_RANGING: string,
     WRITE_CALENDAR: string,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This PR add the permission POST_NOTIFICATIONS in Android, recently released Android 13

https://developer.android.com/reference/android/Manifest.permission#POST_NOTIFICATIONS

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[Android] [Changed] - Add POST_NOTIFICATIONS to PermissionsAndroid

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
`PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS === 'android.permission.POST_NOTIFICATIONS'
`