### PR TITLE
Align android image style / source logic with ios

### DIFF
--- a/Libraries/Image/Image.android.js
+++ b/Libraries/Image/Image.android.js
@@ -129,7 +129,11 @@ export type ImageComponentStatics = $ReadOnly<{|
 /* $FlowFixMe[missing-local-annot] The type annotation(s) required by Flow's
  * LTI update could not be added via codemod */
 const BaseImage = (props: ImagePropsType, forwardedRef) => {
-  let source = getImageSourcesFromImageProps(props);
+  let source = getImageSourcesFromImageProps(props) || {
+    uri: undefined,
+    width: undefined,
+    height: undefined,
+  };
   const defaultSource = resolveAssetSource(props.defaultSource);
   const loadingIndicatorSource = resolveAssetSource(
     props.loadingIndicatorSource,
@@ -147,22 +151,19 @@ const BaseImage = (props: ImagePropsType, forwardedRef) => {
     );
   }
 
-  if (source && !source.uri && !Array.isArray(source)) {
-    source = null;
-  }
-
   let style;
   let sources;
-  if (!Array.isArray(source) && source?.uri != null) {
+  if (Array.isArray(source)) {
+    style = flattenStyle([styles.base, props.style]);
+    sources = source;
+  } else {
     const {width = props.width, height = props.height, uri} = source;
     style = flattenStyle([{width, height}, styles.base, props.style]);
-    sources = [{uri: uri, width: width, height: height}];
+    sources = [source];
+
     if (uri === '') {
       console.warn('source.uri should not be an empty string');
     }
-  } else {
-    style = flattenStyle([styles.base, props.style]);
-    sources = source;
   }
 
   const {height, width, ...restProps} = props;
@@ -212,13 +213,12 @@ const BaseImage = (props: ImagePropsType, forwardedRef) => {
           <TextAncestor.Consumer>
             {hasTextAncestor => {
               if (hasTextAncestor) {
-                let src = Array.isArray(sources) ? sources : [sources];
                 return (
                   <TextInlineImageNativeComponent
                     style={style}
                     resizeMode={resizeMode}
                     headers={nativeProps.headers}
-                    src={src}
+                    src={sources}
                     ref={forwardedRef}
                   />
                 );

--- a/Libraries/Image/ImageViewNativeComponent.js
+++ b/Libraries/Image/ImageViewNativeComponent.js
@@ -35,7 +35,9 @@ type Props = $ReadOnly<{
 
   // Android native props
   shouldNotifyLoadEvents?: boolean,
-  src?: ?ResolvedAssetSource | $ReadOnlyArray<{uri: string, ...}>,
+  src?:
+    | ?ResolvedAssetSource
+    | ?$ReadOnlyArray<?$ReadOnly<{uri?: ?string, ...}>>,
   headers?: ?{[string]: string},
   defaultSrc?: ?string,
   loadingIndicatorSrc?: ?string,

--- a/Libraries/Image/TextInlineImageNativeComponent.js
+++ b/Libraries/Image/TextInlineImageNativeComponent.js
@@ -22,7 +22,7 @@ import type {ColorValue} from '../StyleSheet/StyleSheet';
 type NativeProps = $ReadOnly<{
   ...ViewProps,
   resizeMode?: ?ImageResizeMode,
-  src?: ?$ReadOnlyArray<?$ReadOnly<{uri: string, ...}>>,
+  src?: ?$ReadOnlyArray<?$ReadOnly<{uri?: ?string, ...}>>,
   tintColor?: ?ColorValue,
   headers?: ?{[string]: string},
 }>;


### PR DESCRIPTION
## Summary

This aligns the logic of setting style (width / height) and source of Android with iOS.
iOS handles nullish uris with set width and heigth by passing them through. Android did not.

## Changelog

[Android] [Fixed] - Align android image style / source logic with ios

## Test Plan

```
<Image source={{width: 100, height: 100}} />
```

Before this Patch:
* iOS: Renders a blank image with 100x100
* Android: Renders a blank image with 0x0

After this Patch:
* iOS: Renders a blank image with 100x100
* Android: Renders a blank image with 100x100

