### PR TITLE
fix syntax error on Touchable.js when upgrading old react native proj…

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -14,9 +14,9 @@
     "react-native": "1000.0.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.20.0",
+    "@babel/core": "^7.20.5",
     "@babel/preset-env": "^7.20.0",
-    "@babel/runtime": "^7.12.5",
+    "@babel/runtime": "^7.20.6",
     "@react-native/eslint-config": "^0.72.0",
     "@tsconfig/react-native": "^2.0.2",
     "@types/jest": "^29.2.1",


### PR DESCRIPTION
…ects

## Summary

Fixes #34719 

Based on: https://github.com/facebook/react-native/issues/34719#issuecomment-1331890895, thanks @aprakimble

When creating a new react native project it doesn't include `yarn.lock` file, `^7.12.9` and `^7.12.5` installs the latest version (`7.20.x`) that's why the error does not appear.

But when upgrading an old react native project with `yarn.lock` Eg. `0.69.x` to `0.70.x` (or `0.71`), at least in my project are both locked at `7.12.13` and running `yarn` does not update the lock file.

Seems like my project's `@babel/core` and `@babel/runtime` are locked at `7.12.13` since `0.64.x` and only start to matter now.

<img width="374" alt="Screenshot 2022-12-05 at 14 05 00" src="https://user-images.githubusercontent.com/36528176/205561194-2389d283-7c84-4135-a76a-12d377a80edb.png">

https://react-native-community.github.io/upgrade-helper/?from=0.69.7&to=0.71.0-rc.3

Explicitly changing the version on the `package.json` updates the lock file and completes the upgrade process without an error.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[General] [Fixed] - fix syntax error on Touchable.js when upgrading old react native projects

## Test Plan

CI should pass
