### PR TITLE
Remove unnecessary repositories{} block from top level build.gradle

### DIFF
--- a/template/android/build.gradle
+++ b/template/android/build.gradle
@@ -19,19 +19,3 @@ buildscript {
         classpath("com.facebook.react:react-native-gradle-plugin")
     }
 }
-
-allprojects {
-    repositories {
-        maven {
-            // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-            url("$rootDir/../node_modules/react-native/android")
-        }
-        maven {
-            // Android JSC is installed from npm
-            url("$rootDir/../node_modules/jsc-android/dist")
-        }
-        mavenCentral()
-        google()
-        maven { url 'https://www.jitpack.io' }
-    }
-}


### PR DESCRIPTION
Summary:
The `repositories{}` block in the top level build.gradle is not needed anymore
The React Native Gradle Plugin is taking care of it.
Users can still specify if they need to provide custom repositories.

Changelog:
[Android] [Changed] - Remove unnecessary repositories{} block from top level build.gradle

Reviewed By: cipolleschi

Differential Revision: D42033953

