### PR TITLE
[Codegen] Extract TypeAlias logic of translateTypeAnnotation from the flow and typescript folders in parsers-primitives

### DIFF
--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -39,6 +39,7 @@ const {
   emitNumber,
   emitInt32,
   emitRootTag,
+  typeAliasResolution,
 } = require('../../parsers-primitives');
 const {
   IncorrectlyParameterizedGenericParserError,
@@ -328,48 +329,12 @@ function translateTypeAnnotation(
           .filter(Boolean),
       };
 
-      if (!typeAliasResolutionStatus.successful) {
-        return wrapNullable(nullable, objectTypeAnnotation);
-      }
-
-      /**
-       * All aliases RHS are required.
-       */
-      aliasMap[typeAliasResolutionStatus.aliasName] = objectTypeAnnotation;
-
-      /**
-       * Nullability of type aliases is transitive.
-       *
-       * Consider this case:
-       *
-       * type Animal = ?{
-       *   name: string,
-       * };
-       *
-       * type B = Animal
-       *
-       * export interface Spec extends TurboModule {
-       *   +greet: (animal: B) => void;
-       * }
-       *
-       * In this case, we follow B to Animal, and then Animal to ?{name: string}.
-       *
-       * We:
-       *   1. Replace `+greet: (animal: B) => void;` with `+greet: (animal: ?Animal) => void;`,
-       *   2. Pretend that Animal = {name: string}.
-       *
-       * Why do we do this?
-       *  1. In ObjC, we need to generate a struct called Animal, not B.
-       *  2. This design is simpler than managing nullability within both the type alias usage, and the type alias RHS.
-       *  3. What does it mean for a C++ struct, which is what this type alias RHS will generate, to be nullable? ¯\_(ツ)_/¯
-       *     Nullability is a concept that only makes sense when talking about instances (i.e: usages) of the C++ structs.
-       *     Hence, it's better to manage nullability within the actual TypeAliasTypeAnnotation nodes, and not the
-       *     associated ObjectTypeAnnotations.
-       */
-      return wrapNullable(nullable, {
-        type: 'TypeAliasTypeAnnotation',
-        name: typeAliasResolutionStatus.aliasName,
-      });
+      return typeAliasResolution(
+        typeAliasResolutionStatus,
+        objectTypeAnnotation,
+        aliasMap,
+        nullable,
+      );
     }
     case 'BooleanTypeAnnotation': {
       return emitBoolean(nullable);

--- a/packages/react-native-codegen/src/parsers/flow/utils.js
+++ b/packages/react-native-codegen/src/parsers/flow/utils.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+import type {TypeAliasResolutionStatus} from '../utils';
+
 const {ParserError} = require('../errors');
 
 /**
@@ -54,15 +56,6 @@ function getTypes(ast: $FlowFixMe): TypeDeclarationMap {
 export type ASTNode = Object;
 
 const invariant = require('invariant');
-
-type TypeAliasResolutionStatus =
-  | $ReadOnly<{
-      successful: true,
-      aliasName: string,
-    }>
-  | $ReadOnly<{
-      successful: false,
-    }>;
 
 function resolveTypeAnnotation(
   // TODO(T71778680): This is an Flow TypeAnnotation. Flow-type this

--- a/packages/react-native-codegen/src/parsers/parsers-primitives.js
+++ b/packages/react-native-codegen/src/parsers/parsers-primitives.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @flow strict
+ * @flow strict-local
  */
 
 'use strict';

--- a/packages/react-native-codegen/src/parsers/parsers-primitives.js
+++ b/packages/react-native-codegen/src/parsers/parsers-primitives.js
@@ -11,13 +11,18 @@
 'use strict';
 
 import type {
+  Nullable,
+  NativeModuleAliasMap,
+  NativeModuleBaseTypeAnnotation,
+  NativeModuleTypeAliasTypeAnnotation,
+  NativeModuleNumberTypeAnnotation,
   BooleanTypeAnnotation,
   DoubleTypeAnnotation,
   Int32TypeAnnotation,
-  NativeModuleNumberTypeAnnotation,
-  Nullable,
   ReservedTypeAnnotation,
+  ObjectTypeAnnotation,
 } from '../CodegenSchema';
+import type {TypeAliasResolutionStatus} from './typescript/utils';
 
 const {wrapNullable} = require('./parsers-commons');
 
@@ -54,10 +59,65 @@ function emitDouble(nullable: boolean): Nullable<DoubleTypeAnnotation> {
   });
 }
 
