### PR TITLE
[Codegen]: Extract contents of the case 'BooleanTypeAnnotation' into a single emitBoolean function

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-primitives-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-primitives-test.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+'use-strict';
+
+const {emitBoolean} = require('../parsers-primitives.js');
+
+describe('emitBoolean', () => {
+  describe('when nullable is true', () => {
+    it('returns nullable type annotation', () => {
+      const result = emitBoolean(true);
+      const expected = {
+        type: 'NullableTypeAnnotation',
+        typeAnnotation: {
+          type: 'BooleanTypeAnnotation',
+        },
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+  describe('when nullable is false', () => {
+    it('returns non nullable type annotation', () => {
+      const result = emitBoolean(false);
+      const expected = {
+        type: 'BooleanTypeAnnotation',
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+});

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -33,6 +33,7 @@ const {
   isModuleRegistryCall,
 } = require('../utils.js');
 const {unwrapNullable, wrapNullable} = require('../../parsers-commons');
+const {emitBoolean} = require('../../parsers-primitives');
 const {
   IncorrectlyParameterizedFlowGenericParserError,
   MisnamedModuleFlowInterfaceParserError,
@@ -362,9 +363,7 @@ function translateTypeAnnotation(
       });
     }
     case 'BooleanTypeAnnotation': {
-      return wrapNullable(nullable, {
-        type: 'BooleanTypeAnnotation',
-      });
+      return emitBoolean(nullable);
     }
     case 'NumberTypeAnnotation': {
       return wrapNullable(nullable, {

--- a/packages/react-native-codegen/src/parsers/parsers-primitives.js
+++ b/packages/react-native-codegen/src/parsers/parsers-primitives.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow strict
+ */
+
+'use strict';
+
+import type {BooleanTypeAnnotation, Nullable} from '../CodegenSchema';
+
+const {wrapNullable} = require('./parsers-commons');
+
+function emitBoolean(nullable: boolean): Nullable<BooleanTypeAnnotation> {
+  return wrapNullable(nullable, {
+    type: 'BooleanTypeAnnotation',
+  });
+}
+
+module.exports = {
+  emitBoolean,
+};

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -33,6 +33,7 @@ const {
   isModuleRegistryCall,
 } = require('../utils.js');
 const {unwrapNullable, wrapNullable} = require('../../parsers-commons');
+const {emitBoolean} = require('../../parsers-primitives');
 const {
   IncorrectlyParameterizedTypeScriptGenericParserError,
   MisnamedModuleTypeScriptInterfaceParserError,
@@ -397,9 +398,7 @@ function translateTypeAnnotation(
       });
     }
     case 'TSBooleanKeyword': {
-      return wrapNullable(nullable, {
-        type: 'BooleanTypeAnnotation',
-      });
+      return emitBoolean(nullable);
     }
     case 'TSNumberKeyword': {
       return wrapNullable(nullable, {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Part of https://github.com/facebook/react-native/issues/34872

This PR extracts the content of the case 'BooleanTypeAnnotation' ([Flow](https://github.com/facebook/react-native/blob/b444f0e44e0d8670139acea5f14c2de32c5e2ddc/packages/react-native-codegen/src/parsers/flow/modules/index.js#L365-L367), [TypeScript](https://github.com/facebook/react-native/blob/00b795642a6562fb52d6df12e367b84674994623/packages/react-native-codegen/src/parsers/typescript/modules/index.js#L400-L402)) into a single emitBoolean function in the parsers-primitives.js file. Use the new function in the parsers.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[Internal] [Changed] - Extract contents of the case 'BooleanTypeAnnotation' into a single emitBoolean function

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
Run ```yarn jest react-native-codegen```

<img width="803" alt="image" src="https://user-images.githubusercontent.com/34857453/194751101-3b1a619e-332a-43a9-bfa3-35f5869d7c5f.png">

