### PR TITLE
Buck, etc. changes that enable persisted, sync settings for DevTools

### DIFF
--- a/Libraries/DevToolsSettings/DevToolsSettingsManager.android.js
+++ b/Libraries/DevToolsSettings/DevToolsSettingsManager.android.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ * @format
+ */
+
+import NativeDevToolsSettingsManager from './NativeDevToolsSettingsManager';
+
+module.exports = NativeDevToolsSettingsManager;

--- a/Libraries/DevToolsSettings/DevToolsSettingsManager.ios.js
+++ b/Libraries/DevToolsSettings/DevToolsSettingsManager.ios.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {Spec} from './NativeDevToolsSettingsManager';
+
+import Settings from '../Settings/Settings';
+
+const CONSOLE_PATCH_SETTINGS_KEY = 'ReactDevTools::ConsolePatchSettings';
+
+const DevToolsSettingsManager = {
+  setConsolePatchSettings: (newConsolePatchSettings: string) => {
+    Settings.set({
+      [CONSOLE_PATCH_SETTINGS_KEY]: newConsolePatchSettings,
+    });
+  },
+  getConsolePatchSettings: () => {
+    const value = Settings.get(CONSOLE_PATCH_SETTINGS_KEY);
+    if (typeof value === 'string') {
+      // $FlowFixMe[unclear-type]
+      return ((value: any): string);
+    }
+    return null;
+  },
+};
+
+module.exports = (DevToolsSettingsManager: Spec);

--- a/Libraries/DevToolsSettings/NativeDevToolsSettingsManager.js
+++ b/Libraries/DevToolsSettings/NativeDevToolsSettingsManager.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ * @format
+ */
+
+import type {TurboModule} from '../TurboModule/RCTExport';
+
+import * as TurboModuleRegistry from '../TurboModule/TurboModuleRegistry';
+
+export interface Spec extends TurboModule {
+  +setConsolePatchSettings: (newConsolePatchSettings: string) => void;
+  +getConsolePatchSettings: () => ?string;
+}
+
+export default (TurboModuleRegistry.get<Spec>(
+  'DevToolsSettingsManager',
+): ?Spec);

--- a/React/CoreModules/BUCK
+++ b/React/CoreModules/BUCK
@@ -134,6 +134,7 @@ rn_apple_library(
         "//xplat/js/react-native-github:FBReactNativeSpecApple",
         "//xplat/js/react-native-github:RCTLinkingApple",
         "//xplat/js/react-native-github:RCTPushNotificationApple",
+        "//xplat/js/react-native-github:RCTSettingsApple",
         "//xplat/js/react-native-github:ReactInternalApple",
     ],
 )

--- a/ReactAndroid/src/main/java/com/facebook/react/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/BUCK
@@ -41,6 +41,7 @@ rn_android_library(
         react_native_target("java/com/facebook/react/modules/appearance:appearance"),
         react_native_target("java/com/facebook/react/modules/bundleloader:bundleloader"),
         react_native_target("java/com/facebook/react/modules/debug:debug"),
+        react_native_target("java/com/facebook/react/modules/devtoolssettings:devtoolssettings"),
         react_native_target("java/com/facebook/react/modules/fabric:fabric"),
         react_native_target("java/com/facebook/react/modules/debug:interfaces"),
         react_native_target("java/com/facebook/react/modules/deviceinfo:deviceinfo"),

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/devtoolssettings/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/devtoolssettings/BUCK
@@ -1,0 +1,28 @@
+load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "react_native_root_target", "react_native_target", "rn_android_library")
+
+rn_android_library(
+    name = "devtoolssettings",
+    srcs = glob(["**/*.java"]),
+    autoglob = False,
+    labels = [
+        "pfh:ReactNative_CommonInfrastructurePlaceholder",
+        "supermodule:xplat/default/public.react_native.infra",
+    ],
+    language = "JAVA",
+    provided_deps = [
+        react_native_dep("third-party/android/androidx:annotation"),
+    ],
+    visibility = [
+        "PUBLIC",
+    ],
+    deps = [
+        react_native_dep("libraries/fbcore/src/main/java/com/facebook/common/logging:logging"),
+        react_native_dep("third-party/java/infer-annotations:infer-annotations"),
+        react_native_dep("third-party/java/jsr-305:jsr-305"),
+        react_native_target("java/com/facebook/react/bridge:bridge"),
+        react_native_target("java/com/facebook/react/common:common"),
+        react_native_target("java/com/facebook/react/module/annotations:annotations"),
+        react_native_target("java/com/facebook/react/modules/core:core"),
+    ],
+    exported_deps = [react_native_root_target(":FBReactNativeSpec")],
+)

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/devtoolssettings/DevToolsSettingsManagerModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/devtoolssettings/DevToolsSettingsManagerModule.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.modules.devtoolssettings;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.content.SharedPreferences.Editor;
+import androidx.annotation.Nullable;
+import com.facebook.fbreact.specs.NativeDevToolsSettingsManagerSpec;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.module.annotations.ReactModule;
+
+@ReactModule(name = DevToolsSettingsManagerModule.NAME)
+public class DevToolsSettingsManagerModule extends NativeDevToolsSettingsManagerSpec {
+  public static final String NAME = "DevToolsSettingsManager";
+
+  private static final String SHARED_PREFERENCES_PREFIX = "ReactNative__DevToolsSettings";
+  private static final String KEY_CONSOLE_PATCH_SETTINGS = "ConsolePatchSettings";
+
+  private final SharedPreferences mSharedPreferences;
+
+  public DevToolsSettingsManagerModule(ReactApplicationContext reactContext) {
+    super(reactContext);
+    mSharedPreferences =
+        reactContext.getSharedPreferences(SHARED_PREFERENCES_PREFIX, Context.MODE_PRIVATE);
+  }
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
+
+  @Override
+  public @Nullable String getConsolePatchSettings() {
+    return mSharedPreferences.getString(KEY_CONSOLE_PATCH_SETTINGS, null);
+  }
+
+  @Override
+  public void setConsolePatchSettings(String newSettings) {
+    Editor editor = mSharedPreferences.edit();
+    editor.putString(KEY_CONSOLE_PATCH_SETTINGS, newSettings);
+    editor.apply();
+  }
+}

