### PR TITLE
[android][bugfix] Move destroyed callback to onDestroyView()

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/ReactFragment.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactFragment.java
@@ -103,8 +103,8 @@ public class ReactFragment extends Fragment implements PermissionAwareActivity {
   }
 
   @Override
-  public void onDestroy() {
-    super.onDestroy();
+  public void onDestroyView() {
+    super.onDestroyView();
     mReactDelegate.onHostDestroy();
   }
   // endregion


### PR DESCRIPTION
## Summary

Currently, when navigating back to a `ReactFragment` instance that is on the fragment backstack, we trigger an `IllegalStateException` from within `ReactDelegate.loadApp()`:

> "Cannot loadApp while app is already running."

`ReactFragment` calls `ReactDelegate#loadApp()` from `onCreateView()`
`ReactFragment` calls `ReactDelegate#onHostDestroyed()` from `onDestroy()`

This is a mismatch - `onCreateView()` can be called multiple times before `onDestroy()` is called. 

For example, consider the case where:

- The `ReactFragment` is shown on screen. `onCreateView()` is called.
- The fragment is replaced (with a `FragmentTransaction#replace()` call) and added to the fragment backstack. `ReactFragment#onDestroyView()` is called
- The user navigates back. `ReactFragment#onCreateView()` will be called again.

`onDestroyView()` here is the lifecycle method that matches `onCreateView()`, so it's more appropriate to do this teardown here, given the setup is done in `onCreateView()`

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[Android] [Fixed] - Fix crash when navigating back to a ReactFragment in the backstack

## Test Plan

- Open ReactFragment instance
- Replace original ReactFragment using `fragmentTransaction.replace().addToBackStack()`
- Press system back button
- Observe no more crash