### PR TITLE
[Codegen] Wrap the content of the case Array and case $ReadOnlyArray in Flow into a separate function

### DIFF
--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -75,6 +75,85 @@ function nullGuard<T>(fn: () => T): ?T {
   return fn();
 }
 
+function translateArrayTypeAnnotation(
+  hasteModuleName: string,
+  types: TypeDeclarationMap,
+  aliasMap: {...NativeModuleAliasMap},
+  cxxOnly: boolean,
+  flowArrayType: 'Array' | '$ReadOnlyArray',
+  flowElementType: $FlowFixMe,
+  nullable: boolean,
+): Nullable<NativeModuleTypeAnnotation> {
+  try {
+    /**
+     * TODO(T72031674): Migrate all our NativeModule specs to not use
+     * invalid Array ElementTypes. Then, make the elementType a required
+     * parameter.
+     */
+    const [elementType, isElementTypeNullable] = unwrapNullable(
+      translateTypeAnnotation(
+        hasteModuleName,
+        flowElementType,
+        types,
+        aliasMap,
+        /**
+         * TODO(T72031674): Ensure that all ParsingErrors that are thrown
+         * while parsing the array element don't get captured and collected.
+         * Why? If we detect any parsing error while parsing the element,
+         * we should default it to null down the line, here. This is
+         * the correct behaviour until we migrate all our NativeModule specs
+         * to be parseable.
+         */
+        nullGuard,
+        cxxOnly,
+      ),
+    );
+
+    if (elementType.type === 'VoidTypeAnnotation') {
+      throw new UnsupportedArrayElementTypeAnnotationParserError(
+        hasteModuleName,
+        flowElementType,
+        flowArrayType,
+        'void',
+        language,
+      );
+    }
+
+    if (elementType.type === 'PromiseTypeAnnotation') {
+      throw new UnsupportedArrayElementTypeAnnotationParserError(
+        hasteModuleName,
+        flowElementType,
+        flowArrayType,
+        'Promise',
+        language,
+      );
+    }
+
+    if (elementType.type === 'FunctionTypeAnnotation') {
+      throw new UnsupportedArrayElementTypeAnnotationParserError(
+        hasteModuleName,
+        flowElementType,
+        flowArrayType,
+        'FunctionTypeAnnotation',
+        language,
+      );
+    }
+
+    const finalTypeAnnotation: NativeModuleArrayTypeAnnotation<
+      Nullable<NativeModuleBaseTypeAnnotation>,
+    > = {
+      type: 'ArrayTypeAnnotation',
+      elementType: wrapNullable(isElementTypeNullable, elementType),
+    };
+
+    return wrapNullable(nullable, finalTypeAnnotation);
+  } catch (ex) {
+    return wrapNullable(nullable, {
+      type: 'ArrayTypeAnnotation',
+    });
+  }
+}
+
 function translateTypeAnnotation(
   hasteModuleName: string,
   /**
@@ -111,74 +190,15 @@ function translateTypeAnnotation(
             language,
           );
 
-          try {
-            /**
-             * TODO(T72031674): Migrate all our NativeModule specs to not use
-             * invalid Array ElementTypes. Then, make the elementType a required
-             * parameter.
-             */
-            const [elementType, isElementTypeNullable] = unwrapNullable(
-              translateTypeAnnotation(
-                hasteModuleName,
-                typeAnnotation.typeParameters.params[0],
-                types,
-                aliasMap,
-                /**
-                 * TODO(T72031674): Ensure that all ParsingErrors that are thrown
-                 * while parsing the array element don't get captured and collected.
-                 * Why? If we detect any parsing error while parsing the element,
-                 * we should default it to null down the line, here. This is
-                 * the correct behaviour until we migrate all our NativeModule specs
-                 * to be parseable.
-                 */
-                nullGuard,
-                cxxOnly,
-              ),
-            );
-
-            if (elementType.type === 'VoidTypeAnnotation') {
-              throw new UnsupportedArrayElementTypeAnnotationParserError(
-                hasteModuleName,
-                typeAnnotation.typeParameters.params[0],
-                typeAnnotation.type,
-                'void',
-                language,
-              );
-            }
-
-            if (elementType.type === 'PromiseTypeAnnotation') {
-              throw new UnsupportedArrayElementTypeAnnotationParserError(
-                hasteModuleName,
-                typeAnnotation.typeParameters.params[0],
-                typeAnnotation.type,
-                'Promise',
-                language,
-              );
-            }
-
-            if (elementType.type === 'FunctionTypeAnnotation') {
-              throw new UnsupportedArrayElementTypeAnnotationParserError(
-                hasteModuleName,
-                typeAnnotation.typeParameters.params[0],
-                typeAnnotation.type,
-                'FunctionTypeAnnotation',
-                language,
-              );
-            }
-
-            const finalTypeAnnotation: NativeModuleArrayTypeAnnotation<
-              Nullable<NativeModuleBaseTypeAnnotation>,
-            > = {
-              type: 'ArrayTypeAnnotation',
-              elementType: wrapNullable(isElementTypeNullable, elementType),
-            };
-
-            return wrapNullable(nullable, finalTypeAnnotation);
-          } catch (ex) {
-            return wrapNullable(nullable, {
-              type: 'ArrayTypeAnnotation',
-            });
-          }
+          return translateArrayTypeAnnotation(
+            hasteModuleName,
+            types,
+            aliasMap,
+            cxxOnly,
+            typeAnnotation.type,
+            typeAnnotation.typeParameters.params[0],
+            nullable,
+          );
         }
         case '$ReadOnly': {
           assertGenericTypeAnnotationHasExactlyOneTypeParameter(

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -82,7 +82,7 @@ function translateArrayTypeAnnotation(
   cxxOnly: boolean,
   tsArrayType: 'Array' | 'ReadonlyArray',
   tsElementType: $FlowFixMe,
-  nullable: $FlowFixMe,
+  nullable: boolean,
 ): Nullable<NativeModuleTypeAnnotation> {
   try {
     /**


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
This PR aims to extract translateArrayTypeAnnotation logic into a separate function as it is done in typescript folder. This will enable us to extract translateArrayTypeAnnotation function into a shared folder in a later step. It is a task of #34872:
> Wrap the content of the case Array: and case ReadOnlyArray in [Flow](https://github.com/facebook/react-native/blob/main/packages/react-native-codegen/src/parsers/flow/modules/index.js#L106-L107) into a separate function, as it is for the [TypeScript](https://github.com/facebook/react-native/blob/main/packages/react-native-codegen/src/parsers/typescript/modules/index.js#L218-L234) parser. This will enable us to unify the two parsers in a later step.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
[Internal] [Changed] - Wrap the content of the case Array and case $ReadOnlyArray in Flow into a separate function

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
yarn flow:
<img width="645" alt="image" src="https://user-images.githubusercontent.com/40902940/195200715-7f60d927-e262-4a94-ad91-a884d37726b8.png">

yarn lint:
<img width="502" alt="image" src="https://user-images.githubusercontent.com/40902940/195200799-7959e068-b5b7-4242-a7b1-7afd80866d7f.png">

yarn jest react-native-codegen:
<img width="381" alt="image" src="https://user-images.githubusercontent.com/40902940/195200775-76957c19-d06d-431c-8555-889a4205374e.png">


