### PR TITLE
chore: Extract codegen translateFunctionTypeAnnotation into a common function

### DIFF
--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -51,6 +51,7 @@ const {
   emitString,
   emitStringish,
   typeAliasResolution,
+  translateFunctionTypeAnnotation,
 } = require('../../parsers-primitives');
 
 const {
@@ -355,6 +356,8 @@ function translateTypeAnnotation(
           aliasMap,
           tryParse,
           cxxOnly,
+          translateTypeAnnotation,
+          language,
         );
       return emitFunction(nullable, translateFunctionTypeAnnotationValue);
     }
@@ -383,98 +386,6 @@ function translateTypeAnnotation(
       );
     }
   }
-}
-
-function translateFunctionTypeAnnotation(
-  hasteModuleName: string,
-  // TODO(T71778680): This is a FunctionTypeAnnotation. Type this.
-  flowFunctionTypeAnnotation: $FlowFixMe,
-  types: TypeDeclarationMap,
-  aliasMap: {...NativeModuleAliasMap},
-  tryParse: ParserErrorCapturer,
-  cxxOnly: boolean,
-): NativeModuleFunctionTypeAnnotation {
-  type Param = NamedShape<Nullable<NativeModuleParamTypeAnnotation>>;
-  const params: Array<Param> = [];
-
-  for (const flowParam of (flowFunctionTypeAnnotation.params: $ReadOnlyArray<$FlowFixMe>)) {
-    const parsedParam = tryParse(() => {
-      if (flowParam.name == null) {
-        throw new UnnamedFunctionParamParserError(
-          flowParam,
-          hasteModuleName,
-          language,
-        );
-      }
-
-      const paramName = flowParam.name.name;
-      const [paramTypeAnnotation, isParamTypeAnnotationNullable] =
-        unwrapNullable(
-          translateTypeAnnotation(
-            hasteModuleName,
-            flowParam.typeAnnotation,
-            types,
-            aliasMap,
-            tryParse,
-            cxxOnly,
-          ),
-        );
-
-      if (
-        paramTypeAnnotation.type === 'VoidTypeAnnotation' ||
-        paramTypeAnnotation.type === 'PromiseTypeAnnotation'
-      ) {
-        return throwIfUnsupportedFunctionParamTypeAnnotationParserError(
-          hasteModuleName,
-          flowParam.typeAnnotation,
-          paramName,
-          paramTypeAnnotation.type,
-        );
-      }
-
-      return {
-        name: flowParam.name.name,
-        optional: flowParam.optional,
-        typeAnnotation: wrapNullable(
-          isParamTypeAnnotationNullable,
-          paramTypeAnnotation,
-        ),
-      };
-    });
-
-    if (parsedParam != null) {
-      params.push(parsedParam);
-    }
-  }
-
-  const [returnTypeAnnotation, isReturnTypeAnnotationNullable] = unwrapNullable(
-    translateTypeAnnotation(
-      hasteModuleName,
-      flowFunctionTypeAnnotation.returnType,
-      types,
-      aliasMap,
-      tryParse,
-      cxxOnly,
-    ),
-  );
-
-  throwIfUnsupportedFunctionReturnTypeAnnotationParserError(
-    hasteModuleName,
-    flowFunctionTypeAnnotation,
-    'FunctionTypeAnnotation',
-    language,
-    cxxOnly,
-    returnTypeAnnotation.type,
-  );
-
-  return {
-    type: 'FunctionTypeAnnotation',
-    returnTypeAnnotation: wrapNullable(
-      isReturnTypeAnnotationNullable,
-      returnTypeAnnotation,
-    ),
-    params,
-  };
 }
 
 function buildPropertySchema(
@@ -516,6 +427,8 @@ function buildPropertySchema(
         aliasMap,
         tryParse,
         cxxOnly,
+        translateTypeAnnotation,
+        language,
       ),
     ),
   };

