### PR TITLE
Replace folly::Optional with std::optional

### DIFF
--- a/React/CoreModules/RCTPlatform.mm
+++ b/React/CoreModules/RCTPlatform.mm
@@ -15,7 +15,7 @@
 
 #import "CoreModulesPlugins.h"
 
-#import <folly/Optional.h>
+#import <optional>
 
 using namespace facebook::react;
 
@@ -75,7 +75,7 @@ RCT_EXPORT_MODULE(PlatformConstants)
              .major = [versions[@"major"] doubleValue],
              .patch = [versions[@"patch"] doubleValue],
              .prerelease = [versions[@"prerelease"] isKindOfClass:[NSNull class]]
-                 ? folly::Optional<double>{}
+                 ? std::optional<double>{}
                  : [versions[@"prerelease"] doubleValue]}),
     });
   });

--- a/React/CxxModule/RCTNativeModule.mm
+++ b/React/CxxModule/RCTNativeModule.mm
@@ -160,7 +160,7 @@ static MethodCallResult invokeInner(
        */
       BridgeNativeModulePerfLogger::syncMethodCallFail("N/A", "N/A");
     }
-    return folly::none;
+    return std::nullopt;
   }
 
   id<RCTBridgeMethod> method = moduleData.methods[methodId];
@@ -231,7 +231,7 @@ static MethodCallResult invokeInner(
     RCT_PROFILE_END_EVENT(RCTProfileTagAlways, @"");
   }
 
-  return folly::none;
+  return std::nullopt;
 }
 
 }

--- a/ReactAndroid/src/main/jni/react/jni/JavaModuleWrapper.cpp
+++ b/ReactAndroid/src/main/jni/react/jni/JavaModuleWrapper.cpp
@@ -62,7 +62,7 @@ std::string JavaNativeModule::getSyncMethodName(unsigned int reactMethodId) {
 
   auto &methodInvoker = syncMethods_[reactMethodId];
 
-  if (!methodInvoker.hasValue()) {
+  if (!methodInvoker.has_value()) {
     throw std::invalid_argument(folly::to<std::string>(
         "methodId ", reactMethodId, " is not a recognized sync method"));
   }
@@ -147,7 +147,7 @@ MethodCallResult JavaNativeModule::callSerializableNativeHook(
   }
 
   auto &method = syncMethods_[reactMethodId];
-  CHECK(method.hasValue() && method->isSyncHook())
+  CHECK(method.has_value() && method->isSyncHook())
       << "Trying to invoke a asynchronous method as synchronous hook";
   return method->invoke(instance_, wrapper_->getModule(), params);
 }

--- a/ReactAndroid/src/main/jni/react/jni/JavaModuleWrapper.h
+++ b/ReactAndroid/src/main/jni/react/jni/JavaModuleWrapper.h
@@ -9,7 +9,7 @@
 
 #include <cxxreact/NativeModule.h>
 #include <fbjni/fbjni.h>
-#include <folly/Optional.h>
+#include <optional>
 
 #include "MethodInvoker.h"
 
@@ -82,7 +82,7 @@ class JavaNativeModule : public NativeModule {
   std::weak_ptr<Instance> instance_;
   jni::global_ref<JavaModuleWrapper::javaobject> wrapper_;
   std::shared_ptr<MessageQueueThread> messageQueueThread_;
-  std::vector<folly::Optional<MethodInvoker>> syncMethods_;
+  std::vector<std::optional<MethodInvoker>> syncMethods_;
 };
 
 } // namespace react

--- a/ReactAndroid/src/main/jni/react/jni/MethodInvoker.cpp
+++ b/ReactAndroid/src/main/jni/react/jni/MethodInvoker.cpp
@@ -279,7 +279,7 @@ MethodCallResult MethodInvoker::invoke(
     case 'v':
       env->CallVoidMethodA(module.get(), method_, args);
       throwPendingJniExceptionAsCppException();
-      return folly::none;
+      return std::nullopt;
 
     case 'z':
       PRIMITIVE_CASE_CASTING(Boolean, bool)
@@ -307,7 +307,7 @@ MethodCallResult MethodInvoker::invoke(
 
     default:
       LOG(FATAL) << "Unknown return type: " << returnType;
-      return folly::none;
+      return std::nullopt;
   }
 }
 

--- a/ReactAndroid/src/main/jni/react/jni/ReadableNativeMap.h
+++ b/ReactAndroid/src/main/jni/react/jni/ReadableNativeMap.h
@@ -8,9 +8,9 @@
 #pragma once
 
 #include <fbjni/fbjni.h>
-#include <folly/Optional.h>
 #include <folly/dynamic.h>
 #include <folly/json.h>
+#include <optional>
 
 #include "NativeCommon.h"
 #include "NativeMap.h"
