### PR TITLE
Circle CI: do not share .git cache across different operating systems

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,12 +133,12 @@ commands:
     steps:
       - restore_cache:
             keys:
-              - << parameters.checkout_base_cache_key >>-{{ .Branch }}-{{ .Revision }}
-              - << parameters.checkout_base_cache_key >>-{{ .Branch }}-
-              - << parameters.checkout_base_cache_key >>
+              - << parameters.checkout_base_cache_key >>-{{ arch }}-{{ .Branch }}-{{ .Revision }}
+              - << parameters.checkout_base_cache_key >>-{{ arch }}-{{ .Branch }}-
+              - << parameters.checkout_base_cache_key >>-{{ arch }}-
       - checkout
       - save_cache:
-          key: << parameters.checkout_base_cache_key >>-{{ .Branch }}-{{ .Revision }}
+          key: << parameters.checkout_base_cache_key >>-{{ arch }}-{{ .Branch }}-{{ .Revision }}
           paths:
             - ".git"
 


### PR DESCRIPTION
Summary:
We use workflows extensively in Circle CI, so caching a git checkout should help speed up tests when downstream jobs need to checkout the repository. In the current configuration, the Windows job is most likely to run and write to the .git cache first, which results in permission issues when the .git cache is loaded onto macOS or linux hosts.

By splitting the cache by architecture, we may lose on some reusability across jobs with distinct architectures, but it ensures we avoid cross-platform permission issues.

Changelog: [Internal]

Differential Revision: D40150781

