### PR TITLE
Ensure equivalent Flow and TypeScript turbo module definition generates the same output

### DIFF
--- a/packages/react-native-codegen/src/parsers/consistency/__tests__/checkComponentSnaps-test.js
+++ b/packages/react-native-codegen/src/parsers/consistency/__tests__/checkComponentSnaps-test.js
@@ -20,5 +20,13 @@ const tsSnaps = require('../../../../src/parsers/typescript/components/__tests__
 const tsExtraCases = ['ARRAY2_PROP_TYPES_NO_EVENTS'];
 const ignoredCases = ['ARRAY_PROP_TYPES_NO_EVENTS'];
 
-compareSnaps(flowFixtures, flowSnaps, flowExtraCases, tsFixtures, tsSnaps, tsExtraCases, ignoredCases);
+compareSnaps(
+  flowFixtures,
+  flowSnaps,
+  flowExtraCases,
+  tsFixtures,
+  tsSnaps,
+  tsExtraCases,
+  ignoredCases,
+);
 compareTsArraySnaps(tsSnaps, tsExtraCases);

--- a/packages/react-native-codegen/src/parsers/consistency/__tests__/checkComponentSnaps-test.js
+++ b/packages/react-native-codegen/src/parsers/consistency/__tests__/checkComponentSnaps-test.js
@@ -14,9 +14,11 @@ const {compareSnaps, compareTsArraySnaps} = require('../compareSnaps.js');
 
 const flowFixtures = require('../../flow/components/__test_fixtures__/fixtures.js');
 const flowSnaps = require('../../../../src/parsers/flow/components/__tests__/__snapshots__/component-parser-test.js.snap');
+const flowExtraCases = [];
 const tsFixtures = require('../../typescript/components/__test_fixtures__/fixtures.js');
 const tsSnaps = require('../../../../src/parsers/typescript/components/__tests__/__snapshots__/typescript-component-parser-test.js.snap');
 const tsExtraCases = ['ARRAY2_PROP_TYPES_NO_EVENTS'];
+const ignoredCases = ['ARRAY_PROP_TYPES_NO_EVENTS'];
 
-compareSnaps(flowFixtures, flowSnaps, [], tsFixtures, tsSnaps, tsExtraCases);
+compareSnaps(flowFixtures, flowSnaps, flowExtraCases, tsFixtures, tsSnaps, tsExtraCases, ignoredCases);
 compareTsArraySnaps(tsSnaps, tsExtraCases);

--- a/packages/react-native-codegen/src/parsers/consistency/__tests__/checkModuleSnaps-test.js
+++ b/packages/react-native-codegen/src/parsers/consistency/__tests__/checkModuleSnaps-test.js
@@ -25,5 +25,13 @@ const tsExtraCases = [
 ];
 const ignoredCases = [];
 
-compareSnaps(flowFixtures, flowSnaps, flowExtraCases, tsFixtures, tsSnaps, tsExtraCases,ignoredCases);
+compareSnaps(
+  flowFixtures,
+  flowSnaps,
+  flowExtraCases,
+  tsFixtures,
+  tsSnaps,
+  tsExtraCases,
+  ignoredCases,
+);
 compareTsArraySnaps(tsSnaps, tsExtraCases);

--- a/packages/react-native-codegen/src/parsers/consistency/__tests__/checkModuleSnaps-test.js
+++ b/packages/react-native-codegen/src/parsers/consistency/__tests__/checkModuleSnaps-test.js
@@ -14,6 +14,7 @@ const {compareSnaps, compareTsArraySnaps} = require('../compareSnaps.js');
 
 const flowFixtures = require('../../flow/modules/__test_fixtures__/fixtures.js');
 const flowSnaps = require('../../../../src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap');
+const flowExtraCases = [];
 const tsFixtures = require('../../typescript/modules/__test_fixtures__/fixtures.js');
 const tsSnaps = require('../../../../src/parsers/typescript/modules/__tests__/__snapshots__/typescript-module-parser-snapshot-test.js.snap');
 const tsExtraCases = [
@@ -22,6 +23,7 @@ const tsExtraCases = [
   'NATIVE_MODULE_WITH_BASIC_ARRAY2',
   'NATIVE_MODULE_WITH_COMPLEX_ARRAY2',
 ];
+const ignoredCases = [];
 
-compareSnaps(flowFixtures, flowSnaps, [], tsFixtures, tsSnaps, tsExtraCases);
+compareSnaps(flowFixtures, flowSnaps, flowExtraCases, tsFixtures, tsSnaps, tsExtraCases,ignoredCases);
 compareTsArraySnaps(tsSnaps, tsExtraCases);

--- a/packages/react-native-codegen/src/parsers/consistency/compareSnaps.js
+++ b/packages/react-native-codegen/src/parsers/consistency/compareSnaps.js
@@ -37,22 +37,28 @@ function compareSnaps(
     });
 
     for (const commonCase of commonCases) {
-      const flowSnap = flowSnaps[`RN Codegen Flow Parser can generate fixture ${commonCase} 1`];
-      const tsSnap = tsSnaps[`RN Codegen TypeScript Parser can generate fixture ${commonCase} 1`];
-      
+      const flowSnap =
+        flowSnaps[
+          `RN Codegen Flow Parser can generate fixture ${commonCase} 1`
+        ];
+      const tsSnap =
+        tsSnaps[
+          `RN Codegen TypeScript Parser can generate fixture ${commonCase} 1`
+        ];
+
       it(`should be able to find the snapshot for Flow for case ${commonCase}`, () => {
         expect(typeof flowSnap).toEqual('string');
       });
-      
+
       it(`should be able to find the snapshot for TypeScript for case ${commonCase}`, () => {
         expect(typeof tsSnap).toEqual('string');
       });
 
-      if(ignoredCases.indexOf(commonCase)===-1){
+      if (ignoredCases.indexOf(commonCase) === -1) {
         it(`should generate the same snapshot from Flow and TypeScript for fixture ${commonCase}`, () => {
           expect(flowSnap).toEqual(tsSnap);
         });
-      }else{
+      } else {
         it(`should generate the different snapshot from Flow and TypeScript for fixture ${commonCase}`, () => {
           expect(flowSnap).not.toEqual(tsSnap);
         });

--- a/packages/react-native-codegen/src/parsers/consistency/compareSnaps.js
+++ b/packages/react-native-codegen/src/parsers/consistency/compareSnaps.js
@@ -17,6 +17,7 @@ function compareSnaps(
   tsFixtures,
   tsSnaps,
   tsExtraCases,
+  ignoredCases,
 ) {
   const flowCases = Object.keys(flowFixtures).sort();
   const tsCases = Object.keys(tsFixtures).sort();
@@ -36,17 +37,26 @@ function compareSnaps(
     });
 
     for (const commonCase of commonCases) {
-      it(`should generate the same snap from Flow and TypeScript for fixture ${commonCase}`, () => {
-        expect(
-          flowSnaps[
-            `RN Codegen Flow Parser can generate fixture ${commonCase}`
-          ],
-        ).toEqual(
-          tsSnaps[
-            `RN Codegen TypeScript Parser can generate fixture ${commonCase}`
-          ],
-        );
+      const flowSnap = flowSnaps[`RN Codegen Flow Parser can generate fixture ${commonCase} 1`];
+      const tsSnap = tsSnaps[`RN Codegen TypeScript Parser can generate fixture ${commonCase} 1`];
+      
+      it(`should be able to find the snapshot for Flow for case ${commonCase}`, () => {
+        expect(typeof flowSnap).toEqual('string');
       });
+      
+      it(`should be able to find the snapshot for TypeScript for case ${commonCase}`, () => {
+        expect(typeof tsSnap).toEqual('string');
+      });
+
+      if(ignoredCases.indexOf(commonCase)===-1){
+        it(`should generate the same snapshot from Flow and TypeScript for fixture ${commonCase}`, () => {
+          expect(flowSnap).toEqual(tsSnap);
+        });
+      }else{
+        it(`should generate the different snapshot from Flow and TypeScript for fixture ${commonCase}`, () => {
+          expect(flowSnap).not.toEqual(tsSnap);
+        });
+      }
     }
   });
 }


### PR DESCRIPTION
## Summary

Pull request #34251 only partially worked because I didn't notice that there is ` 1` after the snapshot name. In this change I fixed the issue and find out there is one case that Flow and TypeScript parser generate different result.

It is expected since the test inputs are different. TypeScript removes one member because there is no `{...X, ...}` type in TypeScript. We could make the codegen support intersection type and rewrite it to `X & {...}`, but this will not be included here anyway.

## Changelog

[General] [Changed] - codegen: ensure equivalent Flow and TypeScript TM definition generates the same output

## Test Plan

`yarn jest` passed in `packages/react-native-codegen`
