### PR TITLE
Fix RCTAlertController not showing when using SceneDelegate on iOS 13.0+

### DIFF
--- a/React/CoreModules/RCTAlertController.m
+++ b/React/CoreModules/RCTAlertController.m
@@ -20,17 +20,7 @@
 - (UIWindow *)alertWindow
 {
   if (_alertWindow == nil) {
-#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
-    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
-    if (@available(iOS 13.0, *)) {
-      for (UIScene *scene in RCTSharedApplication().connectedScenes) {
-        if (scene.activationState == UISceneActivationStateForegroundActive && [scene isKindOfClass:[UIWindowScene class]]) {
-          _alertWindow = [[UIWindow alloc] initWithWindowScene:(UIWindowScene *)scene];
-          break;
-        }
-      }
-    }
-#endif
+    _alertWindow = [self getUIWindowFromScene];
 
     if (_alertWindow == nil) {
       UIWindow *keyWindow = RCTSharedApplication().keyWindow;
@@ -71,6 +61,18 @@
   }
 
   _alertWindow = nil;
+}
+
+- (UIWindow *)getUIWindowFromScene
+{
+  if (@available(iOS 13.0, *)) {
+    for (UIScene *scene in RCTSharedApplication().connectedScenes) {
+      if (scene.activationState == UISceneActivationStateForegroundActive && [scene isKindOfClass:[UIWindowScene class]]) {
+        return [[UIWindow alloc] initWithWindowScene:(UIWindowScene *)scene];
+      }
+    }
+  }
+  return nil;
 }
 
 @end

--- a/React/CoreModules/RCTAlertController.m
+++ b/React/CoreModules/RCTAlertController.m
@@ -20,14 +20,31 @@
 - (UIWindow *)alertWindow
 {
   if (_alertWindow == nil) {
-    UIWindow *keyWindow = RCTSharedApplication().keyWindow;
-    if (keyWindow) {
-      _alertWindow = [[UIWindow alloc] initWithFrame:keyWindow.bounds];
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
+    if (@available(iOS 13.0, *)) {
+      for (UIScene *scene in RCTSharedApplication().connectedScenes) {
+        if (scene.activationState == UISceneActivationStateForegroundActive && [scene isKindOfClass:[UIWindowScene class]]) {
+          _alertWindow = [[UIWindow alloc] initWithWindowScene:(UIWindowScene *)scene];
+          break;
+        }
+      }
+    }
+#endif
+
+    if (_alertWindow == nil) {
+      UIWindow *keyWindow = RCTSharedApplication().keyWindow;
+      if (keyWindow) {
+        _alertWindow = [[UIWindow alloc] initWithFrame:keyWindow.bounds];
+      } else {
+        // keyWindow is nil, so we cannot create and initialize _alertWindow
+        NSLog(@"Unable to create alert window: keyWindow is nil");
+      }
+    }
+
+    if (_alertWindow) {
       _alertWindow.rootViewController = [UIViewController new];
       _alertWindow.windowLevel = UIWindowLevelAlert + 1;
-    } else {
-      // keyWindow is nil, so we cannot create and initialize _alertWindow
-      NSLog(@"Unable to create alert window: keyWindow is nil");
     }
   }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

On iOS 13.0+, app may use SceneDelegate for multiple windows support or CarPlay support. RCTAlertController can't find the correct root vc in such scene based apps.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[iOS] [Fixed] - Fix RCTAlertController not showing when using SceneDelegate on iOS 13.0+.

## Test Plan


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
