### PR TITLE
CocoaPods: Split React-jsc out of React-jsi

### DIFF
--- a/Libraries/Blob/React-RCTBlob.podspec
+++ b/Libraries/Blob/React-RCTBlob.podspec
@@ -42,8 +42,8 @@ Pod::Spec.new do |s|
   s.dependency "React-Codegen", version
   s.dependency "ReactCommon/turbomodule/core", version
   s.dependency "React-jsi", version
+  s.dependency "React-jsc", version
   s.dependency "React-Core/RCTBlobHeaders", version
   s.dependency "React-Core/RCTWebSocket", version
   s.dependency "React-RCTNetwork", version
-  s.dependency "React-jsi", version
 end

--- a/Libraries/Image/React-RCTImage.podspec
+++ b/Libraries/Image/React-RCTImage.podspec
@@ -44,6 +44,7 @@ Pod::Spec.new do |s|
   s.dependency "RCTTypeSafety", version
   s.dependency "ReactCommon/turbomodule/core", version
   s.dependency "React-jsi", version
+  s.dependency "React-jsc", version
   s.dependency "React-Core/RCTImageHeaders", version
   s.dependency "React-RCTNetwork", version
 end

--- a/Libraries/LinkingIOS/React-RCTLinking.podspec
+++ b/Libraries/LinkingIOS/React-RCTLinking.podspec
@@ -43,4 +43,5 @@ Pod::Spec.new do |s|
   s.dependency "React-Core/RCTLinkingHeaders", version
   s.dependency "ReactCommon/turbomodule/core", version
   s.dependency "React-jsi", version
+  s.dependency "React-jsc", version
 end

--- a/Libraries/NativeAnimation/React-RCTAnimation.podspec
+++ b/Libraries/NativeAnimation/React-RCTAnimation.podspec
@@ -43,5 +43,6 @@ Pod::Spec.new do |s|
   s.dependency "RCTTypeSafety", version
   s.dependency "ReactCommon/turbomodule/core", version
   s.dependency "React-jsi", version
+  s.dependency "React-jsc", version
   s.dependency "React-Core/RCTAnimationHeaders", version
 end

--- a/Libraries/Network/React-RCTNetwork.podspec
+++ b/Libraries/Network/React-RCTNetwork.podspec
@@ -44,5 +44,6 @@ Pod::Spec.new do |s|
   s.dependency "RCTTypeSafety", version
   s.dependency "ReactCommon/turbomodule/core", version
   s.dependency "React-jsi", version
+  s.dependency "React-jsc", version
   s.dependency "React-Core/RCTNetworkHeaders", version
 end

--- a/Libraries/PushNotificationIOS/React-RCTPushNotification.podspec
+++ b/Libraries/PushNotificationIOS/React-RCTPushNotification.podspec
@@ -45,4 +45,5 @@ Pod::Spec.new do |s|
   s.dependency "React-Core/RCTPushNotificationHeaders", version
   s.dependency "ReactCommon/turbomodule/core", version
   s.dependency "React-jsi", version
+  s.dependency "React-jsc", version
 end

--- a/Libraries/Settings/React-RCTSettings.podspec
+++ b/Libraries/Settings/React-RCTSettings.podspec
@@ -44,5 +44,6 @@ Pod::Spec.new do |s|
   s.dependency "RCTTypeSafety", version
   s.dependency "ReactCommon/turbomodule/core", version
   s.dependency "React-jsi", version
+  s.dependency "React-jsc", version
   s.dependency "React-Core/RCTSettingsHeaders", version
 end

--- a/Libraries/Vibration/React-RCTVibration.podspec
+++ b/Libraries/Vibration/React-RCTVibration.podspec
@@ -44,5 +44,6 @@ Pod::Spec.new do |s|
   s.dependency "React-Codegen", version
   s.dependency "ReactCommon/turbomodule/core", version
   s.dependency "React-jsi", version
+  s.dependency "React-jsc", version
   s.dependency "React-Core/RCTVibrationHeaders", version
 end

--- a/React-Core.podspec
+++ b/React-Core.podspec
@@ -95,6 +95,7 @@ Pod::Spec.new do |s|
   s.dependency "React-cxxreact", version
   s.dependency "React-perflogger", version
   s.dependency "React-jsi", version
+  s.dependency "React-jsc", version
   s.dependency "React-jsiexecutor", version
   s.dependency "Yoga"
   s.dependency "glog"

