### PR TITLE
[LOCAL] fix: use REACT_NATIVE_CI instead of CI envvar

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ executors:
       xcode: *xcode_version
     resource_class: macos.x86.medium.gen2
     environment:
-      - META_CI: true
+      - REACT_NATIVE_CI: true
 
 # -------------------------
 #        COMMANDS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,6 +119,8 @@ executors:
     macos:
       xcode: *xcode_version
     resource_class: macos.x86.medium.gen2
+    environment:
+      - META_CI: true
 
 # -------------------------
 #        COMMANDS
@@ -266,7 +268,7 @@ commands:
             echo "$VERSION" > /tmp/react-native-version
             echo "React Native Version is $(cat /tmp/react-native-version)"
             echo "Hermes commit is $(cat /tmp/hermes/hermesversion)"
-            
+
   with_hermes_tarball_cache_span:
     parameters:
       steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1129,6 +1129,7 @@ jobs:
     environment:
       - HERMES_WS_DIR: *hermes_workspace_root
       - HERMES_VERSION_FILE: "sdks/.hermesversion"
+      - REACT_NATIVE_CI: true
     steps:
       - run:
           name: Install dependencies

--- a/packages/rn-tester/Podfile
+++ b/packages/rn-tester/Podfile
@@ -6,7 +6,7 @@ platform :ios, min_ios_version_supported
 prepare_react_native_project!
 
 USE_FRAMEWORKS = ENV['USE_FRAMEWORKS'] == '1'
-IN_CI = ENV['CI'] == 'true'
+IN_CI = ENV['REACT_NATIVE_CI'] == 'true'
 
 @prefix_path = "../.."
 

--- a/packages/rn-tester/Podfile
+++ b/packages/rn-tester/Podfile
@@ -6,7 +6,7 @@ platform :ios, min_ios_version_supported
 prepare_react_native_project!
 
 USE_FRAMEWORKS = ENV['USE_FRAMEWORKS'] == '1'
-IN_CI = ENV['REACT_NATIVE_CI'] == 'true'
+IN_CI = ENV['CI'] == 'true'
 
 @prefix_path = "../.."
 

--- a/scripts/cocoapods/__tests__/jsengine-test.rb
+++ b/scripts/cocoapods/__tests__/jsengine-test.rb
@@ -107,7 +107,7 @@ class JSEngineTests < Test::Unit::TestCase
         assert_equal($podInvocation["React-jsi"][:path], "../../ReactCommon/jsi")
         assert_equal($podInvocation["React-hermes"][:path], "../../ReactCommon/hermes")
         assert_equal($podInvocation["libevent"][:version], "~> 2.1.12")
-        assert_equal($podInvocation["hermes-engine"][:podspec], "../../sdks/hermes/hermes-engine.podspec")
+        assert_equal($podInvocation["hermes-engine"][:podspec], "../../sdks/hermes-engine/hermes-engine.podspec")
     end
 
     def test_setupHermes_installsPods_installsFabricSubspecWhenFabricEnabled
@@ -120,7 +120,7 @@ class JSEngineTests < Test::Unit::TestCase
         # Assert
         assert_equal($podInvocationCount, 4)
         assert_equal($podInvocation["React-jsi"][:path], "../../ReactCommon/jsi")
-        assert_equal($podInvocation["hermes-engine"][:podspec], "../../sdks/hermes/hermes-engine.podspec")
+        assert_equal($podInvocation["hermes-engine"][:podspec], "../../sdks/hermes-engine/hermes-engine.podspec")
         assert_equal($podInvocation["React-hermes"][:path], "../../ReactCommon/hermes")
         assert_equal($podInvocation["libevent"][:version], "~> 2.1.12")
     end

--- a/scripts/cocoapods/__tests__/jsengine-test.rb
+++ b/scripts/cocoapods/__tests__/jsengine-test.rb
@@ -27,7 +27,7 @@ class JSEngineTests < Test::Unit::TestCase
         Pod::UI.reset()
         podSpy_cleanUp()
         ENV['USE_HERMES'] = '1'
-        ENV['CI'] = nil
+        ENV['REACT_NATIVE_CI'] = nil
         File.reset()
     end
 
@@ -133,7 +133,7 @@ class JSEngineTests < Test::Unit::TestCase
     end
 
     def test_isBuildingHermesFromSource_whenTarballIsNilAndInReleaseBranch_returnTrue
-        ENV['CI'] = 'true'
+        ENV['REACT_NATIVE_CI'] = 'true'
         File.mocked_existing_files(['../../sdks/.hermesversion'])
         assert_true(is_building_hermes_from_source("0.999.0", '../..'))
     end

