### PR TITLE
Properly support both libraries and use_frameworks (#35624)

### DIFF
--- a/ReactCommon/ReactCommon.podspec
+++ b/ReactCommon/ReactCommon.podspec
@@ -61,7 +61,10 @@ Pod::Spec.new do |s|
     ss.subspec "core" do |sss|
       sss.source_files = "react/nativemodule/core/ReactCommon/**/*.{cpp,h}",
                          "react/nativemodule/core/platform/ios/**/*.{mm,cpp,h}"
-      sss.exclude_files = "react/nativemodule/core/ReactCommon/{LongLivedObject,CallbackWrapper}.h"
+      excluded_files = ENV['USE_FRAMEWORKS'] == nil ?
+        "react/nativemodule/core/ReactCommon/LongLivedObject.h" :
+        "react/nativemodule/core/ReactCommon/{LongLivedObject,CallbackWrapper}.h"
+      sss.exclude_files = excluded_files
     end
 
     ss.subspec "samples" do |sss|


### PR DESCRIPTION
## Summary

Backporting a [fix](https://github.com/facebook/react-native/commit/c6fa6335971459158efc8bf094822547a4333235) on the `ReactCommon.podspec` to properly support static libraries and 
static frameworks
## Changelog

[IOS][FIXED] - Properly support static libraries and static frameworks

## Test Plan

Tested in 0.71-RC4
