### PR TITLE
Port Shadow props test page fix from React Native macOS

### DIFF
--- a/packages/rn-tester/js/examples/AnimatedGratuitousApp/AnExSet.js
+++ b/packages/rn-tester/js/examples/AnimatedGratuitousApp/AnExSet.js
@@ -139,10 +139,11 @@ const styles = StyleSheet.create({
   headerText: {
     fontSize: 25,
     color: 'white',
-    shadowRadius: 3,
-    shadowColor: 'black',
-    shadowOpacity: 1,
-    shadowOffset: {height: 1},
+    // [TODO(macOS GH#1409)
+    textShadowRadius: 3,
+    textShadowColor: 'rgba(0, 0, 0, 1.0)',
+    textShadowOffset: {height: 1, width: 0},
+    // ]TODO(macOS GH#1409)
   },
 });
 

--- a/packages/rn-tester/js/examples/AnimatedGratuitousApp/AnExSet.js
+++ b/packages/rn-tester/js/examples/AnimatedGratuitousApp/AnExSet.js
@@ -139,11 +139,9 @@ const styles = StyleSheet.create({
   headerText: {
     fontSize: 25,
     color: 'white',
-    // [TODO(macOS GH#1409)
     textShadowRadius: 3,
     textShadowColor: 'rgba(0, 0, 0, 1.0)',
     textShadowOffset: {height: 1, width: 0},
-    // ]TODO(macOS GH#1409)
   },
 });
 


### PR DESCRIPTION
## Summary

Cherry pick https://github.com/microsoft/react-native-macos/commit/19a62d9f57a6fae7a046741e19978a801f69abee to React Native. These style props were being applied to a <Text> element, not a <View> element. They seemingly only worked because of a quirk of iOS. 

=== Original change notes ===

The issue with the test is that the react native Text component has its own props for shadows - i.e. [textShadowColor, textShadowRadius, etc](https://reactnative.dev/docs/text-style-props) and the shadow props that View uses does not work on Text (i.e. shadowColor, shadowRadius, etc.). Not entirely sure how this test was passing without any errors before my change, it seems like something about the change is causing (expected) errors to actually show up.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[Internal] [Fixed] - Shadow consistency opacity fix with test updates

## Test Plan

Tested in our React Native macOS fork on iOS.
