### PR TITLE
Sets the namespace via Gradle and not via AndroidManifest

### DIFF
--- a/packages/rn-tester/android/app/build.gradle
+++ b/packages/rn-tester/android/app/build.gradle
@@ -88,6 +88,7 @@ def reactNativeArchitectures() {
 android {
     buildToolsVersion = "31.0.0"
     compileSdkVersion 31
+    namespace "com.facebook.react.uiapp"
 
     // Used to override the NDK path/version on internal CI or by allowing
     // users to customize the NDK path/version from their root project (e.g. for M1 support)

--- a/packages/rn-tester/android/app/src/main/AndroidManifest.xml
+++ b/packages/rn-tester/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest
-  xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.facebook.react.uiapp">
+  xmlns:android="http://schemas.android.com/apk/res/android">
 
   <uses-feature
     android:name="android.software.leanback"

--- a/template/android/app/build.gradle
+++ b/template/android/app/build.gradle
@@ -93,6 +93,7 @@ android {
 
     compileSdkVersion rootProject.ext.compileSdkVersion
 
+    namespace "com.helloworld"
     defaultConfig {
         applicationId "com.helloworld"
         minSdkVersion rootProject.ext.minSdkVersion

--- a/template/android/app/src/main/AndroidManifest.xml
+++ b/template/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.helloworld">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
 


### PR DESCRIPTION
Summary:
Currently the build on console is firing this warning:
```
> Task :app:processDebugMainManifest
package="com.androidtemplateproject" found in source AndroidManifest.xml: /tmp/AndroidTemplateProject/android/app/src/main/AndroidManifest.xml.
Setting the namespace via a source AndroidManifest.xml's package attribute is deprecated.
Please instead set the namespace (or testNamespace) in the module's build.gradle file, as described here: https://developer.android.com/studio/build/configure-app-module#set-namespace
This migration can be done automatically using the AGP Upgrade Assistant, please refer to https://developer.android.com/studio/build/agp-upgrade-assistant for more information.
```

This diff fixes it so users won't see it anymore on 0.71

Changelog:
[Android] [Fixed] - Sets the namespace via Gradle and not via AndroidManifest

Differential Revision: D40724654

