### PR TITLE
[Codegen] Improve assertGenericTypeAnnotationHasExactlyOneTypeParameter tests

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-commons-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-commons-test.js
@@ -83,8 +83,25 @@ describe('unwrapNullable', () => {
 });
 
 describe('assertGenericTypeAnnotationHasExactlyOneTypeParameter', () => {
+  const moduleName = 'testModuleName';
+
+  it("doesn't throw any Error when typeAnnotation has exactly one typeParameter", () => {
+    const typeAnnotation = {
+      typeParameters: {
+        type: 'TypeParameterInstantiation',
+        params: [1],
+      },
+    };
+    expect(() =>
+      assertGenericTypeAnnotationHasExactlyOneTypeParameter(
+        moduleName,
+        typeAnnotation,
+        'Flow',
+      ),
+    ).not.toThrow();
+  });
+
   it('throws an IncorrectlyParameterizedGenericParserError if typeParameters is null', () => {
-    const moduleName = 'testModuleName';
     const typeAnnotation = {
       typeParameters: null,
       id: {
@@ -97,14 +114,16 @@ describe('assertGenericTypeAnnotationHasExactlyOneTypeParameter', () => {
         typeAnnotation,
         'Flow',
       ),
-    ).toThrow(IncorrectlyParameterizedGenericParserError);
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Module testModuleName: Generic 'typeAnnotationName' must have type parameters."`,
+    );
   });
 
-  it("throws an error if typeAnnotation.typeParameters.type doesn't have the correct value depending on language", () => {
-    const moduleName = 'testModuleName';
+  it('throws an error if typeAnnotation.typeParameters.type is not TypeParameterInstantiation when language is Flow', () => {
     const flowTypeAnnotation = {
       typeParameters: {
-        type: 'TypeParameterInstantiation',
+        type: 'wrongType',
+        params: [1],
       },
       id: {
         name: 'typeAnnotationName',
@@ -116,11 +135,16 @@ describe('assertGenericTypeAnnotationHasExactlyOneTypeParameter', () => {
         flowTypeAnnotation,
         'Flow',
       ),
-    ).toThrow(Error);
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"assertGenericTypeAnnotationHasExactlyOneTypeParameter: Type parameters must be an AST node of type 'TypeParameterInstantiation'"`,
+    );
+  });
 
+  it('throws an error if typeAnnotation.typeParameters.type is not TSTypeParameterInstantiation when language is TypeScript', () => {
     const typeScriptTypeAnnotation = {
       typeParameters: {
-        type: 'TypeParameterInstantiation',
+        type: 'wrongType',
+        params: [1],
       },
       typeName: {
         name: 'typeAnnotationName',
@@ -132,11 +156,12 @@ describe('assertGenericTypeAnnotationHasExactlyOneTypeParameter', () => {
         typeScriptTypeAnnotation,
         'TypeScript',
       ),
-    ).toThrow(Error);
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"assertGenericTypeAnnotationHasExactlyOneTypeParameter: Type parameters must be an AST node of type 'TSTypeParameterInstantiation'"`,
+    );
   });
 
   it("throws an IncorrectlyParameterizedGenericParserError if typeParameters don't have 1 exactly parameter", () => {
-    const moduleName = 'testModuleName';
     const typeAnnotationWithTwoParams = {
       typeParameters: {
         params: [1, 2],
@@ -152,7 +177,9 @@ describe('assertGenericTypeAnnotationHasExactlyOneTypeParameter', () => {
         typeAnnotationWithTwoParams,
         'Flow',
       ),
-    ).toThrow(IncorrectlyParameterizedGenericParserError);
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Module testModuleName: Generic 'typeAnnotationName' must have exactly one type parameter."`,
+    );
 
     const typeAnnotationWithNoParams = {
       typeParameters: {
@@ -169,6 +196,8 @@ describe('assertGenericTypeAnnotationHasExactlyOneTypeParameter', () => {
         typeAnnotationWithNoParams,
         'Flow',
       ),
-    ).toThrow(IncorrectlyParameterizedGenericParserError);
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Module testModuleName: Generic 'typeAnnotationName' must have exactly one type parameter."`,
+    );
   });
 });

--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-commons-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-commons-test.js
@@ -11,7 +11,6 @@
 
 'use-strict';
 
-import {IncorrectlyParameterizedGenericParserError} from '../errors';
 import {assertGenericTypeAnnotationHasExactlyOneTypeParameter} from '../parsers-commons';
 
 const {wrapNullable, unwrapNullable} = require('../parsers-commons.js');


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

https://github.com/facebook/react-native/pull/34933 has been merged just after I pushed a new commit to the branch to improve tests of `assertGenericTypeAnnotationHasExactlyOneTypeParameter` function, but the last commit was not imported to the internal repository.

The `assertGenericTypeAnnotationHasExactlyOneTypeParameter` can throw different types of Error, and I believe that `.toThrow(Error)` is not specific enough. So I replaced it with `toThrowErrorMatchingInlineSnapshot()`.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[Internal] [Changed] - Improve assertGenericTypeAnnotationHasExactlyOneTypeParameter tests in parsers-commons

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Some test cases were ok because the assertGenericTypeAnnotationHasExactlyOneTypeParameter function threw an Error, but for the wrong reason. I've made sure that the error displayed in the inline snapshot is the one we expect. 