### PR TITLE
chore: Unify codegen Flow and TS default case from translateTypeAnnotation

### DIFF
--- a/packages/react-native-codegen/src/parsers/flow/components/schema.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/schema.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @flow strict-local
+ * @flow strict
  */
 
 'use strict';

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -39,6 +39,7 @@ const {
   assertGenericTypeAnnotationHasExactlyOneTypeParameter,
   emitMixedTypeAnnotation,
   emitUnionTypeAnnotation,
+  translateDefault,
 } = require('../../parsers-commons');
 const {
   emitBoolean,
@@ -59,9 +60,7 @@ const {
 const {
   UnnamedFunctionParamParserError,
   UnsupportedArrayElementTypeAnnotationParserError,
-  UnsupportedGenericParserError,
   UnsupportedTypeAnnotationParserError,
-  UnsupportedEnumDeclarationParserError,
   UnsupportedObjectPropertyTypeAnnotationParserError,
   IncorrectModuleRegistryCallArgumentTypeParserError,
 } = require('../../errors.js');
@@ -250,34 +249,12 @@ function translateTypeAnnotation(
           return emitObject(nullable);
         }
         default: {
-          const maybeEumDeclaration = types[typeAnnotation.id.name];
-          if (
-            maybeEumDeclaration &&
-            maybeEumDeclaration.type === 'EnumDeclaration'
-          ) {
-            const memberType = maybeEumDeclaration.body.type
-              .replace('EnumNumberBody', 'NumberTypeAnnotation')
-              .replace('EnumStringBody', 'StringTypeAnnotation');
-            if (
-              memberType === 'NumberTypeAnnotation' ||
-              memberType === 'StringTypeAnnotation'
-            ) {
-              return wrapNullable(nullable, {
-                type: 'EnumDeclaration',
-                memberType: memberType,
-              });
-            } else {
-              throw new UnsupportedEnumDeclarationParserError(
-                hasteModuleName,
-                typeAnnotation,
-                memberType,
-                language,
-              );
-            }
-          }
-          throw new UnsupportedGenericParserError(
+          return translateDefault(
             hasteModuleName,
             typeAnnotation,
+            types,
+            nullable,
+            language,
             parser,
           );
         }

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -254,7 +254,6 @@ function translateTypeAnnotation(
             typeAnnotation,
             types,
             nullable,
-            language,
             parser,
           );
         }

--- a/packages/react-native-codegen/src/parsers/flow/parser.js
+++ b/packages/react-native-codegen/src/parsers/flow/parser.js
@@ -10,6 +10,7 @@
 
 'use strict';
 
+import type {ParserType} from '../errors';
 import type {Parser} from '../parser';
 
 class FlowParser implements Parser {
@@ -21,6 +22,10 @@ class FlowParser implements Parser {
 
   isEnumDeclaration(maybeEnumDeclaration: $FlowFixMe): boolean {
     return maybeEnumDeclaration.type === 'EnumDeclaration';
+  }
+
+  language(): ParserType {
+    return 'Flow';
   }
 
   nameForGenericTypeAnnotation(typeAnnotation: $FlowFixMe): string {

--- a/packages/react-native-codegen/src/parsers/flow/parser.js
+++ b/packages/react-native-codegen/src/parsers/flow/parser.js
@@ -13,6 +13,16 @@
 import type {Parser} from '../parser';
 
 class FlowParser implements Parser {
+  getMaybeEnumMemberType(maybeEnumDeclaration: $FlowFixMe): string {
+    return maybeEnumDeclaration.body.type
+      .replace('EnumNumberBody', 'NumberTypeAnnotation')
+      .replace('EnumStringBody', 'StringTypeAnnotation');
+  }
+
+  isEnumDeclaration(maybeEnumDeclaration: $FlowFixMe): boolean {
+    return maybeEnumDeclaration.type === 'EnumDeclaration';
+  }
+
   nameForGenericTypeAnnotation(typeAnnotation: $FlowFixMe): string {
     return typeAnnotation.id.name;
   }

--- a/packages/react-native-codegen/src/parsers/parser.js
+++ b/packages/react-native-codegen/src/parsers/parser.js
@@ -17,8 +17,21 @@ import type {ParserType} from './errors';
  * It exposes all the methods that contain language-specific logic.
  */
 export interface Parser {
+  /**
+   * Given a type declaration, it possibly returns the name of the Enum type.
+   * @parameter maybeEnumDeclaration: an object possibly containing an Enum declaration.
+   * @returns: the name of the Enum type.
+   */
   getMaybeEnumMemberType(maybeEnumDeclaration: $FlowFixMe): string;
+  /**
+   * Given a type declaration, it returns a boolean specifying if is an Enum declaration.
+   * @parameter maybeEnumDeclaration: an object possibly containing an Enum declaration.
+   * @returns: a boolean specifying if is an Enum declaration.
+   */
   isEnumDeclaration(maybeEnumDeclaration: $FlowFixMe): boolean;
+  /**
+   * @returns: the Parser language.
+   */
   language(): ParserType;
   /**
    * Given a type annotation for a generic type, it returns the type name.

--- a/packages/react-native-codegen/src/parsers/parser.js
+++ b/packages/react-native-codegen/src/parsers/parser.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+import type {ParserType} from './errors';
+
 /**
  * This is the main interface for Parsers of various languages.
  * It exposes all the methods that contain language-specific logic.
@@ -17,6 +19,7 @@
 export interface Parser {
   getMaybeEnumMemberType(maybeEnumDeclaration: $FlowFixMe): string;
   isEnumDeclaration(maybeEnumDeclaration: $FlowFixMe): boolean;
+  language(): ParserType;
   /**
    * Given a type annotation for a generic type, it returns the type name.
    * @parameter typeAnnotation: the annotation for a type in the AST.

--- a/packages/react-native-codegen/src/parsers/parser.js
+++ b/packages/react-native-codegen/src/parsers/parser.js
@@ -15,6 +15,8 @@
  * It exposes all the methods that contain language-specific logic.
  */
 export interface Parser {
+  getMaybeEnumMemberType(maybeEnumDeclaration: $FlowFixMe): string;
+  isEnumDeclaration(maybeEnumDeclaration: $FlowFixMe): boolean;
   /**
    * Given a type annotation for a generic type, it returns the type name.
    * @parameter typeAnnotation: the annotation for a type in the AST.

--- a/packages/react-native-codegen/src/parsers/parsers-commons.js
+++ b/packages/react-native-codegen/src/parsers/parsers-commons.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @flow strict-local
+ * @flow strict
  */
 
 'use strict';

--- a/packages/react-native-codegen/src/parsers/parsers-commons.js
+++ b/packages/react-native-codegen/src/parsers/parsers-commons.js
@@ -163,21 +163,6 @@ function emitUnionTypeAnnotation(
     memberType: unionTypes[0],
   });
 }
-function getTypeScriptMemberType(maybeEnumDeclaration: $FlowFixMe) {
-  if (maybeEnumDeclaration.members[0].initializer) {
-    return maybeEnumDeclaration.members[0].initializer.type
-      .replace('NumericLiteral', 'NumberTypeAnnotation')
-      .replace('StringLiteral', 'StringTypeAnnotation');
-  }
-
-  return 'StringTypeAnnotation';
-}
-
-function getFlowMemberType(maybeEnumDeclaration: $FlowFixMe) {
-  return maybeEnumDeclaration.body.type
-    .replace('EnumNumberBody', 'NumberTypeAnnotation')
-    .replace('EnumStringBody', 'StringTypeAnnotation');
-}
 
 function translateDefault(
   hasteModuleName: string,
@@ -190,15 +175,8 @@ function translateDefault(
   const maybeEnumDeclaration =
     types[parser.nameForGenericTypeAnnotation(typeAnnotation)];
 
-  if (
-    maybeEnumDeclaration &&
-    (maybeEnumDeclaration.type === 'TSEnumDeclaration' ||
-      maybeEnumDeclaration.type === 'EnumDeclaration')
-  ) {
-    const memberType =
-      language === 'Flow'
-        ? getFlowMemberType(maybeEnumDeclaration)
-        : getTypeScriptMemberType(maybeEnumDeclaration);
+  if (maybeEnumDeclaration && parser.isEnumDeclaration(maybeEnumDeclaration)) {
+    const memberType = parser.getMaybeEnumMemberType(maybeEnumDeclaration);
 
     if (
       memberType === 'NumberTypeAnnotation' ||

--- a/packages/react-native-codegen/src/parsers/parsers-commons.js
+++ b/packages/react-native-codegen/src/parsers/parsers-commons.js
@@ -169,7 +169,6 @@ function translateDefault(
   typeAnnotation: $FlowFixMe,
   types: TypeDeclarationMap,
   nullable: boolean,
-  language: ParserType,
   parser: Parser,
 ): Nullable<NativeModuleEnumDeclaration> {
   const maybeEnumDeclaration =
@@ -191,7 +190,7 @@ function translateDefault(
         hasteModuleName,
         typeAnnotation,
         memberType,
-        language,
+        parser.language(),
       );
     }
   }

--- a/packages/react-native-codegen/src/parsers/typescript/components/schema.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/schema.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @flow strict-local
+ * @flow strict
  */
 
 'use strict';

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -42,6 +42,7 @@ const {
   assertGenericTypeAnnotationHasExactlyOneTypeParameter,
   emitMixedTypeAnnotation,
   emitUnionTypeAnnotation,
+  translateDefault,
 } = require('../../parsers-commons');
 const {
   emitBoolean,
@@ -63,7 +64,6 @@ const {
   UnsupportedArrayElementTypeAnnotationParserError,
   UnsupportedGenericParserError,
   UnsupportedTypeAnnotationParserError,
-  UnsupportedEnumDeclarationParserError,
   UnsupportedObjectPropertyTypeAnnotationParserError,
   IncorrectModuleRegistryCallArgumentTypeParserError,
 } = require('../../errors.js');
@@ -264,36 +264,12 @@ function translateTypeAnnotation(
           return emitObject(nullable);
         }
         default: {
-          const maybeEumDeclaration = types[typeAnnotation.typeName.name];
-          if (
-            maybeEumDeclaration &&
-            maybeEumDeclaration.type === 'TSEnumDeclaration'
-          ) {
-            const memberType = maybeEumDeclaration.members[0].initializer
-              ? maybeEumDeclaration.members[0].initializer.type
-                  .replace('NumericLiteral', 'NumberTypeAnnotation')
-                  .replace('StringLiteral', 'StringTypeAnnotation')
-              : 'StringTypeAnnotation';
-            if (
-              memberType === 'NumberTypeAnnotation' ||
-              memberType === 'StringTypeAnnotation'
-            ) {
-              return wrapNullable(nullable, {
-                type: 'EnumDeclaration',
-                memberType: memberType,
-              });
-            } else {
-              throw new UnsupportedEnumDeclarationParserError(
-                hasteModuleName,
-                typeAnnotation,
-                memberType,
-                language,
-              );
-            }
-          }
-          throw new UnsupportedGenericParserError(
+          return translateDefault(
             hasteModuleName,
             typeAnnotation,
+            types,
+            nullable,
+            language,
             parser,
           );
         }

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -269,7 +269,6 @@ function translateTypeAnnotation(
             typeAnnotation,
             types,
             nullable,
-            language,
             parser,
           );
         }

--- a/packages/react-native-codegen/src/parsers/typescript/parser.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parser.js
@@ -13,6 +13,20 @@
 import type {Parser} from '../parser';
 
 class TypeScriptParser implements Parser {
+  getMaybeEnumMemberType(maybeEnumDeclaration: $FlowFixMe): string {
+    if (maybeEnumDeclaration.members[0].initializer) {
+      return maybeEnumDeclaration.members[0].initializer.type
+        .replace('NumericLiteral', 'NumberTypeAnnotation')
+        .replace('StringLiteral', 'StringTypeAnnotation');
+    }
+
+    return 'StringTypeAnnotation';
+  }
+
+  isEnumDeclaration(maybeEnumDeclaration: $FlowFixMe): boolean {
+    return maybeEnumDeclaration.type === 'TSEnumDeclaration';
+  }
+
   nameForGenericTypeAnnotation(typeAnnotation: $FlowFixMe): string {
     return typeAnnotation.typeName.name;
   }

--- a/packages/react-native-codegen/src/parsers/typescript/parser.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parser.js
@@ -10,6 +10,7 @@
 
 'use strict';
 
+import type {ParserType} from '../errors';
 import type {Parser} from '../parser';
 
 class TypeScriptParser implements Parser {
@@ -25,6 +26,10 @@ class TypeScriptParser implements Parser {
 
   isEnumDeclaration(maybeEnumDeclaration: $FlowFixMe): boolean {
     return maybeEnumDeclaration.type === 'TSEnumDeclaration';
+  }
+
+  language(): ParserType {
+    return 'TypeScript';
   }
 
   nameForGenericTypeAnnotation(typeAnnotation: $FlowFixMe): string {

--- a/packages/react-native-codegen/src/parsers/utils.js
+++ b/packages/react-native-codegen/src/parsers/utils.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow strict-local
+ * @flow strict
  * @format
  */
 


### PR DESCRIPTION
## Summary
 
This PR unifies the Flow and TS `default:` case from codegen `translateTypeAnnotation` function into a single function 
called `translateDefault` inside `parser-commons.js` as requested on https://github.com/facebook/react-native/issues/34872. 
 

## Changelog
 

[Internal] [Changed] - Unify codegen Flow and TS default case from translateTypeAnnotation

## Test Plan

Run `yarn jest react-native-codegen` and ensure CI is green
 
![image](https://user-images.githubusercontent.com/11707729/197931439-a0f0f7cd-eee7-4908-a7f1-856b40954178.png)

