### PR TITLE
Add ability to schedule JS functions as tasks from turbo modules

### DIFF
--- a/ReactCommon/callinvoker/ReactCommon/CallInvoker.h
+++ b/ReactCommon/callinvoker/ReactCommon/CallInvoker.h
@@ -10,8 +10,12 @@
 #include <functional>
 #include <memory>
 
+#include "SchedulerPriority.h"
+
 namespace facebook {
 namespace react {
+
+using CallFunc = std::function<void()>;
 
 /**
  * An interface for a generic native-to-JS call invoker. See BridgeJSCallInvoker
@@ -19,8 +23,13 @@ namespace react {
  */
 class CallInvoker {
  public:
-  virtual void invokeAsync(std::function<void()> &&func) = 0;
-  virtual void invokeSync(std::function<void()> &&func) = 0;
+  virtual void invokeAsync(CallFunc &&func) = 0;
+  virtual void invokeAsync(SchedulerPriority /*priority*/, CallFunc &&func) {
+    // When call with priority is not implemented, fall back to a regular async
+    // execution
+    invokeAsync(std::move(func));
+  }
+  virtual void invokeSync(CallFunc &&func) = 0;
   virtual ~CallInvoker() {}
 };
 

--- a/ReactCommon/callinvoker/ReactCommon/SchedulerPriority.h
+++ b/ReactCommon/callinvoker/ReactCommon/SchedulerPriority.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <chrono>
+
+namespace facebook {
+namespace react {
+
+enum class SchedulerPriority : int {
+  ImmediatePriority = 1,
+  UserBlockingPriority = 2,
+  NormalPriority = 3,
+  LowPriority = 4,
+  IdlePriority = 5,
+};
+
+} // namespace react
+} // namespace facebook

--- a/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.h
+++ b/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.h
@@ -35,7 +35,7 @@ class RuntimeScheduler final {
   RuntimeScheduler(RuntimeScheduler &&) = delete;
   RuntimeScheduler &operator=(RuntimeScheduler &&) = delete;
 
-  void scheduleWork(std::function<void(jsi::Runtime &)> callback) const;
+  void scheduleWork(RawCallback callback) const;
 
   /*
    * Grants access to the runtime synchronously on the caller's thread.
@@ -44,8 +44,7 @@ class RuntimeScheduler final {
    * by dispatching a synchronous event via event emitter in your native
    * component.
    */
-  void executeNowOnTheSameThread(
-      std::function<void(jsi::Runtime &runtime)> callback);
+  void executeNowOnTheSameThread(RawCallback callback);
 
   /*
    * Adds a JavaScript callback to priority queue with given priority.
@@ -56,6 +55,10 @@ class RuntimeScheduler final {
   std::shared_ptr<Task> scheduleTask(
       SchedulerPriority priority,
       jsi::Function callback);
+
+  std::shared_ptr<Task> scheduleTask(
+      SchedulerPriority priority,
+      RawCallback callback);
 
   /*
    * Cancelled task will never be executed.

--- a/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerBinding.cpp
+++ b/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerBinding.cpp
@@ -6,10 +6,10 @@
  */
 
 #include "RuntimeSchedulerBinding.h"
-#include "SchedulerPriority.h"
+#include <ReactCommon/SchedulerPriority.h>
+#include "SchedulerPriorityUtils.h"
 #include "primitives.h"
 
-#include <react/debug/react_native_assert.h>
 #include <chrono>
 #include <memory>
 #include <utility>

--- a/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerCallInvoker.cpp
+++ b/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerCallInvoker.cpp
@@ -15,17 +15,26 @@ RuntimeSchedulerCallInvoker::RuntimeSchedulerCallInvoker(
     std::weak_ptr<RuntimeScheduler> runtimeScheduler)
     : runtimeScheduler_(std::move(runtimeScheduler)) {}
 
-void RuntimeSchedulerCallInvoker::invokeAsync(std::function<void()> &&func) {
+void RuntimeSchedulerCallInvoker::invokeAsync(CallFunc &&func) {
   if (auto runtimeScheduler = runtimeScheduler_.lock()) {
     runtimeScheduler->scheduleWork(
         [func = std::move(func)](jsi::Runtime &) { func(); });
   }
 }
 
-void RuntimeSchedulerCallInvoker::invokeSync(std::function<void()> &&func) {
+void RuntimeSchedulerCallInvoker::invokeSync(CallFunc &&func) {
   if (auto runtimeScheduler = runtimeScheduler_.lock()) {
     runtimeScheduler->executeNowOnTheSameThread(
         [func = std::move(func)](jsi::Runtime &) { func(); });
+  }
+}
+
+void RuntimeSchedulerCallInvoker::invokeAsync(
+    SchedulerPriority priority,
+    CallFunc &&func) {
+  if (auto runtimeScheduler = runtimeScheduler_.lock()) {
+    runtimeScheduler->scheduleTask(
+        priority, [func = std::move(func)](jsi::Runtime &) { func(); });
   }
 }
 

--- a/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerCallInvoker.h
+++ b/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerCallInvoker.h
@@ -14,15 +14,16 @@ namespace facebook {
 namespace react {
 
 /*
- * Exposes RuntimeScheduler to native modules. All calls invonked on JavaScript
+ * Exposes RuntimeScheduler to native modules. All calls invoked on JavaScript
  * queue from native modules will be funneled through RuntimeScheduler.
  */
 class RuntimeSchedulerCallInvoker : public CallInvoker {
  public:
   RuntimeSchedulerCallInvoker(std::weak_ptr<RuntimeScheduler> runtimeScheduler);
 
-  void invokeAsync(std::function<void()> &&func) override;
-  void invokeSync(std::function<void()> &&func) override;
+  void invokeAsync(CallFunc &&func) override;
+  void invokeSync(CallFunc &&func) override;
+  void invokeAsync(SchedulerPriority priority, CallFunc &&func) override;
 
  private:
   /*

--- a/ReactCommon/react/renderer/runtimescheduler/SchedulerPriorityUtils.h
+++ b/ReactCommon/react/renderer/runtimescheduler/SchedulerPriorityUtils.h
@@ -7,19 +7,11 @@
 
 #pragma once
 
+#include <ReactCommon/SchedulerPriority.h>
 #include <react/debug/react_native_assert.h>
 #include <chrono>
 
-namespace facebook {
-namespace react {
-
-enum class SchedulerPriority : int {
-  ImmediatePriority = 1,
-  UserBlockingPriority = 2,
-  NormalPriority = 3,
-  LowPriority = 4,
-  IdlePriority = 5,
-};
+namespace facebook::react {
 
 static constexpr std::underlying_type<SchedulerPriority>::type serialize(
     SchedulerPriority schedulerPriority) {
@@ -61,21 +53,4 @@ static inline std::chrono::milliseconds timeoutForSchedulerPriority(
   }
 }
 
-static inline std::string debugValueForSchedulerPriority(
-    SchedulerPriority schedulerPriority) {
-  switch (schedulerPriority) {
-    case SchedulerPriority::ImmediatePriority:
-      return "SchedulerPriority::ImmediatePriority";
-    case SchedulerPriority::UserBlockingPriority:
-      return "SchedulerPriority::UserBlockingPriority";
-    case SchedulerPriority::NormalPriority:
-      return "SchedulerPriority::NormalPriority";
-    case SchedulerPriority::LowPriority:
-      return "SchedulerPriority::LowPriority";
-    case SchedulerPriority::IdlePriority:
-      return "SchedulerPriority::IdlePriority";
-  }
-}
-
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/ReactCommon/react/renderer/runtimescheduler/Task.cpp
+++ b/ReactCommon/react/renderer/runtimescheduler/Task.cpp
@@ -17,18 +17,35 @@ Task::Task(
       callback(std::move(callback)),
       expirationTime(expirationTime) {}
 
+Task::Task(
+    SchedulerPriority priority,
+    RawCallback callback,
+    std::chrono::steady_clock::time_point expirationTime)
+    : priority(priority),
+      callback(std::move(callback)),
+      expirationTime(expirationTime) {}
+
 jsi::Value Task::execute(jsi::Runtime &runtime, bool didUserCallbackTimeout) {
   auto result = jsi::Value::undefined();
-  // Cancelled task doesn't have a callback.
-  if (callback) {
+  // Canceled task doesn't have a callback.
+  if (!callback) {
+    return result;
+  }
+
+  auto &cbVal = callback.value();
+
+  if (cbVal.index() == 0) {
     // Callback in JavaScript is expecting a single bool parameter.
     // React team plans to remove it in the future when a scheduler bug on web
     // is resolved.
-    result = callback.value().call(runtime, {didUserCallbackTimeout});
-
-    // Destroying callback to prevent calling it twice.
-    callback.reset();
+    result =
+        std::get<jsi::Function>(cbVal).call(runtime, {didUserCallbackTimeout});
+  } else {
+    // Calling a raw callback
+    std::get<RawCallback>(cbVal)(runtime);
   }
+  // Destroying callback to prevent calling it twice.
+  callback.reset();
   return result;
 }
 

--- a/ReactCommon/react/renderer/runtimescheduler/Task.h
+++ b/ReactCommon/react/renderer/runtimescheduler/Task.h
@@ -7,17 +7,19 @@
 
 #pragma once
 
+#include <ReactCommon/SchedulerPriority.h>
 #include <jsi/jsi.h>
 #include <react/renderer/runtimescheduler/RuntimeSchedulerClock.h>
-#include <react/renderer/runtimescheduler/SchedulerPriority.h>
 
 #include <optional>
+#include <variant>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class RuntimeScheduler;
 class TaskPriorityComparer;
+
+using RawCallback = std::function<void(jsi::Runtime &)>;
 
 struct Task final {
   Task(
@@ -25,12 +27,17 @@ struct Task final {
       jsi::Function callback,
       std::chrono::steady_clock::time_point expirationTime);
 
+  Task(
+      SchedulerPriority priority,
+      RawCallback callback,
+      std::chrono::steady_clock::time_point expirationTime);
+
  private:
   friend RuntimeScheduler;
   friend TaskPriorityComparer;
 
   SchedulerPriority priority;
-  std::optional<jsi::Function> callback;
+  std::optional<std::variant<jsi::Function, RawCallback>> callback;
   RuntimeSchedulerClock::time_point expirationTime;
 
   jsi::Value execute(jsi::Runtime &runtime, bool didUserCallbackTimeout);
@@ -45,5 +52,4 @@ class TaskPriorityComparer {
   }
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/ReactCommon/react/renderer/runtimescheduler/tests/SchedulerPriorityTest.cpp
+++ b/ReactCommon/react/renderer/runtimescheduler/tests/SchedulerPriorityTest.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <gtest/gtest.h>
+#include <react/renderer/runtimescheduler/SchedulerPriorityUtils.h>
 #include <react/renderer/runtimescheduler/Task.h>
 #include <chrono>
 


### PR DESCRIPTION
Summary:
[Changelog][Internal]

Adds ability to invoke an async JS callback from a C++ native module, as a task with priority.

This will allow native modules to schedule less important calls to JS thread with lower priority. One example use case is feeding collected perf metrics back to JS.

Reviewed By: javache

Differential Revision: D41492849

