### PR TITLE
Make Hermes transform the default in Babel config

### DIFF
--- a/template/babel.config.js
+++ b/template/babel.config.js
@@ -1,3 +1,8 @@
 module.exports = {
-  presets: ['module:metro-react-native-babel-preset'],
+  presets: [
+    [
+      'module:metro-react-native-babel-preset',
+      {unstable_transformProfile: 'hermes-stable'},
+    ],
+  ],
 };


### PR DESCRIPTION
## Summary

Now that Hermes is the default when you create a new React Native app, let's make the Hermes transforms the default wrt the Babel config.

For instance, if you create a brand new React Native app, then try to do this in code:

```typescript
console.log(2n ** 64n);
```

The old transform is used by default, despite the fact that Hermes now supports `BigInt` exponentiation:

```typescript
console.log(Math.pow(2n, 64n));  // Runtime fatal!
```

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[General] [Changed] – The `hermes-stable` Babel transform is now the default when using `init` to make new apps

## Test Plan

* Run `npx react-native init ExampleApp --version 0.70.0-rc.4`
* Make code change noted above
* Run `yarn android`

Observe code is transformed correctly and correct result for `2^64` is logged (`9007199254740992n`).