### PR TITLE
Handle properly negative values in TS parser

### DIFF
--- a/packages/react-native-codegen/src/parsers/flow/components/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/__test_fixtures__/fixtures.js
@@ -1073,6 +1073,10 @@ type ModuleNativeState = $ReadOnly<{|
   float_null_optional_key?: WithDefault<Float, null>,
   float_null_optional_both?: WithDefault<Float, null>,
 
+  // Float props, negative default
+  negative_float_optional_key?: WithDefault<Float, -1.0>;
+  negative_float_optional_both?: WithDefault<Float, -1.0>;
+
   // Int32 props
   int32_required: Int32,
   int32_optional_key?: WithDefault<Int32, 1>,
@@ -1129,6 +1133,43 @@ type ModuleNativeState = $ReadOnly<{|
 export default (codegenNativeComponent<ModuleProps, Options>(
   'Module',
 ): HostComponent<ModuleProps>);
+`;
+
+const STATE_NEGATIVE_DEFAULTS = `
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+'use strict';
+
+const codegenNativeComponent = require('codegenNativeComponent');
+
+import type {Int32, Double, Float, WithDefault} from 'CodegenTypes';
+import type {ImageSource} from 'ImageSource';
+import type {ColorValue, PointValue, ProcessColorValue, EdgeInsetsValue} from 'StyleSheetTypes';
+import type {ViewProps} from 'ViewPropTypes';
+import type {HostComponent} from 'react-native';
+
+type ModuleProps = $ReadOnly<{|
+  ...ViewProps,
+|}>;
+
+type ModuleNativeState = $ReadOnly<{|
+
+  // Negative numbers default
+  negative_float_optional_key?: WithDefault<Float, -1.0>;
+  negative_int_optional_key?: WithDefault<Int32, -1>;
+  negative_double_optional_key?: WithDefault<Double, -1.0>;
+|}>
+
+export default codegenNativeComponent<ModuleProps>(
+  'Module',
+) as HostComponent<ModuleProps>;
 `;
 
 const ARRAY_STATE_TYPES = `
@@ -1446,5 +1487,6 @@ module.exports = {
   ALL_STATE_TYPES,
   ARRAY_STATE_TYPES,
   OBJECT_STATE_TYPES,
+  STATE_NEGATIVE_DEFAULTS,
   // STATE_ALIASED_LOCALLY,
 };

--- a/packages/react-native-codegen/src/parsers/flow/components/__tests__/__snapshots__/component-parser-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/flow/components/__tests__/__snapshots__/component-parser-test.js.snap
@@ -775,6 +775,22 @@ exports[`RN Codegen Flow Parser can generate fixture ALL_STATE_TYPES 1`] = `
               }
             },
             {
+              'name': 'negative_float_optional_key',
+              'optional': true,
+              'typeAnnotation': {
+                'type': 'FloatTypeAnnotation',
+                'default': -1
+              }
+            },
+            {
+              'name': 'negative_float_optional_both',
+              'optional': true,
+              'typeAnnotation': {
+                'type': 'FloatTypeAnnotation',
+                'default': -1
+              }
+            },
+            {
               'name': 'int32_required',
               'optional': false,
               'typeAnnotation': {
@@ -11351,6 +11367,55 @@ exports[`RN Codegen Flow Parser can generate fixture PROPS_AS_EXTERNAL_TYPES 1`]
             }
           ],
           'commands': []
+        }
+      }
+    }
+  }
+}"
+`;
+
+exports[`RN Codegen Flow Parser can generate fixture STATE_NEGATIVE_DEFAULTS 1`] = `
+"{
+  'modules': {
+    'Module': {
+      'type': 'Component',
+      'components': {
+        'Module': {
+          'extendsProps': [
+            {
+              'type': 'ReactNativeBuiltInType',
+              'knownTypeName': 'ReactNativeCoreViewProps'
+            }
+          ],
+          'events': [],
+          'props': [],
+          'commands': [],
+          'state': [
+            {
+              'name': 'negative_float_optional_key',
+              'optional': true,
+              'typeAnnotation': {
+                'type': 'FloatTypeAnnotation',
+                'default': -1
+              }
+            },
+            {
+              'name': 'negative_int_optional_key',
+              'optional': true,
+              'typeAnnotation': {
+                'type': 'Int32TypeAnnotation',
+                'default': -1
+              }
+            },
+            {
+              'name': 'negative_double_optional_key',
+              'optional': true,
+              'typeAnnotation': {
+                'type': 'DoubleTypeAnnotation',
+                'default': -1
+              }
+            }
+          ]
         }
       }
     }

--- a/packages/react-native-codegen/src/parsers/typescript/components/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/__test_fixtures__/fixtures.js
@@ -1209,6 +1209,10 @@ export interface ModuleNativeState {
   float_null_optional_key?: WithDefault<Float, null>;
   float_null_optional_both?: WithDefault<Float, null>;
 
+  // Float props, negative default
+  negative_float_optional_key?: WithDefault<Float, -1.0>;
+  negative_float_optional_both?: WithDefault<Float, -1.0>;
+
   // Int32 props
   int32_required: Int32;
   int32_optional_key?: WithDefault<Int32, 1>;
@@ -1260,6 +1264,46 @@ export interface ModuleNativeState {
   insets_optional_key?: EdgeInsetsValue;
   insets_optional_value: EdgeInsetsValue | null | undefined;
   insets_optional_both?: EdgeInsetsValue | null | undefined;
+}
+
+export default codegenNativeComponent<ModuleProps>(
+  'Module',
+) as HostComponent<ModuleProps>;
+`;
+
+const STATE_NEGATIVE_DEFAULTS = `
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+'use strict';
+
+const codegenNativeComponent = require('codegenNativeComponent');
+
+import type {Int32, Double, Float, WithDefault} from 'CodegenTypes';
+import type {ImageSource} from 'ImageSource';
+import type {
+  ColorValue,
+  ColorArrayValue,
+  PointValue,
+  EdgeInsetsValue,
+} from 'StyleSheetTypes';
+import type {ViewProps} from 'ViewPropTypes';
+import type {HostComponent} from 'react-native';
+
+export interface ModuleProps extends ViewProps { }
+
+export interface ModuleNativeState {
+
+  // Negative numbers default
+  negative_float_optional_key?: WithDefault<Float, -1.0>;
+  negative_int_optional_key?: WithDefault<Int32, -1>;
+  negative_double_optional_key?: WithDefault<Double, -1.0>;
 }
 
 export default codegenNativeComponent<ModuleProps>(
@@ -1678,4 +1722,5 @@ module.exports = {
   ARRAY_STATE_TYPES,
   ARRAY2_STATE_TYPES,
   OBJECT_STATE_TYPES,
+  STATE_NEGATIVE_DEFAULTS,
 };

--- a/packages/react-native-codegen/src/parsers/typescript/components/__tests__/__snapshots__/typescript-component-parser-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/typescript/components/__tests__/__snapshots__/typescript-component-parser-test.js.snap
@@ -771,6 +771,22 @@ exports[`RN Codegen TypeScript Parser can generate fixture ALL_STATE_TYPES 1`] =
               }
             },
             {
+              'name': 'negative_float_optional_key',
+              'optional': true,
+              'typeAnnotation': {
+                'type': 'FloatTypeAnnotation',
+                'default': -1
+              }
+            },
+            {
+              'name': 'negative_float_optional_both',
+              'optional': true,
+              'typeAnnotation': {
+                'type': 'FloatTypeAnnotation',
+                'default': -1
+              }
+            },
+            {
               'name': 'int32_required',
               'optional': false,
               'typeAnnotation': {
@@ -12981,6 +12997,55 @@ exports[`RN Codegen TypeScript Parser can generate fixture PROPS_AS_EXTERNAL_TYP
             }
           ],
           'commands': []
