### PR TITLE
[react devtools][device storage] Pass a cachedSettingsStore from React Native

### DIFF
--- a/Libraries/Core/cachedSettingsStore.js
+++ b/Libraries/Core/cachedSettingsStore.js
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+'use strict';
+
+import {MMKV} from 'react-native-mmkv';
+
+const storage = new MMKV({
+  id: 'ReactDevTools',
+});
+const SETTINGS_KEY = 'Settings';
+
+export type CachedSettingsStore = {
+  getValue: () => string,
+  setValue: (newValue: string) => void,
+};
+const cachedSettingsStore: CachedSettingsStore = {
+  getValue: () => storage.getString(SETTINGS_KEY),
+  setValue: settingsString => {
+    storage.set(SETTINGS_KEY, settingsString);
+  },
+};
+
+module.exports = cachedSettingsStore;

--- a/Libraries/Core/setUpReactDevTools.js
+++ b/Libraries/Core/setUpReactDevTools.js
@@ -60,14 +60,21 @@ if (__DEV__) {
 
       const ReactNativeStyleAttributes = require('../Components/View/ReactNativeStyleAttributes');
 
-      reactDevTools.connectToDevTools({
+      let connectToDevToolsParams = {
         isAppActive,
         resolveRNStyle: require('../StyleSheet/flattenStyle'),
         nativeStyleEditorValidAttributes: Object.keys(
           ReactNativeStyleAttributes,
         ),
         websocket: ws,
-      });
+      };
+
+      if (__DEV__) {
+        // $FlowFixMe[prop-missing]
+        connectToDevToolsParams.cachedSettingsStore = require('./cachedSettingsStore');
+      }
+
+      reactDevTools.connectToDevTools(connectToDevToolsParams);
     }
   };
 

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "promise": "^8.0.3",
     "react-devtools-core": "4.24.0",
     "react-native-gradle-plugin": "^0.71.0",
+    "react-native-mmkv": "^2.4.3",
     "react-refresh": "^0.4.0",
     "react-shallow-renderer": "^16.15.0",
     "regenerator-runtime": "^0.13.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5926,6 +5926,11 @@ react-is@^18.2.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
 
+react-native-mmkv@^2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/react-native-mmkv/-/react-native-mmkv-2.4.3.tgz#6bb4c2d5e328513da11faab1371d056a189adbd0"
+  integrity sha512-0hYNOTbsjJ5j5cpX+qjwReGIxuYE9MWRsyPQ72fTOvzmEjYXCF4Wr2VQoqx8R6W1/Uinekvln7dGvJ4RExmHhQ==
+
 react-refresh@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.4.0.tgz#d421f9bd65e0e4b9822a399f14ac56bda9c92292"


### PR DESCRIPTION
## Summary

* React DevTools now accepts a `cachedSettingsStore` parameter on the object passed to `connectToDevTools`. These methods provide write and synchronous read access to persistent, on-device storage for a single string.
* This is used by React DevTools to cache certain settings, e.g. whether to append component stacks, etc. that are needed during the intial render of a React Native app. The source of truth of these settings is the frontend of React DevTools. However, during the initial render, the DevTools frontend is unavailable.
* Hence, we cache values on the device to use during initial render.
* When the DevTools frontend connects and whenever any relevant setting is changed, we re-cache the values.

## Changelog

[General] [Added] - Pass methods that read/write from local storage, using `react-mmkv-storage`.

## Test Plan

* Manually tested with standalone, behaved as expected