### PR TITLE
feat: support custom library paths in `react-native.config.js` for codegen on iOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
   "devDependencies": {
     "flow-bin": "^0.186.0",
     "hermes-eslint": "0.8.0",
+    "mock-fs": "^5.1.4",
     "react": "18.2.0",
     "react-test-renderer": "^18.2.0"
   },

--- a/scripts/codegen/__tests__/generate-artifacts-executor-test.js
+++ b/scripts/codegen/__tests__/generate-artifacts-executor-test.js
@@ -13,12 +13,19 @@
 const underTest = require('../generate-artifacts-executor');
 const fixtures = require('../__test_fixtures__/fixtures');
 const path = require('path');
+const fs = require('fs');
+const child_process = require('child_process');
 
 const codegenConfigKey = 'codegenConfig';
 const reactNativeDependencyName = 'react-native';
 const rootPath = path.join(__dirname, '../../..');
 
 describe('generateCode', () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.resetAllMocks();
+  });
+
   it('executeNodes with the right arguments', () => {
     // Define variables and expected values
     const iosOutputDir = 'app/ios/build/generated/ios';
@@ -32,46 +39,32 @@ describe('generateCode', () => {
     const tmpOutDir = path.join(tmpDir, 'out');
 
     // mock used functions
-    let mkdirSyncInvocationCount = 0;
-    jest.mock('fs', () => ({
-      mkdirSync: (location, config) => {
-        if (mkdirSyncInvocationCount === 0) {
-          expect(location).toEqual(tmpOutDir);
-        }
-        if (mkdirSyncInvocationCount === 1) {
-          expect(location).toEqual(iosOutputDir);
-        }
-
-        mkdirSyncInvocationCount += 1;
-      },
-    }));
-
-    let execSyncInvocationCount = 0;
-    jest.mock('child_process', () => ({
-      execSync: command => {
-        if (execSyncInvocationCount === 0) {
-          const expectedCommand = `${node} ${path.join(
-            rnRoot,
-            'generate-specs-cli.js',
-          )} \
-        --platform ios \
-        --schemaPath ${pathToSchema} \
-        --outputDir ${tmpOutDir} \
-        --libraryName ${library.config.name} \
-        --libraryType ${libraryType}`;
-          expect(command).toEqual(expectedCommand);
-        }
-
-        if (execSyncInvocationCount === 1) {
-          expect(command).toEqual(`cp -R ${tmpOutDir}/* ${iosOutputDir}`);
-        }
-
-        execSyncInvocationCount += 1;
-      },
-    }));
+    jest.spyOn(fs, 'mkdirSync').mockImplementation();
+    jest.spyOn(child_process, 'execSync').mockImplementation();
 
     underTest._generateCode(iosOutputDir, library, tmpDir, node, pathToSchema);
-    expect(mkdirSyncInvocationCount).toBe(2);
+
+    const expectedCommand = `${node} ${path.join(
+      rnRoot,
+      'generate-specs-cli.js',
+    )}         --platform ios         --schemaPath ${pathToSchema}         --outputDir ${tmpOutDir}         --libraryName ${
+      library.config.name
+    }         --libraryType ${libraryType}`;
+
+    expect(child_process.execSync).toHaveBeenCalledTimes(2);
+    expect(child_process.execSync).toHaveBeenNthCalledWith(1, expectedCommand);
+    expect(child_process.execSync).toHaveBeenNthCalledWith(
+      2,
+      `cp -R ${tmpOutDir}/* ${iosOutputDir}`,
+    );
+
+    expect(fs.mkdirSync).toHaveBeenCalledTimes(2);
+    expect(fs.mkdirSync).toHaveBeenNthCalledWith(1, tmpOutDir, {
+      recursive: true,
+    });
+    expect(fs.mkdirSync).toHaveBeenNthCalledWith(2, iosOutputDir, {
+      recursive: true,
+    });
   });
 });
 
@@ -199,6 +192,83 @@ describe('extractLibrariesFromJSON', () => {
       },
       libraryPath: myDependencyPath,
     });
