### PR TITLE
Remove unused #import <UIKit/UIGestureRecognizerSubclass.h> import which breaks macOS

### DIFF
--- a/React/Fabric/RCTSurfaceTouchHandler.mm
+++ b/React/Fabric/RCTSurfaceTouchHandler.mm
@@ -10,7 +10,6 @@
 #import <React/RCTReactTaggedView.h>
 #import <React/RCTUtils.h>
 #import <React/RCTViewComponentView.h>
-#import <UIKit/UIGestureRecognizerSubclass.h>
 
 #import "RCTConversions.h"
 #import "RCTTouchableComponentViewProtocol.h"


### PR DESCRIPTION
Summary:
Changelog:
[macOS][Fixed] - Remove unused #import <UIKit/UIGestureRecognizerSubclass.h> import which breaks macOS

Differential Revision: D40797971

