### PR TITLE
feat(jest): move Jest config to use a custom react-native Jest env

### DIFF
--- a/jest-preset.js
+++ b/jest-preset.js
@@ -24,5 +24,5 @@ module.exports = {
     'node_modules/(?!((jest-)?react-native|@react-native(-community)?)/)',
   ],
   setupFiles: [require.resolve('./jest/setup.js')],
-  testEnvironment: 'node',
+  testEnvironment: require.resolve('./jest/react-native-env.js'),
 };

--- a/jest/react-native-env.js
+++ b/jest/react-native-env.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+ 'use strict';
+
+const NodeEnv = require('jest-environment-node').TestEnvironment;
+
+module.exports = class ReactNativeEnv extends NodeEnv {
+  // this is where we'll add our custom logic
+};

--- a/jest/react-native-env.js
+++ b/jest/react-native-env.js
@@ -7,7 +7,7 @@
  * @format
  */
 
- 'use strict';
+'use strict';
 
 const NodeEnv = require('jest-environment-node').TestEnvironment;
 

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "base64-js": "^1.1.2",
     "event-target-shim": "^5.0.1",
     "invariant": "^2.2.4",
+    "jest-environment-node": "^29.0.3",
     "jsc-android": "^250230.2.1",
     "memoize-one": "^5.0.0",
     "metro-react-native-babel-transformer": "0.72.3",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

This PR is the follow up to the conversation started here by @SimenB: https://github.com/react-native-community/discussions-and-proposals/issues/509

Basically, we want to move RN to use its own custom environment so that we can tweak it going forward - this PR in fact only sets up the groundwork for that; @robhogan mentioned that with this in place, Meta engineers can 
> iterate on it (with jest-environment-node as a starting point) against our internal product tests

This is also connected to Rob's work to bring Jest 29 into the codebase https://github.com/facebook/react-native/pull/34724 and my "mirror" PR to bring template in main up to the same version (https://github.com/facebook/react-native/pull/34972)

---

### Next steps
This PR opens the door for 3 follow up steps:
* actually customize the custom jest env
* remove the need of jest-environment-node
* publish the env as its own package `@react-native/jest-env` so that it can be consumed more easily from other tools and developers
---

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[General] [Changed] - move Jest config to use a custom react-native Jest env

## Test Plan

Tested that `yarn test` in main works fine after the changes; CI and Meta's internal CI will also serve the purpose of verifying that it works (but there's no reason not to since it's still pretty much just relying on `node`).
