### PR TITLE
[react devtools] Set top-level window keys related to patching the console on startup

### DIFF
--- a/Libraries/ReactNative/AppRegistry.js
+++ b/Libraries/ReactNative/AppRegistry.js
@@ -209,6 +209,10 @@ const AppRegistry = {
         "* A module failed to load due to an error and `AppRegistry.registerComponent` wasn't called.",
     );
 
+    if (__DEV__) {
+      require('./injectDeviceStorageMethods')();
+    }
+
     SceneTracker.setActiveScene({name: appKey});
     runnables[appKey].run(appParameters, displayMode);
   },

--- a/Libraries/ReactNative/injectDeviceStorageMethods.js
+++ b/Libraries/ReactNative/injectDeviceStorageMethods.js
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+import {MMKV} from 'react-native-mmkv';
+
+const storage = new MMKV();
+
+// Keep in sync with /packages/react-devtools-shared/src/constants.js in the react repo
+const LOCAL_STORAGE_SHOULD_APPEND_COMPONENT_STACK_KEY =
+  'React::DevTools::appendComponentStack';
+const LOCAL_STORAGE_SHOULD_BREAK_ON_CONSOLE_ERRORS =
+  'React::DevTools::breakOnConsoleErrors';
+const LOCAL_STORAGE_SHOW_INLINE_WARNINGS_AND_ERRORS_KEY =
+  'React::DevTools::showInlineWarningsAndErrors';
+const LOCAL_STORAGE_HIDE_CONSOLE_LOGS_IN_STRICT_MODE =
+  'React::DevTools::hideConsoleLogsInStrictMode';
+const LOCAL_STORAGE_BROWSER_THEME = 'React::DevTools::theme';
+
+function maybeInjectDeviceStorageMethods() {
+  if (
+    window.__REACT_DEVTOOLS_GLOBAL_HOOK__ &&
+    window.__REACT_DEVTOOLS_GLOBAL_HOOK__.injectDeviceStorageMethods
+  ) {
+    try {
+      window.__REACT_DEVTOOLS_APPEND_COMPONENT_STACK__ =
+        parseBool(
+          storage.get(LOCAL_STORAGE_SHOULD_APPEND_COMPONENT_STACK_KEY),
+        ) ?? true;
+      window.__REACT_DEVTOOLS_BREAK_ON_CONSOLE_ERRORS__ =
+        parseBool(storage.get(LOCAL_STORAGE_SHOULD_BREAK_ON_CONSOLE_ERRORS)) ??
+        false;
+      window.__REACT_DEVTOOLS_SHOW_INLINE_WARNINGS_AND_ERRORS__ =
+        parseBool(
+          storage.get(LOCAL_STORAGE_SHOW_INLINE_WARNINGS_AND_ERRORS_KEY),
+        ) ?? true;
+      window.__REACT_DEVTOOLS_HIDE_CONSOLE_LOGS_IN_STRICT_MODE__ =
+        parseBool(
+          storage.get(LOCAL_STORAGE_HIDE_CONSOLE_LOGS_IN_STRICT_MODE),
+        ) ?? false;
+      window.__REACT_DEVTOOLS_BROWSER_THEME__ =
+        parseBrowserTheme(storage.get(LOCAL_STORAGE_BROWSER_THEME)) ?? 'light';
+    } catch {}
+    try {
+      window.__REACT_DEVTOOLS_GLOBAL_HOOK__.injectDeviceStorageMethods({
+        setValueOnDevice: (key, value) => {
+          storage.set(key, value);
+        },
+      });
+    } catch (e) {
+      console.warn('injectDeviceStorageMethods was found, but threw.', e);
+    }
+  }
+}
+
+function parseBool(s: string): ?boolean {
+  if (s === 'true') {
+    return true;
+  }
+  if (s === 'false') {
+    return false;
+  }
+}
+
+type BrowserTheme = 'dark' | 'light';
+function parseBrowserTheme(s: string): ?BrowserTheme {
+  if (s === 'light') {
+    return 'light';
+  }
+  if (s === 'dark') {
+    return 'dark';
+  }
+}
+
+module.exports = maybeInjectDeviceStorageMethods;

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "promise": "^8.0.3",
     "react-devtools-core": "4.24.0",
     "react-native-gradle-plugin": "^0.71.0",
+    "react-native-mmkv": "^2.4.3",
     "react-refresh": "^0.4.0",
     "react-shallow-renderer": "^16.15.0",
     "regenerator-runtime": "^0.13.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5926,6 +5926,11 @@ react-is@^18.2.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
 
+react-native-mmkv@^2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/react-native-mmkv/-/react-native-mmkv-2.4.3.tgz#6bb4c2d5e328513da11faab1371d056a189adbd0"
+  integrity sha512-0hYNOTbsjJ5j5cpX+qjwReGIxuYE9MWRsyPQ72fTOvzmEjYXCF4Wr2VQoqx8R6W1/Uinekvln7dGvJ4RExmHhQ==
+
 react-refresh@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.4.0.tgz#d421f9bd65e0e4b9822a399f14ac56bda9c92292"


### PR DESCRIPTION
## Summary

* During startup, we want to do two things: initialize global values (stored on `window`) so that React DevTools patches the console correctly. (This is the existing practice for e.g. React in the browser). These values are read from persistent on-device storage.
* Also, call `window.__REACT_DEVTOOLS_GLOBAL_HOOK__.injectDeviceStorageMethods` with `{ setValueOnDevice }`, giving React DevTools the ability to write values to that on-device local storage.
* This allows us to set settings that are relevant during the initial render, i.e. before React DevTools has had a chance to connect. Currently, this only affects settings controlling whether to append component stacks, etc. However, we would like to use this same functionality to control settings that control whether we are profiling.

## Test Plan

* Manually tested with standalone, behaved as expected