### PR TITLE
[Android][React DevTools] Support persisted settings in Android

### DIFF
--- a/Libraries/Core/setUpReactDevTools.js
+++ b/Libraries/Core/setUpReactDevTools.js
@@ -62,6 +62,7 @@ if (__DEV__) {
       });
 
       const ReactNativeStyleAttributes = require('../Components/View/ReactNativeStyleAttributes');
+      const devToolsSettingsManager = require('../Settings/DevToolsSettingsManager');
 
       reactDevTools.connectToDevTools({
         isAppActive,
@@ -70,6 +71,7 @@ if (__DEV__) {
           ReactNativeStyleAttributes,
         ),
         websocket: ws,
+        devToolsSettingsManager,
       });
     }
   };

--- a/Libraries/Settings/DevToolsSettingsManager.android.js
+++ b/Libraries/Settings/DevToolsSettingsManager.android.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+import NativeDevToolsSettingsManager from './NativeDevToolsSettingsManager';
+
+module.exports = NativeDevToolsSettingsManager;

--- a/Libraries/Settings/DevToolsSettingsManager.ios.js
+++ b/Libraries/Settings/DevToolsSettingsManager.ios.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+import type {Spec} from './NativeDevToolsSettingsManager';
+import Settings from './Settings';
+
+const CONSOLE_PATCH_SETTINGS_KEY = 'ReactDevTools::ConsolePatchSettings';
+
+const DevToolsSettingsManager = {
+  setConsolePatchSettings: (newConsolePatchSettings: string) => {
+    Settings.set({
+      [CONSOLE_PATCH_SETTINGS_KEY]: newConsolePatchSettings,
+    });
+  },
+  getConsolePatchSettings: () =>
+    ((Settings.get(CONSOLE_PATCH_SETTINGS_KEY): any): string),
+};
+
+module.exports = (DevToolsSettingsManager: Spec);

--- a/Libraries/Settings/NativeDevToolsSettingsManager.js
+++ b/Libraries/Settings/NativeDevToolsSettingsManager.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+import type {TurboModule} from '../TurboModule/RCTExport';
+
+import * as TurboModuleRegistry from '../TurboModule/TurboModuleRegistry';
+
+export interface Spec extends TurboModule {
+  +setConsolePatchSettings: (newConsolePatchSettings: string) => void;
+  +getConsolePatchSettings: () => string;
+}
+
+export default (TurboModuleRegistry.get<Spec>(
+  'DevToolsSettingsManager',
+): ?Spec);

--- a/ReactAndroid/src/main/java/com/facebook/react/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/BUCK
@@ -42,6 +42,7 @@ rn_android_library(
         react_native_target("java/com/facebook/react/modules/appearance:appearance"),
         react_native_target("java/com/facebook/react/modules/bundleloader:bundleloader"),
         react_native_target("java/com/facebook/react/modules/debug:debug"),
+        react_native_target("java/com/facebook/react/modules/devtoolssettings:devtoolssettings"),
         react_native_target("java/com/facebook/react/modules/fabric:fabric"),
         react_native_target("java/com/facebook/react/modules/debug:interfaces"),
         react_native_target("java/com/facebook/react/modules/deviceinfo:deviceinfo"),

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/devtoolssettings/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/devtoolssettings/BUCK
@@ -1,0 +1,28 @@
+load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "react_native_root_target", "react_native_target", "rn_android_library")
+
+rn_android_library(
+    name = "devtoolssettings",
+    srcs = glob(["**/*.java"]),
+    autoglob = False,
+    labels = [
+        "pfh:ReactNative_CommonInfrastructurePlaceholder",
+        "supermodule:xplat/default/public.react_native.infra",
+    ],
+    language = "JAVA",
+    visibility = [
+        "PUBLIC",
+    ],
+    provided_deps = [
+        react_native_dep("third-party/android/androidx:annotation"),
+    ],
+    deps = [
+        react_native_dep("libraries/fbcore/src/main/java/com/facebook/common/logging:logging"),
+        react_native_dep("third-party/java/infer-annotations:infer-annotations"),
+        react_native_dep("third-party/java/jsr-305:jsr-305"),
+        react_native_target("java/com/facebook/react/bridge:bridge"),
+        react_native_target("java/com/facebook/react/common:common"),
+        react_native_target("java/com/facebook/react/module/annotations:annotations"),
+        react_native_target("java/com/facebook/react/modules/core:core"),
+    ],
+    exported_deps = [react_native_root_target(":FBReactNativeSpec")],
+)

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/devtoolssettings/DevToolsSettingsManagerModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/devtoolssettings/DevToolsSettingsManagerModule.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.modules.devtoolssettings;
+
+import com.facebook.fbreact.specs.NativeDevToolsSettingsManagerSpec;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.module.annotations.ReactModule;
+import android.content.SharedPreferences;
+import androidx.annotation.Nullable;
+import android.content.SharedPreferences.Editor;
+import android.content.Context;
+
+@ReactModule(name = DevToolsSettingsManagerModule.NAME)
+public class DevToolsSettingsManagerModule extends NativeDevToolsSettingsManagerSpec {
+  public static final String NAME = "DevToolsSettingsManager";
+
+  private static final String SHARED_PREFERENCES_PREFIX = "ReactNative__DevToolsSettings";
+  private static final String KEY_CONSOLE_PATCH_SETTINGS = "ConsolePatchSettings";
+
+  private final SharedPreferences sharedPreferences;
+
+  public DevToolsSettingsManagerModule(ReactApplicationContext reactContext) {
+    super(reactContext);
+    sharedPreferences = reactContext.getSharedPreferences(SHARED_PREFERENCES_PREFIX, Context.MODE_PRIVATE);
+  }
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
+
+  @Override
+  public @Nullable String getConsolePatchSettings() {
+    return sharedPreferences.getString(KEY_CONSOLE_PATCH_SETTINGS, null);
+  }
+
+  @Override
+  public void setConsolePatchSettings(String newSettings) {
+    Editor editor = sharedPreferences.edit();
+    editor.putString(KEY_CONSOLE_PATCH_SETTINGS, newSettings);
+    editor.apply();
+  }
+}

