### PR TITLE
[Codegen] Extract throwIfUnsupportedFunctionParamTypeAnnotationParserError function

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
@@ -22,6 +22,7 @@ const {
   throwIfMoreThanOneModuleInterfaceParserError,
   throwIfModuleTypeIsUnsupported,
   throwIfUntypedModule,
+  throwIfUnsupportedFunctionParamTypeAnnotationParserError,
 } = require('../error-utils');
 const {
   UnsupportedModulePropertyParserError,
@@ -34,6 +35,7 @@ const {
   UnsupportedFunctionReturnTypeAnnotationParserError,
   UntypedModuleRegistryCallParserError,
   MoreThanOneModuleInterfaceParserError,
+  UnsupportedFunctionParamTypeAnnotationParserError,
 } = require('../errors');
 
 describe('throwIfModuleInterfaceIsMisnamed', () => {
@@ -631,5 +633,37 @@ describe('throwIfMoreThanOneModuleInterfaceParserError', () => {
         parserType,
       );
     }).toThrow(MoreThanOneModuleInterfaceParserError);
+  });
+});
+
+describe('throwIfUnsupportedFunctionParamTypeAnnotationParserError', () => {
+  const nativeModuleName = 'moduleName';
+  const languageParamTypeAnnotation = {type: 'DoubleTypeAnnotation'};
+  const paramName = 'paramName';
+  const expectedTypeAnnotation = 'VoidTypeAnnotation';
+  it('throws an UnsupportedFunctionParamTypeAnnotationParserError if paramTypeAnnotationType equals expectedTypeAnnotation', () => {
+    const paramTypeAnnotationType = 'VoidTypeAnnotation';
+    expect(() => {
+      throwIfUnsupportedFunctionParamTypeAnnotationParserError(
+        nativeModuleName,
+        languageParamTypeAnnotation,
+        paramTypeAnnotationType,
+        paramName,
+        expectedTypeAnnotation,
+      );
+    }).toThrow(UnsupportedFunctionParamTypeAnnotationParserError);
+  });
+
+  it("doesn't throw an UnsupportedFunctionParamTypeAnnotationParserError if paramTypeAnnotationType equals expectedTypeAnnotation", () => {
+    const paramTypeAnnotationType = 'NumberTypeAnnotation';
+    expect(() => {
+      throwIfUnsupportedFunctionParamTypeAnnotationParserError(
+        nativeModuleName,
+        languageParamTypeAnnotation,
+        paramTypeAnnotationType,
+        paramName,
+        expectedTypeAnnotation,
+      );
+    }).not.toThrow(UnsupportedFunctionParamTypeAnnotationParserError);
   });
 });

