### PR TITLE
[Codegen] Extract `tryParse` (Flow, TypeScript) lambda into `parseObjectProperty` fn

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-commons-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-commons-test.js
@@ -11,8 +11,11 @@
 
 'use-strict';
 
-import {assertGenericTypeAnnotationHasExactlyOneTypeParameter} from '../parsers-commons';
-import type {ParserType} from '../errors';
+import {
+  assertGenericTypeAnnotationHasExactlyOneTypeParameter,
+  /* parseObjectProperty */
+} from '../parsers-commons';
+
 const {
   wrapNullable,
   unwrapNullable,
@@ -249,22 +252,34 @@ describe('assertGenericTypeAnnotationHasExactlyOneTypeParameter', () => {
   });
 });
 
+/*
 describe('parseObjectProperty', () => {
+  const translateTypeAnnotation = (
+    hasteModuleName: string,
+    languageTypeAnnotation: string,
+    types: {[string]: string},
+    aliasMap: {[string]: string},
+    tryParse: () => null,
+    cxxOnly: boolean,
+    optional: boolean,
+  ) => {};
   const moduleName = 'testModuleName';
   const types = {['wrongName']: 'wrongType'};
   const aliasMap = {['wrongAlias']: 'wrongValue'};
   const tryParse = () => null;
   const cxxOnly = false;
   let language = 'TypeScript';
+  const languageTypeAnnotation =
+    language === 'TypeScript' ? 'wrongTypeAnnotation' : 'wrongValue';
 
-  it(`"throws an 'UnsupportedObjectPropertyTypeAnnotationParserError' error if 'property.type' is not 'ObjectTypeProperty' or 'TSPropertySignature'."`, () => {
+  it("throws an 'UnsupportedObjectPropertyTypeAnnotationParserError' error if 'property.type' is not 'ObjectTypeProperty'.", () => {
     const property = {
       type: 'notObjectTypeProperty',
       typeAnnotation: {
         typeAnnotation: 'wrongTypeAnnotation',
       },
       value: 'wrongValue',
-      key: 'wrongKey',
+      name: 'wrongName',
     };
     expect(() =>
       parseObjectProperty(
@@ -274,7 +289,8 @@ describe('parseObjectProperty', () => {
         aliasMap,
         tryParse,
         cxxOnly,
-        language,
+        'Flow',
+        translateTypeAnnotation,
       ),
     ).toThrowErrorMatchingInlineSnapshot(
       `"Module testModuleName: 'ObjectTypeAnnotation' cannot contain 'notObjectTypeProperty'."`,
@@ -288,47 +304,8 @@ describe('parseObjectProperty', () => {
         typeAnnotation: 'wrongTypeAnnotation',
       },
       value: 'wrongValue',
-      key: 'wrongKey',
+      name: 'wrongName',
     };
-    expect(() =>
-      parseObjectProperty(
-        property,
-        moduleName,
-        types,
-        aliasMap,
-        tryParse,
-        cxxOnly,
-        language,
-      ),
-    ).toThrowErrorMatchingInlineSnapshot(
-      `"Module testModuleName: 'ObjectTypeAnnotation' cannot contain 'notTSPropertySignature'."`,
-    );
-  });
-
-  it("doesn't throw an 'UnsupportedObjectPropertyTypeAnnotationParserError' error if 'property.type' is 'TSPropertySignature'.", () => {
-    const property = {
-      type: 'TSPropertySignature',
-      typeAnnotation: {
-        type: 'FunctionTypeAnnotation',
-        typeAnnotation: 'wrongTypeAnnotation',
-      },
-      value: 'wrongValue',
-      key: 'wrongKey',
-      optional: false,
-    };
-    const languageTypeAnnotation =
-      language === 'TypeScript'
-        ? property.typeAnnotation.typeAnnotation
-        : property.value;
-    const translateTypeAnnotation = (
-      moduleName,
-      languageTypeAnnotation,
-      types,
-      aliasMap,
-      tryParse,
-      cxxOnly,
-    ) => {};
-
     expect(() =>
       parseObjectProperty(
         property,
@@ -340,9 +317,14 @@ describe('parseObjectProperty', () => {
         language,
         translateTypeAnnotation,
       ),
-    ).not.toThrow();
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Module testModuleName: 'ObjectTypeAnnotation' cannot contain 'notTSPropertySignature'."`,
+    );
   });
+
+  // TODO: Add more tests like for `throwIfPropertyValueTypeIsUnsupported`
 });
+*/
 
 describe('emitMixedTypeAnnotation', () => {
   describe('when nullable is true', () => {

--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-commons-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-commons-test.js
@@ -13,16 +13,16 @@
 
 import {
   assertGenericTypeAnnotationHasExactlyOneTypeParameter,
-  /* parseObjectProperty */
+  parseObjectProperty,
 } from '../parsers-commons';
-
+import type {ParserType} from '../errors';
+import type {UnionTypeAnnotationMemberType} from '../../CodegenSchema';
 const {
   wrapNullable,
   unwrapNullable,
   emitUnionTypeAnnotation,
 } = require('../parsers-commons.js');
 const {UnsupportedUnionTypeAnnotationParserError} = require('../errors');
-import type {UnionTypeAnnotationMemberType} from '../../CodegenSchema';
 
 describe('wrapNullable', () => {
   describe('when nullable is true', () => {

--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-commons-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-commons-test.js
@@ -249,6 +249,127 @@ describe('assertGenericTypeAnnotationHasExactlyOneTypeParameter', () => {
   });
 });
 
+describe('parseObjectProperty', () => {
+  const moduleName = 'testModuleName';
+  const types = {['wrongName']: 'wrongType'};
+  const aliasMap = {['wrongAlias']: 'wrongValue'};
+  const tryParse = () => null;
+  const cxxOnly = false;
+  let language = 'TypeScript';
+
+  it(`"throws an 'UnsupportedObjectPropertyTypeAnnotationParserError' error if 'property.type' is not 'ObjectTypeProperty' or 'TSPropertySignature'."`, () => {
+    const property = {
+      type: 'notObjectTypeProperty',
+      typeAnnotation: {
+        typeAnnotation: 'wrongTypeAnnotation',
+      },
+      value: 'wrongValue',
+      key: 'wrongKey',
+    };
+    expect(() =>
+      parseObjectProperty(
+        property,
+        moduleName,
+        types,
+        aliasMap,
+        tryParse,
+        cxxOnly,
+        language,
+      ),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Module testModuleName: 'ObjectTypeAnnotation' cannot contain 'notObjectTypeProperty'."`,
+    );
+  });
+
+  it("throws an 'UnsupportedObjectPropertyTypeAnnotationParserError' error if 'property.type' is not 'TSPropertySignature'.", () => {
+    const property = {
+      type: 'notTSPropertySignature',
+      typeAnnotation: {
+        typeAnnotation: 'wrongTypeAnnotation',
+      },
+      value: 'wrongValue',
+      key: 'wrongKey',
+    };
+    expect(() =>
+      parseObjectProperty(
+        property,
+        moduleName,
+        types,
+        aliasMap,
+        tryParse,
+        cxxOnly,
+        language,
+      ),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Module testModuleName: 'ObjectTypeAnnotation' cannot contain 'notTSPropertySignature'."`,
+    );
+  });
+
+  it("doesn't throw an 'UnsupportedObjectPropertyTypeAnnotationParserError' error if 'property.type' is 'TSPropertySignature'.", () => {
+    const property = {
+      type: 'TSPropertySignature',
+      typeAnnotation: {
+        type: 'FunctionTypeAnnotation',
+        typeAnnotation: 'wrongTypeAnnotation',
+      },
+      value: 'wrongValue',
+      key: 'wrongKey',
+      optional: false,
+    };
+    const languageTypeAnnotation =
+      language === 'TypeScript'
+        ? property.typeAnnotation.typeAnnotation
+        : property.value;
+    const translateTypeAnnotation = (
+      moduleName,
+      languageTypeAnnotation,
+      types,
+      aliasMap,
+      tryParse,
+      cxxOnly,
+    ) => {};
+
+    expect(() =>
+      parseObjectProperty(
+        property,
+        moduleName,
+        types,
+        aliasMap,
+        tryParse,
+        cxxOnly,
+        language,
+        translateTypeAnnotation,
+      ),
+    ).not.toThrow();
+  });
+});
+
+describe('emitMixedTypeAnnotation', () => {
+  describe('when nullable is true', () => {
+    it('returns nullable type annotation', () => {
+      const result = emitMixedTypeAnnotation(true);
+      const expected = {
+        type: 'NullableTypeAnnotation',
+        typeAnnotation: {
+          type: 'MixedTypeAnnotation',
+        },
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+  describe('when nullable is false', () => {
+    it('returns non nullable type annotation', () => {
+      const result = emitMixedTypeAnnotation(false);
+      const expected = {
+        type: 'MixedTypeAnnotation',
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+});
+
 describe('emitUnionTypeAnnotation', () => {
   const hasteModuleName = 'SampleTurboModule';
 

--- a/packages/react-native-codegen/src/parsers/error-utils.js
+++ b/packages/react-native-codegen/src/parsers/error-utils.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow strict-local
+ * @flow strict
  * @format
  */
 

--- a/packages/react-native-codegen/src/parsers/flow/components/schema.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/schema.js
@@ -4,8 +4,8 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @format
  * @flow strict
+ * @format
  */
 
 'use strict';

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -26,8 +26,7 @@ import type {ParserErrorCapturer, TypeDeclarationMap} from '../../utils';
 import type {NativeModuleTypeAnnotation} from '../../../CodegenSchema.js';
 const {nullGuard} = require('../../parsers-utils');
 
-const {throwIfMoreThanOneModuleRegistryCalls} = require('../../error-utils');
-const {visit, isModuleRegistryCall} = require('../../utils');
+const {visit, verifyPlatforms, isModuleRegistryCall} = require('../../utils');
 const {resolveTypeAnnotation, getTypes} = require('../utils.js');
 const {
   unwrapNullable,
@@ -64,14 +63,13 @@ const {
   IncorrectModuleRegistryCallArgumentTypeParserError,
 } = require('../../errors.js');
 
-const {verifyPlatforms} = require('../../utils');
-
 const {
   throwIfUnsupportedFunctionReturnTypeAnnotationParserError,
   throwIfModuleInterfaceNotFound,
   throwIfModuleInterfaceIsMisnamed,
   throwIfUnusedModuleInterfaceParserError,
   throwIfWrongNumberOfCallExpressionArgs,
+  throwIfMoreThanOneModuleRegistryCalls,
   throwIfIncorrectModuleRegistryCallTypeParameterParserError,
   throwIfUntypedModule,
   throwIfModuleTypeIsUnsupported,
@@ -275,6 +273,7 @@ function translateTypeAnnotation(
                   tryParse,
                   cxxOnly,
                   language,
+                  nullable,
                   translateTypeAnnotation,
                 );
               });

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -33,7 +33,6 @@ const {
   wrapNullable,
   assertGenericTypeAnnotationHasExactlyOneTypeParameter,
   parseObjectProperty,
-  emitMixedTypeAnnotation,
   emitUnionTypeAnnotation,
   translateDefault,
 } = require('../../parsers-commons');
@@ -555,4 +554,5 @@ function buildModuleSchema(
 
 module.exports = {
   buildModuleSchema,
+  flowTranslateTypeAnnotation: translateTypeAnnotation,
 };

--- a/packages/react-native-codegen/src/parsers/parsers-commons.js
+++ b/packages/react-native-codegen/src/parsers/parsers-commons.js
@@ -15,14 +15,11 @@ import type {
   NamedShape,
   NativeModuleSchema,
   NativeModuleTypeAnnotation,
-  Nullable,
   NativeModuleAliasMap,
   UnionTypeAnnotationMemberType,
   NativeModuleEnumDeclaration,
-  NativeModuleTypeAnnotation,
   NativeModuleBaseTypeAnnotation,
   NativeModuleUnionTypeAnnotation,
-  NativeModuleMixedTypeAnnotation,
   Nullable,
 } from '../CodegenSchema.js';
 import type {ParserType} from './errors';
@@ -200,14 +197,6 @@ function parseObjectProperty(
   };
 }
 
-function emitMixedTypeAnnotation(
-  nullable: boolean,
-): Nullable<NativeModuleMixedTypeAnnotation> {
-  return wrapNullable(nullable, {
-    type: 'MixedTypeAnnotation',
-  });
-}
-
 function remapUnionTypeAnnotationMemberNames(
   types: $FlowFixMe,
   language: ParserType,
@@ -328,7 +317,6 @@ module.exports = {
   assertGenericTypeAnnotationHasExactlyOneTypeParameter,
   isObjectProperty,
   parseObjectProperty,
-  emitMixedTypeAnnotation,
   emitUnionTypeAnnotation,
   translateDefault,
   getKeyName,

--- a/packages/react-native-codegen/src/parsers/parsers-commons.js
+++ b/packages/react-native-codegen/src/parsers/parsers-commons.js
@@ -27,8 +27,8 @@ import type {
 const {
   MissingTypeParameterGenericParserError,
   MoreThanOneTypeParameterGenericParserError,
-  IncorrectlyParameterizedGenericParserError,
   UnsupportedObjectPropertyTypeAnnotationParserError,
+  UnsupportedUnionTypeAnnotationParserError,
 } = require('./errors');
 const {throwIfPropertyValueTypeIsUnsupported} = require('./error-utils');
 import type {ParserType} from './errors';

--- a/packages/react-native-codegen/src/parsers/parsers-commons.js
+++ b/packages/react-native-codegen/src/parsers/parsers-commons.js
@@ -43,6 +43,20 @@ type TranslateTypeAnnotation = (
   cxxOnly: boolean,
 ) => Nullable<NativeModuleTypeAnnotation>;
 
+function isObjectProperty(
+  property: NamedShape<Nullable<NativeModuleBaseTypeAnnotation>>,
+  language: ParserType,
+): boolean {
+  switch (language) {
+    case 'Flow':
+      return property.type === 'ObjectTypeProperty';
+    case 'TypeScript':
+      return property.type === 'TSPropertySignature';
+    default:
+      return false;
+  }
+}
+
 const invariant = require('invariant');
 import type {TypeDeclarationMap} from './utils';
 const {
@@ -132,10 +146,7 @@ function parseObjectProperty(
   language: ParserType,
   translateTypeAnnotation: TranslateTypeAnnotation,
 ) {
-  if (
-    property.type !== 'ObjectTypeProperty' &&
-    property.type !== 'TSPropertySignature'
-  ) {
+  if (!isObjectProperty(property, language)) {
     throw new UnsupportedObjectPropertyTypeAnnotationParserError(
       hasteModuleName,
       property,
@@ -308,6 +319,7 @@ module.exports = {
   unwrapNullable,
   wrapNullable,
   assertGenericTypeAnnotationHasExactlyOneTypeParameter,
+  isObjectProperty,
   parseObjectProperty,
   emitMixedTypeAnnotation,
   emitUnionTypeAnnotation,

--- a/packages/react-native-codegen/src/parsers/parsers-commons.js
+++ b/packages/react-native-codegen/src/parsers/parsers-commons.js
@@ -34,19 +34,7 @@ const {throwIfPropertyValueTypeIsUnsupported} = require('./error-utils');
 import type {ParserType} from './errors';
 import type {ParserErrorCapturer, TypeDeclarationMap} from './utils';
 
-type TranslateTypeAnnotation = (
-  hasteModuleName: string,
-  languageTypeAnnotation: $FlowFixMe,
-  types: TypeDeclarationMap,
-  aliasMap: {...NativeModuleAliasMap},
-  tryParse: ParserErrorCapturer,
-  cxxOnly: boolean,
-) => Nullable<NativeModuleTypeAnnotation>;
-
-function isObjectProperty(
-  property: NamedShape<Nullable<NativeModuleBaseTypeAnnotation>>,
-  language: ParserType,
-): boolean {
+function isObjectProperty(property: $FlowFixMe, language: ParserType): boolean {
   switch (language) {
     case 'Flow':
       return property.type === 'ObjectTypeProperty';
@@ -137,15 +125,15 @@ function assertGenericTypeAnnotationHasExactlyOneTypeParameter(
 }
 
 function parseObjectProperty(
-  property: NamedShape<Nullable<NativeModuleBaseTypeAnnotation>>,
+  property: $FlowFixMe,
   hasteModuleName: string,
   types: TypeDeclarationMap,
   aliasMap: {...NativeModuleAliasMap},
   tryParse: ParserErrorCapturer,
   cxxOnly: boolean,
   language: ParserType,
-  translateTypeAnnotation: TranslateTypeAnnotation,
-) {
+  translateTypeAnnotation: $FlowFixMe,
+): NamedShape<Nullable<NativeModuleBaseTypeAnnotation>> {
   if (!isObjectProperty(property, language)) {
     throw new UnsupportedObjectPropertyTypeAnnotationParserError(
       hasteModuleName,
@@ -184,13 +172,13 @@ function parseObjectProperty(
       propertyTypeAnnotation.type,
       language,
     );
-  } else {
-    return {
-      name: key.name,
-      optional,
-      typeAnnotation: wrapNullable(isPropertyNullable, propertyTypeAnnotation),
-    };
   }
+
+  return {
+    name: key.name,
+    optional,
+    typeAnnotation: wrapNullable(isPropertyNullable, propertyTypeAnnotation),
+  };
 }
 
 function emitMixedTypeAnnotation(

--- a/packages/react-native-codegen/src/parsers/parsers-primitives.js
+++ b/packages/react-native-codegen/src/parsers/parsers-primitives.js
@@ -4,8 +4,8 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @format
  * @flow strict-local
+ * @format
  */
 
 'use strict';

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -60,7 +60,6 @@ const {
   UnsupportedTypeAnnotationParserError,
   UnsupportedFunctionParamTypeAnnotationParserError,
   UnsupportedEnumDeclarationParserError,
-  UnsupportedUnionTypeAnnotationParserError,
   IncorrectModuleRegistryCallArgumentTypeParserError,
 } = require('../../errors.js');
 

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -17,15 +17,13 @@ import type {
   NativeModuleBaseTypeAnnotation,
   NativeModuleFunctionTypeAnnotation,
   NativeModulePropertyShape,
+  NativeModuleTypeAnnotation,
   NativeModuleSchema,
   Nullable,
 } from '../../../CodegenSchema.js';
 
 import type {ParserErrorCapturer, TypeDeclarationMap} from '../../utils';
-import type {NativeModuleTypeAnnotation} from '../../../CodegenSchema.js';
 const {nullGuard} = require('../../parsers-utils');
-
-const {throwIfMoreThanOneModuleRegistryCalls} = require('../../error-utils');
 const {visit, isModuleRegistryCall} = require('../../utils');
 const {resolveTypeAnnotation, getTypes} = require('../utils.js');
 const {
@@ -58,8 +56,6 @@ const {
   UnsupportedArrayElementTypeAnnotationParserError,
   UnsupportedGenericParserError,
   UnsupportedTypeAnnotationParserError,
-  UnsupportedFunctionParamTypeAnnotationParserError,
-  UnsupportedEnumDeclarationParserError,
   IncorrectModuleRegistryCallArgumentTypeParserError,
 } = require('../../errors.js');
 
@@ -72,6 +68,7 @@ const {
   throwIfModuleInterfaceNotFound,
   throwIfModuleInterfaceIsMisnamed,
   throwIfWrongNumberOfCallExpressionArgs,
+  throwIfMoreThanOneModuleRegistryCalls,
   throwIfMoreThanOneModuleInterfaceParserError,
   throwIfIncorrectModuleRegistryCallTypeParameterParserError,
 } = require('../../error-utils');
@@ -282,6 +279,7 @@ function translateTypeAnnotation(
                   tryParse,
                   cxxOnly,
                   language,
+                  nullable,
                   translateTypeAnnotation,
                 );
               });

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -31,7 +31,6 @@ const {
   wrapNullable,
   assertGenericTypeAnnotationHasExactlyOneTypeParameter,
   parseObjectProperty,
-  emitMixedTypeAnnotation,
   emitUnionTypeAnnotation,
   translateDefault,
 } = require('../../parsers-commons');
@@ -564,4 +563,5 @@ function buildModuleSchema(
 
 module.exports = {
   buildModuleSchema,
+  typeScriptTranslateTypeAnnotation: translateTypeAnnotation,
 };


### PR DESCRIPTION
This PR is a task of #34872
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

> Extract the content of the tryParse (Flow, TypeScript)lambda into a proper `parseObjectProperty` function into the parsers-commons.js file.
also,
- added new helper fn `isObjectProperty` in `parsers-commons.js` file. 
- added tests for `isObjectProperty` and `parseObjectProperty` fn 's

## Changelog

[Internal] [Changed] - Extracted the content of the `tryParse` ([Flow](https://github.com/facebook/react-native/blob/main/packages/react-native-codegen/src/parsers/flow/modules/index.js#L292-L337), [TypeScript](https://github.com/facebook/react-native/blob/main/packages/react-native-codegen/src/parsers/typescript/modules/index.js#L306-L351)) lambda into a proper `parseObjectProperty` fn into the `parsers-commons.js` file.

## Test Plan
- run
```bash
yarn lint && yarn flow && yarn test-ci
```
- and ensure everything is 🟢

<img width="720" alt="image" src="https://user-images.githubusercontent.com/55224033/200105151-360b9b5e-52c7-4586-89b0-6860e9725f6e.png">
