### PR TITLE
build: allow packager override for PROJECT_ROOT

### DIFF
--- a/scripts/packager.sh
+++ b/scripts/packager.sh
@@ -8,14 +8,14 @@
 THIS_DIR=$(cd -P "$(dirname "$(readlink "${BASH_SOURCE[0]}" || echo "${BASH_SOURCE[0]}")")" && pwd)
 REACT_NATIVE_ROOT="$THIS_DIR/.."
 # Application root directory - General use case: react-native is a dependency
-PROJECT_ROOT="$THIS_DIR/../../.."
+PROJECT_ROOT=${PROJECT_ROOT:-"$THIS_DIR/../../.."}
 
 # check and assign NODE_BINARY env
 # shellcheck disable=SC1090
 source "${THIS_DIR}/node-binary.sh"
 
 # When running react-native tests, react-native doesn't live in node_modules but in the PROJECT_ROOT
-if [ ! -d "$PROJECT_ROOT/node_modules/react-native" ];
+if [ ! -d "$THIS_DIR/../../../node_modules/react-native" ];
 then
   PROJECT_ROOT="$THIS_DIR/.."
 fi


### PR DESCRIPTION
## Summary

This allows folks with a monorepo setup for React Native to set a simple configuration on the "Bundle React Native code and images" phase. This is because the bundler was configured to look for node_modules in a specific place, but in a monorepo your node_modules may be at the root one layer lower than a default configuration.

This same pattern of overriding this variable exists in the [react-native-xcode](https://github.com/facebook/react-native/blob/main/scripts/react-native-xcode.sh#L63) file.

Fixes: #33636 - "Unable to resolve module index"

```
Error: Unable to resolve module ./index from /Volumes/Nexus/Projects/xxx/.: 

None of these files exist:
  * index(.native|.android.js|.native.js|.js|.android.jsx|.native.jsx|.jsx|.android.json|.native.json|.json|.android.ts|.native.ts|.ts|.android.tsx|.native.tsx|.tsx)
  * index/index(.native|.android.js|.native.js|.js|.android.jsx|.native.jsx|.jsx|.android.json|.native.json|.json|.android.ts|.native.ts|.ts|.android.tsx|.native.tsx|.tsx)
```

## Changelog

[General] [Added] - Add support for overriding `PROJECT_ROOT` during bundle steps for monorepos.

## Test Plan

Working CI build via CircleCI.
