### PR TITLE
Rename RCTLogBoxView -> RCTLogBoxWindow

### DIFF
--- a/React/CoreModules/RCTLogBox.h
+++ b/React/CoreModules/RCTLogBox.h
@@ -6,13 +6,13 @@
  */
 
 #import <UIKit/UIKit.h>
-#import "RCTLogBoxView.h"
+#import "RCTLogBoxWindow.h"
 
 @interface RCTLogBox : NSObject
 
 #if RCT_DEV_MENU
 
-- (void)setRCTLogBoxView:(RCTLogBoxView *)view;
+- (void)setRCTLogBoxWindow:(RCTLogBoxWindow *)view;
 
 #endif
 

--- a/React/CoreModules/RCTLogBox.mm
+++ b/React/CoreModules/RCTLogBox.mm
@@ -92,7 +92,7 @@ RCT_EXPORT_METHOD(hide)
   return std::make_shared<facebook::react::NativeLogBoxSpecJSI>(params);
 }
 
-- (void)setRCTLogBoxView:(RCTLogBoxWindow *)window
+- (void)setRCTLogBoxWindow:(RCTLogBoxWindow *)window
 {
   self->_window = window;
 }

--- a/React/CoreModules/RCTLogBox.mm
+++ b/React/CoreModules/RCTLogBox.mm
@@ -21,7 +21,7 @@
 @end
 
 @implementation RCTLogBox {
-  RCTLogBoxView *_view;
+  RCTLogBoxWindow *_window;
   __weak id<RCTSurfacePresenterStub> _bridgelessSurfacePresenter;
 }
 
@@ -49,23 +49,23 @@ RCT_EXPORT_METHOD(show)
         return;
       }
 
-      if (strongSelf->_view) {
-        [strongSelf->_view show];
+      if (strongSelf->_window) {
+        [strongSelf->_window show];
         return;
       }
 
       if (strongSelf->_bridgelessSurfacePresenter) {
-        strongSelf->_view = [[RCTLogBoxView alloc] initWithWindow:RCTKeyWindow()
+        strongSelf->_window = [[RCTLogBoxWindow alloc] initWithWindow:RCTKeyWindow()
                                                  surfacePresenter:strongSelf->_bridgelessSurfacePresenter];
-        [strongSelf->_view show];
+        [strongSelf->_window show];
       } else if (strongSelf->_bridge && strongSelf->_bridge.valid) {
         if (strongSelf->_bridge.surfacePresenter) {
-          strongSelf->_view = [[RCTLogBoxView alloc] initWithWindow:RCTKeyWindow()
+          strongSelf->_window = [[RCTLogBoxWindow alloc] initWithWindow:RCTKeyWindow()
                                                    surfacePresenter:strongSelf->_bridge.surfacePresenter];
         } else {
-          strongSelf->_view = [[RCTLogBoxView alloc] initWithWindow:RCTKeyWindow() bridge:strongSelf->_bridge];
+          strongSelf->_window = [[RCTLogBoxWindow alloc] initWithWindow:RCTKeyWindow() bridge:strongSelf->_bridge];
         }
-        [strongSelf->_view show];
+        [strongSelf->_window show];
       }
     });
   }
@@ -80,8 +80,8 @@ RCT_EXPORT_METHOD(hide)
       if (!strongSelf) {
         return;
       }
-      [strongSelf->_view setHidden:YES];
-      strongSelf->_view = nil;
+      [strongSelf->_window setHidden:YES];
+      strongSelf->_window = nil;
     });
   }
 }
@@ -92,9 +92,9 @@ RCT_EXPORT_METHOD(hide)
   return std::make_shared<facebook::react::NativeLogBoxSpecJSI>(params);
 }
 
-- (void)setRCTLogBoxView:(RCTLogBoxView *)view
+- (void)setRCTLogBoxView:(RCTLogBoxWindow *)window
 {
-  self->_view = view;
+  self->_window = window;
 }
 
 @end

--- a/React/CoreModules/RCTLogBoxWindow.h
+++ b/React/CoreModules/RCTLogBoxWindow.h
@@ -10,7 +10,7 @@
 #import <React/RCTSurfaceView.h>
 #import <UIKit/UIKit.h>
 
-@interface RCTLogBoxView : UIWindow
+@interface RCTLogBoxWindow : UIWindow
 
 - (instancetype)initWithFrame:(CGRect)frame;
 

--- a/React/CoreModules/RCTLogBoxWindow.mm
+++ b/React/CoreModules/RCTLogBoxWindow.mm
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import "RCTLogBoxView.h"
+#import "RCTLogBoxWindow.h"
 
 #import <React/RCTLog.h>
 #import <React/RCTSurface.h>

--- a/React/CoreModules/RCTLogBoxWindow.mm
+++ b/React/CoreModules/RCTLogBoxWindow.mm
@@ -11,7 +11,7 @@
 #import <React/RCTSurface.h>
 #import <React/RCTSurfaceHostingView.h>
 
-@implementation RCTLogBoxView {
+@implementation RCTLogBoxWindow {
   RCTSurface *_surface;
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Rename the iOS class `RCTLogBoxView` to `RCTLogBoxWindow`. The reason is twofold:

1) Internally, it _is_ a subclass of UIWindow. This better reflects what this is on both iOS and Mac Catalyst
2) We had this change in our fork, React Native macOS (where we implement RCTLogBox as an NSWindow). This PR is an attempt to reduce a small diff between our two repos. 

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[iOS] [Changed] - Rename RCTLogBoxView -> RCTLogBoxWindow

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

RN-Tester building should be sufficient. Will attach a video of a log box still showing up when I can. 
