### PR TITLE
[codegen]: implement checkIfInvalidModule in parsers

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
@@ -37,6 +37,8 @@ const {
   MoreThanOneModuleInterfaceParserError,
   UnsupportedFunctionParamTypeAnnotationParserError,
 } = require('../errors');
+const {FlowParser} = require('../flow/parser');
+const {TypeScriptParser} = require('../typescript/parser');
 
 describe('throwIfModuleInterfaceIsMisnamed', () => {
   it("don't throw error if module interface name is Spec", () => {
@@ -244,6 +246,9 @@ describe('throwIfIncorrectModuleRegistryCallTypeParameterParserError', () => {
   const nativeModuleName = 'moduleName';
   const methodName = 'methodName';
   const moduleName = 'moduleName';
+  const flowParser = new FlowParser();
+  const typescriptParser = new TypeScriptParser();
+
   it('throw error if flowTypeArguments type is incorrect', () => {
     const flowTypeArguments = {
       type: '',
@@ -257,15 +262,13 @@ describe('throwIfIncorrectModuleRegistryCallTypeParameterParserError', () => {
       ],
     };
 
-    const parserType = 'Flow';
-
     expect(() => {
       throwIfIncorrectModuleRegistryCallTypeParameterParserError(
         nativeModuleName,
         flowTypeArguments,
         methodName,
         moduleName,
-        parserType,
+        flowParser,
       );
     }).toThrow(IncorrectModuleRegistryCallTypeParameterParserError);
   });
@@ -276,15 +279,13 @@ describe('throwIfIncorrectModuleRegistryCallTypeParameterParserError', () => {
       params: [],
     };
 
-    const parserType = 'Flow';
-
     expect(() => {
       throwIfIncorrectModuleRegistryCallTypeParameterParserError(
         nativeModuleName,
         flowTypeArguments,
         methodName,
         moduleName,
-        parserType,
+        flowParser,
       );
     }).toThrow(IncorrectModuleRegistryCallTypeParameterParserError);
   });
@@ -302,15 +303,13 @@ describe('throwIfIncorrectModuleRegistryCallTypeParameterParserError', () => {
       ],
     };
 
-    const parserType = 'Flow';
-
     expect(() => {
       throwIfIncorrectModuleRegistryCallTypeParameterParserError(
         nativeModuleName,
         flowTypeArguments,
         methodName,
         moduleName,
-        parserType,
+        flowParser,
       );
     }).toThrow(IncorrectModuleRegistryCallTypeParameterParserError);
   });
@@ -328,15 +327,13 @@ describe('throwIfIncorrectModuleRegistryCallTypeParameterParserError', () => {
       ],
     };
 
-    const parserType = 'Flow';
-
     expect(() => {
       throwIfIncorrectModuleRegistryCallTypeParameterParserError(
         nativeModuleName,
         flowTypeArguments,
         methodName,
         moduleName,
-        parserType,
+        flowParser,
       );
     }).toThrow(IncorrectModuleRegistryCallTypeParameterParserError);
   });
@@ -354,15 +351,13 @@ describe('throwIfIncorrectModuleRegistryCallTypeParameterParserError', () => {
       ],
     };
 
-    const parserType = 'Flow';
-
     expect(() => {
       throwIfIncorrectModuleRegistryCallTypeParameterParserError(
         nativeModuleName,
         flowTypeArguments,
         methodName,
         moduleName,
-        parserType,
+        flowParser,
       );
     }).not.toThrow(IncorrectModuleRegistryCallTypeParameterParserError);
   });
@@ -380,15 +375,13 @@ describe('throwIfIncorrectModuleRegistryCallTypeParameterParserError', () => {
       ],
     };
 
-    const parserType = 'TypeScript';
-
     expect(() => {
       throwIfIncorrectModuleRegistryCallTypeParameterParserError(
         nativeModuleName,
         typeScriptTypeArguments,
         methodName,
         moduleName,
-        parserType,
+        typescriptParser,
       );
     }).toThrow(IncorrectModuleRegistryCallTypeParameterParserError);
   });
