### PR TITLE
fix(deps, template): remove unnecessary ts eslint deps from template

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -22,8 +22,6 @@
     "@types/jest": "^29.2.1",
     "@types/react": "^18.0.24",
     "@types/react-test-renderer": "^18.0.0",
-    "@typescript-eslint/eslint-plugin": "^5.37.0",
-    "@typescript-eslint/parser": "^5.37.0",
     "babel-jest": "^29.2.1",
     "eslint": "^8.19.0",
     "jest": "^29.2.1",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

In the new TS template, we have two dependencies (`@typescript-eslint/eslint-plugin` and `@typescript-eslint/parser`) that are redundant since they are already dependencies of @react-native-community/eslint-config.

This was raised by @UNIDY2002 at this comment, and then @NickGerleman found the historical reason for it being present in the TS template:

> https://github.com/react-native-community/react-native-template-typescript/pull/240 added these to fix another change to alter options of the community config. The underlying issues were later fixed in the community ESLint config, and really should never have been in the template. I removed the config overrides already because I saw they were fixed, so we should also be able to remove the explicit dependencies now too I think.

We also doublechecked with @radko93 that we can proceed with this removal

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[General] [Fixed] - remove unnecessary ts eslint deps from template

## Test Plan

Not much to test, generate a new project the usual way (`yarn test-e2e-local -t RNTestProject -p Android` or iOS) and check that TS still works.
