### PR TITLE
Switch order of onSelectionChange and onChange events on iOS

### DIFF
--- a/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.m
+++ b/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.m
@@ -168,6 +168,8 @@ static void *TextFieldSelectionObservingContext = &TextFieldSelectionObservingCo
 
 @implementation RCTBackedTextViewDelegateAdapter {
   __weak UITextView<RCTBackedTextInputViewProtocol> *_backedTextInputView;
+  NSAttributedString *_lastStringStateWasUpdatedWith;
+  BOOL _ignoreNextTextInputCall;
   BOOL _textDidChangeIsComing;
   UITextRange *_previousSelectedTextRange;
 }
@@ -254,12 +256,21 @@ static void *TextFieldSelectionObservingContext = &TextFieldSelectionObservingCo
 
 - (void)textViewDidChange:(__unused UITextView *)textView
 {
+  if (_ignoreNextTextInputCall && [_lastStringStateWasUpdatedWith isEqual:_backedTextInputView.attributedText]) {
+    _ignoreNextTextInputCall = NO;
+    return;
+  }
+  _lastStringStateWasUpdatedWith = _backedTextInputView.attributedText;
   _textDidChangeIsComing = NO;
   [_backedTextInputView.textInputDelegate textInputDidChange];
 }
 
 - (void)textViewDidChangeSelection:(__unused UITextView *)textView
 {
+  if (![_lastStringStateWasUpdatedWith isEqual:_backedTextInputView.attributedText]) {
+    [self textViewDidChange:_backedTextInputView];
+    _ignoreNextTextInputCall = YES;
+  }
   [self textViewProbablyDidChangeSelection];
 }
 


### PR DESCRIPTION
## Summary
Switched order of onSelectionChange and onChange events on iOS

This was already fixed but for fabric only https://github.com/facebook/react-native/blob/main/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm#L36-L46

This PR is a complementary of https://github.com/facebook/react-native/commit/7b4889937ceb0eccdbb62a610b58525c29928be7

Fixes https://github.com/facebook/react-native/issues/28865 

## Changelog

[IOS] [FIXED] - onSelectionChange() is fired before onChange() on multiline TextInput

## Test Plan

Reproduce the minimal example provided here https://github.com/facebook/react-native/issues/28865
Verify that the events order is onChange then onSelectionChange with no duplicates