### PR TITLE
Fix onAccessibilityAction on Fabric

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAccessibilityDelegate.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAccessibilityDelegate.java
@@ -41,6 +41,7 @@ import com.facebook.react.bridge.ReadableMapKeySetIterator;
 import com.facebook.react.bridge.ReadableType;
 import com.facebook.react.bridge.UIManager;
 import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.uimanager.common.ViewUtil;
 import com.facebook.react.uimanager.events.Event;
 import com.facebook.react.uimanager.events.EventDispatcher;
 import com.facebook.react.uimanager.util.ReactFindViewUtil;
@@ -403,7 +404,8 @@ public class ReactAccessibilityDelegate extends ExploreByTouchHelper {
       if (reactContext.hasActiveReactInstance()) {
         final int reactTag = host.getId();
         final int surfaceId = UIManagerHelper.getSurfaceId(reactContext);
-        UIManager uiManager = UIManagerHelper.getUIManager(reactContext, reactTag);
+        UIManager uiManager =
+            UIManagerHelper.getUIManager(reactContext, ViewUtil.getUIManagerType(reactTag));
         if (uiManager != null) {
           uiManager
               .<EventDispatcher>getEventDispatcher()


### PR DESCRIPTION
## Summary

fixes https://github.com/facebook/react-native/issues/30841#issuecomment-1228128357. onAccessibilityAction does not work on Fabric and logs:

```
E/unknown:ReactEventEmitter( 3845): com.facebook.react.bridge.ReactNoCrashSoftException: 
Cannot find EventEmitter for receiveEvent: SurfaceId[1] ReactTag[104] UIManagerType[2] 
```

## Changelog

[Android] [Fixed] - Fix onAccessibilityAction on Fabric

## Test Plan

https://github.com/facebook/react-native/pull/35507#issuecomment-1330876598
