### PR TITLE
Fix codegen output for object with indexer

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-commons-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-commons-test.js
@@ -261,18 +261,7 @@ describe('isObjectProperty', () => {
       expect(result).toEqual(true);
     });
 
-    it("returns 'true' if 'property.type' is 'TSIndexSignature'", () => {
-      const result = isObjectProperty(
-        {
-          type: 'TSIndexSignature',
-          ...propertyStub,
-        },
-        language,
-      );
-      expect(result).toEqual(true);
-    });
-
-    it("returns 'false' if 'property.type' is not 'TSPropertySignature' or 'TSIndexSignature'", () => {
+    it("returns 'false' if 'property.type' is not 'TSPropertySignature'", () => {
       const result = isObjectProperty(
         {
           type: 'notTSPropertySignature',
@@ -329,7 +318,7 @@ describe('parseObjectProperty', () => {
 
   describe("when 'language' is 'TypeScript'", () => {
     const language: ParserType = 'TypeScript';
-    it("throws an 'UnsupportedObjectPropertyTypeAnnotationParserError' error if 'property.type' is not 'TSPropertySignature' or 'TSIndexSignature'.", () => {
+    it("throws an 'UnsupportedObjectPropertyTypeAnnotationParserError' error if 'property.type' is not 'TSPropertySignature'.", () => {
       const property = {
         type: 'notTSPropertySignature',
         typeAnnotation: {
@@ -357,41 +346,6 @@ describe('parseObjectProperty', () => {
           parser,
         ),
       ).toThrow(expected);
-    });
-
-    it("returns a 'NativeModuleBaseTypeAnnotation' object with 'typeAnnotation.type' equal to 'GenericObjectTypeAnnotation', if 'property.type' is 'TSIndexSignature'.", () => {
-      const property = {
-        type: 'TSIndexSignature',
-        typeAnnotation: {
-          type: 'TSIndexSignature',
-          typeAnnotation: 'TSIndexSignature',
-        },
-        key: {
-          name: 'testKeyName',
-        },
-        value: 'wrongValue',
-        name: 'wrongName',
-        parameters: [{name: 'testName'}],
-      };
-      const result = parseObjectProperty(
-        property,
-        moduleName,
-        types,
-        aliasMap,
-        tryParse,
-        cxxOnly,
-        nullable,
-        typeScriptTranslateTypeAnnotation,
-        typeScriptParser,
-      );
-      const expected = {
-        name: 'testName',
-        optional: false,
-        typeAnnotation: wrapNullable(nullable, {
-          type: 'GenericObjectTypeAnnotation',
-        }),
-      };
-      expect(result).toEqual(expected);
     });
   });
 });

--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-commons-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-commons-test.js
@@ -225,18 +225,7 @@ describe('isObjectProperty', () => {
       expect(result).toEqual(true);
     });
 
-    it("returns 'true' if 'property.type' is 'ObjectTypeIndexer'", () => {
-      const result = isObjectProperty(
-        {
-          type: 'ObjectTypeIndexer',
-          ...propertyStub,
-        },
-        language,
-      );
-      expect(result).toEqual(true);
-    });
-
-    it("returns 'false' if 'property.type' is not 'ObjectTypeProperty' or 'ObjectTypeIndexer'", () => {
+    it("returns 'false' if 'property.type' is not 'ObjectTypeProperty'", () => {
       const result = isObjectProperty(
         {
           type: 'notObjectTypeProperty',
@@ -284,7 +273,7 @@ describe('parseObjectProperty', () => {
 
   describe("when 'language' is 'Flow'", () => {
     const language: ParserType = 'Flow';
-    it("throws an 'UnsupportedObjectPropertyTypeAnnotationParserError' error if 'property.type' is not 'ObjectTypeProperty' or 'ObjectTypeIndexer'.", () => {
+    it("throws an 'UnsupportedObjectPropertyTypeAnnotationParserError' error if 'property.type' is not 'ObjectTypeProperty'.", () => {
       const property = {
         type: 'notObjectTypeProperty',
         typeAnnotation: {

--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-test.js
@@ -113,23 +113,6 @@ describe('TypeScriptParser', () => {
       });
     });
 
-    describe('when propertyOrIndex is TSIndexSignature', () => {
-      it('returns indexer name', () => {
-        const indexer = {
-          type: 'TSIndexSignature',
-          parameters: [
-            {
-              name: 'indexerName',
-            },
-          ],
-        };
-
-        const expected = 'indexerName';
-
-        expect(parser.getKeyName(indexer, hasteModuleName)).toEqual(expected);
-      });
-    });
-
     describe('when propertyOrIndex is not TSPropertySignature or TSIndexSignature', () => {
       it('throw UnsupportedObjectPropertyTypeAnnotationParserError', () => {
         const indexer = {

--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-test.js
@@ -37,32 +37,6 @@ describe('FlowParser', () => {
       });
     });
 
-    describe('when propertyOrIndex is ObjectTypeIndexer', () => {
-      it('returns indexer name', () => {
-        const indexer = {
-          type: 'ObjectTypeIndexer',
-          id: {
-            name: 'indexerName',
-          },
-        };
-
-        const expected = 'indexerName';
-
-        expect(parser.getKeyName(indexer, hasteModuleName)).toEqual(expected);
-      });
-
-      it('returns `key` if indexer has no name', () => {
-        const indexer = {
-          type: 'ObjectTypeIndexer',
-          id: {},
-        };
-
-        const expected = 'key';
-
-        expect(parser.getKeyName(indexer, hasteModuleName)).toEqual(expected);
-      });
-    });
-
     describe('when propertyOrIndex is not ObjectTypeProperty or ObjectTypeIndexer', () => {
       it('throw UnsupportedObjectPropertyTypeAnnotationParserError', () => {
         const indexer = {

--- a/packages/react-native-codegen/src/parsers/flow/modules/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__test_fixtures__/fixtures.js
@@ -712,7 +712,8 @@ export interface Spec extends TurboModule {
   returnObjectArray(): Promise<Array<Object>>;
   returnNullableNumber(): Promise<number | null>;
   returnEmpty(): Promise<empty>;
-  returnIndex(): Promise<{ [string]: 'authorized' | 'denied' | 'undetermined' | true | false }>;
+  returnUnsupportedIndex(): Promise<{ [string]: 'authorized' | 'denied' | 'undetermined' | true | false }>;
+  returnSupportedIndex(): Promise<{ [string]: CustomObject }>;
   returnEnum() : Promise<Season>;
   returnObject() : Promise<CustomObject>;
 }

--- a/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap
@@ -1774,7 +1774,18 @@ exports[`RN Codegen Flow Parser can generate fixture PROMISE_WITH_COMMONLY_USED_
             }
           },
           {
-            'name': 'returnIndex',
+            'name': 'returnUnsupportedIndex',
+            'optional': false,
+            'typeAnnotation': {
+              'type': 'FunctionTypeAnnotation',
+              'returnTypeAnnotation': {
+                'type': 'PromiseTypeAnnotation'
+              },
+              'params': []
+            }
+          },
+          {
+            'name': 'returnSupportedIndex',
             'optional': false,
             'typeAnnotation': {
               'type': 'FunctionTypeAnnotation',

--- a/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap
@@ -126,32 +126,14 @@ exports[`RN Codegen Flow Parser can generate fixture CXX_ONLY_NATIVE_MODULE 1`] 
             'typeAnnotation': {
               'type': 'FunctionTypeAnnotation',
               'returnTypeAnnotation': {
-                'type': 'ObjectTypeAnnotation',
-                'properties': [
-                  {
-                    'name': 'b',
-                    'optional': false,
-                    'typeAnnotation': {
-                      'type': 'GenericObjectTypeAnnotation'
-                    }
-                  }
-                ]
+                'type': 'GenericObjectTypeAnnotation'
               },
               'params': [
                 {
                   'name': 'arg',
                   'optional': false,
                   'typeAnnotation': {
-                    'type': 'ObjectTypeAnnotation',
-                    'properties': [
-                      {
-                        'name': 'a',
-                        'optional': false,
-                        'typeAnnotation': {
-                          'type': 'GenericObjectTypeAnnotation'
-                        }
-                      }
-                    ]
+                    'type': 'GenericObjectTypeAnnotation'
                   }
                 }
               ]
@@ -163,32 +145,14 @@ exports[`RN Codegen Flow Parser can generate fixture CXX_ONLY_NATIVE_MODULE 1`] 
             'typeAnnotation': {
               'type': 'FunctionTypeAnnotation',
               'returnTypeAnnotation': {
-                'type': 'ObjectTypeAnnotation',
-                'properties': [
-                  {
-                    'name': 'key',
-                    'optional': false,
-                    'typeAnnotation': {
-                      'type': 'GenericObjectTypeAnnotation'
-                    }
-                  }
-                ]
+                'type': 'GenericObjectTypeAnnotation'
               },
               'params': [
                 {
                   'name': 'arg',
                   'optional': false,
                   'typeAnnotation': {
-                    'type': 'ObjectTypeAnnotation',
-                    'properties': [
-                      {
-                        'name': 'key',
-                        'optional': false,
-                        'typeAnnotation': {
-                          'type': 'GenericObjectTypeAnnotation'
-                        }
-                      }
-                    ]
+                    'type': 'GenericObjectTypeAnnotation'
                   }
                 }
               ]

--- a/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap
@@ -1781,16 +1781,7 @@ exports[`RN Codegen Flow Parser can generate fixture PROMISE_WITH_COMMONLY_USED_
               'returnTypeAnnotation': {
                 'type': 'PromiseTypeAnnotation',
                 'elementType': {
-                  'type': 'ObjectTypeAnnotation',
-                  'properties': [
-                    {
-                      'name': 'key',
-                      'optional': false,
-                      'typeAnnotation': {
-                        'type': 'GenericObjectTypeAnnotation'
-                      }
-                    }
-                  ]
+                  'type': 'GenericObjectTypeAnnotation'
                 }
               },
               'params': []

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -174,12 +174,7 @@ function translateTypeAnnotation(
         ).length > 0
       ) {
         // no need to do further checking
-        return typeAliasResolution(
-          typeAliasResolutionStatus,
-          {type: 'GenericObjectTypeAnnotation'},
-          aliasMap,
-          nullable,
-        );
+        return emitObject(nullable);
       } else {
         const objectTypeAnnotation = {
           type: 'ObjectTypeAnnotation',

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -175,41 +175,41 @@ function translateTypeAnnotation(
       ) {
         // no need to do further checking
         return emitObject(nullable);
-      } else {
-        const objectTypeAnnotation = {
-          type: 'ObjectTypeAnnotation',
-          // $FlowFixMe[missing-type-arg]
-          properties: ([
-            ...typeAnnotation.properties,
-            ...typeAnnotation.indexers,
-          ]: Array<$FlowFixMe>)
-            .map<?NamedShape<Nullable<NativeModuleBaseTypeAnnotation>>>(
-              property => {
-                return tryParse(() => {
-                  return parseObjectProperty(
-                    property,
-                    hasteModuleName,
-                    types,
-                    aliasMap,
-                    tryParse,
-                    cxxOnly,
-                    nullable,
-                    translateTypeAnnotation,
-                    parser,
-                  );
-                });
-              },
-            )
-            .filter(Boolean),
-        };
-
-        return typeAliasResolution(
-          typeAliasResolutionStatus,
-          objectTypeAnnotation,
-          aliasMap,
-          nullable,
-        );
       }
+
+      const objectTypeAnnotation = {
+        type: 'ObjectTypeAnnotation',
+        // $FlowFixMe[missing-type-arg]
+        properties: ([
+          ...typeAnnotation.properties,
+          ...typeAnnotation.indexers,
+        ]: Array<$FlowFixMe>)
+          .map<?NamedShape<Nullable<NativeModuleBaseTypeAnnotation>>>(
+            property => {
+              return tryParse(() => {
+                return parseObjectProperty(
+                  property,
+                  hasteModuleName,
+                  types,
+                  aliasMap,
+                  tryParse,
+                  cxxOnly,
+                  nullable,
+                  translateTypeAnnotation,
+                  parser,
+                );
+              });
+            },
+          )
+          .filter(Boolean),
+      };
+
+      return typeAliasResolution(
+        typeAliasResolutionStatus,
+        objectTypeAnnotation,
+        aliasMap,
+        nullable,
+      );
     }
     case 'BooleanTypeAnnotation': {
       return emitBoolean(nullable);

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -173,6 +173,7 @@ function translateTypeAnnotation(
         );
         if (indexers.length > 0) {
           // check the property type to prevent developers from using unsupported types
+          // the return value from `translateTypeAnnotation` is unused
           const propertyType = indexers[0].value;
           translateTypeAnnotation(
             hasteModuleName,
@@ -259,8 +260,9 @@ function translateTypeAnnotation(
     case 'MixedTypeAnnotation': {
       if (cxxOnly) {
         return emitMixed(nullable);
+      } else {
+        return emitObject(nullable);
       }
-      // Fallthrough
     }
     default: {
       throw new UnsupportedTypeAnnotationParserError(

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -171,12 +171,19 @@ function translateTypeAnnotation(
         const indexers = typeAnnotation.indexers.filter(
           member => member.type === 'ObjectTypeIndexer',
         );
-        if(indexers.length > 0) {
+        if (indexers.length > 0) {
           // check the property type to prevent developers from using unsupported types
-        const propertyType = indexers[0].value;
-        translateTypeAnnotation(hasteModuleName,propertyType,types,aliasMap,tryParse,cxxOnly);
-        // no need to do further checking
-        return emitObject(nullable);
+          const propertyType = indexers[0].value;
+          translateTypeAnnotation(
+            hasteModuleName,
+            propertyType,
+            types,
+            aliasMap,
+            tryParse,
+            cxxOnly,
+          );
+          // no need to do further checking
+          return emitObject(nullable);
         }
       }
 

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -167,14 +167,17 @@ function translateTypeAnnotation(
     }
     case 'ObjectTypeAnnotation': {
       // if there is any indexer, then it is a dictionary
-      if (
-        typeAnnotation.indexers &&
-        typeAnnotation.indexers.filter(
+      if (typeAnnotation.indexers) {
+        const indexers = typeAnnotation.indexers.filter(
           member => member.type === 'ObjectTypeIndexer',
-        ).length > 0
-      ) {
+        );
+        if(indexers.length > 0) {
+          // check the property type to prevent developers from using unsupported types
+        const propertyType = indexers[0].value;
+        translateTypeAnnotation(hasteModuleName,propertyType,types,aliasMap,tryParse,cxxOnly);
         // no need to do further checking
         return emitObject(nullable);
+        }
       }
 
       const objectTypeAnnotation = {

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -167,11 +167,16 @@ function translateTypeAnnotation(
     }
     case 'ObjectTypeAnnotation': {
       // if there is any indexer, then it is a dictionary
-      if (typeAnnotation.indexers && typeAnnotation.indexers.filter((member)=>member.type === 'ObjectTypeIndexer').length > 0) {
+      if (
+        typeAnnotation.indexers &&
+        typeAnnotation.indexers.filter(
+          member => member.type === 'ObjectTypeIndexer',
+        ).length > 0
+      ) {
         // no need to do further checking
         return typeAliasResolution(
           typeAliasResolutionStatus,
-          {type:'GenericObjectTypeAnnotation'},
+          {type: 'GenericObjectTypeAnnotation'},
           aliasMap,
           nullable,
         );

--- a/packages/react-native-codegen/src/parsers/flow/parser.js
+++ b/packages/react-native-codegen/src/parsers/flow/parser.js
@@ -21,18 +21,20 @@ const {
 class FlowParser implements Parser {
   typeParameterInstantiation: string = 'TypeParameterInstantiation';
 
-  getKeyName(propertyOrIndex: $FlowFixMe, hasteModuleName: string): string {
-    switch (propertyOrIndex.type) {
-      case 'ObjectTypeProperty':
-        return propertyOrIndex.key.name;
-      default:
-        throw new UnsupportedObjectPropertyTypeAnnotationParserError(
-          hasteModuleName,
-          propertyOrIndex,
-          propertyOrIndex.type,
-          this.language(),
-        );
+  isProperty(property: $FlowFixMe): boolean {
+    return property.type === 'ObjectTypeProperty';
+  }
+
+  getKeyName(property: $FlowFixMe, hasteModuleName: string): string {
+    if (!this.isProperty(property)) {
+      throw new UnsupportedObjectPropertyTypeAnnotationParserError(
+        hasteModuleName,
+        property,
+        property.type,
+        this.language(),
+      );
     }
+    return property.key.name;
   }
 
   getMaybeEnumMemberType(maybeEnumDeclaration: $FlowFixMe): string {

--- a/packages/react-native-codegen/src/parsers/flow/parser.js
+++ b/packages/react-native-codegen/src/parsers/flow/parser.js
@@ -25,9 +25,6 @@ class FlowParser implements Parser {
     switch (propertyOrIndex.type) {
       case 'ObjectTypeProperty':
         return propertyOrIndex.key.name;
-      case 'ObjectTypeIndexer':
-        // flow index name is optional
-        return propertyOrIndex.id?.name ?? 'key';
       default:
         throw new UnsupportedObjectPropertyTypeAnnotationParserError(
           hasteModuleName,

--- a/packages/react-native-codegen/src/parsers/parser.js
+++ b/packages/react-native-codegen/src/parsers/parser.js
@@ -24,13 +24,17 @@ export interface Parser {
   typeParameterInstantiation: string;
 
   /**
-   * Given a property or an index declaration, it returns the key name.
-   * @parameter propertyOrIndex: an object containing a property or an index declaration.
+   * Given a declaration, it returns true if it is a property
+   */
+  isProperty(property: $FlowFixMe): boolean;
+  /**
+   * Given a property declaration, it returns the key name.
+   * @parameter propertyOrIndex: an object containing a property declaration.
    * @parameter hasteModuleName: a string with the native module name.
    * @returns: the key name.
-   * @throws if propertyOrIndex does not contain a property or an index declaration.
+   * @throws if propertyOrIndex does not contain a property declaration.
    */
-  getKeyName(propertyOrIndex: $FlowFixMe, hasteModuleName: string): string;
+  getKeyName(property: $FlowFixMe, hasteModuleName: string): string;
   /**
    * Given a type declaration, it possibly returns the name of the Enum type.
    * @parameter maybeEnumDeclaration: an object possibly containing an Enum declaration.

--- a/packages/react-native-codegen/src/parsers/parser.js
+++ b/packages/react-native-codegen/src/parsers/parser.js
@@ -29,10 +29,10 @@ export interface Parser {
   isProperty(property: $FlowFixMe): boolean;
   /**
    * Given a property declaration, it returns the key name.
-   * @parameter propertyOrIndex: an object containing a property declaration.
+   * @parameter property: an object containing a property declaration.
    * @parameter hasteModuleName: a string with the native module name.
    * @returns: the key name.
-   * @throws if propertyOrIndex does not contain a property declaration.
+   * @throws if property does not contain a property declaration.
    */
   getKeyName(property: $FlowFixMe, hasteModuleName: string): string;
   /**

--- a/packages/react-native-codegen/src/parsers/parserMock.js
+++ b/packages/react-native-codegen/src/parsers/parserMock.js
@@ -21,18 +21,20 @@ const {
 export class MockedParser implements Parser {
   typeParameterInstantiation: string = 'TypeParameterInstantiation';
 
-  getKeyName(propertyOrIndex: $FlowFixMe, hasteModuleName: string): string {
-    switch (propertyOrIndex.type) {
-      case 'ObjectTypeProperty':
-        return propertyOrIndex.key.name;
-      default:
-        throw new UnsupportedObjectPropertyTypeAnnotationParserError(
-          hasteModuleName,
-          propertyOrIndex,
-          propertyOrIndex.type,
-          this.language(),
-        );
+  isProperty(property: $FlowFixMe): boolean {
+    return property.type === 'ObjectTypeProperty';
+  }
+
+  getKeyName(property: $FlowFixMe, hasteModuleName: string): string {
+    if (!this.isProperty(property)) {
+      throw new UnsupportedObjectPropertyTypeAnnotationParserError(
+        hasteModuleName,
+        property,
+        property.type,
+        this.language(),
+      );
     }
+    return property.key.name;
   }
 
   getMaybeEnumMemberType(maybeEnumDeclaration: $FlowFixMe): string {

--- a/packages/react-native-codegen/src/parsers/parserMock.js
+++ b/packages/react-native-codegen/src/parsers/parserMock.js
@@ -25,9 +25,6 @@ export class MockedParser implements Parser {
     switch (propertyOrIndex.type) {
       case 'ObjectTypeProperty':
         return propertyOrIndex.key.name;
-      case 'ObjectTypeIndexer':
-        // flow index name is optional
-        return propertyOrIndex.id?.name ?? 'key';
       default:
         throw new UnsupportedObjectPropertyTypeAnnotationParserError(
           hasteModuleName,

--- a/packages/react-native-codegen/src/parsers/parsers-commons.js
+++ b/packages/react-native-codegen/src/parsers/parsers-commons.js
@@ -40,7 +40,6 @@ const {
   MoreThanOneTypeParameterGenericParserError,
   UnsupportedEnumDeclarationParserError,
   UnsupportedGenericParserError,
-  UnsupportedObjectPropertyTypeAnnotationParserError,
   UnnamedFunctionParamParserError,
 } = require('./errors');
 

--- a/packages/react-native-codegen/src/parsers/parsers-commons.js
+++ b/packages/react-native-codegen/src/parsers/parsers-commons.js
@@ -136,7 +136,6 @@ function parseObjectProperty(
 ): NamedShape<Nullable<NativeModuleBaseTypeAnnotation>> {
   const language = parser.language();
 
-  // getKeyName throw UnsupportedObjectPropertyTypeAnnotationParserError if it is not a property
   const name = parser.getKeyName(property, hasteModuleName);
   const {optional = false} = property;
   const languageTypeAnnotation =

--- a/packages/react-native-codegen/src/parsers/parsers-commons.js
+++ b/packages/react-native-codegen/src/parsers/parsers-commons.js
@@ -137,17 +137,9 @@ function parseObjectProperty(
 ): NamedShape<Nullable<NativeModuleBaseTypeAnnotation>> {
   const language = parser.language();
 
-  if (!isObjectProperty(property, language)) {
-    throw new UnsupportedObjectPropertyTypeAnnotationParserError(
-      hasteModuleName,
-      property,
-      property.type,
-      language,
-    );
-  }
-
-  const {optional = false} = property;
+  // getKeyName throw UnsupportedObjectPropertyTypeAnnotationParserError if it is not a property
   const name = parser.getKeyName(property, hasteModuleName);
+  const {optional = false} = property;
   const languageTypeAnnotation =
     language === 'TypeScript'
       ? property.typeAnnotation.typeAnnotation

--- a/packages/react-native-codegen/src/parsers/parsers-commons.js
+++ b/packages/react-native-codegen/src/parsers/parsers-commons.js
@@ -117,8 +117,7 @@ function isObjectProperty(property: $FlowFixMe, language: ParserType): boolean {
   switch (language) {
     case 'Flow':
       return (
-        property.type === 'ObjectTypeProperty' ||
-        property.type === 'ObjectTypeIndexer'
+        property.type === 'ObjectTypeProperty'
       );
     case 'TypeScript':
       return (
@@ -157,18 +156,6 @@ function parseObjectProperty(
     language === 'TypeScript'
       ? property.typeAnnotation.typeAnnotation
       : property.value;
-
-  if (
-    property.type === 'ObjectTypeIndexer'
-  ) {
-    return {
-      name,
-      optional,
-      typeAnnotation: wrapNullable(nullable, {
-        type: 'GenericObjectTypeAnnotation',
-      }), //TODO: use `emitObject` for typeAnnotation
-    };
-  }
 
   const [propertyTypeAnnotation, isPropertyNullable] =
     unwrapNullable<$FlowFixMe>(

--- a/packages/react-native-codegen/src/parsers/parsers-commons.js
+++ b/packages/react-native-codegen/src/parsers/parsers-commons.js
@@ -116,13 +116,9 @@ function assertGenericTypeAnnotationHasExactlyOneTypeParameter(
 function isObjectProperty(property: $FlowFixMe, language: ParserType): boolean {
   switch (language) {
     case 'Flow':
-      return (
-        property.type === 'ObjectTypeProperty'
-      );
+      return property.type === 'ObjectTypeProperty';
     case 'TypeScript':
-      return (
-        property.type === 'TSPropertySignature'
-      );
+      return property.type === 'TSPropertySignature';
     default:
       return false;
   }

--- a/packages/react-native-codegen/src/parsers/parsers-commons.js
+++ b/packages/react-native-codegen/src/parsers/parsers-commons.js
@@ -122,8 +122,7 @@ function isObjectProperty(property: $FlowFixMe, language: ParserType): boolean {
       );
     case 'TypeScript':
       return (
-        property.type === 'TSPropertySignature' ||
-        property.type === 'TSIndexSignature'
+        property.type === 'TSPropertySignature'
       );
     default:
       return false;
@@ -160,8 +159,7 @@ function parseObjectProperty(
       : property.value;
 
   if (
-    property.type === 'ObjectTypeIndexer' ||
-    property.type === 'TSIndexSignature'
+    property.type === 'ObjectTypeIndexer'
   ) {
     return {
       name,

--- a/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/__snapshots__/typescript-module-parser-snapshot-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/__snapshots__/typescript-module-parser-snapshot-test.js.snap
@@ -124,32 +124,14 @@ exports[`RN Codegen TypeScript Parser can generate fixture CXX_ONLY_NATIVE_MODUL
             'typeAnnotation': {
               'type': 'FunctionTypeAnnotation',
               'returnTypeAnnotation': {
-                'type': 'ObjectTypeAnnotation',
-                'properties': [
-                  {
-                    'name': 'b',
-                    'optional': false,
-                    'typeAnnotation': {
-                      'type': 'GenericObjectTypeAnnotation'
-                    }
-                  }
-                ]
+                'type': 'GenericObjectTypeAnnotation'
               },
               'params': [
                 {
                   'name': 'arg',
                   'optional': false,
                   'typeAnnotation': {
-                    'type': 'ObjectTypeAnnotation',
-                    'properties': [
-                      {
-                        'name': 'a',
-                        'optional': false,
-                        'typeAnnotation': {
-                          'type': 'GenericObjectTypeAnnotation'
-                        }
-                      }
-                    ]
+                    'type': 'GenericObjectTypeAnnotation'
                   }
                 }
               ]
@@ -161,32 +143,14 @@ exports[`RN Codegen TypeScript Parser can generate fixture CXX_ONLY_NATIVE_MODUL
             'typeAnnotation': {
               'type': 'FunctionTypeAnnotation',
               'returnTypeAnnotation': {
-                'type': 'ObjectTypeAnnotation',
-                'properties': [
-                  {
-                    'name': 'key',
-                    'optional': false,
-                    'typeAnnotation': {
-                      'type': 'GenericObjectTypeAnnotation'
-                    }
-                  }
-                ]
+                'type': 'GenericObjectTypeAnnotation'
               },
               'params': [
                 {
                   'name': 'arg',
                   'optional': false,
                   'typeAnnotation': {
-                    'type': 'ObjectTypeAnnotation',
-                    'properties': [
-                      {
-                        'name': 'key',
-                        'optional': false,
-                        'typeAnnotation': {
-                          'type': 'GenericObjectTypeAnnotation'
-                        }
-                      }
-                    ]
+                    'type': 'GenericObjectTypeAnnotation'
                   }
                 }
               ]

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -191,6 +191,7 @@ function translateTypeAnnotation(
         );
         if (indexSignatures.length > 0) {
           // check the property type to prevent developers from using unsupported types
+          // the return value from `translateTypeAnnotation` is unused
           const propertyType = indexSignatures[0].typeAnnotation;
           translateTypeAnnotation(
             hasteModuleName,

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -192,12 +192,7 @@ function translateTypeAnnotation(
         ).length > 0
       ) {
         // no need to do further checking
-        return typeAliasResolution(
-          typeAliasResolutionStatus,
-          {type: 'GenericObjectTypeAnnotation'},
-          aliasMap,
-          nullable,
-        );
+        return emitObject(nullable);
       } else {
         const objectTypeAnnotation = {
           type: 'ObjectTypeAnnotation',

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -193,38 +193,38 @@ function translateTypeAnnotation(
       ) {
         // no need to do further checking
         return emitObject(nullable);
-      } else {
-        const objectTypeAnnotation = {
-          type: 'ObjectTypeAnnotation',
-          // $FlowFixMe[missing-type-arg]
-          properties: (typeAnnotation.members: Array<$FlowFixMe>)
-            .map<?NamedShape<Nullable<NativeModuleBaseTypeAnnotation>>>(
-              property => {
-                return tryParse(() => {
-                  return parseObjectProperty(
-                    property,
-                    hasteModuleName,
-                    types,
-                    aliasMap,
-                    tryParse,
-                    cxxOnly,
-                    nullable,
-                    translateTypeAnnotation,
-                    parser,
-                  );
-                });
-              },
-            )
-            .filter(Boolean),
-        };
-
-        return typeAliasResolution(
-          typeAliasResolutionStatus,
-          objectTypeAnnotation,
-          aliasMap,
-          nullable,
-        );
       }
+
+      const objectTypeAnnotation = {
+        type: 'ObjectTypeAnnotation',
+        // $FlowFixMe[missing-type-arg]
+        properties: (typeAnnotation.members: Array<$FlowFixMe>)
+          .map<?NamedShape<Nullable<NativeModuleBaseTypeAnnotation>>>(
+            property => {
+              return tryParse(() => {
+                return parseObjectProperty(
+                  property,
+                  hasteModuleName,
+                  types,
+                  aliasMap,
+                  tryParse,
+                  cxxOnly,
+                  nullable,
+                  translateTypeAnnotation,
+                  parser,
+                );
+              });
+            },
+          )
+          .filter(Boolean),
+      };
+
+      return typeAliasResolution(
+        typeAliasResolutionStatus,
+        objectTypeAnnotation,
+        aliasMap,
+        nullable,
+      );
     }
     case 'TSBooleanKeyword': {
       return emitBoolean(nullable);

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -189,12 +189,19 @@ function translateTypeAnnotation(
         const indexSignatures = typeAnnotation.members.filter(
           member => member.type === 'TSIndexSignature',
         );
-        if(indexSignatures.length > 0) {
-        // check the property type to prevent developers from using unsupported types
-        const propertyType = indexSignatures[0].typeAnnotation;
-        translateTypeAnnotation(hasteModuleName,propertyType,types,aliasMap,tryParse,cxxOnly);
-        // no need to do further checking
-        return emitObject(nullable);
+        if (indexSignatures.length > 0) {
+          // check the property type to prevent developers from using unsupported types
+          const propertyType = indexSignatures[0].typeAnnotation;
+          translateTypeAnnotation(
+            hasteModuleName,
+            propertyType,
+            types,
+            aliasMap,
+            tryParse,
+            cxxOnly,
+          );
+          // no need to do further checking
+          return emitObject(nullable);
         }
       }
 

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -185,11 +185,16 @@ function translateTypeAnnotation(
     }
     case 'TSTypeLiteral': {
       // if there is TSIndexSignature, then it is a dictionary
-      if (typeAnnotation.members && typeAnnotation.members.filter((member)=>member.type === 'TSIndexSignature').length > 0) {
+      if (
+        typeAnnotation.members &&
+        typeAnnotation.members.filter(
+          member => member.type === 'TSIndexSignature',
+        ).length > 0
+      ) {
         // no need to do further checking
         return typeAliasResolution(
           typeAliasResolutionStatus,
-          {type:'GenericObjectTypeAnnotation'},
+          {type: 'GenericObjectTypeAnnotation'},
           aliasMap,
           nullable,
         );

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -184,8 +184,8 @@ function translateTypeAnnotation(
       }
     }
     case 'TSTypeLiteral': {
-      // if the only member is TSIndexSignature, then it is a dictionary
-      if (typeAnnotation.members && typeAnnotation.members[0] && typeAnnotation.members[0].type === 'TSIndexSignature') {
+      // if there is TSIndexSignature, then it is a dictionary
+      if (typeAnnotation.members && typeAnnotation.members.filter((member)=>member.type === 'TSIndexSignature').length > 0) {
         // no need to do further checking
         return typeAliasResolution(
           typeAliasResolutionStatus,

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -185,14 +185,17 @@ function translateTypeAnnotation(
     }
     case 'TSTypeLiteral': {
       // if there is TSIndexSignature, then it is a dictionary
-      if (
-        typeAnnotation.members &&
-        typeAnnotation.members.filter(
+      if (typeAnnotation.members) {
+        const indexSignatures = typeAnnotation.members.filter(
           member => member.type === 'TSIndexSignature',
-        ).length > 0
-      ) {
+        );
+        if(indexSignatures.length > 0) {
+        // check the property type to prevent developers from using unsupported types
+        const propertyType = indexSignatures[0].typeAnnotation;
+        translateTypeAnnotation(hasteModuleName,propertyType,types,aliasMap,tryParse,cxxOnly);
         // no need to do further checking
         return emitObject(nullable);
+        }
       }
 
       const objectTypeAnnotation = {

--- a/packages/react-native-codegen/src/parsers/typescript/parser.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parser.js
@@ -21,18 +21,20 @@ const {
 class TypeScriptParser implements Parser {
   typeParameterInstantiation: string = 'TSTypeParameterInstantiation';
 
-  getKeyName(propertyOrIndex: $FlowFixMe, hasteModuleName: string): string {
-    switch (propertyOrIndex.type) {
-      case 'TSPropertySignature':
-        return propertyOrIndex.key.name;
-      default:
-        throw new UnsupportedObjectPropertyTypeAnnotationParserError(
-          hasteModuleName,
-          propertyOrIndex,
-          propertyOrIndex.type,
-          this.language(),
-        );
+  isProperty(property: $FlowFixMe): boolean {
+    return property.type === 'TSPropertySignature';
+  }
+
+  getKeyName(property: $FlowFixMe, hasteModuleName: string): string {
+    if (!this.isProperty(property)) {
+      throw new UnsupportedObjectPropertyTypeAnnotationParserError(
+        hasteModuleName,
+        property,
+        property.type,
+        this.language(),
+      );
     }
+    return property.key.name;
   }
 
   getMaybeEnumMemberType(maybeEnumDeclaration: $FlowFixMe): string {

--- a/packages/react-native-codegen/src/parsers/typescript/parser.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parser.js
@@ -25,8 +25,6 @@ class TypeScriptParser implements Parser {
     switch (propertyOrIndex.type) {
       case 'TSPropertySignature':
         return propertyOrIndex.key.name;
-      case 'TSIndexSignature':
-        return propertyOrIndex.parameters[0].name;
       default:
         throw new UnsupportedObjectPropertyTypeAnnotationParserError(
           hasteModuleName,


### PR DESCRIPTION
## Summary

The current implementation think `{[key:T]:U}` and `{key:object}` are the same type, which is semantically wrong.

This pull request fixes the problem and return `{type:'GenericObjectTypeAnnotation'}`, so that `{[key:T]:U}` is `Object`. The current schema cannot represent dictionary type, `Object` is the closest one.

The previous incorrect implementation actually bring in code with logic that doesn't make sense (treating indexer as property), those and related unit test are all undone.

## Changelog

[General] [Changed] - Fix codegen output for object with indexer

## Test Plan

`yarn jest react-native-codegen` passed
