### PR TITLE
Add onStartReached and onStartReachedThreshold to VirtualizedList

### DIFF
--- a/Libraries/Lists/FlatList.d.ts
+++ b/Libraries/Lists/FlatList.d.ts
@@ -147,19 +147,6 @@ export interface FlatListProps<ItemT> extends VirtualizedListProps<ItemT> {
   numColumns?: number | undefined;
 
   /**
-   * Called once when the scroll position gets within onEndReachedThreshold of the rendered content.
-   */
-  onEndReached?: ((info: {distanceFromEnd: number}) => void) | null | undefined;
-
-  /**
-   * How far from the end (in units of visible length of the list) the bottom edge of the
-   * list must be from the end of the content to trigger the `onEndReached` callback.
-   * Thus a value of 0.5 will trigger `onEndReached` when the end of the content is
-   * within half the visible length of the list.
-   */
-  onEndReachedThreshold?: number | null | undefined;
-
-  /**
    * If provided, a standard RefreshControl will be added for "Pull to Refresh" functionality.
    * Make sure to also set the refreshing prop correctly.
    */

--- a/Libraries/Lists/VirtualizedList.d.ts
+++ b/Libraries/Lists/VirtualizedList.d.ts
@@ -232,8 +232,18 @@ export interface VirtualizedListWithoutRenderItemProps<ItemT>
    */
   maxToRenderPerBatch?: number | undefined;
 
+  /**
+   * Called once when the scroll position gets within `onEndReachedThreshold` of the rendered
+   * content.
+   */
   onEndReached?: ((info: {distanceFromEnd: number}) => void) | null | undefined;
 
+  /**
+   * How far from the end (in units of visible length of the list) the trailing edge of the
+   * list must be from the end of the content to trigger the `onEndReached` callback.
+   * Thus, a value of 0.5 will trigger `onEndReached` when the end of the content is
+   * within half the visible length of the list.
+   */
   onEndReachedThreshold?: number | null | undefined;
 
   onLayout?: ((event: LayoutChangeEvent) => void) | undefined;
@@ -256,6 +266,23 @@ export interface VirtualizedListWithoutRenderItemProps<ItemT>
         averageItemLength: number;
       }) => void)
     | undefined;
+
+  /**
+   * Called once when the scroll position gets within `onStartReachedThreshold` of the rendered
+   * content.
+   */
+  onStartReached?:
+    | ((info: {distanceFromStart: number}) => void)
+    | null
+    | undefined;
+
+  /**
+   * How far from the start (in units of visible length of the list) the leading edge of the
+   * list must be from the start of the content to trigger the `onStartReached` callback.
+   * Thus, a value of 0.5 will trigger `onStartReached` when the start of the content is
+   * within half the visible length of the list.
+   */
+  onStartReachedThreshold?: number | null | undefined;
 
   /**
    * Called when the viewability of rows changes, as defined by the

--- a/Libraries/Lists/VirtualizedList.d.ts
+++ b/Libraries/Lists/VirtualizedList.d.ts
@@ -233,8 +233,8 @@ export interface VirtualizedListWithoutRenderItemProps<ItemT>
   maxToRenderPerBatch?: number | undefined;
 
   /**
-   * Called once when the scroll position gets within `onEndReachedThreshold` of the rendered
-   * content.
+   * Called once when the scroll position gets within within `onEndReachedThreshold`
+   * from the logical end of the list.
    */
   onEndReached?: ((info: {distanceFromEnd: number}) => void) | null | undefined;
 
@@ -268,8 +268,8 @@ export interface VirtualizedListWithoutRenderItemProps<ItemT>
     | undefined;
 
   /**
-   * Called once when the scroll position gets within `onStartReachedThreshold` of the rendered
-   * content.
+   * Called once when the scroll position gets within within `onStartReachedThreshold`
+   * from the logical start of the list.
    */
   onStartReached?:
     | ((info: {distanceFromStart: number}) => void)

