### PR TITLE
RNGP - Create DependencyUtil to support with dep version configuration

### DIFF
--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/GenerateCodegenSchemaTask.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/GenerateCodegenSchemaTask.kt
@@ -38,6 +38,8 @@ abstract class GenerateCodegenSchemaTask : Exec() {
         // .js files could be stored/generated. We want to make sure we don't pick them up
         // for execution avoidance.
         it.exclude("**/generated/source/codegen/**/*")
+        it.exclude("**/build/ASSETS/**/*")
+        it.exclude("**/build/RES/**/*")
         it.exclude("**/build/generated/assets/react/**/*")
         it.exclude("**/build/generated/res/react/**/*")
         it.exclude("**/build/generated/sourcemaps/react/**/*")

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/NativeLibraryAabCleanupTask.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/NativeLibraryAabCleanupTask.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.tasks
+
+import com.facebook.react.utils.SoCleanerUtils
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+
+abstract class NativeLibraryAabCleanupTask : DefaultTask() {
+
+  @get:InputFile abstract val inputBundle: RegularFileProperty
+
+  @get:OutputFile abstract val outputBundle: RegularFileProperty
+
+  @get:Input abstract val enableHermes: Property<Boolean>
+
+  @get:Input abstract val debuggableVariant: Property<Boolean>
+
+  @TaskAction
+  fun run() {
+    SoCleanerUtils.clean(
+        input = inputBundle.get().asFile,
+        prefix = "base/lib",
+        enableHermes = enableHermes.get(),
+        debuggableVariant = debuggableVariant.get())
+    inputBundle.get().asFile.copyTo(outputBundle.get().asFile, overwrite = true)
+  }
+}

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/NativeLibraryApkCleanupTask.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/NativeLibraryApkCleanupTask.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.tasks
+
+import com.facebook.react.utils.SoCleanerUtils
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+
+abstract class NativeLibraryApkCleanupTask : DefaultTask() {
+
+  @get:InputDirectory abstract val inputApkDirectory: DirectoryProperty
+
+  @get:OutputDirectory abstract val outputApkDirectory: DirectoryProperty
+
+  @get:Input abstract val enableHermes: Property<Boolean>
+
+  @get:Input abstract val debuggableVariant: Property<Boolean>
+
+  @TaskAction
+  fun run() {
+    inputApkDirectory.get().asFile.walk().forEach {
+      if (it.name.endsWith(".apk")) {
+        SoCleanerUtils.clean(
+            input = it,
+            prefix = "lib/",
+            enableHermes = enableHermes.get(),
+            debuggableVariant = debuggableVariant.get())
+      }
+    }
+  }
+}

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/DependencyUtils.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/DependencyUtils.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.utils
+
+import java.io.File
+import java.net.URI
+import java.util.*
+import org.gradle.api.Project
+import org.gradle.api.artifacts.repositories.MavenArtifactRepository
+
+internal object DependencyUtils {
+
+  fun configureRepositories(project: Project, reactNativeDir: File) {
+    if (project.hasProperty("REACT_NATIVE_MAVEN_LOCAL_REPO")) {
+      project.repositories.add(
+          project.mavenRepoFromUrl("file://${project.property("REACT_NATIVE_MAVEN_LOCAL_REPO")}"))
+    }
+    // We add the snapshot for users on nightlies.
+    project.repositories.add(
+        project.mavenRepoFromUrl("https://oss.sonatype.org/content/repositories/snapshots/"))
+    project.repositories.mavenCentral()
+    // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+    project.repositories.add(project.mavenRepoFromUrl("file://${reactNativeDir}/android"))
+    // Android JSC is installed from npm
+    project.repositories.add(
+        project.mavenRepoFromUrl("file://${reactNativeDir}/../jsc-android/dist"))
+    project.repositories.google()
+    project.repositories.add(project.mavenRepoFromUrl("https://www.jitpack.io"))
+  }
+
+  fun configureDependencies(project: Project, versionString: String) {
+    if (versionString.isBlank()) return
+    project.configurations.all { configuration ->
+      configuration.resolutionStrategy.force(
+          "com.facebook.react:react-native:${versionString}",
+          "com.facebook.react:hermes-engine:${versionString}",
+      )
+    }
+  }
+
+  fun readVersionString(propertiesFile: File): String {
+    val reactAndroidProperties = Properties()
+    propertiesFile.inputStream().use { reactAndroidProperties.load(it) }
+    return reactAndroidProperties["VERSION_NAME"] as? String ?: ""
+  }
+
+  fun Project.mavenRepoFromUrl(url: String): MavenArtifactRepository =
+      project.repositories.maven { it.url = URI.create(url) }
+}

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/SoCleanerUtils.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/SoCleanerUtils.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.utils
+
+import java.io.File
+import java.net.URI
+import java.nio.file.FileSystem
+import java.nio.file.FileSystems
+import java.nio.file.Files
+
+internal object SoCleanerUtils {
+
+  private val zipProperties = mapOf("create" to "false")
+
+  private val archs = listOf("x86", "x86_64", "armeabi-v7a", "arm64-v8a")
+
+  fun clean(input: File, prefix: String, enableHermes: Boolean, debuggableVariant: Boolean) {
+    val zipDisk: URI = URI.create("jar:file:${input.absolutePath}")
+    FileSystems.newFileSystem(zipDisk, zipProperties).use { zipfs ->
+      if (enableHermes) {
+        removeSoFiles(zipfs, prefix, archs, "libjsc.so")
+        removeSoFiles(zipfs, prefix, archs, "libjscexecutor.so")
+        if (debuggableVariant) {
+          removeSoFiles(zipfs, prefix, archs, "libhermes-executor-release.so")
+        } else {
+          removeSoFiles(zipfs, prefix, archs, "libhermes-executor-debug.so")
+        }
+      } else {
+        removeSoFiles(zipfs, prefix, archs, "libhermes.so")
+        removeSoFiles(zipfs, prefix, archs, "libhermes-executor-debug.so")
+        removeSoFiles(zipfs, prefix, archs, "libhermes-executor-release.so")
+      }
+    }
+  }
+
+  fun removeSoFiles(
+      zipfs: FileSystem,
+      prefix: String,
+      archs: List<String>,
+      libraryToRemove: String
+  ) {
+    archs.forEach { arch ->
+      try {
+        Files.delete(zipfs.getPath("$prefix/$arch/$libraryToRemove"))
+      } catch (e: Exception) {
+        // File was already missing due to ABI split, nothing to do here.
+      }
+    }
+  }
+}

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/GenerateCodegenSchemaTaskTest.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/GenerateCodegenSchemaTaskTest.kt
@@ -70,6 +70,8 @@ class GenerateCodegenSchemaTaskTest {
     assertEquals(
         setOf(
             "**/generated/source/codegen/**/*",
+            "**/build/ASSETS/**/*",
+            "**/build/RES/**/*",
             "**/build/generated/assets/react/**/*",
             "**/build/generated/res/react/**/*",
             "**/build/generated/sourcemaps/react/**/*",

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/NativeLibraryAabCleanupTaskTest.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/NativeLibraryAabCleanupTaskTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.tasks
+
+import com.facebook.react.tests.createTestTask
+import com.facebook.react.tests.createZip
+import java.io.File
+import org.gradle.api.tasks.*
+import org.junit.Assert.*
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.net.URI
+import java.nio.file.FileSystems
+import java.nio.file.Files
+import java.nio.file.Files.exists
+
+class NativeLibraryAabCleanupTaskTest {
+
+  @get:Rule val tempFolder = TemporaryFolder()
+
+  @Test
+  fun nativeLibraryAabCleanupTask_runWithAppAab() {
+    val inputAab = File(tempFolder.root, "input.aab")
+    val outputAab = File(tempFolder.root, "output.aab")
+    createZip(
+      inputAab,
+      listOf(
+        "base/lib/x86/libhermes.so",
+        "base/lib/x86/libhermes-executor-debug.so",
+        "base/lib/x86/libhermes-executor-release.so",
+        "base/lib/x86/libjsc.so",
+        "base/lib/x86/libjscexecutor.so",
+      )
+    )
+    val task = createTestTask<NativeLibraryAabCleanupTask> {
+      it.inputBundle.set(inputAab)
+      it.outputBundle.set(outputAab)
+      it.enableHermes.set(true)
+      it.debuggableVariant.set(true)
+    }
+
+    task.run()
+
+    val fs = FileSystems.newFileSystem(
+      URI.create("jar:file:${inputAab.absoluteFile}"),
+      mapOf("create" to "false")
+    )
+    fs.use {
+      assertTrue(exists(it.getPath("base/lib/x86/libhermes.so")))
+      assertTrue(exists(it.getPath("base/lib/x86/libhermes-executor-debug.so")))
+      assertFalse(exists(it.getPath("base/lib/x86/libhermes-executor-release.so")))
+      assertFalse(exists(it.getPath("base/lib/x86/libjsc.so")))
+      assertFalse(exists(it.getPath("base/lib/x86/libjscexecutor.so")))
+    }
+  }
+
+}

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/NativeLibraryApkCleanupTaskTest.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/NativeLibraryApkCleanupTaskTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.tasks
+
+import com.facebook.react.tests.createTestTask
+import com.facebook.react.tests.createZip
+import java.io.File
+import org.gradle.api.tasks.*
+import org.junit.Assert.*
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.net.URI
+import java.nio.file.FileSystems
+import java.nio.file.Files
+import java.nio.file.Files.exists
+
+class NativeLibraryApkCleanupTaskTest {
+
+  @get:Rule val tempFolder = TemporaryFolder()
+
+  @Test
+  fun nativeLibraryApkCleanupTask_runWithAppApk() {
+    val tempApk = File(tempFolder.root, "app.apk")
+    createZip(
+      tempApk,
+      listOf(
+        "lib/x86/libhermes.so",
+        "lib/x86/libhermes-executor-debug.so",
+        "lib/x86/libhermes-executor-release.so",
+        "lib/x86/libjsc.so",
+        "lib/x86/libjscexecutor.so",
+      )
+    )
+    val task = createTestTask<NativeLibraryApkCleanupTask> {
+      it.inputApkDirectory.set(tempFolder.root)
+      it.outputApkDirectory.set(tempFolder.root)
+      it.enableHermes.set(true)
+      it.debuggableVariant.set(true)
+    }
+
+    task.run()
+
+    val fs = FileSystems.newFileSystem(
+      URI.create("jar:file:${tempApk.absoluteFile}"),
+      mapOf("create" to "false")
+    )
+    fs.use {
+      assertTrue(exists(it.getPath("lib/x86/libhermes.so")))
+      assertTrue(exists(it.getPath("lib/x86/libhermes-executor-debug.so")))
+      assertFalse(exists(it.getPath("lib/x86/libhermes-executor-release.so")))
+      assertFalse(exists(it.getPath("lib/x86/libjsc.so")))
+      assertFalse(exists(it.getPath("lib/x86/libjscexecutor.so")))
+    }
+  }
+
+}

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tests/TaskTestUtils.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tests/TaskTestUtils.kt
@@ -8,6 +8,9 @@
 package com.facebook.react.tests
 
 import java.io.*
+import java.net.URI
+import java.nio.file.FileSystems
+import java.nio.file.Files
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 import org.gradle.api.Project
@@ -46,6 +49,21 @@ internal fun zipFiles(destination: File, contents: List<File>) {
           origin.copyTo(out, 1024)
         }
       }
+    }
+  }
+}
+
+/** A util function to create a zip given a list of dummy files path. */
+internal fun createZip(dest: File, paths: List<String>) {
+  val env = mapOf("create" to "true")
+  val uri = URI.create("jar:file:$dest")
+
+  FileSystems.newFileSystem(uri, env).use { zipfs ->
+    paths.forEach {
+      val zipEntryPath = zipfs.getPath(it)
+      val zipEntryFolder = zipEntryPath.subpath(0, zipEntryPath.nameCount - 1)
+      Files.createDirectories(zipEntryFolder)
+      Files.createFile(zipEntryPath)
     }
   }
 }

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/DependencyUtilsTest.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/DependencyUtilsTest.kt
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.utils
+
+import com.facebook.react.tests.createProject
+import com.facebook.react.utils.DependencyUtils.configureDependencies
+import com.facebook.react.utils.DependencyUtils.configureRepositories
+import com.facebook.react.utils.DependencyUtils.mavenRepoFromUrl
+import com.facebook.react.utils.DependencyUtils.readVersionString
+import java.net.URI
+import org.gradle.api.artifacts.repositories.MavenArtifactRepository
+import org.junit.Assert.*
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class DependencyUtilsTest {
+
+  @get:Rule val tempFolder = TemporaryFolder()
+
+  @Test
+  fun configureRepositories_withProjectPropertySet_configuresMavenLocalCorrectly() {
+    val localMaven = tempFolder.newFolder("m2")
+    val localMavenURI = URI.create("file://$localMaven/")
+    val project = createProject()
+    project.extensions.extraProperties.set("REACT_NATIVE_MAVEN_LOCAL_REPO", localMaven)
+
+    configureRepositories(project, tempFolder.root)
+
+    assertNotNull(
+        project.repositories.firstOrNull {
+          it is MavenArtifactRepository && it.url == localMavenURI
+        })
+  }
+
+  @Test
+  fun configureRepositories_containsSnapshotRepo() {
+    val repositoryURI = URI.create("https://oss.sonatype.org/content/repositories/snapshots/")
+    val project = createProject()
+
+    configureRepositories(project, tempFolder.root)
+
+    assertNotNull(
+        project.repositories.firstOrNull {
+          it is MavenArtifactRepository && it.url == repositoryURI
+        })
+  }
+
+  @Test
+  fun configureRepositories_containsReactNativeNpmLocalMavenRepo() {
+    val projectFolder = tempFolder.newFolder()
+    val reactNativeDir = tempFolder.newFolder("react-native")
+    val repositoryURI = URI.create("file://${reactNativeDir}/android")
+    val project = createProject(projectFolder)
+
+    configureRepositories(project, reactNativeDir)
+
+    assertNotNull(
+        project.repositories.firstOrNull {
+          it is MavenArtifactRepository && it.url == repositoryURI
+        })
+  }
+
+  @Test
+  fun configureRepositories_containsJscLocalMavenRepo() {
+    val projectFolder = tempFolder.newFolder()
+    val reactNativeDir = tempFolder.newFolder("react-native")
+    val jscAndroidDir = tempFolder.newFolder("jsc-android")
+    val repositoryURI = URI.create("file://${jscAndroidDir}/dist")
+    val project = createProject(projectFolder)
+
+    configureRepositories(project, reactNativeDir)
+
+    assertNotNull(
+        project.repositories.firstOrNull {
+          it is MavenArtifactRepository && it.url == repositoryURI
+        })
+  }
+
+  @Test
+  fun configureRepositories_containsMavenCentral() {
+    val repositoryURI = URI.create("https://repo.maven.apache.org/maven2/")
+    val project = createProject()
+
+    configureRepositories(project, tempFolder.root)
+
+    assertNotNull(
+        project.repositories.firstOrNull {
+          it is MavenArtifactRepository && it.url == repositoryURI
+        })
+  }
+
+  @Test
+  fun configureRepositories_containsGoogleRepo() {
+    val repositoryURI = URI.create("https://dl.google.com/dl/android/maven2/")
+    val project = createProject()
+
+    configureRepositories(project, tempFolder.root)
+
+    assertNotNull(
+        project.repositories.firstOrNull {
+          it is MavenArtifactRepository && it.url == repositoryURI
+        })
+  }
+
+  @Test
+  fun configureRepositories_containsJitPack() {
+    val repositoryURI = URI.create("https://www.jitpack.io")
+    val project = createProject()
+
+    configureRepositories(project, tempFolder.root)
+
+    assertNotNull(
+        project.repositories.firstOrNull {
+          it is MavenArtifactRepository && it.url == repositoryURI
+        })
+  }
+
+  @Test
+  fun configureRepositories_withProjectPropertySet_hasHigherPriorityThanMavenCentral() {
+    val localMaven = tempFolder.newFolder("m2")
+    val localMavenURI = URI.create("file://$localMaven/")
+    val mavenCentralURI = URI.create("https://repo.maven.apache.org/maven2/")
+    val project = createProject()
+    project.extensions.extraProperties.set("REACT_NATIVE_MAVEN_LOCAL_REPO", localMaven)
+
+    configureRepositories(project, tempFolder.root)
+
+    val indexOfLocalRepo =
+        project.repositories.indexOfFirst {
+          it is MavenArtifactRepository && it.url == localMavenURI
+        }
+    val indexOfMavenCentral =
+        project.repositories.indexOfFirst {
+          it is MavenArtifactRepository && it.url == mavenCentralURI
+        }
+    assertTrue(indexOfLocalRepo < indexOfMavenCentral)
+  }
+
+  @Test
+  fun configureRepositories_snapshotRepoHasHigherPriorityThanMavenCentral() {
+    val repositoryURI = URI.create("https://oss.sonatype.org/content/repositories/snapshots/")
+    val mavenCentralURI = URI.create("https://repo.maven.apache.org/maven2/")
+    val project = createProject()
+
+    configureRepositories(project, tempFolder.root)
+
+    val indexOfSnapshotRepo =
+        project.repositories.indexOfFirst {
+          it is MavenArtifactRepository && it.url == repositoryURI
+        }
+    val indexOfMavenCentral =
+        project.repositories.indexOfFirst {
+          it is MavenArtifactRepository && it.url == mavenCentralURI
+        }
+    assertTrue(indexOfSnapshotRepo < indexOfMavenCentral)
+  }
+
+  @Test
+  fun configureDependencies_withEmptyVersion_doesNothing() {
+    val project = createProject()
+
+    configureDependencies(project, "")
+
+    assertTrue(project.configurations.first().resolutionStrategy.forcedModules.isEmpty())
+  }
+
+  @Test
+  fun configureDependencies_withVersionString_appliesResolutionStrategy() {
+    val project = createProject()
+
+    configureDependencies(project, "1.2.3")
+
+    val forcedModules = project.configurations.first().resolutionStrategy.forcedModules
+    assertTrue(forcedModules.any { it.toString() == "com.facebook.react:react-native:1.2.3" })
+    assertTrue(forcedModules.any { it.toString() == "com.facebook.react:hermes-engine:1.2.3" })
+  }
+
+  @Test
+  fun readVersionString_withCorrectVersionString_returnsIt() {
+    val propertiesFile =
+        tempFolder.newFile("gradle.properties").apply {
+          writeText(
+              """
+        VERSION_NAME=1000.0.0
+        ANOTHER_PROPERTY=true
+      """
+                  .trimIndent())
+        }
+
+    val versionString = readVersionString(propertiesFile)
+
+    assertEquals("1000.0.0", versionString)
+  }
+
+  @Test
+  fun readVersionString_withMissingVersionString_returnsEmpty() {
+    val propertiesFile =
+        tempFolder.newFile("gradle.properties").apply {
+          writeText(
+              """
+        ANOTHER_PROPERTY=true
+      """
+                  .trimIndent())
+        }
+
+    val versionString = readVersionString(propertiesFile)
+    assertEquals("", versionString)
+  }
+
+  @Test
+  fun readVersionString_withEmptyVersionString_returnsEmpty() {
+    val propertiesFile =
+        tempFolder.newFile("gradle.properties").apply {
+          writeText(
+              """
+        VERSION_NAME=
+        ANOTHER_PROPERTY=true
+      """
+                  .trimIndent())
+        }
+
+    val versionString = readVersionString(propertiesFile)
+    assertEquals("", versionString)
+  }
+
+  @Test
+  fun mavenRepoFromUrl_worksCorrectly() {
+    val process = createProject()
+    val mavenRepo = process.mavenRepoFromUrl("https://hello.world")
+
+    assertEquals(URI.create("https://hello.world"), mavenRepo.url)
+  }
+}

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/SoCleanerUtilsTest.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/SoCleanerUtilsTest.kt
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.utils
+
+import com.facebook.react.tests.createZip
+import com.facebook.react.utils.SoCleanerUtils.clean
+import com.facebook.react.utils.SoCleanerUtils.removeSoFiles
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.Test.None
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import java.net.URI
+import java.nio.file.FileSystems
+import java.nio.file.Files
+import java.nio.file.Files.*
+
+class SoCleanerUtilsTest {
+
+  @get:Rule
+  val tempFolder = TemporaryFolder()
+
+  @Test
+  fun clean_withEnableHermesAndDebuggableVariant_removesCorrectly() {
+    val tempZip = File(tempFolder.root, "app.apk").apply {
+      createZip(
+        this, listOf(
+          "lib/x86/libhermes.so",
+          "lib/x86/libhermes-executor-debug.so",
+          "lib/x86/libhermes-executor-release.so",
+          "lib/x86/libjsc.so",
+          "lib/x86/libjscexecutor.so",
+        )
+      )
+    }
+
+    clean(tempZip, "lib", enableHermes = true, debuggableVariant = true)
+
+    val fs = FileSystems.newFileSystem(
+      URI.create("jar:file:${tempZip.absoluteFile}"),
+      mapOf("create" to "false")
+    )
+    fs.use {
+      assertTrue(exists(it.getPath("lib/x86/libhermes.so")))
+      assertTrue(exists(it.getPath("lib/x86/libhermes-executor-debug.so")))
+      assertFalse(exists(it.getPath("lib/x86/libhermes-executor-release.so")))
+      assertFalse(exists(it.getPath("lib/x86/libjsc.so")))
+      assertFalse(exists(it.getPath("lib/x86/libjscexecutor.so")))
+    }
+  }
+
+  @Test
+  fun clean_withEnableHermesAndNonDebuggableVariant_removesCorrectly() {
+    val tempZip = File(tempFolder.root, "app.apk").apply {
+      createZip(
+        this, listOf(
+          "lib/x86/libhermes.so",
+          "lib/x86/libhermes-executor-debug.so",
+          "lib/x86/libhermes-executor-release.so",
+          "lib/x86/libjsc.so",
+          "lib/x86/libjscexecutor.so",
+        )
+      )
+    }
+
+    clean(tempZip, "lib", enableHermes = true, debuggableVariant = false)
+
+    val fs = FileSystems.newFileSystem(
+      URI.create("jar:file:${tempZip.absoluteFile}"),
+      mapOf("create" to "false")
+    )
+    fs.use {
+      assertTrue(exists(it.getPath("lib/x86/libhermes.so")))
+      assertFalse(exists(it.getPath("lib/x86/libhermes-executor-debug.so")))
+      assertTrue(exists(it.getPath("lib/x86/libhermes-executor-release.so")))
+      assertFalse(exists(it.getPath("lib/x86/libjsc.so")))
+      assertFalse(exists(it.getPath("lib/x86/libjscexecutor.so")))
+    }
+  }
+
+
+  @Test
+  fun clean_withJscAndDebuggableVariant_removesCorrectly() {
+    val tempZip = File(tempFolder.root, "app.apk").apply {
+      createZip(
+        this, listOf(
+          "lib/x86/libhermes.so",
+          "lib/x86/libhermes-executor-debug.so",
+          "lib/x86/libhermes-executor-release.so",
+          "lib/x86/libjsc.so",
+          "lib/x86/libjscexecutor.so",
+        )
+      )
+    }
+
+    clean(tempZip, "lib", enableHermes = false, debuggableVariant = true)
+
+    val fs = FileSystems.newFileSystem(
+      URI.create("jar:file:${tempZip.absoluteFile}"),
+      mapOf("create" to "false")
+    )
+    fs.use {
+      assertFalse(exists(it.getPath("lib/x86/libhermes.so")))
+      assertFalse(exists(it.getPath("lib/x86/libhermes-executor-debug.so")))
+      assertFalse(exists(it.getPath("lib/x86/libhermes-executor-release.so")))
+      assertTrue(exists(it.getPath("lib/x86/libjsc.so")))
+      assertTrue(exists(it.getPath("lib/x86/libjscexecutor.so")))
+    }
+  }
+
+  @Test
+  fun clean_withJscAndNonDebuggableVariant_removesCorrectly() {
+    val tempZip = File(tempFolder.root, "app.apk").apply {
+      createZip(
+        this, listOf(
+          "lib/x86/libhermes.so",
+          "lib/x86/libhermes-executor-debug.so",
+          "lib/x86/libhermes-executor-release.so",
+          "lib/x86/libjsc.so",
+          "lib/x86/libjscexecutor.so",
+        )
+      )
+    }
+
+    clean(tempZip, "lib", enableHermes = false, debuggableVariant = false)
+
+    val fs = FileSystems.newFileSystem(
+      URI.create("jar:file:${tempZip.absoluteFile}"),
+      mapOf("create" to "false")
+    )
+    fs.use {
+      assertFalse(exists(it.getPath("lib/x86/libhermes.so")))
+      assertFalse(exists(it.getPath("lib/x86/libhermes-executor-debug.so")))
+      assertFalse(exists(it.getPath("lib/x86/libhermes-executor-release.so")))
+      assertTrue(exists(it.getPath("lib/x86/libjsc.so")))
+      assertTrue(exists(it.getPath("lib/x86/libjscexecutor.so")))
+    }
+  }
+
+  @Test(expected = None::class)
+  fun removeSoFiles_withEmptyZip_doesNothing() {
+    val tempZip = File(tempFolder.root, "app.apk")
+    createZip(tempZip, emptyList())
+
+    val fs = FileSystems.newFileSystem(
+      URI.create("jar:file:${tempZip.absoluteFile}"),
+      mapOf("create" to "false")
+    )
+    val archs = listOf("x86")
+    val libraryToRemove = "libhello.so"
+
+    removeSoFiles(fs, "lib", archs, libraryToRemove)
+  }
+
+  @Test
+  fun removeSoFiles_withValidFiles_filtersThemCorrectly() {
+    val tempZip = File(tempFolder.root, "app.apk")
+    createZip(
+      tempZip,
+      listOf(
+        "base/lib/x86_64/libhermes.so",
+        "base/lib/x86/libhermes.so",
+        "lib/arm64-v8a/libhermes.so",
+        "lib/armeabi-v7a/libhermes.so",
+        "lib/x86/libhermes.so",
+        "lib/x86_64/libhermes.so",
+      )
+    )
+
+    val fs = FileSystems.newFileSystem(
+      URI.create("jar:file:${tempZip.absoluteFile}"),
+      mapOf("create" to "false")
+    )
+    val archs = listOf("x86", "x86_64")
+    val libraryToRemove = "libhermes.so"
+
+    removeSoFiles(fs, "lib", archs, libraryToRemove)
+
+    fs.use {
+      assertTrue(exists(it.getPath("base/lib/x86/libhermes.so")))
+      assertTrue(exists(it.getPath("base/lib/x86_64/libhermes.so")))
+      assertTrue(exists(it.getPath("lib/arm64-v8a/libhermes.so")))
+      assertTrue(exists(it.getPath("lib/armeabi-v7a/libhermes.so")))
+      assertFalse(exists(it.getPath("lib/x86/libhermes.so")))
+      assertFalse(exists(it.getPath("lib/x86_64/libhermes.so")))
+    }
+  }
+}


### PR DESCRIPTION
Summary:
This is part of a series of tasks to make the React Native Gradle Plugin (RNGP) variant-aware.

Here I'm extending preparing classes to handle the Dependency versions and pre-configure the repositories as we wish.

Changelog:
[Internal] [Changed] - RNGP - Create DependencyUtil to support with dep version configuration

Differential Revision: D40512101

