### PR TITLE
[RN][OSS] Make react-native-codegen tests run in OSS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,8 +111,10 @@ package-lock.json
 # react-native-codegen
 /React/FBReactNativeSpec/FBReactNativeSpec
 /packages/react-native-codegen/lib
+/packages/react-native-codegen/tmp/
 /ReactCommon/react/renderer/components/rncore/
 /packages/rn-tester/NativeModuleExample/ScreenshotManagerSpec*
+
 
 # Additional SDKs
 /sdks/download

--- a/packages/react-native-codegen/src/generators/__tests__/RNCodegen-test.js
+++ b/packages/react-native-codegen/src/generators/__tests__/RNCodegen-test.js
@@ -13,9 +13,6 @@
 
 const rnCodegen = require('../RNCodegen.js');
 const fixture = require('../__test_fixtures__/fixtures.js');
-const path = require('path');
-
-const outputDirectory = 'tmp/out/';
 const packageName = 'na';
 
 describe('RNCodegen.generate', () => {
@@ -23,27 +20,31 @@ describe('RNCodegen.generate', () => {
     jest.resetModules();
   });
   it('when type `all`, with default paths', () => {
-    const componentsOutputDir = 'react/renderer/components/library';
-    const modulesOutputDir = 'library';
-
-    const expectedPaths = {
-      'library.h': modulesOutputDir,
-      'library-generated.mm': modulesOutputDir,
-      'ShadowNodes.h': componentsOutputDir,
-      'ShadowNodes.cpp': componentsOutputDir,
-      'Props.h': componentsOutputDir,
-      'Props.cpp': componentsOutputDir,
-      'RCTComponentViewHelpers.h': componentsOutputDir,
-      'EventEmitters.h': componentsOutputDir,
-      'EventEmitters.cpp': componentsOutputDir,
-      'ComponentDescriptors.h': componentsOutputDir,
-    };
-
     jest.mock('fs', () => ({
       existsSync: location => {
         return true;
       },
       writeFileSync: (location, content) => {
+        // Jest in the OSS does not allow to capture variables in closures.
+        // Therefore, we have to bring the variables inside the closure.
+        // see: https://github.com/facebook/jest/issues/2567
+        const path = require('path');
+        const outputDirectory = 'tmp/out/';
+        const componentsOutputDir = 'react/renderer/components/library';
+        const modulesOutputDir = 'library';
+        const expectedPaths = {
+          'library.h': modulesOutputDir,
+          'library-generated.mm': modulesOutputDir,
+          'ShadowNodes.h': componentsOutputDir,
+          'ShadowNodes.cpp': componentsOutputDir,
+          'Props.h': componentsOutputDir,
+          'Props.cpp': componentsOutputDir,
+          'RCTComponentViewHelpers.h': componentsOutputDir,
+          'EventEmitters.h': componentsOutputDir,
+          'EventEmitters.cpp': componentsOutputDir,
+          'ComponentDescriptors.h': componentsOutputDir,
+        };
+
         let receivedDir = path.dirname(location);
         let receivedBasename = path.basename(location);
 
@@ -55,6 +56,7 @@ describe('RNCodegen.generate', () => {
       },
     }));
 
+    const outputDirectory = 'tmp/out/';
     const res = rnCodegen.generate(
       {
         libraryName: 'library',

--- a/packages/react-native-codegen/src/parsers/flow/components/__tests__/component-parser-test.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/__tests__/component-parser-test.js
@@ -15,7 +15,14 @@ const FlowParser = require('../../index.js');
 const fixtures = require('../__test_fixtures__/fixtures.js');
 const failureFixtures = require('../__test_fixtures__/failures.js');
 jest.mock('fs', () => ({
-  readFileSync: filename => fixtures[filename] || failureFixtures[filename],
+  readFileSync: filename => {
+    // Jest in the OSS does not allow to capture variables in closures.
+    // Therefore, we have to bring the variables inside the closure.
+    // see: https://github.com/facebook/jest/issues/2567
+    const readFileFixtures = require('../__test_fixtures__/fixtures.js');
+    const readFileFailureFixtures = require('../__test_fixtures__/failures.js');
+    return readFileFixtures[filename] || readFileFailureFixtures[filename];
+  },
 }));
 
 describe('RN Codegen Flow Parser', () => {

--- a/packages/react-native-codegen/src/parsers/flow/modules/__tests__/module-parser-snapshot-test.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__tests__/module-parser-snapshot-test.js
@@ -12,10 +12,19 @@
 'use strict';
 
 const FlowParser = require('../../index.js');
+
 const fixtures = require('../__test_fixtures__/fixtures.js');
 const failureFixtures = require('../__test_fixtures__/failures.js');
+
 jest.mock('fs', () => ({
-  readFileSync: filename => fixtures[filename] || failureFixtures[filename],
+  readFileSync: filename => {
+    // Jest in the OSS does not allow to capture variables in closures.
+    // Therefore, we have to bring the variables inside the closure.
+    // see: https://github.com/facebook/jest/issues/2567
+    const readFileFixtures = require('../__test_fixtures__/fixtures.js');
+    const readFileFailureFixtures = require('../__test_fixtures__/failures.js');
+    return readFileFixtures[filename] || readFileFailureFixtures[filename];
+  },
 }));
 
 describe('RN Codegen Flow Parser', () => {

--- a/packages/react-native-codegen/src/parsers/typescript/components/__tests__/typescript-component-parser-test.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/__tests__/typescript-component-parser-test.js
@@ -15,7 +15,14 @@ const TypeScriptParser = require('../../index.js');
 const fixtures = require('../__test_fixtures__/fixtures.js');
 const failureFixtures = require('../__test_fixtures__/failures.js');
 jest.mock('fs', () => ({
-  readFileSync: filename => fixtures[filename] || failureFixtures[filename],
+  readFileSync: filename => {
+    // Jest in the OSS does not allow to capture variables in closures.
+    // Therefore, we have to bring the variables inside the closure.
+    // see: https://github.com/facebook/jest/issues/2567
+    const readFileFixtures = require('../__test_fixtures__/fixtures.js');
+    const readFileFailureFixtures = require('../__test_fixtures__/failures.js');
+    return readFileFixtures[filename] || readFileFailureFixtures[filename];
+  },
 }));
 
 describe('RN Codegen TypeScript Parser', () => {

--- a/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/typescript-module-parser-snapshot-test.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/typescript-module-parser-snapshot-test.js
@@ -14,8 +14,16 @@
 const TypeScriptParser = require('../../index.js');
 const fixtures = require('../__test_fixtures__/fixtures.js');
 const failureFixtures = require('../__test_fixtures__/failures.js');
+
 jest.mock('fs', () => ({
-  readFileSync: filename => fixtures[filename] || failureFixtures[filename],
+  readFileSync: filename => {
+    // Jest in the OSS does not allow to capture variables in closures.
+    // Therefore, we have to bring the variables inside the closure.
+    // see: https://github.com/facebook/jest/issues/2567
+    const readFileFixtures = require('../__test_fixtures__/fixtures.js');
+    const readFileFailureFixtures = require('../__test_fixtures__/failures.js');
+    return readFileFixtures[filename] || readFileFailureFixtures[filename];
+  },
 }));
 
 describe('RN Codegen TypeScript Parser', () => {


### PR DESCRIPTION
## Summary

During the CoreContributor summit, we discovered that the `react-native-codegen` tests cannot be executed in the OSS due to this [issue with Jest](https://github.com/facebook/jest/issues/2567).

This PR moves the required variables inside the proper closure so that we can run tests in the OSS.

## Changelog

[General] [Fixed] - Enable the `react-native-codegen` tests in the OSS.

## Test Plan

1. Run `yarn install` in the `react-native-codegen` folder.
2. Run `yarn jest`, see the test fail.
3. Apply the changes in this diff.
4. Run `yarn jest`, see the test pass. 
