### PR TITLE
Link against the app codegen if available

### DIFF
--- a/ReactAndroid/cmake-utils/ReactNative-application.cmake
+++ b/ReactAndroid/cmake-utils/ReactNative-application.cmake
@@ -95,7 +95,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME}
         turbomodulejsijni                   # prefab ready
         yoga)                               # prefab ready
 
-# We use an interface targe to propagate flags to all the generated targets
+# We use an interface target to propagate flags to all the generated targets
 # such as the folly flags or others.
 add_library(common_flags INTERFACE)
 target_compile_options(common_flags INTERFACE ${folly_FLAGS})
@@ -106,6 +106,14 @@ if(EXISTS ${PROJECT_BUILD_DIR}/generated/rncli/src/main/jni/Android-rncli.cmake)
         include(${PROJECT_BUILD_DIR}/generated/rncli/src/main/jni/Android-rncli.cmake)
         target_link_libraries(${CMAKE_PROJECT_NAME} ${AUTOLINKED_LIBRARIES})
         foreach(autolinked_library ${AUTOLINKED_LIBRARIES})
-            target_link_libraries(autolinked_library INTERFACE common_flags)
+            target_link_libraries(autolinked_library common_flags)
         endforeach()
+endif()
+
+# If project is running codegen at the app level, we want to link and build the generated library.
+if(EXISTS ${PROJECT_BUILD_DIR}/generated/source/codegen/jni/CMakeLists.txt)
+        add_subdirectory(${PROJECT_BUILD_DIR}/generated/source/codegen/jni/ codegen_app_build)
+        get_property(APP_CODEGEN_TARGET DIRECTORY ${PROJECT_BUILD_DIR}/generated/source/codegen/jni/ PROPERTY BUILDSYSTEM_TARGETS)
+        target_link_libraries(${CMAKE_PROJECT_NAME} ${APP_CODEGEN_TARGET})
+        target_link_libraries(${APP_CODEGEN_TARGET} common_flags)
 endif()

--- a/packages/rn-tester/android/app/src/main/jni/CMakeLists.txt
+++ b/packages/rn-tester/android/app/src/main/jni/CMakeLists.txt
@@ -10,10 +10,8 @@ project(appmodules)
 
 include(${REACT_ANDROID_DIR}/cmake-utils/ReactNative-application.cmake)
 
-add_subdirectory(${PROJECT_BUILD_DIR}/generated/source/codegen/jni/ codegen_build)
 add_subdirectory(${REACT_COMMON_DIR}/react/nativemodule/samples/platform/android/ sampleturbomodule_build)
 
-# RN Tester needs to link against the local codegen-ned library and a sample turbomobule
+# RN Tester needs to link against the sample turbomobule
 target_link_libraries(${CMAKE_PROJECT_NAME}
-        react_codegen_AppSpecs
         sampleturbomodule)


### PR DESCRIPTION
Summary:
This commit extends the ReactNative-application.cmake logic so
that if the app is using codegen at the app level, the generate library
is properly built and linked.

It helps us simplify the RN Tester setup and makes it easier for app users
to use the codegen at the app level.

Changelog:
[Internal] [Changed] - [Android] Link against the app codegen if available

Differential Revision: D40936941

