### PR TITLE
RNGP - Fix DependencyUtils for Windows support

### DIFF
--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/DependencyUtils.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/DependencyUtils.kt
@@ -23,14 +23,14 @@ internal object DependencyUtils {
     project.rootProject.allprojects { eachProject ->
       with(eachProject) {
         if (hasProperty("REACT_NATIVE_MAVEN_LOCAL_REPO")) {
-          mavenRepoFromUrl("file://${property("REACT_NATIVE_MAVEN_LOCAL_REPO")}")
+          val mavenLocalRepoPath = property("REACT_NATIVE_MAVEN_LOCAL_REPO") as String
+          mavenRepoFromURI(File(mavenLocalRepoPath).toURI())
         }
         // We add the snapshot for users on nightlies.
         mavenRepoFromUrl("https://oss.sonatype.org/content/repositories/snapshots/")
         repositories.mavenCentral()
         // Android JSC is installed from npm
-        mavenRepoFromUrl(
-            "file://${reactNativeDir}${File.separator}..${File.separator}jsc-android${File.separator}dist")
+        mavenRepoFromURI(File(reactNativeDir, "../jsc-android/dist").toURI())
         repositories.google()
         mavenRepoFromUrl("https://www.jitpack.io")
       }
@@ -83,4 +83,7 @@ internal object DependencyUtils {
 
   fun Project.mavenRepoFromUrl(url: String): MavenArtifactRepository =
       project.repositories.maven { it.url = URI.create(url) }
+
+  fun Project.mavenRepoFromURI(uri: URI): MavenArtifactRepository =
+      project.repositories.maven { it.url = uri }
 }

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/DependencyUtilsTest.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/DependencyUtilsTest.kt
@@ -10,6 +10,7 @@ package com.facebook.react.utils
 import com.facebook.react.tests.createProject
 import com.facebook.react.utils.DependencyUtils.configureDependencies
 import com.facebook.react.utils.DependencyUtils.configureRepositories
+import com.facebook.react.utils.DependencyUtils.mavenRepoFromURI
 import com.facebook.react.utils.DependencyUtils.mavenRepoFromUrl
 import com.facebook.react.utils.DependencyUtils.readVersionString
 import java.net.URI
@@ -27,9 +28,9 @@ class DependencyUtilsTest {
   @Test
   fun configureRepositories_withProjectPropertySet_configuresMavenLocalCorrectly() {
     val localMaven = tempFolder.newFolder("m2")
-    val localMavenURI = URI.create("file://$localMaven/")
+    val localMavenURI = localMaven.toURI()
     val project = createProject()
-    project.extensions.extraProperties.set("REACT_NATIVE_MAVEN_LOCAL_REPO", localMaven)
+    project.extensions.extraProperties.set("REACT_NATIVE_MAVEN_LOCAL_REPO", localMaven.absolutePath)
 
     configureRepositories(project, tempFolder.root)
 
@@ -110,10 +111,10 @@ class DependencyUtilsTest {
   @Test
   fun configureRepositories_withProjectPropertySet_hasHigherPriorityThanMavenCentral() {
     val localMaven = tempFolder.newFolder("m2")
-    val localMavenURI = URI.create("file://$localMaven/")
+    val localMavenURI = localMaven.toURI()
     val mavenCentralURI = URI.create("https://repo.maven.apache.org/maven2/")
     val project = createProject()
-    project.extensions.extraProperties.set("REACT_NATIVE_MAVEN_LOCAL_REPO", localMaven)
+    project.extensions.extraProperties.set("REACT_NATIVE_MAVEN_LOCAL_REPO", localMaven.absolutePath)
 
     configureRepositories(project, tempFolder.root)
 
@@ -296,5 +297,14 @@ class DependencyUtilsTest {
     val mavenRepo = process.mavenRepoFromUrl("https://hello.world")
 
     assertEquals(URI.create("https://hello.world"), mavenRepo.url)
+  }
+
+  @Test
+  fun mavenRepoFromURI_worksCorrectly() {
+    val process = createProject()
+    val repoFolder = tempFolder.newFolder("maven-repo")
+    val mavenRepo = process.mavenRepoFromURI(repoFolder.toURI())
+
+    assertEquals(repoFolder.toURI(), mavenRepo.url)
   }
 }


### PR DESCRIPTION
Summary:
It turns out that my previous diff hasn't really solved the Windows support.
The problem is that we're not escaping the URI of the Maven Local repository
properly on Windows.

To overcome this, I'll instead use the `toURI()` Api of File to properly
create a valid URI for a given folder.

Changelog:
[Internal] [Changed] - RNGP - Fix DependencyUtils for Windows support

Differential Revision: D41581849

