### PR TITLE
Test the Android Template with the JSC engine

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -555,7 +555,7 @@ jobs:
   # -------------------------
   #    JOBS: Test Buck
   # -------------------------
-    test_buck:
+  test_buck:
     executor: reactnativeandroid
     environment:
       KOTLIN_HOME=third-party/kotlin

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -555,7 +555,7 @@ jobs:
   # -------------------------
   #    JOBS: Test Buck
   # -------------------------
-  test_buck:
+    test_buck:
     executor: reactnativeandroid
     environment:
       KOTLIN_HOME=third-party/kotlin
@@ -674,6 +674,9 @@ jobs:
       newarchitecture:
         type: boolean
         default: false
+      jsengine:
+        type: string
+        default: "Hermes"
     environment:
       - PROJECT_NAME: "AndroidTemplateProject"
     steps:
@@ -681,6 +684,16 @@ jobs:
       - run_yarn
       - attach_workspace:
           at: .
+      - when:
+          condition:
+            equal: ["JSC", << parameters.jsengine >>]
+          steps:
+            - run:
+                name: Set enableHermes in buld.gradle to false
+                command: |
+                  gsed -i "/enableHermes:/ s/:.*/: false/" template/android/app/build.gradle
+                  echo "Hermes disabled."
+                  grep enableHermes: template/android/app/build.gradle
 
       - run:
           name: Create Android template project
@@ -692,7 +705,7 @@ jobs:
             yarn
 
       - run:
-          name: Build the template application for << parameters.flavor >> with New Architecture set << parameters.newarchitecture >>
+          name: Build the template application for << parameters.flavor >> with New Architecture set to << parameters.newarchitecture >>, and using the << parameters.jsengine>> JS engine.
           command: cd /tmp/$PROJECT_NAME/android/ && ./gradlew assemble<< parameters.flavor >> -PnewArchEnabled=<< parameters.newarchitecture >>
 
   # -------------------------
@@ -1376,6 +1389,7 @@ workflows:
           matrix:
             parameters:
               newarchitecture: [true, false]
+              jsengine: ["Hermes", "JSC"]
               flavor: ["Debug", "Release"]
       - test_buck
       - test_ios_template:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -691,7 +691,7 @@ jobs:
             - run:
                 name: Set enableHermes in buld.gradle to false
                 command: |
-                  gsed -i "/enableHermes:/ s/:.*/: false/" template/android/app/build.gradle
+                  node ./scripts/set-rn-engine.js -e jsc
                   echo "Hermes disabled."
                   grep enableHermes: template/android/app/build.gradle
 

--- a/scripts/set-rn-engine.js
+++ b/scripts/set-rn-engine.js
@@ -37,14 +37,15 @@ sed(
   'template/android/app/build.gradle',
 );
 
-//Validate the hermes flag has been changed properly
-const hermes = exec(
-  `grep enableHermes: template/android/app/build.gradle | awk '{split($0,a,"[:,]"); print a[2]}'`,
-  {silent: true},
-).stdout.trim() === 'true';
+// Validate the hermes flag has been changed properly
+const hermes =
+  exec(
+    'grep enableHermes: template/android/app/build.gradle | awk \'{split($0,a,"[:,]"); print a[2]}\'',
+    {silent: true},
+  ).stdout.trim() === 'true';
 
-if (engine === 'jsc' && hermes || engine === 'hermes' && !hermes) {
-  echo(`Failed to update the engine in template/android/app/build.gradle`);
+if ((engine === 'jsc' && hermes) || (engine === 'hermes' && !hermes)) {
+  echo('Failed to update the engine in template/android/app/build.gradle');
   echo('Fix the issue and try again');
   exit(1);
 }

--- a/scripts/set-rn-engine.js
+++ b/scripts/set-rn-engine.js
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+'use strict';
+
+/**
+ * This script updates the engine used by React Native
+ */
+const fs = require('fs');
+const {echo, exec, exit, sed} = require('shelljs');
+const yargs = require('yargs');
+
+let argv = yargs.option('e', {
+  alias: 'engine',
+  describe: 'Choose an engine',
+  type: 'string',
+  choices: ['hermes', 'jsc'],
+}).argv;
+
+const engine = argv.engine;
+
+if (!engine) {
+  echo('You must specify an engine using -e');
+  exit(1);
+}
+
+// Change the template build.gradle
+sed(
+  '-i',
+  /enableHermes:.*/,
+  engine === 'jsc' ? 'enableHermes: false' : 'enableHermes: true',
+  'template/android/app/build.gradle',
+)
+
+//Validate the hermes flag has been changed properly
+const hermes = exec(
+  `grep enableHermes: template/android/app/build.gradle | awk '{split($0,a,"[:,]"); print a[2]}'`,
+  {silent: true},
+).stdout.trim() === 'true';
+
+if (engine === 'jsc' && hermes || engine === 'hermes' && !hermes) {
+  echo(`Failed to update the engine in template/android/app/build.gradle`);
+  echo('Fix the issue and try again');
+  exit(1);
+}
+
+exit(0);

--- a/scripts/set-rn-engine.js
+++ b/scripts/set-rn-engine.js
@@ -12,7 +12,6 @@
 /**
  * This script updates the engine used by React Native
  */
-const fs = require('fs');
 const {echo, exec, exit, sed} = require('shelljs');
 const yargs = require('yargs');
 
@@ -36,7 +35,7 @@ sed(
   /enableHermes:.*/,
   engine === 'jsc' ? 'enableHermes: false' : 'enableHermes: true',
   'template/android/app/build.gradle',
-)
+);
 
 //Validate the hermes flag has been changed properly
 const hermes = exec(


### PR DESCRIPTION
## Summary

https://www.internalfb.com/T131530362

We are testing the New App template in CircleCI.

For Android we test the combination of Debug/Release and Old/New Architecture, and always use the Hermes engine.
We don't test the JSC engines (in iOS this is already happening).

We're not automatically testing that we can create a new project with JSC, forcing release managers to do it manually.

## Changelog

[Android] [Added] - Automatic testing of the new project template with the JSC engine.

## Test Plan

- Open the circle-ci dashboard
- Verify there are now 8 jobs adeed to the pipeline:
```
test_android_template-Debug-Hermes-false
test_android_template-Debug-Hermes-true
test_android_template-Debug-JSC-false
test_android_template-Debug-JSC-true
test_android_template-Release-Hermes-false
test_android_template-Release-Hermes-true
test_android_template-Release-JSC-false
test_android_template-Release-JSC-true
```
- Verify they are all passing.
