### PR TITLE
make `react_native_path` path agnostic

### DIFF
--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -200,7 +200,7 @@ end
 # - installer: the Cocoapod object that allows to customize the project.
 # - react_native_path: path to React Native.
 # - mac_catalyst_enabled: whether we are running the Pod on a Mac Catalyst project or not.
-def react_native_post_install(installer, react_native_path = "../node_modules/react-native", mac_catalyst_enabled: false)
+def react_native_post_install(installer, react_native_path = File.expand_path("..", __dir__), mac_catalyst_enabled: false)
   ReactNativePodsUtils.turn_off_resource_bundle_react_core(installer)
 
   ReactNativePodsUtils.apply_mac_catalyst_patches(installer) if mac_catalyst_enabled


### PR DESCRIPTION
## Summary

On the usual flow, we use `cd ios; bundle exec pod install;` to install pods which makes the path `"../node_modules/react-native"` correct.

But pods support `--project-directory` which in my case I use `bundle exec pod install --project-directory=ios` from the root directory instead of navigating into `ios` folder.

This raises the following error:
```
No such file or directory @ rb_sysopen - ../node_modules/react-native/package.json

/Users/davidangulo/Desktop/mobile/myapp/node_modules/react-native/scripts/react_native_pods.rb:212:in `read'
/Users/davidangulo/Desktop/mobile/myapp/node_modules/react-native/scripts/react_native_pods.rb:212:in `react_native_post_install'
```

This PR makes it path agnostic so that it works with both.

## Changelog

[IOS] [CHANGED] - make `react_native_path` path agnostic

## Test Plan

Should build as is.
