### PR TITLE
Native side implementation for Performance.measure()

### DIFF
--- a/Libraries/WebPerformance/NativePerformance.cpp
+++ b/Libraries/WebPerformance/NativePerformance.cpp
@@ -22,4 +22,21 @@ void NativePerformance::mark(
   PerformanceEntryReporter::getInstance().mark(name, startTime, duration);
 }
 
+void NativePerformance::clearMarks(
+    jsi::Runtime &rt,
+    std::optional<std::string> markName) {}
+
+void NativePerformance::measure(
+    jsi::Runtime &rt,
+    std::string name,
+    double startTime,
+    double endTime,
+    std::optional<double> duration,
+    std::optional<std::string> startMark,
+    std::optional<std::string> endMark) {}
+
+void NativePerformance::clearMeasures(
+    jsi::Runtime &rt,
+    std::optional<std::string> measureName) {}
+
 } // namespace facebook::react

--- a/Libraries/WebPerformance/NativePerformance.cpp
+++ b/Libraries/WebPerformance/NativePerformance.cpp
@@ -24,7 +24,9 @@ void NativePerformance::mark(
 
 void NativePerformance::clearMarks(
     jsi::Runtime &rt,
-    std::optional<std::string> markName) {}
+    std::optional<std::string> markName) {
+  PerformanceEntryReporter::getInstance().clearMarks(markName);
+}
 
 void NativePerformance::measure(
     jsi::Runtime &rt,
@@ -33,10 +35,15 @@ void NativePerformance::measure(
     double endTime,
     std::optional<double> duration,
     std::optional<std::string> startMark,
-    std::optional<std::string> endMark) {}
+    std::optional<std::string> endMark) {
+  PerformanceEntryReporter::getInstance().measure(
+      name, startTime, endTime, duration, startMark, endMark);
+}
 
 void NativePerformance::clearMeasures(
     jsi::Runtime &rt,
-    std::optional<std::string> measureName) {}
+    std::optional<std::string> measureName) {
+  PerformanceEntryReporter::getInstance().clearMeasures(measureName);
+}
 
 } // namespace facebook::react

--- a/Libraries/WebPerformance/NativePerformance.h
+++ b/Libraries/WebPerformance/NativePerformance.h
@@ -37,7 +37,6 @@ class NativePerformance : public NativePerformanceCxxSpec<NativePerformance>,
       std::optional<double> duration,
       std::optional<std::string> startMark,
       std::optional<std::string> endMark);
-
   void clearMeasures(jsi::Runtime &rt, std::optional<std::string> measureName);
 
  private:

--- a/Libraries/WebPerformance/NativePerformance.h
+++ b/Libraries/WebPerformance/NativePerformance.h
@@ -27,6 +27,18 @@ class NativePerformance : public NativePerformanceCxxSpec<NativePerformance>,
 
   void
   mark(jsi::Runtime &rt, std::string name, double startTime, double duration);
+  void clearMarks(jsi::Runtime &rt, std::optional<std::string> markName);
+
+  void measure(
+      jsi::Runtime &rt,
+      std::string name,
+      double startTime,
+      double endTime,
+      std::optional<double> duration,
+      std::optional<std::string> startMark,
+      std::optional<std::string> endMark);
+
+  void clearMeasures(jsi::Runtime &rt, std::optional<std::string> measureName);
 
  private:
 };

--- a/Libraries/WebPerformance/NativePerformance.js
+++ b/Libraries/WebPerformance/NativePerformance.js
@@ -14,6 +14,17 @@ import * as TurboModuleRegistry from '../TurboModule/TurboModuleRegistry';
 
 export interface Spec extends TurboModule {
   +mark?: (name: string, startTime: number, duration: number) => void;
+  +clearMarks?: (markName?: string) => void;
+
+  +measure?: (
+    name: string,
+    startTime: number,
+    endTime: number,
+    duration?: number,
+    startMark?: string,
+    endMark?: string,
+  ) => void;
+  +clearMeasures?: (measureName?: string) => void;
 }
 
 export default (TurboModuleRegistry.get<Spec>('NativePerformanceCxx'): ?Spec);

