### PR TITLE
Fix mCatalystInstance field may not be visible to other threads.

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
@@ -55,7 +55,7 @@ public class ReactContext extends ContextWrapper {
   private LifecycleState mLifecycleState = LifecycleState.BEFORE_CREATE;
 
   private volatile boolean mDestroyed = false;
-  private @Nullable CatalystInstance mCatalystInstance;
+  private @Nullable volatile CatalystInstance mCatalystInstance;
   private @Nullable LayoutInflater mInflater;
   private @Nullable MessageQueueThread mUiMessageQueueThread;
   private @Nullable MessageQueueThread mNativeModulesMessageQueueThread;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
I believe the `mCatalystInstance` field may not be visible in another thread. Because it is initialized in `initializeWithInstance` in a background thread, however, it is accessed in other threads (main thread). This field is used in `hasActiveCatalystInstance` and this method is used in many react modules as follows:

```
  // ReactContextBaseJavaModule.java
  protected @Nullable final ReactApplicationContext getReactApplicationContextIfActiveOrWarn() {
    if (mReactApplicationContext.hasActiveCatalystInstance()
        || mReactApplicationContext.isBridgeless()) {
      return mReactApplicationContext;
    }
   ....
}
```

For example:
`NativeAnimatedModule.getNodesManager` is using `getReactApplicationContextIfActiveOrWarn` on main thread to retrieve `NativeAnimatedNodesManager` instance:

```
  @Nullable
  public NativeAnimatedNodesManager getNodesManager() {
    if (mNodesManager.get() == null) {
      ReactApplicationContext reactApplicationContext = getReactApplicationContextIfActiveOrWarn();

      if (reactApplicationContext != null) {
        mNodesManager.compareAndSet(null, new NativeAnimatedNodesManager(reactApplicationContext));
      }
    }

    return mNodesManager.get();
  }
```
As I mentioned above, calling `getReactApplicationContextIfActiveOrWarn` may return `null` because `mCatalystInstance` field in `ReactContext` is not thread-safe.


I also believe that the cause of the issue https://github.com/facebook/react-native/issues/30115 may relate to this thread-safe issue.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry.
[Android] [Fixed] - Fix `ReactContext.mCatalystInstance` field may not be visible to other threads.
Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
