### PR TITLE
Move close-pr workflow from react-native-bot to actions/github-script@v6

### DIFF
--- a/.github/workflows/close_pr.yml
+++ b/.github/workflows/close_pr.yml
@@ -1,6 +1,10 @@
 name: Label closed PR as merged and leave a comment
 on:
   push
+  
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   comment-and-label:

--- a/.github/workflows/close_pr.yml
+++ b/.github/workflows/close_pr.yml
@@ -1,7 +1,7 @@
 name: Label closed PR as merged and leave a comment
-on: 
+on:
   push
-  
+
 jobs:
   comment-and-label:
     runs-on: ubuntu-latest
@@ -17,36 +17,36 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
             })).data;
-            
+
             // Looking at the commit message, checks which PR number, if any, was closed by this commit
             const getClosedPrIfExists = (commit) => {
               if(!commit || !commit.message) return;
-              const prClosingRegex = /Closes https:\/\/github.com\/SlyCaptainFlint\/react-native\/pull\/([0-9]+)|Pull Request resolved: https:\/\/github.com\/SlyCaptainFlint\/react-native\/pull\/([0-9]+)/;
+              const prClosingRegex = /Closes https:\/\/github.com\/facebook\/react-native\/pull\/([0-9]+)|Pull Request resolved: https:\/\/github.com\/facebook\/react-native\/pull\/([0-9]+)/;
               const prClosingMatch = commit.message.match(prClosingRegex);
               if(!prClosingMatch || (!prClosingMatch[1] && ! prClosingMatch[2])) return;
               return prClosingMatch[1] ?? prClosingMatch[2];
             };
-            
+
             const closedPrNumber = getClosedPrIfExists(commit);
             if(!closedPrNumber) return;
-            
+
             const pr = (await github.rest.pulls.get({
               pull_number: closedPrNumber,
               owner: context.repo.owner,
               repo: context.repo.repo,
             })).data;
-            
+
             // If the PR has already been processed (labeled as Merged), skip it
             const mergedLabel = "Merged";
             if(pr.labels && pr.labels.some(label => label.name === mergedLabel)) return;
-            
+
             github.rest.issues.createComment({
               issue_number: closedPrNumber,
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: `This pull request was successfully merged by ${commit.author.name} in **${sha}**.\n\n<sup>[When will my fix make it into a release?](https://github.com/facebook/react-native/wiki/Release-FAQ#when-will-my-fix-make-it-into-a-release) | [Upcoming Releases](https://github.com/reactwg/react-native-releases/discussions/categories/releases)</sup>`
             });
