### PR TITLE
Remove useJavaGenerator key from ReactAndroid/build.gradle file

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -605,7 +605,6 @@ react {
     root = file("..")
     jsRootDir = file("../Libraries")
     reactNativeDir = file("$projectDir/..")
-    useJavaGenerator = System.getenv("USE_CODEGEN_JAVAPOET")?.toBoolean() ?: false
     // We search for the codegen in either one of the `node_modules` folder or in the
     // root packages folder (that's for when we build from source without calling `yarn install`).
     codegenDir = file(findNodeModulePath(projectDir, "react-native-codegen") ?: "../packages/react-native-codegen/")


### PR DESCRIPTION
## Summary

This configuration was stale and has no effect on the Gradle Plugin, I'm removing it then 👍 

## Changelog

[Internal] - Remove useJavaGenerator key from ReactAndroid/build.gradle file

## Test Plan

n/a