### PR TITLE
Typescript keyboard type fix

### DIFF
--- a/Libraries/Components/TextInput/TextInput.d.ts
+++ b/Libraries/Components/TextInput/TextInput.d.ts
@@ -27,15 +27,15 @@ import {ViewProps} from '../View/ViewPropTypes';
 
 export type KeyboardType =
   | 'default'
-  | 'email-address'
-  | 'numeric'
-  | 'phone-pad'
   | 'number-pad'
-  | 'decimal-pad';
+  | 'decimal-pad'
+  | 'numeric'
+  | 'email-address'
+  | 'phone-pad'
+  | 'url';
 export type KeyboardTypeIOS =
   | 'ascii-capable'
   | 'numbers-and-punctuation'
-  | 'url'
   | 'name-phone-pad'
   | 'twitter'
   | 'web-search';


### PR DESCRIPTION
## Summary

Made typescript typings for keyboardType correct

## Changelog

[INTERNAL] [FIXED] - Typescript typings for TextInput Keyboard type.
Url was placed in incorrect section, so I moved it to general type. Sorted keyboard types order as in React native docs.
![image](https://user-images.githubusercontent.com/57757211/209436128-beb7b872-b5fb-4122-8a82-11bff70f919d.png)
![image](https://user-images.githubusercontent.com/57757211/209436135-4453b398-1424-4e20-afea-40f54dbe88dc.png)


## Test Plan

I think this fix can be merged without tests, because of it shortness
