### PR TITLE
fix: adjust clipboard mock

### DIFF
--- a/jest/setup.js
+++ b/jest/setup.js
@@ -135,6 +135,10 @@ jest
       getRecommendedTimeoutMillis: jest.fn(),
     },
   }))
+  .mock('../Libraries/Components/Clipboard/Clipboard', () => ({
+    getString: jest.fn(() => ''),
+    setString: jest.fn(),
+  }))
   .mock('../Libraries/Components/RefreshControl/RefreshControl', () =>
     jest.requireActual(
       '../Libraries/Components/RefreshControl/__mocks__/RefreshControlMock',
@@ -200,10 +204,6 @@ jest
       getAllKeys: jest.fn(callback =>
         process.nextTick(() => callback(null, [])),
       ),
-    },
-    Clipboard: {
-      getString: jest.fn(() => ''),
-      setString: jest.fn(),
     },
     DeviceInfo: {
       getConstants() {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Currently, Clipboard's methods (setString, getString) can't be asserted when writing tests as the mock targeted `Libraries/BatchedBridge/NativeModules` instead of `Libraries/Components/Clipboard/Clipboard` that's used on react-native [entry point](https://github.com/facebook/react-native/blob/main/index.js#L270) so it won't be considered as `mock function`.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[General] [Changed] - Update `Clipboard` mock path

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

```js
// App-test.js

import { Clipboard } from 'react-native';
import React from 'react';

it('renders correctly', () => {
  Clipboard.setString('string');
  expect(Clipboard.setString).toBeCalled();
});
```

### before

<img width="473" alt="Screen Shot 2022-09-13 at 16 24 30" src="https://user-images.githubusercontent.com/5382429/189864957-6b926478-6781-4291-a1eb-4493779de1a2.png" />

### after

<img width="598" alt="Screen Shot 2022-09-13 at 16 26 34" src="https://user-images.githubusercontent.com/5382429/189865131-e7c39f97-1cc1-4eb9-b4c0-d9ddf7a05c9c.png" />