### PR TITLE
Move `react_render_debug` to be consumed via prefab

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -19,8 +19,11 @@ plugins {
 }
 
 import com.facebook.react.tasks.internal.*
+import com.facebook.react.tasks.internal.utils.*
 
 import java.nio.file.Paths
+
+import kotlin.Pair
 
 import de.undercouch.gradle.tasks.download.Download
 import org.apache.tools.ant.taskdefs.condition.Os
@@ -48,8 +51,25 @@ def dependenciesPath = System.getenv("REACT_NATIVE_DEPENDENCIES")
 // and the build will use that.
 def boostPath = dependenciesPath ?: System.getenv("REACT_NATIVE_BOOST_PATH")
 
-// Setup build type for NDK, supported values: {debug, release}
-def nativeBuildType = System.getenv("NATIVE_BUILD_TYPE") ?: "release"
+// By setting REACT_NATIVE_SKIP_PREFAB we can skip prefab publishing, to
+// reduce the size of the React Native published .AAR.
+def skipPrefabPublishing = System.getenv("REACT_NATIVE_SKIP_PREFAB") != null
+def prefabHeadersDir = project.file("$buildDir/prefab-headers")
+
+final def preparePrefab = tasks.register("preparePrefab", PreparePrefabHeadersTask) {
+    // To export to a ReactNativePrefabProcessingEntities.kt once all
+    // libraries have been moved. We keep it here for now as it make easier to
+    // migrate one library at a time.
+    it.input.set(
+        [
+            new PrefabPreprocessingEntry(
+                "react_render_debug",
+                new Pair("../ReactCommon/react/renderer/debug/", "react/renderer/debug/")
+            )
+        ]
+    )
+    it.outputDir.set(prefabHeadersDir)
+}
 
 // We put the publishing version from gradle.properties inside ext. so other
 // subprojects can access it as well.
@@ -300,7 +320,9 @@ android {
                     "reactperfloggerjni",
                     "react_newarchdefaults",
                     "turbomodulejsijni",
-                    "fabricjni"
+                    "fabricjni",
+                    // prefab targets
+                    "react_render_debug"
             }
         }
         ndk {
@@ -334,6 +356,7 @@ android {
 
     preBuild.dependsOn(prepareJSC, prepareBoost, prepareDoubleConversion, prepareFmt, prepareFolly, prepareGlog, prepareLibevent, extractNativeDependencies)
     preBuild.dependsOn("generateCodegenArtifactsFromSchema")
+    preBuild.dependsOn(preparePrefab)
 
     sourceSets.main {
         res.srcDirs = ["src/main/res/devsupport", "src/main/res/shell", "src/main/res/views/modal", "src/main/res/views/uimanager"]
@@ -366,6 +389,13 @@ android {
 
     buildFeatures {
         prefab true
+        prefabPublishing !skipPrefabPublishing
+    }
+
+    prefab {
+        react_render_debug {
+            headers(new File(prefabHeadersDir, "react_render_debug").absolutePath)
+        }
     }
 
     publishing {

--- a/ReactAndroid/cmake-utils/Android-prebuilt.cmake
+++ b/ReactAndroid/cmake-utils/Android-prebuilt.cmake
@@ -124,14 +124,6 @@ target_include_directories(react_render_core
         ${REACT_COMMON_DIR}
         ${REACT_COMMON_DIR}/react/renderer/core)
 
-## react_render_debug
-add_library(react_render_debug SHARED IMPORTED GLOBAL)
-set_target_properties(react_render_debug
-        PROPERTIES
-        IMPORTED_LOCATION
-        ${REACT_NDK_EXPORT_DIR}/${ANDROID_ABI}/libreact_render_debug.so)
-target_include_directories(react_render_debug INTERFACE ${REACT_COMMON_DIR}/react/renderer/debug)
-
 ## react_debug
 add_library(react_debug SHARED IMPORTED GLOBAL)
 set_target_properties(react_debug

--- a/ReactAndroid/cmake-utils/ReactNative-application.cmake
+++ b/ReactAndroid/cmake-utils/ReactNative-application.cmake
@@ -39,6 +39,10 @@ target_include_directories(${CMAKE_PROJECT_NAME}
 
 target_compile_options(${CMAKE_PROJECT_NAME} PRIVATE -Wall -Werror -fexceptions -frtti -std=c++17 -DWITH_INSPECTOR=1 -DLOG_TAG=\"ReactNative\")
 
+# Prefab packages
+find_package(ReactAndroid REQUIRED CONFIG)
+add_library(react_render_debug ALIAS ReactAndroid::react_render_debug)
+
 target_link_libraries(${CMAKE_PROJECT_NAME}
         fabricjni
         fbjni
@@ -51,7 +55,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME}
         react_newarchdefaults
         react_render_componentregistry
         react_render_core
-        react_render_debug
+        react_render_debug                  # prefab ready
         react_render_graphics
         react_render_mapbuffer
         rrc_view

--- a/packages/rn-tester/android/app/build.gradle
+++ b/packages/rn-tester/android/app/build.gradle
@@ -191,6 +191,9 @@ android {
             ]
         }
     }
+    buildFeatures {
+        prefab true
+    }
     packagingOptions {
         pickFirst '**/libhermes.so'
         pickFirst '**/libjsc.so'

--- a/scripts/publish-npm.js
+++ b/scripts/publish-npm.js
@@ -197,6 +197,7 @@ if (isCommitly) {
 }
 
 // -------- Generating Android Artifacts
+env.REACT_NATIVE_SKIP_PREFAB = true;
 if (exec('./gradlew :ReactAndroid:installArchives').code) {
   echo('Could not generate artifacts');
   exit(1);

--- a/template/android/app/build.gradle
+++ b/template/android/app/build.gradle
@@ -167,6 +167,9 @@ android {
                 path "$projectDir/src/main/jni/CMakeLists.txt"
             }
         }
+        buildFeatures {
+            prefab true
+        }
         def reactAndroidProjectDir = project(':ReactAndroid').projectDir
         def packageReactNdkDebugLibs = tasks.register("packageReactNdkDebugLibs", Copy) {
             dependsOn(":ReactAndroid:packageReactNdkDebugLibsForBuck")


### PR DESCRIPTION
Summary:
This removes the old way of consuming `libreact_render_debug.so` from
`Android-prebuilt.cmake` to using Prefab which is natively supported
by the Android pipeline.

Changelog:
[Internal] [Changed] - Move `react_render_debug` to be consumed via prefab

Differential Revision: D39849622

