### PR TITLE
Speed up hermes build

### DIFF
--- a/sdks/hermes-engine/hermes-engine.podspec
+++ b/sdks/hermes-engine/hermes-engine.podspec
@@ -65,6 +65,8 @@ Pod::Spec.new do |spec|
 
   spec.xcconfig            = { "CLANG_CXX_LANGUAGE_STANDARD" => "c++17", "CLANG_CXX_LIBRARY" => "compiler-default", "GCC_PREPROCESSOR_DEFINITIONS" => "HERMES_ENABLE_DEBUGGER=1" }
 
+  fix_script = "#{Dir.getwd}-engine/utils/fix-hermes.js"
+
   if source[:git] then
     spec.prepare_command = <<-EOS
       # When true, debug build will be used.
@@ -74,6 +76,9 @@ Pod::Spec.new do |spec|
       # Set HERMES_OVERRIDE_HERMESC_PATH if pre-built HermesC is available
       #{File.exist?(import_hermesc_file) ? "export HERMES_OVERRIDE_HERMESC_PATH=#{import_hermesc_file}" : ""}
       #{File.exist?(import_hermesc_file) ? "echo \"Overriding HermesC path...\"" : ""}
+
+      # Remove this when Hermes properly support multi core builds
+      "$NODE_BINARY" #{fix_script} $(pwd)/utils/build-apple-framework.sh
 
       # Build iOS framework
       ./utils/build-ios-framework.sh

--- a/sdks/hermes-engine/utils/fix-hermes.js
+++ b/sdks/hermes-engine/utils/fix-hermes.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+const fs = require('fs');
+
+const filePath = process.argv[2];
+const file = fs.readFileSync(filePath).toString();
+const toReplace = '(cd "./build_$1" && make install/strip)';
+const replacement =
+  'NUM_CORES=$(sysctl -n hw.ncpu)\n\techo "[Build Apple] Running with ${NUM_CORES} cores"\n\t(cd "./build_$1" && make install/strip -j "${NUM_CORES}")';
+const replaced = file.replace(toReplace, replacement);
+fs.writeFileSync(filePath, replaced);


### PR DESCRIPTION
Summary:
After kudo investigation, we figured out that when we build hermes from source we are not using multiple cores.
This Diff is a workaround to speedup iOS builds, waiting for Hermes to support that use case too.

## Changelog
[iOS][Fixed] - Speedup Hermes build

Differential Revision: D39539570

