### PR TITLE
build: Bump ws to 6.2.2 due to ReDoS vulnerability 

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "stacktrace-parser": "^0.1.3",
     "use-sync-external-store": "^1.0.0",
     "whatwg-fetch": "^3.0.0",
-    "ws": "^6.1.4"
+    "ws": "^6.2.2"
   },
   "devDependencies": {
     "flow-bin": "^0.188.1",

--- a/packages/rn-tester/package.json
+++ b/packages/rn-tester/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "connect": "^3.6.5",
-    "ws": "^6.1.4"
+    "ws": "^6.2.2"
   },
   "codegenConfig": {
     "name": "AppSpecs",

--- a/repo-config/package.json
+++ b/repo-config/package.json
@@ -51,7 +51,7 @@
     "shelljs": "^0.8.5",
     "signedsource": "^1.0.0",
     "typescript": "4.1.3",
-    "ws": "^6.1.4",
+    "ws": "^6.2.2",
     "yargs": "^17.5.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8608,7 +8608,7 @@ ws@>=7.4.6:
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.9.0.tgz#2a994bb67144be1b53fe2d23c53c028adeb7f45e"
   integrity sha512-Ja7nszREasGaYUYCI2k4lCKIRTt+y7XuqVoHR44YpI49TtryyqbqvDMn5eqfW7e6HzTukDRIsXqzVHScqRcafg==
 
-ws@^6.1.4:
+ws@^6.2.2:
   version "6.2.2"
   resolved "https://registry.yarnpkg.com/ws/-/ws-6.2.2.tgz#dd5cdbd57a9979916097652d78f1cc5faea0c32e"
   integrity sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==


### PR DESCRIPTION
## Summary

A moderate vulnerability was found in all versions of `ws` below 7.4.6 June last year. React native current uses v6.1.4 which is susceptible to it, fortunately this security fix has been backported to v6.X.X and we don't need to upgrade any major versions/worry about breaking changes. This PR bumps `ws` to 6.2.2 ([CHANGELOG](https://github.com/websockets/ws/releases/tag/6.2.2)) due to this ReDoS vulnerability 

More information about this vulnerability can be found here -> https://github.com/advisories/GHSA-6fc8-4gx4-v693

Closes https://github.com/facebook/react-native/issues/31646

## Changelog
 

[Internal] [Security] - Bump ws to 6.2.2 due to ReDoS vulnerability 

## Test Plan

Ensure WebSocket tests are working as expected 
