### PR TITLE
chore: rename all redbox occurences to 'redBox'

### DIFF
--- a/Libraries/BugReporting/BugReporting.js
+++ b/Libraries/BugReporting/BugReporting.js
@@ -37,7 +37,7 @@ class BugReporting {
   static _extraSources: Map<string, SourceCallback> = new Map();
   static _fileSources: Map<string, SourceCallback> = new Map();
   static _subscription: ?EventSubscription = null;
-  static _redboxSubscription: ?EventSubscription = null;
+  static _redBoxSubscription: ?EventSubscription = null;
 
   static _maybeInit() {
     if (!BugReporting._subscription) {
@@ -50,8 +50,8 @@ class BugReporting {
       defaultExtras();
     }
 
-    if (!BugReporting._redboxSubscription) {
-      BugReporting._redboxSubscription = RCTDeviceEventEmitter.addListener(
+    if (!BugReporting._redBoxSubscription) {
+      BugReporting._redBoxSubscription = RCTDeviceEventEmitter.addListener(
         'collectRedBoxExtraData',
         // $FlowFixMe[method-unbinding]
         BugReporting.collectExtraData,

--- a/Libraries/Core/ExceptionsManager.js
+++ b/Libraries/Core/ExceptionsManager.js
@@ -201,7 +201,7 @@ function reactConsoleErrorHandler(...args) {
     const stringifySafe = require('../Utilities/stringifySafe').default;
     if (typeof firstArg === 'string' && firstArg.startsWith('Warning: ')) {
       // React warnings use console.error so that a stack trace is shown, but
-      // we don't (currently) want these to show a redbox
+      // we don't (currently) want these to show a RedBox
       // (Note: Logic duplicated in polyfills/console.js.)
       return;
     }
@@ -223,7 +223,7 @@ function reactConsoleErrorHandler(...args) {
 }
 
 /**
- * Shows a redbox with stacktrace for all console.error messages.  Disable by
+ * Shows a RedBox with stacktrace for all console.error messages.  Disable by
  * setting `console.reportErrorsAsExceptions = false;` in your app.
  */
 function installConsoleErrorReporter() {

--- a/Libraries/Core/ReactFiberErrorDialog.js
+++ b/Libraries/Core/ReactFiberErrorDialog.js
@@ -22,7 +22,7 @@ export type CapturedError = {
 const ReactFiberErrorDialog = {
   /**
    * Intercept lifecycle errors and ensure they are shown with the correct stack
-   * trace within the native redbox component.
+   * trace within the native RedBox component.
    */
   showErrorDialog({componentStack, error: errorValue}: CapturedError): boolean {
     let error: ?ExtendedError;
@@ -53,7 +53,7 @@ const ReactFiberErrorDialog = {
 
     // Return false here to prevent ReactFiberErrorLogger default behavior of
     // logging error details to console.error. Calls to console.error are
-    // automatically routed to the native redbox controller, which we've already
+    // automatically routed to the native RedBox controller, which we've already
     // done above by calling ExceptionsManager.
     return false;
   },

--- a/Libraries/Core/setUpErrorHandling.js
+++ b/Libraries/Core/setUpErrorHandling.js
@@ -11,7 +11,7 @@
 'use strict';
 
 /**
- * Sets up the console and exception handling (redbox) for React Native.
+ * Sets up the console and exception handling (RedBox) for React Native.
  * You can use this module directly, or just require InitializeCore.
  */
 const ExceptionsManager = require('./ExceptionsManager');

--- a/Libraries/LogBox/Data/LogBoxData.js
+++ b/Libraries/LogBox/Data/LogBoxData.js
@@ -423,7 +423,7 @@ export function withSubscription(
 
     render(): React.Node {
       if (this.state.hasError) {
-        // This happens when the component failed to render, in which case we delegate to the native redbox.
+        // This happens when the component failed to render, in which case we delegate to the native RedBox.
         // We can't show anyback fallback UI here, because the error may be with <View> or <Text>.
         return null;
       }

--- a/Libraries/LogBox/Data/__tests__/LogBoxData-test.js
+++ b/Libraries/LogBox/Data/__tests__/LogBoxData-test.js
@@ -662,7 +662,7 @@ describe('LogBoxData', () => {
     expect(observer.mock.calls.length).toBe(3);
   });
 
-  it('reportLogBoxError creates a native redbox with a componentStack', () => {
+  it('reportLogBoxError creates a native RedBox with a componentStack', () => {
     LogBoxData.reportLogBoxError(
       /* $FlowFixMe[class-object-subtyping] added when improving typing for
        * this parameters */
@@ -677,7 +677,7 @@ describe('LogBoxData', () => {
     );
   });
 
-  it('reportLogBoxError creates a native redbox without a componentStack', () => {
+  it('reportLogBoxError creates a native RedBox without a componentStack', () => {
     /* $FlowFixMe[class-object-subtyping] added when improving typing for this
      * parameters */
     LogBoxData.reportLogBoxError(new Error('Simulated Error'));

--- a/Libraries/Network/XMLHttpRequest.js
+++ b/Libraries/Network/XMLHttpRequest.js
@@ -191,7 +191,7 @@ class XMLHttpRequest extends (EventTarget(...XHR_EVENTS): any) {
       return;
     }
 
-    // redboxes early, e.g. for 'arraybuffer' on ios 7
+    // RedBoxes early, e.g. for 'arraybuffer' on ios 7
     invariant(
       SUPPORTED_RESPONSE_TYPES[responseType] || responseType === 'document',
       `The provided value '${responseType}' is unsupported in this environment.`,

--- a/Libraries/Renderer/implementations/ReactFabric-dev.js
+++ b/Libraries/Renderer/implementations/ReactFabric-dev.js
@@ -13120,7 +13120,7 @@ function showErrorDialog(boundary, errorInfo) {
 function logCapturedError(boundary, errorInfo) {
   try {
     var logError = showErrorDialog(boundary, errorInfo); // Allow injected showErrorDialog() to prevent default console.error logging.
-    // This enables renderers like ReactNative to better manage redbox behavior.
+    // This enables renderers like ReactNative to better manage RedBox behavior.
 
     if (logError === false) {
       return;
@@ -24391,6 +24391,6 @@ if (
 ) {
   __REACT_DEVTOOLS_GLOBAL_HOOK__.registerInternalModuleStop(new Error());
 }
-        
+
   })();
 }

--- a/Libraries/Renderer/implementations/ReactNativeRenderer-dev.js
+++ b/Libraries/Renderer/implementations/ReactNativeRenderer-dev.js
@@ -13249,7 +13249,7 @@ function showErrorDialog(boundary, errorInfo) {
 function logCapturedError(boundary, errorInfo) {
   try {
     var logError = showErrorDialog(boundary, errorInfo); // Allow injected showErrorDialog() to prevent default console.error logging.
-    // This enables renderers like ReactNative to better manage redbox behavior.
+    // This enables renderers like ReactNative to better manage RedBox behavior.
 
     if (logError === false) {
       return;
@@ -24752,6 +24752,6 @@ if (
 ) {
   __REACT_DEVTOOLS_GLOBAL_HOOK__.registerInternalModuleStop(new Error());
 }
-        
+
   })();
 }

--- a/Libraries/Utilities/HMRClient.js
+++ b/Libraries/Utilities/HMRClient.js
@@ -211,7 +211,7 @@ Error: ${e.message}`;
 
     client.on('update', ({isInitialUpdate}) => {
       if (client.isEnabled() && !isInitialUpdate) {
-        dismissRedbox();
+        dismissRedBox();
         LogBox.clearAllLogs();
       }
     });
@@ -301,7 +301,7 @@ function flushEarlyLogs(client: MetroHMRClient) {
   }
 }
 
-function dismissRedbox() {
+function dismissRedBox() {
   if (
     Platform.OS === 'ios' &&
     NativeRedBox != null &&
@@ -312,8 +312,8 @@ function dismissRedbox() {
     const NativeExceptionsManager =
       require('../Core/NativeExceptionsManager').default;
     NativeExceptionsManager &&
-      NativeExceptionsManager.dismissRedbox &&
-      NativeExceptionsManager.dismissRedbox();
+      NativeExceptionsManager.dismissRedBox &&
+      NativeExceptionsManager.dismissRedBox();
   }
 }
 
@@ -322,9 +322,9 @@ function showCompileError() {
     return;
   }
 
-  // Even if there is already a redbox, syntax errors are more important.
+  // Even if there is already a RedBox, syntax errors are more important.
   // Otherwise you risk seeing a stale runtime error while a syntax error is more recent.
-  dismissRedbox();
+  dismissRedBox();
 
   const message = currentCompileErrorMessage;
   currentCompileErrorMessage = null;

--- a/React/Base/RCTLog.h
+++ b/React/Base/RCTLog.h
@@ -19,7 +19,7 @@
 #endif
 
 /**
- * Thresholds for logs to display a redbox. You can override these values when debugging
+ * Thresholds for logs to display a RedBox. You can override these values when debugging
  * in order to tweak the default logging behavior.
  */
 #ifndef RCTLOG_REDBOX_LEVEL

--- a/React/Base/RCTLog.mm
+++ b/React/Base/RCTLog.mm
@@ -301,14 +301,14 @@ void _RCTLogNativeInternal(RCTLogLevel level, const char *fileName, int lineNumb
         // red box is thread safe, but by deferring to main queue we avoid a startup
         // race condition that causes the module to be accessed before it has loaded
         RCTModuleRegistry *moduleRegistry = RCTLogBridgeModuleRegistry ?: RCTLogBridgelessModuleRegistry;
-        id redbox = [moduleRegistry moduleForName:"RedBox" lazilyLoadIfNecessary:YES];
-        if (redbox) {
+        id redBox = [moduleRegistry moduleForName:"RedBox" lazilyLoadIfNecessary:YES];
+        if (redBox) {
           void (*showErrorMessage)(id, SEL, NSString *, NSMutableArray<NSDictionary *> *) =
               (__typeof__(showErrorMessage))objc_msgSend;
           SEL showErrorMessageSEL = NSSelectorFromString(@"showErrorMessage:withStack:");
 
-          if ([redbox respondsToSelector:showErrorMessageSEL]) {
-            showErrorMessage(redbox, showErrorMessageSEL, message, stack);
+          if ([redBox respondsToSelector:showErrorMessageSEL]) {
+            showErrorMessage(redBox, showErrorMessageSEL, message, stack);
           }
         }
       });

--- a/React/CoreModules/RCTExceptionsManager.mm
+++ b/React/CoreModules/RCTExceptionsManager.mm
@@ -40,8 +40,8 @@ RCT_EXPORT_MODULE()
         exceptionId:(double)exceptionId
     extraDataAsJSON:(nullable NSString *)extraDataAsJSON
 {
-  RCTRedBox *redbox = [_moduleRegistry moduleForName:"RedBox"];
-  [redbox showErrorMessage:message withStack:stack errorCookie:(int)exceptionId];
+  RCTRedBox *redBox = [_moduleRegistry moduleForName:"RedBox"];
+  [redBox showErrorMessage:message withStack:stack errorCookie:(int)exceptionId];
 
   if (_delegate) {
     [_delegate handleSoftJSExceptionWithMessage:message
@@ -56,8 +56,8 @@ RCT_EXPORT_MODULE()
         exceptionId:(double)exceptionId
     extraDataAsJSON:(nullable NSString *)extraDataAsJSON
 {
-  RCTRedBox *redbox = [_moduleRegistry moduleForName:"RedBox"];
-  [redbox showErrorMessage:message withStack:stack errorCookie:(int)exceptionId];
+  RCTRedBox *redBox = [_moduleRegistry moduleForName:"RedBox"];
+  [redBox showErrorMessage:message withStack:stack errorCookie:(int)exceptionId];
 
   if (_delegate) {
     [_delegate handleFatalJSExceptionWithMessage:message
@@ -99,8 +99,8 @@ RCT_EXPORT_METHOD(updateExceptionMessage
                   : (NSArray<NSDictionary *> *)stack exceptionId
                   : (double)exceptionId)
 {
-  RCTRedBox *redbox = [_moduleRegistry moduleForName:"RedBox"];
-  [redbox updateErrorMessage:message withStack:stack errorCookie:(int)exceptionId];
+  RCTRedBox *redBox = [_moduleRegistry moduleForName:"RedBox"];
+  [redBox updateErrorMessage:message withStack:stack errorCookie:(int)exceptionId];
 
   if (_delegate && [_delegate respondsToSelector:@selector(updateJSExceptionWithMessage:stack:exceptionId:)]) {
     [_delegate updateJSExceptionWithMessage:message stack:stack exceptionId:[NSNumber numberWithDouble:exceptionId]];

--- a/React/CoreModules/RCTRedBox.mm
+++ b/React/CoreModules/RCTRedBox.mm
@@ -122,19 +122,19 @@
 #endif
 
     UIButton *dismissButton = [self redBoxButton:dismissText
-                         accessibilityIdentifier:@"redbox-dismiss"
+                         accessibilityIdentifier:@"redBox-dismiss"
                                         selector:@selector(dismiss)
                                            block:nil];
     UIButton *reloadButton = [self redBoxButton:reloadText
-                        accessibilityIdentifier:@"redbox-reload"
+                        accessibilityIdentifier:@"redBox-reload"
                                        selector:@selector(reload)
                                           block:nil];
     UIButton *copyButton = [self redBoxButton:copyText
-                      accessibilityIdentifier:@"redbox-copy"
+                      accessibilityIdentifier:@"redBox-copy"
                                      selector:@selector(copyStack)
                                         block:nil];
     UIButton *extraButton = [self redBoxButton:extraText
-                       accessibilityIdentifier:@"redbox-extra"
+                       accessibilityIdentifier:@"redBox-extra"
                                       selector:@selector(showExtraDataViewController)
                                          block:nil];
 
@@ -326,7 +326,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)aDecoder)
 {
   if (!cell) {
     cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"msg-cell"];
-    cell.textLabel.accessibilityIdentifier = @"redbox-error";
+    cell.textLabel.accessibilityIdentifier = @"redBox-error";
     cell.textLabel.textColor = [UIColor whiteColor];
     if (@available(iOS 13.0, *)) {
       // Prefer a monofont for formatting messages that were designed

--- a/React/CxxBridge/RCTCxxBridge.mm
+++ b/React/CxxBridge/RCTCxxBridge.mm
@@ -1152,7 +1152,7 @@ struct RCTInstanceCallback : public InstanceCallback {
   }
 
   // Hack: once the bridge is invalidated below, it won't initialize any new native
-  // modules. Initialize the redbox module now so we can still report this error.
+  // modules. Initialize the RedBox module now so we can still report this error.
   RCTRedBox *redBox = [self redBox];
 
   _loading = NO;

--- a/React/Modules/RCTRedBoxExtraDataViewController.m
+++ b/React/Modules/RCTRedBoxExtraDataViewController.m
@@ -92,7 +92,7 @@
 
     UIButton *dismissButton = [UIButton buttonWithType:UIButtonTypeCustom];
     dismissButton.translatesAutoresizingMaskIntoConstraints = NO;
-    dismissButton.accessibilityIdentifier = @"redbox-extra-data-dismiss";
+    dismissButton.accessibilityIdentifier = @"redBox-extra-data-dismiss";
     dismissButton.titleLabel.font = [UIFont systemFontOfSize:13];
     [dismissButton setTitle:dismissText forState:UIControlStateNormal];
     [dismissButton setTitleColor:[UIColor colorWithWhite:1 alpha:0.5] forState:UIControlStateNormal];
@@ -100,7 +100,7 @@
     [dismissButton addTarget:self action:@selector(dismiss) forControlEvents:UIControlEventTouchUpInside];
 
     UIButton *reloadButton = [UIButton buttonWithType:UIButtonTypeCustom];
-    reloadButton.accessibilityIdentifier = @"redbox-reload";
+    reloadButton.accessibilityIdentifier = @"redBox-reload";
     reloadButton.titleLabel.font = [UIFont systemFontOfSize:13];
     [reloadButton setTitle:reloadText forState:UIControlStateNormal];
     [reloadButton setTitleColor:[UIColor colorWithWhite:1 alpha:0.5] forState:UIControlStateNormal];

--- a/ReactAndroid/src/androidTest/java/com/facebook/react/testing/ReactAppTestActivity.java
+++ b/ReactAndroid/src/androidTest/java/com/facebook/react/testing/ReactAppTestActivity.java
@@ -238,8 +238,8 @@ public class ReactAppTestActivity extends FragmentActivity
     builder
         .addPackage(new InstanceSpecForTestPackage(spec))
         // By not setting a JS module name, we force the bundle to be always loaded from
-        // assets, not the devserver, even if dev mode is enabled (such as when testing redboxes).
-        // This makes sense because we never run the devserver in tests.
+        // assets, not the dev server, even if dev mode is enabled (such as when testing RedBoxes).
+        // This makes sense because we never run the dev server in tests.
         // .setJSMainModuleName()
         .setUseDeveloperSupport(useDevSupport)
         .setBridgeIdleDebugListener(mBridgeIdleSignaler)

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManagerBuilder.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManagerBuilder.java
@@ -241,7 +241,7 @@ public class ReactInstanceManagerBuilder {
 
   /**
    * Set the exception handler for all native module calls. If not set, the default {@link
-   * DevSupportManager} will be used, which shows a redbox in dev mode and rethrows (crashes the
+   * DevSupportManager} will be used, which shows a RedBox in dev mode and rethrows (crashes the
    * app) in prod mode.
    */
   public ReactInstanceManagerBuilder setJSExceptionHandler(JSExceptionHandler handler) {

--- a/ReactAndroid/src/main/java/com/facebook/react/common/JavascriptException.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/common/JavascriptException.java
@@ -11,7 +11,7 @@ import javax.annotation.Nullable;
 
 /**
  * A JS exception that was propagated to native. In debug mode, these exceptions are normally shown
- * to developers in a redbox.
+ * to developers in a RedBox.
  */
 public class JavascriptException extends RuntimeException
     implements HasJavascriptExceptionMetadata {

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/BridgeDevSupportManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/BridgeDevSupportManager.java
@@ -209,8 +209,8 @@ public final class BridgeDevSupportManager extends DevSupportManagerBase {
         ReactMarkerConstants.RELOAD,
         getDevSettings().getPackagerConnectionSettings().getDebugServerHost());
 
-    // dismiss redbox if exists
-    hideRedboxDialog();
+    // dismiss RedBox if exists
+    hideRedBoxDialog();
 
     if (getDevSettings().isRemoteJSDebugEnabled()) {
       PrinterHolder.getPrinter()

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
@@ -311,7 +311,7 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
   }
 
   @Override
-  public void hideRedboxDialog() {
+  public void hideRedBoxDialog() {
     if (mRedBoxSurfaceDelegate == null) {
       return;
     }
@@ -1178,8 +1178,8 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
         mIsReceiverRegistered = false;
       }
 
-      // hide redbox dialog
-      hideRedboxDialog();
+      // hide RedBox dialog
+      hideRedBoxDialog();
 
       // hide dev options dialog
       hideDevOptionsDialog();

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DisabledDevSupportManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DisabledDevSupportManager.java
@@ -60,7 +60,7 @@ public class DisabledDevSupportManager implements DevSupportManager {
   public void updateJSError(String message, ReadableArray details, int errorCookie) {}
 
   @Override
-  public void hideRedboxDialog() {}
+  public void hideRedBoxDialog() {}
 
   @Override
   public void showDevOptionsDialog() {}

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/RedBoxContentView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/RedBoxContentView.java
@@ -169,7 +169,7 @@ public class RedBoxContentView extends LinearLayout implements AdapterView.OnIte
                 ? (TextView) convertView
                 : (TextView)
                     LayoutInflater.from(parent.getContext())
-                        .inflate(R.layout.redbox_item_title, parent, false);
+                        .inflate(R.layout.redBox_item_title, parent, false);
         // Remove ANSI color codes from the title
         String titleSafe = (mTitle == null ? "<unknown title>" : mTitle);
         title.setText(titleSafe.replaceAll("\\x1b\\[[0-9;]*m", ""));
@@ -178,7 +178,7 @@ public class RedBoxContentView extends LinearLayout implements AdapterView.OnIte
         if (convertView == null) {
           convertView =
               LayoutInflater.from(parent.getContext())
-                  .inflate(R.layout.redbox_item_frame, parent, false);
+                  .inflate(R.layout.redBox_item_frame, parent, false);
           convertView.setTag(new FrameViewHolder(convertView));
         }
         StackFrame frame = mStack[position - 1];
@@ -249,12 +249,12 @@ public class RedBoxContentView extends LinearLayout implements AdapterView.OnIte
   }
 
   public void init() {
-    LayoutInflater.from(getContext()).inflate(R.layout.redbox_view, this);
+    LayoutInflater.from(getContext()).inflate(R.layout.redBox_view, this);
 
-    mStackView = (ListView) findViewById(R.id.rn_redbox_stack);
+    mStackView = (ListView) findViewById(R.id.rn_redBox_stack);
     mStackView.setOnItemClickListener(this);
 
-    mReloadJsButton = (Button) findViewById(R.id.rn_redbox_reload_button);
+    mReloadJsButton = (Button) findViewById(R.id.rn_redBox_reload_button);
     mReloadJsButton.setOnClickListener(
         new View.OnClickListener() {
           @Override
@@ -262,22 +262,22 @@ public class RedBoxContentView extends LinearLayout implements AdapterView.OnIte
             Assertions.assertNotNull(mDevSupportManager).handleReloadJS();
           }
         });
-    mDismissButton = (Button) findViewById(R.id.rn_redbox_dismiss_button);
+    mDismissButton = (Button) findViewById(R.id.rn_redBox_dismiss_button);
     mDismissButton.setOnClickListener(
         new View.OnClickListener() {
           @Override
           public void onClick(View v) {
-            Assertions.assertNotNull(mDevSupportManager).hideRedboxDialog();
+            Assertions.assertNotNull(mDevSupportManager).hideRedBoxDialog();
           }
         });
 
     if (mRedBoxHandler != null && mRedBoxHandler.isReportEnabled()) {
-      mLoadingIndicator = (ProgressBar) findViewById(R.id.rn_redbox_loading_indicator);
-      mLineSeparator = (View) findViewById(R.id.rn_redbox_line_separator);
-      mReportTextView = (TextView) findViewById(R.id.rn_redbox_report_label);
+      mLoadingIndicator = (ProgressBar) findViewById(R.id.rn_redBox_loading_indicator);
+      mLineSeparator = (View) findViewById(R.id.rn_redBox_line_separator);
+      mReportTextView = (TextView) findViewById(R.id.rn_redBox_report_label);
       mReportTextView.setMovementMethod(LinkMovementMethod.getInstance());
       mReportTextView.setHighlightColor(Color.TRANSPARENT);
-      mReportButton = (Button) findViewById(R.id.rn_redbox_report_button);
+      mReportButton = (Button) findViewById(R.id.rn_redBox_report_button);
       mReportButton.setOnClickListener(mReportButtonOnClickListener);
     }
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/RedBoxDialogSurfaceDelegate.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/RedBoxDialogSurfaceDelegate.java
@@ -46,8 +46,8 @@ public class RedBoxDialogSurfaceDelegate implements SurfaceDelegate {
       @Nullable String message = mDevSupportManager.getLastErrorTitle();
       FLog.e(
           ReactConstants.TAG,
-          "Unable to launch redbox because react activity "
-              + "is not available, here is the error that redbox would've displayed: "
+          "Unable to launch RedBox because react activity "
+              + "is not available, here is the error that RedBox would've displayed: "
               + (message != null ? message : "N/A"));
       return;
     }
@@ -76,8 +76,8 @@ public class RedBoxDialogSurfaceDelegate implements SurfaceDelegate {
     if (context == null || context.isFinishing()) {
       FLog.e(
           ReactConstants.TAG,
-          "Unable to launch redbox because react activity "
-              + "is not available, here is the error that redbox would've displayed: "
+          "Unable to launch RedBox because react activity "
+              + "is not available, here is the error that RedBox would've displayed: "
               + (message != null ? message : "N/A"));
       return;
     }
@@ -111,7 +111,7 @@ public class RedBoxDialogSurfaceDelegate implements SurfaceDelegate {
 
   @Override
   public void hide() {
-    // dismiss redbox if exists
+    // dismiss RedBox if exists
     if (mDialog != null) {
       mDialog.dismiss();
       destroyContentView();

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DevSupportManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DevSupportManager.java
@@ -38,7 +38,7 @@ public interface DevSupportManager extends JSExceptionHandler {
 
   void updateJSError(final String message, final ReadableArray details, final int errorCookie);
 
-  void hideRedboxDialog();
+  void hideRedBoxDialog();
 
   void showDevOptionsDialog();
 

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/ErrorCustomizer.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/ErrorCustomizer.java
@@ -9,7 +9,7 @@ package com.facebook.react.devsupport.interfaces;
 
 import android.util.Pair;
 
-/** Interface that lets parts of the app process the errors before showing the redbox */
+/** Interface that lets parts of the app process the errors before showing the RedBox */
 public interface ErrorCustomizer {
 
   /**

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/RedBoxHandler.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/RedBoxHandler.java
@@ -12,26 +12,26 @@ import android.text.SpannedString;
 import androidx.annotation.Nullable;
 
 /**
- * Interface used by {@link BridgeDevSupportManager} to allow interception on any redboxes during
- * development and handling the information from the redbox. The implementation should be passed by
+ * Interface used by {@link BridgeDevSupportManager} to allow interception on any RedBoxes during
+ * development and handling the information from the RedBox. The implementation should be passed by
  * setRedBoxHandler in ReactInstanceManager.
  */
 public interface RedBoxHandler {
-  /** Callback interface for {@link #reportRedbox}. */
+  /** Callback interface for {@link #reportRedBox}. */
   interface ReportCompletedListener {
     void onReportSuccess(SpannedString spannedString);
 
     void onReportError(SpannedString spannedString);
   }
 
-  /** Handle the information from the redbox. */
-  void handleRedbox(@Nullable String title, StackFrame[] stack, ErrorType errorType);
+  /** Handle the information from the RedBox. */
+  void handleRedBox(@Nullable String title, StackFrame[] stack, ErrorType errorType);
 
   /** Whether the report feature is enabled. */
   boolean isReportEnabled();
 
-  /** Report the information from the redbox and set up a callback listener. */
-  void reportRedbox(
+  /** Report the information from the RedBox and set up a callback listener. */
+  void reportRedBox(
       Context context,
       String title,
       StackFrame[] stack,

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/core/ExceptionsManagerModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/core/ExceptionsManagerModule.java
@@ -90,9 +90,9 @@ public class ExceptionsManagerModule extends NativeExceptionsManagerSpec {
   }
 
   @Override
-  public void dismissRedbox() {
+  public void dismissRedBox() {
     if (mDevSupportManager.getDevSupportEnabled()) {
-      mDevSupportManager.hideRedboxDialog();
+      mDevSupportManager.hideRedBoxDialog();
     }
   }
 }

--- a/ReactAndroid/src/main/res/devsupport/layout/redbox_item_title.xml
+++ b/ReactAndroid/src/main/res/devsupport/layout/redbox_item_title.xml
@@ -1,5 +1,5 @@
 <TextView xmlns:android="http://schemas.android.com/apk/res/android"
-  android:id="@+id/catalyst_redbox_title"
+  android:id="@+id/catalyst_redBox_title"
   android:layout_width="match_parent"
   android:layout_height="wrap_content"
   android:padding="16dp"

--- a/ReactAndroid/src/main/res/devsupport/layout/redbox_view.xml
+++ b/ReactAndroid/src/main/res/devsupport/layout/redbox_view.xml
@@ -6,7 +6,7 @@
     android:background="#1A1A1A"
     >
     <ListView
-        android:id="@+id/rn_redbox_stack"
+        android:id="@+id/rn_redBox_stack"
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1"
@@ -14,7 +14,7 @@
         android:dividerHeight="0dp"
         />
     <View
-        android:id="@+id/rn_redbox_line_separator"
+        android:id="@+id/rn_redBox_line_separator"
         android:layout_width="match_parent"
         android:layout_height="1dp"
         android:background="@android:color/darker_gray"
@@ -26,7 +26,7 @@
         android:orientation="horizontal"
         >
         <ProgressBar
-            android:id="@+id/rn_redbox_loading_indicator"
+            android:id="@+id/rn_redBox_loading_indicator"
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
             style="@android:style/Widget.ProgressBar.Small"
@@ -35,7 +35,7 @@
             android:paddingLeft="16dp"
             />
         <TextView
-            android:id="@+id/rn_redbox_report_label"
+            android:id="@+id/rn_redBox_report_label"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:textColor="@android:color/white"
@@ -53,23 +53,23 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        android:background="@drawable/redbox_top_border_background"
+        android:background="@drawable/redBox_top_border_background"
         >
         <Button
-            android:id="@+id/rn_redbox_dismiss_button"
+            android:id="@+id/rn_redBox_dismiss_button"
             android:text="@string/catalyst_dismiss_button"
-            style="@style/redboxButton"
+            style="@style/redBoxButton"
             />
         <Button
-            android:id="@+id/rn_redbox_reload_button"
+            android:id="@+id/rn_redBox_reload_button"
             android:text="@string/catalyst_reload_button"
-            style="@style/redboxButton"
+            style="@style/redBoxButton"
             />
         <Button
-            android:id="@+id/rn_redbox_report_button"
+            android:id="@+id/rn_redBox_report_button"
             android:text="@string/catalyst_report_button"
             android:visibility="gone"
-            style="@style/redboxButton"
+            style="@style/redBoxButton"
             />
     </LinearLayout>
 </LinearLayout>

--- a/ReactAndroid/src/main/res/devsupport/values/colors.xml
+++ b/ReactAndroid/src/main/res/devsupport/values/colors.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-  <color name="catalyst_redbox_background">#eecc0000</color>
+  <color name="catalyst_redBox_background">#eecc0000</color>
   <color name="catalyst_logbox_background">#ffffffff</color>
 </resources>

--- a/ReactAndroid/src/main/res/devsupport/values/styles.xml
+++ b/ReactAndroid/src/main/res/devsupport/values/styles.xml
@@ -3,7 +3,7 @@
   <style name="Theme" />
   <style name="Theme.Catalyst"/>
   <style name="Theme.Catalyst.RedBox">
-    <item name="android:windowBackground">@color/catalyst_redbox_background</item>
+    <item name="android:windowBackground">@color/catalyst_redBox_background</item>
     <item name="android:windowAnimationStyle">@style/Animation.Catalyst.RedBox</item>
     <item name="android:inAnimation">@android:anim/fade_in</item>
     <item name="android:outAnimation">@android:anim/fade_out</item>
@@ -26,7 +26,7 @@
     <item name="android:windowEnterAnimation">@anim/catalyst_push_up_in</item>
     <item name="android:windowExitAnimation">@anim/catalyst_push_up_out</item>
   </style>
-  <style name="redboxButton">
+  <style name="redBoxButton">
     <item name="android:layout_width">0dp</item>
     <item name="android:layout_height">wrap_content</item>
     <item name="android:layout_weight">1</item>

--- a/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaTurboModule.cpp
+++ b/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaTurboModule.cpp
@@ -456,7 +456,7 @@ jsi::Value JavaTurboModule::invokeJavaMethod(
     jclass cls = env->GetObjectClass(instance);
     methodID = env->GetMethodID(cls, methodName, methodSignature.c_str());
 
-    // If the method signature doesn't match, show a redbox here instead of
+    // If the method signature doesn't match, show a RedBox here instead of
     // crashing later.
     checkJNIErrorForMethodCall();
   }

--- a/packages/polyfills/console.js
+++ b/packages/polyfills/console.js
@@ -423,7 +423,7 @@ function getNativeLogFunction(level) {
       logLevel >= LOG_LEVELS.error
     ) {
       // React warnings use console.error so that a stack trace is shown,
-      // but we don't (currently) want these to show a redbox
+      // but we don't (currently) want these to show a RedBox
       // (Note: Logic duplicated in ExceptionsManager.js.)
       logLevel = LOG_LEVELS.warn;
     }

--- a/packages/rn-tester/RCTTest/RCTTestRunner.m
+++ b/packages/rn-tester/RCTTest/RCTTestRunner.m
@@ -159,7 +159,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
   __weak RCTBridge *batchedBridge;
   NSNumber *rootTag;
   RCTLogFunction defaultLogFunction = RCTGetLogFunction();
-  // Catch all error logs, that are equivalent to redboxes in dev mode.
+  // Catch all error logs, that are equivalent to RedBoxes in dev mode.
   __block NSMutableArray<NSString *> *errors = nil;
   RCTSetLogFunction(
       ^(RCTLogLevel level, RCTLogSource source, NSString *fileName, NSNumber *lineNumber, NSString *message) {

--- a/packages/rn-tester/js/examples/PlatformColor/PlatformColorExample.js
+++ b/packages/rn-tester/js/examples/PlatformColor/PlatformColorExample.js
@@ -157,8 +157,8 @@ function PlatformColorsExample() {
           color: PlatformColor('@android:color/holo_green_light'),
         },
         {
-          label: '@color/catalyst_redbox_background',
-          color: PlatformColor('@color/catalyst_redbox_background'),
+          label: '@color/catalyst_redBox_background',
+          color: PlatformColor('@color/catalyst_redBox_background'),
         },
         {
           label: '@color/catalyst_logbox_background',
@@ -196,8 +196,8 @@ function FallbackColorsExample() {
     };
   } else if (Platform.OS === 'android') {
     color = {
-      label: "PlatformColor('bogus', '@color/catalyst_redbox_background')",
-      color: PlatformColor('bogus', '@color/catalyst_redbox_background'),
+      label: "PlatformColor('bogus', '@color/catalyst_redBox_background')",
+      color: PlatformColor('bogus', '@color/catalyst_redBox_background'),
     };
   } else {
     color = {

--- a/scripts/run-ci-e2e-tests.js
+++ b/scripts/run-ci-e2e-tests.js
@@ -12,8 +12,8 @@
 /**
  * This script tests that React Native end to end installation/bootstrap works for different platforms
  * Available arguments:
- * --ios - 'react-native init' and check iOS app doesn't redbox
- * --android - 'react-native init' and check Android app doesn't redbox
+ * --ios - 'react-native init' and check iOS app doesn't RedBox
+ * --android - 'react-native init' and check Android app doesn't RedBox
  * --js - 'react-native init' and only check the packager returns a bundle
  * --skip-cli-install - to skip react-native-cli global installation (for local debugging)
  * --retries [num] - how many times to retry possible flaky commands: yarn add and running tests, default 1

--- a/template/ios/HelloWorldTests/HelloWorldTests.m
+++ b/template/ios/HelloWorldTests/HelloWorldTests.m
@@ -32,17 +32,17 @@
   NSDate *date = [NSDate dateWithTimeIntervalSinceNow:TIMEOUT_SECONDS];
   BOOL foundElement = NO;
 
-  __block NSString *redboxError = nil;
+  __block NSString *redBoxError = nil;
 #ifdef DEBUG
   RCTSetLogFunction(
       ^(RCTLogLevel level, RCTLogSource source, NSString *fileName, NSNumber *lineNumber, NSString *message) {
         if (level >= RCTLogLevelError) {
-          redboxError = message;
+          redBoxError = message;
         }
       });
 #endif
 
-  while ([date timeIntervalSinceNow] > 0 && !foundElement && !redboxError) {
+  while ([date timeIntervalSinceNow] > 0 && !foundElement && !redBoxError) {
     [[NSRunLoop mainRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
     [[NSRunLoop mainRunLoop] runMode:NSRunLoopCommonModes beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
 
@@ -59,7 +59,7 @@
   RCTSetLogFunction(RCTDefaultLogFunction);
 #endif
 
-  XCTAssertNil(redboxError, @"RedBox error: %@", redboxError);
+  XCTAssertNil(redBoxError, @"RedBox error: %@", redBoxError);
   XCTAssertTrue(foundElement, @"Couldn't find element with text '%@' in %d seconds", TEXT_TO_LOOK_FOR, TIMEOUT_SECONDS);
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
- To keep consistency with the native modules defined as "RedBox" (f.x. "RedBoxHandler.java" or "RCTRedBox.mm")
- Use "redBox" in code
- Use "RedBox" and "RedBoxes" in comments

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[General] [Changed] - Rename "redbox" occurences to "redBox" to keep consistency with original module names

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

- Run tests