### PR TITLE
Add `TSMethodSignature` to react-native-codegen

### DIFF
--- a/packages/react-native-codegen/src/parsers/flow/components/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/__test_fixtures__/fixtures.js
@@ -871,13 +871,13 @@ type NativeType = HostComponent<ModuleProps>;
 interface NativeCommands {
   +handleRootTag: (viewRef: React.ElementRef<NativeType>, rootTag: RootTag) => void;
   +hotspotUpdate: (viewRef: React.ElementRef<NativeType>, x: Int32, y: Int32) => void;
-  +scrollTo: (
+  scrollTo(
     viewRef: React.ElementRef<NativeType>,
     x: Float,
     y: Int32,
     z: Double,
     animated: boolean,
-  ) => void;
+  ): void;
 }
 
 export const Commands = codegenNativeCommands<NativeCommands>({

--- a/packages/react-native-codegen/src/parsers/flow/components/__tests__/__snapshots__/component-parser-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/flow/components/__tests__/__snapshots__/component-parser-test.js.snap
@@ -1280,6 +1280,7 @@ exports[`RN Codegen Flow Parser can generate fixture COMMANDS_DEFINED_WITH_ALL_T
                 'params': [
                   {
                     'name': 'rootTag',
+                    'optional': false,
                     'typeAnnotation': {
                       'type': 'ReservedTypeAnnotation',
                       'name': 'RootTag'
@@ -1299,12 +1300,14 @@ exports[`RN Codegen Flow Parser can generate fixture COMMANDS_DEFINED_WITH_ALL_T
                 'params': [
                   {
                     'name': 'x',
+                    'optional': false,
                     'typeAnnotation': {
                       'type': 'Int32TypeAnnotation'
                     }
                   },
                   {
                     'name': 'y',
+                    'optional': false,
                     'typeAnnotation': {
                       'type': 'Int32TypeAnnotation'
                     }
@@ -1323,24 +1326,28 @@ exports[`RN Codegen Flow Parser can generate fixture COMMANDS_DEFINED_WITH_ALL_T
                 'params': [
                   {
                     'name': 'x',
+                    'optional': false,
                     'typeAnnotation': {
                       'type': 'FloatTypeAnnotation'
                     }
                   },
                   {
                     'name': 'y',
+                    'optional': false,
                     'typeAnnotation': {
                       'type': 'Int32TypeAnnotation'
                     }
                   },
                   {
                     'name': 'z',
+                    'optional': false,
                     'typeAnnotation': {
                       'type': 'DoubleTypeAnnotation'
                     }
                   },
                   {
                     'name': 'animated',
+                    'optional': false,
                     'typeAnnotation': {
                       'type': 'BooleanTypeAnnotation'
                     }
@@ -2898,12 +2905,14 @@ exports[`RN Codegen Flow Parser can generate fixture COMMANDS_EVENTS_TYPES_EXPOR
                 'params': [
                   {
                     'name': 'y',
+                    'optional': false,
                     'typeAnnotation': {
                       'type': 'Int32TypeAnnotation'
                     }
                   },
                   {
                     'name': 'animated',
+                    'optional': false,
                     'typeAnnotation': {
                       'type': 'BooleanTypeAnnotation'
                     }
@@ -2946,12 +2955,14 @@ exports[`RN Codegen Flow Parser can generate fixture COMMANDS_WITH_EXTERNAL_TYPE
                 'params': [
                   {
                     'name': 'y',
+                    'optional': false,
                     'typeAnnotation': {
                       'type': 'Int32TypeAnnotation'
                     }
                   },
                   {
                     'name': 'animated',
+                    'optional': false,
                     'typeAnnotation': {
                       'type': 'BooleanTypeAnnotation'
                     }

--- a/packages/react-native-codegen/src/parsers/flow/components/commands.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/commands.js
@@ -90,6 +90,7 @@ function buildCommandSchema(property: EventTypeAST, types: TypeDeclarationMap) {
 
     return {
       name: paramName,
+      optional: false,
       typeAnnotation: returnType,
     };
   });

--- a/packages/react-native-codegen/src/parsers/flow/modules/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__test_fixtures__/fixtures.js
@@ -591,7 +591,7 @@ export enum StringOptions {
 }
 
 export interface Spec extends TurboModule {
-  +getEnums: (quality: Quality, resolution?: Resolution, floppy: Floppy, stringOptions: StringOptions) => string;
+  getEnums(quality: Quality, resolution?: Resolution, floppy: Floppy, stringOptions: StringOptions): string;
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModuleIOS');

--- a/packages/react-native-codegen/src/parsers/typescript/components/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/__test_fixtures__/fixtures.js
@@ -981,13 +981,13 @@ type NativeType = HostComponent<ModuleProps>;
  interface NativeCommands {
    readonly handleRootTag: (viewRef: React.ElementRef<NativeType>, rootTag: RootTag) => void;
    readonly hotspotUpdate: (viewRef: React.ElementRef<NativeType>, x: Int32, y: Int32) => void;
-   readonly scrollTo: (
+   scrollTo(
      viewRef: React.ElementRef<NativeType>,
      x: Float,
      y: Int32,
      z: Double,
      animated: boolean,
-   ) => void;
+   ): void;
  }
 
  export const Commands = codegenNativeCommands<NativeCommands>({

--- a/packages/react-native-codegen/src/parsers/typescript/components/__tests__/__snapshots__/typescript-component-parser-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/typescript/components/__tests__/__snapshots__/typescript-component-parser-test.js.snap
@@ -1985,6 +1985,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture COMMANDS_DEFINED_WITH
                 'params': [
                   {
                     'name': 'rootTag',
+                    'optional': false,
                     'typeAnnotation': {
                       'type': 'ReservedTypeAnnotation',
                       'name': 'RootTag'
@@ -2004,12 +2005,14 @@ exports[`RN Codegen TypeScript Parser can generate fixture COMMANDS_DEFINED_WITH
                 'params': [
                   {
                     'name': 'x',
+                    'optional': false,
                     'typeAnnotation': {
                       'type': 'Int32TypeAnnotation'
                     }
                   },
                   {
                     'name': 'y',
+                    'optional': false,
                     'typeAnnotation': {
                       'type': 'Int32TypeAnnotation'
                     }
@@ -2028,24 +2031,28 @@ exports[`RN Codegen TypeScript Parser can generate fixture COMMANDS_DEFINED_WITH
                 'params': [
                   {
                     'name': 'x',
+                    'optional': false,
                     'typeAnnotation': {
                       'type': 'FloatTypeAnnotation'
                     }
                   },
                   {
                     'name': 'y',
+                    'optional': false,
                     'typeAnnotation': {
                       'type': 'Int32TypeAnnotation'
                     }
                   },
                   {
                     'name': 'z',
+                    'optional': false,
                     'typeAnnotation': {
                       'type': 'DoubleTypeAnnotation'
                     }
                   },
                   {
                     'name': 'animated',
+                    'optional': false,
                     'typeAnnotation': {
                       'type': 'BooleanTypeAnnotation'
                     }
@@ -3603,12 +3610,14 @@ exports[`RN Codegen TypeScript Parser can generate fixture COMMANDS_EVENTS_TYPES
                 'params': [
                   {
                     'name': 'y',
+                    'optional': false,
                     'typeAnnotation': {
                       'type': 'Int32TypeAnnotation'
                     }
                   },
                   {
                     'name': 'animated',
+                    'optional': false,
                     'typeAnnotation': {
                       'type': 'BooleanTypeAnnotation'
                     }
@@ -3651,12 +3660,14 @@ exports[`RN Codegen TypeScript Parser can generate fixture COMMANDS_WITH_EXTERNA
                 'params': [
                   {
                     'name': 'y',
+                    'optional': false,
                     'typeAnnotation': {
                       'type': 'Int32TypeAnnotation'
                     }
                   },
                   {
                     'name': 'animated',
+                    'optional': false,
                     'typeAnnotation': {
                       'type': 'BooleanTypeAnnotation'
                     }

--- a/packages/react-native-codegen/src/parsers/typescript/components/commands.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/commands.js
@@ -24,7 +24,7 @@ function buildCommandSchemaInternal(
   optional: boolean,
   parameters: Array<$FlowFixMe>,
   types: TypeDeclarationMap,
-) {
+): NamedShape<CommandTypeAnnotation> {
   const firstParam = parameters[0].typeAnnotation;
   if (
     !(
@@ -110,8 +110,11 @@ function buildCommandSchemaInternal(
   };
 }
 
-function buildCommandSchema(property: EventTypeAST, types: TypeDeclarationMap) {
-  if(property.type === 'TSPropertySignature') {
+function buildCommandSchema(
+  property: EventTypeAST,
+  types: TypeDeclarationMap,
+): NamedShape<CommandTypeAnnotation> {
+  if (property.type === 'TSPropertySignature') {
     const topLevelType = parseTopLevelType(
       property.typeAnnotation.typeAnnotation,
       types,
@@ -119,12 +122,12 @@ function buildCommandSchema(property: EventTypeAST, types: TypeDeclarationMap) {
     const name = property.key.name;
     const optional = property.optional || topLevelType.optional;
     const parameters = topLevelType.type.parameters || topLevelType.type.params;
-    return buildCommandSchemaInternal(name,optional,parameters,types);
+    return buildCommandSchemaInternal(name, optional, parameters, types);
   } else {
     const name = property.key.name;
-    const optional=false;
-    const parameters=property.parameters || property.params;
-    return buildCommandSchemaInternal(name,optional,parameters,types);
+    const optional = property.optional || false;
+    const parameters = property.parameters || property.params;
+    return buildCommandSchemaInternal(name, optional, parameters, types);
   }
 }
 
@@ -133,7 +136,11 @@ function getCommands(
   types: TypeDeclarationMap,
 ): $ReadOnlyArray<NamedShape<CommandTypeAnnotation>> {
   return commandTypeAST
-    .filter(property => property.type === 'TSPropertySignature' || property.type === 'TSMethodSignature')
+    .filter(
+      property =>
+        property.type === 'TSPropertySignature' ||
+        property.type === 'TSMethodSignature',
+    )
     .map(property => buildCommandSchema(property, types))
     .filter(Boolean);
 }

--- a/packages/react-native-codegen/src/parsers/typescript/components/commands.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/commands.js
@@ -19,16 +19,13 @@ const {parseTopLevelType} = require('../parseTopLevelType');
 
 type EventTypeAST = Object;
 
-function buildCommandSchema(property: EventTypeAST, types: TypeDeclarationMap) {
-  const topLevelType = parseTopLevelType(
-    property.typeAnnotation.typeAnnotation,
-    types,
-  );
-  const name = property.key.name;
-  const optional = property.optional || topLevelType.optional;
-  const parameters = topLevelType.type.parameters;
+function buildCommandSchemaInternal(
+  name: string,
+  optional: boolean,
+  parameters: Array<$FlowFixMe>,
+  types: TypeDeclarationMap,
+) {
   const firstParam = parameters[0].typeAnnotation;
-
   if (
     !(
       firstParam.typeAnnotation != null &&
@@ -111,6 +108,17 @@ function buildCommandSchema(property: EventTypeAST, types: TypeDeclarationMap) {
       },
     },
   };
+}
+
+function buildCommandSchema(property: EventTypeAST, types: TypeDeclarationMap) {
+  const topLevelType = parseTopLevelType(
+    property.typeAnnotation.typeAnnotation,
+    types,
+  );
+  const name = property.key.name;
+  const optional = property.optional || topLevelType.optional;
+  const parameters = topLevelType.type.parameters;
+  return buildCommandSchemaInternal(name,optional,parameters,types);
 }
 
 function getCommands(

--- a/packages/react-native-codegen/src/parsers/typescript/components/commands.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/commands.js
@@ -26,8 +26,8 @@ function buildCommandSchema(property: EventTypeAST, types: TypeDeclarationMap) {
   );
   const name = property.key.name;
   const optional = property.optional || topLevelType.optional;
-  const value = topLevelType.type;
-  const firstParam = value.parameters[0].typeAnnotation;
+  const parameters = topLevelType.type.parameters;
+  const firstParam = parameters[0].typeAnnotation;
 
   if (
     !(
@@ -42,7 +42,7 @@ function buildCommandSchema(property: EventTypeAST, types: TypeDeclarationMap) {
     );
   }
 
-  const params = value.parameters.slice(1).map(param => {
+  const params = parameters.slice(1).map(param => {
     const paramName = param.name;
     const paramValue = parseTopLevelType(
       param.typeAnnotation.typeAnnotation,

--- a/packages/react-native-codegen/src/parsers/typescript/components/commands.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/commands.js
@@ -111,14 +111,21 @@ function buildCommandSchemaInternal(
 }
 
 function buildCommandSchema(property: EventTypeAST, types: TypeDeclarationMap) {
-  const topLevelType = parseTopLevelType(
-    property.typeAnnotation.typeAnnotation,
-    types,
-  );
-  const name = property.key.name;
-  const optional = property.optional || topLevelType.optional;
-  const parameters = topLevelType.type.parameters;
-  return buildCommandSchemaInternal(name,optional,parameters,types);
+  if(property.type === 'TSPropertySignature') {
+    const topLevelType = parseTopLevelType(
+      property.typeAnnotation.typeAnnotation,
+      types,
+    );
+    const name = property.key.name;
+    const optional = property.optional || topLevelType.optional;
+    const parameters = topLevelType.type.parameters || topLevelType.type.params;
+    return buildCommandSchemaInternal(name,optional,parameters,types);
+  } else {
+    const name = property.key.name;
+    const optional=false;
+    const parameters=property.parameters || property.params;
+    return buildCommandSchemaInternal(name,optional,parameters,types);
+  }
 }
 
 function getCommands(
@@ -126,7 +133,7 @@ function getCommands(
   types: TypeDeclarationMap,
 ): $ReadOnlyArray<NamedShape<CommandTypeAnnotation>> {
   return commandTypeAST
-    .filter(property => property.type === 'TSPropertySignature')
+    .filter(property => property.type === 'TSPropertySignature' || property.type === 'TSMethodSignature')
     .map(property => buildCommandSchema(property, types))
     .filter(Boolean);
 }

--- a/packages/react-native-codegen/src/parsers/typescript/components/commands.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/commands.js
@@ -93,6 +93,7 @@ function buildCommandSchemaInternal(
 
     return {
       name: paramName,
+      optional: false,
       typeAnnotation: returnType,
     };
   });

--- a/packages/react-native-codegen/src/parsers/typescript/modules/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/__test_fixtures__/fixtures.js
@@ -412,9 +412,9 @@ import type {TurboModule} from 'react-native/Libraries/TurboModule/RCTExport';
 import * as TurboModuleRegistry from 'react-native/Libraries/TurboModule/TurboModuleRegistry';
 
 export interface Spec extends TurboModule {
-  readonly getArray: (
+  getArray(
     arg: [string, string][],
-  ) => (string | number | boolean)[];
+  ): (string | number | boolean)[];
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');


### PR DESCRIPTION
## Summary

Refering to "Support function signature along with function type properties in commands" in https://github.com/facebook/react-native/issues/34872

Many TypeScript programmers prefer `{ name(arg:string):void; }` to `{ readonly name:(arg:string)=>void; }`.

In this pull request, I updated test cases in both commands and modules to cover it, with missing implementation.

Command arguments are `NamedShape<T>` but the `optional` field is missing, it is also fixed.

## Changelog

[General] [Changed] - Add `TSMethodSignature` to react-native-codegen

## Test Plan

`yarn jest react-native-codegen` passed
