### PR TITLE
Local filenames with colon should be parsed correctly

### DIFF
--- a/React/Base/RCTConvert.m
+++ b/React/Base/RCTConvert.m
@@ -91,7 +91,7 @@ RCT_CUSTOM_CONVERTER(NSData *, NSData, [json dataUsingEncoding:NSUTF8StringEncod
     }
 
     // Check if it has a scheme
-    if ([path rangeOfString:@":"].location != NSNotFound) {
+    if ([path rangeOfString:@"://"].location != NSNotFound) {
       NSMutableCharacterSet *urlAllowedCharacterSet = [NSMutableCharacterSet new];
       [urlAllowedCharacterSet formUnionWithCharacterSet:[NSCharacterSet URLUserAllowedCharacterSet]];
       [urlAllowedCharacterSet formUnionWithCharacterSet:[NSCharacterSet URLPasswordAllowedCharacterSet]];

--- a/packages/rn-tester/RNTesterUnitTests/RCTConvert_NSURLTests.m
+++ b/packages/rn-tester/RNTesterUnitTests/RCTConvert_NSURLTests.m
@@ -45,6 +45,9 @@ TEST_BUNDLE_PATH(filePathWithEncodedSpaces, @"blah%20blah/hello.jsbundle", @"bla
 TEST_BUNDLE_PATH(imageAt2XPath, @"images/foo@2x.jpg", @"images/foo@2x.jpg")
 TEST_BUNDLE_PATH(imageFile, @"foo.jpg", @"foo.jpg")
 
+TEST_BUNDLE_PATH(imageFileWithSemicolon, @"folder/foo:bar-baz.jpg", @"folder/foo:bar-baz.jpg")
+TEST_URL(filePathWithSemicolon, @"/folder/foo:bar-baz.jpg", @"file:///folder/foo:bar-baz.jpg")
+
 // User documents
 TEST_PATH(
     documentsFolder,


### PR DESCRIPTION
Summary:

On RN Desktop, images can be copy/pasted into text inputs.
When copy/pasting local files w/ semi-colons in the filename (`/downloads/devices:pre-call-IMG_346C38284B2B-1.jpeg`), RN would throw this error.

![CleanShot 2022-10-28 at 11 13 36](https://user-images.githubusercontent.com/96719/198704618-e24a9362-e209-4aaf-ae0c-6098d1cb9371.jpg)

This was due to not having the correct asset loader because the local file path being parsed incorrectly.

To parse the url, we convert the string URI to a `NSURL` using a custom convertor fn.
The conversion was matching any `:` and assuming it was a network url scheme:
https://github.com/facebook/react-native/blob/main/React/Base/RCTConvert.m#L93-L107

When an image path with `:` in the name was passed to this, it was assuming it was a valid network url and not file path.

Because this is a local filepath, the image path needs to be a filesystem url. Since this was parsed as network url, it did not have the `file://` prefix and would not pass this check, causing the loader to throw.
https://github.com/facebook/react-native/blob/main/Libraries/Image/RCTImageLoader.mm#L220-L231

## Changelog

[iOS] [Added] -  Add support for parsing local files w/ `:` in filename

Reviewed By: christophpurrer

Differential Revision: D40729963