### PR TITLE
Hermes scripts: rename tarball methods to distinguish between source code and prebuilt artifacts

### DIFF
--- a/scripts/__tests__/hermes-utils-test.js
+++ b/scripts/__tests__/hermes-utils-test.js
@@ -13,9 +13,9 @@ const {
   configureMakeForPrebuiltHermesC,
   copyBuildScripts,
   copyPodSpec,
-  downloadHermesTarball,
-  expandHermesTarball,
-  getHermesTarballName,
+  downloadHermesSourceTarball,
+  expandHermesSourceTarball,
+  getHermesPrebuiltArtifactsTarballName,
   getHermesTagSHA,
   readHermesTag,
   setHermesTag,
@@ -155,29 +155,29 @@ describe('hermes-utils', () => {
       expect(readHermesTag()).toEqual(hermesTag);
     });
   });
-  describe('getHermesTarballName', () => {
+  describe('getHermesPrebuiltArtifactsTarballName', () => {
     it('should return Hermes tarball name', () => {
-      expect(getHermesTarballName('Debug', '1000.0.0')).toEqual(
-        'hermes-runtime-darwin-debug-v1000.0.0.tar.gz',
-      );
+      expect(
+        getHermesPrebuiltArtifactsTarballName('Debug', '1000.0.0'),
+      ).toEqual('hermes-runtime-darwin-debug-v1000.0.0.tar.gz');
     });
     it('should throw if build type is undefined', () => {
       expect(() => {
-        getHermesTarballName();
+        getHermesPrebuiltArtifactsTarballName();
       }).toThrow('Did not specify build type.');
     });
     it('should throw if release version is undefined', () => {
       expect(() => {
-        getHermesTarballName('Release');
+        getHermesPrebuiltArtifactsTarballName('Release');
       }).toThrow('Did not specify release version.');
     });
     it('should return debug Hermes tarball name for RN 0.70.0', () => {
-      expect(getHermesTarballName('Debug', '0.70.0')).toEqual(
+      expect(getHermesPrebuiltArtifactsTarballName('Debug', '0.70.0')).toEqual(
         'hermes-runtime-darwin-debug-v0.70.0.tar.gz',
       );
     });
     it('should return a wildcard Hermes tarball name for any RN version', () => {
-      expect(getHermesTarballName('Debug', '*')).toEqual(
+      expect(getHermesPrebuiltArtifactsTarballName('Debug', '*')).toEqual(
         'hermes-runtime-darwin-debug-v*.tar.gz',
       );
     });
@@ -188,10 +188,10 @@ describe('hermes-utils', () => {
       expect(execCalls.git).toBe(true);
     });
   });
-  describe('downloadHermesTarball', () => {
-    it('should download Hermes tarball to download dir', () => {
+  describe('downloadHermesSourceTarball', () => {
+    it('should download Hermes source tarball to download dir', () => {
       fs.writeFileSync(path.join(SDKS_DIR, '.hermesversion'), hermesTag);
-      downloadHermesTarball();
+      downloadHermesSourceTarball();
       expect(execCalls.curl).toBe(true);
       expect(
         fs.readFileSync(
@@ -210,25 +210,25 @@ describe('hermes-utils', () => {
         tarballContents,
       );
 
-      downloadHermesTarball();
+      downloadHermesSourceTarball();
       expect(execCalls.curl).toBeUndefined();
     });
   });
-  describe('expandHermesTarball', () => {
-    it('should expand Hermes tarball to Hermes source dir', () => {
+  describe('expandHermesSourceTarball', () => {
+    it('should expand Hermes source tarball to Hermes source dir', () => {
       fs.mkdirSync(path.join(SDKS_DIR, 'download'), {recursive: true});
       fs.writeFileSync(
         path.join(SDKS_DIR, 'download', `hermes-${hermesTagSha}.tgz`),
         tarballContents,
       );
       expect(fs.existsSync(path.join(SDKS_DIR, 'hermes'))).toBeFalsy();
-      expandHermesTarball();
+      expandHermesSourceTarball();
       expect(execCalls.tar).toBe(true);
       expect(fs.existsSync(path.join(SDKS_DIR, 'hermes'))).toBe(true);
     });
-    it('should fail if Hermes tarball does not exist', () => {
+    it('should fail if Hermes source tarball does not exist', () => {
       expect(() => {
-        expandHermesTarball();
+        expandHermesSourceTarball();
       }).toThrow('[Hermes] Could not locate Hermes tarball.');
       expect(execCalls.tar).toBeUndefined();
     });

--- a/scripts/hermes/create-tarball.js
+++ b/scripts/hermes/create-tarball.js
@@ -18,7 +18,7 @@ const path = require('path');
  * Must be invoked after Hermes has been built.
  */
 const yargs = require('yargs');
-const {createHermesTarball} = require('./hermes-utils');
+const {createHermesPrebuiltArtifactsTarball} = require('./hermes-utils');
 
 let argv = yargs
   .option('i', {
@@ -60,7 +60,7 @@ async function main() {
     }
   }
 
-  const tarballOutputPath = createHermesTarball(
+  const tarballOutputPath = createHermesPrebuiltArtifactsTarball(
     hermesDir,
     buildType,
     releaseVersion,

--- a/scripts/hermes/get-tarball-name.js
+++ b/scripts/hermes/get-tarball-name.js
@@ -14,7 +14,7 @@
  * Hermes tarball for the given build type and release version.
  */
 const yargs = require('yargs');
-const {getHermesTarballName} = require('./hermes-utils');
+const {getHermesPrebuiltArtifactsTarballName} = require('./hermes-utils');
 
 let argv = yargs
   .option('b', {
@@ -31,7 +31,10 @@ let argv = yargs
   }).argv;
 
 async function main() {
-  const tarballName = getHermesTarballName(argv.buildType, argv.releaseVersion);
+  const tarballName = getHermesPrebuiltArtifactsTarballName(
+    argv.buildType,
+    argv.releaseVersion,
+  );
   console.log(tarballName);
   return tarballName;
 }

--- a/scripts/hermes/hermes-utils.js
+++ b/scripts/hermes/hermes-utils.js
@@ -17,7 +17,8 @@ const {execSync} = require('child_process');
 const SDKS_DIR = path.normalize(path.join(__dirname, '..', '..', 'sdks'));
 const HERMES_DIR = path.join(SDKS_DIR, 'hermes');
 const HERMES_TAG_FILE_PATH = path.join(SDKS_DIR, '.hermesversion');
-const HERMES_TARBALL_BASE_URL = 'https://github.com/facebook/hermes/tarball/';
+const HERMES_SOURCE_TARBALL_BASE_URL =
+  'https://github.com/facebook/hermes/tarball/';
 const HERMES_TARBALL_DOWNLOAD_DIR = path.join(SDKS_DIR, 'download');
 const MACOS_BIN_DIR = path.join(SDKS_DIR, 'hermesc', 'osx-bin');
 const MACOS_HERMESC_PATH = path.join(MACOS_BIN_DIR, 'hermesc');
@@ -71,11 +72,11 @@ function getHermesTarballDownloadPath(hermesTag) {
   return path.join(HERMES_TARBALL_DOWNLOAD_DIR, `hermes-${hermesTagSHA}.tgz`);
 }
 
-function downloadHermesTarball() {
+function downloadHermesSourceTarball() {
   const hermesTag = readHermesTag();
   const hermesTagSHA = getHermesTagSHA(hermesTag);
   const hermesTarballDownloadPath = getHermesTarballDownloadPath(hermesTag);
-  let hermesTarballUrl = HERMES_TARBALL_BASE_URL + hermesTag;
+  let hermesTarballUrl = HERMES_SOURCE_TARBALL_BASE_URL + hermesTag;
 
   if (fs.existsSync(hermesTarballDownloadPath)) {
     return;
@@ -95,7 +96,7 @@ function downloadHermesTarball() {
   }
 }
 
-function expandHermesTarball() {
+function expandHermesSourceTarball() {
   const hermesTag = readHermesTag();
   const hermesTagSHA = getHermesTagSHA(hermesTag);
   const hermesTarballDownloadPath = getHermesTarballDownloadPath(hermesTag);
@@ -196,7 +197,7 @@ set_target_properties(native-hermesc PROPERTIES
   }
 }
 
-function getHermesTarballName(buildType, releaseVersion) {
+function getHermesPrebuiltArtifactsTarballName(buildType, releaseVersion) {
   if (!buildType) {
     throw Error('Did not specify build type.');
   }
@@ -206,7 +207,7 @@ function getHermesTarballName(buildType, releaseVersion) {
   return `hermes-runtime-darwin-${buildType.toLowerCase()}-v${releaseVersion}.tar.gz`;
 }
 
-function createHermesTarball(
+function createHermesPrebuiltArtifactsTarball(
   hermesDir,
   buildType,
   releaseVersion,
@@ -245,7 +246,10 @@ function createHermesTarball(
     throw new Error(`Failed to copy destroot to tempdir: ${error}`);
   }
 
-  const tarballFilename = getHermesTarballName(buildType, releaseVersion);
+  const tarballFilename = getHermesPrebuiltArtifactsTarballName(
+    buildType,
+    releaseVersion,
+  );
   const tarballOutputPath = path.join(tarballOutputDir, tarballFilename);
 
   try {
@@ -267,11 +271,11 @@ module.exports = {
   configureMakeForPrebuiltHermesC,
   copyBuildScripts,
   copyPodSpec,
-  createHermesTarball,
-  downloadHermesTarball,
-  expandHermesTarball,
+  createHermesPrebuiltArtifactsTarball,
+  downloadHermesSourceTarball,
+  expandHermesSourceTarball,
   getHermesTagSHA,
-  getHermesTarballName,
+  getHermesPrebuiltArtifactsTarballName,
   readHermesTag,
   setHermesTag,
   shouldBuildHermesFromSource,

--- a/scripts/hermes/prepare-hermes-for-build.js
+++ b/scripts/hermes/prepare-hermes-for-build.js
@@ -17,8 +17,8 @@ const {
   configureMakeForPrebuiltHermesC,
   copyBuildScripts,
   copyPodSpec,
-  downloadHermesTarball,
-  expandHermesTarball,
+  downloadHermesSourceTarball,
+  expandHermesSourceTarball,
   shouldUsePrebuiltHermesC,
   shouldBuildHermesFromSource,
 } = require('./hermes-utils');
@@ -28,8 +28,8 @@ async function main(isInCI) {
     copyPodSpec();
     return;
   }
-  downloadHermesTarball();
-  expandHermesTarball();
+  downloadHermesSourceTarball();
+  expandHermesSourceTarball();
   copyPodSpec();
   copyBuildScripts();
 


### PR DESCRIPTION
Summary:
There are two tarballs: the source code for Hermes that is downloaded from GitHub, and the hermes-runtime-darwin-{}-v{}.tar.gz tarball with prebuilt artifacts that is built in CI.
Renamed some methods to make it clearer which tarball they work with.

Changelog: [internal]

Reviewed By: cipolleschi, dmytrorykun

Differential Revision: D40812290

