### PR TITLE
Do not depend on an ENV variable when publishing and setting the RN version

### DIFF
--- a/scripts/__tests__/scm-utils-test.js
+++ b/scripts/__tests__/scm-utils-test.js
@@ -11,7 +11,6 @@ const {isTaggedLatest, saveFiles, revertFiles} = require('../scm-utils');
 
 let execResult = null;
 const cpMock = jest.fn();
-// const existsSyncMock = jest.fn();
 const mkdirpSyncMock = jest.fn();
 jest
   .mock('shelljs', () => ({
@@ -63,9 +62,9 @@ describe('scm-utils', () => {
 
   describe('saveFiles', () => {
     it('it should save files in the temp folder', () => {
-      process.env.TMP_PUBLISH_DIR = '/tmp';
-      saveFiles('package.json', 'android/package.json');
-      expect(mkdirpSyncMock).toHaveBeenCalledWith(`/tmp/android`);
+      const tmpFolder = '/tmp';
+      saveFiles(['package.json', 'android/package.json'], tmpFolder);
+      expect(mkdirpSyncMock).toHaveBeenCalledWith(`${tmpFolder}/android`);
       expect(cpMock).toHaveBeenNthCalledWith(
         1,
         'package.json',
@@ -74,27 +73,25 @@ describe('scm-utils', () => {
       expect(cpMock).toHaveBeenNthCalledWith(
         2,
         'android/package.json',
-        '/tmp/android/package.json',
+        `${tmpFolder}/android/package.json`,
       );
-      process.env.TMP_PUBLISH_DIR = '';
     });
   });
 
   describe('revertFiles', () => {
     it('it should revert files from the temp folder', () => {
-      process.env.TMP_PUBLISH_DIR = '/tmp';
-      revertFiles('package.json', 'android/package.json');
+      const tmpFolder = '/tmp';
+      revertFiles(['package.json', 'android/package.json'], tmpFolder);
       expect(cpMock).toHaveBeenNthCalledWith(
         1,
-        '/tmp/package.json',
+        `${tmpFolder}/package.json`,
         'package.json',
       );
       expect(cpMock).toHaveBeenNthCalledWith(
         2,
-        '/tmp/android/package.json',
+        `${tmpFolder}/android/package.json`,
         'android/package.json',
       );
-      process.env.TMP_PUBLISH_DIR = '';
     });
   });
 });

--- a/scripts/publish-npm.js
+++ b/scripts/publish-npm.js
@@ -47,10 +47,10 @@ const yargs = require('yargs');
 
 const buildTag = process.env.CIRCLE_TAG;
 const otp = process.env.NPM_CONFIG_OTP;
-process.env.TMP_PUBLISH_DIR = fs.mkdtempSync(
+const tmpPublishingFolder = fs.mkdtempSync(
   path.join(os.tmpdir(), 'rn-publish-'),
 );
-echo(`The temp folder is ${process.env.TMP_PUBLISH_DIR}`);
+echo(`The temp publishing folder is ${tmpPublishingFolder}`);
 
 const argv = yargs
   .option('n', {
@@ -88,7 +88,7 @@ const filesToSaveAndRestore = [
   'ReactCommon/cxxreact/ReactNativeVersion.h',
 ];
 
-saveFiles(...filesToSaveAndRestore);
+saveFiles(filesToSaveAndRestore, tmpPublishingFolder);
 
 if (includeHermes) {
   const HERMES_INSTALL_LOCATION = 'sdks';
@@ -210,7 +210,7 @@ if (exec('./gradlew :ReactAndroid:hermes-engine:installArchives').code) {
 }
 
 // undo uncommenting javadoc setting
-revertFiles('ReactAndroid/gradle.properties');
+revertFiles(['ReactAndroid/gradle.properties'], tmpPublishingFolder);
 
 echo('Generated artifacts for Maven');
 

--- a/scripts/scm-utils.js
+++ b/scripts/scm-utils.js
@@ -60,20 +60,20 @@ function getCurrentCommit() {
     : 'TEMP';
 }
 
-function saveFiles(...filePaths) {
+function saveFiles(filePaths, tmpFolder) {
   for (const filePath of filePaths) {
     const dirName = path.dirname(filePath);
     if (dirName !== '.') {
-      const destFolder = `${process.env.TMP_PUBLISH_DIR}/${dirName}`;
+      const destFolder = `${tmpFolder}/${dirName}`;
       mkdirp.sync(destFolder);
     }
-    cp(filePath, `${process.env.TMP_PUBLISH_DIR}/${filePath}`);
+    cp(filePath, `${tmpFolder}/${filePath}`);
   }
 }
 
-function revertFiles(...filePaths) {
+function revertFiles(filePaths, tmpFolder) {
   for (const filePath of filePaths) {
-    const absoluteTmpPath = `${process.env.TMP_PUBLISH_DIR}/${filePath}`;
+    const absoluteTmpPath = `${tmpFolder}/${filePath}`;
     if (fs.existsSync(absoluteTmpPath)) {
       cp(absoluteTmpPath, filePath);
     } else {

--- a/scripts/set-rn-version.js
+++ b/scripts/set-rn-version.js
@@ -17,10 +17,17 @@
  *   * Creates a gemfile
  */
 const fs = require('fs');
+const os = require('os');
+const path = require('path');
 const {cat, echo, exec, exit, sed} = require('shelljs');
 const yargs = require('yargs');
 const {parseVersion} = require('./version-utils');
 const {saveFiles} = require('./scm-utils');
+
+const tmpVersioningFolder = fs.mkdtempSync(
+  path.join(os.tmpdir(), 'rn-set-version'),
+);
+echo(`The temp versioning folder is ${tmpVersioningFolder}`);
 
 let argv = yargs.option('v', {
   alias: 'to-version',
@@ -45,7 +52,7 @@ try {
   exit(1);
 }
 
-saveFiles('package.json', 'template/package.json');
+saveFiles(['package.json', 'template/package.json'], tmpVersioningFolder);
 
 fs.writeFileSync(
   'ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/ReactNativeVersion.java',
@@ -119,7 +126,7 @@ packageJson.dependencies = {
 fs.writeFileSync('package.json', JSON.stringify(packageJson, null, 2), 'utf-8');
 
 // Change ReactAndroid/gradle.properties
-saveFiles('ReactAndroid/gradle.properties');
+saveFiles(['ReactAndroid/gradle.properties'], tmpVersioningFolder);
 if (
   sed(
     '-i',
@@ -149,7 +156,7 @@ const filesToValidate = [
 ];
 
 const numberOfChangedLinesWithNewVersion = exec(
-  `diff -r ${process.env.TMP_PUBLISH_DIR} . | grep '^[>]' | grep -c ${version} `,
+  `diff -r ${tmpVersioningFolder} . | grep '^[>]' | grep -c ${version} `,
   {silent: true},
 ).stdout.trim();
 


### PR DESCRIPTION
Summary:
The changes made in
https://github.com/facebook/react-native/pull/34694
introduced the need to have the env variable TMP_PUBLISH_DIR for the publishing and set-rn-version scripts to work.
This break any usage of set-rn-version when the env variable is not set upfront.

With this change, we are creating a temp folder in the scope that requires it (e.g. set-rn-version.js) and then passing the path to the save/revert functions.

## Changelog
[Internal] [Added] - Do not depend on an ENV variable when publishing and setting the RN version.

Differential Revision: D39683565

