### PR TITLE
fix(dependencies): move mockfs to the right package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,6 @@
     "metro-runtime": "0.73.3",
     "metro-source-map": "0.73.3",
     "mkdirp": "^0.5.1",
-    "mock-fs": "^5.1.4",
     "nullthrows": "^1.1.1",
     "pretty-format": "^26.5.2",
     "promise": "^8.3.0",
@@ -146,6 +145,7 @@
   "devDependencies": {
     "flow-bin": "^0.193.0",
     "hermes-eslint": "0.8.0",
+    "mock-fs": "^5.1.4",
     "react": "18.2.0",
     "react-test-renderer": "^18.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
     "metro-runtime": "0.73.3",
     "metro-source-map": "0.73.3",
     "mkdirp": "^0.5.1",
+    "mock-fs": "^5.1.4",
     "nullthrows": "^1.1.1",
     "pretty-format": "^26.5.2",
     "promise": "^8.3.0",

--- a/repo-config/package.json
+++ b/repo-config/package.json
@@ -54,8 +54,5 @@
     "typescript": "4.1.3",
     "ws": "^6.2.2",
     "yargs": "^17.5.1"
-  },
-  "devDependencies": {
-    "mock-fs": "^5.1.4"
   }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

While working on 0.71 we noticed that we were hitting a "mock-fs not found" issue on CI, caused by the fact that the dependency was set in the wrong spot.

This PR backports to main the fix: https://github.com/facebook/react-native/commit/05646f8f38b65abb9487a348d0ba7e02a35751d9 & https://github.com/facebook/react-native/commit/ceaebc69759e59bfc465722924fee98f2deac825

This is related to the black magics of repo-config, and the fact that devDeps from repo-config don't get propagated back to the root package.json when on stable branch. Because of that, this commit doesn't NOT have a yarn.lock entry (the dep is there in main).

I'm confused as to how that dep ended in the devDeps of repo config, it seems something went wrong in migrating some commits from GH to monorepo and back?
check out:
* https://github.com/facebook/react-native/pull/34580
* https://github.com/facebook/react-native/commit/f0ffd2291c850682e293d9a9ca3dbe7f46bf2e25

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[Internal] [Changed] - move mockfs to the right package.json

## Test Plan

N/A, change is transparent