### PR TITLE
Remove :packages:react-native-codegen:android from top level settings

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,7 +16,6 @@ pluginManagement {
 include(
     ":ReactAndroid",
     ":ReactAndroid:hermes-engine",
-    ":packages:react-native-codegen:android",
     ":packages:rn-tester:android:app")
 
 // Include this to enable codegen Gradle plugin.


### PR DESCRIPTION
## Summary

The folder `/packages/react-native-codegen/android` is not existing anymore, I'm removing it.

## Changelog

[Internal] - Remove :packages:react-native-codegen:android from top level settings

## Test Plan

Will rely on a green CI
