### PR TITLE
Don't use the internal `native_modules.rb` script yet

### DIFF
--- a/template/ios/Podfile
+++ b/template/ios/Podfile
@@ -1,5 +1,5 @@
 require_relative '../node_modules/react-native/scripts/react_native_pods'
-require_relative '../node_modules/react-native/scripts/native_modules'
+require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
 
 platform :ios, min_ios_version_supported
 prepare_react_native_project!


### PR DESCRIPTION
## Summary

Revert the template `Podfile` to using `@react-native-community/cli-platform-ios/native_modules`. The new internal script currently has a hard-coded path to `@react-native-community/cli-platform-ios` which may not work in monorepos. The path in the `Podfile` is also hard-coded, but this is a file that the user has access to and can fix themselves if necessary.

## Changelog

[iOS] [Fixed] - Don't use the internal `native_modules.rb` script yet, as it hides a hard-coded path

## Test Plan

n/a