### PR TITLE
Fix: Avoid path in the template import

### DIFF
--- a/template/ios/HelloWorld/AppDelegate.h
+++ b/template/ios/HelloWorld/AppDelegate.h
@@ -1,4 +1,4 @@
-#import <React-RCTAppDelegate/RCTAppDelegate.h>
+#import <RCTAppDelegate.h>
 #import <UIKit/UIKit.h>
 
 @interface AppDelegate : RCTAppDelegate


### PR DESCRIPTION
## Summary

Investigating [this comment](https://github.com/reactwg/react-native-releases/discussions/41#discussioncomment-4170008), I made some tests.
It seems like we can simply use `#import <RCTAppDelegate.h>` instead of the `#import <React-RCTAppDelegate/RCTAppDelegate.h>` in both setups:
- default setup
- `use_frameworks! :linkage => :static`

## Changelog

[iOS] [Fixed] - Support `use_framework! :linkage => :static` in template

## Test Plan

1. Manually tested with a new app
2. CircleCI
3. Sandcastle
