### PR TITLE
fix: fix the potential race condition when dismissing and presentating modal

### DIFF
--- a/React/Views/RCTModalHostViewManager.m
+++ b/React/Views/RCTModalHostViewManager.m
@@ -75,13 +75,15 @@ RCT_EXPORT_MODULE()
       modalHostView.onShow(nil);
     }
   };
-  if (_presentationBlock) {
-    _presentationBlock([modalHostView reactViewController], viewController, animated, completionBlock);
-  } else {
-    [[modalHostView reactViewController] presentViewController:viewController
-                                                      animated:animated
-                                                    completion:completionBlock];
-  }
+  dispatch_async(dispatch_get_main_queue(), ^{
+    if (self->_presentationBlock) {
+      self->_presentationBlock([modalHostView reactViewController], viewController, animated, completionBlock);
+    } else {
+      [[modalHostView reactViewController] presentViewController:viewController
+                                                        animated:animated
+                                                      completion:completionBlock];
+    }
+  });
 }
 
 - (void)dismissModalHostView:(RCTModalHostView *)modalHostView
@@ -93,11 +95,13 @@ RCT_EXPORT_MODULE()
       [[self.bridge moduleForClass:[RCTModalManager class]] modalDismissed:modalHostView.identifier];
     }
   };
-  if (_dismissalBlock) {
-    _dismissalBlock([modalHostView reactViewController], viewController, animated, completionBlock);
-  } else {
-    [viewController.presentingViewController dismissViewControllerAnimated:animated completion:completionBlock];
-  }
+  dispatch_async(dispatch_get_main_queue(), ^{
+    if (self->_dismissalBlock) {
+      self->_dismissalBlock([modalHostView reactViewController], viewController, animated, completionBlock);
+    } else {
+      [viewController.presentingViewController dismissViewControllerAnimated:animated completion:completionBlock];
+    }
+  });
 }
 
 - (RCTShadowView *)shadowView


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
`react-native-screens` has a bug about `UIViewControllerHierarchyInconsistency` when dismissing a `react-native` `<Modal>`. Here is the bug https://github.com/software-mansion/react-native-screens/issues/944

After adding `dispatch_async` block, it solves the issue. But I do not know if this is the right fix.

Here is the example repo https://github.com/wood1986/react-native-modal-crash.

You can revert my last commit https://github.com/wood1986/react-native-modal-crash/commit/86e7bc1adf444c1645c0d6078b0d6d427cdf6a36 to reproduce the issue. (after revert or hard reset, you need to rerun `git clean -xfdq` and `yarn install`)



## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[IOS] [FIXED] - fixed the potential race condition when dismissing and presentating modal

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
