### PR TITLE
fix: margin auto conversion in fabric

### DIFF
--- a/ReactCommon/react/renderer/components/view/conversions.h
+++ b/ReactCommon/react/renderer/components/view/conversions.h
@@ -382,7 +382,7 @@ inline void fromRawValue(
   } else if (value.hasType<std::string>()) {
     const auto stringValue = (std::string)value;
     if (stringValue == "auto") {
-      result = YGValueUndefined;
+      result = YGValueAuto;
       return;
     } else {
       if (stringValue.back() == '%') {

--- a/ReactCommon/react/renderer/components/view/conversions.h
+++ b/ReactCommon/react/renderer/components/view/conversions.h
@@ -11,6 +11,7 @@
 #include <folly/Conv.h>
 #include <folly/dynamic.h>
 #include <glog/logging.h>
+#include <react/config/ReactNativeConfig.h>
 #include <react/debug/react_native_assert.h>
 #include <react/renderer/components/view/primitives.h>
 #include <react/renderer/core/LayoutMetrics.h>
@@ -382,7 +383,8 @@ inline void fromRawValue(
   } else if (value.hasType<std::string>()) {
     const auto stringValue = (std::string)value;
     if (stringValue == "auto") {
-      result = YGValueAuto;
+      auto reactNativeConfig = context.contextContainer.at<std::shared_ptr<ReactNativeConfig const>>("ReactNativeConfig");
+      result = reactNativeConfig->getBool("react_fabric:treat_auto_as_undefined") ? YGValueUndefined : YGValueAuto;
       return;
     } else {
       if (stringValue.back() == '%') {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
Auto margin is not working as expected in fabric views. Below snippet results in different outputs in fabric and non-fabric runtime. 

```jsx
<View style={{ backgroundColor: "black", width: "100%", height: "100%" }}>
  <View style={{ marginLeft: "auto", width: 100, height: 100, backgroundColor: "pink" }} />
</View>
```
### Current Result | Expected Result

<div style="display: flex;">
<img width="100" alt="Screenshot 2022-12-14 at 11 00 22 AM" src="https://user-images.githubusercontent.com/23293248/207513912-633910e2-cf92-4f50-b839-c5abfa8041fb.png">

<img width="100" alt="Screenshot 2022-12-14 at 10 55 31 AM" src="https://user-images.githubusercontent.com/23293248/207513196-94650c60-ffe5-4475-9a95-2a59f8f0e9d9.png">
</div>


 
## Issue

This issue doesn't happen on non-fabric as it uses [YGNodeStyleSetMarginAuto](https://github.com/facebook/react-native/blob/9f9111bd7b75fb5f60b74b127b417512e29afb67/ReactCommon/yoga/yoga/Yoga.cpp#L749) to set the auto margins. In fabric, it uses the [convert function](https://github.com/intergalacticspacehighway/react-native/blob/2a15f9190266d90abbe3fc7e5437ea77e99e4290/ReactCommon/react/renderer/components/view/conversions.h#L375). The change in this PR can affect some other styles e.g. padding, borders. We could also create a different setter just for margins. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:


For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
[GENERAL] [FIXED] - margin auto style conversion in fabric

## Test Plan
- Test above snippet in fabric and non fabric runtime. 

- I think we should have test cases for RN + layouts. Maybe we can use something like https://github.com/FormidableLabs/react-native-owl
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
