### PR TITLE
Fix broken template tests due to missing boost headers

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -57,6 +57,8 @@ def skipPrefabPublishing = System.getenv("REACT_NATIVE_SKIP_PREFAB") != null
 def prefabHeadersDir = project.file("$buildDir/prefab-headers")
 
 final def preparePrefab = tasks.register("preparePrefab", PreparePrefabHeadersTask) {
+    dependsOn(prepareBoost, prepareDoubleConversion, prepareFolly, prepareGlog)
+    dependsOn("generateCodegenArtifactsFromSchema")
     // To export to a ReactNativePrefabProcessingEntities.kt once all
     // libraries have been moved. We keep it here for now as it make easier to
     // migrate one library at a time.

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "pretty-format": "^26.5.2",
     "promise": "^8.2.0",
     "react-devtools-core": "^4.26.0",
-    "react-native-gradle-plugin": "^0.71.2",
+    "react-native-gradle-plugin": "^0.71.4",
     "react-refresh": "^0.4.0",
     "react-shallow-renderer": "^16.15.0",
     "regenerator-runtime": "^0.13.2",

--- a/packages/react-native-gradle-plugin/package.json
+++ b/packages/react-native-gradle-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-gradle-plugin",
-  "version": "0.71.2",
+  "version": "0.71.4",
   "description": "⚛️ Gradle Plugin for React Native",
   "homepage": "https://github.com/facebook/react-native/tree/HEAD/packages/react-native-gradle-plugin",
   "repository": {


### PR DESCRIPTION
Summary:
This unblocks the Android Template CI jobs which are currently red.
The reason is that the way how the `exclude` is computed is different
between RN Tester and the template (relative/absolute paths).

By adding `**` to the exclude regexes, this will make it work for both scenarios.

Changelog:
[Internal] [Changed] - Fix broken template tests due to missing boost headers

Reviewed By: cipolleschi

Differential Revision: D39968622

