### PR TITLE
Fix codegen to add `T` of `Promise<T>` in CodegenSchema.js

### DIFF
--- a/packages/react-native-codegen/src/CodegenSchema.js
+++ b/packages/react-native-codegen/src/CodegenSchema.js
@@ -297,8 +297,9 @@ export type NativeModuleTypeAliasTypeAnnotation = $ReadOnly<{
   name: string,
 }>;
 
-export type NativeModulePromiseTypeAnnotation = $ReadOnly<{
+export type NativeModulePromiseTypeAnnotation<T> = $ReadOnly<{
   type: 'PromiseTypeAnnotation',
+  elementType?: T,
 }>;
 
 export type UnionTypeAnnotationMemberType =
@@ -346,5 +347,5 @@ export type NativeModuleTypeAnnotation =
 
 type NativeModuleParamOnlyTypeAnnotation = NativeModuleFunctionTypeAnnotation;
 type NativeModuleReturnOnlyTypeAnnotation =
-  | NativeModulePromiseTypeAnnotation
+  | NativeModulePromiseTypeAnnotation<Nullable<NativeModuleBaseTypeAnnotation>>
   | VoidTypeAnnotation;

--- a/packages/react-native-codegen/src/CodegenSchema.js
+++ b/packages/react-native-codegen/src/CodegenSchema.js
@@ -297,9 +297,9 @@ export type NativeModuleTypeAliasTypeAnnotation = $ReadOnly<{
   name: string,
 }>;
 
-export type NativeModulePromiseTypeAnnotation<T> = $ReadOnly<{
+export type NativeModulePromiseTypeAnnotation = $ReadOnly<{
   type: 'PromiseTypeAnnotation',
-  elementType?: T,
+  elementType?: Nullable<NativeModuleBaseTypeAnnotation>,
 }>;
 
 export type UnionTypeAnnotationMemberType =
@@ -347,5 +347,5 @@ export type NativeModuleTypeAnnotation =
 
 type NativeModuleParamOnlyTypeAnnotation = NativeModuleFunctionTypeAnnotation;
 type NativeModuleReturnOnlyTypeAnnotation =
-  | NativeModulePromiseTypeAnnotation<Nullable<NativeModuleBaseTypeAnnotation>>
+  | NativeModulePromiseTypeAnnotation
   | VoidTypeAnnotation;

--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-primitives-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-primitives-test.js
@@ -380,13 +380,13 @@ describe('emitPromise', () => {
           undefined,
           undefined,
           undefined,
-          (_,elementType)=>elementType,
+          (_, elementType) => elementType,
         );
         const expected = {
           type: 'NullableTypeAnnotation',
           typeAnnotation: {
             type: 'PromiseTypeAnnotation',
-            elementType:1,
+            elementType: 1,
           },
         };
 
@@ -406,11 +406,11 @@ describe('emitPromise', () => {
           undefined,
           undefined,
           undefined,
-          (_,elementType)=>elementType,
+          (_, elementType) => elementType,
         );
         const expected = {
           type: 'PromiseTypeAnnotation',
-          elementType:1,
+          elementType: 1,
         };
 
         expect(result).toEqual(expected);

--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-primitives-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-primitives-test.js
@@ -338,7 +338,10 @@ describe('typeAliasResolution', () => {
 describe('emitPromise', () => {
   const moduleName = 'testModuleName';
 
-  function emitPromiseForUnitTest(typeAnnotation: $FlowFixMe, nullable: boolean): $FlowFixMe {
+  function emitPromiseForUnitTest(
+    typeAnnotation: $FlowFixMe,
+    nullable: boolean,
+  ): $FlowFixMe {
     return emitPromise(
       moduleName,
       typeAnnotation,
@@ -357,7 +360,7 @@ describe('emitPromise', () => {
       false,
       /* the translateTypeAnnotation function */
       (_, elementType) => elementType,
-    )
+    );
   }
 
   describe("when typeAnnotation doesn't have exactly one typeParameter", () => {
@@ -372,12 +375,7 @@ describe('emitPromise', () => {
     };
     it('throws an IncorrectlyParameterizedGenericParserError error', () => {
       const nullable = false;
-      expect(() =>
-        emitPromiseForUnitTest(
-          typeAnnotation,
-          nullable,
-        ),
-      ).toThrow();
+      expect(() => emitPromiseForUnitTest(typeAnnotation, nullable)).toThrow();
     });
   });
 
@@ -395,10 +393,7 @@ describe('emitPromise', () => {
     describe('when nullable is true', () => {
       const nullable = true;
       it('returns nullable type annotation', () => {
-        const result = emitPromiseForUnitTest(
-          typeAnnotation,
-          nullable,
-        );
+        const result = emitPromiseForUnitTest(typeAnnotation, nullable);
         const expected = {
           type: 'NullableTypeAnnotation',
           typeAnnotation: {
@@ -413,10 +408,7 @@ describe('emitPromise', () => {
     describe('when nullable is false', () => {
       const nullable = false;
       it('returns non nullable type annotation', () => {
-        const result = emitPromiseForUnitTest(
-          typeAnnotation,
-          nullable,
-        );
+        const result = emitPromiseForUnitTest(typeAnnotation, nullable);
         const expected = {
           type: 'PromiseTypeAnnotation',
           elementType: 1,

--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-primitives-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-primitives-test.js
@@ -375,11 +375,18 @@ describe('emitPromise', () => {
           typeAnnotation,
           parser,
           nullable,
+          // mock translateTypeAnnotation function
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          (_,elementType)=>elementType,
         );
         const expected = {
           type: 'NullableTypeAnnotation',
           typeAnnotation: {
             type: 'PromiseTypeAnnotation',
+            elementType:1,
           },
         };
 
@@ -394,9 +401,16 @@ describe('emitPromise', () => {
           typeAnnotation,
           parser,
           nullable,
+          // mock translateTypeAnnotation function
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          (_,elementType)=>elementType,
         );
         const expected = {
           type: 'PromiseTypeAnnotation',
+          elementType:1,
         };
 
         expect(result).toEqual(expected);

--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-primitives-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-primitives-test.js
@@ -338,6 +338,28 @@ describe('typeAliasResolution', () => {
 describe('emitPromise', () => {
   const moduleName = 'testModuleName';
 
+  function emitPromiseForUnitTest(typeAnnotation: $FlowFixMe, nullable: boolean): $FlowFixMe {
+    return emitPromise(
+      moduleName,
+      typeAnnotation,
+      parser,
+      nullable,
+      // mock translateTypeAnnotation function
+      /* types: TypeDeclarationMap */
+      {},
+      /* aliasMap: {...NativeModuleAliasMap} */
+      {},
+      /* tryParse: ParserErrorCapturer */
+      function <T>(_: () => T) {
+        return null;
+      },
+      /* cxxOnly: boolean */
+      false,
+      /* the translateTypeAnnotation function */
+      (_, elementType) => elementType,
+    )
+  }
+
   describe("when typeAnnotation doesn't have exactly one typeParameter", () => {
     const typeAnnotation = {
       typeParameters: {
@@ -351,19 +373,9 @@ describe('emitPromise', () => {
     it('throws an IncorrectlyParameterizedGenericParserError error', () => {
       const nullable = false;
       expect(() =>
-        emitPromise(
-          moduleName,
+        emitPromiseForUnitTest(
           typeAnnotation,
-          parser,
           nullable,
-          // mock translateTypeAnnotation function
-          {},
-          {},
-          function <T>(_: () => T) {
-            return null;
-          },
-          false,
-          (_, elementType) => elementType,
         ),
       ).toThrow();
     });
@@ -383,19 +395,9 @@ describe('emitPromise', () => {
     describe('when nullable is true', () => {
       const nullable = true;
       it('returns nullable type annotation', () => {
-        const result = emitPromise(
-          moduleName,
+        const result = emitPromiseForUnitTest(
           typeAnnotation,
-          parser,
           nullable,
-          // mock translateTypeAnnotation function
-          {},
-          {},
-          function <T>(_: () => T) {
-            return null;
-          },
-          false,
-          (_, elementType) => elementType,
         );
         const expected = {
           type: 'NullableTypeAnnotation',
@@ -411,19 +413,9 @@ describe('emitPromise', () => {
     describe('when nullable is false', () => {
       const nullable = false;
       it('returns non nullable type annotation', () => {
-        const result = emitPromise(
-          moduleName,
+        const result = emitPromiseForUnitTest(
           typeAnnotation,
-          parser,
           nullable,
-          // mock translateTypeAnnotation function
-          {},
-          {},
-          function <T>(_: () => T) {
-            return null;
-          },
-          false,
-          (_, elementType) => elementType,
         );
         const expected = {
           type: 'PromiseTypeAnnotation',

--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-primitives-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-primitives-test.js
@@ -351,7 +351,20 @@ describe('emitPromise', () => {
     it('throws an IncorrectlyParameterizedGenericParserError error', () => {
       const nullable = false;
       expect(() =>
-        emitPromise(moduleName, typeAnnotation, parser, nullable),
+        emitPromise(
+          moduleName,
+          typeAnnotation,
+          parser,
+          nullable,
+          // mock translateTypeAnnotation function
+          {},
+          {},
+          function <T>(_: () => T) {
+            return null;
+          },
+          false,
+          (_, elementType) => elementType,
+        ),
       ).toThrow();
     });
   });
@@ -376,10 +389,12 @@ describe('emitPromise', () => {
           parser,
           nullable,
           // mock translateTypeAnnotation function
-          undefined,
-          undefined,
-          undefined,
-          undefined,
+          {},
+          {},
+          function <T>(_: () => T) {
+            return null;
+          },
+          false,
           (_, elementType) => elementType,
         );
         const expected = {
@@ -402,10 +417,12 @@ describe('emitPromise', () => {
           parser,
           nullable,
           // mock translateTypeAnnotation function
-          undefined,
-          undefined,
-          undefined,
-          undefined,
+          {},
+          {},
+          function <T>(_: () => T) {
+            return null;
+          },
+          false,
           (_, elementType) => elementType,
         );
         const expected = {

--- a/packages/react-native-codegen/src/parsers/consistency/__tests__/checkModuleSnaps-test.js
+++ b/packages/react-native-codegen/src/parsers/consistency/__tests__/checkModuleSnaps-test.js
@@ -14,7 +14,7 @@ const {compareSnaps, compareTsArraySnaps} = require('../compareSnaps.js');
 
 const flowFixtures = require('../../flow/modules/__test_fixtures__/fixtures.js');
 const flowSnaps = require('../../../../src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap');
-const flowExtraCases = [];
+const flowExtraCases = ['PROMISE_WITH_COMMONLY_USED_TYPES'];
 const tsFixtures = require('../../typescript/modules/__test_fixtures__/fixtures.js');
 const tsSnaps = require('../../../../src/parsers/typescript/modules/__tests__/__snapshots__/typescript-module-parser-snapshot-test.js.snap');
 const tsExtraCases = [

--- a/packages/react-native-codegen/src/parsers/flow/modules/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__test_fixtures__/fixtures.js
@@ -700,6 +700,13 @@ import * as TurboModuleRegistry from '../TurboModuleRegistry';
 
 export type Season = 'Spring' | 'Summer' | 'Autumn' | 'Winter';
 
+export type CustomObject = {|
+  field1: Array<Object>,
+  field2: boolean,
+  field3: string,
+  type: 'A_String_Literal',
+|};
+
 export interface Spec extends TurboModule {
   returnStringArray(): Promise<Array<string>>;
   returnObjectArray(): Promise<Array<Object>>;
@@ -707,6 +714,7 @@ export interface Spec extends TurboModule {
   returnEmpty(): Promise<empty>;
   returnIndex(): Promise<{ [string]: 'authorized' | 'denied' | 'undetermined' | true | false }>;
   returnEnum() : Promise<Season>;
+  returnObject() : Promise<CustomObject>;
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');

--- a/packages/react-native-codegen/src/parsers/flow/modules/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__test_fixtures__/fixtures.js
@@ -698,12 +698,15 @@ const PROMISE_WITH_COMMONLY_USED_TYPES = `
 import type {TurboModule} from '../RCTExport';
 import * as TurboModuleRegistry from '../TurboModuleRegistry';
 
+export type Season = 'Spring' | 'Summer' | 'Autumn' | 'Winter';
+
 export interface Spec extends TurboModule {
   returnStringArray(): Promise<Array<string>>;
   returnObjectArray(): Promise<Array<Object>>;
   returnNullableNumber(): Promise<number | null>;
   returnEmpty(): Promise<empty>;
   returnIndex(): Promise<{ [string]: 'authorized' | 'denied' | 'undetermined' | true | false }>;
+  returnEnum() : Promise<Season>;
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');

--- a/packages/react-native-codegen/src/parsers/flow/modules/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__test_fixtures__/fixtures.js
@@ -682,6 +682,33 @@ export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModuleCxx');
 
 `;
 
+const PROMISE_WITH_COMMONLY_USED_TYPES = `
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+'use strict';
+
+import type {TurboModule} from '../RCTExport';
+import * as TurboModuleRegistry from '../TurboModuleRegistry';
+
+export interface Spec extends TurboModule {
+  returnStringArray(): Promise<Array<string>>;
+  returnObjectArray(): Promise<Array<Object>>;
+  returnNullableNumber(): Promise<number | null>;
+  returnEmpty(): Promise<empty>;
+  returnIndex(): Promise<{ [string]: 'authorized' | 'denied' | 'undetermined' | true | false }>;
+}
+
+export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+`;
+
 module.exports = {
   NATIVE_MODULE_WITH_OBJECT_WITH_OBJECT_DEFINED_IN_FILE_AS_PROPERTY,
   NATIVE_MODULE_WITH_ARRAY_WITH_UNION_AND_TOUPLE,
@@ -705,4 +732,5 @@ module.exports = {
   ANDROID_ONLY_NATIVE_MODULE,
   IOS_ONLY_NATIVE_MODULE,
   CXX_ONLY_NATIVE_MODULE,
+  PROMISE_WITH_COMMONLY_USED_TYPES,
 };

--- a/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap
@@ -1837,6 +1837,21 @@ exports[`RN Codegen Flow Parser can generate fixture PROMISE_WITH_COMMONLY_USED_
               },
               'params': []
             }
+          },
+          {
+            'name': 'returnEnum',
+            'optional': false,
+            'typeAnnotation': {
+              'type': 'FunctionTypeAnnotation',
+              'returnTypeAnnotation': {
+                'type': 'PromiseTypeAnnotation',
+                'elementType': {
+                  'type': 'UnionTypeAnnotation',
+                  'memberType': 'StringTypeAnnotation'
+                }
+              },
+              'params': []
+            }
           }
         ]
       },

--- a/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap
@@ -1750,3 +1750,100 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_UNSAFE_O
   }
 }"
 `;
+
+exports[`RN Codegen Flow Parser can generate fixture PROMISE_WITH_COMMONLY_USED_TYPES 1`] = `
+"{
+  'modules': {
+    'NativeSampleTurboModule': {
+      'type': 'NativeModule',
+      'aliases': {},
+      'spec': {
+        'properties': [
+          {
+            'name': 'returnStringArray',
+            'optional': false,
+            'typeAnnotation': {
+              'type': 'FunctionTypeAnnotation',
+              'returnTypeAnnotation': {
+                'type': 'PromiseTypeAnnotation',
+                'elementType': {
+                  'type': 'ArrayTypeAnnotation',
+                  'elementType': {
+                    'type': 'StringTypeAnnotation'
+                  }
+                }
+              },
+              'params': []
+            }
+          },
+          {
+            'name': 'returnObjectArray',
+            'optional': false,
+            'typeAnnotation': {
+              'type': 'FunctionTypeAnnotation',
+              'returnTypeAnnotation': {
+                'type': 'PromiseTypeAnnotation',
+                'elementType': {
+                  'type': 'ArrayTypeAnnotation',
+                  'elementType': {
+                    'type': 'GenericObjectTypeAnnotation'
+                  }
+                }
+              },
+              'params': []
+            }
+          },
+          {
+            'name': 'returnNullableNumber',
+            'optional': false,
+            'typeAnnotation': {
+              'type': 'FunctionTypeAnnotation',
+              'returnTypeAnnotation': {
+                'type': 'PromiseTypeAnnotation'
+              },
+              'params': []
+            }
+          },
+          {
+            'name': 'returnEmpty',
+            'optional': false,
+            'typeAnnotation': {
+              'type': 'FunctionTypeAnnotation',
+              'returnTypeAnnotation': {
+                'type': 'PromiseTypeAnnotation'
+              },
+              'params': []
+            }
+          },
+          {
+            'name': 'returnIndex',
+            'optional': false,
+            'typeAnnotation': {
+              'type': 'FunctionTypeAnnotation',
+              'returnTypeAnnotation': {
+                'type': 'PromiseTypeAnnotation',
+                'elementType': {
+                  'type': 'ObjectTypeAnnotation',
+                  'properties': [
+                    {
+                      'name': 'key',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'GenericObjectTypeAnnotation'
+                      }
+                    }
+                  ]
+                }
+              },
+              'params': []
+            }
+          }
+        ]
+      },
+      'moduleNames': [
+        'SampleTurboModule'
+      ]
+    }
+  }
+}"
+`;

--- a/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap
@@ -1506,7 +1506,20 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_PROMISE 
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {},
+      'aliases': {
+        'SomeObj': {
+          'type': 'ObjectTypeAnnotation',
+          'properties': [
+            {
+              'name': 'a',
+              'optional': false,
+              'typeAnnotation': {
+                'type': 'StringTypeAnnotation'
+              }
+            }
+          ]
+        }
+      },
       'spec': {
         'properties': [
           {
@@ -1515,7 +1528,10 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_PROMISE 
             'typeAnnotation': {
               'type': 'FunctionTypeAnnotation',
               'returnTypeAnnotation': {
-                'type': 'PromiseTypeAnnotation'
+                'type': 'PromiseTypeAnnotation',
+                'elementType': {
+                  'type': 'StringTypeAnnotation'
+                }
               },
               'params': []
             }
@@ -1526,7 +1542,10 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_PROMISE 
             'typeAnnotation': {
               'type': 'FunctionTypeAnnotation',
               'returnTypeAnnotation': {
-                'type': 'PromiseTypeAnnotation'
+                'type': 'PromiseTypeAnnotation',
+                'elementType': {
+                  'type': 'StringTypeAnnotation'
+                }
               },
               'params': []
             }
@@ -1537,7 +1556,11 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_PROMISE 
             'typeAnnotation': {
               'type': 'FunctionTypeAnnotation',
               'returnTypeAnnotation': {
-                'type': 'PromiseTypeAnnotation'
+                'type': 'PromiseTypeAnnotation',
+                'elementType': {
+                  'type': 'TypeAliasTypeAnnotation',
+                  'name': 'SomeObj'
+                }
               },
               'params': []
             }

--- a/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap
@@ -1756,7 +1756,45 @@ exports[`RN Codegen Flow Parser can generate fixture PROMISE_WITH_COMMONLY_USED_
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {},
+      'aliases': {
+        'CustomObject': {
+          'type': 'ObjectTypeAnnotation',
+          'properties': [
+            {
+              'name': 'field1',
+              'optional': false,
+              'typeAnnotation': {
+                'type': 'ArrayTypeAnnotation',
+                'elementType': {
+                  'type': 'GenericObjectTypeAnnotation'
+                }
+              }
+            },
+            {
+              'name': 'field2',
+              'optional': false,
+              'typeAnnotation': {
+                'type': 'BooleanTypeAnnotation'
+              }
+            },
+            {
+              'name': 'field3',
+              'optional': false,
+              'typeAnnotation': {
+                'type': 'StringTypeAnnotation'
+              }
+            },
+            {
+              'name': 'type',
+              'optional': false,
+              'typeAnnotation': {
+                'type': 'UnionTypeAnnotation',
+                'memberType': 'StringTypeAnnotation'
+              }
+            }
+          ]
+        }
+      },
       'spec': {
         'properties': [
           {
@@ -1848,6 +1886,21 @@ exports[`RN Codegen Flow Parser can generate fixture PROMISE_WITH_COMMONLY_USED_
                 'elementType': {
                   'type': 'UnionTypeAnnotation',
                   'memberType': 'StringTypeAnnotation'
+                }
+              },
+              'params': []
+            }
+          },
+          {
+            'name': 'returnObject',
+            'optional': false,
+            'typeAnnotation': {
+              'type': 'FunctionTypeAnnotation',
+              'returnTypeAnnotation': {
+                'type': 'PromiseTypeAnnotation',
+                'elementType': {
+                  'type': 'TypeAliasTypeAnnotation',
+                  'name': 'CustomObject'
                 }
               },
               'params': []

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -150,7 +150,17 @@ function translateTypeAnnotation(
           return emitRootTag(nullable);
         }
         case 'Promise': {
-          return emitPromise(hasteModuleName, typeAnnotation, parser, nullable);
+          return emitPromise(
+            hasteModuleName,
+            typeAnnotation,
+            parser,
+            nullable,
+            types,
+            aliasMap,
+            tryParse,
+            cxxOnly,
+            translateTypeAnnotation,
+          );
         }
         case 'Array':
         case '$ReadOnlyArray': {

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -296,10 +296,10 @@ function translateTypeAnnotation(
       );
     }
     case 'StringLiteralTypeAnnotation': {
-      // 'a' is a special case for 'a' | 'b' because the type name is different
+      // 'a' is a special case for 'a' | 'b' but the type name is different
       return wrapNullable(nullable, {
         type: 'UnionTypeAnnotation',
-        memberType: 'StringTypeAnnotation'
+        memberType: 'StringTypeAnnotation',
       });
     }
     case 'MixedTypeAnnotation': {

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -295,6 +295,13 @@ function translateTypeAnnotation(
         parser,
       );
     }
+    case 'StringLiteralTypeAnnotation': {
+      // 'a' is a special case for 'a' | 'b' because the type name is different
+      return wrapNullable(nullable, {
+        type: 'UnionTypeAnnotation',
+        memberType: 'StringTypeAnnotation'
+      });
+    }
     case 'MixedTypeAnnotation': {
       if (cxxOnly) {
         return emitMixedTypeAnnotation(nullable);

--- a/packages/react-native-codegen/src/parsers/parsers-primitives.js
+++ b/packages/react-native-codegen/src/parsers/parsers-primitives.js
@@ -199,22 +199,31 @@ function emitPromise(
   );
 
   const elementType = typeAnnotation.typeParameters.params[0];
-  if (elementType.type === 'ExistsTypeAnnotation') {
+  if (
+    elementType.type === 'ExistsTypeAnnotation' ||
+    elementType.type === 'EmptyTypeAnnotation'
+  ) {
     return wrapNullable(nullable, {
       type: 'PromiseTypeAnnotation',
     });
   } else {
-    return wrapNullable(nullable, {
-      type: 'PromiseTypeAnnotation',
-      elementType: translateTypeAnnotation(
-        hasteModuleName,
-        typeAnnotation.typeParameters.params[0],
-        types,
-        aliasMap,
-        tryParse,
-        cxxOnly,
-      ),
-    });
+    try {
+      return wrapNullable(nullable, {
+        type: 'PromiseTypeAnnotation',
+        elementType: translateTypeAnnotation(
+          hasteModuleName,
+          typeAnnotation.typeParameters.params[0],
+          types,
+          aliasMap,
+          tryParse,
+          cxxOnly,
+        ),
+      });
+    } catch {
+      return wrapNullable(nullable, {
+        type: 'PromiseTypeAnnotation',
+      });
+    }
   }
 }
 

--- a/packages/react-native-codegen/src/parsers/parsers-primitives.js
+++ b/packages/react-native-codegen/src/parsers/parsers-primitives.js
@@ -186,6 +186,11 @@ function emitPromise(
   typeAnnotation: $FlowFixMe,
   parser: Parser,
   nullable: boolean,
+  types: TypeDeclarationMap,
+  aliasMap: {...NativeModuleAliasMap},
+  tryParse: ParserErrorCapturer,
+  cxxOnly: boolean,
+  translateTypeAnnotation: $FlowFixMe,
 ): Nullable<NativeModulePromiseTypeAnnotation> {
   assertGenericTypeAnnotationHasExactlyOneTypeParameter(
     hasteModuleName,
@@ -195,6 +200,14 @@ function emitPromise(
 
   return wrapNullable(nullable, {
     type: 'PromiseTypeAnnotation',
+    elementType: translateTypeAnnotation(
+      hasteModuleName,
+      typeAnnotation.typeParameters.params[0],
+      types,
+      aliasMap,
+      tryParse,
+      cxxOnly,
+    ),
   });
 }
 

--- a/packages/react-native-codegen/src/parsers/parsers-primitives.js
+++ b/packages/react-native-codegen/src/parsers/parsers-primitives.js
@@ -198,17 +198,24 @@ function emitPromise(
     parser,
   );
 
-  return wrapNullable(nullable, {
-    type: 'PromiseTypeAnnotation',
-    elementType: translateTypeAnnotation(
-      hasteModuleName,
-      typeAnnotation.typeParameters.params[0],
-      types,
-      aliasMap,
-      tryParse,
-      cxxOnly,
-    ),
-  });
+  const elementType = typeAnnotation.typeParameters.params[0];
+  if (elementType.type === 'ExistsTypeAnnotation') {
+    return wrapNullable(nullable, {
+      type: 'PromiseTypeAnnotation',
+    });
+  } else {
+    return wrapNullable(nullable, {
+      type: 'PromiseTypeAnnotation',
+      elementType: translateTypeAnnotation(
+        hasteModuleName,
+        typeAnnotation.typeParameters.params[0],
+        types,
+        aliasMap,
+        tryParse,
+        cxxOnly,
+      ),
+    });
+  }
 }
 
 function emitObject(

--- a/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/__snapshots__/typescript-module-parser-snapshot-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/__snapshots__/typescript-module-parser-snapshot-test.js.snap
@@ -1713,7 +1713,20 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_PR
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {},
+      'aliases': {
+        'SomeObj': {
+          'type': 'ObjectTypeAnnotation',
+          'properties': [
+            {
+              'name': 'a',
+              'optional': false,
+              'typeAnnotation': {
+                'type': 'StringTypeAnnotation'
+              }
+            }
+          ]
+        }
+      },
       'spec': {
         'properties': [
           {
@@ -1722,7 +1735,10 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_PR
             'typeAnnotation': {
               'type': 'FunctionTypeAnnotation',
               'returnTypeAnnotation': {
-                'type': 'PromiseTypeAnnotation'
+                'type': 'PromiseTypeAnnotation',
+                'elementType': {
+                  'type': 'StringTypeAnnotation'
+                }
               },
               'params': []
             }
@@ -1733,7 +1749,10 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_PR
             'typeAnnotation': {
               'type': 'FunctionTypeAnnotation',
               'returnTypeAnnotation': {
-                'type': 'PromiseTypeAnnotation'
+                'type': 'PromiseTypeAnnotation',
+                'elementType': {
+                  'type': 'StringTypeAnnotation'
+                }
               },
               'params': []
             }
@@ -1744,7 +1763,11 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_PR
             'typeAnnotation': {
               'type': 'FunctionTypeAnnotation',
               'returnTypeAnnotation': {
-                'type': 'PromiseTypeAnnotation'
+                'type': 'PromiseTypeAnnotation',
+                'elementType': {
+                  'type': 'TypeAliasTypeAnnotation',
+                  'name': 'SomeObj'
+                }
               },
               'params': []
             }

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -185,7 +185,17 @@ function translateTypeAnnotation(
           return emitRootTag(nullable);
         }
         case 'Promise': {
-          return emitPromise(hasteModuleName, typeAnnotation, parser, nullable);
+          return emitPromise(
+            hasteModuleName,
+            typeAnnotation,
+            parser,
+            nullable,
+            types,
+            aliasMap,
+            tryParse,
+            cxxOnly,
+            translateTypeAnnotation,
+          );
         }
         case 'Array':
         case 'ReadonlyArray': {


### PR DESCRIPTION
## Summary

`Promise<T>` is used very often in turbo module as function return types. So `T` is a critical thing for type safety. To enable future generator to produce more specific type for `Promise`, `T` is added to the schema.

## Changelog

[General] [Changed] - Fix codegen to add `T` of `Promise<T>` in CodegenSchema.js

## Test Plan

`yarn jest react-native-codegen` passed
