### PR TITLE
[Codegen] extract assertGenericTypeAnnotationHasExactlyOneTypeParameter to parsers-commons

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-commons-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-commons-test.js
@@ -11,6 +11,9 @@
 
 'use-strict';
 
+import {IncorrectlyParameterizedGenericParserError} from '../errors';
+import {assertGenericTypeAnnotationHasExactlyOneTypeParameter} from '../parsers-commons';
+
 const {wrapNullable, unwrapNullable} = require('../parsers-commons.js');
 
 describe('wrapNullable', () => {
@@ -76,5 +79,96 @@ describe('unwrapNullable', () => {
 
       expect(result).toEqual(expected);
     });
+  });
+});
+
+describe('assertGenericTypeAnnotationHasExactlyOneTypeParameter', () => {
+  it('throws an IncorrectlyParameterizedGenericParserError if typeParameters is null', () => {
+    const moduleName = 'testModuleName';
+    const typeAnnotation = {
+      typeParameters: null,
+      id: {
+        name: 'typeAnnotationName',
+      },
+    };
+    expect(() =>
+      assertGenericTypeAnnotationHasExactlyOneTypeParameter(
+        moduleName,
+        typeAnnotation,
+        'Flow',
+      ),
+    ).toThrow(IncorrectlyParameterizedGenericParserError);
+  });
+
+  it("throws an error if typeAnnotation.typeParameters.type doesn't have the correct value depending on language", () => {
+    const moduleName = 'testModuleName';
+    const flowTypeAnnotation = {
+      typeParameters: {
+        type: 'TypeParameterInstantiation',
+      },
+      id: {
+        name: 'typeAnnotationName',
+      },
+    };
+    expect(() =>
+      assertGenericTypeAnnotationHasExactlyOneTypeParameter(
+        moduleName,
+        flowTypeAnnotation,
+        'Flow',
+      ),
+    ).toThrow(Error);
+
+    const typeScriptTypeAnnotation = {
+      typeParameters: {
+        type: 'TypeParameterInstantiation',
+      },
+      typeName: {
+        name: 'typeAnnotationName',
+      },
+    };
+    expect(() =>
+      assertGenericTypeAnnotationHasExactlyOneTypeParameter(
+        moduleName,
+        typeScriptTypeAnnotation,
+        'TypeScript',
+      ),
+    ).toThrow(Error);
+  });
+
+  it("throws an IncorrectlyParameterizedGenericParserError if typeParameters don't have 1 exactly parameter", () => {
+    const moduleName = 'testModuleName';
+    const typeAnnotationWithTwoParams = {
+      typeParameters: {
+        params: [1, 2],
+        type: 'TypeParameterInstantiation',
+      },
+      id: {
+        name: 'typeAnnotationName',
+      },
+    };
+    expect(() =>
+      assertGenericTypeAnnotationHasExactlyOneTypeParameter(
+        moduleName,
+        typeAnnotationWithTwoParams,
+        'Flow',
+      ),
+    ).toThrow(IncorrectlyParameterizedGenericParserError);
+
+    const typeAnnotationWithNoParams = {
+      typeParameters: {
+        params: [],
+        type: 'TypeParameterInstantiation',
+      },
+      id: {
+        name: 'typeAnnotationName',
+      },
+    };
+    expect(() =>
+      assertGenericTypeAnnotationHasExactlyOneTypeParameter(
+        moduleName,
+        typeAnnotationWithNoParams,
+        'Flow',
+      ),
+    ).toThrow(IncorrectlyParameterizedGenericParserError);
   });
 });

