### PR TITLE
fix: RNTester TransformExample crash

### DIFF
--- a/packages/rn-tester/js/examples/Transform/TransformExample.js
+++ b/packages/rn-tester/js/examples/Transform/TransformExample.js
@@ -208,7 +208,7 @@ const styles = StyleSheet.create({
     width: 50,
   },
   box7Transform: {
-    transform: 'translate(-50, 35) rotate(50deg) scale(2)',
+    transform: 'translate(-50px, 35px) rotate(50deg) scale(2)',
   },
   flipCardContainer: {
     marginVertical: 40,
@@ -337,7 +337,7 @@ exports.examples = [
   },
   {
     title: 'Transform using a string',
-    description: "transform: 'translate(-50, 35) rotate(50deg) scale(2)'",
+    description: "transform: 'translate(-50px, 35px) rotate(50deg) scale(2)'",
     render(): Node {
       return (
         <View style={styles.container}>


### PR DESCRIPTION
## Summary

As pointed out by @kelset on https://github.com/facebook/react-native/pull/34660#issuecomment-1309081429 accessing the `TransformExample` is currently crashing the `RNTester` app due to missing units in one of the transformers. This PR fixes it by updating the transform value to a valid string.

## Changelog
 
[Internal] [Fixed] - Add missing translate units to  `RNTester` `TransformExample` 

## Test Plan

1. Open the RNTester app and navigate to the Transforms page
2. Check the transform style through the `Transform using a string` section

https://user-images.githubusercontent.com/11707729/200916399-779b2eeb-2bd8-4642-97a3-f050d6dd4278.mov


