### PR TITLE
fix detection of android emulator

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/AndroidInfoHelpers.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/AndroidInfoHelpers.java
@@ -32,7 +32,7 @@ public class AndroidInfoHelpers {
   }
 
   private static boolean isRunningOnStockEmulator() {
-    return Build.FINGERPRINT.contains("generic");
+    return Build.FINGERPRINT.contains("generic") || Build.FINGERPRINT.startsWith("google/sdk_gphone");
   }
 
   public static String getServerHost(Integer port) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

at some point, the `Build.FINGERPRINT` of the emulator has changed and no longer includes `generic` as an option.

It apparently now, on all platforms, includes `google/sdk_gphone` at the beginning. Older emulators may still include `generic` in the `Build.FINGERPRINT` so we should maintain that check too.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[Android] [Fixed] - Fix android emulator detection for packager host

## Test Plan

When running on a modern emulator, ensure that the packager attempts to load from `10.0.2.2`.
