### PR TITLE
Refactor: removed duplicated words in comments

### DIFF
--- a/Libraries/Components/ScrollView/ScrollView.d.ts
+++ b/Libraries/Components/ScrollView/ScrollView.d.ts
@@ -508,7 +508,7 @@ export interface ScrollViewPropsIOS {
   scrollsToTop?: boolean | undefined;
 
   /**
-   * When `snapToInterval` is set, `snapToAlignment` will define the relationship of the the snapping to the scroll view.
+   * When `snapToInterval` is set, `snapToAlignment` will define the relationship of the snapping to the scroll view.
    *      - `start` (the default) will align the snap at the left (horizontal) or top (vertical)
    *      - `center` will align the snap in the center
    *      - `end` will align the snap at the right (horizontal) or bottom (vertical)
@@ -564,7 +564,7 @@ export interface ScrollViewPropsAndroid {
   nestedScrollEnabled?: boolean | undefined;
 
   /**
-   * Fades out the edges of the the scroll content.
+   * Fades out the edges of the scroll content.
    *
    * If the value is greater than 0, the fading edges will be set accordingly
    * to the current scroll direction and position,

--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -413,7 +413,7 @@ type AndroidProps = $ReadOnly<{|
    */
   persistentScrollbar?: ?boolean,
   /**
-   * Fades out the edges of the the scroll content.
+   * Fades out the edges of the scroll content.
    *
    * If the value is greater than 0, the fading edges will be set accordingly
    * to the current scroll direction and position,

--- a/Libraries/Components/Switch/Switch.d.ts
+++ b/Libraries/Components/Switch/Switch.d.ts
@@ -66,7 +66,7 @@ export interface SwitchProps extends SwitchPropsIOS {
   disabled?: boolean | undefined;
 
   /**
-   * Invoked with the the change event as an argument when the value changes.
+   * Invoked with the change event as an argument when the value changes.
    */
   onChange?:
     | ((event: SwitchChangeEvent) => Promise<void> | void)

--- a/Libraries/Lists/FlatList.d.ts
+++ b/Libraries/Lists/FlatList.d.ts
@@ -209,7 +209,7 @@ export interface FlatListProps<ItemT> extends VirtualizedListProps<ItemT> {
   removeClippedSubviews?: boolean | undefined;
 
   /**
-   * Fades out the edges of the the scroll content.
+   * Fades out the edges of the scroll content.
    *
    * If the value is greater than 0, the fading edges will be set accordingly
    * to the current scroll direction and position,

--- a/Libraries/Lists/__tests__/VirtualizedList-test.js
+++ b/Libraries/Lists/__tests__/VirtualizedList-test.js
@@ -501,7 +501,7 @@ describe('VirtualizedList', () => {
 
     // The initial render is specified to be the length of items provided.
     // Expect that all sticky items (1 every 3) are passed to the underlying
-    // scrollview, indices offset by 1 to account for the the header component.
+    // scrollview, indices offset by 1 to account for the header component.
     expect(component).toMatchSnapshot();
   });
 

--- a/React/CxxBridge/RCTCxxBridge.mm
+++ b/React/CxxBridge/RCTCxxBridge.mm
@@ -808,7 +808,7 @@ struct RCTInstanceCallback : public InstanceCallback {
 
   NSMutableArray<id<RCTBridgeModule>> *extraModules = [NSMutableArray new];
 
-  // Prevent TurboModules from appearing the the NativeModule system
+  // Prevent TurboModules from appearing the NativeModule system
   for (id<RCTBridgeModule> module in appExtraModules) {
     if (!(RCTTurboModuleEnabled() && [module conformsToProtocol:@protocol(RCTTurboModule)])) {
       [extraModules addObject:module];


### PR DESCRIPTION
## Summary

Found and removed duplicates of the word "the" in comments.

## Changelog

[Internal] [Removed] – Removed duplicates of the word "the" in comments.

## Test Plan

Not applicable.
