### PR TITLE
feat: Added objectFit prop for Image

### DIFF
--- a/Libraries/Image/Image.android.js
+++ b/Libraries/Image/Image.android.js
@@ -22,6 +22,8 @@ import NativeImageLoaderAndroid from './NativeImageLoaderAndroid';
 import TextInlineImageNativeComponent from './TextInlineImageNativeComponent';
 
 import type {ImageProps as ImagePropsType} from './ImageProps';
+import type {ImageObjectFit} from './ImageObjectFit';
+import type {ImageResizeMode} from './ImageResizeMode';
 import type {RootTag} from '../Types/RootTagTypes';
 
 let _requestId = 1;
@@ -49,6 +51,21 @@ function getSize(
           console.warn('Failed to get size for image: ' + url);
         },
     );
+}
+
+function getResizeModeEquivalentFromObjectFit(
+  objectFit?: ?ImageObjectFit,
+): ImageResizeMode {
+  if (!objectFit) {
+    return null;
+  }
+  const objectFitMappingToResizeMode = {
+    contain: 'contain',
+    cover: 'cover',
+    fill: 'stretch',
+    'scale-down': 'contain',
+  };
+  return objectFitMappingToResizeMode[objectFit] ?? null;
 }
 
 /**
@@ -188,6 +205,11 @@ const BaseImage = (props: ImagePropsType, forwardedRef) => {
     ref: forwardedRef,
   };
 
+  const updatedResizeMode =
+    getResizeModeEquivalentFromObjectFit(props.objectFit) ||
+    getResizeModeEquivalentFromObjectFit(style.objectFit) ||
+    props.resizeMode;
+
   return (
     <ImageAnalyticsTagContext.Consumer>
       {analyticTag => {
@@ -206,7 +228,7 @@ const BaseImage = (props: ImagePropsType, forwardedRef) => {
                 return (
                   <TextInlineImageNativeComponent
                     style={style}
-                    resizeMode={props.resizeMode}
+                    resizeMode={updatedResizeMode}
                     headers={nativeProps.headers}
                     src={src}
                     ref={forwardedRef}
@@ -214,7 +236,12 @@ const BaseImage = (props: ImagePropsType, forwardedRef) => {
                 );
               }
 
-              return <ImageViewNativeComponent {...nativePropsWithAnalytics} />;
+              return (
+                <ImageViewNativeComponent
+                  resizeMode={updatedResizeMode}
+                  {...nativePropsWithAnalytics}
+                />
+              );
             }}
           </TextAncestor.Consumer>
         );

--- a/Libraries/Image/Image.ios.js
+++ b/Libraries/Image/Image.ios.js
@@ -17,6 +17,8 @@ import flattenStyle from '../StyleSheet/flattenStyle';
 import resolveAssetSource from './resolveAssetSource';
 
 import type {ImageProps as ImagePropsType} from './ImageProps';
+import type {ImageObjectFit} from './ImageObjectFit';
+import type {ImageResizeMode} from './ImageResizeMode';
 
 import type {ImageStyleProp} from '../StyleSheet/StyleSheet';
 import NativeImageLoaderIOS from './NativeImageLoaderIOS';
@@ -37,6 +39,21 @@ function getSize(
           console.warn('Failed to get size for image ' + uri);
         },
     );
+}
+
+function getResizeModeEquivalentFromObjectFit(
+  objectFit?: ?ImageObjectFit,
+): ?ImageResizeMode {
+  if (!objectFit) {
+    return null;
+  }
+  const objectFitMappingToResizeMode = {
+    contain: 'contain',
+    cover: 'cover',
+    fill: 'stretch',
+    'scale-down': 'contain',
+  };
+  return objectFitMappingToResizeMode[objectFit] ?? null;
 }
 
 function getSizeWithHeaders(
@@ -128,6 +145,14 @@ const BaseImage = (props: ImagePropsType, forwardedRef) => {
 
   // $FlowFixMe[prop-missing]
   const resizeMode = props.resizeMode || style.resizeMode || 'cover';
+
+  const updatedResizeMode =
+    // $FlowFixMe[prop-missing]
+    getResizeModeEquivalentFromObjectFit(props.objectFit) ||
+    // $FlowFixMe[prop-missing]
+    getResizeModeEquivalentFromObjectFit(style.objectFit) ||
+    resizeMode;
+
   // $FlowFixMe[prop-missing]
   const tintColor = style.tintColor;
 
@@ -151,7 +176,7 @@ const BaseImage = (props: ImagePropsType, forwardedRef) => {
             {...props}
             ref={forwardedRef}
             style={style}
-            resizeMode={resizeMode}
+            resizeMode={updatedResizeMode}
             tintColor={tintColor}
             source={sources}
             internal_analyticTag={analyticTag}

--- a/Libraries/Image/ImageObjectFit.js
+++ b/Libraries/Image/ImageObjectFit.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ * @format
+ */
+
+'use strict';
+
+/**
+ * ImageObjectFit partially equals to ImageResizeMode, defines valid values for different image resizing modes set
+ * via the `objectFit` style property on `<Image>`.
+ */
+export type ImageObjectFit =
+  // Resize such that the entire area of the view is covered by the image,
+  // potentially clipping parts of the image.
+  | 'cover'
+
+  // Resize by stretching it to fill the entire frame of the view without
+  // clipping. This may change the aspect ratio of the image, distorting it.
+  | 'fill'
+
+  // Resize such that it will be completely visible, contained within the frame
+  // of the View.
+  | 'scale-down'
+
+  // Resize such that it will be completely visible, contained within the frame
+  // of the View.
+  | 'contain';

