### PR TITLE
Make sure that release uses the right Ruby version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,6 +159,27 @@ commands:
           paths:
             - vendor/bundle
 
+  # TODO: add cache to speed-up the ruby install
+  install_ruby_ubuntu:
+    steps:
+      - run:
+          name: setup rbenv
+          command: |
+            curl -fsSL https://github.com/rbenv/rbenv-installer/raw/HEAD/bin/rbenv-installer | bash
+
+            echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bashrc
+            echo "add eval(rbenv init) to ~/.bashrc"
+            echo 'eval "$(rbenv init -)"' >> ~/.bashrc
+            source ~/.bashrc
+            rbenv --version
+      - run:
+          name: install ruby
+          command: |
+            source ~/.bashrc
+            RUBY_VERSION=$(cat .ruby-version)
+            rbenv install "$RUBY_VERSION" --verbose
+            rbenv global "$RUBY_VERSION"
+
   run_yarn:
     parameters:
       yarn_base_cache_key:
@@ -1388,6 +1409,7 @@ jobs:
             echo '|1|If6MU203eXTaaWL678YEfWkVMrw=|kqLeIAyTy8pzpj8x8Ae4Fr8Mtlc= ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==' >> ~/.ssh/known_hosts
       - checkout
       - *attach_hermes_workspace
+      - install_ruby_ubuntu
       - run:
           name: Copy Hermes binaries
           command: |
@@ -1497,7 +1519,7 @@ jobs:
   # -------------------------
   nightly_job:
     machine:
-      image: ubuntu-2004:202010-01
+      image: ubuntu-2204:2022.10.1
     steps:
       - run:
           name: Nightly

--- a/scripts/update-ruby.sh
+++ b/scripts/update-ruby.sh
@@ -23,15 +23,25 @@ die() {
     exit 1
 }
 
+# This assume that this script is invoked from the root of
+# react-native. The only place where this is invoked is the
+# `set-rn-version.js` script which invoked the script as
+# scripts/update-ruby.sh.
+MANAGED_RUBY_VERSION=$(cat .ruby-version)
+
 if [ $# -eq 1 ]; then
     VERSION=$1
+elif [ -n "$MANAGED_RUBY_VERSION" ]; then
+    VERSION="$MANAGED_RUBY_VERSION"
 else
     VERSION=$(ruby --version | cut -d' ' -f2 | cut -dp -f1)
 fi
 
-if [ -z "$VERSION" ]; then
-    die "Please provide an installed/usable Ruby version"
+VERSION_INSTALLED=$(ruby --version | cut -d' ' -f2 | cut -dp -f1)
+if [ "$VERSION" != "$VERSION_INSTALLED" ]; then
+  die "Please provide an installed/usable Ruby version. The command ruby --version returns $VERSION_INSTALLED"
 fi
+
 echo "Setting Ruby version to: $VERSION"
 
 cd "$ROOT" || die "Failed to change to $ROOT"


### PR DESCRIPTION
## Summary:
This diff changes the `update-ruby.sh` script to honour the content of the `.ruby-version` file.
More context, [here](https://discord.com/channels/514829729862516747/514831609116098571/1036292073491546112)

## Changelog
[iOS][Fixed] - Release should honour the proper Ruby version.

Differential Revision: D40851447

