### PR TITLE
Fix hardcoded path to codegen cli for monorepos

### DIFF
--- a/scripts/react_native_pods_utils/script_phases.sh
+++ b/scripts/react_native_pods_utils/script_phases.sh
@@ -13,8 +13,6 @@ GENERATED_SCHEMA_FILE="$GENERATED_SRCS_DIR/schema.json"
 
 cd "$RCT_SCRIPT_RN_DIR"
 
-CODEGEN_REPO_PATH="$RCT_SCRIPT_RN_DIR/packages/react-native-codegen"
-CODEGEN_NPM_PATH="$RCT_SCRIPT_RN_DIR/../react-native-codegen"
 CODEGEN_CLI_PATH=""
 
 error () {
@@ -23,21 +21,19 @@ error () {
     exit 1
 }
 
-# Determine path to react-native-codegen
-if [ -d "$CODEGEN_REPO_PATH" ]; then
-    CODEGEN_CLI_PATH=$(cd "$CODEGEN_REPO_PATH" && pwd)
-elif [ -d "$CODEGEN_NPM_PATH" ]; then
-    CODEGEN_CLI_PATH=$(cd "$CODEGEN_NPM_PATH" && pwd)
-else
-    error "error: Could not determine react-native-codegen location in $CODEGEN_REPO_PATH or $CODEGEN_NPM_PATH. Try running 'yarn install' or 'npm install' in your project root."
-fi
-
 find_node () {
     NODE_BINARY="${NODE_BINARY:-$(command -v node || true)}"
     if [ -z "$NODE_BINARY" ]; then
         error "[Error] Could not find node. It looks like that the .xcode.env or .xcode.env.local " \
 "files are misconfigured. Please check that they are exporting a valid NODE_BINARY " \
 "variable, pointing to a node executable."
+    fi
+}
+
+find_codegen () {
+    CODEGEN_CLI_PATH=$("$NODE_BINARY" --print "require('path').dirname(require.resolve('react-native-codegen/package.json'))")
+    if ! [ -d "$CODEGEN_CLI_PATH" ]; then
+        error "error: Could not determine react-native-codegen location, using node module resolution. Try running 'yarn install' or 'npm install' in your project root."
     fi
 }
 
@@ -116,6 +112,7 @@ moveOutputs () {
 withCodgenDiscovery () {
     setup_dirs
     find_node
+    find_codegen
     generateArtifacts
     moveOutputs
 }
@@ -123,6 +120,7 @@ withCodgenDiscovery () {
 noCodegenDiscovery () {
     setup_dirs
     find_node
+    find_codegen
     generateCodegenSchemaFromJavaScript
     generateCodegenArtifactsFromSchema
     moveOutputs


### PR DESCRIPTION
## Summary

Fixes #35429

This fix is fairly straightforward. Instead of hardcoding two separate paths for this repo or a simple user's project, we ask Node to resolve `react-native-codegen`.

Because `react-native-codegen` is moved [into the `/packages/*` folder](https://github.com/facebook/react-native/blob/main/package.json#L104), it's part of a workspace in this repository. That means that this fix works not only for monorepos in general but also resolves the right path within the react native repository.

You can test this out yourself when running this command in either the root, or any other workspace in this repository:
```bash
node --print "require('path').dirname(require.resolve('react-native-codegen/package.json'))"
```

I've tested this on Node 16 and 18, and seems to work nicely. Note that you _**have to specify `react-native-codegen/package.json`**_. That's because the `react-native-codegen` package itself is technically invalid; it's missing an entry point within the package (no `main`). When running `node --print "require.resolve('react-native-codegen')"` Node can't resolve the main entry point, and will fail during this process.



## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[iOS] [Fixed] - Fix incorrect codegen CLI paths in monorepo projects

## Test Plan

See PR #35429
