### PR TITLE
Make autorebase less restrictive

### DIFF
--- a/.github/workflows/autorebase.yml
+++ b/.github/workflows/autorebase.yml
@@ -10,7 +10,7 @@ jobs:
       contents: write  # for cirrus-actions/rebase to push code to rebase
       pull-requests: read  # for cirrus-actions/rebase to get info about PR
     name: Rebase
-    if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/rebase') && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER')
+    if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/rebase')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the latest code


### PR DESCRIPTION
## Summary

Currently the autorebase feature doesn't work because it fails the `if` validation due to how we distribute permissions.

For now I'm making this action less restricted. We can tweak it if we notice abuse.
Config now is the same as https://github.com/cirrus-actions/rebase

## Changelog

[Internal] - Make autorebase less restrictive

## Test Plan

Nothing to test