### PR TITLE
[Codegen] refactor module's platform verification

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/utils-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/utils-test.js
@@ -14,6 +14,7 @@
 const {
   extractNativeModuleName,
   createParserErrorCapturer,
+  verifyPlatforms,
   visit,
 } = require('../utils.js');
 const {ParserError} = require('../errors');
@@ -114,6 +115,71 @@ describe('createParserErrorCapturer', () => {
       expect(() => guard(fn)).toThrow(errorMessage);
       expect(errors).toHaveLength(0);
     });
+  });
+});
+
+describe('verifyPlatforms', () => {
+  it('exclude android given an iOS only module', () => {
+    let result = verifyPlatforms('NativeSampleTurboModule', [
+      'SampleTurboModuleIOS',
+    ]);
+
+    expect(result.cxxOnly).toBe(false);
+    expect(result.excludedPlatforms).toEqual(['android']);
+
+    result = verifyPlatforms('NativeSampleTurboModuleIOS', [
+      'SampleTurboModule',
+    ]);
+    expect(result.cxxOnly).toBe(false);
+    expect(result.excludedPlatforms).toEqual(['android']);
+
+    result = verifyPlatforms('NativeSampleTurboModuleIOS', [
+      'SampleTurboModuleIOS',
+    ]);
+    expect(result.cxxOnly).toBe(false);
+    expect(result.excludedPlatforms).toEqual(['android']);
+  });
+
+  it('exclude iOS given an android only module', () => {
+    let result = verifyPlatforms('NativeSampleTurboModule', [
+      'SampleTurboModuleAndroid',
+    ]);
+
+    expect(result.cxxOnly).toBe(false);
+    expect(result.excludedPlatforms).toEqual(['iOS']);
+
+    result = verifyPlatforms('NativeSampleTurboModuleAndroid', [
+      'SampleTurboModule',
+    ]);
+    expect(result.cxxOnly).toBe(false);
+    expect(result.excludedPlatforms).toEqual(['iOS']);
+
+    result = verifyPlatforms('NativeSampleTurboModuleAndroid', [
+      'SampleTurboModuleAndroid',
+    ]);
+    expect(result.cxxOnly).toBe(false);
+    expect(result.excludedPlatforms).toEqual(['iOS']);
+  });
+
+  it('exclude iOS and android given a Cxx only module', () => {
+    let result = verifyPlatforms('NativeSampleTurboModule', [
+      'SampleTurboModuleCxx',
+    ]);
+
+    expect(result.cxxOnly).toBe(true);
+    expect(result.excludedPlatforms).toEqual(['iOS', 'android']);
+
+    result = verifyPlatforms('NativeSampleTurboModuleCxx', [
+      'SampleTurboModule',
+    ]);
+    expect(result.cxxOnly).toBe(true);
+    expect(result.excludedPlatforms).toEqual(['iOS', 'android']);
+
+    result = verifyPlatforms('NativeSampleTurboModuleCxx', [
+      'SampleTurboModuleCxx',
+    ]);
+    expect(result.cxxOnly).toBe(true);
+    expect(result.excludedPlatforms).toEqual(['iOS', 'android']);
   });
 });
 

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -66,6 +66,7 @@ const {
   UnsupportedObjectPropertyValueTypeAnnotationParserError,
   IncorrectModuleRegistryCallArgumentTypeParserError,
 } = require('../../errors.js');
