### PR TITLE
Circle CI: Replace string parameters with enums where applicable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -742,14 +742,18 @@ jobs:
     executor: reactnativeandroid
     parameters:
       flavor:
-        type: string
         default: "Debug"
+        description: The Android build type. Must be one of "Debug", "Release".
+        type: enum
+        enum: ["Debug", "Release"]
       newarchitecture:
         type: boolean
         default: false
       jsengine:
-        type: string
         default: "Hermes"
+        description: Which JavaScript engine to use. Must be one of "Hermes", "JSC".
+        type: enum
+        enum: ["Hermes", "JSC"]
     environment:
       - PROJECT_NAME: "AndroidTemplateProject"
     steps:
@@ -788,17 +792,25 @@ jobs:
     executor: reactnativeios
     parameters:
       flavor:
-        type: string
         default: "Debug"
+        description: The Xcode build type. Must be one of "Debug", "Release".
+        type: enum
+        enum: ["Debug", "Release"]
       architecture:
-        type: string
         default: "OldArch"
+        description: Which React Native architecture to use. Must be one of "NewArch", "OldArch".
+        type: enum
+        enum: ["NewArch", "OldArch"]
       jsengine:
-        type: string
         default: "Hermes"
+        description: Which JavaScript engine to use. Must be one of "Hermes", "JSC".
+        type: enum
+        enum: ["Hermes", "JSC"]
       flipper:
-        type: string
         default: "WithFlipper"
+        description: Whether Flipper is enabled. Must be one of "WithFlipper", "WithoutFlipper".
+        type: enum
+        enum: ["WithFlipper", "WithoutFlipper"]
     environment:
       - PROJECT_NAME: "iOSTemplateProject"
       - HERMES_WS_DIR: *hermes_workspace_root
@@ -877,8 +889,10 @@ jobs:
     executor: reactnativeios
     parameters:
       architecture:
-        type: string
         default: "OldArch"
+        description: Which React Native architecture to use. Must be one of "OldArch", "NewArch".
+        type: enum
+        enum: ["NewArch", "OldArch"]
     steps:
       - checkout_code_with_cache
       - run_yarn


### PR DESCRIPTION
Summary:
For jobs that took a string parameter, where that string parameter is expected to be one of a set of accepted values, use an enum.

If an unexpected value is passed to a enum parameter, then `circleci config validate` will flag the issue.

Changelog: [Internal]

Differential Revision: D40310118

