### PR TITLE
Fix detectCliPath check for cliJsFromNode

### DIFF
--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/PathUtils.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/PathUtils.kt
@@ -29,7 +29,7 @@ internal fun detectedEntryFile(config: ReactExtension): File =
 /**
  * Computes the CLI location for React Native. The Algo follows this order:
  * 1. The path provided by the `cliPath` config in the `reactApp` Gradle extension
- * 2. The output of `node -e "console.log(require('react-native/cli').bin);"` if not failing.
+ * 2. The output of `node --print "require.resolve('react-native/cli');"` if not failing.
  * 3. The `node_modules/react-native/cli.js` file if exists
  * 4. Fails otherwise
  */
@@ -88,9 +88,9 @@ private fun detectCliPath(
   val nodeProcess =
       Runtime.getRuntime()
           .exec(
-              arrayOf("node", "-e", "console.log(require('react-native/cli').bin);"),
+              arrayOf("node", "--print", "require.resolve('react-native/cli');"),
               emptyArray(),
-              projectDir)
+              reactRoot)
 
   val nodeProcessOutput = nodeProcess.inputStream.use { it.bufferedReader().readText().trim() }
 

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/PathUtilsTest.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/PathUtilsTest.kt
@@ -124,16 +124,17 @@ class PathUtilsTest {
   fun detectedCliPath_withCliFromNodeModules() {
     val project = ProjectBuilder.builder().build()
     val extension = TestReactExtension(project)
-    extension.root.set(tempFolder.root)
     val expected =
         File(tempFolder.root, "node_modules/react-native/cli.js").apply {
           parentFile.mkdirs()
           writeText("<!-- nothing to see here -->")
         }
+    val locationToResolveFrom = File(tempFolder.root, "a-subdirectory").apply { mkdirs() }
+    extension.root.set(locationToResolveFrom)
 
     val actual = detectedCliPath(project.projectDir, extension)
 
-    assertEquals(expected.toString(), actual)
+    assertEquals(expected.canonicalPath, actual)
   }
 
   @Test(expected = IllegalStateException::class)

--- a/react.gradle
+++ b/react.gradle
@@ -53,7 +53,7 @@ def detectCliPath(config, reactRoot) {
     }
 
     // 2. node module path
-    def cliJsFromNode = new File(["node", "--print", "require.resolve('react-native/cli').bin"].execute(null, rootDir).text.trim())
+    def cliJsFromNode = new File(["node", "--print", "require.resolve('react-native/cli')"].execute(null, rootDir).text.trim())
     if (cliJsFromNode.exists()) {
         return cliJsFromNode.getAbsolutePath()
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

`react.gradle`'s `detectCliPath` was not working correctly for the `cliJsFromNode` check, this fixes it.

## Changelog

[Android] [Fixed] - Fix react.gradle's detectCliPath's for finding the path from Node

## Test Plan

Tested manually from a monorepo setup, this incorrect check was preventing the CLI from being found correctly:

```
❯ pwd
/Users/liam.jones/code/monorepo/packages/apps/app1/android

❯ node --print "require.resolve('react-native/cli').bin" # old code
undefined

❯ node --print "require.resolve('react-native/cli')" # new code
/Users/liam.jones/code/monorepo/node_modules/react-native/cli.js