### PR TITLE
feat: Add "option" to available role values

### DIFF
--- a/Libraries/Components/View/ViewAccessibility.d.ts
+++ b/Libraries/Components/View/ViewAccessibility.d.ts
@@ -330,6 +330,7 @@ export type Role =
   | 'navigation'
   | 'none'
   | 'note'
+  | 'option'
   | 'presentation'
   | 'progressbar'
   | 'radio'

--- a/Libraries/Components/View/ViewAccessibility.js
+++ b/Libraries/Components/View/ViewAccessibility.js
@@ -85,6 +85,7 @@ export type Role =
   | 'navigation'
   | 'none'
   | 'note'
+  | 'option'
   | 'presentation'
   | 'progressbar'
   | 'radio'

--- a/Libraries/Utilities/AcessibilityMapping.js
+++ b/Libraries/Utilities/AcessibilityMapping.js
@@ -92,6 +92,8 @@ export function getAccessibilityRoleFromRole(role: Role): ?AccessibilityRole {
       return 'none';
     case 'note':
       return undefined;
+    case 'option':
+      return undefined;
     case 'presentation':
       return 'none';
     case 'progressbar':


### PR DESCRIPTION
## Summary

As pointed out by @efoken on https://github.com/facebook/react-native/issues/34424#issuecomment-1283854395 we forgot we add the `option` value to the `role` prop, so this PR adds this missing value as requested on https://github.com/facebook/react-native/issues/34424.  

## Changelog

[General] [Added] - Add "option" to available role values

## Test Plan

Ensure that CI is green as there isn't much to test in this case because we're just adding a value that maps to `undefined`