### PR TITLE
RNGP - Do not set GENERATED_SRC_DIR and REACT_ANDROID_BUILD_DIR

### DIFF
--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/NdkConfiguratorUtils.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/NdkConfiguratorUtils.kt
@@ -39,21 +39,12 @@ internal object NdkConfiguratorUtils {
         // Parameters should be provided in an additive manner (do not override what
         // the user provided, but allow for sensible defaults).
         val cmakeArgs = ext.defaultConfig.externalNativeBuild.cmake.arguments
-        if ("-DGENERATED_SRC_DIR" !in cmakeArgs) {
-          cmakeArgs.add("-DGENERATED_SRC_DIR=${File(project.buildDir, "generated/source")}")
-        }
         if ("-DPROJECT_BUILD_DIR" !in cmakeArgs) {
           cmakeArgs.add("-DPROJECT_BUILD_DIR=${project.buildDir}")
         }
         if ("-DREACT_ANDROID_DIR" !in cmakeArgs) {
           cmakeArgs.add(
               "-DREACT_ANDROID_DIR=${extension.reactNativeDir.file("ReactAndroid").get().asFile}")
-        }
-        if ("-DREACT_ANDROID_BUILD_DIR" !in cmakeArgs) {
-          cmakeArgs.add(
-              "-DREACT_ANDROID_BUILD_DIR=${
-              extension.reactNativeDir.file("ReactAndroid/build").get().asFile
-            }")
         }
         if ("-DANDROID_STL" !in cmakeArgs) {
           cmakeArgs.add("-DANDROID_STL=c++_shared")


### PR DESCRIPTION
Summary:
Those CMake variables are effectively unused now. They're raising a warning on CMake builds
of templates + let's not expose them as we haven't released RNGP yet, before libraries
or other tools start relying on them.

Changelog:
[Internal] [Changed] - RNGP - Do not set GENERATED_SRC_DIR and REACT_ANDROID_BUILD_DIR

Reviewed By: cipolleschi

Differential Revision: D40751998

