### PR TITLE
Backport fix copy-hermes-xcode.sh from 0.71-stable

### DIFF
--- a/sdks/hermes-engine/utils/copy-hermes-xcode.sh
+++ b/sdks/hermes-engine/utils/copy-hermes-xcode.sh
@@ -6,9 +6,17 @@
 
 set -x
 
-source="${PODS_ROOT}/hermes-engine/destroot/Library/Frameworks/${PLATFORM_NAME}/hermes.framework"
+src="${PODS_ROOT}/hermes-engine/destroot/Library/Frameworks/${PLATFORM_NAME}/hermes.framework"
 
-if [[ -f "$source" ]]; then
-    cp -R "$source" "${PODS_XCFRAMEWORKS_BUILD_DIR}/hermes/hermes.framework"
-    cp -R "$source" "${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}"
+if [[ ! -e "$src" ]]; then
+  echo "$src does not exist."
+  exit 1
 fi
+
+dst1="${PODS_XCFRAMEWORKS_BUILD_DIR}/hermes"
+[ ! -f "$dst1" ] && mkdir -p "$dst1"
+cp -R "$src" "$dst1"
+
+dst2="${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}"
+[ ! -f "$dst2" ] && mkdir -p "$dst2"
+cp -R "$src" "$dst2"


### PR DESCRIPTION
Summary:
`[ -f "$source" ]` was wrong.
`man test` reads:
>  -f file       True if file exists and is a regular file.
-e file       True if file exists (regardless of type).

hermes.framework is not a regular file but a directory. `-e` is beter here.
Also intermediate destiantion directories are now created if they didn't exist.

Changelog:
[iOS][Fixed] - Make copy-hermes-xcode.sh more reliable.

Reviewed By: robhogan

Differential Revision: D41472846

