### PR TITLE
chore: Export codegen parseFile function

### DIFF
--- a/packages/react-native-codegen/e2e/__tests__/components/GenerateComponentDescriptorH-test.js
+++ b/packages/react-native-codegen/e2e/__tests__/components/GenerateComponentDescriptorH-test.js
@@ -11,7 +11,8 @@
 
 'use strict';
 
-const parser = require('../../../src/parsers/flow');
+const {parseFile} = require('../../../src/parsers/utils');
+const FlowParser = require('../../../src/parsers/flow');
 const generator = require('../../../src/generators/components/GenerateComponentDescriptorH');
 const fs = require('fs');
 
@@ -22,7 +23,10 @@ const fixtures = fs.readdirSync(FIXTURE_DIR);
 fixtures.forEach(fixture => {
   it(`GenerateComponentDescriptorH can generate for '${fixture}'`, () => {
     const libName = 'RNCodegenModuleFixtures';
-    const schema = parser.parseFile(`${FIXTURE_DIR}/${fixture}`);
+    const schema = parseFile(
+      `${FIXTURE_DIR}/${fixture}`,
+      FlowParser.buildSchema,
+    );
     const output = generator.generate(libName, schema);
     expect(Object.fromEntries(output)).toMatchSnapshot();
   });

--- a/packages/react-native-codegen/e2e/__tests__/components/GenerateComponentHObjCpp-test.js
+++ b/packages/react-native-codegen/e2e/__tests__/components/GenerateComponentHObjCpp-test.js
@@ -11,7 +11,8 @@
 
 'use strict';
 
-const parser = require('../../../src/parsers/flow');
+const {parseFile} = require('../../../src/parsers/utils');
+const FlowParser = require('../../../src/parsers/flow');
 const generator = require('../../../src/generators/components/GenerateComponentHObjCpp');
 const fs = require('fs');
 
@@ -22,7 +23,10 @@ const fixtures = fs.readdirSync(FIXTURE_DIR);
 fixtures.forEach(fixture => {
   it(`GenerateComponentHObjCpp can generate for '${fixture}'`, () => {
     const libName = 'RNCodegenModuleFixtures';
-    const schema = parser.parseFile(`${FIXTURE_DIR}/${fixture}`);
+    const schema = parseFile(
+      `${FIXTURE_DIR}/${fixture}`,
+      FlowParser.buildSchema,
+    );
     const output = generator.generate(libName, schema);
     expect(Object.fromEntries(output)).toMatchSnapshot();
   });

--- a/packages/react-native-codegen/e2e/__tests__/components/GenerateEventEmitterCpp-test.js
+++ b/packages/react-native-codegen/e2e/__tests__/components/GenerateEventEmitterCpp-test.js
@@ -11,7 +11,8 @@
 
 'use strict';
 
-const parser = require('../../../src/parsers/flow');
+const {parseFile} = require('../../../src/parsers/utils');
+const FlowParser = require('../../../src/parsers/flow');
 const generator = require('../../../src/generators/components/GenerateEventEmitterCpp');
 const fs = require('fs');
 
@@ -22,7 +23,10 @@ const fixtures = fs.readdirSync(FIXTURE_DIR);
 fixtures.forEach(fixture => {
   it(`GenerateEventEmitterCpp can generate for '${fixture}'`, () => {
     const libName = 'RNCodegenModuleFixtures';
-    const schema = parser.parseFile(`${FIXTURE_DIR}/${fixture}`);
+    const schema = parseFile(
+      `${FIXTURE_DIR}/${fixture}`,
+      FlowParser.buildSchema,
+    );
     const output = generator.generate(libName, schema);
     expect(Object.fromEntries(output)).toMatchSnapshot();
   });

--- a/packages/react-native-codegen/e2e/__tests__/components/GenerateEventEmitterH-test.js
+++ b/packages/react-native-codegen/e2e/__tests__/components/GenerateEventEmitterH-test.js
@@ -11,7 +11,8 @@
 
 'use strict';
 
-const parser = require('../../../src/parsers/flow');
+const {parseFile} = require('../../../src/parsers/utils');
+const FlowParser = require('../../../src/parsers/flow');
 const generator = require('../../../src/generators/components/GenerateEventEmitterH');
 const fs = require('fs');
 
@@ -22,7 +23,10 @@ const fixtures = fs.readdirSync(FIXTURE_DIR);
 fixtures.forEach(fixture => {
   it(`GenerateEventEmitterH can generate for '${fixture}'`, () => {
     const libName = 'RNCodegenModuleFixtures';
-    const schema = parser.parseFile(`${FIXTURE_DIR}/${fixture}`);
+    const schema = parseFile(
+      `${FIXTURE_DIR}/${fixture}`,
+      FlowParser.buildSchema,
+    );
     const output = generator.generate(libName, schema);
     expect(Object.fromEntries(output)).toMatchSnapshot();
   });

--- a/packages/react-native-codegen/e2e/__tests__/components/GeneratePropsCpp-test.js
+++ b/packages/react-native-codegen/e2e/__tests__/components/GeneratePropsCpp-test.js
@@ -11,7 +11,8 @@
 
 'use strict';
 
-const parser = require('../../../src/parsers/flow');
+const {parseFile} = require('../../../src/parsers/utils');
+const FlowParser = require('../../../src/parsers/flow');
 const generator = require('../../../src/generators/components/GeneratePropsCpp');
 const fs = require('fs');
 
@@ -22,7 +23,10 @@ const fixtures = fs.readdirSync(FIXTURE_DIR);
 fixtures.forEach(fixture => {
   it(`GeneratePropsCpp can generate for '${fixture}'`, () => {
     const libName = 'RNCodegenModuleFixtures';
-    const schema = parser.parseFile(`${FIXTURE_DIR}/${fixture}`);
+    const schema = parseFile(
+      `${FIXTURE_DIR}/${fixture}`,
+      FlowParser.buildSchema,
+    );
     const output = generator.generate(libName, schema);
     expect(Object.fromEntries(output)).toMatchSnapshot();
   });

--- a/packages/react-native-codegen/e2e/__tests__/components/GeneratePropsH-test.js
+++ b/packages/react-native-codegen/e2e/__tests__/components/GeneratePropsH-test.js
@@ -11,7 +11,8 @@
 
 'use strict';
 
-const parser = require('../../../src/parsers/flow');
+const {parseFile} = require('../../../src/parsers/utils');
+const FlowParser = require('../../../src/parsers/flow');
 const generator = require('../../../src/generators/components/GeneratePropsH');
 const fs = require('fs');
 
@@ -22,7 +23,10 @@ const fixtures = fs.readdirSync(FIXTURE_DIR);
 fixtures.forEach(fixture => {
   it(`GeneratePropsH can generate for '${fixture}'`, () => {
     const libName = 'RNCodegenModuleFixtures';
-    const schema = parser.parseFile(`${FIXTURE_DIR}/${fixture}`);
+    const schema = parseFile(
+      `${FIXTURE_DIR}/${fixture}`,
+      FlowParser.buildSchema,
+    );
     const output = generator.generate(libName, schema);
     expect(Object.fromEntries(output)).toMatchSnapshot();
   });

--- a/packages/react-native-codegen/e2e/__tests__/components/GeneratePropsJavaDelegate-test.js
+++ b/packages/react-native-codegen/e2e/__tests__/components/GeneratePropsJavaDelegate-test.js
@@ -11,7 +11,8 @@
 
 'use strict';
 
-const parser = require('../../../src/parsers/flow');
+const {parseFile} = require('../../../src/parsers/utils');
+const FlowParser = require('../../../src/parsers/flow');
 const generator = require('../../../src/generators/components/GeneratePropsJavaDelegate');
 const fs = require('fs');
 
@@ -22,7 +23,10 @@ const fixtures = fs.readdirSync(FIXTURE_DIR);
 fixtures.forEach(fixture => {
   it(`GeneratePropsJavaDelegate can generate for '${fixture}'`, () => {
     const libName = 'RNCodegenModuleFixtures';
-    const schema = parser.parseFile(`${FIXTURE_DIR}/${fixture}`);
+    const schema = parseFile(
+      `${FIXTURE_DIR}/${fixture}`,
+      FlowParser.buildSchema,
+    );
     const output = generator.generate(libName, schema);
     expect(Object.fromEntries(output)).toMatchSnapshot();
   });

--- a/packages/react-native-codegen/e2e/__tests__/components/GeneratePropsJavaInterface-test.js
+++ b/packages/react-native-codegen/e2e/__tests__/components/GeneratePropsJavaInterface-test.js
@@ -11,7 +11,8 @@
 
 'use strict';
 
-const parser = require('../../../src/parsers/flow');
+const {parseFile} = require('../../../src/parsers/utils');
+const FlowParser = require('../../../src/parsers/flow');
 const generator = require('../../../src/generators/components/GeneratePropsJavaInterface');
 const fs = require('fs');
 
@@ -21,7 +22,10 @@ const fixtures = fs.readdirSync(FIXTURE_DIR);
 fixtures.forEach(fixture => {
   it(`GeneratePropsJavaInterface can generate for '${fixture}'`, () => {
     const libName = 'RNCodegenModuleFixtures';
-    const schema = parser.parseFile(`${FIXTURE_DIR}/${fixture}`);
+    const schema = parseFile(
+      `${FIXTURE_DIR}/${fixture}`,
+      FlowParser.buildSchema,
+    );
     const output = generator.generate(libName, schema, undefined, false);
     expect(Object.fromEntries(output)).toMatchSnapshot();
   });

--- a/packages/react-native-codegen/e2e/__tests__/components/GenerateShadowNodeCpp-test.js
+++ b/packages/react-native-codegen/e2e/__tests__/components/GenerateShadowNodeCpp-test.js
@@ -11,7 +11,8 @@
 
 'use strict';
 
-const parser = require('../../../src/parsers/flow');
+const {parseFile} = require('../../../src/parsers/utils');
+const FlowParser = require('../../../src/parsers/flow');
 const generator = require('../../../src/generators/components/GenerateShadowNodeCpp');
 const fs = require('fs');
 
@@ -21,7 +22,10 @@ const fixtures = fs.readdirSync(FIXTURE_DIR);
 fixtures.forEach(fixture => {
   it(`GenerateShadowNodeCpp can generate for '${fixture}'`, () => {
     const libName = 'RNCodegenModuleFixtures';
-    const schema = parser.parseFile(`${FIXTURE_DIR}/${fixture}`);
+    const schema = parseFile(
+      `${FIXTURE_DIR}/${fixture}`,
+      FlowParser.buildSchema,
+    );
     const output = generator.generate(libName, schema, undefined, false);
     expect(Object.fromEntries(output)).toMatchSnapshot();
   });

--- a/packages/react-native-codegen/e2e/__tests__/components/GenerateShadowNodeH-test.js
+++ b/packages/react-native-codegen/e2e/__tests__/components/GenerateShadowNodeH-test.js
@@ -11,7 +11,8 @@
 
 'use strict';
 
-const parser = require('../../../src/parsers/flow');
+const {parseFile} = require('../../../src/parsers/utils');
+const FlowParser = require('../../../src/parsers/flow');
 const generator = require('../../../src/generators/components/GenerateShadowNodeH');
 const fs = require('fs');
 
@@ -21,7 +22,10 @@ const fixtures = fs.readdirSync(FIXTURE_DIR);
 fixtures.forEach(fixture => {
   it(`GenerateShadowNodeH can generate for '${fixture}'`, () => {
     const libName = 'RNCodegenModuleFixtures';
-    const schema = parser.parseFile(`${FIXTURE_DIR}/${fixture}`);
+    const schema = parseFile(
+      `${FIXTURE_DIR}/${fixture}`,
+      FlowParser.buildSchema,
+    );
     const output = generator.generate(libName, schema, undefined, false);
     expect(Object.fromEntries(output)).toMatchSnapshot();
   });

--- a/packages/react-native-codegen/e2e/__tests__/components/GenerateViewConfigJs-test.js
+++ b/packages/react-native-codegen/e2e/__tests__/components/GenerateViewConfigJs-test.js
@@ -11,7 +11,8 @@
 
 'use strict';
 
-const parser = require('../../../src/parsers/flow');
+const {parseFile} = require('../../../src/parsers/utils');
+const FlowParser = require('../../../src/parsers/flow');
 const generator = require('../../../src/generators/components/GenerateViewConfigJs');
 const fs = require('fs');
 
@@ -22,7 +23,10 @@ const fixtures = fs.readdirSync(FIXTURE_DIR);
 fixtures.forEach(fixture => {
   it(`GenerateViewConfigJs can generate for '${fixture}'`, () => {
     const libName = 'RNCodegenModuleFixtures';
-    const schema = parser.parseFile(`${FIXTURE_DIR}/${fixture}`);
+    const schema = parseFile(
+      `${FIXTURE_DIR}/${fixture}`,
+      FlowParser.buildSchema,
+    );
     const output = generator.generate(libName, schema);
     expect(output).toMatchSnapshot();
   });

--- a/packages/react-native-codegen/e2e/__tests__/modules/GenerateModuleObjCpp-test.js
+++ b/packages/react-native-codegen/e2e/__tests__/modules/GenerateModuleObjCpp-test.js
@@ -11,7 +11,8 @@
 
 'use strict';
 
-const parser = require('../../../src/parsers/flow');
+const {parseFile} = require('../../../src/parsers/utils');
+const FlowParser = require('../../../src/parsers/flow');
 const generator = require('../../../src/generators/modules/GenerateModuleObjCpp');
 const fs = require('fs');
 
@@ -23,7 +24,10 @@ function getModules(): SchemaType {
   const filenames: Array<string> = fs.readdirSync(FIXTURE_DIR);
   return filenames.reduce<SchemaType>(
     (accumulator, file) => {
-      const schema = parser.parseFile(`${FIXTURE_DIR}/${file}`);
+      const schema = parseFile(
+        `${FIXTURE_DIR}/${file}`,
+        FlowParser.buildSchema,
+      );
       return {
         modules: {
           ...accumulator.modules,

--- a/packages/react-native-codegen/src/cli/combine/combine-js-to-schema.js
+++ b/packages/react-native-codegen/src/cli/combine/combine-js-to-schema.js
@@ -11,6 +11,7 @@
 'use strict';
 import type {SchemaType} from '../../CodegenSchema.js';
 
+const {parseFile} = require('../../parsers/utils');
 const FlowParser = require('../../parsers/flow');
 const TypeScriptParser = require('../../parsers/typescript');
 const fs = require('fs');
@@ -29,9 +30,10 @@ function combineSchemas(files: Array<string>): SchemaType {
         const isTypeScript =
           path.extname(filename) === '.ts' || path.extname(filename) === '.tsx';
 
-        const schema = isTypeScript
-          ? TypeScriptParser.parseFile(filename)
-          : FlowParser.parseFile(filename);
+        const schema = parseFile(
+          filename,
+          isTypeScript ? TypeScriptParser.buildSchema : FlowParser.buildSchema,
+        );
 
         if (schema && schema.modules) {
           merged.modules = {...merged.modules, ...schema.modules};

--- a/packages/react-native-codegen/src/cli/parser/parser.js
+++ b/packages/react-native-codegen/src/cli/parser/parser.js
@@ -11,6 +11,7 @@
 'use strict';
 
 const path = require('path');
+const {parseFile} = require('../../parsers/utils');
 const FlowParser = require('../../parsers/flow');
 const TypeScriptParser = require('../../parsers/typescript');
 
@@ -22,9 +23,10 @@ function parseFiles(files: Array<string>) {
     console.log(
       filename,
       JSON.stringify(
-        isTypeScript
-          ? TypeScriptParser.parseFile(filename)
-          : FlowParser.parseFile(filename),
+        parseFile(
+          filename,
+          isTypeScript ? TypeScriptParser.buildSchema : FlowParser.buildSchema,
+        ),
         null,
         2,
       ),

--- a/packages/react-native-codegen/src/parsers/flow/components/__tests__/component-parser-test.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/__tests__/component-parser-test.js
@@ -12,6 +12,7 @@
 'use strict';
 
 const FlowParser = require('../../index.js');
+const {parseFile} = require('../../../utils.js');
 const fixtures = require('../__test_fixtures__/fixtures.js');
 const failureFixtures = require('../__test_fixtures__/failures.js');
 jest.mock('fs', () => ({
@@ -30,7 +31,7 @@ describe('RN Codegen Flow Parser', () => {
     .sort()
     .forEach(fixtureName => {
       it(`can generate fixture ${fixtureName}`, () => {
-        const schema = FlowParser.parseFile(fixtureName);
+        const schema = parseFile(fixtureName, FlowParser.buildSchema);
         const serializedSchema = JSON.stringify(schema, null, 2).replace(
           /"/g,
           "'",
@@ -44,7 +45,7 @@ describe('RN Codegen Flow Parser', () => {
     .forEach(fixtureName => {
       it(`Fails with error message ${fixtureName}`, () => {
         expect(() => {
-          FlowParser.parseFile(fixtureName);
+          parseFile(fixtureName, FlowParser.buildSchema);
         }).toThrowErrorMatchingSnapshot();
       });
     });

--- a/packages/react-native-codegen/src/parsers/flow/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/index.js
@@ -119,12 +119,6 @@ function buildSchema(contents: string, filename: ?string): SchemaType {
   }
 }
 
-function parseFile(filename: string): SchemaType {
-  const contents = fs.readFileSync(filename, 'utf8');
-
-  return buildSchema(contents, filename);
-}
-
 function parseModuleFixture(filename: string): SchemaType {
   const contents = fs.readFileSync(filename, 'utf8');
 
@@ -136,7 +130,7 @@ function parseString(contents: string, filename: ?string): SchemaType {
 }
 
 module.exports = {
-  parseFile,
+  buildSchema,
   parseModuleFixture,
   parseString,
 };

--- a/packages/react-native-codegen/src/parsers/typescript/components/__tests__/typescript-component-parser-test.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/__tests__/typescript-component-parser-test.js
@@ -12,6 +12,7 @@
 'use strict';
 
 const TypeScriptParser = require('../../index.js');
+const {parseFile} = require('../../../utils.js');
 const fixtures = require('../__test_fixtures__/fixtures.js');
 const failureFixtures = require('../__test_fixtures__/failures.js');
 jest.mock('fs', () => ({
@@ -30,7 +31,7 @@ describe('RN Codegen TypeScript Parser', () => {
     .sort()
     .forEach(fixtureName => {
       it(`can generate fixture ${fixtureName}`, () => {
-        const schema = TypeScriptParser.parseFile(fixtureName);
+        const schema = parseFile(fixtureName, TypeScriptParser.buildSchema);
         const serializedSchema = JSON.stringify(schema, null, 2).replace(
           /"/g,
           "'",
@@ -44,7 +45,7 @@ describe('RN Codegen TypeScript Parser', () => {
     .forEach(fixtureName => {
       it(`Fails with error message ${fixtureName}`, () => {
         expect(() => {
-          TypeScriptParser.parseFile(fixtureName);
+          parseFile(fixtureName, TypeScriptParser.buildSchema);
         }).toThrowErrorMatchingSnapshot();
       });
     });

--- a/packages/react-native-codegen/src/parsers/typescript/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/index.js
@@ -130,12 +130,6 @@ function buildSchema(contents: string, filename: ?string): SchemaType {
   }
 }
 
-function parseFile(filename: string): SchemaType {
-  const contents = fs.readFileSync(filename, 'utf8');
-
-  return buildSchema(contents, filename);
-}
-
 function parseModuleFixture(filename: string): SchemaType {
   const contents = fs.readFileSync(filename, 'utf8');
 
@@ -147,7 +141,7 @@ function parseString(contents: string, filename: ?string): SchemaType {
 }
 
 module.exports = {
-  parseFile,
+  buildSchema,
   parseModuleFixture,
   parseString,
 };

--- a/packages/react-native-codegen/src/parsers/utils.js
+++ b/packages/react-native-codegen/src/parsers/utils.js
@@ -10,8 +10,11 @@
 
 'use strict';
 
+import type {SchemaType} from '../CodegenSchema';
+
 const {ParserError} = require('./errors');
 
+const fs = require('fs');
 const path = require('path');
 
 export type TypeDeclarationMap = {[declarationName: string]: $FlowFixMe};
@@ -52,6 +55,15 @@ function createParserErrorCapturer(): [
   }
 
   return [errors, guard];
+}
+
+function parseFile(
+  filename: string,
+  callback: (contents: string, filename: string) => SchemaType,
+): SchemaType {
+  const contents = fs.readFileSync(filename, 'utf8');
+
+  return callback(contents, filename);
 }
 
 function verifyPlatforms(
@@ -122,6 +134,7 @@ function visit(
 module.exports = {
   extractNativeModuleName,
   createParserErrorCapturer,
+  parseFile,
   verifyPlatforms,
   visit,
 };


### PR DESCRIPTION
## Summary

 This PR export the content of the `parseFile` into a parseFile function accepting a callback to buildSchema properly in `parsers/utils.js` as requested on https://github.com/facebook/react-native/issues/34872. 

## Changelog
 
[Internal] [Changed] - Export ` parseFile` in to a `parseFile` function in `parsers/utils.js`

## Test Plan

Run `yarn jest react-native-codegen` and ensure CI is green
 
![image](https://user-images.githubusercontent.com/11707729/196051689-1b61838c-477c-4be5-8df0-9f5969fcf90d.png)
