### PR TITLE
Remove version from the tarball

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,8 +55,8 @@ references:
     hermes_workspace_debug_cache_key: &hermes_workspace_debug_cache_key v2-hermes-{{ .Environment.CIRCLE_JOB }}-debug-{{ checksum "/tmp/hermes/hermesversion" }}
     hermes_workspace_release_cache_key: &hermes_workspace_release_cache_key v2-hermes-{{ .Environment.CIRCLE_JOB }}-release-{{ checksum "/tmp/hermes/hermesversion" }}
     hermes_windows_cache_key: &hermes_windows_cache_key v3-hermes-{{ .Environment.CIRCLE_JOB }}-{{ checksum "tmp/hermes/hermesversion" }}
-    hermes_tarball_debug_cache_key: &hermes_tarball_debug_cache_key v2-hermes-tarball-debug-{{ checksum "/tmp/hermes/hermesversion" }}
-    hermes_tarball_release_cache_key: &hermes_tarball_release_cache_key v1-hermes-tarball-release-{{ checksum "/tmp/hermes/hermesversion" }}
+    hermes_tarball_debug_cache_key: &hermes_tarball_debug_cache_key v3-hermes-tarball-debug-{{ checksum "/tmp/hermes/hermesversion" }}
+    hermes_tarball_release_cache_key: &hermes_tarball_release_cache_key v2-hermes-tarball-release-{{ checksum "/tmp/hermes/hermesversion" }}
     pods_cache_key: &pods_cache_key v8-pods-{{ .Environment.CIRCLE_JOB }}-{{ checksum "packages/rn-tester/Podfile.lock.bak" }}-{{ checksum "packages/rn-tester/Podfile" }}
     windows_yarn_cache_key: &windows_yarn_cache_key v1-win-yarn-cache-{{ arch }}-{{ checksum "yarn.lock" }}
     yarn_cache_key: &yarn_cache_key v5-yarn-cache-{{ .Environment.CIRCLE_JOB }}
@@ -303,8 +303,8 @@ commands:
                     exit 0
                   fi
 
-                  TARBALL_FILENAME=$(node ~/react-native/scripts/hermes/get-tarball-name.js --buildType "<< parameters.flavor >>" --releaseVersion "*")
-                  TARBALL_PATH=$(ls $HERMES_TARBALL_ARTIFACTS_DIR/$TARBALL_FILENAME)
+                  TARBALL_FILENAME=$(node ~/react-native/scripts/hermes/get-tarball-name.js --buildType "<< parameters.flavor >>")
+                  TARBALL_PATH=$HERMES_TARBALL_ARTIFACTS_DIR/$TARBALL_FILENAME
 
                   echo "Looking for $TARBALL_FILENAME in $HERMES_TARBALL_ARTIFACTS_DIR"
                   echo "$TARBALL_PATH"
@@ -852,7 +852,9 @@ jobs:
             - run:
                 name: Set HERMES_ENGINE_TARBALL_PATH
                 command: |
-                  echo "export HERMES_ENGINE_TARBALL_PATH=$(ls -AU $HERMES_WS_DIR/hermes-runtime-darwin/hermes-runtime-darwin-*.tar.gz | head -1)" >> $BASH_ENV
+                  BUILD_TYPE="<< parameters.flavor >>"
+                  TARBALL_FILENAME=$(node ./scripts/hermes/get-tarball-name.js --buildType "$BUILD_TYPE")
+                  echo "export HERMES_ENGINE_TARBALL_PATH=$HERMES_WS_DIR/hermes-runtime-darwin/$TARBALL_FILENAME" >> $BASH_ENV
       - run:
           name: Create iOS template project
           command: |
@@ -1224,20 +1226,13 @@ jobs:
 
                   TARBALL_OUTPUT_DIR=$(mktemp -d /tmp/hermes-tarball-output-XXXXXXXX)
 
