### PR TITLE
[RN][iOS] Do not add LongLivedObject wrapper in OSS

### DIFF
--- a/ReactCommon/ReactCommon.podspec
+++ b/ReactCommon/ReactCommon.podspec
@@ -62,6 +62,7 @@ Pod::Spec.new do |s|
       sss.source_files = "react/nativemodule/core/ReactCommon/**/*.{cpp,h}",
                          "react/nativemodule/core/platform/ios/**/*.{mm,cpp,h}"
       sss.dependency "React-jsidynamic", version
+      sss.exclude_files = "react/nativemodule/core/ReactCommon/LongLivedObject.h"
     end
 
     ss.subspec "samples" do |sss|


### PR DESCRIPTION
## Summary

This change excludes the `LongLivedObject.h` file from the pod in the ReactCommon library. 

The file creates a problem when the `use_frameworks!` option is used in an app because there can't be two files with the same name, despite being in different paths, 
within the same framework. Specifically, this `LongLivedObject` is just a redirect to the other one, so it should be safe to exclude this.  

## Changelog

[iOS][Fixed] - Exclude redirector to `LongLivedObject.h` from ReactCommon podspec

## Test Plan

1. Manually tested in an app from RC2
