### PR TITLE
[Codegen]: extract emitMixedTypeAnnotation to parsers-commons

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-commons-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-commons-test.js
@@ -14,7 +14,11 @@
 import {IncorrectlyParameterizedGenericParserError} from '../errors';
 import {assertGenericTypeAnnotationHasExactlyOneTypeParameter} from '../parsers-commons';
 
-const {wrapNullable, unwrapNullable} = require('../parsers-commons.js');
+const {
+  wrapNullable,
+  unwrapNullable,
+  emitMixedTypeAnnotation,
+} = require('../parsers-commons.js');
 
 describe('wrapNullable', () => {
   describe('when nullable is true', () => {
@@ -170,5 +174,31 @@ describe('assertGenericTypeAnnotationHasExactlyOneTypeParameter', () => {
         'Flow',
       ),
     ).toThrow(IncorrectlyParameterizedGenericParserError);
+  });
+});
+
+describe('emitMixedTypeAnnotation', () => {
+  describe('when nullable is true', () => {
+    it('returns nullable type annotation', () => {
+      const result = emitMixedTypeAnnotation(true);
+      const expected = {
+        type: 'NullableTypeAnnotation',
+        typeAnnotation: {
+          type: 'MixedTypeAnnotation',
+        },
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+  describe('when nullable is false', () => {
+    it('returns non nullable type annotation', () => {
+      const result = emitMixedTypeAnnotation(false);
+      const expected = {
+        type: 'MixedTypeAnnotation',
+      };
+
+      expect(result).toEqual(expected);
+    });
   });
 });

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -36,6 +36,7 @@ const {
   unwrapNullable,
   wrapNullable,
   assertGenericTypeAnnotationHasExactlyOneTypeParameter,
+  emitMixedTypeAnnotation,
 } = require('../../parsers-commons');
 const {
   emitBoolean,
@@ -397,9 +398,7 @@ function translateTypeAnnotation(
     }
     case 'MixedTypeAnnotation': {
       if (cxxOnly) {
-        return wrapNullable(nullable, {
-          type: 'MixedTypeAnnotation',
-        });
+        return emitMixedTypeAnnotation(nullable);
       }
       // Fallthrough
     }

--- a/packages/react-native-codegen/src/parsers/parsers-commons.js
+++ b/packages/react-native-codegen/src/parsers/parsers-commons.js
@@ -15,6 +15,7 @@ import type {
   NativeModuleSchema,
   NativeModuleTypeAnnotation,
   Nullable,
+  NativeModuleMixedTypeAnnotation,
 } from '../CodegenSchema.js';
 const {IncorrectlyParameterizedGenericParserError} = require('./errors');
 import type {ParserType} from './errors';
@@ -91,9 +92,18 @@ function assertGenericTypeAnnotationHasExactlyOneTypeParameter(
   }
 }
 
+function emitMixedTypeAnnotation(
+  nullable: boolean,
+): Nullable<NativeModuleMixedTypeAnnotation> {
+  return wrapNullable(nullable, {
+    type: 'MixedTypeAnnotation',
+  });
+}
+
 module.exports = {
   wrapModuleSchema,
   unwrapNullable,
   wrapNullable,
   assertGenericTypeAnnotationHasExactlyOneTypeParameter,
+  emitMixedTypeAnnotation,
 };

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -36,6 +36,7 @@ const {
   unwrapNullable,
   wrapNullable,
   assertGenericTypeAnnotationHasExactlyOneTypeParameter,
+  emitMixedTypeAnnotation,
 } = require('../../parsers-commons');
 const {
   emitBoolean,
@@ -432,9 +433,7 @@ function translateTypeAnnotation(
     }
     case 'TSUnknownKeyword': {
       if (cxxOnly) {
-        return wrapNullable(nullable, {
-          type: 'MixedTypeAnnotation',
-        });
+        return emitMixedTypeAnnotation(nullable);
       }
       // Fallthrough
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Create a function emitMixedTypeAnnotation into the parsers-commons.js file to put together this code from [Flow](https://github.com/facebook/react-native/blob/main/packages/react-native-codegen/src/parsers/flow/modules/index.js#L400-L404) and [TypeScript](https://github.com/facebook/react-native/blob/main/packages/react-native-codegen/src/parsers/typescript/modules/index.js#L435-L440).

Part of #34872 

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[Internal] [Changed] - Extract emitMixedTypeAnnotation into the parsers-commons

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
run ```yarn jest react-native-codegen```

<img width="781" alt="image" src="https://user-images.githubusercontent.com/34857453/195291603-f138c64c-1b49-41af-a133-ee366d02706a.png">

