### PR TITLE
feat: Extract case Array and ReadOnlyArray into a single emitArrayType function

### DIFF
--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -32,6 +32,7 @@ const {
   buildPropertySchema,
 } = require('../../parsers-commons');
 const {
+  emitArrayType,
   emitBoolean,
   emitDouble,
   emitFloat,
@@ -106,21 +107,14 @@ function translateTypeAnnotation(
         }
         case 'Array':
         case '$ReadOnlyArray': {
-          assertGenericTypeAnnotationHasExactlyOneTypeParameter(
+          return emitArrayType(
             hasteModuleName,
             typeAnnotation,
             parser,
-          );
-
-          return translateArrayTypeAnnotation(
-            hasteModuleName,
             types,
             aliasMap,
             cxxOnly,
-            typeAnnotation.type,
-            typeAnnotation.typeParameters.params[0],
             nullable,
-            language,
             translateTypeAnnotation,
           );
         }

--- a/packages/react-native-codegen/src/parsers/parsers-primitives.js
+++ b/packages/react-native-codegen/src/parsers/parsers-primitives.js
@@ -333,7 +333,37 @@ function translateArrayTypeAnnotation(
   }
 }
 
+function emitArrayType(
+  hasteModuleName: string,
+  typeAnnotation: $FlowFixMe,
+  parser: Parser,
+  types: TypeDeclarationMap,
+  aliasMap: {...NativeModuleAliasMap},
+  cxxOnly: boolean,
+  nullable: boolean,
+  translateTypeAnnotation: $FlowFixMe,
+): Nullable<NativeModuleTypeAnnotation> {
+  assertGenericTypeAnnotationHasExactlyOneTypeParameter(
+    hasteModuleName,
+    typeAnnotation,
+    parser,
+  );
+
+  return translateArrayTypeAnnotation(
+    hasteModuleName,
+    types,
+    aliasMap,
+    cxxOnly,
+    typeAnnotation.type,
+    typeAnnotation.typeParameters.params[0],
+    nullable,
+    parser.language(),
+    translateTypeAnnotation,
+  );
+}
+
 module.exports = {
+  emitArrayType,
   emitBoolean,
   emitDouble,
   emitFloat,

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -26,13 +26,13 @@ const {visit, isModuleRegistryCall, verifyPlatforms} = require('../../utils');
 const {resolveTypeAnnotation, getTypes} = require('../utils.js');
 
 const {
-  assertGenericTypeAnnotationHasExactlyOneTypeParameter,
   parseObjectProperty,
   translateDefault,
   buildPropertySchema,
 } = require('../../parsers-commons');
 
 const {
+  emitArrayType,
   emitBoolean,
   emitDouble,
   emitFloat,
@@ -145,21 +145,14 @@ function translateTypeAnnotation(
         }
         case 'Array':
         case 'ReadonlyArray': {
-          assertGenericTypeAnnotationHasExactlyOneTypeParameter(
+          return emitArrayType(
             hasteModuleName,
             typeAnnotation,
             parser,
-          );
-
-          return translateArrayTypeAnnotation(
-            hasteModuleName,
             types,
             aliasMap,
             cxxOnly,
-            typeAnnotation.type,
-            typeAnnotation.typeParameters.params[0],
             nullable,
-            language,
             translateTypeAnnotation,
           );
         }


### PR DESCRIPTION
## Summary

This PR extracts the content of the codegen case `'Array'` and `'ReadOnlyArray'` into a single `emitArrayType` function inside the `parsers-primitives.js` file and uses it in both Flow and TypeScript parsers as requested on https://github.com/facebook/react-native/issues/34872. This also adds unit tests to the new `emitArrayType` function.

## Changelog 

[Internal] [Changed]  - Extract the content of the case 'Array' and 'ReadOnlyArray'  into a single emitArrayType function

## Test Plan

Run `yarn jest react-native-codegen` and ensure CI is green

![image](https://user-images.githubusercontent.com/11707729/205375599-3bbf02bf-85b5-41e6-ae77-fc6e12bee538.png)

