### PR TITLE
[codegen] move remapUnionTypeAnnotationMemberNames to Parser

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-commons-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-commons-test.js
@@ -29,8 +29,10 @@ const {
 
 import {MockedParser} from '../parserMock';
 import {TypeScriptParser} from '../typescript/parser';
+import {FlowParser} from '../flow/parser';
 
 const parser = new MockedParser();
+const flowParser = new FlowParser();
 const typeScriptParser = new TypeScriptParser();
 
 const flowTranslateTypeAnnotation = require('../flow/modules/index');
@@ -399,8 +401,6 @@ describe('emitUnionTypeAnnotation', () => {
   const hasteModuleName = 'SampleTurboModule';
 
   describe('when language is flow', () => {
-    const language: ParserType = 'Flow';
-
     describe('when members type is numeric', () => {
       const typeAnnotation = {
         type: 'UnionTypeAnnotation',
@@ -415,7 +415,7 @@ describe('emitUnionTypeAnnotation', () => {
             true,
             hasteModuleName,
             typeAnnotation,
-            language,
+            flowParser,
           );
 
           const expected = {
@@ -436,7 +436,7 @@ describe('emitUnionTypeAnnotation', () => {
             false,
             hasteModuleName,
             typeAnnotation,
-            language,
+            flowParser,
           );
 
           const expected = {
@@ -463,7 +463,7 @@ describe('emitUnionTypeAnnotation', () => {
             true,
             hasteModuleName,
             typeAnnotation,
-            language,
+            flowParser,
           );
 
           const expected = {
@@ -484,7 +484,7 @@ describe('emitUnionTypeAnnotation', () => {
             false,
             hasteModuleName,
             typeAnnotation,
-            language,
+            flowParser,
           );
 
           const expected = {
@@ -508,7 +508,7 @@ describe('emitUnionTypeAnnotation', () => {
             true,
             hasteModuleName,
             typeAnnotation,
-            language,
+            flowParser,
           );
 
           const expected = {
@@ -529,7 +529,7 @@ describe('emitUnionTypeAnnotation', () => {
             false,
             hasteModuleName,
             typeAnnotation,
-            language,
+            flowParser,
           );
 
           const expected = {
@@ -562,7 +562,7 @@ describe('emitUnionTypeAnnotation', () => {
             hasteModuleName,
             typeAnnotation,
             unionTypes,
-            language,
+            flowParser.language(),
           );
 
           expect(() => {
@@ -570,7 +570,7 @@ describe('emitUnionTypeAnnotation', () => {
               true,
               hasteModuleName,
               typeAnnotation,
-              language,
+              flowParser,
             );
           }).toThrow(expected);
         });
@@ -582,7 +582,7 @@ describe('emitUnionTypeAnnotation', () => {
             hasteModuleName,
             typeAnnotation,
             unionTypes,
-            language,
+            flowParser.language(),
           );
 
           expect(() => {
@@ -590,7 +590,7 @@ describe('emitUnionTypeAnnotation', () => {
               false,
               hasteModuleName,
               typeAnnotation,
-              language,
+              flowParser,
             );
           }).toThrow(expected);
         });
@@ -599,8 +599,6 @@ describe('emitUnionTypeAnnotation', () => {
   });
 
   describe('when language is typescript', () => {
-    const language: ParserType = 'TypeScript';
-
     describe('when members type is numeric', () => {
       const typeAnnotation = {
         type: 'TSUnionType',
@@ -621,7 +619,7 @@ describe('emitUnionTypeAnnotation', () => {
             true,
             hasteModuleName,
             typeAnnotation,
-            language,
+            typeScriptParser,
           );
 
           const expected = {
@@ -642,7 +640,7 @@ describe('emitUnionTypeAnnotation', () => {
             false,
             hasteModuleName,
             typeAnnotation,
-            language,
+            typeScriptParser,
           );
 
           const expected = {
@@ -675,7 +673,7 @@ describe('emitUnionTypeAnnotation', () => {
             true,
             hasteModuleName,
             typeAnnotation,
-            language,
+            typeScriptParser,
           );
 
           const expected = {
@@ -696,7 +694,7 @@ describe('emitUnionTypeAnnotation', () => {
             false,
             hasteModuleName,
             typeAnnotation,
-            language,
+            typeScriptParser,
           );
 
           const expected = {
@@ -727,7 +725,7 @@ describe('emitUnionTypeAnnotation', () => {
             true,
             hasteModuleName,
             typeAnnotation,
-            language,
+            typeScriptParser,
           );
 
           const expected = {
@@ -748,7 +746,7 @@ describe('emitUnionTypeAnnotation', () => {
             false,
             hasteModuleName,
             typeAnnotation,
-            language,
+            typeScriptParser,
           );
 
           const expected = {
@@ -789,7 +787,7 @@ describe('emitUnionTypeAnnotation', () => {
             hasteModuleName,
             typeAnnotation,
             unionTypes,
-            language,
+            typeScriptParser.language(),
           );
 
           expect(() => {
@@ -797,7 +795,7 @@ describe('emitUnionTypeAnnotation', () => {
               true,
               hasteModuleName,
               typeAnnotation,
-              language,
+              typeScriptParser,
             );
           }).toThrow(expected);
         });
@@ -809,7 +807,7 @@ describe('emitUnionTypeAnnotation', () => {
             hasteModuleName,
             typeAnnotation,
             unionTypes,
-            language,
+            typeScriptParser.language(),
           );
 
           expect(() => {
@@ -817,7 +815,7 @@ describe('emitUnionTypeAnnotation', () => {
               false,
               hasteModuleName,
               typeAnnotation,
-              language,
+              typeScriptParser,
             );
           }).toThrow(expected);
         });

--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-test.js
@@ -19,7 +19,7 @@ import {TypeScriptParser} from '../typescript/parser';
 import {FlowParser} from '../flow/parser';
 
 const hasteModuleName = 'moduleName';
-describe('TypeScriptParser', () => {
+describe('FlowParser', () => {
   const parser = new FlowParser();
   describe('getKeyName', () => {
     describe('when propertyOrIndex is ObjectTypeProperty', () => {
@@ -76,9 +76,26 @@ describe('TypeScriptParser', () => {
       });
     });
   });
+
+  describe('remapUnionTypeAnnotationMemberNames', () => {
+    it('returns remaped union annotation member types without duplicates', () => {
+      const membersType = [
+        {type: 'NumberLiteralTypeAnnotation'},
+        {type: 'ObjectTypeAnnotation'},
+        {type: 'StringLiteralTypeAnnotation'},
+        {type: 'ObjectTypeAnnotation'},
+      ];
+
+      expect(parser.remapUnionTypeAnnotationMemberNames(membersType)).toEqual([
+        'NumberTypeAnnotation',
+        'ObjectTypeAnnotation',
+        'StringTypeAnnotation',
+      ]);
+    });
+  });
 });
 
-describe('FlowParser', () => {
+describe('TypeScriptParser', () => {
   const parser = new TypeScriptParser();
   describe('getKeyName', () => {
     describe('when propertyOrIndex is TSPropertySignature', () => {
@@ -124,6 +141,22 @@ describe('FlowParser', () => {
           UnsupportedObjectPropertyTypeAnnotationParserError,
         );
       });
+    });
+  });
+  describe('remapUnionTypeAnnotationMemberNames', () => {
+    it('returns remaped union annotation member types without duplicates', () => {
+      const membersType = [
+        {literal: {type: 'NumericLiteral'}},
+        {type: 'ObjectTypeAnnotation'},
+        {literal: {type: 'StringLiteral'}},
+        {type: 'ObjectTypeAnnotation'},
+      ];
+
+      expect(parser.remapUnionTypeAnnotationMemberNames(membersType)).toEqual([
+        'NumberTypeAnnotation',
+        'ObjectTypeAnnotation',
+        'StringTypeAnnotation',
+      ]);
     });
   });
 });

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -314,7 +314,7 @@ function translateTypeAnnotation(
           nullable,
           hasteModuleName,
           typeAnnotation,
-          language,
+          parser,
         );
       }
       // Fallthrough

--- a/packages/react-native-codegen/src/parsers/flow/parser.js
+++ b/packages/react-native-codegen/src/parsers/flow/parser.js
@@ -10,6 +10,7 @@
 
 'use strict';
 
+import type {UnionTypeAnnotationMemberType} from '../../CodegenSchema.js';
 import type {ParserType} from '../errors';
 import type {Parser} from '../parser';
 
@@ -62,6 +63,18 @@ class FlowParser implements Parser {
       typeArguments.params[0].type !== 'GenericTypeAnnotation' ||
       typeArguments.params[0].id.name !== 'Spec'
     );
+  }
+
+  remapUnionTypeAnnotationMemberNames(
+    membersTypes: $FlowFixMe[],
+  ): UnionTypeAnnotationMemberType[] {
+    const remapLiteral = (item: $FlowFixMe) => {
+      return item.type
+        .replace('NumberLiteralTypeAnnotation', 'NumberTypeAnnotation')
+        .replace('StringLiteralTypeAnnotation', 'StringTypeAnnotation');
+    };
+
+    return [...new Set(membersTypes.map(remapLiteral))];
   }
 }
 

--- a/packages/react-native-codegen/src/parsers/parser.js
+++ b/packages/react-native-codegen/src/parsers/parser.js
@@ -10,6 +10,7 @@
 
 'use strict';
 
+import type {UnionTypeAnnotationMemberType} from '../CodegenSchema.js';
 import type {ParserType} from './errors';
 
 /**
@@ -58,4 +59,12 @@ export interface Parser {
    * @returns: a boolean specifying if the Module is Invalid.
    */
   checkIfInvalidModule(typeArguments: $FlowFixMe): boolean;
+  /**
+   * Given a union annotation members types, it returns an array of remaped members names without duplicates.
+   * @parameter membersTypes: union annotation members types
+   * @returns: an array of remaped members names without duplicates.
+   */
+  remapUnionTypeAnnotationMemberNames(
+    types: $FlowFixMe,
+  ): UnionTypeAnnotationMemberType[];
 }

--- a/packages/react-native-codegen/src/parsers/parserMock.js
+++ b/packages/react-native-codegen/src/parsers/parserMock.js
@@ -10,6 +10,7 @@
 
 'use strict';
 
+import type {UnionTypeAnnotationMemberType} from '../CodegenSchema.js';
 import type {Parser} from './parser';
 import type {ParserType} from './errors';
 
@@ -57,5 +58,11 @@ export class MockedParser implements Parser {
 
   checkIfInvalidModule(typeArguments: $FlowFixMe): boolean {
     return false;
+  }
+
+  remapUnionTypeAnnotationMemberNames(
+    membersTypes: $FlowFixMe[],
+  ): UnionTypeAnnotationMemberType[] {
+    return [];
   }
 }

--- a/packages/react-native-codegen/src/parsers/parsers-commons.js
+++ b/packages/react-native-codegen/src/parsers/parsers-commons.js
@@ -20,7 +20,6 @@ import type {
   NativeModuleUnionTypeAnnotation,
   Nullable,
   SchemaType,
-  UnionTypeAnnotationMemberType,
 } from '../CodegenSchema.js';
 import type {ParserType} from './errors';
 import type {Parser} from './parser';
@@ -196,38 +195,14 @@ function parseObjectProperty(
   };
 }
 
-function remapUnionTypeAnnotationMemberNames(
-  types: $FlowFixMe,
-  language: ParserType,
-): UnionTypeAnnotationMemberType[] {
-  const remapLiteral = (item: $FlowFixMe) => {
-    if (language === 'Flow') {
-      return item.type
-        .replace('NumberLiteralTypeAnnotation', 'NumberTypeAnnotation')
-        .replace('StringLiteralTypeAnnotation', 'StringTypeAnnotation');
-    }
-
-    return item.literal
-      ? item.literal.type
-          .replace('NumericLiteral', 'NumberTypeAnnotation')
-          .replace('StringLiteral', 'StringTypeAnnotation')
-      : 'ObjectTypeAnnotation';
-  };
-
-  return types
-    .map(remapLiteral)
-    .filter((value, index, self) => self.indexOf(value) === index);
-}
-
 function emitUnionTypeAnnotation(
   nullable: boolean,
   hasteModuleName: string,
   typeAnnotation: $FlowFixMe,
-  language: ParserType,
+  parser: Parser,
 ): Nullable<NativeModuleUnionTypeAnnotation> {
-  const unionTypes = remapUnionTypeAnnotationMemberNames(
+  const unionTypes = parser.remapUnionTypeAnnotationMemberNames(
     typeAnnotation.types,
-    language,
   );
 
   // Only support unionTypes of the same kind
@@ -236,7 +211,7 @@ function emitUnionTypeAnnotation(
       hasteModuleName,
       typeAnnotation,
       unionTypes,
-      language,
+      parser.language(),
     );
   }
 

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -15,7 +15,6 @@ import type {
   NativeModuleAliasMap,
   NativeModuleArrayTypeAnnotation,
   NativeModuleBaseTypeAnnotation,
-  NativeModuleFunctionTypeAnnotation,
   NativeModulePropertyShape,
   NativeModuleTypeAnnotation,
   NativeModuleSchema,
@@ -320,7 +319,7 @@ function translateTypeAnnotation(
           nullable,
           hasteModuleName,
           typeAnnotation,
-          language,
+          parser,
         );
       }
       // Fallthrough

--- a/packages/react-native-codegen/src/parsers/typescript/parser.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parser.js
@@ -10,6 +10,7 @@
 
 'use strict';
 
+import type {UnionTypeAnnotationMemberType} from '../../CodegenSchema.js';
 import type {ParserType} from '../errors';
 import type {Parser} from '../parser';
 
@@ -65,6 +66,20 @@ class TypeScriptParser implements Parser {
       typeArguments.params[0].type !== 'TSTypeReference' ||
       typeArguments.params[0].typeName.name !== 'Spec'
     );
+  }
+
+  remapUnionTypeAnnotationMemberNames(
+    membersTypes: $FlowFixMe[],
+  ): UnionTypeAnnotationMemberType[] {
+    const remapLiteral = (item: $FlowFixMe) => {
+      return item.literal
+        ? item.literal.type
+            .replace('NumericLiteral', 'NumberTypeAnnotation')
+            .replace('StringLiteral', 'StringTypeAnnotation')
+        : 'ObjectTypeAnnotation';
+    };
+
+    return [...new Set(membersTypes.map(remapLiteral))];
   }
 }
 module.exports = {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Part of https://github.com/facebook/react-native/issues/34872#issuecomment-1304236257

> [Assigned to @youedd] Create a new function [remapUnionTypeAnnotationMemberNames](https://github.com/facebook/react-native/blob/main/packages/react-native-codegen/src/parsers/parsers-commons.js#L110) in the [parser.js file](https://github.com/facebook/react-native/blob/main/packages/react-native-codegen/src/parsers/parser.js) and add documentation to it. Implement it properly in the [FlowParser.js](https://github.com/facebook/react-native/blob/main/packages/react-native-codegen/src/parsers/flow/parser.js#L15) and in the [TypeScriptParser.js](https://github.com/facebook/react-native/blob/main/packages/react-native-codegen/src/parsers/typescript/parser.js#L15). Remove the function [remapUnionTypeAnnotationMemberNames](https://github.com/facebook/react-native/blob/main/packages/react-native-codegen/src/parsers/parsers-commons.js#L110) and update the [emitUnionTypeAnnotation](https://github.com/facebook/react-native/blob/main/packages/react-native-codegen/src/parsers/parsers-commons.js#L110) signature to accept a Parser parameter instead of a language one. Use the new Parser function instead of the old one [here](https://github.com/facebook/react-native/blob/main/packages/react-native-codegen/src/parsers/parsers-commons.js#L139).

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[Internal] [changed] - move remapUnionTypeAnnotationMemberNames to the parsers implementations

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
`yarn jest react-native-codegen`

![image](https://user-images.githubusercontent.com/19575877/201389910-31d48601-7023-4c94-a6d5-efccb18629cd.png)

