### PR TITLE
chore: untrack stack dumps; `*.stackdump`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,9 @@ package-lock.json
 # Test Reports
 /reports
 
+# Stack Dumps generated when programs crash (Ex. bash.exe.stackdump on Win)
+*.stackdump
+
 # Root dir shouldn't have Xcode project
 /*.xcodeproj
 


### PR DESCRIPTION
## Summary

- Untracking StackDump files through `.gitignore`
- Most of the programs like shell (bash) **_crashes_** it generates **_StackDump_**; `*.stackdump` file(s)
- Such files are only for low level debugging purpose and _shouldn't be tracked_
- PS: When using integrated terminals on IDEs it's common to have these files especially on Win m/c :)

## Changelog

[Internal] [Changed] - Untracking Stack Dumps; `*.stackdump` files

## Test Plan

- [NO-CODE] Diff