### PR TITLE
Set C++ version for libs

### DIFF
--- a/scripts/cocoapods/__tests__/new_architecture-test.rb
+++ b/scripts/cocoapods/__tests__/new_architecture-test.rb
@@ -124,6 +124,7 @@ class NewArchitectureTests < Test::Unit::TestCase
         # Assert
         assert_equal(spec.compiler_flags, NewArchitectureHelper.folly_compiler_flags)
         assert_equal(spec.pod_target_xcconfig["HEADER_SEARCH_PATHS"], "\"$(PODS_ROOT)/boost\"")
+        assert_equal(spec.pod_target_xcconfig["CLANG_CXX_LANGUAGE_STANDARD"], "c++17")
         assert_equal(
             spec.dependencies,
             [
@@ -152,6 +153,7 @@ class NewArchitectureTests < Test::Unit::TestCase
         # Assert
         assert_equal(spec.compiler_flags, "-Wno-nullability-completeness #{NewArchitectureHelper.folly_compiler_flags}")
         assert_equal(spec.pod_target_xcconfig["HEADER_SEARCH_PATHS"], "#{other_flags} \"$(PODS_ROOT)/boost\"")
+        assert_equal(spec.pod_target_xcconfig["CLANG_CXX_LANGUAGE_STANDARD"], "c++17")
         assert_equal(
             spec.dependencies,
             [

--- a/scripts/cocoapods/new_architecture.rb
+++ b/scripts/cocoapods/new_architecture.rb
@@ -10,6 +10,8 @@ class NewArchitectureHelper
 
     @@new_arch_cpp_flags = "$(inherited) -DRCT_NEW_ARCH_ENABLED=1 #{@@shared_flags}"
 
+    @@cplusplus_version = "c++17"
+
     def self.set_clang_cxx_language_standard_if_needed(installer)
         language_standard = nil
 
@@ -73,6 +75,7 @@ class NewArchitectureHelper
 
         spec.compiler_flags = compiler_flags.empty? ? @@folly_compiler_flags : "#{compiler_flags} #{@@folly_compiler_flags}"
         current_config["HEADER_SEARCH_PATHS"] = current_headers.empty? ? boost_search_path : "#{current_headers} #{boost_search_path}"
+        current_config["CLANG_CXX_LANGUAGE_STANDARD"] = @@cplusplus_version
         spec.pod_target_xcconfig = current_config
 
         spec.dependency "React-Core"


### PR DESCRIPTION
Summary:
With the simplified migration to the new arch, we are offering a function in cocoapods that takes care of configuring all the dependencies for libraries.

That function was not setting the proper version of C++ for the library. This could lead to build problems.

This Diff make sure that the libraries that are created with this function call have the proper C++ version.

NOTE: we already have a post install hook that was setting the the proper C++ version, but that was only working for the project. Plus, we can't read that version from the React-Core podspec because at the podspec definition time, cocoapods has not read that yet. Therefore, I just hardcoded the C++ version on top of the file, so it will be easier to update if we decide to change it.

## Changelog
[iOS][Fixed] - Make sure that libraries created with `install_modules_dependencies` has the right C++ version.

Differential Revision: D40894561

