### PR TITLE
Prototype - Storing the Hermes iOS tarballs on Maven.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ project.xcworkspace
 /ReactAndroid/gradle/
 /ReactAndroid/gradlew
 /ReactAndroid/gradlew.bat
+/ReactAndroid/external-artifacts/build/
+/ReactAndroid/external-artifacts/artifacts/
 /ReactAndroid/hermes-engine/build/
 /ReactAndroid/hermes-engine/.cxx/
 /template/android/app/build/

--- a/ReactAndroid/external-artifacts/build.gradle
+++ b/ReactAndroid/external-artifacts/build.gradle
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+plugins {
+    id("maven-publish")
+    id("signing")
+}
+
+//version = parent.publishing_version
+version = "0.0.1" // To avoid to accidentally publish a 1000.0.0-main
+
+def REPO_URL = "file://${projectDir}/../../android"
+configurations.maybeCreate("default")
+
+// The artifact should be placed inside the `artifacts/hermes-ios.tar.gz` location.
+def hermesiOSArtifactFile = layout.projectDirectory.file('artifacts/hermes-ios.tar.gz')
+def hermesiOSArtifact = artifacts.add('default', hermesiOSArtifactFile) {
+    type 'tgz'
+    extension 'tar.gz'
+    classifier 'hermes-ios'
+}
+
+publishing {
+    publications {
+        artifacts(MavenPublication) {
+            artifactId = "react-native-artifacts"
+            groupId = GROUP
+            artifact hermesiOSArtifact
+
+            pom {
+                name = POM_NAME
+                description = "Supporting artifacts to for the React Native framework"
+                url = "https://github.com/facebook/react-native"
+
+                developers {
+                    developer {
+                        id = "facebook"
+                        name = "Facebook"
+                    }
+                }
+
+                licenses {
+                    license {
+                        name = "MIT License"
+                        url = "https://github.com/facebook/react-native/blob/HEAD/LICENSE"
+                        distribution = "repo"
+                    }
+                }
+
+                scm {
+                    url = "https://github.com/facebook/react-native.git"
+                    connection = "scm:git:https://github.com/facebook/react-native.git"
+                    developerConnection = "scm:git:git@github.com:facebook/react-native.git"
+                }
+            }
+        }
+    }
+
+    repositories {
+        maven {
+            name = "npm"
+            url = REPO_URL
+        }
+        if (project.hasProperty("SONATYPE_USERNAME") && project.hasProperty("SONATYPE_PASSWORD")) {
+            maven {
+                name = "mavenCentral"
+                url = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+                credentials {
+                    username = SONATYPE_USERNAME
+                    password = SONATYPE_PASSWORD
+                }
+            }
+        }
+    }
+
+    if (!project.hasProperty("SIGNING_KEY")) {
+        logger.info("Signing Disable as the PGP key was not found")
+    } else {
+        logger.info("PGP Key found - Signing enabled")
+        signing {
+            useInMemoryPgpKeys(SIGNING_KEY, SIGNING_PWD)
+            sign(publishing.publications.artifacts)
+        }
+    }
+}
+

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,7 +13,11 @@ pluginManagement {
   }
 }
 
-include(":ReactAndroid", ":ReactAndroid:hermes-engine", ":packages:rn-tester:android:app")
+include(
+    ":ReactAndroid",
+    ":ReactAndroid:hermes-engine",
+    ":ReactAndroid:external-artifacts",
+    ":packages:rn-tester:android:app")
 
 // Include this to enable codegen Gradle plugin.
 includeBuild("packages/react-native-gradle-plugin/")


### PR DESCRIPTION
## Summary

I'm not going to merge this as it is, this is mostly for discussions with the community for the sake of
RFC #508 https://github.com/react-native-community/discussions-and-proposals/pull/508

Here I'm setting up a :ReactAndroid:external-artifacts Gradle module which is responsible of
uploading arbitrary artifacts to Maven (Central or any other repo).

In this specific example I'm uploading the Hermes iOS tarball which is 500+ Mb.
In this module I've configured the auth with Sonatype for publishing and the GPG signing of the artifacts.

## Changelog

[Internal] [Changed] - Store the iOS Hermes tarball on Maven

## Testing

I've tested this in a couple of ways:

### Maven Local

1. Added the tarball in the expected location: `ReactAndroid/external-artifacts/artifacts/hermes-ios.tar.gz`
2. Publish to Maven Local with: `./gradlew :ReactAndroid:external-artifacts:publishToMavenLocal`
3. Verify that the artifacts are there:

```
$ tree ~/.m2/repository/com/facebook/react/react-native-artifacts

/Users/ncor/.m2/repository/com/facebook/react/react-native-artifacts
├── 0.0.1
│   ├── react-native-artifacts-0.0.1-hermes-ios.gz
│   ├── react-native-artifacts-0.0.1-hermes-ios.gz.asc
│   ├── react-native-artifacts-0.0.1.pom
│   └── react-native-artifacts-0.0.1.pom.asc
└── maven-metadata-local.xml
```

### Maven Central Staging Repository

I've pushed to a staging repository the tarball (so it's not released yet). It's currently available on:

https://oss.sonatype.org/service/local/repositories/comfacebook-3529/content/com/facebook/react/react-native-artifacts/0.0.1/react-native-artifacts-0.0.1-hermes-ios.tar.gz

(Link will expire in ~7 days).

If we were to release this to Maven Central, the final URL would be:
https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.0.1/react-native-artifacts-0.0.1-hermes-ios.tar.gz

To publish you need to:
1. Make sure you have a Sonatype account which has push right on the `com.facebook` group
2. Make sure you have a GPG key + passphrase
3. Set the Gradle properties using environment variables as follows (or using the gradle.properties file):
```
export ORG_GRADLE_PROJECT_SONATYPE_USERNAME=<sonatype-username>
export ORG_GRADLE_PROJECT_SONATYPE_PASSWORD=<sonatype-password>
export ORG_GRADLE_PROJECT_SIGNING_KEY=$(cat ~/your-armored-private-key.pgp)
export ORG_GRADLE_PROJECT_SIGNING_PWD=<gpg-passphrase>
```
4. Publish with `./gradlew :ReactAndroid:external-artifacts:publishAllPublicationsToMavenCentralRepository`

More on this is described here: https://github.com/cortinico/kotlin-android-template#to-maven-central

Differential Revision: D39886167

