### PR TITLE
Fix issues for nightly build

### DIFF
--- a/scripts/publish-npm.js
+++ b/scripts/publish-npm.js
@@ -210,9 +210,6 @@ if (exec('./gradlew :ReactAndroid:hermes-engine:installArchives').code) {
   exit(1);
 }
 
-// undo uncommenting javadoc setting
-revertFiles(['ReactAndroid/gradle.properties'], tmpPublishingFolder);
-
 echo('Generated artifacts for Maven');
 
 let artifacts = [

--- a/scripts/publish-npm.js
+++ b/scripts/publish-npm.js
@@ -37,7 +37,6 @@ const {
   exitIfNotOnGit,
   getCurrentCommit,
   isTaggedLatest,
-  revertFiles,
   saveFiles,
 } = require('./scm-utils');
 const fs = require('fs');

--- a/sdks/hermes-engine/hermes-engine.podspec
+++ b/sdks/hermes-engine/hermes-engine.podspec
@@ -28,7 +28,7 @@ git = "https://github.com/facebook/hermes.git"
 if ENV.has_key?('HERMES_ENGINE_TARBALL_PATH')
   Pod::UI.puts '[Hermes] Using pre-built Hermes binaries from local path.' if Object.const_defined?("Pod::UI")
   source[:http] = "file://#{ENV['HERMES_ENGINE_TARBALL_PATH']}"
-elsif version == '1000.0.0'
+elsif version == '1000.0.0' || version.start_with?('0.0.0-')
   Pod::UI.puts '[Hermes] Installing hermes-engine may take a while, building Hermes from source...'.yellow if Object.const_defined?("Pod::UI")
   source[:git] = git
   source[:commit] = `git ls-remote https://github.com/facebook/hermes main | cut -f 1`.strip


### PR DESCRIPTION
## Summary

There are two issues from nightly builds.

#### 1. `VERSION_NAME=1000.0.0-main` in  _ReactAndroid/gradle.properties_ 

the solution is to remove unused _ReactAndroid/gradle.properties_  git revert when publishing package.

#### 2. `pod install` error from downloading hermes, e.g. the url is unavailable. `https://github.com/facebook/react-native/releases/download/v0.0.0-20221002-2027-2319f75c8/hermes-runtime-darwin-debug-v0.0.0-20221002-2027-2319f75c8.tar.gz`

fix _hermes-engine.podspec_ to support nightly build and build hermes from main branch.
  
## Changelog

[General] [Fixed] - Fix nightly build issues

## Test Plan

1. i cannot fully test publish-npm.js workflow and it stops at `npm publish`. i can just check at this moment, the _ReactAndroid/gradle.properties_ is right.
2. create a `npx react-native init` project and `yarn add react-native@nightly`. patch `node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec` and try `pod install`
