### PR TITLE
Fix TouchableOpacity componentDidUpdate causing an excessive number of pending callbacks

### DIFF
--- a/Libraries/Components/Touchable/TouchableOpacity.js
+++ b/Libraries/Components/Touchable/TouchableOpacity.js
@@ -301,9 +301,8 @@ class TouchableOpacity extends React.Component<Props, State> {
     this.state.pressability.configure(this._createPressabilityConfig());
     if (
       this.props.disabled !== prevProps.disabled ||
-      (flattenStyle(prevProps.style)?.opacity !==
-        flattenStyle(this.props.style)?.opacity) !==
-        undefined
+      flattenStyle(prevProps.style)?.opacity !==
+        flattenStyle(this.props.style)?.opacity
     ) {
       this._opacityInactive(250);
     }


### PR DESCRIPTION
## Summary

The commit https://github.com/facebook/react-native/commit/3eddc9abb70eb54209c68aab7dbd69e363cc7b29 included on v0.69 introduced a wrong `if` statement inside the `componentDidUpdate` function of the `TouchableOpacity` component. As this `if` statement always evaluates to `true` (`(true || false) !== undefined`) we end up making unnecessary calls to the `_opacityInactive` method every time the component props changes, e.g. every time a `<Text>` inside the TouchableOpacity changes we call this function over and over, and this has been causing some performance issues on big lists. 

This PR fixes this problem by adjusting the `componentDidUpdate` function to only call  `_opacityInactive` when necessary.


Closes https://github.com/facebook/react-native/issues/34442
Closes https://github.com/facebook/react-native/issues/32476 

## Changelog 

[General] [Fixed] - Fix TouchableOpacity componentDidUpdate causing an excessive number of pending callbacks

## Test Plan

1. Open the RNTester app and navigate to the `Touchable* and onPress` page
2. Test the `TouchableOpacity` component through the many sections
