### PR TITLE
feat: Adding support for objectFit a partial equivalent to the resizeMode style and prop of <Image>.

### DIFF
--- a/Libraries/Components/View/ReactNativeStyleAttributes.js
+++ b/Libraries/Components/View/ReactNativeStyleAttributes.js
@@ -141,6 +141,7 @@ const ReactNativeStyleAttributes: {[string]: AnyAttributeType, ...} = {
   overlayColor: colorAttributes,
   resizeMode: true,
   tintColor: colorAttributes,
+  objectFit: true,
 };
 
 module.exports = ReactNativeStyleAttributes;

--- a/Libraries/Image/Image.android.js
+++ b/Libraries/Image/Image.android.js
@@ -197,7 +197,7 @@ const BaseImage = (props: ImagePropsType, forwardedRef) => {
     : null;
   // $FlowFixMe[prop-missing]
   const resizeMode =
-    objectFit || props.resizeMode || (style && style.resizeMode);
+    objectFit || props.resizeMode || (style && style.resizeMode) || 'cover';
 
   return (
     <ImageAnalyticsTagContext.Consumer>

--- a/Libraries/Image/Image.android.js
+++ b/Libraries/Image/Image.android.js
@@ -21,6 +21,8 @@ import NativeImageLoaderAndroid from './NativeImageLoaderAndroid';
 
 import TextInlineImageNativeComponent from './TextInlineImageNativeComponent';
 
+import {convertObjectFitToResizeMode} from './ImageUtils';
+
 import type {ImageProps as ImagePropsType} from './ImageProps';
 import type {RootTag} from '../Types/RootTagTypes';
 
@@ -188,6 +190,11 @@ const BaseImage = (props: ImagePropsType, forwardedRef) => {
     ref: forwardedRef,
   };
 
+  const objectFit =
+    convertObjectFitToResizeMode(props.objectFit) ||
+    convertObjectFitToResizeMode(style.objectFit);
+  const resizeMode = objectFit || props.resizeMode || style.resizeMode;
+
   return (
     <ImageAnalyticsTagContext.Consumer>
       {analyticTag => {
@@ -206,7 +213,7 @@ const BaseImage = (props: ImagePropsType, forwardedRef) => {
                 return (
                   <TextInlineImageNativeComponent
                     style={style}
-                    resizeMode={props.resizeMode}
+                    resizeMode={resizeMode}
                     headers={nativeProps.headers}
                     src={src}
                     ref={forwardedRef}
@@ -214,7 +221,12 @@ const BaseImage = (props: ImagePropsType, forwardedRef) => {
                 );
               }
 
-              return <ImageViewNativeComponent {...nativePropsWithAnalytics} />;
+              return (
+                <ImageViewNativeComponent
+                  {...nativePropsWithAnalytics}
+                  resizeMode={resizeMode}
+                />
+              );
             }}
           </TextAncestor.Consumer>
         );

--- a/Libraries/Image/Image.android.js
+++ b/Libraries/Image/Image.android.js
@@ -190,11 +190,10 @@ const BaseImage = (props: ImagePropsType, forwardedRef) => {
     ref: forwardedRef,
   };
 
-  const objectFit = props.objectFit
-    ? convertObjectFitToResizeMode(props.objectFit)
-    : style && style.objectFit
-    ? convertObjectFitToResizeMode(style.objectFit)
-    : null;
+  const objectFit =
+    style && style.objectFit
+      ? convertObjectFitToResizeMode(style.objectFit)
+      : null;
   // $FlowFixMe[prop-missing]
   const resizeMode =
     objectFit || props.resizeMode || (style && style.resizeMode) || 'cover';

--- a/Libraries/Image/Image.android.js
+++ b/Libraries/Image/Image.android.js
@@ -190,9 +190,12 @@ const BaseImage = (props: ImagePropsType, forwardedRef) => {
     ref: forwardedRef,
   };
 
+  // $FlowFixMe[prop-missing]
   const objectFit =
     convertObjectFitToResizeMode(props.objectFit) ||
+    // $FlowFixMe[prop-missing]
     convertObjectFitToResizeMode(style.objectFit);
+  // $FlowFixMe[prop-missing]
   const resizeMode = objectFit || props.resizeMode || style.resizeMode;
 
   return (

--- a/Libraries/Image/Image.android.js
+++ b/Libraries/Image/Image.android.js
@@ -190,13 +190,14 @@ const BaseImage = (props: ImagePropsType, forwardedRef) => {
     ref: forwardedRef,
   };
 
+  const objectFit = props.objectFit
+    ? convertObjectFitToResizeMode(props.objectFit)
+    : style && style.objectFit
+    ? convertObjectFitToResizeMode(style.objectFit)
+    : null;
   // $FlowFixMe[prop-missing]
-  const objectFit =
-    convertObjectFitToResizeMode(props.objectFit) ||
-    // $FlowFixMe[prop-missing]
-    convertObjectFitToResizeMode(style.objectFit);
-  // $FlowFixMe[prop-missing]
-  const resizeMode = objectFit || props.resizeMode || style.resizeMode;
+  const resizeMode =
+    objectFit || props.resizeMode || (style && style.resizeMode);
 
   return (
     <ImageAnalyticsTagContext.Consumer>

--- a/Libraries/Image/Image.ios.js
+++ b/Libraries/Image/Image.ios.js
@@ -133,8 +133,9 @@ const BaseImage = (props: ImagePropsType, forwardedRef) => {
     convertObjectFitToResizeMode(props.objectFit) ||
     // $FlowFixMe[prop-missing]
     convertObjectFitToResizeMode(style.objectFit);
-  // $FlowFixMe[prop-missing]
-  const resizeMode = objectFit || props.resizeMode || style.resizeMode;
+  const resizeMode =
+    // $FlowFixMe[prop-missing]
+    objectFit || props.resizeMode || style.resizeMode || 'cover';
   // $FlowFixMe[prop-missing]
   const tintColor = props.tintColor || style.tintColor;
 

--- a/Libraries/Image/Image.ios.js
+++ b/Libraries/Image/Image.ios.js
@@ -21,6 +21,8 @@ import type {ImageProps as ImagePropsType} from './ImageProps';
 import type {ImageStyleProp} from '../StyleSheet/StyleSheet';
 import NativeImageLoaderIOS from './NativeImageLoaderIOS';
 
+import {convertObjectFitToResizeMode} from './ImageUtils';
+
 import ImageViewNativeComponent from './ImageViewNativeComponent';
 import type {RootTag} from 'react-native/Libraries/Types/RootTagTypes';
 
@@ -127,7 +129,12 @@ const BaseImage = (props: ImagePropsType, forwardedRef) => {
   }
 
   // $FlowFixMe[prop-missing]
-  const resizeMode = props.resizeMode || style.resizeMode || 'cover';
+  const objectFit =
+    convertObjectFitToResizeMode(props.objectFit) ||
+    // $FlowFixMe[prop-missing]
+    convertObjectFitToResizeMode(style.objectFit);
+  // $FlowFixMe[prop-missing]
+  const resizeMode = objectFit || props.resizeMode || style.resizeMode;
   // $FlowFixMe[prop-missing]
   const tintColor = props.tintColor || style.tintColor;
 

--- a/Libraries/Image/Image.ios.js
+++ b/Libraries/Image/Image.ios.js
@@ -128,14 +128,14 @@ const BaseImage = (props: ImagePropsType, forwardedRef) => {
     }
   }
 
-  // $FlowFixMe[prop-missing]
   const objectFit =
-    convertObjectFitToResizeMode(props.objectFit) ||
     // $FlowFixMe[prop-missing]
-    convertObjectFitToResizeMode(style.objectFit);
+    style && style.objectFit
+      ? convertObjectFitToResizeMode(style.objectFit)
+      : null;
   const resizeMode =
     // $FlowFixMe[prop-missing]
-    objectFit || props.resizeMode || style.resizeMode || 'cover';
+    objectFit || props.resizeMode || (style && style.resizeMode) || 'cover';
   // $FlowFixMe[prop-missing]
   const tintColor = props.tintColor || style.tintColor;
 

--- a/Libraries/Image/ImageProps.js
+++ b/Libraries/Image/ImageProps.js
@@ -167,6 +167,14 @@ export type ImageProps = {|
   resizeMode?: ?('cover' | 'contain' | 'stretch' | 'repeat' | 'center'),
 
   /**
+   * Determines how to resize the image when the frame doesn't match the raw
+   * image dimensions. Partial equivalent to the resizeMode style.
+   *
+   * See https://reactnative.dev/docs/image#resizemode
+   */
+  objectFit?: ?('cover' | 'contain' | 'fill' | 'scale-down'),
+
+  /**
    * A unique identifier for this element to be used in UI Automation
    * testing scripts.
    *

--- a/Libraries/Image/ImageProps.js
+++ b/Libraries/Image/ImageProps.js
@@ -167,14 +167,6 @@ export type ImageProps = {|
   resizeMode?: ?('cover' | 'contain' | 'stretch' | 'repeat' | 'center'),
 
   /**
-   * Determines how to resize the image when the frame doesn't match the raw
-   * image dimensions. Partial equivalent to the resizeMode style.
-   *
-   * See https://reactnative.dev/docs/image#resizemode
-   */
-  objectFit?: ?('cover' | 'contain' | 'fill' | 'scale-down'),
-
-  /**
    * A unique identifier for this element to be used in UI Automation
    * testing scripts.
    *

--- a/Libraries/Image/ImageUtils.js
+++ b/Libraries/Image/ImageUtils.js
@@ -8,11 +8,9 @@
  * @format
  */
 
-type ObjectFit = 'cover' | 'contain' | 'fill' | 'scale-down';
 type ResizeMode = 'cover' | 'contain' | 'stretch' | 'repeat' | 'center';
-export function convertObjectFitToResizeMode(
-  objectFit: ?ObjectFit,
-): ?ResizeMode {
+
+export function convertObjectFitToResizeMode(objectFit?: ?string): ?ResizeMode {
   switch (objectFit) {
     case 'contain':
     case 'scale-down':
@@ -22,6 +20,6 @@ export function convertObjectFitToResizeMode(
     case 'fill':
       return 'stretch';
     default:
-      return undefined;
+      return null;
   }
 }

--- a/Libraries/Image/ImageUtils.js
+++ b/Libraries/Image/ImageUtils.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+type ObjectFit = 'cover' | 'contain' | 'fill' | 'scale-down';
+type ResizeMode = 'cover' | 'contain' | 'stretch' | 'repeat' | 'center';
+export function convertObjectFitToResizeMode(
+  objectFit: ?ObjectFit,
+): ?ResizeMode {
+  switch (objectFit) {
+    case 'contain':
+    case 'scale-down':
+      return 'contain';
+    case 'cover':
+      return 'cover';
+    case 'fill':
+      return 'stretch';
+    default:
+      return undefined;
+  }
+}

--- a/Libraries/Image/ImageUtils.js
+++ b/Libraries/Image/ImageUtils.js
@@ -10,16 +10,12 @@
 
 type ResizeMode = 'cover' | 'contain' | 'stretch' | 'repeat' | 'center';
 
-export function convertObjectFitToResizeMode(objectFit?: ?string): ?ResizeMode {
-  switch (objectFit) {
-    case 'contain':
-    case 'scale-down':
-      return 'contain';
-    case 'cover':
-      return 'cover';
-    case 'fill':
-      return 'stretch';
-    default:
-      return null;
-  }
+export function convertObjectFitToResizeMode(objectFit: string): ResizeMode {
+  const objectFitMap = {
+    contain: 'contain',
+    cover: 'cover',
+    fill: 'stretch',
+    'scale-down': 'contain',
+  };
+  return objectFitMap[objectFit];
 }

--- a/Libraries/StyleSheet/StyleSheetTypes.js
+++ b/Libraries/StyleSheet/StyleSheetTypes.js
@@ -642,8 +642,8 @@ export type ____TextStyle_Internal = $ReadOnly<{
 export type ____ImageStyle_InternalCore = $ReadOnly<{
   ...$Exact<____ViewStyle_Internal>,
   resizeMode?: 'contain' | 'cover' | 'stretch' | 'center' | 'repeat',
-  tintColor?: ____ColorValue_Internal,
   objectFit?: 'cover' | 'contain' | 'fill' | 'scale-down',
+  tintColor?: ____ColorValue_Internal,
   overlayColor?: string,
 }>;
 

--- a/Libraries/StyleSheet/StyleSheetTypes.js
+++ b/Libraries/StyleSheet/StyleSheetTypes.js
@@ -643,6 +643,7 @@ export type ____ImageStyle_InternalCore = $ReadOnly<{
   ...$Exact<____ViewStyle_Internal>,
   resizeMode?: 'contain' | 'cover' | 'stretch' | 'center' | 'repeat',
   tintColor?: ____ColorValue_Internal,
+  objectFit?: 'cover' | 'contain' | 'fill' | 'scale-down',
   overlayColor?: string,
 }>;
 
@@ -654,6 +655,7 @@ export type ____ImageStyle_Internal = $ReadOnly<{
 export type ____DangerouslyImpreciseStyle_InternalCore = $ReadOnly<{
   ...$Exact<____TextStyle_Internal>,
   resizeMode?: 'contain' | 'cover' | 'stretch' | 'center' | 'repeat',
+  objectFit?: 'cover' | 'contain' | 'fill' | 'scale-down',
   tintColor?: ____ColorValue_Internal,
   overlayColor?: string,
 }>;

--- a/packages/rn-tester/js/examples/Image/ImageExample.js
+++ b/packages/rn-tester/js/examples/Image/ImageExample.js
@@ -1036,6 +1036,59 @@ exports.examples = [
     },
   },
   {
+    title: 'Object Fit',
+    description: ('The `objectFit` style prop controls how the image is ' +
+      'rendered within the frame.': string),
+    render: function (): React.Node {
+      return (
+        <View>
+          {[smallImage, fullImage].map((image, index) => {
+            return (
+              <View key={index}>
+                <View style={styles.horizontal}>
+                  <View>
+                    <Text style={styles.resizeModeText}>Contain</Text>
+                    <Image
+                      style={styles.resizeMode}
+                      objectFit="contain"
+                      source={image}
+                    />
+                  </View>
+                  <View style={styles.leftMargin}>
+                    <Text style={styles.resizeModeText}>Cover</Text>
+                    <Image
+                      style={styles.resizeMode}
+                      objectFit="cover"
+                      source={image}
+                    />
+                  </View>
+                </View>
+                <View style={styles.horizontal}>
+                  <View>
+                    <Text style={styles.resizeModeText}>Fill</Text>
+                    <Image
+                      style={styles.resizeMode}
+                      objectFit="fill"
+                      source={image}
+                    />
+                  </View>
+                  <View style={styles.leftMargin}>
+                    <Text style={styles.resizeModeText}>Scale Down</Text>
+                    <Image
+                      style={styles.resizeMode}
+                      objectFit="scale-down"
+                      source={image}
+                    />
+                  </View>
+                </View>
+              </View>
+            );
+          })}
+        </View>
+      );
+    },
+  },
+  {
     title: 'Resize Mode',
     description: ('The `resizeMode` style prop controls how the image is ' +
       'rendered within the frame.': string),

--- a/packages/rn-tester/js/examples/Image/ImageExample.js
+++ b/packages/rn-tester/js/examples/Image/ImageExample.js
@@ -1049,16 +1049,14 @@ exports.examples = [
                   <View>
                     <Text style={styles.resizeModeText}>Contain</Text>
                     <Image
-                      style={styles.resizeMode}
-                      objectFit="contain"
+                      style={[styles.resizeMode, {objectFit: 'contain'}]}
                       source={image}
                     />
                   </View>
                   <View style={styles.leftMargin}>
                     <Text style={styles.resizeModeText}>Cover</Text>
                     <Image
-                      style={styles.resizeMode}
-                      objectFit="cover"
+                      style={[styles.resizeMode, {objectFit: 'cover'}]}
                       source={image}
                     />
                   </View>
@@ -1067,16 +1065,14 @@ exports.examples = [
                   <View>
                     <Text style={styles.resizeModeText}>Fill</Text>
                     <Image
-                      style={styles.resizeMode}
-                      objectFit="fill"
+                      style={[styles.resizeMode, {objectFit: 'fill'}]}
                       source={image}
                     />
                   </View>
                   <View style={styles.leftMargin}>
                     <Text style={styles.resizeModeText}>Scale Down</Text>
                     <Image
-                      style={styles.resizeMode}
-                      objectFit="scale-down"
+                      style={[styles.resizeMode, {objectFit: 'scale-down'}]}
                       source={image}
                     />
                   </View>


### PR DESCRIPTION
## Summary

This PR aims to add support for objectFit a partial equivalent to the resizeMode style and prop of Image.

## Changelog

[General] [Added] - Add support for objectFit style of Image.

## Test Plan

1. Open the RNTester app and navigate to the Image page
2. See the Object Fit section.

![Screenshot_1662112702](https://user-images.githubusercontent.com/8868908/188115315-5d5aa971-93ba-4437-a54b-c5ea69b00c08.png)



