### PR TITLE
Retain usage of HERMES_ENABLE_DEBUGGER flag

### DIFF
--- a/ReactCommon/hermes/React-hermes.podspec
+++ b/ReactCommon/hermes/React-hermes.podspec
@@ -42,7 +42,7 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig    = {
                                "HEADER_SEARCH_PATHS" => "\"${PODS_ROOT}/hermes-engine/destroot/include\" \"$(PODS_TARGET_SRCROOT)/..\" \"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/libevent/include\"",
                                "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
-                             }
+                             }.merge!(build_type == :debug ? { "GCC_PREPROCESSOR_DEFINITIONS" => "HERMES_ENABLE_DEBUGGER=1" } : {})
   s.header_dir             = "reacthermes"
   s.dependency "React-cxxreact", version
   s.dependency "React-jsiexecutor", version


### PR DESCRIPTION
Summary:
Changelog:
[iOS][Fixed] - We erroneously deleted usage of the HERMES_ENABLE_DEBUGGER flag, add it back.

Differential Revision: D42041827