-            
+
             github.rest.issues.addLabels({
               issue_number: closedPrNumber,
               owner: context.repo.owner,

--- a/.github/workflows/close_pr.yml
+++ b/.github/workflows/close_pr.yml
@@ -1,11 +1,11 @@
 name: Label closed PR as merged and leave a comment
-on:
+on: 
   push
-  
+
 permissions:
   contents: read
   pull-requests: write
-
+  
 jobs:
   comment-and-label:
     runs-on: ubuntu-latest
@@ -16,41 +16,44 @@ jobs:
           script: |
             if(!context.payload.commits || !context.payload.commits.length) return;
             const sha = context.payload.commits[0].id;
-            const commit = (await github.rest.git.getCommit({
-              commit_sha: sha,
+            
+            const {commit, author} = (await github.rest.repos.getCommit({
+              ref: sha,
               owner: context.repo.owner,
               repo: context.repo.repo,
             })).data;
-
+        
             // Looking at the commit message, checks which PR number, if any, was closed by this commit
             const getClosedPrIfExists = (commit) => {
               if(!commit || !commit.message) return;
-              const prClosingRegex = /Closes https:\/\/github.com\/facebook\/react-native\/pull\/([0-9]+)|Pull Request resolved: https:\/\/github.com\/facebook\/react-native\/pull\/([0-9]+)/;
+              const prClosingRegex = /Closes https:\/\/github.com\/SlyCaptainFlint\/react-native\/pull\/([0-9]+)|Pull Request resolved: https:\/\/github.com\/SlyCaptainFlint\/react-native\/pull\/([0-9]+)/;
               const prClosingMatch = commit.message.match(prClosingRegex);
               if(!prClosingMatch || (!prClosingMatch[1] && ! prClosingMatch[2])) return;
               return prClosingMatch[1] ?? prClosingMatch[2];
             };
-
+            
             const closedPrNumber = getClosedPrIfExists(commit);
             if(!closedPrNumber) return;
-
+            
             const pr = (await github.rest.pulls.get({
               pull_number: closedPrNumber,
               owner: context.repo.owner,
               repo: context.repo.repo,
             })).data;
-
+            
             // If the PR has already been processed (labeled as Merged), skip it
             const mergedLabel = "Merged";
             if(pr.labels && pr.labels.some(label => label.name === mergedLabel)) return;
-
+            
+            const authorName = author?.login ? `@${author.login}` : commit.author.name;
+        
             github.rest.issues.createComment({
               issue_number: closedPrNumber,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `This pull request was successfully merged by ${commit.author.name} in **${sha}**.\n\n<sup>[When will my fix make it into a release?](https://github.com/facebook/react-native/wiki/Release-FAQ#when-will-my-fix-make-it-into-a-release) | [Upcoming Releases](https://github.com/reactwg/react-native-releases/discussions/categories/releases)</sup>`
+              body: `This pull request was successfully merged by ${authorName} in **${sha}**.\n\n<sup>[When will my fix make it into a release?](https://github.com/facebook/react-native/wiki/Release-FAQ#when-will-my-fix-make-it-into-a-release) | [Upcoming Releases](https://github.com/reactwg/react-native-releases/discussions/categories/releases)</sup>`
             });
-
+            
             github.rest.issues.addLabels({
               issue_number: closedPrNumber,
               owner: context.repo.owner,

--- a/.github/workflows/close_pr.yml
+++ b/.github/workflows/close_pr.yml
@@ -1,11 +1,11 @@
 name: Label closed PR as merged and leave a comment
-on: 
+on:
   push
 
 permissions:
   contents: read
   pull-requests: write
-  
+
 jobs:
   comment-and-label:
     runs-on: ubuntu-latest
@@ -16,13 +16,13 @@ jobs:
           script: |
             if(!context.payload.commits || !context.payload.commits.length) return;
             const sha = context.payload.commits[0].id;
-            
+
             const {commit, author} = (await github.rest.repos.getCommit({
               ref: sha,
               owner: context.repo.owner,
               repo: context.repo.repo,
             })).data;
-        
+
             // Looking at the commit message, checks which PR number, if any, was closed by this commit
             const getClosedPrIfExists = (commit) => {
               if(!commit || !commit.message) return;
@@ -31,29 +31,29 @@ jobs:
               if(!prClosingMatch || (!prClosingMatch[1] && ! prClosingMatch[2])) return;
               return prClosingMatch[1] ?? prClosingMatch[2];
             };
-            
+
             const closedPrNumber = getClosedPrIfExists(commit);
             if(!closedPrNumber) return;
-            
+
             const pr = (await github.rest.pulls.get({
               pull_number: closedPrNumber,
               owner: context.repo.owner,
               repo: context.repo.repo,
             })).data;
-            
+
             // If the PR has already been processed (labeled as Merged), skip it
             const mergedLabel = "Merged";
             if(pr.labels && pr.labels.some(label => label.name === mergedLabel)) return;
-            
+
             const authorName = author?.login ? `@${author.login}` : commit.author.name;
-        
+
             github.rest.issues.createComment({
               issue_number: closedPrNumber,
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: `This pull request was successfully merged by ${authorName} in **${sha}**.\n\n<sup>[When will my fix make it into a release?](https://github.com/facebook/react-native/wiki/Release-FAQ#when-will-my-fix-make-it-into-a-release) | [Upcoming Releases](https://github.com/reactwg/react-native-releases/discussions/categories/releases)</sup>`
             });
-            
+
             github.rest.issues.addLabels({
               issue_number: closedPrNumber,
               owner: context.repo.owner,

--- a/.github/workflows/close_pr.yml
+++ b/.github/workflows/close_pr.yml
@@ -26,7 +26,7 @@ jobs:
             // Looking at the commit message, checks which PR number, if any, was closed by this commit
             const getClosedPrIfExists = (commit) => {
               if(!commit || !commit.message) return;
-              const prClosingRegex = /Closes https:\/\/github.com\/SlyCaptainFlint\/react-native\/pull\/([0-9]+)|Pull Request resolved: https:\/\/github.com\/SlyCaptainFlint\/react-native\/pull\/([0-9]+)/;
+              const prClosingRegex = /Closes https:\/\/github.com\/facebook\/react-native\/pull\/([0-9]+)|Pull Request resolved: https:\/\/github.com\/facebook\/react-native\/pull\/([0-9]+)/;
               const prClosingMatch = commit.message.match(prClosingRegex);
               if(!prClosingMatch || (!prClosingMatch[1] && ! prClosingMatch[2])) return;
               return prClosingMatch[1] ?? prClosingMatch[2];

--- a/.github/workflows/close_pr.yml
+++ b/.github/workflows/close_pr.yml
@@ -1,0 +1,55 @@
+name: Label closed PR as merged and leave a comment
+on: 
+  push
+  
+jobs:
+  comment-and-label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            if(!context.payload.commits || !context.payload.commits.length) return;
+            const sha = context.payload.commits[0].id;
+            const commit = (await github.rest.git.getCommit({
+              commit_sha: sha,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            })).data;
+            
+            // Looking at the commit message, checks which PR number, if any, was closed by this commit
+            const getClosedPrIfExists = (commit) => {
+              if(!commit || !commit.message) return;
+              const prClosingRegex = /Closes https:\/\/github.com\/SlyCaptainFlint\/react-native\/pull\/([0-9]+)|Pull Request resolved: https:\/\/github.com\/SlyCaptainFlint\/react-native\/pull\/([0-9]+)/;
+              const prClosingMatch = commit.message.match(prClosingRegex);
+              if(!prClosingMatch || (!prClosingMatch[1] && ! prClosingMatch[2])) return;
+              return prClosingMatch[1] ?? prClosingMatch[2];
+            };
+            
+            const closedPrNumber = getClosedPrIfExists(commit);
+            if(!closedPrNumber) return;
+            
+            const pr = (await github.rest.pulls.get({
+              pull_number: closedPrNumber,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            })).data;
+            
+            // If the PR has already been processed (labeled as Merged), skip it
+            const mergedLabel = "Merged";
+            if(pr.labels && pr.labels.some(label => label.name === mergedLabel)) return;
+            
+            github.rest.issues.createComment({
+              issue_number: closedPrNumber,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `This pull request was successfully merged by ${commit.author.name} in **${sha}**.\n\n<sup>[When will my fix make it into a release?](https://github.com/facebook/react-native/wiki/Release-FAQ#when-will-my-fix-make-it-into-a-release) | [Upcoming Releases](https://github.com/reactwg/react-native-releases/discussions/categories/releases)</sup>`
+            });
+            
+            github.rest.issues.addLabels({
+              issue_number: closedPrNumber,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: [mergedLabel]
+            });


### PR DESCRIPTION
## Summary

This change adds a new action and workflow that will run whenever a commit is pushed that closes a PR via its message. When this happens, the corresponding PR will be labeled with "Merged" and a comment will be added with the name of the committer and the sha of the commit that resolved the PR.
This is not new functionality - it merely replaces a portion of the react-native-bot's functionality with a GitHub action.

## Changelog

[Internal] [Changed] - Moved close PR actions to a GitHub action

## Test Plan

Tested the golden path here ("Merged" label and comment added): https://github.com/SlyCaptainFlint/react-native/pull/27
Tested the case where a PR already labeled with Merged was processed and no new comment was left on it (simulates the case where react-native-bot, which is still going to be running, got to the PR and processed it before the new GitHub action did): https://github.com/SlyCaptainFlint/react-native/pull/26
