### PR TITLE
Extracted content of the case FunctionTypeAnnotation into emitFunction in parsers-primitives file

### DIFF
--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -40,6 +40,7 @@ const {
 const {
   emitBoolean,
   emitDouble,
+  emitFunction,
   emitNumber,
   emitInt32,
   emitRootTag,
@@ -356,8 +357,7 @@ function translateTypeAnnotation(
       });
     }
     case 'FunctionTypeAnnotation': {
-      return wrapNullable(
-        nullable,
+      const translateFunctionTypeAnnotationValue: NativeModuleFunctionTypeAnnotation =
         translateFunctionTypeAnnotation(
           hasteModuleName,
           typeAnnotation,
@@ -365,8 +365,8 @@ function translateTypeAnnotation(
           aliasMap,
           tryParse,
           cxxOnly,
-        ),
-      );
+        );
+      return emitFunction(nullable, translateFunctionTypeAnnotationValue);
     }
     case 'UnionTypeAnnotation': {
       if (cxxOnly) {

--- a/packages/react-native-codegen/src/parsers/parsers-primitives.js
+++ b/packages/react-native-codegen/src/parsers/parsers-primitives.js
@@ -14,6 +14,7 @@ import type {
   Nullable,
   NativeModuleAliasMap,
   NativeModuleBaseTypeAnnotation,
+  NativeModuleFunctionTypeAnnotation,
   NativeModuleTypeAliasTypeAnnotation,
   NativeModuleNumberTypeAnnotation,
   BooleanTypeAnnotation,
@@ -62,6 +63,12 @@ function emitDouble(nullable: boolean): Nullable<DoubleTypeAnnotation> {
   return wrapNullable(nullable, {
     type: 'DoubleTypeAnnotation',
   });
+}
+function emitFunction(
+  nullable: boolean,
+  translateFunctionTypeAnnotationValue: NativeModuleFunctionTypeAnnotation,
+): Nullable<NativeModuleFunctionTypeAnnotation> {
+  return wrapNullable(nullable, translateFunctionTypeAnnotationValue);
 }
 
 function typeAliasResolution(
@@ -138,6 +145,7 @@ function emitPromise(
 module.exports = {
   emitBoolean,
   emitDouble,
+  emitFunction,
   emitInt32,
   emitNumber,
   emitRootTag,

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -40,6 +40,7 @@ const {
 const {
   emitBoolean,
   emitDouble,
+  emitFunction,
   emitNumber,
   emitInt32,
   emitRootTag,
@@ -391,8 +392,7 @@ function translateTypeAnnotation(
       });
     }
     case 'TSFunctionType': {
-      return wrapNullable(
-        nullable,
+      const translateFunctionTypeAnnotationValue: NativeModuleFunctionTypeAnnotation =
         translateFunctionTypeAnnotation(
           hasteModuleName,
           typeAnnotation,
@@ -400,8 +400,9 @@ function translateTypeAnnotation(
           aliasMap,
           tryParse,
           cxxOnly,
-        ),
-      );
+        );
+
+      return emitFunction(nullable, translateFunctionTypeAnnotationValue);
     }
     case 'TSUnionType': {
       if (cxxOnly) {


### PR DESCRIPTION

## Summary
This PR is part of #34872 
This PR extracts the content of the case `FunctionTypeAnnotation` into a single `emitFunction` function inside the parsers-primitives.js file and uses it in both Flow and TypeScript parsers
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[Internal] [Changed] - Extract the content of the case `FunctionTypeAnnotation` into a single `emitFunction` function



## Test Plan
Run yarn jest react-native-codegen and ensure CI is green
<img width="984" alt="Screenshot 2022-10-12 at 11 18 54 AM" src="https://user-images.githubusercontent.com/86604753/195260414-136f918f-e4b7-4fcf-b0b9-9142872f3cf9.png">

