### PR TITLE
Simplify Template ESLint Configuration

### DIFF
--- a/template/_eslintrc.js
+++ b/template/_eslintrc.js
@@ -1,6 +1,4 @@
 module.exports = {
   root: true,
   extends: '@react-native',
-  parser: '@typescript-eslint/parser',
-  plugins: ['@typescript-eslint'],
 };

--- a/template/package.json
+++ b/template/package.json
@@ -22,8 +22,6 @@
     "@types/jest": "^29.2.1",
     "@types/react": "^18.0.24",
     "@types/react-test-renderer": "^18.0.0",
-    "@typescript-eslint/eslint-plugin": "^5.37.0",
-    "@typescript-eslint/parser": "^5.37.0",
     "babel-jest": "^29.2.1",
     "eslint": "^8.19.0",
     "jest": "^29.2.1",


### PR DESCRIPTION
Summary:
ESLint configuration is derived from `react-native/eslint-config`, which has supported Flow, vanilla JS, and TypeScript.

https://github.com/react-native-community/react-native-template-typescript/pull/238 and a related PR ended up adding new rules to the TypeScript config, to fix bugs with TS linting. It required a followup change, to specify the parser/plugin, and explicity reference them as devDependencies. https://github.com/react-native-community/react-native-template-typescript/pull/240

`react-native/eslint-config` already includes setting the plugin/parser. But overriding rules requires declaring that again, and directly referencing a plugin means a need for the app to declare dependencies, since ESLint resolves modules from the current config.

The rules overridedn were later fixed in `react-native/eslint-config`, which is really the right place for the fix (e.g. https://github.com/facebook/react-native/pull/32644). I noticed this when deriving from the TS template in https://github.com/facebook/react-native/pull/32644 and removed the rule overrides, but didn't have the historical context to realize this means we can then:
1. Remove the explicit parser/plugins since `react-native/eslint-config` already sets them, and we are no longer overriding any rules.
2. Remove the devDependencies, to let the versions be managed entirely by `react-native/eslint-config`.

Changelog:
[General][Changed] - Simplify Template ESLint Configuration

Differential Revision: D41652699

