### PR TITLE
Fix Catalyst @availablity checks in RCTPullToRefreshViewComponentView.mm

### DIFF
--- a/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.mm
@@ -131,7 +131,10 @@ using namespace facebook::react;
   if (!_scrollViewComponentView) {
     return;
   }
-  _scrollViewComponentView.scrollView.refreshControl = _refreshControl;
+
+  if (@available(macCatalyst 13.1, *)) {
+    _scrollViewComponentView.scrollView.refreshControl = _refreshControl;
+  }
 }
 
 - (void)_detach
@@ -143,7 +146,9 @@ using namespace facebook::react;
   // iOS requires to end refreshing before unmounting.
   [_refreshControl endRefreshing];
 
-  _scrollViewComponentView.scrollView.refreshControl = nil;
+  if (@available(macCatalyst 13.1, *)) {
+     _scrollViewComponentView.scrollView.refreshControl = nil;
+   }
   _scrollViewComponentView = nil;
 }
 

--- a/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.mm
@@ -131,10 +131,7 @@ using namespace facebook::react;
   if (!_scrollViewComponentView) {
     return;
   }
-
-  if (@available(iOS 13.0, *)) {
-    _scrollViewComponentView.scrollView.refreshControl = _refreshControl;
-  }
+  _scrollViewComponentView.scrollView.refreshControl = _refreshControl;
 }
 
 - (void)_detach
@@ -146,9 +143,7 @@ using namespace facebook::react;
   // iOS requires to end refreshing before unmounting.
   [_refreshControl endRefreshing];
 
-  if (@available(iOS 13.0, *)) {
-    _scrollViewComponentView.scrollView.refreshControl = nil;
-  }
+  _scrollViewComponentView.scrollView.refreshControl = nil;
   _scrollViewComponentView = nil;
 }
 

--- a/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.mm
@@ -132,7 +132,7 @@ using namespace facebook::react;
     return;
   }
 
-  if (@available(macOS 13.0, *)) {
+  if (@available(iOS 13.0, *)) {
     _scrollViewComponentView.scrollView.refreshControl = _refreshControl;
   }
 }
@@ -146,7 +146,7 @@ using namespace facebook::react;
   // iOS requires to end refreshing before unmounting.
   [_refreshControl endRefreshing];
 
-  if (@available(macOS 13.0, *)) {
+  if (@available(iOS 13.0, *)) {
     _scrollViewComponentView.scrollView.refreshControl = nil;
   }
   _scrollViewComponentView = nil;

--- a/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.mm
@@ -147,8 +147,8 @@ using namespace facebook::react;
   [_refreshControl endRefreshing];
 
   if (@available(macCatalyst 13.1, *)) {
-     _scrollViewComponentView.scrollView.refreshControl = nil;
-   }
+    _scrollViewComponentView.scrollView.refreshControl = nil;
+  }
   _scrollViewComponentView = nil;
 }
 


### PR DESCRIPTION
## Summary

Judging from the original [commit](https://github.com/facebook/react-native/commit/4c4948b6e83208cd517dd977b3462b1959505e1d), the availability check is probably for Catalyst, not macOS.  That matches the [apple documentation](https://developer.apple.com/documentation/uikit/uiscrollview/2127691-refreshcontrol?language=objc) as well (though we need 13.1, not 13).

To avoid needing to introduce a diff in React Native macOS (where we actually compile for macOS and not Mac Catalyst) let's fix the availability check to be more accurate. Changing `macOS` to `MacCatalyst` should be supported as per https://docs.swift.org/swift-book/ReferenceManual/Attributes.html#ID348


## Changelog

[IOS] [FIXED] - Fixed Mac Catalyst availability checks

## Test Plan

Code compiles
