### PR TITLE
Add intersection types in react-native-codegen for TypeScript

### DIFF
--- a/packages/react-native-codegen/src/parsers/consistency/__tests__/checkComponentSnaps-test.js
+++ b/packages/react-native-codegen/src/parsers/consistency/__tests__/checkComponentSnaps-test.js
@@ -21,7 +21,7 @@ const tsExtraCases = [
   'ARRAY2_PROP_TYPES_NO_EVENTS',
   'PROPS_AND_EVENTS_WITH_INTERFACES',
 ];
-const ignoredCases = ['ARRAY_PROP_TYPES_NO_EVENTS'];
+const ignoredCases = [];
 
 compareSnaps(
   flowFixtures,

--- a/packages/react-native-codegen/src/parsers/typescript/components/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/__test_fixtures__/fixtures.js
@@ -452,6 +452,13 @@ export interface ModuleProps extends ViewProps {
   array_of_array_of_object_required_in_file: ReadonlyArray<
     ReadonlyArray<ObjectType>
   >;
+
+  // Nested array of array of object types (with spread)
+  array_of_array_of_object_required_with_spread: ReadonlyArray<
+    ReadonlyArray<
+      Readonly<ObjectType & {}>,
+    >,
+  >,
 }
 
 export default codegenNativeComponent<ModuleProps>(
@@ -584,6 +591,9 @@ export interface ModuleProps extends ViewProps {
 
   // Nested array of array of object types (in file)
   array_of_array_of_object_required_in_file: readonly ObjectType[][];
+
+  // Nested array of array of object types (with spread)
+  array_of_array_of_object_required_with_spread: readonly Readonly<ObjectType & {}>[][];
 }
 
 export default codegenNativeComponent<ModuleProps>(

--- a/packages/react-native-codegen/src/parsers/typescript/components/__tests__/__snapshots__/typescript-component-parser-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/typescript/components/__tests__/__snapshots__/typescript-component-parser-test.js.snap
@@ -1221,6 +1221,29 @@ exports[`RN Codegen TypeScript Parser can generate fixture ARRAY_PROP_TYPES_NO_E
                   }
                 }
               }
+            },
+            {
+              'name': 'array_of_array_of_object_required_with_spread',
+              'optional': false,
+              'typeAnnotation': {
+                'type': 'ArrayTypeAnnotation',
+                'elementType': {
+                  'type': 'ArrayTypeAnnotation',
+                  'elementType': {
+                    'type': 'ObjectTypeAnnotation',
+                    'properties': [
+                      {
+                        'name': 'prop',
+                        'optional': false,
+                        'typeAnnotation': {
+                          'type': 'StringTypeAnnotation',
+                          'default': null
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
             }
           ],
           'commands': []
@@ -1885,6 +1908,29 @@ exports[`RN Codegen TypeScript Parser can generate fixture ARRAY2_PROP_TYPES_NO_
             },
             {
               'name': 'array_of_array_of_object_required_in_file',
+              'optional': false,
+              'typeAnnotation': {
+                'type': 'ArrayTypeAnnotation',
+                'elementType': {
+                  'type': 'ArrayTypeAnnotation',
+                  'elementType': {
+                    'type': 'ObjectTypeAnnotation',
+                    'properties': [
+                      {
+                        'name': 'prop',
+                        'optional': false,
+                        'typeAnnotation': {
+                          'type': 'StringTypeAnnotation',
+                          'default': null
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              'name': 'array_of_array_of_object_required_with_spread',
               'optional': false,
               'typeAnnotation': {
                 'type': 'ArrayTypeAnnotation',

--- a/packages/react-native-codegen/src/parsers/typescript/components/componentsUtils.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/componentsUtils.js
@@ -293,7 +293,15 @@ function getTypeAnnotationForArray<T>(
         extractedTypeAnnotation.typeName?.name ||
         extractedTypeAnnotation.type;
 
-  const common = getCommonTypeAnnotation(name, true, type, extractedTypeAnnotation, defaultValue, types, buildSchema);
+  const common = getCommonTypeAnnotation(
+    name,
+    true,
+    type,
+    extractedTypeAnnotation,
+    defaultValue,
+    types,
+    buildSchema,
+  );
   if (common) {
     return common;
   }
@@ -336,12 +344,18 @@ function getTypeAnnotation<T>(
       ? typeAnnotation.typeName.name
       : typeAnnotation.type;
 
-  const common = getCommonTypeAnnotation(name, false, type, typeAnnotation, defaultValue, types, buildSchema);
+  const common = getCommonTypeAnnotation(
+    name,
+    false,
+    type,
+    typeAnnotation,
+    defaultValue,
+    types,
+    buildSchema,
+  );
   if (common) {
     switch (common.type) {
       case 'Int32TypeAnnotation':
-        common.default = ((defaultValue ? defaultValue : 0): number);
-        break;
       case 'DoubleTypeAnnotation':
         common.default = ((defaultValue ? defaultValue : 0): number);
         break;
@@ -351,14 +365,14 @@ function getTypeAnnotation<T>(
           : defaultValue
           ? defaultValue
           : 0): number | null);
-          break;
+        break;
       case 'BooleanTypeAnnotation':
-        common.default = (defaultValue === null ? null : !!defaultValue);
+        common.default = defaultValue === null ? null : !!defaultValue;
         break;
       case 'StringTypeAnnotation':
         common.default = ((defaultValue === undefined ? null : defaultValue):
-        | string
-        | null);
+          | string
+          | null);
         break;
     }
     return common;

--- a/packages/react-native-codegen/src/parsers/typescript/components/componentsUtils.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/componentsUtils.js
@@ -326,6 +326,33 @@ function getTypeAnnotationForArray<T>(
   }
 }
 
+function setDefaultValue(
+  common: $FlowFixMe,
+  defaultValue: $FlowFixMe | void
+): void {
+  switch (common.type) {
+    case 'Int32TypeAnnotation':
+    case 'DoubleTypeAnnotation':
+      common.default = ((defaultValue ? defaultValue : 0): number);
+      break;
+    case 'FloatTypeAnnotation':
+      common.default = ((defaultValue === null
+        ? null
+        : defaultValue
+        ? defaultValue
+        : 0): number | null);
+      break;
+    case 'BooleanTypeAnnotation':
+      common.default = defaultValue === null ? null : !!defaultValue;
+      break;
+    case 'StringTypeAnnotation':
+      common.default = ((defaultValue === undefined ? null : defaultValue):
+        | string
+        | null);
+      break;
+  }
+}
+
 function getTypeAnnotation<T>(
   name: string,
   annotation: $FlowFixMe | ASTNode,
@@ -363,27 +390,7 @@ function getTypeAnnotation<T>(
     buildSchema,
   );
   if (common) {
-    switch (common.type) {
-      case 'Int32TypeAnnotation':
-      case 'DoubleTypeAnnotation':
-        common.default = ((defaultValue ? defaultValue : 0): number);
-        break;
-      case 'FloatTypeAnnotation':
-        common.default = ((defaultValue === null
-          ? null
-          : defaultValue
-          ? defaultValue
-          : 0): number | null);
-        break;
-      case 'BooleanTypeAnnotation':
-        common.default = defaultValue === null ? null : !!defaultValue;
-        break;
-      case 'StringTypeAnnotation':
-        common.default = ((defaultValue === undefined ? null : defaultValue):
-          | string
-          | null);
-        break;
-    }
+    setDefaultValue(common, defaultValue);
     return common;
   }
 

--- a/packages/react-native-codegen/src/parsers/typescript/components/componentsUtils.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/componentsUtils.js
@@ -186,6 +186,32 @@ function getCommonTypeAnnotation<T>(
         properties,
       };
     }
+    case 'ImageSource':
+      return {
+        type: 'ReservedPropTypeAnnotation',
+        name: 'ImageSourcePrimitive',
+      };
+    case 'ImageRequest':
+      return {
+        type: 'ReservedPropTypeAnnotation',
+        name: 'ImageRequestPrimitive',
+      };
+    case 'ColorValue':
+    case 'ProcessedColorValue':
+      return {
+        type: 'ReservedPropTypeAnnotation',
+        name: 'ColorPrimitive',
+      };
+    case 'PointValue':
+      return {
+        type: 'ReservedPropTypeAnnotation',
+        name: 'PointPrimitive',
+      };
+    case 'EdgeInsetsValue':
+      return {
+        type: 'ReservedPropTypeAnnotation',
+        name: 'EdgeInsetsPrimitive',
+      };
     default:
       return undefined;
   }
@@ -244,32 +270,6 @@ function getTypeAnnotationForArray<T>(
     case 'TSNumberKeyword':
       return {
         type: 'FloatTypeAnnotation',
-      };
-    case 'ImageSource':
-      return {
-        type: 'ReservedPropTypeAnnotation',
-        name: 'ImageSourcePrimitive',
-      };
-    case 'ImageRequest':
-      return {
-        type: 'ReservedPropTypeAnnotation',
-        name: 'ImageRequestPrimitive',
-      };
-    case 'ColorValue':
-    case 'ProcessedColorValue':
-      return {
-        type: 'ReservedPropTypeAnnotation',
-        name: 'ColorPrimitive',
-      };
-    case 'PointValue':
-      return {
-        type: 'ReservedPropTypeAnnotation',
-        name: 'PointPrimitive',
-      };
-    case 'EdgeInsetsValue':
-      return {
-        type: 'ReservedPropTypeAnnotation',
-        name: 'EdgeInsetsPrimitive',
       };
     case 'Stringish':
       return {
@@ -342,22 +342,6 @@ function getTypeAnnotation<T>(
   }
 
   switch (type) {
-    case 'ImageSource':
-      return {
-        type: 'ReservedPropTypeAnnotation',
-        name: 'ImageSourcePrimitive',
-      };
-    case 'ImageRequest':
-      return {
-        type: 'ReservedPropTypeAnnotation',
-        name: 'ImageRequestPrimitive',
-      };
-    case 'ColorValue':
-    case 'ProcessedColorValue':
-      return {
-        type: 'ReservedPropTypeAnnotation',
-        name: 'ColorPrimitive',
-      };
     case 'ColorArrayValue':
       return {
         type: 'ArrayTypeAnnotation',
@@ -365,16 +349,6 @@ function getTypeAnnotation<T>(
           type: 'ReservedPropTypeAnnotation',
           name: 'ColorPrimitive',
         },
-      };
-    case 'PointValue':
-      return {
-        type: 'ReservedPropTypeAnnotation',
-        name: 'PointPrimitive',
-      };
-    case 'EdgeInsetsValue':
-      return {
-        type: 'ReservedPropTypeAnnotation',
-        name: 'EdgeInsetsPrimitive',
       };
     case 'Int32':
       return {

--- a/packages/react-native-codegen/src/parsers/typescript/components/componentsUtils.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/componentsUtils.js
@@ -164,8 +164,11 @@ function detectArrayType<T>(
 }
 
 function getCommonTypeAnnotation<T>(
+  name: string,
+  forArray: boolean,
   type: string,
   typeAnnotation: $FlowFixMe,
+  defaultValue: $FlowFixMe | void,
   types: TypeDeclarationMap,
   buildSchema: (property: PropAST, types: TypeDeclarationMap) => ?NamedShape<T>,
 ): $FlowFixMe {
@@ -212,6 +215,14 @@ function getCommonTypeAnnotation<T>(
         type: 'ReservedPropTypeAnnotation',
         name: 'EdgeInsetsPrimitive',
       };
+    case 'TSUnionType':
+      return getUnionOfLiterals(
+        name,
+        forArray,
+        typeAnnotation.types,
+        defaultValue,
+        types,
+      );
     default:
       return undefined;
   }
@@ -261,7 +272,7 @@ function getTypeAnnotationForArray<T>(
         extractedTypeAnnotation.typeName?.name ||
         extractedTypeAnnotation.type;
 
-  const common = getCommonTypeAnnotation(type, extractedTypeAnnotation, types, buildSchema);
+  const common = getCommonTypeAnnotation(name, true, type, extractedTypeAnnotation, defaultValue, types, buildSchema);
   if (common) {
     return common;
   }
@@ -295,14 +306,6 @@ function getTypeAnnotationForArray<T>(
       return {
         type: 'StringTypeAnnotation',
       };
-    case 'TSUnionType':
-      return getUnionOfLiterals(
-        name,
-        true,
-        extractedTypeAnnotation.types,
-        defaultValue,
-        types,
-      );
     default:
       (type: empty);
       throw new Error(`Unknown prop type for "${name}": ${type}`);
@@ -336,7 +339,7 @@ function getTypeAnnotation<T>(
       ? typeAnnotation.typeName.name
       : typeAnnotation.type;
 
-  const common = getCommonTypeAnnotation(type, typeAnnotation, types, buildSchema);
+  const common = getCommonTypeAnnotation(name, false, type, typeAnnotation, defaultValue, types, buildSchema);
   if (common) {
     return common;
   }
@@ -391,14 +394,6 @@ function getTypeAnnotation<T>(
     case 'TSNumberKeyword':
       throw new Error(
         `Cannot use "${type}" type annotation for "${name}": must use a specific numeric type like Int32, Double, or Float`,
-      );
-    case 'TSUnionType':
-      return getUnionOfLiterals(
-        name,
-        false,
-        typeAnnotation.types,
-        defaultValue,
-        types,
       );
     default:
       (type: empty);

--- a/packages/react-native-codegen/src/parsers/typescript/components/componentsUtils.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/componentsUtils.js
@@ -11,7 +11,10 @@
 'use strict';
 import type {ASTNode} from '../utils';
 import type {NamedShape} from '../../../CodegenSchema.js';
-const {parseTopLevelType, flattenIntersectionType} = require('../parseTopLevelType');
+const {
+  parseTopLevelType,
+  flattenIntersectionType,
+} = require('../parseTopLevelType');
 import type {TypeDeclarationMap} from '../../utils';
 
 function getProperties(
@@ -177,9 +180,11 @@ function getCommonTypeAnnotation<T>(
     case 'TSInterfaceDeclaration':
     case 'TSIntersectionType': {
       const rawProperties =
-        type === 'TSInterfaceDeclaration' ? [typeAnnotation]:
-        type === 'TSIntersectionType' ? flattenIntersectionType(typeAnnotation, types) :
-        typeAnnotation.members;
+        type === 'TSInterfaceDeclaration'
+          ? [typeAnnotation]
+          : type === 'TSIntersectionType'
+          ? flattenIntersectionType(typeAnnotation, types)
+          : typeAnnotation.members;
       const flattenedProperties = flattenProperties(rawProperties, types);
       const properties = flattenedProperties
         .map(prop => buildSchema(prop, types))

--- a/packages/react-native-codegen/src/parsers/typescript/components/componentsUtils.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/componentsUtils.js
@@ -223,6 +223,27 @@ function getCommonTypeAnnotation<T>(
         defaultValue,
         types,
       );
+    case 'Int32':
+      return {
+        type: 'Int32TypeAnnotation',
+      };
+    case 'Double':
+      return {
+        type: 'DoubleTypeAnnotation',
+      };
+    case 'Float':
+      return {
+        type: 'FloatTypeAnnotation',
+      };
+    case 'TSBooleanKeyword':
+      return {
+        type: 'BooleanTypeAnnotation',
+      };
+    case 'Stringish':
+    case 'TSStringKeyword':
+      return {
+        type: 'StringTypeAnnotation',
+      };
     default:
       return undefined;
   }
@@ -282,30 +303,6 @@ function getTypeAnnotationForArray<T>(
       return {
         type: 'FloatTypeAnnotation',
       };
-    case 'Stringish':
-      return {
-        type: 'StringTypeAnnotation',
-      };
-    case 'Int32':
-      return {
-        type: 'Int32TypeAnnotation',
-      };
-    case 'Double':
-      return {
-        type: 'DoubleTypeAnnotation',
-      };
-    case 'Float':
-      return {
-        type: 'FloatTypeAnnotation',
-      };
-    case 'TSBooleanKeyword':
-      return {
-        type: 'BooleanTypeAnnotation',
-      };
-    case 'TSStringKeyword':
-      return {
-        type: 'StringTypeAnnotation',
-      };
     default:
       (type: empty);
       throw new Error(`Unknown prop type for "${name}": ${type}`);
@@ -341,6 +338,29 @@ function getTypeAnnotation<T>(
 
   const common = getCommonTypeAnnotation(name, false, type, typeAnnotation, defaultValue, types, buildSchema);
   if (common) {
+    switch (common.type) {
+      case 'Int32TypeAnnotation':
+        common.default = ((defaultValue ? defaultValue : 0): number);
+        break;
+      case 'DoubleTypeAnnotation':
+        common.default = ((defaultValue ? defaultValue : 0): number);
+        break;
+      case 'FloatTypeAnnotation':
+        common.default = ((defaultValue === null
+          ? null
+          : defaultValue
+          ? defaultValue
+          : 0): number | null);
+          break;
+      case 'BooleanTypeAnnotation':
+        common.default = (defaultValue === null ? null : !!defaultValue);
+        break;
+      case 'StringTypeAnnotation':
+        common.default = ((defaultValue === undefined ? null : defaultValue):
+        | string
+        | null);
+        break;
+    }
     return common;
   }
 
@@ -352,44 +372,6 @@ function getTypeAnnotation<T>(
           type: 'ReservedPropTypeAnnotation',
           name: 'ColorPrimitive',
         },
-      };
-    case 'Int32':
-      return {
-        type: 'Int32TypeAnnotation',
-        default: ((defaultValue ? defaultValue : 0): number),
-      };
-    case 'Double':
-      return {
-        type: 'DoubleTypeAnnotation',
-        default: ((defaultValue ? defaultValue : 0): number),
-      };
-    case 'Float':
-      return {
-        type: 'FloatTypeAnnotation',
-        default: ((defaultValue === null
-          ? null
-          : defaultValue
-          ? defaultValue
-          : 0): number | null),
-      };
-    case 'TSBooleanKeyword':
-      return {
-        type: 'BooleanTypeAnnotation',
-        default: defaultValue === null ? null : !!defaultValue,
-      };
-    case 'TSStringKeyword':
-      return {
-        type: 'StringTypeAnnotation',
-        default: ((defaultValue === undefined ? null : defaultValue):
-          | string
-          | null),
-      };
-    case 'Stringish':
-      return {
-        type: 'StringTypeAnnotation',
-        default: ((defaultValue === undefined ? null : defaultValue):
-          | string
-          | null),
       };
     case 'TSNumberKeyword':
       throw new Error(

--- a/packages/react-native-codegen/src/parsers/typescript/components/componentsUtils.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/componentsUtils.js
@@ -197,7 +197,11 @@ function getCommonTypeAnnotation<T>(
     case 'TSInterfaceDeclaration':
       return buildObjectType([typeAnnotation], types, buildSchema);
     case 'TSIntersectionType':
-      return buildObjectType(flattenIntersectionType(typeAnnotation, types), types, buildSchema);
+      return buildObjectType(
+        flattenIntersectionType(typeAnnotation, types),
+        types,
+        buildSchema,
+      );
     case 'ImageSource':
       return {
         type: 'ReservedPropTypeAnnotation',
@@ -328,7 +332,7 @@ function getTypeAnnotationForArray<T>(
 
 function setDefaultValue(
   common: $FlowFixMe,
-  defaultValue: $FlowFixMe | void
+  defaultValue: $FlowFixMe | void,
 ): void {
   switch (common.type) {
     case 'Int32TypeAnnotation':

--- a/packages/react-native-codegen/src/parsers/typescript/parseTopLevelType.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parseTopLevelType.js
@@ -184,6 +184,58 @@ function parseTopLevelType(
   }
 }
 
+function handleIntersectionAndParen(
+  type: $FlowFixMe,
+  result: Array<$FlowFixMe>,
+  knownTypes?: TypeDeclarationMap,
+): void {
+  switch (type.type) {
+    case 'TSParenthesizedType': {
+      handleIntersectionAndParen(type.typeAnnotation, result, knownTypes);
+      break;
+    }
+    case 'TSIntersectionType': {
+      for (const t of type.types) {
+        handleIntersectionAndParen(t, result, knownTypes);
+      }
+      break;
+    }
+    case 'TSTypeReference':
+      if (type.typeName.name === 'Readonly') {
+        handleIntersectionAndParen(type.typeParameters.params[0], result, knownTypes);
+      } else if (type.typeName.name === 'WithDefault') {
+        throw new Error(
+          'WithDefault<> is now allowed in intersection types.',
+        );
+      } else if (!knownTypes) {
+        result.push(type);
+      } else {
+        const resolvedType = getValueFromTypes(type, knownTypes);
+        if (
+          resolvedType.type === 'TSTypeReference' &&
+          resolvedType.typeName.name === type.typeName.name
+        ) {
+          result.push(type);
+        } else {
+          handleIntersectionAndParen(resolvedType, result, knownTypes);
+        }
+      }
+      break;
+    default:
+      result.push(type);
+  }
+}
+
+function flattenIntersectionType(
+  type: $FlowFixMe,
+  knownTypes?: TypeDeclarationMap,
+): Array<$FlowFixMe> {
+  const result: Array<$FlowFixMe> = [];
+  handleIntersectionAndParen(type, result, knownTypes);
+  return result;
+}
+
 module.exports = {
   parseTopLevelType,
+  flattenIntersectionType,
 };

--- a/packages/react-native-codegen/src/parsers/typescript/parseTopLevelType.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parseTopLevelType.js
@@ -202,11 +202,13 @@ function handleIntersectionAndParen(
     }
     case 'TSTypeReference':
       if (type.typeName.name === 'Readonly') {
-        handleIntersectionAndParen(type.typeParameters.params[0], result, knownTypes);
-      } else if (type.typeName.name === 'WithDefault') {
-        throw new Error(
-          'WithDefault<> is now allowed in intersection types.',
+        handleIntersectionAndParen(
+          type.typeParameters.params[0],
+          result,
+          knownTypes,
         );
+      } else if (type.typeName.name === 'WithDefault') {
+        throw new Error('WithDefault<> is now allowed in intersection types.');
       } else if (!knownTypes) {
         result.push(type);
       } else {


### PR DESCRIPTION
## Summary

Refer to "Support intersection of object types, `{...a, ...b, ...}` in Flow is equivalent to `a & b & {...}` in TypeScript, the order and the form is not important." in https://github.com/facebook/react-native/issues/34872

In this change I also extract the common part from `getTypeAnnotation` and `getTypeAnnotationForArray` into `getCommonTypeAnnotation`. Most of the differences are about `default` in the schema. After a schema is generated from `getCommonTypeAnnotation` successfully, `getTypeAnnotation` will fill `default` if necessary, while `getTypeAnnotationForArray` does nothing.

## Changelog

[General] [Changed] - Add intersection types in react-native-codegen for TypeScript

## Test Plan

`yarn jest react-native-codegen` passed
