### PR TITLE
[Codegen] Extract isModuleRegistryCall function in parsers/utils

### DIFF
--- a/packages/react-native-codegen/src/parsers/flow/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/index.js
@@ -15,11 +15,14 @@ import type {SchemaType} from '../../CodegenSchema.js';
 // $FlowFixMe[untyped-import] there's no flowtype flow-parser
 const flowParser = require('flow-parser');
 const fs = require('fs');
-const {buildSchemaFromConfigType, getConfigType} = require('../utils');
+const {
+  buildSchemaFromConfigType,
+  getConfigType,
+  isModuleRegistryCall,
+} = require('../utils');
 const {buildComponentSchema} = require('./components');
 const {wrapComponentSchema} = require('./components/schema');
 const {buildModuleSchema} = require('./modules');
-const {isModuleRegistryCall} = require('./utils');
 
 function Visitor(infoMap: {isComponent: boolean, isModule: boolean}) {
   return {

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -27,12 +27,8 @@ import type {NativeModuleTypeAnnotation} from '../../../CodegenSchema.js';
 const {nullGuard} = require('../../parsers-utils');
 
 const {throwIfMoreThanOneModuleRegistryCalls} = require('../../error-utils');
-const {visit} = require('../../utils');
-const {
-  resolveTypeAnnotation,
-  getTypes,
-  isModuleRegistryCall,
-} = require('../utils.js');
+const {visit, isModuleRegistryCall} = require('../../utils');
+const {resolveTypeAnnotation, getTypes} = require('../utils.js');
 const {
   unwrapNullable,
   wrapNullable,

--- a/packages/react-native-codegen/src/parsers/flow/utils.js
+++ b/packages/react-native-codegen/src/parsers/flow/utils.js
@@ -116,48 +116,8 @@ function getValueFromTypes(value: ASTNode, types: TypeDeclarationMap): ASTNode {
   return value;
 }
 
-// TODO(T71778680): Flow-type ASTNodes.
-function isModuleRegistryCall(node: $FlowFixMe): boolean {
-  if (node.type !== 'CallExpression') {
-    return false;
-  }
-
-  const callExpression = node;
-
-  if (callExpression.callee.type !== 'MemberExpression') {
-    return false;
-  }
-
-  const memberExpression = callExpression.callee;
-  if (
-    !(
-      memberExpression.object.type === 'Identifier' &&
-      memberExpression.object.name === 'TurboModuleRegistry'
-    )
-  ) {
-    return false;
-  }
-
-  if (
-    !(
-      memberExpression.property.type === 'Identifier' &&
-      (memberExpression.property.name === 'get' ||
-        memberExpression.property.name === 'getEnforcing')
-    )
-  ) {
-    return false;
-  }
-
-  if (memberExpression.computed) {
-    return false;
-  }
-
-  return true;
-}
-
 module.exports = {
   getValueFromTypes,
   resolveTypeAnnotation,
   getTypes,
-  isModuleRegistryCall,
 };

--- a/packages/react-native-codegen/src/parsers/typescript/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/index.js
@@ -14,12 +14,14 @@ import type {SchemaType} from '../../CodegenSchema.js';
 
 const babelParser = require('@babel/parser');
 const fs = require('fs');
-const {buildSchemaFromConfigType, getConfigType} = require('../utils');
+const {
+  buildSchemaFromConfigType,
+  getConfigType,
+  isModuleRegistryCall,
+} = require('../utils');
 const {buildComponentSchema} = require('./components');
 const {wrapComponentSchema} = require('./components/schema');
 const {buildModuleSchema} = require('./modules');
-
-const {isModuleRegistryCall} = require('./utils');
 
 function Visitor(infoMap: {isComponent: boolean, isModule: boolean}) {
   return {

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -30,12 +30,8 @@ const {
   throwIfMoreThanOneModuleRegistryCalls,
   throwIfUnsupportedFunctionParamTypeAnnotationParserError,
 } = require('../../error-utils');
-const {visit} = require('../../utils');
-const {
-  resolveTypeAnnotation,
-  getTypes,
-  isModuleRegistryCall,
-} = require('../utils.js');
+const {visit, isModuleRegistryCall} = require('../../utils');
+const {resolveTypeAnnotation, getTypes} = require('../utils.js');
 const {
   unwrapNullable,
   wrapNullable,

--- a/packages/react-native-codegen/src/parsers/typescript/utils.js
+++ b/packages/react-native-codegen/src/parsers/typescript/utils.js
@@ -109,47 +109,7 @@ function resolveTypeAnnotation(
   };
 }
 
-// TODO(T108222691): Use flow-types for @babel/parser
-function isModuleRegistryCall(node: $FlowFixMe): boolean {
-  if (node.type !== 'CallExpression') {
-    return false;
-  }
-
-  const callExpression = node;
-
-  if (callExpression.callee.type !== 'MemberExpression') {
-    return false;
-  }
-
-  const memberExpression = callExpression.callee;
-  if (
-    !(
-      memberExpression.object.type === 'Identifier' &&
-      memberExpression.object.name === 'TurboModuleRegistry'
-    )
-  ) {
-    return false;
-  }
-
-  if (
-    !(
-      memberExpression.property.type === 'Identifier' &&
-      (memberExpression.property.name === 'get' ||
-        memberExpression.property.name === 'getEnforcing')
-    )
-  ) {
-    return false;
-  }
-
-  if (memberExpression.computed) {
-    return false;
-  }
-
-  return true;
-}
-
 module.exports = {
   resolveTypeAnnotation,
   getTypes,
-  isModuleRegistryCall,
 };

--- a/packages/react-native-codegen/src/parsers/utils.js
+++ b/packages/react-native-codegen/src/parsers/utils.js
@@ -215,6 +215,45 @@ function getConfigType(
   }
 }
 
+// TODO(T71778680): Flow-type ASTNodes.
+function isModuleRegistryCall(node: $FlowFixMe): boolean {
+  if (node.type !== 'CallExpression') {
+    return false;
+  }
+
+  const callExpression = node;
+
+  if (callExpression.callee.type !== 'MemberExpression') {
+    return false;
+  }
+
+  const memberExpression = callExpression.callee;
+  if (
+    !(
+      memberExpression.object.type === 'Identifier' &&
+      memberExpression.object.name === 'TurboModuleRegistry'
+    )
+  ) {
+    return false;
+  }
+
+  if (
+    !(
+      memberExpression.property.type === 'Identifier' &&
+      (memberExpression.property.name === 'get' ||
+        memberExpression.property.name === 'getEnforcing')
+    )
+  ) {
+    return false;
+  }
+
+  if (memberExpression.computed) {
+    return false;
+  }
+
+  return true;
+}
+
 module.exports = {
   getConfigType,
   extractNativeModuleName,
@@ -223,4 +262,5 @@ module.exports = {
   parseFile,
   visit,
   buildSchemaFromConfigType,
+  isModuleRegistryCall,
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This PR is a task from https://github.com/facebook/react-native/issues/34872:
> Extract the function isModuleRegistryCall ([Flow](https://github.com/facebook/react-native/blob/main/packages/react-native-codegen/src/parsers/flow/utils.js#L175-L211) [TypeScript](https://github.com/facebook/react-native/blob/main/packages/react-native-codegen/src/parsers/typescript/utils.js#L167-L203)) into a single function in the parsers/utils.js file and replace its invocation with this new function.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[Internal] [Changed] - Extract the function isModuleRegistryCall in parsers/utils

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

I tested using Jest and Flow commands.