### PR TITLE
Remove usage of UIApplication.sharedApplication

### DIFF
--- a/React/Base/RCTKeyCommands.m
+++ b/React/Base/RCTKeyCommands.m
@@ -128,7 +128,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
     isKeyDown = [event _isKeyDown];
   }
 
-  BOOL interactionEnabled = !UIApplication.sharedApplication.isIgnoringInteractionEvents;
+  BOOL interactionEnabled = !RCTSharedApplication().isIgnoringInteractionEvents;
   BOOL hasFirstResponder = NO;
   if (isKeyDown && modifiedInput.length > 0 && interactionEnabled) {
     UIResponder *firstResponder = nil;


### PR DESCRIPTION
## Summary

Brings in line with rest of code base and avoids running into this error
```
‘sharedApplication’ is unavailable: not available on iOS (App Extension) — Use view controller based solutions where appropriate instead.
```
when `Requires Only App-Extension-Safe-API` is set to Yes.

## Changelog

[iOS] [Fixed] - Update usage of UIApplication.sharedApplication in RCTKeyCommands

## Test Plan

Setting `Requires Only App-Extension-Safe-API` to Yes before this change means the app will not compile, after the change it does.
