### PR TITLE
Revert: make RCTBlobManager TurboModule-compatible

### DIFF
--- a/React/CoreModules/CoreModulesPlugins.h
+++ b/React/CoreModules/CoreModulesPlugins.h
@@ -53,7 +53,6 @@ Class RCTWebSocketModuleCls(void) __attribute__((used));
 Class RCTDevLoadingViewCls(void) __attribute__((used));
 Class RCTDevSplitBundleLoaderCls(void) __attribute__((used));
 Class RCTEventDispatcherCls(void) __attribute__((used));
-Class RCTBlobManagerCls(void) __attribute__((used));
 
 #ifdef __cplusplus
 }

--- a/React/CoreModules/CoreModulesPlugins.mm
+++ b/React/CoreModules/CoreModulesPlugins.mm
@@ -36,7 +36,6 @@ Class RCTCoreModulesClassProvider(const char *name) {
     {"PerfMonitor", RCTPerfMonitorCls},
     {"DevMenu", RCTDevMenuCls},
     {"DevSettings", RCTDevSettingsCls},
-    {"BlobModule", RCTBlobManagerCls},
     {"RedBox", RCTRedBoxCls},
     {"LogBox", RCTLogBoxCls},
     {"WebSocketExecutor", RCTWebSocketExecutorCls},


### PR DESCRIPTION
Summary:
This diff reverts D40716048 (https://github.com/facebook/react-native/commit/279cfec55fdf404fdb9198edbb37d3adfdfb3bf1) (https://github.com/facebook/react-native/pull/35047) which breaks RCTImageLoader.
https://pxl.cl/2jKrM
Those files are auto-generated and are not supposed to be edited manually.
Changelog: [iOS] [Fixed] - https://github.com/facebook/react-native/pull/35047 reverted.

Reviewed By: cipolleschi

Differential Revision: D40979350

