### PR TITLE
Replace Toast with Log.w on ReactImageView when null URL specified

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/image/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/image/BUCK
@@ -65,6 +65,7 @@ rn_android_library(
         react_native_target("java/com/facebook/react/common:common"),
         react_native_target("java/com/facebook/react/module/annotations:annotations"),
         react_native_target("java/com/facebook/react/uimanager:uimanager"),
+        react_native_target("java/com/facebook/react/util:util"),
         react_native_target("java/com/facebook/react/modules/fresco:fresco"),
         react_native_target("java/com/facebook/react/uimanager/annotations:annotations"),
         react_native_target("java/com/facebook/react/views/imagehelper:withmultisource"),

--- a/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.java
@@ -19,7 +19,6 @@ import android.graphics.Shader;
 import android.graphics.drawable.Animatable;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
-import android.widget.Toast;
 import androidx.annotation.Nullable;
 import com.facebook.common.internal.Objects;
 import com.facebook.common.references.CloseableReference;
@@ -51,6 +50,7 @@ import com.facebook.react.uimanager.FloatUtil;
 import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.UIManagerHelper;
 import com.facebook.react.uimanager.events.EventDispatcher;
+import com.facebook.react.util.RNLog;
 import com.facebook.react.views.imagehelper.ImageSource;
 import com.facebook.react.views.imagehelper.MultiSourceHelper;
 import com.facebook.react.views.imagehelper.MultiSourceHelper.MultiSourceResult;
@@ -597,11 +597,9 @@ public class ReactImageView extends GenericDraweeView {
 
   private void warnImageSource(String uri) {
     if (ReactBuildConfig.DEBUG) {
-      Toast.makeText(
-              getContext(),
-              "Warning: Image source \"" + uri + "\" doesn't exist",
-              Toast.LENGTH_SHORT)
-          .show();
+      RNLog.w(
+          (ReactContext) getContext(),
+          "ReactImageView: Image source \"" + uri + "\" doesn't exist");
     }
   }
 }


### PR DESCRIPTION
Summary: This is crashing on A12 because of using the regular Context instead of the application context. That said, this probably makes more sense as a log warning.

Reviewed By: javache

Differential Revision: D39852058

## Changelog
[Android][Changed] - Replaces a Toast warning with a Log warning on ReactImageView to prevent a crash on A12.
