### PR TITLE
[iOS][Fix]: Network -  XMLHttpRequest response headers are undefined

### DIFF
--- a/Libraries/Network/XMLHttpRequest.js
+++ b/Libraries/Network/XMLHttpRequest.js
@@ -445,8 +445,10 @@ class XMLHttpRequest extends (EventTarget(...XHR_EVENTS): any) {
       }
     }
 
+    // Convert Map to array
+    const unsortedHeadersArray = Array.from(unsortedHeaders.values());
     // Sort in ascending order, with a being less than b if a's name is legacy-uppercased-byte less than b's name.
-    const sortedHeaders = [...unsortedHeaders.values()].sort((a, b) => {
+    const sortedHeaders = unsortedHeadersArray.sort((a, b) => {
       if (a.upperHeaderName < b.upperHeaderName) {
         return -1;
       }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

After upgrading from react-native 0.66.4 to 0.68.3 i face a problem with my authentication API call. 
Indeed, this POST call need to retrieve tokens into response headers and then should be reinjected into all the other API calls as request header.

After some investigation i found that the problem come from a modification in the 0.68.0 release and specifically this change: https://github.com/facebook/react-native/commit/b2415c48669391ee1ab7c6450748c4d91097a666

It seems that spread operator to convert Map to Array (`[...unsortedHeaders.values()]`) doesn't work at all (may be cause of my node version ?) and return reponse.headers = { undefined: 'undefined' }, as you can see here :

![Capture d’écran 2022-09-13 à 17 16 55](https://user-images.githubusercontent.com/27803113/189940679-e66b7823-dda7-4312-8ac9-3e6045c760ba.png)

So here i prefer to use `Array.from()` method to make the convertion and it works well for me, headers are now well define and return the expected JSON object (sorted and in lower case)

Output of npx react-native info
```
System:
    OS: macOS 12.1
    CPU: (8) x64 Intel(R) Core(TM) i5-8279U CPU @ 2.40GHz
    Memory: 53.72 MB / 8.00 GB
    Shell: 5.8 - /bin/zsh
  Binaries:
    Node: 16.17.0 - /usr/local/bin/node
    Yarn: 1.22.17 - /usr/local/bin/yarn
    npm: 8.18.0 - /usr/local/bin/npm
    Watchman: 2022.08.29.00 - /usr/local/bin/watchman
  Managers:
    CocoaPods: 1.11.3 - /usr/local/bin/pod
  SDKs:
    iOS SDK:
      Platforms: DriverKit 21.2, iOS 15.2, macOS 12.1, tvOS 15.2, watchOS 8.3
    Android SDK:
      API Levels: 29, 30, 31
      Build Tools: 28.0.3, 29.0.3, 30.0.0, 30.0.1, 30.0.2, 30.0.3, 31.0.0, 31.0.0
      System Images: android-29 | Google APIs Intel x86 Atom, android-29 | Google APIs Intel x86 Atom_64, android-29 | Google Play Intel x86 Atom, android-29 | Google Play Intel x86 Atom_64, android-30 | Google APIs Intel x86 Atom, android-30 | Google APIs Intel x86 Atom_64, android-30 | Google Play Intel x86 Atom, android-30 | Google Play Intel x86 Atom_64
      Android NDK: Not Found
  IDEs:
    Android Studio: 2021.2 AI-212.5712.43.2112.8512546
    Xcode: 13.2.1/13C100 - /usr/bin/xcodebuild
  Languages:
    Java: 11.0.14 - /usr/bin/javac
  npmPackages:
    @react-native-community/cli: Not Found
    react: Not Found
    react-native: Not Found
    react-native-macos: Not Found
  npmGlobalPackages:
    *react-native*: Not Found
```

## Changelog

[iOS] [Fixed] - XMLHttpRequest response headers undefined - Introduce in 0.68.0

## Test Plan

1) Make a rest api call from the app
```
 return fetch('https://mywebsite.com/endpoint/', {
      method: 'POST',
      headers: {
        Accept: 'application/json',
        'Content-Type': 'application/json'
      },
    })
    .then((response) => {
      // here headers should be ok
      console.log(response.headers)
      return response.data;
    })
    .catch((error) => {
      console.error(error);
    });
```
2) Note that response.headers are well defined, in lower case and sorted

Test derived from Web Platform Test repository:
https://github.com/web-platform-tests/wpt/tree/master/xhr