### PR TITLE
RNGP - `findPackageJsonFile` should return `null` if `package.json` does not exist

### DIFF
--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/PathUtils.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/PathUtils.kt
@@ -188,12 +188,19 @@ internal fun projectPathToLibraryName(projectPath: String): String =
  * Gradle module (generally the case for library projects) or we fallback to looking into the `root`
  * folder of a React Native project (generally the case for app projects).
  */
-internal fun findPackageJsonFile(project: Project, extension: ReactExtension): File? =
-    if (project.file("../package.json").exists()) {
-      project.file("../package.json")
-    } else {
-      extension.root.file("package.json").orNull?.asFile
-    }
+internal fun findPackageJsonFile(project: Project, extension: ReactExtension): File? {
+  val inParent = project.file("../package.json")
+  if (inParent.exists()) {
+    return inParent
+  }
+
+  val fromExtension = extension.root.file("package.json").orNull?.asFile
+  if (fromExtension?.exists() == true) {
+    return fromExtension
+  }
+
+  return null
+}
 
 /**
  * Function to look for the `package.json` and parse it. It returns a [ModelPackageJson] if found or

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/PathUtilsTest.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/PathUtilsTest.kt
@@ -249,7 +249,7 @@ class PathUtilsTest {
     assertEquals(localFile, findPackageJsonFile(project, extension))
   }
 
-  @Test(expected = FileNotFoundException::class)
+  @Test
   fun readPackageJsonFile_withMissingFile_returnsNull() {
     val moduleFolder = tempFolder.newFolder("awesome-module")
     val project = ProjectBuilder.builder().withProjectDir(moduleFolder).build()

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/ProjectUtilsTest.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/ProjectUtilsTest.kt
@@ -161,4 +161,12 @@ class ProjectUtilsTest {
 
     assertFalse(project.needsCodegenFromPackageJson(model))
   }
+
+  @Test
+  fun needsCodegenFromPackageJson_withMissingPackageJson_returnsFalse() {
+    val project = createProject()
+    val extension = TestReactExtension(project)
+
+    assertFalse(project.needsCodegenFromPackageJson(extension))
+  }
 }


### PR DESCRIPTION
## Summary

`findPackageJsonFile` always returns a path even though `package.json` does not exist. This causes issues in libraries whose repo setups look like:

```
react-native-webview
├── android
│   └── build.gradle
├── example  <-- Note the lack of `package.json` here
│   └── App.tsx
├── ios
│   └── RNCWebView.xcodeproj
├── macos
│   └── RNCWebView.xcodeproj
├── package.json
└── src
```

When `newArchEnabled=true`, running `yarn android` will fail with the following:

```
FAILURE: Build failed with an exception.

* What went wrong:
Could not determine the dependencies of task ':app:generateCodegenArtifactsFromSchema'.
> Could not create task ':app:generateCodegenSchemaFromJavaScript'.
   > /~/react-native-webview/example/package.json (No such file or directory)
```

## Changelog

[Android] [Fixed] - `findPackageJsonFile` should return `null` if `package.json` does not exist

## Test Plan

```
git clone https://github.com/react-native-webview/react-native-webview.git
cd react-native-webview
git checkout new-arch-ios
yarn
cd example/android
./gradlew clean assembleDebug
```