--- a/Libraries/Lists/VirtualizedListProps.js
+++ b/Libraries/Lists/VirtualizedListProps.js
@@ -170,8 +170,8 @@ type OptionalProps = {|
    */
   maxToRenderPerBatch?: ?number,
   /**
-   * Called once when the scroll position gets within `onEndReachedThreshold` of the rendered
-   * content.
+   * Called once when the scroll position gets within within `onEndReachedThreshold`
+   * from the logical end of the list.
    */
   onEndReached?: ?(info: {distanceFromEnd: number, ...}) => void,
   /**
@@ -198,8 +198,8 @@ type OptionalProps = {|
     ...
   }) => void,
   /**
-   * Called once when the scroll position gets within `onStartReachedThreshold` of the rendered
-   * content.
+   * Called once when the scroll position gets within within `onStartReachedThreshold`
+   * from the logical start of the list.
    */
   onStartReached?: ?(info: {distanceFromStart: number, ...}) => void,
   /**

--- a/Libraries/Lists/VirtualizedListProps.js
+++ b/Libraries/Lists/VirtualizedListProps.js
@@ -175,11 +175,10 @@ type OptionalProps = {|
    */
   onEndReached?: ?(info: {distanceFromEnd: number, ...}) => void,
   /**
-   * How far from the end (in units of visible length of the list) the bottom edge of the
+   * How far from the end (in units of visible length of the list) the trailing edge of the
    * list must be from the end of the content to trigger the `onEndReached` callback.
-   * Thus a value of 0.5 will trigger `onEndReached` when the end of the content is
-   * within half the visible length of the list. A value of 0 will not trigger until scrolling
-   * to the very end of the list.
+   * Thus, a value of 0.5 will trigger `onEndReached` when the end of the content is
+   * within half the visible length of the list.
    */
   onEndReachedThreshold?: ?number,
   /**
@@ -198,6 +197,18 @@ type OptionalProps = {|
     averageItemLength: number,
     ...
   }) => void,
+  /**
+   * Called once when the scroll position gets within `onStartReachedThreshold` of the rendered
+   * content.
+   */
+  onStartReached?: ?(info: {distanceFromStart: number, ...}) => void,
+  /**
+   * How far from the start (in units of visible length of the list) the leading edge of the
+   * list must be from the start of the content to trigger the `onStartReached` callback.
+   * Thus, a value of 0.5 will trigger `onStartReached` when the start of the content is
+   * within half the visible length of the list.
+   */
+  onStartReachedThreshold?: ?number,
   /**
    * Called when the viewability of rows changes, as defined by the
    * `viewabilityConfig` prop.

--- a/Libraries/Lists/__tests__/VirtualizedList-test.js
+++ b/Libraries/Lists/__tests__/VirtualizedList-test.js
@@ -356,6 +356,168 @@ describe('VirtualizedList', () => {
     expect(scrollRef.measureLayout).toBeInstanceOf(jest.fn().constructor);
     expect(scrollRef.measureInWindow).toBeInstanceOf(jest.fn().constructor);
   });
+
+  it('calls onStartReached when near the start', () => {
+    const ITEM_HEIGHT = 40;
+    const layout = {width: 300, height: 600};
+    let data = Array(40)
+      .fill()
+      .map((_, index) => ({key: `key-${index}`}));
+    const onStartReached = jest.fn();
+    const props = {
+      data,
+      initialNumToRender: 10,
+      onStartReachedThreshold: 1,
+      windowSize: 10,
+      renderItem: ({item}) => <item value={item.key} />,
+      getItem: (items, index) => items[index],
+      getItemCount: items => items.length,
+      getItemLayout: (items, index) => ({
+        length: ITEM_HEIGHT,
+        offset: ITEM_HEIGHT * index,
+        index,
+      }),
+      onStartReached,
+      initialScrollIndex: data.length - 1,
+    };
+
+    const component = ReactTestRenderer.create(<VirtualizedList {...props} />);
+
+    const instance = component.getInstance();
+
+    instance._onLayout({nativeEvent: {layout, zoomScale: 1}});
+    instance._onContentSizeChange(300, data.length * ITEM_HEIGHT);
+
+    // Make sure onStartReached is not called initially when initialScrollIndex is set.
+    performAllBatches();
+    expect(onStartReached).not.toHaveBeenCalled();
+
+    // Scroll for a small amount and make sure onStartReached is not called.
+    instance._onScroll({
+      timeStamp: 1000,
+      nativeEvent: {
+        contentOffset: {y: (data.length - 2) * ITEM_HEIGHT, x: 0},
+        layoutMeasurement: layout,
+        contentSize: {...layout, height: data.length * ITEM_HEIGHT},
+        zoomScale: 1,
+        contentInset: {right: 0, top: 0, left: 0, bottom: 0},
+      },
+    });
+    performAllBatches();
+    expect(onStartReached).not.toHaveBeenCalled();
+
+    // Scroll to end and make sure onStartReached is called.
+    instance._onScroll({
+      timeStamp: 1000,
+      nativeEvent: {
+        contentOffset: {y: 0, x: 0},
+        layoutMeasurement: layout,
+        contentSize: {...layout, height: data.length * ITEM_HEIGHT},
+        zoomScale: 1,
+        contentInset: {right: 0, top: 0, left: 0, bottom: 0},
+      },
+    });
+    performAllBatches();
+    expect(onStartReached).toHaveBeenCalled();
+  });
+
+  it('calls onStartReached initially', () => {
+    const ITEM_HEIGHT = 40;
+    const layout = {width: 300, height: 600};
+    let data = Array(40)
+      .fill()
+      .map((_, index) => ({key: `key-${index}`}));
+    const onStartReached = jest.fn();
+    const props = {
+      data,
+      initialNumToRender: 10,
+      onStartReachedThreshold: 1,
+      windowSize: 10,
+      renderItem: ({item}) => <item value={item.key} />,
+      getItem: (items, index) => items[index],
+      getItemCount: items => items.length,
+      getItemLayout: (items, index) => ({
+        length: ITEM_HEIGHT,
+        offset: ITEM_HEIGHT * index,
+        index,
+      }),
+      onStartReached,
+    };
+
+    const component = ReactTestRenderer.create(<VirtualizedList {...props} />);
+
+    const instance = component.getInstance();
+
+    instance._onLayout({nativeEvent: {layout, zoomScale: 1}});
+    instance._onContentSizeChange(300, data.length * ITEM_HEIGHT);
+
+    performAllBatches();
+    expect(onStartReached).toHaveBeenCalled();
+  });
+
+  it('calls onEndReached when near the end', () => {
+    const ITEM_HEIGHT = 40;
+    const layout = {width: 300, height: 600};
+    let data = Array(40)
+      .fill()
+      .map((_, index) => ({key: `key-${index}`}));
+    const onEndReached = jest.fn();
+    const props = {
+      data,
+      initialNumToRender: 10,
+      onEndReachedThreshold: 1,
+      windowSize: 10,
+      renderItem: ({item}) => <item value={item.key} />,
+      getItem: (items, index) => items[index],
+      getItemCount: items => items.length,
+      getItemLayout: (items, index) => ({
+        length: ITEM_HEIGHT,
+        offset: ITEM_HEIGHT * index,
+        index,
+      }),
+      onEndReached,
+    };
+
+    const component = ReactTestRenderer.create(<VirtualizedList {...props} />);
+
+    const instance = component.getInstance();
+
+    instance._onLayout({nativeEvent: {layout, zoomScale: 1}});
+    instance._onContentSizeChange(300, data.length * ITEM_HEIGHT);
+
+    // Make sure onEndReached is not called initially.
+    performAllBatches();
+    expect(onEndReached).not.toHaveBeenCalled();
+
+    // Scroll for a small amount and make sure onEndReached is not called.
+    instance._onScroll({
+      timeStamp: 1000,
+      nativeEvent: {
+        contentOffset: {y: ITEM_HEIGHT, x: 0},
+        layoutMeasurement: layout,
+        contentSize: {...layout, height: data.length * ITEM_HEIGHT},
+        zoomScale: 1,
+        contentInset: {right: 0, top: 0, left: 0, bottom: 0},
+      },
+    });
+    performAllBatches();
+    expect(onEndReached).not.toHaveBeenCalled();
+
+    // Scroll to end and make sure onEndReached is called.
+    instance._onScroll({
+      timeStamp: 1000,
+      nativeEvent: {
+        contentOffset: {y: data.length * ITEM_HEIGHT, x: 0},
+        layoutMeasurement: layout,
+        contentSize: {...layout, height: data.length * ITEM_HEIGHT},
+        zoomScale: 1,
+        contentInset: {right: 0, top: 0, left: 0, bottom: 0},
+      },
+    });
+    performAllBatches();
+    expect(onEndReached).toHaveBeenCalled();
+  });
+
   it('does not call onEndReached when onContentSizeChange happens after onLayout', () => {
     const ITEM_HEIGHT = 40;
     const layout = {width: 300, height: 600};

--- a/Libraries/Lists/__tests__/VirtualizedList-test.js
+++ b/Libraries/Lists/__tests__/VirtualizedList-test.js
@@ -406,7 +406,7 @@ describe('VirtualizedList', () => {
     performAllBatches();
     expect(onStartReached).not.toHaveBeenCalled();
 
-    // Scroll to end and make sure onStartReached is called.
+    // Scroll to start and make sure onStartReached is called.
     instance._onScroll({
       timeStamp: 1000,
       nativeEvent: {

--- a/packages/rn-tester/js/examples/FlatList/BaseFlatListExample.js
+++ b/packages/rn-tester/js/examples/FlatList/BaseFlatListExample.js
@@ -103,11 +103,17 @@ export default (BaseFlatListExample: React.AbstractComponent<
   FlatList<string>,
 >);
 
+const ITEM_INNER_HEIGHT = 70;
+const ITEM_MARGIN = 8;
+export const ITEM_HEIGHT: number = ITEM_INNER_HEIGHT + ITEM_MARGIN * 2;
+
 const styles = StyleSheet.create({
   item: {
     backgroundColor: 'pink',
-    padding: 20,
-    marginVertical: 8,
+    paddingHorizontal: 20,
+    height: ITEM_INNER_HEIGHT,
+    marginVertical: ITEM_MARGIN,
+    justifyContent: 'center',
   },
   header: {
     fontSize: 32,

--- a/packages/rn-tester/js/examples/FlatList/FlatList-onStartReached.js
+++ b/packages/rn-tester/js/examples/FlatList/FlatList-onStartReached.js
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+'use strict';
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+import BaseFlatListExample, {ITEM_HEIGHT} from './BaseFlatListExample';
+import * as React from 'react';
+
+export function FlatList_onStartReached(): React.Node {
+  const [output, setOutput] = React.useState('');
+  const exampleProps = {
+    onStartReached: (info: {distanceFromStart: number, ...}) =>
+      setOutput('onStartReached'),
+    onStartReachedThreshold: 0,
+    initialScrollIndex: 5,
+    getItemLayout: (data: any, index: number) => ({
+      length: ITEM_HEIGHT,
+      offset: ITEM_HEIGHT * index,
+      index,
+    }),
+  };
+  const ref = React.useRef(null);
+
+  const onTest = () => {
+    const scrollResponder = ref?.current?.getScrollResponder();
+    if (scrollResponder != null) {
+      scrollResponder.scrollTo({y: 0});
+    }
+  };
+
+  return (
+    <BaseFlatListExample
+      ref={ref}
+      exampleProps={exampleProps}
+      testOutput={output}
+      onTest={onTest}
+    />
+  );
+}
+
+export default ({
+  title: 'onStartReached',
+  name: 'onStartReached',
+  description:
+    'Scroll to start of list or tap Test button to see `onStartReached` triggered.',
+  render: function (): React.Element<typeof FlatList_onStartReached> {
+    return <FlatList_onStartReached />;
+  },
+}: RNTesterModuleExample);

--- a/packages/rn-tester/js/examples/FlatList/FlatListExampleIndex.js
+++ b/packages/rn-tester/js/examples/FlatList/FlatListExampleIndex.js
@@ -10,6 +10,7 @@
 
 import type {RNTesterModule} from '../../types/RNTesterTypes';
 import BasicExample from './FlatList-basic';
+import OnStartReachedExample from './FlatList-onStartReached';
 import OnEndReachedExample from './FlatList-onEndReached';
 import ContentInsetExample from './FlatList-contentInset';
 import InvertedExample from './FlatList-inverted';
@@ -28,6 +29,7 @@ export default ({
   showIndividualExamples: true,
   examples: [
     BasicExample,
+    OnStartReachedExample,
     OnEndReachedExample,
     ContentInsetExample,
     InvertedExample,


### PR DESCRIPTION
## Summary

Add  `onStartReached` and `onStartReachedThreshold` to `VirtualizedList`. This allows implementing bidirectional paging.

## Changelog

[General] [Added] - Add onStartReached and onStartReachedThreshold to VirtualizedList

## Test Plan

Tested in the new RN tester example that the callback is triggered when close to the start of the list.
