### PR TITLE
Fix prefab prefix for fabricjni

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -122,7 +122,7 @@ final def preparePrefab = tasks.register("preparePrefab", PreparePrefabHeadersTa
             new PrefabPreprocessingEntry(
                 "fabricjni",
                 [
-                    new Pair("src/main/jni/react/fabric", ""),
+                    new Pair("src/main/jni/react/fabric", "react/fabric/"),
                     new Pair("src/main/jni/react/cxxcomponents", "react/cxxcomponents/")
                 ]
             ),

--- a/ReactAndroid/src/main/jni/react/newarchdefaults/DefaultComponentsRegistry.h
+++ b/ReactAndroid/src/main/jni/react/newarchdefaults/DefaultComponentsRegistry.h
@@ -7,8 +7,8 @@
 
 #pragma once
 
-#include <ComponentFactory.h>
 #include <fbjni/fbjni.h>
+#include <react/fabric/ComponentFactory.h>
 #include <react/renderer/componentregistry/ComponentDescriptorProviderRegistry.h>
 #include <react/renderer/componentregistry/ComponentDescriptorRegistry.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>


### PR DESCRIPTION
Summary:
The `fabricjni` prefab module was missing the `react/fabric` prefix.
I'm adding it here.
Ref: https://github.com/reactwg/react-native-releases/discussions/41#discussioncomment-4402506

Changelog:
[Internal] [Changed] - Fix prefab prefix for fabricjni

Differential Revision: D42047434