--- a/packages/react-native-codegen/src/parsers/parsers-primitives.js
+++ b/packages/react-native-codegen/src/parsers/parsers-primitives.js
@@ -27,11 +27,25 @@ import type {
   StringTypeAnnotation,
   VoidTypeAnnotation,
   NativeModuleFloatTypeAnnotation,
+  NativeModuleParamTypeAnnotation,
+  NamedShape,
 } from '../CodegenSchema';
 import type {ParserType} from './errors';
-import type {TypeAliasResolutionStatus} from './utils';
+import type {
+  ParserErrorCapturer,
+  TypeAliasResolutionStatus,
+  TypeDeclarationMap,
+} from './utils';
+
+const {UnnamedFunctionParamParserError} = require('./errors');
 
 const {
+  throwIfUnsupportedFunctionParamTypeAnnotationParserError,
+  throwIfUnsupportedFunctionReturnTypeAnnotationParserError,
+} = require('./error-utils');
+
+const {
+  unwrapNullable,
   wrapNullable,
   assertGenericTypeAnnotationHasExactlyOneTypeParameter,
 } = require('./parsers-commons');
@@ -180,6 +194,137 @@ function emitFloat(
   });
 }
 
+function getTypeAnnotationParameters(
+  typeAnnotation: $FlowFixMe,
+  language: ParserType,
+): $ReadOnlyArray<$FlowFixMe> {
+  return language === 'Flow'
+    ? typeAnnotation.params
+    : typeAnnotation.parameters;
+}
+
+function getFunctionNameFromParameter(
+  param: NamedShape<Nullable<NativeModuleParamTypeAnnotation>>,
+  language: ParserType,
+) {
+  return language === 'Flow' ? param.name : param.typeAnnotation;
+}
+
+function getParameterName(param: $FlowFixMe, language: ParserType): string {
+  return language === 'Flow' ? param.name.name : param.name;
+}
+
+function getParameterTypeAnnotation(param: $FlowFixMe, language: ParserType) {
+  return language === 'Flow'
+    ? param.typeAnnotation
+    : param.typeAnnotation.typeAnnotation;
+}
+
+function getTypeAnnotationReturnType(
+  typeAnnotation: $FlowFixMe,
+  language: ParserType,
+) {
+  return language === 'Flow'
+    ? typeAnnotation.returnType
+    : typeAnnotation.typeAnnotation.typeAnnotation;
+}
+
+function translateFunctionTypeAnnotation(
+  hasteModuleName: string,
+  // TODO(T108222691): Use flow-types for @babel/parser
+  // TODO(T71778680): This is a FunctionTypeAnnotation. Type this.
+  typeAnnotation: $FlowFixMe,
+  types: TypeDeclarationMap,
+  aliasMap: {...NativeModuleAliasMap},
+  tryParse: ParserErrorCapturer,
+  cxxOnly: boolean,
+  translateTypeAnnotation: $FlowFixMe,
+  language: ParserType,
+): NativeModuleFunctionTypeAnnotation {
+  type Param = NamedShape<Nullable<NativeModuleParamTypeAnnotation>>;
+  const params: Array<Param> = [];
+
+  for (const param of getTypeAnnotationParameters(typeAnnotation, language)) {
+    const parsedParam = tryParse(() => {
+      if (getFunctionNameFromParameter(param, language) == null) {
+        throw new UnnamedFunctionParamParserError(
+          param,
+          hasteModuleName,
+          language,
+        );
+      }
+
+      const paramName = getParameterName(param, language);
+
+      const [paramTypeAnnotation, isParamTypeAnnotationNullable] =
+        unwrapNullable(
+          translateTypeAnnotation(
+            hasteModuleName,
+            getParameterTypeAnnotation(param, language),
+            types,
+            aliasMap,
+            tryParse,
+            cxxOnly,
+          ),
+        );
+
+      if (
+        paramTypeAnnotation.type === 'VoidTypeAnnotation' ||
+        paramTypeAnnotation.type === 'PromiseTypeAnnotation'
+      ) {
+        return throwIfUnsupportedFunctionParamTypeAnnotationParserError(
+          hasteModuleName,
+          param.typeAnnotation,
+          paramName,
+          paramTypeAnnotation.type,
+        );
+      }
+
+      return {
+        name: paramName,
+        optional: Boolean(param.optional),
+        typeAnnotation: wrapNullable(
+          isParamTypeAnnotationNullable,
+          paramTypeAnnotation,
+        ),
+      };
+    });
+
+    if (parsedParam != null) {
+      params.push(parsedParam);
+    }
+  }
+
+  const [returnTypeAnnotation, isReturnTypeAnnotationNullable] = unwrapNullable(
+    translateTypeAnnotation(
+      hasteModuleName,
+      getTypeAnnotationReturnType(typeAnnotation, language),
+      types,
+      aliasMap,
+      tryParse,
+      cxxOnly,
+    ),
+  );
+
+  throwIfUnsupportedFunctionReturnTypeAnnotationParserError(
+    hasteModuleName,
+    typeAnnotation,
+    'FunctionTypeAnnotation',
+    language,
+    cxxOnly,
+    returnTypeAnnotation.type,
+  );
+
+  return {
+    type: 'FunctionTypeAnnotation',
+    returnTypeAnnotation: wrapNullable(
+      isReturnTypeAnnotationNullable,
+      returnTypeAnnotation,
+    ),
+    params,
+  };
+}
+
 module.exports = {
   emitBoolean,
   emitDouble,
@@ -194,4 +339,5 @@ module.exports = {
   emitString,
   emitStringish,
   typeAliasResolution,
+  translateFunctionTypeAnnotation,
 };

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -16,7 +16,6 @@ import type {
   NativeModuleArrayTypeAnnotation,
   NativeModuleBaseTypeAnnotation,
   NativeModuleFunctionTypeAnnotation,
-  NativeModuleParamTypeAnnotation,
   NativeModulePropertyShape,
   NativeModuleSchema,
   Nullable,
@@ -26,10 +25,7 @@ import type {ParserErrorCapturer, TypeDeclarationMap} from '../../utils';
 import type {NativeModuleTypeAnnotation} from '../../../CodegenSchema.js';
 const {nullGuard} = require('../../parsers-utils');
 
-const {
-  throwIfMoreThanOneModuleRegistryCalls,
-  throwIfUnsupportedFunctionParamTypeAnnotationParserError,
-} = require('../../error-utils');
+const {throwIfMoreThanOneModuleRegistryCalls} = require('../../error-utils');
 const {visit, isModuleRegistryCall} = require('../../utils');
 const {resolveTypeAnnotation, getTypes} = require('../utils.js');
 const {
@@ -54,9 +50,9 @@ const {
   emitString,
   emitStringish,
   typeAliasResolution,
+  translateFunctionTypeAnnotation,
 } = require('../../parsers-primitives');
 const {
-  UnnamedFunctionParamParserError,
   UnsupportedArrayElementTypeAnnotationParserError,
   UnsupportedGenericParserError,
   UnsupportedTypeAnnotationParserError,
@@ -76,7 +72,6 @@ const {
   throwIfWrongNumberOfCallExpressionArgs,
   throwIfMoreThanOneModuleInterfaceParserError,
   throwIfIncorrectModuleRegistryCallTypeParameterParserError,
-  throwIfUnsupportedFunctionReturnTypeAnnotationParserError,
 } = require('../../error-utils');
 
 const {TypeScriptParser} = require('../parser');
@@ -367,6 +362,8 @@ function translateTypeAnnotation(
           aliasMap,
           tryParse,
           cxxOnly,
+          translateTypeAnnotation,
+          language,
         );
 
       return emitFunction(nullable, translateFunctionTypeAnnotationValue);
@@ -396,98 +393,6 @@ function translateTypeAnnotation(
       );
     }
   }
-}
-
-function translateFunctionTypeAnnotation(
-  hasteModuleName: string,
-  // TODO(T108222691): Use flow-types for @babel/parser
-  typescriptFunctionTypeAnnotation: $FlowFixMe,
-  types: TypeDeclarationMap,
-  aliasMap: {...NativeModuleAliasMap},
-  tryParse: ParserErrorCapturer,
-  cxxOnly: boolean,
-): NativeModuleFunctionTypeAnnotation {
-  type Param = NamedShape<Nullable<NativeModuleParamTypeAnnotation>>;
-  const params: Array<Param> = [];
-
-  for (const typeScriptParam of (typescriptFunctionTypeAnnotation.parameters: $ReadOnlyArray<$FlowFixMe>)) {
-    const parsedParam = tryParse(() => {
-      if (typeScriptParam.typeAnnotation == null) {
-        throw new UnnamedFunctionParamParserError(
-          typeScriptParam,
-          hasteModuleName,
-          language,
-        );
-      }
-
-      const paramName = typeScriptParam.name;
-      const [paramTypeAnnotation, isParamTypeAnnotationNullable] =
-        unwrapNullable(
-          translateTypeAnnotation(
-            hasteModuleName,
-            typeScriptParam.typeAnnotation.typeAnnotation,
-            types,
-            aliasMap,
-            tryParse,
-            cxxOnly,
-          ),
-        );
-
-      if (
-        paramTypeAnnotation.type === 'VoidTypeAnnotation' ||
-        paramTypeAnnotation.type === 'PromiseTypeAnnotation'
-      ) {
-        return throwIfUnsupportedFunctionParamTypeAnnotationParserError(
-          hasteModuleName,
-          typeScriptParam.typeAnnotation,
-          paramName,
-          paramTypeAnnotation.type,
-        );
-      }
-
-      return {
-        name: typeScriptParam.name,
-        optional: Boolean(typeScriptParam.optional),
-        typeAnnotation: wrapNullable(
-          isParamTypeAnnotationNullable,
-          paramTypeAnnotation,
-        ),
-      };
-    });
-
-    if (parsedParam != null) {
-      params.push(parsedParam);
-    }
-  }
-
-  const [returnTypeAnnotation, isReturnTypeAnnotationNullable] = unwrapNullable(
-    translateTypeAnnotation(
-      hasteModuleName,
-      typescriptFunctionTypeAnnotation.typeAnnotation.typeAnnotation,
-      types,
-      aliasMap,
-      tryParse,
-      cxxOnly,
-    ),
-  );
-
-  throwIfUnsupportedFunctionReturnTypeAnnotationParserError(
-    hasteModuleName,
-    typescriptFunctionTypeAnnotation,
-    'FunctionTypeAnnotation',
-    language,
-    cxxOnly,
-    returnTypeAnnotation.type,
-  );
-
-  return {
-    type: 'FunctionTypeAnnotation',
-    returnTypeAnnotation: wrapNullable(
-      isReturnTypeAnnotationNullable,
-      returnTypeAnnotation,
-    ),
-    params,
-  };
 }
 
 function buildPropertySchema(
@@ -527,6 +432,8 @@ function buildPropertySchema(
         aliasMap,
         tryParse,
         cxxOnly,
+        translateTypeAnnotation,
+        language,
       ),
     ),
   };


### PR DESCRIPTION
## Summary

This PR extracts the codegen `translateFunctionTypeAnnotation` Flow and TypeScript functions into a single common function in the `parsers-primitives.js` file that can be used by both parsers as requested on https://github.com/facebook/react-native/issues/34872. 


## Changelog 

[Internal] [Changed] -  Extract codegen `translateFunctionTypeAnnotation` into a common function in the` parsers-primitives.js` file

## Test Plan

Run `yarn jest react-native-codegen` and ensure CI is green

![image](https://user-images.githubusercontent.com/11707729/199625849-e89b647f-63fb-40f8-b643-a59dedb4c59a.png)

