### PR TITLE
Corrected documentation to be more gramatically correct

### DIFF
--- a/Libraries/Utilities/Appearance.d.ts
+++ b/Libraries/Utilities/Appearance.d.ts
@@ -38,6 +38,6 @@ export namespace Appearance {
 
 /**
  * A new useColorScheme hook is provided as the preferred way of accessing
- * the user's preferred color scheme (aka Dark Mode).
+ * the user's preferred color scheme (e.g. Dark Mode).
  */
 export function useColorScheme(): ColorSchemeName;


### PR DESCRIPTION
## Summary
The documentation for `useColorScheme()` suggested that the user's preferred color scheme will be 'Dark Mode'. Instead suggesting 'Dark Mode' as an example of what the user's preferred color scheme could be is more correct.

## Changelog
[INTERNAL] [FIXED] - Edited documentation for `useColorScheme()` hook
Edited
```javascript
/**
 * A new useColorScheme hook is provided as the preferred way of accessing
 * the user's preferred color scheme (aka Dark Mode).
 */
export function useColorScheme(): ColorSchemeName;
```
to
```javascript
/**
 * A new useColorScheme hook is provided as the preferred way of accessing
 * the user's preferred color scheme (e.g. Dark Mode).
 */
export function useColorScheme(): ColorSchemeName;
```

## Test Plan

Documentation only - no testing required.