### PR TITLE
Circle CI: Fix release workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1340,6 +1340,8 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             - "1c:98:e0:3a:52:79:95:29:12:cd:b4:87:5b:41:e2:bb"
+      - brew_install:
+          package: cmake
       - run:
           name: "Set new react-native version and commit changes"
           command: |


### PR DESCRIPTION
Summary:
Due to a missing cmake dependency, the prepare_package_for_release job will fail.

Changelog: [Internal]

Differential Revision: D40310829

