### PR TITLE
Bump AGP to 7.3.0 inside the template

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "pretty-format": "^26.5.2",
     "promise": "^8.2.0",
     "react-devtools-core": "4.24.0",
-    "react-native-gradle-plugin": "^0.71.0",
+    "react-native-gradle-plugin": "^0.71.1",
     "react-refresh": "^0.4.0",
     "react-shallow-renderer": "^16.15.0",
     "regenerator-runtime": "^0.13.2",

--- a/packages/react-native-gradle-plugin/package.json
+++ b/packages/react-native-gradle-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-gradle-plugin",
-  "version": "0.71.0",
+  "version": "0.71.1",
   "description": "⚛️ Gradle Plugin for React Native",
   "homepage": "https://github.com/facebook/react-native/tree/HEAD/packages/react-native-gradle-plugin",
   "repository": {

--- a/template/android/app/build.gradle
+++ b/template/android/app/build.gradle
@@ -184,20 +184,6 @@ android {
             // preBuild.dependsOn("generateCodegenArtifactsFromSchema")
             preDebugBuild.dependsOn(packageReactNdkDebugLibs)
             preReleaseBuild.dependsOn(packageReactNdkReleaseLibs)
-
-            // Due to a bug inside AGP, we have to explicitly set a dependency
-            // between configureCMakeDebug* tasks and the preBuild tasks.
-            // This can be removed once this is solved: https://issuetracker.google.com/issues/207403732
-            configureCMakeRelWithDebInfo.dependsOn(preReleaseBuild)
-            configureCMakeDebug.dependsOn(preDebugBuild)
-            reactNativeArchitectures().each { architecture ->
-                tasks.findByName("configureCMakeDebug[${architecture}]")?.configure {
-                    dependsOn("preDebugBuild")
-                }
-                tasks.findByName("configureCMakeRelWithDebInfo[${architecture}]")?.configure {
-                    dependsOn("preReleaseBuild")
-                }
-            }
         }
     }
 

--- a/template/android/build.gradle
+++ b/template/android/build.gradle
@@ -20,7 +20,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:7.2.1")
+        classpath("com.android.tools.build:gradle:7.3.0")
         classpath("com.facebook.react:react-native-gradle-plugin")
         classpath("de.undercouch:gradle-download-task:5.0.1")
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
Summary:
AGP 7.3.0 just got released which is glorious!
This allows us to remove a lot of unnecessary boilerplate to handle correct task ordering
inside the template

This requires "react-native-gradle-plugin" version 0.71.1 to be published on NPM.

Changelog:
[Android] [Changed] - Bump AGP to 7.3.0 inside the template

Reviewed By: mdvacca, dmytrorykun

Differential Revision: D39653419