--- a/React/CoreModules/React-CoreModules.podspec
+++ b/React/CoreModules/React-CoreModules.podspec
@@ -44,4 +44,5 @@ Pod::Spec.new do |s|
   s.dependency "React-RCTImage", version
   s.dependency "ReactCommon/turbomodule/core", version
   s.dependency "React-jsi", version
+  s.dependency "React-jsc", version
 end

--- a/React/FBReactNativeSpec/FBReactNativeSpec.podspec
+++ b/React/FBReactNativeSpec/FBReactNativeSpec.podspec
@@ -47,6 +47,7 @@ Pod::Spec.new do |s|
   s.dependency "RCTTypeSafety", version
   s.dependency "React-Core", version
   s.dependency "React-jsi", version
+  s.dependency "React-jsc", version
   s.dependency "ReactCommon/turbomodule/core", version
 
   use_react_native_codegen!(s, {

--- a/ReactCommon/React-Fabric.podspec
+++ b/ReactCommon/React-Fabric.podspec
@@ -42,6 +42,7 @@ Pod::Spec.new do |s|
   s.dependency "RCTTypeSafety", version
   s.dependency "ReactCommon/turbomodule/core", version
   s.dependency "React-jsi", version
+  s.dependency "React-jsc", version
 
   s.subspec "animations" do |ss|
     ss.dependency             folly_dep_name, folly_version

--- a/ReactCommon/React-bridging.podspec
+++ b/ReactCommon/React-bridging.podspec
@@ -40,4 +40,5 @@ Pod::Spec.new do |s|
 
   s.dependency "RCT-Folly", folly_version
   s.dependency "React-jsi", version
+  s.dependency "React-jsc", version
 end

--- a/ReactCommon/ReactCommon.podspec
+++ b/ReactCommon/ReactCommon.podspec
@@ -46,6 +46,7 @@ Pod::Spec.new do |s|
     ss.dependency "React-Core", version
     ss.dependency "React-cxxreact", version
     ss.dependency "React-jsi", version
+    ss.dependency "React-jsc", version
     ss.dependency "RCT-Folly", folly_version
     s.dependency "React-logger", version
     ss.dependency "DoubleConversion"

--- a/ReactCommon/cxxreact/React-cxxreact.podspec
+++ b/ReactCommon/cxxreact/React-cxxreact.podspec
@@ -45,5 +45,6 @@ Pod::Spec.new do |s|
   s.dependency "React-runtimeexecutor", version
   s.dependency "React-perflogger", version
   s.dependency "React-jsi", version
+  s.dependency "React-jsc", version
   s.dependency "React-logger", version
 end

--- a/ReactCommon/hermes/React-hermes.podspec
+++ b/ReactCommon/hermes/React-hermes.podspec
@@ -27,7 +27,7 @@ boost_compiler_flags = '-Wno-documentation'
 Pod::Spec.new do |s|
   s.name                   = "React-hermes"
   s.version                = version
-  s.summary                = "-"  # TODO
+  s.summary                = "Hermes engine for React Native"
   s.homepage               = "https://reactnative.dev/"
   s.license                = package['license']
   s.author                 = "Facebook, Inc. and its affiliates"

--- a/ReactCommon/jsi/React-jsc.podspec
+++ b/ReactCommon/jsi/React-jsc.podspec
@@ -16,22 +16,27 @@ else
   source[:tag] = "v#{version}"
 end
 
-folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
-folly_version = '2021.07.22.00'
-boost_compiler_flags = '-Wno-documentation'
-
 Pod::Spec.new do |s|
-  s.name                   = "React-runtimeexecutor"
+  s.name                   = "React-jsc"
   s.version                = version
-  s.summary                = "-"  # TODO
+  s.summary                = "JavaScriptCore engine for React Native"
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Facebook, Inc. and its affiliates"
   s.platforms              = { :ios => "12.4" }
   s.source                 = source
-  s.source_files           = "**/*.{cpp,h}"
-  s.header_dir             = "ReactCommon"
-
+  s.source_files           = "JSCRuntime.{cpp,h}"
+  s.exclude_files          = "**/test/*"
+  s.framework              = "JavaScriptCore"
   s.dependency "React-jsi", version
-  s.dependency "React-jsc", version
+
+  s.default_subspec        = "Default"
+
+  s.subspec "Default" do
+    # no-op
+  end
+
+  s.subspec "Fabric" do |ss|
+    ss.pod_target_xcconfig  = { "OTHER_CFLAGS" => "$(inherited) -DRN_FABRIC_ENABLED" }
+  end
 end

--- a/ReactCommon/jsi/React-jsi.podspec
+++ b/ReactCommon/jsi/React-jsi.podspec
@@ -16,41 +16,21 @@ else
   source[:tag] = "v#{version}"
 end
 
-folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
-folly_version = '2021.07.22.00'
-boost_compiler_flags = '-Wno-documentation'
-
 Pod::Spec.new do |s|
   s.name                   = "React-jsi"
   s.version                = version
-  s.summary                = "-"  # TODO
+  s.summary                = "JavaScript Interface layer for React Native"
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Facebook, Inc. and its affiliates"
   s.platforms              = { :ios => "12.4" }
   s.source                 = source
-  s.source_files           = "**/*.{cpp,h}"
+  s.source_files           = "jsi/*.{cpp,h}"
   s.exclude_files          = [
                                "jsi/JSIDynamic.{h,cpp}",
-                               "jsi/jsilib-*.{h,cpp}",
+                               "jsi/jsilib-posix.cpp",
+                               "jsi/jsilib-windows.cpp",
                                "**/test/*"
                              ]
-  s.framework              = "JavaScriptCore"
-  s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
-  s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/DoubleConversion\"" }
   s.header_dir             = "jsi"
-  s.default_subspec        = "Default"
-
-  s.dependency "boost", "1.76.0"
-  s.dependency "DoubleConversion"
-  s.dependency "RCT-Folly", folly_version
-  s.dependency "glog"
-
-  s.subspec "Default" do
-    # no-op
-  end
-
-  s.subspec "Fabric" do |ss|
-    ss.pod_target_xcconfig  = { "OTHER_CFLAGS" => "$(inherited) -DRN_FABRIC_ENABLED" }
-  end
 end

--- a/ReactCommon/jsi/React-jsidynamic.podspec
+++ b/ReactCommon/jsi/React-jsidynamic.podspec
@@ -39,4 +39,5 @@ Pod::Spec.new do |s|
   s.dependency "RCT-Folly", folly_version
   s.dependency "glog"
   s.dependency "React-jsi", version
+  s.dependency "React-jsc", version
 end

--- a/packages/rn-tester/RCTTest/React-RCTTest.podspec
+++ b/packages/rn-tester/RCTTest/React-RCTTest.podspec
@@ -44,4 +44,5 @@ Pod::Spec.new do |s|
   s.dependency "React-CoreModules", version
   s.dependency "ReactCommon/turbomodule/core", version
   s.dependency "React-jsi", version
+  s.dependency "React-jsc", version
 end

--- a/scripts/cocoapods/__tests__/codegen_utils-test.rb
+++ b/scripts/cocoapods/__tests__/codegen_utils-test.rb
@@ -463,6 +463,7 @@ class CodegenUtilsTests < Test::Unit::TestCase
             "RCTTypeSafety": ["99.98.97"],
             "React-Core": ["99.98.97"],
             "React-jsi": ["99.98.97"],
+            "React-jsc": ["99.98.97"],
             "ReactCommon/turbomodule/core": ["99.98.97"]
           }
         }

