### PR TITLE
Setup gradle-nexus to automate closing and releasing staging repositories

### DIFF
--- a/ReactAndroid/publish.gradle
+++ b/ReactAndroid/publish.gradle
@@ -9,8 +9,6 @@ apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
 def isNightly = findProperty("isNightly")?.toBoolean()
-def sonatypeUsername = findProperty("SONATYPE_USERNAME")
-def sonatypePassword = findProperty("SONATYPE_PASSWORD")
 def signingKey = findProperty("SIGNING_KEY")
 def signingPwd = findProperty("SIGNING_PWD")
 
@@ -69,24 +67,6 @@ publishing {
         maven {
             name = "npm"
             url = androidOutputUrl
-        }
-        if (sonatypeUsername && sonatypePassword) {
-            maven {
-                name = "mavenCentral"
-                url = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
-                credentials {
-                    username = sonatypeUsername
-                    password = sonatypePassword
-                }
-            }
-            maven {
-                name = "mavenSnapshots"
-                url = "https://oss.sonatype.org/content/repositories/snapshots/"
-                credentials {
-                    username = sonatypeUsername
-                    password = sonatypePassword
-                }
-            }
         }
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+plugins { id("io.github.gradle-nexus.publish-plugin") version "1.1.0" }
+
 val ndkPath by extra(System.getenv("ANDROID_NDK"))
 val ndkVersion by extra(System.getenv("ANDROID_NDK_VERSION"))
 
@@ -12,10 +14,23 @@ buildscript {
   repositories {
     google()
     mavenCentral()
+    gradlePluginPortal()
   }
   dependencies {
     classpath("com.android.tools.build:gradle:7.3.0")
     classpath("de.undercouch:gradle-download-task:5.0.1")
+  }
+}
+
+val sonatypeUsername = findProperty("SONATYPE_USERNAME")?.toString()
+val sonatypePassword = findProperty("SONATYPE_PASSWORD")?.toString()
+
+nexusPublishing {
+  repositories {
+    create("sonatype") {
+      username.set(sonatypeUsername)
+      password.set(sonatypePassword)
+    }
   }
 }
 
@@ -91,17 +106,9 @@ tasks.register("publishAllToMavenLocal") {
   dependsOn(":ReactAndroid:hermes-engine:publishToMavenLocal")
 }
 
-tasks.register("publishAllToMavenSnapshots") {
-  description =
-      "Publish all the artifacts as a snapshot (used for testing/nightly) on Maven Central."
-  dependsOn(":ReactAndroid:publishAllPublicationsToMavenSnapshotsRepository")
-  dependsOn(":ReactAndroid:external-artifacts:publishAllPublicationsToMavenSnapshotsRepository")
-  dependsOn(":ReactAndroid:hermes-engine:publishAllPublicationsToMavenSnapshotsRepository")
-}
-
-tasks.register("publishAllToMavenCentral") {
-  description = "Publish all the artifacts as a release on Maven Central."
-  dependsOn(":ReactAndroid:publishAllPublicationsToMavenCentralRepository")
-  dependsOn(":ReactAndroid:external-artifacts:publishAllPublicationsToMavenCentralRepository")
-  dependsOn(":ReactAndroid:hermes-engine:publishAllPublicationsToMavenCentralRepository")
+tasks.register("publishAllToSonatype") {
+  description = "Publish all the artifacts to Sonatype (Maven Central or Snapshot repository)"
+  dependsOn(":ReactAndroid:publishToSonatype")
+  dependsOn(":ReactAndroid:external-artifacts:publishToSonatype")
+  dependsOn(":ReactAndroid:hermes-engine:publishToSonatype")
 }


### PR DESCRIPTION
Summary:
I'm setting up `gradle-nexus` on our build to simplify the closing and releasing of staging repositories.
As of now, you'll have to go to Sonatype UI and manually click the release button.

With this plugin, we can instruct CircleCI to do the publishing automatically for us as
part of the nightly/stable release process.

Changelog:
[Internal] [Changed] - Setup gradle-nexus to automate closing and releasing staging repositories

Differential Revision: D40342759

