### PR TITLE
Set isPressable for onPressIn/Out

### DIFF
--- a/Libraries/Text/Text.js
+++ b/Libraries/Text/Text.js
@@ -81,6 +81,8 @@ const Text: React.AbstractComponent<
 
   const isPressable =
     (onPress != null ||
+      onPressIn != null ||
+      onPressOut != null ||
       onLongPress != null ||
       onStartShouldSetResponder != null) &&
     _disabled !== true;


### PR DESCRIPTION
Summary:
In react-native-windows, the ability to detect a press event on a virtual span is dependent on setting a native only `isPressable` prop.

This modifies the Text component to include `onPressIn` and `onPressOut`. As a side-effect, this will also lazily initialize the pressability config when `onPressIn` or `onPressOut` only is set.

Changelog:
[General][Fixed] - Pressability for text with only `onPressIn` / `onPressOut` props

Differential Revision: D40264432