--- a/scripts/cocoapods/jsengine.rb
+++ b/scripts/cocoapods/jsengine.rb
@@ -30,7 +30,7 @@ def setup_hermes!(react_native_path: "../node_modules/react-native", fabric_enab
     abort unless prep_status == 0
 
     pod 'React-jsi', :path => "#{react_native_path}/ReactCommon/jsi"
-    pod 'hermes-engine', :podspec => "#{react_native_path}/sdks/hermes/hermes-engine.podspec"
+    pod 'hermes-engine', :podspec => "#{react_native_path}/sdks/hermes-engine/hermes-engine.podspec"
     pod 'React-hermes', :path => "#{react_native_path}/ReactCommon/hermes"
     pod 'libevent', '~> 2.1.12'
 end

--- a/scripts/cocoapods/jsengine.rb
+++ b/scripts/cocoapods/jsengine.rb
@@ -72,7 +72,7 @@ def is_building_hermes_from_source(react_native_version, react_native_path)
     isInMain = react_native_version.include?('1000.0.0')
 
     hermestag_file = File.join(react_native_path, "sdks", ".hermesversion")
-    isInCI = ENV['CI'] === 'true'
+    isInCI = ENV['REACT_NATIVE_CI'] === 'true'
 
     isReleaseBranch = File.exist?(hermestag_file) && isInCI
 

--- a/scripts/hermes/prepare-hermes-for-build.js
+++ b/scripts/hermes/prepare-hermes-for-build.js
@@ -39,7 +39,7 @@ async function main(isInCI) {
   }
 }
 
-const isInCI = process.env.META_CI === 'true';
+const isInCI = process.env.REACT_NATIVE_CI === 'true';
 
 main(isInCI).then(() => {
   process.exit(0);

--- a/scripts/hermes/prepare-hermes-for-build.js
+++ b/scripts/hermes/prepare-hermes-for-build.js
@@ -39,7 +39,7 @@ async function main(isInCI) {
   }
 }
 
-const isInCI = process.env.CI === 'true';
+const isInCI = process.env.META_CI === 'true';
 
 main(isInCI).then(() => {
   process.exit(0);

--- a/scripts/test-e2e-local.js
+++ b/scripts/test-e2e-local.js
@@ -97,7 +97,7 @@ if (argv.target === 'RNTester') {
     exec(
       `cd packages/rn-tester && USE_HERMES=${
         argv.hermes ? 1 : 0
-      } CI=${onReleaseBranch} RCT_NEW_ARCH_ENABLED=1 bundle exec pod install --ansi`,
+      } REACT_NATIVE_CI=${onReleaseBranch} RCT_NEW_ARCH_ENABLED=1 bundle exec pod install --ansi`,
     );
 
     // if everything succeeded so far, we can launch Metro and the app

--- a/sdks/hermes-engine/hermes-engine.podspec
+++ b/sdks/hermes-engine/hermes-engine.podspec
@@ -17,7 +17,7 @@ version = package['version']
 
 # sdks/.hermesversion
 hermestag_file = File.join(react_native_path, "sdks", ".hermesversion")
-isInCI = ENV['CI'] === 'true'
+isInCI = ENV['META_CI'] === 'true'
 
 source = {}
 git = "https://github.com/facebook/hermes.git"

--- a/sdks/hermes-engine/hermes-engine.podspec
+++ b/sdks/hermes-engine/hermes-engine.podspec
@@ -17,7 +17,7 @@ version = package['version']
 
 # sdks/.hermesversion
 hermestag_file = File.join(react_native_path, "sdks", ".hermesversion")
-isInCI = ENV['META_CI'] === 'true'
+isInCI = ENV['REACT_NATIVE_CI'] === 'true'
 
 source = {}
 git = "https://github.com/facebook/hermes.git"


### PR DESCRIPTION
## Summary

Use `REACT_NATIVE_CI` instead of `CI` environment variable to trigger building Hermes from source on CircleCI. `CI` envvar is defined in many other CIs, which may lead to undesirable behavior: https://github.com/facebook/react-native/issues/35547

## Changelog

[INTERNAL] [CHANGED] - Use `REACT_NATIVE_CI` instead of `CI` environment variable to trigger building Hermes from source on CircleCI.

## Test Plan

`pod install` and `CI=true pod install` both consume Hermes prebuilt if available.
`REACT_NATIVE_CI=true pod install` builds Hermes from tag specified in `.hermesversion`.
CircleCI.
