### PR TITLE
feat: Add support for verticalAlign style

### DIFF
--- a/Libraries/Components/TextInput/TextInput.d.ts
+++ b/Libraries/Components/TextInput/TextInput.d.ts
@@ -435,6 +435,11 @@ export interface TextInputAndroidProps {
    * When false, it will prevent the soft keyboard from showing when the field is focused. The default value is true
    */
   showSoftInputOnFocus?: boolean | undefined;
+
+  /**
+   * Vertically align text when `multiline` is set to true
+   */
+  verticalAlign?: 'auto' | 'top' | 'bottom' | 'middle' | undefined;
 }
 
 /**

--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -1602,8 +1602,7 @@ const ExportedForwardRef: React.AbstractComponent<
 ) {
   let style = flattenStyle(restProps.style);
 
-  if (style && style.verticalAlign !== undefined) {
-    // $FlowFixMe
+  if (style?.verticalAlign != null) {
     style.textAlignVertical =
       verticalAlignToTextAlignVerticalMap[style.verticalAlign];
   }

--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -23,6 +23,7 @@ import StyleSheet, {
   type TextStyleProp,
   type ViewStyleProp,
 } from '../../StyleSheet/StyleSheet';
+import flattenStyle from '../../StyleSheet/flattenStyle';
 import Text from '../../Text/Text';
 import TextAncestor from '../../Text/TextAncestor';
 import Platform from '../../Utilities/Platform';
@@ -1599,13 +1600,12 @@ const ExportedForwardRef: React.AbstractComponent<
     React.ElementRef<HostComponent<mixed>> & ImperativeMethods,
   >,
 ) {
-  let style = restProps.style;
+  let style = flattenStyle(restProps.style);
+
   if (style && style.verticalAlign !== undefined) {
-    style = StyleSheet.compose(style, {
-      textAlignVertical:
-        // $FlowFixMe
-        verticalAlignToTextAlignVerticalMap[style.verticalAlign],
-    });
+    // $FlowFixMe
+    style.textAlignVertical =
+      verticalAlignToTextAlignVerticalMap[style.verticalAlign];
   }
 
   return (

--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -1600,7 +1600,7 @@ const ExportedForwardRef: React.AbstractComponent<
     React.ElementRef<HostComponent<mixed>> & ImperativeMethods,
   >,
 ) {
-  let style = flattenStyle(restProps.style);
+  const style = flattenStyle(restProps.style);
 
   if (style?.verticalAlign != null) {
     style.textAlignVertical =

--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -1599,6 +1599,15 @@ const ExportedForwardRef: React.AbstractComponent<
     React.ElementRef<HostComponent<mixed>> & ImperativeMethods,
   >,
 ) {
+  let style = restProps.style;
+  if (style && style.verticalAlign !== undefined) {
+    style = StyleSheet.compose(style, {
+      textAlignVertical:
+        // $FlowFixMe
+        verticalAlignToTextAlignVerticalMap[style.verticalAlign],
+    });
+  }
+
   return (
     <InternalTextInput
       allowFontScaling={allowFontScaling}
@@ -1628,6 +1637,7 @@ const ExportedForwardRef: React.AbstractComponent<
       }
       {...restProps}
       forwardedRef={forwardedRef}
+      style={style}
     />
   );
 });
@@ -1658,6 +1668,13 @@ const styles = StyleSheet.create({
     paddingTop: 5,
   },
 });
+
+const verticalAlignToTextAlignVerticalMap = {
+  auto: 'auto',
+  top: 'top',
+  bottom: 'bottom',
+  middle: 'center',
+};
 
 // $FlowFixMe[unclear-type] Unclear type. Using `any` type is not safe.
 module.exports = ((ExportedForwardRef: any): TextInputType);

--- a/Libraries/Components/View/ReactNativeStyleAttributes.js
+++ b/Libraries/Components/View/ReactNativeStyleAttributes.js
@@ -138,6 +138,7 @@ const ReactNativeStyleAttributes: {[string]: AnyAttributeType, ...} = {
   textShadowRadius: true,
   textTransform: true,
   userSelect: true,
+  verticalAlign: true,
   writingDirection: true,
 
   /**

--- a/Libraries/StyleSheet/StyleSheetTypes.d.ts
+++ b/Libraries/StyleSheet/StyleSheetTypes.d.ts
@@ -261,6 +261,7 @@ export interface TextStyleIOS extends ViewStyle {
 
 export interface TextStyleAndroid extends ViewStyle {
   textAlignVertical?: 'auto' | 'top' | 'bottom' | 'center' | undefined;
+  verticalAlign?: 'auto' | 'top' | 'bottom' | 'middle' | undefined;
   includeFontPadding?: boolean | undefined;
 }
 

--- a/Libraries/StyleSheet/StyleSheetTypes.js
+++ b/Libraries/StyleSheet/StyleSheetTypes.js
@@ -671,6 +671,7 @@ export type ____TextStyle_InternalCore = $ReadOnly<{
   textDecorationColor?: ____ColorValue_Internal,
   textTransform?: 'none' | 'capitalize' | 'uppercase' | 'lowercase',
   userSelect?: 'auto' | 'text' | 'none' | 'contain' | 'all',
+  verticalAlign?: 'auto' | 'top' | 'bottom' | 'middle',
   writingDirection?: 'auto' | 'ltr' | 'rtl',
 }>;
 

--- a/Libraries/Text/Text.js
+++ b/Libraries/Text/Text.js
@@ -179,6 +179,7 @@ const Text: React.AbstractComponent<
   }
 
   if (style && style.verticalAlign !== undefined) {
+    // $FlowFixMe[prop-missing]
     style = StyleSheet.compose(style, {
       textAlignVertical:
         verticalAlignToTextAlignVerticalMap[style.verticalAlign],

--- a/Libraries/Text/Text.js
+++ b/Libraries/Text/Text.js
@@ -178,6 +178,13 @@ const Text: React.AbstractComponent<
     _selectable = userSelectToSelectableMap[style.userSelect];
   }
 
+  if (style && style.verticalAlign !== undefined) {
+    style = StyleSheet.compose(style, {
+      textAlignVertical:
+        verticalAlignToTextAlignVerticalMap[style.verticalAlign],
+    });
+  }
+
   if (__DEV__) {
     if (PressabilityDebug.isEnabled() && onPress != null) {
       style = StyleSheet.compose(restProps.style, {
@@ -273,6 +280,13 @@ const userSelectToSelectableMap = {
   none: false,
   contain: true,
   all: true,
+};
+
+const verticalAlignToTextAlignVerticalMap = {
+  auto: 'auto',
+  top: 'top',
+  bottom: 'bottom',
+  middle: 'center',
 };
 
 module.exports = Text;

--- a/Libraries/Text/Text.js
+++ b/Libraries/Text/Text.js
@@ -178,8 +178,7 @@ const Text: React.AbstractComponent<
     _selectable = userSelectToSelectableMap[style.userSelect];
   }
 
-  if (style && style.verticalAlign !== undefined) {
-    // $FlowFixMe[prop-missing]
+  if (style?.verticalAlign != null) {
     style = StyleSheet.compose(style, {
       textAlignVertical:
         verticalAlignToTextAlignVerticalMap[style.verticalAlign],

--- a/packages/rn-tester/js/examples/Text/TextExample.android.js
+++ b/packages/rn-tester/js/examples/Text/TextExample.android.js
@@ -18,7 +18,13 @@ const React = require('react');
 const TextInlineView = require('../../components/TextInlineView');
 import TextLegend from '../../components/TextLegend';
 
-const {LayoutAnimation, StyleSheet, Text, View} = require('react-native');
+const {
+  LayoutAnimation,
+  StyleSheet,
+  Text,
+  View,
+  TextInput,
+} = require('react-native');
 
 class Entity extends React.Component<{|children: React.Node|}> {
   render(): React.Node {
@@ -997,6 +1003,28 @@ exports.examples = [
       return (
         <View>
           <Text style={{userSelect: 'auto'}}>Text element is selectable</Text>
+        </View>
+      );
+    },
+  },
+  {
+    title: 'Text alignment',
+    render: function (): React.Node {
+      return (
+        <View>
+          <Text style={{textAlignVertical: 'top', borderWidth: 1, height: 75}}>
+            Text element aligned to the top via textAlignVertical
+          </Text>
+          <Text style={{verticalAlign: 'top', borderWidth: 1, height: 75}}>
+            Text element aligned to the top via verticalAlign
+          </Text>
+          <Text
+            style={{textAlignVertical: 'center', borderWidth: 1, height: 75}}>
+            Text element aligned to the middle textAlignVertical
+          </Text>
+          <Text style={{verticalAlign: 'middle', borderWidth: 1, height: 75}}>
+            Text element aligned to the middle via textAlignVertical
+          </Text>
         </View>
       );
     },

--- a/packages/rn-tester/js/examples/Text/TextExample.android.js
+++ b/packages/rn-tester/js/examples/Text/TextExample.android.js
@@ -18,13 +18,7 @@ const React = require('react');
 const TextInlineView = require('../../components/TextInlineView');
 import TextLegend from '../../components/TextLegend';
 
-const {
-  LayoutAnimation,
-  StyleSheet,
-  Text,
-  View,
-  TextInput,
-} = require('react-native');
+const {LayoutAnimation, StyleSheet, Text, View} = require('react-native');
 
 class Entity extends React.Component<{|children: React.Node|}> {
   render(): React.Node {
@@ -1020,10 +1014,10 @@ exports.examples = [
           </Text>
           <Text
             style={{textAlignVertical: 'center', borderWidth: 1, height: 75}}>
-            Text element aligned to the middle textAlignVertical
+            Text element aligned to the middle via textAlignVertical
           </Text>
           <Text style={{verticalAlign: 'middle', borderWidth: 1, height: 75}}>
-            Text element aligned to the middle via textAlignVertical
+            Text element aligned to the middle via verticalAlign
           </Text>
         </View>
       );


### PR DESCRIPTION
## Summary

This adds support for the `verticalAlign` style attribute, mapping the already existing `textAlignVertical` attribute as requested on https://github.com/facebook/react-native/issues/34425. This PR also updates the TextExample.android on the RNTester in order to facilitate the manual QA of this.

## Changelog

[Android] [Added] - Add support for verticalAlign style

## Test Plan

1. On Android open the RNTester app and navigate to the Text page
2. Check the text alignment through the `Text alignment` section

https://user-images.githubusercontent.com/11707729/188051914-bf15f7eb-e53f-4de5-8033-d1b572352935.mov




