### PR TITLE
Fix typo in OsRule

### DIFF
--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tests/OsRule.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tests/OsRule.kt
@@ -47,6 +47,6 @@ class OsRule : TestRule {
 
   companion object {
     const val OS_NAME_KEY = "os.name"
-    const val OS_ARCH_KEY = "os.arc"
+    const val OS_ARCH_KEY = "os.arch"
   }
 }


### PR DESCRIPTION
## Summary

I've just realized we have a typo in the `OsRule`. This is actually causing those tests to fail if run locally on M1 (but not on CI as it runs on a `amd64` architecture).

## Changelog

[Internal] - Fix typo in OsRule

## Test Plan

Not much to test other than it's green locally, previously it was red. CI should be green regardless