### PR TITLE
edited the parser and define the function

### DIFF
--- a/packages/react-native-codegen/src/parsers/error-utils.js
+++ b/packages/react-native-codegen/src/parsers/error-utils.js
@@ -172,30 +172,8 @@ function throwIfModuleTypeIsUnsupported(
   propertyValue: $FlowFixMe,
   propertyName: string,
   propertyValueType: string,
-  language: ParserType,
-) {
-  if (language === 'Flow' && propertyValueType !== 'FunctionTypeAnnotation') {
-    throw new UnsupportedModulePropertyParserError(
-      nativeModuleName,
-      propertyValue,
-      propertyName,
-      propertyValueType,
-      language,
-    );
-  } else if (
-    language === 'TypeScript' &&
-    propertyValueType !== 'TSFunctionType' &&
-    propertyValueType !== 'TSMethodSignature'
-  ) {
-    throw new UnsupportedModulePropertyParserError(
-      nativeModuleName,
-      propertyValue,
-      propertyName,
-      propertyValueType,
-      language,
-    );
-  }
-}
+  parser: Parser
+) 
 
 const UnsupportedObjectPropertyTypeToInvalidPropertyValueTypeMap = {
   FunctionTypeAnnotation: 'FunctionTypeAnnotation',

--- a/packages/react-native-codegen/src/parsers/flow/parser.js
+++ b/packages/react-native-codegen/src/parsers/flow/parser.js
@@ -53,7 +53,17 @@ class FlowParser implements Parser {
   }
 
   nameForGenericTypeAnnotation(typeAnnotation: $FlowFixMe): string {
-    return typeAnnotation.id.name;
+    if (language === 'Flow' && propertyValueType !== 'FunctionTypeAnnotation') {
+      throw new UnsupportedModulePropertyParserError(
+        nativeModuleName,
+        propertyValue,
+        propertyName,
+        propertyValueType,
+        parser.language(),
+      );
+    } else {
+      return typeAnnotation.id.name
+    }
   }
 
   checkIfInvalidModule(typeArguments: $FlowFixMe): boolean {

--- a/packages/react-native-codegen/src/parsers/parser.js
+++ b/packages/react-native-codegen/src/parsers/parser.js
@@ -24,6 +24,11 @@ export interface Parser {
   typeParameterInstantiation: string;
 
   /**
+   * This is the functionTypeAnnotation value
+   */
+  functionTypeAnnotation: string;
+
+  /**
    * Given a property or an index declaration, it returns the key name.
    * @parameter propertyOrIndex: an object containing a property or an index declaration.
    * @parameter hasteModuleName: a string with the native module name.
@@ -59,6 +64,7 @@ export interface Parser {
    * @returns: a boolean specifying if the Module is Invalid.
    */
   checkIfInvalidModule(typeArguments: $FlowFixMe): boolean;
+
   /**
    * Given a union annotation members types, it returns an array of remaped members names without duplicates.
    * @parameter membersTypes: union annotation members types

--- a/packages/react-native-codegen/src/parsers/parsers-commons.js
+++ b/packages/react-native-codegen/src/parsers/parsers-commons.js
@@ -414,6 +414,7 @@ function buildPropertySchema(
   // - a NullableTypeAnnoation containing a FunctionTypeAnnotation or GenericTypeAnnotation
   // Flow type this node
   property: $FlowFixMe,
+  parser: Parser,
   types: TypeDeclarationMap,
   aliasMap: {...NativeModuleAliasMap},
   tryParse: ParserErrorCapturer,
@@ -440,7 +441,7 @@ function buildPropertySchema(
     property.value,
     key.name,
     value.type,
-    language,
+    parser,
   );
 
   return {

--- a/packages/react-native-codegen/src/parsers/typescript/parser.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parser.js
@@ -56,7 +56,20 @@ class TypeScriptParser implements Parser {
   }
 
   nameForGenericTypeAnnotation(typeAnnotation: $FlowFixMe): string {
-    return typeAnnotation.typeName.name;
+    if (language === 'TypeScript' &&
+      propertyValueType !== 'TSFunctionType' &&
+      propertyValueType !== 'TSMethodSignature')
+   {
+      throw new UnsupportedModulePropertyParserError(
+        nativeModuleName,
+        propertyValue,
+        propertyName,
+        propertyValueType,
+        language,
+      );
+    } else {
+      return typeAnnotation.typeName.name
+    }
   }
 
   checkIfInvalidModule(typeArguments: $FlowFixMe): boolean {

--- a/packages/react-native-codegen/src/parsers/typescript/parser.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parser.js
@@ -56,20 +56,17 @@ class TypeScriptParser implements Parser {
   }
 
   nameForGenericTypeAnnotation(typeAnnotation: $FlowFixMe): string {
-    if (language === 'TypeScript' &&
-      propertyValueType !== 'TSFunctionType' &&
-      propertyValueType !== 'TSMethodSignature')
-   {
-      throw new UnsupportedModulePropertyParserError(
-        nativeModuleName,
-        propertyValue,
-        propertyName,
-        propertyValueType,
-        language,
-      );
+    if language === 'TypeScript' && propertyValueType !== 'TSFunctionType' && propertyValueType !== 'TSMethodSignature' {
+        throw new UnsupportedModulePropertyParserError(
+          nativeModuleName,
+          propertyValue,
+          propertyName,
+          propertyValueType,
+          language,
+        )
     } else {
       return typeAnnotation.typeName.name
-    }
+    };
   }
 
   checkIfInvalidModule(typeArguments: $FlowFixMe): boolean {


### PR DESCRIPTION
### Summary
This is for issue https://github.com/facebook/react-native/issues/34872 but the subtask where you have to define functionTypeAnnotation in the parser.js file and document it. In addition, I had to implement a certain logic in the flowparser.js and typescriptparser.js. Lastly, I would have to refactor the throwIfModuleTypeIsUnsupported function to accept a parser instead of a parsertype and use the newly created function instead of the if (language) logic. 

### Changelog: 
Javascript Fixed - fixed both the flowparser.js and typescriptparser.js to implement the specific logic that is needed. 

### Test Plan:
I used the test plan that was stated in the issue, which was `yarn jest react-native-codegen `



### Questions:
I am doing this for my assignment but I do want to know why my code isn't passing and if you can give me any tips, it will be greatly appreciated. 