### PR TITLE
infra(e2e): fix enabling new arch for RNTester iOS in the E2E script

### DIFF
--- a/scripts/test-e2e-local.js
+++ b/scripts/test-e2e-local.js
@@ -79,7 +79,7 @@ if (argv.target === 'RNTester') {
     exec(
       `cd packages/rn-tester && USE_HERMES=${
         argv.hermes ? 1 : 0
-      } bundle exec pod install --ansi`,
+      } RCT_NEW_ARCH_ENABLED=1 bundle exec pod install --ansi`,
     );
 
     // if everything succeeded so far, we can launch Metro and the app

--- a/scripts/test-e2e-local.js
+++ b/scripts/test-e2e-local.js
@@ -74,7 +74,7 @@ if (argv.target === 'RNTester') {
     console.info(
       `We're going to test the ${
         argv.hermes ? 'Hermes' : 'JSC'
-      } version of RNTester iOS`,
+      } version of RNTester iOS with the new Architecture enabled`,
     );
     exec(
       `cd packages/rn-tester && USE_HERMES=${
@@ -98,7 +98,7 @@ if (argv.target === 'RNTester') {
     console.info(
       `We're going to test the ${
         argv.hermes ? 'Hermes' : 'JSC'
-      } version of RNTester Android`,
+      } version of RNTester Android with the new Architecture enabled`,
     );
     exec(
       `./gradlew :packages:rn-tester:android:app:${


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Quick follow up to https://github.com/facebook/react-native/pull/34513 to fix an issue that has been bothering the release crew for a while: the iOS new arch component not working! Turns out, we're silly billies 🤣

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[Internal] [Changed] - Add new arch flag to iOS pod install command in E2E script

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Everything works correctly now:

<img width="987" alt="Screenshot 2022-10-06 at 14 20 09" src="https://user-images.githubusercontent.com/16104054/194327768-4da7d607-879b-46ad-a453-504983980831.png">
