### PR TITLE
Add compiler flag for the new Arch when enabled.

### DIFF
--- a/scripts/cocoapods/__tests__/new_architecture-test.rb
+++ b/scripts/cocoapods/__tests__/new_architecture-test.rb
@@ -125,6 +125,7 @@ class NewArchitectureTests < Test::Unit::TestCase
         assert_equal(spec.compiler_flags, NewArchitectureHelper.folly_compiler_flags)
         assert_equal(spec.pod_target_xcconfig["HEADER_SEARCH_PATHS"], "\"$(PODS_ROOT)/boost\"")
         assert_equal(spec.pod_target_xcconfig["CLANG_CXX_LANGUAGE_STANDARD"], "c++17")
+        assert_equal(spec.pod_target_xcconfig["OTHER_CPLUSPLUSFLAGS"], "$(inherited) -DRCT_NEW_ARCH_ENABLED=1 -DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1")
         assert_equal(
             spec.dependencies,
             [

--- a/scripts/cocoapods/new_architecture.rb
+++ b/scripts/cocoapods/new_architecture.rb
@@ -76,12 +76,13 @@ class NewArchitectureHelper
         spec.compiler_flags = compiler_flags.empty? ? @@folly_compiler_flags : "#{compiler_flags} #{@@folly_compiler_flags}"
         current_config["HEADER_SEARCH_PATHS"] = current_headers.empty? ? boost_search_path : "#{current_headers} #{boost_search_path}"
         current_config["CLANG_CXX_LANGUAGE_STANDARD"] = @@cplusplus_version
-        spec.pod_target_xcconfig = current_config
+
 
         spec.dependency "React-Core"
         spec.dependency "RCT-Folly", '2021.07.22.00'
 
         if new_arch_enabled
+            current_config["OTHER_CPLUSPLUSFLAGS"] = @@new_arch_cpp_flags
             spec.dependency "React-RCTFabric" # This is for Fabric Component
             spec.dependency "React-Codegen"
 
@@ -90,6 +91,8 @@ class NewArchitectureHelper
             spec.dependency "ReactCommon/turbomodule/bridging"
             spec.dependency "ReactCommon/turbomodule/core"
         end
+
+        spec.pod_target_xcconfig = current_config
     end
 
     def self.folly_compiler_flags


### PR DESCRIPTION
Summary:
While working on some example, I discovered that the helper function `install_module_dependencies` was not adding the proper `-DRCT_NEW_ARCH_ENABLED=1` flag to the compiler flags.

## Changelog:
[iOS][Fixed] - Make sure to add the New Arch flag to libraries

Differential Revision: D42131287

