### PR TITLE
Rename `POST_NOTIFICATION` to `POST_NOTIFICATIONS`

### DIFF
--- a/Libraries/PermissionsAndroid/PermissionsAndroid.js
+++ b/Libraries/PermissionsAndroid/PermissionsAndroid.js
@@ -75,7 +75,8 @@ const PERMISSIONS = Object.freeze({
   ANSWER_PHONE_CALLS: 'android.permission.ANSWER_PHONE_CALLS',
   READ_PHONE_NUMBERS: 'android.permission.READ_PHONE_NUMBERS',
   UWB_RANGING: 'android.permission.UWB_RANGING',
-  POST_NOTIFICATION: 'android.permission.POST_NOTIFICATIONS',
+  POST_NOTIFICATION: 'android.permission.POST_NOTIFICATIONS', // Remove in 0.72
+  POST_NOTIFICATIONS: 'android.permission.POST_NOTIFICATIONS',
   NEARBY_WIFI_DEVICES: 'android.permission.NEARBY_WIFI_DEVICES',
 });
 
@@ -106,7 +107,8 @@ class PermissionsAndroid {
     CAMERA: string,
     GET_ACCOUNTS: string,
     NEARBY_WIFI_DEVICES: string,
-    POST_NOTIFICATION: string,
+    POST_NOTIFICATION: string, // Remove in 0.72
+    POST_NOTIFICATIONS: string,
     PROCESS_OUTGOING_CALLS: string,
     READ_CALENDAR: string,
     READ_CALL_LOG: string,

--- a/packages/rn-tester/js/examples/PermissionsAndroid/PermissionsExample.js
+++ b/packages/rn-tester/js/examples/PermissionsAndroid/PermissionsExample.js
@@ -83,13 +83,13 @@ function PermissionsExample() {
             style={styles.option}
           />
           <RNTOption
-            label={PermissionsAndroid.PERMISSIONS.POST_NOTIFICATION}
-            key={PermissionsAndroid.PERMISSIONS.POST_NOTIFICATION}
+            label={PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS}
+            key={PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS}
             onPress={() =>
-              setPermission(PermissionsAndroid.PERMISSIONS.POST_NOTIFICATION)
+              setPermission(PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS)
             }
             selected={
-              permission === PermissionsAndroid.PERMISSIONS.POST_NOTIFICATION
+              permission === PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS
             }
             style={styles.option}
           />


### PR DESCRIPTION
## Summary

After adding `<uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>` on my `AndroidManifest.xml`, I expected to use `PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS` but `POST_NOTIFICATIONS` is `undefined` and is named `POST_NOTIFICATION` instead.

Every other Android permission is 1:1 in spelling except this one where it lacks `S`.

Not sure if this is a welcome change since this can be breaking. Or maybe we can include both with and without `S` to not be a breaking change. Or just keep it as is and close this PR.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[Android] [Changed] - Rename `POST_NOTIFICATION` to `POST_NOTIFICATIONS`

## Test Plan

`PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS` should not be `undefined`.