### PR TITLE
Add a `moduleNameMapper` field to jest-preset.js

### DIFF
--- a/jest-preset.js
+++ b/jest-preset.js
@@ -25,7 +25,7 @@ module.exports = {
   ],
   moduleNameMapper: {
     '^.+\\.(bmp|gif|jpg|jpeg|mp4|png|psd|svg|webp)$': require.resolve(
-      './jest/assetFileTransformer.js',
+      './jest/assetFileMock.js',
     ),
   },
   setupFiles: [require.resolve('./jest/setup.js')],

--- a/jest-preset.js
+++ b/jest-preset.js
@@ -16,9 +16,6 @@ module.exports = {
   },
   transform: {
     '^.+\\.(js|ts|tsx)$': 'babel-jest',
-    '^.+\\.(bmp|gif|jpg|jpeg|mp4|png|psd|svg|webp)$': require.resolve(
-      './jest/assetFileTransformer.js',
-    ),
   },
   transformIgnorePatterns: [
     'node_modules/(?!((jest-)?react-native|@react-native(-community)?)/)',

--- a/jest-preset.js
+++ b/jest-preset.js
@@ -23,6 +23,11 @@ module.exports = {
   transformIgnorePatterns: [
     'node_modules/(?!((jest-)?react-native|@react-native(-community)?)/)',
   ],
+  moduleNameMapper: {
+    '^.+\\.(bmp|gif|jpg|jpeg|mp4|png|psd|svg|webp)$': require.resolve(
+      './jest/assetFileTransformer.js',
+    ),
+  },
   setupFiles: [require.resolve('./jest/setup.js')],
   testEnvironment: require.resolve('./jest/react-native-env.js'),
 };

--- a/jest/assetFileMock.js
+++ b/jest/assetFileMock.js
@@ -1,0 +1,1 @@
+export default '';


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

If **a third-party library** contains image assets, testing a RN project under the preset jest config will usually fail.

This has caused issues like https://github.com/facebook/jest/issues/2663 and https://github.com/react-navigation/react-navigation/issues/8669. While there are already workarounds to solve the problem (adding a `moduleNameMapper` field to **the project's jest configuration**, as stated in the issues), I wonder if it could be better to include the `moduleNameMapper` field into **the preset configuration**, thus saving developers from searching on the internet for a workaround.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry.
For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[GENERAL] [FIXED] - Include a default `moduleNameMapper` field in the preset jest configuration to stub out image assets from third-party libraries

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

I've created a repo to reproduce the issue: https://github.com/UNIDY2002/JestPresetRepro

It is an example project of react navigation, and when I run `yarn test`, it fails (you can refer to [the GitHub Action](https://github.com/UNIDY2002/JestPresetRepro/actions/runs/3730218539/jobs/6327012058)).

```
$ jest
FAIL __tests__/App-test.js
  ● Test suite failed to run

    /home/runner/work/JestPresetRepro/JestPresetRepro/node_modules/@react-navigation/elements/lib/commonjs/assets/back-icon.png:1
    ({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,global,jest){�PNG
                                                                                             

    SyntaxError: Invalid or unexpected token

      2 | import {View, Text} from 'react-native';
      3 | import {NavigationContainer} from '@react-navigation/native';
    > 4 | import {createNativeStackNavigator} from '@react-navigation/native-stack';
        | ^
      5 |
      6 | function HomeScreen() {
      7 |   return (

      at Runtime.createScriptFromCode (node_modules/jest-runtime/build/index.js:1350:14)
      at Object.<anonymous> (node_modules/@react-navigation/elements/lib/commonjs/index.tsx:20:3)
      at Object.<anonymous> (node_modules/@react-navigation/native-stack/lib/commonjs/views/NativeStackView.native.tsx:1:1)
      at Object.<anonymous> (node_modules/@react-navigation/native-stack/lib/commonjs/navigators/createNativeStackNavigator.tsx:19:1)
      at Object.<anonymous> (node_modules/@react-navigation/native-stack/lib/commonjs/index.tsx:4:1)
      at Object.<anonymous> (App.js:4:1)
      at Object.<anonymous> (__tests__/App-test.js:7:1)

Test Suites: 1 failed, 1 total
Tests:       0 total
Snapshots:   0 total
Time:        6.394 s
Ran all test suites.
```

Once I applied [the patch](https://github.com/UNIDY2002/JestPresetRepro/blob/master/patches/react-native%2B0.70.6.patch) to the `react-native` dependency (by running `yarn patch-package`) and ran `yarn test` again, the test passed (see: [GitHub Action](https://github.com/UNIDY2002/JestPresetRepro/actions/runs/3730218539/jobs/6327011920)).

And it will save consumers of `react-native` from manually editing the jest config in their projects.

Besides, since it serves as a default configuration and can be overridden, I think this will not break existing projects.

However, I have little knowledge about the details of jest, and please do correct me if I got anything wrong.