### PR TITLE
Fix crash on release versions after AGP 7.3 bump

### DIFF
--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/TaskConfiguration.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/TaskConfiguration.kt
@@ -193,8 +193,8 @@ internal fun Project.configureReactTasks(variant: BaseVariant, config: ReactExte
           it.into(jsBundleDirConfigValue.get())
         } else {
           it.into(mergeAssetsTask.map { mergeFoldersTask -> mergeFoldersTask.outputDir.get() })
-          // Workaround for Android Gradle Plugin 7.1 asset directory
-          it.into("$buildDir/intermediates/assets/${variant.name}/merge${targetName}Assets")
+          // Workaround for Android Gradle Plugin 7.3 asset directory
+          it.into("$buildDir/intermediates/assets/${variant.name}")
         }
 
         it.dependsOn(mergeAssetsTask)

--- a/react.gradle
+++ b/react.gradle
@@ -387,7 +387,7 @@ afterEvaluate {
                     into ("merged_assets/${variant.name}/out")
 
                     // Workaround for Android Gradle Plugin 7.1 asset directory
-                    into("$buildDir/intermediates/assets/${variant.name}/merge${targetName}Assets")
+                    into("$buildDir/intermediates/assets/${variant.name}")
                 }
             }
 


### PR DESCRIPTION
## Summary

Release versions are currently broken on `main`. This happened once we bumped the AGP version to 7.3. It seems like that the path we used to use for assets has changed.

The app build successfully but it fails to start as it can't load the bundle.

This is also causing the hermes e2e test to fail: https://github.com/facebook/hermes/pull/821

## Changelog

[Android] [Fixed] - Fix crash on release versions after AGP 7.3 bump

## Test Plan

Tested this locally and it works fine with RN Tester (can run a release version of it).

Plus, inspecting the zip:

### Before

```
$ unzip -l packages/rn-tester/android/app/build/outputs/apk/hermes/release/app-hermes-arm64-v8a-release.apk | grep android.bundle
  1248608  01-01-1981 01:01   assets/mergeHermesReleaseAssets/RNTesterApp.android.bundle
```

### After

```
$ unzip -l packages/rn-tester/android/app/build/outputs/apk/hermes/release/app-hermes-arm64-v8a-release.apk | grep android.bundle
  1248608  01-01-1981 01:01   assets/RNTesterApp.android.bundle
```