### PR TITLE
Eliminate double call of `shadowNodeFromValue` in `dispatchCommand`

### DIFF
--- a/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
+++ b/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
@@ -493,7 +493,7 @@ jsi::Value UIManagerBinding::get(
           auto shadowNode = shadowNodeFromValue(runtime, arguments[0]);
           if (shadowNode) {
             uiManager->dispatchCommand(
-                shadowNodeFromValue(runtime, arguments[0]),
+                shadowNode,
                 stringFromValue(runtime, arguments[1]),
                 commandArgsFromValue(runtime, arguments[2]));
           }


### PR DESCRIPTION
## Summary

This PR slightly improves the implementation of `dispatchCommand` method of `UIManagerBinding` to use existing variable `shadowNode` instead of calling `shadowNodeFromValue` again.

## Changelog

[INTERNAL] [CHANGED] - Eliminated double call of `shadowNodeFromValue` in `dispatchCommand`

## Test Plan

Launch RNTester with Fabric enabled and check if `scrollTo` or some other command works properly.
