### PR TITLE
fix(hermes): change logic in build scripts for Apple to use the right version

### DIFF
--- a/sdks/hermes-engine/hermes-engine.podspec
+++ b/sdks/hermes-engine/hermes-engine.podspec
@@ -66,25 +66,25 @@ Pod::Spec.new do |spec|
   }
 
   if source[:git] then
-    hermes_utils_path = "#{react_native_path}/sdks/hermes-engine/utils"
+    ENV['REACT_NATIVE_PATH'] = react_native_path
+    hermes_utils_path = "/sdks/hermes-engine/utils"
+
     spec.prepare_command = <<-EOS
-      # When true, debug build will be used.
-      # See `build-apple-framework.sh` for details
+    export BUILD_TYPE=#{build_type.to_s.capitalize}
+    export RELEASE_VERSION="#{version}"
+    export IOS_DEPLOYMENT_TARGET="#{spec.deployment_target('ios')}"
+    export MAC_DEPLOYMENT_TARGET="#{spec.deployment_target('osx')}"
+    export JSI_PATH="$REACT_NATIVE_PATH/ReactCommon/jsi"
 
-      export BUILD_TYPE=#{get_hermes_build_type.to_s.capitalize}
-      export RELEASE_VERSION="#{version}"
-      export IOS_DEPLOYMENT_TARGET="#{spec.deployment_target('ios')}"
-      export MAC_DEPLOYMENT_TARGET="#{spec.deployment_target('osx')}"
+    # Set HERMES_OVERRIDE_HERMESC_PATH if pre-built HermesC is available
+    #{File.exist?(import_hermesc_file) ? "export HERMES_OVERRIDE_HERMESC_PATH=#{import_hermesc_file}" : ""}
+    #{File.exist?(import_hermesc_file) ? "echo \"Overriding HermesC path...\"" : ""}
 
-      # Set HERMES_OVERRIDE_HERMESC_PATH if pre-built HermesC is available
-      #{File.exist?(import_hermesc_file) ? "export HERMES_OVERRIDE_HERMESC_PATH=#{import_hermesc_file}" : ""}
-      #{File.exist?(import_hermesc_file) ? "echo \"Overriding HermesC path...\"" : ""}
+    # Build iOS framework
+    $REACT_NATIVE_PATH#{hermes_utils_path}/build-ios-framework.sh
 
-      # Build iOS framework
-      #{hermes_utils_path}/build-ios-framework.sh
-
-      # Build Mac framework
-      #{hermes_utils_path}/build-mac-framework.sh
+    # Build Mac framework
+    $REACT_NATIVE_PATH#{hermes_utils_path}/build-mac-framework.sh
     EOS
   end
 end

--- a/sdks/hermes-engine/hermes-engine.podspec
+++ b/sdks/hermes-engine/hermes-engine.podspec
@@ -21,6 +21,7 @@ isInCI = ENV['CI'] == true
 
 # sdks/hermesc/osx-bin/ImportHermesc.cmake
 import_hermesc_file=File.join(react_native_path, "sdks", "hermesc", "osx-bin", "ImportHermesc.cmake")
+ENV['REACT_NATIVE_PATH'] = File.join(__dir__, "..", "..")
 
 source = {}
 git = "https://github.com/facebook/hermes.git"
@@ -67,17 +68,22 @@ Pod::Spec.new do |spec|
 
   if source[:git] then
     spec.prepare_command = <<-EOS
-    BUILD_TYPE=#{build_type.to_s.capitalize}
+      # When true, debug build will be used.
+      # See `build-apple-framework.sh` for details
+      export BUILD_TYPE=#{get_hermes_build_type.to_s.capitalize}
+      export RELEASE_VERSION="#{version}"
+      export IOS_DEPLOYMENT_TARGET="#{spec.deployment_target('ios')}"
+      export MAC_DEPLOYMENT_TARGET="#{spec.deployment_target('osx')}"
 
     # Set HERMES_OVERRIDE_HERMESC_PATH if pre-built HermesC is available
     #{File.exist?(import_hermesc_file) ? "export HERMES_OVERRIDE_HERMESC_PATH=#{import_hermesc_file}" : ""}
     #{File.exist?(import_hermesc_file) ? "echo \"Overriding HermesC path...\"" : ""}
 
