### PR TITLE
- Send to Logview and RedBox the correct JS stack trace for unhandled JS errors in Bridge

### DIFF
--- a/React/CxxBridge/RCTCxxBridge.mm
+++ b/React/CxxBridge/RCTCxxBridge.mm
@@ -1137,10 +1137,7 @@ struct RCTInstanceCallback : public InstanceCallback {
   // In state 3: do nothing.
 
   if (self->_valid && !self->_loading) {
-    if ([error userInfo][RCTJSRawStackTraceKey]) {
-      [self.redBox showErrorMessage:[error localizedDescription] withRawStack:[error userInfo][RCTJSRawStackTraceKey]];
-    }
-
+    [self showJsError:error onRedBox:self.redBox];
     RCTFatal(error);
 
     // RN will stop, but let the rest of the app keep going.
@@ -1171,13 +1168,18 @@ struct RCTInstanceCallback : public InstanceCallback {
     [[NSNotificationCenter defaultCenter] postNotificationName:RCTJavaScriptDidFailToLoadNotification
                                                         object:self->_parentBridge
                                                       userInfo:@{@"bridge" : self, @"error" : error}];
-
-    if ([error userInfo][RCTJSRawStackTraceKey]) {
-      [redBox showErrorMessage:[error localizedDescription] withRawStack:[error userInfo][RCTJSRawStackTraceKey]];
-    }
-
+    [self showJsError:error onRedBox:redBox];
     RCTFatal(error);
   });
+}
+
+- (void)showJsError:(NSError *)error onRedBox:(RCTRedBox *)redbox
+{
+  if ([error userInfo][RCTJSStackTraceKey]) {
+    [redbox showErrorMessage:[error localizedDescription] withStack:[error userInfo][RCTJSStackTraceKey]];
+  } else if ([error userInfo][RCTJSRawStackTraceKey]) {
+    [redbox showErrorMessage:[error localizedDescription] withRawStack:[error userInfo][RCTJSRawStackTraceKey]];
+  }
 }
 
 RCT_NOT_IMPLEMENTED(-(instancetype)initWithDelegate

--- a/React/CxxModule/JSErrorHandler2.h
+++ b/React/CxxModule/JSErrorHandler2.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <jsi/jsi.h>
+#import <optional>
+#import <string>
+#import <vector>
+
+namespace facebook {
+namespace react {
+
+struct JSStackFrame {
+  std::string fileName;
+  std::string methodName;
+  std::optional<int> lineNumber;
+  std::optional<int> columnNumber;
+};
+
+struct ParsedJSError {
+  std::vector<JSStackFrame> frames;
+  std::string message;
+  int exceptionId;
+  bool isFatal;
+};
+
+ParsedJSError
+parseJSErrorStack(const jsi::JSError &error, bool isFatal, bool isHermes);
+
+} // namespace react
+} // namespace facebook

--- a/React/CxxModule/JSErrorHandler2.mm
+++ b/React/CxxModule/JSErrorHandler2.mm
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "JSErrorHandler2.h"
+#import <regex>
+#import <sstream>
+
+namespace facebook::react {
+
+// TODO: (T136286213) Refactor JSErrorHandler in Bridgeless with this
+// and remove dependencies on MapBuffer from iOS.
+ParsedJSError parseJSErrorStack(const jsi::JSError &error, bool isFatal, bool isHermes)
+{
+  /**
+   * This parses the different stack traces and puts them into one format
+   * This borrows heavily from TraceKit (https://github.com/occ/TraceKit)
+   * This is the same regex from stacktrace-parser.js.
+   */
+  const std::regex REGEX_CHROME(
+      R"(^\s*at (?:(?:(?:Anonymous function)?|((?:\[object object\])?\S+(?: \[as \S+\])?)) )?\(?((?:file|http|https):.*?):(\d+)(?::(\d+))?\)?\s*$)");
+  const std::regex REGEX_GECKO(R"(^(?:\s*([^@]*)(?:\((.*?)\))?@)?(\S.*?):(\d+)(?::(\d+))?\s*$)");
+  const std::regex REGEX_NODE(
+      R"(^\s*at (?:((?:\[object object\])?\S+(?: \[as \S+\])?) )?\(?(.*?):(\d+)(?::(\d+))?\)?\s*$)");
+
+  // Capture groups for Hermes (from parseHermesStack.js):
+  // 1. function name
+  // 2. is this a native stack frame?
+  // 3. is this a bytecode address or a source location?
+  // 4. source URL (filename)
+  // 5. line number (1 based)
+  // 6. column number (1 based) or virtual offset (0 based)
+  const std::regex REGEX_HERMES(R"(^ {4}at (.+?)(?: \((native)\)?| \((address at )?(.*?):(\d+):(\d+)\))$)");
+
+  std::string line;
+  std::stringstream strStream(error.getStack());
+
+  std::vector<JSStackFrame> frames;
+
+  while (std::getline(strStream, line, '\n')) {
+    auto searchResults = std::smatch{};
+    if (isHermes) {
+      if (std::regex_search(line, searchResults, REGEX_HERMES)) {
+        std::string str2 = std::string(searchResults[2]);
+        if (str2.compare("native")) {
+          frames.push_back(JSStackFrame{
+              .fileName = std::string(searchResults[4]),
+              .methodName = std::string(searchResults[1]),
+              .lineNumber = std::stoi(searchResults[5]),
+              .columnNumber = std::stoi(searchResults[6])});
+        }
+      }
+    } else {
+      if (std::regex_search(line, searchResults, REGEX_GECKO)) {
+        frames.push_back(JSStackFrame{
+            .fileName = std::string(searchResults[3]),
+            .methodName = std::string(searchResults[1]),
+            .lineNumber = std::stoi(searchResults[4]),
+            .columnNumber = std::stoi(searchResults[5])});
+      } else if (
+          std::regex_search(line, searchResults, REGEX_CHROME) || std::regex_search(line, searchResults, REGEX_NODE)) {
+        frames.push_back(JSStackFrame{
+            .fileName = std::string(searchResults[2]),
+            .methodName = std::string(searchResults[1]),
+            .lineNumber = std::stoi(searchResults[3]),
+            .columnNumber = std::stoi(searchResults[4])});
+      } else {
+        continue;
+      }
+    }
+  }
+
+  return ParsedJSError{.frames = frames, .message = error.getMessage(), .exceptionId = 0, .isFatal = isFatal};
+}
+
+} // namespace facebook::react


### PR DESCRIPTION
Summary:
Changelog: [iOS][ErrorHandling] - Display RedBox with the correct JS stack trace for unhandled JS errors.

This feature is currently gated by `RCTGetParseUnhandledJSErrorStackNatively()`.

Differential Revision: D40772321

