### PR TITLE
chore: Extract codegen case 'Float' into a single emitFloat function

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-primitives-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-primitives-test.js
@@ -14,6 +14,7 @@
 const {
   emitBoolean,
   emitDouble,
+  emitFloat,
   emitNumber,
   emitInt32,
   emitObject,
@@ -422,6 +423,32 @@ describe('emitObject', () => {
       };
 
       expect(result).toEqual(expected);
+    });
+  });
+
+  describe('emitFloat', () => {
+    describe('when nullable is true', () => {
+      it('returns nullable type annotation', () => {
+        const result = emitFloat(true);
+        const expected = {
+          type: 'NullableTypeAnnotation',
+          typeAnnotation: {
+            type: 'FloatTypeAnnotation',
+          },
+        };
+
+        expect(result).toEqual(expected);
+      });
+    });
+    describe('when nullable is false', () => {
+      it('returns non nullable type annotation', () => {
+        const result = emitFloat(false);
+        const expected = {
+          type: 'FloatTypeAnnotation',
+        };
+
+        expect(result).toEqual(expected);
+      });
     });
   });
 });

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -43,6 +43,7 @@ const {
 const {
   emitBoolean,
   emitDouble,
+  emitFloat,
   emitFunction,
   emitNumber,
   emitInt32,
@@ -242,9 +243,7 @@ function translateTypeAnnotation(
           return emitDouble(nullable);
         }
         case 'Float': {
-          return wrapNullable(nullable, {
-            type: 'FloatTypeAnnotation',
-          });
+          return emitFloat(nullable);
         }
         case 'UnsafeObject':
         case 'Object': {

--- a/packages/react-native-codegen/src/parsers/parsers-primitives.js
+++ b/packages/react-native-codegen/src/parsers/parsers-primitives.js
@@ -26,6 +26,7 @@ import type {
   NativeModulePromiseTypeAnnotation,
   StringTypeAnnotation,
   VoidTypeAnnotation,
+  NativeModuleFloatTypeAnnotation,
 } from '../CodegenSchema';
 import type {ParserType} from './errors';
 import type {TypeAliasResolutionStatus} from './utils';
@@ -171,9 +172,18 @@ function emitObject(
   });
 }
 
+function emitFloat(
+  nullable: boolean,
+): Nullable<NativeModuleFloatTypeAnnotation> {
+  return wrapNullable(nullable, {
+    type: 'FloatTypeAnnotation',
+  });
+}
+
 module.exports = {
   emitBoolean,
   emitDouble,
+  emitFloat,
   emitFunction,
   emitInt32,
   emitNumber,

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -46,6 +46,7 @@ const {
 const {
   emitBoolean,
   emitDouble,
+  emitFloat,
   emitFunction,
   emitNumber,
   emitInt32,
@@ -255,9 +256,7 @@ function translateTypeAnnotation(
           return emitDouble(nullable);
         }
         case 'Float': {
-          return wrapNullable(nullable, {
-            type: 'FloatTypeAnnotation',
-          });
+          return emitFloat(nullable);
         }
         case 'UnsafeObject':
         case 'Object': {


### PR DESCRIPTION
 ## Summary

This PR extracts the content of the codegen case `'Float'` into a single `emitFloat` function inside the `parsers-primitives.js` file and uses it in both Flow and TypeScript parsers as requested on https://github.com/facebook/react-native/issues/34872. This also adds unit tests to the new `emitFloat` function.

## Changelog
 

[Internal] [Changed]  - Extract the content of the case 'Float' into a single emitFloat function

## Test Plan

Run `yarn jest react-native-codegen` and ensure CI is green

![image](https://user-images.githubusercontent.com/11707729/198704932-202e2cd7-5b04-4009-b47e-b4999fee6c98.png)

