### PR TITLE
Fix interface support in turbo module TypeScript codegen (component only)

### DIFF
--- a/packages/react-native-codegen/src/parsers/consistency/__tests__/checkComponentSnaps-test.js
+++ b/packages/react-native-codegen/src/parsers/consistency/__tests__/checkComponentSnaps-test.js
@@ -17,7 +17,7 @@ const flowSnaps = require('../../../../src/parsers/flow/components/__tests__/__s
 const flowExtraCases = [];
 const tsFixtures = require('../../typescript/components/__test_fixtures__/fixtures.js');
 const tsSnaps = require('../../../../src/parsers/typescript/components/__tests__/__snapshots__/typescript-component-parser-test.js.snap');
-const tsExtraCases = ['ARRAY2_PROP_TYPES_NO_EVENTS', 'ARRAY2_STATE_TYPES'];
+const tsExtraCases = ['ARRAY2_PROP_TYPES_NO_EVENTS', 'ARRAY2_STATE_TYPES', 'PROPS_AND_EVENTS_WITH_INTERFACES'];
 const ignoredCases = ['ARRAY_PROP_TYPES_NO_EVENTS', 'ARRAY_STATE_TYPES'];
 
 compareSnaps(

--- a/packages/react-native-codegen/src/parsers/consistency/__tests__/checkComponentSnaps-test.js
+++ b/packages/react-native-codegen/src/parsers/consistency/__tests__/checkComponentSnaps-test.js
@@ -17,7 +17,11 @@ const flowSnaps = require('../../../../src/parsers/flow/components/__tests__/__s
 const flowExtraCases = [];
 const tsFixtures = require('../../typescript/components/__test_fixtures__/fixtures.js');
 const tsSnaps = require('../../../../src/parsers/typescript/components/__tests__/__snapshots__/typescript-component-parser-test.js.snap');
-const tsExtraCases = ['ARRAY2_PROP_TYPES_NO_EVENTS', 'ARRAY2_STATE_TYPES', 'PROPS_AND_EVENTS_WITH_INTERFACES'];
+const tsExtraCases = [
+  'ARRAY2_PROP_TYPES_NO_EVENTS',
+  'ARRAY2_STATE_TYPES',
+  'PROPS_AND_EVENTS_WITH_INTERFACES',
+];
 const ignoredCases = ['ARRAY_PROP_TYPES_NO_EVENTS', 'ARRAY_STATE_TYPES'];
 
 compareSnaps(

--- a/packages/react-native-codegen/src/parsers/typescript/components/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/__test_fixtures__/fixtures.js
@@ -1095,6 +1095,44 @@ export default codegenNativeComponent<ModuleProps>(
 ) as NativeType;
 `;
 
+const PROPS_AND_EVENTS_WITH_INTERFACES = `
+import type {
+  BubblingEventHandler,
+  DirectEventHandler,
+} from 'CodegenTypes';
+import type {ViewProps} from 'ViewPropTypes';
+import type {HostComponent} from 'react-native';
+
+const codegenNativeComponent = require('codegenNativeComponent');
+
+export interface Base1 {
+  x: string;
+}
+
+export interface Base2 {
+  y: number;
+}
+
+export interface Derived extends Base1, Base2 {
+  z: boolean;
+}
+
+export interface ModuleProps extends ViewProps {
+  // Props
+  ordinary_prop: Readonly<Derived>;
+  array_prop?: readonly Derived[];
+
+  // Events
+  onDirect: DirectEventHandler<Derived>;
+  onBubbling: BubblingEventHandler<Derived>;
+}
+
+export default codegenNativeComponent<ModuleProps>('Module', {
+  interfaceOnly: true,
+  paperComponentName: 'RCTModule',
+}) as HostComponent<ModuleProps>;
+`;
+
 // === STATE ===
 const ALL_STATE_TYPES = `
 /**
@@ -1630,6 +1668,7 @@ module.exports = {
   COMMANDS_DEFINED_WITH_ALL_TYPES,
   PROPS_AS_EXTERNAL_TYPES,
   COMMANDS_WITH_EXTERNAL_TYPES,
+  PROPS_AND_EVENTS_WITH_INTERFACES,
   ALL_STATE_TYPES,
   ARRAY_STATE_TYPES,
   ARRAY2_STATE_TYPES,

--- a/packages/react-native-codegen/src/parsers/typescript/components/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/__test_fixtures__/fixtures.js
@@ -1107,21 +1107,23 @@ import type {HostComponent} from 'react-native';
 const codegenNativeComponent = require('codegenNativeComponent');
 
 export interface Base1 {
-  x: string;
+  readonly x: string;
 }
 
 export interface Base2 {
-  y: Int32;
+  readonly y: Int32;
 }
 
 export interface Derived extends Base1, Base2 {
-  z: boolean;
+  readonly z: boolean;
 }
 
 export interface ModuleProps extends ViewProps {
   // Props
-  ordinary_prop: Readonly<Derived>;
-  array_prop?: readonly Derived[];
+  ordinary_prop: Derived;
+  readonly_prop: Readonly<Derived>;
+  ordinary_array_prop?: readonly Derived[];
+  readonly_array_prop?: readonly Readonly<Derived>[];
 
   // Events
   onDirect: DirectEventHandler<Derived>;

--- a/packages/react-native-codegen/src/parsers/typescript/components/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/__test_fixtures__/fixtures.js
@@ -1124,6 +1124,8 @@ export interface ModuleProps extends ViewProps {
   readonly_prop: Readonly<Derived>;
   ordinary_array_prop?: readonly Derived[];
   readonly_array_prop?: readonly Readonly<Derived>[];
+  ordinary_nested_array_prop?: readonly Derived[][];
+  readonly_nested_array_prop?: readonly Readonly<Derived>[][];
 
   // Events
   onDirect: DirectEventHandler<Derived>;

--- a/packages/react-native-codegen/src/parsers/typescript/components/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/__test_fixtures__/fixtures.js
@@ -1127,7 +1127,7 @@ export interface ModuleProps extends ViewProps {
 
   // Events
   onDirect: DirectEventHandler<Derived>;
-  onBubbling: BubblingEventHandler<Derived>;
+  onBubbling: BubblingEventHandler<Readonly<Derived>>;
 }
 
 export default codegenNativeComponent<ModuleProps>('Module', {

--- a/packages/react-native-codegen/src/parsers/typescript/components/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/__test_fixtures__/fixtures.js
@@ -1099,6 +1099,7 @@ const PROPS_AND_EVENTS_WITH_INTERFACES = `
 import type {
   BubblingEventHandler,
   DirectEventHandler,
+  Int32,
 } from 'CodegenTypes';
 import type {ViewProps} from 'ViewPropTypes';
 import type {HostComponent} from 'react-native';
@@ -1110,7 +1111,7 @@ export interface Base1 {
 }
 
 export interface Base2 {
-  y: number;
+  y: Int32;
 }
 
 export interface Derived extends Base1, Base2 {

--- a/packages/react-native-codegen/src/parsers/typescript/components/__tests__/__snapshots__/typescript-component-parser-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/typescript/components/__tests__/__snapshots__/typescript-component-parser-test.js.snap
@@ -12863,6 +12863,84 @@ exports[`RN Codegen TypeScript Parser can generate fixture PROPS_AND_EVENTS_WITH
                   ]
                 }
               }
+            },
+            {
+              'name': 'ordinary_nested_array_prop',
+              'optional': true,
+              'typeAnnotation': {
+                'type': 'ArrayTypeAnnotation',
+                'elementType': {
+                  'type': 'ArrayTypeAnnotation',
+                  'elementType': {
+                    'type': 'ObjectTypeAnnotation',
+                    'properties': [
+                      {
+                        'name': 'x',
+                        'optional': false,
+                        'typeAnnotation': {
+                          'type': 'StringTypeAnnotation',
+                          'default': null
+                        }
+                      },
+                      {
+                        'name': 'y',
+                        'optional': false,
+                        'typeAnnotation': {
+                          'type': 'Int32TypeAnnotation',
+                          'default': 0
+                        }
+                      },
+                      {
+                        'name': 'z',
+                        'optional': false,
+                        'typeAnnotation': {
+                          'type': 'BooleanTypeAnnotation',
+                          'default': false
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              'name': 'readonly_nested_array_prop',
+              'optional': true,
+              'typeAnnotation': {
+                'type': 'ArrayTypeAnnotation',
+                'elementType': {
+                  'type': 'ArrayTypeAnnotation',
+                  'elementType': {
+                    'type': 'ObjectTypeAnnotation',
+                    'properties': [
+                      {
+                        'name': 'x',
+                        'optional': false,
+                        'typeAnnotation': {
+                          'type': 'StringTypeAnnotation',
+                          'default': null
+                        }
+                      },
+                      {
+                        'name': 'y',
+                        'optional': false,
+                        'typeAnnotation': {
+                          'type': 'Int32TypeAnnotation',
+                          'default': 0
+                        }
+                      },
+                      {
+                        'name': 'z',
+                        'optional': false,
+                        'typeAnnotation': {
+                          'type': 'BooleanTypeAnnotation',
+                          'default': false
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
             }
           ],
           'commands': []

--- a/packages/react-native-codegen/src/parsers/typescript/components/__tests__/__snapshots__/typescript-component-parser-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/typescript/components/__tests__/__snapshots__/typescript-component-parser-test.js.snap
@@ -12640,6 +12640,239 @@ exports[`RN Codegen TypeScript Parser can generate fixture PROPS_AND_EVENTS_TYPE
 }"
 `;
 
+exports[`RN Codegen TypeScript Parser can generate fixture PROPS_AND_EVENTS_WITH_INTERFACES 1`] = `
+"{
+  'modules': {
+    'Module': {
+      'type': 'Component',
+      'components': {
+        'Module': {
+          'interfaceOnly': true,
+          'paperComponentName': 'RCTModule',
+          'extendsProps': [
+            {
+              'type': 'ReactNativeBuiltInType',
+              'knownTypeName': 'ReactNativeCoreViewProps'
+            }
+          ],
+          'events': [
+            {
+              'name': 'onDirect',
+              'optional': false,
+              'bubblingType': 'direct',
+              'typeAnnotation': {
+                'type': 'EventTypeAnnotation',
+                'argument': {
+                  'type': 'ObjectTypeAnnotation',
+                  'properties': [
+                    {
+                      'name': 'x',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'StringTypeAnnotation'
+                      }
+                    },
+                    {
+                      'name': 'y',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'Int32TypeAnnotation'
+                      }
+                    },
+                    {
+                      'name': 'z',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'BooleanTypeAnnotation'
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              'name': 'onBubbling',
+              'optional': false,
+              'bubblingType': 'bubble',
+              'typeAnnotation': {
+                'type': 'EventTypeAnnotation',
+                'argument': {
+                  'type': 'ObjectTypeAnnotation',
+                  'properties': [
+                    {
+                      'name': 'x',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'StringTypeAnnotation'
+                      }
+                    },
+                    {
+                      'name': 'y',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'Int32TypeAnnotation'
+                      }
+                    },
+                    {
+                      'name': 'z',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'BooleanTypeAnnotation'
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ],
+          'props': [
+            {
+              'name': 'ordinary_prop',
+              'optional': false,
+              'typeAnnotation': {
+                'type': 'ObjectTypeAnnotation',
+                'properties': [
+                  {
+                    'name': 'x',
+                    'optional': false,
+                    'typeAnnotation': {
+                      'type': 'StringTypeAnnotation',
+                      'default': null
+                    }
+                  },
+                  {
+                    'name': 'y',
+                    'optional': false,
+                    'typeAnnotation': {
+                      'type': 'Int32TypeAnnotation',
+                      'default': 0
+                    }
+                  },
+                  {
+                    'name': 'z',
+                    'optional': false,
+                    'typeAnnotation': {
+                      'type': 'BooleanTypeAnnotation',
+                      'default': false
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              'name': 'readonly_prop',
+              'optional': false,
+              'typeAnnotation': {
+                'type': 'ObjectTypeAnnotation',
+                'properties': [
+                  {
+                    'name': 'x',
+                    'optional': false,
+                    'typeAnnotation': {
+                      'type': 'StringTypeAnnotation',
+                      'default': null
+                    }
+                  },
+                  {
+                    'name': 'y',
+                    'optional': false,
+                    'typeAnnotation': {
+                      'type': 'Int32TypeAnnotation',
+                      'default': 0
+                    }
+                  },
+                  {
+                    'name': 'z',
+                    'optional': false,
+                    'typeAnnotation': {
+                      'type': 'BooleanTypeAnnotation',
+                      'default': false
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              'name': 'ordinary_array_prop',
+              'optional': true,
+              'typeAnnotation': {
+                'type': 'ArrayTypeAnnotation',
+                'elementType': {
+                  'type': 'ObjectTypeAnnotation',
+                  'properties': [
+                    {
+                      'name': 'x',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'StringTypeAnnotation',
+                        'default': null
+                      }
+                    },
+                    {
+                      'name': 'y',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'Int32TypeAnnotation',
+                        'default': 0
+                      }
+                    },
+                    {
+                      'name': 'z',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'BooleanTypeAnnotation',
+                        'default': false
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              'name': 'readonly_array_prop',
+              'optional': true,
+              'typeAnnotation': {
+                'type': 'ArrayTypeAnnotation',
+                'elementType': {
+                  'type': 'ObjectTypeAnnotation',
+                  'properties': [
+                    {
+                      'name': 'x',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'StringTypeAnnotation',
+                        'default': null
+                      }
+                    },
+                    {
+                      'name': 'y',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'Int32TypeAnnotation',
+                        'default': 0
+                      }
+                    },
+                    {
+                      'name': 'z',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'BooleanTypeAnnotation',
+                        'default': false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ],
+          'commands': []
+        }
+      }
+    }
+  }
+}"
+`;
+
 exports[`RN Codegen TypeScript Parser can generate fixture PROPS_AS_EXTERNAL_TYPES 1`] = `
 "{
   'modules': {

--- a/packages/react-native-codegen/src/parsers/typescript/components/componentsUtils.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/componentsUtils.js
@@ -162,7 +162,7 @@ function getTypeAnnotationForArray<T>(
       return {
         type: 'ObjectTypeAnnotation',
         properties: flattenProperties(rawProperties, types)
-          .map(prop => buildPropSchema(prop, types))
+          .map(prop => buildSchema(prop, types))
           .filter(Boolean),
       };
     }
@@ -383,7 +383,7 @@ function getTypeAnnotation<T>(
           : typeAnnotation.members;
       const flattenedProperties = flattenProperties(rawProperties, types);
       const properties = flattenedProperties
-        .map(prop => buildPropSchema(prop, types))
+        .map(prop => buildSchema(prop, types))
         .filter(Boolean);
 
       return {

--- a/packages/react-native-codegen/src/parsers/typescript/components/componentsUtils.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/componentsUtils.js
@@ -698,10 +698,7 @@ function flattenProperties(
       } else if (property.type === 'TSTypeLiteral') {
         return flattenProperties(property.members, types);
       } else if (property.type === 'TSInterfaceDeclaration') {
-        return flattenProperties(
-          getProperties(property.id.name, types),
-          types,
-        );
+        return flattenProperties(getProperties(property.id.name, types), types);
       } else {
         throw new Error(
           `${property.type} is not a supported object literal type.`,

--- a/packages/react-native-codegen/src/parsers/typescript/components/events.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/events.js
@@ -15,6 +15,7 @@ import type {
   NamedShape,
   EventTypeAnnotation,
 } from '../../../CodegenSchema.js';
+const {flattenProperties} = require('./props');
 
 function getPropertyType(
   /* $FlowFixMe[missing-local-annot] The type annotation(s) required by Flow's
@@ -126,16 +127,28 @@ function findEventArgumentsAndType(
   bubblingType: void | 'direct' | 'bubble',
   paperName: ?$FlowFixMe,
 ) {
+  if (typeAnnotation.type === 'TSInterfaceDeclaration') {
+    return {
+      argumentProps: flattenProperties([typeAnnotation], types),
+      paperTopLevelNameDeprecated: paperName,
+      bubblingType,
+    };
+  }
+
+  if (typeAnnotation.type === 'TSTypeLiteral') {
+    return {
+      argumentProps: typeAnnotation.members,
+      paperTopLevelNameDeprecated: paperName,
+      bubblingType,
+    };
+  }
+
   if (!typeAnnotation.typeName) {
     throw new Error("typeAnnotation of event doesn't have a name");
   }
   const name = typeAnnotation.typeName.name;
   if (name === 'Readonly') {
-    return {
-      argumentProps: typeAnnotation.typeParameters.params[0].members,
-      paperTopLevelNameDeprecated: paperName,
-      bubblingType,
-    };
+    return findEventArgumentsAndType(typeAnnotation.typeParameters.params[0], types, bubblingType, paperName);
   } else if (name === 'BubblingEventHandler' || name === 'DirectEventHandler') {
     const eventType = name === 'BubblingEventHandler' ? 'bubble' : 'direct';
     const paperTopLevelNameDeprecated =
@@ -160,8 +173,12 @@ function findEventArgumentsAndType(
         );
     }
   } else if (types[name]) {
+    let elementType = types[name];
+    if (elementType.type === 'TSTypeAliasDeclaration') {
+      elementType = elementType.typeAnnotation;
+    }
     return findEventArgumentsAndType(
-      types[name].typeAnnotation,
+      elementType,
       types,
       bubblingType,
       paperName,

--- a/packages/react-native-codegen/src/parsers/typescript/components/events.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/events.js
@@ -148,7 +148,12 @@ function findEventArgumentsAndType(
   }
   const name = typeAnnotation.typeName.name;
   if (name === 'Readonly') {
-    return findEventArgumentsAndType(typeAnnotation.typeParameters.params[0], types, bubblingType, paperName);
+    return findEventArgumentsAndType(
+      typeAnnotation.typeParameters.params[0],
+      types,
+      bubblingType,
+      paperName,
+    );
   } else if (name === 'BubblingEventHandler' || name === 'DirectEventHandler') {
     const eventType = name === 'BubblingEventHandler' ? 'bubble' : 'direct';
     const paperTopLevelNameDeprecated =

--- a/packages/react-native-codegen/src/parsers/typescript/components/events.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/events.js
@@ -15,7 +15,7 @@ import type {
   NamedShape,
   EventTypeAnnotation,
 } from '../../../CodegenSchema.js';
-const {flattenProperties} = require('./props');
+const {flattenProperties} = require('./componentsUtils');
 
 function getPropertyType(
   /* $FlowFixMe[missing-local-annot] The type annotation(s) required by Flow's

--- a/packages/react-native-codegen/src/parsers/typescript/components/props.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/props.js
@@ -54,5 +54,6 @@ function getProps(
 }
 
 module.exports = {
+  flattenProperties,
   getProps,
 };

--- a/packages/react-native-codegen/src/parsers/typescript/components/props.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/props.js
@@ -54,6 +54,5 @@ function getProps(
 }
 
 module.exports = {
-  flattenProperties,
   getProps,
 };

--- a/packages/react-native-codegen/src/parsers/typescript/utils.js
+++ b/packages/react-native-codegen/src/parsers/typescript/utils.js
@@ -125,15 +125,18 @@ function resolveTypeAnnotation(
 }
 
 function getValueFromTypes(value: ASTNode, types: TypeDeclarationMap): ASTNode {
-  if (value.type === 'TSTypeReference' && types[value.typeName.name]) {
-    return getValueFromTypes(types[value.typeName.name], types);
+  switch (value.type) {
+    case 'TSTypeReference':
+      if (types[value.typeName.name]) {
+        return getValueFromTypes(types[value.typeName.name], types);
+      } else {
+        return value;
+      }
+    case 'TSTypeAliasDeclaration':
+      return getValueFromTypes(value.typeAnnotation, types);
+    default:
+      return value;
   }
-
-  if (value.type === 'TSTypeAliasDeclaration') {
-    return value.typeAnnotation;
-  }
-
-  return value;
 }
 
 export type ParserErrorCapturer = <T>(fn: () => T) => ?T;


### PR DESCRIPTION
## Summary

Interface was supported in component, but it only allows interfaces in limited cases.

In this change, I extended interface support to all places where object literal type is supported.

I also refactor the code so that properties and events are able to share the same implementation.

In order not to mess up the diff, I noticed that implementations are repeated in processing array properties and non-array properties. But I leave it without refactoring. I will do it in future PRs.

I also commented potential problems I found in the code.

## Changelog

[General] [Changed] - Fix interface support in turbo module TypeScript codegen (component only)

## Test Plan

`yarn jest react-native-codegen` passed
