### PR TITLE
[LOCAL] properly support both libraries and use_frameworks

### DIFF
--- a/ReactCommon/ReactCommon.podspec
+++ b/ReactCommon/ReactCommon.podspec
@@ -61,7 +61,10 @@ Pod::Spec.new do |s|
     ss.subspec "core" do |sss|
       sss.source_files = "react/nativemodule/core/ReactCommon/**/*.{cpp,h}",
                          "react/nativemodule/core/platform/ios/**/*.{mm,cpp,h}"
-      sss.exclude_files = "react/nativemodule/core/ReactCommon/{LongLivedObject,CallbackWrapper}.h"
+      excluded_files = ENV['USE_FRAMEWORKS'] == nil ?
+        "react/nativemodule/core/ReactCommon/LongLivedObject.h" :
+        "react/nativemodule/core/ReactCommon/{LongLivedObject,CallbackWrapper}.h"
+      sss.exclude_files = excluded_files
     end
 
     s.subspec "react_debug_core" do |sss|


### PR DESCRIPTION
## Summary

Following up [this comment](https://github.com/reactwg/react-native-releases/discussions/41#discussioncomment-4382407), this PR tries to fix the issue with `use_frameworks!` and the missing header.

## Changelog

[IOS] [FIXED] - Properly exclude files depending on the `use_frameworks!` option.

## Test Plan

CircleCI should be green