### PR TITLE
fix(scripts): remove leftover code for tmpPublishingFolder

### DIFF
--- a/scripts/publish-npm.js
+++ b/scripts/publish-npm.js
@@ -43,15 +43,11 @@ const {
   publishAndroidArtifactsToMaven,
 } = require('./release-utils');
 const fs = require('fs');
-const os = require('os');
 const path = require('path');
 const yargs = require('yargs');
 
 const buildTag = process.env.CIRCLE_TAG;
 const otp = process.env.NPM_CONFIG_OTP;
-const tmpPublishingFolder = fs.mkdtempSync(
-  path.join(os.tmpdir(), 'rn-publish-'),
-);
 
 const argv = yargs
   .option('n', {
@@ -80,10 +76,6 @@ const buildType = releaseBuild
   : nightlyBuild
   ? 'nightly'
   : 'dry-run';
-
-if (!argv.help) {
-  echo(`The temp publishing folder is ${tmpPublishingFolder}`);
-}
 
 // 34c034298dc9cad5a4553964a5a324450fda0385
 const currentCommit = getCurrentCommit();
@@ -138,7 +130,7 @@ if (isCommitly) {
   }
 }
 
-generateAndroidArtifacts(releaseVersion, tmpPublishingFolder);
+generateAndroidArtifacts(releaseVersion);
 
 // Write version number to the build folder
 const releaseVersionFile = path.join('build', '.version');

--- a/scripts/release-utils.js
+++ b/scripts/release-utils.js
@@ -12,7 +12,7 @@
 const {exec, echo, exit, test, env, pushd, popd} = require('shelljs');
 const {createHermesPrebuiltArtifactsTarball} = require('./hermes/hermes-utils');
 
-function generateAndroidArtifacts(releaseVersion, tmpPublishingFolder) {
+function generateAndroidArtifacts(releaseVersion) {
   // -------- Generating Android Artifacts
   echo('Generating Android artifacts inside /tmp/maven-local');
   if (exec('./gradlew publishAllToMavenTempLocal').code) {

--- a/scripts/test-e2e-local.js
+++ b/scripts/test-e2e-local.js
@@ -31,7 +31,6 @@ const {
 
 const {
   generateAndroidArtifacts,
-  saveFilesToRestore,
   generateiOSArtifacts,
 } = require('./release-utils');
 
@@ -146,12 +145,6 @@ if (argv.target === 'RNTester') {
   // create the local npm package to feed the CLI
 
   // base setup required (specular to publish-npm.js)
-  const tmpPublishingFolder = fs.mkdtempSync(
-    path.join(os.tmpdir(), 'rn-publish-'),
-  );
-  console.info(`The temp publishing folder is ${tmpPublishingFolder}`);
-
-  saveFilesToRestore(tmpPublishingFolder);
 
   // we need to add the unique timestamp to avoid npm/yarn to use some local caches
   const baseVersion = require('../package.json').version;
@@ -176,7 +169,7 @@ if (argv.target === 'RNTester') {
   ).code;
 
   // Generate native files for Android
-  generateAndroidArtifacts(releaseVersion, tmpPublishingFolder);
+  generateAndroidArtifacts(releaseVersion);
 
   // Setting up generating native iOS (will be done later)
   const repoRoot = pwd();
@@ -249,9 +242,6 @@ if (argv.target === 'RNTester') {
     exec('yarn android');
   }
   popd();
-
-  // just cleaning up the temp folder, the rest is done by the test clean script
-  exec(`rm -rf ${tmpPublishingFolder}`);
 }
 
 exit(0);

--- a/scripts/test-e2e-local.js
+++ b/scripts/test-e2e-local.js
@@ -19,8 +19,6 @@
 const {exec, exit, pushd, popd, pwd, cd, cp} = require('shelljs');
 const yargs = require('yargs');
 const fs = require('fs');
-const path = require('path');
-const os = require('os');
 const {getBranchName} = require('./scm-utils');
 
 const {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

When this was done https://github.com/facebook/react-native/commit/ad43deca232b208956f44d46151571ba8064dd68 (most likely because the scripts folder is not type-checked) some references to this script were left lying around.

This PR takes care of it.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[Internal] [Fixed] - remove leftover code for tmpPublishingFolder

## Test Plan

Running  `yarn test-e2e-local` doesn't insta-fail.
