### PR TITLE
fix: Update incorrect `SwitchChangeEvent` type

### DIFF
--- a/Libraries/Components/Switch/AndroidSwitchNativeComponent.js
+++ b/Libraries/Components/Switch/AndroidSwitchNativeComponent.js
@@ -10,7 +10,11 @@
 
 import type {HostComponent} from '../../Renderer/shims/ReactNativeTypes';
 import type {ColorValue} from '../../StyleSheet/StyleSheet';
-import type {BubblingEventHandler, WithDefault} from '../../Types/CodegenTypes';
+import type {
+  BubblingEventHandler,
+  Int32,
+  WithDefault,
+} from '../../Types/CodegenTypes';
 import type {ViewProps} from '../View/ViewPropTypes';
 
 import codegenNativeCommands from '../../Utilities/codegenNativeCommands';
@@ -19,6 +23,7 @@ import * as React from 'react';
 
 type SwitchChangeEvent = $ReadOnly<{|
   value: boolean,
+  target: Int32,
 |}>;
 
 type NativeProps = $ReadOnly<{|

--- a/Libraries/Components/Switch/Switch.d.ts
+++ b/Libraries/Components/Switch/Switch.d.ts
@@ -13,6 +13,7 @@ import {NativeMethods} from '../../Renderer/shims/ReactNativeTypes';
 import {ColorValue, StyleProp} from '../../StyleSheet/StyleSheet';
 import {ViewStyle} from '../../StyleSheet/StyleSheetTypes';
 import {ViewProps} from '../View/ViewPropTypes';
+import {NativeSyntheticEvent, TargetedEvent} from '../../Types/CoreEventTypes';
 
 export interface SwitchPropsIOS extends ViewProps {
   /**
@@ -37,9 +38,12 @@ export interface SwitchPropsIOS extends ViewProps {
   tintColor?: ColorValue | undefined;
 }
 
-export interface SwitchChangeEvent extends React.SyntheticEvent {
+export interface SwitchChangeEventData extends TargetedEvent {
   value: boolean;
 }
+
+export interface SwitchChangeEvent
+  extends NativeSyntheticEvent<SwitchChangeEventData> {}
 
 export interface SwitchProps extends SwitchPropsIOS {
   /**

--- a/Libraries/Components/Switch/Switch.js
+++ b/Libraries/Components/Switch/Switch.js
@@ -27,6 +27,7 @@ import * as React from 'react';
 type SwitchChangeEvent = SyntheticEvent<
   $ReadOnly<{|
     value: boolean,
+    target: number,
   |}>,
 >;
 

--- a/Libraries/Components/Switch/SwitchNativeComponent.js
+++ b/Libraries/Components/Switch/SwitchNativeComponent.js
@@ -10,7 +10,11 @@
 
 import type {HostComponent} from '../../Renderer/shims/ReactNativeTypes';
 import type {ColorValue} from '../../StyleSheet/StyleSheet';
-import type {BubblingEventHandler, WithDefault} from '../../Types/CodegenTypes';
+import type {
+  BubblingEventHandler,
+  Int32,
+  WithDefault,
+} from '../../Types/CodegenTypes';
 import type {ViewProps} from '../View/ViewPropTypes';
 
 import codegenNativeCommands from '../../Utilities/codegenNativeCommands';
@@ -19,6 +23,7 @@ import * as React from 'react';
 
 type SwitchChangeEvent = $ReadOnly<{|
   value: boolean,
+  target: Int32,
 |}>;
 
 type NativeProps = $ReadOnly<{|

--- a/types/__typetests__/index.tsx
+++ b/types/__typetests__/index.tsx
@@ -1429,7 +1429,7 @@ const SwitchOnChangePromiseTest = () => (
   <Switch
     onChange={event => {
       const e: SwitchChangeEvent = event;
-      return new Promise(() => e.value);
+      return new Promise(() => e.nativeEvent.value);
     }}
   />
 );


### PR DESCRIPTION
## Summary

I noticed that typescript type for `onChange`  event of `<Switch/>` was incorrect


```tsx
<Switch
  onChange={(event) => {
    // TS
    event.value; // boolean
    event.nativeEvent.value; //TS2339: Property 'value' does not exist on type 'Event'.
    // JS
    console.log(event.nativeEvent); // {value:false,target:87}
    console.log(event.value); // undefined
  }}
/>
```

## Changelog

[General] [Changed] - Typescript: update incorrect `SwitchChangeEvent` type

## Test Plan

...