### PR TITLE
De-bump AGP to 7.3.1 and do not use `addGeneratedSourceDirectory`

### DIFF
--- a/packages/react-native-gradle-plugin/build.gradle.kts
+++ b/packages/react-native-gradle-plugin/build.gradle.kts
@@ -33,7 +33,7 @@ group = "com.facebook.react"
 
 dependencies {
   implementation(gradleApi())
-  implementation("com.android.tools.build:gradle:7.4.0-beta05")
+  implementation("com.android.tools.build:gradle:7.3.1")
   implementation("com.google.code.gson:gson:2.8.9")
   implementation("com.google.guava:guava:31.0.1-jre")
   implementation("com.squareup:javapoet:1.13.0")

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
@@ -8,6 +8,7 @@
 package com.facebook.react
 
 import com.android.build.api.variant.AndroidComponentsExtension
+import com.android.build.gradle.AppExtension
 import com.android.build.gradle.internal.tasks.factory.dependsOn
 import com.facebook.react.tasks.BuildCodegenCLITask
 import com.facebook.react.tasks.GenerateCodegenArtifactsTask
@@ -52,6 +53,17 @@ class ReactPlugin : Plugin<Project> {
       project.extensions.getByType(AndroidComponentsExtension::class.java).apply {
         onVariants(selector().all()) { variant ->
           project.configureReactTasks(variant = variant, config = extension)
+        }
+      }
+
+      // This is a legacy AGP api. Needed as AGP 7.3 is not consuming generated resources correctly.
+      // Can be removed as we bump to AGP 7.4 stable.
+      // This registers the $buildDir/generated/res/react/<variant> folder as a
+      // res folder to be consumed with the old AGP Apis which are not broken.
+      project.extensions.getByType(AppExtension::class.java).apply {
+        this.applicationVariants.all {
+          it.registerGeneratedResFolders(
+              project.layout.buildDirectory.files("generated/res/react/${it.name}"))
         }
       }
       configureCodegen(project, extension, isLibrary = false)

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/TaskConfiguration.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/TaskConfiguration.kt
@@ -70,7 +70,9 @@ internal fun Project.configureReactTasks(variant: Variant, config: ReactExtensio
           it.hermesFlags.set(config.hermesFlags)
           it.reactNativeDir.set(config.reactNativeDir)
         }
-    variant.sources.res?.addGeneratedSourceDirectory(bundleTask, BundleHermesCTask::resourcesDir)
+    // Currently broken inside AGP 7.3 We need to wait for a release of AGP 7.4 in order to use
+    // the addGeneratedSourceDirectory API.
+    // variant.sources.res?.addGeneratedSourceDirectory(bundleTask, BundleHermesCTask::resourcesDir)
     variant.sources.assets?.addGeneratedSourceDirectory(bundleTask, BundleHermesCTask::jsBundleDir)
   }
 }

--- a/template/android/build.gradle
+++ b/template/android/build.gradle
@@ -15,7 +15,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:7.4.0-beta05")
+        classpath("com.android.tools.build:gradle:7.3.1")
         classpath("com.facebook.react:react-native-gradle-plugin")
     }
 }


### PR DESCRIPTION
Summary:
Fixes #35592
I'm de-bumping AGP from 7.4 to 7.3 as per #35592. There is no stable release
of AGP that is working fine with the `addGeneratedSourceDirectory` API for resources.
Here I'm reverting to use the older APIs.

Changelog:
[Internal] [Changed] - De-bump AGP to 7.3.1 and do not use `addGeneratedSourceDirectory`

Differential Revision: D42004813

