### PR TITLE
Prevent the tail-spacer gets negative values in VirtualizedList on scrolling toward new items with dynamic height.

### DIFF
--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -907,8 +907,10 @@ export default class VirtualizedList extends StateSafePureComponent<
             this.props,
           );
           const lastMetrics = this.__getFrameMetricsApprox(last, this.props);
-          const spacerSize =
-            lastMetrics.offset + lastMetrics.length - firstMetrics.offset;
+          const spacerSize = Math.max(
+            lastMetrics.offset + lastMetrics.length - firstMetrics.offset,
+            0,
+          );
           cells.push(
             <View
               key={`$spacer-${section.first}`}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Flatlist on [Web has scroll issues when used with expensive items](https://github.com/necolas/react-native-web/issues/2432). 

I noticed this issue in an App called Expensify. It uses Flatlist for a chat of reports that supports text, images, emojis, and reports as items (and perhaps others that I am not aware of). These items have complex code to support interactions and features on them. As you scroll in the report chat in Web, especially if you scroll fast, you will notice scroll issues like scroll jumps, items appearing and disappearing, or items not showing at all.

Here's Expensify Flatlist Web current state:

https://user-images.githubusercontent.com/48106652/202822381-3730f8ea-adfe-4e2e-a60c-cba09c3c29f4.mp4

I recreate a sandbox with expensive items where you can experience the scroll issues I mentioned [here](https://codesandbox.io/p/github/Lucio-s-Forks/react-native-web/only-longFlatlist-expensive-items-VirtualizedList-updated-no-proposal?file=%2Fpackages%2Freact-native-web-examples%2Fpages%2Findex.js&selection=%5B%7B%22endColumn%22%3A43%2C%22endLineNumber%22%3A90%2C%22startColumn%22%3A43%2C%22startLineNumber%22%3A90%7D%5D).

Steps to reproduce the scroll issues in the sandbox:

1. Scroll down for a while until you render a few items beyond the virtual area.
2. Use the mouse and drag the scroll bar up and down.
3. Things should start looking weird: scroll jumps, items appearing, and disappearing.

I take on the task to improve the scroll experience of react-native-web's Flatlist. I found 3 problems that cause this issue and present their corresponding solution: 

1. $lead_spacer expands scroll artificially when VirtualizedList is mounting new items —> Problem Explanation and Solution below.

2. VirtualizedList skip items for offset measuring when the user scrolls very fast while new items are mounted and measured —> [Problem Explanation and Solution in this PR.](https://github.com/facebook/react-native/pull/35414)

3. VirtualizedList gets offsets below or equal to zero for items that are not the list's first item —> [Problem Explanation and Solution in this PR.](https://github.com/facebook/react-native/pull/35415)

These solutions involve adding or modifying VirtualizedList.js but they improve drastically the scroll experience on Web without causing any problems on Android or iOS. 

Also here's Expensify's App after solutions (plus [another solution for Inverted VirtualizedLists in react-native-web](https://github.com/necolas/react-native-web/pull/2412)):

https://user-images.githubusercontent.com/48106652/202822857-a6172ea0-b081-45f6-85ba-b6e6c317a743.mp4


---

This PR is the **First Part** solution to fix the 'Flatlist with expensive items breaks scroll' issue in react-native-web.

### $lead_spacer expands scroll limit artificially when Inverted VirtualizedList is mounting new items. (1st of 3 problems that cause 'Flatlist with expensive items breaks scroll' ) ###

In a FlatList with items with different heights, the scroll is limited to the last measured item. That’s because `VirtualizedList` (the inner `FlatList`'s component) must measure the offset of mounted items before it tries to mount new items. In this way, all items in the virtual area are measured and the `_frames` object is complete.

The scroll limit should be only expanded when the user tries to scroll beyond the scroll limit (unmeasured area) and then new items are mounted and their offsets are measured and saved in `_frames`. When recently mounted items are measured, the scroll limit is expanded to the new latest measured item, then the user will be ready to keep scrolling to unmeasured area and repeat the process to keep expanding the scroll limit until the last item is met.

Sometimes users may “overscroll” to unmeasured areas while previously mounted items haven't been measured yet, and `VirtualizedList` starts skipping items for measuring and measures others that shouldn’t be measured yet, leading to a fragmented map of offsets (e.g. we have offset values for …31, 32, 33, then jumps to 37, 38…).

**Why do users “overscroll”?**

Flaltlist constantly mounts and unmounts items. A white space is mounted on our list called `$tail_spacer`. It helps us to fill with white space the bottom outside of our virtual area (for the inverted list, it fills the top), where items were previously mounted and measured but unmounted afterward, so the scroll limit sticks to our latest measured item offset.

![Screen Shot 2022-10-12 at 18 02 58](https://user-images.githubusercontent.com/48106652/195463601-f7dc7396-5df8-49da-aa6f-049c3d2f7921.png)

`$tail_spacer` height depends on how many areas we had measured, but it reduces to zero when the latest measured item is mounted and the user pretends to scroll to an unmeasured area looking for more items. When `$tail_spacer`'s height is zero, the scroll is limited and prevents the user from “overscroll”. This gives time to VirtualizedList to properly mount and measure new items to then use their offsets as our new scroll limit.

Sometimes `$tail_spacer` has a height greater than zero when it should be zero, allowing the user to “overscroll”.

**Why sometimes does `$tail_spacer` has a height greater than zero when it should be zero?**

On some updates, `$tail_spacer` gets a negative value for its height, which is invalid on Web. Invalid values will be ignored and $tail-spacer’s height will set the valid value of the previous state, instead of setting it to zero.

### Solution: ###

The solution is simple. Set spacerSize to zero if the metrics calculation returns negative values.

![Screen Shot 2022-11-18 at 14 34 26](https://user-images.githubusercontent.com/48106652/202812308-84bcee02-6492-4e60-9cf2-2c9f72503e4e.png)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[GENERAL] [FIXED] prevent the tail-spacer gets negative values in VirtualizedList on scrolling toward new items with dynamic height.

## Test Plan

This issue is difficult to reproduce on its own but fixing it does provide more stability used along with the other two solutions that I present with it. You can test the Flatlist with all solutions applied in this [sandbox](https://codesandbox.io/p/github/Lucio-s-Forks/react-native-web/only-longFlatlist-expensive-items-VirtualizedList-updated-WITH-proposal?selection=%5B%7B%22endColumn%22%3A34%2C%22endLineNumber%22%3A100%2C%22startColumn%22%3A34%2C%22startLineNumber%22%3A100%7D%5D&file=%2Fpackages%2Freact-native-web-examples%2Fpages%2Findex.js)

Naturally, expensive items will take time to show but you should find no issues on scroll fast.

Also tested in Expensify's App I am working on (see video above).

No problem with iOS


https://user-images.githubusercontent.com/48106652/202923249-fdb2bde6-c393-4ef4-92a9-fe084055ba7e.mp4

No problem with Android


https://user-images.githubusercontent.com/48106652/202923277-02ad0e24-efd0-4853-8876-b11ab3558dc1.mp4




<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

---
Thank you for reading, let me know what you think!