### PR TITLE
android: Ensure we use the local Maven repo to get react-native

### DIFF
--- a/template/android/build.gradle
+++ b/template/android/build.gradle
@@ -22,9 +22,19 @@ buildscript {
 
 allprojects {
     repositories {
-        maven {
-            // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-            url("$rootDir/../node_modules/react-native/android")
+        exclusiveContent {
+            // We get React Native's Android binaries exclusively through npm,
+            // from a local Maven repo inside node_modules/react-native/.
+            // (The use of exclusiveContent prevents looking elsewhere like Maven Central
+            // and potentially getting a wrong version.)
+            filter {
+                includeGroup "com.facebook.react"
+            }
+            forRepository {
+                maven {
+                    url "$rootDir/../node_modules/react-native/android"
+                }
+            }
         }
         maven {
             // Android JSC is installed from npm


### PR DESCRIPTION
## Summary

This fixes #35204.  It ensures that for getting the Android binary dependencies provided by React Native, the build always looks only in the local Maven repo inside node_modules/react-native/.

Without this, the build also looks in the other configured repositories like Maven Central.  Those sometimes have RN binaries in them, by mistake or otherwise, which may be the wrong version.

For how this snippet works, see Gradle documentation:
  https://docs.gradle.org/current/userguide/declaring_repositories.html#sec:repository-content-filtering

Thanks to inckie for pointing out this feature:
  https://github.com/facebook/react-native/issues/35204#issuecomment-1304255623

## Changelog

[Android] [Fixed] - Always get React Native Android libraries from node_modules

## Test Plan

I applied this change to my own project where #35204 was reproducing, and the build started succeeding again.
