### PR TITLE
Expose ReactAndroid/src/main/jni/react/cxxcomponents via prefab

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -117,7 +117,10 @@ final def preparePrefab = tasks.register("preparePrefab", PreparePrefabHeadersTa
             ),
             new PrefabPreprocessingEntry(
                 "fabricjni",
-                new Pair("src/main/jni/react/fabric", "")
+                [
+                    new Pair("src/main/jni/react/fabric", ""),
+                    new Pair("src/main/jni/react/cxxcomponents", "react/cxxcomponents/")
+                ]
             ),
             new PrefabPreprocessingEntry(
                 "react_render_mapbuffer",
@@ -206,7 +209,10 @@ final def preparePrefab = tasks.register("preparePrefab", PreparePrefabHeadersTa
             ),
             new PrefabPreprocessingEntry(
                 "reactnativejni",
-                new Pair("src/main/jni/react/jni", "react/jni/"),
+                [
+                    new Pair("src/main/jni/react/jni", "react/jni/"),
+                    new Pair("../ReactCommon/cxxreact/", "cxxreact/"),
+                ]
             ),
         ]
     )

--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -147,6 +147,7 @@ final def preparePrefab = tasks.register("preparePrefab", PreparePrefabHeadersTa
                     new Pair(new File(buildDir, "third-party-ndk/glog/exported/").absolutePath, ""),
                     new Pair("../ReactCommon/butter/", "butter/"),
                     new Pair("../ReactCommon/callinvoker/", ""),
+                    new Pair("../ReactCommon/cxxreact/", "cxxreact/"),
                     new Pair("../ReactCommon/react/bridging/", "react/bridging/"),
                     new Pair("../ReactCommon/react/config/", "react/config/"),
                     new Pair("../ReactCommon/react/nativemodule/core/", ""),


### PR DESCRIPTION
Summary:
Reference https://github.com/reactwg/react-native-releases/discussions/41#discussioncomment-4353534
I'm exposing `ReactAndroid/src/main/jni/react/cxxcomponents` to be consumed via prefab.
It will be available to both: `react_nativemodule_core` and `reactnativejni`

Changelog:
[Internal] [Changed] - Expose ReactAndroid/src/main/jni/react/cxxcomponents via prefab

Differential Revision: D41965512