+const {verifyPlatforms} = require('../../utils');
 
 const {
   throwIfModuleInterfaceNotFound,
@@ -691,19 +692,10 @@ function buildModuleSchema(
   // Eventually this should be made explicit in the Flow type itself.
   // Also check the hasteModuleName for platform suffix.
   // Note: this shape is consistent with ComponentSchema.
-  let cxxOnly = false;
-  const excludedPlatforms = [];
-  const namesToValidate = [...moduleNames, hasteModuleName];
-  namesToValidate.forEach(name => {
-    if (name.endsWith('Android')) {
-      excludedPlatforms.push('iOS');
-    } else if (name.endsWith('IOS')) {
-      excludedPlatforms.push('android');
-    } else if (name.endsWith('Cxx')) {
-      cxxOnly = true;
-      excludedPlatforms.push('iOS', 'android');
-    }
-  });
+  const {cxxOnly, excludedPlatforms} = verifyPlatforms(
+    hasteModuleName,
+    moduleNames,
+  );
 
   // $FlowFixMe[missing-type-arg]
   return (moduleSpec.body.properties: $ReadOnlyArray<$FlowFixMe>)

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -66,6 +66,7 @@ const {
   UnsupportedObjectPropertyValueTypeAnnotationParserError,
   IncorrectModuleRegistryCallArgumentTypeParserError,
 } = require('../../errors.js');
+const {verifyPlatforms} = require('../../utils');
 
 const {
   throwIfUntypedModule,
@@ -705,19 +706,10 @@ function buildModuleSchema(
   // Eventually this should be made explicit in the Flow type itself.
   // Also check the hasteModuleName for platform suffix.
   // Note: this shape is consistent with ComponentSchema.
-  let cxxOnly = false;
-  const excludedPlatforms = [];
-  const namesToValidate = [...moduleNames, hasteModuleName];
-  namesToValidate.forEach(name => {
-    if (name.endsWith('Android')) {
-      excludedPlatforms.push('iOS');
-    } else if (name.endsWith('IOS')) {
-      excludedPlatforms.push('android');
-    } else if (name.endsWith('Cxx')) {
-      cxxOnly = true;
-      excludedPlatforms.push('iOS', 'android');
-    }
-  });
+  const {cxxOnly, excludedPlatforms} = verifyPlatforms(
+    hasteModuleName,
+    moduleNames,
+  );
 
   // $FlowFixMe[missing-type-arg]
   return (moduleSpec.body.body: $ReadOnlyArray<$FlowFixMe>)

--- a/packages/react-native-codegen/src/parsers/utils.js
+++ b/packages/react-native-codegen/src/parsers/utils.js
@@ -61,39 +61,33 @@ function verifyPlatforms(
   cxxOnly: boolean,
   excludedPlatforms: Array<'iOS' | 'android'>,
 }> {
-  let cxxOnly = false,
-    excludeIOS = false,
-    excludeAndroid = false;
-
+  let cxxOnly = false;
+  const excludedPlatforms = new Set<'iOS' | 'android'>();
   const namesToValidate = [...moduleNames, hasteModuleName];
 
   namesToValidate.forEach(name => {
     if (name.endsWith('Android')) {
-      excludeIOS = true;
+      excludedPlatforms.add('iOS');
+      return;
     }
 
     if (name.endsWith('IOS')) {
-      excludeAndroid = true;
+      excludedPlatforms.add('android');
+      return;
     }
 
     if (name.endsWith('Cxx')) {
       cxxOnly = true;
-      excludeIOS = true;
-      excludeAndroid = true;
+      excludedPlatforms.add('iOS');
+      excludedPlatforms.add('android');
+      return;
     }
   });
 
-  const excludedPlatforms = [];
-
-  if (excludeIOS) {
-    excludedPlatforms.push('iOS');
-  }
-
-  if (excludeAndroid) {
-    excludedPlatforms.push('android');
-  }
-
-  return {cxxOnly, excludedPlatforms};
+  return {
+    cxxOnly,
+    excludedPlatforms: Array.from(excludedPlatforms),
+  };
 }
 
 // TODO(T108222691): Use flow-types for @babel/parser

--- a/packages/react-native-codegen/src/parsers/utils.js
+++ b/packages/react-native-codegen/src/parsers/utils.js
@@ -54,6 +54,48 @@ function createParserErrorCapturer(): [
   return [errors, guard];
 }
 
+function verifyPlatforms(
+  hasteModuleName: string,
+  moduleNames: string[],
+): $ReadOnly<{
+  cxxOnly: boolean,
+  excludedPlatforms: Array<'iOS' | 'android'>,
+}> {
+  let cxxOnly = false,
+    excludeIOS = false,
+    excludeAndroid = false;
+
+  const namesToValidate = [...moduleNames, hasteModuleName];
+
+  namesToValidate.forEach(name => {
+    if (name.endsWith('Android')) {
+      excludeIOS = true;
+    }
+
+    if (name.endsWith('IOS')) {
+      excludeAndroid = true;
+    }
+
+    if (name.endsWith('Cxx')) {
+      cxxOnly = true;
+      excludeIOS = true;
+      excludeAndroid = true;
+    }
+  });
+
+  const excludedPlatforms = [];
+
+  if (excludeIOS) {
+    excludedPlatforms.push('iOS');
+  }
+
+  if (excludeAndroid) {
+    excludedPlatforms.push('android');
+  }
+
+  return {cxxOnly, excludedPlatforms};
+}
+
 // TODO(T108222691): Use flow-types for @babel/parser
 function visit(
   astNode: $FlowFixMe,
@@ -86,5 +128,6 @@ function visit(
 module.exports = {
   extractNativeModuleName,
   createParserErrorCapturer,
+  verifyPlatforms,
   visit,
 };


### PR DESCRIPTION
## Summary
Part of https://github.com/facebook/react-native/issues/34872

> [Assigned to @youedd] Extract the nameToValidate logic ([Flow](https://github.com/facebook/react-native/blob/main/packages/react-native-codegen/src/parsers/flow/modules/index.js#L704-L713), [TypeScript](https://github.com/facebook/react-native/blob/f353119113d6fc85491765ba1e90ac83cb00fd61/packages/react-native-codegen/src/parsers/typescript/modules/index.js#L738-L747)) into a shared function into the parser/utils.js file. Notice that you may need a callback to update the cxx boolean.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[Changed] [Internal] - refactor parser module platform verification

## Test Plan
`yarn jest react-native-codegen`

![image](https://user-images.githubusercontent.com/19575877/195425654-46f9e560-efd3-4945-b913-c6d9f6bb7ec2.png)

