### PR TITLE
feat: Add string support to the transform property

### DIFF
--- a/Libraries/StyleSheet/__tests__/__snapshots__/processTransform-test.js.snap
+++ b/Libraries/StyleSheet/__tests__/__snapshots__/processTransform-test.js.snap
@@ -10,8 +10,6 @@ exports[`processTransform validation should throw when not passing an array to a
 
 exports[`processTransform validation should throw when not passing an array to an array prop 2`] = `"Transform with key of translate must have an array as the value: {\\"translate\\":10}"`;
 
-exports[`processTransform validation should throw when not passing an array to an array prop 3`] = `"Transform with key translate must be an array of length 2 or 3, found 1: {\\"translate\\":[10]}"`;
-
 exports[`processTransform validation should throw when passing a matrix of the wrong size 1`] = `"Matrix transform must have a length of 9 (2d) or 16 (3d). Provided matrix has a length of 4: {\\"matrix\\":[1,1,1,1]}"`;
 
 exports[`processTransform validation should throw when passing a matrix of the wrong size 2`] = `"Matrix transform must have a length of 9 (2d) or 16 (3d). Provided matrix has a length of 4: {\\"matrix\\":[1,1,1,1]}"`;
@@ -22,11 +20,9 @@ exports[`processTransform validation should throw when passing a perspective of 
 
 exports[`processTransform validation should throw when passing a translate of the wrong size 1`] = `"Transform with key translate must be an array of length 2 or 3, found 1: {\\"translate\\":[1]}"`;
 
-exports[`processTransform validation should throw when passing a translate of the wrong size 2`] = `"Transform with key translate must be an array of length 2 or 3, found 1: {\\"translate\\":[1]}"`;
+exports[`processTransform validation should throw when passing a translate of the wrong size 2`] = `"Transform with key translate must be an array of length 2 or 3, found 4: {\\"translate\\":[1,1,1,1]}"`;
 
-exports[`processTransform validation should throw when passing a translate of the wrong size 3`] = `"Transform with key translate must be an array of length 2 or 3, found 4: {\\"translate\\":[1,1,1,1]}"`;
-
-exports[`processTransform validation should throw when passing a translate of the wrong size 4`] = `"Transform with key translate must be an array of length 2 or 3, found 4: {\\"translate\\":[1,1,1,1]}"`;
+exports[`processTransform validation should throw when passing a translate of the wrong size 3`] = `"Transform with key translate must be an string with 1 or 2 two parameters, found 4: translate(1, 1, 1, 1)"`;
 
 exports[`processTransform validation should throw when passing an Animated.Value 1`] = `"You passed an Animated.Value to a normal component. You need to wrap that component in an Animated. For example, replace <View /> by <Animated.View />."`;
 

--- a/Libraries/StyleSheet/__tests__/__snapshots__/processTransform-test.js.snap
+++ b/Libraries/StyleSheet/__tests__/__snapshots__/processTransform-test.js.snap
@@ -22,7 +22,7 @@ exports[`processTransform validation should throw when passing a translate of th
 
 exports[`processTransform validation should throw when passing a translate of the wrong size 2`] = `"Transform with key translate must be an array of length 2 or 3, found 4: {\\"translate\\":[1,1,1,1]}"`;
 
-exports[`processTransform validation should throw when passing a translate of the wrong size 3`] = `"Transform with key translate must be an string with 1 or 2 two parameters, found 4: translate(1, 1, 1, 1)"`;
+exports[`processTransform validation should throw when passing a translate of the wrong size 3`] = `"Transform with key translate must be an string with 1 or 2 two parameters, found 4: translate(1px, 1px, 1px, 1px)"`;
 
 exports[`processTransform validation should throw when passing an Animated.Value 1`] = `"You passed an Animated.Value to a normal component. You need to wrap that component in an Animated. For example, replace <View /> by <Animated.View />."`;
 

--- a/Libraries/StyleSheet/__tests__/__snapshots__/processTransform-test.js.snap
+++ b/Libraries/StyleSheet/__tests__/__snapshots__/processTransform-test.js.snap
@@ -16,13 +16,11 @@ exports[`processTransform validation should throw when passing a matrix of the w
 
 exports[`processTransform validation should throw when passing a perspective of 0 1`] = `"Transform with key of \\"perspective\\" cannot be zero: {\\"perspective\\":0}"`;
 
-exports[`processTransform validation should throw when passing a perspective of 0 2`] = `"Transform with key of \\"perspective\\" cannot be zero: {\\"perspective\\":0}"`;
-
 exports[`processTransform validation should throw when passing a translate of the wrong size 1`] = `"Transform with key translate must be an array of length 2 or 3, found 1: {\\"translate\\":[1]}"`;
 
 exports[`processTransform validation should throw when passing a translate of the wrong size 2`] = `"Transform with key translate must be an array of length 2 or 3, found 4: {\\"translate\\":[1,1,1,1]}"`;
 
-exports[`processTransform validation should throw when passing a translate of the wrong size 3`] = `"Transform with key translate must be an string with 1 or 2 two parameters, found 4: translate(1px, 1px, 1px, 1px)"`;
+exports[`processTransform validation should throw when passing a translate of the wrong size 3`] = `"Transform with key translate must be an string with 1 or 2 parameters, found 4: translate(1px, 1px, 1px, 1px)"`;
 
 exports[`processTransform validation should throw when passing an Animated.Value 1`] = `"You passed an Animated.Value to a normal component. You need to wrap that component in an Animated. For example, replace <View /> by <Animated.View />."`;
 

--- a/Libraries/StyleSheet/__tests__/__snapshots__/processTransform-test.js.snap
+++ b/Libraries/StyleSheet/__tests__/__snapshots__/processTransform-test.js.snap
@@ -2,25 +2,41 @@
 
 exports[`processTransform validation should throw on invalid transform property 1`] = `"Invalid transform translateW: {\\"translateW\\":10}"`;
 
+exports[`processTransform validation should throw on invalid transform property 2`] = `"Invalid transform translateW: {\\"translateW\\":10}"`;
+
 exports[`processTransform validation should throw on object with multiple properties 1`] = `"You must specify exactly one property per transform object. Passed properties: {\\"scale\\":0.5,\\"translateY\\":10}"`;
 
 exports[`processTransform validation should throw when not passing an array to an array prop 1`] = `"Transform with key of matrix must have an array as the value: {\\"matrix\\":\\"not-a-matrix\\"}"`;
 
 exports[`processTransform validation should throw when not passing an array to an array prop 2`] = `"Transform with key of translate must have an array as the value: {\\"translate\\":10}"`;
 
+exports[`processTransform validation should throw when not passing an array to an array prop 3`] = `"Transform with key translate must be an array of length 2 or 3, found 1: {\\"translate\\":[10]}"`;
+
 exports[`processTransform validation should throw when passing a matrix of the wrong size 1`] = `"Matrix transform must have a length of 9 (2d) or 16 (3d). Provided matrix has a length of 4: {\\"matrix\\":[1,1,1,1]}"`;
+
+exports[`processTransform validation should throw when passing a matrix of the wrong size 2`] = `"Matrix transform must have a length of 9 (2d) or 16 (3d). Provided matrix has a length of 4: {\\"matrix\\":[1,1,1,1]}"`;
 
 exports[`processTransform validation should throw when passing a perspective of 0 1`] = `"Transform with key of \\"perspective\\" cannot be zero: {\\"perspective\\":0}"`;
 
+exports[`processTransform validation should throw when passing a perspective of 0 2`] = `"Transform with key of \\"perspective\\" cannot be zero: {\\"perspective\\":0}"`;
+
 exports[`processTransform validation should throw when passing a translate of the wrong size 1`] = `"Transform with key translate must be an array of length 2 or 3, found 1: {\\"translate\\":[1]}"`;
 
-exports[`processTransform validation should throw when passing a translate of the wrong size 2`] = `"Transform with key translate must be an array of length 2 or 3, found 4: {\\"translate\\":[1,1,1,1]}"`;
+exports[`processTransform validation should throw when passing a translate of the wrong size 2`] = `"Transform with key translate must be an array of length 2 or 3, found 1: {\\"translate\\":[1]}"`;
+
+exports[`processTransform validation should throw when passing a translate of the wrong size 3`] = `"Transform with key translate must be an array of length 2 or 3, found 4: {\\"translate\\":[1,1,1,1]}"`;
+
+exports[`processTransform validation should throw when passing a translate of the wrong size 4`] = `"Transform with key translate must be an array of length 2 or 3, found 4: {\\"translate\\":[1,1,1,1]}"`;
 
 exports[`processTransform validation should throw when passing an Animated.Value 1`] = `"You passed an Animated.Value to a normal component. You need to wrap that component in an Animated. For example, replace <View /> by <Animated.View />."`;
 
 exports[`processTransform validation should throw when passing an invalid angle prop 1`] = `"Transform with key of \\"rotate\\" must be a string: {\\"rotate\\":10}"`;
 
-exports[`processTransform validation should throw when passing an invalid angle prop 2`] = `"Rotate transform must be expressed in degrees (deg) or radians (rad): {\\"skewX\\":\\"10drg\\"}"`;
+exports[`processTransform validation should throw when passing an invalid angle prop 2`] = `"Transform with key of \\"rotate\\" must be a string: {\\"rotate\\":10}"`;
+
+exports[`processTransform validation should throw when passing an invalid angle prop 3`] = `"Rotate transform must be expressed in degrees (deg) or radians (rad): {\\"skewX\\":\\"10drg\\"}"`;
+
+exports[`processTransform validation should throw when passing an invalid angle prop 4`] = `"Rotate transform must be expressed in degrees (deg) or radians (rad): {\\"skewX\\":\\"10drg\\"}"`;
 
 exports[`processTransform validation should throw when passing an invalid value to a number prop 1`] = `"Transform with key of \\"translateY\\" must be a number: {\\"translateY\\":\\"20deg\\"}"`;
 

--- a/Libraries/StyleSheet/__tests__/processTransform-test.js
+++ b/Libraries/StyleSheet/__tests__/processTransform-test.js
@@ -18,6 +18,10 @@ describe('processTransform', () => {
       processTransform([]);
     });
 
+    it('should accept an empty string', () => {
+      processTransform('');
+    });
+
     it('should accept a simple valid transform', () => {
       processTransform([
         {scale: 0.5},
@@ -25,6 +29,9 @@ describe('processTransform', () => {
         {translateY: 20},
         {rotate: '10deg'},
       ]);
+      processTransform(
+        'scale(0.5) translateX(10) translateY(20) rotate(10deg)',
+      );
     });
 
     it('should throw on object with multiple properties', () => {
@@ -37,6 +44,9 @@ describe('processTransform', () => {
       expect(() =>
         processTransform([{translateW: 10}]),
       ).toThrowErrorMatchingSnapshot();
+      expect(() =>
+        processTransform('translateW(10)'),
+      ).toThrowErrorMatchingSnapshot();
     });
 
     it('should throw when not passing an array to an array prop', () => {
@@ -46,24 +56,36 @@ describe('processTransform', () => {
       expect(() =>
         processTransform([{translate: 10}]),
       ).toThrowErrorMatchingSnapshot();
+      expect(() =>
+        processTransform('translate(10)'),
+      ).toThrowErrorMatchingSnapshot();
     });
 
     it('should accept a valid matrix', () => {
       processTransform([{matrix: [1, 1, 1, 1, 1, 1, 1, 1, 1]}]);
+      processTransform('matrix(1, 1, 1, 1, 1, 1, 1, 1, 1)');
       processTransform([
         {matrix: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]},
       ]);
+      processTransform(
+        'matrix(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1)',
+      );
     });
 
     it('should throw when passing a matrix of the wrong size', () => {
       expect(() =>
         processTransform([{matrix: [1, 1, 1, 1]}]),
       ).toThrowErrorMatchingSnapshot();
+      expect(() =>
+        processTransform('matrix(1, 1, 1, 1)'),
+      ).toThrowErrorMatchingSnapshot();
     });
 
     it('should accept a valid translate', () => {
       processTransform([{translate: [1, 1]}]);
+      processTransform('translate(1, 1)');
       processTransform([{translate: [1, 1, 1]}]);
+      processTransform('translate(1, 1, 1)');
     });
 
     it('should throw when passing a translate of the wrong size', () => {
@@ -71,7 +93,13 @@ describe('processTransform', () => {
         processTransform([{translate: [1]}]),
       ).toThrowErrorMatchingSnapshot();
       expect(() =>
+        processTransform('translate(1)'),
+      ).toThrowErrorMatchingSnapshot();
+      expect(() =>
         processTransform([{translate: [1, 1, 1, 1]}]),
+      ).toThrowErrorMatchingSnapshot();
+      expect(() =>
+        processTransform('translate(1, 1, 1, 1)'),
       ).toThrowErrorMatchingSnapshot();
     });
 
@@ -91,11 +119,16 @@ describe('processTransform', () => {
       expect(() =>
         processTransform([{perspective: 0}]),
       ).toThrowErrorMatchingSnapshot();
+      expect(() =>
+        processTransform('perspective(0)'),
+      ).toThrowErrorMatchingSnapshot();
     });
 
     it('should accept an angle in degrees or radians', () => {
       processTransform([{skewY: '10deg'}]);
+      processTransform('skewY(10deg)');
       processTransform([{rotateX: '1.16rad'}]);
+      processTransform('rotateX(1.16rad)');
     });
 
     it('should throw when passing an invalid angle prop', () => {
@@ -103,7 +136,13 @@ describe('processTransform', () => {
         processTransform([{rotate: 10}]),
       ).toThrowErrorMatchingSnapshot();
       expect(() =>
+        processTransform('rotate(10)'),
+      ).toThrowErrorMatchingSnapshot();
+      expect(() =>
         processTransform([{skewX: '10drg'}]),
+      ).toThrowErrorMatchingSnapshot();
+      expect(() =>
+        processTransform('skewX(10drg)'),
       ).toThrowErrorMatchingSnapshot();
     });
 

--- a/Libraries/StyleSheet/__tests__/processTransform-test.js
+++ b/Libraries/StyleSheet/__tests__/processTransform-test.js
@@ -80,8 +80,8 @@ describe('processTransform', () => {
 
     it('should accept a valid translate', () => {
       processTransform([{translate: [1, 1]}]);
-      processTransform('translate(1)');
-      processTransform('translate(1, 1)');
+      processTransform('translate(1px)');
+      processTransform('translate(1px, 1px)');
       processTransform([{translate: [1, 1, 1]}]);
     });
 
@@ -93,7 +93,7 @@ describe('processTransform', () => {
         processTransform([{translate: [1, 1, 1, 1]}]),
       ).toThrowErrorMatchingSnapshot();
       expect(() =>
-        processTransform('translate(1, 1, 1, 1)'),
+        processTransform('translate(1px, 1px, 1px, 1px)'),
       ).toThrowErrorMatchingSnapshot();
     });
 

--- a/Libraries/StyleSheet/__tests__/processTransform-test.js
+++ b/Libraries/StyleSheet/__tests__/processTransform-test.js
@@ -30,7 +30,7 @@ describe('processTransform', () => {
         {rotate: '10deg'},
       ]);
       processTransform(
-        'scale(0.5) translateX(10) translateY(20) rotate(10deg)',
+        'scale(0.5) translateX(10px) translateY(20px) rotate(10deg)',
       );
     });
 
@@ -112,9 +112,6 @@ describe('processTransform', () => {
     it('should throw when passing a perspective of 0', () => {
       expect(() =>
         processTransform([{perspective: 0}]),
-      ).toThrowErrorMatchingSnapshot();
-      expect(() =>
-        processTransform('perspective(0)'),
       ).toThrowErrorMatchingSnapshot();
     });
 

--- a/Libraries/StyleSheet/__tests__/processTransform-test.js
+++ b/Libraries/StyleSheet/__tests__/processTransform-test.js
@@ -56,9 +56,6 @@ describe('processTransform', () => {
       expect(() =>
         processTransform([{translate: 10}]),
       ).toThrowErrorMatchingSnapshot();
-      expect(() =>
-        processTransform('translate(10)'),
-      ).toThrowErrorMatchingSnapshot();
     });
 
     it('should accept a valid matrix', () => {
@@ -83,17 +80,14 @@ describe('processTransform', () => {
 
     it('should accept a valid translate', () => {
       processTransform([{translate: [1, 1]}]);
+      processTransform('translate(1)');
       processTransform('translate(1, 1)');
       processTransform([{translate: [1, 1, 1]}]);
-      processTransform('translate(1, 1, 1)');
     });
 
     it('should throw when passing a translate of the wrong size', () => {
       expect(() =>
         processTransform([{translate: [1]}]),
-      ).toThrowErrorMatchingSnapshot();
-      expect(() =>
-        processTransform('translate(1)'),
       ).toThrowErrorMatchingSnapshot();
       expect(() =>
         processTransform([{translate: [1, 1, 1, 1]}]),

--- a/Libraries/StyleSheet/private/_TransformStyle.js
+++ b/Libraries/StyleSheet/private/_TransformStyle.js
@@ -27,27 +27,29 @@ export type ____TransformStyle_Internal = $ReadOnly<{|
    *
    * `transform([{ skewX: '45deg' }])`
    */
-  transform?: $ReadOnlyArray<
-    | {|+perspective: number | AnimatedNode|}
-    | {|+rotate: string | AnimatedNode|}
-    | {|+rotateX: string | AnimatedNode|}
-    | {|+rotateY: string | AnimatedNode|}
-    | {|+rotateZ: string | AnimatedNode|}
-    | {|+scale: number | AnimatedNode|}
-    | {|+scaleX: number | AnimatedNode|}
-    | {|+scaleY: number | AnimatedNode|}
-    | {|+translateX: number | AnimatedNode|}
-    | {|+translateY: number | AnimatedNode|}
-    | {|
-        +translate:
-          | [number | AnimatedNode, number | AnimatedNode]
-          | AnimatedNode,
-      |}
-    | {|+skewX: string|}
-    | {|+skewY: string|}
-    // TODO: what is the actual type it expects?
-    | {|
-        +matrix: $ReadOnlyArray<number | AnimatedNode> | AnimatedNode,
-      |},
-  >,
+  transform?:
+    | $ReadOnlyArray<
+        | {|+perspective: number | AnimatedNode|}
+        | {|+rotate: string | AnimatedNode|}
+        | {|+rotateX: string | AnimatedNode|}
+        | {|+rotateY: string | AnimatedNode|}
+        | {|+rotateZ: string | AnimatedNode|}
+        | {|+scale: number | AnimatedNode|}
+        | {|+scaleX: number | AnimatedNode|}
+        | {|+scaleY: number | AnimatedNode|}
+        | {|+translateX: number | AnimatedNode|}
+        | {|+translateY: number | AnimatedNode|}
+        | {|
+            +translate:
+              | [number | AnimatedNode, number | AnimatedNode]
+              | AnimatedNode,
+          |}
+        | {|+skewX: string|}
+        | {|+skewY: string|}
+        // TODO: what is the actual type it expects?
+        | {|
+            +matrix: $ReadOnlyArray<number | AnimatedNode> | AnimatedNode,
+          |},
+      >
+    | string,
 |}>;

--- a/packages/rn-tester/js/examples/Transform/TransformExample.js
+++ b/packages/rn-tester/js/examples/Transform/TransformExample.js
@@ -199,6 +199,17 @@ const styles = StyleSheet.create({
     backgroundColor: 'salmon',
     alignSelf: 'center',
   },
+  box7: {
+    backgroundColor: 'lightseagreen',
+    height: 50,
+    position: 'absolute',
+    right: 0,
+    top: 0,
+    width: 50,
+  },
+  box7Transform: {
+    transform: 'translate(-50, 35) rotate(50deg) scale(2)',
+  },
   flipCardContainer: {
     marginVertical: 40,
     flex: 1,
@@ -322,6 +333,17 @@ exports.examples = [
     description: "rotate: '360deg'",
     render(): Node {
       return <AnimateTansformSingleProp />;
+    },
+  },
+  {
+    title: 'Transform using a string',
+    description: "transform: 'translate(-50, 35) rotate(50deg) scale(2)'",
+    render(): Node {
+      return (
+        <View style={styles.container}>
+          <View style={[styles.box7, styles.box7Transform]} />
+        </View>
+      );
     },
   },
 ];


### PR DESCRIPTION
## Summary

This updates the `transform` property to support string values as requested on https://github.com/facebook/react-native/issues/34425. This also updates the existing unit tests of the `processTransform` function ensuring the style processing works as expected and updates the TransformExample on RNTester in order to facilitate the manual QA of this. 

## Changelog 

[General] [Added] -  Add string support to the transform property

## Test Plan

1. Open the RNTester app and navigate to the Transforms page
2. Check the transform style through the `Transform using a string` section



https://user-images.githubusercontent.com/11707729/189550548-ee3c14dd-11c6-4fd1-bd74-f6b52ecb9eae.mov



