### PR TITLE
Restore Filtering platform in codegen

### DIFF
--- a/packages/react-native-codegen/package.json
+++ b/packages/react-native-codegen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-codegen",
-  "version": "0.71.0",
+  "version": "0.71.1",
   "description": "⚛️ Code generation tools for React Native",
   "homepage": "https://github.com/facebook/react-native/tree/HEAD/packages/react-native-codegen",
   "repository": {

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/GenerateCodegenSchemaTask.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/GenerateCodegenSchemaTask.kt
@@ -63,7 +63,6 @@ abstract class GenerateCodegenSchemaTask : Exec() {
   }
 
   internal fun setupCommandLine() {
-    // TODO: restore the --platform android parameters as soon as we publish the codegen package.
     commandLine(
         windowsAwareCommandLine(
             *nodeExecutableAndArgs.get().toTypedArray(),
@@ -72,8 +71,8 @@ abstract class GenerateCodegenSchemaTask : Exec() {
                 .get()
                 .asFile
                 .absolutePath,
-            // "--platform",
-            // "android",
+            "--platform",
+            "android",
             generatedSchemaFile.get().asFile.absolutePath,
             jsRootDir.asFile.get().absolutePath,
         ))

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/GenerateCodegenSchemaTaskTest.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/GenerateCodegenSchemaTaskTest.kt
@@ -144,13 +144,13 @@ class GenerateCodegenSchemaTaskTest {
         }
 
     task.setupCommandLine()
-    // TODO: restore the --platform android parameters as soon as we publish the codegen package.
+
     assertEquals(
         listOf(
             "--verbose",
             File(codegenDir, "lib/cli/combine/combine-js-to-schema-cli.js").toString(),
-            // "--platform",
-            // "android",
+            "--platform",
+            "android",
             File(outputDir, "schema.json").toString(),
             jsRootDir.toString(),
         ),

--- a/repo-config/package.json
+++ b/repo-config/package.json
@@ -46,7 +46,7 @@
     "mkdirp": "^0.5.1",
     "prettier": "^2.4.1",
     "react": "18.2.0",
-    "react-native-codegen": "^0.71.0",
+    "react-native-codegen": "^0.71.1",
     "react-test-renderer": "18.2.0",
     "shelljs": "^0.8.5",
     "signedsource": "^1.0.0",

--- a/scripts/codegen/generate-artifacts-executor.js
+++ b/scripts/codegen/generate-artifacts-executor.js
@@ -311,7 +311,6 @@ function generateSchema(tmpDir, library, node, codegenCliPath) {
 
   console.log(`\n\n[Codegen] >>>>> Processing ${library.config.name}`);
   // Generate one schema for the entire library...
-  // TODO: restore the `--platform ios` parameters as soon as we publish the codegen package.
   executeNodeScript(
     node,
     `${path.join(
@@ -320,7 +319,7 @@ function generateSchema(tmpDir, library, node, codegenCliPath) {
       'cli',
       'combine',
       'combine-js-to-schema-cli.js',
-    )} ${pathToSchema} ${pathToJavaScriptSources}`,
+    )} --platform ios ${pathToSchema} ${pathToJavaScriptSources}`,
   );
   console.log(`[Codegen] Generated schema: ${pathToSchema}`);
   return pathToSchema;


### PR DESCRIPTION
Summary:
**This Diff require a bump in the react-native-codegen (including this [commit](https://github.com/facebook/react-native/commit/7680bdeb4f96a8092393372a59c77a9d7b729cae)) to work**

This diff sets up iOS and Android to pass their platform to the codegen so that we can have platform-specific specs.

## Changelog
[General][Added] - Enable platform-specific Codegen Specs

Differential Revision: D40516395