@@ -399,15 +392,13 @@ describe('throwIfIncorrectModuleRegistryCallTypeParameterParserError', () => {
       params: [],
     };
 
-    const parserType = 'TypeScript';
-
     expect(() => {
       throwIfIncorrectModuleRegistryCallTypeParameterParserError(
         nativeModuleName,
         typeScriptTypeArguments,
         methodName,
         moduleName,
-        parserType,
+        typescriptParser,
       );
     }).toThrow(IncorrectModuleRegistryCallTypeParameterParserError);
   });
@@ -425,15 +416,13 @@ describe('throwIfIncorrectModuleRegistryCallTypeParameterParserError', () => {
       ],
     };
 
-    const parserType = 'TypeScript';
-
     expect(() => {
       throwIfIncorrectModuleRegistryCallTypeParameterParserError(
         nativeModuleName,
         typeScriptTypeArguments,
         methodName,
         moduleName,
-        parserType,
+        typescriptParser,
       );
     }).toThrow(IncorrectModuleRegistryCallTypeParameterParserError);
   });
@@ -451,15 +440,13 @@ describe('throwIfIncorrectModuleRegistryCallTypeParameterParserError', () => {
       ],
     };
 
-    const parserType = 'TypeScript';
-
     expect(() => {
       throwIfIncorrectModuleRegistryCallTypeParameterParserError(
         nativeModuleName,
         typeScriptTypeArguments,
         methodName,
         moduleName,
-        parserType,
+        typescriptParser,
       );
     }).toThrow(IncorrectModuleRegistryCallTypeParameterParserError);
   });
@@ -477,15 +464,13 @@ describe('throwIfIncorrectModuleRegistryCallTypeParameterParserError', () => {
       ],
     };
 
-    const parserType = 'TypeScript';
-
     expect(() => {
       throwIfIncorrectModuleRegistryCallTypeParameterParserError(
         nativeModuleName,
         typeScriptTypeArguments,
         methodName,
         moduleName,
-        parserType,
+        typescriptParser,
       );
     }).not.toThrow(IncorrectModuleRegistryCallTypeParameterParserError);
   });

--- a/packages/react-native-codegen/src/parsers/error-utils.js
+++ b/packages/react-native-codegen/src/parsers/error-utils.js
@@ -12,6 +12,7 @@
 
 import type {NativeModuleTypeAnnotation} from '../CodegenSchema';
 import type {ParserType} from './errors';
