### PR TITLE
Add cursor position to textInput onChange event

### DIFF
--- a/Libraries/Text/TextInput/RCTBaseTextInputView.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputView.m
@@ -503,6 +503,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
       @"text" : [self.attributedText.string copy],
       @"target" : self.reactTag,
       @"eventCount" : @(_nativeEventCount),
+      @"cursorPosition": [NSNumber numberWithInt: self.selection.start],
     });
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextChangedEvent.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextChangedEvent.java
@@ -22,16 +22,18 @@ public class ReactTextChangedEvent extends Event<ReactTextChangedEvent> {
 
   private String mText;
   private int mEventCount;
+  private int mCursorPosition;
 
   @Deprecated
-  public ReactTextChangedEvent(int viewId, String text, int eventCount) {
-    this(-1, viewId, text, eventCount);
+  public ReactTextChangedEvent(int viewId, String text, int eventCount, int cursorPosition) {
+    this(-1, viewId, text, eventCount, cursorPosition);
   }
 
-  public ReactTextChangedEvent(int surfaceId, int viewId, String text, int eventCount) {
+  public ReactTextChangedEvent(int surfaceId, int viewId, String text, int eventCount, int cursorPosition) {
     super(surfaceId, viewId);
     mText = text;
     mEventCount = eventCount;
+    mCursorPosition = cursorPosition;
   }
 
   @Override
@@ -46,6 +48,7 @@ public class ReactTextChangedEvent extends Event<ReactTextChangedEvent> {
     eventData.putString("text", mText);
     eventData.putInt("eventCount", mEventCount);
     eventData.putInt("target", getViewTag());
+    eventData.putInt("cursorPosition", mCursorPosition);
     return eventData;
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -1050,7 +1050,8 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
               mSurfaceId,
               mEditText.getId(),
               s.toString(),
-              mEditText.incrementAndGetEventCounter()));
+              mEditText.incrementAndGetEventCounter(),
+              start + count));
 
       mEventDispatcher.dispatchEvent(
           new ReactTextInputEvent(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
Somethimes we need to know where is the cursor inside the `Textinput`, unfortunately [onChangeText](https://reactnative.dev/docs/textinput#onchangetext) only give us the text inside the `TextInput` and it receives a string (changing a string to an object isn't a good idea). 

[onChange](https://reactnative.dev/docs/textinput#onchange) callback receives an object so we can add the cursor position to it.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
[GENERAL] [ADDED] - Add cursor position to textInput onChange event
## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

https://user-images.githubusercontent.com/108357004/207102608-5ea858a8-d385-43d6-a682-43ab4cac9163.mov

