### PR TITLE
Make sure nightly versions are using the -SNAPSHOT artifacts

### DIFF
--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/DependencyUtils.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/DependencyUtils.kt
@@ -45,7 +45,13 @@ internal object DependencyUtils {
   fun readVersionString(propertiesFile: File): String {
     val reactAndroidProperties = Properties()
     propertiesFile.inputStream().use { reactAndroidProperties.load(it) }
-    return reactAndroidProperties["VERSION_NAME"] as? String ?: ""
+    val versionString = reactAndroidProperties["VERSION_NAME"] as? String ?: ""
+    // If on a nightly, we need to fetch the -SNAPSHOT artifact from Sonatype.
+    return if (versionString.startsWith("0.0.0")) {
+      "$versionString-SNAPSHOT"
+    } else {
+      versionString
+    }
   }
 
   fun Project.mavenRepoFromUrl(url: String): MavenArtifactRepository =

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/DependencyUtilsTest.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/DependencyUtilsTest.kt
@@ -199,6 +199,23 @@ class DependencyUtilsTest {
   }
 
   @Test
+  fun readVersionString_withNightlyVersionString_returnsSnapshotVersion() {
+    val propertiesFile =
+        tempFolder.newFile("gradle.properties").apply {
+          writeText(
+              """
+        VERSION_NAME=0.0.0-20221101-2019-cfe811ab1
+        ANOTHER_PROPERTY=true
+      """
+                  .trimIndent())
+        }
+
+    val versionString = readVersionString(propertiesFile)
+
+    assertEquals("0.0.0-20221101-2019-cfe811ab1-SNAPSHOT", versionString)
+  }
+
+  @Test
   fun readVersionString_withMissingVersionString_returnsEmpty() {
     val propertiesFile =
         tempFolder.newFile("gradle.properties").apply {


### PR DESCRIPTION
Summary:
I forgot to add the logic to fetch the -SNAPSHOT version when on nightlies.
This code takes care of it.

Changelog:
[Internal] [Changed] - Make sure nightly versions are using the -SNAPSHOT artifacts

Differential Revision: D40939367

