### PR TITLE
Fix ImageLoader.getSize jest mock

### DIFF
--- a/jest/setup.js
+++ b/jest/setup.js
@@ -231,7 +231,7 @@ jest
       reload: jest.fn(),
     },
     ImageLoader: {
-      getSize: jest.fn(url => Promise.resolve({width: 320, height: 240})),
+      getSize: jest.fn(url => Promise.resolve([320, 240])),
       prefetchImage: jest.fn(),
     },
     ImageViewManager: {


### PR DESCRIPTION
`getSize` should resolve with an array of `[width, height]` but this mock resolves with `{ width, height }`.

It should be `ReadOnlyArray<number>` instead of `{width: number, height: number}`

The native image loader call is [here](https://github.com/facebook/react-native/blob/main/Libraries/Image/NativeImageLoaderIOS.js#L18): 
```js
  +getSize: (uri: string) => Promise<$ReadOnlyArray<number>>;
```

but in the [jest setup file](https://github.com/facebook/react-native/blob/main/jest/setup.js):
```js
  getSize: jest.fn(url => Promise.resolve({width: 320, height: 240})),
```

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

My tests were failing on `Image.getSize()` - `TypeError: Invalid attempt to destructure non-iterable instance.` 

I managed to trace this down to this object being returned by the Jest mock - looks like it's returning a size object instead of a dimensions array.

## Workaround

If you are hitting this issue, you can work around this mock by using:

```js
ReactNative.NativeModules.ImageLoader.getSize = jest.fn((_) => Promise.resolve([320, 240]));
```

## Changelog

[JavaScript] [Changed]: Changed the mocked return value of `ImageLoader.getSize` to be `[320, 240]` instead of `{ width: 320, height: 240 }`

## Test Plan

TBD? I think a test with `Image.getSize(path)` will cover it. That's where I hit the error with the ios-specific imageLoader's getSize method.