### PR TITLE
fix: Support 120 FPS in `RCTFPSGraph`

### DIFF
--- a/React/CoreModules/RCTFPSGraph.m
+++ b/React/CoreModules/RCTFPSGraph.m
@@ -97,7 +97,8 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)aDecoder)
       self->_label.text = [NSString stringWithFormat:@"%lu", (unsigned long)self->_FPS];
     });
 
-    CGFloat scale = 60.0 / (CGFloat)_height;
+    CGFloat targetFps = MAX(_maxFPS, 60.0);
+    CGFloat scale = targetFps / (CGFloat)_height;
     for (NSUInteger i = 0; i < _length - 1; i++) {
       _frames[i] = _frames[i + 1];
     }

--- a/React/CoreModules/RCTFPSGraph.m
+++ b/React/CoreModules/RCTFPSGraph.m
@@ -32,6 +32,7 @@
   NSUInteger _minFPS;
   NSUInteger _length;
   NSUInteger _height;
+  CGFloat _scale;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame color:(UIColor *)color
@@ -43,6 +44,7 @@
     _minFPS = 60;
     _length = (NSUInteger)floor(frame.size.width);
     _height = (NSUInteger)floor(frame.size.height);
+    _scale = 60.0 / (CGFloat)_height;
     _frames = calloc(sizeof(CGFloat), _length);
     _color = color;
 
@@ -97,12 +99,14 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)aDecoder)
       self->_label.text = [NSString stringWithFormat:@"%lu", (unsigned long)self->_FPS];
     });
 
+    CGFloat previousScale = _scale;
     CGFloat targetFps = MAX(_maxFPS, 60.0);
-    CGFloat scale = targetFps / (CGFloat)_height;
+    _scale = targetFps / (CGFloat)_height;
     for (NSUInteger i = 0; i < _length - 1; i++) {
-      _frames[i] = _frames[i + 1];
+      // Move each Frame back one position and adjust to new scale (if there is a new scale)
+      _frames[i] = _frames[i + 1] * previousScale / _scale;
     }
-    _frames[_length - 1] = (double)_FPS / scale;
+    _frames[_length - 1] = (double)_FPS / _scale;
 
     CGMutablePathRef path = CGPathCreateMutable();
     CGPathMoveToPoint(path, NULL, 0, (CGFloat)_height);


### PR DESCRIPTION


<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Currently the `RCTFPSGraph` component is hardcoded/capped at a Frame Rate of 60.

Since there are phones that support more than 60 FPS (newer iPhones can do 120 FPS), and there might be other use-cases for the RCTFPSGraph (I use it in VisionCamera to show Camera FPS), this PR changes the scale to also support higher FPS by adjusting it on the fly (when a new maximum arrives)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog


<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[iOS] [Fixed] - Support 120 FPS or more in `RCTFPSGraph`

## Test Plan

Before:

![IMG_1075](https://user-images.githubusercontent.com/15199031/205340761-12954d36-82dd-4102-868a-b7234fdfc21c.jpg)

After:

![IMG_1074](https://user-images.githubusercontent.com/15199031/205340790-092bfa57-c291-418b-9ce3-2a8d2389436a.jpg)

