### PR TITLE
Chore: mv `translateFunctionTypeAnnotation` fn > `parsers-commons.js`

### DIFF
--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -33,6 +33,7 @@ const {
   parseObjectProperty,
   emitUnionTypeAnnotation,
   translateDefault,
+  translateFunctionTypeAnnotation,
 } = require('../../parsers-commons');
 const {
   emitBoolean,
@@ -49,7 +50,6 @@ const {
   emitStringish,
   emitMixedTypeAnnotation,
   typeAliasResolution,
-  translateFunctionTypeAnnotation,
 } = require('../../parsers-primitives');
 
 const {

--- a/packages/react-native-codegen/src/parsers/parsers-primitives.js
+++ b/packages/react-native-codegen/src/parsers/parsers-primitives.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow strict-local
+ * @flow strict
  * @format
  */
 
@@ -14,7 +14,6 @@ import type {
   BooleanTypeAnnotation,
   DoubleTypeAnnotation,
   Int32TypeAnnotation,
-  NamedShape,
   NativeModuleAliasMap,
   NativeModuleBaseTypeAnnotation,
   NativeModuleFloatTypeAnnotation,
@@ -22,7 +21,6 @@ import type {
   NativeModuleGenericObjectTypeAnnotation,
   NativeModuleMixedTypeAnnotation,
   NativeModuleNumberTypeAnnotation,
-  NativeModuleParamTypeAnnotation,
   NativeModulePromiseTypeAnnotation,
   NativeModuleTypeAliasTypeAnnotation,
   Nullable,
@@ -40,14 +38,9 @@ import type {
 } from './utils';
 
 const {
-  throwIfUnsupportedFunctionParamTypeAnnotationParserError,
-  throwIfUnsupportedFunctionReturnTypeAnnotationParserError,
-} = require('./error-utils');
-const {UnnamedFunctionParamParserError} = require('./errors');
-const {
   assertGenericTypeAnnotationHasExactlyOneTypeParameter,
-  unwrapNullable,
   wrapNullable,
+  translateFunctionTypeAnnotation,
 } = require('./parsers-commons');
 
 function emitBoolean(nullable: boolean): Nullable<BooleanTypeAnnotation> {
@@ -221,138 +214,6 @@ function emitFloat(
   });
 }
 
-function getTypeAnnotationParameters(
-  typeAnnotation: $FlowFixMe,
-  language: ParserType,
-): $ReadOnlyArray<$FlowFixMe> {
-  return language === 'Flow'
-    ? typeAnnotation.params
-    : typeAnnotation.parameters;
-}
-
-function getFunctionNameFromParameter(
-  param: NamedShape<Nullable<NativeModuleParamTypeAnnotation>>,
-  language: ParserType,
-) {
-  return language === 'Flow' ? param.name : param.typeAnnotation;
-}
-
-function getParameterName(param: $FlowFixMe, language: ParserType): string {
-  return language === 'Flow' ? param.name.name : param.name;
-}
-
-function getParameterTypeAnnotation(param: $FlowFixMe, language: ParserType) {
-  return language === 'Flow'
-    ? param.typeAnnotation
-    : param.typeAnnotation.typeAnnotation;
-}
-
-function getTypeAnnotationReturnType(
-  typeAnnotation: $FlowFixMe,
-  language: ParserType,
-) {
-  return language === 'Flow'
-    ? typeAnnotation.returnType
-    : typeAnnotation.typeAnnotation.typeAnnotation;
-}
-
-function translateFunctionTypeAnnotation(
-  hasteModuleName: string,
-  // TODO(T108222691): Use flow-types for @babel/parser
-  // TODO(T71778680): This is a FunctionTypeAnnotation. Type this.
-  typeAnnotation: $FlowFixMe,
-  types: TypeDeclarationMap,
-  aliasMap: {...NativeModuleAliasMap},
-  tryParse: ParserErrorCapturer,
-  cxxOnly: boolean,
-  translateTypeAnnotation: $FlowFixMe,
-  language: ParserType,
-): NativeModuleFunctionTypeAnnotation {
-  type Param = NamedShape<Nullable<NativeModuleParamTypeAnnotation>>;
-  const params: Array<Param> = [];
-
-  for (const param of getTypeAnnotationParameters(typeAnnotation, language)) {
-    const parsedParam = tryParse(() => {
-      if (getFunctionNameFromParameter(param, language) == null) {
-        throw new UnnamedFunctionParamParserError(
-          param,
-          hasteModuleName,
-          language,
-        );
-      }
-
-      const paramName = getParameterName(param, language);
-
-      const [paramTypeAnnotation, isParamTypeAnnotationNullable] =
-        unwrapNullable<$FlowFixMe>(
-          translateTypeAnnotation(
-            hasteModuleName,
-            getParameterTypeAnnotation(param, language),
-            types,
-            aliasMap,
-            tryParse,
-            cxxOnly,
-          ),
-        );
-
-      if (
-        paramTypeAnnotation.type === 'VoidTypeAnnotation' ||
-        paramTypeAnnotation.type === 'PromiseTypeAnnotation'
-      ) {
-        return throwIfUnsupportedFunctionParamTypeAnnotationParserError(
-          hasteModuleName,
-          param.typeAnnotation,
-          paramName,
-          paramTypeAnnotation.type,
-        );
-      }
-
-      return {
-        name: paramName,
-        optional: Boolean(param.optional),
-        typeAnnotation: wrapNullable(
-          isParamTypeAnnotationNullable,
-          paramTypeAnnotation,
-        ),
-      };
-    });
-
-    if (parsedParam != null) {
-      params.push(parsedParam);
-    }
-  }
-
-  const [returnTypeAnnotation, isReturnTypeAnnotationNullable] =
-    unwrapNullable<$FlowFixMe>(
-      translateTypeAnnotation(
-        hasteModuleName,
-        getTypeAnnotationReturnType(typeAnnotation, language),
-        types,
-        aliasMap,
-        tryParse,
-        cxxOnly,
-      ),
-    );
-
-  throwIfUnsupportedFunctionReturnTypeAnnotationParserError(
-    hasteModuleName,
-    typeAnnotation,
-    'FunctionTypeAnnotation',
-    language,
-    cxxOnly,
-    returnTypeAnnotation.type,
-  );
-
-  return {
-    type: 'FunctionTypeAnnotation',
-    returnTypeAnnotation: wrapNullable(
-      isReturnTypeAnnotationNullable,
-      returnTypeAnnotation,
-    ),
-    params,
-  };
-}
-
 module.exports = {
   emitBoolean,
   emitDouble,
@@ -368,5 +229,4 @@ module.exports = {
   emitStringish,
   emitMixedTypeAnnotation,
   typeAliasResolution,
-  translateFunctionTypeAnnotation,
 };

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -32,6 +32,7 @@ const {
   parseObjectProperty,
   emitUnionTypeAnnotation,
   translateDefault,
+  translateFunctionTypeAnnotation,
 } = require('../../parsers-commons');
 const {
   emitBoolean,
@@ -48,7 +49,6 @@ const {
   emitStringish,
   emitMixedTypeAnnotation,
   typeAliasResolution,
-  translateFunctionTypeAnnotation,
 } = require('../../parsers-primitives');
 const {
   UnsupportedArrayElementTypeAnnotationParserError,


### PR DESCRIPTION
## Summary
This PR should solve the `"Circular Dependencies"` problem/issue because of which some PRs are getting blocked as discussed here https://github.com/facebook/react-native/pull/35288#issuecomment-1314081952

- also moved below helpers to `parsers-commons.js`;
- `getTypeAnnotationParameters`
- `getFunctionNameFromParameter`
- `getParameterName`
- `getParameterTypeAnnotation`
- `getTypeAnnotationReturnType`

<3

## Changelog

[INTERNAL] [CHANGED] - Moved `translateFunctionTypeAnnotation` fn from `parsers-primitives.js` to `parsers-commons.js` also, moved it's helpers

## Test Plan

- ensure 👇 is `#00ff00`

`yarn lint && yarn flow && yarn test-ci`