### PR TITLE
feat(jest): bump jest to 29 in the template

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -17,9 +17,9 @@
     "@babel/core": "^7.12.9",
     "@babel/runtime": "^7.12.5",
     "@react-native-community/eslint-config": "^3.0.0",
-    "babel-jest": "^26.6.3",
+    "babel-jest": "^29.0.3",
     "eslint": "^8.19.0",
-    "jest": "^26.6.3",
+    "jest": "^29.0.3",
     "metro-react-native-babel-preset": "0.72.3",
     "react-test-renderer": "18.2.0"
   },


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This PR is the follow up of https://github.com/facebook/react-native/pull/34724 for the template; this way, we'll have version alignment and RN71 will use this.

This wants to be merged along https://github.com/facebook/react-native/pull/34971

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[General] [Changed] - upgrade Jest in template to 29

## Test Plan

Generated a test project via `yarn test-e2e-local -t RNTestProject` and then run `yarn test` in that project to verify that there's no regression. ✅