--- a/ReactAndroid/src/main/java/com/facebook/react/shell/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/shell/BUCK
@@ -38,6 +38,7 @@ rn_android_library(
         react_native_target("java/com/facebook/react/modules/clipboard:clipboard"),
         react_native_target("java/com/facebook/react/modules/core:core"),
         react_native_target("java/com/facebook/react/modules/debug:debug"),
+        react_native_target("java/com/facebook/react/modules/devtoolssettings:devtoolssettings"),
         react_native_target("java/com/facebook/react/modules/dialog:dialog"),
         react_native_target("java/com/facebook/react/modules/fresco:fresco"),
         react_native_target("java/com/facebook/react/modules/i18nmanager:i18nmanager"),

--- a/ReactAndroid/src/main/java/com/facebook/react/shell/MainReactPackage.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/shell/MainReactPackage.java
@@ -30,6 +30,7 @@ import com.facebook.react.modules.image.ImageLoaderModule;
 import com.facebook.react.modules.intent.IntentModule;
 import com.facebook.react.modules.network.NetworkingModule;
 import com.facebook.react.modules.permissions.PermissionsModule;
+import com.facebook.react.modules.devtoolssettings.DevToolsSettingsManagerModule;
 import com.facebook.react.modules.share.ShareModule;
 import com.facebook.react.modules.sound.SoundManagerModule;
 import com.facebook.react.modules.statusbar.StatusBarModule;
@@ -145,6 +146,8 @@ public class MainReactPackage extends TurboReactPackage {
         return new VibrationModule(context);
       case WebSocketModule.NAME:
         return new WebSocketModule(context);
+      case DevToolsSettingsManagerModule.NAME:
+        return new DevToolsSettingsManagerModule(context);
       default:
         return null;
     }
@@ -185,7 +188,8 @@ public class MainReactPackage extends TurboReactPackage {
           Class.forName("com.facebook.react.shell.MainReactPackage$$ReactModuleInfoProvider");
       return (ReactModuleInfoProvider) reactModuleInfoProviderClass.newInstance();
     } catch (ClassNotFoundException e) {
-      // In OSS case, the annotation processor does not run. We fall back on creating this byhand
+      // In the OSS case, the annotation processor does not run. We fall back to creating this by
+      // hand
       Class<? extends NativeModule>[] moduleList =
           new Class[] {
             AccessibilityInfoModule.class,
@@ -204,6 +208,7 @@ public class MainReactPackage extends TurboReactPackage {
             NativeAnimatedModule.class,
             NetworkingModule.class,
             PermissionsModule.class,
+            DevToolsSettingsManagerModule.class,
             ShareModule.class,
             StatusBarModule.class,
             SoundManagerModule.class,

--- a/ReactAndroid/src/test/java/com/facebook/react/modules/BUCK
+++ b/ReactAndroid/src/test/java/com/facebook/react/modules/BUCK
@@ -34,6 +34,7 @@ rn_robolectric_test(
         react_native_target("java/com/facebook/react/modules/core:core"),
         react_native_target("java/com/facebook/react/modules/debug:debug"),
         react_native_target("java/com/facebook/react/modules/deviceinfo:deviceinfo"),
+        react_native_target("java/com/facebook/react/modules/devtoolssettings:devtoolssettings"),
         react_native_target("java/com/facebook/react/modules/dialog:dialog"),
         react_native_target("java/com/facebook/react/modules/network:network"),
         react_native_target("java/com/facebook/react/modules/share:share"),


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

* The SettingsManager turbomodule exists in iOS, but not for Android. Add support for it.
* One accesses the SettingsManager TM via `Libraries/Settings/Settings`. Implement **part** of that for Android, leaving `watchKeys` and `clearWatch` as no-ops.

### Turbomodule implementation

* The Java implementation writes to/from a file in the application's directory. Clearing the storage associated with the app removes this file.
* This file stores a JSON object that represents settings the user has set. In particular, it will store something like `{"ReactDevTools::Settings::ConsolePatchSettings":"{\"consolePatchSettings\":{\"appendComponentStack\":false,\"breakOnConsoleErrors\":false,\"showInlineWarningsAndErrors\":true,\"hideConsoleLogsInStrictMode\":true,\"browserTheme\":\"light\"}}"}` when used with React DevTools.

### Integation with DevTools
* This implementation works as-is with the DevTools implementation [here](https://github.com/facebook/react/pull/25452) (except per @motiz88 's comments, I will rename some params in both diffs.)

## Changelog

[General] [Added] - Add a SettingsManager TurboModule to Android

## Test Plan

* Extensive manual testing
