### PR TITLE
[Codegen] extract emitDouble from parsers modules to shared parsers-primitives

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-primitives-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-primitives-test.js
@@ -15,6 +15,7 @@ const {
   emitBoolean,
   emitNumber,
   emitInt32,
+  emitDouble,
 } = require('../parsers-primitives.js');
 
 describe('emitBoolean', () => {
@@ -88,6 +89,32 @@ describe('emitNumber', () => {
       const result = emitNumber(false);
       const expected = {
         type: 'NumberTypeAnnotation',
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+});
+
+describe('emitDouble', () => {
+  describe('when nullable is true', () => {
+    it('returns nullable type annotation', () => {
+      const result = emitDouble(true);
+      const expected = {
+        type: 'NullableTypeAnnotation',
+        typeAnnotation: {
+          type: 'DoubleTypeAnnotation',
+        },
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+  describe('when nullable is false', () => {
+    it('returns non nullable type annotation', () => {
+      const result = emitDouble(false);
+      const expected = {
+        type: 'DoubleTypeAnnotation',
       };
 
       expect(result).toEqual(expected);

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -37,6 +37,7 @@ const {
   emitBoolean,
   emitNumber,
   emitInt32,
+  emitDouble,
 } = require('../../parsers-primitives');
 const {
   IncorrectlyParameterizedFlowGenericParserError,
@@ -202,9 +203,7 @@ function translateTypeAnnotation(
           return emitInt32(nullable);
         }
         case 'Double': {
-          return wrapNullable(nullable, {
-            type: 'DoubleTypeAnnotation',
-          });
+          return emitDouble(nullable);
         }
         case 'Float': {
           return wrapNullable(nullable, {

--- a/packages/react-native-codegen/src/parsers/parsers-primitives.js
+++ b/packages/react-native-codegen/src/parsers/parsers-primitives.js
@@ -14,6 +14,7 @@ import type {
   BooleanTypeAnnotation,
   Int32TypeAnnotation,
   NativeModuleNumberTypeAnnotation,
+  DoubleTypeAnnotation,
   Nullable,
 } from '../CodegenSchema';
 
@@ -39,8 +40,15 @@ function emitNumber(
   });
 }
 
+function emitDouble(nullable: boolean): Nullable<DoubleTypeAnnotation> {
+  return wrapNullable(nullable, {
+    type: 'DoubleTypeAnnotation',
+  });
+}
+
 module.exports = {
   emitBoolean,
   emitInt32,
   emitNumber,
+  emitDouble,
 };

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -37,6 +37,7 @@ const {
   emitBoolean,
   emitNumber,
   emitInt32,
+  emitDouble,
 } = require('../../parsers-primitives');
 const {
   IncorrectlyParameterizedTypeScriptGenericParserError,
@@ -235,9 +236,7 @@ function translateTypeAnnotation(
           return emitInt32(nullable);
         }
         case 'Double': {
-          return wrapNullable(nullable, {
-            type: 'DoubleTypeAnnotation',
-          });
+          return emitDouble(nullable);
         }
         case 'Float': {
           return wrapNullable(nullable, {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Part of https://github.com/facebook/react-native/issues/34872

This PR extracts the content of the case 'Double' ([Flow](https://github.com/facebook/react-native/blob/b444f0e44e0d8670139acea5f14c2de32c5e2ddc/packages/react-native-codegen/src/parsers/flow/modules/index.js#L202-L204), [TypeScript](https://github.com/facebook/react-native/blob/00b795642a6562fb52d6df12e367b84674994623/packages/react-native-codegen/src/parsers/typescript/modules/index.js#L1235-L237)) into a single emitDouble function in the parsers-primitives.js file. Use the new function in the parsers.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[Internal] [Changed] - Extract contents of the case 'Double' into a single emitDouble function inside parsers-primitives

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

I tested using jest and flow commands.