### PR TITLE
[RN][OSS][iOS] Add Matrix tests for Flipper/NoFlipper

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -689,11 +689,24 @@ jobs:
       jsengine:
         type: string
         default: "Hermes"
+      flipper:
+        type: string
+        default: "WithFlipper"
     environment:
       - PROJECT_NAME: "iOSTemplateProject"
       - HERMES_WS_DIR: *hermes_workspace_root
-
     steps:
+      # Early exit in case of Release and WithFlipper. The two does not make sense together.
+      # Unfortunately, the `exclude` parameter of `matrix` does not work, so we have to do it manually.
+      - when:
+          condition:
+            and:
+              - equal: [ << parameters.flavor >>, "Release"]
+              - equal: [ << parameters.flipper >>, "WithFlipper" ]
+          steps:
+            - run:
+                command: circleci-agent step halt # this interrupts the job successfully.
+      # Valid configuration, we can continue
       - checkout_code_with_cache
       - run_yarn
       - attach_workspace:
@@ -716,7 +729,7 @@ jobs:
             node ./scripts/set-rn-template-version.js "file:$PATH_TO_PACKAGE"
             node cli.js init $PROJECT_NAME --directory "/tmp/$PROJECT_NAME" --template $REPO_ROOT --verbose --skip-install
       - run:
-          name: Install iOS dependencies - Configuration << parameters.flavor >>; New Architecture << parameters.architecture >>; JS Engine << parameters.jsengine>>
+          name: Install iOS dependencies - Configuration << parameters.flavor >>; New Architecture << parameters.architecture >>; JS Engine << parameters.jsengine>>; Flipper << parameters.flipper >>
           command: |
             cd /tmp/$PROJECT_NAME
             yarn install
@@ -734,6 +747,10 @@ jobs:
 
             if [[ << parameters.jsengine >> == "JSC" ]]; then
               export USE_HERMES=0
+            fi
+
+            if [[ << parameters.flipper >> == "WithoutFlipper" ]]; then
+              export NO_FLIPPER=1
             fi
 
             bundle exec pod install
@@ -1347,6 +1364,7 @@ workflows:
               architecture: ["NewArch", "OldArch"]
               flavor: ["Debug", "Release"]
               jsengine: ["Hermes", "JSC"]
+              flipper: ["WithFlipper", "WithoutFlipper"]
       - test_ios_rntester:
           requires:
             - build_hermes_macos

--- a/template/ios/Podfile
+++ b/template/ios/Podfile
@@ -4,6 +4,8 @@ require_relative '../node_modules/react-native/scripts/native_modules'
 platform :ios, '12.4'
 install! 'cocoapods', :deterministic_uuids => false
 
+flipper_config = ENV['NO_FLIPPER'] == "1" ? FlipperConfiguration.disabled : FlipperConfiguration.enabled
+
 target 'HelloWorld' do
   config = use_native_modules!
 
@@ -21,7 +23,7 @@ target 'HelloWorld' do
     #
     # Note that if you have use_frameworks! enabled, Flipper will not work and
     # you should disable the next line.
-    :flipper_configuration => FlipperConfiguration.enabled,
+    :flipper_configuration => flipper_config,
     # An absolute path to your application root.
     :app_path => "#{Pod::Config.instance.installation_root}/.."
   )


### PR DESCRIPTION
## Summary

This PR adds some tests to verify that we can build the template in every Debug configuration using Flipper and without Flipper.

## Changelog


[iOS] [Added] - Add CircleCI tests to verify that we can run the Template with and without Flipper

## Test Plan

CircleCI is green
