### PR TITLE
chore: Extract codegen case 'Stringish' into a single emitStringish function

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-primitives-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-primitives-test.js
@@ -17,6 +17,7 @@ const {
   emitNumber,
   emitInt32,
   emitRootTag,
+  emitStringish,
   typeAliasResolution,
   emitPromise,
 } = require('../parsers-primitives.js');
@@ -121,6 +122,33 @@ describe('emitRootTag', () => {
       const result = emitRootTag(false);
 
       expect(result).toEqual(reservedTypeAnnotation);
+    });
+  });
+});
+
+describe('emitStringish', () => {
+  describe('when nullable is true', () => {
+    it('returns nullable type annotation', () => {
+      const result = emitStringish(true);
+      const expected = {
+        type: 'NullableTypeAnnotation',
+        typeAnnotation: {
+          type: 'StringTypeAnnotation',
+        },
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when nullable is false', () => {
+    it('returns non nullable type annotation', () => {
+      const result = emitStringish(false);
+      const expected = {
+        type: 'StringTypeAnnotation',
+      };
+
+      expect(result).toEqual(expected);
     });
   });
 });

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -43,6 +43,7 @@ const {
   emitNumber,
   emitInt32,
   emitRootTag,
+  emitStringish,
   typeAliasResolution,
   emitPromise,
 } = require('../../parsers-primitives');
@@ -201,9 +202,7 @@ function translateTypeAnnotation(
           return wrapNullable(nullable || isParamNullable, paramType);
         }
         case 'Stringish': {
-          return wrapNullable(nullable, {
-            type: 'StringTypeAnnotation',
-          });
+          return emitStringish(nullable);
         }
         case 'Int32': {
           return emitInt32(nullable);

--- a/packages/react-native-codegen/src/parsers/parsers-primitives.js
+++ b/packages/react-native-codegen/src/parsers/parsers-primitives.js
@@ -22,6 +22,7 @@ import type {
   ReservedTypeAnnotation,
   ObjectTypeAnnotation,
   NativeModulePromiseTypeAnnotation,
+  StringTypeAnnotation,
 } from '../CodegenSchema';
 import type {ParserType} from './errors';
 import type {TypeAliasResolutionStatus} from './utils';
@@ -61,6 +62,12 @@ function emitRootTag(nullable: boolean): Nullable<ReservedTypeAnnotation> {
 function emitDouble(nullable: boolean): Nullable<DoubleTypeAnnotation> {
   return wrapNullable(nullable, {
     type: 'DoubleTypeAnnotation',
+  });
+}
+
+function emitStringish(nullable: boolean): Nullable<StringTypeAnnotation> {
+  return wrapNullable(nullable, {
+    type: 'StringTypeAnnotation',
   });
 }
 
@@ -141,6 +148,7 @@ module.exports = {
   emitInt32,
   emitNumber,
   emitRootTag,
+  emitStringish,
   typeAliasResolution,
   emitPromise,
 };

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -43,6 +43,7 @@ const {
   emitNumber,
   emitInt32,
   emitRootTag,
+  emitStringish,
   typeAliasResolution,
   emitPromise,
 } = require('../../parsers-primitives');
@@ -234,9 +235,7 @@ function translateTypeAnnotation(
           );
         }
         case 'Stringish': {
-          return wrapNullable(nullable, {
-            type: 'StringTypeAnnotation',
-          });
+          return emitStringish(nullable);
         }
         case 'Int32': {
           return emitInt32(nullable);


### PR DESCRIPTION
## Summary

This PR extracts the content of the codegen case `'Stringish'` into a single `emitStringish` function inside the `parsers-primitives.js` file and uses it in both Flow and TypeScript parsers as requested on https://github.com/facebook/react-native/issues/34872. This also adds unit tests to the new `emitStringish` function.
  

## Changelog

[Internal] [Changed] - Extract the content of the case 'Stringish' into a single emitStringish function
## Test Plan


Run `yarn jest react-native-codegen` and ensure CI is green

![image](https://user-images.githubusercontent.com/11707729/194987664-b588b82b-a9e0-49a9-a3cc-a03cb0a230e6.png)
