### PR TITLE
Set RCT_NEW_ARCH_ENABLED to true when using cocoapod flag

### DIFF
--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -46,6 +46,9 @@ def use_react_native! (
 
   CodegenUtils.clean_up_build_folder(app_path, $CODEGEN_OUTPUT_DIR)
 
+  # We are relying on this flag also in third parties libraries to proper install dependencies.
+  # Better to rely and enable this environment flag if the new architecture is turned on using flags.
+  ENV['RCT_NEW_ARCH_ENABLED'] = new_arch_enabled ? "1" : "0"
   fabric_enabled = fabric_enabled || new_arch_enabled
 
   prefix = path
@@ -180,7 +183,7 @@ def react_native_post_install(installer, react_native_path = "../node_modules/re
   ReactNativePodsUtils.set_node_modules_user_settings(installer, react_native_path)
 
   NewArchitectureHelper.set_clang_cxx_language_standard_if_needed(installer)
-  is_new_arch_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
+  is_new_arch_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == "1"
   NewArchitectureHelper.modify_flags_for_new_architecture(installer, is_new_arch_enabled)
 
   Pod::UI.puts "Pod install took #{Time.now.to_i - $START_TIME} [s] to run".green
@@ -190,7 +193,7 @@ end
 # We need to keep this while we continue to support the old architecture.
 # =====================
 def use_react_native_codegen!(spec, options={})
-  return if ENV['RCT_NEW_ARCH_ENABLED'] == '1'
+  return if ENV['RCT_NEW_ARCH_ENABLED'] == "1"
   # TODO: Once the new codegen approach is ready for use, we should output a warning here to let folks know to migrate.
 
   # The prefix to react-native


### PR DESCRIPTION
Summary:
Users can enable the New Architecture on iOS in two way: using the `RCT_NEW_ACRH_ENABLED` env variable or setting the `new_arch_enabled` flag when invoking the `use_react_native` function.

We need to set the `RCT_NEW_ACRH_ENABLED` even when the other method is used because we need to inject that flag into the codebase.

## Changelog
[iOS][Fixed] Make sure to turn on the `RCT_NEW_ACRH_ENABLED` flag

Differential Revision: D39430904

