### PR TITLE
Remove support for is_androidx arg for robolectric tests

### DIFF
--- a/ReactAndroid/src/test/java/com/facebook/react/uimanager/BUCK
+++ b/ReactAndroid/src/test/java/com/facebook/react/uimanager/BUCK
@@ -10,7 +10,6 @@ rn_robolectric_test(
         "SimpleViewPropertyTest.java",
     ],
     contacts = ["oncall+fbandroid_sheriff@xmail.facebook.com"],
-    is_androidx = True,
     language = "JAVA",
     visibility = [
         "PUBLIC",


### PR DESCRIPTION
## Changelog

[Android] [Changed] - Remove internal buck rule arg for robolectric tests

Reviewed By: xiphirx

Differential Revision: D39452733

