### PR TITLE
Create the Parser interface

### DIFF
--- a/packages/react-native-codegen/src/parsers/errors.js
+++ b/packages/react-native-codegen/src/parsers/errors.js
@@ -11,7 +11,7 @@
 'use strict';
 
 const invariant = require('invariant');
-
+import type {Parser} from './parser';
 export type ParserType = 'Flow' | 'TypeScript';
 
 class ParserError extends Error {
@@ -114,12 +114,11 @@ class UnsupportedGenericParserError extends ParserError {
   constructor(
     nativeModuleName: string,
     genericTypeAnnotation: $FlowFixMe,
-    language: ParserType,
+    parser: Parser,
   ) {
-    const genericName =
-      language === 'TypeScript'
-        ? genericTypeAnnotation.typeName.name
-        : genericTypeAnnotation.id.name;
+    const genericName = parser.nameForGenericTypeAnnotation(
+      genericTypeAnnotation,
+    );
     super(
       nativeModuleName,
       genericTypeAnnotation,

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -81,7 +81,10 @@ const {
   throwIfMoreThanOneModuleInterfaceParserError,
 } = require('../../error-utils');
 
+const {FlowParser} = require('../parser.js');
+
 const language = 'Flow';
+const parser = new FlowParser();
 
 function translateArrayTypeAnnotation(
   hasteModuleName: string,
@@ -276,7 +279,7 @@ function translateTypeAnnotation(
           throw new UnsupportedGenericParserError(
             hasteModuleName,
             typeAnnotation,
-            language,
+            parser,
           );
         }
       }

--- a/packages/react-native-codegen/src/parsers/flow/parser.js
+++ b/packages/react-native-codegen/src/parsers/flow/parser.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ * @format
+ */
+
+'use strict';
+
+import type {Parser} from '../parser';
+
+class FlowParser implements Parser {
+  nameForGenericTypeAnnotation(typeAnnotation: $FlowFixMe): string {
+    return typeAnnotation.id.name;
+  }
+}
+
+module.exports = {
+  FlowParser,
+};

--- a/packages/react-native-codegen/src/parsers/parser.js
+++ b/packages/react-native-codegen/src/parsers/parser.js
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ * @format
+ */
+
+'use strict';
+
+export interface Parser {
+  nameForGenericTypeAnnotation(typeAnnotation: $FlowFixMe): string;
+}

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -80,7 +80,10 @@ const {
   throwIfUnsupportedFunctionReturnTypeAnnotationParserError,
 } = require('../../error-utils');
 
+const {TypeScriptParser} = require('../parser');
+
 const language = 'TypeScript';
+const parser = new TypeScriptParser();
 
 function translateArrayTypeAnnotation(
   hasteModuleName: string,
@@ -205,7 +208,7 @@ function translateTypeAnnotation(
         throw new UnsupportedGenericParserError(
           hasteModuleName,
           typeAnnotation,
-          language,
+          parser,
         );
       }
     }
@@ -290,7 +293,7 @@ function translateTypeAnnotation(
           throw new UnsupportedGenericParserError(
             hasteModuleName,
             typeAnnotation,
-            language,
+            parser,
           );
         }
       }

--- a/packages/react-native-codegen/src/parsers/typescript/parser.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parser.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ * @format
+ */
+
+'use strict';
+
+import type {Parser} from '../parser';
+
+class TypeScriptParser implements Parser {
+  nameForGenericTypeAnnotation(typeAnnotation: $FlowFixMe): string {
+    return typeAnnotation.typeName.name;
+  }
+}
+module.exports = {
+  TypeScriptParser,
+};


### PR DESCRIPTION
Summary:
This diff is the base to create a polimorphic behavior for TypeScript and Flow parser. This type will allow to share a lot of code between the parsers and also to keep their differences a part.

It will be the base diff/PR for further tasks in the Codegen umbrella Issue

## Changelog:
[General][Added] - Parser interface to divide parser logic.

Differential Revision: D40548707

