### PR TITLE
Extracted UnsupportedFunctionReturnTypeAnnotationParserError to throwIfUnsupportedFunctionReturnTypeAnnotationParserError

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow strict-local
+ * @oncall react_native
+ */
+
+'use strict';
+
+const {
+  throwIfUnsupportedFunctionReturnTypeAnnotationParserError,
+} = require('../error-utils');
+
+const {
+  UnsupportedFunctionReturnTypeAnnotationParserError,
+} = require('../errors');
+
+describe('throwIfUnsupportedFunctionReturnTypeAnnotationParserError', () => {
+  const flowReturnTypeAnnotation = {
+      returnType: '',
+    },
+    nativeModuleName = 'moduleName',
+    invalidReturnType = 'FunctionTypeAnnotation',
+    language = 'Flow';
+
+  it('do not throw error if cxxOnly is true', () => {
+    const cxxOnly = true,
+      returnTypeAnnotation = {
+        type: 'FunctionTypeAnnotation',
+      };
+
+    expect(() => {
+      throwIfUnsupportedFunctionReturnTypeAnnotationParserError(
+        nativeModuleName,
+        flowReturnTypeAnnotation,
+        invalidReturnType,
+        language,
+        cxxOnly,
+        returnTypeAnnotation,
+      );
+    }).not.toThrow(UnsupportedFunctionReturnTypeAnnotationParserError);
+  });
+
+  it('do not throw error if returnTypeAnnotation type is not FunctionTypeAnnotation', () => {
+    const cxxOnly = false,
+      returnTypeAnnotation = {
+        type: '',
+      };
+
+    expect(() => {
+      throwIfUnsupportedFunctionReturnTypeAnnotationParserError(
+        nativeModuleName,
+        flowReturnTypeAnnotation,
+        invalidReturnType,
+        language,
+        cxxOnly,
+        returnTypeAnnotation,
+      );
+    }).not.toThrow(UnsupportedFunctionReturnTypeAnnotationParserError);
+  });
+
+  it('throw error if cxxOnly is false and returnTypeAnnotation type is FunctionTypeAnnotation', () => {
+    const cxxOnly = false,
+      returnTypeAnnotation = {
+        type: 'FunctionTypeAnnotation',
+      };
+
+    expect(() => {
+      throwIfUnsupportedFunctionReturnTypeAnnotationParserError(
+        nativeModuleName,
+        flowReturnTypeAnnotation,
+        invalidReturnType,
+        language,
+        cxxOnly,
+        returnTypeAnnotation,
+      );
+    }).toThrow(UnsupportedFunctionReturnTypeAnnotationParserError);
+  });
+});

--- a/packages/react-native-codegen/src/parsers/error-utils.js
+++ b/packages/react-native-codegen/src/parsers/error-utils.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+'use strict';
+
+import type {ParserType} from './errors';
+
+const {
+  UnsupportedFunctionReturnTypeAnnotationParserError,
+} = require('./errors.js');
+
+function throwIfUnsupportedFunctionReturnTypeAnnotationParserError(
+  nativeModuleName: string,
+  flowReturnTypeAnnotation: $FlowFixMe,
+  invalidReturnType: string,
+  language: ParserType,
+  cxxOnly: boolean,
+  returnTypeAnnotation: $FlowFixMe,
+) {
+  if (!cxxOnly && returnTypeAnnotation.type === 'FunctionTypeAnnotation') {
+    throw new UnsupportedFunctionReturnTypeAnnotationParserError(
+      nativeModuleName,
+      flowReturnTypeAnnotation.returnType,
+      'FunctionTypeAnnotation',
+      language,
+    );
+  }
+}
+
+module.exports = {
+  throwIfUnsupportedFunctionReturnTypeAnnotationParserError,
+};

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -58,7 +58,6 @@ const {
   UnsupportedGenericParserError,
   UnsupportedTypeAnnotationParserError,
   UnsupportedFunctionParamTypeAnnotationParserError,
-  UnsupportedFunctionReturnTypeAnnotationParserError,
   UnsupportedEnumDeclarationParserError,
   UnsupportedUnionTypeAnnotationParserError,
   UnsupportedModulePropertyParserError,
@@ -71,6 +70,10 @@ const {
   IncorrectModuleRegistryCallArityParserError,
   IncorrectModuleRegistryCallArgumentTypeParserError,
 } = require('../../errors.js');
+
+const {
+  throwIfUnsupportedFunctionReturnTypeAnnotationParserError,
+} = require('../../error-utils');
 
 const language = 'Flow';
 
@@ -492,14 +495,14 @@ function translateFunctionTypeAnnotation(
     ),
   );
 
-  if (!cxxOnly && returnTypeAnnotation.type === 'FunctionTypeAnnotation') {
-    throw new UnsupportedFunctionReturnTypeAnnotationParserError(
-      hasteModuleName,
-      flowFunctionTypeAnnotation.returnType,
-      'FunctionTypeAnnotation',
-      language,
-    );
-  }
+  throwIfUnsupportedFunctionReturnTypeAnnotationParserError(
+    hasteModuleName,
+    flowFunctionTypeAnnotation,
+    'FunctionTypeAnnotation',
+    language,
+    cxxOnly,
+    returnTypeAnnotation,
+  );
 
   return {
     type: 'FunctionTypeAnnotation',

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -58,7 +58,6 @@ const {
   UnsupportedGenericParserError,
   UnsupportedTypeAnnotationParserError,
   UnsupportedFunctionParamTypeAnnotationParserError,
-  UnsupportedFunctionReturnTypeAnnotationParserError,
   UnsupportedEnumDeclarationParserError,
   UnsupportedUnionTypeAnnotationParserError,
   UnsupportedModulePropertyParserError,
@@ -71,6 +70,10 @@ const {
   IncorrectModuleRegistryCallArityParserError,
   IncorrectModuleRegistryCallArgumentTypeParserError,
 } = require('../../errors.js');
+
+const {
+  throwIfUnsupportedFunctionReturnTypeAnnotationParserError,
+} = require('../../error-utils');
 
 const language = 'TypeScript';
 
@@ -527,14 +530,14 @@ function translateFunctionTypeAnnotation(
     ),
   );
 
-  if (!cxxOnly && returnTypeAnnotation.type === 'FunctionTypeAnnotation') {
-    throw new UnsupportedFunctionReturnTypeAnnotationParserError(
-      hasteModuleName,
-      typescriptFunctionTypeAnnotation.returnType,
-      'FunctionTypeAnnotation',
-      language,
-    );
-  }
+  throwIfUnsupportedFunctionReturnTypeAnnotationParserError(
+    hasteModuleName,
+    typescriptFunctionTypeAnnotation,
+    'FunctionTypeAnnotation',
+    language,
+    cxxOnly,
+    returnTypeAnnotation,
+  );
 
   return {
     type: 'FunctionTypeAnnotation',


### PR DESCRIPTION
## Summary

This PR is part of #34872 
This PR extracts `UnsupportedFunctionReturnTypeAnnotationParserError` exception to a separate function inside an `error-utils.js` file

## Changelog

[Internal] [Changed] - Extract `UnsupportedFunctionReturnTypeAnnotationParserError` to a seperate function inside `error-utils.js`

## Test Plan

```sh
yarn jest react-native-codegen
```
Added unit case in `error-utils-test.js` file

<img width="939" alt="Screenshot 2022-10-13 at 11 46 54 AM" src="https://user-images.githubusercontent.com/86605635/195517350-dcb7a26d-434c-4e45-a174-ce82931073e5.png">