+        }
+      }
+    }
+  }
+}"
+`;
+
+exports[`RN Codegen TypeScript Parser can generate fixture STATE_NEGATIVE_DEFAULTS 1`] = `
+"{
+  'modules': {
+    'Module': {
+      'type': 'Component',
+      'components': {
+        'Module': {
+          'extendsProps': [
+            {
+              'type': 'ReactNativeBuiltInType',
+              'knownTypeName': 'ReactNativeCoreViewProps'
+            }
+          ],
+          'events': [],
+          'props': [],
+          'commands': [],
+          'state': [
+            {
+              'name': 'negative_float_optional_key',
+              'optional': true,
+              'typeAnnotation': {
+                'type': 'FloatTypeAnnotation',
+                'default': -1
+              }
+            },
+            {
+              'name': 'negative_int_optional_key',
+              'optional': true,
+              'typeAnnotation': {
+                'type': 'Int32TypeAnnotation',
+                'default': -1
+              }
+            },
+            {
+              'name': 'negative_double_optional_key',
+              'optional': true,
+              'typeAnnotation': {
+                'type': 'DoubleTypeAnnotation',
+                'default': -1
+              }
+            }
+          ]
         }
       }
     }

--- a/packages/react-native-codegen/src/parsers/typescript/components/componentsUtils.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/componentsUtils.js
@@ -637,6 +637,15 @@ function getSchemaInfo(
     if (defaultValueType === 'TSLiteralType') {
       defaultValueType = typeAnnotation.typeParameters.params[1].literal.type;
       defaultValue = typeAnnotation.typeParameters.params[1].literal.value;
+      if (
+        defaultValueType === 'UnaryExpression' &&
+        typeAnnotation.typeParameters.params[1].literal.argument.type ===
+          'NumericLiteral' &&
+        typeAnnotation.typeParameters.params[1].literal.operator === '-'
+      ) {
+        defaultValue =
+          -1 * typeAnnotation.typeParameters.params[1].literal.argument.value;
+      }
     }
 
     if (defaultValueType === 'TSNullKeyword') {


### PR DESCRIPTION
Summary:
The TypeScript parser was not handling negative default values properly. The reason why is because the AST for those values is structurally different and wraps them in a `UnaryExpression` with the `-` operator.

This Diff adds the support for those default values and it also add some tests in both Flow and TS.

## Changelog
[General][Fixed] - Properly parse negative values

Differential Revision: D39847784

