### PR TITLE
Chore/extract codegen parser more than one module exception

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
@@ -13,6 +13,7 @@
 
 const {
   throwIfModuleInterfaceNotFound,
+  throwIfMoreThanOneModuleInterfaceParserError,
   throwIfMoreThanOneModuleRegistryCalls,
   throwIfModuleInterfaceIsMisnamed,
   throwIfUnusedModuleInterfaceParserError,
@@ -541,5 +542,34 @@ describe('throwIfMoreThanOneModuleRegistryCalls', () => {
         language,
       );
     }).toThrow(UnsupportedModulePropertyParserError);
+  });
+});
+describe('throwIfMoreThanOneModuleInterfaceParserError', () => {
+  const {MoreThanOneModuleInterfaceParserError} = require('../errors.js');
+  it("don't throw error if module specs length is <= 1", () => {
+    const nativeModuleName = 'moduleName';
+    const moduleSpecs = [];
+    const parserType = 'Flow';
+
+    expect(() => {
+      throwIfMoreThanOneModuleInterfaceParserError(
+        nativeModuleName,
+        moduleSpecs,
+        parserType,
+      );
+    }).not.toThrow(MoreThanOneModuleInterfaceParserError);
+  });
+  it('throw error if module specs is > 1 ', () => {
+    const nativeModuleName = 'moduleName';
+    const moduleSpecs = [{id: {name: 'Name-1'}}, {id: {name: 'Name-2'}}];
+    const parserType = 'TypeScript';
+
+    expect(() => {
+      throwIfMoreThanOneModuleInterfaceParserError(
+        nativeModuleName,
+        moduleSpecs,
+        parserType,
+      );
+    }).toThrow(MoreThanOneModuleInterfaceParserError);
   });
 });

--- a/packages/react-native-codegen/src/parsers/error-utils.js
+++ b/packages/react-native-codegen/src/parsers/error-utils.js
@@ -15,6 +15,7 @@ import type {ParserType} from './errors';
 const {
   MisnamedModuleInterfaceParserError,
   ModuleInterfaceNotFoundParserError,
+  MoreThanOneModuleInterfaceParserError,
   MoreThanOneModuleRegistryCallsParserError,
   UnusedModuleInterfaceParserError,
   IncorrectModuleRegistryCallArityParserError,
@@ -47,6 +48,21 @@ function throwIfModuleInterfaceNotFound(
     throw new ModuleInterfaceNotFoundParserError(
       nativeModuleName,
       ast,
+      parserType,
+    );
+  }
+}
+
+function throwIfMoreThanOneModuleInterfaceParserError(
+  nativeModuleName: string,
+  moduleSpecs: ASTNode[],
+  parserType: ParserType,
+) {
+  if (moduleSpecs.length > 1) {
+    throw new MoreThanOneModuleInterfaceParserError(
+      nativeModuleName,
+      moduleSpecs,
+      moduleSpecs.map(node => node.id.name),
       parserType,
     );
   }
@@ -191,6 +207,7 @@ function throwIfModuleTypeIsUnsupported(
 module.exports = {
   throwIfModuleInterfaceIsMisnamed,
   throwIfModuleInterfaceNotFound,
+  throwIfMoreThanOneModuleInterfaceParserError,
   throwIfMoreThanOneModuleRegistryCalls,
   throwIfUnusedModuleInterfaceParserError,
   throwIfWrongNumberOfCallExpressionArgs,

--- a/packages/react-native-codegen/src/parsers/error-utils.js
+++ b/packages/react-native-codegen/src/parsers/error-utils.js
@@ -55,7 +55,7 @@ function throwIfModuleInterfaceNotFound(
 
 function throwIfMoreThanOneModuleInterfaceParserError(
   nativeModuleName: string,
-  moduleSpecs: ASTNode[],
+  moduleSpecs: $ReadOnlyArray<$FlowFixMe>,
   parserType: ParserType,
 ) {
   if (moduleSpecs.length > 1) {

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -54,6 +54,7 @@ const {
 } = require('../../parsers-primitives');
 const {
   MoreThanOneModuleInterfaceParserError,
+  ModuleInterfaceNotFoundParserError,
   UnnamedFunctionParamParserError,
   UnsupportedArrayElementTypeAnnotationParserError,
   UnsupportedGenericParserError,
@@ -66,6 +67,9 @@ const {
   UnsupportedObjectPropertyValueTypeAnnotationParserError,
   IncorrectModuleRegistryCallArgumentTypeParserError,
 } = require('../../errors.js');
+const {
+  throwIfMoreThanOneModuleInterfaceParserError,
+} = require('../../error-utils');
 
 const {
   throwIfModuleInterfaceNotFound,
@@ -602,14 +606,11 @@ function buildModuleSchema(
     language,
   );
 
-  if (moduleSpecs.length > 1) {
-    throw new MoreThanOneModuleInterfaceParserError(
-      hasteModuleName,
-      moduleSpecs,
-      moduleSpecs.map(node => node.id.name),
-      language,
-    );
-  }
+  throwIfMoreThanOneModuleInterfaceParserError(
+    hasteModuleName,
+    moduleSpecs,
+    'Flow',
+  );
 
   const [moduleSpec] = moduleSpecs;
 

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -609,7 +609,7 @@ function buildModuleSchema(
   throwIfMoreThanOneModuleInterfaceParserError(
     hasteModuleName,
     moduleSpecs,
-    'Flow',
+    language,
   );
 
   const [moduleSpec] = moduleSpecs;

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -54,6 +54,7 @@ const {
 } = require('../../parsers-primitives');
 const {
   MoreThanOneModuleInterfaceParserError,
+  ModuleInterfaceNotFoundParserError,
   UnnamedFunctionParamParserError,
   UnsupportedArrayElementTypeAnnotationParserError,
   UnsupportedGenericParserError,
@@ -66,6 +67,9 @@ const {
   UnsupportedObjectPropertyValueTypeAnnotationParserError,
   IncorrectModuleRegistryCallArgumentTypeParserError,
 } = require('../../errors.js');
+const {
+  throwIfMoreThanOneModuleInterfaceParserError,
+} = require('../../error-utils');
 
 const {
   throwIfUntypedModule,
@@ -616,14 +620,11 @@ function buildModuleSchema(
     language,
   );
 
-  if (moduleSpecs.length > 1) {
-    throw new MoreThanOneModuleInterfaceParserError(
-      hasteModuleName,
-      moduleSpecs,
-      moduleSpecs.map(node => node.id.name),
-      language,
-    );
-  }
+  throwIfMoreThanOneModuleInterfaceParserError(
+    hasteModuleName,
+    moduleSpecs,
+    'TypeScript',
+  );
 
   const [moduleSpec] = moduleSpecs;
 

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -623,7 +623,7 @@ function buildModuleSchema(
   throwIfMoreThanOneModuleInterfaceParserError(
     hasteModuleName,
     moduleSpecs,
-    'TypeScript',
+    language,
   );
 
   const [moduleSpec] = moduleSpecs;


### PR DESCRIPTION
## Summary

This PR is part of https://github.com/facebook/react-native/issues/34872
This PR extracts MoreThanOneModuleInterfaceParserError exception to a separate function inside an error-utils.js file

## Changelog

[Internal] [Changed] - Extract MoreThanOneModuleInterfaceParserError to a seperate function inside error-utils.js

## Test Plan

<img width="297" alt="image" src="https://user-images.githubusercontent.com/18408823/194859284-7d3ff330-c644-472e-9ae0-3b9444bc12e8.png">
