### PR TITLE
[Android] Allow non-ascii header values & add utf-8 filename fallback

### DIFF
--- a/packages/react-native/Libraries/Network/FormData.js
+++ b/packages/react-native/Libraries/Network/FormData.js
@@ -82,7 +82,9 @@ class FormData {
       // content type (cf. web Blob interface.)
       if (typeof value === 'object' && !Array.isArray(value) && value) {
         if (typeof value.name === 'string') {
-          headers['content-disposition'] += '; filename="' + value.name + '"';
+          headers['content-disposition'] += `; filename="${
+            value.name
+          }"; filename*=utf-8''${encodeURI(value.name)}`;
         }
         if (typeof value.type === 'string') {
           headers['content-type'] = value.type;

--- a/packages/react-native/Libraries/Network/__tests__/FormData-test.js
+++ b/packages/react-native/Libraries/Network/__tests__/FormData-test.js
@@ -48,7 +48,29 @@ describe('FormData', function () {
       type: 'image/jpeg',
       name: 'photo.jpg',
       headers: {
-        'content-disposition': 'form-data; name="photo"; filename="photo.jpg"',
+        'content-disposition':
+          'form-data; name="photo"; filename="photo.jpg"; filename*=utf-8\'\'photo.jpg',
+        'content-type': 'image/jpeg',
+      },
+      fieldName: 'photo',
+    };
+    expect(formData.getParts()[0]).toMatchObject(expectedPart);
+  });
+
+  it('should return blob with the correct utf-8 handling', function () {
+    formData.append('photo', {
+      uri: 'arbitrary/path',
+      type: 'image/jpeg',
+      name: '测试photo.jpg',
+    });
+
+    const expectedPart = {
+      uri: 'arbitrary/path',
+      type: 'image/jpeg',
+      name: '测试photo.jpg',
+      headers: {
+        'content-disposition':
+          'form-data; name="photo"; filename="测试photo.jpg"; filename*=utf-8\'\'%E6%B5%8B%E8%AF%95photo.jpg',
         'content-type': 'image/jpeg',
       },
       fieldName: 'photo',


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Fix https://github.com/facebook/react-native/issues/31537: [Android] React Native strips non-ASCII characters from HTTP headers

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[Android] [Changed] - Allow non-ascii header values on Android and add utf-8 filename fallback in FormData

## Test Plan

1. Clone the `react-native` repo.
2. Build the rn-tester app.
3. Prepare tests
   1. Add `android:usesCleartextTraffic="true"` to AndroidManifest.xml
   2. Use the following code as a server:
       ```javascript
		const http = require('http');
		
		const requestListener = function (req, res) {
		    // raw header value
		    console.log(req.headers['content-disposition']);
		    // nodejs assumes the header value is ISO-8859-1 encoded
		    console.log(Buffer.from(req.headers['content-disposition'], 'latin1').toString('utf-8'));
		    // decode encoded header value if it's sent as UTF-8
		    console.log(decodeURI(req.headers['content-disposition']));
		    res.writeHead(200);
		    res.end();
		};
		
		const server = http.createServer(requestListener);
		server.listen(3000);
       ```
  	3. Run `adb reverse tcp:3000 tcp:3000` to connect the 3000 port on the emulator if necessary.
4. Edit `RNTesterAppShared.js` to include test code:
    ```javascript
	  useEffect(() => {
	    fetch('http://localhost:3000/', {
	      headers: {
	        'Content-Type': 'multipart/form-data; charset=utf-8',
	        'Content-Disposition': `attachment; filename*=utf-8''${encodeURI(
	          'filename测试abc.jpg',
	        )}`,
	      },
	    }).then(res => {
	      console.log(res.ok);
	    });
	    fetch('http://localhost:3000/', {
	      headers: {
	        'Content-Type': 'multipart/form-data; charset=utf-8',
	        'Content-Disposition': `attachment; filename="filename测试abc.jpg"`,
	      },
	    }).then(res => {
	      console.log(res.ok);
	    });
	  }, []);
    ```
5. Both requests should succeed; without the fix, the second request received by the server will not have the utf-8 characters "测试" in the header value.