### PR TITLE
Port RCTDisplayLink fix from React Native macOS

### DIFF
--- a/React/Base/RCTDisplayLink.m
+++ b/React/Base/RCTDisplayLink.m
@@ -95,6 +95,15 @@
 
 - (void)invalidate
 {
+  // [TODO: GH#858
+  // ensure observer callbacks do not hold a reference to weak self via pauseCallback
+  for (RCTModuleData *moduleData in _frameUpdateObservers) {
+    id<RCTFrameUpdateObserver> observer = (id<RCTFrameUpdateObserver>)moduleData.instance;
+    [observer setPauseCallback:nil];
+  }
+  [_frameUpdateObservers removeAllObjects];	// just to be explicit
+  // TODO: GH#858]
+
   [_jsDisplayLink invalidate];
 }
 

--- a/React/Base/RCTDisplayLink.m
+++ b/React/Base/RCTDisplayLink.m
@@ -95,14 +95,12 @@
 
 - (void)invalidate
 {
-  // [TODO: GH#858
   // ensure observer callbacks do not hold a reference to weak self via pauseCallback
   for (RCTModuleData *moduleData in _frameUpdateObservers) {
     id<RCTFrameUpdateObserver> observer = (id<RCTFrameUpdateObserver>)moduleData.instance;
     [observer setPauseCallback:nil];
   }
   [_frameUpdateObservers removeAllObjects];	// just to be explicit
-  // TODO: GH#858]
 
   [_jsDisplayLink invalidate];
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Cherry pick https://github.com/microsoft/react-native-macos/commit/e877ebfe083ffaa252738477098322504492f4be from React Native macOS into React Native Core. We've had this bug fix in our fork for a while now, so it's probably safe.

=== Original change notes ===

First, misc straightforward deprecated API updates.

Second, defensive changes to potentially address RCTDisplayLink crash.
Real-world data suggests crashes with this stack:
CVDisplayLink::start()
-[RCTDisplayLink updateJSDisplayLinkState] (RCTDisplayLink.m:157)
-[RCTDisplayLink registerModuleForFrameUpdates:withModuleData:]_block_invoke (RCTDisplayLink.m:67)
-[RCTTiming timerDidFire] (RCTTiming.mm:324)
-[_RCTTimingProxy timerDidFire] (RCTTiming.mm:93)

Some symbols are missing in this stack, presumably due to compiler optimizations.
-updateJSDisplayLinkState is calling CVDisplayLinkStart as a result of a
call to "_jsDisplayLink.paused = NO".
-registerModuleForFrameUpdates block is presumably getting called via pauseCallback,
likely via [RCTTiming startTimers], presumably owned by RCTCxxBridge.

The most likely immediate explanation for the crash is that we are calling
CVDisplayLinkStart with a zombie _displayLink pointer.
However there is a lot of indirection here as well as thread-hopping, and
unfortunately no clearly incorrect code that would explain such a zombie pointer.

Some defensive changes:
-explicitly remove the association to pauseCallback when underlying display link object is invalidated.
-remove a prior attempt at additional check in updateJSDisplayLinkState itself as it is not relevant.
-make sure we explicitly set _displayLink to NULL when we release it, such that there is one less failure point.


## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[Internal] [Changed] - RCTDisplayLink fix plus bonus deprecated API cleanup

## Test Plan

CI should pass.
