### PR TITLE
Adding Dev Loading controller without activity for VR

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -82,6 +82,7 @@ import com.facebook.react.config.ReactFeatureFlags;
 import com.facebook.react.devsupport.DevSupportManagerFactory;
 import com.facebook.react.devsupport.ReactInstanceDevHelper;
 import com.facebook.react.devsupport.interfaces.DevBundleDownloadListener;
+import com.facebook.react.devsupport.interfaces.DevLoadingViewManager;
 import com.facebook.react.devsupport.interfaces.DevSupportManager;
 import com.facebook.react.devsupport.interfaces.PackagerStatusCallback;
 import com.facebook.react.devsupport.interfaces.RedBoxHandler;
@@ -233,7 +234,8 @@ public class ReactInstanceManager {
       @Nullable JSIModulePackage jsiModulePackage,
       @Nullable Map<String, RequestHandler> customPackagerCommandHandlers,
       @Nullable ReactPackageTurboModuleManagerDelegate.Builder tmmDelegateBuilder,
-      @Nullable SurfaceDelegateFactory surfaceDelegateFactory) {
+      @Nullable SurfaceDelegateFactory surfaceDelegateFactory,
+      @Nullable DevLoadingViewManager devLoadingViewManager) {
     FLog.d(TAG, "ReactInstanceManager.ctor()");
     initializeSoLoaderIfNecessary(applicationContext);
 
@@ -261,7 +263,8 @@ public class ReactInstanceManager {
             devBundleDownloadListener,
             minNumShakes,
             customPackagerCommandHandlers,
-            surfaceDelegateFactory);
+            surfaceDelegateFactory,
+            devLoadingViewManager);
     Systrace.endSection(TRACE_TAG_REACT_JAVA_BRIDGE);
     mBridgeIdleDebugListener = bridgeIdleDebugListener;
     mLifecycleState = initialLifecycleState;

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManagerBuilder.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManagerBuilder.java
@@ -28,6 +28,7 @@ import com.facebook.react.common.SurfaceDelegateFactory;
 import com.facebook.react.devsupport.DefaultDevSupportManagerFactory;
 import com.facebook.react.devsupport.DevSupportManagerFactory;
 import com.facebook.react.devsupport.interfaces.DevBundleDownloadListener;
+import com.facebook.react.devsupport.interfaces.DevLoadingViewManager;
 import com.facebook.react.devsupport.interfaces.DevSupportManager;
 import com.facebook.react.devsupport.interfaces.RedBoxHandler;
 import com.facebook.react.jscexecutor.JSCExecutor;
