### PR TITLE
#34610 Fix invalid range "t-5" in string transliteration [iOS]

### DIFF
--- a/scripts/cocoapods/utils.rb
+++ b/scripts/cocoapods/utils.rb
@@ -139,14 +139,16 @@ class ReactNativePodsUtils
             return
         end
 
-        # $(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME) causes problem with Xcode 12.5 + arm64 (Apple M1)
-        # since the libraries there are only built for x86_64 and i386.
-        lib_search_paths.delete("$(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)")
-        lib_search_paths.delete("\"$(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)\"")
+        if lib_search_paths.include?("$(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)") || lib_search_paths.include?("\"$(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)\"")
+            # $(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME) causes problem with Xcode 12.5 + arm64 (Apple M1)
+            # since the libraries there are only built for x86_64 and i386.
+            lib_search_paths.delete("$(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)")
+            lib_search_paths.delete("\"$(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)\"")
 
-        if !(lib_search_paths.include?("$(SDKROOT)/usr/lib/swift") || lib_search_paths.include?("\"$(SDKROOT)/usr/lib/swift\""))
-            # however, $(SDKROOT)/usr/lib/swift is required, at least if user is not running CocoaPods 1.11
-            lib_search_paths.insert(0, "$(SDKROOT)/usr/lib/swift")
+            if !(lib_search_paths.include?("$(SDKROOT)/usr/lib/swift") || lib_search_paths.include?("\"$(SDKROOT)/usr/lib/swift\""))
+                # however, $(SDKROOT)/usr/lib/swift is required, at least if user is not running CocoaPods 1.11
+                lib_search_paths.insert(0, "$(SDKROOT)/usr/lib/swift")
+            end
         end
     end
 

--- a/scripts/cocoapods/utils.rb
+++ b/scripts/cocoapods/utils.rb
@@ -144,11 +144,11 @@ class ReactNativePodsUtils
             # since the libraries there are only built for x86_64 and i386.
             lib_search_paths.delete("$(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)")
             lib_search_paths.delete("\"$(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)\"")
+        end
 
-            if !(lib_search_paths.include?("$(SDKROOT)/usr/lib/swift") || lib_search_paths.include?("\"$(SDKROOT)/usr/lib/swift\""))
-                # however, $(SDKROOT)/usr/lib/swift is required, at least if user is not running CocoaPods 1.11
-                lib_search_paths.insert(0, "$(SDKROOT)/usr/lib/swift")
-            end
+        if !(lib_search_paths.include?("$(SDKROOT)/usr/lib/swift") || lib_search_paths.include?("\"$(SDKROOT)/usr/lib/swift\""))
+            # however, $(SDKROOT)/usr/lib/swift is required, at least if user is not running CocoaPods 1.11
+            lib_search_paths.insert(0, "$(SDKROOT)/usr/lib/swift")
         end
     end
 


### PR DESCRIPTION
Fix invalid range "t-5" in string transliteration [iOS] for M1 pod install issue.

## Summary
This should fix pod install error for M1 machines.

## Changelog
[iOS] [Fixed] - Fix ios pod install error

## Test Plan
Run pod install on M1 machine.
