### PR TITLE
RNGP - Remove enableCodegenInApps and infer it from package.json

### DIFF
--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactExtension.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactExtension.kt
@@ -156,11 +156,4 @@ abstract class ReactExtension @Inject constructor(project: Project) {
    */
   val codegenJavaPackageName: Property<String> =
       objects.property(String::class.java).convention("com.facebook.fbreact.specs")
-
-  /**
-   * Toggles the Codegen for App modules. By default we enable the codegen only for library modules.
-   * If you want to enable codegen in your app, you will have to set this to true. Default: false
-   */
-  val enableCodegenInApps: Property<Boolean> =
-      objects.property(Boolean::class.java).convention(false)
 }

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
@@ -91,7 +91,13 @@ class ReactPlugin : Plugin<Project> {
           it.codegenDir.set(extension.codegenDir)
           val bashWindowsHome = project.findProperty("REACT_WINDOWS_BASH") as String?
           it.bashWindowsHome.set(bashWindowsHome)
-          it.onlyIf { isLibrary || extension.enableCodegenInApps.get() }
+
+          // We're reading the package.json at configuration time to properly feed
+          // the onlyIf condition of this task. Therefore, the
+          // parsePackageJson should be invoked inside this lambda.
+          val packageJson = findPackageJsonFile(project, extension)
+          val parsedPackageJson = packageJson?.let { JsonUtils.fromCodegenJson(it) }
+          it.onlyIf { isLibrary || parsedPackageJson?.codegenConfig != null }
         }
 
     // We create the task to produce schema from JS files.
@@ -102,10 +108,9 @@ class ReactPlugin : Plugin<Project> {
               it.nodeExecutableAndArgs.set(extension.nodeExecutableAndArgs)
               it.codegenDir.set(extension.codegenDir)
               it.generatedSrcDir.set(generatedSrcDir)
-              it.onlyIf { isLibrary || extension.enableCodegenInApps.get() }
 
               // We're reading the package.json at configuration time to properly feed
-              // the `jsRootDir` @Input property of this task. Therefore, the
+              // the `jsRootDir` @Input property of this task & the onlyIf. Therefore, the
               // parsePackageJson should be invoked inside this lambda.
               val packageJson = findPackageJsonFile(project, extension)
               val parsedPackageJson = packageJson?.let { JsonUtils.fromCodegenJson(it) }
@@ -116,6 +121,7 @@ class ReactPlugin : Plugin<Project> {
               } else {
                 it.jsRootDir.set(extension.jsRootDir)
               }
+              it.onlyIf { isLibrary || parsedPackageJson?.codegenConfig != null }
             }
 
     // We create the task to generate Java code from schema.
@@ -130,7 +136,13 @@ class ReactPlugin : Plugin<Project> {
               it.packageJsonFile.set(findPackageJsonFile(project, extension))
               it.codegenJavaPackageName.set(extension.codegenJavaPackageName)
               it.libraryName.set(extension.libraryName)
-              it.onlyIf { isLibrary || extension.enableCodegenInApps.get() }
+
+              // We're reading the package.json at configuration time to properly feed
+              // the onlyIf condition of this task. Therefore, the
+              // parsePackageJson should be invoked inside this lambda.
+              val packageJson = findPackageJsonFile(project, extension)
+              val parsedPackageJson = packageJson?.let { JsonUtils.fromCodegenJson(it) }
+              it.onlyIf { isLibrary || parsedPackageJson?.codegenConfig != null }
             }
 
     // We update the android configuration to include the generated sources.

--- a/packages/rn-tester/android/app/build.gradle
+++ b/packages/rn-tester/android/app/build.gradle
@@ -88,7 +88,6 @@ react {
     // Codegen Configs
     reactNativeDir = rootDir
     codegenDir = new File(rootDir, "node_modules/react-native-codegen")
-    enableCodegenInApps = true
 }
 
 /**


### PR DESCRIPTION
Summary:
We don't need to `enableCodegenInApps` keys but we can instead rely on the
existence of the `codegenConfig` key inside the `package.json` to decide if
Codegen should run in App modules or not.

Changelog:
[Internal] [Changed] - RNGP - Remove enableCodegenInApps and infer it from package.json

Differential Revision: D40687079

