### PR TITLE
adding togglebutton to attributedstring conversions

### DIFF
--- a/ReactCommon/react/renderer/attributedstring/conversions.h
+++ b/ReactCommon/react/renderer/attributedstring/conversions.h
@@ -717,7 +717,7 @@ inline void fromRawValue(
     auto string = (std::string)value;
     if (string == "none") {
       result = AccessibilityRole::None;
-    } else if (string == "button") {
+    } else if (string == "button" || string == "togglebutton") {
       result = AccessibilityRole::Button;
     } else if (string == "link") {
       result = AccessibilityRole::Link;


### PR DESCRIPTION
## Summary

fixes runtime error `E/ReactNativeJNI(24576): Unsupported AccessibilityRole value: togglebutton` when using togglebutton accessibilityRole with Text. Related https://github.com/fabriziobertoglio1987/react-native/commit/da899c0cc4372830e5ca053a096b74fff2a19cb8


## Changelog

[GENERAL] [FIXED] - Fixes crash when using togglebutton accessibilityRole with Text

## Test Plan
