### PR TITLE
fix: use_framework! + hermes enable = Undefined symbols "vtable for f…

### DIFF
--- a/React-Core.podspec
+++ b/React-Core.podspec
@@ -112,6 +112,7 @@ Pod::Spec.new do |s|
   s.dependency "React-perflogger", version
   s.dependency "React-jsi", version
   s.dependency "React-jsiexecutor", version
+  s.dependency "React-hermes", version
   s.dependency "Yoga"
   s.dependency "glog"
 end


### PR DESCRIPTION
…acebook::react::HermesExecutorFactory" #34344

clang: error: linker command failed with exit code 1 (use -v to see invocation)

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

  in Podfile use_framework! with :hermes_enabled => true, Xcode build will show:
  Undefined symbols for architecture x86_64:
  "vtable for facebook::react::HermesExecutorFactory", referenced from:
  facebook::react::HermesExecutorFactory::HermesExecutorFactory(std::__1::function<void (facebook::jsi::Runtime&)>, std::__1::function<void (std::__1::function<void ()> const&, std::__1::function<std::__1::basic_string<char, std::__1::char_traits, std::__1::allocator > ()>)> const&, hermes::vm::RuntimeConfig) in RCTCxxBridge.o
  NOTE: a missing vtable usually means the first non-inline virtual member function has no definition.
  ld: symbol(s) not found for architecture x86_64

Reason:
  podspec without dependency, it can not find hermes framework.

## Changelog

[iOS][Fixed] - fix use_framework! can not find hermes

## Test Plan

1.add use_framework in you project
2.set hermes enable
3.build your project
4.build success
