### PR TITLE
Add enum example to Android/iOS rn-tester TurboModule

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,8 @@
+{
+  "presets": [
+    "module:metro-react-native-babel-preset"
+  ],
+  "plugins": [
+    "babel-plugin-transform-flow-enums"
+  ]
+}

--- a/.flowconfig
+++ b/.flowconfig
@@ -30,6 +30,7 @@ flow/
 
 [options]
 emoji=true
+enums=true
 
 exact_by_default=true
 

--- a/.flowconfig.android
+++ b/.flowconfig.android
@@ -30,6 +30,7 @@ flow/
 
 [options]
 emoji=true
+enums=true
 
 exact_by_default=true
 

--- a/BUCK
+++ b/BUCK
@@ -747,6 +747,7 @@ rn_library(
         "//xplat/js:node_modules__base64_19js",
         "//xplat/js:node_modules__deprecated_19react_19native_19prop_19types",
         "//xplat/js:node_modules__event_19target_19shim",
+        "//xplat/js:node_modules__flow_19enums_19runtime",
         "//xplat/js:node_modules__invariant",
         "//xplat/js:node_modules__memoize_19one",
         "//xplat/js:node_modules__nullthrows",

--- a/Libraries/TurboModule/samples/NativeSampleTurboModule.js
+++ b/Libraries/TurboModule/samples/NativeSampleTurboModule.js
@@ -13,6 +13,11 @@ import type {RootTag, TurboModule} from '../RCTExport';
 
 import * as TurboModuleRegistry from '../TurboModuleRegistry';
 
+export enum EnumInt {
+  A = 23,
+  B = 42,
+}
+
 export interface Spec extends TurboModule {
   // Exported methods.
   +getConstants: () => {|
@@ -22,6 +27,7 @@ export interface Spec extends TurboModule {
   |};
   +voidFunc: () => void;
   +getBool: (arg: boolean) => boolean;
+  +getEnum?: (arg: EnumInt) => EnumInt;
   +getNumber: (arg: number) => number;
   +getString: (arg: string) => string;
   +getArray: (arg: Array<any>) => Array<any>;

--- a/ReactCommon/react/nativemodule/samples/ReactCommon/NativeSampleTurboCxxModuleSpecJSI.cpp
+++ b/ReactCommon/react/nativemodule/samples/ReactCommon/NativeSampleTurboCxxModuleSpecJSI.cpp
@@ -31,6 +31,16 @@ static jsi::Value __hostFunction_NativeSampleTurboCxxModuleSpecJSI_getBool(
           ->getBool(rt, args[0].getBool()));
 }
 
+static jsi::Value __hostFunction_NativeSampleTurboCxxModuleSpecJSI_getEnum(
+    jsi::Runtime &rt,
+    TurboModule &turboModule,
+    const jsi::Value *args,
+    size_t count) {
+  return jsi::Value(
+      static_cast<NativeSampleTurboCxxModuleSpecJSI *>(&turboModule)
+          ->getEnum(rt, args[0].getNumber()));
+}
+
 static jsi::Value __hostFunction_NativeSampleTurboCxxModuleSpecJSI_getNumber(
     jsi::Runtime &rt,
     TurboModule &turboModule,
@@ -119,6 +129,8 @@ NativeSampleTurboCxxModuleSpecJSI::NativeSampleTurboCxxModuleSpecJSI(
       0, __hostFunction_NativeSampleTurboCxxModuleSpecJSI_voidFunc};
   methodMap_["getBool"] = MethodMetadata{
       1, __hostFunction_NativeSampleTurboCxxModuleSpecJSI_getBool};
+  methodMap_["getEnum"] = MethodMetadata{
+      1, __hostFunction_NativeSampleTurboCxxModuleSpecJSI_getEnum};
   methodMap_["getNumber"] = MethodMetadata{
       1, __hostFunction_NativeSampleTurboCxxModuleSpecJSI_getNumber};
   methodMap_["getString"] = MethodMetadata{

--- a/ReactCommon/react/nativemodule/samples/ReactCommon/NativeSampleTurboCxxModuleSpecJSI.h
+++ b/ReactCommon/react/nativemodule/samples/ReactCommon/NativeSampleTurboCxxModuleSpecJSI.h
@@ -23,6 +23,7 @@ class JSI_EXPORT NativeSampleTurboCxxModuleSpecJSI : public TurboModule {
  public:
   virtual void voidFunc(jsi::Runtime &rt) = 0;
   virtual bool getBool(jsi::Runtime &rt, bool arg) = 0;
+  virtual double getEnum(jsi::Runtime &rt, double arg) = 0;
   virtual double getNumber(jsi::Runtime &rt, double arg) = 0;
   virtual jsi::String getString(jsi::Runtime &rt, const jsi::String &arg) = 0;
   virtual jsi::Array getArray(jsi::Runtime &rt, const jsi::Array &arg) = 0;

--- a/ReactCommon/react/nativemodule/samples/ReactCommon/SampleTurboCxxModule.cpp
+++ b/ReactCommon/react/nativemodule/samples/ReactCommon/SampleTurboCxxModule.cpp
@@ -26,6 +26,10 @@ bool SampleTurboCxxModule::getBool(jsi::Runtime &rt, bool arg) {
   return arg;
 }
 
+double SampleTurboCxxModule::getEnum(jsi::Runtime &rt, double arg) {
+  return arg;
+}
+
 double SampleTurboCxxModule::getNumber(jsi::Runtime &rt, double arg) {
   return arg;
 }

--- a/ReactCommon/react/nativemodule/samples/ReactCommon/SampleTurboCxxModule.h
+++ b/ReactCommon/react/nativemodule/samples/ReactCommon/SampleTurboCxxModule.h
@@ -25,6 +25,7 @@ class SampleTurboCxxModule : public NativeSampleTurboCxxModuleSpecJSI {
 
   void voidFunc(jsi::Runtime &rt) override;
   bool getBool(jsi::Runtime &rt, bool arg) override;
+  double getEnum(jsi::Runtime &rt, double arg) override;
   double getNumber(jsi::Runtime &rt, double arg) override;
   jsi::String getString(jsi::Runtime &rt, const jsi::String &arg) override;
   jsi::Array getArray(jsi::Runtime &rt, const jsi::Array &arg) override;

--- a/ReactCommon/react/nativemodule/samples/platform/android/NativeSampleTurboModuleSpec.java
+++ b/ReactCommon/react/nativemodule/samples/platform/android/NativeSampleTurboModuleSpec.java
@@ -66,6 +66,9 @@ public abstract class NativeSampleTurboModuleSpec extends ReactContextBaseJavaMo
   @ReactMethod(isBlockingSynchronousMethod = true)
   public abstract boolean getBool(boolean arg);
 
+  @ReactMethod(isBlockingSynchronousMethod = true)
+  public abstract double getEnum(double arg);
+
   protected abstract Map<String, Object> getTypedExportedConstants();
 
   @Override

--- a/ReactCommon/react/nativemodule/samples/platform/android/ReactCommon/SampleTurboModuleSpec.cpp
+++ b/ReactCommon/react/nativemodule/samples/platform/android/ReactCommon/SampleTurboModuleSpec.cpp
@@ -37,6 +37,18 @@ __hostFunction_NativeSampleTurboModuleSpecJSI_getBool(
 }
 
 static facebook::jsi::Value
+__hostFunction_NativeSampleTurboModuleSpecJSI_getEnum(
+    facebook::jsi::Runtime &rt,
+    TurboModule &turboModule,
+    const facebook::jsi::Value *args,
+    size_t count) {
+  static jmethodID cachedMethodId = nullptr;
+  return static_cast<JavaTurboModule &>(turboModule)
+      .invokeJavaMethod(
+          rt, NumberKind, "getEnum", "(D)D", args, count, cachedMethodId);
+}
+
+static facebook::jsi::Value
 __hostFunction_NativeSampleTurboModuleSpecJSI_getNumber(
     facebook::jsi::Runtime &rt,
     TurboModule &turboModule,
@@ -194,6 +206,9 @@ NativeSampleTurboModuleSpecJSI::NativeSampleTurboModuleSpecJSI(
 
   methodMap_["getBool"] =
       MethodMetadata{1, __hostFunction_NativeSampleTurboModuleSpecJSI_getBool};
+
+  methodMap_["getEnum"] =
+      MethodMetadata{1, __hostFunction_NativeSampleTurboModuleSpecJSI_getEnum};
 
   methodMap_["getNumber"] = MethodMetadata{
       1, __hostFunction_NativeSampleTurboModuleSpecJSI_getNumber};

--- a/ReactCommon/react/nativemodule/samples/platform/android/SampleTurboModule.java
+++ b/ReactCommon/react/nativemodule/samples/platform/android/SampleTurboModule.java
@@ -48,6 +48,14 @@ public class SampleTurboModule extends NativeSampleTurboModuleSpec {
     return arg;
   }
 
+  @DoNotStrip
+  @SuppressWarnings("unused")
+  @Override
+  public double getEnum(double arg) {
+    log("getEnum", arg, arg);
+    return arg;
+  }
+
   @Override
   protected Map<String, Object> getTypedExportedConstants() {
     Map<String, Object> result = new HashMap<>();

--- a/ReactCommon/react/nativemodule/samples/platform/ios/RCTNativeSampleTurboModuleSpec.h
+++ b/ReactCommon/react/nativemodule/samples/platform/ios/RCTNativeSampleTurboModuleSpec.h
@@ -22,6 +22,7 @@
 
 - (void)voidFunc;
 - (NSNumber *)getBool:(BOOL)arg;
+- (NSNumber *)getEnum:(double)arg;
 - (NSNumber *)getNumber:(double)arg;
 - (NSString *)getString:(NSString *)arg;
 - (NSArray<id<NSObject>> *)getArray:(NSArray *)arg;

--- a/ReactCommon/react/nativemodule/samples/platform/ios/RCTNativeSampleTurboModuleSpec.mm
+++ b/ReactCommon/react/nativemodule/samples/platform/ios/RCTNativeSampleTurboModuleSpec.mm
@@ -30,6 +30,16 @@ static facebook::jsi::Value __hostFunction_NativeSampleTurboModuleSpecJSI_getBoo
       .invokeObjCMethod(rt, BooleanKind, "getBool", @selector(getBool:), args, count);
 }
 
+static facebook::jsi::Value __hostFunction_NativeSampleTurboModuleSpecJSI_getEnum(
+    facebook::jsi::Runtime &rt,
+    TurboModule &turboModule,
+    const facebook::jsi::Value *args,
+    size_t count)
+{
+  return static_cast<ObjCTurboModule &>(turboModule)
+      .invokeObjCMethod(rt, NumberKind, "getEnum", @selector(getEnum:), args, count);
+}
+
 static facebook::jsi::Value __hostFunction_NativeSampleTurboModuleSpecJSI_getNumber(
     facebook::jsi::Runtime &rt,
     TurboModule &turboModule,
@@ -136,6 +146,7 @@ NativeSampleTurboModuleSpecJSI::NativeSampleTurboModuleSpecJSI(const ObjCTurboMo
 {
   methodMap_["voidFunc"] = MethodMetadata{0, __hostFunction_NativeSampleTurboModuleSpecJSI_voidFunc};
   methodMap_["getBool"] = MethodMetadata{1, __hostFunction_NativeSampleTurboModuleSpecJSI_getBool};
+  methodMap_["getEnum"] = MethodMetadata{1, __hostFunction_NativeSampleTurboModuleSpecJSI_getEnum};
   methodMap_["getNumber"] = MethodMetadata{1, __hostFunction_NativeSampleTurboModuleSpecJSI_getNumber};
   methodMap_["getString"] = MethodMetadata{1, __hostFunction_NativeSampleTurboModuleSpecJSI_getString};
   methodMap_["getArray"] = MethodMetadata{1, __hostFunction_NativeSampleTurboModuleSpecJSI_getArray};

--- a/ReactCommon/react/nativemodule/samples/platform/ios/RCTSampleTurboModule.mm
+++ b/ReactCommon/react/nativemodule/samples/platform/ios/RCTSampleTurboModule.mm
@@ -74,6 +74,11 @@ RCT_EXPORT_SYNCHRONOUS_TYPED_METHOD(NSNumber *, getBool : (BOOL)arg)
   return @(arg);
 }
 
+RCT_EXPORT_SYNCHRONOUS_TYPED_METHOD(NSNumber *, getEnum : (double)arg)
+{
+  return @(arg);
+}
+
 RCT_EXPORT_SYNCHRONOUS_TYPED_METHOD(NSNumber *, getNumber : (double)arg)
 {
   return @(arg);

--- a/ReactCommon/react/nativemodule/samples/platform/ios/SampleTurboCxxModuleLegacyImpl.cpp
+++ b/ReactCommon/react/nativemodule/samples/platform/ios/SampleTurboCxxModuleLegacyImpl.cpp
@@ -40,6 +40,12 @@ std::vector<CxxModule::Method> SampleTurboCxxModuleLegacyImpl::getMethods() {
           },
           CxxModule::SyncTag),
       CxxModule::Method(
+          "getEnum",
+          [this](folly::dynamic args) {
+            return getEnum(xplat::jsArgAsDouble(args, 0));
+          },
+          CxxModule::SyncTag),
+      CxxModule::Method(
           "getNumber",
           [this](folly::dynamic args) {
             return getNumber(xplat::jsArgAsDouble(args, 0));
@@ -111,6 +117,10 @@ void SampleTurboCxxModuleLegacyImpl::voidFunc() {
 }
 
 bool SampleTurboCxxModuleLegacyImpl::getBool(bool arg) {
+  return arg;
+}
+
+double SampleTurboCxxModuleLegacyImpl::getEnum(double arg) {
   return arg;
 }
 

--- a/ReactCommon/react/nativemodule/samples/platform/ios/SampleTurboCxxModuleLegacyImpl.h
+++ b/ReactCommon/react/nativemodule/samples/platform/ios/SampleTurboCxxModuleLegacyImpl.h
@@ -27,6 +27,7 @@ class SampleTurboCxxModuleLegacyImpl
   // API
   void voidFunc();
   bool getBool(bool arg);
+  double getEnum(double arg);
   double getNumber(double arg);
   std::string getString(const std::string &arg);
   folly::dynamic getArray(const folly::dynamic &arg);

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "base64-js": "^1.1.2",
     "deprecated-react-native-prop-types": "^2.3.0",
     "event-target-shim": "^5.0.1",
+    "flow-enums-runtime": "^0.0.5",
     "invariant": "^2.2.4",
     "jest-environment-node": "^29.2.1",
     "jsc-android": "^250230.2.1",

--- a/packages/rn-tester/js/examples/TurboModule/SampleTurboModuleExample.js
+++ b/packages/rn-tester/js/examples/TurboModule/SampleTurboModuleExample.js
@@ -9,6 +9,7 @@
  */
 
 import NativeSampleTurboModule from 'react-native/Libraries/TurboModule/samples/NativeSampleTurboModule';
+import {EnumInt} from 'react-native/Libraries/TurboModule/samples/NativeSampleTurboModule';
 import type {RootTag} from 'react-native/Libraries/ReactNative/RootTag';
 import {
   StyleSheet,
@@ -57,6 +58,10 @@ class SampleTurboModuleExample extends React.Component<{||}, State> {
     getConstants: () => NativeSampleTurboModule.getConstants(),
     voidFunc: () => NativeSampleTurboModule.voidFunc(),
     getBool: () => NativeSampleTurboModule.getBool(true),
+    getEnum: () =>
+      NativeSampleTurboModule.getEnum
+        ? NativeSampleTurboModule.getEnum(EnumInt.A)
+        : null,
     getNumber: () => NativeSampleTurboModule.getNumber(99.95),
     getString: () => NativeSampleTurboModule.getString('Hello'),
     getArray: () =>
@@ -80,6 +85,7 @@ class SampleTurboModuleExample extends React.Component<{||}, State> {
       | 'callback'
       | 'getArray'
       | 'getBool'
+      | 'getEnum'
       | 'getConstants'
       | 'getNumber'
       | 'getObject'
@@ -120,6 +126,7 @@ class SampleTurboModuleExample extends React.Component<{||}, State> {
       | 'callback'
       | 'getArray'
       | 'getBool'
+      | 'getEnum'
       | 'getConstants'
       | 'getNumber'
       | 'getObject'

--- a/packages/rn-tester/package.json
+++ b/packages/rn-tester/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "invariant": "^2.2.4",
+    "flow-enums-runtime": "^0.0.5",
     "nullthrows": "^1.1.1"
   },
   "peerDependencies": {
@@ -29,6 +30,8 @@
   },
   "devDependencies": {
     "connect": "^3.6.5",
+    "babel-plugin-transform-flow-enums":"^0.0.1",
+    "jscodeshift": "^0.13.1",
     "ws": "^6.2.2"
   },
   "codegenConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -508,7 +508,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
 
-"@babel/plugin-syntax-flow@^7.0.0", "@babel/plugin-syntax-flow@^7.18.6", "@babel/plugin-syntax-flow@^7.2.0":
+"@babel/plugin-syntax-flow@^7.0.0", "@babel/plugin-syntax-flow@^7.12.1", "@babel/plugin-syntax-flow@^7.18.6", "@babel/plugin-syntax-flow@^7.2.0":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.18.6.tgz#774d825256f2379d06139be0c723c4dd444f3ca1"
   integrity sha512-LUbR+KNTBWCUAqRG9ex5Gnzu2IOkt8jRJbHHXFT9q+L9zm7M/QQbEqXyw1n1pohYvOyWC8CjeyjrSaIwiYjK7A==
@@ -2946,6 +2946,13 @@ babel-plugin-syntax-trailing-function-commas@^7.0.0-beta.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-7.0.0-beta.0.tgz#aa213c1435e2bffeb6fca842287ef534ad05d5cf"
   integrity sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ==
 
+babel-plugin-transform-flow-enums@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-flow-enums/-/babel-plugin-transform-flow-enums-0.0.1.tgz#ac9777bd1c5998364f83c0ec000ef878d169ec1a"
+  integrity sha512-dxkLaUvIvY8t+OmYzSyMBPee4f0u8WvRj8Ql9xFDTj2nV/qy8KorlOXggSrWe1cOGlsCcMaNE4fO/jbrnJBPiQ==
+  dependencies:
+    "@babel/plugin-syntax-flow" "^7.12.1"
+
 babel-preset-current-node-syntax@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz#b4399239b89b2a011f9ddbe3e4f401fc40cff73b"
@@ -4526,6 +4533,11 @@ flow-bin@^0.192.0:
   version "0.192.0"
   resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.192.0.tgz#a1d75fb955b3980b23cff43577044c52f5d95d33"
   integrity sha512-RlHhXn9m1IRTB5yKhnLGgLWq9z4qJ76slum/DXvmTlrAUPaVcmU/IsTHiY4JpjqK7nFz4oyrnU/YES8xDVBoZg==
+
+flow-enums-runtime@^0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/flow-enums-runtime/-/flow-enums-runtime-0.0.5.tgz#95884bfcc82edaf27eef7e1dd09732331cfbafbc"
+  integrity sha512-PSZF9ZuaZD03sT9YaIs0FrGJ7lSUw7rHZIex+73UYVXg46eL/wxN5PaVcPJFudE2cJu5f0fezitV5aBkLHPUOQ==
 
 flow-parser@0.*, flow-parser@^0.185.0:
   version "0.185.0"


### PR DESCRIPTION
Summary:
Add enum example to Android/iOS rn-tester TurboModule

Changelog:
[General][Added] - Add enum example to Android/iOS rn-tester TurboModule

Differential Revision: D40711269

