### PR TITLE
refactor(rn tester app): change activity indicator to hooks

### DIFF
--- a/packages/rn-tester/js/examples/ActivityIndicator/ActivityIndicatorExample.js
+++ b/packages/rn-tester/js/examples/ActivityIndicator/ActivityIndicatorExample.js
@@ -10,46 +10,37 @@
 
 import type {Node} from 'React';
 import {ActivityIndicator, StyleSheet, View} from 'react-native';
-import React, {Component} from 'react';
+import React, {useState} from 'react';
+import {useEffect} from 'react';
 
-type State = {|animating: boolean|};
-type Props = $ReadOnly<{||}>;
-type Timer = TimeoutID;
+function ToggleAnimatingActivityIndicator() {
+  let _timer;
 
-class ToggleAnimatingActivityIndicator extends Component<Props, State> {
-  _timer: Timer;
+  const [animating, setAnimating] = useState(true);
 
-  constructor(props: Props) {
-    super(props);
-    this.state = {
-      animating: true,
-    };
-  }
-
-  componentDidMount() {
-    this.setToggleTimeout();
-  }
-
-  componentWillUnmount() {
-    clearTimeout(this._timer);
-  }
-
-  setToggleTimeout() {
-    this._timer = setTimeout(() => {
-      this.setState({animating: !this.state.animating});
-      this.setToggleTimeout();
+  const setToggleTimeout = () => {
+    _timer = setTimeout(() => {
+      setAnimating(currentState => !currentState);
+      setToggleTimeout();
     }, 2000);
-  }
+  };
 
-  render(): Node {
-    return (
-      <ActivityIndicator
-        animating={this.state.animating}
-        style={[styles.centering, {height: 80}]}
-        size="large"
-      />
-    );
-  }
+  useEffect(() => {
+    setToggleTimeout();
+
+    return () => {
+      clearTimeout(_timer);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [_timer]);
+
+  return (
+    <ActivityIndicator
+      animating={animating}
+      style={[styles.centering, {height: 80}]}
+      size="large"
+    />
+  );
 }
 
 const styles = StyleSheet.create({

--- a/packages/rn-tester/js/examples/ActivityIndicator/ActivityIndicatorExample.js
+++ b/packages/rn-tester/js/examples/ActivityIndicator/ActivityIndicatorExample.js
@@ -13,12 +13,12 @@ import {ActivityIndicator, StyleSheet, View} from 'react-native';
 import React, {useState, useCallback, useRef, useEffect} from 'react';
 
 function ToggleAnimatingActivityIndicator() {
-  let _timer = useRef();
+  let timer = useRef();
 
   const [animating, setAnimating] = useState(true);
 
   const setToggleTimeout = useCallback(() => {
-    _timer.current = setTimeout(() => {
+    timer.current = setTimeout(() => {
       setAnimating(currentState => !currentState);
       setToggleTimeout();
     }, 2000);
@@ -28,9 +28,9 @@ function ToggleAnimatingActivityIndicator() {
     setToggleTimeout();
 
     return () => {
-      clearTimeout(_timer);
+      clearTimeout(timer.current);
     };
-  }, [_timer, setToggleTimeout]);
+  }, [timer, setToggleTimeout]);
 
   return (
     <ActivityIndicator

--- a/packages/rn-tester/js/examples/ActivityIndicator/ActivityIndicatorExample.js
+++ b/packages/rn-tester/js/examples/ActivityIndicator/ActivityIndicatorExample.js
@@ -13,7 +13,7 @@ import {ActivityIndicator, StyleSheet, View} from 'react-native';
 import React, {useState, useCallback, useRef, useEffect} from 'react';
 
 function ToggleAnimatingActivityIndicator() {
-  let timer = useRef();
+  const timer = useRef();
 
   const [animating, setAnimating] = useState(true);
 

--- a/packages/rn-tester/js/examples/ActivityIndicator/ActivityIndicatorExample.js
+++ b/packages/rn-tester/js/examples/ActivityIndicator/ActivityIndicatorExample.js
@@ -10,20 +10,19 @@
 
 import type {Node} from 'React';
 import {ActivityIndicator, StyleSheet, View} from 'react-native';
-import React, {useState} from 'react';
-import {useEffect} from 'react';
+import React, {useState, useCallback, useRef, useEffect} from 'react';
 
 function ToggleAnimatingActivityIndicator() {
-  let _timer;
+  let _timer = useRef();
 
   const [animating, setAnimating] = useState(true);
 
-  const setToggleTimeout = () => {
-    _timer = setTimeout(() => {
+  const setToggleTimeout = useCallback(() => {
+    _timer.current = setTimeout(() => {
       setAnimating(currentState => !currentState);
       setToggleTimeout();
     }, 2000);
-  };
+  }, []);
 
   useEffect(() => {
     setToggleTimeout();
@@ -31,8 +30,7 @@ function ToggleAnimatingActivityIndicator() {
     return () => {
       clearTimeout(_timer);
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [_timer]);
+  }, [_timer, setToggleTimeout]);
 
   return (
     <ActivityIndicator


### PR DESCRIPTION
## Summary
This pull request migrates the activity indicator example to using React Hooks.

## Changelog
[General] [Changed] - RNTester: Migrate ActivityIndicator to hooks

## Test Plan
The animation works exactly as it did as when it was a class component