### PR TITLE
extracted `nullguard` function to `parsers-util.js` file 

### DIFF
--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -25,6 +25,7 @@ import type {
 import type {TypeDeclarationMap} from '../utils.js';
 import type {ParserErrorCapturer} from '../../utils';
 import type {NativeModuleTypeAnnotation} from '../../../CodegenSchema.js';
+import {nullGuard} from '../../parsers-utils';
 
 const {
   resolveTypeAnnotation,
@@ -71,10 +72,6 @@ const {
 } = require('../../errors.js');
 
 const language = 'Flow';
-
-function nullGuard<T>(fn: () => T): ?T {
-  return fn();
-}
 
 function translateTypeAnnotation(
   hasteModuleName: string,

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -25,7 +25,7 @@ import type {
 import type {TypeDeclarationMap} from '../utils.js';
 import type {ParserErrorCapturer} from '../../utils';
 import type {NativeModuleTypeAnnotation} from '../../../CodegenSchema.js';
-import {nullGuard} from '../../parsers-utils';
+const {nullGuard} = require('../../parsers-utils');
 
 const {
   resolveTypeAnnotation,

--- a/packages/react-native-codegen/src/parsers/parsers-utils.js
+++ b/packages/react-native-codegen/src/parsers/parsers-utils.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow strict
+ */
+
+'use strict';
+
+function nullGuard<T>(fn: () => T): ?T {
+  return fn();
+}
+
+module.exports = {
+  nullGuard,
+};

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -25,7 +25,7 @@ import type {
 import type {TypeDeclarationMap} from '../utils.js';
 import type {ParserErrorCapturer} from '../../utils';
 import type {NativeModuleTypeAnnotation} from '../../../CodegenSchema.js';
-import {nullGuard} from '../../parsers-utils';
+const {nullGuard} = require('../../parsers-utils');
 
 const {
   resolveTypeAnnotation,

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -25,6 +25,7 @@ import type {
 import type {TypeDeclarationMap} from '../utils.js';
 import type {ParserErrorCapturer} from '../../utils';
 import type {NativeModuleTypeAnnotation} from '../../../CodegenSchema.js';
+import {nullGuard} from '../../parsers-utils';
 
 const {
   resolveTypeAnnotation,
@@ -71,10 +72,6 @@ const {
 } = require('../../errors.js');
 
 const language = 'TypeScript';
-
-function nullGuard<T>(fn: () => T): ?T {
-  return fn();
-}
 
 function translateArrayTypeAnnotation(
   hasteModuleName: string,


### PR DESCRIPTION
## Summary

This PR is a part of #34872 
This PR extracts Extract the `nullGuard` function ([Flow](https://github.com/facebook/react-native/blob/main/packages/react-native-codegen/src/parsers/typescript/modules/index.js#L74-L76), [TypeScript](https://github.com/facebook/react-native/blob/main/packages/react-native-codegen/src/parsers/typescript/modules/index.js#L74-L76)) into a function in the `parsers-utils.js` file

## Changelog
[Internal] [Changed] - Extracted `nullGuard` function from flow and typescript to a file `parsers-utils.js`.

## Test Plan
yarn jest react-native-codegen
<img width="1042" alt="Screenshot 2022-10-12 at 12 52 02 PM" src="https://user-images.githubusercontent.com/22423684/195277414-dc0122f4-603a-4e93-aef1-2ac0c33a960d.png">

