### PR TITLE
[react devtools] Pass a CachedSettingsStore to `connectToDevTools`

### DIFF
--- a/Libraries/Core/cachedSettingsStore.js
+++ b/Libraries/Core/cachedSettingsStore.js
@@ -1,0 +1,29 @@
+
+const settingsModule = require('../Settings/Settings');
+const REACT_DEVTOOLS_SETTINGS_KEY_PREFIX = 'ReactDevTools::Settings::';
+
+export type CachedSettingsStore = {
+  setValue: (key: string, value: string) => void,
+  getValue: (key: string) => ?string,
+};
+
+function getFullKey(suffix: string): string {
+  return `${REACT_DEVTOOLS_SETTINGS_KEY_PREFIX}${suffix}`;
+}
+
+const cachedSettingsStore: CachedSettingsStore = {
+  setValue: (key, value) => {
+    try {
+      settingsModule.set({
+        [getFullKey(key)]: value,
+      });
+    } catch {}
+  },
+  getValue: (key) => {
+    try {
+      return settingsModule.get(getFullKey(key));
+    } catch {}
+  },
+};
+
+module.exports = cachedSettingsStore;

--- a/Libraries/Core/setUpReactDevTools.js
+++ b/Libraries/Core/setUpReactDevTools.js
@@ -62,6 +62,7 @@ if (__DEV__) {
       });
 
       const ReactNativeStyleAttributes = require('../Components/View/ReactNativeStyleAttributes');
+      const cachedSettingsStore = require('./cachedSettingsStore');
 
       reactDevTools.connectToDevTools({
         isAppActive,
@@ -70,6 +71,7 @@ if (__DEV__) {
           ReactNativeStyleAttributes,
         ),
         websocket: ws,
+        cachedSettingsStore,
       });
     }
   };


### PR DESCRIPTION
## Summary

* Expose an interface atom the existing settings module (`Libraries/Settings/Settings`) that namespaces all gets/sets
* Pass this to `connectToDevTools`.
* See https://github.com/facebook/react/pull/25452 for the use of this on the DevTools side.

## Test plan

See https://github.com/facebook/react/pull/25452

## Changelog

[General] [Added] Pass `cachedSettingsStore` to `connectToDevTools` to support persisted settings.

## Android

* This **does not work with Android**, because the `Settings/Settings` module is not implemented for Android. However, all calls to `cachedSettingsStore` are wrapped in try/catch blocks, so we're good — this will be implemented as a follow up.