### PR TITLE
Hermes: Strip debug symbols during tarball creation

### DIFF
--- a/scripts/hermes/create-tarball.js
+++ b/scripts/hermes/create-tarball.js
@@ -40,12 +40,18 @@ let argv = yargs
   .option('o', {
     alias: 'outputDir',
     describe: 'Location where the tarball will be saved to.',
+  })
+  .option('exclude-debug-symbols', {
+    describe: 'Whether dSYMs should be excluded from the tarball.',
+    type: 'boolean',
+    default: true,
   }).argv;
 
 async function main() {
   const hermesDir = argv.inputDir;
   const buildType = argv.buildType;
   const releaseVersion = argv.releaseVersion;
+  const excludeDebugSymbols = argv.excludeDebugSymbols;
   let tarballOutputDir = argv.outputDir;
 
   if (!tarballOutputDir) {
@@ -65,6 +71,7 @@ async function main() {
     buildType,
     releaseVersion,
     tarballOutputDir,
+    excludeDebugSymbols,
   );
   console.log(tarballOutputPath);
   return tarballOutputPath;

--- a/scripts/hermes/hermes-utils.js
+++ b/scripts/hermes/hermes-utils.js
@@ -212,33 +212,28 @@ function createHermesPrebuiltArtifactsTarball(
   buildType,
   releaseVersion,
   tarballOutputDir,
+  excludeDebugSymbols,
 ) {
-  if (!hermesDir) {
-    hermesDir = HERMES_DIR;
-  }
-  if (!fs.existsSync(hermesDir)) {
-    throw new Error(`Path to Hermes does not exist at ${hermesDir}`);
-  }
-  if (!fs.existsSync(path.join(hermesDir, 'destroot'))) {
-    throw new Error(
-      `destroot not found at ${path.join(
-        hermesDir,
-        'destroot',
-      )}. Are you sure Hermes has been built?`,
-    );
-  }
+  validateHermesPrebuiltArtifactsPrerequisites(hermesDir);
+
   if (!fs.existsSync(tarballOutputDir)) {
     fs.mkdirSync(tarballOutputDir, {recursive: true});
   }
 
   let tarballTempDir;
-
   try {
     tarballTempDir = fs.mkdtempSync(
       path.join(os.tmpdir(), 'hermes-engine-destroot-'),
     );
 
-    execSync(`cp -R ./destroot ${tarballTempDir}`, {cwd: hermesDir});
+    let args = ['-a'];
+    if (excludeDebugSymbols) {
+      args.push('--exclude=dSYMs/');
+      args.push('--exclude=*.dSYM/');
+    }
+    execSync(`rsync ${args.join(' ')} ./destroot ${tarballTempDir}`, {
+      cwd: hermesDir,
+    });
     if (fs.existsSync(path.join(hermesDir, 'LICENSE'))) {
       execSync(`cp LICENSE ${tarballTempDir}`, {cwd: hermesDir});
     }
@@ -265,6 +260,44 @@ function createHermesPrebuiltArtifactsTarball(
   }
 
   return tarballOutputPath;
+}
+
+function validateHermesPrebuiltArtifactsPrerequisites(hermesDir) {
+  if (!fs.existsSync(hermesDir)) {
+    throw new Error(`Path to Hermes does not exist at ${hermesDir}`);
+  }
+  if (!fs.existsSync(path.join(hermesDir, 'destroot'))) {
+    throw new Error(
+      `destroot not found at ${path.join(
+        hermesDir,
+        'destroot',
+      )}. Are you sure Hermes has been built?`,
+    );
+  }
+  if (
+    !fs.existsSync(
+      path.join(
+        hermesDir,
+        'destroot/Library/Frameworks/macosx/hermes.framework',
+      ),
+    )
+  ) {
+    throw new Error(
+      'Error: Hermes macOS Framework not found. Are you sure Hermes has been built?',
+    );
+  }
+  if (
+    !fs.existsSync(
+      path.join(
+        hermesDir,
+        'destroot/Library/Frameworks/universal/hermes.xcframework',
+      ),
+    )
+  ) {
+    throw new Error(
+      'Error: Hermes iOS XCFramework not found. Are you sure Hermes has been built?',
+    );
+  }
 }
 
 module.exports = {


### PR DESCRIPTION
Summary:
The dSYMs for Apple will not be distributed as part of the prebuilts tarball. They can still be included in the tarball by passing a `-d` flag to the create-tarball script.

Changelog: [internal]

Reviewed By: cipolleschi

Differential Revision: D40813679

