### PR TITLE
Check for system bars apperance on newer SDKs

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
@@ -330,7 +330,7 @@ public class ReactModalHostView extends ViewGroup
         if (Build.VERSION.SDK_INT > Build.VERSION_CODES.R) {
           mDialog
               .getWindow()
-              .getInsetsController();
+              .getInsetsController()
               .setSystemBarsAppearance(
                   ((Activity) context).getWindow().getInsetsController().getSystemBarsAppearance());
         } else {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
@@ -328,11 +328,14 @@ public class ReactModalHostView extends ViewGroup
       mDialog.show();
       if (context instanceof Activity) {
         if (Build.VERSION.SDK_INT > Build.VERSION_CODES.R) {
+          int appearance = ((Activity) context)
+              .getWindow()
+              .getInsetsController()
+              .getSystemBarsAppearance();
           mDialog
               .getWindow()
               .getInsetsController()
-              .setSystemBarsAppearance(
-                  ((Activity) context).getWindow().getInsetsController().getSystemBarsAppearance());
+              .setSystemBarsAppearance(appearance, appearance);
         } else {
           mDialog
               .getWindow()

--- a/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
@@ -12,6 +12,7 @@ import android.app.Activity;
 import android.app.Dialog;
 import android.content.Context;
 import android.content.DialogInterface;
+import android.os.Build;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.View;
@@ -326,11 +327,19 @@ public class ReactModalHostView extends ViewGroup
     if (currentActivity != null && !currentActivity.isFinishing()) {
       mDialog.show();
       if (context instanceof Activity) {
-        mDialog
-            .getWindow()
-            .getDecorView()
-            .setSystemUiVisibility(
-                ((Activity) context).getWindow().getDecorView().getSystemUiVisibility());
+        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.R) {
+          mDialog
+              .getWindow()
+              .getInsetsController();
+              .setSystemBarsAppearance(
+                  ((Activity) context).getWindow().getInsetsController().getSystemBarsAppearance());
+        } else {
+          mDialog
+              .getWindow()
+              .getDecorView()
+              .setSystemUiVisibility(
+                  ((Activity) context).getWindow().getDecorView().getSystemUiVisibility());
+        }
       }
       mDialog.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE);
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

As identified in https://github.com/facebook/react-native/issues/34350, modals do not honor the system's status bar colors because they may not be set by the deprecated `systemUiVisibility` flags. Unless `android:windowLightStatusBar` is set to true, the default flag is a zero-integer (a.k.a. "dark mode", where the icons show as white). Since the `StatusBar` component is using the new `setSystemBarsAppearance` API, the ModalHost should also infer its status bar settings from the same API. Some additional context can be found in [my comment here](https://github.com/facebook/react-native/issues/34350#issuecomment-1271779890).

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[Android] [Fixed] - Fixed an issue on Android API 31+ where modals would turn status bar icons white by default

## Test Plan

- On a screen with the `StatusBar` bar style set to `dark-content`, the modal also uses white icons
- On a screen with the `StatusBar` bar style set to `light-content`, the modal also uses black icons

### Preview

Here, I change the `barStyle` from `light-content` to `dark-content` and demonstrate that the proper attributes are retained. The "Before" is a recording from `main` and the "After" is this branch. Notice how in "Before", the status bar is always turning the icons white when the modal opens.

|Before|After|
|-|-|
|![ezgif-5-586e81991d](https://user-images.githubusercontent.com/10366495/194954666-71f69bd6-c02a-4725-9562-e1f5fcfdeddf.gif)|![ezgif-5-b212d7bb01](https://user-images.githubusercontent.com/10366495/194954244-9c205821-1d7f-4630-861b-f5dbe207f7cd.gif)|

## Other considerations

There's some argument towards removing this check entirely--the status bar appearance should be derived from the theming and/or the parent activity's settings, thereby removing the need to apply separate styling