@@ -67,6 +68,7 @@ public class ReactInstanceManagerBuilder {
   private @Nullable Map<String, RequestHandler> mCustomPackagerCommandHandlers;
   private @Nullable ReactPackageTurboModuleManagerDelegate.Builder mTMMDelegateBuilder;
   private @Nullable SurfaceDelegateFactory mSurfaceDelegateFactory;
+  private @Nullable DevLoadingViewManager mDevLoadingViewManager;
   private JSEngineResolutionAlgorithm jsEngineResolutionAlgorithm = null;
 
   /* package protected */ ReactInstanceManagerBuilder() {}
@@ -216,6 +218,13 @@ public class ReactInstanceManagerBuilder {
     return this;
   }
 
+  /** Sets the Dev Loading View Manager. */
+  public ReactInstanceManagerBuilder setDevLoadingViewManager(
+      @Nullable DevLoadingViewManager devLoadingViewManager) {
+    mDevLoadingViewManager = devLoadingViewManager;
+    return this;
+  }
+
   /**
    * Sets the initial lifecycle state of the host. For example, if the host is already resumed at
    * creation time, we wouldn't expect an onResume call until we get an onPause call.
@@ -337,7 +346,8 @@ public class ReactInstanceManagerBuilder {
         mJSIModulesPackage,
         mCustomPackagerCommandHandlers,
         mTMMDelegateBuilder,
-        mSurfaceDelegateFactory);
+        mSurfaceDelegateFactory,
+        mDevLoadingViewManager);
   }
 
   private JavaScriptExecutorFactory getDefaultJSExecutorFactory(

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactNativeHost.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactNativeHost.java
@@ -18,6 +18,7 @@ import com.facebook.react.common.LifecycleState;
 import com.facebook.react.common.SurfaceDelegate;
 import com.facebook.react.common.SurfaceDelegateFactory;
 import com.facebook.react.devsupport.DevSupportManagerFactory;
+import com.facebook.react.devsupport.interfaces.DevLoadingViewManager;
 import com.facebook.react.devsupport.interfaces.RedBoxHandler;
 import java.util.List;
 
@@ -71,6 +72,7 @@ public abstract class ReactNativeHost {
             .setJSMainModulePath(getJSMainModuleName())
             .setUseDeveloperSupport(getUseDeveloperSupport())
             .setDevSupportManagerFactory(getDevSupportManagerFactory())
+            .setDevLoadingViewManager(getDevLoadingViewManager())
             .setRequireActivity(getShouldRequireActivity())
             .setSurfaceDelegateFactory(getSurfaceDelegateFactory())
             .setLazyViewManagersEnabled(getLazyViewManagersEnabled())
@@ -147,6 +149,13 @@ public abstract class ReactNativeHost {
         return null;
       }
     };
+  }
+
+  /**
+   * Get the {@link DevLoadingViewManager}. Override this to use a custom dev loading view manager
+   */
+  protected @Nullable DevLoadingViewManager getDevLoadingViewManager() {
+    return null;
   }
 
   /**

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/BridgeDevSupportManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/BridgeDevSupportManager.java
@@ -25,6 +25,7 @@ import com.facebook.react.common.ReactConstants;
 import com.facebook.react.common.SurfaceDelegateFactory;
 import com.facebook.react.common.futures.SimpleSettableFuture;
 import com.facebook.react.devsupport.interfaces.DevBundleDownloadListener;
+import com.facebook.react.devsupport.interfaces.DevLoadingViewManager;
 import com.facebook.react.devsupport.interfaces.DevOptionHandler;
 import com.facebook.react.devsupport.interfaces.DevSplitBundleCallback;
 import com.facebook.react.devsupport.interfaces.RedBoxHandler;
@@ -74,7 +75,8 @@ public final class BridgeDevSupportManager extends DevSupportManagerBase {
       @Nullable DevBundleDownloadListener devBundleDownloadListener,
       int minNumShakes,
       @Nullable Map<String, RequestHandler> customPackagerCommandHandlers,
-      @Nullable SurfaceDelegateFactory surfaceDelegateFactory) {
+      @Nullable SurfaceDelegateFactory surfaceDelegateFactory,
+      @Nullable DevLoadingViewManager devLoadingViewManager) {
     super(
         applicationContext,
         reactInstanceManagerHelper,
@@ -84,7 +86,8 @@ public final class BridgeDevSupportManager extends DevSupportManagerBase {
         devBundleDownloadListener,
         minNumShakes,
         customPackagerCommandHandlers,
-        surfaceDelegateFactory);
+        surfaceDelegateFactory,
+        devLoadingViewManager);
 
     if (getDevSettings().isStartSamplingProfilerOnInit()) {
       // Only start the profiler. If its already running, there is an error

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DefaultDevLoadingViewImplementation.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DefaultDevLoadingViewImplementation.java
@@ -25,8 +25,11 @@ import com.facebook.react.common.ReactConstants;
 import com.facebook.react.devsupport.interfaces.DevLoadingViewManager;
 import java.util.Locale;
 
-/** Controller to display loading messages on top of the screen. All methods are thread safe. */
-public class DevLoadingViewController implements DevLoadingViewManager {
+/**
+ * Default implementation of Dev Loading View Manager to display loading messages on top of the
+ * screen. All methods are thread safe.
+ */
+public class DefaultDevLoadingViewImplementation implements DevLoadingViewManager {
   private static boolean sEnabled = true;
   private final ReactInstanceDevHelper mReactInstanceManagerHelper;
   private @Nullable TextView mDevLoadingView;
@@ -36,7 +39,7 @@ public class DevLoadingViewController implements DevLoadingViewManager {
     sEnabled = enabled;
   }
 
-  public DevLoadingViewController(ReactInstanceDevHelper reactInstanceManagerHelper) {
+  public DefaultDevLoadingViewImplementation(ReactInstanceDevHelper reactInstanceManagerHelper) {
     mReactInstanceManagerHelper = reactInstanceManagerHelper;
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DefaultDevSupportManagerFactory.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DefaultDevSupportManagerFactory.java
@@ -11,6 +11,7 @@ import android.content.Context;
 import androidx.annotation.Nullable;
 import com.facebook.react.common.SurfaceDelegateFactory;
 import com.facebook.react.devsupport.interfaces.DevBundleDownloadListener;
+import com.facebook.react.devsupport.interfaces.DevLoadingViewManager;
 import com.facebook.react.devsupport.interfaces.DevSupportManager;
 import com.facebook.react.devsupport.interfaces.RedBoxHandler;
 import com.facebook.react.packagerconnection.RequestHandler;
@@ -46,6 +47,7 @@ public class DefaultDevSupportManagerFactory implements DevSupportManagerFactory
         null,
         minNumShakes,
         null,
+        null,
         null);
   }
 
@@ -59,7 +61,8 @@ public class DefaultDevSupportManagerFactory implements DevSupportManagerFactory
       @Nullable DevBundleDownloadListener devBundleDownloadListener,
       int minNumShakes,
       @Nullable Map<String, RequestHandler> customPackagerCommandHandlers,
-      @Nullable SurfaceDelegateFactory surfaceDelegateFactory) {
+      @Nullable SurfaceDelegateFactory surfaceDelegateFactory,
+      @Nullable DevLoadingViewManager devLoadingViewManager) {
     if (!enableOnCreate) {
       return new DisabledDevSupportManager();
     }
@@ -87,7 +90,8 @@ public class DefaultDevSupportManagerFactory implements DevSupportManagerFactory
               DevBundleDownloadListener.class,
               int.class,
               Map.class,
-              SurfaceDelegateFactory.class);
+              SurfaceDelegateFactory.class,
+              DevLoadingViewManager.class);
       return (DevSupportManager)
           constructor.newInstance(
               applicationContext,
@@ -98,7 +102,8 @@ public class DefaultDevSupportManagerFactory implements DevSupportManagerFactory
               devBundleDownloadListener,
               minNumShakes,
               customPackagerCommandHandlers,
-              surfaceDelegateFactory);
+              surfaceDelegateFactory,
+              devLoadingViewManager);
     } catch (Exception e) {
       return new PerftestDevSupportManager(applicationContext);
     }

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
@@ -46,6 +46,7 @@ import com.facebook.react.common.SurfaceDelegateFactory;
 import com.facebook.react.devsupport.DevServerHelper.PackagerCommandListener;
 import com.facebook.react.devsupport.interfaces.BundleLoadCallback;
 import com.facebook.react.devsupport.interfaces.DevBundleDownloadListener;
