### PR TITLE
feat(ios): allow for custom project dir in react-native-xcode script

### DIFF
--- a/packages/rn-tester/.xcode.env
+++ b/packages/rn-tester/.xcode.env
@@ -11,6 +11,6 @@
 export NODE_BINARY=$(command -v node)
 
 # If you're not using the default file structure, e.g. a monorepo
-# then you can pass in the directory below, this must be realtive
+# then you can pass in the directory, this must be realtive
 # to the top level node_modules folder
 # export CUSTOM_DIR=

--- a/packages/rn-tester/.xcode.env
+++ b/packages/rn-tester/.xcode.env
@@ -9,3 +9,8 @@
 # For example, to use nvm with brew, add the following line
 # . "$(brew --prefix nvm)/nvm.sh" --no-use
 export NODE_BINARY=$(command -v node)
+
+# If you're not using the default file structure, e.g. a monorepo
+# then you can pass in the directory below, this must be realtive
+# to the top level node_modules folder
+# export CUSTOM_DIR=

--- a/packages/rn-tester/.xcode.env
+++ b/packages/rn-tester/.xcode.env
@@ -11,6 +11,6 @@
 export NODE_BINARY=$(command -v node)
 
 # If you're not using the default file structure, e.g. a monorepo
-# then you can pass in the directory, this must be realtive
-# to the top level node_modules folder
-# export CUSTOM_DIR=
+# then you can pass in the root react native directory.
+# E.g. To set it to be the parent directory of the ios folder
+# export PROJECT_ROOT="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )/../"

--- a/scripts/react-native-xcode.sh
+++ b/scripts/react-native-xcode.sh
@@ -60,7 +60,7 @@ esac
 REACT_NATIVE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # The project should be located next to where react-native is installed
 # in node_modules.
-PROJECT_ROOT=${PROJECT_ROOT:-"$REACT_NATIVE_DIR/../.."}
+PROJECT_ROOT=${PROJECT_ROOT:-"$REACT_NATIVE_DIR/../../$CUSTOM_DIR"}
 
 cd "$PROJECT_ROOT" || exit
 

--- a/scripts/react-native-xcode.sh
+++ b/scripts/react-native-xcode.sh
@@ -60,7 +60,7 @@ esac
 REACT_NATIVE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # The project should be located next to where react-native is installed
 # in node_modules.
-PROJECT_ROOT=${PROJECT_ROOT:-"$REACT_NATIVE_DIR/../../$CUSTOM_DIR"}
+PROJECT_ROOT=${PROJECT_ROOT:-"$REACT_NATIVE_DIR/../.."}
 
 cd "$PROJECT_ROOT" || exit
 


### PR DESCRIPTION
## Summary
The `react-native-xcode` script assumes the that `node_modules` folder are in the same location as the react native project. This adds the ability to declare `CUSTOM_DIR` in `.xcode.env` file to let react-native-xcode know where the react native project is located - required for monorepos

## Issue
At the moment if a project is not using the default react native file structure then when trying to create a build or archive using Xcode it will fail, with the following error:

> File /Users/itxch/Library/Developer/Xcode/DerivedData/app-evgjukoxhuupzzdglopjnhcntvpw/Build/Intermediates.noindex/ArchiveIntermediates/jungul/BuildProductsPath/Release-iphoneos/app.app/main.jsbundle does not exist. This must be a bug with React Native, please report it here: https://github.com/facebook/react-native/issues

## Background
My project is a monorepo, using `npm` workspaces. 

#### This is the relevant file structure
![files](https://user-images.githubusercontent.com/54910400/203641210-596ee866-9f9f-429c-8bae-62d0f3afc623.png)

This file structure is incompatible with line 63 of `react-native-xcode.sh`

https://github.com/facebook/react-native/blob/c5a8425fada10b715f356731426db666975569c9/scripts/react-native-xcode.sh#L63
Note: `$REACT_NATIVE_DIR` is the `react-native` package directory inside node modules. 

So by default this sets project root to be the parent folder of the `node_modules` folder. However in my case this is not correct, it should actually be:
```sh
PROJECT_ROOT=${PROJECT_ROOT:-"$REACT_NATIVE_DIR/../../app"}
```

## Solution
Seeing as hardcoding the value would not work, the simplest solution is to set the directory via a variable
```sh
PROJECT_ROOT=${PROJECT_ROOT:-"$REACT_NATIVE_DIR/../../$CUSTOM_DIR"}
```
`$CUSTOM_DIR` can easily be set via `.xcode.env` file.



## Changelog
[IOS] [Added] - allow for custom project dir in react-native-xcode script

## Test Plan
After updating my `.xcode.env` file to include `export CUSTOM_DIR=app`, I can successfully create a build or an archive.
If the variable is not set it will be black, so it will not effect `$PROJECT_ROOT`

