### PR TITLE
RCTRefreshControl: Updates progressOffset behaviour to prevent it from being applied by default

### DIFF
--- a/React/Views/RefreshControl/RCTRefreshControl.m
+++ b/React/Views/RefreshControl/RCTRefreshControl.m
@@ -121,7 +121,10 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)aDecoder)
   // the coordinate space of the RefreshControl. This ensures that the control respects any
   // offset in the view hierarchy, and that progressViewOffset is not inadvertently applied
   // multiple times.
-    
+
+  // Setting the UIRefreshControl's frame breaks integration with ContentInset from the superview
+  // if it is a UIScrollView. This integration happens when setting the UIScrollView's .refreshControl
+  // property. For this reason, setting the frame manually should be avoided, if not needed.
   if (_progressViewOffset > 0.f) {
     UIView *scrollView = self.superview;
     UIView *target = scrollView.superview;

--- a/React/Views/RefreshControl/RCTRefreshControl.m
+++ b/React/Views/RefreshControl/RCTRefreshControl.m
@@ -117,21 +117,22 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)aDecoder)
 
 - (void)_applyProgressViewOffset
 {
+  // Setting the UIRefreshControl's frame breaks integration with ContentInset from the superview
+  // if it is a UIScrollView. This integration happens when setting the UIScrollView's .refreshControl
+  // property. For this reason, setting the frame manually should be avoided, if not needed.
+  if (_progressViewOffset == 0.f) {
+    return;
+  }
+
   // progressViewOffset must be converted from the ScrollView parent's coordinate space to
   // the coordinate space of the RefreshControl. This ensures that the control respects any
   // offset in the view hierarchy, and that progressViewOffset is not inadvertently applied
   // multiple times.
-
-  // Setting the UIRefreshControl's frame breaks integration with ContentInset from the superview
-  // if it is a UIScrollView. This integration happens when setting the UIScrollView's .refreshControl
-  // property. For this reason, setting the frame manually should be avoided, if not needed.
-  if (_progressViewOffset != 0.f) {
-    UIView *scrollView = self.superview;
-    UIView *target = scrollView.superview;
-    CGPoint rawOffset = CGPointMake(0, _progressViewOffset);
-    CGPoint converted = [self convertPoint:rawOffset fromView:target];
-    self.frame = CGRectOffset(self.frame, 0, converted.y);
-  }
+  UIView *scrollView = self.superview;
+  UIView *target = scrollView.superview;
+  CGPoint rawOffset = CGPointMake(0, _progressViewOffset);
+  CGPoint converted = [self convertPoint:rawOffset fromView:target];
+  self.frame = CGRectOffset(self.frame, 0, converted.y);
 }
 
 - (NSString *)title

--- a/React/Views/RefreshControl/RCTRefreshControl.m
+++ b/React/Views/RefreshControl/RCTRefreshControl.m
@@ -121,11 +121,14 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)aDecoder)
   // the coordinate space of the RefreshControl. This ensures that the control respects any
   // offset in the view hierarchy, and that progressViewOffset is not inadvertently applied
   // multiple times.
-  UIView *scrollView = self.superview;
-  UIView *target = scrollView.superview;
-  CGPoint rawOffset = CGPointMake(0, _progressViewOffset);
-  CGPoint converted = [self convertPoint:rawOffset fromView:target];
-  self.frame = CGRectOffset(self.frame, 0, converted.y);
+    
+  if (_progressViewOffset > 0.f) {
+    UIView *scrollView = self.superview;
+    UIView *target = scrollView.superview;
+    CGPoint rawOffset = CGPointMake(0, _progressViewOffset);
+    CGPoint converted = [self convertPoint:rawOffset fromView:target];
+    self.frame = CGRectOffset(self.frame, 0, converted.y);
+  }
 }
 
 - (NSString *)title

--- a/React/Views/RefreshControl/RCTRefreshControl.m
+++ b/React/Views/RefreshControl/RCTRefreshControl.m
@@ -125,7 +125,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)aDecoder)
   // Setting the UIRefreshControl's frame breaks integration with ContentInset from the superview
   // if it is a UIScrollView. This integration happens when setting the UIScrollView's .refreshControl
   // property. For this reason, setting the frame manually should be avoided, if not needed.
-  if (_progressViewOffset > 0.f) {
+  if (_progressViewOffset != 0.f) {
     UIView *scrollView = self.superview;
     UIView *target = scrollView.superview;
     CGPoint rawOffset = CGPointMake(0, _progressViewOffset);


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

UIRefreshControl has a tight integration with iOS in terms of UINavigationBar/UIScrollView. In this regard, whenever there's a UIScrollView with a UINavigationBar on top, the OS automatically adjusts the contentInset of the UIScrollView to reflect that (something that is exposed to React Native). In a similar manner, UIScrollView passes this along to the attached UIRefreshControl.

By setting the frame manually, the RCTRefreshControl component was preventing this behavior. Although having the option is desired, it should not be done by default. In the past it was possible to adjust for this by manually setting the correct value, calculating the statusBar's height/safeAreaInsets.top and appending 44pt (the UINavigationBar height). However, due to changes related to the Dynamic Island (see [here](https://useyourloaf.com/blog/iphone-14-screen-sizes)), the safe area and the status bar size no longer align, making this calculation more tricky.

In summary: this changes allows `progressViewOffset` to exist (in order to maintain feature parity with Android) but provides the opportunity for the OSs default behavior to kick in when applicable.

| Applying by default  | Not applying by default (this change) |
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/753361/200828632-0c9aa605-770c-47be-a825-1e061478c2b4.gif)  |  ![](https://user-images.githubusercontent.com/753361/200828664-dded9a47-bdbc-4b88-8ab7-92a76cea47e8.gif)

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[iOS] [Fixed] - Fix application of _progressViewOffset in RCTRefreshControl to not occur by default (when value is unset)

## Test Plan

The GIFs attached display the behavior as expected/unexpected. I'm unaware of any tests written for RCTRefreshControl that could be improved to cover this change. Notes appreciated.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
