### PR TITLE
Fix warnings around mixing int and size_t usage in unsafe ways

### DIFF
--- a/ReactCommon/react/renderer/core/LayoutableShadowNode.cpp
+++ b/ReactCommon/react/renderer/core/LayoutableShadowNode.cpp
@@ -27,15 +27,15 @@ static LayoutableSmallVector<Rect> calculateTransformedFrames(
   auto transformedFrames = LayoutableSmallVector<Rect>{size};
   auto transformation = Transform::Identity();
 
-  for (int i = size - 1; i >= 0; --i) {
+  for (auto i = size; i > 0; --i) {
     auto currentShadowNode =
-        traitCast<LayoutableShadowNode const *>(shadowNodeList.at(i));
+        traitCast<LayoutableShadowNode const *>(shadowNodeList.at(i - 1));
     auto currentFrame = currentShadowNode->getLayoutMetrics().frame;
 
     if (policy.includeTransform) {
       if (Transform::isVerticalInversion(transformation)) {
         auto parentShadowNode =
-            traitCast<LayoutableShadowNode const *>(shadowNodeList.at(i + 1));
+            traitCast<LayoutableShadowNode const *>(shadowNodeList.at(i));
         currentFrame.origin.y =
             parentShadowNode->getLayoutMetrics().frame.size.height -
             currentFrame.size.height - currentFrame.origin.y;
@@ -43,15 +43,15 @@ static LayoutableSmallVector<Rect> calculateTransformedFrames(
 
       if (Transform::isHorizontalInversion(transformation)) {
         auto parentShadowNode =
-            traitCast<LayoutableShadowNode const *>(shadowNodeList.at(i + 1));
+            traitCast<LayoutableShadowNode const *>(shadowNodeList.at(i));
         currentFrame.origin.x =
             parentShadowNode->getLayoutMetrics().frame.size.width -
             currentFrame.size.width - currentFrame.origin.x;
       }
 
-      if (i != size - 1) {
+      if (i != size) {
         auto parentShadowNode =
-            traitCast<LayoutableShadowNode const *>(shadowNodeList.at(i + 1));
+            traitCast<LayoutableShadowNode const *>(shadowNodeList.at(i));
         auto contentOritinOffset = parentShadowNode->getContentOriginOffset();
         if (Transform::isVerticalInversion(transformation)) {
           contentOritinOffset.y = -contentOritinOffset.y;
@@ -65,7 +65,7 @@ static LayoutableSmallVector<Rect> calculateTransformedFrames(
       transformation = transformation * currentShadowNode->getTransform();
     }
 
-    transformedFrames[i] = currentFrame;
+    transformedFrames[i - 1] = currentFrame;
   }
 
   return transformedFrames;


### PR DESCRIPTION
## Summary
react-native-windows builds treat a lot of c++ compiler warnings as errors.  Including ones that cause value truncation when assigning `size_t` values to an `int`.

This fixes the compiler warning, by using `size_t` as the type for `i`, which matches `size`.  I then modified the loop to avoid the value underflow that occurs when decrementing an unsigned zero value.

## Changelog
[Internal] [Changed] - Fix compiler warnings around mixing int and size_t usage in unsafe ways

## Test Plan
This code change was made in react-native-windows when integrating latest react-native changes.  -- our fabric implementation was able to run through this code without any issues.