+  });
+});
+
+describe('findCodegenEnabledLibraries', () => {
+  const mock = require('mock-fs');
+  const {
+    _findCodegenEnabledLibraries: findCodegenEnabledLibraries,
+  } = require('../generate-artifacts-executor');
+
+  afterEach(() => {
+    mock.restore();
+  });
+
+  it('returns libraries defined in react-native.config.js', () => {
+    const projectDir = path.join(__dirname, '../../../../test-project');
+    const baseCodegenConfigFileDir = path.join(__dirname, '../../..');
+    const baseCodegenConfigFilePath = path.join(
+      baseCodegenConfigFileDir,
+      'package.json',
+    );
+
+    mock({
+      [baseCodegenConfigFilePath]: `
+      {
+        "codegenConfig": {}
+      }
+      `,
+      [projectDir]: {
+        app: {
+          'package.json': `{
+            "name": "my-app"
+          }`,
+          'react-native.config.js': '',
+        },
+        'library-foo': {
+          'package.json': `{
+            "name": "react-native-foo",
+            "codegenConfig": {
+              "name": "RNFooSpec",
+              "type": "modules",
+              "jsSrcsDir": "src"
+            }
+          }`,
+        },
+      },
+    });
+
+    jest.mock(path.join(projectDir, 'app', 'react-native.config.js'), () => ({
+      dependencies: {
+        'react-native-foo': {
+          root: path.join(projectDir, 'library-foo'),
+        },
+        'react-native-bar': {
+          root: path.join(projectDir, 'library-bar'),
+        },
+      },
+    }));
+
+    const libraries = findCodegenEnabledLibraries(
+      `${projectDir}/app`,
+      baseCodegenConfigFileDir,
+      `package.json`,
+      'codegenConfig',
+    );
+
+    expect(libraries).toEqual([
+      {
+        library: 'react-native',
+        config: {},
+        libraryPath: baseCodegenConfigFileDir,
+      },
+      {
+        library: 'react-native-foo',
+        config: {name: 'RNFooSpec', type: 'modules', jsSrcsDir: 'src'},
+        libraryPath: path.join(projectDir, 'library-foo'),
+      },
+    ]);
   });
 });
 

--- a/scripts/codegen/__tests__/generate-artifacts-executor-test.js
+++ b/scripts/codegen/__tests__/generate-artifacts-executor-test.js
@@ -19,7 +19,7 @@ const reactNativeDependencyName = 'react-native';
 const rootPath = path.join(__dirname, '../../..');
 
 describe('generateCode', () => {
-  it('executeNodes with the right arguents', () => {
+  it('executeNodes with the right arguments', () => {
     // Define variables and expected values
     const iosOutputDir = 'app/ios/build/generated/ios';
     const library = {config: {name: 'library', type: 'all'}};

--- a/yarn.lock
+++ b/yarn.lock
@@ -5301,6 +5301,11 @@ mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
+mock-fs@^5.1.4:
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/mock-fs/-/mock-fs-5.1.4.tgz#d64dc37b2793613ca7148b510b1167b5b8afb6b8"
+  integrity sha512-sudhLjCjX37qWIcAlIv1OnAxB2wI4EmXByVuUjILh1rKGNGpGU8GNnzw+EAbrhdpBe0TL/KONbK1y3RXZk8SxQ==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"


### PR DESCRIPTION
## Summary

Currently for codegen to work for a library on iOS, it needs to be located
inside `node_modules`. This patch adds support for libraries defined in
`react-native.config.js`.

This is useful when developing libraries as well as monorepos where the library
may exist outside of the `node_modules`.

Example:

```js
// react-native.config.js
const path = require('path');

module.exports = {
  dependencies: {
    'react-native-library-name': {
      root: path.join(__dirname, '..'),
    },
  },
};
```

## Changelog

[Internal] [Added] - Support custom library paths in `react-native.config.js` for codegen on iOS

## Test Plan

Tested on a test application and ensured that codegen finds the library specified in `react-native.config.js`

https://user-images.githubusercontent.com/1174278/188141056-bce03730-2a13-4648-8889-9727aaf2c3c4.mp4

I have also added a basic test case for this scenario.