### PR TITLE
Fix variable expansion in ReactNative-application.cmake

### DIFF
--- a/ReactAndroid/cmake-utils/ReactNative-application.cmake
+++ b/ReactAndroid/cmake-utils/ReactNative-application.cmake
@@ -106,7 +106,7 @@ if(EXISTS ${PROJECT_BUILD_DIR}/generated/rncli/src/main/jni/Android-rncli.cmake)
         include(${PROJECT_BUILD_DIR}/generated/rncli/src/main/jni/Android-rncli.cmake)
         target_link_libraries(${CMAKE_PROJECT_NAME} ${AUTOLINKED_LIBRARIES})
         foreach(autolinked_library ${AUTOLINKED_LIBRARIES})
-            target_link_libraries(autolinked_library common_flags)
+            target_link_libraries(${autolinked_library} common_flags)
         endforeach()
 endif()
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Hi, while adjusting [react-native-screens](https://github.com/software-mansion/react-native-screens) to `0.71.0-rc.0` I encountered the same problems as reported [here](https://github.com/reactwg/react-native-releases/discussions/41#discussioncomment-4085694) by @WoLewicki. 

Basically inside `CMake`'s `foreach` loop iterator variable is not being expanded to the actual value: 

```cmake
foreach(autolinked_library ${AUTOLINKED_LIBRARIES})
    target_link_libraries(autolinked_library common_flags) // <-- here we are literally linking to "autolinked_library".
endforeach()
```



## Changelog

[Android] [Fixed] - Fix Android autolinking failing because of not expanded variable

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
