### PR TITLE
fix(CI): prevent the e2e test from running on 0.71

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -533,8 +533,17 @@ jobs:
       - run:
           name: "Run Tests: JavaScript Tests"
           command: node ./scripts/run-ci-javascript-tests.js --maxWorkers 2
-      - run_e2e:
-          platform: js
+
+      # When not in 0.XX-stable branch, run e2e tests
+      - when:
+          condition:
+            not:
+              matches:
+                pattern: "0.[0-9]{2}-stable"
+                value: << pipeline.git.branch >>
+          steps:
+            - run_e2e:
+                platform: js
 
       # Optionally, run disabled tests
       - when:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

(new variation of https://github.com/facebook/react-native/pull/35667, read [the last comment there](https://github.com/facebook/react-native/pull/35667#issuecomment-1357548196) for more info)

## Summary

Because of the usual ✨dark magic✨ that we do 'cause RN is not a proper monorepo (usual link https://github.com/react-native-community/discussions-and-proposals/pull/480), one of the side effects is that `test_js` and `test_js_prev_lts ` insta-crash whenever they run in a `-stable` branch because of the `run_e2e` job, that runs verdaccio and verdaccio needs the workspace, but the workspace is not there because of the aforementioned ✨dark magic✨

This PR fixes that by not allowing said command to be run when we are in 0.XX-stable branches. (TIL that under the hood CircleCI wants [Java regex](https://circleci.com/docs/workflows/#using-regular-expressions-to-filter-tags-and-branches))

In main we don't need it because of the work of @hoxyq (see https://github.com/facebook/react-native/commit/7f29357c7c7dcbf4b59bb072db613169944ba2cf)

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:


For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[INTERNAL] [FIXED] -  prevent the e2e test from running on 0.71

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

I used this PR for testing: https://github.com/facebook/react-native/pull/35665

here's a screenshot of when things work (no E2E command run):
<img width="1634" alt="Screenshot 2022-12-16 at 14 52 00" src="https://user-images.githubusercontent.com/16104054/208127617-6dc5e670-9660-46f5-bf0b-f55d7cadcec7.png">

here's how it looks when they don't (E2E runs and crashes):
<img width="1636" alt="Screenshot 2022-12-16 at 14 58 04" src="https://user-images.githubusercontent.com/16104054/208127628-fcb3773a-b03d-4305-96a7-1837956d47b2.png">


You can also verify that the condition is correct by throwing this sample code in an online Java ide:

```java
import java.util.regex.*;  

public class Main
{
    public static void main(String[] args) {
        System.out.println(Pattern.matches("0.[0-9]{2}-stable", "main"));//false  
        System.out.println(Pattern.matches("0.[0-9]{2}-stable", "0.71-stable"));//true
        System.out.println(Pattern.matches("0.[0-9]{2}-stable", "just-a-test-with-stable"));//false
        System.out.println(Pattern.matches("0.[0-9]{2}-stable", "just-a-test-with-stable-test"));//false  
    }
}
```

### It's expected to fail here because the name of the branch is NOT `0.XX-stable` ;)
