### PR TITLE
Rename hermes-* target to don't use dashes

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -180,9 +180,9 @@ final def preparePrefab = tasks.register("preparePrefab", PreparePrefabHeadersTa
             ),
             // These prefab targets are used by Expo & Reanimated
             new PrefabPreprocessingEntry(
-                "hermes-executor",
-                // "hermes-executor" is statically linking against "hermes-executor-common"
-                // and "hermes-inspector". Here we expose only the headers that we know are needed.
+                "hermes_executor",
+                // "hermes_executor" is statically linking against "hermes_executor_common"
+                // and "hermes_inspector". Here we expose only the headers that we know are needed.
                 new Pair("../ReactCommon/hermes/inspector/", "hermes/inspector/")
             ),
             new PrefabPreprocessingEntry(
@@ -463,7 +463,7 @@ android {
                     "react_render_uimanager",
                     "react_render_scheduler",
                     "react_render_mounting",
-                    "hermes-executor"
+                    "hermes_executor"
             }
         }
         ndk {
@@ -580,8 +580,8 @@ android {
         reactnativejni {
             headers(new File(prefabHeadersDir, "reactnativejni").absolutePath)
         }
-        "hermes-executor" {
-            headers(new File(prefabHeadersDir, "hermes-executor").absolutePath)
+        hermes_executor {
+            headers(new File(prefabHeadersDir, "hermes_executor").absolutePath)
         }
     }
 

--- a/ReactAndroid/src/main/java/com/facebook/hermes/reactexecutor/HermesExecutor.java
+++ b/ReactAndroid/src/main/java/com/facebook/hermes/reactexecutor/HermesExecutor.java
@@ -24,8 +24,8 @@ public class HermesExecutor extends JavaScriptExecutor {
     if (mode_ == null) {
       // libhermes must be loaded explicitly to invoke its JNI_OnLoad.
       SoLoader.loadLibrary("hermes");
-      SoLoader.loadLibrary("hermes-executor");
-      // libhermes-executor is built differently for Debug & Release so we load the proper mode.
+      SoLoader.loadLibrary("hermes_executor");
+      // libhermes_executor is built differently for Debug & Release so we load the proper mode.
       if (ReactBuildConfig.DEBUG == true) {
         mode_ = "Debug";
       } else {

--- a/ReactAndroid/src/main/jni/react/hermes/reactexecutor/BUCK
+++ b/ReactAndroid/src/main/jni/react/hermes/reactexecutor/BUCK
@@ -14,6 +14,6 @@ rn_xplat_cxx_library(
     headers = [],
     header_namespace = "",
     compiler_flags = ["-fexceptions"],
-    soname = "libhermes-executor.$(ext)",
+    soname = "libhermes_executor.$(ext)",
     visibility = ["PUBLIC"],
 )

--- a/ReactAndroid/src/main/jni/react/hermes/reactexecutor/CMakeLists.txt
+++ b/ReactAndroid/src/main/jni/react/hermes/reactexecutor/CMakeLists.txt
@@ -8,21 +8,21 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 file(GLOB_RECURSE hermes_executor_SRC CONFIGURE_DEPENDS *.cpp)
 
-add_library(hermes-executor
+add_library(hermes_executor
         SHARED
         ${hermes_executor_SRC}
 )
 target_compile_options(
-        hermes-executor
+        hermes_executor
         PRIVATE
         $<$<CONFIG:Debug>:-DHERMES_ENABLE_DEBUGGER=1>
         -std=c++17
         -fexceptions
 )
-target_include_directories(hermes-executor PRIVATE .)
+target_include_directories(hermes_executor PRIVATE .)
 target_link_libraries(
-        hermes-executor
-        hermes-executor-common
+        hermes_executor
+        hermes_executor_common
         jsireact
         fb
         fbjni

--- a/ReactCommon/hermes/executor/CMakeLists.txt
+++ b/ReactCommon/hermes/executor/CMakeLists.txt
@@ -10,22 +10,22 @@ add_compile_options(-std=c++17)
 
 file(GLOB_RECURSE hermes_executor_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(
-        hermes-executor-common
+        hermes_executor_common
         STATIC
         ${hermes_executor_SRC}
 )
-target_include_directories(hermes-executor-common PUBLIC .)
-target_link_libraries(hermes-executor-common
+target_include_directories(hermes_executor_common PUBLIC .)
+target_link_libraries(hermes_executor_common
         jsireact
         hermes-engine::libhermes
         jsi
         debug
-        hermes-inspector
+        hermes_inspector
 )
 
 if(${CMAKE_BUILD_TYPE} MATCHES Debug)
         target_compile_options(
-                hermes-executor-common
+                hermes_executor_common
                 PRIVATE
                 -DHERMES_ENABLE_DEBUGGER=1
         )

--- a/ReactCommon/hermes/inspector/CMakeLists.txt
+++ b/ReactCommon/hermes/inspector/CMakeLists.txt
@@ -8,12 +8,12 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 file(GLOB hermesinspector_SRC CONFIGURE_DEPENDS *.cpp detail/*.cpp chrome/*.cpp)
 
-add_library(hermes-inspector
+add_library(hermes_inspector
         STATIC
         ${hermesinspector_SRC})
 
 target_compile_options(
-        hermes-inspector
+        hermes_inspector
         PRIVATE
         -DHERMES_ENABLE_DEBUGGER=1
         -DHERMES_INSPECTOR_FOLLY_KLUDGE=1
@@ -21,8 +21,8 @@ target_compile_options(
         -fexceptions
 )
 
-target_include_directories(hermes-inspector PUBLIC ${REACT_COMMON_DIR})
-target_link_libraries(hermes-inspector
+target_include_directories(hermes_inspector PUBLIC ${REACT_COMMON_DIR})
+target_link_libraries(hermes_inspector
         jsinspector
         fb
         fbjni

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/NdkConfiguratorUtils.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/NdkConfiguratorUtils.kt
@@ -127,10 +127,10 @@ internal object NdkConfiguratorUtils {
       excludes.add("**/libjsc.so")
       excludes.add("**/libjscexecutor.so")
       includes.add("**/libhermes.so")
-      includes.add("**/libhermes-executor.so")
+      includes.add("**/libhermes_executor.so")
     } else {
       excludes.add("**/libhermes.so")
-      excludes.add("**/libhermes-executor.so")
+      excludes.add("**/libhermes_executor.so")
       includes.add("**/libjsc.so")
       includes.add("**/libjscexecutor.so")
     }

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/NdkConfiguratorUtilsTest.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/NdkConfiguratorUtilsTest.kt
@@ -24,9 +24,9 @@ class NdkConfiguratorUtilsTest {
     assertFalse("**/libjscexecutor.so" in includes)
 
     assertTrue("**/libhermes.so" in includes)
-    assertTrue("**/libhermes-executor.so" in includes)
+    assertTrue("**/libhermes_executor.so" in includes)
     assertFalse("**/libhermes.so" in excludes)
-    assertFalse("**/libhermes-executor.so" in excludes)
+    assertFalse("**/libhermes_executor.so" in excludes)
   }
 
   @Test
@@ -34,9 +34,9 @@ class NdkConfiguratorUtilsTest {
     val (excludes, includes) = getPackagingOptionsForVariant(hermesEnabled = false)
 
     assertTrue("**/libhermes.so" in excludes)
-    assertTrue("**/libhermes-executor.so" in excludes)
+    assertTrue("**/libhermes_executor.so" in excludes)
     assertFalse("**/libhermes.so" in includes)
-    assertFalse("**/libhermes-executor.so" in includes)
+    assertFalse("**/libhermes_executor.so" in includes)
 
     assertTrue("**/libjsc.so" in includes)
     assertTrue("**/libjscexecutor.so" in includes)

--- a/react.gradle
+++ b/react.gradle
@@ -442,11 +442,11 @@ afterEvaluate {
 
                     if (cleanup) {
                         // Reduce size by deleting the debugger/inspector
-                        include '**/libhermes-executor-debug.so'
+                        include '**/libhermes_executor_debug.so'
                     } else {
                         // Release libs take precedence and must be removed
                         // to allow debugging
-                        include '**/libhermes-executor-release.so'
+                        include '**/libhermes_executor_release.so'
                     }
                 } else {
                     // For JSC, delete all the libhermes* files


### PR DESCRIPTION
Summary:
In our build we had a mixture of `_` and `-` to separate targets.
Dashes don't play well with Gradle + as we expose them now via Prefab,
let's stick to use only underscores

Changelog:
[Internal] [Changed] - Rename target to don't use dashes

Reviewed By: cipolleschi

Differential Revision: D41578938

