### PR TITLE
Refactor in turbo module TypeScript codegen: process `(T)`, `T|U`, `T|undefined` and related stuff in a central place

### DIFF
--- a/packages/react-native-codegen/src/parsers/typescript/components/commands.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/commands.js
@@ -20,7 +20,10 @@ const {parseTopLevelType} = require('../parseTopLevelType');
 type EventTypeAST = Object;
 
 function buildCommandSchema(property: EventTypeAST, types: TypeDeclarationMap) {
-  const topLevelType = parseTopLevelType(property.typeAnnotation.typeAnnotation, types);
+  const topLevelType = parseTopLevelType(
+    property.typeAnnotation.typeAnnotation,
+    types,
+  );
   const name = property.key.name;
   const optional = property.optional || topLevelType.optional;
   const value = topLevelType.type;

--- a/packages/react-native-codegen/src/parsers/typescript/components/commands.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/commands.js
@@ -15,19 +15,15 @@ import type {
   CommandTypeAnnotation,
 } from '../../../CodegenSchema.js';
 import type {TypeDeclarationMap} from '../utils.js';
-
-const {getValueFromTypes} = require('../utils.js');
+const {parseTopLevelType} = require('../parseTopLevelType');
 
 type EventTypeAST = Object;
 
 function buildCommandSchema(property: EventTypeAST, types: TypeDeclarationMap) {
+  const topLevelType = parseTopLevelType(property.typeAnnotation.typeAnnotation, types);
   const name = property.key.name;
-  const optional = property.optional || false;
-  const value = getValueFromTypes(
-    property.typeAnnotation.typeAnnotation,
-    types,
-  );
-
+  const optional = property.optional || topLevelType.optional;
+  const value = topLevelType.type;
   const firstParam = value.parameters[0].typeAnnotation;
 
   if (
@@ -45,10 +41,10 @@ function buildCommandSchema(property: EventTypeAST, types: TypeDeclarationMap) {
 
   const params = value.parameters.slice(1).map(param => {
     const paramName = param.name;
-    const paramValue = getValueFromTypes(
+    const paramValue = parseTopLevelType(
       param.typeAnnotation.typeAnnotation,
       types,
-    );
+    ).type;
 
     const type =
       paramValue.type === 'TSTypeReference'

--- a/packages/react-native-codegen/src/parsers/typescript/components/componentsUtils.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/componentsUtils.js
@@ -88,6 +88,7 @@ function getUnionOfLiterals(
       currType.type === 'TSLiteralType' ? currType.literal.type : currType.type;
 
     if (lastFlattenedType && currFlattenedType !== lastFlattenedType) {
+      throw new Error(JSON.stringify(elementTypes,undefined,4));
       throw new Error(`Mixed types are not supported (see "${name}")`);
     }
     return currType;
@@ -429,24 +430,18 @@ function getTypeAnnotation<T>(
     case 'TSBooleanKeyword':
       return {
         type: 'BooleanTypeAnnotation',
-        default: !!defaultValue,
+        default: (defaultValue === null ? null : !!defaultValue),
       };
     case 'TSStringKeyword':
-      if (defaultValue !== undefined) {
-        return {
-          type: 'StringTypeAnnotation',
-          default: (defaultValue: string | null),
-        };
-      }
-      throw new Error(`A default string (or null) is required for "${name}"`);
+      return {
+        type: 'StringTypeAnnotation',
+        default: ((defaultValue === undefined ? null : defaultValue): string | null),
+      };
     case 'Stringish':
-      if (defaultValue !== undefined) {
-        return {
-          type: 'StringTypeAnnotation',
-          default: (defaultValue: string | null),
-        };
-      }
-      throw new Error(`A default string (or null) is required for "${name}"`);
+      return {
+        type: 'StringTypeAnnotation',
+        default: ((defaultValue === undefined ? null : defaultValue): string | null),
+      };
     case 'TSNumberKeyword':
       throw new Error(
         `Cannot use "${type}" type annotation for "${name}": must use a specific numeric type like Int32, Double, or Float`,

--- a/packages/react-native-codegen/src/parsers/typescript/components/componentsUtils.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/componentsUtils.js
@@ -75,7 +75,7 @@ function getUnionOfLiterals(
   name: string,
   forArray: boolean,
   elementTypes: $FlowFixMe[],
-  defaultValue: $FlowFixMe | undefined,
+  defaultValue: $FlowFixMe | void,
   types: TypeDeclarationMap,
 ) {
   elementTypes.reduce((lastType, currType) => {
@@ -133,7 +133,7 @@ function getUnionOfLiterals(
 function detectArrayType<T>(
   name: string,
   typeAnnotation: $FlowFixMe | ASTNode,
-  defaultValue: $FlowFixMe | undefined,
+  defaultValue: $FlowFixMe | void,
   types: TypeDeclarationMap,
   buildSchema: (property: PropAST, types: TypeDeclarationMap) => ?NamedShape<T>,
 ): $FlowFixMe {
@@ -193,7 +193,7 @@ function detectArrayType<T>(
 function getTypeAnnotationForArray<T>(
   name: string,
   typeAnnotation: $FlowFixMe,
-  defaultValue: $FlowFixMe | undefined,
+  defaultValue: $FlowFixMe | void,
   types: TypeDeclarationMap,
   buildSchema: (property: PropAST, types: TypeDeclarationMap) => ?NamedShape<T>,
 ): $FlowFixMe {
@@ -310,7 +310,7 @@ function getTypeAnnotationForArray<T>(
 function getTypeAnnotation<T>(
   name: string,
   annotation: $FlowFixMe | ASTNode,
-  defaultValue: $FlowFixMe | undefined,
+  defaultValue: $FlowFixMe | void,
   types: TypeDeclarationMap,
   buildSchema: (property: PropAST, types: TypeDeclarationMap) => ?NamedShape<T>,
 ): $FlowFixMe {

--- a/packages/react-native-codegen/src/parsers/typescript/components/componentsUtils.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/componentsUtils.js
@@ -470,9 +470,14 @@ function getSchemaInfo(
     property.typeAnnotation.typeAnnotation,
     types,
   );
+
   const name = property.key.name;
   if (!isProp(name, topLevelType.type)) {
     return null;
+  }
+
+  if(!property.optional && topLevelType.defaultValue!==undefined){
+    throw new Error(`key ${name} must be optional if used with WithDefault<> annotation`);
   }
 
   return {

--- a/packages/react-native-codegen/src/parsers/typescript/components/componentsUtils.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/componentsUtils.js
@@ -88,7 +88,6 @@ function getUnionOfLiterals(
       currType.type === 'TSLiteralType' ? currType.literal.type : currType.type;
 
     if (lastFlattenedType && currFlattenedType !== lastFlattenedType) {
-      throw new Error(JSON.stringify(elementTypes,undefined,4));
       throw new Error(`Mixed types are not supported (see "${name}")`);
     }
     return currType;
@@ -114,7 +113,7 @@ function getUnionOfLiterals(
   ) {
     if (forArray) {
       throw new Error(`Arrays of int enums are not supported (see: "${name}")`);
-    }else{
+    } else {
       return {
         type: 'Int32EnumTypeAnnotation',
         default: (defaultValue: number),
@@ -158,9 +157,7 @@ function detectArrayType<T>(
   }
 
   // Covers: T[]
-  if (
-    typeAnnotation.type === 'TSArrayType'
-  ) {
+  if (typeAnnotation.type === 'TSArrayType') {
     return {
       type: 'ArrayTypeAnnotation',
       elementType: getTypeAnnotationForArray(
@@ -176,7 +173,8 @@ function detectArrayType<T>(
   // Covers: Array<T> and ReadonlyArray<T>
   if (
     typeAnnotation.type === 'TSTypeReference' &&
-    (typeAnnotation.typeName.name === 'ReadonlyArray' || typeAnnotation.typeName.name === 'Array')
+    (typeAnnotation.typeName.name === 'ReadonlyArray' ||
+      typeAnnotation.typeName.name === 'Array')
   ) {
     return {
       type: 'ArrayTypeAnnotation',
@@ -213,9 +211,15 @@ function getTypeAnnotationForArray<T>(
     );
   }
 
-  const extractedTypeAnnotation = getValueFromTypes(topLevelType.type,types);
-  const arrayType = detectArrayType(name, extractedTypeAnnotation, defaultValue, types, buildSchema);
-  if(arrayType) return arrayType;
+  const extractedTypeAnnotation = getValueFromTypes(topLevelType.type, types);
+  const arrayType = detectArrayType(
+    name,
+    extractedTypeAnnotation,
+    defaultValue,
+    types,
+    buildSchema,
+  );
+  if (arrayType) return arrayType;
 
   const type =
     extractedTypeAnnotation.elementType === 'TSTypeReference'
@@ -231,7 +235,7 @@ function getTypeAnnotationForArray<T>(
         type === 'TSInterfaceDeclaration'
           ? [extractedTypeAnnotation]
           : extractedTypeAnnotation.members;
-      if (rawProperties===undefined){
+      if (rawProperties === undefined) {
         throw new Error(type);
       }
       return {
@@ -291,7 +295,13 @@ function getTypeAnnotationForArray<T>(
         type: 'StringTypeAnnotation',
       };
     case 'TSUnionType':
-      return getUnionOfLiterals(name, true, extractedTypeAnnotation.types, defaultValue, types);
+      return getUnionOfLiterals(
+        name,
+        true,
+        extractedTypeAnnotation.types,
+        defaultValue,
+        types,
+      );
     default:
       (type: empty);
       throw new Error(`Unknown prop type for "${name}": ${type}`);
@@ -308,8 +318,14 @@ function getTypeAnnotation<T>(
   // unpack WithDefault, (T) or T|U
   const topLevelType = parseTopLevelType(annotation);
   const typeAnnotation = getValueFromTypes(topLevelType.type, types);
-  const arrayType = detectArrayType(name, typeAnnotation, defaultValue, types, buildSchema);
-  if(arrayType) return arrayType;
+  const arrayType = detectArrayType(
+    name,
+    typeAnnotation,
+    defaultValue,
+    types,
+    buildSchema,
+  );
+  if (arrayType) return arrayType;
 
   const type =
     typeAnnotation.type === 'TSTypeReference' ||
@@ -376,56 +392,67 @@ function getTypeAnnotation<T>(
     case 'Float':
       return {
         type: 'FloatTypeAnnotation',
-        default: ((defaultValue === null ? null : defaultValue ? defaultValue : 0): number | null),
+        default: ((defaultValue === null
+          ? null
+          : defaultValue
+          ? defaultValue
+          : 0): number | null),
       };
     case 'TSBooleanKeyword':
       return {
         type: 'BooleanTypeAnnotation',
-        default: (defaultValue === null ? null : !!defaultValue),
+        default: defaultValue === null ? null : !!defaultValue,
       };
     case 'TSStringKeyword':
       return {
         type: 'StringTypeAnnotation',
-        default: ((defaultValue === undefined ? null : defaultValue): string | null),
+        default: ((defaultValue === undefined ? null : defaultValue):
+          | string
+          | null),
       };
     case 'Stringish':
       return {
         type: 'StringTypeAnnotation',
-        default: ((defaultValue === undefined ? null : defaultValue): string | null),
+        default: ((defaultValue === undefined ? null : defaultValue):
+          | string
+          | null),
       };
     case 'TSNumberKeyword':
       throw new Error(
         `Cannot use "${type}" type annotation for "${name}": must use a specific numeric type like Int32, Double, or Float`,
       );
     case 'TSUnionType':
-      return getUnionOfLiterals(name, false, typeAnnotation.types, defaultValue, types);
+      return getUnionOfLiterals(
+        name,
+        false,
+        typeAnnotation.types,
+        defaultValue,
+        types,
+      );
     default:
       (type: empty);
       throw new Error(`Unknown prop type for "${name}": "${type}"`);
   }
 }
 
-function findProp(
-  name: string,
-  typeAnnotation: $FlowFixMe,
-) {
+function findProp(name: string, typeAnnotation: $FlowFixMe) {
   // unpack WithDefault, (T) or T|U
   const topLevelType = parseTopLevelType(typeAnnotation);
   if (topLevelType.type.type === 'TSTypeReference') {
-      // Remove unwanted types
-      if (
-        topLevelType.type.typeName.name === 'DirectEventHandler' ||
-        topLevelType.type.typeName.name === 'BubblingEventHandler'
-      ) {
-        return null;
-      }
-      if (
-        name === 'style' &&
-        topLevelType.type.type === 'GenericTypeAnnotation' &&
-        topLevelType.type.typeName.name === 'ViewStyleProp'
-      ) {
-        return null;
-      }
+    // Remove unwanted types
+    if (
+      topLevelType.type.typeName.name === 'DirectEventHandler' ||
+      topLevelType.type.typeName.name === 'BubblingEventHandler'
+    ) {
+      return null;
+    }
+    if (
+      name === 'style' &&
+      topLevelType.type.type === 'GenericTypeAnnotation' &&
+      topLevelType.type.typeName.name === 'ViewStyleProp'
+    ) {
+      return null;
+    }
   }
   return topLevelType;
 }
@@ -455,9 +482,9 @@ function getSchemaInfo(
 
   return {
     name,
-    optional:property.optional || topLevelType.optional,
-    typeAnnotation:topLevelType.type,
-    defaultValue:topLevelType.defaultValue,
+    optional: property.optional || topLevelType.optional,
+    typeAnnotation: topLevelType.type,
+    defaultValue: topLevelType.defaultValue,
   };
 }
 

--- a/packages/react-native-codegen/src/parsers/typescript/components/componentsUtils.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/componentsUtils.js
@@ -44,33 +44,6 @@ function getProperties(
   }
 }
 
-function getTypeAnnotationForObjectAsArrayElement<T>(
-  name: string,
-  typeAnnotation: $FlowFixMe,
-  types: TypeDeclarationMap,
-  buildSchema: (property: PropAST, types: TypeDeclarationMap) => ?NamedShape<T>,
-): $FlowFixMe {
-  // for array of array of a type
-  // such type must be an object literal
-  const elementType = getTypeAnnotationForArray(
-    name,
-    typeAnnotation,
-    null,
-    types,
-    buildSchema,
-  );
-  if (elementType.type !== 'ObjectTypeAnnotation') {
-    throw new Error(
-      `Only array of array of object is supported for "${name}".`,
-    );
-  }
-
-  return {
-    type: 'ArrayTypeAnnotation',
-    elementType,
-  };
-}
-
 function getUnionOfLiterals(
   name: string,
   forArray: boolean,
@@ -218,7 +191,14 @@ function getTypeAnnotationForArray<T>(
     types,
     buildSchema,
   );
-  if (arrayType) return arrayType;
+  if (arrayType) {
+    if (arrayType.elementType.type !== 'ObjectTypeAnnotation') {
+      throw new Error(
+        `Only array of array of object is supported for "${name}".`,
+      );
+    }
+    return arrayType;
+  }
 
   const type =
     extractedTypeAnnotation.elementType === 'TSTypeReference'
@@ -324,7 +304,9 @@ function getTypeAnnotation<T>(
     types,
     buildSchema,
   );
-  if (arrayType) return arrayType;
+  if (arrayType) {
+    return arrayType;
+  }
 
   const type =
     typeAnnotation.type === 'TSTypeReference' ||

--- a/packages/react-native-codegen/src/parsers/typescript/components/componentsUtils.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/componentsUtils.js
@@ -13,7 +13,6 @@ import type {ASTNode} from '../utils';
 import type {TypeDeclarationMap} from '../utils.js';
 import type {NamedShape} from '../../../CodegenSchema.js';
 const {parseTopLevelType} = require('../parseTopLevelType');
-const {getValueFromTypes} = require('../utils.js');
 
 function getProperties(
   typeName: string,

--- a/packages/react-native-codegen/src/parsers/typescript/components/componentsUtils.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/componentsUtils.js
@@ -476,8 +476,10 @@ function getSchemaInfo(
     return null;
   }
 
-  if(!property.optional && topLevelType.defaultValue!==undefined){
-    throw new Error(`key ${name} must be optional if used with WithDefault<> annotation`);
+  if (!property.optional && topLevelType.defaultValue !== undefined) {
+    throw new Error(
+      `key ${name} must be optional if used with WithDefault<> annotation`,
+    );
   }
 
   return {

--- a/packages/react-native-codegen/src/parsers/typescript/components/componentsUtils.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/componentsUtils.js
@@ -435,7 +435,7 @@ function getTypeAnnotation<T>(
   }
 }
 
-function isProp(name:string, typeAnnotation: $FlowFixMe) {
+function isProp(name: string, typeAnnotation: $FlowFixMe) {
   if (typeAnnotation.type === 'TSTypeReference') {
     // Remove unwanted types
     if (
@@ -467,7 +467,10 @@ function getSchemaInfo(
   types: TypeDeclarationMap,
 ): ?SchemaInfo {
   // unpack WithDefault, (T) or T|U
-  const topLevelType = parseTopLevelType(property.typeAnnotation.typeAnnotation, types);
+  const topLevelType = parseTopLevelType(
+    property.typeAnnotation.typeAnnotation,
+    types,
+  );
   const name = property.key.name;
   if (!isProp(name, topLevelType.type)) {
     return null;

--- a/packages/react-native-codegen/src/parsers/typescript/components/events.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/events.js
@@ -218,13 +218,16 @@ function buildEventSchema(
   property: EventTypeAST,
 ): ?EventTypeShape {
   // unpack WithDefault, (T) or T|U
-  const topLevelType = parseTopLevelType(property.typeAnnotation.typeAnnotation, types);
+  const topLevelType = parseTopLevelType(
+    property.typeAnnotation.typeAnnotation,
+    types,
+  );
   if (!isEvent(topLevelType.type)) {
     return null;
   }
-  
+
   const name = property.key.name;
-  const typeAnnotation=topLevelType.type;
+  const typeAnnotation = topLevelType.type;
   const optional = property.optional || topLevelType.optional;
   const {argumentProps, bubblingType, paperTopLevelNameDeprecated} =
     findEventArgumentsAndType(typeAnnotation, types);

--- a/packages/react-native-codegen/src/parsers/typescript/components/events.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/events.js
@@ -16,19 +16,21 @@ import type {
   EventTypeAnnotation,
 } from '../../../CodegenSchema.js';
 const {flattenProperties} = require('./componentsUtils');
+const {parseTopLevelType} = require('../parseTopLevelType');
+const {TypeDeclarationMap} = require('./utils.js');
 
 function getPropertyType(
   /* $FlowFixMe[missing-local-annot] The type annotation(s) required by Flow's
    * LTI update could not be added via codemod */
   name,
-  optional: boolean,
+  optionalProperty: boolean,
   /* $FlowFixMe[missing-local-annot] The type annotation(s) required by Flow's
    * LTI update could not be added via codemod */
-  typeAnnotation,
+  annotation,
 ): NamedShape<EventTypeAnnotation> {
-  if (typeAnnotation.type === 'TSParenthesizedType') {
-    return getPropertyType(name, optional, typeAnnotation.typeAnnotation);
-  }
+  const topLevelType = parseTopLevelType(annotation);
+  const typeAnnotation = topLevelType.type;
+  const optional = optionalProperty || topLevelType.optional;
   const type =
     typeAnnotation.type === 'TSTypeReference'
       ? typeAnnotation.typeName.name
@@ -75,13 +77,6 @@ function getPropertyType(
           type: 'FloatTypeAnnotation',
         },
       };
-    case 'Readonly':
-      return getPropertyType(
-        name,
-        optional,
-        typeAnnotation.typeParameters.params[0],
-      );
-
     case 'TSTypeLiteral':
       return {
         name,
@@ -93,20 +88,6 @@ function getPropertyType(
       };
 
     case 'TSUnionType':
-      // Check for <T | null | undefined>
-      if (
-        typeAnnotation.types.some(
-          t => t.type === 'TSNullKeyword' || t.type === 'TSUndefinedKeyword',
-        )
-      ) {
-        const optionalType = typeAnnotation.types.filter(
-          t => t.type !== 'TSNullKeyword' && t.type !== 'TSUndefinedKeyword',
-        )[0];
-
-        // Check for <(T | T2) | null | undefined>
-        return getPropertyType(name, true, optionalType);
-      }
-
       return {
         name,
         optional,
@@ -123,7 +104,7 @@ function getPropertyType(
 
 function findEventArgumentsAndType(
   typeAnnotation: $FlowFixMe,
-  types: TypeMap,
+  types: TypeDeclarationMap,
   bubblingType: void | 'direct' | 'bubble',
   paperName: ?$FlowFixMe,
 ) {
@@ -216,49 +197,35 @@ function getEventArgument(argumentProps, name: $FlowFixMe) {
   };
 }
 
-function findEvent(typeAnnotation: $FlowFixMe, optional: boolean) {
+function isEvent(typeAnnotation: $FlowFixMe) {
   switch (typeAnnotation.type) {
-    // Check for T | null | undefined
-    case 'TSUnionType':
-      return findEvent(
-        typeAnnotation.types.filter(
-          t => t.type !== 'TSNullKeyword' && t.type !== 'TSUndefinedKeyword',
-        )[0],
-        optional ||
-          typeAnnotation.types.some(
-            t => t.type === 'TSNullKeyword' || t.type === 'TSUndefinedKeyword',
-          ),
-      );
-    // Check for (T)
-    case 'TSParenthesizedType':
-      return findEvent(typeAnnotation.typeAnnotation, optional);
     case 'TSTypeReference':
       if (
         typeAnnotation.typeName.name !== 'BubblingEventHandler' &&
         typeAnnotation.typeName.name !== 'DirectEventHandler'
       ) {
-        return null;
+        return false;
       } else {
-        return {typeAnnotation, optional};
+        return true;
       }
     default:
-      return null;
+      return false;
   }
 }
 
 function buildEventSchema(
-  types: TypeMap,
+  types: TypeDeclarationMap,
   property: EventTypeAST,
 ): ?EventTypeShape {
-  const name = property.key.name;
-  const foundEvent = findEvent(
-    property.typeAnnotation.typeAnnotation,
-    property.optional || false,
-  );
-  if (!foundEvent) {
+  // unpack WithDefault, (T) or T|U
+  const topLevelType = parseTopLevelType(property.typeAnnotation.typeAnnotation, types);
+  if (!isEvent(topLevelType.type)) {
     return null;
   }
-  const {typeAnnotation, optional} = foundEvent;
+  
+  const name = property.key.name;
+  const typeAnnotation=topLevelType.type;
+  const optional = property.optional || topLevelType.optional;
   const {argumentProps, bubblingType, paperTopLevelNameDeprecated} =
     findEventArgumentsAndType(typeAnnotation, types);
 
@@ -299,15 +266,9 @@ function buildEventSchema(
 // $FlowFixMe[unclear-type] TODO(T108222691): Use flow-types for @babel/parser
 type EventTypeAST = Object;
 
-type TypeMap = {
-  // $FlowFixMe[unclear-type] TODO(T108222691): Use flow-types for @babel/parser
-  [string]: Object,
-  ...
-};
-
 function getEvents(
   eventTypeAST: $ReadOnlyArray<EventTypeAST>,
-  types: TypeMap,
+  types: TypeDeclarationMap,
 ): $ReadOnlyArray<EventTypeShape> {
   return eventTypeAST
     .filter(property => property.type === 'TSPropertySignature')

--- a/packages/react-native-codegen/src/parsers/typescript/components/events.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/events.js
@@ -17,7 +17,7 @@ import type {
 } from '../../../CodegenSchema.js';
 const {flattenProperties} = require('./componentsUtils');
 const {parseTopLevelType} = require('../parseTopLevelType');
-const {TypeDeclarationMap} = require('../utils.js');
+import type {TypeDeclarationMap} from '../utils.js';
 
 function getPropertyType(
   /* $FlowFixMe[missing-local-annot] The type annotation(s) required by Flow's

--- a/packages/react-native-codegen/src/parsers/typescript/components/events.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/events.js
@@ -17,7 +17,7 @@ import type {
 } from '../../../CodegenSchema.js';
 const {flattenProperties} = require('./componentsUtils');
 const {parseTopLevelType} = require('../parseTopLevelType');
-const {TypeDeclarationMap} = require('./utils.js');
+const {TypeDeclarationMap} = require('../utils.js');
 
 function getPropertyType(
   /* $FlowFixMe[missing-local-annot] The type annotation(s) required by Flow's

--- a/packages/react-native-codegen/src/parsers/typescript/components/props.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/props.js
@@ -29,7 +29,7 @@ function buildPropSchema(
   if (info == null) {
     return null;
   }
-  const {name, optional, typeAnnotation, defaultValue, withNullDefault} = info;
+  const {name, optional, typeAnnotation, defaultValue} = info;
   return {
     name,
     optional,
@@ -37,7 +37,6 @@ function buildPropSchema(
       name,
       typeAnnotation,
       defaultValue,
-      withNullDefault,
       types,
       buildPropSchema,
     ),

--- a/packages/react-native-codegen/src/parsers/typescript/components/states.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/states.js
@@ -29,7 +29,7 @@ function buildStateSchema(
   if (info == null) {
     return null;
   }
-  const {name, optional, typeAnnotation, defaultValue, withNullDefault} = info;
+  const {name, optional, typeAnnotation, defaultValue} = info;
   return {
     name,
     optional,
@@ -37,7 +37,6 @@ function buildStateSchema(
       name,
       typeAnnotation,
       defaultValue,
-      withNullDefault,
       types,
       buildStateSchema,
     ),

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -154,16 +154,6 @@ function translateTypeAnnotation(
     resolveTypeAnnotation(typeScriptTypeAnnotation, types);
 
   switch (typeAnnotation.type) {
-    case 'TSParenthesizedType': {
-      return translateTypeAnnotation(
-        hasteModuleName,
-        typeAnnotation.typeAnnotation,
-        types,
-        aliasMap,
-        tryParse,
-        cxxOnly,
-      );
-    }
     case 'TSArrayType': {
       return translateArrayTypeAnnotation(
         hasteModuleName,
@@ -230,25 +220,6 @@ function translateTypeAnnotation(
             typeAnnotation.typeParameters.params[0],
             nullable,
           );
-        }
-        case 'Readonly': {
-          assertGenericTypeAnnotationHasExactlyOneTypeParameter(
-            hasteModuleName,
-            typeAnnotation,
-          );
-
-          const [paramType, isParamNullable] = unwrapNullable(
-            translateTypeAnnotation(
-              hasteModuleName,
-              typeAnnotation.typeParameters.params[0],
-              types,
-              aliasMap,
-              tryParse,
-              cxxOnly,
-            ),
-          );
-
-          return wrapNullable(nullable || isParamNullable, paramType);
         }
         case 'Stringish': {
           return wrapNullable(nullable, {
@@ -484,6 +455,7 @@ function translateTypeAnnotation(
         });
       }
       // Fallthrough
+      throw new Error(JSON.stringify(typeAnnotation,undefined,4));
     }
     case 'TSUnknownKeyword': {
       if (cxxOnly) {

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -455,7 +455,6 @@ function translateTypeAnnotation(
         });
       }
       // Fallthrough
-      throw new Error(JSON.stringify(typeAnnotation,undefined,4));
     }
     case 'TSUnknownKeyword': {
       if (cxxOnly) {

--- a/packages/react-native-codegen/src/parsers/typescript/parseTopLevelType.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parseTopLevelType.js
@@ -62,7 +62,11 @@ function handleUnionAndParen(
     }
     case 'TSUnionType': {
       for (const t of type.types) {
-        if (t.type === 'TSNullKeyword' || t.type === 'TSUndefinedKeyword' || t.type === 'TSVoidKeyword') {
+        if (
+          t.type === 'TSNullKeyword' ||
+          t.type === 'TSUndefinedKeyword' ||
+          t.type === 'TSVoidKeyword'
+        ) {
           result.optional = true;
         } else {
           handleUnionAndParen(t, result, knownTypes);

--- a/packages/react-native-codegen/src/parsers/typescript/parseTopLevelType.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parseTopLevelType.js
@@ -26,7 +26,10 @@ export type TopLevelType = {
   defaultValue?: LegalDefaultValues,
 };
 
-function getValueFromTypes(value: ASTNode, types: TypeDeclarationMap): ASTNode {
+function getValueFromTypes(
+  value: $FlowFixMe,
+  types: TypeDeclarationMap,
+): $FlowFixMe {
   switch (value.type) {
     case 'TSTypeReference':
       if (types[value.typeName.name]) {
@@ -151,8 +154,8 @@ function handleUnionAndParen(
 }
 
 export function parseTopLevelType(
-  type: TSTypeAnnotation,
-  knownTypes: TypeDeclarationMap,
+  type: $FlowFixMe,
+  knownTypes?: TypeDeclarationMap,
 ): TopLevelType {
   let result: TopLevelTypeInternal = {unions: [], optional: false};
   handleUnionAndParen(type, result, knownTypes);

--- a/packages/react-native-codegen/src/parsers/typescript/parseTopLevelType.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parseTopLevelType.js
@@ -74,8 +74,9 @@ function evaluateLiteral(
     } else if (
       literal.type === 'UnaryExpression' &&
       literal.operator === '-' &&
-      literal.argument.type === 'Literal' &&
-      typeof literal.argument.literal === 'number'
+      (literal.argument.type === 'Literal' ||
+        literal.argument.type === 'NumericLiteral') &&
+      typeof literal.argument.value === 'number'
     ) {
       return -literal.argument.value;
     }
@@ -87,7 +88,7 @@ function evaluateLiteral(
   }
 
   throw new Error(
-    'The default value in WithDefault must be string, number, boolean or null.',
+    'The default value in WithDefault must be string, number, boolean or null .',
   );
 }
 

--- a/packages/react-native-codegen/src/parsers/typescript/parseTopLevelType.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parseTopLevelType.js
@@ -39,7 +39,8 @@ function handleUnionAndParen(
     }
     case 'TSTypeReference':
       if (type.typeName.name==='Readonly') {
-        handleUnionAndParen(type.typeAnnotation, result);
+        handleUnionAndParen(type.typeParameters.params[0], result);
+        break;
       } else if (type.typeName.name === 'WithDefault') {
         if(result.optional) {
             throw new Error(

--- a/packages/react-native-codegen/src/parsers/typescript/parseTopLevelType.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parseTopLevelType.js
@@ -45,11 +45,11 @@ function getValueFromTypes(
 }
 
 function isNull(t: $FlowFixMe) {
-  return (
-    t.type === 'TSNullKeyword' ||
-    t.type === 'TSUndefinedKeyword' ||
-    t.type === 'TSVoidKeyword'
-  );
+  return t.type === 'TSNullKeyword' || t.type === 'TSUndefinedKeyword';
+}
+
+function isNullOrVoid(t: $FlowFixMe) {
+  return  isNull(t) ||  t.type === 'TSVoidKeyword';
 }
 
 function evaluateLiteral(
@@ -80,10 +80,7 @@ function evaluateLiteral(
     ) {
       return -literal.argument.value;
     }
-  } else if (
-    valueType === 'TSNullKeyword' ||
-    valueType === 'TSUndefinedKeyword'
-  ) {
+  } else if (isNull(literalNode)) {
     return null;
   }
 
@@ -106,12 +103,12 @@ function handleUnionAndParen(
       // the order is important
       // result.optional must be set first
       for (const t of type.types) {
-        if (isNull(t)) {
+        if (isNullOrVoid(t)) {
           result.optional = true;
         }
       }
       for (const t of type.types) {
-        if (!isNull(t)) {
+        if (!isNullOrVoid(t)) {
           handleUnionAndParen(t, result, knownTypes);
         }
       }

--- a/packages/react-native-codegen/src/parsers/typescript/parseTopLevelType.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parseTopLevelType.js
@@ -50,10 +50,12 @@ function getValueFromTypes(value: ASTNode, types: TypeDeclarationMap): ASTNode {
   }
 }
 
-function isNull(t:LegalTypeNode){
-  return t.type === 'TSNullKeyword' ||
-  t.type === 'TSUndefinedKeyword' ||
-  t.type === 'TSVoidKeyword';
+function isNull(t: LegalTypeNode) {
+  return (
+    t.type === 'TSNullKeyword' ||
+    t.type === 'TSUndefinedKeyword' ||
+    t.type === 'TSVoidKeyword'
+  );
 }
 
 function handleUnionAndParen(

--- a/packages/react-native-codegen/src/parsers/typescript/parseTopLevelType.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parseTopLevelType.js
@@ -12,7 +12,7 @@
 
 import type {TSTypeAnnotation} from '@babel/types';
 
-export type LegalDefaultValues = string | number | boolean | null
+export type LegalDefaultValues = string | number | boolean | null;
 
 type TopLevelTypeInternal = {
   unions: Array<TSTypeAnnotation>,
@@ -46,14 +46,14 @@ function handleUnionAndParen(
       break;
     }
     case 'TSTypeReference':
-      if (type.typeName.name==='Readonly') {
+      if (type.typeName.name === 'Readonly') {
         handleUnionAndParen(type.typeParameters.params[0], result);
         break;
       } else if (type.typeName.name === 'WithDefault') {
-        if(result.optional) {
-            throw new Error(
-              'WithDefault<> is optional and does not need to be marked as optional. Please remove the union of undefined and/or null',
-            );
+        if (result.optional) {
+          throw new Error(
+            'WithDefault<> is optional and does not need to be marked as optional. Please remove the union of undefined and/or null',
+          );
         }
         if (type.typeParameters.params.length !== 2) {
           throw new Error(
@@ -71,7 +71,12 @@ function handleUnionAndParen(
         const valueType = type.typeParameters.params[1].type;
         if (valueType === 'TSLiteralType') {
           const literal = type.typeParameters.params[1].literal;
-          if (literal.type === 'Literal' || literal.type === 'StringLiteral' || literal.type === 'NumericLiteral' || literal.type === 'BooleanLiteral') {
+          if (
+            literal.type === 'Literal' ||
+            literal.type === 'StringLiteral' ||
+            literal.type === 'NumericLiteral' ||
+            literal.type === 'BooleanLiteral'
+          ) {
             if (
               typeof literal.value === 'string' ||
               typeof literal.value === 'number' ||
@@ -111,17 +116,17 @@ export function parseTopLevelType(type: TSTypeAnnotation): TopLevelType {
   handleUnionAndParen(type, result);
   if (result.unions.length === 0) {
     throw new Error('Union type could not be just null or undefined.');
-  } else if (result.unions.length===1) {
+  } else if (result.unions.length === 1) {
     return {
-      type:result.unions[0],
-      optional:result.optional,
-      defaultValue:result.defaultValue,
+      type: result.unions[0],
+      optional: result.optional,
+      defaultValue: result.defaultValue,
     };
   } else {
     return {
-      type:{type:'TSUnionType',types:result.unions},
-      optional:result.optional,
-      defaultValue:result.defaultValue,
+      type: {type: 'TSUnionType', types: result.unions},
+      optional: result.optional,
+      defaultValue: result.defaultValue,
     };
   }
 }

--- a/packages/react-native-codegen/src/parsers/typescript/parseTopLevelType.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parseTopLevelType.js
@@ -38,7 +38,9 @@ function handleUnionAndParen(
       break;
     }
     case 'TSTypeReference':
-      if (type.typeName.name === 'WithDefault') {
+      if (type.typeName.name==='Readonly') {
+        handleUnionAndParen(type.typeAnnotation, result);
+      } else if (type.typeName.name === 'WithDefault') {
         if(result.optional) {
             throw new Error(
               'WithDefault<> is optional and does not need to be marked as optional. Please remove the union of undefined and/or null',

--- a/packages/react-native-codegen/src/parsers/typescript/parseTopLevelType.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parseTopLevelType.js
@@ -93,5 +93,8 @@ function handleUnionAndParen(
 export function parseTopLevelType(type: TSTypeAnnotation): TopLevelType {
   let result: TopLevelType = {unions: [], optional: false};
   handleUnionAndParen(type, result);
+  if (result.unions.length === 0) {
+    throw new Error('Union type could not be just null or undefined.');
+  }
   return result;
 }

--- a/packages/react-native-codegen/src/parsers/typescript/parseTopLevelType.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parseTopLevelType.js
@@ -10,27 +10,18 @@
 
 'use strict';
 
-import type {
-  TSEnumDeclaration,
-  TSInterfaceDeclaration,
-  TSTypeAnnotation,
-} from '@babel/types';
-const {TypeDeclarationMap} = require('./utils.js');
+import type {TypeDeclarationMap} from './utils.js';
 
 export type LegalDefaultValues = string | number | boolean | null;
-export type LegalTypeNode =
-  | TSEnumDeclaration
-  | TSInterfaceDeclaration
-  | TSTypeAnnotation;
 
 type TopLevelTypeInternal = {
-  unions: Array<LegalTypeNode>,
+  unions: Array<$FlowFixMe>,
   optional: boolean,
   defaultValue?: LegalDefaultValues,
 };
 
 export type TopLevelType = {
-  type: LegalTypeNode,
+  type: $FlowFixMe,
   optional: boolean,
   defaultValue?: LegalDefaultValues,
 };
@@ -50,7 +41,7 @@ function getValueFromTypes(value: ASTNode, types: TypeDeclarationMap): ASTNode {
   }
 }
 
-function isNull(t: LegalTypeNode) {
+function isNull(t: $FlowFixMe) {
   return (
     t.type === 'TSNullKeyword' ||
     t.type === 'TSUndefinedKeyword' ||
@@ -59,7 +50,7 @@ function isNull(t: LegalTypeNode) {
 }
 
 function handleUnionAndParen(
-  type: LegalTypeNode,
+  type: $FlowFixMe,
   result: TopLevelTypeInternal,
   knownTypes?: TypeDeclarationMap,
 ): void {

--- a/packages/react-native-codegen/src/parsers/typescript/parseTopLevelType.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parseTopLevelType.js
@@ -52,18 +52,21 @@ function isNullOrVoid(t: $FlowFixMe) {
   return  isNull(t) ||  t.type === 'TSVoidKeyword';
 }
 
+function couldBeNumericLiteral(type:string) {
+  return type==='Literal' || type==='NumericLiteral';
+}
+
+function couldBeSimpleLiteral(type:string) {
+  return couldBeNumericLiteral(type) || type==='StringLiteral' || type==='BooleanLiteral';
+}
+
 function evaluateLiteral(
   literalNode: $FlowFixMe,
 ): string | number | boolean | null {
   const valueType = literalNode.type;
   if (valueType === 'TSLiteralType') {
     const literal = literalNode.literal;
-    if (
-      literal.type === 'Literal' ||
-      literal.type === 'StringLiteral' ||
-      literal.type === 'NumericLiteral' ||
-      literal.type === 'BooleanLiteral'
-    ) {
+    if (couldBeSimpleLiteral(literal.type)) {
       if (
         typeof literal.value === 'string' ||
         typeof literal.value === 'number' ||
@@ -74,8 +77,7 @@ function evaluateLiteral(
     } else if (
       literal.type === 'UnaryExpression' &&
       literal.operator === '-' &&
-      (literal.argument.type === 'Literal' ||
-        literal.argument.type === 'NumericLiteral') &&
+      couldBeNumericLiteral(literal.argument.type) &&
       typeof literal.argument.value === 'number'
     ) {
       return -literal.argument.value;

--- a/packages/react-native-codegen/src/parsers/typescript/parseTopLevelType.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parseTopLevelType.js
@@ -15,7 +15,7 @@ import type {
   TSInterfaceDeclaration,
   TSTypeAnnotation,
 } from '@babel/types';
-const {getValueFromTypes, TypeDeclarationMap} = require('./utils.js');
+const {TypeDeclarationMap} = require('./utils.js');
 
 export type LegalDefaultValues = string | number | boolean | null;
 export type LegalTypeNode =
@@ -34,6 +34,21 @@ export type TopLevelType = {
   optional: boolean,
   defaultValue?: LegalDefaultValues,
 };
+
+function getValueFromTypes(value: ASTNode, types: TypeDeclarationMap): ASTNode {
+  switch (value.type) {
+    case 'TSTypeReference':
+      if (types[value.typeName.name]) {
+        return getValueFromTypes(types[value.typeName.name], types);
+      } else {
+        return value;
+      }
+    case 'TSTypeAliasDeclaration':
+      return getValueFromTypes(value.typeAnnotation, types);
+    default:
+      return value;
+  }
+}
 
 function handleUnionAndParen(
   type: LegalTypeNode,

--- a/packages/react-native-codegen/src/parsers/typescript/parseTopLevelType.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parseTopLevelType.js
@@ -88,12 +88,12 @@ function handleUnionAndParen(
         }
         if (type.typeParameters.params.length !== 2) {
           throw new Error(
-            `WithDefault requires two parameters: type and default value.`,
+            'WithDefault requires two parameters: type and default value.',
           );
         }
         if (result.defaultValue !== undefined) {
           throw new Error(
-            `Multiple WithDefault is not allowed in a union type.`,
+            'Multiple WithDefault is not allowed in a union type.',
           );
         }
         result.optional = true;

--- a/packages/react-native-codegen/src/parsers/typescript/parseTopLevelType.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parseTopLevelType.js
@@ -10,68 +10,88 @@
 
 'use strict';
 
-import type { TSTypeAnnotation } from '@babel/types';
+import type {TSTypeAnnotation} from '@babel/types';
 
 export type TopLevelType = {
-    unions: Array<TSTypeAnnotation>,
-    optional: boolean,
-    defaultValue?: string | number | boolean | null,
+  unions: Array<TSTypeAnnotation>,
+  optional: boolean,
+  defaultValue?: string | number | boolean | null,
 };
 
-function handleUnionAndParen(type: TSTypeAnnotation, result: TopLevelType): void {
-    switch (type.type) {
-        case 'TSParenthesizedType': {
-            handleUnionAndParen(type.typeAnnotation, result);
-            break;
-        }
-        case 'TSUnionType': {
-            for (const t of type.types) {
-                if (t.type === 'TSNullKeyword' || t.type === 'TSUndefinedKeyword') {
-                    result.optional = true;
-                } else {
-                    handleUnionAndParen(t, result);
-                }
-            }
-            break;
-        }
-        case 'TSTypeReference':
-            if (type.typeName.name === 'WithDefault') {
-                if (type.typeParameters.params.length !== 2) {
-                    throw new Error(`WithDefault requires two parameters: type and default value.`);
-                }
-                if (result.defaultValue !== undefined) {
-                    throw new Error(`Multiple WithDefault is not allowed in a union type.`);
-                }
-                result.optional = true;
-                handleUnionAndParen(typeParameters.params[0], result);
-
-                const valueType = typeParameters.params[1].type;
-                if (valueType === 'TSLiteralType') {
-                    const literal = defaultLiteralType.literal;
-                    if (literal.type === 'Literal') {
-                        if (typeof literal.value === 'string' || typeof literal.value === 'number' || typeof literal.value === 'boolean') {
-                            result.defaultValue = literal.value;
-                        }
-                    } else if (literal.type === 'UnaryExpression' && literal.argument.type === 'Literal' && typeof literal.argument.literal === 'number') {
-                        result.defaultValue = -literal.argument.value;
-                    }
-                } else if (valueType === 'TSNullKeyword' || valueType === 'TSUndefinedKeyword') {
-                    result.defaultValue = null;
-                }
-
-                if (result.defaultValue === undefined) {
-                    throw new Error('The default value in WithDefault must be string, number, boolean or null.');
-                }
-                break;
-            }
-        // fall through
-        default:
-            result.unions.push(type);
+function handleUnionAndParen(
+  type: TSTypeAnnotation,
+  result: TopLevelType,
+): void {
+  switch (type.type) {
+    case 'TSParenthesizedType': {
+      handleUnionAndParen(type.typeAnnotation, result);
+      break;
     }
+    case 'TSUnionType': {
+      for (const t of type.types) {
+        if (t.type === 'TSNullKeyword' || t.type === 'TSUndefinedKeyword') {
+          result.optional = true;
+        } else {
+          handleUnionAndParen(t, result);
+        }
+      }
+      break;
+    }
+    case 'TSTypeReference':
+      if (type.typeName.name === 'WithDefault') {
+        if (type.typeParameters.params.length !== 2) {
+          throw new Error(
+            `WithDefault requires two parameters: type and default value.`,
+          );
+        }
+        if (result.defaultValue !== undefined) {
+          throw new Error(
+            `Multiple WithDefault is not allowed in a union type.`,
+          );
+        }
+        result.optional = true;
+        handleUnionAndParen(typeParameters.params[0], result);
+
+        const valueType = typeParameters.params[1].type;
+        if (valueType === 'TSLiteralType') {
+          const literal = defaultLiteralType.literal;
+          if (literal.type === 'Literal') {
+            if (
+              typeof literal.value === 'string' ||
+              typeof literal.value === 'number' ||
+              typeof literal.value === 'boolean'
+            ) {
+              result.defaultValue = literal.value;
+            }
+          } else if (
+            literal.type === 'UnaryExpression' &&
+            literal.argument.type === 'Literal' &&
+            typeof literal.argument.literal === 'number'
+          ) {
+            result.defaultValue = -literal.argument.value;
+          }
+        } else if (
+          valueType === 'TSNullKeyword' ||
+          valueType === 'TSUndefinedKeyword'
+        ) {
+          result.defaultValue = null;
+        }
+
+        if (result.defaultValue === undefined) {
+          throw new Error(
+            'The default value in WithDefault must be string, number, boolean or null.',
+          );
+        }
+        break;
+      }
+    // fall through
+    default:
+      result.unions.push(type);
+  }
 }
 
 export function parseTopLevelType(type: TSTypeAnnotation): TopLevelType {
-    let result: TopLevelType = { unions: [], optional: false };
-    handleUnionAndParen(type, result);
-    return result;
+  let result: TopLevelType = {unions: [], optional: false};
+  handleUnionAndParen(type, result);
+  return result;
 }

--- a/packages/react-native-codegen/src/parsers/typescript/parseTopLevelType.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parseTopLevelType.js
@@ -49,15 +49,19 @@ function isNull(t: $FlowFixMe) {
 }
 
 function isNullOrVoid(t: $FlowFixMe) {
-  return  isNull(t) ||  t.type === 'TSVoidKeyword';
+  return isNull(t) || t.type === 'TSVoidKeyword';
 }
 
-function couldBeNumericLiteral(type:string) {
-  return type==='Literal' || type==='NumericLiteral';
+function couldBeNumericLiteral(type: string) {
+  return type === 'Literal' || type === 'NumericLiteral';
 }
 
-function couldBeSimpleLiteral(type:string) {
-  return couldBeNumericLiteral(type) || type==='StringLiteral' || type==='BooleanLiteral';
+function couldBeSimpleLiteral(type: string) {
+  return (
+    couldBeNumericLiteral(type) ||
+    type === 'StringLiteral' ||
+    type === 'BooleanLiteral'
+  );
 }
 
 function evaluateLiteral(

--- a/packages/react-native-codegen/src/parsers/typescript/parseTopLevelType.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parseTopLevelType.js
@@ -62,7 +62,7 @@ function handleUnionAndParen(
     }
     case 'TSUnionType': {
       for (const t of type.types) {
-        if (t.type === 'TSNullKeyword' || t.type === 'TSUndefinedKeyword') {
+        if (t.type === 'TSNullKeyword' || t.type === 'TSUndefinedKeyword' || t.type === 'TSVoidKeyword') {
           result.optional = true;
         } else {
           handleUnionAndParen(t, result, knownTypes);

--- a/packages/react-native-codegen/src/parsers/typescript/parseTopLevelType.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parseTopLevelType.js
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+'use strict';
+
+import type { TSTypeAnnotation } from '@babel/types';
+
+export type TopLevelType = {
+    unions: Array<TSTypeAnnotation>,
+    optional: boolean,
+    defaultValue?: string | number | boolean | null,
+};
+
+function handleUnionAndParen(type: TSTypeAnnotation, result: TopLevelType): void {
+    switch (type.type) {
+        case 'TSParenthesizedType': {
+            handleUnionAndParen(type.typeAnnotation, result);
+            break;
+        }
+        case 'TSUnionType': {
+            for (const t of type.types) {
+                if (t.type === 'TSNullKeyword' || t.type === 'TSUndefinedKeyword') {
+                    result.optional = true;
+                } else {
+                    handleUnionAndParen(t, result);
+                }
+            }
+            break;
+        }
+        case 'TSTypeReference':
+            if (type.typeName.name === 'WithDefault') {
+                if (type.typeParameters.params.length !== 2) {
+                    throw new Error(`WithDefault requires two parameters: type and default value.`);
+                }
+                if (result.defaultValue !== undefined) {
+                    throw new Error(`Multiple WithDefault is not allowed in a union type.`);
+                }
+                result.optional = true;
+                handleUnionAndParen(typeParameters.params[0], result);
+
+                const valueType = typeParameters.params[1].type;
+                if (valueType === 'TSLiteralType') {
+                    const literal = defaultLiteralType.literal;
+                    if (literal.type === 'Literal') {
+                        if (typeof literal.value === 'string' || typeof literal.value === 'number' || typeof literal.value === 'boolean') {
+                            result.defaultValue = literal.value;
+                        }
+                    } else if (literal.type === 'UnaryExpression' && literal.argument.type === 'Literal' && typeof literal.argument.literal === 'number') {
+                        result.defaultValue = -literal.argument.value;
+                    }
+                } else if (valueType === 'TSNullKeyword' || valueType === 'TSUndefinedKeyword') {
+                    result.defaultValue = null;
+                }
+
+                if (result.defaultValue === undefined) {
+                    throw new Error('The default value in WithDefault must be string, number, boolean or null.');
+                }
+                break;
+            }
+        // fall through
+        default:
+            result.unions.push(type);
+    }
+}
+
+export function parseTopLevelType(type: TSTypeAnnotation): TopLevelType {
+    let result: TopLevelType = { unions: [], optional: false };
+    handleUnionAndParen(type, result);
+    return result;
+}

--- a/packages/react-native-codegen/src/parsers/typescript/parseTopLevelType.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parseTopLevelType.js
@@ -50,6 +50,12 @@ function getValueFromTypes(value: ASTNode, types: TypeDeclarationMap): ASTNode {
   }
 }
 
+function isNull(t:LegalTypeNode){
+  return t.type === 'TSNullKeyword' ||
+  t.type === 'TSUndefinedKeyword' ||
+  t.type === 'TSVoidKeyword';
+}
+
 function handleUnionAndParen(
   type: LegalTypeNode,
   result: TopLevelTypeInternal,
@@ -61,14 +67,15 @@ function handleUnionAndParen(
       break;
     }
     case 'TSUnionType': {
+      // the order is important
+      // result.optional must be set first
       for (const t of type.types) {
-        if (
-          t.type === 'TSNullKeyword' ||
-          t.type === 'TSUndefinedKeyword' ||
-          t.type === 'TSVoidKeyword'
-        ) {
+        if (isNull(t)) {
           result.optional = true;
-        } else {
+        }
+      }
+      for (const t of type.types) {
+        if (!isNull(t)) {
           handleUnionAndParen(t, result, knownTypes);
         }
       }

--- a/packages/react-native-codegen/src/parsers/typescript/parseTopLevelType.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parseTopLevelType.js
@@ -38,7 +38,7 @@ export type TopLevelType = {
 function handleUnionAndParen(
   type: LegalTypeNode,
   result: TopLevelTypeInternal,
-  knownTypes: TypeDeclarationMap,
+  knownTypes?: TypeDeclarationMap,
 ): void {
   switch (type.type) {
     case 'TSParenthesizedType': {
@@ -112,6 +112,8 @@ function handleUnionAndParen(
             'The default value in WithDefault must be string, number, boolean or null.',
           );
         }
+      } else if (!knownTypes) {
+        result.unions.push(type);
       } else {
         const resolvedType = getValueFromTypes(type, knownTypes);
         if (

--- a/packages/react-native-codegen/src/parsers/typescript/parseTopLevelType.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parseTopLevelType.js
@@ -39,6 +39,11 @@ function handleUnionAndParen(
     }
     case 'TSTypeReference':
       if (type.typeName.name === 'WithDefault') {
+        if(result.optional) {
+            throw new Error(
+              'WithDefault<> is optional and does not need to be marked as optional. Please remove the union of undefined and/or null',
+            );
+        }
         if (type.typeParameters.params.length !== 2) {
           throw new Error(
             `WithDefault requires two parameters: type and default value.`,
@@ -50,12 +55,12 @@ function handleUnionAndParen(
           );
         }
         result.optional = true;
-        handleUnionAndParen(typeParameters.params[0], result);
+        handleUnionAndParen(type.typeParameters.params[0], result);
 
-        const valueType = typeParameters.params[1].type;
+        const valueType = type.typeParameters.params[1].type;
         if (valueType === 'TSLiteralType') {
-          const literal = defaultLiteralType.literal;
-          if (literal.type === 'Literal') {
+          const literal = type.typeParameters.params[1].literal;
+          if (literal.type === 'Literal' || literal.type === 'StringLiteral' || literal.type === 'NumericLiteral' || literal.type === 'BooleanLiteral') {
             if (
               typeof literal.value === 'string' ||
               typeof literal.value === 'number' ||

--- a/packages/react-native-codegen/src/parsers/typescript/utils.js
+++ b/packages/react-native-codegen/src/parsers/typescript/utils.js
@@ -124,21 +124,6 @@ function resolveTypeAnnotation(
   };
 }
 
-function getValueFromTypes(value: ASTNode, types: TypeDeclarationMap): ASTNode {
-  switch (value.type) {
-    case 'TSTypeReference':
-      if (types[value.typeName.name]) {
-        return getValueFromTypes(types[value.typeName.name], types);
-      } else {
-        return value;
-      }
-    case 'TSTypeAliasDeclaration':
-      return getValueFromTypes(value.typeAnnotation, types);
-    default:
-      return value;
-  }
-}
-
 export type ParserErrorCapturer = <T>(fn: () => T) => ?T;
 
 function createParserErrorCapturer(): [
@@ -231,7 +216,6 @@ function isModuleRegistryCall(node: $FlowFixMe): boolean {
 }
 
 module.exports = {
-  getValueFromTypes,
   resolveTypeAnnotation,
   createParserErrorCapturer,
   getTypes,

--- a/packages/react-native-codegen/src/parsers/typescript/utils.js
+++ b/packages/react-native-codegen/src/parsers/typescript/utils.js
@@ -85,7 +85,7 @@ function resolveTypeAnnotation(
   for (;;) {
     const topLevelType = parseTopLevelType(node);
     nullable ||= topLevelType.optional;
-    node=topLevelType.type;
+    node = topLevelType.type;
 
     if (node.type === 'TSTypeReference') {
       typeAliasResolutionStatus = {

--- a/packages/react-native-codegen/src/parsers/typescript/utils.js
+++ b/packages/react-native-codegen/src/parsers/typescript/utils.js
@@ -11,6 +11,7 @@
 'use strict';
 
 const {ParserError} = require('./errors');
+const {parseTopLevelType} = require('./parseTopLevelType');
 
 /**
  * TODO(T108222691): Use flow-types for @babel/parser
@@ -82,18 +83,11 @@ function resolveTypeAnnotation(
   };
 
   for (;;) {
-    // Check for optional type in union e.g. T | null | undefined
-    if (
-      node.type === 'TSUnionType' &&
-      node.types.some(
-        t => t.type === 'TSNullKeyword' || t.type === 'TSUndefinedKeyword',
-      )
-    ) {
-      node = node.types.filter(
-        t => t.type !== 'TSNullKeyword' && t.type !== 'TSUndefinedKeyword',
-      )[0];
-      nullable = true;
-    } else if (node.type === 'TSTypeReference') {
+    const topLevelType = parseTopLevelType(node);
+    nullable ||= topLevelType.optional;
+    node=topLevelType.type;
+
+    if (node.type === 'TSTypeReference') {
       typeAliasResolutionStatus = {
         successful: true,
         aliasName: node.typeName.name,

--- a/packages/react-native-codegen/src/parsers/typescript/utils.js
+++ b/packages/react-native-codegen/src/parsers/typescript/utils.js
@@ -84,7 +84,7 @@ function resolveTypeAnnotation(
 
   for (;;) {
     const topLevelType = parseTopLevelType(node);
-    nullable ||= topLevelType.optional;
+    nullable = nullable || topLevelType.optional;
     node = topLevelType.type;
 
     if (node.type === 'TSTypeReference') {


### PR DESCRIPTION
## Summary

`TSParenthesizedType`, `TSUnionType`, `TSNullKeyword`, `TSUndefinedKeyword`, `TSVoidKeyword` etc are repeatly processed in so many places. In this change I put them in a new file `parseTopLevelType.js`, and everyone call that file, all repeat implementation are deleted.

The `parseTopLevelType` function will look into a type consisted by the above types in any possible combination (but still very easy to do), and tell you if a type is nullable, or if there is a default value, and what is the real type with all noises removed.

Array types and union types are processed in component twice, for property of array, and property of nested arrays (`componentsUtils.js`). They are extracted into single functions.

## Changelog

[General] [Changed] - Refactor in turbo module TypeScript codegen: process `(T)`, `T|U`, `T|undefined` and related stuff in a central place

## Test Plan

`yarn jest react-native-codegen` passed
