### PR TITLE
Back out "Add enum example to Android/iOS rn-tester TurboModule"

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -30,7 +30,6 @@ flow/
 
 [options]
 emoji=true
-enums=true
 
 exact_by_default=true
 exact_empty_objects=true

--- a/.flowconfig.android
+++ b/.flowconfig.android
@@ -30,7 +30,6 @@ flow/
 
 [options]
 emoji=true
-enums=true
 
 exact_by_default=true
 exact_empty_objects=true

--- a/BUCK
+++ b/BUCK
@@ -743,7 +743,6 @@ rn_library(
         "//xplat/js:node_modules__anser",
         "//xplat/js:node_modules__base64_19js",
         "//xplat/js:node_modules__event_19target_19shim",
-        "//xplat/js:node_modules__flow_19enums_19runtime",
         "//xplat/js:node_modules__invariant",
         "//xplat/js:node_modules__memoize_19one",
         "//xplat/js:node_modules__nullthrows",

--- a/Libraries/TurboModule/samples/NativeSampleTurboModule.js
+++ b/Libraries/TurboModule/samples/NativeSampleTurboModule.js
@@ -13,11 +13,6 @@ import type {RootTag, TurboModule} from '../RCTExport';
 
 import * as TurboModuleRegistry from '../TurboModuleRegistry';
 
-export enum EnumInt {
-  A = 23,
-  B = 42,
-}
-
 export interface Spec extends TurboModule {
   // Exported methods.
   +getConstants: () => {|
@@ -27,7 +22,6 @@ export interface Spec extends TurboModule {
   |};
   +voidFunc: () => void;
   +getBool: (arg: boolean) => boolean;
-  +getEnum?: (arg: EnumInt) => EnumInt;
   +getNumber: (arg: number) => number;
   +getString: (arg: string) => string;
   +getArray: (arg: Array<any>) => Array<any>;

--- a/ReactCommon/react/nativemodule/samples/ReactCommon/NativeSampleTurboCxxModuleSpecJSI.cpp
+++ b/ReactCommon/react/nativemodule/samples/ReactCommon/NativeSampleTurboCxxModuleSpecJSI.cpp
@@ -31,16 +31,6 @@ static jsi::Value __hostFunction_NativeSampleTurboCxxModuleSpecJSI_getBool(
           ->getBool(rt, args[0].getBool()));
 }
 
-static jsi::Value __hostFunction_NativeSampleTurboCxxModuleSpecJSI_getEnum(
-    jsi::Runtime &rt,
-    TurboModule &turboModule,
-    const jsi::Value *args,
-    size_t count) {
-  return jsi::Value(
-      static_cast<NativeSampleTurboCxxModuleSpecJSI *>(&turboModule)
-          ->getEnum(rt, args[0].getNumber()));
-}
-
 static jsi::Value __hostFunction_NativeSampleTurboCxxModuleSpecJSI_getNumber(
     jsi::Runtime &rt,
     TurboModule &turboModule,
@@ -129,8 +119,6 @@ NativeSampleTurboCxxModuleSpecJSI::NativeSampleTurboCxxModuleSpecJSI(
       0, __hostFunction_NativeSampleTurboCxxModuleSpecJSI_voidFunc};
   methodMap_["getBool"] = MethodMetadata{
       1, __hostFunction_NativeSampleTurboCxxModuleSpecJSI_getBool};
-  methodMap_["getEnum"] = MethodMetadata{
-      1, __hostFunction_NativeSampleTurboCxxModuleSpecJSI_getEnum};
   methodMap_["getNumber"] = MethodMetadata{
       1, __hostFunction_NativeSampleTurboCxxModuleSpecJSI_getNumber};
   methodMap_["getString"] = MethodMetadata{

--- a/ReactCommon/react/nativemodule/samples/ReactCommon/NativeSampleTurboCxxModuleSpecJSI.h
+++ b/ReactCommon/react/nativemodule/samples/ReactCommon/NativeSampleTurboCxxModuleSpecJSI.h
@@ -23,7 +23,6 @@ class JSI_EXPORT NativeSampleTurboCxxModuleSpecJSI : public TurboModule {
  public:
   virtual void voidFunc(jsi::Runtime &rt) = 0;
   virtual bool getBool(jsi::Runtime &rt, bool arg) = 0;
-  virtual double getEnum(jsi::Runtime &rt, double arg) = 0;
   virtual double getNumber(jsi::Runtime &rt, double arg) = 0;
   virtual jsi::String getString(jsi::Runtime &rt, const jsi::String &arg) = 0;
   virtual jsi::Array getArray(jsi::Runtime &rt, const jsi::Array &arg) = 0;

--- a/ReactCommon/react/nativemodule/samples/ReactCommon/SampleTurboCxxModule.cpp
+++ b/ReactCommon/react/nativemodule/samples/ReactCommon/SampleTurboCxxModule.cpp
@@ -26,10 +26,6 @@ bool SampleTurboCxxModule::getBool(jsi::Runtime &rt, bool arg) {
   return arg;
 }
 
-double SampleTurboCxxModule::getEnum(jsi::Runtime &rt, double arg) {
-  return arg;
-}
-
 double SampleTurboCxxModule::getNumber(jsi::Runtime &rt, double arg) {
   return arg;
 }

--- a/ReactCommon/react/nativemodule/samples/ReactCommon/SampleTurboCxxModule.h
+++ b/ReactCommon/react/nativemodule/samples/ReactCommon/SampleTurboCxxModule.h
@@ -25,7 +25,6 @@ class SampleTurboCxxModule : public NativeSampleTurboCxxModuleSpecJSI {
 
   void voidFunc(jsi::Runtime &rt) override;
   bool getBool(jsi::Runtime &rt, bool arg) override;
-  double getEnum(jsi::Runtime &rt, double arg) override;
   double getNumber(jsi::Runtime &rt, double arg) override;
   jsi::String getString(jsi::Runtime &rt, const jsi::String &arg) override;
   jsi::Array getArray(jsi::Runtime &rt, const jsi::Array &arg) override;

--- a/ReactCommon/react/nativemodule/samples/platform/android/NativeSampleTurboModuleSpec.java
+++ b/ReactCommon/react/nativemodule/samples/platform/android/NativeSampleTurboModuleSpec.java
@@ -66,9 +66,6 @@ public abstract class NativeSampleTurboModuleSpec extends ReactContextBaseJavaMo
   @ReactMethod(isBlockingSynchronousMethod = true)
   public abstract boolean getBool(boolean arg);
 
-  @ReactMethod(isBlockingSynchronousMethod = true)
-  public abstract double getEnum(double arg);
-
   protected abstract Map<String, Object> getTypedExportedConstants();
 
   @Override

--- a/ReactCommon/react/nativemodule/samples/platform/android/ReactCommon/SampleTurboModuleSpec.cpp
+++ b/ReactCommon/react/nativemodule/samples/platform/android/ReactCommon/SampleTurboModuleSpec.cpp
@@ -37,18 +37,6 @@ __hostFunction_NativeSampleTurboModuleSpecJSI_getBool(
 }
 
 static facebook::jsi::Value
-__hostFunction_NativeSampleTurboModuleSpecJSI_getEnum(
-    facebook::jsi::Runtime &rt,
-    TurboModule &turboModule,
-    const facebook::jsi::Value *args,
-    size_t count) {
-  static jmethodID cachedMethodId = nullptr;
-  return static_cast<JavaTurboModule &>(turboModule)
-      .invokeJavaMethod(
-          rt, NumberKind, "getEnum", "(D)D", args, count, cachedMethodId);
-}
-
-static facebook::jsi::Value
 __hostFunction_NativeSampleTurboModuleSpecJSI_getNumber(
     facebook::jsi::Runtime &rt,
     TurboModule &turboModule,
@@ -206,9 +194,6 @@ NativeSampleTurboModuleSpecJSI::NativeSampleTurboModuleSpecJSI(
 
   methodMap_["getBool"] =
       MethodMetadata{1, __hostFunction_NativeSampleTurboModuleSpecJSI_getBool};
-
-  methodMap_["getEnum"] =
-      MethodMetadata{1, __hostFunction_NativeSampleTurboModuleSpecJSI_getEnum};
 
   methodMap_["getNumber"] = MethodMetadata{
       1, __hostFunction_NativeSampleTurboModuleSpecJSI_getNumber};

--- a/ReactCommon/react/nativemodule/samples/platform/android/SampleTurboModule.java
+++ b/ReactCommon/react/nativemodule/samples/platform/android/SampleTurboModule.java
@@ -48,14 +48,6 @@ public class SampleTurboModule extends NativeSampleTurboModuleSpec {
     return arg;
   }
 
-  @DoNotStrip
-  @SuppressWarnings("unused")
-  @Override
-  public double getEnum(double arg) {
-    log("getEnum", arg, arg);
-    return arg;
-  }
-
   @Override
   protected Map<String, Object> getTypedExportedConstants() {
     Map<String, Object> result = new HashMap<>();

--- a/ReactCommon/react/nativemodule/samples/platform/ios/RCTNativeSampleTurboModuleSpec.h
+++ b/ReactCommon/react/nativemodule/samples/platform/ios/RCTNativeSampleTurboModuleSpec.h
@@ -22,7 +22,6 @@
 
 - (void)voidFunc;
 - (NSNumber *)getBool:(BOOL)arg;
-- (NSNumber *)getEnum:(double)arg;
 - (NSNumber *)getNumber:(double)arg;
 - (NSString *)getString:(NSString *)arg;
 - (NSArray<id<NSObject>> *)getArray:(NSArray *)arg;

--- a/ReactCommon/react/nativemodule/samples/platform/ios/RCTNativeSampleTurboModuleSpec.mm
+++ b/ReactCommon/react/nativemodule/samples/platform/ios/RCTNativeSampleTurboModuleSpec.mm
@@ -30,16 +30,6 @@ static facebook::jsi::Value __hostFunction_NativeSampleTurboModuleSpecJSI_getBoo
       .invokeObjCMethod(rt, BooleanKind, "getBool", @selector(getBool:), args, count);
 }
 
-static facebook::jsi::Value __hostFunction_NativeSampleTurboModuleSpecJSI_getEnum(
-    facebook::jsi::Runtime &rt,
-    TurboModule &turboModule,
-    const facebook::jsi::Value *args,
-    size_t count)
-{
-  return static_cast<ObjCTurboModule &>(turboModule)
-      .invokeObjCMethod(rt, NumberKind, "getEnum", @selector(getEnum:), args, count);
-}
-
 static facebook::jsi::Value __hostFunction_NativeSampleTurboModuleSpecJSI_getNumber(
     facebook::jsi::Runtime &rt,
     TurboModule &turboModule,
@@ -146,7 +136,6 @@ NativeSampleTurboModuleSpecJSI::NativeSampleTurboModuleSpecJSI(const ObjCTurboMo
 {
   methodMap_["voidFunc"] = MethodMetadata{0, __hostFunction_NativeSampleTurboModuleSpecJSI_voidFunc};
   methodMap_["getBool"] = MethodMetadata{1, __hostFunction_NativeSampleTurboModuleSpecJSI_getBool};
-  methodMap_["getEnum"] = MethodMetadata{1, __hostFunction_NativeSampleTurboModuleSpecJSI_getEnum};
   methodMap_["getNumber"] = MethodMetadata{1, __hostFunction_NativeSampleTurboModuleSpecJSI_getNumber};
   methodMap_["getString"] = MethodMetadata{1, __hostFunction_NativeSampleTurboModuleSpecJSI_getString};
   methodMap_["getArray"] = MethodMetadata{1, __hostFunction_NativeSampleTurboModuleSpecJSI_getArray};

--- a/ReactCommon/react/nativemodule/samples/platform/ios/RCTSampleTurboModule.mm
+++ b/ReactCommon/react/nativemodule/samples/platform/ios/RCTSampleTurboModule.mm
@@ -74,11 +74,6 @@ RCT_EXPORT_SYNCHRONOUS_TYPED_METHOD(NSNumber *, getBool : (BOOL)arg)
   return @(arg);
 }
 
-RCT_EXPORT_SYNCHRONOUS_TYPED_METHOD(NSNumber *, getEnum : (double)arg)
-{
-  return @(arg);
-}
-
 RCT_EXPORT_SYNCHRONOUS_TYPED_METHOD(NSNumber *, getNumber : (double)arg)
 {
   return @(arg);

--- a/ReactCommon/react/nativemodule/samples/platform/ios/SampleTurboCxxModuleLegacyImpl.cpp
+++ b/ReactCommon/react/nativemodule/samples/platform/ios/SampleTurboCxxModuleLegacyImpl.cpp
@@ -40,12 +40,6 @@ std::vector<CxxModule::Method> SampleTurboCxxModuleLegacyImpl::getMethods() {
           },
           CxxModule::SyncTag),
       CxxModule::Method(
-          "getEnum",
-          [this](folly::dynamic args) {
-            return getEnum(xplat::jsArgAsDouble(args, 0));
-          },
-          CxxModule::SyncTag),
-      CxxModule::Method(
           "getNumber",
           [this](folly::dynamic args) {
             return getNumber(xplat::jsArgAsDouble(args, 0));
@@ -117,10 +111,6 @@ void SampleTurboCxxModuleLegacyImpl::voidFunc() {
 }
 
 bool SampleTurboCxxModuleLegacyImpl::getBool(bool arg) {
-  return arg;
-}
-
-double SampleTurboCxxModuleLegacyImpl::getEnum(double arg) {
   return arg;
 }
 

--- a/ReactCommon/react/nativemodule/samples/platform/ios/SampleTurboCxxModuleLegacyImpl.h
+++ b/ReactCommon/react/nativemodule/samples/platform/ios/SampleTurboCxxModuleLegacyImpl.h
@@ -27,7 +27,6 @@ class SampleTurboCxxModuleLegacyImpl
   // API
   void voidFunc();
   bool getBool(bool arg);
-  double getEnum(double arg);
   double getNumber(double arg);
   std::string getString(const std::string &arg);
   folly::dynamic getArray(const folly::dynamic &arg);

--- a/package.json
+++ b/package.json
@@ -119,7 +119,6 @@
     "anser": "^1.4.9",
     "base64-js": "^1.1.2",
     "event-target-shim": "^5.0.1",
-    "flow-enums-runtime": "^0.0.6",
     "invariant": "^2.2.4",
     "jest-environment-node": "^29.2.1",
     "jsc-android": "^250230.2.1",

--- a/packages/rn-tester/js/examples/TurboModule/SampleTurboModuleExample.js
+++ b/packages/rn-tester/js/examples/TurboModule/SampleTurboModuleExample.js
@@ -9,7 +9,6 @@
  */
 
 import NativeSampleTurboModule from 'react-native/Libraries/TurboModule/samples/NativeSampleTurboModule';
-import {EnumInt} from 'react-native/Libraries/TurboModule/samples/NativeSampleTurboModule';
 import type {RootTag} from 'react-native/Libraries/ReactNative/RootTag';
 import {
   StyleSheet,
@@ -58,10 +57,6 @@ class SampleTurboModuleExample extends React.Component<{||}, State> {
     getConstants: () => NativeSampleTurboModule.getConstants(),
     voidFunc: () => NativeSampleTurboModule.voidFunc(),
     getBool: () => NativeSampleTurboModule.getBool(true),
-    getEnum: () =>
-      NativeSampleTurboModule.getEnum
-        ? NativeSampleTurboModule.getEnum(EnumInt.A)
-        : null,
     getNumber: () => NativeSampleTurboModule.getNumber(99.95),
     getString: () => NativeSampleTurboModule.getString('Hello'),
     getArray: () =>
@@ -85,7 +80,6 @@ class SampleTurboModuleExample extends React.Component<{||}, State> {
       | 'callback'
       | 'getArray'
       | 'getBool'
-      | 'getEnum'
       | 'getConstants'
       | 'getNumber'
       | 'getObject'
@@ -126,7 +120,6 @@ class SampleTurboModuleExample extends React.Component<{||}, State> {
       | 'callback'
       | 'getArray'
       | 'getBool'
-      | 'getEnum'
       | 'getConstants'
       | 'getNumber'
       | 'getObject'

--- a/yarn.lock
+++ b/yarn.lock
@@ -4909,11 +4909,6 @@ flow-bin@^0.190.1:
   resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.190.1.tgz#59ccbc9aaa2515fe32acc66117a05e7ef6a11061"
   integrity sha512-5c9/6eEkMTTfdNuK2WwssrKfsUXKMUXlZVJZnrlWiqJpDSVc70/Smwyi9sXict9k/oq0f+Mo5wVH0d7peBYREg==
 
-flow-enums-runtime@^0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/flow-enums-runtime/-/flow-enums-runtime-0.0.6.tgz#5bb0cd1b0a3e471330f4d109039b7eba5cb3e787"
-  integrity sha512-3PYnM29RFXwvAN6Pc/scUfkI7RwhQ/xqyLUyPNlXUp9S40zI8nup9tUSrTLSVnWGBN38FNiGWbwZOB6uR4OGdw==
-
 flow-parser@0.*, flow-parser@^0.185.0:
   version "0.185.0"
   resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.185.0.tgz#56bde60805bad19b2934ebfc50c9485e5c5424f9"


### PR DESCRIPTION
Summary:
Changelog:
[General][Fixed] - Back out "Add enum example to Android/iOS rn-tester TurboModule"

This broke the rn-tester adding due to an invalid flow-enum setup. Needs further investigation

Differential Revision: D40714320

