### PR TITLE
Remove project.android block from rn-tester's CLI config

### DIFF
--- a/packages/rn-tester/react-native.config.js
+++ b/packages/rn-tester/react-native.config.js
@@ -25,4 +25,9 @@ module.exports = {
     },
   },
   reactNativePath: '../../',
+  project: {
+    ios: {
+      sourceDir: '.',
+    },
+  },
 };

--- a/packages/rn-tester/react-native.config.js
+++ b/packages/rn-tester/react-native.config.js
@@ -25,12 +25,4 @@ module.exports = {
     },
   },
   reactNativePath: '../../',
-  project: {
-    ios: {
-      sourceDir: '.',
-    },
-    android: {
-      sourceDir: '.',
-    },
-  },
 };


### PR DESCRIPTION
## Summary

The project.android block is unnecessary and contains a wrong path. Let's use the default path which is `./android`.

## Changelog

[Internal] - Remove project.android block from rn-tester's CLI config

## Test Plan

Tested locally + will wait for a CI run