### PR TITLE
Remove `disable_infer_precompiled_header` to unblock Buck OSS

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -592,7 +592,6 @@ rn_apple_library(
     autoglob = False,
     complete_nullability = True,
     contacts = ["oncall+react_native@xmail.facebook.com"],
-    disable_infer_precompiled_header = True,
     extension_api_only = True,
     frameworks = [
         "Foundation",

--- a/Libraries/RCTRequired/BUCK
+++ b/Libraries/RCTRequired/BUCK
@@ -8,7 +8,6 @@ rn_apple_library(
     autoglob = False,
     complete_nullability = True,
     contacts = ["oncall+react_native@xmail.facebook.com"],
-    disable_infer_precompiled_header = True,
     extension_api_only = True,
     frameworks = ["Foundation"],
     labels = [


### PR DESCRIPTION
Summary:
A codemod landed which broke our public CI as it added
`disable_infer_precompiled_header` which is not known to Buck OSS.
I'm unblocking the public CI by removing it.

Changelog:
[Internal] [Changed] - Remove `disable_infer_precompiled_header` to unblock Buck OSS

Differential Revision: D41729534

