### PR TITLE
[Codegen] Use parser instead of language in MissingTypeParameterGenericParserError and MoreThanOneTypeParameterGenericParserError

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-commons-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-commons-test.js
@@ -109,7 +109,7 @@ describe('assertGenericTypeAnnotationHasExactlyOneTypeParameter', () => {
     ).not.toThrow();
   });
 
-  it('throws an IncorrectlyParameterizedGenericParserError if typeParameters is null', () => {
+  it('throws a MissingTypeParameterGenericParserError if typeParameters is null', () => {
     const typeAnnotation = {
       typeParameters: null,
       id: {
@@ -148,7 +148,7 @@ describe('assertGenericTypeAnnotationHasExactlyOneTypeParameter', () => {
     );
   });
 
-  it("throws an IncorrectlyParameterizedGenericParserError if typeParameters don't have 1 exactly parameter", () => {
+  it("throws a MoreThanOneTypeParameterGenericParserError if typeParameters don't have 1 exactly parameter", () => {
     const typeAnnotationWithTwoParams = {
       typeParameters: {
         params: [1, 2],

--- a/packages/react-native-codegen/src/parsers/errors.js
+++ b/packages/react-native-codegen/src/parsers/errors.js
@@ -134,12 +134,11 @@ class MissingTypeParameterGenericParserError extends ParserError {
   constructor(
     nativeModuleName: string,
     genericTypeAnnotation: $FlowFixMe,
-    language: ParserType,
+    parser: Parser,
   ) {
-    const genericName =
-      language === 'TypeScript'
-        ? genericTypeAnnotation.typeName.name
-        : genericTypeAnnotation.id.name;
+    const genericName = parser.nameForGenericTypeAnnotation(
+      genericTypeAnnotation,
+    );
 
     super(
       nativeModuleName,
@@ -153,12 +152,11 @@ class MoreThanOneTypeParameterGenericParserError extends ParserError {
   constructor(
     nativeModuleName: string,
     genericTypeAnnotation: $FlowFixMe,
-    language: ParserType,
+    parser: Parser,
   ) {
-    const genericName =
-      language === 'TypeScript'
-        ? genericTypeAnnotation.typeName.name
-        : genericTypeAnnotation.id.name;
+    const genericName = parser.nameForGenericTypeAnnotation(
+      genericTypeAnnotation,
+    );
 
     super(
       nativeModuleName,

--- a/packages/react-native-codegen/src/parsers/parsers-commons.js
+++ b/packages/react-native-codegen/src/parsers/parsers-commons.js
@@ -83,7 +83,7 @@ function assertGenericTypeAnnotationHasExactlyOneTypeParameter(
     throw new MissingTypeParameterGenericParserError(
       moduleName,
       typeAnnotation,
-      parser.language(),
+      parser,
     );
   }
 
@@ -98,7 +98,7 @@ function assertGenericTypeAnnotationHasExactlyOneTypeParameter(
     throw new MoreThanOneTypeParameterGenericParserError(
       moduleName,
       typeAnnotation,
-      parser.language(),
+      parser,
     );
   }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Part of https://github.com/facebook/react-native/issues/34872:
> Update the [IncorrectlyParameterizedGenericParserError](https://github.com/facebook/react-native/blob/main/packages/react-native-codegen/src/parsers/errors.js#L134) error in the error.js file to accept a Parser instead of a ParserType parameter. Use the nameForGenericTypeAnnotation method of the parser to extract the genericName and delete the ternary operator.

Since the task was added to the issue we split the IncorrectlyParameterizedGenericParserError into 2 errors: MissingTypeParameterGenericParserError and MissingTypeParameterGenericParserError (https://github.com/facebook/react-native/pull/35134/), so I applied the change on both errors.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[Internal] [Changed] - Use parser instead of language in MissingTypeParameterGenericParserError and MoreThanOneTypeParameterGenericParserError

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

I tested using Flow and Jest commands. More specifically, the tests that cover this change are the ones I renamed.