### PR TITLE
remove return type from constructor

### DIFF
--- a/Libraries/Events/EventPolyfill.js
+++ b/Libraries/Events/EventPolyfill.js
@@ -159,7 +159,7 @@ class EventPolyfill implements IEvent {
   // data with the other in sync.
   _syntheticEvent: mixed;
 
-  constructor(type: string, eventInitDict?: Event$Init): void {
+  constructor(type: string, eventInitDict?: Event$Init) {
     this.type = type;
     this.bubbles = !!(eventInitDict?.bubbles || false);
     this.cancelable = !!(eventInitDict?.cancelable || false);


### PR DESCRIPTION
## Summary

I'm getting `node_modules/react-native/Libraries/Events/EventPolyfill.js: Unexpected token, expected "{"` when building an app. Looking at the source code, it seems odd there'd be a return type defined for a constructor. Unless I'm missing something (I don't use flow), I think it should be removed?

## Changelog

[Internal] [Fixed] - Remove return type from constructor

## Test Plan

N/A