### PR TITLE
types: make image source required to be defined

### DIFF
--- a/Libraries/Image/ImageProps.js
+++ b/Libraries/Image/ImageProps.js
@@ -151,7 +151,7 @@ export type ImageProps = {|
    *
    * See https://reactnative.dev/docs/image#source
    */
-  source?: ?ImageSource,
+  source: ?ImageSource,
 
   /**
    * See https://reactnative.dev/docs/image#style


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

I believe having an Image component without source property strictly defined makes no sense.
Let's ask, "What should be rendered when we have <Image /> without any props?" 
From a code perspective, I have no idea what should be the result.

From DX I feel it is an improvement because it will automatically remind the name of this major prop.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[General] [Changed] - Force `source` to be strictly defined on `Image` component

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
I have prepared a small Flow playground to show the difference and allow you to play with it.
[Playground](https://flow.org/try/#0PQKgBAAgZgNg9gdzCYAoVBLAtgBzgJwBcwAlAUwEMBjYqfOLMAcn0pqYG51CBPHMsAEksFAOZkAynACu+KmQAK9HABU+AgLxgA3gGc5ALjC7C+DADtRAGjAUYhIybOWAvl0znCZfFGoClcDi6OqhgxjJyZEYA-MJikhHyAarqqC7oUNLmNBhw5kIi4gAU2uGy8mAuBsm6AJQhYayEsvnm0jAwXOmoADxx4mWRGtp6hsy6DAKyMEw2dg7M897mFIQYAG4CXgAehEwuLmDAAHxcfYUCE+Vkw1kAJmRQFmR3hydn-ZeJN9ptHW+nXqfI6nIA)

https://github.com/DefinitelyTyped/DefinitelyTyped/pull/62065
