### PR TITLE
Fix port as -1 if dev server without specifying port on Android

### DIFF
--- a/Libraries/Core/setUpReactDevTools.js
+++ b/Libraries/Core/setUpReactDevTools.js
@@ -39,7 +39,10 @@ if (__DEV__) {
       // Get hostname from development server (packager)
       const devServer = getDevServer();
       const host = devServer.bundleLoadedFromServer
-        ? devServer.url.replace(/https?:\/\//, '').split(':')[0]
+        ? devServer.url
+            .replace(/https?:\/\//, '')
+            .replace(/\/$/, '')
+            .split(':')[0]
         : 'localhost';
 
       // Read the optional global variable for backward compatibility.

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevLoadingViewController.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevLoadingViewController.java
@@ -69,9 +69,9 @@ public class DevLoadingViewController {
       return;
     }
 
+    int port = parsedURL.getPort() != -1 ? parsedURL.getPort() : parsedURL.getDefaultPort();
     showMessage(
-        context.getString(
-            R.string.catalyst_loading_from_url, parsedURL.getHost() + ":" + parsedURL.getPort()));
+        context.getString(R.string.catalyst_loading_from_url, parsedURL.getHost() + ":" + port));
   }
 
   public void showForRemoteJSEnabled() {

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevLoadingViewController.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevLoadingViewController.java
@@ -22,8 +22,9 @@ import com.facebook.common.logging.FLog;
 import com.facebook.react.R;
 import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.common.ReactConstants;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.Locale;
-import okhttp3.HttpUrl;
 
 /** Controller to display loading messages on top of the screen. All methods are thread safe. */
 public class DevLoadingViewController {
@@ -60,17 +61,17 @@ public class DevLoadingViewController {
       return;
     }
 
-    HttpUrl parsedURL;
+    URL parsedURL;
     try {
-      parsedURL = HttpUrl.get(url);
-    } catch (IllegalArgumentException e) {
+      parsedURL = new URL(url);
+    } catch (MalformedURLException e) {
       FLog.e(ReactConstants.TAG, "Bundle url format is invalid. \n\n" + e.toString());
       return;
     }
 
     showMessage(
         context.getString(
-            R.string.catalyst_loading_from_url, parsedURL.host() + ":" + parsedURL.port()));
+            R.string.catalyst_loading_from_url, parsedURL.getHost() + ":" + parsedURL.getPort()));
   }
 
   public void showForRemoteJSEnabled() {

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevLoadingViewController.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevLoadingViewController.java
@@ -22,9 +22,8 @@ import com.facebook.common.logging.FLog;
 import com.facebook.react.R;
 import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.common.ReactConstants;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.Locale;
+import okhttp3.HttpUrl;
 
 /** Controller to display loading messages on top of the screen. All methods are thread safe. */
 public class DevLoadingViewController {
@@ -61,17 +60,17 @@ public class DevLoadingViewController {
       return;
     }
 
-    URL parsedURL;
+    HttpUrl parsedURL;
     try {
-      parsedURL = new URL(url);
-    } catch (MalformedURLException e) {
+      parsedURL = HttpUrl.get(url);
+    } catch (IllegalArgumentException e) {
       FLog.e(ReactConstants.TAG, "Bundle url format is invalid. \n\n" + e.toString());
       return;
     }
 
     showMessage(
         context.getString(
-            R.string.catalyst_loading_from_url, parsedURL.getHost() + ":" + parsedURL.getPort()));
+            R.string.catalyst_loading_from_url, parsedURL.host() + ":" + parsedURL.port()));
   }
 
   public void showForRemoteJSEnabled() {

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
@@ -703,7 +703,7 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
         URL sourceUrl = new URL(getSourceUrl());
         String path = sourceUrl.getPath().substring(1); // strip initial slash in path
         String host = sourceUrl.getHost();
-        int port = sourceUrl.getPort();
+        int port = sourceUrl.getPort() != -1 ? sourceUrl.getPort() : sourceUrl.getDefaultPort();
         mCurrentContext
             .getJSModule(HMRClient.class)
             .setup("android", path, host, port, mDevSettings.isHotModuleReplacementEnabled());

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
@@ -57,12 +57,13 @@ import com.facebook.react.modules.core.RCTNativeAppEventEmitter;
 import com.facebook.react.packagerconnection.RequestHandler;
 import com.facebook.react.packagerconnection.Responder;
 import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import okhttp3.HttpUrl;
 
 public abstract class DevSupportManagerBase implements DevSupportManager {
 
@@ -699,14 +700,14 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
 
     if (mCurrentContext != null) {
       try {
-        HttpUrl sourceUrl = HttpUrl.get(getSourceUrl());
-        String path = sourceUrl.encodedPath().substring(1); // strip initial slash in path
-        String host = sourceUrl.host();
-        int port = sourceUrl.port();
+        URL sourceUrl = new URL(getSourceUrl());
+        String path = sourceUrl.getPath().substring(1); // strip initial slash in path
+        String host = sourceUrl.getHost();
+        int port = sourceUrl.getPort();
         mCurrentContext
             .getJSModule(HMRClient.class)
             .setup("android", path, host, port, mDevSettings.isHotModuleReplacementEnabled());
-      } catch (IllegalArgumentException e) {
+      } catch (MalformedURLException e) {
         showNewJavaError(e.getMessage(), e);
       }
     }

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
@@ -57,13 +57,12 @@ import com.facebook.react.modules.core.RCTNativeAppEventEmitter;
 import com.facebook.react.packagerconnection.RequestHandler;
 import com.facebook.react.packagerconnection.Responder;
 import java.io.File;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import okhttp3.HttpUrl;
 
 public abstract class DevSupportManagerBase implements DevSupportManager {
 
@@ -700,14 +699,14 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
 
     if (mCurrentContext != null) {
       try {
-        URL sourceUrl = new URL(getSourceUrl());
-        String path = sourceUrl.getPath().substring(1); // strip initial slash in path
-        String host = sourceUrl.getHost();
-        int port = sourceUrl.getPort();
+        HttpUrl sourceUrl = HttpUrl.get(getSourceUrl());
+        String path = sourceUrl.encodedPath().substring(1); // strip initial slash in path
+        String host = sourceUrl.host();
+        int port = sourceUrl.port();
         mCurrentContext
             .getJSModule(HMRClient.class)
             .setup("android", path, host, port, mDevSettings.isHotModuleReplacementEnabled());
-      } catch (MalformedURLException e) {
+      } catch (IllegalArgumentException e) {
         showNewJavaError(e.getMessage(), e);
       }
     }


### PR DESCRIPTION
## Summary

when specifying dev server without port, e.g. http://www.example.com/, there are some issues.

1. redbox error
<img src="https://user-images.githubusercontent.com/46429/190540390-8ee420f2-7642-427b-9f2e-e0c6d31015f8.png" width="30%">

2. showing -1 in loading view

<img src="https://user-images.githubusercontent.com/46429/190540727-158f35ad-359f-443a-a4b0-768dd2f7e400.png" width="50%">

the root cause is coming from [`java.net.URL.getPort()` will return -1 when the url doesn't have a port](https://developer.android.com/reference/java/net/URL#getPort()).

~this pr replaces the parser to [`okhttp3.HttpUrl`](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-http-url/#port) that it will have default port 80 for http or port 443 for https. the two call paths should only serve http/https address, not file:// address. it should be safe to change from java.net.URL to okhttp3.HttpUrl.~
Update: adding `java.net.URL.getDefaultPort` fallback when the default port is -1


not fully related, in the case above, android will connect to `ws://www.example.com/:8097` for react-devtools
we should strip the trailing slash in *setUpReactDevTools.js*

## Changelog

[Android] [Fixed] - Fix port as -1 if dev server without specifying port on Android

## Test Plan

test on rn-tester with the following steps

1. `yarn start`
2. open another terminal and run `ngrok http 8081` and it will return a tunnel url, e.g. `71a1-114-36-194-97.jp.ngrok.io`
3. open dev setting in app and change the dev server to `71a1-114-36-194-97.jp.ngrok.io`
5. reload the app
