### PR TITLE
CircleCI: Remove `test_codegen`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -403,27 +403,6 @@ jobs:
       - store_test_results:
           path: ./reports/junit
 
-  # -----------------------
-  #     JOBS: Codegen Tests
-  # -----------------------
-  test_codegen:
-    parameters:
-      executor:
-        type: executor
-        default: nodelts
-    executor: << parameters.executor >>
-    steps:
-      - checkout
-      - setup_artifacts
-      - run:
-          name: Install Yarn in codegen
-          command: yarn install
-          working_directory: packages/react-native-codegen
-      - run:
-          name: Run Tests
-          command: yarn jest
-          working_directory: packages/react-native-codegen
-
   # -------------------------
   #     JOBS: iOS Unit Tests
   # -------------------------

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1340,7 +1340,6 @@ workflows:
     unless: << pipeline.parameters.run_package_release_workflow_only >>
     jobs:
       - prepare_hermes_workspace
-      - test_codegen
       - build_hermesc_linux:
           requires:
             - prepare_hermes_workspace


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

The CircleCI `test_codegen` job currently runs tests under `packages/react-native-codegen`. Because it runs from that working directory, it doesn't pick up the project root's `jest.config.js`, which is a problem for https://github.com/facebook/react-native/pull/34724 (snapshot format configuration in `jest.config.js`)

`react-native-codegen` tests are *already run* by the `test_js` job, as can be seen from the CircleCI logs
https://app.circleci.com/pipelines/github/facebook/react-native/15818/workflows/41034d00-7061-46e8-a03d-abdcc7fd7e2f/jobs/295804/parallel-runs/0/steps/0-107 , so the job isn't necessary, and this PR removes it. CC @cipolleschi

## Changelog

[Internal] [Fixed] - Remove redundant `test_codegen` job from CircleCI.

## Test Plan

CircleCI!