--- a/Libraries/Image/ImageProps.js
+++ b/Libraries/Image/ImageProps.js
@@ -163,6 +163,12 @@ export type ImageProps = {|
   resizeMode?: ?('cover' | 'contain' | 'stretch' | 'repeat' | 'center'),
 
   /**
+   * Partially equivalent to resizeMode, determines how to resize the image when the frame doesn't match the raw
+   * image dimensions.
+   */
+  objectFit?: ?('cover' | 'fill' | 'scale-down' | 'contain'),
+
+  /**
    * A unique identifier for this element to be used in UI Automation
    * testing scripts.
    *

--- a/Libraries/StyleSheet/StyleSheetTypes.js
+++ b/Libraries/StyleSheet/StyleSheetTypes.js
@@ -642,6 +642,7 @@ export type ____TextStyle_Internal = $ReadOnly<{
 export type ____ImageStyle_InternalCore = $ReadOnly<{
   ...$Exact<____ViewStyle_Internal>,
   resizeMode?: 'contain' | 'cover' | 'stretch' | 'center' | 'repeat',
+  objectFit?: 'cover' | 'fill' | 'scale-down' | 'contain',
   tintColor?: ____ColorValue_Internal,
   overlayColor?: string,
 }>;
@@ -654,6 +655,7 @@ export type ____ImageStyle_Internal = $ReadOnly<{
 export type ____DangerouslyImpreciseStyle_InternalCore = $ReadOnly<{
   ...$Exact<____TextStyle_Internal>,
   resizeMode?: 'contain' | 'cover' | 'stretch' | 'center' | 'repeat',
+  objectFit?: 'cover' | 'fill' | 'scale-down' | 'contain',
   tintColor?: ____ColorValue_Internal,
   overlayColor?: string,
 }>;

--- a/packages/rn-tester/js/examples/Image/ImageExample.js
+++ b/packages/rn-tester/js/examples/Image/ImageExample.js
@@ -602,6 +602,16 @@ const styles = StyleSheet.create({
     fontSize: 11,
     marginBottom: 3,
   },
+  objectFit: {
+    width: 90,
+    height: 60,
+    borderWidth: 0.5,
+    borderColor: 'black',
+  },
+  objectFitText: {
+    fontSize: 11,
+    marginBottom: 3,
+  },
   icon: {
     width: 15,
     height: 15,
@@ -1035,6 +1045,60 @@ exports.examples = [
                     <Image
                       style={styles.resizeMode}
                       resizeMode="center"
+                      source={image}
+                    />
+                  </View>
+                </View>
+              </View>
+            );
+          })}
+        </View>
+      );
+    },
+  },
+  {
+    title: 'Object Fit',
+    description:
+      ('The `objectFit` style props that is partially equivalent to resizeMode style prop, controls how the image is ' +
+        'rendered within the frame.': string),
+    render: function (): React.Node {
+      return (
+        <View>
+          {[smallImage, fullImage].map((image, index) => {
+            return (
+              <View key={index}>
+                <View style={styles.horizontal}>
+                  <View>
+                    <Text style={styles.objectFitText}>Cover</Text>
+                    <Image
+                      style={styles.objectFit}
+                      objectFit="cover"
+                      source={image}
+                    />
+                  </View>
+                  <View style={styles.leftMargin}>
+                    <Text style={styles.objectFitText}>Fill</Text>
+                    <Image
+                      style={styles.objectFit}
+                      objectFit="fill"
+                      source={image}
+                    />
+                  </View>
+                </View>
+                <View style={styles.horizontal}>
+                  <View>
+                    <Text style={styles.objectFitText}>Scale Down</Text>
+                    <Image
+                      style={styles.objectFit}
+                      objectFit="scale-down"
+                      source={image}
+                    />
+                  </View>
+                  <View style={styles.leftMargin}>
+                    <Text style={styles.objectFitText}>Contain</Text>
+                    <Image
+                      style={styles.objectFit}
+                      objectFit="contain"
                       source={image}
                     />
                   </View>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

This adds `objectFit` prop which is partially equivalent to `resizeMode` as requested in #34425

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[General] [Added] - Added objectFit prop partially equivalent to resizeMode

## Test Plan

```jsx
<Image
 style={styles.objectFit}
 objectFit="cover"
 source={image}
/>
   ```
