### PR TITLE
Allow react-native and expo to build when using GNU coreutils

### DIFF
--- a/scripts/react_native_pods_utils/script_phases.sh
+++ b/scripts/react_native_pods_utils/script_phases.sh
@@ -104,7 +104,7 @@ moveOutputs () {
     mkdir -p "$RCT_SCRIPT_OUTPUT_DIR"
 
     # Copy all output to output_dir
-    cp -R "$TEMP_OUTPUT_DIR/" "$RCT_SCRIPT_OUTPUT_DIR" || exit 1
+    cp -R "$TEMP_OUTPUT_DIR/." "$RCT_SCRIPT_OUTPUT_DIR/." || exit 1
     echo "$LIBRARY_NAME output has been written to $RCT_SCRIPT_OUTPUT_DIR:" >> "${SCRIPT_OUTPUT_FILE_0}" 2>&1
     ls -1 "$RCT_SCRIPT_OUTPUT_DIR" >> "${SCRIPT_OUTPUT_FILE_0}" 2>&1
 }

--- a/scripts/react_native_pods_utils/script_phases.sh
+++ b/scripts/react_native_pods_utils/script_phases.sh
@@ -104,7 +104,7 @@ moveOutputs () {
     mkdir -p "$RCT_SCRIPT_OUTPUT_DIR"
 
     # Copy all output to output_dir
-    cp -R "$TEMP_OUTPUT_DIR/." "$RCT_SCRIPT_OUTPUT_DIR/." || exit 1
+    cp -R "$TEMP_OUTPUT_DIR/." "$RCT_SCRIPT_OUTPUT_DIR" || exit 1
     echo "$LIBRARY_NAME output has been written to $RCT_SCRIPT_OUTPUT_DIR:" >> "${SCRIPT_OUTPUT_FILE_0}" 2>&1
     ls -1 "$RCT_SCRIPT_OUTPUT_DIR" >> "${SCRIPT_OUTPUT_FILE_0}" 2>&1
 }


### PR DESCRIPTION
## Summary

See the issue at https://github.com/facebook/react-native/issues/32432#issuecomment-1242234121

This fixes a bizarre issue when using the GNU coreutils tools. There are very minor differences in the standard BSD based command-line tools on macOS and the GNU coreutils versions. In particular, the `cp` command has slightly different semantics across these two versions. This commit normalizes those differences and allows the GNU coreutils `cp` command to work the same as the BSD version, thus fixing a hard to track down bug.

## Changelog

[General] [Fixed] - Allow GNU coreutils to be used to build projects

## Test Plan

This change allows the use of the system or GNU coreutils verson of `cp`.