### PR TITLE
Unbreak test_android by passing the correct file to hermesc

### DIFF
--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/BundleHermesCTask.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/BundleHermesCTask.kt
@@ -90,16 +90,16 @@ abstract class BundleHermesCTask : DefaultTask() {
 
     if (hermesEnabled.get()) {
       val detectedHermesCommand = detectOSAwareHermesCommand(root.get().asFile, hermesCommand.get())
-      val bytecodeTempFile = File("${bundleFile}.hbc")
+      val bytecodeFile = File("${bundleFile}.hbc")
       val outputSourceMap = resolveOutputSourceMap(bundleAssetFilename)
       val compilerSourceMap = resolveCompilerSourceMap(bundleAssetFilename)
 
-      val hermesCommand = getHermescCommand(detectedHermesCommand, bundleFile, packagerSourceMap)
+      val hermesCommand = getHermescCommand(detectedHermesCommand, bytecodeFile, bundleFile)
       runCommand(hermesCommand)
-      bytecodeTempFile.moveTo(bundleFile)
+      bytecodeFile.moveTo(bundleFile)
 
       if (hermesFlags.get().contains("-output-source-map")) {
-        val hermesTempSourceMapFile = File("$bytecodeTempFile.map")
+        val hermesTempSourceMapFile = File("$bytecodeFile.map")
         hermesTempSourceMapFile.moveTo(compilerSourceMap)
         val composeSourceMapsCommand =
             getComposeSourceMapsCommand(packagerSourceMap, compilerSourceMap, outputSourceMap)
@@ -159,14 +159,14 @@ abstract class BundleHermesCTask : DefaultTask() {
 
   internal fun getHermescCommand(
       hermesCommand: String,
-      bundleFile: File,
-      outputFile: File
+      bytecodeFile: File,
+      bundleFile: File
   ): List<Any> =
       windowsAwareCommandLine(
           hermesCommand,
           "-emit-binary",
           "-out",
-          outputFile.absolutePath,
+          bytecodeFile.absolutePath,
           bundleFile.absolutePath,
           *hermesFlags.get().toTypedArray())
 

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/BundleHermesCTaskTest.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/BundleHermesCTaskTest.kt
@@ -270,17 +270,17 @@ class BundleHermesCTaskTest {
   @Test
   fun getHermescCommand_returnsCorrectCommand() {
     val customHermesc = "hermesc"
+    val bytecodeFile = tempFolder.newFile("bundle.js.hbc")
     val bundleFile = tempFolder.newFile("bundle.js")
-    val outputFile = tempFolder.newFile("bundle.js.packager.map")
     val task =
         createTestTask<BundleHermesCTask> { it.hermesFlags.set(listOf("my-custom-hermes-flag")) }
 
-    val hermesCommand = task.getHermescCommand(customHermesc, bundleFile, outputFile)
+    val hermesCommand = task.getHermescCommand(customHermesc, bytecodeFile, bundleFile)
 
     assertEquals(customHermesc, hermesCommand[0])
     assertEquals("-emit-binary", hermesCommand[1])
     assertEquals("-out", hermesCommand[2])
-    assertEquals(outputFile.absolutePath, hermesCommand[3])
+    assertEquals(bytecodeFile.absolutePath, hermesCommand[3])
     assertEquals(bundleFile.absolutePath, hermesCommand[4])
     assertEquals("my-custom-hermes-flag", hermesCommand[5])
     assertEquals(6, hermesCommand.size)


### PR DESCRIPTION
Summary:
I accidentally broke test_android by landing a diff without waiting for
the full CI output.

Changelog:
[Internal] [Fixed] - Unbreak test_android by passing the correct file to hermesc

Differential Revision: D40638239

