### PR TITLE
[RN][CI][OSS] Make prepare_hermes_workspace work again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -905,7 +905,7 @@ jobs:
   # -------------------------
   prepare_hermes_workspace:
     docker:
-      - image: debian:bullseye
+      - image: debian:11.4
     environment:
       - HERMES_WS_DIR: *hermes_workspace_root
       - HERMES_VERSION_FILE: "sdks/.hermesversion"


### PR DESCRIPTION
## Summary

Something changed in the CircleCI infra, and they SSH keys for `debian:bullseye` have been revoked or they expired.
This PR changes the image from `bullseye` to `11.4` which should be equivalent

## Changelog

[General] [Fixed] - Make Hermes job work again.

## Test Plan
Hermes jobs in CircleCI are green.