### PR TITLE
Fix forward: Filtering platform in codegen

### DIFF
--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/GenerateCodegenSchemaTask.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/GenerateCodegenSchemaTask.kt
@@ -61,6 +61,7 @@ abstract class GenerateCodegenSchemaTask : Exec() {
   }
 
   internal fun setupCommandLine() {
+    // TODO: restore the --platform android parameters as soon as we publish the codegen package.
     commandLine(
         windowsAwareCommandLine(
             *nodeExecutableAndArgs.get().toTypedArray(),
@@ -69,8 +70,8 @@ abstract class GenerateCodegenSchemaTask : Exec() {
                 .get()
                 .asFile
                 .absolutePath,
-            "--platform",
-            "android",
+            // "--platform",
+            // "android",
             generatedSchemaFile.get().asFile.absolutePath,
             jsRootDir.asFile.get().absolutePath,
         ))

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/GenerateCodegenSchemaTaskTest.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/GenerateCodegenSchemaTaskTest.kt
@@ -142,13 +142,13 @@ class GenerateCodegenSchemaTaskTest {
         }
 
     task.setupCommandLine()
-
+    // TODO: restore the --platform android parameters as soon as we publish the codegen package.
     assertEquals(
         listOf(
             "--verbose",
             File(codegenDir, "lib/cli/combine/combine-js-to-schema-cli.js").toString(),
-            "--platform",
-            "android",
+            // "--platform",
+            // "android",
             File(outputDir, "schema.json").toString(),
             jsRootDir.toString(),
         ),

--- a/scripts/codegen/generate-artifacts-executor.js
+++ b/scripts/codegen/generate-artifacts-executor.js
@@ -311,6 +311,7 @@ function generateSchema(tmpDir, library, node, codegenCliPath) {
 
   console.log(`\n\n[Codegen] >>>>> Processing ${library.config.name}`);
   // Generate one schema for the entire library...
+  // TODO: restore the `--platform ios` parameters as soon as we publish the codegen package.
   executeNodeScript(
     node,
     `${path.join(
@@ -319,7 +320,7 @@ function generateSchema(tmpDir, library, node, codegenCliPath) {
       'cli',
       'combine',
       'combine-js-to-schema-cli.js',
-    )} --platform ios ${pathToSchema} ${pathToJavaScriptSources}`,
+    )} ${pathToSchema} ${pathToJavaScriptSources}`,
   );
   console.log(`[Codegen] Generated schema: ${pathToSchema}`);
   return pathToSchema;


### PR DESCRIPTION
Summary:
This [commit](https://github.com/facebook/react-native/commit/7680bdeb4f96a8092393372a59c77a9d7b729cae) added the possibility to create a Codegen specs that are platform specific.
However, it also modifies how the codegen is invoked and we need to publish a new version of the `react-native-codegen` package on NPM before we can use that feature.

## Changelog:
[General][Fixed] - Remove usage of the codegen spec filtering until we publish a new version of the codegen.

Differential Revision: D40176447