+import type {Parser} from './parser';
 
 const {
   MisnamedModuleInterfaceParserError,
@@ -111,7 +112,7 @@ function throwIfIncorrectModuleRegistryCallTypeParameterParserError(
   typeArguments: $FlowFixMe,
   methodName: string,
   moduleName: string,
-  language: ParserType,
+  parser: Parser,
 ) {
   function throwError() {
     throw new IncorrectModuleRegistryCallTypeParameterParserError(
@@ -119,28 +120,12 @@ function throwIfIncorrectModuleRegistryCallTypeParameterParserError(
       typeArguments,
       methodName,
       moduleName,
-      language,
+      parser.language(),
     );
   }
 
-  if (language === 'Flow') {
-    if (
-      typeArguments.type !== 'TypeParameterInstantiation' ||
-      typeArguments.params.length !== 1 ||
-      typeArguments.params[0].type !== 'GenericTypeAnnotation' ||
-      typeArguments.params[0].id.name !== 'Spec'
-    ) {
-      throwError();
-    }
-  } else if (language === 'TypeScript') {
-    if (
-      typeArguments.type !== 'TSTypeParameterInstantiation' ||
-      typeArguments.params.length !== 1 ||
-      typeArguments.params[0].type !== 'TSTypeReference' ||
-      typeArguments.params[0].typeName.name !== 'Spec'
-    ) {
-      throwError();
-    }
+  if (parser.checkIfInvalidModule(typeArguments)) {
+    throwError();
   }
 }
 

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -537,7 +537,7 @@ function buildModuleSchema(
       typeArguments,
       methodName,
       $moduleName,
-      language,
+      parser,
     );
 
     return $moduleName;

--- a/packages/react-native-codegen/src/parsers/flow/parser.js
+++ b/packages/react-native-codegen/src/parsers/flow/parser.js
@@ -31,6 +31,15 @@ class FlowParser implements Parser {
   nameForGenericTypeAnnotation(typeAnnotation: $FlowFixMe): string {
     return typeAnnotation.id.name;
   }
+
+  checkIfInvalidModule(typeArguments: $FlowFixMe): boolean {
+    return (
+      typeArguments.type !== 'TypeParameterInstantiation' ||
+      typeArguments.params.length !== 1 ||
+      typeArguments.params[0].type !== 'GenericTypeAnnotation' ||
+      typeArguments.params[0].id.name !== 'Spec'
+    );
+  }
 }
 
 module.exports = {

--- a/packages/react-native-codegen/src/parsers/parser.js
+++ b/packages/react-native-codegen/src/parsers/parser.js
@@ -39,4 +39,10 @@ export interface Parser {
    * @returns: the name of the type.
    */
   nameForGenericTypeAnnotation(typeAnnotation: $FlowFixMe): string;
+  /**
+   * Given a type arguments, it returns a boolean specifying if the Module is Invalid.
+   * @parameter typeArguments: the type arguments.
+   * @returns: a boolean specifying if the Module is Invalid.
+   */
+  checkIfInvalidModule(typeArguments: $FlowFixMe): boolean;
 }

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -542,7 +542,7 @@ function buildModuleSchema(
       typeParameters,
       methodName,
       $moduleName,
-      language,
+      parser,
     );
 
     return $moduleName;

--- a/packages/react-native-codegen/src/parsers/typescript/parser.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parser.js
@@ -35,6 +35,15 @@ class TypeScriptParser implements Parser {
   nameForGenericTypeAnnotation(typeAnnotation: $FlowFixMe): string {
     return typeAnnotation.typeName.name;
   }
+
+  checkIfInvalidModule(typeArguments: $FlowFixMe): boolean {
+    return (
+      typeArguments.type !== 'TSTypeParameterInstantiation' ||
+      typeArguments.params.length !== 1 ||
+      typeArguments.params[0].type !== 'TSTypeReference' ||
+      typeArguments.params[0].typeName.name !== 'Spec'
+    );
+  }
 }
 module.exports = {
   TypeScriptParser,


### PR DESCRIPTION
## Summary
Part of the Codegen umbrella Issue #34872 

> Create a checkIfInvalidModule function in the [parser.js file](https://github.com/facebook/react-native/blob/main/packages/react-native-codegen/src/parsers/parser.js) and document it. Implement [this logic](https://github.com/facebook/react-native/blob/main/packages/react-native-codegen/src/parsers/error-utils.js#L127-L132) in the [FlowParser.js](https://github.com/facebook/react-native/blob/main/packages/react-native-codegen/src/parsers/flow/parser.js#L15) and [this logic](https://github.com/facebook/react-native/blob/main/packages/react-native-codegen/src/parsers/error-utils.js#L136-L141) in the [TypeScriptParser.js](https://github.com/facebook/react-native/blob/main/packages/react-native-codegen/src/parsers/typescript/parser.js#L15). Refactor the [throwIfIncorrectModuleRegistryCallTypeParameterParserError function](https://github.com/facebook/react-native/blob/main/packages/react-native-codegen/src/parsers/error-utils.js#L109) to accept a Parser instead of a ParserType and use the newly created function instead of the if (language) logic.

## Changelog

[Internal] [Added] - Add checkIfInvalidModule in the Parser interface and implement it in both parsers. Refactor [throwIfIncorrectModuleRegistryCallTypeParameterParserError](https://github.com/facebook/react-native/blob/main/packages/react-native-codegen/src/parsers/error-utils.js#L109) to use this new function.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
Run yarn jest react-native-codegen
<img width="788" alt="image" src="https://user-images.githubusercontent.com/34857453/200616752-155d638c-5ef4-4d8b-be79-07a128523910.png">

