### PR TITLE
Exclude `react-native-flipper` when `NO_FLIPPER=1` to prevent iOS build fail

### DIFF
--- a/template/ios/Podfile
+++ b/template/ios/Podfile
@@ -4,6 +4,15 @@ require_relative '../node_modules/@react-native-community/cli-platform-ios/nativ
 platform :ios, min_ios_version_supported
 prepare_react_native_project!
 
+# If you are using a `react-native-flipper` your iOS build will fail when `NO_FLIPPER=1` is set.
+# because `react-native-flipper` depends on (FlipperKit,...) that will be excluded
+#
+# To fix this you can also exclude `react-native-flipper` using a `react-native.config.js`
+# ```js
+# module.exports = {
+#   dependencies: {
+#     ...(process.env.NO_FLIPPER ? { 'react-native-flipper': { platforms: { ios: null } } } : {}),
+# ```
 flipper_config = ENV['NO_FLIPPER'] == "1" ? FlipperConfiguration.disabled : FlipperConfiguration.enabled
 
 linkage = ENV['USE_FRAMEWORKS']


### PR DESCRIPTION
## Summary

- Flipper issue: https://github.com/facebook/flipper/issues/3995#issuecomment-1333863641

iOS build fail with an error:

```sh
node_modules/react-native-flipper/ios/FlipperReactNativeJavaScriptPlugin.h:9:9: 'FlipperKit/FlipperConnection.h' file not found

#import <FlipperKit/FlipperConnection.h>
```

## Changelog

[IOS] [FIXED] - Exclude `react-native-flipper` when `NO_FLIPPER=1` to prevent iOS build fail


## Test Plan

```sh
npx react-native init RN0710RC5 --version 0.71.0-rc.5
cd RN0710RC5
yarn add react-native-flipper
NO_FLIPPER=1 pod install --project-directory=ios
yarn ios # will fail
```
