### PR TITLE
[RN][iOS] Automatically detect when use frameworks is used

### DIFF
--- a/scripts/cocoapods/__tests__/test_utils/TargetDefinitionMock.rb
+++ b/scripts/cocoapods/__tests__/test_utils/TargetDefinitionMock.rb
@@ -1,0 +1,12 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+class TargetDefinitionMock
+    attr_reader :build_type
+
+    def initialize(build_type)
+        @build_type = build_type
+    end
+end

--- a/scripts/cocoapods/utils.rb
+++ b/scripts/cocoapods/utils.rb
@@ -163,4 +163,26 @@ class ReactNativePodsUtils
 
         system("echo 'export NODE_BINARY=$(command -v node)' > #{file_path}")
     end
+
+    # It examines the target_definition property and sets the appropriate value for
+    # ENV['USE_FRAMEWORKS'] variable.
+    #
+    # - parameter target_definition: The current target definition
+    def self.detect_use_frameworks(target_definition)
+        if ENV['USE_FRAMEWORKS'] != nil
+            return
+        end
+
+        framework_build_type = target_definition.build_type.to_s
+
+        Pod::UI.puts("Framework build type is #{framework_build_type}")
+
+        if framework_build_type === "static framework"
+            ENV['USE_FRAMEWORKS'] = 'static'
+        elsif framework_build_type === "dynamic framework"
+            ENV['USE_FRAMEWORKS'] = 'dynamic'
+        else
+            ENV['USE_FRAMEWORKS'] = nil
+        end
+    end
 end

--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -61,6 +61,10 @@ def use_react_native! (
   app_path: '..',
   config_file_dir: '')
 
+  # Current target definition is provided by Cocoapods and it refers to the target
+  # that has invoked the `use_react_native!` function.
+  ReactNativePodsUtils.detect_use_frameworks(current_target_definition)
+
   CodegenUtils.clean_up_build_folder(app_path, $CODEGEN_OUTPUT_DIR)
 
   # We are relying on this flag also in third parties libraries to proper install dependencies.


### PR DESCRIPTION
## Summary

This PR introduce an automatic way to detect whether the user sets its podfile to use frameworks.
In this way, users don't have to install pods with a specific environment flag but they can rely on the standard Cocoapods usage

## Changelog

[IOS][ADDED] - Automatically detect whether use_frameworks! is used

## Test Plan

- CircleCI is Green
- Added unit tests
- Tested locally with an app 
