### PR TITLE
fix: script phases warning

### DIFF
--- a/scripts/react_native_pods_utils/script_phases.rb
+++ b/scripts/react_native_pods_utils/script_phases.rb
@@ -48,6 +48,6 @@ def get_script_template(react_native_path, export_vars={})
         WITH_ENVIRONMENT="$RCT_SCRIPT_RN_DIR/scripts/xcode/with-environment.sh"
         /bin/sh -c "$WITH_ENVIRONMENT $SCRIPT_PHASES_SCRIPT"
         EOS
-    result = ERB.new(template, 0, '->').result(binding)
+    result = ERB.new(template, trim_mode: '->').result(binding)
     return result
 end


### PR DESCRIPTION
## Summary

Running pod install result in some warninigs on ruby v3:
```
script_phases.rb:51: warning: Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.
script_phases.rb:51: warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.
```

## Changelog

[INTERNAL] [FIXED] - warnings while running `pod-install` inside script phase script

## Test Plan

- Install ruby v3 (I haven't tested on ruby v2.7, most m1 users need to upgrade to v3)
- Run `pod install` in ios folder
