### PR TITLE
Store RN Tester and Template APKs for Android on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -710,16 +710,6 @@ jobs:
       - checkout
       - setup_artifacts
       - run_yarn
-
-      # Starting emulator in advance as it takes some time to boot.
-      - run:
-          name: Create Android Virtual Device
-          command: source scripts/android-setup.sh && createAVD
-      - run:
-          name: Launch Android Virtual Device in Background
-          command: source scripts/android-setup.sh && launchAVD
-          background: true
-
       - download_gradle_dependencies
 
       - run:
@@ -729,11 +719,6 @@ jobs:
       - run:
           name: Build RN Tester for Release using Gradle
           command: ./gradlew packages:rn-tester:android:app:assembleRelease
-
-      # Wait for AVD to finish booting before running tests
-      - run:
-          name: Wait for Android Virtual Device
-          command: source scripts/android-setup.sh && waitForAVD
 
       - report_bundle_size:
           platform: android

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -723,6 +723,10 @@ jobs:
       - report_bundle_size:
           platform: android
 
+      - store_artifacts:
+          path: ~/react-native/packages/rn-tester/android/app/build/outputs/apk/
+          destination: rntester-apk
+
       # Optionally, run disabled tests
       - when:
           condition: << parameters.run_disabled_tests >>
@@ -781,6 +785,10 @@ jobs:
               export ORG_GRADLE_PROJECT_hermesEnabled=false
             fi
             ./gradlew assemble<< parameters.flavor >> -PREACT_NATIVE_MAVEN_LOCAL_REPO=/root/react-native/maven-local
+
+      - store_artifacts:
+          path: /tmp/$PROJECT_NAME/android/app/build/outputs/apk/
+          destination: template-apk
 
   # -------------------------
   #    JOBS: Test iOS Template


### PR DESCRIPTION
Summary:
This will allow us to easily retrieve debug/release APK for
both RN-Tester and the Template jobs for every run of the CI.

Changelog:
[Internal] [Changed] - Store RN Tester and Template APKs for Android on CI

Differential Revision: D41521977