+function typeAliasResolution(
+  typeAliasResolutionStatus: TypeAliasResolutionStatus,
+  objectTypeAnnotation: ObjectTypeAnnotation<
+    Nullable<NativeModuleBaseTypeAnnotation>,
+  >,
+  aliasMap: {...NativeModuleAliasMap},
+  nullable: boolean,
+):
+  | Nullable<NativeModuleTypeAliasTypeAnnotation>
+  | Nullable<ObjectTypeAnnotation<Nullable<NativeModuleBaseTypeAnnotation>>> {
+  if (!typeAliasResolutionStatus.successful) {
+    return wrapNullable(nullable, objectTypeAnnotation);
+  }
+
+  /**
+   * All aliases RHS are required.
+   */
+  aliasMap[typeAliasResolutionStatus.aliasName] = objectTypeAnnotation;
+
+  /**
+   * Nullability of type aliases is transitive.
+   *
+   * Consider this case:
+   *
+   * type Animal = ?{
+   *   name: string,
+   * };
+   *
+   * type B = Animal
+   *
+   * export interface Spec extends TurboModule {
+   *   +greet: (animal: B) => void;
+   * }
+   *
+   * In this case, we follow B to Animal, and then Animal to ?{name: string}.
+   *
+   * We:
+   *   1. Replace `+greet: (animal: B) => void;` with `+greet: (animal: ?Animal) => void;`,
+   *   2. Pretend that Animal = {name: string}.
+   *
+   * Why do we do this?
+   *  1. In ObjC, we need to generate a struct called Animal, not B.
+   *  2. This design is simpler than managing nullability within both the type alias usage, and the type alias RHS.
+   *  3. What does it mean for a C++ struct, which is what this type alias RHS will generate, to be nullable? ¯\_(ツ)_/¯
+   *     Nullability is a concept that only makes sense when talking about instances (i.e: usages) of the C++ structs.
+   *     Hence, it's better to manage nullability within the actual TypeAliasTypeAnnotation nodes, and not the
+   *     associated ObjectTypeAnnotations.
+   */
+  return wrapNullable(nullable, {
+    type: 'TypeAliasTypeAnnotation',
+    name: typeAliasResolutionStatus.aliasName,
+  });
+}
+
 module.exports = {
   emitBoolean,
   emitDouble,
   emitInt32,
   emitNumber,
   emitRootTag,
+  typeAliasResolution,
 };

--- a/packages/react-native-codegen/src/parsers/parsers-primitives.js
+++ b/packages/react-native-codegen/src/parsers/parsers-primitives.js
@@ -22,7 +22,7 @@ import type {
   ReservedTypeAnnotation,
   ObjectTypeAnnotation,
 } from '../CodegenSchema';