@@ -38,7 +38,7 @@ struct ReadableNativeMap : jni::HybridClass<ReadableNativeMap, NativeMap> {
   jni::local_ref<jni::JArrayClass<jstring>> importKeys();
   jni::local_ref<jni::JArrayClass<jobject>> importValues();
   jni::local_ref<jni::JArrayClass<jobject>> importTypes();
-  folly::Optional<folly::dynamic> keys_;
+  std::optional<folly::dynamic> keys_;
   static jni::local_ref<jhybridobject> createWithContents(folly::dynamic &&map);
 
   static void mapException(const std::exception &ex);

--- a/ReactCommon/cxxreact/ModuleRegistry.cpp
+++ b/ReactCommon/cxxreact/ModuleRegistry.cpp
@@ -92,8 +92,7 @@ std::vector<std::string> ModuleRegistry::moduleNames() {
   return names;
 }
 
-folly::Optional<ModuleConfig> ModuleRegistry::getConfig(
-    const std::string &name) {
+std::optional<ModuleConfig> ModuleRegistry::getConfig(const std::string &name) {
   SystraceSection s("ModuleRegistry::getConfig", "module", name);
 
   // Initialize modulesByName_
@@ -107,14 +106,14 @@ folly::Optional<ModuleConfig> ModuleRegistry::getConfig(
     if (unknownModules_.find(name) != unknownModules_.end()) {
       BridgeNativeModulePerfLogger::moduleJSRequireBeginningFail(name.c_str());
       BridgeNativeModulePerfLogger::moduleJSRequireEndingStart(name.c_str());
-      return folly::none;
+      return std::nullopt;
     }
 
     if (!moduleNotFoundCallback_) {
       unknownModules_.insert(name);
       BridgeNativeModulePerfLogger::moduleJSRequireBeginningFail(name.c_str());
       BridgeNativeModulePerfLogger::moduleJSRequireEndingStart(name.c_str());
-      return folly::none;
+      return std::nullopt;
     }
 
     BridgeNativeModulePerfLogger::moduleJSRequireBeginningEnd(name.c_str());
@@ -128,7 +127,7 @@ folly::Optional<ModuleConfig> ModuleRegistry::getConfig(
     if (!wasModuleRegisteredWithRegistry) {
       BridgeNativeModulePerfLogger::moduleJSRequireEndingStart(name.c_str());
       unknownModules_.insert(name);
-      return folly::none;
+      return std::nullopt;
     }
   } else {
     BridgeNativeModulePerfLogger::moduleJSRequireBeginningEnd(name.c_str());
@@ -187,7 +186,7 @@ folly::Optional<ModuleConfig> ModuleRegistry::getConfig(
 
   if (config.size() == 2 && config[1].empty()) {
     // no constants or methods
-    return folly::none;
+    return std::nullopt;
   } else {
     return ModuleConfig{index, std::move(config)};
   }

--- a/ReactCommon/cxxreact/ModuleRegistry.h
+++ b/ReactCommon/cxxreact/ModuleRegistry.h
@@ -12,8 +12,8 @@
 #include <vector>
 
 #include <cxxreact/JSExecutor.h>
-#include <folly/Optional.h>
 #include <folly/dynamic.h>
+#include <optional>
 
 #ifndef RN_EXPORT
 #define RN_EXPORT __attribute__((visibility("default")))
@@ -47,7 +47,7 @@ class RN_EXPORT ModuleRegistry {
 
   std::vector<std::string> moduleNames();
 
-  folly::Optional<ModuleConfig> getConfig(const std::string &name);
+  std::optional<ModuleConfig> getConfig(const std::string &name);
 
   void callNativeMethod(
       unsigned int moduleId,

--- a/ReactCommon/cxxreact/NativeModule.h
+++ b/ReactCommon/cxxreact/NativeModule.h
@@ -10,8 +10,8 @@
 #include <string>
 #include <vector>
 
-#include <folly/Optional.h>
 #include <folly/dynamic.h>
+#include <optional>
 
 namespace facebook {
 namespace react {
@@ -25,7 +25,7 @@ struct MethodDescriptor {
       : name(std::move(n)), type(std::move(t)) {}
 };
 
-using MethodCallResult = folly::Optional<folly::dynamic>;
+using MethodCallResult = std::optional<folly::dynamic>;
 
 class NativeModule {
  public:

--- a/ReactCommon/jsiexecutor/jsireact/JSIExecutor.cpp
+++ b/ReactCommon/jsiexecutor/jsireact/JSIExecutor.cpp
@@ -495,20 +495,21 @@ Value JSIExecutor::nativeCallSyncHook(const Value *args, size_t count) {
 
   /**
    * Note:
-   * In RCTNativeModule, folly::none is returned from callSerializableNativeHook
-   * when executing a NativeModule method fails. Therefore, it's safe to not
-   * terminate the syncMethodCall when folly::none is returned.
+   * In RCTNativeModule, std::nullopt is returned from
+   * callSerializableNativeHook when executing a NativeModule method fails.
+   * Therefore, it's safe to not terminate the syncMethodCall when std::nullopt
+   * is returned.
    *
-   * TODO: In JavaNativeModule, folly::none is returned when the synchronous
+   * TODO: In JavaNativeModule, std::nullopt is returned when the synchronous
    * NativeModule method has the void return type. Change this to return
-   * folly::dynamic(nullptr) instead, so that folly::none is reserved for
+   * folly::dynamic(nullptr) instead, so that std::nullopt is reserved for
    * exceptional scenarios.
    *
-   * TODO: Investigate CxxModule infra to see if folly::none is used for
+   * TODO: Investigate CxxModule infra to see if std::nullopt is used for
    * returns in exceptional scenarios.
    **/
 
-  if (!result.hasValue()) {
+  if (!result.has_value()) {
     return Value::undefined();
   }
 

--- a/ReactCommon/jsiexecutor/jsireact/JSIExecutor.h
+++ b/ReactCommon/jsiexecutor/jsireact/JSIExecutor.h
@@ -15,6 +15,7 @@
 #include <jsi/jsi.h>
 #include <functional>
 #include <mutex>
+#include <optional>
 
 namespace facebook {
 namespace react {
@@ -127,9 +128,9 @@ class JSIExecutor : public JSExecutor {
   JSIScopedTimeoutInvoker scopedTimeoutInvoker_;
   RuntimeInstaller runtimeInstaller_;
 
-  folly::Optional<jsi::Function> callFunctionReturnFlushedQueue_;
-  folly::Optional<jsi::Function> invokeCallbackAndReturnFlushedQueue_;
-  folly::Optional<jsi::Function> flushedQueue_;
+  std::optional<jsi::Function> callFunctionReturnFlushedQueue_;
+  std::optional<jsi::Function> invokeCallbackAndReturnFlushedQueue_;
+  std::optional<jsi::Function> flushedQueue_;
 };
 
 using Logger =

--- a/ReactCommon/jsiexecutor/jsireact/JSINativeModules.cpp
+++ b/ReactCommon/jsiexecutor/jsireact/JSINativeModules.cpp
@@ -45,7 +45,7 @@ Value JSINativeModules::getModule(Runtime &rt, const PropNameID &name) {
   }
 
   auto module = createModule(rt, moduleName);
-  if (!module.hasValue()) {
+  if (!module.has_value()) {
     BridgeNativeModulePerfLogger::moduleJSRequireEndingFail(moduleName.c_str());
     // Allow lookup to continue in the objects own properties, which allows for
     // overrides of NativeModules
@@ -61,11 +61,11 @@ Value JSINativeModules::getModule(Runtime &rt, const PropNameID &name) {
 }
 
 void JSINativeModules::reset() {
-  m_genNativeModuleJS = folly::none;
+  m_genNativeModuleJS = std::nullopt;
   m_objects.clear();
 }
 
-folly::Optional<Object> JSINativeModules::createModule(
+std::optional<Object> JSINativeModules::createModule(
     Runtime &rt,
     const std::string &name) {
   bool hasLogger(ReactMarker::logTaggedMarker);
@@ -80,8 +80,8 @@ folly::Optional<Object> JSINativeModules::createModule(
   }
 
   auto result = m_moduleRegistry->getConfig(name);
-  if (!result.hasValue()) {
-    return folly::none;
+  if (!result.has_value()) {
+    return std::nullopt;
   }
 
   Value moduleInfo = m_genNativeModuleJS->call(
@@ -92,7 +92,7 @@ folly::Optional<Object> JSINativeModules::createModule(
   CHECK(moduleInfo.isObject())
       << "Module returned from genNativeModule isn't an Object";
 
-  folly::Optional<Object> module(
+  std::optional<Object> module(
       moduleInfo.asObject(rt).getPropertyAsObject(rt, "module"));
 
   if (hasLogger) {

--- a/ReactCommon/jsiexecutor/jsireact/JSINativeModules.h
+++ b/ReactCommon/jsiexecutor/jsireact/JSINativeModules.h
@@ -11,8 +11,8 @@
 #include <string>
 
 #include <cxxreact/ModuleRegistry.h>
-#include <folly/Optional.h>
 #include <jsi/jsi.h>
+#include <optional>
 
 namespace facebook {
 namespace react {
@@ -27,11 +27,11 @@ class JSINativeModules {
   void reset();
 
  private:
-  folly::Optional<jsi::Function> m_genNativeModuleJS;
+  std::optional<jsi::Function> m_genNativeModuleJS;
   std::shared_ptr<ModuleRegistry> m_moduleRegistry;
   std::unordered_map<std::string, jsi::Object> m_objects;
 
-  folly::Optional<jsi::Object> createModule(
+  std::optional<jsi::Object> createModule(
       jsi::Runtime &rt,
       const std::string &name);
 };

--- a/ReactCommon/react/renderer/components/text/ParagraphShadowNode.h
+++ b/ReactCommon/react/renderer/components/text/ParagraphShadowNode.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <folly/Optional.h>
 #include <react/renderer/components/text/ParagraphEventEmitter.h>
 #include <react/renderer/components/text/ParagraphProps.h>
 #include <react/renderer/components/text/ParagraphState.h>

--- a/packages/hermes-inspector-msggen/__tests__/HeaderWriterTest.js
+++ b/packages/hermes-inspector-msggen/__tests__/HeaderWriterTest.js
@@ -45,7 +45,7 @@ test('emits type decl', () => {
 
       runtime::ScriptId scriptId{};
       int lineNumber{};
-      folly::Optional<int> columnNumber;
+      std::optional<int> columnNumber;
     };
   `);
 });

--- a/packages/hermes-inspector-msggen/__tests__/PropertyTest.js
+++ b/packages/hermes-inspector-msggen/__tests__/PropertyTest.js
@@ -41,7 +41,7 @@ test('parses optional primitive prop', () => {
   expect(prop.optional).toBe(true);
   expect(prop.description).toBe('Average sample interval in bytes.');
 
-  expect(prop.getFullCppType()).toBe('folly::Optional<double>');
+  expect(prop.getFullCppType()).toBe('std::optional<double>');
   expect(prop.getCppIdentifier()).toBe('samplingInterval');
   expect(prop.getInitializer()).toBe('');
 });
@@ -61,7 +61,7 @@ test('parses optional ref prop', () => {
   expect(prop.$ref).toBe('Runtime.ExceptionDetails');
   expect(prop.description).toBe('Exception details if any.');
 
-  expect(prop.getFullCppType()).toBe('folly::Optional<runtime::ExceptionDetails>');
+  expect(prop.getFullCppType()).toBe('std::optional<runtime::ExceptionDetails>');
   expect(prop.getCppIdentifier()).toBe('exceptionDetails');
   expect(prop.getInitializer()).toBe('');
 });
@@ -105,7 +105,7 @@ test('parses optional array items prop', () => {
   expect(prop.items).toEqual({ 'type': 'string' });
   expect(prop.description).toBe('Hit breakpoints IDs');
 
-  expect(prop.getFullCppType()).toBe('folly::Optional<std::vector<std::string>>');
+  expect(prop.getFullCppType()).toBe('std::optional<std::vector<std::string>>');
   expect(prop.getCppIdentifier()).toBe('hitBreakpoints');
   expect(prop.getInitializer()).toBe('');
 });

--- a/packages/hermes-inspector-msggen/src/HeaderWriter.js
+++ b/packages/hermes-inspector-msggen/src/HeaderWriter.js
@@ -53,9 +53,8 @@ export class HeaderWriter {
 
       #include <hermes/inspector/chrome/MessageInterfaces.h>
 
+      #include <optional>
       #include <vector>
-
-      #include <folly/Optional.h>
 
       namespace facebook {
       namespace hermes {
@@ -242,7 +241,7 @@ function emitUnknownRequestDecl(stream: Writable) {
     folly::dynamic toDynamic() const override;
     void accept(RequestHandler &handler) const override;
 
-    folly::Optional<folly::dynamic> params;
+    std::optional<folly::dynamic> params;
   };
 
   `);
@@ -273,7 +272,7 @@ function emitErrorResponseDecl(stream: Writable) {
 
     int code;
     std::string message;
-    folly::Optional<folly::dynamic> data;
+    std::optional<folly::dynamic> data;
   };
 
   `);

--- a/packages/hermes-inspector-msggen/src/Property.js
+++ b/packages/hermes-inspector-msggen/src/Property.js
@@ -80,7 +80,7 @@ function maybeWrapOptional(
   recursive: ?boolean,
 ) {
   if (optional) {
-    return recursive ? `std::unique_ptr<${type}>` : `folly::Optional<${type}>`;
+    return recursive ? `std::unique_ptr<${type}>` : `std::optional<${type}>`;
   }
   return type;
 }
@@ -130,7 +130,7 @@ class PrimitiveProperty extends Property {
   }
 
   getInitializer(): string {
-    // folly::Optional doesn't need to be explicitly zero-init
+    // std::optional doesn't need to be explicitly zero-init
     if (this.optional) {
       return '';
     }


### PR DESCRIPTION
Summary:
Using std::optional as react-native has been using C++17 for quite some time

changelog: [Internal]

Differential Revision: D41415031

