### PR TITLE
Fix HERMES_ENABLED check in scripts/react-native-xcode.sh

### DIFF
--- a/scripts/react-native-xcode.sh
+++ b/scripts/react-native-xcode.sh
@@ -78,11 +78,11 @@ fi
 # shellcheck source=/dev/null
 source "$REACT_NATIVE_DIR/scripts/node-binary.sh"
 
-# If hermes-engine is in the podfile.lock, it means that Hermes is a dependency of the project
+# If hermes-engine is in the Podfile.lock, it means that Hermes is a dependency of the project
 # and it is enabled. If not, it means that hermes is disabled.
-HERMES_ENABLED=$(grep hermes-engine podfile.lock)
+HERMES_ENABLED=$(grep hermes-engine $PODS_PODFILE_DIR_PATH/Podfile.lock)
 
-# If hermes-engine is not in the podfile.lock, it means that the app is not using Hermes.
+# If hermes-engine is not in the Podfile.lock, it means that the app is not using Hermes.
 # Setting USE_HERMES is no the only way to set whether the app can use hermes or not: users
 # can also modify manually the Podfile.
 if [[ -z "$HERMES_ENABLED" ]]; then


### PR DESCRIPTION
## Summary

Checking if Hermes is enabled is failing because there is no `podfile.lock` file in the directory where this script is executed and `USE_HERMES` will be set to `false` which will prevent building Hermes binary jsbundle. 

## Changelog

[iOS] [Fixed] - `HERMES_ENABLED` check fixed in react-native-xcode.sh

## Test Plan

1. Enable Hermes
2. Make a release build
3. Verify the `main.jsbundle` file is Hermes binary bundle