### PR TITLE
Enable ManagedObjectWrapper on react-native-macOS

### DIFF
--- a/ReactCommon/react/utils/ManagedObjectWrapper.h
+++ b/ReactCommon/react/utils/ManagedObjectWrapper.h
@@ -14,7 +14,7 @@
 #endif
 
 #if defined(__OBJC__) && defined(__cplusplus)
-#if TARGET_OS_MAC && TARGET_OS_IPHONE
+#if TARGET_OS_MAC && (TARGET_OS_IPHONE || TARGET_OS_OSX)
 
 #include <memory>
 

--- a/ReactCommon/react/utils/ManagedObjectWrapper.mm
+++ b/ReactCommon/react/utils/ManagedObjectWrapper.mm
@@ -8,7 +8,7 @@
 #include "ManagedObjectWrapper.h"
 
 #if defined(__OBJC__) && defined(__cplusplus)
-#if TARGET_OS_MAC && TARGET_OS_IPHONE
+#if TARGET_OS_MAC && (TARGET_OS_IPHONE || TARGET_OS_OSX)
 
 namespace facebook {
 namespace react {


### PR DESCRIPTION
Summary:
This class is used by Fabric - but does not compile on macOS yet.

Changelog:
[iOS][Fixed] Make ManagedObjectWrapper compile on macOS

Differential Revision: D40839241

