### PR TITLE
Fix RCTLoggingTests in OSS

### DIFF
--- a/packages/rn-tester/RNTesterIntegrationTests/RCTLoggingTests.m
+++ b/packages/rn-tester/RNTesterIntegrationTests/RCTLoggingTests.m
@@ -129,7 +129,7 @@ const int64_t LOGGER_TIMEOUT = 10 * NSEC_PER_SEC;
   XCTAssertEqual(waitRet, 0, @"Timed out waiting for throwError");
 
   // For local bundles, we may first get a warning about symbolication
-  if (![_lastLogMessage isEqualToString:@"Error: Throwing an error"]) {
+  if (![_lastLogMessage containsString:@"Error: Throwing an error"]) {
     waitRet = dispatch_semaphore_wait(_logSem, dispatch_time(DISPATCH_TIME_NOW, LOGGER_TIMEOUT));
     XCTAssertEqual(waitRet, 0, @"Timed out waiting for throwError #2");
   }


### PR DESCRIPTION
fd917481463bf6ba9c4e14919250aec2ffad2c2f added a condition not to pump an extra message when we didn't see symbolication warnings (which do not seem to show up in a stock internal build), but I missed that the test specific to RCTLogLevelError checked for string containment instead of equality, and the last assertion we process on log level is incorrect in OSS as a result. See if that fixes the tests running on CircleCI.

Changelog:
[Internal][Fixed] - Fix RCTLoggingTests in OSS