### PR TITLE
Fixed typo in ReactCommon/buffer/map.h

### DIFF
--- a/ReactCommon/butter/map.h
+++ b/ReactCommon/butter/map.h
@@ -23,7 +23,7 @@ namespace facebook {
 namespace butter {
 
 /*
- * Note: In Butter, `map` aliases to `unorderd_map` because everyone agrees that
+ * Note: In Butter, `map` aliases to `unordered_map` because everyone agrees that
  * an *ordered* map is nonsense and was a huge mistake for standardization. If
  * you need an *ordered* map, feel free to introduce that as
  * `butter::ordered_map`.


### PR DESCRIPTION
## Summary

Fixed a typo inside ReactCommon.

## Changelog

[General] [Fixed] - Fixed typo in comment

## Test Plan

_This change does not require testing._
