### PR TITLE
feat: make RCTBlobManager TurboModule-compatible

### DIFF
--- a/React/CoreModules/CoreModulesPlugins.h
+++ b/React/CoreModules/CoreModulesPlugins.h
@@ -54,6 +54,7 @@ Class RCTWebSocketModuleCls(void) __attribute__((used));
 Class RCTDevLoadingViewCls(void) __attribute__((used));
 Class RCTDevSplitBundleLoaderCls(void) __attribute__((used));
 Class RCTEventDispatcherCls(void) __attribute__((used));
+Class RCTBlobManagerCls(void) __attribute__((used));
 
 #ifdef __cplusplus
 }

--- a/React/CoreModules/CoreModulesPlugins.mm
+++ b/React/CoreModules/CoreModulesPlugins.mm
@@ -37,6 +37,7 @@ Class RCTCoreModulesClassProvider(const char *name) {
     {"PerfMonitor", RCTPerfMonitorCls},
     {"DevMenu", RCTDevMenuCls},
     {"DevSettings", RCTDevSettingsCls},
+    {"BlobModule", RCTBlobManagerCls},
     {"RedBox", RCTRedBoxCls},
     {"LogBox", RCTLogBoxCls},
     {"WebSocketExecutor", RCTWebSocketExecutorCls},


### PR DESCRIPTION
## Summary

Currently, RCTBlobManager (the native module for Blob support) cannot be loaded on iOS when the new architecture is enabled. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

[General] [Added] - `BlobModule` to `RCTCoreModulesClassProvider`

## Test Plan

The snippet below can be used to test Blob support with the new architecture enabled.

```
// App.tsx
import { useEffect } from 'react';
import { View } from 'react-native';
function uriToBlob(uri: any) {
  return new Promise((resolve, reject) => {
    const xhr = new XMLHttpRequest();
    xhr.responseType = 'blob';
    xhr.onload = () => {
      const blob = xhr.response;
      resolve(blob);
    };
    xhr.onerror = err => {
      reject(err);
    };
    xhr.open('GET', uri);
    xhr.send();
  });
}

export default function App() {
  useEffect(() => {
    uriToBlob('https://www.google.com/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png');
  });
  return <View />;
}

```

Related issue: https://github.com/facebook/react-native/issues/35042