### PR TITLE
Fix: Publish types folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     "!template/node_modules",
     "!template/package-lock.json",
     "!template/yarn.lock",
-    "third-party-podspecs"
+    "third-party-podspecs",
+    "types"
   ],
   "scripts": {
     "start": "react-native start",

--- a/scripts/.npmignore
+++ b/scripts/.npmignore
@@ -1,2 +1,2 @@
 # Make sure we never publish __test__ folders (Gradle output)
-**/__*tests__/
+**/__tests__/

--- a/types/.npmignore
+++ b/types/.npmignore
@@ -1,0 +1,1 @@
+__typetests__


### PR DESCRIPTION
## Summary

From changes in https://github.com/facebook/react-native/pull/34614, I forgot to actually export the types directory.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[Changelog][Internal] - Add types directory as part of the npm package

## Test Plan

Verified on [`build_npm_package_1`](https://app.circleci.com/pipelines/github/facebook/react-native/15799/workflows/4fd57bfc-0142-49d9-a1a6-83fa43f0e371/jobs/295438) job where we create the commitly, that `types` folder is included and `__typetests__` are ignored