### PR TITLE
RN: Upgrade to deprecated-react-native-prop-types@3.0.0

### DIFF
--- a/Libraries/Image/ImageSource.js
+++ b/Libraries/Image/ImageSource.js
@@ -11,8 +11,6 @@
 'use strict';
 
 /**
- * Keep this in sync with `DeprecatedImageSourcePropType.js`.
- *
  * This type is intentionally inexact in order to permit call sites that supply
  * extra properties.
  */

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "abort-controller": "^3.0.0",
     "anser": "^1.4.9",
     "base64-js": "^1.1.2",
-    "deprecated-react-native-prop-types": "^2.3.0",
+    "deprecated-react-native-prop-types": "^3.0.1",
     "event-target-shim": "^5.0.1",
     "invariant": "^2.2.4",
     "jest-environment-node": "^29.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3594,10 +3594,10 @@ depd@~1.1.2:
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
 
-deprecated-react-native-prop-types@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/deprecated-react-native-prop-types/-/deprecated-react-native-prop-types-2.3.0.tgz#c10c6ee75ff2b6de94bb127f142b814e6e08d9ab"
-  integrity sha512-pWD0voFtNYxrVqvBMYf5gq3NA2GCpfodS1yNynTPc93AYA/KEMGeWDqqeUB6R2Z9ZofVhks2aeJXiuQqKNpesA==
+deprecated-react-native-prop-types@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/deprecated-react-native-prop-types/-/deprecated-react-native-prop-types-3.0.1.tgz#a275f84cd8519cd1665e8df3c99e9067d57a23ec"
+  integrity sha512-J0jCJcsk4hMlIb7xwOZKLfMpuJn6l8UtrPEzzQV5ewz5gvKNYakhBuq9h2rWX7YwHHJZFhU5W8ye7dB9oN8VcQ==
   dependencies:
     "@react-native/normalize-color" "*"
     invariant "*"


### PR DESCRIPTION
Summary:
Upgrades `react-native` to the newly published `deprecated-react-native-prop-types@3.0.0`, which brings prop-types compatibility up-to-speed with React Native 0.71. (This **is** a release blocker for 0.71.)

Changelog:
[General][Changed] Updated Prop Types for 0.71: https://github.com/facebook/react-native-deprecated-modules/blob/main/deprecated-react-native-prop-types/CHANGELOG.md

Differential Revision: D41708199

