### PR TITLE
Fix build errors when inheriting RCTAppDelegate in Swift modules

### DIFF
--- a/Libraries/AppDelegate/RCTAppDelegate.h
+++ b/Libraries/AppDelegate/RCTAppDelegate.h
@@ -9,13 +9,8 @@
 #import <React/RCTBridgeDelegate.h>
 #import <UIKit/UIKit.h>
 
-#if RCT_NEW_ARCH_ENABLED
-// When the new architecture is enabled, the RCTAppDelegate imports some additional headers
-#import <React/RCTCxxBridgeDelegate.h>
-#import <React/RCTSurfacePresenterBridgeAdapter.h>
-#import <ReactCommon/RCTTurboModuleManager.h>
-
-#endif
+@class RCTSurfacePresenterBridgeAdapter;
+@class RCTTurboModuleManager;
 
 /**
  * The RCTAppDelegate is an utility class that implements some base configurations for all the React Native apps.
@@ -98,11 +93,7 @@
  */
 - (UIViewController *)createRootViewController;
 
-@end
-
 #if RCT_NEW_ARCH_ENABLED
-/// Extension that makes the RCTAppDelegate conform to New Architecture delegates
-@interface RCTAppDelegate () <RCTTurboModuleManagerDelegate, RCTCxxBridgeDelegate>
 
 /// The TurboModule manager
 @property (nonatomic, strong) RCTTurboModuleManager *turboModuleManager;
@@ -126,5 +117,6 @@
 /// @return: `true` if the Fabric Renderer is enabled. Otherwise, it returns `false`.
 - (BOOL)fabricEnabled;
 
-@end
 #endif
+
+@end

--- a/Libraries/AppDelegate/RCTAppDelegate.h
+++ b/Libraries/AppDelegate/RCTAppDelegate.h
@@ -9,7 +9,7 @@
 #import <React/RCTBridgeDelegate.h>
 #import <UIKit/UIKit.h>
 
-#if RCT_NEW_ARCH_ENABLED
+#if RCT_NEW_ARCH_ENABLED && __cplusplus
 // When the new architecture is enabled, the RCTAppDelegate imports some additional headers
 #import <React/RCTCxxBridgeDelegate.h>
 #import <React/RCTSurfacePresenterBridgeAdapter.h>
@@ -100,7 +100,7 @@
 
 @end
 
-#if RCT_NEW_ARCH_ENABLED
+#if RCT_NEW_ARCH_ENABLED && __cplusplus
 /// Extension that makes the RCTAppDelegate conform to New Architecture delegates
 @interface RCTAppDelegate () <RCTTurboModuleManagerDelegate, RCTCxxBridgeDelegate>
 

--- a/Libraries/AppDelegate/RCTAppDelegate.h
+++ b/Libraries/AppDelegate/RCTAppDelegate.h
@@ -9,7 +9,7 @@
 #import <React/RCTBridgeDelegate.h>
 #import <UIKit/UIKit.h>
 
-#if RCT_NEW_ARCH_ENABLED && __cplusplus
+#if RCT_NEW_ARCH_ENABLED
 // When the new architecture is enabled, the RCTAppDelegate imports some additional headers
 #import <React/RCTCxxBridgeDelegate.h>
 #import <React/RCTSurfacePresenterBridgeAdapter.h>
@@ -100,7 +100,7 @@
 
 @end
 
-#if RCT_NEW_ARCH_ENABLED && __cplusplus
+#if RCT_NEW_ARCH_ENABLED
 /// Extension that makes the RCTAppDelegate conform to New Architecture delegates
 @interface RCTAppDelegate () <RCTTurboModuleManagerDelegate, RCTCxxBridgeDelegate>
 

--- a/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -11,13 +11,16 @@
 
 #if RCT_NEW_ARCH_ENABLED
 #import <React/CoreModulesPlugins.h>
+#import <React/RCTCxxBridgeDelegate.h>
 #import <React/RCTFabricSurfaceHostingProxyRootView.h>
 #import <React/RCTSurfacePresenter.h>
+#import <React/RCTSurfacePresenterBridgeAdapter.h>
+#import <ReactCommon/RCTTurboModuleManager.h>
 #import <react/config/ReactNativeConfig.h>
 
 static NSString *const kRNConcurrentRoot = @"concurrentRoot";
 
-@interface RCTAppDelegate () {
+@interface RCTAppDelegate () <RCTTurboModuleManagerDelegate, RCTCxxBridgeDelegate> {
   std::shared_ptr<const facebook::react::ReactNativeConfig> _reactNativeConfig;
   facebook::react::ContextContainer::Shared _contextContainer;
 }


### PR DESCRIPTION
## Summary

When inheriting `RCTAppDelegate` in a module with swift code, the compiler will have a build error when it goes through module headers. because swift does not support cxx headers. we found this issue when we try to inherit the class at Expo's [`EXAppDelegateWrapper`](https://github.com/expo/expo/blob/main/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.h) with RCTAppDelegate in new architecture mode.

## Changelog

[IOS][FIXED] - Fix build errors when inheriting RCTAppDelegate in Swift modules

## Test Plan

- ci passed
- tested with expo's setup: https://github.com/expo/expo/pull/20470