### PR TITLE
[Codegen]: Extract contents of the case 'VoidTypeAnnotation' into a single emitVoid function

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-primitives-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-primitives-test.js
@@ -17,6 +17,7 @@ const {
   emitNumber,
   emitInt32,
   emitRootTag,
+  emitVoid,
   typeAliasResolution,
 } = require('../parsers-primitives.js');
 
@@ -143,6 +144,32 @@ describe('emitDouble', () => {
       const result = emitDouble(false);
       const expected = {
         type: 'DoubleTypeAnnotation',
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+});
+
+describe('emitVoid', () => {
+  describe('when nullable is true', () => {
+    it('returns nullable type annotation', () => {
+      const result = emitVoid(true);
+      const expected = {
+        type: 'NullableTypeAnnotation',
+        typeAnnotation: {
+          type: 'VoidTypeAnnotation',
+        },
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+  describe('when nullable is false', () => {
+    it('returns non nullable type annotation', () => {
+      const result = emitVoid(false);
+      const expected = {
+        type: 'VoidTypeAnnotation',
       };
 
       expect(result).toEqual(expected);

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -39,6 +39,7 @@ const {
   emitNumber,
   emitInt32,
   emitRootTag,
+  emitVoid,
   typeAliasResolution,
 } = require('../../parsers-primitives');
 const {
@@ -343,9 +344,7 @@ function translateTypeAnnotation(
       return emitNumber(nullable);
     }
     case 'VoidTypeAnnotation': {
-      return wrapNullable(nullable, {
-        type: 'VoidTypeAnnotation',
-      });
+      return emitVoid(nullable);
     }
     case 'StringTypeAnnotation': {
       return wrapNullable(nullable, {

--- a/packages/react-native-codegen/src/parsers/parsers-primitives.js
+++ b/packages/react-native-codegen/src/parsers/parsers-primitives.js
@@ -21,6 +21,7 @@ import type {
   Int32TypeAnnotation,
   ReservedTypeAnnotation,
   ObjectTypeAnnotation,
+  VoidTypeAnnotation,
 } from '../CodegenSchema';
 import type {TypeAliasResolutionStatus} from './utils';
 
@@ -56,6 +57,12 @@ function emitRootTag(nullable: boolean): Nullable<ReservedTypeAnnotation> {
 function emitDouble(nullable: boolean): Nullable<DoubleTypeAnnotation> {
   return wrapNullable(nullable, {
     type: 'DoubleTypeAnnotation',
+  });
+}
+
+function emitVoid(nullable: boolean): Nullable<VoidTypeAnnotation> {
+  return wrapNullable(nullable, {
+    type: 'VoidTypeAnnotation',
   });
 }
 
@@ -119,5 +126,6 @@ module.exports = {
   emitInt32,
   emitNumber,
   emitRootTag,
+  emitVoid,
   typeAliasResolution,
 };

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -39,6 +39,7 @@ const {
   emitNumber,
   emitInt32,
   emitRootTag,
+  emitVoid,
   typeAliasResolution,
 } = require('../../parsers-primitives');
 const {
@@ -379,9 +380,7 @@ function translateTypeAnnotation(
       return emitNumber(nullable);
     }
     case 'TSVoidKeyword': {
-      return wrapNullable(nullable, {
-        type: 'VoidTypeAnnotation',
-      });
+      return emitVoid(nullable);
     }
     case 'TSStringKeyword': {
       return wrapNullable(nullable, {


### PR DESCRIPTION
## Summary

Part of https://github.com/facebook/react-native/issues/34872

This PR:
- extracts the content of the case 'VoidTypeAnnotation' ([Flow](https://github.com/facebook/react-native/blob/b444f0e44e0d8670139acea5f14c2de32c5e2ddc/packages/react-native-codegen/src/parsers/flow/modules/index.js#L375-L377), [TypeScript](https://github.com/facebook/react-native/blob/00b795642a6562fb52d6df12e367b84674994623/packages/react-native-codegen/src/parsers/typescript/modules/index.js#L410-L412)) into a single emitVoid function in the parsers-primitives.js file. Use the new function in the parsers.
- unit tests emitVoid function

## Changelog

[Internal] [Changed] - Extract contents of the case 'VoidTypeAnnotation' into a single emitVoid function

## Test Plan
` yarn jest react-native-codegen`

<img width="957" alt="image" src="https://user-images.githubusercontent.com/19575877/194931977-d5cfc5f5-c9db-498d-9e5c-ae40a38d3623.png">

