### PR TITLE
untrack test reports generated by test libraries (reporters)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,9 @@ package-lock.json
 /coverage
 /third-party
 
+# Test Reports
+/reports
+
 # Root dir shouldn't have Xcode project
 /*.xcodeproj
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
- Untrack Test Reports generated by test libraries (reporters E.g. `jest-junit`)
- E.g. `/reports/junit/js-test-results.xml` report is generated; when we exec `yarn test-ci`, which is **_shouldn't_ be tracked**

### NOTE: Used `[skip ci]` to avoid wastage of compute resources 🤗🌏
- Feel free to init tests manually if you find it necessary


## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[GENERAL] [CHANGED] - Untrack Test Reports generated by test libraries (reporters E.g. `jest-junit`)

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
`yarn test-ci`
![image](https://user-images.githubusercontent.com/55224033/199709131-240d844c-a98a-419b-a370-cafe8e927de4.png)
