### PR TITLE
Fix windows build of RectangleEdges

### DIFF
--- a/ReactCommon/react/renderer/graphics/RectangleEdges.h
+++ b/ReactCommon/react/renderer/graphics/RectangleEdges.h
@@ -44,7 +44,7 @@ struct RectangleEdges {
 };
 
 template <typename T>
-constexpr RectangleEdges<T> const RectangleEdges<T>::ZERO = {};
+RectangleEdges<T> const RectangleEdges<T>::ZERO = {};
 
 template <typename T>
 RectangleEdges<T> operator+(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

[PR: Avoid emitting mountitems for default values](https://github.com/facebook/react-native/commit/56e9aa369f5c13af38cf80ba47e9eb29d835ec89) used a constexpr in a template, which windows is unable to compile since type at this point is incomplete. Once removed, windows is able to build again. Let me know if there's a better way to fix this!

See [10072](https://github.com/microsoft/react-native-windows/issues/10072) for windows error messages

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
[General] [Fixed] - Remove constexpr from RectangleEdges.h

## Test Plan
Windows has forked this file and had the change for ~5 month, all tests pass on Windows side