### PR TITLE
[RN][iOS] Improve Codegen Cleanup

### DIFF
--- a/scripts/cocoapods/__tests__/test_utils/DirMock.rb
+++ b/scripts/cocoapods/__tests__/test_utils/DirMock.rb
@@ -49,7 +49,11 @@ class Dir
 
     def self.glob(path)
         @@glob_invocation.push(path)
-        return @@mocked_existing_globs[path]
+        return @@mocked_existing_globs[path] != nil ? @@mocked_existing_globs[path] : []
+    end
+
+    def self.remove_mocked_paths(path)
+        @@mocked_existing_globs = @@mocked_existing_globs.select { |k, v| v != path }
     end
 
     def self.set_pwd(pwd)

--- a/scripts/cocoapods/__tests__/test_utils/FileUtilsMock.rb
+++ b/scripts/cocoapods/__tests__/test_utils/FileUtilsMock.rb
@@ -3,9 +3,9 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+require_relative './DirMock.rb'
+
 module FileUtils
-
-
     class FileUtilsStorage
         @@RMRF_INVOCATION_COUNT = 0
         @@RMRF_PATHS = []
@@ -35,5 +35,6 @@ module FileUtils
     def self.rm_rf(path)
         FileUtilsStorage.push_rmrf_path(path)
         FileUtilsStorage.increase_rmrfi_invocation_count
+        Dir.remove_mocked_paths(path)
     end
 end

--- a/scripts/cocoapods/codegen_utils.rb
+++ b/scripts/cocoapods/codegen_utils.rb
@@ -314,6 +314,17 @@ class CodegenUtils
       return if !Dir.exist?(codegen_path)
 
       FileUtils.rm_rf(Dir.glob("#{codegen_path}/*"))
-      CodegenUtils.set_cleanup_done(true)
+      CodegenUtils.assert_codegen_folder_is_empty(app_path, codegen_dir)
+    end
+
+    # Need to split this function from the previous one to be able to test it properly.
+    def self.assert_codegen_folder_is_empty(app_path, codegen_dir)
+      # double check that the files have actually been deleted.
+      # Emit an error message if not.
+      codegen_path = File.join(app_path, codegen_dir)
+      if Dir.exist?(codegen_path) && Dir.glob("#{codegen_path}/*").length() != 0
+        Pod::UI.warn "Unable to remove the content of #{codegen_path} folder. Please run rm -rf #{codegen_path} and try again."
+        abort
+      end
     end
 end


### PR DESCRIPTION
## Summary

This PR adds a safety check in case the Cocoapod build script is not able to clean the build folder.
We had evidences where this process failed, and in this way the user has a clear and actionable message to fix its situation.

## Changelog

[iOS][Added] - Add message with instructions about what to do if the cleanup of the build folder fails.

## Test Plan

I was not able to reproduce the issue locally. 
The fix is not destructive, let's see if the amount of issues decreases.
