### PR TITLE
Do not import/use the deprecated ReactFlipperPlugin

### DIFF
--- a/template/android/app/src/debug/java/com/helloworld/ReactNativeFlipper.java
+++ b/template/android/app/src/debug/java/com/helloworld/ReactNativeFlipper.java
@@ -17,7 +17,6 @@ import com.facebook.flipper.plugins.inspector.DescriptorMapping;
 import com.facebook.flipper.plugins.inspector.InspectorFlipperPlugin;
 import com.facebook.flipper.plugins.network.FlipperOkhttpInterceptor;
 import com.facebook.flipper.plugins.network.NetworkFlipperPlugin;
-import com.facebook.flipper.plugins.react.ReactFlipperPlugin;
 import com.facebook.flipper.plugins.sharedpreferences.SharedPreferencesFlipperPlugin;
 import com.facebook.react.ReactInstanceEventListener;
 import com.facebook.react.ReactInstanceManager;
@@ -35,7 +34,6 @@ public class ReactNativeFlipper {
       final FlipperClient client = AndroidFlipperClient.getInstance(context);
 
       client.addPlugin(new InspectorFlipperPlugin(context, DescriptorMapping.withDefaults()));
-      client.addPlugin(new ReactFlipperPlugin());
       client.addPlugin(new DatabasesFlipperPlugin(context));
       client.addPlugin(new SharedPreferencesFlipperPlugin(context));
       client.addPlugin(CrashReporterPlugin.getInstance());


### PR DESCRIPTION
Summary:
I'm removing the ReactFlipperPlugin from the new app template.
That plugin is effectively empty and is a stub + is deprecated
so is generating a warning for all the users.

Changelog:
[Android] [Changed] - Do not import/use the deprecated ReactFlipperPlugin

Reviewed By: cipolleschi

Differential Revision: D40751984

