### PR TITLE
[Codegen] Fix assertGenericTypeAnnotationHasExactlyOneTypeParameter throwing wrong error

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-commons-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-commons-test.js
@@ -167,7 +167,8 @@ describe('assertGenericTypeAnnotationHasExactlyOneTypeParameter', () => {
     );
   });
 
-  it("throws an IncorrectlyParameterizedGenericParserError if typeParameters don't have 1 exactly parameter", () => {
+  it("throws an IncorrectlyParameterizedGenericParserError if typeParameters don't have 1 exactly parameter for Flow", () => {
+    const language: ParserType = 'Flow';
     const typeAnnotationWithTwoParams = {
       typeParameters: {
         params: [1, 2],
@@ -181,7 +182,7 @@ describe('assertGenericTypeAnnotationHasExactlyOneTypeParameter', () => {
       assertGenericTypeAnnotationHasExactlyOneTypeParameter(
         moduleName,
         typeAnnotationWithTwoParams,
-        'Flow',
+        language,
       ),
     ).toThrowErrorMatchingInlineSnapshot(
       `"Module testModuleName: Generic 'typeAnnotationName' must have exactly one type parameter."`,
@@ -200,7 +201,48 @@ describe('assertGenericTypeAnnotationHasExactlyOneTypeParameter', () => {
       assertGenericTypeAnnotationHasExactlyOneTypeParameter(
         moduleName,
         typeAnnotationWithNoParams,
-        'Flow',
+        language,
+      ),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Module testModuleName: Generic 'typeAnnotationName' must have exactly one type parameter."`,
+    );
+  });
+
+  it("throws an IncorrectlyParameterizedGenericParserError if typeParameters don't have 1 exactly parameter for TS", () => {
+    const language: ParserType = 'TypeScript';
+    const typeAnnotationWithTwoParams = {
+      typeParameters: {
+        params: [1, 2],
+        type: 'TSTypeParameterInstantiation',
+      },
+      typeName: {
+        name: 'typeAnnotationName',
+      },
+    };
+    expect(() =>
+      assertGenericTypeAnnotationHasExactlyOneTypeParameter(
+        moduleName,
+        typeAnnotationWithTwoParams,
+        language,
+      ),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Module testModuleName: Generic 'typeAnnotationName' must have exactly one type parameter."`,
+    );
+
+    const typeAnnotationWithNoParams = {
+      typeParameters: {
+        params: [],
+        type: 'TSTypeParameterInstantiation',
+      },
+      typeName: {
+        name: 'typeAnnotationName',
+      },
+    };
+    expect(() =>
+      assertGenericTypeAnnotationHasExactlyOneTypeParameter(
+        moduleName,
+        typeAnnotationWithNoParams,
+        language,
       ),
     ).toThrowErrorMatchingInlineSnapshot(
       `"Module testModuleName: Generic 'typeAnnotationName' must have exactly one type parameter."`,

--- a/packages/react-native-codegen/src/parsers/errors.js
+++ b/packages/react-native-codegen/src/parsers/errors.js
@@ -12,7 +12,6 @@
 
 import type {UnionTypeAnnotationMemberType} from '../CodegenSchema';
 
-const invariant = require('invariant');
 import type {Parser} from './parser';
 export type ParserType = 'Flow' | 'TypeScript';
 
@@ -131,11 +130,7 @@ class UnsupportedGenericParserError extends ParserError {
   }
 }
 
-class IncorrectlyParameterizedGenericParserError extends ParserError {
-  +genericName: string;
-  +numTypeParameters: number;
-
-  // $FlowFixMe[missing-local-annot]
+class MissingTypeParameterGenericParserError extends ParserError {
   constructor(
     nativeModuleName: string,
     genericTypeAnnotation: $FlowFixMe,
@@ -145,31 +140,30 @@ class IncorrectlyParameterizedGenericParserError extends ParserError {
       language === 'TypeScript'
         ? genericTypeAnnotation.typeName.name
         : genericTypeAnnotation.id.name;
-    if (genericTypeAnnotation.typeParameters == null) {
-      super(
-        nativeModuleName,
-        genericTypeAnnotation,
-        `Generic '${genericName}' must have type parameters.`,
-      );
-      return;
-    }
 
-    if (
-      genericTypeAnnotation.typeParameters.type ===
-        'TypeParameterInstantiation' &&
-      genericTypeAnnotation.typeParameters.params.length !== 1
-    ) {
-      super(
-        nativeModuleName,
-        genericTypeAnnotation.typeParameters,
-        `Generic '${genericName}' must have exactly one type parameter.`,
-      );
-      return;
-    }
+    super(
+      nativeModuleName,
+      genericTypeAnnotation,
+      `Generic '${genericName}' must have type parameters.`,
+    );
+  }
+}
 
-    invariant(
-      false,
-      "Couldn't create IncorrectlyParameterizedGenericParserError",
+class MoreThanOneTypeParameterGenericParserError extends ParserError {
+  constructor(
+    nativeModuleName: string,
+    genericTypeAnnotation: $FlowFixMe,
+    language: ParserType,
+  ) {
+    const genericName =
+      language === 'TypeScript'
+        ? genericTypeAnnotation.typeName.name
+        : genericTypeAnnotation.id.name;
+
+    super(
+      nativeModuleName,
+      genericTypeAnnotation,
+      `Generic '${genericName}' must have exactly one type parameter.`,
     );
   }
 }
@@ -423,7 +417,8 @@ class IncorrectModuleRegistryCallArgumentTypeParserError extends ParserError {
 
 module.exports = {
   ParserError,
-  IncorrectlyParameterizedGenericParserError,
+  MissingTypeParameterGenericParserError,
+  MoreThanOneTypeParameterGenericParserError,
   MisnamedModuleInterfaceParserError,
   ModuleInterfaceNotFoundParserError,
   MoreThanOneModuleInterfaceParserError,

--- a/packages/react-native-codegen/src/parsers/flow/modules/__tests__/module-parser-e2e-test.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__tests__/module-parser-e2e-test.js
@@ -21,7 +21,7 @@ const {
   UnsupportedGenericParserError,
   UnsupportedTypeAnnotationParserError,
   UnnamedFunctionParamParserError,
-  IncorrectlyParameterizedGenericParserError,
+  MissingTypeParameterGenericParserError,
 } = require('../../../errors');
 const invariant = require('invariant');
 
@@ -212,7 +212,7 @@ describe('Flow Module Parser', () => {
           describe('Array Types', () => {
             it(`should not parse methods that have ${PARAM_TYPE_DESCRIPTION} parameter of type 'Array'`, () => {
               expect(() => parseParamType('arg', 'Array')).toThrow(
-                IncorrectlyParameterizedGenericParserError,
+                MissingTypeParameterGenericParserError,
               );
             });
 
@@ -510,7 +510,7 @@ describe('Flow Module Parser', () => {
                   it(`should not parse methods that have ${PARAM_TYPE_DESCRIPTION} parameter type of an object literal with ${PROP_TYPE_DESCRIPTION} prop of type 'Array`, () => {
                     expect(() =>
                       parseParamTypeObjectLiteralProp('prop', 'Array'),
-                    ).toThrow(IncorrectlyParameterizedGenericParserError);
+                    ).toThrow(MissingTypeParameterGenericParserError);
                   });
 
                   function parseArrayElementType(
@@ -782,7 +782,7 @@ describe('Flow Module Parser', () => {
           describe('Array Types', () => {
             it(`should not parse methods that have ${RETURN_TYPE_DESCRIPTION} return of type 'Array'`, () => {
               expect(() => parseReturnType('Array')).toThrow(
-                IncorrectlyParameterizedGenericParserError,
+                MissingTypeParameterGenericParserError,
               );
             });
 
@@ -1050,7 +1050,7 @@ describe('Flow Module Parser', () => {
                     it(`should not parse methods that have ${RETURN_TYPE_DESCRIPTION} return type of an object literal with ${PROP_TYPE_DESCRIPTION} prop of type 'Array`, () => {
                       expect(() =>
                         parseObjectLiteralReturnTypeProp('prop', 'Array'),
-                      ).toThrow(IncorrectlyParameterizedGenericParserError);
+                      ).toThrow(MissingTypeParameterGenericParserError);
                     });
 
                     function parseArrayElementType(

--- a/packages/react-native-codegen/src/parsers/parsers-commons.js
+++ b/packages/react-native-codegen/src/parsers/parsers-commons.js
@@ -20,7 +20,8 @@ import type {
   NativeModuleUnionTypeAnnotation,
 } from '../CodegenSchema.js';
 const {
-  IncorrectlyParameterizedGenericParserError,
+  MissingTypeParameterGenericParserError,
+  MoreThanOneTypeParameterGenericParserError,
   UnsupportedUnionTypeAnnotationParserError,
 } = require('./errors');
 import type {ParserType} from './errors';
@@ -71,7 +72,7 @@ function assertGenericTypeAnnotationHasExactlyOneTypeParameter(
   language: ParserType,
 ) {
   if (typeAnnotation.typeParameters == null) {
-    throw new IncorrectlyParameterizedGenericParserError(
+    throw new MissingTypeParameterGenericParserError(
       moduleName,
       typeAnnotation,
       language,
@@ -89,7 +90,7 @@ function assertGenericTypeAnnotationHasExactlyOneTypeParameter(
   );
 
   if (typeAnnotation.typeParameters.params.length !== 1) {
-    throw new IncorrectlyParameterizedGenericParserError(
+    throw new MoreThanOneTypeParameterGenericParserError(
       moduleName,
       typeAnnotation,
       language,

--- a/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/typescript-module-parser-e2e-test.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/typescript-module-parser-e2e-test.js
@@ -21,7 +21,7 @@ const {
   UnsupportedGenericParserError,
   UnsupportedTypeAnnotationParserError,
   UnnamedFunctionParamParserError,
-  IncorrectlyParameterizedGenericParserError,
+  MissingTypeParameterGenericParserError,
 } = require('../../../errors');
 const invariant = require('invariant');
 
@@ -212,7 +212,7 @@ describe('TypeScript Module Parser', () => {
           describe('Array Types', () => {
             it(`should not parse methods that have ${PARAM_TYPE_DESCRIPTION} parameter of type 'Array'`, () => {
               expect(() => parseParamType('arg', 'Array')).toThrow(
-                IncorrectlyParameterizedGenericParserError,
+                MissingTypeParameterGenericParserError,
               );
             });
 
@@ -510,7 +510,7 @@ describe('TypeScript Module Parser', () => {
                   it(`should not parse methods that have ${PARAM_TYPE_DESCRIPTION} parameter type of an object literal with ${PROP_TYPE_DESCRIPTION} prop of type 'Array`, () => {
                     expect(() =>
                       parseParamTypeObjectLiteralProp('prop', 'Array'),
-                    ).toThrow(IncorrectlyParameterizedGenericParserError);
+                    ).toThrow(MissingTypeParameterGenericParserError);
                   });
 
                   function parseArrayElementType(
@@ -780,7 +780,7 @@ describe('TypeScript Module Parser', () => {
           describe('Array Types', () => {
             it(`should not parse methods that have ${RETURN_TYPE_DESCRIPTION} return of type 'Array'`, () => {
               expect(() => parseReturnType('Array')).toThrow(
-                IncorrectlyParameterizedGenericParserError,
+                MissingTypeParameterGenericParserError,
               );
             });
 
@@ -1049,7 +1049,7 @@ describe('TypeScript Module Parser', () => {
                     it(`should not parse methods that have ${RETURN_TYPE_DESCRIPTION} return type of an object literal with ${PROP_TYPE_DESCRIPTION} prop of type 'Array`, () => {
                       expect(() =>
                         parseObjectLiteralReturnTypeProp('prop', 'Array'),
-                      ).toThrow(IncorrectlyParameterizedGenericParserError);
+                      ).toThrow(MissingTypeParameterGenericParserError);
                     });
 
                     function parseArrayElementType(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

1. I noticed there was a mistake in the [IncorrectlyParameterizedGenericParserError](https://github.com/facebook/react-native/blob/main/packages/react-native-codegen/src/parsers/errors.js#L159):
```
if (
  genericTypeAnnotation.typeParameters.type ===
    'TypeParameterInstantiation' &&
  genericTypeAnnotation.typeParameters.params.length !== 1
) {
```

Here we should replace ` 'TypeParameterInstantiation'` with ` 'TSTypeParameterInstantiation'` when the language is `TypeScript`.

The result is that we get a ["Couldn't create IncorrectlyParameterizedGenericParserError"](https://github.com/facebook/react-native/blob/main/packages/react-native-codegen/src/parsers/errors.js#L172) error instead of ["Module testModuleName: Generic 'typeAnnotationName' must have exactly one type parameter."](https://github.com/facebook/react-native/blob/main/packages/react-native-codegen/src/parsers/parsers-commons.js#L88).

I added a [test case](https://github.com/facebook/react-native/commit/2f161166c033cc9de67e04cd683554b05c6173f8) to cover this case:
<img width="1008" alt="Capture d’écran 2022-10-30 à 13 55 56" src="https://user-images.githubusercontent.com/17070498/198879598-ab5a6092-8cbf-422a-9993-2f3f92c9d84c.png">


2. Looking closely at where IncorrectlyParameterizedGenericParserError is used, I noticed that the logic was duplicated in [assertGenericTypeAnnotationHasExactlyOneTypeParameter](https://github.com/facebook/react-native/blob/main/packages/react-native-codegen/src/parsers/parsers-commons.js#L65).

I believe that the logic should reside in `assertGenericTypeAnnotationHasExactlyOneTypeParameter` so I split the `IncorrectlyParameterizedGenericParserError` in 2 different errors.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[Internal] [Changed] - Fix assertGenericTypeAnnotationHasExactlyOneTypeParameter throwing wrong error

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

I tested using Jest and Flow commands.
