### PR TITLE
feat: Update TextInput inputMode to map "none" to showSoftInputOnFocus

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -1602,6 +1602,7 @@ const ExportedForwardRef: React.AbstractComponent<
     enterKeyHint,
     returnKeyType,
     inputMode,
+    showSoftInputOnFocus,
     keyboardType,
     ...restProps
   },
@@ -1628,6 +1629,7 @@ const ExportedForwardRef: React.AbstractComponent<
       keyboardType={
         inputMode ? inputModeToKeyboardTypeMap[inputMode] : keyboardType
       }
+      showSoftInputOnFocus={inputMode === 'none' ? false : showSoftInputOnFocus}
       autoComplete={
         Platform.OS === 'android'
           ? // $FlowFixMe

--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -1629,7 +1629,9 @@ const ExportedForwardRef: React.AbstractComponent<
       keyboardType={
         inputMode ? inputModeToKeyboardTypeMap[inputMode] : keyboardType
       }
-      showSoftInputOnFocus={inputMode === 'none' ? false : showSoftInputOnFocus}
+      showSoftInputOnFocus={
+        inputMode == null ? showSoftInputOnFocus : inputMode !== 'none'
+      }
       autoComplete={
         Platform.OS === 'android'
           ? // $FlowFixMe


### PR DESCRIPTION
## Summary

This PR updates `inputMode` prop from the `TextInput` component to map the `none` option to `showSoftInputOnFocus={false}`  as suggested by @necolas here -> https://github.com/facebook/react-native/pull/34460#issuecomment-1304837271. This change makes the inputMode API behaves a bit more similarly across platforms.

Related to https://github.com/necolas/react-native-web/issues/2421

## Changelog

[General] [Changed] -  Update TextInput inputMode to map "none" to showSoftInputOnFocus

## Test Plan 

1. Open the RNTester app and navigate to the TextInput page
2. Test the `TextInput` component through the `Input modes` section


https://user-images.githubusercontent.com/11707729/200218435-6a33b319-e989-4086-aac3-506546982b38.mov

