### PR TITLE
Properly expose `jscexecutor` as a prefab target

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -435,8 +435,7 @@ android {
                     "-DANDROID_TOOLCHAIN=clang",
                     "-DANDROID_PLATFORM=android-21"
 
-                targets "jscexecutor",
-                    "jsijniprofiler",
+                targets "jsijniprofiler",
                     "reactnativeblob",
                     "reactperfloggerjni",
                     // prefab targets
@@ -463,7 +462,8 @@ android {
                     "react_render_uimanager",
                     "react_render_scheduler",
                     "react_render_mounting",
-                    "hermes_executor"
+                    "hermes_executor",
+                    "jscexecutor"
             }
         }
         ndk {
@@ -582,6 +582,9 @@ android {
         }
         hermes_executor {
             headers(new File(prefabHeadersDir, "hermes_executor").absolutePath)
+        }
+        jscexecutor {
+            headers(new File(prefabHeadersDir, "jscexecutor").absolutePath)
         }
     }
 


### PR DESCRIPTION
Summary:
Inside RC3 the jscexecutor target was prepared for prefab consumption
but not properly exposed.
This was not caught by the CI as we're not effectively using this target,
but some of our popular libraries do (i.e. Reanimated). I'm exposing it here.

Changelog:
[Internal] [Changed] - Properly expose `jscexecutor` as a prefab target

Reviewed By: javache

Differential Revision: D41648349