+import com.facebook.react.devsupport.interfaces.DevLoadingViewManager;
 import com.facebook.react.devsupport.interfaces.DevOptionHandler;
 import com.facebook.react.devsupport.interfaces.DevSupportManager;
 import com.facebook.react.devsupport.interfaces.ErrorCustomizer;
@@ -95,7 +96,7 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
   private final File mJSBundleDownloadedFile;
   private final File mJSSplitBundlesDir;
   private final DefaultJSExceptionHandler mDefaultJSExceptionHandler;
-  private final DevLoadingViewController mDevLoadingViewController;
+  private final DevLoadingViewManager mDevLoadingViewManager;
 
   private @Nullable SurfaceDelegate mRedBoxSurfaceDelegate;
   private @Nullable AlertDialog mDevOptionsDialog;
@@ -132,7 +133,8 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
       @Nullable DevBundleDownloadListener devBundleDownloadListener,
       int minNumShakes,
       @Nullable Map<String, RequestHandler> customPackagerCommandHandlers,
-      @Nullable SurfaceDelegateFactory surfaceDelegateFactory) {
+      @Nullable SurfaceDelegateFactory surfaceDelegateFactory,
+      @Nullable DevLoadingViewManager devLoadingViewManager) {
     mReactInstanceDevHelper = reactInstanceDevHelper;
     mApplicationContext = applicationContext;
     mJSAppBundleName = packagerPathForJSBundleName;
@@ -206,7 +208,10 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
     setDevSupportEnabled(enableOnCreate);
 
     mRedBoxHandler = redBoxHandler;
-    mDevLoadingViewController = new DevLoadingViewController(reactInstanceDevHelper);
+    mDevLoadingViewManager =
+        devLoadingViewManager != null
+            ? devLoadingViewManager
+            : new DefaultDevLoadingViewImplementation(reactInstanceDevHelper);
     mSurfaceDelegateFactory = surfaceDelegateFactory;
   };
 
