### PR TITLE
chore: Extract codegen ModuleInterfaceNotFoundParserError in a separate function

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @flow strict-local
  * @oncall react_native
  */
 

--- a/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @oncall react_native
+ */
+
+'use strict';
+
+const {throwIfModuleInterfaceNotFound} = require('../error-utils');
+const {ModuleInterfaceNotFoundParserError} = require('../errors');
+
+describe('throwIfModuleInterfaceNotFound', () => {
+  it('throw error if there are zero module specs', () => {
+    const nativeModuleName = 'moduleName';
+    const specId = {name: 'Name'};
+    const parserType = 'TypeScript';
+
+    expect(() => {
+      throwIfModuleInterfaceNotFound(0, nativeModuleName, specId, parserType);
+    }).toThrow(ModuleInterfaceNotFoundParserError);
+  });
+
+  it("don't throw error if there is at least one module spec", () => {
+    const nativeModuleName = 'moduleName';
+    const specId = {name: 'Spec'};
+    const parserType = 'Flow';
+
+    expect(() => {
+      throwIfModuleInterfaceNotFound(1, nativeModuleName, specId, parserType);
+    }).not.toThrow(ModuleInterfaceNotFoundParserError);
+  });
+});

--- a/packages/react-native-codegen/src/parsers/error-utils.js
+++ b/packages/react-native-codegen/src/parsers/error-utils.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+'use strict';
+
+import type {ParserType} from './errors';
+const {ModuleInterfaceNotFoundParserError} = require('./errors.js');
+
+function throwIfModuleInterfaceNotFound(
+  numberOfModuleSpecs: number,
+  nativeModuleName: string,
+  ast: $FlowFixMe,
+  parserType: ParserType,
+) {
+  if (numberOfModuleSpecs === 0) {
+    throw new ModuleInterfaceNotFoundParserError(
+      nativeModuleName,
+      ast,
+      parserType,
+    );
+  }
+}
+
+module.exports = {
+  throwIfModuleInterfaceNotFound,
+};

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -587,7 +587,7 @@ function buildModuleSchema(
     moduleSpecs.length,
     hasteModuleName,
     ast,
-    'Flow',
+    language,
   );
 
   if (moduleSpecs.length > 1) {

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -48,7 +48,6 @@ const {
 } = require('../../parsers-primitives');
 const {
   MisnamedModuleInterfaceParserError,
-  ModuleInterfaceNotFoundParserError,
   MoreThanOneModuleInterfaceParserError,
   UnnamedFunctionParamParserError,
   UnsupportedArrayElementTypeAnnotationParserError,
@@ -68,6 +67,8 @@ const {
   IncorrectModuleRegistryCallArityParserError,
   IncorrectModuleRegistryCallArgumentTypeParserError,
 } = require('../../errors.js');
+
+const {throwIfModuleInterfaceNotFound} = require('../../error-utils');
 
 const language = 'Flow';
 
@@ -582,13 +583,12 @@ function buildModuleSchema(
     isModuleInterface,
   );
 
-  if (moduleSpecs.length === 0) {
-    throw new ModuleInterfaceNotFoundParserError(
-      hasteModuleName,
-      ast,
-      language,
-    );
-  }
+  throwIfModuleInterfaceNotFound(
+    moduleSpecs.length,
+    hasteModuleName,
+    ast,
+    'Flow',
+  );
 
   if (moduleSpecs.length > 1) {
     throw new MoreThanOneModuleInterfaceParserError(

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -48,7 +48,6 @@ const {
 } = require('../../parsers-primitives');
 const {
   MisnamedModuleInterfaceParserError,
-  ModuleInterfaceNotFoundParserError,
   MoreThanOneModuleInterfaceParserError,
   UnnamedFunctionParamParserError,
   UnsupportedArrayElementTypeAnnotationParserError,
@@ -68,6 +67,7 @@ const {
   IncorrectModuleRegistryCallArityParserError,
   IncorrectModuleRegistryCallArgumentTypeParserError,
 } = require('../../errors.js');
+const {throwIfModuleInterfaceNotFound} = require('../../error-utils');
 
 const language = 'TypeScript';
 
@@ -616,13 +616,12 @@ function buildModuleSchema(
     isModuleInterface,
   );
 
-  if (moduleSpecs.length === 0) {
-    throw new ModuleInterfaceNotFoundParserError(
-      hasteModuleName,
-      ast,
-      language,
-    );
-  }
+  throwIfModuleInterfaceNotFound(
+    moduleSpecs.length,
+    hasteModuleName,
+    ast,
+    'TypeScript',
+  );
 
   if (moduleSpecs.length > 1) {
     throw new MoreThanOneModuleInterfaceParserError(

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -620,7 +620,7 @@ function buildModuleSchema(
     moduleSpecs.length,
     hasteModuleName,
     ast,
-    'TypeScript',
+    language,
   );
 
   if (moduleSpecs.length > 1) {


### PR DESCRIPTION
## Summary

This PR extracts the codegen `ModuleInterfaceNotFoundParserError` exception into a separate function inside `error-utils.js` so that it can be used by both Flow and Typescript parsers as requested on https://github.com/facebook/react-native/issues/34872. This also adds unit tests to the new `throwIfModuleInterfaceNotFound` function.
  

## Changelog

[Internal] [Changed] - Extract codegen `ModuleInterfaceNotFoundParserError` in a separate function that can de used by Flow and TypeScript parsers

## Test Plan


Run `yarn jest react-native-codegen` and ensure CI is green

![image](https://user-images.githubusercontent.com/11707729/194876017-8e98e3d2-4518-4cbe-b7f0-b77a54060b1e.png)
