### PR TITLE
Extracted UnsupportedModulePropertyParserError into throwIfModuleTypeIsUnsupported function in error-utils.js file

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow strict-local
+ * @oncall react_native
+ */
+
+'use strict';
+
+describe('throwIfMoreThanOneModuleRegistryCalls', () => {
+  const {throwIfModuleTypeIsUnsupported} = require('../error-utils.js');
+  const {UnsupportedModulePropertyParserError} = require('../errors.js');
+  const hasteModuleName = 'moduleName';
+  const property = {value: 'value', key: {name: 'name'}};
+  it("don't throw error if module type is FunctionTypeAnnotation in Flow", () => {
+    const value = {type: 'FunctionTypeAnnotation'};
+    const language = 'Flow';
+
+    expect(() => {
+      throwIfModuleTypeIsUnsupported(
+        hasteModuleName,
+        property.value,
+        property.key.name,
+        value.type,
+        language,
+      );
+    }).not.toThrow(UnsupportedModulePropertyParserError);
+  });
+  it('throw error if module type is unsupported in Flow', () => {
+    const value = {type: ''};
+    const language = 'Flow';
+
+    expect(() => {
+      throwIfModuleTypeIsUnsupported(
+        hasteModuleName,
+        property.value,
+        property.key.name,
+        value.type,
+        language,
+      );
+    }).toThrow(UnsupportedModulePropertyParserError);
+  });
+  it("don't throw error if module type is TSFunctionType in TypeScript", () => {
+    const value = {type: 'TSFunctionType'};
+    const language = 'TypeScript';
+
+    expect(() => {
+      throwIfModuleTypeIsUnsupported(
+        hasteModuleName,
+        property.value,
+        property.key.name,
+        value.type,
+        language,
+      );
+    }).not.toThrow(UnsupportedModulePropertyParserError);
+  });
+  it("don't throw error if module type is TSMethodSignature in TypeScript", () => {
+    const value = {type: 'TSMethodSignature'};
+    const language = 'TypeScript';
+
+    expect(() => {
+      throwIfModuleTypeIsUnsupported(
+        hasteModuleName,
+        property.value,
+        property.key.name,
+        value.type,
+        language,
+      );
+    }).not.toThrow(UnsupportedModulePropertyParserError);
+  });
+  it('throw error if module type is unsupported in TypeScript', () => {
+    const value = {type: ''};
+    const language = 'TypeScript';
+
+    expect(() => {
+      throwIfModuleTypeIsUnsupported(
+        hasteModuleName,
+        property.value,
+        property.key.name,
+        value.type,
+        language,
+      );
+    }).toThrow(UnsupportedModulePropertyParserError);
+  });
+});

--- a/packages/react-native-codegen/src/parsers/error-utils.js
+++ b/packages/react-native-codegen/src/parsers/error-utils.js
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+'use strict';
+
+import type {ParserType} from './errors';
+
+const {UnsupportedModulePropertyParserError} = require('./errors.js');
+
+function throwIfModuleTypeIsUnsupported(
+  nativeModuleName: string,
+  propertyValue: $FlowFixMe,
+  propertyName: string,
+  propertyValueType: string,
+  language: ParserType,
+) {
+  if (language === 'Flow') {
+    if (propertyValueType !== 'FunctionTypeAnnotation') {
+      throw new UnsupportedModulePropertyParserError(
+        nativeModuleName,
+        propertyValue,
+        propertyName,
+        propertyValueType,
+        language,
+      );
+    }
+  } else if (language === 'TypeScript') {
+    if (
+      propertyValueType !== 'TSFunctionType' &&
+      propertyValueType !== 'TSMethodSignature'
+    ) {
+      throw new UnsupportedModulePropertyParserError(
+        nativeModuleName,
+        propertyValue,
+        propertyName,
+        propertyValueType,
+        language,
+      );
+    }
+  }
+}
+
+module.exports = {
+  throwIfModuleTypeIsUnsupported,
+};

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -61,7 +61,6 @@ const {
   UnsupportedFunctionReturnTypeAnnotationParserError,
   UnsupportedEnumDeclarationParserError,
   UnsupportedUnionTypeAnnotationParserError,
-  UnsupportedModulePropertyParserError,
   UnsupportedObjectPropertyTypeAnnotationParserError,
   UnsupportedObjectPropertyValueTypeAnnotationParserError,
   UnusedModuleInterfaceParserError,
@@ -71,6 +70,7 @@ const {
   IncorrectModuleRegistryCallArityParserError,
   IncorrectModuleRegistryCallArgumentTypeParserError,
 } = require('../../errors.js');
+const {throwIfModuleTypeIsUnsupported} = require('../../error-utils');
 
 const language = 'Flow';
 
@@ -530,15 +530,13 @@ function buildPropertySchema(
 
   ({nullable, typeAnnotation: value} = resolveTypeAnnotation(value, types));
 
-  if (value.type !== 'FunctionTypeAnnotation') {
-    throw new UnsupportedModulePropertyParserError(
-      hasteModuleName,
-      property.value,
-      property.key.name,
-      value.type,
-      language,
-    );
-  }
+  throwIfModuleTypeIsUnsupported(
+    hasteModuleName,
+    property.value,
+    property.key.name,
+    value.type,
+    language,
+  );
 
   return {
     name: methodName,

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -61,7 +61,6 @@ const {
   UnsupportedFunctionReturnTypeAnnotationParserError,
   UnsupportedEnumDeclarationParserError,
   UnsupportedUnionTypeAnnotationParserError,
-  UnsupportedModulePropertyParserError,
   UnsupportedObjectPropertyTypeAnnotationParserError,
   UnsupportedObjectPropertyValueTypeAnnotationParserError,
   UnusedModuleInterfaceParserError,
@@ -71,6 +70,7 @@ const {
   IncorrectModuleRegistryCallArityParserError,
   IncorrectModuleRegistryCallArgumentTypeParserError,
 } = require('../../errors.js');
+const {throwIfModuleTypeIsUnsupported} = require('../../error-utils');
 
 const language = 'TypeScript';
 
@@ -563,16 +563,13 @@ function buildPropertySchema(
   const methodName: string = key.name;
 
   ({nullable, typeAnnotation: value} = resolveTypeAnnotation(value, types));
-
-  if (value.type !== 'TSFunctionType' && value.type !== 'TSMethodSignature') {
-    throw new UnsupportedModulePropertyParserError(
-      hasteModuleName,
-      property.value,
-      property.key.name,
-      value.type,
-      language,
-    );
-  }
+  throwIfModuleTypeIsUnsupported(
+    hasteModuleName,
+    property.value,
+    property.key.name,
+    value.type,
+    language,
+  );
 
   return {
     name: methodName,


### PR DESCRIPTION


<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

This PR is part of #34872 
This PR extracts `UnsupportedModulePropertyParserError` exception to `throwIfModuleTypeIsUnsupported` function inside `error-utils.js` file

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[Internal] [Changed] - Extract `UnsupportedModulePropertyParserError` to `throwIfModuleTypeIsUnsupported` function inside `error-utils.js`


## Test Plan

`yarn jest react-native-codegen`
Added unit case in `error-utils-test.js` file

<img width="939" alt="Screenshot 2022-10-13 at 12 14 19 PM" src="https://user-images.githubusercontent.com/86604753/195521643-6a197b51-7038-48f1-8b92-2c8c2786d66b.png">

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
