### PR TITLE
RN: Fix `no-react-native-imports` for Windows

### DIFF
--- a/tools/eslint/rules/no-react-native-imports.js
+++ b/tools/eslint/rules/no-react-native-imports.js
@@ -86,9 +86,11 @@ module.exports = {
       const sourcePath = path.dirname(context.getPhysicalFilename());
       const relativePath = path.relative(sourcePath, importPath);
       // If importing from the same directory, prepend `./` to source path.
-      return relativePath.includes(path.sep)
+      const relativePathWithLeadingSlash = relativePath.includes(path.sep)
         ? relativePath
         : ['.', path.sep, relativePath].join('');
+      // Normalize backslash (on Windows) to forward slash.
+      return relativePathWithLeadingSlash.replace(/\\/g, '/');
     }
 
     function isValidImportPath(importPath) {


### PR DESCRIPTION
Summary:
This lint rule (and the associated Jest test) fails because `path` on Windows outputs backslashes. This diff fixes the rule.

Changelog:
[Internal]

Reviewed By: cortinico, cipolleschi

Differential Revision: D39887464

