### PR TITLE
Bump AGP to 7.3.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,7 @@ buildscript {
     gradlePluginPortal()
   }
   dependencies {
-    classpath("com.android.tools.build:gradle:7.3.0")
+    classpath("com.android.tools.build:gradle:7.3.1")
     classpath("de.undercouch:gradle-download-task:5.0.1")
   }
 }

--- a/packages/react-native-gradle-plugin/build.gradle.kts
+++ b/packages/react-native-gradle-plugin/build.gradle.kts
@@ -33,7 +33,7 @@ group = "com.facebook.react"
 
 dependencies {
   implementation(gradleApi())
-  implementation("com.android.tools.build:gradle:7.3.0")
+  implementation("com.android.tools.build:gradle:7.3.1")
   implementation("com.google.code.gson:gson:2.8.9")
   implementation("com.google.guava:guava:31.0.1-jre")
   implementation("com.squareup:javapoet:1.13.0")

--- a/template/android/build.gradle
+++ b/template/android/build.gradle
@@ -15,7 +15,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:7.3.0")
+        classpath("com.android.tools.build:gradle:7.3.1")
         classpath("com.facebook.react:react-native-gradle-plugin")
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
Summary:
That's just a minor bump of AGP before the branch cut.

Changelog:
[Android] [Changed] - Bump AGP to 7.3.1

Reviewed By: cipolleschi

Differential Revision: D40752006