@@ -766,7 +771,7 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
     }
 
     int port = parsedURL.getPort() != -1 ? parsedURL.getPort() : parsedURL.getDefaultPort();
-    mDevLoadingViewController.showMessage(
+    mDevLoadingViewManager.showMessage(
         mApplicationContext.getString(
             R.string.catalyst_loading_from_url, parsedURL.getHost() + ":" + port));
     mDevLoadingViewVisible = true;
@@ -778,14 +783,14 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
       return;
     }
 
-    mDevLoadingViewController.showMessage(
+    mDevLoadingViewManager.showMessage(
         mApplicationContext.getString(R.string.catalyst_debug_connecting));
     mDevLoadingViewVisible = true;
   }
 
   @UiThread
   protected void hideDevLoadingView() {
-    mDevLoadingViewController.hide();
+    mDevLoadingViewManager.hide();
     mDevLoadingViewVisible = false;
   }
 
@@ -827,7 +832,7 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
                   @Override
                   public void onProgress(
                       @Nullable String status, @Nullable Integer done, @Nullable Integer total) {
-                    mDevLoadingViewController.updateProgress(status, done, total);
+                    mDevLoadingViewManager.updateProgress(status, done, total);
                   }
 
                   @Override
@@ -983,7 +988,7 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
               @Nullable final String status,
               @Nullable final Integer done,
               @Nullable final Integer total) {
-            mDevLoadingViewController.updateProgress(status, done, total);
+            mDevLoadingViewManager.updateProgress(status, done, total);
             if (mBundleDownloadListener != null) {
               mBundleDownloadListener.onProgress(status, done, total);
             }
@@ -1125,7 +1130,7 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
 
       // show the dev loading if it should be
       if (mDevLoadingViewVisible) {
-        mDevLoadingViewController.showMessage("Reloading...");
+        mDevLoadingViewManager.showMessage("Reloading...");
       }
 
       mDevServerHelper.openPackagerConnection(
@@ -1206,7 +1211,7 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
       hideDevOptionsDialog();
 
       // hide loading view
-      mDevLoadingViewController.hide();
+      mDevLoadingViewManager.hide();
       mDevServerHelper.closePackagerConnection();
     }
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerFactory.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerFactory.java
@@ -11,6 +11,7 @@ import android.content.Context;
 import androidx.annotation.Nullable;
 import com.facebook.react.common.SurfaceDelegateFactory;
 import com.facebook.react.devsupport.interfaces.DevBundleDownloadListener;
+import com.facebook.react.devsupport.interfaces.DevLoadingViewManager;
 import com.facebook.react.devsupport.interfaces.DevSupportManager;
 import com.facebook.react.devsupport.interfaces.RedBoxHandler;
 import com.facebook.react.packagerconnection.RequestHandler;
@@ -26,5 +27,6 @@ public interface DevSupportManagerFactory {
       @Nullable DevBundleDownloadListener devBundleDownloadListener,
       int minNumShakes,
       @Nullable Map<String, RequestHandler> customPackagerCommandHandlers,
-      @Nullable SurfaceDelegateFactory surfaceDelegateFactory);
+      @Nullable SurfaceDelegateFactory surfaceDelegateFactory,
+      @Nullable DevLoadingViewManager devLoadingViewManager);
 }


### PR DESCRIPTION
Summary:
Changelog:
    [General][Added] - For supporting Dev Loading View across platforms, adding the DevLoadingViewController without an activity/context.

Differential Revision: D40947239

