### PR TITLE
Support TypeScript type `(T)` for turbo module codegen (module only)

### DIFF
--- a/packages/react-native-codegen/src/parsers/typescript/modules/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/__test_fixtures__/fixtures.js
@@ -315,8 +315,8 @@ import type {TurboModule} from 'react-native/Libraries/TurboModule/RCTExport';
 import * as TurboModuleRegistry from 'react-native/Libraries/TurboModule/TurboModuleRegistry';
 
 export interface Spec extends TurboModule {
-  readonly getArray: (arg: Array<string>) => Array<string>;
-  readonly getArray: (arg: ReadonlyArray<string>) => ReadonlyArray<string>;
+  readonly getArray: (arg: Array<string>) => (Array<(string)>);
+  readonly getArray: (arg: ReadonlyArray<string>) => (ReadonlyArray<(string)>);
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
@@ -336,8 +336,8 @@ import type {TurboModule} from 'react-native/Libraries/TurboModule/RCTExport';
 import * as TurboModuleRegistry from 'react-native/Libraries/TurboModule/TurboModuleRegistry';
 
 export interface Spec extends TurboModule {
-  readonly getArray: (arg: string[]) => string[];
-  readonly getArray: (arg: readonly string[]) => readonly string[];
+  readonly getArray: (arg: string[]) => ((string)[]);
+  readonly getArray: (arg: readonly string[]) => (readonly (string)[]);
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -154,6 +154,16 @@ function translateTypeAnnotation(
     resolveTypeAnnotation(typeScriptTypeAnnotation, types);
 
   switch (typeAnnotation.type) {
+    case 'TSParenthesizedType': {
+      return translateTypeAnnotation(
+        hasteModuleName,
+        typeAnnotation.typeAnnotation,
+        types,
+        aliasMap,
+        tryParse,
+        cxxOnly,
+      );
+    }
     case 'TSArrayType': {
       return translateArrayTypeAnnotation(
         hasteModuleName,

--- a/packages/react-native-codegen/src/parsers/typescript/utils.js
+++ b/packages/react-native-codegen/src/parsers/typescript/utils.js
@@ -19,26 +19,26 @@ export type TypeDeclarationMap = {[declarationName: string]: $FlowFixMe};
 
 function getTypes(ast: $FlowFixMe): TypeDeclarationMap {
   return ast.body.reduce((types, node) => {
-    if (node.type === 'ExportNamedDeclaration') {
-      if (
-        node.declaration.type === 'TSTypeAliasDeclaration' ||
-        node.declaration.type === 'TSInterfaceDeclaration'
-      ) {
-        types[node.declaration.id.name] = node.declaration;
+    switch (node.type) {
+      case 'ExportNamedDeclaration': {
+        if (node.declaration) {
+          switch(node.declaration.type) {
+            case 'TSTypeAliasDeclaration':
+            case 'TSInterfaceDeclaration':
+            case 'TSEnumDeclaration': {
+              types[node.declaration.id.name] = node.declaration;
+              break;
+            }
+          }
+        }
+        break;
       }
-    } else if (
-      node.type === 'ExportNamedDeclaration' &&
-      node.exportKind === 'value' &&
-      node.declaration &&
-      node.declaration.type === 'TSEnumDeclaration'
-    ) {
-      types[node.declaration.id.name] = node.declaration;
-    } else if (
-      node.type === 'TSTypeAliasDeclaration' ||
-      node.type === 'TSInterfaceDeclaration' ||
-      node.type === 'TSEnumDeclaration'
-    ) {
-      types[node.id.name] = node;
+      case 'TSTypeAliasDeclaration':
+      case 'TSInterfaceDeclaration':
+      case 'TSEnumDeclaration': {
+        types[node.id.name] = node;
+        break;
+      }
     }
     return types;
   }, {});

--- a/packages/react-native-codegen/src/parsers/typescript/utils.js
+++ b/packages/react-native-codegen/src/parsers/typescript/utils.js
@@ -22,7 +22,7 @@ function getTypes(ast: $FlowFixMe): TypeDeclarationMap {
     switch (node.type) {
       case 'ExportNamedDeclaration': {
         if (node.declaration) {
-          switch(node.declaration.type) {
+          switch (node.declaration.type) {
             case 'TSTypeAliasDeclaration':
             case 'TSInterfaceDeclaration':
             case 'TSEnumDeclaration': {

--- a/packages/react-native-codegen/src/parsers/typescript/utils.js
+++ b/packages/react-native-codegen/src/parsers/typescript/utils.js
@@ -19,7 +19,7 @@ export type TypeDeclarationMap = {[declarationName: string]: $FlowFixMe};
 
 function getTypes(ast: $FlowFixMe): TypeDeclarationMap {
   return ast.body.reduce((types, node) => {
-    if (node.type === 'ExportNamedDeclaration' && node.exportKind === 'type') {
+    if (node.type === 'ExportNamedDeclaration') {
       if (
         node.declaration.type === 'TSTypeAliasDeclaration' ||
         node.declaration.type === 'TSInterfaceDeclaration'


### PR DESCRIPTION
## Summary

1. In some situation (I don't know exactly how it is triggered but I found that during porting it to `react-native-windows`), `ExportNamedDeclaration.exportKind` is missing. Just skip the checking to `exportKind` because the rest of the checking is sufficient without reading this field.
2. Add `TSParenthesizedType` to module codegen in TypeScript, so that type `(T)` is treated like `T`.

## Changelog

[General] [Changed] - codegen: support TypeScript type `(T)` for turbo module codegen (module only)

## Test Plan

`yarn jest` passed in `packages/react-native-codegen`
