### PR TITLE
fix(internal, dangerfile): fix changelog entries for dangerfiles and PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,11 +6,15 @@
 
 ## Changelog
 
-<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
+<!-- Help reviewers and the release process by writing your own changelog entry.
+
+Pick one each for the category and type tags:
+
+[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message
+
+For more details, see:
 https://reactnative.dev/contributing/changelogs-in-pull-requests
 -->
-
-[CATEGORY] [TYPE] - Message
 
 ## Test Plan
 

--- a/packages/react-native-bots/dangerfile.js
+++ b/packages/react-native-bots/dangerfile.js
@@ -59,7 +59,7 @@ if (!includesTestPlan && !isFromPhabricator) {
 
 // Regex looks for given categories, types, a file/framework/component, and a message - broken into 4 capture groups
 const changelogRegex =
-  /\[\s?(ANDROID|GENERAL|IOS|JS|JAVASCRIPT|INTERNAL)\s?\]\s?\[\s?(ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY)\s?\]\s*?-?\s*?(.*)/gi;
+  /\[\s?(ANDROID|GENERAL|IOS|INTERNAL)\s?\]\s?\[\s?(BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY)\s?\]\s*?-?\s*?(.*)/gi;
 const internalChangelogRegex = /\[\s?(INTERNAL)\s?\].*/gi;
 const includesChangelog =
   danger.github.pr.body &&


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

A few days back @leotm pointed out how the dangerfile was disaligned with the docs around the valid changelog entries for categories and types here: https://github.com/facebook/react-native/pull/35443#issuecomment-1327449113

I dug a bit deeper into the whole thing and went to the source of truth, which is the changelog generator, in particular here: https://github.com/microsoft/rnx-kit/blob/main/incubator/rn-changelog-generator/src/utils/getChangeDimensions.ts

So I've updated the dangerfile to respect the options listed there. Also did a parallel PR on the website side: https://github.com/facebook/react-native-website/pull/3447

So now all comms will be aligned.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[INTERNAL] [FIXED] - fix changelog entries for dangerfiles and PR template

## Test Plan

N/A
