### PR TITLE
Chore: move translateFunctionTypeAnnotation into emitFunction

### DIFF
--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -296,18 +296,17 @@ function translateTypeAnnotation(
       return emitString(nullable);
     }
     case 'FunctionTypeAnnotation': {
-      const translateFunctionTypeAnnotationValue: NativeModuleFunctionTypeAnnotation =
-        translateFunctionTypeAnnotation(
-          hasteModuleName,
-          typeAnnotation,
-          types,
-          aliasMap,
-          tryParse,
-          cxxOnly,
-          translateTypeAnnotation,
-          language,
-        );
-      return emitFunction(nullable, translateFunctionTypeAnnotationValue);
+      return emitFunction(
+        nullable,
+        hasteModuleName,
+        typeAnnotation,
+        types,
+        aliasMap,
+        tryParse,
+        cxxOnly,
+        translateTypeAnnotation,
+        language,
+      );
     }
     case 'UnionTypeAnnotation': {
       if (cxxOnly) {

--- a/packages/react-native-codegen/src/parsers/parsers-primitives.js
+++ b/packages/react-native-codegen/src/parsers/parsers-primitives.js
@@ -99,8 +99,26 @@ function emitStringish(nullable: boolean): Nullable<StringTypeAnnotation> {
 
 function emitFunction(
   nullable: boolean,
-  translateFunctionTypeAnnotationValue: NativeModuleFunctionTypeAnnotation,
+  hasteModuleName: string,
+  typeAnnotation: $FlowFixMe,
+  types: TypeDeclarationMap,
+  aliasMap: {...NativeModuleAliasMap},
+  tryParse: ParserErrorCapturer,
+  cxxOnly: boolean,
+  translateTypeAnnotation: $FlowFixMe,
+  language: ParserType,
 ): Nullable<NativeModuleFunctionTypeAnnotation> {
+  const translateFunctionTypeAnnotationValue: NativeModuleFunctionTypeAnnotation =
+    translateFunctionTypeAnnotation(
+      hasteModuleName,
+      typeAnnotation,
+      types,
+      aliasMap,
+      tryParse,
+      cxxOnly,
+      translateTypeAnnotation,
+      language,
+    );
   return wrapNullable(nullable, translateFunctionTypeAnnotationValue);
 }
 

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -302,19 +302,17 @@ function translateTypeAnnotation(
       return emitString(nullable);
     }
     case 'TSFunctionType': {
-      const translateFunctionTypeAnnotationValue: NativeModuleFunctionTypeAnnotation =
-        translateFunctionTypeAnnotation(
-          hasteModuleName,
-          typeAnnotation,
-          types,
-          aliasMap,
-          tryParse,
-          cxxOnly,
-          translateTypeAnnotation,
-          language,
-        );
-
-      return emitFunction(nullable, translateFunctionTypeAnnotationValue);
+      return emitFunction(
+        nullable,
+        hasteModuleName,
+        typeAnnotation,
+        types,
+        aliasMap,
+        tryParse,
+        cxxOnly,
+        translateTypeAnnotation,
+        language,
+      );
     }
     case 'TSUnionType': {
       if (cxxOnly) {


### PR DESCRIPTION
## Summary

Part of https://github.com/facebook/react-native/issues/34872

In this PR was moved the translateFunctionTypeAnnotation invocation ([Flow](https://github.com/facebook/react-native/blob/main/packages/react-native-codegen/src/parsers/flow/modules/index.js#L362), [TypeScript](https://github.com/facebook/react-native/blob/main/packages/react-native-codegen/src/parsers/typescript/modules/index.js#L376)) into the emitFunction call so that the case FuntionTypeAnnotation results in a one-liner

## Changelog

[Internal] [Changed] - Move the translateFunctionTypeAnnotation invocation into the emitFunction

## Test Plan

<img width="266" alt="image" src="https://user-images.githubusercontent.com/18408823/200852605-96c233d9-b524-4b7c-bc41-5543534c296b.png">