--- a/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
@@ -638,32 +638,17 @@ describe('throwIfMoreThanOneModuleInterfaceParserError', () => {
 
 describe('throwIfUnsupportedFunctionParamTypeAnnotationParserError', () => {
   const nativeModuleName = 'moduleName';
-  const languageParamTypeAnnotation = {type: 'DoubleTypeAnnotation'};
+  const languageParamTypeAnnotation = {type: 'VoidTypeAnnotation'};
   const paramName = 'paramName';
-  const expectedTypeAnnotation = 'VoidTypeAnnotation';
-  it('throws an UnsupportedFunctionParamTypeAnnotationParserError if paramTypeAnnotationType equals expectedTypeAnnotation', () => {
+  it('throws an UnsupportedFunctionParamTypeAnnotationParserError', () => {
     const paramTypeAnnotationType = 'VoidTypeAnnotation';
     expect(() => {
       throwIfUnsupportedFunctionParamTypeAnnotationParserError(
         nativeModuleName,
         languageParamTypeAnnotation,
-        paramTypeAnnotationType,
         paramName,
-        expectedTypeAnnotation,
+        paramTypeAnnotationType,
       );
     }).toThrow(UnsupportedFunctionParamTypeAnnotationParserError);
-  });
-
-  it("doesn't throw an UnsupportedFunctionParamTypeAnnotationParserError if paramTypeAnnotationType equals expectedTypeAnnotation", () => {
-    const paramTypeAnnotationType = 'NumberTypeAnnotation';
-    expect(() => {
-      throwIfUnsupportedFunctionParamTypeAnnotationParserError(
-        nativeModuleName,
-        languageParamTypeAnnotation,
-        paramTypeAnnotationType,
-        paramName,
-        expectedTypeAnnotation,
-      );
-    }).not.toThrow(UnsupportedFunctionParamTypeAnnotationParserError);
   });
 });

--- a/packages/react-native-codegen/src/parsers/error-utils.js
+++ b/packages/react-native-codegen/src/parsers/error-utils.js
@@ -254,18 +254,15 @@ function throwIfMoreThanOneModuleInterfaceParserError(
 function throwIfUnsupportedFunctionParamTypeAnnotationParserError(
   nativeModuleName: string,
   languageParamTypeAnnotation: $FlowFixMe,
-  paramTypeAnnotationType: NativeModuleTypeAnnotation['type'],
   paramName: string,
-  expectedTypeAnnotation: string,
+  paramTypeAnnotationType: NativeModuleTypeAnnotation['type'],
 ) {
-  if (paramTypeAnnotationType === expectedTypeAnnotation) {
-    throw new UnsupportedFunctionParamTypeAnnotationParserError(
-      nativeModuleName,
-      languageParamTypeAnnotation,
-      paramName,
-      expectedTypeAnnotation,
-    );
-  }
+  throw new UnsupportedFunctionParamTypeAnnotationParserError(
+    nativeModuleName,
+    languageParamTypeAnnotation,
+    paramName,
+    paramTypeAnnotationType,
+  );
 }
 
 module.exports = {

--- a/packages/react-native-codegen/src/parsers/error-utils.js
+++ b/packages/react-native-codegen/src/parsers/error-utils.js
@@ -10,6 +10,7 @@
 
 'use strict';
 
+import type {NativeModuleTypeAnnotation} from '../CodegenSchema';
 import type {ParserType} from './errors';
 
 const {
@@ -24,6 +25,7 @@ const {
   UntypedModuleRegistryCallParserError,
   UnsupportedModulePropertyParserError,
   MoreThanOneModuleInterfaceParserError,
+  UnsupportedFunctionParamTypeAnnotationParserError,
 } = require('./errors.js');
 
 function throwIfModuleInterfaceIsMisnamed(
@@ -249,6 +251,23 @@ function throwIfMoreThanOneModuleInterfaceParserError(
   }
 }
 
+function throwIfUnsupportedFunctionParamTypeAnnotationParserError(
+  nativeModuleName: string,
+  languageParamTypeAnnotation: $FlowFixMe,
+  paramTypeAnnotationType: NativeModuleTypeAnnotation['type'],
+  paramName: string,
+  expectedTypeAnnotation: string,
+) {
+  if (paramTypeAnnotationType === expectedTypeAnnotation) {
+    throw new UnsupportedFunctionParamTypeAnnotationParserError(
+      nativeModuleName,
+      languageParamTypeAnnotation,
+      paramName,
+      expectedTypeAnnotation,
+    );
+  }
+}
+
 module.exports = {
   throwIfModuleInterfaceIsMisnamed,
   throwIfUnsupportedFunctionReturnTypeAnnotationParserError,
@@ -261,4 +280,5 @@ module.exports = {
   throwIfUntypedModule,
   throwIfModuleTypeIsUnsupported,
   throwIfMoreThanOneModuleInterfaceParserError,
+  throwIfUnsupportedFunctionParamTypeAnnotationParserError,
 };

--- a/packages/react-native-codegen/src/parsers/errors.js
+++ b/packages/react-native-codegen/src/parsers/errors.js
@@ -257,7 +257,6 @@ class UnsupportedFunctionParamTypeAnnotationParserError extends ParserError {
     flowParamTypeAnnotation: $FlowFixMe,
     paramName: string,
     invalidParamType: string,
-    language: ParserType,
   ) {
     super(
       nativeModuleName,

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -59,7 +59,6 @@ const {
   UnsupportedArrayElementTypeAnnotationParserError,
   UnsupportedGenericParserError,
   UnsupportedTypeAnnotationParserError,
-  UnsupportedFunctionParamTypeAnnotationParserError,
   UnsupportedEnumDeclarationParserError,
   UnsupportedUnionTypeAnnotationParserError,
   UnsupportedObjectPropertyTypeAnnotationParserError,
@@ -79,6 +78,7 @@ const {
   throwIfUntypedModule,
   throwIfModuleTypeIsUnsupported,
   throwIfMoreThanOneModuleInterfaceParserError,
+  throwIfUnsupportedFunctionParamTypeAnnotationParserError,
 } = require('../../error-utils');
 
 const language = 'Flow';
@@ -450,25 +450,21 @@ function translateFunctionTypeAnnotation(
           ),
         );
 
-      if (paramTypeAnnotation.type === 'VoidTypeAnnotation') {
-        throw new UnsupportedFunctionParamTypeAnnotationParserError(
-          hasteModuleName,
-          flowParam.typeAnnotation,
-          paramName,
-          'void',
-          language,
-        );
-      }
+      throwIfUnsupportedFunctionParamTypeAnnotationParserError(
+        hasteModuleName,
+        flowParam.typeAnnotation,
+        paramTypeAnnotation.type,
+        paramName,
+        'VoidTypeAnnotation',
+      );
 
-      if (paramTypeAnnotation.type === 'PromiseTypeAnnotation') {
-        throw new UnsupportedFunctionParamTypeAnnotationParserError(
-          hasteModuleName,
-          flowParam.typeAnnotation,
-          paramName,
-          'Promise',
-          language,
-        );
-      }
+      throwIfUnsupportedFunctionParamTypeAnnotationParserError(
+        hasteModuleName,
+        flowParam.typeAnnotation,
+        paramTypeAnnotation.type,
+        paramName,
+        'PromiseTypeAnnotation',
+      );
 
       return {
         name: flowParam.name.name,

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -450,21 +450,19 @@ function translateFunctionTypeAnnotation(
           ),
         );
 
-      throwIfUnsupportedFunctionParamTypeAnnotationParserError(
-        hasteModuleName,
-        flowParam.typeAnnotation,
-        paramTypeAnnotation.type,
-        paramName,
+      const forbiddenTypes = new Set([
         'VoidTypeAnnotation',
-      );
-
-      throwIfUnsupportedFunctionParamTypeAnnotationParserError(
-        hasteModuleName,
-        flowParam.typeAnnotation,
-        paramTypeAnnotation.type,
-        paramName,
         'PromiseTypeAnnotation',
-      );
+      ]);
+
+      if (forbiddenTypes.has(paramTypeAnnotation.type)) {
+        return throwIfUnsupportedFunctionParamTypeAnnotationParserError(
+          hasteModuleName,
+          flowParam.typeAnnotation,
+          paramName,
+          paramTypeAnnotation.type,
+        );
+      }
 
       return {
         name: flowParam.name.name,

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -450,12 +450,10 @@ function translateFunctionTypeAnnotation(
           ),
         );
 
-      const forbiddenTypes = new Set([
-        'VoidTypeAnnotation',
-        'PromiseTypeAnnotation',
-      ]);
-
-      if (forbiddenTypes.has(paramTypeAnnotation.type)) {
+      if (
+        paramTypeAnnotation.type === 'VoidTypeAnnotation' ||
+        paramTypeAnnotation.type === 'PromiseTypeAnnotation'
+      ) {
         return throwIfUnsupportedFunctionParamTypeAnnotationParserError(
           hasteModuleName,
           flowParam.typeAnnotation,

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -26,7 +26,10 @@ import type {ParserErrorCapturer, TypeDeclarationMap} from '../../utils';
 import type {NativeModuleTypeAnnotation} from '../../../CodegenSchema.js';
 const {nullGuard} = require('../../parsers-utils');
 
-const {throwIfMoreThanOneModuleRegistryCalls} = require('../../error-utils');
+const {
+  throwIfMoreThanOneModuleRegistryCalls,
+  throwIfUnsupportedFunctionParamTypeAnnotationParserError,
+} = require('../../error-utils');
 const {visit} = require('../../utils');
 const {
   resolveTypeAnnotation,
@@ -58,7 +61,6 @@ const {
   UnsupportedArrayElementTypeAnnotationParserError,
   UnsupportedGenericParserError,
   UnsupportedTypeAnnotationParserError,
-  UnsupportedFunctionParamTypeAnnotationParserError,
   UnsupportedEnumDeclarationParserError,
   UnsupportedUnionTypeAnnotationParserError,
   UnsupportedObjectPropertyTypeAnnotationParserError,
@@ -465,25 +467,21 @@ function translateFunctionTypeAnnotation(
           ),
         );
 
-      if (paramTypeAnnotation.type === 'VoidTypeAnnotation') {
-        throw new UnsupportedFunctionParamTypeAnnotationParserError(
-          hasteModuleName,
-          typeScriptParam.typeAnnotation,
-          paramName,
-          'void',
-          language,
-        );
-      }
+      throwIfUnsupportedFunctionParamTypeAnnotationParserError(
+        hasteModuleName,
+        typeScriptParam.typeAnnotation,
+        paramTypeAnnotation.type,
+        paramName,
+        'VoidTypeAnnotation',
+      );
 
-      if (paramTypeAnnotation.type === 'PromiseTypeAnnotation') {
-        throw new UnsupportedFunctionParamTypeAnnotationParserError(
-          hasteModuleName,
-          typeScriptParam.typeAnnotation,
-          paramName,
-          'Promise',
-          language,
-        );
-      }
+      throwIfUnsupportedFunctionParamTypeAnnotationParserError(
+        hasteModuleName,
+        typeScriptParam.typeAnnotation,
+        paramTypeAnnotation.type,
+        paramName,
+        'PromiseTypeAnnotation',
+      );
 
       return {
         name: typeScriptParam.name,

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -467,12 +467,10 @@ function translateFunctionTypeAnnotation(
           ),
         );
 
-      const forbiddenTypes = new Set([
-        'VoidTypeAnnotation',
-        'PromiseTypeAnnotation',
-      ]);
-
-      if (forbiddenTypes.has(paramTypeAnnotation.type)) {
+      if (
+        paramTypeAnnotation.type === 'VoidTypeAnnotation' ||
+        paramTypeAnnotation.type === 'PromiseTypeAnnotation'
+      ) {
         return throwIfUnsupportedFunctionParamTypeAnnotationParserError(
           hasteModuleName,
           typeScriptParam.typeAnnotation,

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -467,21 +467,19 @@ function translateFunctionTypeAnnotation(
           ),
         );
 
-      throwIfUnsupportedFunctionParamTypeAnnotationParserError(
-        hasteModuleName,
-        typeScriptParam.typeAnnotation,
-        paramTypeAnnotation.type,
-        paramName,
+      const forbiddenTypes = new Set([
         'VoidTypeAnnotation',
-      );
-
-      throwIfUnsupportedFunctionParamTypeAnnotationParserError(
-        hasteModuleName,
-        typeScriptParam.typeAnnotation,
-        paramTypeAnnotation.type,
-        paramName,
         'PromiseTypeAnnotation',
-      );
+      ]);
+
+      if (forbiddenTypes.has(paramTypeAnnotation.type)) {
+        return throwIfUnsupportedFunctionParamTypeAnnotationParserError(
+          hasteModuleName,
+          typeScriptParam.typeAnnotation,
+          paramName,
+          paramTypeAnnotation.type,
+        );
+      }
 
       return {
         name: typeScriptParam.name,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This PR is a task from https://github.com/facebook/react-native/issues/34872:

> Extract the UnsupportedFunctionParamTypeAnnotationParserError in its own throwing function (if it does not exists already) and reuse that function passing a proper type. Then, refactor the code using a dictionary and avoiding the three different ifs in both parsers.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[Internal] [Changed] - Extract the UnsupportedFunctionParamTypeAnnotationParserError in its own throwing function in error-utils

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
