### PR TITLE
Remove Android.mk from internal Gradle task

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -84,7 +84,7 @@ task downloadDoubleConversion(dependsOn: createNativeDepsDirectories, type: Down
 task prepareDoubleConversion(dependsOn: dependenciesPath ? [] : [downloadDoubleConversion], type: Copy) {
     from(dependenciesPath ?: tarTree(downloadDoubleConversion.dest))
     from("src/main/jni/third-party/double-conversion/")
-    include("double-conversion-${DOUBLE_CONVERSION_VERSION}/src/**/*", "Android.mk", "CMakeLists.txt")
+    include("double-conversion-${DOUBLE_CONVERSION_VERSION}/src/**/*", "CMakeLists.txt")
     filesMatching("*/src/**/*", { fname -> fname.path = "double-conversion/${fname.name}" })
     includeEmptyDirs = false
     into("$thirdPartyNdkDir/double-conversion")
@@ -100,7 +100,7 @@ task downloadFolly(dependsOn: createNativeDepsDirectories, type: Download) {
 task prepareFolly(dependsOn: dependenciesPath ? [] : [downloadFolly], type: Copy) {
     from(dependenciesPath ?: tarTree(downloadFolly.dest))
     from("src/main/jni/third-party/folly/")
-    include("folly-${FOLLY_VERSION}/folly/**/*", "Android.mk", "CMakeLists.txt")
+    include("folly-${FOLLY_VERSION}/folly/**/*", "CMakeLists.txt")
     eachFile { fname -> fname.path = (fname.path - "folly-${FOLLY_VERSION}/") }
     includeEmptyDirs = false
     into("$thirdPartyNdkDir/folly")
@@ -116,7 +116,7 @@ task downloadFmt(dependsOn: createNativeDepsDirectories, type: Download) {
 task prepareFmt(dependsOn: dependenciesPath ? [] : [downloadFmt], type: Copy) {
     from(dependenciesPath ?: tarTree(downloadFmt.dest))
     from("src/main/jni/third-party/fmt/")
-    include("fmt-${FMT_VERSION}/src/**/*", "fmt-${FMT_VERSION}/include/**/*", "Android.mk", "CMakeLists.txt")
+    include("fmt-${FMT_VERSION}/src/**/*", "fmt-${FMT_VERSION}/include/**/*", "CMakeLists.txt")
     eachFile { fname -> fname.path = (fname.path - "fmt-${FMT_VERSION}/") }
     includeEmptyDirs = false
     into("$thirdPartyNdkDir/fmt")
@@ -153,7 +153,7 @@ final def prepareGlog = tasks.register("prepareGlog", PrepareGlogTask) {
     it.outputDir.set(new File(thirdPartyNdkDir, "glog"))
 }
 
-// Create Android.mk library module based on jsc from npm
+// Create Android native library module based on jsc from npm
 tasks.register('prepareJSC', PrepareJSCTask) {
     it.jscPackagePath.set(findNodeModulePath(projectDir, "jsc-android"))
     it.outputDir = project.layout.buildDirectory.dir("third-party-ndk/jsc")

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/internal/PrepareBoostTask.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/internal/PrepareBoostTask.kt
@@ -32,7 +32,6 @@ abstract class PrepareBoostTask : DefaultTask() {
       it.from(boostPath)
       it.from(project.file("src/main/jni/third-party/boost"))
       it.include(
-          "Android.mk",
           "CMakeLists.txt",
           "boost_${boostVersion.get()}/boost/**/*.hpp",
           "boost/boost/**/*.hpp",

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/internal/PrepareGlogTask.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/internal/PrepareGlogTask.kt
@@ -33,7 +33,7 @@ abstract class PrepareGlogTask : DefaultTask() {
     project.copy {
       it.from(glogPath)
       it.from(project.file("src/main/jni/third-party/glog/"))
-      it.include("glog-${glogVersion.get()}/src/**/*", "Android.mk", "CMakeLists.txt", "config.h")
+      it.include("glog-${glogVersion.get()}/src/**/*", "CMakeLists.txt", "config.h")
       it.duplicatesStrategy = DuplicatesStrategy.WARN
       it.includeEmptyDirs = false
       it.filesMatching("**/*.h.in") { matchedFile ->

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/internal/PrepareJSCTask.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/internal/PrepareJSCTask.kt
@@ -41,7 +41,6 @@ abstract class PrepareJSCTask : DefaultTask() {
     project.copy { it ->
       it.from(soFiles)
       it.from(headerFiles)
-      it.from(project.file("src/main/jni/third-party/jsc/Android.mk"))
       it.from(project.file("src/main/jni/third-party/jsc/CMakeLists.txt"))
       it.filesMatching("**/*.h") { it.path = "JavaScriptCore/${it.name}" }
       it.includeEmptyDirs = false

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/internal/PrepareLibeventTask.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/internal/PrepareLibeventTask.kt
@@ -37,8 +37,7 @@ abstract class PrepareLibeventTask : DefaultTask() {
           "libevent-${libeventVersion.get()}-stable/include/**/*",
           "evconfig-private.h",
           "event-config.h",
-          "CMakeLists.txt",
-          "Android.mk")
+          "CMakeLists.txt")
       it.eachFile { it.path = it.path.removePrefix("libevent-${libeventVersion.get()}-stable/") }
       it.includeEmptyDirs = false
       it.into(outputDir)

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/internal/PrepareBoostTaskTest.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/internal/PrepareBoostTaskTest.kt
@@ -27,7 +27,7 @@ class PrepareBoostTaskTest {
   }
 
   @Test
-  fun prepareBoostTask_copiesMakefile() {
+  fun prepareBoostTask_copiesCMakefile() {
     val boostpath = tempFolder.newFolder("boostpath")
     val output = tempFolder.newFolder("output")
     val project = createProject()

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/internal/PrepareBoostTaskTest.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/internal/PrepareBoostTaskTest.kt
@@ -37,13 +37,9 @@ class PrepareBoostTaskTest {
           it.boostVersion.set("1.0.0")
           it.outputDir.set(output)
         }
-    File(project.projectDir, "src/main/jni/third-party/boost/Android.mk").apply {
-      parentFile.mkdirs()
-      createNewFile()
-    }
     task.taskAction()
 
-    assertTrue(output.listFiles()!!.any { it.name == "Android.mk" })
+    assertTrue(output.listFiles()!!.any { it.name == "CMakeLists.txt" })
   }
 
   @Test

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/internal/PrepareBoostTaskTest.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/internal/PrepareBoostTaskTest.kt
@@ -37,6 +37,10 @@ class PrepareBoostTaskTest {
           it.boostVersion.set("1.0.0")
           it.outputDir.set(output)
         }
+    File(project.projectDir, "src/main/jni/third-party/boost/CMakeLists.txt").apply {
+      parentFile.mkdirs()
+      createNewFile()
+    }
     task.taskAction()
 
     assertTrue(output.listFiles()!!.any { it.name == "CMakeLists.txt" })

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/internal/PrepareGlogTaskTest.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/internal/PrepareGlogTaskTest.kt
@@ -37,6 +37,10 @@ class PrepareGlogTaskTest {
           it.glogVersion.set("1.0.0")
           it.outputDir.set(output)
         }
+    File(project.projectDir, "src/main/jni/third-party/glog/CMakeLists.txt").apply {
+      parentFile.mkdirs()
+      createNewFile()
+    }
     task.taskAction()
 
     assertTrue(output.listFiles()!!.any { it.name == "CMakeLists.txt" })

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/internal/PrepareGlogTaskTest.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/internal/PrepareGlogTaskTest.kt
@@ -37,13 +37,9 @@ class PrepareGlogTaskTest {
           it.glogVersion.set("1.0.0")
           it.outputDir.set(output)
         }
-    File(project.projectDir, "src/main/jni/third-party/glog/Android.mk").apply {
-      parentFile.mkdirs()
-      createNewFile()
-    }
     task.taskAction()
 
-    assertTrue(output.listFiles()!!.any { it.name == "Android.mk" })
+    assertTrue(output.listFiles()!!.any { it.name == "CMakeLists.txt" })
   }
 
   @Test

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/internal/PrepareGlogTaskTest.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/internal/PrepareGlogTaskTest.kt
@@ -27,7 +27,7 @@ class PrepareGlogTaskTest {
   }
 
   @Test
-  fun prepareGlogTask_copiesMakefile() {
+  fun prepareGlogTask_copiesCMakefile() {
     val glogpath = tempFolder.newFolder("glogpath")
     val output = tempFolder.newFolder("output")
     val project = createProject()

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/internal/PrepareJSCTaskTest.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/internal/PrepareJSCTaskTest.kt
@@ -100,10 +100,6 @@ class PrepareJSCTaskTest {
   fun prepareJSCTask_copiesMakefile() {
     val project = createProject()
     prepareInputFolder()
-    File(project.projectDir, "src/main/jni/third-party/jsc/Android.mk").apply {
-      parentFile.mkdirs()
-      createNewFile()
-    }
     val output = tempFolder.newFolder("output")
 
     val task =
@@ -114,7 +110,7 @@ class PrepareJSCTaskTest {
 
     task.taskAction()
 
-    assertTrue(File(output, "Android.mk").exists())
+    assertTrue(File(output, "CMakeLists.txt").exists())
   }
 
   private fun prepareInputFolder(aarContent: List<File> = listOf(tempFolder.newFile())) {

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/internal/PrepareJSCTaskTest.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/internal/PrepareJSCTaskTest.kt
@@ -97,7 +97,7 @@ class PrepareJSCTaskTest {
   }
 
   @Test
-  fun prepareJSCTask_copiesMakefile() {
+  fun prepareJSCTask_copiesCMakefile() {
     val project = createProject()
     prepareInputFolder()
     File(project.projectDir, "src/main/jni/third-party/jsc/CMakeLists.txt").apply {

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/internal/PrepareJSCTaskTest.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/internal/PrepareJSCTaskTest.kt
@@ -100,6 +100,10 @@ class PrepareJSCTaskTest {
   fun prepareJSCTask_copiesMakefile() {
     val project = createProject()
     prepareInputFolder()
+    File(project.projectDir, "src/main/jni/third-party/jsc/CMakeLists.txt").apply {
+      parentFile.mkdirs()
+      createNewFile()
+    }
     val output = tempFolder.newFolder("output")
 
     val task =

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/internal/PrepareLibeventTaskTest.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/internal/PrepareLibeventTaskTest.kt
@@ -27,7 +27,7 @@ class PrepareLibeventTaskTest {
   }
 
   @Test
-  fun prepareBoostTask_copiesMakefile() {
+  fun prepareBoostTask_copiesCMakefile() {
     val libeventPath = tempFolder.newFolder("libeventPath")
     val output = tempFolder.newFolder("output")
     val project = createProject()

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/internal/PrepareLibeventTaskTest.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/internal/PrepareLibeventTaskTest.kt
@@ -37,13 +37,9 @@ class PrepareLibeventTaskTest {
           it.libeventVersion.set("1.0.0")
           it.outputDir.set(output)
         }
-    File(project.projectDir, "src/main/jni/third-party/libevent/Android.mk").apply {
-      parentFile.mkdirs()
-      createNewFile()
-    }
     task.taskAction()
 
-    assertTrue(File(output, "Android.mk").exists())
+    assertTrue(File(output, "CMakeLists.txt").exists())
   }
 
   @Test

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/internal/PrepareLibeventTaskTest.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/internal/PrepareLibeventTaskTest.kt
@@ -37,6 +37,10 @@ class PrepareLibeventTaskTest {
           it.libeventVersion.set("1.0.0")
           it.outputDir.set(output)
         }
+    File(project.projectDir, "src/main/jni/third-party/libevent/CMakeLists.txt").apply {
+      parentFile.mkdirs()
+      createNewFile()
+    }
     task.taskAction()
 
     assertTrue(File(output, "CMakeLists.txt").exists())


### PR DESCRIPTION
## Summary

`Android.mk`s are no longer used for internal Gradle tasks since [First Round of CMake files for React Android](https://github.com/facebook/react-native/commit/b676ca560d8af686276ac4b88e4feb9c5b7e468d) and [CMake setup for ReactAndroid](https://github.com/facebook/react-native/commit/e3830ddffd9260fe071e0c9f9df40b379d54cf26)

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[General] [Fixed] - Remove Android.mk from internal Gradle task

## Test Plan

None