### PR TITLE
[Fix] Update debian to fix CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -943,7 +943,7 @@ jobs:
   # -------------------------
   prepare_hermes_workspace:
     docker:
-      - image: debian:11.4
+      - image: debian:11
     environment:
       - HERMES_WS_DIR: *hermes_workspace_root
       - HERMES_VERSION_FILE: "sdks/.hermesversion"


### PR DESCRIPTION
## Summary

The keys of the current debian version expired again. This PR is an attempt to use a different version

## Changelog

[General] [Fixed] - Update debian version

## Test Plan

CircleCI is green