--- a/ReactAndroid/src/main/java/com/facebook/react/shell/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/shell/BUCK
@@ -37,6 +37,7 @@ rn_android_library(
         react_native_target("java/com/facebook/react/modules/clipboard:clipboard"),
         react_native_target("java/com/facebook/react/modules/core:core"),
         react_native_target("java/com/facebook/react/modules/debug:debug"),
+        react_native_target("java/com/facebook/react/modules/devtoolssettings:devtoolssettings"),
         react_native_target("java/com/facebook/react/modules/dialog:dialog"),
         react_native_target("java/com/facebook/react/modules/fresco:fresco"),
         react_native_target("java/com/facebook/react/modules/i18nmanager:i18nmanager"),

--- a/ReactAndroid/src/main/java/com/facebook/react/shell/MainReactPackage.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/shell/MainReactPackage.java
@@ -23,6 +23,7 @@ import com.facebook.react.modules.blob.BlobModule;
 import com.facebook.react.modules.blob.FileReaderModule;
 import com.facebook.react.modules.camera.ImageStoreManager;
 import com.facebook.react.modules.clipboard.ClipboardModule;
+import com.facebook.react.modules.devtoolssettings.DevToolsSettingsManagerModule;
 import com.facebook.react.modules.dialog.DialogModule;
 import com.facebook.react.modules.fresco.FrescoModule;
 import com.facebook.react.modules.i18nmanager.I18nManagerModule;
@@ -141,6 +142,8 @@ public class MainReactPackage extends TurboReactPackage {
         return new VibrationModule(context);
       case WebSocketModule.NAME:
         return new WebSocketModule(context);
+      case DevToolsSettingsManagerModule.NAME:
+        return new DevToolsSettingsManagerModule(context);
       default:
         return null;
     }
@@ -181,7 +184,8 @@ public class MainReactPackage extends TurboReactPackage {
           Class.forName("com.facebook.react.shell.MainReactPackage$$ReactModuleInfoProvider");
       return (ReactModuleInfoProvider) reactModuleInfoProviderClass.newInstance();
     } catch (ClassNotFoundException e) {
-      // In OSS case, the annotation processor does not run. We fall back on creating this byhand
+      // In the OSS case, the annotation processor does not run. We fall back to creating this by
+      // hand
       Class<? extends NativeModule>[] moduleList =
           new Class[] {
             AccessibilityInfoModule.class,
@@ -199,6 +203,7 @@ public class MainReactPackage extends TurboReactPackage {
             NativeAnimatedModule.class,
             NetworkingModule.class,
             PermissionsModule.class,
+            DevToolsSettingsManagerModule.class,
             ShareModule.class,
             StatusBarModule.class,
             SoundManagerModule.class,

--- a/ReactAndroid/src/test/java/com/facebook/react/modules/BUCK
+++ b/ReactAndroid/src/test/java/com/facebook/react/modules/BUCK
@@ -34,6 +34,7 @@ rn_robolectric_test(
         react_native_target("java/com/facebook/react/modules/core:core"),
         react_native_target("java/com/facebook/react/modules/debug:debug"),
         react_native_target("java/com/facebook/react/modules/deviceinfo:deviceinfo"),
+        react_native_target("java/com/facebook/react/modules/devtoolssettings:devtoolssettings"),
         react_native_target("java/com/facebook/react/modules/dialog:dialog"),
         react_native_target("java/com/facebook/react/modules/network:network"),
         react_native_target("java/com/facebook/react/modules/share:share"),


### PR DESCRIPTION
Summary:
# What

This diff contains all the changes from D40333083 (https://github.com/facebook/react-native/commit/0fac9817df403e31d8256befe52409c948614706) (aka https://github.com/facebook/react-native/pull/34964), **except** the change to `setUpReactDevTools.js`, which actually uses the new files.

# Why

* We want to ship the Buck, C++, etc. changes before the JavaScript changes that depend on those files.
* Otherwise, apps can fail at startup with the message:
```
`TurboModuleRegistry.getEnforcing(...): '${name}' could not be found. ` +
      'Verify that a module by this name is registered in the native binary.',
```
* Note that this only occurs if you are using a previously-built version of the C++, Obj C, etc. files in RN, but a more recent version of the JavaScript files. If you are building from matching sources, this does not occur.
* After a few days, we can land the JS files.

## Changelog
[General][Added] Add, but don't use, DevTools Settings Manager.

Differential Revision: D40873390

