### PR TITLE
Use the right logic to decide when we build Hermes from source

### DIFF
--- a/scripts/cocoapods/__tests__/jsengine-test.rb
+++ b/scripts/cocoapods/__tests__/jsengine-test.rb
@@ -14,8 +14,10 @@ class JSEngineTests < Test::Unit::TestCase
     :react_native_path
 
     def setup
+        File.enable_testing_mode!
         @react_native_path = "../.."
         podSpy_cleanUp()
+
     end
 
     def teardown
@@ -25,6 +27,8 @@ class JSEngineTests < Test::Unit::TestCase
         Pod::UI.reset()
         podSpy_cleanUp()
         ENV['USE_HERMES'] = '1'
+        ENV['CI'] = nil
+        File.reset()
     end
 
     # =============== #
@@ -125,16 +129,26 @@ class JSEngineTests < Test::Unit::TestCase
     # TEST - isBuildingHermesFromSource #
     # ================================= #
     def test_isBuildingHermesFromSource_whenTarballIsNilAndVersionIsNotNightly_returnTrue
-        assert_true(is_building_hermes_from_source("1000.0.0"))
+        assert_true(is_building_hermes_from_source("1000.0.0", '../..'))
+    end
+
+    def test_isBuildingHermesFromSource_whenTarballIsNilAndInReleaseBranch_returnTrue
+        ENV['CI'] = 'true'
+        File.mocked_existing_files(['../../sdks/.hermesversion'])
+        assert_true(is_building_hermes_from_source("0.999.0", '../..'))
     end
 
     def test_isBuildingHermesFromSource_whenTarballIsNotNil_returnFalse
         ENV['HERMES_ENGINE_TARBALL_PATH'] = "~/Downloads/hermes-ios-debug.tar.gz"
-        assert_false(is_building_hermes_from_source("1000.0.0"))
+        assert_false(is_building_hermes_from_source("1000.0.0", '../..'))
     end
 
     def test_isBuildingHermesFromSource_whenIsNigthly_returnsFalse
-        assert_false(is_building_hermes_from_source("0.0.0-"))
+        assert_false(is_building_hermes_from_source("0.0.0-", '../..'))
+    end
+
+    def test_isBuildingHermesFromSource_whenIsStbleRelease_returnsFalse
+        assert_false(is_building_hermes_from_source("0.71.0", '../..'))
     end
 
 end

--- a/scripts/cocoapods/jsengine.rb
+++ b/scripts/cocoapods/jsengine.rb
@@ -60,14 +60,19 @@ def remove_copy_hermes_framework_script_phase(installer, react_native_path)
     project.save()
 end
 
-def is_building_hermes_from_source(react_native_version)
-    is_nightly = react_native_version.start_with?('0.0.0-')
-    has_tarball = ENV['HERMES_ENGINE_TARBALL_PATH'] != nil
-
-    # this is the same logic in the hermes-engine.podspec
-    if has_tarball || is_nightly
+# TODO: Use this same function in the `hermes-engine.podspec` somehow
+def is_building_hermes_from_source(react_native_version, react_native_path)
+    if ENV['HERMES_ENGINE_TARBALL_PATH'] != nil
         return false
     end
 
-    return true
+    isInMain = react_native_version.include?('1000.0.0')
+
+    hermestag_file = File.join(react_native_path, "sdks", ".hermesversion")
+    isInCI = ENV['CI'] === 'true'
+
+    isReleaseBranch = File.exist?(hermestag_file) && isInCI
+
+
+    return isInMain || isReleaseBranch
 end

--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -205,7 +205,7 @@ def react_native_post_install(installer, react_native_path = "../node_modules/re
   package = JSON.parse(File.read(File.join(react_native_path, "package.json")))
   version = package['version']
 
-  if ReactNativePodsUtils.has_pod(installer, 'hermes-engine') && is_building_hermes_from_source(version)
+  if ReactNativePodsUtils.has_pod(installer, 'hermes-engine') && is_building_hermes_from_source(version, react_native_path)
     add_copy_hermes_framework_script_phase(installer, react_native_path)
   else
     remove_copy_hermes_framework_script_phase(installer, react_native_path)


### PR DESCRIPTION
## Summary

This PR backports the changes in 0.71 to apply the same logic to decide when we have to build Hermes from source in both the `hermes-engine.podspec` 
and in the `react_native_pods.rb` script.

## Changelog

[iOS] [Fixed] - Use the right logic to decide when we have to build from source 

## Test Plan

Working on RC2
