### PR TITLE
Extracted IncorrectModuleRegistryCallArityParserError as a seperate function in error-utils.js

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow strict-local
+ * @oncall react_native
+ */
+
+'use strict';
+
+const {
+  throwIfIncorrectModuleRegistryCallArityParserError,
+} = require('../error-utils');
+const {IncorrectModuleRegistryCallArityParserError} = require('../errors');
+
+describe('throwIfIncorrectModuleRegistryCallArityParserError', () => {
+  it('throw error if incorrect module registry call arity is used', () => {
+    const nativeModuleName = 'moduleName';
+    const flowCallExpression = {argument: []};
+    const methodName = 'methodName';
+    const incorrectArity = flowCallExpression.argument.length;
+    const language = 'Flow';
+    expect(() => {
+      throwIfIncorrectModuleRegistryCallArityParserError(
+        nativeModuleName,
+        flowCallExpression,
+        methodName,
+        incorrectArity,
+        language,
+      );
+    }).toThrow(IncorrectModuleRegistryCallArityParserError);
+  });
+
+  it("don't throw error if correct module registry call arity is used", () => {
+    const nativeModuleName = 'moduleName';
+    const flowCallExpression = {argument: ['argument']};
+    const methodName = 'methodName';
+    const incorrectArity = flowCallExpression.argument.length;
+    const language = 'Flow';
+    expect(() => {
+      throwIfIncorrectModuleRegistryCallArityParserError(
+        nativeModuleName,
+        flowCallExpression,
+        methodName,
+        incorrectArity,
+        language,
+      );
+    }).not.toThrow(IncorrectModuleRegistryCallArityParserError);
+  });
+});

--- a/packages/react-native-codegen/src/parsers/error-utils.js
+++ b/packages/react-native-codegen/src/parsers/error-utils.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+('use strict');
+
+import type {ParserType} from './errors';
+
+const {IncorrectModuleRegistryCallArityParserError} = require('./errors');
+
+function throwIfIncorrectModuleRegistryCallArityParserError(
+  nativeModuleName: string,
+  flowCallExpression: $FlowFixMe,
+  methodName: string,
+  incorrectArity: number,
+  language: ParserType,
+) {
+  if (incorrectArity !== 1) {
+    throw new IncorrectModuleRegistryCallArityParserError(
+      nativeModuleName,
+      flowCallExpression,
+      methodName,
+      incorrectArity,
+      language,
+    );
+  }
+}
+
+module.exports = {
+  throwIfIncorrectModuleRegistryCallArityParserError,
+};

--- a/packages/react-native-codegen/src/parsers/errors.js
+++ b/packages/react-native-codegen/src/parsers/errors.js
@@ -12,7 +12,7 @@
 
 const invariant = require('invariant');
 
-type ParserType = 'Flow' | 'TypeScript';
+export type ParserType = 'Flow' | 'TypeScript';
 
 class ParserError extends Error {
   nodes: $ReadOnlyArray<$FlowFixMe>;

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -61,9 +61,12 @@ const {
   MoreThanOneModuleRegistryCallsParserError,
   UntypedModuleRegistryCallParserError,
   IncorrectModuleRegistryCallTypeParameterParserError,
-  IncorrectModuleRegistryCallArityParserError,
   IncorrectModuleRegistryCallArgumentTypeParserError,
 } = require('../../errors.js');
+
+const {
+  throwIfIncorrectModuleRegistryCallArityParserError,
+} = require('../../error-utils');
 
 const invariant = require('invariant');
 const language = 'Flow';
@@ -667,15 +670,13 @@ function buildModuleSchema(
     const {typeArguments} = callExpression;
     const methodName = callExpression.callee.property.name;
 
-    if (callExpression.arguments.length !== 1) {
-      throw new IncorrectModuleRegistryCallArityParserError(
-        hasteModuleName,
-        callExpression,
-        methodName,
-        callExpression.arguments.length,
-        language,
-      );
-    }
+    throwIfIncorrectModuleRegistryCallArityParserError(
+      hasteModuleName,
+      callExpression,
+      methodName,
+      callExpression.arguments.length,
+      language,
+    );
 
     if (callExpression.arguments[0].type !== 'Literal') {
       const {type} = callExpression.arguments[0];

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -61,9 +61,12 @@ const {
   MoreThanOneModuleRegistryCallsParserError,
   UntypedModuleRegistryCallParserError,
   IncorrectModuleRegistryCallTypeParameterParserError,
-  IncorrectModuleRegistryCallArityParserError,
   IncorrectModuleRegistryCallArgumentTypeParserError,
 } = require('../../errors.js');
+
+const {
+  throwIfIncorrectModuleRegistryCallArityParserError,
+} = require('../../error-utils');
 
 const invariant = require('invariant');
 const language = 'TypeScript';
@@ -702,15 +705,13 @@ function buildModuleSchema(
     const {typeParameters} = callExpression;
     const methodName = callExpression.callee.property.name;
 
-    if (callExpression.arguments.length !== 1) {
-      throw new IncorrectModuleRegistryCallArityParserError(
-        hasteModuleName,
-        callExpression,
-        methodName,
-        callExpression.arguments.length,
-        language,
-      );
-    }
+    throwIfIncorrectModuleRegistryCallArityParserError(
+      hasteModuleName,
+      callExpression,
+      methodName,
+      callExpression.arguments.length,
+      language,
+    );
 
     if (callExpression.arguments[0].type !== 'StringLiteral') {
       const {type} = callExpression.arguments[0];


### PR DESCRIPTION
## Summary

This PR is part of #34872 
This PR extracts `IncorrectModuleRegistryCallArityParserError` exception to `throwIfIncorrectModuleRegistryCallArityParserError` inside an `error-utils.js` file.

## Changelog
[Internal] [Changed] - Extracted IncorrectModuleRegistryCallArityParserError exception to throwIfIncorrectModuleRegistryCallArityParserError function

## Test Plan

 Added unit case in error-utils-test.js file
 
 yarn jest react-native-codegen
 
<img width="1144" alt="Screenshot 2022-10-11 at 4 04 55 PM" src="https://user-images.githubusercontent.com/22423684/195070498-627d1bb8-53b1-43d3-b410-462e4f0da23a.png">



