### PR TITLE
Fix avoid forcing podspec versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,6 +159,22 @@ commands:
           paths:
             - vendor/bundle
 
+  install_ruby_ubuntu:
+    steps:
+      - run:
+          name: setup rbenv
+          command: |
+            curl -fsSL https://github.com/rbenv/rbenv-installer/raw/HEAD/bin/rbenv-installer | bash
+
+            echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bashrc
+            echo "add eval(rbenv init) to ~/.bashrc"
+            echo 'eval "$(rbenv init -)"' >> ~/.bashrc
+      - run:
+          name: install ruby
+          command: |
+            rbenv install 2.7.6 --verbose
+            rbenv global 2.7.6
+
   run_yarn:
     parameters:
       yarn_base_cache_key:
@@ -1360,6 +1376,10 @@ jobs:
     steps:
       - checkout_code_with_cache
       - run_yarn
+      - install_ruby_ubuntu
+      - run:
+          name: Which Ruby
+          command: which ruby
       - add_ssh_keys:
           fingerprints:
             - "1c:98:e0:3a:52:79:95:29:12:cd:b4:87:5b:41:e2:bb"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,22 +159,6 @@ commands:
           paths:
             - vendor/bundle
 
-  install_ruby_ubuntu:
-    steps:
-      - run:
-          name: setup rbenv
-          command: |
-            curl -fsSL https://github.com/rbenv/rbenv-installer/raw/HEAD/bin/rbenv-installer | bash
-
-            echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bashrc
-            echo "add eval(rbenv init) to ~/.bashrc"
-            echo 'eval "$(rbenv init -)"' >> ~/.bashrc
-      - run:
-          name: install ruby
-          command: |
-            rbenv install 2.7.6 --verbose
-            rbenv global 2.7.6
-
   run_yarn:
     parameters:
       yarn_base_cache_key:
@@ -1376,10 +1360,6 @@ jobs:
     steps:
       - checkout_code_with_cache
       - run_yarn
-      - install_ruby_ubuntu
-      - run:
-          name: Which Ruby
-          command: which ruby
       - add_ssh_keys:
           fingerprints:
             - "1c:98:e0:3a:52:79:95:29:12:cd:b4:87:5b:41:e2:bb"

--- a/scripts/cocoapods/__tests__/codegen_utils-test.rb
+++ b/scripts/cocoapods/__tests__/codegen_utils-test.rb
@@ -458,16 +458,16 @@ class CodegenUtilsTests < Test::Unit::TestCase
             ].join(' ')
           },
           'dependencies': {
-            "FBReactNativeSpec":  ["99.98.97"],
-            "React-jsiexecutor":  ["99.98.97"],
-            "RCT-Folly": ["2021.07.22.00"],
-            "RCTRequired": ["99.98.97"],
-            "RCTTypeSafety": ["99.98.97"],
-            "React-Core": ["99.98.97"],
-            "React-jsi": ["99.98.97"],
-            "hermes-engine": ["99.98.97"],
-            "ReactCommon/turbomodule/bridging": ["99.98.97"],
-            "ReactCommon/turbomodule/core": ["99.98.97"]
+            "FBReactNativeSpec":  [],
+            "React-jsiexecutor":  [],
+            "RCT-Folly": [],
+            "RCTRequired": [],
+            "RCTTypeSafety": [],
+            "React-Core": [],
+            "React-jsi": [],
+            "hermes-engine": [],
+            "ReactCommon/turbomodule/bridging": [],
+            "ReactCommon/turbomodule/core": []
           }
         }
     end
@@ -476,8 +476,8 @@ class CodegenUtilsTests < Test::Unit::TestCase
         specs = get_podspec_no_fabric_no_script()
 
         specs[:dependencies].merge!({
-            'React-graphics': ["99.98.97"],
-            'React-rncore':  ["99.98.97"],
+            'React-graphics': [],
+            'React-rncore':  [],
         })
 
         specs[:'script_phases'] = script_phases

--- a/scripts/cocoapods/codegen_utils.rb
+++ b/scripts/cocoapods/codegen_utils.rb
@@ -98,32 +98,32 @@ class CodegenUtils
             ].join(' ')
           },
           'dependencies': {
-            "FBReactNativeSpec": [version],
-            "React-jsiexecutor": [version],
-            "RCT-Folly": [folly_version],
-            "RCTRequired": [version],
-            "RCTTypeSafety": [version],
-            "React-Core": [version],
-            "React-jsi": [version],
-            "ReactCommon/turbomodule/bridging": [version],
-            "ReactCommon/turbomodule/core": [version]
+            "FBReactNativeSpec": [],
+            "React-jsiexecutor": [],
+            "RCT-Folly": [],
+            "RCTRequired": [],
+            "RCTTypeSafety": [],
+            "React-Core": [],
+            "React-jsi": [],
+            "ReactCommon/turbomodule/bridging": [],
+            "ReactCommon/turbomodule/core": []
           }
         }
 
         if fabric_enabled
           spec[:'dependencies'].merge!({
-            'React-graphics': [version],
-            'React-rncore':  [version],
+            'React-graphics': [],
+            'React-rncore':  [],
           });
         end
 
         if hermes_enabled
           spec[:'dependencies'].merge!({
-            'hermes-engine': [version],
+            'hermes-engine': [],
           });
         else
           spec[:'dependencies'].merge!({
-            'React-jsc': [version],
+            'React-jsc': [],
           });
         end
 


### PR DESCRIPTION
## Summary

This is a backport of [this](https://github.com/facebook/react-native/commit/becb47ccb6a6ed77e81b5488561ef6d683933ffe) local fix we made on 
0.71-stable.

All our podspecs delegates to the main React Native pods script to set up the dependencies properly. The React-Codegen.podspec, which is generated by 
the script itself, was generated with hardcoded dependencies. This PR aligns the versioning with the other podspec.

On a side note, this could create issues in CI and when releaseing, because we are changing the versions to prepare the new release and it breaks some 
steps.  

## Changelog

[iOS] [Fixed] - Make sure that the React-Codegen.podspec does not enforce specific versions of its dependencies.

## Test Plan

1. Ruby tests are passing
2. Manually tested that pods are correctly installed in the following configurations
  - RNTester - Hermes - Old Architecture
  - RNTester - Hermes - New Architecture
  - RNTester - JSC - Old Architecture
  - RNTester - JSC - New Architecture
