### PR TITLE
Add exclusiveContent on template for 0.70

### DIFF
--- a/template/android/build.gradle
+++ b/template/android/build.gradle
@@ -30,6 +30,20 @@ buildscript {
 
 allprojects {
     repositories {
+        exclusiveContent {
+            // We get React Native's Android binaries exclusively through npm,
+            // from a local Maven repo inside node_modules/react-native/.
+            // (The use of exclusiveContent prevents looking elsewhere like Maven Central
+            // and potentially getting a wrong version.)
+            filter {
+                includeGroup "com.facebook.react"
+            }
+            forRepository {
+                maven {
+                    url "$rootDir/../node_modules/react-native/android"
+                }
+            }
+        }
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
             url("$rootDir/../node_modules/react-native/android")


### PR DESCRIPTION
## Summary

This PR applies the fix suggested in #35210 to the template for 0.70.x

## Changelog

[Android] [Fix] - Add exclusiveContent on Android template to fix build failures

## Test Plan

See #35210 