### PR TITLE
Fix ReactAndroid not found in rn-tester build

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins { id("io.github.gradle-nexus.publish-plugin") version "1.1.0" }
 
 val reactAndroidProperties = java.util.Properties()
 
-File("./ReactAndroid/gradle.properties").inputStream().use { reactAndroidProperties.load(it) }
+File("$rootDir/ReactAndroid/gradle.properties").inputStream().use { reactAndroidProperties.load(it) }
 
 version =
     if (project.hasProperty("isNightly") &&


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

I tried to build the source locally to test changes with `rn-tester`. However, the gradle build failed due to "./ReactAndroid/gradle.properties (No such file or directory)". I believe this error was introduced by https://github.com/facebook/react-native/commit/3d05bac5872b42a5f412ec9042ce5be0b5d5b8d3.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[Internal] [Fixed] - Fix ReactAndroid not found in rn-tester build

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
- Clone the react-native repo.
- Run `cd packages/rn-tester`.
- Run `yarn install-android-jsc` and encounter the error.
- Apply the fix.
- Run `yarn install-android-jsc` and build succeeds.
