### PR TITLE
Add butter/function.h

### DIFF
--- a/ReactCommon/butter/function.h
+++ b/ReactCommon/butter/function.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <butter/butter.h>
+
+#if (                                            \
+    defined(BUTTER_FUNCTION_OVERRIDE_INCLUDE) && \
+    defined(BUTTER_FUNCTION_OVERRIDE))
+
+#include BUTTER_FUNCTION_OVERRIDE_INCLUDE
+
+#elif defined(BUTTER_USE_FOLLY_CONTAINERS)
+
+#include <folly/Function.h>
+
+#else
+
+#include <functional>
+
+#endif
+
+namespace facebook {
+namespace butter {
+
+#if (                                            \
+    defined(BUTTER_FUNCTION_OVERRIDE_INCLUDE) && \
+    defined(BUTTER_FUNCTION_OVERRIDE))
+
+template <typename... Ts>
+using function = BUTTER_FUNCTION_OVERRIDE<Ts...>;
+
+#elif defined(BUTTER_USE_FOLLY_CONTAINERS)
+
+template <typename... Ts>
+using function = folly::Function<Ts...>;
+
+#else
+
+template <typename... Ts>
+using function = std::function<Ts...>;
+
+#endif
+
+} // namespace butter
+} // namespace facebook

--- a/ReactCommon/react/bridging/Base.h
+++ b/ReactCommon/react/bridging/Base.h
@@ -10,7 +10,7 @@
 #include <react/bridging/Convert.h>
 
 #include <ReactCommon/CallInvoker.h>
-#include <folly/Function.h>
+#include <butter/function.h>
 #include <jsi/jsi.h>
 
 #include <cstdint>
@@ -36,12 +36,12 @@ struct function_wrapper;
 
 template <typename C, typename R, typename... Args>
 struct function_wrapper<R (C::*)(Args...)> {
-  using type = folly::Function<R(Args...)>;
+  using type = butter::function<R(Args...)>;
 };
 
 template <typename C, typename R, typename... Args>
 struct function_wrapper<R (C::*)(Args...) const> {
-  using type = folly::Function<R(Args...)>;
+  using type = butter::function<R(Args...)>;
 };
 
 template <typename T, typename = void>

--- a/ReactCommon/react/bridging/Function.h
+++ b/ReactCommon/react/bridging/Function.h
@@ -10,7 +10,7 @@
 #include <react/bridging/Base.h>
 #include <react/bridging/CallbackWrapper.h>
 
-#include <folly/Function.h>
+#include <butter/function.h>
 
 namespace facebook::react {
 
@@ -154,8 +154,8 @@ struct Bridging<SyncCallback<R(Args...)>> {
 };
 
 template <typename R, typename... Args>
-struct Bridging<folly::Function<R(Args...)>> {
-  using Func = folly::Function<R(Args...)>;
+struct Bridging<butter::function<R(Args...)>> {
+  using Func = butter::function<R(Args...)>;
   using IndexSequence = std::index_sequence_for<Args...>;
 
   static constexpr size_t kArgumentCount = sizeof...(Args);
@@ -202,13 +202,17 @@ struct Bridging<folly::Function<R(Args...)>> {
 };
 
 template <typename R, typename... Args>
-struct Bridging<std::function<R(Args...)>>
-    : Bridging<folly::Function<R(Args...)>> {};
+struct Bridging<
+    std::function<R(Args...)>,
+    std::enable_if_t<!std::is_same_v<
+        std::function<R(Args...)>,
+        butter::function<R(Args...)>>>>
+    : Bridging<butter::function<R(Args...)>> {};
 
 template <typename R, typename... Args>
-struct Bridging<R(Args...)> : Bridging<folly::Function<R(Args...)>> {};
+struct Bridging<R(Args...)> : Bridging<butter::function<R(Args...)>> {};
 
 template <typename R, typename... Args>
-struct Bridging<R (*)(Args...)> : Bridging<folly::Function<R(Args...)>> {};
+struct Bridging<R (*)(Args...)> : Bridging<butter::function<R(Args...)>> {};
 
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
In OpenSource builds folly:: types are not always easy to consume.

With butter:: we actually allow consumers to opt-into other/non folly:: types (by providing a custom butter:: implementation).

This change adds a butter::function for that purpose.

It is especially useful for react-native-windows which prefers Mso::Functor over folly::Function.

You can use it by setting those compiler flags:
-DBUTTER_FUNCTION_OVERRIDE_INCLUDE=<functional/functor.h>
-DBUTTER_FUNCTION_OVERRIDE=Mso::Functor

std::function is no option as it is not move-only and we can't wait till 2025 > https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p0288r9.html

Changelog: [Internal]

Differential Revision: D41388193