-    # Build iOS framework
-    ./utils/build-ios-framework.sh
+      # Build iOS framework
+      $REACT_NATIVE_PATH/sdks/hermes-engine/utils/build-ios-framework.sh
 
-    # Build Mac framework
-    ./utils/build-mac-framework.sh
+      # Build Mac framework
+      $REACT_NATIVE_PATH/sdks/hermes-engine/utils/build-mac-framework.sh
     EOS
   end
 end

--- a/sdks/hermes-engine/hermes-engine.podspec
+++ b/sdks/hermes-engine/hermes-engine.podspec
@@ -21,7 +21,6 @@ isInCI = ENV['CI'] == true
 
 # sdks/hermesc/osx-bin/ImportHermesc.cmake
 import_hermesc_file=File.join(react_native_path, "sdks", "hermesc", "osx-bin", "ImportHermesc.cmake")
-ENV['REACT_NATIVE_PATH'] = File.join(__dir__, "..", "..")
 
 source = {}
 git = "https://github.com/facebook/hermes.git"
@@ -67,23 +66,25 @@ Pod::Spec.new do |spec|
   }
 
   if source[:git] then
+    hermes_utils_path = "#{react_native_path}/sdks/hermes-engine/utils"
     spec.prepare_command = <<-EOS
       # When true, debug build will be used.
       # See `build-apple-framework.sh` for details
+
       export BUILD_TYPE=#{get_hermes_build_type.to_s.capitalize}
       export RELEASE_VERSION="#{version}"
       export IOS_DEPLOYMENT_TARGET="#{spec.deployment_target('ios')}"
       export MAC_DEPLOYMENT_TARGET="#{spec.deployment_target('osx')}"
 
-    # Set HERMES_OVERRIDE_HERMESC_PATH if pre-built HermesC is available
-    #{File.exist?(import_hermesc_file) ? "export HERMES_OVERRIDE_HERMESC_PATH=#{import_hermesc_file}" : ""}
-    #{File.exist?(import_hermesc_file) ? "echo \"Overriding HermesC path...\"" : ""}
+      # Set HERMES_OVERRIDE_HERMESC_PATH if pre-built HermesC is available
+      #{File.exist?(import_hermesc_file) ? "export HERMES_OVERRIDE_HERMESC_PATH=#{import_hermesc_file}" : ""}
+      #{File.exist?(import_hermesc_file) ? "echo \"Overriding HermesC path...\"" : ""}
 
       # Build iOS framework
-      $REACT_NATIVE_PATH/sdks/hermes-engine/utils/build-ios-framework.sh
+      #{hermes_utils_path}/build-ios-framework.sh
 
       # Build Mac framework
-      $REACT_NATIVE_PATH/sdks/hermes-engine/utils/build-mac-framework.sh
+      #{hermes_utils_path}/build-mac-framework.sh
     EOS
   end
 end

--- a/sdks/hermes-engine/utils/build-apple-framework.sh
+++ b/sdks/hermes-engine/utils/build-apple-framework.sh
@@ -18,7 +18,7 @@ function get_ios_deployment_target {
 }
 
 function get_mac_deployment_target {
-  echo ${MAC_DEPLOYMENT_TARGET}
+  echo "${MAC_DEPLOYMENT_TARGET}"
 }
 
 # Build host hermes compiler for internal bytecode

