### PR TITLE
Read `.ruby-version` file in `Gemfile`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
 # You may use http://rbenv.org/ or https://rvm.io/ to install and use this version
-ruby '2.7.6'
+ruby File.read('.ruby-version').strip
 
 gem 'cocoapods', '~> 1.11', '>= 1.11.3'

--- a/scripts/run-ci-e2e-tests.js
+++ b/scripts/run-ci-e2e-tests.js
@@ -90,6 +90,7 @@ try {
   cd(REACT_NATIVE_APP_DIR);
 
   mv('_bundle', '.bundle');
+  mv('_ruby-version', '.ruby-version');
   mv('_eslintrc.js', '.eslintrc.js');
   mv('_prettierrc.js', '.prettierrc.js');
   mv('_watchmanconfig', '.watchmanconfig');

--- a/scripts/update-ruby.sh
+++ b/scripts/update-ruby.sh
@@ -50,9 +50,6 @@ fi
 
 echo "$VERSION" > template/_ruby-version
 
-sed_i -e "s/^\(ruby '\)[^']*\('.*\)$/\1$VERSION\2/" Gemfile
-sed_i -e "s/^\(ruby '\)[^']*\('.*\)$/\1$VERSION\2/" template/Gemfile
-
 rm -f Gemfile.lock
 
 export BUNDLE_APP_CONFIG="$ROOT/.bundle"
@@ -67,10 +64,8 @@ export GIT_DISCOVERY_ACROSS_FILESYSTEM=0;
 if [ "$IS_GIT_REPO" = "true" ]; then
     git add \
         .ruby-version \
-        Gemfile \
         Gemfile.lock \
-        template/_ruby-version \
-        template/Gemfile
+        template/_ruby-version
 else
     echo "Detected that you're not in Git. If on another SCM, don't forget to commit the edited files."
 fi

--- a/template/Gemfile
+++ b/template/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
 # You may use http://rbenv.org/ or https://rvm.io/ to install and use this version
-ruby '2.7.6'
+ruby File.read('.ruby-version').strip
 
 gem 'cocoapods', '~> 1.11', '>= 1.11.3'


### PR DESCRIPTION
## Summary

When updating the Ruby version, 2 files are always needed to be updated (`.ruby-version` and `Gemfile`). When not in sync it can lead to an error like `Your Ruby version is 2.7.6, but your Gemfile specified 2.7.5`.

This lessens the files that need to be updated when upgrading the Ruby version and makes it in sync always. It makes the `.ruby-version` the source of truth.

### Example 1:

<img width="481" alt="Screenshot 2022-11-20 at 13 56 08" src="https://user-images.githubusercontent.com/36528176/202888191-450ab6d0-32a4-4d37-ad82-0beb2b22fa82.png">

When upgrading from `0.70.0` to `0.71.0-rc.0`. 2 files needs to be updated when it could have been just 1.

Source: https://react-native-community.github.io/upgrade-helper/?from=0.70.0&to=0.71.0-rc.0

### Example 2:

21c8837c1264cd96f5899e33132fa764bb9c2293 updates 4 files (`.ruby-version`, `Gemfile`, `template/Gemfile`, `template/_ruby-version`) when it could have been just 2.

### Other Sources:
* https://andycroll.com/ruby/read-ruby-version-in-your-gemfile/
* https://render.com/docs/ruby-version (Heroku alternative)
* https://stackoverflow.com/a/35823132/9375533

## Changelog

[General] [Changed] - Read `.ruby-version` file in `Gemfile`

## Test Plan

Only `.ruby-version` and `template/_ruby-version` needs to be updated when upgrading Ruby version.
