### PR TITLE
react-native-codegen: Enable C++ TurboModule generation in OpenSource builds

### DIFF
--- a/scripts/codegen/__tests__/generate-specs-cli-executor-test.js
+++ b/scripts/codegen/__tests__/generate-specs-cli-executor-test.js
@@ -26,7 +26,7 @@ describe('generateSpec', () => {
     const outputDirectory = normalize('app/ios/build/generated/ios');
     const libraryName = 'library';
     const packageName = 'com.library';
-    const generators = ['componentsIOS', 'modulesIOS'];
+    const generators = ['componentsIOS', 'modulesIOS', 'modulesCxx'];
 
     jest.mock('fs', () => ({
       readFileSync: (path, encoding) => {

--- a/scripts/codegen/generate-specs-cli-executor.js
+++ b/scripts/codegen/generate-specs-cli-executor.js
@@ -17,16 +17,16 @@ const RNCodegen = utils.getCodegen();
 
 const GENERATORS = {
   all: {
-    android: ['componentsAndroid', 'modulesAndroid'],
-    ios: ['componentsIOS', 'modulesIOS'],
+    android: ['componentsAndroid', 'modulesAndroid', 'modulesCxx'],
+    ios: ['componentsIOS', 'modulesIOS', 'modulesCxx'],
   },
   components: {
     android: ['componentsAndroid'],
     ios: ['componentsIOS'],
   },
   modules: {
-    android: ['modulesAndroid'],
-    ios: ['modulesIOS'],
+    android: ['modulesAndroid', 'modulesCxx'],
+    ios: ['modulesIOS', 'modulesCxx'],
   },
 };
 


### PR DESCRIPTION
Summary:
This enables the generation of C++ TurboModule specs in addition to existing Java/ObjC ones.

An example is shown in https://github.com/facebook/react-native/pull/35138

Changelog: [Internal]

Differential Revision: D41057630

