### PR TITLE
Chore/extract codegen case object to parser primitives

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-primitives-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-primitives-test.js
@@ -17,6 +17,7 @@ const {
   emitNumber,
   emitInt32,
   emitRootTag,
+  emitObject,
 } = require('../parsers-primitives.js');
 
 describe('emitBoolean', () => {
@@ -142,6 +143,32 @@ describe('emitDouble', () => {
       const result = emitDouble(false);
       const expected = {
         type: 'DoubleTypeAnnotation',
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+});
+
+describe('emitObject', () => {
+  describe('when nullable is true', () => {
+    it('returns nullable type annotation', () => {
+      const result = emitObject(true);
+      const expected = {
+        type: 'NullableTypeAnnotation',
+        typeAnnotation: {
+          type: 'GenericObjectTypeAnnotation',
+        },
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+  describe('when nullable is false', () => {
+    it('returns non nullable type annotation', () => {
+      const result = emitObject(false);
+      const expected = {
+        type: 'GenericObjectTypeAnnotation',
       };
 
       expect(result).toEqual(expected);

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -39,6 +39,7 @@ const {
   emitNumber,
   emitInt32,
   emitRootTag,
+  emitObject,
 } = require('../../parsers-primitives');
 const {
   IncorrectlyParameterizedGenericParserError,
@@ -214,9 +215,7 @@ function translateTypeAnnotation(
         }
         case 'UnsafeObject':
         case 'Object': {
-          return wrapNullable(nullable, {
-            type: 'GenericObjectTypeAnnotation',
-          });
+          return emitObject(nullable);
         }
         default: {
           const maybeEumDeclaration = types[typeAnnotation.id.name];

--- a/packages/react-native-codegen/src/parsers/parsers-primitives.js
+++ b/packages/react-native-codegen/src/parsers/parsers-primitives.js
@@ -15,6 +15,7 @@ import type {
   DoubleTypeAnnotation,
   Int32TypeAnnotation,
   NativeModuleNumberTypeAnnotation,
+  ObjectTypeAnnotation,
   Nullable,
   ReservedTypeAnnotation,
 } from '../CodegenSchema';
@@ -54,10 +55,17 @@ function emitDouble(nullable: boolean): Nullable<DoubleTypeAnnotation> {
   });
 }
 
+function emitObject(nullable: boolean): Nullable<ObjectTypeAnnotation> {
+  return wrapNullable(nullable, {
+    type: 'GenericObjectTypeAnnotation',
+  });
+}
+
 module.exports = {
   emitBoolean,
   emitDouble,
   emitInt32,
   emitNumber,
   emitRootTag,
+  emitObject,
 };

--- a/packages/react-native-codegen/src/parsers/parsers-primitives.js
+++ b/packages/react-native-codegen/src/parsers/parsers-primitives.js
@@ -15,7 +15,7 @@ import type {
   DoubleTypeAnnotation,
   Int32TypeAnnotation,
   NativeModuleNumberTypeAnnotation,
-  ObjectTypeAnnotation,
+  NativeModuleGenericObjectTypeAnnotation,
   Nullable,
   ReservedTypeAnnotation,
 } from '../CodegenSchema';
@@ -55,7 +55,9 @@ function emitDouble(nullable: boolean): Nullable<DoubleTypeAnnotation> {
   });
 }
 
-function emitObject(nullable: boolean): Nullable<ObjectTypeAnnotation> {
+function emitObject(
+  nullable: boolean,
+): Nullable<NativeModuleGenericObjectTypeAnnotation> {
   return wrapNullable(nullable, {
     type: 'GenericObjectTypeAnnotation',
   });

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -39,6 +39,7 @@ const {
   emitNumber,
   emitInt32,
   emitRootTag,
+  emitObject,
 } = require('../../parsers-primitives');
 const {
   IncorrectlyParameterizedGenericParserError,
@@ -248,9 +249,7 @@ function translateTypeAnnotation(
         }
         case 'UnsafeObject':
         case 'Object': {
-          return wrapNullable(nullable, {
-            type: 'GenericObjectTypeAnnotation',
-          });
+          return emitObject(nullable);
         }
         default: {
           const maybeEumDeclaration = types[typeAnnotation.typeName.name];


### PR DESCRIPTION
## Summary

Part of https://github.com/facebook/react-native/issues/34872

This PR extracts the content of the case 'Object' ([Flow](https://github.com/facebook/react-native/blob/b444f0e44e0d8670139acea5f14c2de32c5e2ddc/packages/react-native-codegen/src/parsers/flow/modules/index.js#L365-L367), [TypeScript](https://github.com/facebook/react-native/blob/00b795642a6562fb52d6df12e367b84674994623/packages/react-native-codegen/src/parsers/typescript/modules/index.js#L400-L402)) into a single emitObject function in the parsers-primitives.js file. Use the new function in the parsers.

## Changelog

[Internal] [Changed] - Extract contents of the case 'Object' into a single emitObject function

## Test Plan

<img width="276" alt="image" src="https://user-images.githubusercontent.com/18408823/194892107-1da9d6e5-c659-47f9-8597-ff4a4b7710ca.png">

