### PR TITLE
fix: codegen crash when parsing TS interfaces

### DIFF
--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -316,7 +316,7 @@ function translateTypeAnnotation(
 function isModuleInterface(node: $FlowFixMe) {
   return (
     node.type === 'TSInterfaceDeclaration' &&
-    node.extends.length === 1 &&
+    node.extends?.length === 1 &&
     node.extends[0].type === 'TSExpressionWithTypeArguments' &&
     node.extends[0].expression.name === 'TurboModule'
   );


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

when I'm defining a turbomodule spec, I tried to extract a common parameter into an interface.

The error I get is this:

```
[Codegen] >>>>> Processing RNSimpleToastSpec


[Codegen] Done.
/Users/vojta/_dev/_own/simple-toast/example/node_modules/react-native-codegen/lib/parsers/typescript/utils.js:111
        throw error;
        ^

TypeError: Cannot read properties of undefined (reading 'length')
    at isModuleInterface (/Users/vojta/_dev/_own/simple-toast/example/node_modules/react-native-codegen/lib/parsers/typescript/modules/index.js:695:18)
    at Array.filter (<anonymous>)
    at buildModuleSchema (/Users/vojta/_dev/_own/simple-toast/example/node_modules/react-native-codegen/lib/parsers/typescript/modules/index.js:709:44)
    at /Users/vojta/_dev/_own/simple-toast/example/node_modules/react-native-codegen/lib/parsers/typescript/index.js:158:9
    at guard (/Users/vojta/_dev/_own/simple-toast/example/node_modules/react-native-codegen/lib/parsers/typescript/utils.js:108:14)
    at buildSchema (/Users/vojta/_dev/_own/simple-toast/example/node_modules/react-native-codegen/lib/parsers/typescript/index.js:157:22)
    at Object.parseFile (/Users/vojta/_dev/_own/simple-toast/example/node_modules/react-native-codegen/lib/parsers/typescript/index.js:185:10)
```

After the fix I get this:

```
[Codegen] >>>>> Processing RNSimpleToastSpec


[Codegen] Done.
/Users/vojta/_dev/_own/simple-toast/example/node_modules/react-native-codegen/lib/parsers/typescript/utils.js:111
        throw error;
        ^

Invariant Violation: GenericTypeAnnotation 'Styles' must resolve to a TSTypeAliasDeclaration. Instead, it resolved to a 'TSInterfaceDeclaration'
```

Then I know that I should not be using an `interface` but a `type`


## Changelog

[Internal] [Fixed] - TS codegen crash when parsing interfaces

## Test Plan

tested locally

let me know if you want an automated test