-                  # get_release_version() is defined in build-apple-framework.sh
-                  pushd ./sdks/hermes || exit 1
-                    BUILD_TYPE=$BUILD_TYPE source ./utils/build-apple-framework.sh
-                    RELEASE_VERSION=$(get_release_version)
-                  popd
-
-                  TARBALL_FILENAME=$(node ./scripts/hermes/get-tarball-name.js --buildType "$BUILD_TYPE" --releaseVersion "$RELEASE_VERSION")
+                  TARBALL_FILENAME=$(node ./scripts/hermes/get-tarball-name.js --buildType "$BUILD_TYPE")
 
                   echo "Packaging Hermes Apple frameworks for $BUILD_TYPE build type"
 
                   TARBALL_OUTPUT_PATH=$(node ./scripts/hermes/create-tarball.js \
                     --inputDir ./sdks/hermes \
                     --buildType "$BUILD_TYPE" \
-                    --releaseVersion "$RELEASE_VERSION" \
                     --outputDir $TARBALL_OUTPUT_DIR)
 
                   echo "Hermes tarball saved to $TARBALL_OUTPUT_PATH"
@@ -1406,8 +1401,8 @@ jobs:
             cp -r $HERMES_WS_DIR/win64-bin/* ./sdks/hermesc/win64-bin/.
             cp -r $HERMES_WS_DIR/linux64-bin/* ./sdks/hermesc/linux64-bin/.
             mkdir -p ./ReactAndroid/external-artifacts/artifacts/
-            cp $HERMES_WS_DIR/hermes-runtime-darwin/hermes-runtime-darwin-debug-*.tar.gz ./ReactAndroid/external-artifacts/artifacts/hermes-ios-debug.tar.gz
-            cp $HERMES_WS_DIR/hermes-runtime-darwin/hermes-runtime-darwin-release-*.tar.gz ./ReactAndroid/external-artifacts/artifacts/hermes-ios-release.tar.gz
+            cp $HERMES_WS_DIR/hermes-runtime-darwin/hermes-ios-debug.tar.gz ./ReactAndroid/external-artifacts/artifacts/hermes-ios-debug.tar.gz
+            cp $HERMES_WS_DIR/hermes-runtime-darwin/hermes-ios-release.tar.gz ./ReactAndroid/external-artifacts/artifacts/hermes-ios-release.tar.gz
 
       - run_yarn
       - download_gradle_dependencies

--- a/scripts/hermes/__tests__/hermes-utils-test.js
+++ b/scripts/hermes/__tests__/hermes-utils-test.js
@@ -387,29 +387,14 @@ describe('hermes-utils', () => {
 
     describe('getHermesPrebuiltArtifactsTarballName', () => {
       it('should return Hermes prebuilts tarball name', () => {
-        expect(
-          getHermesPrebuiltArtifactsTarballName('Debug', '1000.0.0'),
-        ).toEqual('hermes-runtime-darwin-debug-v1000.0.0.tar.gz');
+        expect(getHermesPrebuiltArtifactsTarballName('Debug')).toEqual(
+          'hermes-ios-debug.tar.gz',
+        );
       });
       it('should throw if build type is undefined', () => {
         expect(() => {
           getHermesPrebuiltArtifactsTarballName();
         }).toThrow('Did not specify build type.');
-      });
-      it('should throw if release version is undefined', () => {
-        expect(() => {
-          getHermesPrebuiltArtifactsTarballName('Release');
-        }).toThrow('Did not specify release version.');
-      });
-      it('should return debug Hermes prebuilts tarball name for RN 0.70.0', () => {
-        expect(
-          getHermesPrebuiltArtifactsTarballName('Debug', '0.70.0'),
-        ).toEqual('hermes-runtime-darwin-debug-v0.70.0.tar.gz');
-      });
-      it('should return a wildcard Hermes prebuilts tarball name for any RN version', () => {
-        expect(getHermesPrebuiltArtifactsTarballName('Debug', '*')).toEqual(
-          'hermes-runtime-darwin-debug-v*.tar.gz',
-        );
       });
     });
 
@@ -426,7 +411,6 @@ describe('hermes-utils', () => {
         const tarballOutputPath = createHermesPrebuiltArtifactsTarball(
           path.join(SDKS_DIR, 'hermes'),
           'Debug',
-          '1000.0.0',
           tarballOutputDir,
           excludeDebugSymbols,
         );
@@ -448,7 +432,6 @@ describe('hermes-utils', () => {
         const tarballOutputPath = createHermesPrebuiltArtifactsTarball(
           path.join(SDKS_DIR, 'hermes'),
           'Debug',
-          '1000.0.0',
           tarballOutputDir,
           excludeDebugSymbols,
         );

--- a/scripts/hermes/create-tarball.js
+++ b/scripts/hermes/create-tarball.js
@@ -31,12 +31,6 @@ let argv = yargs
     describe: 'Specifies whether Hermes was built for Debug or Release.',
     default: 'Debug',
   })
-  .option('v', {
-    alias: 'releaseVersion',
-    type: 'string',
-    describe: 'The version of React Native that will use this tarball.',
-    default: '1000.0.0',
-  })
   .option('o', {
     alias: 'outputDir',
     describe: 'Location where the tarball will be saved to.',
@@ -50,7 +44,6 @@ let argv = yargs
 async function main() {
   const hermesDir = argv.inputDir;
   const buildType = argv.buildType;
-  const releaseVersion = argv.releaseVersion;
   const excludeDebugSymbols = argv.excludeDebugSymbols;
   let tarballOutputDir = argv.outputDir;
 
@@ -69,7 +62,6 @@ async function main() {
   const tarballOutputPath = createHermesPrebuiltArtifactsTarball(
     hermesDir,
     buildType,
-    releaseVersion,
     tarballOutputDir,
     excludeDebugSymbols,
   );

--- a/scripts/hermes/get-tarball-name.js
+++ b/scripts/hermes/get-tarball-name.js
@@ -16,25 +16,15 @@
 const yargs = require('yargs');
 const {getHermesPrebuiltArtifactsTarballName} = require('./hermes-utils');
 
-let argv = yargs
-  .option('b', {
-    alias: 'buildType',
-    type: 'string',
-    describe: 'Specifies whether Hermes was built for Debug or Release.',
-    default: 'Debug',
-  })
-  .option('v', {
-    alias: 'releaseVersion',
-    type: 'string',
-    describe: 'The version of React Native that will use this tarball.',
-    default: '1000.0.0',
-  }).argv;
+let argv = yargs.option('b', {
+  alias: 'buildType',
+  type: 'string',
+  describe: 'Specifies whether Hermes was built for Debug or Release.',
+  default: 'Debug',
+}).argv;
 
 async function main() {
-  const tarballName = getHermesPrebuiltArtifactsTarballName(
-    argv.buildType,
-    argv.releaseVersion,
-  );
+  const tarballName = getHermesPrebuiltArtifactsTarballName(argv.buildType);
   console.log(tarballName);
   return tarballName;
 }

--- a/scripts/hermes/hermes-utils.js
+++ b/scripts/hermes/hermes-utils.js
@@ -212,14 +212,11 @@ set_target_properties(native-hermesc PROPERTIES
   }
 }
 
-function getHermesPrebuiltArtifactsTarballName(buildType, releaseVersion) {
+function getHermesPrebuiltArtifactsTarballName(buildType) {
   if (!buildType) {
     throw Error('Did not specify build type.');
   }
-  if (!releaseVersion) {
-    throw Error('Did not specify release version.');
-  }
-  return `hermes-runtime-darwin-${buildType.toLowerCase()}-v${releaseVersion}.tar.gz`;
+  return `hermes-ios-${buildType.toLowerCase()}.tar.gz`;
 }
 
 /**
@@ -233,7 +230,6 @@ function createTarballFromDirectory(directory, filename) {
 function createHermesPrebuiltArtifactsTarball(
   hermesDir,
   buildType,
-  releaseVersion,
   tarballOutputDir,
   excludeDebugSymbols,
 ) {
@@ -268,7 +264,7 @@ function createHermesPrebuiltArtifactsTarball(
 
   const tarballFilename = path.join(
     tarballOutputDir,
-    getHermesPrebuiltArtifactsTarballName(buildType, releaseVersion),
+    getHermesPrebuiltArtifactsTarballName(buildType),
   );
 
   try {


### PR DESCRIPTION
Summary:
While doing the release 0f 0.71.0-RC0, we noticed that having the RN version in the hermes tarball was causing more harm than good.

With the version in the name, we ended up with multiple tarballs for debug and release and we were not able to explicitly pick the right tarball given a build.

This change remove the version from the tarball name.

## Changelog
[General][Changed] - Remove React Native version from Hermes tarball name

Differential Revision: D41156353

