### PR TITLE
Build RNTester Release inside buildAll

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -726,10 +726,6 @@ jobs:
           name: Build & Test React Native using Gradle
           command: ./gradlew buildAll
 
-      - run:
-          name: Build RN Tester for Release using Gradle
-          command: ./gradlew packages:rn-tester:android:app:assembleRelease
-
       # Wait for AVD to finish booting before running tests
       - run:
           name: Wait for Android Virtual Device

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -89,8 +89,8 @@ tasks.register("buildAll") {
   dependsOn(":ReactAndroid:assemble")
   // This creates all the Maven artifacts and makes them available in the /android folder
   dependsOn(":ReactAndroid:installArchives")
-  // This builds RN Tester for Hermes/JSC for debug only
-  dependsOn(":packages:rn-tester:android:app:assembleDebug")
+  // This builds RN Tester for Hermes/JSC for debug and release
+  dependsOn(":packages:rn-tester:android:app:assemble")
   // This compiles the Unit Test sources (without running them as they're partially broken)
   dependsOn(":ReactAndroid:compileDebugUnitTestSources")
   dependsOn(":ReactAndroid:compileReleaseUnitTestSources")


### PR DESCRIPTION
Summary:
This extends the buildAll task to build both RNTester Debug and Release
We can finally do this now as debug and release are fully isolated
and don't clash on each other.

Changelog:
[Internal] [Changed] - Build RNTester Release inside buildAll

Differential Revision: D41521995

