### PR TITLE
Enable flow enums

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,8 @@
+{
+  "presets": [
+    "module:metro-react-native-babel-preset"
+  ],
+  "plugins": [
+    "babel-plugin-transform-flow-enums"
+  ]
+}

--- a/.flowconfig
+++ b/.flowconfig
@@ -30,6 +30,7 @@ flow/
 
 [options]
 emoji=true
+enums=true
 
 exact_by_default=true
 

--- a/.flowconfig.android
+++ b/.flowconfig.android
@@ -30,6 +30,7 @@ flow/
 
 [options]
 emoji=true
+enums=true
 
 exact_by_default=true
 

--- a/BUCK
+++ b/BUCK
@@ -748,6 +748,7 @@ rn_library(
         "//xplat/js:node_modules__base64_19js",
         "//xplat/js:node_modules__deprecated_19react_19native_19prop_19types",
         "//xplat/js:node_modules__event_19target_19shim",
+        "//xplat/js:node_modules__flow_19enums_19runtime",
         "//xplat/js:node_modules__invariant",
         "//xplat/js:node_modules__memoize_19one",
         "//xplat/js:node_modules__nullthrows",

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "base64-js": "^1.1.2",
     "deprecated-react-native-prop-types": "^2.3.0",
     "event-target-shim": "^5.0.1",
+    "flow-enums-runtime": "^0.0.5",
     "invariant": "^2.2.4",
     "jest-environment-node": "^29.2.1",
     "jsc-android": "^250230.2.1",

--- a/packages/rn-tester/package.json
+++ b/packages/rn-tester/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "invariant": "^2.2.4",
+    "flow-enums-runtime": "^0.0.5",
     "nullthrows": "^1.1.1"
   },
   "peerDependencies": {
@@ -29,6 +30,8 @@
   },
   "devDependencies": {
     "connect": "^3.6.5",
+    "babel-plugin-transform-flow-enums":"^0.0.1",
+    "jscodeshift": "^0.13.1",
     "ws": "^6.2.2"
   },
   "codegenConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -508,7 +508,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
 
-"@babel/plugin-syntax-flow@^7.0.0", "@babel/plugin-syntax-flow@^7.18.6", "@babel/plugin-syntax-flow@^7.2.0":
+"@babel/plugin-syntax-flow@^7.0.0", "@babel/plugin-syntax-flow@^7.12.1", "@babel/plugin-syntax-flow@^7.18.6", "@babel/plugin-syntax-flow@^7.2.0":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.18.6.tgz#774d825256f2379d06139be0c723c4dd444f3ca1"
   integrity sha512-LUbR+KNTBWCUAqRG9ex5Gnzu2IOkt8jRJbHHXFT9q+L9zm7M/QQbEqXyw1n1pohYvOyWC8CjeyjrSaIwiYjK7A==
@@ -2946,6 +2946,13 @@ babel-plugin-syntax-trailing-function-commas@^7.0.0-beta.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-7.0.0-beta.0.tgz#aa213c1435e2bffeb6fca842287ef534ad05d5cf"
   integrity sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ==
 
+babel-plugin-transform-flow-enums@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-flow-enums/-/babel-plugin-transform-flow-enums-0.0.1.tgz#ac9777bd1c5998364f83c0ec000ef878d169ec1a"
+  integrity sha512-dxkLaUvIvY8t+OmYzSyMBPee4f0u8WvRj8Ql9xFDTj2nV/qy8KorlOXggSrWe1cOGlsCcMaNE4fO/jbrnJBPiQ==
+  dependencies:
+    "@babel/plugin-syntax-flow" "^7.12.1"
+
 babel-preset-current-node-syntax@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz#b4399239b89b2a011f9ddbe3e4f401fc40cff73b"
@@ -4526,6 +4533,11 @@ flow-bin@^0.193.0:
   version "0.193.0"
   resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.193.0.tgz#250df37ec2d209dbf6dbec654e06d9e48da72ccb"
   integrity sha512-DREsJfNcU94P3rfh8TrydflQTKI5u8INzqCzi/R7iG2fBo+QKiEdNiv9NRlt4cRmOEsVvQ+5ed2U+u/68M8a6Q==
+
+flow-enums-runtime@^0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/flow-enums-runtime/-/flow-enums-runtime-0.0.5.tgz#95884bfcc82edaf27eef7e1dd09732331cfbafbc"
+  integrity sha512-PSZF9ZuaZD03sT9YaIs0FrGJ7lSUw7rHZIex+73UYVXg46eL/wxN5PaVcPJFudE2cJu5f0fezitV5aBkLHPUOQ==
 
 flow-parser@0.*, flow-parser@^0.185.0:
   version "0.185.0"


### PR DESCRIPTION
Summary:
Flow enums shipped in 2020 and now we enable it react-native-github

changelog: [Internal]

Differential Revision: D41339656

