### PR TITLE
Configure CircleCI to publish artifacts to Maven Central

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1378,12 +1378,14 @@ jobs:
       - checkout
       - *attach_hermes_workspace
       - run:
-          name: Copy HermesC binaries
+          name: Copy Hermes binaries
           command: |
             mkdir -p ./sdks/hermesc ./sdks/hermesc/osx-bin ./sdks/hermesc/win64-bin ./sdks/hermesc/linux64-bin
             cp -r $HERMES_WS_DIR/osx-bin/* ./sdks/hermesc/osx-bin/.
             cp -r $HERMES_WS_DIR/win64-bin/* ./sdks/hermesc/win64-bin/.
             cp -r $HERMES_WS_DIR/linux64-bin/* ./sdks/hermesc/linux64-bin/.
+            mkdir -p ./ReactAndroid/external-artifacts/artifacts/
+            cp $HERMES_WS_DIR/hermes-runtime-darwin/hermes-runtime-darwin-debug-*.tar.gz ./ReactAndroid/external-artifacts/artifacts/hermes-ios.tar.gz
 
       - run_yarn
       - download_gradle_dependencies

--- a/scripts/publish-npm.js
+++ b/scripts/publish-npm.js
@@ -40,6 +40,7 @@ const {
 } = require('./scm-utils');
 const {
   generateAndroidArtifacts,
+  publishAndroidArtifactsToMaven,
   saveFilesToRestore,
 } = require('./release-utils');
 const fs = require('fs');
@@ -195,6 +196,10 @@ const isLatest = exitIfNotOnGit(
   () => isTaggedLatest(currentCommit),
   'Not in git. We do not want to publish anything',
 );
+
+// We first publish on Maven Central all the necessary artifacts.
+// NPM publishing is done just after.
+publishAndroidArtifactsToMaven(nightlyBuild);
 
 const releaseBranch = `${major}.${minor}-stable`;
 

--- a/scripts/release-utils.js
+++ b/scripts/release-utils.js
@@ -76,7 +76,31 @@ function generateAndroidArtifacts(releaseVersion, tmpPublishingFolder) {
   });
 }
 
+function publishAndroidArtifactsToMaven(isNightly) {
+  // -------- Publish every artifact to Maven Central
+  if (exec('./gradlew publishAllToSonatype -PisNightly=' + isNightly).code) {
+    echo('Failed to publish artifacts to Sonatype (Maven Central)');
+    exit(1);
+  }
+
+  if (!isNightly) {
+    // -------- For stable releases, we also need to close and release the staging repository.
+    // TODO(ncor): Remove the --dry-run before RC0
+    if (
+      exec('./gradlew closeAndReleaseSonatypeStagingRepository --dry-run').code
+    ) {
+      echo(
+        'Failed to close and release the staging repository on Sonatype (Maven Central)',
+      );
+      exit(1);
+    }
+  }
+
+  echo('Published artifacts to Maven Central');
+}
+
 module.exports = {
   generateAndroidArtifacts,
+  publishAndroidArtifactsToMaven,
   saveFilesToRestore,
 };


### PR DESCRIPTION
Summary:
This sets up our CircleCI logic to publish artifacts to Maven Central.
I will check if tomorrow's nightly successfully landed on Maven Central
Snapshot repository.

I've added a --dry-run to the the close and release step of the publishing
to avoid accidentally publishing to Maven Central. We'll remove this if
we decide to go with the Maven Central publishing.

Changelog:
[Internal] [Changed] - Configure CircleCI to publish artifacts to Maven Central

Differential Revision: D40377691

