### PR TITLE
Enable C++17 for cxxreact and jsiexecutor/inspector and ...

### DIFF
--- a/ReactAndroid/src/main/jni/CMakeLists.txt
+++ b/ReactAndroid/src/main/jni/CMakeLists.txt
@@ -17,7 +17,7 @@ endif(CCACHE_FOUND)
 
 # Make sure every shared lib includes a .note.gnu.build-id header
 add_link_options(-Wl,--build-id)
-add_compile_options(-Wall -Werror -std=c++1y)
+add_compile_options(-Wall -Werror -std=c++17)
 
 function(add_react_android_subdir relative_path)
   add_subdirectory(${REACT_ANDROID_DIR}/${relative_path} ReactAndroid/${relative_path})

--- a/ReactAndroid/src/main/jni/react/hermes/reactexecutor/CMakeLists.txt
+++ b/ReactAndroid/src/main/jni/react/hermes/reactexecutor/CMakeLists.txt
@@ -25,6 +25,7 @@ target_compile_options(
         ${HERMES_TARGET_NAME}
         PRIVATE
         $<$<CONFIG:Debug>:-DHERMES_ENABLE_DEBUGGER=1>
+        -std=c++17
         -fexceptions
 )
 target_include_directories(${HERMES_TARGET_NAME} PRIVATE .)

--- a/ReactCommon/cxxreact/CMakeLists.txt
+++ b/ReactCommon/cxxreact/CMakeLists.txt
@@ -9,6 +9,7 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 add_compile_options(
         -fexceptions
         -frtti
+        -std=c++17
         -Wno-unused-lambda-capture
         -DLOG_TAG=\"ReactNative\")
 

--- a/ReactCommon/cxxreact/React-cxxreact.podspec
+++ b/ReactCommon/cxxreact/React-cxxreact.podspec
@@ -33,7 +33,8 @@ Pod::Spec.new do |s|
   s.source_files           = "*.{cpp,h}"
   s.exclude_files          = "SampleCxxModule.*"
   s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
-  s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/DoubleConversion\"" }
+  s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/DoubleConversion\"",
+                               "CLANG_CXX_LANGUAGE_STANDARD" => "c++17" }
   s.header_dir             = "cxxreact"
 
   s.dependency "boost", "1.76.0"

--- a/ReactCommon/hermes/React-hermes.podspec
+++ b/ReactCommon/hermes/React-hermes.podspec
@@ -40,7 +40,8 @@ Pod::Spec.new do |s|
   s.public_header_files    = "executor/HermesExecutorFactory.h"
   s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
   s.pod_target_xcconfig    = {
-                               "HEADER_SEARCH_PATHS" => "\"${PODS_ROOT}/hermes-engine/destroot/include\" \"$(PODS_TARGET_SRCROOT)/..\" \"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/libevent/include\""
+                               "HEADER_SEARCH_PATHS" => "\"${PODS_ROOT}/hermes-engine/destroot/include\" \"$(PODS_TARGET_SRCROOT)/..\" \"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/libevent/include\"",
+                               "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
                              }.merge!(build_type == :debug ? { "GCC_PREPROCESSOR_DEFINITIONS" => "HERMES_ENABLE_DEBUGGER=1" } : {})
   s.header_dir             = "reacthermes"
   s.dependency "React-cxxreact", version

--- a/ReactCommon/hermes/executor/CMakeLists.txt
+++ b/ReactCommon/hermes/executor/CMakeLists.txt
@@ -6,6 +6,8 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
+add_compile_options(-std=c++17)
+
 file(GLOB_RECURSE hermes_executor_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(
         hermes-executor-common

--- a/ReactCommon/hermes/inspector/CMakeLists.txt
+++ b/ReactCommon/hermes/inspector/CMakeLists.txt
@@ -17,6 +17,7 @@ target_compile_options(
         PRIVATE
         -DHERMES_ENABLE_DEBUGGER=1
         -DHERMES_INSPECTOR_FOLLY_KLUDGE=1
+        -std=c++17
         -fexceptions
 )
 

--- a/ReactCommon/jsiexecutor/CMakeLists.txt
+++ b/ReactCommon/jsiexecutor/CMakeLists.txt
@@ -6,7 +6,11 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-fexceptions -frtti -O3)
+add_compile_options(
+        -fexceptions
+        -frtti
+        -std=c++17
+        -O3)
 
 add_library(jsireact
         STATIC

--- a/ReactCommon/jsiexecutor/React-jsiexecutor.podspec
+++ b/ReactCommon/jsiexecutor/React-jsiexecutor.podspec
@@ -31,7 +31,8 @@ Pod::Spec.new do |s|
   s.source                 = source
   s.source_files         = "jsireact/*.{cpp,h}"
   s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
-  s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/DoubleConversion\"" }
+  s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/DoubleConversion\"",
+                               "CLANG_CXX_LANGUAGE_STANDARD" => "c++17" }
   s.header_dir             = "jsireact"
 
   s.dependency "React-cxxreact", version

--- a/ReactCommon/jsinspector/CMakeLists.txt
+++ b/ReactCommon/jsinspector/CMakeLists.txt
@@ -6,7 +6,9 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-fexceptions)
+add_compile_options(
+        -fexceptions
+        -std=c++17)
 
 file(GLOB jsinspector_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(jsinspector SHARED ${jsinspector_SRC})

--- a/ReactCommon/jsinspector/React-jsinspector.podspec
+++ b/ReactCommon/jsinspector/React-jsinspector.podspec
@@ -27,4 +27,5 @@ Pod::Spec.new do |s|
   s.source                 = source
   s.source_files           = "*.{cpp,h}"
   s.header_dir             = 'jsinspector'
+  s.pod_target_xcconfig    = { "CLANG_CXX_LANGUAGE_STANDARD" => "c++17" }
 end


### PR DESCRIPTION
Summary:
This raises the C++ language standard to C++17 which is needed to remove some folly:: dependencies

changelog: [Internal]

Differential Revision: D41482821

