### PR TITLE
Do not use InteractionManager to wait for Activity

### DIFF
--- a/Libraries/Linking/Linking.js
+++ b/Libraries/Linking/Linking.js
@@ -11,7 +11,6 @@
 import type {EventSubscription} from '../vendor/emitter/EventEmitter';
 
 import NativeEventEmitter from '../EventEmitter/NativeEventEmitter';
-import InteractionManager from '../Interaction/InteractionManager';
 import Platform from '../Utilities/Platform';
 import NativeIntentAndroid from './NativeIntentAndroid';
 import NativeLinkingManager from './NativeLinkingManager';
@@ -96,9 +95,7 @@ class Linking extends NativeEventEmitter<LinkingEventDefinitions> {
    */
   getInitialURL(): Promise<?string> {
     return Platform.OS === 'android'
-      ? InteractionManager.runAfterInteractions().then(() =>
-          nullthrows(NativeIntentAndroid).getInitialURL(),
-        )
+      ? nullthrows(NativeIntentAndroid).getInitialURL()
       : nullthrows(NativeLinkingManager).getInitialURL();
   }
 


### PR DESCRIPTION
Summary:
This was originally added in D15258046 (https://github.com/facebook/react-native/commit/c802d0b757912358d703d4d8a114073377a905b9) but seems to be the wrong solution to the problem from my perspective. InteractionManager does not provide timing information on the activity being available, but ReactContext's LifecycleEventListener does.

This should also address some of the issues raised in https://github.com/facebook/react-native/issues/25675

Changelog: [Android][Fixed] Linking.getInitialUrl should not wait for InteractionManager

Differential Revision: D41157646

