### PR TITLE
Back out "add oncall annotation for BUCK files in xplat based on supermodule information - /home/s2shi/tmp/xplat_buck_oncall/xplat_buck_batch10"

### DIFF
--- a/Libraries/FBLazyVector/BUCK
+++ b/Libraries/FBLazyVector/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "fb_apple_library")
 
-oncall("react_native")
-
 fb_apple_library(
     name = "FBLazyVector",
     exported_headers = [

--- a/Libraries/RCTRequired/BUCK
+++ b/Libraries/RCTRequired/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "fb_apple_library")
 
-oncall("react_native")
-
 fb_apple_library(
     name = "RCTRequired",
     exported_headers = [

--- a/React/CoreModules/BUCK
+++ b/React/CoreModules/BUCK
@@ -5,8 +5,6 @@ load(
     "react_module_plugin_providers",
 )
 
-oncall("react_native")
-
 rn_apple_library(
     name = "CoreModulesApple",
     srcs = glob(

--- a/ReactAndroid/src/androidTest/java/com/facebook/react/testing/network/BUCK
+++ b/ReactAndroid/src/androidTest/java/com/facebook/react/testing/network/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "react_native_target", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "network",
     srcs = glob(["**/*.java"]),

--- a/ReactAndroid/src/main/java/com/facebook/debug/holder/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/debug/holder/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "holder",
     srcs = glob(["*.java"]),

--- a/ReactAndroid/src/main/java/com/facebook/debug/tags/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/debug/tags/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "tags",
     srcs = glob(["*.java"]),

--- a/ReactAndroid/src/main/java/com/facebook/hermes/instrumentation/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/hermes/instrumentation/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "react_native_target", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "instrumentation",
     srcs = ["HermesMemoryDumper.java"],

--- a/ReactAndroid/src/main/java/com/facebook/react/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "react_native_target", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "react",
     srcs = glob(["*.java"]),

--- a/ReactAndroid/src/main/java/com/facebook/react/animated/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/animated/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "react_native_root_target", "react_native_target", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "animated",
     srcs = glob([

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "IS_OSS_BUILD", "react_native_dep", "react_native_target", "react_native_tests_target", "rn_android_library")
 
-oncall("react_native")
-
 INTERFACES = [
     "Dynamic.java",
     "ReadableMap.java",

--- a/ReactAndroid/src/main/java/com/facebook/react/common/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/common/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "HERMES_BYTECODE_VERSION", "react_native_dep", "rn_android_build_config", "rn_android_library")
 
-oncall("react_native")
-
 SUB_PROJECTS = [
     "network/**/*",
     "mapbuffer/**/*",

--- a/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/common/mapbuffer/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "FBJNI_TARGET", "react_native_dep", "react_native_target", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "mapbuffer",
     srcs = glob([

--- a/ReactAndroid/src/main/java/com/facebook/react/common/network/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/common/network/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "network",
     srcs = glob(["**/*.java"]),

--- a/ReactAndroid/src/main/java/com/facebook/react/config/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/config/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "config",
     srcs = glob(["**/*.java"]),

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "react_native_root_target", "react_native_target", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "devsupport",
     srcs = glob(["*.java"]),

--- a/ReactAndroid/src/main/java/com/facebook/react/fabric/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/fabric/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "IS_OSS_BUILD", "YOGA_TARGET", "react_native_android_toplevel_dep", "react_native_dep", "react_native_target", "rn_android_library")
 
-oncall("react_native")
-
 # TODO(T115916830): Remove when Kotlin files are used in this module
 KOTLIN_STDLIB_DEPS = [react_native_android_toplevel_dep("third-party/kotlin:kotlin-stdlib")] if IS_OSS_BUILD else []
 

--- a/ReactAndroid/src/main/java/com/facebook/react/jscexecutor/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/jscexecutor/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "react_native_target", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "jscexecutor",
     srcs = glob(["*.java"]),

--- a/ReactAndroid/src/main/java/com/facebook/react/jstasks/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/jstasks/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "react_native_target", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "jstasks",
     srcs = glob(["*.java"]),

--- a/ReactAndroid/src/main/java/com/facebook/react/module/annotations/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/module/annotations/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "react_native_target", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "annotations",
     srcs = glob(["**/*.java"]),

--- a/ReactAndroid/src/main/java/com/facebook/react/module/model/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/module/model/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "model",
     srcs = glob(["**/*.java"]),

--- a/ReactAndroid/src/main/java/com/facebook/react/module/processing/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/module/processing/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "react_native_target", "rn_java_annotation_processor", "rn_java_library")
 
-oncall("react_native")
-
 rn_java_annotation_processor(
     name = "processing",
     does_not_affect_abi = True,

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/accessibilityinfo/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/accessibilityinfo/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "react_native_root_target", "react_native_target", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "accessibilityinfo",
     srcs = glob(["**/*.java"]),

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/appearance/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/appearance/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "react_native_root_target", "react_native_target", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "appearance",
     srcs = glob(["**/*.java"]),

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/appregistry/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/appregistry/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_target", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "appregistry",
     srcs = glob(["**/*.java"]),

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/appstate/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/appstate/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "react_native_root_target", "react_native_target", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "appstate",
     srcs = glob(["**/*.java"]),

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/blob/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/blob/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "react_native_root_target", "react_native_target", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "blob",
     srcs = glob(["**/*.java"]),

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/bundleloader/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/bundleloader/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "react_native_root_target", "react_native_target", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "bundleloader",
     srcs = glob(["*.java"]),

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/camera/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/camera/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "react_native_root_target", "react_native_target", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "camera",
     srcs = glob(["**/*.java"]),

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/clipboard/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/clipboard/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "react_native_root_target", "react_native_target", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "clipboard",
     srcs = glob(["**/*.java"]),

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/common/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/common/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "react_native_target", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "common",
     srcs = glob(["**/*.java"]),

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/core/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/core/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "react_native_root_target", "react_native_target", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "core",
     srcs = glob(["**/*.java"]),

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/debug/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/debug/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "react_native_root_target", "react_native_target", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "debug",
     srcs = glob(["*.java"]),

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/deviceinfo/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/deviceinfo/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "react_native_root_target", "react_native_target", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "deviceinfo",
     srcs = glob(["**/*.java"]),

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "react_native_root_target", "react_native_target", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "dialog",
     srcs = glob(["**/*.java"]),

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/fabric/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/fabric/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_target", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "fabric",
     srcs = glob(["**/*.java"]),

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/fresco/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/fresco/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "react_native_target", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "fresco",
     srcs = glob(["**/*.java"]),

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/i18nmanager/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/i18nmanager/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "react_native_root_target", "react_native_target", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "i18nmanager",
     srcs = glob(["*.java"]),

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/image/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/image/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "react_native_root_target", "react_native_target", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "image",
     srcs = glob(["*.java"]),

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/intent/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/intent/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "react_native_root_target", "react_native_target", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "intent",
     srcs = glob(["**/*.java"]),

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/network/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/network/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "react_native_root_target", "react_native_target", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "network",
     srcs = glob(["**/*.java"]),

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/permissions/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/permissions/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "react_native_root_target", "react_native_target", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "permissions",
     srcs = glob(["**/*.java"]),

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/share/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/share/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "react_native_root_target", "react_native_target", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "share",
     srcs = glob(["**/*.java"]),

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/sound/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/sound/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "react_native_root_target", "react_native_target", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "sound",
     srcs = glob(["**/*.java"]),

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/statusbar/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/statusbar/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "react_native_root_target", "react_native_target", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "statusbar",
     srcs = glob(["**/*.java"]),

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/storage/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/storage/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "react_native_root_target", "react_native_target", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "storage",
     srcs = glob(["**/*.java"]),

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "react_native_root_target", "react_native_target", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "systeminfo",
     srcs = [

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/toast/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/toast/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "react_native_root_target", "react_native_target", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "toast",
     srcs = glob(["**/*.java"]),

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/vibration/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/vibration/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "react_native_root_target", "react_native_target", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "vibration",
     srcs = glob(["**/*.java"]),

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "react_native_root_target", "react_native_target", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "websocket",
     srcs = glob(["**/*.java"]),

--- a/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "react_native_target", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "packagerconnection",
     srcs = glob(

--- a/ReactAndroid/src/main/java/com/facebook/react/processing/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/processing/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "react_native_target", "rn_java_annotation_processor", "rn_java_library")
 
-oncall("react_native")
-
 rn_java_annotation_processor(
     name = "processing",
     does_not_affect_abi = True,

--- a/ReactAndroid/src/main/java/com/facebook/react/reactperflogger/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/reactperflogger/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "react_native_target", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "reactperflogger",
     srcs = glob(

--- a/ReactAndroid/src/main/java/com/facebook/react/shell/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/shell/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "react_native_target", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "shell",
     srcs = glob(["**/*.java"]),

--- a/ReactAndroid/src/main/java/com/facebook/react/surface/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/surface/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "YOGA_TARGET", "react_native_dep", "react_native_target", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "surface",
     srcs = glob(["*.java"]),

--- a/ReactAndroid/src/main/java/com/facebook/react/touch/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/touch/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "touch",
     srcs = glob(["**/*.java"]),

--- a/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "react_native_target", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "core",
     srcs = glob(

--- a/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/interfaces/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/interfaces/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "interfaces",
     srcs = glob(

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "YOGA_TARGET", "react_native_dep", "react_native_target", "rn_android_library")
 
-oncall("react_native")
-
 INTERFACES_FILES = [
     "BaseViewManagerDelegate.java",
     "BaseViewManagerInterface.java",

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/annotations/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/annotations/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "annotations",
     srcs = glob(["*.java"]),

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/common/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/common/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "common",
     srcs = glob(["*.java"]),

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/util/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/util/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "react_native_target", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "util",
     srcs = glob(["*.java"]),

--- a/ReactAndroid/src/main/java/com/facebook/react/util/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/util/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "react_native_target", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "util",
     srcs = glob(["**/*.java"]),

--- a/ReactAndroid/src/main/java/com/facebook/react/views/common/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/common/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "common",
     srcs = glob(["*.java"]),

--- a/ReactAndroid/src/main/java/com/facebook/react/views/image/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/image/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "YOGA_TARGET", "react_native_dep", "react_native_target", "rn_android_library")
 
-oncall("react_native")
-
 IMAGE_EVENT_FILES = [
     "ImageLoadEvent.java",
 ]

--- a/ReactAndroid/src/main/java/com/facebook/react/views/imagehelper/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/imagehelper/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "imagehelper",
     srcs = glob(

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "YOGA_TARGET", "react_native_dep", "react_native_target", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "scroll",
     srcs = glob(["*.java"]),

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "IS_OSS_BUILD", "YOGA_TARGET", "react_native_android_toplevel_dep", "react_native_dep", "react_native_target", "rn_android_library")
 
-oncall("react_native")
-
 # TODO(T115916830): Remove when Kotlin files are used in this module
 KOTLIN_STDLIB_DEPS = [react_native_android_toplevel_dep("third-party/kotlin:kotlin-stdlib")] if IS_OSS_BUILD else []
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/frescosupport/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/frescosupport/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "YOGA_TARGET", "react_native_dep", "react_native_target", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "frescosupport",
     srcs = glob(["*.java"]),

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "IS_OSS_BUILD", "YOGA_TARGET", "react_native_android_toplevel_dep", "react_native_dep", "react_native_target", "rn_android_library")
 
-oncall("react_native")
-
 # TODO(T115916830): Remove when Kotlin files are used in this module
 KOTLIN_STDLIB_DEPS = [react_native_android_toplevel_dep("third-party/kotlin:kotlin-stdlib")] if IS_OSS_BUILD else []
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/unimplementedview/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/unimplementedview/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "react_native_target", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "unimplementedview",
     srcs = glob(["*.java"]),

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "YOGA_TARGET", "react_native_dep", "react_native_target", "rn_android_library")
 
-oncall("react_native")
-
 rn_android_library(
     name = "view",
     srcs = glob([

--- a/ReactAndroid/src/main/jni/react/cxxcomponents/BUCK
+++ b/ReactAndroid/src/main/jni/react/cxxcomponents/BUCK
@@ -8,8 +8,6 @@ load(
     "subdir_glob",
 )
 
-oncall("react_native")
-
 rn_xplat_cxx_library(
     name = "components",
     srcs = glob(

--- a/ReactAndroid/src/main/jni/react/hermes/instrumentation/BUCK
+++ b/ReactAndroid/src/main/jni/react/hermes/instrumentation/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "ANDROID", "FBJNI_TARGET", "react_native_target", "react_native_xplat_dep", "rn_xplat_cxx_library")
 
-oncall("react_native")
-
 rn_xplat_cxx_library(
     name = "jni_hermes_samplingprofiler",
     srcs = [

--- a/ReactAndroid/src/main/jni/react/jni/BUCK
+++ b/ReactAndroid/src/main/jni/react/jni/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "ANDROID", "FBJNI_TARGET", "IS_OSS_BUILD", "react_native_target", "react_native_xplat_dep", "react_native_xplat_target", "rn_xplat_cxx_library")
 
-oncall("react_native")
-
 EXPORTED_HEADERS = [
     "CxxModuleWrapper.h",
     "CxxModuleWrapperBase.h",

--- a/ReactAndroid/src/main/jni/react/mapbuffer/BUCK
+++ b/ReactAndroid/src/main/jni/react/mapbuffer/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "ANDROID", "FBJNI_TARGET", "react_native_xplat_target", "rn_xplat_cxx_library", "subdir_glob")
 
-oncall("react_native")
-
 rn_xplat_cxx_library(
     name = "jni",
     srcs = glob(["**/*.cpp"]),

--- a/ReactAndroid/src/main/jni/react/reactnativeblob/BUCK
+++ b/ReactAndroid/src/main/jni/react/reactnativeblob/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "ANDROID", "FBJNI_TARGET", "react_native_target", "react_native_xplat_dep", "rn_xplat_cxx_library")
 
-oncall("react_native")
-
 rn_xplat_cxx_library(
     name = "jni",
     srcs = glob(["*.cpp"]),

--- a/ReactAndroid/src/main/jni/react/reactperflogger/BUCK
+++ b/ReactAndroid/src/main/jni/react/reactperflogger/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "ANDROID", "FBJNI_TARGET", "react_native_xplat_target", "rn_xplat_cxx_library")
 
-oncall("react_native")
-
 rn_xplat_cxx_library(
     name = "jni",
     srcs = [

--- a/ReactAndroid/src/main/jni/react/turbomodule/BUCK
+++ b/ReactAndroid/src/main/jni/react/turbomodule/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "ANDROID", "FBJNI_TARGET", "react_native_target", "react_native_xplat_shared_library_target", "react_native_xplat_target", "rn_xplat_cxx_library")
 
-oncall("react_native")
-
 rn_xplat_cxx_library(
     name = "jni",
     srcs = [

--- a/ReactAndroid/src/main/jni/react/uimanager/BUCK
+++ b/ReactAndroid/src/main/jni/react/uimanager/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "ANDROID", "FBJNI_TARGET", "react_native_target", "react_native_xplat_target", "rn_xplat_cxx_library", "subdir_glob")
 
-oncall("react_native")
-
 rn_xplat_cxx_library(
     name = "jni",
     srcs = glob(["*.cpp"]),

--- a/ReactCommon/butter/BUCK
+++ b/ReactCommon/butter/BUCK
@@ -10,8 +10,6 @@ load(
     "subdir_glob",
 )
 
-oncall("react_native")
-
 APPLE_COMPILER_FLAGS = get_apple_compiler_flags()
 
 rn_xplat_cxx_library(

--- a/ReactCommon/callinvoker/BUCK
+++ b/ReactCommon/callinvoker/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "ANDROID", "APPLE", "CXX", "rn_xplat_cxx_library", "subdir_glob")
 
-oncall("react_native")
-
 rn_xplat_cxx_library(
     name = "callinvoker",
     srcs = glob(["**/*.cpp"]),

--- a/ReactCommon/cxxreact/BUCK
+++ b/ReactCommon/cxxreact/BUCK
@@ -1,8 +1,6 @@
 load("@fbsource//tools/build_defs:glob_defs.bzl", "subdir_glob")
 load("//tools/build_defs/oss:rn_defs.bzl", "ANDROID", "APPLE", "CXX", "get_android_inspector_flags", "get_apple_compiler_flags", "get_apple_inspector_flags", "get_preprocessor_flags_for_build_mode", "react_native_xplat_target", "rn_xplat_cxx_library")
 
-oncall("react_native")
-
 rn_xplat_cxx_library(
     name = "module",
     header_namespace = "",

--- a/ReactCommon/jsi/BUCK
+++ b/ReactCommon/jsi/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "APPLE", "IOS", "MACOSX", "react_native_xplat_dep", "rn_xplat_cxx_library")
 
-oncall("react_native")
-
 rn_xplat_cxx_library(
     name = "jsi",
     srcs = [

--- a/ReactCommon/jsiexecutor/BUCK
+++ b/ReactCommon/jsiexecutor/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "ANDROID", "APPLE", "cxx_library", "react_native_xplat_dep", "react_native_xplat_target")
 
-oncall("react_native")
-
 cxx_library(
     name = "jsiexecutor",
     srcs = [

--- a/ReactCommon/jsinspector/BUCK
+++ b/ReactCommon/jsinspector/BUCK
@@ -2,8 +2,6 @@ load("@fbsource//tools/build_defs:glob_defs.bzl", "subdir_glob")
 load("@fbsource//tools/build_defs:platform_defs.bzl", "ANDROID", "APPLE", "CXX", "FBCODE", "WINDOWS")
 load("//tools/build_defs/oss:rn_defs.bzl", "get_hermes_shared_library_preprocessor_flags", "rn_xplat_cxx_library")
 
-oncall("react_native")
-
 EXPORTED_HEADERS = [
     "InspectorInterfaces.h",
 ]

--- a/ReactCommon/logger/BUCK
+++ b/ReactCommon/logger/BUCK
@@ -2,8 +2,6 @@ load("@fbsource//tools/build_defs:glob_defs.bzl", "subdir_glob")
 load("@fbsource//tools/build_defs:platform_defs.bzl", "ANDROID", "APPLE", "CXX", "FBCODE", "WINDOWS")
 load("//tools/build_defs/oss:rn_defs.bzl", "rn_xplat_cxx_library")
 
-oncall("react_native")
-
 EXPORTED_HEADERS = [
     "react_native_log.h",
 ]

--- a/ReactCommon/react/config/BUCK
+++ b/ReactCommon/react/config/BUCK
@@ -3,8 +3,6 @@ load("@fbsource//tools/build_defs:platform_defs.bzl", "ANDROID", "APPLE", "CXX")
 load("@fbsource//tools/build_defs/apple:flag_defs.bzl", "flags", "get_preprocessor_flags_for_build_mode", "get_static_library_ios_flags")
 load("@fbsource//tools/build_defs/oss:rn_defs.bzl", "get_apple_inspector_flags", "rn_xplat_cxx_library")
 
-oncall("react_native")
-
 APPLE_COMPILER_FLAGS = flags.get_flag_value(
     get_static_library_ios_flags(),
     "compiler_flags",

--- a/ReactCommon/react/debug/BUCK
+++ b/ReactCommon/react/debug/BUCK
@@ -10,8 +10,6 @@ load(
     "subdir_glob",
 )
 
-oncall("react_native")
-
 APPLE_COMPILER_FLAGS = get_apple_compiler_flags()
 
 rn_xplat_cxx_library(

--- a/ReactCommon/react/nativemodule/core/BUCK
+++ b/ReactCommon/react/nativemodule/core/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "ANDROID", "APPLE", "CXX", "FBJNI_TARGET", "get_objc_arc_preprocessor_flags", "get_preprocessor_flags_for_build_mode", "get_static_library_ios_flags", "react_native_target", "react_native_xplat_shared_library_target", "react_native_xplat_target", "rn_xplat_cxx_library", "subdir_glob")
 
-oncall("react_native")
-
 rn_xplat_cxx_library(
     name = "core",
     srcs = glob(

--- a/ReactCommon/react/nativemodule/samples/BUCK
+++ b/ReactCommon/react/nativemodule/samples/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "ANDROID", "APPLE", "FBJNI_TARGET", "get_objc_arc_preprocessor_flags", "get_preprocessor_flags_for_build_mode", "get_static_library_ios_flags", "react_native_dep", "react_native_target", "react_native_xplat_target", "rn_android_library", "rn_xplat_cxx_library", "subdir_glob")
 
-oncall("react_native")
-
 rn_xplat_cxx_library(
     name = "samples",
     srcs = glob(

--- a/ReactCommon/react/renderer/componentregistry/BUCK
+++ b/ReactCommon/react/renderer/componentregistry/BUCK
@@ -11,8 +11,6 @@ load(
     "subdir_glob",
 )
 
-oncall("react_native")
-
 APPLE_COMPILER_FLAGS = get_apple_compiler_flags()
 
 rn_xplat_cxx_library(

--- a/ReactCommon/react/renderer/componentregistry/native/BUCK
+++ b/ReactCommon/react/renderer/componentregistry/native/BUCK
@@ -10,8 +10,6 @@ load(
     "subdir_glob",
 )
 
-oncall("react_native")
-
 APPLE_COMPILER_FLAGS = get_apple_compiler_flags()
 
 rn_xplat_cxx_library(

--- a/ReactCommon/react/renderer/components/text/BUCK
+++ b/ReactCommon/react/renderer/components/text/BUCK
@@ -13,8 +13,6 @@ load(
     "subdir_glob",
 )
 
-oncall("react_native")
-
 APPLE_COMPILER_FLAGS = get_apple_compiler_flags()
 
 rn_xplat_cxx_library(

--- a/ReactCommon/react/renderer/components/textinput/BUCK
+++ b/ReactCommon/react/renderer/components/textinput/BUCK
@@ -13,8 +13,6 @@ load(
     "subdir_glob",
 )
 
-oncall("react_native")
-
 APPLE_COMPILER_FLAGS = get_apple_compiler_flags()
 
 rn_xplat_cxx_library(

--- a/ReactCommon/react/renderer/components/textinput/iostextinput/BUCK
+++ b/ReactCommon/react/renderer/components/textinput/iostextinput/BUCK
@@ -12,8 +12,6 @@ load(
     "subdir_glob",
 )
 
-oncall("react_native")
-
 APPLE_COMPILER_FLAGS = get_apple_compiler_flags()
 
 rn_xplat_cxx_library(

--- a/ReactCommon/react/renderer/leakchecker/BUCK
+++ b/ReactCommon/react/renderer/leakchecker/BUCK
@@ -11,8 +11,6 @@ load(
     "subdir_glob",
 )
 
-oncall("react_native")
-
 APPLE_COMPILER_FLAGS = get_apple_compiler_flags()
 
 rn_xplat_cxx_library(

--- a/ReactCommon/react/renderer/scheduler/BUCK
+++ b/ReactCommon/react/renderer/scheduler/BUCK
@@ -11,8 +11,6 @@ load(
     "subdir_glob",
 )
 
-oncall("react_native")
-
 APPLE_COMPILER_FLAGS = get_apple_compiler_flags()
 
 rn_xplat_cxx_library(

--- a/ReactCommon/react/renderer/textlayoutmanager/BUCK
+++ b/ReactCommon/react/renderer/textlayoutmanager/BUCK
@@ -14,8 +14,6 @@ load(
     "subdir_glob",
 )
 
-oncall("react_native")
-
 APPLE_COMPILER_FLAGS = get_apple_compiler_flags()
 
 rn_xplat_cxx_library(

--- a/ReactCommon/react/test_utils/BUCK
+++ b/ReactCommon/react/test_utils/BUCK
@@ -11,8 +11,6 @@ load(
     "subdir_glob",
 )
 
-oncall("react_native")
-
 APPLE_COMPILER_FLAGS = get_apple_compiler_flags()
 
 rn_xplat_cxx_library(

--- a/ReactCommon/react/utils/BUCK
+++ b/ReactCommon/react/utils/BUCK
@@ -12,8 +12,6 @@ load(
     "subdir_glob",
 )
 
-oncall("react_native")
-
 APPLE_COMPILER_FLAGS = get_apple_compiler_flags()
 
 rn_xplat_cxx_library(

--- a/ReactCommon/reactperflogger/BUCK
+++ b/ReactCommon/reactperflogger/BUCK
@@ -1,7 +1,5 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "ANDROID", "APPLE", "CXX", "rn_xplat_cxx_library")
 
-oncall("react_native")
-
 rn_xplat_cxx_library(
     name = "reactperflogger",
     srcs = glob(["**/*.cpp"]),

--- a/ReactCommon/runtimeexecutor/BUCK
+++ b/ReactCommon/runtimeexecutor/BUCK
@@ -9,8 +9,6 @@ load(
     "rn_xplat_cxx_library",
 )
 
-oncall("react_native")
-
 APPLE_COMPILER_FLAGS = get_apple_compiler_flags()
 
 rn_xplat_cxx_library(

--- a/packages/assets/BUCK
+++ b/packages/assets/BUCK
@@ -1,8 +1,6 @@
 load("@fbsource//tools/build_defs/third_party:yarn_defs.bzl", "yarn_workspace")
 load("@fbsource//xplat/js:JS_DEFS.bzl", "rn_library")
 
-oncall("react_native")
-
 rn_library(
     name = "assets",
     labels = [

--- a/packages/normalize-color/BUCK
+++ b/packages/normalize-color/BUCK
@@ -1,8 +1,6 @@
 load("@fbsource//tools/build_defs/third_party:yarn_defs.bzl", "yarn_workspace")
 load("@fbsource//xplat/js:JS_DEFS.bzl", "rn_library")
 
-oncall("react_native")
-
 rn_library(
     name = "normalize-color",
     labels = [

--- a/packages/polyfills/BUCK
+++ b/packages/polyfills/BUCK
@@ -1,8 +1,6 @@
 load("@fbsource//tools/build_defs/third_party:yarn_defs.bzl", "yarn_workspace")
 load("@fbsource//xplat/js:JS_DEFS.bzl", "relative_path_to_js_root", "rn_library")
 
-oncall("react_native")
-
 yarn_workspace(
     name = "yarn-workspace",
     srcs = glob(

--- a/packages/react-native-codegen/src/parsers/errors.js
+++ b/packages/react-native-codegen/src/parsers/errors.js
@@ -11,7 +11,7 @@
 'use strict';
 
 const invariant = require('invariant');
-
+import type {Parser} from './parser';
 export type ParserType = 'Flow' | 'TypeScript';
 
 class ParserError extends Error {
@@ -110,23 +110,22 @@ class UnsupportedTypeAnnotationParserError extends ParserError {
 }
 
 class UnsupportedGenericParserError extends ParserError {
-  +genericName: string;
+  // +genericName: string;
   constructor(
     nativeModuleName: string,
     genericTypeAnnotation: $FlowFixMe,
-    language: ParserType,
+    parser: Parser,
   ) {
-    const genericName =
-      language === 'TypeScript'
-        ? genericTypeAnnotation.typeName.name
-        : genericTypeAnnotation.id.name;
+    const genericName = parser.nameForGenericTypeAnnotation(
+      genericTypeAnnotation,
+    );
     super(
       nativeModuleName,
       genericTypeAnnotation,
       `Unrecognized generic type '${genericName}' in NativeModule spec.`,
     );
 
-    this.genericName = genericName;
+    // this.genericName = genericName;
   }
 }
 

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -81,7 +81,10 @@ const {
   throwIfMoreThanOneModuleInterfaceParserError,
 } = require('../../error-utils');
 
+const {FlowParser} = require('../parser.js');
+
 const language = 'Flow';
+const parser = new FlowParser();
 
 function translateArrayTypeAnnotation(
   hasteModuleName: string,
@@ -276,7 +279,7 @@ function translateTypeAnnotation(
           throw new UnsupportedGenericParserError(
             hasteModuleName,
             typeAnnotation,
-            language,
+            parser,
           );
         }
       }

--- a/packages/react-native-codegen/src/parsers/flow/parser.js
+++ b/packages/react-native-codegen/src/parsers/flow/parser.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ * @format
+ */
+
+'use strict';
+
+import type {Parser} from '../parser';
+
+class FlowParser implements Parser {
+  nameForGenericTypeAnnotation(typeAnnotation: $FlowFixMe): string {
+    return typeAnnotation.id.name;
+  }
+}
+
+module.exports = {
+  FlowParser,
+};

--- a/packages/react-native-codegen/src/parsers/parser.js
+++ b/packages/react-native-codegen/src/parsers/parser.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ * @format
+ */
+
+'use strict';
+
+/**
+ * This is the main interface for Parsers of various languages.
+ * It exposes all the methods that contain language-specific logic.
+ */
+export interface Parser {
+  /**
+   * Given a type annotation for a generic type, it returns the type name.
+   * @parameter typeAnnotation: the annotation for a type in the AST.
+   * @returns: the name of the type.
+   */
+  nameForGenericTypeAnnotation(typeAnnotation: $FlowFixMe): string;
+}

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -80,7 +80,10 @@ const {
   throwIfUnsupportedFunctionReturnTypeAnnotationParserError,
 } = require('../../error-utils');
 
+const {TypeScriptParser} = require('../parser');
+
 const language = 'TypeScript';
+const parser = new TypeScriptParser();
 
 function translateArrayTypeAnnotation(
   hasteModuleName: string,
@@ -205,7 +208,7 @@ function translateTypeAnnotation(
         throw new UnsupportedGenericParserError(
           hasteModuleName,
           typeAnnotation,
-          language,
+          parser,
         );
       }
     }
@@ -290,7 +293,7 @@ function translateTypeAnnotation(
           throw new UnsupportedGenericParserError(
             hasteModuleName,
             typeAnnotation,
-            language,
+            parser,
           );
         }
       }

--- a/packages/react-native-codegen/src/parsers/typescript/parser.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parser.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ * @format
+ */
+
+'use strict';
+
+import type {Parser} from '../parser';
+
+class TypeScriptParser implements Parser {
+  nameForGenericTypeAnnotation(typeAnnotation: $FlowFixMe): string {
+    return typeAnnotation.typeName.name;
+  }
+}
+module.exports = {
+  TypeScriptParser,
+};


### PR DESCRIPTION
Summary:
Original commit changeset: 0fb0db845c04

Original Phabricator Diff: D40610875 (https://github.com/facebook/react-native/commit/d941940b4ce7ed9030be4f72980fb45d9b62365d)

Open source is using BUCK 1 which does not seem to have the `oncall` directive.

Backing it out because it is breaking the external CI.

## Changelog: internal

Differential Revision: D40635873

