### PR TITLE
Pass execution context ID in Debugger.scriptParsed event

### DIFF
--- a/ReactCommon/hermes/inspector/chrome/Connection.cpp
+++ b/ReactCommon/hermes/inspector/chrome/Connection.cpp
@@ -390,8 +390,7 @@ void Connection::Impl::onScriptParsed(
   m::debugger::ScriptParsedNotification note;
   note.scriptId = folly::to<std::string>(info.fileId);
   note.url = info.fileName;
-  // TODO(jpporto): fix test cases sending invalid context id.
-  // note.executionContextId = kHermesExecutionContextId;
+  note.executionContextId = kHermesExecutionContextId;
 
   if (!info.sourceMappingUrl.empty()) {
     note.sourceMapURL = info.sourceMappingUrl;


### PR DESCRIPTION
## Summary

As generated by ReactCommon code, the CDP [Debugger.scriptParsed](https://chromedevtools.github.io/devtools-protocol/tot/Debugger/#event-scriptParsed) event carries a zero execution context ID. It should match the execution context ID contained in the []() argument of the [Runtime.executionContextCreated](https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#event-executionContextCreated) event. Tracking issue is RN:34639](https://github.com/facebook/react-native/issues/34639).

## Changelog

[General] [Changed] - Correct execution context ID in Debugger.scriptParsed event.

## Test Plan

Verified via packet tracer (Wireshark, Chrome DevTools protocol monitor) that Debugger.scriptParsed carries execution context ID.
