### PR TITLE
Extract the content of the case 'StringTypeAnnotation' into a single …

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-primitives-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-primitives-test.js
@@ -20,6 +20,7 @@ const {
   emitPromise,
   emitRootTag,
   emitVoid,
+  emitString,
   emitStringish,
   typeAliasResolution,
 } = require('../parsers-primitives.js');
@@ -146,6 +147,33 @@ describe('emitStringish', () => {
   describe('when nullable is false', () => {
     it('returns non nullable type annotation', () => {
       const result = emitStringish(false);
+      const expected = {
+        type: 'StringTypeAnnotation',
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+});
+
+describe('emitString', () => {
+  describe('when nullable is true', () => {
+    it('returns nullable type annotation', () => {
+      const result = emitString(true);
+      const expected = {
+        type: 'NullableTypeAnnotation',
+        typeAnnotation: {
+          type: 'StringTypeAnnotation',
+        },
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when nullable is false', () => {
+    it('returns non nullable type annotation', () => {
+      const result = emitString(false);
       const expected = {
         type: 'StringTypeAnnotation',
       };

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -45,6 +45,7 @@ const {
   emitPromise,
   emitRootTag,
   emitVoid,
+  emitString,
   emitStringish,
   typeAliasResolution,
 } = require('../../parsers-primitives');
@@ -347,9 +348,7 @@ function translateTypeAnnotation(
       return emitVoid(nullable);
     }
     case 'StringTypeAnnotation': {
-      return wrapNullable(nullable, {
-        type: 'StringTypeAnnotation',
-      });
+      return emitString(nullable);
     }
     case 'FunctionTypeAnnotation': {
       return wrapNullable(

--- a/packages/react-native-codegen/src/parsers/parsers-primitives.js
+++ b/packages/react-native-codegen/src/parsers/parsers-primitives.js
@@ -79,6 +79,12 @@ function emitStringish(nullable: boolean): Nullable<StringTypeAnnotation> {
   });
 }
 
+function emitString(nullable: boolean): Nullable<StringTypeAnnotation> {
+  return wrapNullable(nullable, {
+    type: 'StringTypeAnnotation',
+  });
+}
+
 function typeAliasResolution(
   typeAliasResolutionStatus: TypeAliasResolutionStatus,
   objectTypeAnnotation: ObjectTypeAnnotation<
@@ -167,6 +173,7 @@ module.exports = {
   emitPromise,
   emitRootTag,
   emitVoid,
+  emitString,
   emitStringish,
   typeAliasResolution,
 };

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -45,6 +45,7 @@ const {
   emitPromise,
   emitRootTag,
   emitVoid,
+  emitString,
   emitStringish,
   typeAliasResolution,
 } = require('../../parsers-primitives');
@@ -382,9 +383,7 @@ function translateTypeAnnotation(
       return emitVoid(nullable);
     }
     case 'TSStringKeyword': {
-      return wrapNullable(nullable, {
-        type: 'StringTypeAnnotation',
-      });
+      return emitString(nullable);
     }
     case 'TSFunctionType': {
       return wrapNullable(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This PR extracts the content of the codegen case 'String' into a single `emitString` function inside the parsers-primitives.js file and uses it in both Flow and TypeScript parsers as requested on https://github.com/facebook/react-native/issues/34872. This also adds unit tests to the new `emitString` function.

ref: https://github.com/facebook/react-native/pull/34936

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[Internal] [Changed] - Extract the content of the case 'StringTypeAnnotation' into a single emitString function

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Run `yarn jest react-native-codegen` and ensure CI is green