### PR TITLE
bump codegen to v0.71.1

### DIFF
--- a/packages/react-native-codegen/package.json
+++ b/packages/react-native-codegen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-codegen",
-  "version": "0.71.0",
+  "version": "0.71.1",
   "description": "⚛️ Code generation tools for React Native",
   "homepage": "https://github.com/facebook/react-native/tree/HEAD/packages/react-native-codegen",
   "repository": {

--- a/repo-config/package.json
+++ b/repo-config/package.json
@@ -46,7 +46,7 @@
     "mkdirp": "^0.5.1",
     "prettier": "^2.4.1",
     "react": "18.2.0",
-    "react-native-codegen": "^0.71.0",
+    "react-native-codegen": "^0.71.1",
     "react-test-renderer": "18.2.0",
     "shelljs": "^0.8.5",
     "signedsource": "^1.0.0",


### PR DESCRIPTION
Summary:
This diff bumps the codegen to v0.71.1, preparing it for the branch cut.

## Changelog
[General][Changed] - Bump codegen version

Reviewed By: dmytrorykun

Differential Revision: D40852498

