### PR TITLE
Prevent VirtualizedList saves items with offsets equal to or below zero and lengths equal to zero

### DIFF
--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -1181,6 +1181,16 @@ export default class VirtualizedList extends StateSafePureComponent<
       inLayout: true,
     };
     const curr = this._frames[cellKey];
+    // Measures on discarded Low Priority updates will return zero for dimensions in Web, even negative offsets
+    // no cell should have an offset of zero in frames, except for first cell
+    if (
+      next.offset < 0 ||
+      next.length === 0 ||
+      (next.offset === 0 && index !== 0)
+    ) {
+      this._scheduleCellsToRenderUpdate();
+      return;
+    }
     if (
       !curr ||
       next.offset !== curr.offset ||


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Flatlist on Web [has scroll issues when used with expensive items](https://github.com/necolas/react-native-web/issues/2432). 

I noticed this issue in an App called Expensify. It uses Flatlist for a chat of reports that supports text, images, emojis, and reports as items (and perhaps others that I am not aware of). These items have complex code to support interactions and features on them. As you scroll in the report chat in Web, especially if you scroll fast, you will notice scroll issues like scroll jumps, items appearing and disappearing, or items not showing at all.

Here's Expensify Flatlist Web current state:

https://user-images.githubusercontent.com/48106652/202822381-3730f8ea-adfe-4e2e-a60c-cba09c3c29f4.mp4

I recreate a sandbox with expensive items where you can experience the scroll issues I mentioned [here](https://codesandbox.io/p/github/Lucio-s-Forks/react-native-web/only-longFlatlist-expensive-items-VirtualizedList-updated-no-proposal?file=%2Fpackages%2Freact-native-web-examples%2Fpages%2Findex.js&selection=%5B%7B%22endColumn%22%3A43%2C%22endLineNumber%22%3A90%2C%22startColumn%22%3A43%2C%22startLineNumber%22%3A90%7D%5D).

Steps to reproduce the scroll issues in the sandbox:

1. Scroll down for a while until you render a few items beyond the virtual area.
2. Use the mouse and drag the scroll bar up and down.
3. Things should start looking weird: scroll jumps, items appearing, and disappearing.

I take on the task to improve the scroll experience of react-native-web's Flatlist. I found 3 problems that cause this issue and present their corresponding solution: 

1. $lead_spacer expands scroll artificially when VirtualizedList is mounting new items —> [Problem Explanation and Solution in this PR.](https://github.com/facebook/react-native/pull/35413)

2. VirtualizedList skip items for offset measuring when the user scrolls very fast while new items are mounted and measured —> [Problem Explanation and Solution in this PR.](https://github.com/facebook/react-native/pull/35414)

3. VirtualizedList gets offsets below or equal to zero for items that are not the list's first item —> Problem Explanation and Solution below.

These solutions involve adding or modifying VirtualizedList.js but they improve drastically the scroll experience on Web without causing any regression on Android or iOS. 

Also here's Expensify's App after solutions (plus [another solution for Inverted VirtualizedLists in react-native-web](https://github.com/necolas/react-native-web/pull/2412)):

https://user-images.githubusercontent.com/48106652/202822857-a6172ea0-b081-45f6-85ba-b6e6c317a743.mp4


---

This PR is the **Third Part** solution to fix the 'Flatlist with expensive items breaks scroll' issue in react-native-web.

### VirtualizedList saves offsets equal to or below zero and lengths equal to zero ###
As explained in the **Second Part** PR, a High Priority update cancels every Low Priority update. A canceled Low Priority update will make `onLayout` returns offset and height equal to zero for the items this update pretended to mount. These zero values will be saved in `_frames`, associated with the canceled item, even if that item was properly measured on previous updates.

`_frames` object with offsets equal to zero will cause a miss calculation to get items for the virtual area. Because it does not make sense that items in higher positions than the bottom of the list have an offset equal to or below zero.

### Solution: ###

Skip the action to save values on our `_frames` and trigger another update if any of the following conditions are met:
1. zero for offset and the item measured is not the first item of the FlatList.
2. offset below zero
3. length equal to zero

![Screen Shot 2022-11-18 at 19 19 40](https://user-images.githubusercontent.com/48106652/202827155-5a8a7f35-73b1-4cda-9875-b14f9cafdad9.png)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[GENERAL] [FIXED] prevent VirtualizedList saves offsets equal to or below zero and lengths equal to zero

## Test Plan

You can test the Flatlist with all solutions applied in this [sandbox](https://codesandbox.io/p/github/Lucio-s-Forks/react-native-web/only-longFlatlist-expensive-items-VirtualizedList-updated-WITH-proposal?selection=%5B%7B%22endColumn%22%3A34%2C%22endLineNumber%22%3A100%2C%22startColumn%22%3A34%2C%22startLineNumber%22%3A100%7D%5D&file=%2Fpackages%2Freact-native-web-examples%2Fpages%2Findex.js)

Naturally, expensive items will take time to show but you should find no issues on scroll fast.

Also tested in Expensify's App I am working on (see video above)

No problem with iOS


https://user-images.githubusercontent.com/48106652/202923249-fdb2bde6-c393-4ef4-92a9-fe084055ba7e.mp4

No problem with Android


https://user-images.githubusercontent.com/48106652/202923277-02ad0e24-efd0-4853-8876-b11ab3558dc1.mp4

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

---
Thank you for reading, let me know what you think!