### PR TITLE
Add flow/format pragmas to NativeComponentRegistryUnstable

### DIFF
--- a/Libraries/NativeComponent/NativeComponentRegistryUnstable.js
+++ b/Libraries/NativeComponent/NativeComponentRegistryUnstable.js
@@ -3,6 +3,9 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
  */
 
 let componentNameToExists: Map<string, boolean> = new Map();


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

I maintain an [alternative bundler for react native using esbuild](https://github.com/oblador/react-native-esbuild). It does not support Flow syntax so I have to strip those annotations before feeding it back in. However since this step is using babel and is slow (and flow-bin is even slower, so not an alternative) I want to only do it for the files actually containing flow. In the react-native codebase these files are annotated with the `@flow`/`@noflow` pragmas in every file except for `NativeComponentRegistryUnstable.js` after it was split out from another file in https://github.com/facebook/react-native/commit/a620d7dc8514da0d0d4e2268c374321536820c04 by @p-sun. It seems the omission was accidental as the original file had the pragma, so this PR simply adds it back to correctly mark the file as containing flow syntax. 

## Changelog

[Internal] [Fixed] - Add flow/format pragmas to NativeComponentRegistryUnstable

## Test Plan

`yarn flow` has the same amount of errors before and after, and build tools correctly identifies the file as flow not JS. 