### PR TITLE
codegen module names are messed up when using ts files for source

### DIFF
--- a/packages/react-native-codegen/src/parsers/flow/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/index.js
@@ -88,7 +88,7 @@ function buildSchema(contents: string, filename: ?string): SchemaType {
       if (filename === undefined || filename === null) {
         throw new Error('Filepath expected while parasing a module');
       }
-      const hasteModuleName = path.basename(filename).replace(/\.js$/, '');
+      const hasteModuleName = path.basename(filename).replace(/\.[jt]s$/, '');
 
       const [parsingErrors, tryParse] = createParserErrorCapturer();
       const schema = tryParse(() =>


### PR DESCRIPTION
Codegen modules names strip the file extension when the file is a .js file.  But when using ts files for a spec file, the modulename ends up with a .ts in the name.

This is causing the @react-native-windows\codegen project to produce invalid C++ files, as it tries to name structs Foo.tsSpec when it should call it FooSpec.

## Changelog
[Internal] [Fixed] - codegen module names are messed up when using TypeScript