### PR TITLE
fix RCTNetworking contentType issue

### DIFF
--- a/Libraries/Network/RCTNetworking.mm
+++ b/Libraries/Network/RCTNetworking.mm
@@ -111,7 +111,7 @@ static NSString *RCTGenerateFormBoundary()
   // Print headers.
   NSMutableDictionary<NSString *, NSString *> *headers = [_parts[0][@"headers"] mutableCopy];
   NSString *partContentType = result[@"contentType"];
-  if (partContentType != nil) {
+  if (partContentType != nil && ![partContentType isEqual:[NSNull null]]) {
     headers[@"content-type"] = partContentType;
   }
   [headers enumerateKeysAndObjectsUsingBlock:^(NSString *parameterKey, NSString *parameterValue, BOOL *stop) {
@@ -331,7 +331,7 @@ RCT_EXPORT_MODULE()
                                 request.HTTPBody = result[@"body"];
                                 NSString *dataContentType = result[@"contentType"];
                                 NSString *requestContentType = [request valueForHTTPHeaderField:@"Content-Type"];
-                                BOOL isMultipart = [dataContentType hasPrefix:@"multipart"];
+                                BOOL isMultipart = ![dataContentType isEqual:[NSNull null]] && [dataContentType hasPrefix:@"multipart"];
 
                                 // For multipart requests we need to override caller-specified content type with one
                                 // from the data object, because it contains the boundary string


### PR DESCRIPTION
## Summary

https://github.com/facebook/react-native/blob/96027f787ade1a465569975059426d2c03ee5ad0/Libraries/Network/RCTNetworking.mm#L418

because  `RCTNullIfNil(response.MIMEType)`,  `contentType` may be `[NSNull null]` 

https://github.com/facebook/react-native/blob/96027f787ade1a465569975059426d2c03ee5ad0/Libraries/Network/RCTNetworking.mm#L114

Here only check `partContentType` is not nil, This causes the custom type never used

https://github.com/facebook/react-native/blob/96027f787ade1a465569975059426d2c03ee5ad0/Libraries/Network/RCTNetworking.mm#L334

more serious here, if `dataContentType` is `[NSNull null]` ,  it will crash the application

`-[NSNull hasPrefix:]: unrecognized selector sent to instance 0x7fff8004b700`

## Changelog

[iOS] [Fixed] - fix dataContentType may be [NSNull null] issue

## Test Plan
