### PR TITLE
RNGP - Correctly Support Gradle Configuration Cache

### DIFF
--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
@@ -96,7 +96,8 @@ class ReactPlugin : Plugin<Project> {
           // Please note that appNeedsCodegen is triggering a read of the package.json at
           // configuration time as we need to feed the onlyIf condition of this task.
           // Therefore, the appNeedsCodegen needs to be invoked inside this lambda.
-          it.onlyIf { isLibrary || project.needsCodegenFromPackageJson(extension) }
+          val needsCodegenFromPackageJson = project.needsCodegenFromPackageJson(extension)
+          it.onlyIf { isLibrary || needsCodegenFromPackageJson }
         }
 
     // We create the task to produce schema from JS files.
@@ -120,7 +121,8 @@ class ReactPlugin : Plugin<Project> {
               } else {
                 it.jsRootDir.set(extension.jsRootDir)
               }
-              it.onlyIf { isLibrary || project.needsCodegenFromPackageJson(parsedPackageJson) }
+              val needsCodegenFromPackageJson = project.needsCodegenFromPackageJson(extension)
+              it.onlyIf { isLibrary || needsCodegenFromPackageJson }
             }
 
     // We create the task to generate Java code from schema.
@@ -139,7 +141,8 @@ class ReactPlugin : Plugin<Project> {
               // Please note that appNeedsCodegen is triggering a read of the package.json at
               // configuration time as we need to feed the onlyIf condition of this task.
               // Therefore, the appNeedsCodegen needs to be invoked inside this lambda.
-              it.onlyIf { isLibrary || project.needsCodegenFromPackageJson(extension) }
+              val needsCodegenFromPackageJson = project.needsCodegenFromPackageJson(extension)
+              it.onlyIf { isLibrary || needsCodegenFromPackageJson }
             }
 
     // We update the android configuration to include the generated sources.


### PR DESCRIPTION
Summary:
This little change allows to support Gradle Configuration cache in user projects:
https://docs.gradle.org/current/userguide/configuration_cache.html

It allows to save several seconds on the build time.
We'll keep it disabled for now, but Gradle plans to enable it by default for everyone
in the future, so this changes makes us ready for it.

Changelog:
[Internal] [Changed] - RNGP - Correctly Support Gradle Configuration Cache

Differential Revision: D41519506

