### PR TITLE
Back out "RN: Switch to `Choco-Install` from Windows Hermes CI"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1204,9 +1204,9 @@ jobs:
           name: Build HermesC for Windows
           command: |
             if (-not(Test-Path -Path $Env:HERMES_WS_DIR\win64-bin\hermesc.exe)) {
-              Choco-Install -PackageName cmake -ArgumentList "--no-progress", "--version 3.14.7"
+              choco install --no-progress cmake --version 3.14.7
               if (-not $?) { throw "Failed to install CMake" }
-              Choco-Install -PackageName python3 -ArgumentList "--no-progress"
+              choco install --no-progress python3
               if (-not $?) { throw "Failed to install Python" }
 
               cd $Env:HERMES_WS_DIR\icu


### PR DESCRIPTION
Summary:
Original commit changeset: 69c03845d2f2

I had to back this out because Choco-Install is not recognized by CircleCI and currently the OSS pipeline is broken.

This didn't happen in previous Jobs because Hermes has not changed and the build was skipped.
See [this job](https://app.circleci.com/pipelines/github/facebook/react-native/16088/workflows/d9e1c028-9422-4609-ba9f-6c35460efbb5/jobs/303255?invite=true#step-104-40) for example.

## Changelog
[General][Fixed] - Fix the Windows Pipeline

Differential Revision: D39928281

