### PR TITLE
fix(template, ios): add marketing version to template project

### DIFF
--- a/template/ios/HelloWorld.xcodeproj/project.pbxproj
+++ b/template/ios/HelloWorld.xcodeproj/project.pbxproj
@@ -492,6 +492,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				MARKETING_VERSION = 1.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -517,6 +518,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				MARKETING_VERSION = 1.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Recently this PR got merged https://github.com/facebook/react-native/pull/34919 that aligned the info.plist to the current default. Problem: the variable `MARKETING_VERSION` was not set in the template, so generating a new project and testing on iOS would fail accordingly:

<img width="1400" alt="Screenshot 2022-10-18 at 15 27 27" src="https://user-images.githubusercontent.com/16104054/196461640-470079f5-0f64-471f-8221-0d17f2b0114f.png">

This PR takes care of setting the variable so that the app can build successfully.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[iOS] [Fixed] - add MARKETING_VERSION to template project

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Run `yarn test-e2e-local -t RNTestProject`, apps builds correctly and runs on simulator.
