### PR TITLE
Fix HERMES_ENABLED in react-native-xcode.sh

### DIFF
--- a/scripts/react-native-xcode.sh
+++ b/scripts/react-native-xcode.sh
@@ -78,11 +78,11 @@ fi
 # shellcheck source=/dev/null
 source "$REACT_NATIVE_DIR/scripts/node-binary.sh"
 
-# If hermes-engine is in the podfile.lock, it means that Hermes is a dependency of the project
+# If hermes-engine is in the Podfile.lock, it means that Hermes is a dependency of the project
 # and it is enabled. If not, it means that hermes is disabled.
-HERMES_ENABLED=$(grep hermes-engine podfile.lock)
+HERMES_ENABLED=$(grep hermes-engine "$PODS_PODFILE_DIR_PATH/Podfile.lock")
 
-# If hermes-engine is not in the podfile.lock, it means that the app is not using Hermes.
+# If hermes-engine is not in the Podfile.lock, it means that the app is not using Hermes.
 # Setting USE_HERMES is no the only way to set whether the app can use hermes or not: users
 # can also modify manually the Podfile.
 if [[ -z "$HERMES_ENABLED" ]]; then


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

`HERMES_ENABLED` value is currently wrong when running in a normal project setup. When running grep the current directory is the project root directory, which is not where the Podfile.lock usually is ("$rootProject/ios"). To make sure to grep the right folder we can use the `PODS_PODFILE_DIR_PATH` env provided by Cocoapods.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[General] [Fixed] - Fix HERMES_ENABLED in react-native-xcode.sh

## Test Plan

Verify that hermes cli runs properly in a project with hermes enabled.
