### PR TITLE
Cleanup of ReactAndroid/build.gradle after AGP 7.3.x bump

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -432,15 +432,6 @@ react {
 }
 
 afterEvaluate {
-    // Needed as some of the native sources needs to be downloaded
-    // before configureNdkBuildDebug could be executed.
-    reactNativeArchitectures().each { architecture ->
-        tasks.findByName("configureCMakeDebug[${architecture}]")?.configure { dependsOn(preBuild) }
-        tasks.findByName("configureCMakeRelWithDebInfo[${architecture}]")?.configure { dependsOn(preBuild) }
-    }
-    configureCMakeDebug.dependsOn(preBuild)
-    configureCMakeRelWithDebInfo.dependsOn(preBuild)
-
     publishing {
         publications {
             release(MavenPublication) {


### PR DESCRIPTION
Summary:
Just a minor cleanup after the AGP bump.

Changelog:
[Internal] [Changed] - Cleanup of ReactAndroid/build.gradle after AGP 7.3.x bump

Reviewed By: cipolleschi

Differential Revision: D39687286

