### PR TITLE
Remove `HERMES_BUILD_FROM_SOURCE` flag

### DIFF
--- a/scripts/cocoapods/__tests__/jsengine-test.rb
+++ b/scripts/cocoapods/__tests__/jsengine-test.rb
@@ -19,6 +19,7 @@ class JSEngineTests < Test::Unit::TestCase
     end
 
     def teardown
+        ENV['HERMES_ENGINE_TARBALL_PATH'] = nil
         Open3.reset()
         Pod::Config.reset()
         Pod::UI.reset()
@@ -119,4 +120,21 @@ class JSEngineTests < Test::Unit::TestCase
         assert_equal($podInvocation["React-hermes"][:path], "../../ReactCommon/hermes")
         assert_equal($podInvocation["libevent"][:version], "~> 2.1.12")
     end
+
+    # ================================= #
+    # TEST - isBuildingHermesFromSource #
+    # ================================= #
+    def test_isBuildingHermesFromSource_whenTarballIsNilAndVersionIsNotNightly_returnTrue
+        assert_true(is_building_hermes_from_source("1000.0.0"))
+    end
+
+    def test_isBuildingHermesFromSource_whenTarballIsNotNil_returnFalse
+        ENV['HERMES_ENGINE_TARBALL_PATH'] = "~/Downloads/hermes-ios-debug.tar.gz"
+        assert_false(is_building_hermes_from_source("1000.0.0"))
+    end
+
+    def test_isBuildingHermesFromSource_whenIsNigthly_returnsFalse
+        assert_false(is_building_hermes_from_source("0.0.0-"))
+    end
+
 end

--- a/scripts/cocoapods/jsengine.rb
+++ b/scripts/cocoapods/jsengine.rb
@@ -63,3 +63,15 @@ end
 def remove_hermesc_build_dir(react_native_path)
     %x(rm -rf #{react_native_path}/sdks/hermes-engine/build_host_hermesc)
 end
+
+def is_building_hermes_from_source(react_native_version)
+    is_nightly = react_native_version.start_with?('0.0.0-')
+    has_tarball = ENV['HERMES_ENGINE_TARBALL_PATH'] != nil
+
+    # this is the same logic in the hermes-engine.podspec
+    if has_tarball || is_nightly
+        return false
+    end
+
+    return true
+end

--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -202,7 +202,10 @@ def react_native_post_install(installer, react_native_path = "../node_modules/re
     flipper_post_install(installer)
   end
 
-  if ReactNativePodsUtils.has_pod(installer, 'hermes-engine') && ENV['HERMES_BUILD_FROM_SOURCE'] == "1"
+  package = JSON.parse(File.read(File.join(react_native_path, "package.json")))
+  version = package['version']
+
+  if ReactNativePodsUtils.has_pod(installer, 'hermes-engine') && is_building_hermes_from_source(version)
     add_copy_hermes_framework_script_phase(installer, react_native_path)
   else
     remove_copy_hermes_framework_script_phase(installer, react_native_path)

--- a/sdks/hermes-engine/hermes-engine.podspec
+++ b/sdks/hermes-engine/hermes-engine.podspec
@@ -80,8 +80,6 @@ Pod::Spec.new do |spec|
 
   elsif source[:git] then
 
-    ENV['HERMES_BUILD_FROM_SOURCE'] = "1"
-
     spec.subspec 'Hermes' do |ss|
       ss.source_files = ''
       ss.public_header_files = 'API/hermes/*.h'
@@ -108,6 +106,7 @@ Pod::Spec.new do |spec|
       # Keep hermesc_path synchronized with .gitignore entry.
       ENV['REACT_NATIVE_PATH'] = react_native_path
       hermesc_path = "${REACT_NATIVE_PATH}/sdks/hermes-engine/build_host_hermesc"
+      # NOTE: Prepare command is not run  if the pod is not downloaded.
       spec.prepare_command = ". #{react_native_path}/sdks/hermes-engine/utils/build-hermesc-xcode.sh #{hermesc_path}"
     end
 


### PR DESCRIPTION
Summary:
This Diff removes the `HERMES_BUILD_FROM_SOURCE` that was not always propagated to the original script. This lead to some cases where hermesC was built during `pod install` and then removed by the `react_native_post_install`'s `else` branch.

## Changelog:
[iOS][Changed] - Remove `HERMES_BUILD_FROM_SOURCE` flag

Reviewed By: cortinico

Differential Revision: D41373439

