### PR TITLE
[FIX] Add a check for scrollEnabled to VirtualizedList error 

### DIFF
--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -898,7 +898,8 @@ class VirtualizedList extends React.PureComponent<Props, State> {
               !scrollContext.horizontal ===
                 !horizontalOrDefault(this.props.horizontal) &&
               !this._hasWarned.nesting &&
-              this.context == null
+              this.context == null &&
+              this.props.scrollEnabled !== false
             ) {
               // TODO (T46547044): use React.warn once 16.9 is sync'd: https://github.com/facebook/react/pull/15170
               console.error(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Already merged PR [here](https://github.com/facebook/react-native/pull/34560), but there was confusion that the changes should _also_ be in `VirtualizedList_EXPERIMENTAL.js` _and_ `VirtualizedList.js`, not one or the other.

## Changelog

[General] [Added] - Added a check to if `scrollEnabled` is not false, if so then fire the `VirtualizedList` error in `VirtualizedList.js` to match `VirtualizedList_EXPERIMENTAL.js`

[CATEGORY] [TYPE] - Message

## Test Plan

Passes all provided automatic tests. In a personal app, there is a situation of nested ScrollViews that had triggered the error. After defining scrollEnabled={false} and adding the check, the error no longer appears.

Previously spoke with @NickGerleman so @ mentioning him again to get attention. 