--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-commons-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-commons-test.js
@@ -83,8 +83,25 @@ describe('unwrapNullable', () => {
 });
 
 describe('assertGenericTypeAnnotationHasExactlyOneTypeParameter', () => {
+  const moduleName = 'testModuleName';
+
+  it("doesn't throw any Error when typeAnnotation has exactly one typeParameter", () => {
+    const typeAnnotation = {
+      typeParameters: {
+        type: 'TypeParameterInstantiation',
+        params: [1],
+      },
+    };
+    expect(() =>
+      assertGenericTypeAnnotationHasExactlyOneTypeParameter(
+        moduleName,
+        typeAnnotation,
+        'Flow',
+      ),
+    ).not.toThrow(Error);
+  });
+
   it('throws an IncorrectlyParameterizedGenericParserError if typeParameters is null', () => {
-    const moduleName = 'testModuleName';
     const typeAnnotation = {
       typeParameters: null,
       id: {
@@ -100,11 +117,11 @@ describe('assertGenericTypeAnnotationHasExactlyOneTypeParameter', () => {
     ).toThrow(IncorrectlyParameterizedGenericParserError);
   });
 
-  it("throws an error if typeAnnotation.typeParameters.type doesn't have the correct value depending on language", () => {
-    const moduleName = 'testModuleName';
+  it('throws an error if typeAnnotation.typeParameters.type is not TypeParameterInstantiation when language is Flow', () => {
     const flowTypeAnnotation = {
       typeParameters: {
-        type: 'TypeParameterInstantiation',
+        type: 'wrongType',
+        params: [1],
       },
       id: {
         name: 'typeAnnotationName',
@@ -117,10 +134,13 @@ describe('assertGenericTypeAnnotationHasExactlyOneTypeParameter', () => {
         'Flow',
       ),
     ).toThrow(Error);
+  });
 
+  it('throws an error if typeAnnotation.typeParameters.type is not TSTypeParameterInstantiation when language is TypeScript', () => {
     const typeScriptTypeAnnotation = {
       typeParameters: {
-        type: 'TypeParameterInstantiation',
+        type: 'wrongType',
+        params: [1],
       },
       typeName: {
         name: 'typeAnnotationName',
@@ -136,7 +156,6 @@ describe('assertGenericTypeAnnotationHasExactlyOneTypeParameter', () => {
   });
 
   it("throws an IncorrectlyParameterizedGenericParserError if typeParameters don't have 1 exactly parameter", () => {
-    const moduleName = 'testModuleName';
     const typeAnnotationWithTwoParams = {
       typeParameters: {
         params: [1, 2],

--- a/packages/react-native-codegen/src/parsers/errors.js
+++ b/packages/react-native-codegen/src/parsers/errors.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow strict-local
+ * @flow strict
  * @format
  */
 
@@ -12,7 +12,7 @@
 
 const invariant = require('invariant');
 
-type ParserType = 'Flow' | 'TypeScript';
+export type ParserType = 'Flow' | 'TypeScript';
 
 class ParserError extends Error {
   nodes: $ReadOnlyArray<$FlowFixMe>;

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -68,7 +68,6 @@ const {
   IncorrectModuleRegistryCallArgumentTypeParserError,
 } = require('../../errors.js');
 
-const invariant = require('invariant');
 const language = 'Flow';
 
 function nullGuard<T>(fn: () => T): ?T {

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -32,7 +32,11 @@ const {
   visit,
   isModuleRegistryCall,
 } = require('../utils.js');
-const {unwrapNullable, wrapNullable} = require('../../parsers-commons');
+const {
+  unwrapNullable,
+  wrapNullable,
+  assertGenericTypeAnnotationHasExactlyOneTypeParameter,
+} = require('../../parsers-commons');
 const {
   emitBoolean,
   emitDouble,
@@ -42,7 +46,6 @@ const {
   typeAliasResolution,
 } = require('../../parsers-primitives');
 const {
-  IncorrectlyParameterizedGenericParserError,
   MisnamedModuleInterfaceParserError,
   ModuleInterfaceNotFoundParserError,
   MoreThanOneModuleInterfaceParserError,
@@ -96,6 +99,7 @@ function translateTypeAnnotation(
           assertGenericTypeAnnotationHasExactlyOneTypeParameter(
             hasteModuleName,
             typeAnnotation,
+            language,
           );
 
           return wrapNullable(nullable, {
@@ -107,6 +111,7 @@ function translateTypeAnnotation(
           assertGenericTypeAnnotationHasExactlyOneTypeParameter(
             hasteModuleName,
             typeAnnotation,
+            language,
           );
 
           try {
@@ -182,6 +187,7 @@ function translateTypeAnnotation(
           assertGenericTypeAnnotationHasExactlyOneTypeParameter(
             hasteModuleName,
             typeAnnotation,
+            language,
           );
 
           const [paramType, isParamNullable] = unwrapNullable(
@@ -408,35 +414,6 @@ function translateTypeAnnotation(
         language,
       );
     }
-  }
-}
-
-function assertGenericTypeAnnotationHasExactlyOneTypeParameter(
-  moduleName: string,
-  /**
-   * TODO(T71778680): This is a GenericTypeAnnotation. Flow type this node
-   */
-  typeAnnotation: $FlowFixMe,
-) {
-  if (typeAnnotation.typeParameters == null) {
-    throw new IncorrectlyParameterizedGenericParserError(
-      moduleName,
-      typeAnnotation,
-      language,
-    );
-  }
-
-  invariant(
-    typeAnnotation.typeParameters.type === 'TypeParameterInstantiation',
-    "assertGenericTypeAnnotationHasExactlyOneTypeParameter: Type parameters must be an AST node of type 'TypeParameterInstantiation'",
-  );
-
-  if (typeAnnotation.typeParameters.params.length !== 1) {
-    throw new IncorrectlyParameterizedGenericParserError(
-      moduleName,
-      typeAnnotation,
-      language,
-    );
   }
 }
 

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -32,7 +32,11 @@ const {
   visit,
   isModuleRegistryCall,
 } = require('../utils.js');
-const {unwrapNullable, wrapNullable} = require('../../parsers-commons');
+const {
+  unwrapNullable,
+  wrapNullable,
+  assertGenericTypeAnnotationHasExactlyOneTypeParameter,
+} = require('../../parsers-commons');
 const {
   emitBoolean,
   emitDouble,
@@ -42,7 +46,6 @@ const {
   typeAliasResolution,
 } = require('../../parsers-primitives');
 const {
-  IncorrectlyParameterizedGenericParserError,
   MisnamedModuleInterfaceParserError,
   ModuleInterfaceNotFoundParserError,
   MoreThanOneModuleInterfaceParserError,
@@ -65,7 +68,6 @@ const {
   IncorrectModuleRegistryCallArgumentTypeParserError,
 } = require('../../errors.js');
 
-const invariant = require('invariant');
 const language = 'TypeScript';
 
 function nullGuard<T>(fn: () => T): ?T {
@@ -208,6 +210,7 @@ function translateTypeAnnotation(
           assertGenericTypeAnnotationHasExactlyOneTypeParameter(
             hasteModuleName,
             typeAnnotation,
+            language,
           );
 
           return wrapNullable(nullable, {
@@ -219,6 +222,7 @@ function translateTypeAnnotation(
           assertGenericTypeAnnotationHasExactlyOneTypeParameter(
             hasteModuleName,
             typeAnnotation,
+            language,
           );
 
           return translateArrayTypeAnnotation(
@@ -444,35 +448,6 @@ function translateTypeAnnotation(
         language,
       );
     }
-  }
-}
-
-function assertGenericTypeAnnotationHasExactlyOneTypeParameter(
-  moduleName: string,
-  /**
-   * TODO(T108222691): Use flow-types for @babel/parser
-   */
-  typeAnnotation: $FlowFixMe,
-) {
-  if (typeAnnotation.typeParameters == null) {
-    throw new IncorrectlyParameterizedGenericParserError(
-      moduleName,
-      typeAnnotation,
-      language,
-    );
-  }
-
-  invariant(
-    typeAnnotation.typeParameters.type === 'TSTypeParameterInstantiation',
-    "assertGenericTypeAnnotationHasExactlyOneTypeParameter: Type parameters must be an AST node of type 'TSTypeParameterInstantiation'",
-  );
-
-  if (typeAnnotation.typeParameters.params.length !== 1) {
-    throw new IncorrectlyParameterizedGenericParserError(
-      moduleName,
-      typeAnnotation,
-      language,
-    );
   }
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This PR is a task from https://github.com/facebook/react-native/issues/34872:
> Extract the function assertGenericTypeAnnotationHasExactlyOneTypeParameter ([Flow](https://github.com/facebook/react-native/blob/b444f0e44e0d8670139acea5f14c2de32c5e2ddc/packages/react-native-codegen/src/parsers/flow/modules/index.js#L441) [TypeScript](https://github.com/facebook/react-native/blob/00b795642a6562fb52d6df12e367b84674994623/packages/react-native-codegen/src/parsers/typescript/modules/index.js#L476)) into a single function in the parsers-common.js file and replace its invocation with this new function.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[Internal] [Changed] - Extract assertGenericTypeAnnotationHasExactlyOneTypeParameter from the flow and typescript folders to parsers-commons

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

I tested using jest and flow commands.