### PR TITLE
Consume Hermes from Maven in release

### DIFF
--- a/sdks/hermes-engine/hermes-engine.podspec
+++ b/sdks/hermes-engine/hermes-engine.podspec
@@ -46,7 +46,9 @@ elsif File.exists?(hermestag_file) && isInCI
   source[:git] = git
   source[:tag] = hermestag
 else
-  source[:http] = "https://github.com/facebook/react-native/releases/download/v#{version}/hermes-runtime-darwin-#{build_type.to_s}-v#{version}.tar.gz"
+  # Sample url from Maven:
+  # https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.71.0/react-native-artifacts-0.71.0-hermes-ios-debug.tar.gz
+  source[:http] = "https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/#{version}/react-native-artifacts-#{version}-hermes-ios-#{build_type.to_s}.tar.gz"
 end
 
 Pod::Spec.new do |spec|

--- a/sdks/hermes-engine/hermes-utils.rb
+++ b/sdks/hermes-engine/hermes-utils.rb
@@ -15,7 +15,6 @@ require 'rexml/document'
 # - version: the version of React Native that requires the Hermes tarball
 # Returns: the path to the downloaded Hermes tarball
 def download_nightly_hermes(react_native_path, version)
-    # TODO: convert hermes-ios to hermes-ios-debug
     params = "r=snapshots\&g=com.facebook.react\&a=react-native-artifacts\&c=hermes-ios-debug\&e=tar.gz\&v=#{version}-SNAPSHOT"
     tarball_url = "http://oss.sonatype.org/service/local/artifact/maven/redirect\?#{params}"
 


### PR DESCRIPTION
Summary:
This diff let release versions of React Native to consume the Hermes tarball from Maven.

It is already setup to download proper debug/release version

## Changelog
[iOS][Added] - Download Hermes from Maven while for -stables

Differential Revision: D40794707

