### PR TITLE
Add setup-nightly script for 3rd party libs to test nightly builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "scripts/react_native_pods.rb",
     "scripts/cocoapods",
     "scripts/react-native-xcode.sh",
+    "scripts/setup-nightly.js",
     "sdks/.hermesversion",
     "sdks/hermes-engine",
     "sdks/hermesc",

--- a/scripts/publish-npm.js
+++ b/scripts/publish-npm.js
@@ -196,6 +196,14 @@ if (isCommitly) {
   }
 }
 
+// Add setup-nightly.js postinstall script for nightly build
+if (nightlyBuild) {
+  const packageJsonPath = path.join(tmpPublishingFolder, 'package.json');
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+  packageJson.scripts.postinstall = './scripts/setup-nightly.js';
+  fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
+}
+
 // -------- Generating Android Artifacts
 env.REACT_NATIVE_SKIP_PREFAB = true;
 if (exec('./gradlew :ReactAndroid:installArchives').code) {

--- a/scripts/setup-nightly.js
+++ b/scripts/setup-nightly.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const {exit} = require('process');
+
+const ROOT_DIR = path.join(__dirname, '..');
+
+// Version for nightly build. Since third party libraries used to check the minor version for feature detections.
+// The nightly build version we published to npm is `0.0.0` which will break third party libraries assumption.
+// This script will overwrite the nightly build version as `999.999.999`.
+const NIGHTLY_VERSION = '999.999.999';
+
+async function main() {
+  // Rewrite version in _package.json_
+  const packageJsonPath = path.join(ROOT_DIR, 'package.json');
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+  packageJson.version = NIGHTLY_VERSION;
+  fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
+
+  // Rewrite version in _ReactAndroid/gradle.properties_
+  const gradlePropertiesPath = path.join(
+    ROOT_DIR,
+    'ReactAndroid',
+    'gradle.properties',
+  );
+  let content = fs.readFileSync(gradlePropertiesPath, 'utf-8');
+  content = content.replace(/^(VERSION_NAME)(.*)$/gm, `$1=${NIGHTLY_VERSION}`);
+  fs.writeFileSync(gradlePropertiesPath, content);
+}
+
+main().then(() => {
+  exit(0);
+});

--- a/sdks/hermes-engine/hermes-engine.podspec
+++ b/sdks/hermes-engine/hermes-engine.podspec
@@ -28,7 +28,7 @@ git = "https://github.com/facebook/hermes.git"
 if ENV.has_key?('HERMES_ENGINE_TARBALL_PATH')
   Pod::UI.puts '[Hermes] Using pre-built Hermes binaries from local path.' if Object.const_defined?("Pod::UI")
   source[:http] = "file://#{ENV['HERMES_ENGINE_TARBALL_PATH']}"
-elsif version == '1000.0.0'
+elsif version == '1000.0.0' || version == '999.999.999'
   Pod::UI.puts '[Hermes] Installing hermes-engine may take a while, building Hermes from source...'.yellow if Object.const_defined?("Pod::UI")
   source[:git] = git
   source[:commit] = `git ls-remote https://github.com/facebook/hermes main | cut -f 1`.strip


### PR DESCRIPTION
## Summary

Most third-party libraries used to deal with react-native breaking changes by checking the package version, e.g. [expo](https://github.com/expo/expo/blob/f2b83416fd7bdf6cee98c7815cf29c32fa5577eb/packages/expo-modules-core/android/build.gradle#L76) or [reanimated](https://github.com/software-mansion/react-native-reanimated/blob/1fcf2e288f5236bb2cdd340c51b1c801ecd9e6f8/RNReanimated.podspec#L68). However, the nightly build version on npm is something like `0.0.0-20221001-2020-436362670`. If we check the version, that would be the oldest version.

I've tried to visit some proper solutions. If we try to publish nightly versions as `0.999.0` or even `1000.999.0`. That would be strange because there're newer published versions on npm than release versions. Maybe the current state to keep the 0.0.0 as nightly builds would still be a good idea. As a workaround, this PR tries to add the `setup-nightly.js` postinstall script. It will rewrite the version after installing the package:
  - Rewrite version in _package.json_ as `999.999.999`
  - Rewrite VERSION_NAME in _ReactAndroid/gradle.properties_ as `999.999.999`

## Changelog

[General] [Fixed] - Fix nightly builds break version detection for third-party libraries

## Test Plan

#### Test install local pakcage

1. `cd /path/to/react-native ; npm pack --pack-destination $HOME`
2. `cd /path/to/app ; yarn add file:$HOME/react-native-1000.0.0.tgz`
check whether the versions in pacakge.json and gradle.properties are 999.999.999
3. test build and launch both on android and ios

#### Publish nightly build

I didn't test the publishing workflow. Maybe we should check whether CI results.