### PR TITLE
remove hermes note

### DIFF
--- a/template/ios/Podfile
+++ b/template/ios/Podfile
@@ -21,8 +21,6 @@ target 'HelloWorld' do
   use_react_native!(
     :path => config[:reactNativePath],
     # Hermes is now enabled by default. Disable by setting this flag to false.
-    # Upcoming versions of React Native may rely on get_default_flags(), but
-    # we make it explicit here to aid in the React Native upgrade process.
     :hermes_enabled => flags[:hermes_enabled],
     :fabric_enabled => flags[:fabric_enabled],
     # Enables Flipper.


### PR DESCRIPTION
## Summary

This note was added when upgrading from 0.69x to 0.70.x when `hermes_enabled` is explicitly set to `true`.

<img width="669" alt="Screenshot 2022-12-05 at 11 26 15" src="https://user-images.githubusercontent.com/36528176/205543104-b4a72c1c-57c0-422b-881e-8a0cb9d5c2a1.png">

But on 0.71, we are now using  `get_default_flags` again which makes the note obsolete.

## Changelog

[Internal] [Removed] - removed hermes note

## Test Plan

N/A