### PR TITLE
chore: Update Text props aria-labelledby documentation

### DIFF
--- a/Libraries/Components/View/ViewPropTypes.js
+++ b/Libraries/Components/View/ViewPropTypes.js
@@ -543,7 +543,7 @@ export type ViewProps = $ReadOnly<{|
   'aria-hidden'?: ?boolean,
 
   /**
-   * It reperesents the nativeID of the associated label text. When the assistive technology focuses on the component with this props, the text is read aloud.
+   * It represents the nativeID of the associated label text. When the assistive technology focuses on the component with this props, the text is read aloud.
    *
    * @platform android
    */

--- a/Libraries/Image/ImageProps.js
+++ b/Libraries/Image/ImageProps.js
@@ -93,7 +93,7 @@ export type ImageProps = {|
   'aria-label'?: ?Stringish,
 
   /**
-   * Reperesents the nativeID of the associated label. When the assistive technology focuses on the component with this props.
+   * Represents the nativeID of the associated label. When the assistive technology focuses on the component with this props.
    *
    * @platform android
    */

--- a/Libraries/Text/TextProps.js
+++ b/Libraries/Text/TextProps.js
@@ -92,9 +92,8 @@ export type TextProps = $ReadOnly<{|
   'aria-selected'?: ?boolean,
 
   /**
-   * Reperesents the nativeID of the associated label text. When the assistive technology focuses on the component with this props, the text is read aloud.
-   *
-   * @platform android
+   * Represents the nativeID of the associated label text. When the assistive technology focuses on the component with this props, the text is read aloud.
+   * This prop is listed for cross-platform reasons and has no real effect on Android or iOS.
    */
   'aria-labelledby'?: ?string,
 


### PR DESCRIPTION
## Summary

`aria-labelledby` Flow types were added to the Text props on https://github.com/facebook/react-native/commit/f353119113d6fc85491765ba1e90ac83cb00fd61  but the text component does not support `accessibilityLabelledBy`, which is the prop we were supposed to map `aria-labelledby` to. As the Text component does not really support `aria-labelledby` this PR updates the `TextProps` documentation to explain that this prop is necessary for cross-platform purposes and that other platforms need it.

## Changelog

[Android] [Changed] - Add notes to `aria-labelledby` from Text props

## Test Plan

Ensure CI is green
