### PR TITLE
VirtualizedList onViewableItemsChanged won't trigger if first item in data evaluate to false #35280

### DIFF
--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -1749,7 +1749,10 @@ export default class VirtualizedList extends StateSafePureComponent<
       'Tried to get frame for out of range index ' + index,
     );
     const item = getItem(data, index);
-    const frame = item && this._frames[this._keyExtractor(item, index, props)];
+    const frame =
+      item != null
+        ? this._frames[this._keyExtractor(item, index, props)]
+        : undefined;
     if (!frame || frame.index !== index) {
       if (getItemLayout) {
         /* $FlowFixMe[prop-missing] (>=0.63.0 site=react_native_fb) This comment


### PR DESCRIPTION
VirtualizedList onViewableItemsChanged won't trigger if first item in data evaluate to false #35280
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Described in https://github.com/facebook/react-native/issues/35280

## Changelog

- [General] [Fixed] Fix VirtualizedList onViewableItemsChanged won't trigger if first item in data evaluate to false

## Test Plan

this snack will be able to log `onViewableItemsChanged triggered` after the fix:
https://snack.expo.dev/tmQo_R_3Y
