### PR TITLE
[Codegen] Extract RootTag case of translateTypeAnnotation from the flow and typescript folders in parsers-primitives

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-primitives-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-primitives-test.js
@@ -15,7 +15,8 @@ const {
   emitBoolean,
   emitNumber,
   emitInt32,
-} = require('../parsers-primitives.js');
+  emitRootTag,
+} = require('../parsers-primitives');
 
 describe('emitBoolean', () => {
   describe('when nullable is true', () => {
@@ -91,6 +92,32 @@ describe('emitNumber', () => {
       };
 
       expect(result).toEqual(expected);
+    });
+  });
+});
+
+describe('emitRootTag', () => {
+  const reservedTypeAnnotation = {
+    type: 'ReservedTypeAnnotation',
+    name: 'RootTag',
+  };
+
+  describe('when nullable is true', () => {
+    it('returns nullable type annotation', () => {
+      const result = emitRootTag(true);
+
+      expect(result).toEqual({
+        type: 'NullableTypeAnnotation',
+        typeAnnotation: reservedTypeAnnotation,
+      });
+    });
+  });
+
+  describe('when nullable is false', () => {
+    it('returns non nullable type annotation', () => {
+      const result = emitRootTag(false);
+
+      expect(result).toEqual(reservedTypeAnnotation);
     });
   });
 });

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -37,6 +37,7 @@ const {
   emitBoolean,
   emitNumber,
   emitInt32,
+  emitRootTag,
 } = require('../../parsers-primitives');
 const {
   IncorrectlyParameterizedFlowGenericParserError,
@@ -86,10 +87,7 @@ function translateTypeAnnotation(
     case 'GenericTypeAnnotation': {
       switch (typeAnnotation.id.name) {
         case 'RootTag': {
-          return wrapNullable(nullable, {
-            type: 'ReservedTypeAnnotation',
-            name: 'RootTag',
-          });
+          return emitRootTag(nullable);
         }
         case 'Promise': {
           assertGenericTypeAnnotationHasExactlyOneTypeParameter(

--- a/packages/react-native-codegen/src/parsers/parsers-primitives.js
+++ b/packages/react-native-codegen/src/parsers/parsers-primitives.js
@@ -15,6 +15,7 @@ import type {
   Int32TypeAnnotation,
   NativeModuleNumberTypeAnnotation,
   Nullable,
+  ReservedTypeAnnotation,
 } from '../CodegenSchema';
 
 const {wrapNullable} = require('./parsers-commons');
@@ -39,8 +40,16 @@ function emitNumber(
   });
 }
 
+function emitRootTag(nullable: boolean): Nullable<ReservedTypeAnnotation> {
+  return wrapNullable(nullable, {
+    type: 'ReservedTypeAnnotation',
+    name: 'RootTag',
+  });
+}
+
 module.exports = {
   emitBoolean,
   emitInt32,
   emitNumber,
+  emitRootTag,
 };

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -37,6 +37,7 @@ const {
   emitBoolean,
   emitNumber,
   emitInt32,
+  emitRootTag,
 } = require('../../parsers-primitives');
 const {
   IncorrectlyParameterizedTypeScriptGenericParserError,
@@ -194,10 +195,7 @@ function translateTypeAnnotation(
     case 'TSTypeReference': {
       switch (typeAnnotation.typeName.name) {
         case 'RootTag': {
-          return wrapNullable(nullable, {
-            type: 'ReservedTypeAnnotation',
-            name: 'RootTag',
-          });
+          return emitRootTag(nullable);
         }
         case 'Promise': {
           assertGenericTypeAnnotationHasExactlyOneTypeParameter(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
This PR aims to reduce code duplication by extracting `emitRootTag` logic from the flow and typescript folders into a shared parsers-primitives file. It is a task of #34872:
> Extract the content of the case 'RootTag' (Flow TypeScript) into a single emitRootTag function in the parsers-primitives.js file. Use the new function in the parsers.

~~Note that #34898 should be merged first. I rebased on it's branch.~~

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
[Internal] [Changed] - Extract RootTag case of translateTypeAnnotation from the flow and typescript folders in parsers-primitives

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
All tests are passing, with `yarn jest react-native-codegen`:
<img width="934" alt="image" src="https://user-images.githubusercontent.com/40902940/194777150-6136c1b6-11f8-4e21-829b-fda418b6925c.png">

