### PR TITLE
Bump AGP from 7.4 beta05 to rc1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,7 @@ buildscript {
     gradlePluginPortal()
   }
   dependencies {
-    classpath("com.android.tools.build:gradle:7.3.1")
+    classpath("com.android.tools.build:gradle:7.4.0-rc01")
     classpath("de.undercouch:gradle-download-task:5.0.1")
   }
 }

--- a/packages/react-native-gradle-plugin/build.gradle.kts
+++ b/packages/react-native-gradle-plugin/build.gradle.kts
@@ -33,7 +33,7 @@ group = "com.facebook.react"
 
 dependencies {
   implementation(gradleApi())
-  implementation("com.android.tools.build:gradle:7.4.0-beta05")
+  implementation("com.android.tools.build:gradle:7.4.0-rc01")
   implementation("com.google.code.gson:gson:2.8.9")
   implementation("com.google.guava:guava:31.0.1-jre")
   implementation("com.squareup:javapoet:1.13.0")

--- a/template/android/build.gradle
+++ b/template/android/build.gradle
@@ -15,7 +15,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:7.4.0-beta05")
+        classpath("com.android.tools.build:gradle:7.4.0-rc01")
         classpath("com.facebook.react:react-native-gradle-plugin")
     }
 }


### PR DESCRIPTION
Summary:
As AGP 7.4 is reaching it's stable status, let's move from beta05 to rc01.
That's needed for the sake of RN 0.71

Changelog:
[Internal] [Changed] - Bump AGP from 7.4 beta05 to rc1

allow-large-files

Reviewed By: rshest

Differential Revision: D41648863

