### PR TITLE
Use monospace font for RCTRedBox.mm message

### DIFF
--- a/React/CoreModules/RCTRedBox.mm
+++ b/React/CoreModules/RCTRedBox.mm
@@ -328,7 +328,13 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)aDecoder)
     cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"msg-cell"];
     cell.textLabel.accessibilityIdentifier = @"redbox-error";
     cell.textLabel.textColor = [UIColor whiteColor];
-    cell.textLabel.font = [UIFont boldSystemFontOfSize:16];
+    if (@available(iOS 13.0, *)) {
+      // Prefer a monofont for formatting messages that were designed
+      // to be displayed in a terminal.
+      cell.textLabel.font = [UIFont monospacedSystemFontOfSize:14 weight:UIFontWeightBold];
+    } else {
+      cell.textLabel.font = [UIFont boldSystemFontOfSize:14];
+    }
     cell.textLabel.lineBreakMode = NSLineBreakByWordWrapping;
     cell.textLabel.numberOfLines = 0;
     cell.detailTextLabel.textColor = [UIColor whiteColor];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

The format is crunching spaces:

![Simulator Screen Shot - iPhone 14 Pro Max - 2022-09-24 at 16 25 33](https://user-images.githubusercontent.com/9664363/192119593-30d5c82f-9f8c-465d-af29-6914d4111351.png)

Now it preserves the space and makes the error look a little less scary:

![Simulator Screen Shot - iPhone 14 Pro Max - 2022-09-24 at 16 25 02](https://user-images.githubusercontent.com/9664363/192119603-8214a38b-6511-413b-b999-5d2739cd0293.png)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[iOS] [Fixed] - RedBox title font by using a monospace font on iOS +13.

## Test Plan

See pictures. You can repro by applying changes and starting a project with a misc `>` character. The first load triggers the error message.