### PR TITLE
chore: fail prepare package for release if tag exists

### DIFF
--- a/scripts/bump-oss-version.js
+++ b/scripts/bump-oss-version.js
@@ -21,6 +21,7 @@ const request = require('request');
 const {getBranchName, exitIfNotOnGit} = require('./scm-utils');
 
 const {parseVersion, isReleaseBranch} = require('./version-utils');
+const {failIfTagExists} = require('./release-utils');
 
 let argv = yargs
   .option('r', {
@@ -75,6 +76,7 @@ async function main() {
   );
   const token = argv.token;
   const releaseVersion = argv.toVersion;
+  failIfTagExists(releaseVersion);
 
   const {pushed} = await inquirer.prompt({
     type: 'confirm',

--- a/scripts/prepare-package-for-release.js
+++ b/scripts/prepare-package-for-release.js
@@ -21,6 +21,7 @@
 const {echo, exec, exit} = require('shelljs');
 const yargs = require('yargs');
 const {isReleaseBranch, parseVersion} = require('./version-utils');
+const {failIfTagExists} = require('./release-utils');
 
 const argv = yargs
   .option('r', {
@@ -48,6 +49,8 @@ const remote = argv.remote;
 const releaseVersion = argv.toVersion;
 const isLatest = argv.latest;
 const isDryRun = argv.dryRun;
+
+failIfTagExists(releaseVersion);
 
 if (branch && !isReleaseBranch(branch) && !isDryRun) {
   console.error(`This needs to be on a release branch. On branch: ${branch}`);

--- a/scripts/release-utils.js
+++ b/scripts/release-utils.js
@@ -117,8 +117,27 @@ function generateiOSArtifacts(
   return tarballOutputPath;
 }
 
+function failIfTagExists(version) {
+  if (checkIfTagExists(version)) {
+    echo(`Tag v${version} already exists.`);
+    echo('You may want to rollback the last commit');
+    echo('git reset --hard HEAD~1');
+    exit(1);
+  }
+}
+
+function checkIfTagExists(version) {
+  const {code, stdout} = exec('git tag -l', {silent: true});
+  if (code !== 0) {
+    throw new Error('Failed to retrieve the list of tags');
+  }
+  const tags = new Set(stdout.split('\n'));
+  return tags.has(`v${version}`);
+}
+
 module.exports = {
   generateAndroidArtifacts,
   generateiOSArtifacts,
   publishAndroidArtifactsToMaven,
+  failIfTagExists,
 };


### PR DESCRIPTION
## Summary

This PR makes sure that the `preapre_package_for_release` script fail fast if there is already a tag for the desired version 
on github.

## Changelog

[General] [Added] - Make the `prepare_package_for_release` fail if there is already a git tag with that version 

## Test Plan

Tested manually. The script is currently only invoked during the release process.
<img width="1238" alt="Screenshot 2022-11-10 at 12 24 03" src="https://user-images.githubusercontent.com/11162307/201090947-274c1b1c-0b6a-4619-bc85-fa60e5eaeee1.png">
