### PR TITLE
Adding missing #import <QuartzCore/QuartzCore.h> imports

### DIFF
--- a/Libraries/Text/Text/RCTTextView.m
+++ b/Libraries/Text/Text/RCTTextView.m
@@ -14,6 +14,8 @@
 
 #import <React/RCTTextShadowView.h>
 
+#import <QuartzCore/QuartzCore.h>
+
 @implementation RCTTextView {
   CAShapeLayer *_highlightLayer;
   UILongPressGestureRecognizer *_longPressGestureRecognizer;

--- a/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -8,6 +8,7 @@
 #import "RCTViewComponentView.h"
 
 #import <CoreGraphics/CoreGraphics.h>
+#import <QuartzCore/QuartzCore.h>
 #import <objc/runtime.h>
 
 #import <React/RCTAssert.h>

--- a/React/Fabric/Mounting/RCTMountingManager.mm
+++ b/React/Fabric/Mounting/RCTMountingManager.mm
@@ -7,6 +7,7 @@
 
 #import "RCTMountingManager.h"
 
+#import <QuartzCore/QuartzCore.h>
 #import <butter/map.h>
 
 #import <React/RCTAssert.h>

--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -7,6 +7,7 @@
 
 #import "RCTView.h"
 
+#import <QuartzCore/QuartzCore.h>
 #import <React/RCTMockDef.h>
 
 #import "RCTAutoInsetsProtocol.h"


### PR DESCRIPTION
Summary:
These headers are needed on react-native-macOS, but not explicitly imported all the time. It seems that some UIKit header will implicitly import them.

Changelog: [Internal]

Differential Revision: D41229835

