### PR TITLE
Add Map / indexed object support for TypeScript parser

### DIFF
--- a/packages/react-native-codegen/src/parsers/flow/modules/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__test_fixtures__/fixtures.js
@@ -644,6 +644,8 @@ export interface Spec extends TurboModule {
   +getCallback: () => () => void;
   +getMixed: (arg: mixed) => mixed;
   +getEnums: (quality: Quality, resolution?: Resolution, floppy: Floppy, stringOptions: StringOptions) => string;
+  +getMap: (arg: {[a: string]: ?number}) => {[b: string]: ?number};
+  +getAnotherMap: (arg: {[string]: string}) => {[string]: string};
   +getUnion: (chooseInt: ChooseInt, chooseFloat: ChooseFloat, chooseObject: ChooseObject, chooseString: ChooseString) => ChooseObject;
 }
 

--- a/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap
@@ -123,6 +123,80 @@ exports[`RN Codegen Flow Parser can generate fixture CXX_ONLY_NATIVE_MODULE 1`] 
             }
           },
           {
+            'name': 'getMap',
+            'optional': false,
+            'typeAnnotation': {
+              'type': 'FunctionTypeAnnotation',
+              'returnTypeAnnotation': {
+                'type': 'ObjectTypeAnnotation',
+                'properties': [
+                  {
+                    'name': 'b',
+                    'optional': false,
+                    'typeAnnotation': {
+                      'type': 'GenericObjectTypeAnnotation'
+                    }
+                  }
+                ]
+              },
+              'params': [
+                {
+                  'name': 'arg',
+                  'optional': false,
+                  'typeAnnotation': {
+                    'type': 'ObjectTypeAnnotation',
+                    'properties': [
+                      {
+                        'name': 'a',
+                        'optional': false,
+                        'typeAnnotation': {
+                          'type': 'GenericObjectTypeAnnotation'
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            'name': 'getAnotherMap',
+            'optional': false,
+            'typeAnnotation': {
+              'type': 'FunctionTypeAnnotation',
+              'returnTypeAnnotation': {
+                'type': 'ObjectTypeAnnotation',
+                'properties': [
+                  {
+                    'name': 'key',
+                    'optional': false,
+                    'typeAnnotation': {
+                      'type': 'GenericObjectTypeAnnotation'
+                    }
+                  }
+                ]
+              },
+              'params': [
+                {
+                  'name': 'arg',
+                  'optional': false,
+                  'typeAnnotation': {
+                    'type': 'ObjectTypeAnnotation',
+                    'properties': [
+                      {
+                        'name': 'key',
+                        'optional': false,
+                        'typeAnnotation': {
+                          'type': 'GenericObjectTypeAnnotation'
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
             'name': 'getUnion',
             'optional': false,
             'typeAnnotation': {

--- a/packages/react-native-codegen/src/parsers/parsers-commons.js
+++ b/packages/react-native-codegen/src/parsers/parsers-commons.js
@@ -24,7 +24,9 @@ const {
   UnsupportedUnionTypeAnnotationParserError,
 } = require('./errors');
 import type {ParserType} from './errors';
-
+const {
+  UnsupportedObjectPropertyTypeAnnotationParserError,
+} = require('./errors');
 const invariant = require('invariant');
 
 function wrapModuleSchema(
@@ -155,6 +157,31 @@ function emitUnionTypeAnnotation(
   });
 }
 
+function getKeyName(
+  propertyOrIndex: $FlowFixMe,
+  hasteModuleName: string,
+  language: ParserType,
+): string {
+  switch (propertyOrIndex.type) {
+    case 'ObjectTypeProperty':
+    case 'TSPropertySignature':
+      return propertyOrIndex.key.name;
+    case 'ObjectTypeIndexer':
+      // flow index name is optional
+      return propertyOrIndex.id?.name ?? 'key';
+    case 'TSIndexSignature':
+      // TypeScript index name is mandatory
+      return propertyOrIndex.parameters[0].name;
+    default:
+      throw new UnsupportedObjectPropertyTypeAnnotationParserError(
+        hasteModuleName,
+        propertyOrIndex,
+        propertyOrIndex.type,
+        language,
+      );
+  }
+}
+
 module.exports = {
   wrapModuleSchema,
   unwrapNullable,
@@ -162,4 +189,5 @@ module.exports = {
   assertGenericTypeAnnotationHasExactlyOneTypeParameter,
   emitMixedTypeAnnotation,
   emitUnionTypeAnnotation,
+  getKeyName,
 };

--- a/packages/react-native-codegen/src/parsers/typescript/modules/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/__test_fixtures__/fixtures.js
@@ -661,6 +661,8 @@ export interface Spec extends TurboModule {
   readonly getCallback: () => () => void;
   readonly getMixed: (arg: unknown) => unknown;
   readonly getEnums: (quality: Quality, resolution?: Resolution, floppy: Floppy, stringOptions: StringOptions) => string;
+  readonly getMap: (arg: {[a: string]: number | null;}) => {[b: string]: number | null;};
+  readonly getAnotherMap: (arg: {[key: string]: string}) => {[key: string]: string};
   readonly getUnion: (chooseInt: ChooseInt, chooseFloat: ChooseFloat, chooseObject: ChooseObject, chooseString: ChooseString) => ChooseObject;
 }
 

--- a/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/__snapshots__/typescript-module-parser-snapshot-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/__snapshots__/typescript-module-parser-snapshot-test.js.snap
@@ -121,6 +121,80 @@ exports[`RN Codegen TypeScript Parser can generate fixture CXX_ONLY_NATIVE_MODUL
             }
           },
           {
+            'name': 'getMap',
+            'optional': false,
+            'typeAnnotation': {
+              'type': 'FunctionTypeAnnotation',
+              'returnTypeAnnotation': {
+                'type': 'ObjectTypeAnnotation',
+                'properties': [
+                  {
+                    'name': 'b',
+                    'optional': false,
+                    'typeAnnotation': {
+                      'type': 'GenericObjectTypeAnnotation'
+                    }
+                  }
+                ]
+              },
+              'params': [
+                {
+                  'name': 'arg',
+                  'optional': false,
+                  'typeAnnotation': {
+                    'type': 'ObjectTypeAnnotation',
+                    'properties': [
+                      {
+                        'name': 'a',
+                        'optional': false,
+                        'typeAnnotation': {
+                          'type': 'GenericObjectTypeAnnotation'
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            'name': 'getAnotherMap',
+            'optional': false,
+            'typeAnnotation': {
+              'type': 'FunctionTypeAnnotation',
+              'returnTypeAnnotation': {
+                'type': 'ObjectTypeAnnotation',
+                'properties': [
+                  {
+                    'name': 'key',
+                    'optional': false,
+                    'typeAnnotation': {
+                      'type': 'GenericObjectTypeAnnotation'
+                    }
+                  }
+                ]
+              },
+              'params': [
+                {
+                  'name': 'arg',
+                  'optional': false,
+                  'typeAnnotation': {
+                    'type': 'ObjectTypeAnnotation',
+                    'properties': [
+                      {
+                        'name': 'key',
+                        'optional': false,
+                        'typeAnnotation': {
+                          'type': 'GenericObjectTypeAnnotation'
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
             'name': 'getUnion',
             'optional': false,
             'typeAnnotation': {


### PR DESCRIPTION
Summary:
Changelog:
[General][Fixed] [react-native-codegen] react-native-codegen : Add Map / indexed object support for TypeScript parser

In flow we can expose Maps via the following syntax in TM specs

`
+getMap: (arg: {[key: string]: ?number}) => {[key: string]: ?number};
`

In TypeScript writing the same spec:

`
readonly getMap: (arg: { [key: string]: number | null; }) => { [key: string]: number | null; };
`

leads to an exception the TypeScript code-gen parser

```UnsupportedObjectPropertyTypeAnnotationParserError: Module NativeTurboModuleCxx: 'ObjectTypeAnnotation' cannot contain 'TSIndexSignature'.
    at react-native-github/packages/react-native-codegen/src/parsers/typescript/modules/index.js:309:23```

This change fixes the TypeScript parser

Reviewed By: cipolleschi

Differential Revision: D40753368

