### PR TITLE
Bump Flipper to 0.174.0

### DIFF
--- a/packages/rn-tester/android/app/gradle.properties
+++ b/packages/rn-tester/android/app/gradle.properties
@@ -10,7 +10,7 @@ android.useAndroidX=true
 android.enableJetifier=true
 
 # Version of flipper SDK to use with React Native
-FLIPPER_VERSION=0.125.0
+FLIPPER_VERSION=0.174.0
 
 # RN-Tester is building with NewArch always enabled
 newArchEnabled=true

--- a/template/android/gradle.properties
+++ b/template/android/gradle.properties
@@ -25,7 +25,7 @@ android.useAndroidX=true
 android.enableJetifier=true
 
 # Version of flipper SDK to use with React Native
-FLIPPER_VERSION=0.125.0
+FLIPPER_VERSION=0.174.0
 
 # Use this property to specify which architecture you want to build.
 # You can also override it from the CLI using


### PR DESCRIPTION
Summary:
As Flipper version is a bit old, let's bump it to the latest stable: 0.174.0.

This is a follow-up from D33583090 (https://github.com/facebook/react-native/commit/50057158ca32842d70160541e3cb5d4bd512f8f5).

At the time, it wasn't possible to update to the latest stable Flipper as crashes were observed due to NDK mismatch.

Changelog:
[Android] [Changed] - Bump Flipper to 0.174.0

Differential Revision: D41492705