-import type {TypeAliasResolutionStatus} from './typescript/utils';
+import type {TypeAliasResolutionStatus} from './utils';
 
 const {wrapNullable} = require('./parsers-commons');
 

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -39,6 +39,7 @@ const {
   emitNumber,
   emitInt32,
   emitRootTag,
+  typeAliasResolution,
 } = require('../../parsers-primitives');
 const {
   IncorrectlyParameterizedGenericParserError,
@@ -364,48 +365,12 @@ function translateTypeAnnotation(
           .filter(Boolean),
       };
 
-      if (!typeAliasResolutionStatus.successful) {
-        return wrapNullable(nullable, objectTypeAnnotation);
-      }
-
-      /**
-       * All aliases RHS are required.
-       */
-      aliasMap[typeAliasResolutionStatus.aliasName] = objectTypeAnnotation;
-
-      /**
-       * Nullability of type aliases is transitive.
-       *
-       * Consider this case:
-       *
-       * type Animal = ?{
-       *   name: string,
-       * };
-       *
-       * type B = Animal
-       *
-       * export interface Spec extends TurboModule {
-       *   +greet: (animal: B) => void;
-       * }
-       *
-       * In this case, we follow B to Animal, and then Animal to ?{name: string}.
-       *
-       * We:
-       *   1. Replace `+greet: (animal: B) => void;` with `+greet: (animal: ?Animal) => void;`,
-       *   2. Pretend that Animal = {name: string}.
-       *
-       * Why do we do this?
-       *  1. In ObjC, we need to generate a struct called Animal, not B.
-       *  2. This design is simpler than managing nullability within both the type alias usage, and the type alias RHS.
-       *  3. What does it mean for a C++ struct, which is what this type alias RHS will generate, to be nullable? ¯\_(ツ)_/¯
-       *     Nullability is a concept that only makes sense when talking about instances (i.e: usages) of the C++ structs.
-       *     Hence, it's better to manage nullability within the actual TypeAliasTypeAnnotation nodes, and not the
-       *     associated ObjectTypeAnnotations.
-       */
-      return wrapNullable(nullable, {
-        type: 'TypeAliasTypeAnnotation',
-        name: typeAliasResolutionStatus.aliasName,
-      });
+      return typeAliasResolution(
+        typeAliasResolutionStatus,
+        objectTypeAnnotation,
+        aliasMap,
+        nullable,
+      );
     }
     case 'TSBooleanKeyword': {
       return emitBoolean(nullable);

--- a/packages/react-native-codegen/src/parsers/typescript/utils.js
+++ b/packages/react-native-codegen/src/parsers/typescript/utils.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+import type {TypeAliasResolutionStatus} from '../utils';
+
 const {ParserError} = require('../errors');
 const {parseTopLevelType} = require('./parseTopLevelType');
 
@@ -49,15 +51,6 @@ function getTypes(ast: $FlowFixMe): TypeDeclarationMap {
 export type ASTNode = Object;
 
 const invariant = require('invariant');
-
-export type TypeAliasResolutionStatus =
-  | $ReadOnly<{
-      successful: true,
-      aliasName: string,
-    }>
-  | $ReadOnly<{
-      successful: false,
-    }>;
 
 function resolveTypeAnnotation(
   // TODO(T108222691): Use flow-types for @babel/parser

--- a/packages/react-native-codegen/src/parsers/typescript/utils.js
+++ b/packages/react-native-codegen/src/parsers/typescript/utils.js
@@ -50,7 +50,7 @@ export type ASTNode = Object;
 
 const invariant = require('invariant');
 
-type TypeAliasResolutionStatus =
+export type TypeAliasResolutionStatus =
   | $ReadOnly<{
       successful: true,
       aliasName: string,

--- a/packages/react-native-codegen/src/parsers/utils.js
+++ b/packages/react-native-codegen/src/parsers/utils.js
@@ -12,6 +12,15 @@
 
 const path = require('path');
 
+export type TypeAliasResolutionStatus =
+  | $ReadOnly<{
+      successful: true,
+      aliasName: string,
+    }>
+  | $ReadOnly<{
+      successful: false,
+    }>;
+
 function extractNativeModuleName(filename: string): string {
   // this should drop everything after the file name. For Example it will drop:
   // .android.js, .android.ts, .android.tsx, .ios.js, .ios.ts, .ios.tsx, .js, .ts, .tsx


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
This PR aims to reduce code duplication by extracting `typeAliasResolution` logic from the flow and typescript folders into a shared parsers-primitives file. It is a task of #34872:
> Wrap the TypeAlias resolution lines ([Flow](https://github.com/facebook/react-native/blob/b444f0e44e0d8670139acea5f14c2de32c5e2ddc/packages/react-native-codegen/src/parsers/flow/modules/index.js#L321-L362), [TypeScript](https://github.com/facebook/react-native/blob/00b795642a6562fb52d6df12e367b84674994623/packages/react-native-codegen/src/parsers/typescript/modules/index.js#L356-L397)) in a proper typeAliasResolution function in the parsers-primitives.js files and replace those lines with the new function.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
[Internal] [Changed] - Extract TypeAlias logic of translateTypeAnnotation from the flow and typescript folders in parsers-primitives

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
All tests are passing, with `yarn jest react-native-codegen`:
<img width="930" alt="image" src="https://user-images.githubusercontent.com/40902940/194835192-49478b1c-3e04-40f9-b6f3-e26491f272ab.png">

