### PR TITLE
Bypass tag check in dry run (#35428)

### DIFF
--- a/scripts/bump-oss-version.js
+++ b/scripts/bump-oss-version.js
@@ -76,7 +76,7 @@ async function main() {
   );
   const token = argv.token;
   const releaseVersion = argv.toVersion;
-  failIfTagExists(releaseVersion);
+  failIfTagExists(releaseVersion, 'release');
 
   const {pushed} = await inquirer.prompt({
     type: 'confirm',

--- a/scripts/prepare-package-for-release.js
+++ b/scripts/prepare-package-for-release.js
@@ -50,7 +50,13 @@ const releaseVersion = argv.toVersion;
 const isLatest = argv.latest;
 const isDryRun = argv.dryRun;
 
-failIfTagExists(releaseVersion);
+const buildType = isDryRun
+  ? 'dry-run'
+  : isReleaseBranch(branch)
+  ? 'release'
+  : 'nightly';
+
+failIfTagExists(releaseVersion, buildType);
 
 if (branch && !isReleaseBranch(branch) && !isDryRun) {
   console.error(`This needs to be on a release branch. On branch: ${branch}`);
@@ -59,12 +65,6 @@ if (branch && !isReleaseBranch(branch) && !isDryRun) {
   console.error('This needs to be on a release branch.');
   exit(1);
 }
-
-const buildType = isDryRun
-  ? 'dry-run'
-  : isReleaseBranch(branch)
-  ? 'release'
-  : 'nightly';
 
 const {version} = parseVersion(releaseVersion, buildType);
 if (version == null) {

--- a/scripts/release-utils.js
+++ b/scripts/release-utils.js
@@ -115,7 +115,13 @@ function generateiOSArtifacts(
   return tarballOutputPath;
 }
 
-function failIfTagExists(version) {
+function failIfTagExists(version, buildType) {
+  // When dry-run in stable branch, the tag already exists.
+  // We are bypassing the tag-existence check when in a dry-run to have the CI pass
+  if (buildType === 'dry-run') {
+    return;
+  }
+
   if (checkIfTagExists(version)) {
     echo(`Tag v${version} already exists.`);
     echo('You may want to rollback the last commit');


### PR DESCRIPTION
## Summary

When dry-run in stable branch, the tag already exists. We are bypassing the tag-existence check when in a dry-run to have the CI pass

## Changelog

[General] [Fixed] - Bypass tag version check when dry-run

## Test Plan

CircleCI
It worked for RC1 and RC2
