### PR TITLE
fix(e2e script): backport from 71 fixes to the E2E script

### DIFF
--- a/scripts/release-utils.js
+++ b/scripts/release-utils.js
@@ -85,7 +85,6 @@ function generateiOSArtifacts(
   jsiFolder,
   hermesCoreSourceFolder,
   buildType,
-  releaseVersion,
   targetFolder,
 ) {
   pushd(`${hermesCoreSourceFolder}`);

--- a/scripts/release-utils.js
+++ b/scripts/release-utils.js
@@ -109,7 +109,6 @@ function generateiOSArtifacts(
   const tarballOutputPath = createHermesPrebuiltArtifactsTarball(
     hermesCoreSourceFolder,
     buildType,
-    releaseVersion,
     targetFolder,
     true, // this is excludeDebugSymbols, we keep it as the default
   );

--- a/scripts/test-e2e-local-clean.js
+++ b/scripts/test-e2e-local-clean.js
@@ -49,6 +49,9 @@ exec('rm -rf /tmp/maven-local');
 console.info('\n** Nuking the derived data folder **\n');
 exec('rm -rf ~/Library/Developer/Xcode/DerivedData');
 
+console.info('\n** Removing the hermes-engine pod cache **\n');
+exec('rm -rf ~/Library/Caches/CocoaPods/Pods/External/hermes-engine');
+
 // RNTester Pods
 console.info('\n** Removing the RNTester Pods **\n');
 exec('rm -rf packages/rn-tester/Pods');

--- a/scripts/test-e2e-local.js
+++ b/scripts/test-e2e-local.js
@@ -208,7 +208,6 @@ if (argv.target === 'RNTester') {
     jsiFolder,
     hermesCoreSourceFolder,
     buildTypeiOSArtifacts,
-    releaseVersion,
     localMavenPath,
   );
 

--- a/scripts/test-e2e-local.js
+++ b/scripts/test-e2e-local.js
@@ -198,7 +198,7 @@ if (argv.target === 'RNTester') {
 
   // for this scenario, we only need to create the debug build
   // (env variable PRODUCTION defines that podspec side)
-  const buildType = 'Debug';
+  const buildTypeiOSArtifacts = 'Debug';
 
   // the android ones get set into /private/tmp/maven-local
   const localMavenPath = '/private/tmp/maven-local';
@@ -207,7 +207,7 @@ if (argv.target === 'RNTester') {
   const tarballOutputPath = generateiOSArtifacts(
     jsiFolder,
     hermesCoreSourceFolder,
-    buildType,
+    buildTypeiOSArtifacts,
     releaseVersion,
     localMavenPath,
   );


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Because the /scripts folder for some reason is not typechecked at all, some changes broke the script and went undetected until we tried running it. This is a backport of those fixes:
* https://github.com/facebook/react-native/commit/67c373ff3a4ab0dfaaa752f08f6cc22657d4dadc
* https://github.com/facebook/react-native/commit/6107793fda11a85297b3a3e2b8f259930d6c0f41
* https://github.com/facebook/react-native/commit/6107793fda11a85297b3a3e2b8f259930d6c0f41

Also, it's backporting an improvement to the e2e local script clean to remove the hermes-engine pod cache which has been proven annoyingly in the way while testing:
* https://github.com/facebook/react-native/commit/9979e38c7093ba78db5d5b4b11456c78592ea8c5

## Changelog

[Internal] [Fixed] - Fix e2e script not working and augment clean script

## Test Plan

Works on 0.71 ;)
