### PR TITLE
Fix `analyze_code` CircleCI Job

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -72,7 +72,7 @@ module.exports = {
       },
     },
     {
-      files: ['types/**/*.{ts,tsx}'],
+      files: ['**/*.{ts,tsx}'],
       parser: '@typescript-eslint/parser',
       plugins: ['@typescript-eslint/eslint-plugin'],
       rules: {

--- a/Libraries/vendor/core/ErrorUtils.d.ts
+++ b/Libraries/vendor/core/ErrorUtils.d.ts
@@ -7,7 +7,7 @@
  * @format
  */
 
- type ErrorHandlerCallback = (error: any, isFatal?: boolean) => void;
+type ErrorHandlerCallback = (error: any, isFatal?: boolean) => void;
 
 export interface ErrorUtils {
   setGlobalHandler: (callback: ErrorHandlerCallback) => void;

--- a/Libraries/vendor/emitter/EventEmitter.d.ts
+++ b/Libraries/vendor/emitter/EventEmitter.d.ts
@@ -7,158 +7,158 @@
  * @format
  */
 
- /**
+/**
  * EventSubscription represents a subscription to a particular event. It can
  * remove its own subscription.
  */
 interface EventSubscription {
-    eventType: string;
-    key: number;
-    subscriber: EventSubscriptionVendor;
-
-    /**
-     * @param subscriber the subscriber that controls
-     *   this subscription.
-     */
-    new (subscriber: EventSubscriptionVendor): EventSubscription;
-
-    /**
-     * Removes this subscription from the subscriber that controls it.
-     */
-    remove(): void;
-  }
+  eventType: string;
+  key: number;
+  subscriber: EventSubscriptionVendor;
 
   /**
-   * EventSubscriptionVendor stores a set of EventSubscriptions that are
-   * subscribed to a particular event type.
+   * @param subscriber the subscriber that controls
+   *   this subscription.
    */
-  declare class EventSubscriptionVendor {
-    constructor();
-
-    /**
-     * Adds a subscription keyed by an event type.
-     *
-     */
-    addSubscription(
-      eventType: string,
-      subscription: EventSubscription,
-    ): EventSubscription;
-
-    /**
-     * Removes a bulk set of the subscriptions.
-     *
-     * @param eventType - Optional name of the event type whose
-     *   registered supscriptions to remove, if null remove all subscriptions.
-     */
-    removeAllSubscriptions(eventType?: string): void;
-
-    /**
-     * Removes a specific subscription. Instead of calling this function, call
-     * `subscription.remove()` directly.
-     *
-     */
-    removeSubscription(subscription: any): void;
-
-    /**
-     * Returns the array of subscriptions that are currently registered for the
-     * given event type.
-     *
-     * Note: This array can be potentially sparse as subscriptions are deleted
-     * from it when they are removed.
-     *
-     */
-    getSubscriptionsForType(eventType: string): EventSubscription[];
-  }
+  new (subscriber: EventSubscriptionVendor): EventSubscription;
 
   /**
-   * EmitterSubscription represents a subscription with listener and context data.
+   * Removes this subscription from the subscriber that controls it.
    */
-  interface EmitterSubscription extends EventSubscription {
-    emitter: EventEmitter;
-    listener: () => any;
-    context: any;
+  remove(): void;
+}
 
-    /**
-     * @param emitter - The event emitter that registered this
-     *   subscription
-     * @param subscriber - The subscriber that controls
-     *   this subscription
-     * @param listener - Function to invoke when the specified event is
-     *   emitted
-     * @param context - Optional context object to use when invoking the
-     *   listener
-     */
-    new (
-      emitter: EventEmitter,
-      subscriber: EventSubscriptionVendor,
-      listener: () => any,
-      context: any,
-    ): EmitterSubscription;
+/**
+ * EventSubscriptionVendor stores a set of EventSubscriptions that are
+ * subscribed to a particular event type.
+ */
+declare class EventSubscriptionVendor {
+  constructor();
 
-    /**
-     * Removes this subscription from the emitter that registered it.
-     * Note: we're overriding the `remove()` method of EventSubscription here
-     * but deliberately not calling `super.remove()` as the responsibility
-     * for removing the subscription lies with the EventEmitter.
-     */
-    remove(): void;
-  }
+  /**
+   * Adds a subscription keyed by an event type.
+   *
+   */
+  addSubscription(
+    eventType: string,
+    subscription: EventSubscription,
+  ): EventSubscription;
 
-  export declare class EventEmitter {
-    /**
-     *
-     * @param subscriber - Optional subscriber instance
-     *   to use. If omitted, a new subscriber will be created for the emitter.
-     */
-    constructor(subscriber?: EventSubscriptionVendor | null);
+  /**
+   * Removes a bulk set of the subscriptions.
+   *
+   * @param eventType - Optional name of the event type whose
+   *   registered supscriptions to remove, if null remove all subscriptions.
+   */
+  removeAllSubscriptions(eventType?: string): void;
 
-    /**
-     * Adds a listener to be invoked when events of the specified type are
-     * emitted. An optional calling context may be provided. The data arguments
-     * emitted will be passed to the listener function.
-     *
-     * @param eventType - Name of the event to listen to
-     * @param listener - Function to invoke when the specified event is
-     *   emitted
-     * @param context - Optional context object to use when invoking the
-     *   listener
-     */
-    addListener(
-      eventType: string,
-      listener: (...args: any[]) => any,
-      context?: any,
-    ): EmitterSubscription;
+  /**
+   * Removes a specific subscription. Instead of calling this function, call
+   * `subscription.remove()` directly.
+   *
+   */
+  removeSubscription(subscription: any): void;
 
-    /**
-     * Removes all of the registered listeners, including those registered as
-     * listener maps.
-     *
-     * @param eventType - Optional name of the event whose registered
-     *   listeners to remove
-     */
-    removeAllListeners(eventType?: string): void;
+  /**
+   * Returns the array of subscriptions that are currently registered for the
+   * given event type.
+   *
+   * Note: This array can be potentially sparse as subscriptions are deleted
+   * from it when they are removed.
+   *
+   */
+  getSubscriptionsForType(eventType: string): EventSubscription[];
+}
 
-    /**
-     * Returns the number of listeners that are currently registered for the given
-     * event.
-     *
-     * @param eventType - Name of the event to query
-     */
-    listenerCount(eventType: string): number;
+/**
+ * EmitterSubscription represents a subscription with listener and context data.
+ */
+interface EmitterSubscription extends EventSubscription {
+  emitter: EventEmitter;
+  listener: () => any;
+  context: any;
 
-    /**
-     * Emits an event of the given type with the given data. All handlers of that
-     * particular type will be notified.
-     *
-     * @param eventType - Name of the event to emit
-     * @param Arbitrary arguments to be passed to each registered listener
-     *
-     * @example
-     *   emitter.addListener('someEvent', function(message) {
-     *     console.log(message);
-     *   });
-     *
-     *   emitter.emit('someEvent', 'abc'); // logs 'abc'
-     */
-    emit(eventType: string, ...params: any[]): void;
-  }
+  /**
+   * @param emitter - The event emitter that registered this
+   *   subscription
+   * @param subscriber - The subscriber that controls
+   *   this subscription
+   * @param listener - Function to invoke when the specified event is
+   *   emitted
+   * @param context - Optional context object to use when invoking the
+   *   listener
+   */
+  new (
+    emitter: EventEmitter,
+    subscriber: EventSubscriptionVendor,
+    listener: () => any,
+    context: any,
+  ): EmitterSubscription;
+
+  /**
+   * Removes this subscription from the emitter that registered it.
+   * Note: we're overriding the `remove()` method of EventSubscription here
+   * but deliberately not calling `super.remove()` as the responsibility
+   * for removing the subscription lies with the EventEmitter.
+   */
+  remove(): void;
+}
+
+export declare class EventEmitter {
+  /**
+   *
+   * @param subscriber - Optional subscriber instance
+   *   to use. If omitted, a new subscriber will be created for the emitter.
+   */
+  constructor(subscriber?: EventSubscriptionVendor | null);
+
+  /**
+   * Adds a listener to be invoked when events of the specified type are
+   * emitted. An optional calling context may be provided. The data arguments
+   * emitted will be passed to the listener function.
+   *
+   * @param eventType - Name of the event to listen to
+   * @param listener - Function to invoke when the specified event is
+   *   emitted
+   * @param context - Optional context object to use when invoking the
+   *   listener
+   */
+  addListener(
+    eventType: string,
+    listener: (...args: any[]) => any,
+    context?: any,
+  ): EmitterSubscription;
+
+  /**
+   * Removes all of the registered listeners, including those registered as
+   * listener maps.
+   *
+   * @param eventType - Optional name of the event whose registered
+   *   listeners to remove
+   */
+  removeAllListeners(eventType?: string): void;
+
+  /**
+   * Returns the number of listeners that are currently registered for the given
+   * event.
+   *
+   * @param eventType - Name of the event to query
+   */
+  listenerCount(eventType: string): number;
+
+  /**
+   * Emits an event of the given type with the given data. All handlers of that
+   * particular type will be notified.
+   *
+   * @param eventType - Name of the event to emit
+   * @param Arbitrary arguments to be passed to each registered listener
+   *
+   * @example
+   *   emitter.addListener('someEvent', function(message) {
+   *     console.log(message);
+   *   });
+   *
+   *   emitter.emit('someEvent', 'abc'); // logs 'abc'
+   */
+  emit(eventType: string, ...params: any[]): void;
+}

--- a/types/legacy-properties.d.ts
+++ b/types/legacy-properties.d.ts
@@ -20,12 +20,10 @@ import {
   ViewProps,
   ViewPropsIOS,
   ViewPropsAndroid,
-  ViewPagerAndroidProps,
   ScrollViewProps,
   ScrollViewPropsIOS,
   ScrollViewPropsAndroid,
   InputAccessoryViewProps,
-  NavigatorIOSProps,
   ActivityIndicatorProps,
   ActivityIndicatorIOSProps,
   DatePickerIOSProps,
@@ -35,11 +33,9 @@ import {
   RefreshControlProps,
   RefreshControlPropsIOS,
   RefreshControlPropsAndroid,
-  RecyclerViewBackedScrollViewProps,
   SliderProps,
   SliderPropsIOS,
   SliderPropsAndroid,
-  SwitchIOSProps,
   ImageSourcePropType,
   ImageProps,
   ImagePropsIOS,
@@ -48,16 +44,11 @@ import {
   FlatListProps,
   VirtualizedListProps,
   SectionListProps,
-  ListViewProps,
-  MaskedViewIOSProps,
   ModalProps,
   TouchableWithoutFeedbackProps,
   TouchableHighlightProps,
   TouchableOpacityProps,
   TouchableNativeFeedbackProps,
-  TabBarIOSItemProps,
-  TabBarIOSProps,
-  SnapshotViewIOSProps,
   ButtonProps,
   StatusBarProps,
   StatusBarPropsIOS,
@@ -109,9 +100,6 @@ declare module 'react-native' {
   /** @deprecated Use ViewPropsAndroid */
   export type ViewPropertiesAndroid = ViewPropsAndroid;
 
-  /** @deprecated Use ViewPagerAndroidProps */
-  export type ViewPagerAndroidProperties = ViewPagerAndroidProps;
-
   /** @deprecated Use ScrollViewProps */
   export type ScrollViewProperties = ScrollViewProps;
 
@@ -123,9 +111,6 @@ declare module 'react-native' {
 
   /** @deprecated Use InputAccessoryViewProps */
   export type InputAccessoryViewProperties = InputAccessoryViewProps;
-
-  /** @deprecated Use NavigatorIOSProps */
-  export type NavigatorIOSProperties = NavigatorIOSProps;
 
   /** @deprecated Use ActivityIndicatorProps */
   export type ActivityIndicatorProperties = ActivityIndicatorProps;
@@ -154,10 +139,6 @@ declare module 'react-native' {
   /** @deprecated Use RefreshControlPropsAndroid */
   export type RefreshControlPropertiesAndroid = RefreshControlPropsAndroid;
 
-  /** @deprecated Use RecyclerViewBackedScrollViewProps */
-  export type RecyclerViewBackedScrollViewProperties =
-    RecyclerViewBackedScrollViewProps;
-
   /** @deprecated Use SliderProps */
   export type SliderProperties = SliderProps;
 
@@ -166,9 +147,6 @@ declare module 'react-native' {
 
   /** @deprecated Use SliderPropsAndroid */
   export type SliderPropertiesAndroid = SliderPropsAndroid;
-
-  /** @deprecated Use SwitchIOSProps */
-  export type SwitchIOSProperties = SwitchIOSProps;
 
   /** @deprecated Use ImageSourcePropType */
   export type ImagePropertiesSourceOptions = ImageSourcePropType;
@@ -194,12 +172,6 @@ declare module 'react-native' {
   /** @deprecated Use SectionListProps */
   export type SectionListProperties<ItemT> = SectionListProps<ItemT>;
 
-  /** @deprecated Use ListViewProps */
-  export type ListViewProperties = ListViewProps;
-
-  /** @deprecated Use MaskedViewIOSProps */
-  export type MaskedViewIOSProperties = MaskedViewIOSProps;
-
   /** @deprecated Use ModalProps */
   export type ModalProperties = ModalProps;
 
@@ -215,15 +187,6 @@ declare module 'react-native' {
 
   /** @deprecated Use TouchableNativeFeedbackProps */
   export type TouchableNativeFeedbackProperties = TouchableNativeFeedbackProps;
-
-  /** @deprecated Use TabBarIOSItemProps */
-  export type TabBarIOSItemProperties = TabBarIOSItemProps;
-
-  /** @deprecated Use TabBarIOSProps */
-  export type TabBarIOSProperties = TabBarIOSProps;
-
-  /** @deprecated Use SnapshotViewIOSProps */
-  export type SnapshotViewIOSProperties = SnapshotViewIOSProps;
 
   /** @deprecated Use ButtonProps */
   export type ButtonProperties = ButtonProps;


### PR DESCRIPTION
Summary:
D39796598 (https://github.com/facebook/react-native/commit/8cdc9e7f04e2dd3026d15dcd5765952bfb2c5c08) broke this CircleCI job, causing failures for `dtslint` and `prettier`. This fixes both issues, by upating formatting, and removing types from `legacy-properties.d.ts` that we no longer export.

These were not flagged by sandcastle. It looks like this is because:
1. We run eslint, but not dtslint internally
2. Arcanist will ignore anything under a "vendor" directory, while we do not exlude anything from the prettier check in OSS.

I also updated the eslint config to lint any TypeScript that appears outside the types directory, since typings are now spread out.

Changelog:
[Internal][Fixed] - Fix `analyze_code` CircleCI Job

Differential Revision: D39848604

