### PR TITLE
Fixing failure building RN codegen CLI on Windows 

### DIFF
--- a/ReactAndroid/cmake-utils/ReactNative-application.cmake
+++ b/ReactAndroid/cmake-utils/ReactNative-application.cmake
@@ -26,9 +26,14 @@ endif(CCACHE_FOUND)
 
 include(${REACT_ANDROID_DIR}/cmake-utils/Android-prebuilt.cmake)
 
+set(BUILD_DIR ${PROJECT_BUILD_DIR})
+if(CMAKE_HOST_WIN32)
+        string(REPLACE "\\" "/" BUILD_DIR ${BUILD_DIR})
+endif()
+
 file(GLOB input_SRC CONFIGURE_DEPENDS
         *.cpp
-        ${PROJECT_BUILD_DIR}/generated/rncli/src/main/jni/*.cpp)
+        ${BUILD_DIR}/generated/rncli/src/main/jni/*.cpp)
 
 add_library(${CMAKE_PROJECT_NAME} SHARED ${input_SRC})
 


### PR DESCRIPTION
Ensuring the file paths uses forward slashes as separator to avoid the characters from being interpreted as ASCII escape characters.

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

Fixing build failure building RN codegen CLI on Windows. Ensuring the file paths uses forward slashes as separator to avoid the characters from being interpreted as ASCII escape characters.

[Android] [Fixed] - Fixing failure building RN codegen CLI on Windows

## Test Plan
Ensured RN main branch builds on Windows with new architecture turned on.