### PR TITLE
chore: RCTConvert - allocate array with capacity

### DIFF
--- a/Libraries/TypeSafety/RCTConvertHelpers.h
+++ b/Libraries/TypeSafety/RCTConvertHelpers.h
@@ -23,7 +23,7 @@ using LazyVector = FB::LazyVector<T, id>;
 template <typename ContainerT>
 NSArray *RCTConvertVecToArray(const ContainerT &vec, id (^convertor)(typename ContainerT::value_type element))
 {
-  NSMutableArray *array = [[[NSMutableArray alloc] initWithCapacity:vec.size()];
+  NSMutableArray *array = [[NSMutableArray alloc] initWithCapacity:vec.size()];
   for (size_t i = 0, size = vec.size(); i < size; ++i) {
     id object = convertor(vec[i]);
     array[i] = object ?: (id)kCFNull;

--- a/Libraries/TypeSafety/RCTConvertHelpers.h
+++ b/Libraries/TypeSafety/RCTConvertHelpers.h
@@ -23,7 +23,7 @@ using LazyVector = FB::LazyVector<T, id>;
 template <typename ContainerT>
 NSArray *RCTConvertVecToArray(const ContainerT &vec, id (^convertor)(typename ContainerT::value_type element))
 {
-  NSMutableArray *array = [NSMutableArray new];
+  NSMutableArray *array = [[[NSMutableArray alloc] initWithCapacity:vec.size()];
   for (size_t i = 0, size = vec.size(); i < size; ++i) {
     id object = convertor(vec[i]);
     array[i] = object ?: (id)kCFNull;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

this is a trivial change that allocates the NSMutableArray with the correct capacity before it is filled

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[Internal] [Changed] - RCTConvertVecToArray - allocate array with capacity

## Test Plan

tested locally: the code builds and runs as expected
