### PR TITLE
Use PRODUCTION envvar directly in hermes-engine Pod to determine build type

### DIFF
--- a/scripts/cocoapods/__tests__/hermes-test.rb
+++ b/scripts/cocoapods/__tests__/hermes-test.rb
@@ -22,7 +22,6 @@ class HermesTests < Test::Unit::TestCase
         Pod::Config.reset()
         Pod::UI.reset()
         podSpy_cleanUp()
-        ENV['PRODUCTION'] = '0'
     end
 
     # ============================= #
@@ -84,55 +83,4 @@ class HermesTests < Test::Unit::TestCase
         assert_equal($podInvocation["libevent"][:version], "~> 2.1.12")
         assert_equal($podInvocation["hermes-engine"][:podspec], "../../sdks/hermes/hermes-engine.podspec")
     end
-
-    # ========================= #
-    # TEST - getHermesBuildType #
-    # ========================= #
-    def test_getHermesBuildType_whenNotInProduction
-        # Arrange
-        ENV['PRODUCTION'] = '0'
-
-        # Act
-        build_type = get_hermes_build_type
-
-        # Assert
-        assert_equal(build_type, :debug)
-    end
-
-    def test_getHermesBuildType_whenInProduction
-        # Arrange
-        ENV['PRODUCTION'] = '1'
-
-        # Act
-        build_type = get_hermes_build_type
-
-        # Assert
-        assert_equal(build_type, :release)
-    end
-
-    def test_getHermesBuildType_whenProductionIsNotSet
-        # Arrange
-        ENV.delete 'PRODUCTION'
-
-        # Act
-        build_type = get_hermes_build_type
-
-        # Assert
-        assert_equal(build_type, :debug)
-    end
-
-    def test_getHermesBuildType_symbolsMatchStrings
-        # Arrange
-        ENV['PRODUCTION'] = '0'
-
-        # Act
-        build_type = get_hermes_build_type
-
-        # Assert
-        assert_equal(build_type, :debug)
-        assert_equal(build_type.to_s, "debug")
-        assert_equal(build_type.to_s.capitalize, "Debug")
-    end
-
-
 end

--- a/scripts/cocoapods/hermes.rb
+++ b/scripts/cocoapods/hermes.rb
@@ -18,7 +18,3 @@ def install_hermes_if_enabled(hermes_enabled, react_native_path)
     pod 'libevent', '~> 2.1.12'
     pod 'hermes-engine', :podspec => "#{react_native_path}/sdks/hermes/hermes-engine.podspec"
 end
-
-def get_hermes_build_type()
-    return ENV['PRODUCTION'] == "1" ? :release : :debug
-end


### PR DESCRIPTION
Summary:
CocoaPods is not used when Hermes is built in Circle CI, so we cannot rely on the React Native CocoaPods scripts to be loaded.
The get_hermes_build_type function is removed from the RN CocoaPods scripts and in its place, the ENV['PRODUCTION'] envvar is accessed directly.

Changelog: [Internal]

Reviewed By: cipolleschi

Differential Revision: D39778190

