### PR TITLE
Add inputType textNoSuggestions in react-native to disable the autocomplete

### DIFF
--- a/Libraries/Components/TextInput/TextInput.d.ts
+++ b/Libraries/Components/TextInput/TextInput.d.ts
@@ -39,7 +39,7 @@ export type KeyboardTypeIOS =
   | 'name-phone-pad'
   | 'twitter'
   | 'web-search';
-export type KeyboardTypeAndroid = 'visible-password';
+export type KeyboardTypeAndroid = 'no-suggestions' | 'visible-password';
 export type KeyboardTypeOptions =
   | KeyboardType
   | KeyboardTypeAndroid

--- a/Libraries/Components/TextInput/TextInput.flow.js
+++ b/Libraries/Components/TextInput/TextInput.flow.js
@@ -120,6 +120,7 @@ export type KeyboardType =
   // iOS 10+ only
   | 'ascii-capable-number-pad'
   // Android-only
+  | 'no-suggestions'
   | 'visible-password';
 
 export type InputMode =

--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -158,6 +158,7 @@ export type KeyboardType =
   // iOS 10+ only
   | 'ascii-capable-number-pad'
   // Android-only
+  | 'no-suggestions'
   | 'visible-password';
 
 export type InputMode =
@@ -677,6 +678,7 @@ export type Props = $ReadOnly<{|
    *
    * The following values work on Android only:
    *
+   * - `no-suggestions`
    * - `visible-password`
    *
    */

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -165,6 +165,7 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
   private static final String KEYBOARD_TYPE_PHONE_PAD = "phone-pad";
   private static final String KEYBOARD_TYPE_VISIBLE_PASSWORD = "visible-password";
   private static final String KEYBOARD_TYPE_URI = "url";
+  private static final String KEYBOARD_TYPE_NO_SUGGESTIONS = "no-suggestions";
   private static final InputFilter[] EMPTY_FILTERS = new InputFilter[0];
   private static final int UNSET = -1;
   private static final String[] DRAWABLE_FIELDS = {
@@ -874,6 +875,8 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
       flagsToSet = InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD;
     } else if (KEYBOARD_TYPE_URI.equalsIgnoreCase(keyboardType)) {
       flagsToSet = InputType.TYPE_TEXT_VARIATION_URI;
+    } else if (KEYBOARD_TYPE_NO_SUGGESTIONS.equalsIgnoreCase(keyboardType)) {
+      flagsToSet = InputType.TYPE_TEXT_VARIATION_FILTER | InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS;
     }
 
     updateStagedInputTypeFlag(view, InputType.TYPE_MASK_CLASS, flagsToSet);

--- a/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
@@ -598,6 +598,7 @@ module.exports = ([
     render: function (): React.Node {
       return (
         <TextInput
+          keyboardType={'numeric'}
           autoFocus={true}
           style={styles.default}
           accessibilityLabel="I am the accessibility label for text input"
@@ -633,6 +634,7 @@ module.exports = ([
         <View>
           <WithLabel label="none">
             <TextInput
+              keyboardType="no-suggestions"
               testID="capitalize-none"
               autoCapitalize="none"
               style={styles.default}
@@ -640,6 +642,7 @@ module.exports = ([
           </WithLabel>
           <WithLabel label="sentences">
             <TextInput
+              keyboardType="numeric"
               testID="capitalize-sentences"
               autoCapitalize="sentences"
               style={styles.default}


### PR DESCRIPTION
## Summary

fixes #33139 fixes #35155 fixes #35590
Related #30263, #35350

## Changelog

[ANDROID] [FIXED] - Fixes TextInput causing app to hang on Samsung devices with Android 13 with autocomplete/Grammarly enabled

## Test Plan


https://user-images.githubusercontent.com/24992535/208752434-94e881de-a63b-4067-b5f5-a447a1022b87.mp4


