### PR TITLE
fix(jest-env): pass `exportConditions`

### DIFF
--- a/jest/react-native-env.js
+++ b/jest/react-native-env.js
@@ -12,5 +12,7 @@
 const NodeEnv = require('jest-environment-node').TestEnvironment;
 
 module.exports = class ReactNativeEnv extends NodeEnv {
-  // this is where we'll add our custom logic
+  exportConditions() {
+    return ['react-native'];
+  }
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Like discussed in https://github.com/react-native-community/discussions-and-proposals/issues/509, RN should override the default `node` and `node-addons` conditions.

You might consider supporting (or just setting) [`customExportConditions`](https://github.com/facebook/jest/blob/4670d3be0d80d47844673eb163666253e788f006/packages/jest-environment-node/src/index.ts#L187-L189) instead, but the default of the node env should be overwritten 🙂 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[General] [Changed] - use `'react-native'` export conditions in Jest environment

## Test Plan

Green CI?