### PR TITLE
CircleCI: Use `nodejs-lts` for Windows tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -855,16 +855,19 @@ jobs:
       - checkout_code_with_cache
 
       - run:
-          name: Install Node
+          name: Disable NVM
+          # Use choco to manage node versions due to https://github.com/npm/cli/issues/4234
+          command: nvm off
+
+      - run:
+          name: Install Node JS
           # Note: Version set separately for non-Windows builds, see above.
-          command: |
-            nvm install 16
-            nvm use 16
+          command: choco install nodejs-lts
 
       # Setup Dependencies
       - run:
-          name: Install Yarn
-          command: choco install yarn
+          name: Enable Yarn with corepack
+          command: corepack enable
 
       - run:
           name: Display Environment info


### PR DESCRIPTION
## Summary

Currently we use `nvm install 16` in the `test_windows` CircleCI job. With the "official" NVM, this means latest 16 (16.17.0), but that's not the case for NVM windows, [which simply appends `.0.0`](https://github.com/coreybutler/nvm-windows/blob/1.1.7/src/nvm.go#L384) unless [the major version is one character long](https://github.com/coreybutler/nvm-windows/blob/1.1.7/src/nvm.go#L210). The Windows orb includes NVM-Windows 1.1.7 (even on the latest 5.0.0 orb), which does not support `nvm install lts` (added 1.1.9). Updating NVM isn't trivial as the system/orb version takes precedence over any Chocolately installation.

Running tests on 16.0.0 blocks Jest 29, which requires [`^16.10.0`](https://github.com/facebook/jest/blob/v29.0.3/packages/jest-create-cache-key-function/package.json#L17).

I initially tried installing a specific Node JS version with NVM, but NVM-Windows 1.1.7 doesn't support newer Node versions due to https://github.com/npm/cli/issues/4234.

So this PR switches from using NVM-Windows to just using Chocolately Node JS packages. `nodejs-lts` tracks the latest LTS. IMO, given we're only testing against one Node JS version with Windows, the latest LTS is a good option, but versions can be specified with `--version` if we want to pin it instead.

Yarn is available through [corepack](https://nodejs.org/api/corepack.html#corepack) since 16.9, so doesn't need to be installed separately.

## Changelog

[Internal] [Fixed] - CircleCI: Update Node JS version used on Windows tests from 16.0.0 to 16.17.0

## Test Plan

Tested via painful trial and error on my fork: https://app.circleci.com/pipelines/github/robhogan/react-native/19/workflows/0c23a77f-40d2-4c36-933b-53c14acb7907