### PR TITLE
Bump the Android Docker image to 6.0 (for NDK 23)

### DIFF
--- a/.circleci/Dockerfiles/Dockerfile.android
+++ b/.circleci/Dockerfiles/Dockerfile.android
@@ -14,7 +14,7 @@
 # and build a Android application that can be used to run the
 # tests specified in the scripts/ directory.
 #
-FROM reactnativecommunity/react-native-android:5.4
+FROM reactnativecommunity/react-native-android:6.0
 
 LABEL Description="React Native Android Test Image"
 LABEL maintainer="Héctor Ramos <hector@fb.com>"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ executors:
   reactnativeandroid:
     <<: *defaults
     docker:
-      - image: reactnativecommunity/react-native-android:5.4
+      - image: reactnativecommunity/react-native-android:6.0
     resource_class: "xlarge"
     environment:
       - TERM: "dumb"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -670,10 +670,6 @@ jobs:
             buck build ReactAndroid/src/main/java/com/facebook/react/shell
 
       - run:
-          name: Validate Android Test Environment
-          command: ./scripts/validate-android-test-env.sh
-
-      - run:
           name: Run Tests - Android Unit Tests with Buck
           command: buck test ReactAndroid/src/test/... --config build.threads=$BUILD_THREADS --xml ./reports/buck/all-results-raw.xml
 
@@ -717,10 +713,6 @@ jobs:
       - checkout
       - setup_artifacts
       - run_yarn
-
-      - run:
-          name: Validate Android SDK Install
-          command: ./scripts/validate-android-sdk.sh
 
       # Starting emulator in advance as it takes some time to boot.
       - run:

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "prettier": "prettier --write \"./**/*.{js,md,yml,ts,tsx}\"",
     "format-check": "prettier --list-different \"./**/*.{js,md,yml,ts,tsx}\"",
     "update-lock": "npx yarn-deduplicate",
-    "docker-setup-android": "docker pull reactnativecommunity/react-native-android:5.2",
+    "docker-setup-android": "docker pull reactnativecommunity/react-native-android:6.0",
     "docker-build-android": "docker build -t reactnativeci/android -f .circleci/Dockerfiles/Dockerfile.android .",
     "test-android-run-instrumentation": "docker run --cap-add=SYS_ADMIN -it reactnativeci/android bash .circleci/Dockerfiles/scripts/run-android-docker-instrumentation-tests.sh",
     "test-android-run-unit": "docker run --cap-add=SYS_ADMIN -it reactnativeci/android bash .circleci/Dockerfiles/scripts/run-android-docker-unit-tests.sh",


### PR DESCRIPTION
Summary:
This bumps the Docker image for React Native Android to 6.0
shipping the NDK 23 with it, finalizing all the work needed
to support NDK 23.

Changelog:
[Internal] [Changed] - Bump the Android Docker image to 6.0 (for NDK 23)

Differential Revision: D40675449

