### PR TITLE
fix (deps): add explicitly eslint config to dependencies

### DIFF
--- a/repo-config/package.json
+++ b/repo-config/package.json
@@ -14,6 +14,7 @@
     "@babel/generator": "^7.14.0",
     "@babel/plugin-transform-regenerator": "^7.0.0",
     "@definitelytyped/dtslint": "^0.0.127",
+    "@react-native-community/eslint-config": "*",
     "@react-native-community/eslint-plugin": "*",
     "@react-native/eslint-plugin-specs": "^0.71.0",
     "@reactions/component": "^2.0.2",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Basically since this change https://github.com/facebook/react-native/pull/34423 everything worked ok because in the main branch where the monorepo has the workspace section and everything, `@react-native-community/eslint-config` was getting pulled in as a node_module anyway - but when moving to a stable branch and wanting to do a release, as we are now with 0.71, because of what the final package.json looks like for react-native and [the modifications that it goes through](https://github.com/facebook/react-native/commit/f0054e1e303e238d40970d23a3b3ae47502c32ea#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) (ex. the `workspace` section disappears), the fact that it's not directly listed as dependency makes [the CI fails](https://app.circleci.com/pipelines/github/facebook/react-native/17124/workflows/54a4162d-f466-4eab-94ba-ec9fe77e2ecf/jobs/339643) with `Error: Failed to load config "@react-native-community" to extend from.`


## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[General] [Fixed] - add explicitly eslint config to dependencies

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

In 0.71, add the deps to see the error disappear (it gets replaced by a different one though, looking into that)
