### PR TITLE
Void the Maven coordinates for react-native and hermes-engine

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -616,11 +616,13 @@ apply plugin: "org.jetbrains.kotlin.android"
 apply from: "./publish.gradle"
 
 // We need to override the artifact ID as this project is called `ReactAndroid` but
-// the maven coordinates are on `react-native`.
+// the maven coordinates are on `react-android`.
+// Please note that the original coordinates, `react-native`, have been voided
+// as they caused https://github.com/facebook/react-native/issues/35210
 publishing {
     publications {
         getByName("release") {
-            artifactId 'react-native'
+            artifactId 'react-android'
         }
     }
 }

--- a/ReactAndroid/hermes-engine/build.gradle
+++ b/ReactAndroid/hermes-engine/build.gradle
@@ -234,4 +234,17 @@ afterEvaluate {
     prepareHeadersForPrefab.dependsOn(buildHermes)
 }
 
+/* Publishing Configuration */
 apply from: "../publish.gradle"
+
+// We need to override the artifact ID as this project is called `hermes-engine` but
+// the maven coordinates are on `hermes-android`.
+// Please note that the original coordinates, `hermes-engine`, have been voided
+// as they caused https://github.com/facebook/react-native/issues/35210
+publishing {
+    publications {
+        getByName("release") {
+            artifactId 'hermes-android'
+        }
+    }
+}

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/DependencyUtils.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/DependencyUtils.kt
@@ -35,9 +35,23 @@ internal object DependencyUtils {
   fun configureDependencies(project: Project, versionString: String) {
     if (versionString.isBlank()) return
     project.configurations.all { configuration ->
+      // Here we set a dependencySubstitution for both react-native and hermes-engine as those
+      // coordinates are voided due to https://github.com/facebook/react-native/issues/35210
+      // This allows users to import libraries that are still using
+      // implementation("com.facebook.react:react-native:+") and resolve the right dependency.
+      configuration.resolutionStrategy.dependencySubstitution {
+        it.substitute(it.module("com.facebook.react:react-native"))
+            .using(it.module("com.facebook.react:react-android:${versionString}"))
+            .because(
+                "The react-native artifact was deprecated in favor of react-android due to https://github.com/facebook/react-native/issues/35210.")
+        it.substitute(it.module("com.facebook.react:hermes-engine"))
+            .using(it.module("com.facebook.react:hermes-android:${versionString}"))
+            .because(
+                "The hermes-engine artifact was deprecated in favor of hermes-android due to https://github.com/facebook/react-native/issues/35210.")
+      }
       configuration.resolutionStrategy.force(
-          "com.facebook.react:react-native:${versionString}",
-          "com.facebook.react:hermes-engine:${versionString}",
+          "com.facebook.react:react-android:${versionString}",
+          "com.facebook.react:hermes-android:${versionString}",
       )
     }
   }

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/DependencyUtilsTest.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/DependencyUtilsTest.kt
@@ -177,8 +177,8 @@ class DependencyUtilsTest {
     configureDependencies(project, "1.2.3")
 
     val forcedModules = project.configurations.first().resolutionStrategy.forcedModules
-    assertTrue(forcedModules.any { it.toString() == "com.facebook.react:react-native:1.2.3" })
-    assertTrue(forcedModules.any { it.toString() == "com.facebook.react:hermes-engine:1.2.3" })
+    assertTrue(forcedModules.any { it.toString() == "com.facebook.react:react-android:1.2.3" })
+    assertTrue(forcedModules.any { it.toString() == "com.facebook.react:hermes-android:1.2.3" })
   }
 
   @Test

--- a/scripts/release-utils.js
+++ b/scripts/release-utils.js
@@ -30,19 +30,19 @@ function generateAndroidArtifacts(releaseVersion, tmpPublishingFolder) {
     '-debug-sources.jar',
     '-release-sources.jar',
   ].map(suffix => {
-    return `react-native-${releaseVersion}${suffix}`;
+    return `react-android-${releaseVersion}${suffix}`;
   });
 
   artifacts.forEach(name => {
     if (
       !test(
         '-e',
-        `/tmp/maven-local/com/facebook/react/react-native/${releaseVersion}/${name}`,
+        `/tmp/maven-local/com/facebook/react/react-android/${releaseVersion}/${name}`,
       )
     ) {
       echo(
         `Failing as expected file: \n\
-      /tmp/maven-local/com/facebook/react/react-native/${releaseVersion}/${name}\n\
+      /tmp/maven-local/com/facebook/react/react-android/${releaseVersion}/${name}\n\
       was not correctly generated.`,
       );
       exit(1);

--- a/scripts/test-manual-e2e.sh
+++ b/scripts/test-manual-e2e.sh
@@ -141,7 +141,6 @@ init_template_app(){
 
     info "Double checking the versions in package.json are correct:"
     grep "\"react-native\": \".*react-native-$PACKAGE_VERSION-$TIMESTAMP.tgz\"" "/tmp/${project_name}/package.json" || error "Incorrect version number in /tmp/${project_name}/package.json"
-    grep -E "com.facebook.react:react-native:\\+" "${project_name}/android/app/build.gradle" || error "Dependency in /tmp/${project_name}/android/app/build.gradle must be com.facebook.react:react-native:+"
 
     success "New sample project generated at /tmp/${project_name}"
     popd >/dev/null || exit

--- a/template/android/app/build.gradle
+++ b/template/android/app/build.gradle
@@ -150,7 +150,7 @@ android {
 
 dependencies {
     // The version of react-native is set by the React Native Gradle Plugin
-    implementation("com.facebook.react:react-native")
+    implementation("com.facebook.react:react-android")
 
     implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.0.0")
 
@@ -161,7 +161,7 @@ dependencies {
 
     debugImplementation("com.facebook.flipper:flipper-fresco-plugin:${FLIPPER_VERSION}")
     if (hermesEnabled.toBoolean()) {
-        implementation("com.facebook.react:hermes-engine")
+        implementation("com.facebook.react:hermes-android")
     } else {
         implementation jscFlavor
     }


### PR DESCRIPTION
Summary:
This diff moves the publishing coordinates from:
```
com.facebook.react:react-native
com.facebook.react:hermes-engine
```

to

```
com.facebook.react:react-android
com.facebook.react:hermes-android
```

I've picked those they are the most layout friendly when building from source, but we can discuss if we want others.
I've updated the Gradle plugin to have a dependencySubstitution rule + update the template with those changes.

It should now be possible to still use `implementation("com.facebook.react:react-native:+")` inside libraries
on 0.71+ and RNGP will resolve dependencies correctly.

Changelog:
[Android] [Changed] - Void the Maven coordinates for react-native and hermes-engine

Differential Revision: D41380525

