### PR TITLE
[Codegen]: extracted `UntypedModuleRegistryCallParserError` to a throwing function in error-utils.js

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow strict-local
+ * @oncall react_native
+ */
+
+'use strict';
+
+describe('throwIfUntypedModule', () => {
+  const {throwIfUntypedModule} = require('../error-utils');
+  const {UntypedModuleRegistryCallParserError} = require('../errors');
+  const hasteModuleName = 'moduleName';
+  const methodName = 'methodName';
+  const moduleName = 'moduleName';
+  const callExpressions = [];
+
+  it('should throw error if module does not have a type', () => {
+    const typeArguments = null;
+    const language = 'Flow';
+    expect(() =>
+      throwIfUntypedModule(
+        typeArguments,
+        hasteModuleName,
+        callExpressions,
+        methodName,
+        moduleName,
+        language,
+      ),
+    ).toThrowError(UntypedModuleRegistryCallParserError);
+  });
+
+  it('should not throw error if module have a type', () => {
+    const typeArguments = {
+      type: 'TSTypeParameterInstantiations',
+      params: [],
+    };
+
+    const language = 'TypeScript';
+    expect(() =>
+      throwIfUntypedModule(
+        typeArguments,
+        hasteModuleName,
+        callExpressions,
+        methodName,
+        moduleName,
+        language,
+      ),
+    ).not.toThrowError(UntypedModuleRegistryCallParserError);
+  });
+});

--- a/packages/react-native-codegen/src/parsers/error-utils.js
+++ b/packages/react-native-codegen/src/parsers/error-utils.js
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+'use strict';
+
+import type {ParserType} from './errors';
+
+const {UntypedModuleRegistryCallParserError} = require('./errors');
+
+function throwIfUntypedModule(
+  typeArguments: $FlowFixMe,
+  hasteModuleName: string,
+  callExpression: $FlowFixMe,
+  methodName: string,
+  $moduleName: string,
+  language: ParserType,
+) {
+  if (typeArguments == null) {
+    throw new UntypedModuleRegistryCallParserError(
+      hasteModuleName,
+      callExpression,
+      methodName,
+      $moduleName,
+      language,
+    );
+  }
+}
+
+module.exports = {
+  throwIfUntypedModule,
+};

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -64,11 +64,11 @@ const {
   UnsupportedObjectPropertyValueTypeAnnotationParserError,
   UnusedModuleInterfaceParserError,
   MoreThanOneModuleRegistryCallsParserError,
-  UntypedModuleRegistryCallParserError,
   IncorrectModuleRegistryCallTypeParameterParserError,
   IncorrectModuleRegistryCallArityParserError,
   IncorrectModuleRegistryCallArgumentTypeParserError,
 } = require('../../errors.js');
+const {throwIfUntypedModule} = require('../../error-utils');
 
 const language = 'Flow';
 
@@ -663,15 +663,14 @@ function buildModuleSchema(
 
     const $moduleName = callExpression.arguments[0].value;
 
-    if (typeArguments == null) {
-      throw new UntypedModuleRegistryCallParserError(
-        hasteModuleName,
-        callExpression,
-        methodName,
-        $moduleName,
-        language,
-      );
-    }
+    throwIfUntypedModule(
+      typeArguments,
+      hasteModuleName,
+      callExpression,
+      methodName,
+      $moduleName,
+      language,
+    );
 
     if (
       typeArguments.type !== 'TypeParameterInstantiation' ||

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -64,11 +64,11 @@ const {
   UnsupportedObjectPropertyValueTypeAnnotationParserError,
   UnusedModuleInterfaceParserError,
   MoreThanOneModuleRegistryCallsParserError,
-  UntypedModuleRegistryCallParserError,
   IncorrectModuleRegistryCallTypeParameterParserError,
   IncorrectModuleRegistryCallArityParserError,
   IncorrectModuleRegistryCallArgumentTypeParserError,
 } = require('../../errors.js');
+const {throwIfUntypedModule} = require('../../error-utils');
 
 const language = 'TypeScript';
 
@@ -697,15 +697,14 @@ function buildModuleSchema(
 
     const $moduleName = callExpression.arguments[0].value;
 
-    if (typeParameters == null) {
-      throw new UntypedModuleRegistryCallParserError(
-        hasteModuleName,
-        callExpression,
-        methodName,
-        $moduleName,
-        language,
-      );
-    }
+    throwIfUntypedModule(
+      typeParameters,
+      hasteModuleName,
+      callExpression,
+      methodName,
+      $moduleName,
+      language,
+    );
 
     if (
       typeParameters.type !== 'TSTypeParameterInstantiation' ||


### PR DESCRIPTION
## Summary

This PR is part of #34872.
As a part of this PR, `UntypedModuleRegistryCallParserError` is separated into its own throwing function in `error-utils.js` file and is used in both Flow and TypeScript parsers

## Changelog

[Internal] [Changed] - Extract `UntypedModuleRegistryCallParserError` to a separate function inside `error-utils.js` file.

## Test Plan

Added unit case in error-utils-test.js file to test the new function.
Output of `yarn jest react-native-codegen` ensures all passed test cases. 

<img width="450" alt="Screenshot 2022-10-12 at 12 44 36 PM" src="https://user-images.githubusercontent.com/32268377/195277708-97340db3-f3d8-48a3-9a59-95d2747c67b0.png">


