### PR TITLE
RN: Switch to `Choco-Install` from Windows Hermes CI

### DIFF
--- a/.circleci/Dockerfiles/scripts/run-android-docker-instrumentation-tests.sh
+++ b/.circleci/Dockerfiles/scripts/run-android-docker-instrumentation-tests.sh
@@ -33,7 +33,7 @@ node cli.js bundle --platform android --dev true --entry-file ReactAndroid/src/a
 
 # build test APK
 # shellcheck disable=SC1091
-source ./scripts/android-setup.sh && NO_BUCKD=1 retry3 buck install ReactAndroid/src/androidTest/buck-runner:instrumentation-tests --config build.threads=1
+source ./scripts/android-setup.sh && NO_BUCKD=1 scripts/retry3 buck install ReactAndroid/src/androidTest/buck-runner:instrumentation-tests --config build.threads=1
 
 # run installed apk with tests
 node ./.circleci/Dockerfiles/scripts/run-android-ci-instrumentation-tests.js "$*"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -617,7 +617,7 @@ jobs:
             if [[ ! -e ReactAndroid/src/androidTest/assets/AndroidTestBundle.js ]]; then
               echo "JavaScript bundle missing, cannot run instrumentation tests. Verify Build JavaScript Bundle step completed successfully."; exit 1;
             fi
-            source scripts/android-setup.sh && NO_BUCKD=1 retry3 timeout 300 buck build ReactAndroid/src/androidTest/buck-runner:instrumentation-tests --config build.threads=$BUILD_THREADS
+            source scripts/android-setup.sh && NO_BUCKD=1 scripts/retry3 timeout 300 buck build ReactAndroid/src/androidTest/buck-runner:instrumentation-tests --config build.threads=$BUILD_THREADS
 
       - run:
           name: Collect Test Results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1204,9 +1204,9 @@ jobs:
           name: Build HermesC for Windows
           command: |
             if (-not(Test-Path -Path $Env:HERMES_WS_DIR\win64-bin\hermesc.exe)) {
-              choco install --no-progress cmake --version 3.14.7
+              Choco-Install -PackageName cmake -ArgumentList "--no-progress", "--version 3.14.7"
               if (-not $?) { throw "Failed to install CMake" }
-              choco install --no-progress python3
+              Choco-Install -PackageName python3 -ArgumentList "--no-progress"
               if (-not $?) { throw "Failed to install Python" }
 
               cd $Env:HERMES_WS_DIR\icu

--- a/scripts/android-setup.sh
+++ b/scripts/android-setup.sh
@@ -94,21 +94,3 @@ function waitForAVD {
     echo "Skipping AVD-related test setup..."
   fi
 }
-
-function retry3 {
-  local n=1
-  local max=3
-  local delay=1
-  while true; do
-    "$@" && break || {
-      if [[ $n -lt $max ]]; then
-        ((n++))
-        echo "Command failed. Attempt $n/$max:"
-        sleep $delay;
-      else
-        echo "The command has failed after $n attempts." >&2
-        return 1
-      fi
-    }
-  done
-}


### PR DESCRIPTION
Summary:
Switches the Windows Hermes CI step to use `Choco-Install` which implicitly supports retries for more reliable builds.

See: https://github.com/actions/runner-images/pull/721

Changelog:
[Internal]

Differential Revision: D39890407

