### PR TITLE
A hotfix for the issue with calling onChange for multiline input on blur

### DIFF
--- a/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.m
+++ b/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.m
@@ -77,7 +77,7 @@ static void *TextFieldSelectionObservingContext = &TextFieldSelectionObservingCo
     return NO;
   }
 
-  if ([newText isEqualToString:string]) {
+  if ([newText isEqualToString:string] && ![newText isEqualToString:@""]) {
     _textDidChangeIsComing = YES;
     return YES;
   }
@@ -229,7 +229,7 @@ static void *TextFieldSelectionObservingContext = &TextFieldSelectionObservingCo
     return NO;
   }
 
-  if ([newText isEqualToString:text]) {
+  if ([newText isEqualToString:text] && ![newText isEqualToString:@""]) {
     _textDidChangeIsComing = YES;
     return YES;
   }


### PR DESCRIPTION
## Summary
Fix #34891 
Added additional checks In Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.m file in order to avoid setting _textDidChangeIsComing flag as YES when input text value is empty string. It makes sense since this flag is used to maintain calling onChange during autocorrection, but no autocorrection is possible for the empty string, is n't it?

## Changelog
[IOS] [Fixed] - fixed setting _textDidChangeIsComing flag in Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.m file when input is empty and backspace was pressed

## Test Plan
I just checked steps to reproduce from #34891 issue.
This scenario is implemented in [expo snack](https://snack.expo.dev/@eyshella/textinput-multiline-weird-onchange) by the way