### PR TITLE
Update Expo domain to expo.dev

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -40,7 +40,7 @@ body:
     attributes:
       label: Snack, code example, screenshot, or link to a repository
       description: |
-        Please provide a Snack (https://snack.expo.io/), a link to a repository on GitHub, or provide a minimal code example that reproduces the problem.
+        Please provide a Snack (https://snack.expo.dev/), a link to a repository on GitHub, or provide a minimal code example that reproduces the problem.
         You may provide a screenshot of the application if you think it is relevant to your bug report.
         Here are some tips for providing a minimal example: https://stackoverflow.com/help/mcve
         Please note that a reproducer is mandatory. Issues without reproducer are more likely to stall and will be closed.

--- a/.github/ISSUE_TEMPLATE/new_architecture_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/new_architecture_bug_report.yml
@@ -45,7 +45,7 @@ body:
     attributes:
       label: Snack, code example, screenshot, or link to a repository
       description: |
-        Please provide a Snack (https://snack.expo.io/), a link to a repository on GitHub, or provide a minimal code example that reproduces the problem.
+        Please provide a Snack (https://snack.expo.dev/), a link to a repository on GitHub, or provide a minimal code example that reproduces the problem.
         You may provide a screenshot of the application if you think it is relevant to your bug report.
         Here are some tips for providing a minimal example: https://stackoverflow.com/help/mcve
         Please note that a reproducer is mandatory. Issues without reproducer are more likely to stall and will be closed.

--- a/.github/respond-to-issue-based-on-label.yml
+++ b/.github/respond-to-issue-based-on-label.yml
@@ -46,7 +46,7 @@
     <table><tbody><tr><th width="50">:warning:</th><th width="100%">
     Missing Reproducible Example
     </th></tr><tr><td>:information_source:</td><td>
-    It looks like your issue is missing a reproducible example. Please provide a <a href="https://snack.expo.io">Snack</a> or a repository that demonstrates the issue you are reporting in a <a href="https://stackoverflow.com/help/minimal-reproducible-example">minimal, complete, and reproducible</a> manner.
+    It looks like your issue is missing a reproducible example. Please provide a <a href="https://snack.expo.dev">Snack</a> or a repository that demonstrates the issue you are reporting in a <a href="https://stackoverflow.com/help/minimal-reproducible-example">minimal, complete, and reproducible</a> manner.
     </td></tr></tbody></table>
   labels:
     - "Needs: Author Feedback"

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ React Native is developed and supported by many companies and individual core co
 
 ## 📋 Requirements
 
-React Native apps may target iOS 12.4 and Android 5.0 (API 21) or newer. You may use Windows, macOS, or Linux as your development operating system, though building and running iOS apps is limited to macOS. Tools like [Expo](https://expo.io) can be used to work around this.
+React Native apps may target iOS 12.4 and Android 5.0 (API 21) or newer. You may use Windows, macOS, or Linux as your development operating system, though building and running iOS apps is limited to macOS. Tools like [Expo](https://expo.dev) can be used to work around this.
 
 ## 🎉 Building your first React Native app
 
@@ -77,7 +77,7 @@ Follow the [Getting Started guide](https://reactnative.dev/docs/getting-started)
 - [Creating a New Application][new-app]
 - [Adding React Native to an Existing Application][existing]
 
-[hello-world]: https://snack.expo.io/@hramos/hello,-world!
+[hello-world]: https://snack.expo.dev/@hramos/hello,-world!
 [new-app]: https://reactnative.dev/docs/getting-started
 [existing]: https://reactnative.dev/docs/integration-with-existing-apps
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Some time ago, we moved the Expo domain over to `expo.dev` ([see this PR for example](https://github.com/expo/expo/commit/c5e091a0155d138abdb24283d92c84816e5a1c09)). This does the same thing here :)

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

Internal Changed - Update Expo domain to expo.dev

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Just a minor change, unrelated to React Native code.
