### PR TITLE
fix: Eslint on Danger not matching project config

### DIFF
--- a/packages/react-native-bots/dangerfile.js
+++ b/packages/react-native-bots/dangerfile.js
@@ -109,4 +109,6 @@ if (isMergeRefStable) {
   });
 }
 
+// Ensures that eslint is run from root folder and that it can find .eslintrc
+process.chdir('../../');
 eslint.default();


### PR DESCRIPTION
## Summary

I've been noticing this for a while now, every time that someone changes a file inside rn-tester Danger comments a bunch of warnings regarding inline styles, e.g. https://github.com/facebook/react-native/pull/34567#issuecomment-1257956893, even though that is disabled inside .eslintrc https://github.com/facebook/react-native/blob/8edf4e9e3adcc85743e3c86a25ab3748b276a3da/packages/rn-tester/.eslintrc#L3 

After some investigation, I realized that the problem was that the Eslint Node.js API used by [@seadub/danger-plugin-eslint](https://www.npmjs.com/package/@seadub/danger-plugin-eslint) was not able to locate any `.eslintrc` files due to the location of the directory where danger is invoked. By using `process.chdir` we can ensure that eslint will run from the root folder and that it will be able to find all .eslintrc files


## Changelog
 

[Internal] [Fixed] - fix eslint config when running Danger

## Test Plan

run `yarn danger pr https://github.com/facebook/react-native/pull/34976`

After

![image](https://user-images.githubusercontent.com/11707729/195751496-5225a32f-f4b3-4ce2-833f-ae5723f647c0.png)


Before

![image](https://user-images.githubusercontent.com/11707729/195751673-34ba87fc-ce50-4020-9688-a486e3021c4f.png)