--- a/scripts/cocoapods/__tests__/fabric-test.rb
+++ b/scripts/cocoapods/__tests__/fabric-test.rb
@@ -5,6 +5,7 @@
 
 require "test/unit"
 require_relative "../fabric.rb"
+require_relative "../utils.rb"
 require_relative "./test_utils/podSpy.rb"
 
 class FabricTest < Test::Unit::TestCase
@@ -13,6 +14,13 @@ class FabricTest < Test::Unit::TestCase
         podSpy_cleanUp()
     end
 
+    def teardown
+        podSpy_cleanUp()
+    end
+
+    # ================== #
+    # TEST - setupFabric #
+    # ================== #
     def test_setupFabric_installsPods
         # Arrange
         prefix = "../.."
@@ -30,7 +38,7 @@ class FabricTest < Test::Unit::TestCase
         check_pod("React-Fabric", :path => "#{prefix}/ReactCommon")
         check_pod("React-rncore", :path => "#{prefix}/ReactCommon")
         check_pod("React-graphics", :path => "#{prefix}/ReactCommon/react/renderer/graphics")
-        check_pod("React-jsi/Fabric", :path => "#{prefix}/ReactCommon/jsi")
+        check_pod("React-jsc/Fabric", :path => "#{prefix}/ReactCommon/jsi")
         check_pod("React-RCTFabric", :path => "#{prefix}/React", :modular_headers => true)
         check_pod("RCT-Folly/Fabric", :podspec => "#{prefix}/third-party-podspecs/RCT-Folly.podspec")
     end
