### PR TITLE
Nested horizontal virtualized list viewability

### DIFF
--- a/Libraries/Lists/ViewabilityHelper.js
+++ b/Libraries/Lists/ViewabilityHelper.js
@@ -80,7 +80,7 @@ class ViewabilityHelper {
   _timers: Set<number> = new Set();
   _viewableIndices: Array<number> = [];
   _viewableItems: Map<string, ViewToken> = new Map();
-  _parentWasViewable: boolean = undefined;
+  _parentWasViewable: ?boolean = undefined;
 
   constructor(
     config: ViewabilityConfig = {viewAreaCoveragePercentThreshold: 0},
@@ -103,7 +103,7 @@ class ViewabilityHelper {
    */
   computeViewableItems(
     props: FrameMetricProps,
-    isParentViewable: boolean | undefined,
+    isParentViewable: ?boolean,
     scrollOffset: number,
     viewportSize: number,
     getFrameMetrics: (
@@ -182,7 +182,7 @@ class ViewabilityHelper {
    */
   onUpdate(
     props: FrameMetricProps,
-    isParentViewable: boolean | undefined,
+    isParentViewable: ?boolean,
     scrollOffset: number,
     viewportSize: number,
     getFrameMetrics: (
@@ -331,7 +331,7 @@ class ViewabilityHelper {
 
 function _isViewable(
   viewAreaMode: boolean,
-  isParentViewable: boolean | undefined,
+  isParentViewable: ?boolean,
   viewablePercentThreshold: number,
   start: number,
   end: number,

--- a/Libraries/Lists/ViewabilityHelper.js
+++ b/Libraries/Lists/ViewabilityHelper.js
@@ -103,7 +103,7 @@ class ViewabilityHelper {
   computeViewableItems(
     props: FrameMetricProps,
     scrollOffset: number,
-    viewportHeight: number,
+    viewportSize: number,
     getFrameMetrics: (
       index: number,
       props: FrameMetricProps,
@@ -150,17 +150,17 @@ class ViewabilityHelper {
       if (!metrics) {
         continue;
       }
-      const top = metrics.offset - scrollOffset;
-      const bottom = top + metrics.length;
-      if (top < viewportHeight && bottom > 0) {
+      const start = metrics.offset - scrollOffset;
+      const end = start + metrics.length;
+      if (start < viewportSize && end > 0) {
         firstVisible = idx;
         if (
           _isViewable(
             viewAreaMode,
             viewablePercentThreshold,
-            top,
-            bottom,
-            viewportHeight,
+            start,
+            end,
+            viewportSize,
             metrics.length,
           )
         ) {
@@ -180,7 +180,7 @@ class ViewabilityHelper {
   onUpdate(
     props: FrameMetricProps,
     scrollOffset: number,
-    viewportHeight: number,
+    viewportSize: number,
     getFrameMetrics: (
       index: number,
       props: FrameMetricProps,
@@ -219,7 +219,7 @@ class ViewabilityHelper {
       viewableIndices = this.computeViewableItems(
         props,
         scrollOffset,
-        viewportHeight,
+        viewportSize,
         getFrameMetrics,
         renderRange,
       );
@@ -325,36 +325,36 @@ class ViewabilityHelper {
 function _isViewable(
   viewAreaMode: boolean,
   viewablePercentThreshold: number,
-  top: number,
-  bottom: number,
-  viewportHeight: number,
+  start: number,
+  end: number,
+  viewportSize: number,
   itemLength: number,
 ): boolean {
-  if (_isEntirelyVisible(top, bottom, viewportHeight)) {
+  } else if (_isEntirelyVisible(start, end, viewportSize)) {
     return true;
   } else {
-    const pixels = _getPixelsVisible(top, bottom, viewportHeight);
+    const pixels = _getPixelsVisible(start, end, viewportSize);
     const percent =
-      100 * (viewAreaMode ? pixels / viewportHeight : pixels / itemLength);
+      100 * (viewAreaMode ? pixels / viewportSize : pixels / itemLength);
     return percent >= viewablePercentThreshold;
   }
 }
 
 function _getPixelsVisible(
-  top: number,
-  bottom: number,
-  viewportHeight: number,
+  start: number,
+  end: number,
+  viewportSize: number,
 ): number {
-  const visibleHeight = Math.min(bottom, viewportHeight) - Math.max(top, 0);
-  return Math.max(0, visibleHeight);
+  const visibleSize = Math.min(end, viewportSize) - Math.max(start, 0);
+  return Math.max(0, visibleSize);
 }
 
 function _isEntirelyVisible(
-  top: number,
-  bottom: number,
-  viewportHeight: number,
+  start: number,
+  end: number,
+  viewportSize: number,
 ): boolean {
-  return top >= 0 && bottom <= viewportHeight && bottom > top;
+  return start >= 0 && end <= viewportSize && end > start;
 }
 
 module.exports = ViewabilityHelper;

--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -776,7 +776,7 @@ export default class VirtualizedList extends StateSafePureComponent<
     });
   };
 
-  _isNestedWithSameOrientation(props: FrameMetricProps = this.props): boolean {
+  _isNestedWithSameOrientation(props: Props = this.props): boolean {
     const nestedContext = this.context;
     return !!(
       nestedContext &&
@@ -1849,7 +1849,7 @@ export default class VirtualizedList extends StateSafePureComponent<
      * false - nested in parent list and not visible
      * undefined - not nested in parent list
      */
-    const isParentViewable: boolean | undefined = !this._isNested()
+    const isParentViewable: ?boolean = !this._isNested()
       ? undefined
       : !!this._getOutermostParentListRef()._viewableItems?.find(
           item => item.key === this.context.cellKey,

--- a/Libraries/Lists/__tests__/ViewabilityHelper-test.js
+++ b/Libraries/Lists/__tests__/ViewabilityHelper-test.js
@@ -38,9 +38,9 @@ describe('computeViewableItems', function () {
       d: {y: 150, height: 50},
     };
     data = [{key: 'a'}, {key: 'b'}, {key: 'c'}, {key: 'd'}];
-    expect(helper.computeViewableItems(props, 0, 200, getFrameMetrics)).toEqual(
-      [0, 1, 2, 3],
-    );
+    expect(
+      helper.computeViewableItems(props, null, 0, 200, getFrameMetrics),
+    ).toEqual([0, 1, 2, 3]);
   });
 
   it('returns top 2 rows as viewable (1. entirely visible and 2. majority)', function () {
@@ -54,9 +54,9 @@ describe('computeViewableItems', function () {
       d: {y: 250, height: 50},
     };
     data = [{key: 'a'}, {key: 'b'}, {key: 'c'}, {key: 'd'}];
-    expect(helper.computeViewableItems(props, 0, 200, getFrameMetrics)).toEqual(
-      [0, 1],
-    );
+    expect(
+      helper.computeViewableItems(props, null, 0, 200, getFrameMetrics),
+    ).toEqual([0, 1]);
   });
 
   it('returns only 2nd row as viewable (majority)', function () {
@@ -71,7 +71,7 @@ describe('computeViewableItems', function () {
     };
     data = [{key: 'a'}, {key: 'b'}, {key: 'c'}, {key: 'd'}];
     expect(
-      helper.computeViewableItems(props, 25, 200, getFrameMetrics),
+      helper.computeViewableItems(props, null, 25, 200, getFrameMetrics),
     ).toEqual([1]);
   });
 
@@ -81,9 +81,9 @@ describe('computeViewableItems', function () {
     });
     rowFrames = {};
     data = [];
-    expect(helper.computeViewableItems(props, 0, 200, getFrameMetrics)).toEqual(
-      [],
-    );
+    expect(
+      helper.computeViewableItems(props, null, 0, 200, getFrameMetrics),
+    ).toEqual([]);
   });
 
   it('handles different view area coverage percent thresholds', function () {
@@ -96,39 +96,39 @@ describe('computeViewableItems', function () {
     data = [{key: 'a'}, {key: 'b'}, {key: 'c'}, {key: 'd'}];
 
     let helper = new ViewabilityHelper({viewAreaCoveragePercentThreshold: 0});
-    expect(helper.computeViewableItems(props, 0, 50, getFrameMetrics)).toEqual([
-      0,
-    ]);
-    expect(helper.computeViewableItems(props, 1, 50, getFrameMetrics)).toEqual([
-      0, 1,
-    ]);
     expect(
-      helper.computeViewableItems(props, 199, 50, getFrameMetrics),
+      helper.computeViewableItems(props, null, 0, 50, getFrameMetrics),
+    ).toEqual([0]);
+    expect(
+      helper.computeViewableItems(props, null, 1, 50, getFrameMetrics),
+    ).toEqual([0, 1]);
+    expect(
+      helper.computeViewableItems(props, null, 199, 50, getFrameMetrics),
     ).toEqual([1, 2]);
     expect(
-      helper.computeViewableItems(props, 250, 50, getFrameMetrics),
+      helper.computeViewableItems(props, null, 250, 50, getFrameMetrics),
     ).toEqual([2]);
 
     helper = new ViewabilityHelper({viewAreaCoveragePercentThreshold: 100});
-    expect(helper.computeViewableItems(props, 0, 200, getFrameMetrics)).toEqual(
-      [0, 1],
-    );
-    expect(helper.computeViewableItems(props, 1, 200, getFrameMetrics)).toEqual(
-      [1],
-    );
     expect(
-      helper.computeViewableItems(props, 400, 200, getFrameMetrics),
+      helper.computeViewableItems(props, null, 0, 200, getFrameMetrics),
+    ).toEqual([0, 1]);
+    expect(
+      helper.computeViewableItems(props, null, 1, 200, getFrameMetrics),
+    ).toEqual([1]);
+    expect(
+      helper.computeViewableItems(props, null, 400, 200, getFrameMetrics),
     ).toEqual([2]);
     expect(
-      helper.computeViewableItems(props, 600, 200, getFrameMetrics),
+      helper.computeViewableItems(props, null, 600, 200, getFrameMetrics),
     ).toEqual([3]);
 
     helper = new ViewabilityHelper({viewAreaCoveragePercentThreshold: 10});
     expect(
-      helper.computeViewableItems(props, 30, 200, getFrameMetrics),
+      helper.computeViewableItems(props, null, 30, 200, getFrameMetrics),
     ).toEqual([0, 1, 2]);
     expect(
-      helper.computeViewableItems(props, 31, 200, getFrameMetrics),
+      helper.computeViewableItems(props, null, 31, 200, getFrameMetrics),
     ).toEqual([1, 2]);
   });
 
@@ -141,30 +141,30 @@ describe('computeViewableItems', function () {
     };
     data = [{key: 'a'}, {key: 'b'}, {key: 'c'}, {key: 'd'}];
     let helper = new ViewabilityHelper({itemVisiblePercentThreshold: 0});
-    expect(helper.computeViewableItems(props, 0, 50, getFrameMetrics)).toEqual([
-      0,
-    ]);
-    expect(helper.computeViewableItems(props, 1, 50, getFrameMetrics)).toEqual([
-      0, 1,
-    ]);
+    expect(
+      helper.computeViewableItems(props, null, 0, 50, getFrameMetrics),
+    ).toEqual([0]);
+    expect(
+      helper.computeViewableItems(props, null, 1, 50, getFrameMetrics),
+    ).toEqual([0, 1]);
 
     helper = new ViewabilityHelper({itemVisiblePercentThreshold: 100});
-    expect(helper.computeViewableItems(props, 0, 250, getFrameMetrics)).toEqual(
-      [0, 1, 2],
-    );
-    expect(helper.computeViewableItems(props, 1, 250, getFrameMetrics)).toEqual(
-      [1, 2],
-    );
+    expect(
+      helper.computeViewableItems(props, null, 0, 250, getFrameMetrics),
+    ).toEqual([0, 1, 2]);
+    expect(
+      helper.computeViewableItems(props, null, 1, 250, getFrameMetrics),
+    ).toEqual([1, 2]);
 
     helper = new ViewabilityHelper({itemVisiblePercentThreshold: 10});
     expect(
-      helper.computeViewableItems(props, 184, 20, getFrameMetrics),
+      helper.computeViewableItems(props, null, 184, 20, getFrameMetrics),
     ).toEqual([1]);
     expect(
-      helper.computeViewableItems(props, 185, 20, getFrameMetrics),
+      helper.computeViewableItems(props, null, 185, 20, getFrameMetrics),
     ).toEqual([1, 2]);
     expect(
-      helper.computeViewableItems(props, 186, 20, getFrameMetrics),
+      helper.computeViewableItems(props, null, 186, 20, getFrameMetrics),
     ).toEqual([2]);
   });
 });
@@ -179,6 +179,7 @@ describe('onUpdate', function () {
     const onViewableItemsChanged = jest.fn();
     helper.onUpdate(
       props,
+      null,
       0,
       200,
       getFrameMetrics,
@@ -193,6 +194,7 @@ describe('onUpdate', function () {
     });
     helper.onUpdate(
       props,
+      null,
       0,
       200,
       getFrameMetrics,
@@ -202,6 +204,7 @@ describe('onUpdate', function () {
     expect(onViewableItemsChanged.mock.calls.length).toBe(1); // nothing changed!
     helper.onUpdate(
       props,
+      null,
       100,
       200,
       getFrameMetrics,
@@ -226,6 +229,7 @@ describe('onUpdate', function () {
     const onViewableItemsChanged = jest.fn();
     helper.onUpdate(
       props,
+      null,
       0,
       200,
       getFrameMetrics,
@@ -240,6 +244,7 @@ describe('onUpdate', function () {
     });
     helper.onUpdate(
       props,
+      null,
       100,
       200,
       getFrameMetrics,
@@ -258,6 +263,7 @@ describe('onUpdate', function () {
     });
     helper.onUpdate(
       props,
+      null,
       200,
       200,
       getFrameMetrics,
@@ -285,6 +291,7 @@ describe('onUpdate', function () {
     const onViewableItemsChanged = jest.fn();
     helper.onUpdate(
       props,
+      null,
       0,
       200,
       getFrameMetrics,
@@ -319,6 +326,7 @@ describe('onUpdate', function () {
     const onViewableItemsChanged = jest.fn();
     helper.onUpdate(
       props,
+      null,
       0,
       200,
       getFrameMetrics,
@@ -327,6 +335,7 @@ describe('onUpdate', function () {
     );
     helper.onUpdate(
       props,
+      null,
       300, // scroll past item 'a'
       200,
       getFrameMetrics,
@@ -360,6 +369,7 @@ describe('onUpdate', function () {
     const onViewableItemsChanged = jest.fn();
     helper.onUpdate(
       props,
+      null,
       0,
       100,
       getFrameMetrics,
@@ -372,6 +382,7 @@ describe('onUpdate', function () {
 
     helper.onUpdate(
       props,
+      null,
       20,
       100,
       getFrameMetrics,
@@ -399,6 +410,7 @@ describe('onUpdate', function () {
     const onViewableItemsChanged = jest.fn();
     helper.onUpdate(
       props,
+      null,
       0,
       200,
       getFrameMetrics,
@@ -424,6 +436,7 @@ describe('onUpdate', function () {
 
     helper.onUpdate(
       props,
+      null,
       0,
       200,
       getFrameMetrics,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

This Pull Request fixes issues with viewability events in the Virtualized List component when nesting in opposing directions.

Essentially, the VirtualizedList is currently only considering same-direction viewability. To fix that and stop the viewability computations from running on nested Flatlists, I needed a way to allow nested Flatlists to access the parent's currently visible elements. By storing the list's currently viewable items in-memory, I was able to reach into the parent's context and pass that data to the ViewabilityHelper of all of its children.

See #35180 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[General] [Fixed] - Nested horizontal virtualized list viewability events

## Test Plan

Working on adding some jest tests but there's some interesting stuff happening with react-test-renderer in the virtualized list related to viewability (likely need to trigger some onLayout events). Doesn't seem easy to test at this point.

https://user-images.githubusercontent.com/22749569/200435788-31abe231-3fc5-498d-979e-aa4f3f12798b.mp4

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
