### PR TITLE
refactor(rn tester app): change dimensions example to hooks

### DIFF
--- a/packages/rn-tester/js/examples/Dimensions/DimensionsExample.js
+++ b/packages/rn-tester/js/examples/Dimensions/DimensionsExample.js
@@ -10,26 +10,19 @@
 
 import {Dimensions, Text, useWindowDimensions} from 'react-native';
 import * as React from 'react';
-import {useState, useEffect, useRef} from 'react';
+import {useState, useEffect} from 'react';
 
 type Props = {dim: string};
 
 function DimensionsSubscription(props: Props) {
   const [dims, setDims] = useState(Dimensions.get(props.dim));
 
-  let dimensionsSubscription = useRef();
-
   useEffect(() => {
-    dimensionsSubscription.current = Dimensions.addEventListener(
-      'change',
-      dimensions => {
-        setDims(dimensions[props.dim]);
-      },
-    );
+    const subscription = Dimensions.addEventListener('change', dimensions => {
+      setDims(dimensions[props.dim]);
+    });
 
-    return () => {
-      dimensionsSubscription?.current?.remove();
-    };
+    return () => subscription?.remove();
   }, [props.dim]);
 
   return <Text>{JSON.stringify(dims, null, 2)}</Text>;

--- a/packages/rn-tester/js/examples/Dimensions/DimensionsExample.js
+++ b/packages/rn-tester/js/examples/Dimensions/DimensionsExample.js
@@ -9,9 +9,12 @@
  */
 
 import {Dimensions, Text, useWindowDimensions} from 'react-native';
-import React, {useState, useRef, useEffect} from 'react';
+import * as React from 'react';
+import {useState, useEffect, useRef} from 'react';
 
-function DimensionsSubscription(props) {
+type Props = {dim: string};
+
+function DimensionsSubscription(props: Props) {
   const [dims, setDims] = useState(Dimensions.get(props.dim));
 
   let dimensionsSubscription = useRef();

--- a/packages/rn-tester/js/examples/Dimensions/DimensionsExample.js
+++ b/packages/rn-tester/js/examples/Dimensions/DimensionsExample.js
@@ -8,38 +8,28 @@
  * @flow
  */
 
-import type {EventSubscription} from 'react-native/Libraries/vendor/emitter/EventEmitter';
 import {Dimensions, Text, useWindowDimensions} from 'react-native';
-import * as React from 'react';
+import React, {useState, useRef, useEffect} from 'react';
 
-class DimensionsSubscription extends React.Component<
-  {dim: string, ...},
-  {dims: Object, ...},
-> {
-  state: {dims: any, ...} = {
-    dims: Dimensions.get(this.props.dim),
-  };
+function DimensionsSubscription(props) {
+  const [dims, setDims] = useState(Dimensions.get(props.dim));
 
-  _dimensionsSubscription: ?EventSubscription;
+  let dimensionsSubscription = useRef();
 
-  componentDidMount() {
-    this._dimensionsSubscription = Dimensions.addEventListener(
+  useEffect(() => {
+    dimensionsSubscription.current = Dimensions.addEventListener(
       'change',
       dimensions => {
-        this.setState({
-          dims: dimensions[this.props.dim],
-        });
+        setDims(dimensions[props.dim]);
       },
     );
-  }
 
-  componentWillUnmount() {
-    this._dimensionsSubscription?.remove();
-  }
+    return () => {
+      dimensionsSubscription?.current?.remove();
+    };
+  }, [props.dim]);
 
-  render(): React.Node {
-    return <Text>{JSON.stringify(this.state.dims, null, 2)}</Text>;
-  }
+  return <Text>{JSON.stringify(dims, null, 2)}</Text>;
 }
 
 const DimensionsViaHook = () => {


### PR DESCRIPTION
## Summary
This pull request migrates the dimensions example to using React Hooks.

## Changelog
[General] [Changed] - RNTester: Migrate Dimensions to hooks

## Test Plan
The animation works exactly as it did as when it was a class component