--- a/Libraries/WebPerformance/NativePerformanceObserver.cpp
+++ b/Libraries/WebPerformance/NativePerformanceObserver.cpp
@@ -15,6 +15,8 @@ static PerformanceEntryType stringToPerformanceEntryType(
     const std::string &entryType) {
   if (entryType == "mark") {
     return PerformanceEntryType::MARK;
+  } else if (entryType == "measure") {
+    return PerformanceEntryType::MEASURE;
   } else {
     return PerformanceEntryType::UNDEFINED;
   }

--- a/Libraries/WebPerformance/NativePerformanceObserver.js
+++ b/Libraries/WebPerformance/NativePerformanceObserver.js
@@ -15,6 +15,7 @@ import * as TurboModuleRegistry from '../TurboModule/TurboModuleRegistry';
 export const RawPerformanceEntryTypeValues = {
   UNDEFINED: 0,
   MARK: 1,
+  MEASURE: 2,
 };
 
 export type RawPerformanceEntryType = number;

--- a/Libraries/WebPerformance/PerformanceEntryReporter.cpp
+++ b/Libraries/WebPerformance/PerformanceEntryReporter.cpp
@@ -59,6 +59,24 @@ void PerformanceEntryReporter::mark(
     const std::string &name,
     double startTime,
     double duration) {
+  // Register the mark for further possible "measure" lookup, as well as add
+  // it to a circular buffer:
+  PerformanceMark &mark = marks_buffer_[marks_buffer_position_];
+  marks_buffer_position_ = (marks_buffer_position_ + 1) % marks_buffer_.size();
+
+  if (!mark.name.empty()) {
+    // Drop off the oldest mark out of the queue, but only if that's indeed the
+    // oldest one
+    auto it = marks_registry_.find(&mark);
+    if (it != marks_registry_.end() && *it == &mark) {
+      marks_registry_.erase(it);
+    }
+  }
+
+  mark.name = name;
+  mark.timeStamp = startTime;
+  marks_registry_.insert(&mark);
+
   logEntry(
       {name,
        static_cast<int>(PerformanceEntryType::MARK),
@@ -68,4 +86,83 @@ void PerformanceEntryReporter::mark(
        std::nullopt,
        std::nullopt});
 }
+
+void PerformanceEntryReporter::clearMarks(
+    const std::optional<std::string> &markName) {
+  if (markName) {
+    PerformanceMark mark{{*markName, 0}};
+    marks_registry_.erase(&mark);
+    clearEntries([&markName](const RawPerformanceEntry &entry) {
+      return entry.entryType == static_cast<int>(PerformanceEntryType::MARK) &&
+          entry.name == markName;
+    });
+  } else {
+    marks_registry_.clear();
+    clearEntries([](const RawPerformanceEntry &entry) {
+      return entry.entryType == static_cast<int>(PerformanceEntryType::MARK);
+    });
+  }
+}
+
+void PerformanceEntryReporter::measure(
+    const std::string &name,
+    double startTime,
+    double endTime,
+    const std::optional<double> &duration,
+    const std::optional<std::string> &startMark,
+    const std::optional<std::string> &endMark) {
+  double startTimeVal = startMark ? getMarkTime(*startMark) : startTime;
+  double endTimeVal = endMark ? getMarkTime(*endMark) : endTime;
+  double durationVal = duration ? *duration : endTimeVal - startTimeVal;
+  logEntry(
+      {name,
+       static_cast<int>(PerformanceEntryType::MEASURE),
+       startTimeVal,
+       durationVal,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt});
+}
+
+void PerformanceEntryReporter::clearMeasures(
+    const std::optional<std::string> &measureName) {
+  if (measureName) {
+    clearEntries([&measureName](const RawPerformanceEntry &entry) {
+      return entry.entryType ==
+          static_cast<int>(PerformanceEntryType::MEASURE) &&
+          entry.name == measureName;
+    });
+  } else {
+    marks_registry_.clear();
+    clearEntries([](const RawPerformanceEntry &entry) {
+      return entry.entryType == static_cast<int>(PerformanceEntryType::MEASURE);
+    });
+  }
+}
+
+double PerformanceEntryReporter::getMarkTime(
+    const std::string &markName) const {
+  PerformanceMark mark{{std::move(markName), 0}};
+  auto it = marks_registry_.find(&mark);
+  if (it != marks_registry_.end()) {
+    return (*it)->timeStamp;
+  } else {
+    return 0.0;
+  }
+}
+
+void PerformanceEntryReporter::clearEntries(
+    std::function<bool(const RawPerformanceEntry &)> predicate) {
+  int lastPos = entries_.size() - 1;
+  int pos = lastPos;
+  while (pos >= 0) {
+    if (predicate(entries_[pos])) {
+      entries_[pos] = entries_[lastPos];
+      lastPos--;
+    }
+    pos--;
+  }
+  entries_.resize(lastPos + 1);
+}
+
 } // namespace facebook::react

--- a/Libraries/WebPerformance/PerformanceEntryReporter.h
+++ b/Libraries/WebPerformance/PerformanceEntryReporter.h
@@ -9,15 +9,43 @@
 
 #include <react/bridging/Function.h>
 #include <array>
+#include <functional>
 #include <optional>
+#include <unordered_set>
 #include "NativePerformanceObserver.h"
 
 namespace facebook::react {
 
+struct PerformanceMark {
+  std::string name;
+  double timeStamp;
+};
+
+struct PerformanceMarkHash {
+  size_t operator()(const PerformanceMark *mark) const {
+    return std::hash<std::string>()(mark->name);
+  }
+};
+
+struct PerformanceMarkEqual {
+  bool operator()(const PerformanceMark *lhs, const PerformanceMark *rhs)
+      const {
+    return lhs->name == rhs->name;
+  }
+};
+
+using PerformanceMarkRegistryType = std::
+    unordered_set<PerformanceMark *, PerformanceMarkHash, PerformanceMarkEqual>;
+
+// Only the MARKS_BUFFER_SIZE amount of the latest marks will be kept in
+// memory for the sake of the "Performance.measure" mark name lookup
+constexpr size_t MARKS_BUFFER_SIZE = 1024;
+
 enum class PerformanceEntryType {
   UNDEFINED = 0,
   MARK = 1,
-  _COUNT = 2,
+  MEASURE = 2,
+  _COUNT = 3,
 };
 
 class PerformanceEntryReporter {
@@ -45,13 +73,31 @@ class PerformanceEntryReporter {
   }
 
   void mark(const std::string &name, double startTime, double duration);
+  void clearMarks(const std::optional<std::string> &markName);
+
+  void measure(
+      const std::string &name,
+      double startTime,
+      double endTime,
+      const std::optional<double> &duration,
+      const std::optional<std::string> &startMark,
+      const std::optional<std::string> &endMark);
+  void clearMeasures(const std::optional<std::string> &measureName);
 
  private:
   PerformanceEntryReporter() {}
 
+  double getMarkTime(const std::string &markName) const;
+  void clearEntries(std::function<bool(const RawPerformanceEntry &)> predicate);
+
   std::optional<AsyncCallback<>> callback_;
   std::vector<RawPerformanceEntry> entries_;
   std::array<bool, (size_t)PerformanceEntryType::_COUNT> reportingType_{false};
+
+  // Mark registry for "measure" lookup
+  PerformanceMarkRegistryType marks_registry_;
+  std::array<PerformanceMark, MARKS_BUFFER_SIZE> marks_buffer_;
+  size_t marks_buffer_position_{0};
 };
 
 } // namespace facebook::react

--- a/Libraries/WebPerformance/PerformanceObserver.js
+++ b/Libraries/WebPerformance/PerformanceObserver.js
@@ -14,11 +14,12 @@ import type {
 } from './NativePerformanceObserver';
 
 import warnOnce from '../Utilities/warnOnce';
-import NativePerformanceObserver from './NativePerformanceObserver';
+import NativePerformanceObserver, {
+  RawPerformanceEntryTypeValues,
+} from './NativePerformanceObserver';
 
 export type HighResTimeStamp = number;
-// TODO: Extend once new types (such as event) are supported.
-export type PerformanceEntryType = 'mark';
+export type PerformanceEntryType = 'mark' | 'measure';
 
 export class PerformanceEntry {
   name: string;
@@ -52,7 +53,11 @@ export class PerformanceEntry {
 function rawToPerformanceEntryType(
   type: RawPerformanceEntryType,
 ): PerformanceEntryType {
-  return 'mark';
+  if (type === RawPerformanceEntryTypeValues.MARK) {
+    return 'mark';
+  } else {
+    return 'measure';
+  }
 }
 
 function rawToPerformanceEntry(entry: RawPerformanceEntry): PerformanceEntry {
@@ -232,5 +237,5 @@ export default class PerformanceObserver {
 
   static supportedEntryTypes: $ReadOnlyArray<PerformanceEntryType> =
     // TODO: add types once they are fully supported
-    Object.freeze(['mark']);
+    Object.freeze(['mark', 'measure']);
 }


### PR DESCRIPTION
Summary:
Changelog: [Internal]

This implements the C++ side logic of handling `Performance.measure` calls.

Since measures may refer to earlier logged marks by name, we need to keep track of the former. I also use a fixed size (circular) buffer to prevent the marks from piling forever.

Also adds implementation of clearing marks/measures, as per standard.

Reviewed By: mdvacca

Differential Revision: D41756928