--- a/sdks/hermes-engine/utils/build-apple-framework.sh
+++ b/sdks/hermes-engine/utils/build-apple-framework.sh
@@ -10,15 +10,15 @@ REACT_NATIVE_PATH=${REACT_NATIVE_PATH:-$PWD/../..}
 JSI_PATH="$REACT_NATIVE_PATH/ReactCommon/jsi"
 
 function get_release_version {
-  ruby -rcocoapods-core -rjson -e "puts Pod::Specification.from_file('hermes-engine.podspec').version"
+  echo ${RELEASE_VERSION}
 }
 
 function get_ios_deployment_target {
-  ruby -rcocoapods-core -rjson -e "puts Pod::Specification.from_file('hermes-engine.podspec').deployment_target('ios')"
+  echo ${IOS_DEPLOYMENT_TARGET}
 }
 
 function get_mac_deployment_target {
-  ruby -rcocoapods-core -rjson -e "puts Pod::Specification.from_file('hermes-engine.podspec').deployment_target('osx')"
+  echo ${MAC_DEPLOYMENT_TARGET}
 }
 
 # Build host hermes compiler for internal bytecode

--- a/sdks/hermes-engine/utils/build-apple-framework.sh
+++ b/sdks/hermes-engine/utils/build-apple-framework.sh
@@ -9,16 +9,24 @@ IMPORT_HERMESC_PATH=${HERMES_OVERRIDE_HERMESC_PATH:-$PWD/build_host_hermesc/Impo
 REACT_NATIVE_PATH=${REACT_NATIVE_PATH:-$PWD/../..}
 JSI_PATH="$REACT_NATIVE_PATH/ReactCommon/jsi"
 
+function use_env_var_or_ruby_prop {
+  if [[ -n "$1" ]]; then
+    echo "$1"
+  else
+    ruby -rcocoapods-core -rjson -e "puts Pod::Specification.from_file('hermes-engine.podspec').$2"
+  fi
+}
+
 function get_release_version {
-  echo "${RELEASE_VERSION}"
+  use_env_var_or_ruby_prop "${RELEASE_VERSION}" "version"
 }
 
 function get_ios_deployment_target {
-  echo "${IOS_DEPLOYMENT_TARGET}"
+  use_env_var_or_ruby_prop "${IOS_DEPLOYMENT_TARGET}" "deployment_target('ios')"
 }
 
 function get_mac_deployment_target {
-  echo "${MAC_DEPLOYMENT_TARGET}"
+  use_env_var_or_ruby_prop "${MAC_DEPLOYMENT_TARGET}" "deployment_target('osx')"
 }
 
 # Build host hermes compiler for internal bytecode

--- a/sdks/hermes-engine/utils/build-apple-framework.sh
+++ b/sdks/hermes-engine/utils/build-apple-framework.sh
@@ -7,7 +7,9 @@
 NUM_CORES=$(sysctl -n hw.ncpu)
 IMPORT_HERMESC_PATH=${HERMES_OVERRIDE_HERMESC_PATH:-$PWD/build_host_hermesc/ImportHermesc.cmake}
 REACT_NATIVE_PATH=${REACT_NATIVE_PATH:-$PWD/../..}
-JSI_PATH="$REACT_NATIVE_PATH/ReactCommon/jsi"
+if [[ -z "$JSI_PATH" ]]; then
+  JSI_PATH="$REACT_NATIVE_PATH/ReactCommon/jsi"
+fi
 
 function use_env_var_or_ruby_prop {
   if [[ -n "$1" ]]; then

--- a/sdks/hermes-engine/utils/build-apple-framework.sh
+++ b/sdks/hermes-engine/utils/build-apple-framework.sh
@@ -10,7 +10,7 @@ REACT_NATIVE_PATH=${REACT_NATIVE_PATH:-$PWD/../..}
 JSI_PATH="$REACT_NATIVE_PATH/ReactCommon/jsi"
 
 function get_release_version {
-  echo ${RELEASE_VERSION}
+  echo "${RELEASE_VERSION}"
 }
 
 function get_ios_deployment_target {

--- a/sdks/hermes-engine/utils/build-apple-framework.sh
+++ b/sdks/hermes-engine/utils/build-apple-framework.sh
@@ -14,7 +14,7 @@ function get_release_version {
 }
 
 function get_ios_deployment_target {
-  echo ${IOS_DEPLOYMENT_TARGET}
+  echo "${IOS_DEPLOYMENT_TARGET}"
 }
 
 function get_mac_deployment_target {

--- a/sdks/hermes-engine/utils/build-ios-framework.sh
+++ b/sdks/hermes-engine/utils/build-ios-framework.sh
@@ -6,7 +6,7 @@
 
 # shellcheck source=xplat/js/react-native-github/sdks/hermes-engine/utils/build-apple-framework.sh
 CURR_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
-. ${CURR_SCRIPT_DIR}/build-apple-framework.sh
+. "${CURR_SCRIPT_DIR}/build-apple-framework.sh"
 
 if [ ! -d destroot/Library/Frameworks/universal/hermes.xcframework ]; then
     ios_deployment_target=$(get_ios_deployment_target)

--- a/sdks/hermes-engine/utils/build-ios-framework.sh
+++ b/sdks/hermes-engine/utils/build-ios-framework.sh
@@ -5,7 +5,8 @@
 # LICENSE file in the root directory of this source tree.
 
 # shellcheck source=xplat/js/react-native-github/sdks/hermes-engine/utils/build-apple-framework.sh
-. ./utils/build-apple-framework.sh
+CURR_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+. ${CURR_SCRIPT_DIR}/build-apple-framework.sh
 
 if [ ! -d destroot/Library/Frameworks/universal/hermes.xcframework ]; then
     ios_deployment_target=$(get_ios_deployment_target)

--- a/sdks/hermes-engine/utils/build-mac-framework.sh
+++ b/sdks/hermes-engine/utils/build-mac-framework.sh
@@ -5,7 +5,8 @@
 # LICENSE file in the root directory of this source tree.
 
 # shellcheck source=xplat/js/react-native-github/sdks/hermes-engine/utils/build-apple-framework.sh
-. ./utils/build-apple-framework.sh
+CURR_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+. ${CURR_SCRIPT_DIR}/build-apple-framework.sh
 
 if [ ! -d destroot/Library/Frameworks/macosx/hermes.framework ]; then
     mac_deployment_target=$(get_mac_deployment_target)

--- a/sdks/hermes-engine/utils/build-mac-framework.sh
+++ b/sdks/hermes-engine/utils/build-mac-framework.sh
@@ -6,7 +6,7 @@
 
 # shellcheck source=xplat/js/react-native-github/sdks/hermes-engine/utils/build-apple-framework.sh
 CURR_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
-. ${CURR_SCRIPT_DIR}/build-apple-framework.sh
+. "${CURR_SCRIPT_DIR}/build-apple-framework.sh"
 
 if [ ! -d destroot/Library/Frameworks/macosx/hermes.framework ]; then
     mac_deployment_target=$(get_mac_deployment_target)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Within the `hermes-engine.podspec` contained in the RN repo (at `react-native/main/sdks/hermes-engine/`), there's a bit of logic that triggers `./utils/build-ios-framework.sh` and `./utils/build-mac-framework.sh` .

The issue is that we all thought that that  `./utils/build-ios-framework.sh` would invoke the React native version of the scripts (since the podspec file lives right next to the `utils` folder) but, in reality, it doesn't. It just so happens that the Hermes repo has a root level `utils` folder which is (you guessed it) where the Hermes variation of those build scripts live.
So, when running the pod install command in a react-native project (build from source), it will go and download the hermes source code (since the `source[:git]` gets set) but then it will use the **hermes** variation of the `build-*.sh` scripts.

[Read more here](https://github.com/facebook/react-native/pull/34513#issuecomment-1248286691).

This PR is taking @kudo's proposed [patch here](https://github.com/reactwg/react-native-new-architecture/discussions/68#discussioncomment-3654191) - props for the fix go to him.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[iOS] [Fixed] -  Change hermes logic in build scripts for Apple to use the correct files

## Test Plan

Tested by @kudo in his work, and in my PR locally - [see here](https://github.com/facebook/react-native/pull/34513#issuecomment-1249431302).