@@ -45,5 +53,4 @@ class FabricTest < Test::Unit::TestCase
 
         assert_equal(params, expected_params)
     end
-
 end

--- a/scripts/cocoapods/codegen_utils.rb
+++ b/scripts/cocoapods/codegen_utils.rb
@@ -104,6 +104,7 @@ class CodegenUtils
             "RCTTypeSafety": [version],
             "React-Core": [version],
             "React-jsi": [version],
+            "React-jsc": [version],
             "ReactCommon/turbomodule/core": [version]
           }
         }

--- a/scripts/cocoapods/fabric.rb
+++ b/scripts/cocoapods/fabric.rb
@@ -4,16 +4,14 @@
 # LICENSE file in the root directory of this source tree.
 
 
-# It sets up the faric dependencies.
+# It sets up the Fabric dependencies.
 #
-# @parameter prefix: prefix to use to reach react-native
-# @parameter new_arch_enabled: whether the new arch is enabled or not
-# @parameter codegen_output_dir: the directory where the code is generated
-def setup_fabric!(prefix)
-    pod 'React-Fabric', :path => "#{prefix}/ReactCommon"
-    pod 'React-rncore', :path => "#{prefix}/ReactCommon"
-    pod 'React-graphics', :path => "#{prefix}/ReactCommon/react/renderer/graphics"
-    pod 'React-jsi/Fabric', :path => "#{prefix}/ReactCommon/jsi"
-    pod 'React-RCTFabric', :path => "#{prefix}/React", :modular_headers => true
-    pod 'RCT-Folly/Fabric', :podspec => "#{prefix}/third-party-podspecs/RCT-Folly.podspec"
+# @parameter react_native_path: relative path to react-native
+def setup_fabric!(react_native_path)
+    pod 'React-Fabric', :path => "#{react_native_path}/ReactCommon"
+    pod 'React-rncore', :path => "#{react_native_path}/ReactCommon"
+    pod 'React-graphics', :path => "#{react_native_path}/ReactCommon/react/renderer/graphics"
+    pod 'React-jsc/Fabric', :path => "#{react_native_path}/ReactCommon/jsi"
+    pod 'React-RCTFabric', :path => "#{react_native_path}/React", :modular_headers => true
+    pod 'RCT-Folly/Fabric', :podspec => "#{react_native_path}/third-party-podspecs/RCT-Folly.podspec"
 end

--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -95,6 +95,7 @@ def use_react_native! (
   pod 'React-bridging', :path => "#{prefix}/ReactCommon"
   pod 'React-cxxreact', :path => "#{prefix}/ReactCommon/cxxreact"
   pod 'React-jsi', :path => "#{prefix}/ReactCommon/jsi"
+  pod 'React-jsc', :path => "#{prefix}/ReactCommon/jsi"
   pod 'React-jsidynamic', :path => "#{prefix}/ReactCommon/jsi"
   pod 'React-jsiexecutor', :path => "#{prefix}/ReactCommon/jsiexecutor"
   pod 'React-jsinspector', :path => "#{prefix}/ReactCommon/jsinspector"


### PR DESCRIPTION
Summary:
The React-jsi Pod was serving two purposes: building JSI, and configuring JavaScriptCore as the JS engine.

By splitting the React-jsi Pod into React-jsi and React-jsi, we can start working towards de-coupling the JSI dependency from any particular JS engine.

Pods that depended on React-jsi, now depend on React-jsi and React-jsc.
One exception to this is React-hermes, which is only installed when Hermes is enabled, and thus does not require JavaScriptCore.
Upcoming commits should take care of removing the React-jsc dependency when Hermes is enabled, but it is out of scope for this commit.

Changelog:
[iOS][Changed] - The JSC Runtime is now provided by the React-jsc Pod instead of React-jsi. Libraries that declared a dependency on React-jsi in order to specifically create a JSC runtime (`makeJSCRuntime()`) will need to add React-jsc to their dependencies.

Reviewed By: dmytrorykun

Differential Revision: D40442603

