### PR TITLE
[Android][Improvement] Improve support for non debug/release variants

### DIFF
--- a/react.gradle
+++ b/react.gradle
@@ -172,7 +172,10 @@ def bundleForVariant = config.bundleForVariant ?: {
 // Set deleteDebugFilesForVariant to a function to configure per variant,
 // defaults to True for Release variants and False for debug variants
 def deleteDebugFilesForVariant = config.deleteDebugFilesForVariant ?: {
-    def variant -> variant.name.toLowerCase().contains("release")
+    def variant -> 
+      config."deleteDebugFilesIn${variant.name.capitalize()}" ||
+      config."deleteDebugFilesIn${variant.buildType.name.capitalize()}" ||
+      variant.name.toLowerCase().contains("release")
 }
 
 android {


### PR DESCRIPTION
The current change allows projects to use different variants, staging in our case, properly.

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

In one of our projects, we have a third variant which is Staging. Without this change, our staging builds will crash with #33120

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[Android] [Added] - Add conditionals for releases that are not named debug/release

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
