### PR TITLE
Allow setting project root when starting packer in a terminal

### DIFF
--- a/scripts/packager.sh
+++ b/scripts/packager.sh
@@ -7,18 +7,25 @@
 # scripts directory
 THIS_DIR=$(cd -P "$(dirname "$(readlink "${BASH_SOURCE[0]}" || echo "${BASH_SOURCE[0]}")")" && pwd)
 REACT_NATIVE_ROOT="$THIS_DIR/.."
-# Application root directory - General use case: react-native is a dependency
-PROJECT_ROOT="$THIS_DIR/../../.."
+
+if [ -n "$RCT_PROJECT_ROOT" ]; then
+  # Application root directory
+  PROJECT_ROOT="$RCT_PROJECT_ROOT"
+else
+  # Application root directory - General use case: react-native is a dependency
+  PROJECT_ROOT="$THIS_DIR/../../.."
+
+  # When running react-native tests, react-native doesn't live in node_modules but in the PROJECT_ROOT
+  if [ ! -d "$PROJECT_ROOT/node_modules/react-native" ];
+  then
+    PROJECT_ROOT="$THIS_DIR/.."
+  fi
+fi
 
 # check and assign NODE_BINARY env
 # shellcheck disable=SC1090
 source "${THIS_DIR}/node-binary.sh"
 
-# When running react-native tests, react-native doesn't live in node_modules but in the PROJECT_ROOT
-if [ ! -d "$PROJECT_ROOT/node_modules/react-native" ];
-then
-  PROJECT_ROOT="$THIS_DIR/.."
-fi
 # Start packager from PROJECT_ROOT
 cd "$PROJECT_ROOT" || exit
 "$NODE_BINARY" "$REACT_NATIVE_ROOT/cli.js" start --custom-log-reporter-path "$THIS_DIR/packager-reporter.js" "$@"


### PR DESCRIPTION
## Summary

See https://github.com/facebook/react-native/issues/34565

This PR allows setting the project root directlry when running the packer. This fixes https://github.com/facebook/react-native/issues/34565 together with https://github.com/react-native-community/cli/pull/1693.

## Changelog

[General] [Fixed] - Fixes packager project root when running in a terminal

## Test Plan

See https://github.com/facebook/react-native/issues/34565

```
$ git clone https://github.com/johanblumenberg/react-native-monorepo-demo
$ cd react-native-monorepo-demo
$ yarn install
$ cd apps/App1
$ yarn android
```

Without this PR the packager fails to find the index file. With this change the packager finds the index file, and the app starts successfully.