### PR TITLE
Bump AGP to 7.3.0 inside ReactAndroid

### DIFF
--- a/.circleci/Dockerfiles/Dockerfile.android
+++ b/.circleci/Dockerfiles/Dockerfile.android
@@ -21,7 +21,6 @@ LABEL maintainer="Héctor Ramos <hector@fb.com>"
 
 # set default environment variables
 ENV GRADLE_OPTS="-Dorg.gradle.daemon=false -Dorg.gradle.jvmargs=\"-Xmx512m -XX:+HeapDumpOnOutOfMemoryError\""
-ENV JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
 ENV KOTLIN_HOME="third-party/kotlin"
 
 ADD .buckconfig /app/.buckconfig

--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -432,15 +432,6 @@ react {
 }
 
 afterEvaluate {
-    // Needed as some of the native sources needs to be downloaded
-    // before configureNdkBuildDebug could be executed.
-    reactNativeArchitectures().each { architecture ->
-        tasks.findByName("configureCMakeDebug[${architecture}]")?.configure { dependsOn(preBuild) }
-        tasks.findByName("configureCMakeRelWithDebInfo[${architecture}]")?.configure { dependsOn(preBuild) }
-    }
-    configureCMakeDebug.dependsOn(preBuild)
-    configureCMakeRelWithDebInfo.dependsOn(preBuild)
-
     publishing {
         publications {
             release(MavenPublication) {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,10 +14,8 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath("com.android.tools.build:gradle:7.2.1")
+    classpath("com.android.tools.build:gradle:7.3.0")
     classpath("de.undercouch:gradle-download-task:5.0.1")
-    // NOTE: Do not place your application dependencies here; they belong
-    // in the individual module build.gradle files
   }
 }
 
@@ -37,6 +35,9 @@ allprojects {
 tasks.register("cleanAll", Delete::class.java) {
   description = "Remove all the build files and intermediate build outputs"
   dependsOn(gradle.includedBuild("react-native-gradle-plugin").task(":clean"))
+  dependsOn(":ReactAndroid:clean")
+  dependsOn(":ReactAndroid:hermes-engine:clean")
+  dependsOn(":packages:rn-tester:android:app:clean")
   delete(allprojects.map { it.buildDir })
   delete(rootProject.file("./ReactAndroid/.cxx"))
   delete(rootProject.file("./ReactAndroid/hermes-engine/.cxx"))

--- a/packages/react-native-gradle-plugin/build.gradle.kts
+++ b/packages/react-native-gradle-plugin/build.gradle.kts
@@ -8,6 +8,7 @@
 import org.gradle.api.internal.classpath.ModuleRegistry
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.configurationcache.extensions.serviceOf
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
   kotlin("jvm") version "1.6.10"
@@ -32,7 +33,7 @@ group = "com.facebook.react"
 
 dependencies {
   implementation(gradleApi())
-  implementation("com.android.tools.build:gradle:7.2.1")
+  implementation("com.android.tools.build:gradle:7.3.0")
   implementation("com.google.code.gson:gson:2.8.9")
   implementation("com.google.guava:guava:31.0.1-jre")
   implementation("com.squareup:javapoet:1.13.0")

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
@@ -7,6 +7,7 @@
 
 package com.facebook.react
 
+import com.android.build.api.variant.AndroidComponentsExtension
 import com.android.build.gradle.AppExtension
 import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.LibraryExtension
@@ -18,6 +19,7 @@ import com.facebook.react.utils.JsonUtils
 import com.facebook.react.utils.findPackageJsonFile
 import java.io.File
 import kotlin.system.exitProcess
+import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -71,6 +73,7 @@ class ReactPlugin : Plugin<Project> {
    * A plugin to enable react-native-codegen in Gradle environment. See the Gradle API docs for more
    * information: https://docs.gradle.org/current/javadoc/org/gradle/api/Project.html
    */
+  @Suppress("UnstableApiUsage")
   private fun applyCodegenPlugin(project: Project, extension: ReactExtension) {
     // First, we set up the output dir for the codegen.
     val generatedSrcDir = File(project.buildDir, "generated/source/codegen")
@@ -120,26 +123,20 @@ class ReactPlugin : Plugin<Project> {
               it.libraryName.set(extension.libraryName)
             }
 
-    // We add dependencies & generated sources to the project.
-    // Note: This last step needs to happen after the project has been evaluated.
-    project.afterEvaluate {
-
-      // `preBuild` is one of the base tasks automatically registered by Gradle.
-      // This will invoke the codegen before compiling the entire project.
-      project.tasks.named("preBuild", Task::class.java).dependsOn(generateCodegenArtifactsTask)
-
-      /**
-       * Finally, update the android configuration to include the generated sources. This equivalent
-       * to this DSL:
-       *
-       * android { sourceSets { main { java { srcDirs += "$generatedSrcDir/java" } } } }
-       *
-       * See documentation at
-       * https://google.github.io/android-gradle-dsl/current/com.android.build.gradle.BaseExtension.html.
-       */
-      val android = project.extensions.getByName("android") as BaseExtension
-
-      android.sourceSets.getByName("main").java.srcDir(File(generatedSrcDir, "java"))
+    // We update the android configuration to include the generated sources.
+    // This equivalent to this DSL:
+    //
+    // android { sourceSets { main { java { srcDirs += "$generatedSrcDir/java" } } } }
+    project.extensions.getByType(AndroidComponentsExtension::class.java).finalizeDsl { ext ->
+      ext.sourceSets.getByName("main").java.srcDir(File(generatedSrcDir, "java"))
     }
+
+    // `preBuild` is one of the base tasks automatically registered by Gradle.
+    // This will invoke the codegen before compiling the entire project.
+    val androidPluginHandler = Action { _: Plugin<*> ->
+      project.tasks.named("preBuild", Task::class.java).dependsOn(generateCodegenArtifactsTask)
+    }
+    project.plugins.withId("com.android.application", androidPluginHandler)
+    project.plugins.withId("com.android.library", androidPluginHandler)
   }
 }

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/GenerateCodegenArtifactsTaskTest.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/GenerateCodegenArtifactsTaskTest.kt
@@ -77,7 +77,7 @@ class GenerateCodegenArtifactsTaskTest {
   }
 
   @Test
-  @WithOs(OS.UNIX)
+  @WithOs(OS.LINUX)
   fun setupCommandLine_willSetupCorrectly() {
     val reactNativeDir = tempFolder.newFolder("node_modules/react-native/")
     val codegenDir = tempFolder.newFolder("codegen")

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/GenerateCodegenSchemaTaskTest.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/GenerateCodegenSchemaTaskTest.kt
@@ -12,7 +12,6 @@ import com.facebook.react.tests.OsRule
 import com.facebook.react.tests.WithOs
 import com.facebook.react.tests.createTestTask
 import java.io.File
-import org.gradle.api.tasks.*
 import org.junit.Assert.*
 import org.junit.Rule
 import org.junit.Test
@@ -89,7 +88,7 @@ class GenerateCodegenSchemaTaskTest {
   }
 
   @Test
-  @WithOs(OS.UNIX)
+  @WithOs(OS.LINUX)
   fun setupCommandLine_willSetupCorrectly() {
     val codegenDir = tempFolder.newFolder("codegen")
     val jsRootDir = tempFolder.newFolder("js")

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tests/OsRule.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tests/OsRule.kt
@@ -12,12 +12,13 @@ import org.junit.runner.Description
 import org.junit.runners.model.Statement
 
 /**
- * A JUnit [TestRule] to override values of [System.getProperties] with the support of the
- * [WithSystemProperty] annotation.
+ * A JUnit [TestRule] to override values of [System.getProperties] with the support of the [WithOs]
+ * annotation.
  */
 class OsRule : TestRule {
 
-  private var retain: String? = null
+  private var retainOs: String? = null
+  private var retainArch: String? = null
 
   override fun apply(statement: Statement, description: Description): Statement {
     return object : Statement() {
@@ -25,13 +26,20 @@ class OsRule : TestRule {
         val annotation = description.annotations.filterIsInstance<WithOs>().firstOrNull()
 
         annotation?.os?.propertyName?.let {
-          retain = System.getProperty(OS_NAME_KEY)
+          retainOs = System.getProperty(OS_NAME_KEY)
           System.setProperty(OS_NAME_KEY, it)
+        }
+        annotation?.arch?.let {
+          if (it.isNotBlank()) {
+            retainArch = System.getProperty(OS_ARCH_KEY)
+            System.setProperty(OS_ARCH_KEY, it)
+          }
         }
         try {
           statement.evaluate()
         } finally {
-          retain?.let { System.setProperty(OS_NAME_KEY, it) }
+          retainOs?.let { System.setProperty(OS_NAME_KEY, it) }
+          retainArch?.let { System.setProperty(OS_ARCH_KEY, it) }
         }
       }
     }
@@ -39,5 +47,6 @@ class OsRule : TestRule {
 
   companion object {
     const val OS_NAME_KEY = "os.name"
+    const val OS_ARCH_KEY = "os.arc"
   }
 }

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tests/TaskTestUtils.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tests/TaskTestUtils.kt
@@ -16,6 +16,7 @@ import org.gradle.testfixtures.ProjectBuilder
 
 internal fun createProject(): Project {
   with(ProjectBuilder.builder().build()) {
+    plugins.apply("com.android.library")
     plugins.apply("com.facebook.react")
     return this
   }

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tests/WithOs.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tests/WithOs.kt
@@ -8,10 +8,10 @@
 package com.facebook.react.tests
 
 /** Annotation to specify an Operating System to override the "os.name" System Property. */
-@Retention(AnnotationRetention.RUNTIME) annotation class WithOs(val os: OS)
+@Retention(AnnotationRetention.RUNTIME) annotation class WithOs(val os: OS, val arch: String = "")
 
 enum class OS(val propertyName: String) {
-  WIN("windows"),
-  MAC("macos"),
-  UNIX("unix")
+  WIN("Windows"),
+  MAC("MacOs"),
+  LINUX("Linux")
 }

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/OsTest.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/OsTest.kt
@@ -20,11 +20,11 @@ class OsTest {
   @get:Rule val osRule = OsRule()
 
   @Test
-  @WithOs(OS.UNIX)
-  fun onUnix_checksOsCorrectly() {
+  @WithOs(OS.LINUX, "amd64")
+  fun onLinuxAmd64_checksOsCorrectly() {
     assertFalse(Os.isWindows())
     assertFalse(Os.isMac())
-    assertFalse(Os.isLinuxAmd64())
+    assertTrue(Os.isLinuxAmd64())
   }
 
   @Test

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/PathUtilsTest.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/PathUtilsTest.kt
@@ -261,14 +261,14 @@ class PathUtilsTest {
   }
 
   @Test
-  @WithOs(OS.UNIX)
-  fun getHermesCBin_onUnix_returnsHermesc() {
+  @WithOs(OS.LINUX)
+  fun getHermesCBin_onLinux_returnsHermesc() {
     assertEquals("hermesc", getHermesCBin())
   }
 
   @Test
   @WithOs(OS.MAC)
-  fun getHermesCBin_onMax_returnsHermesc() {
+  fun getHermesCBin_onMac_returnsHermesc() {
     assertEquals("hermesc", getHermesCBin())
   }
 
@@ -278,6 +278,7 @@ class PathUtilsTest {
     val moduleFolder = tempFolder.newFolder("awesome-module")
 
     val project = ProjectBuilder.builder().withProjectDir(moduleFolder).build()
+    project.plugins.apply("com.android.library")
     project.plugins.apply("com.facebook.react")
     val extension = project.extensions.getByType(ReactExtension::class.java)
 
@@ -290,6 +291,7 @@ class PathUtilsTest {
     val localFile = File(moduleFolder, "package.json").apply { writeText("{}") }
 
     val project = ProjectBuilder.builder().withProjectDir(moduleFolder).build()
+    project.plugins.apply("com.android.library")
     project.plugins.apply("com.facebook.react")
     val extension =
         project.extensions.getByType(ReactExtension::class.java).apply { root.set(moduleFolder) }

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/TaskUtilsTest.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/TaskUtilsTest.kt
@@ -31,7 +31,7 @@ class TaskUtilsTest {
   }
 
   @Test
-  @WithOs(OS.UNIX)
+  @WithOs(OS.LINUX)
   fun windowsAwareCommandLine_onLinux_returnsTheList() {
     assertEquals(listOf("a", "b", "c"), windowsAwareCommandLine("a", "b", "c"))
   }
@@ -50,7 +50,7 @@ class TaskUtilsTest {
   }
 
   @Test
-  @WithOs(OS.UNIX)
+  @WithOs(OS.LINUX)
   fun windowsAwareBashCommandLine_onLinux_returnsTheList() {
     assertEquals(listOf("a", "b", "c"), windowsAwareBashCommandLine("a", "b", "c"))
   }

--- a/packages/rn-tester/android/app/build.gradle
+++ b/packages/rn-tester/android/app/build.gradle
@@ -268,20 +268,8 @@ def packageReactReleaseNdkLibs = tasks.register("packageReactReleaseNdkLibs", Co
 }
 
 afterEvaluate {
-    reactNativeArchitectures().each { architecture ->
-        tasks.findByName("configureCMakeDebug[${architecture}]")?.configure {
-            dependsOn("preHermesDebugBuild")
-            dependsOn("preJscDebugBuild")
-        }
-        tasks.findByName("configureCMakeRelWithDebInfo[${architecture}]")?.configure {
-            dependsOn("preHermesReleaseBuild")
-            dependsOn("preJscReleaseBuild")
-        }
-    }
-    configureCMakeRelWithDebInfo.dependsOn(packageReactReleaseNdkLibs)
     preHermesReleaseBuild.dependsOn(packageReactReleaseNdkLibs)
     preJscReleaseBuild.dependsOn(packageReactReleaseNdkLibs)
-    configureCMakeDebug.dependsOn(packageReactDebugNdkLibs)
     preHermesDebugBuild.dependsOn(packageReactDebugNdkLibs)
     preJscDebugBuild.dependsOn(packageReactDebugNdkLibs)
 


### PR DESCRIPTION
Summary:
AGP 7.3.0 just got released which is glorious!
This allows us to remove a lot of unnecessary boilerplate to handle correct task ordering
on both React Android & the template

Changelog:
[Android] [Changed] - Bump AGP to 7.3.0

Differential Revision: D39553534

