### PR TITLE
[RFC] Pass props (information) to view constructor

### DIFF
--- a/React/Modules/RCTUIManager.m
+++ b/React/Modules/RCTUIManager.m
@@ -1004,7 +1004,8 @@ RCT_EXPORT_METHOD(createView
       return;
     }
 
-    preliminaryCreatedView = [componentData createViewWithTag:reactTag rootTag:rootTag];
+    // preliminaryCreatedView = [componentData createViewWithTag:reactTag rootTag:rootTag];
+    preliminaryCreatedView = [componentData createViewWithTag:reactTag rootTag:rootTag props:props];
 
     if (preliminaryCreatedView) {
       self->_viewRegistry[reactTag] = preliminaryCreatedView;

--- a/React/Modules/RCTUIManager.m
+++ b/React/Modules/RCTUIManager.m
@@ -1005,7 +1005,7 @@ RCT_EXPORT_METHOD(createView
     }
 
     // preliminaryCreatedView = [componentData createViewWithTag:reactTag rootTag:rootTag];
-    preliminaryCreatedView = [componentData createViewWithTag:reactTag rootTag:rootTag props:props];
+    preliminaryCreatedView = [componentData createpropsViewWithTag:reactTag rootTag:rootTag props:props];
 
     if (preliminaryCreatedView) {
       self->_viewRegistry[reactTag] = preliminaryCreatedView;

--- a/React/Views/RCTComponentData.h
+++ b/React/Views/RCTComponentData.h
@@ -35,6 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
                      eventDispatcher:(id<RCTEventDispatcherProtocol>)eventDispatcher NS_DESIGNATED_INITIALIZER;
 
 - (UIView *)createViewWithTag:(nullable NSNumber *)tag rootTag:(nullable NSNumber *)rootTag;
+- (UIView *)createpropsViewWithTag:(nullable NSNumber *)tag rootTag:(nullable NSNumber *)rootTag props:(NSDictionary *)props;
 - (RCTShadowView *)createShadowViewWithTag:(NSNumber *)tag;
 - (void)setProps:(NSDictionary<NSString *, id> *)props forView:(id<RCTComponent>)view;
 - (void)setProps:(NSDictionary<NSString *, id> *)props forShadowView:(RCTShadowView *)shadowView;

--- a/React/Views/RCTComponentData.m
+++ b/React/Views/RCTComponentData.m
@@ -88,6 +88,19 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
   return view;
 }
 
+- (UIView *)createpropsViewWithTag:(nullable NSNumber *)tag rootTag:(nullable NSNumber *)rootTag props:(NSDictionary *)props
+{
+  RCTAssertMainQueue();
+
+  UIView *view = [self.manager view:props];
+  view.reactTag = tag;
+  view.rootTag = rootTag;
+  view.multipleTouchEnabled = YES;
+  view.userInteractionEnabled = YES; // required for touch handling
+  view.layer.allowsGroupOpacity = YES; // required for touch handling
+  return view;
+}
+
 - (RCTShadowView *)createShadowViewWithTag:(NSNumber *)tag
 {
   RCTShadowView *shadowView = [self.manager shadowView];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
(This is a draft PR, looking for feedback on this change)

One of our use cases involves the creation (construction/init) of a Native Component view based on some information (variables/props) from JS. Change in that information (prop) doesn't need to cause any re-render or updates in the native component. Right now, there is no way to achieve this.

I was wondering if it's possible to modify the createView method so that it passes props (it could be a new entity as well, e.g. constructionProps, but the thing is we already have props being passed from JS so this would involve least amount of change) to the view() defined in the Native Component's view manager. It could be documented that these props are subject to change due to batched updates etc and should not be relied upon for any rendering apart from View Creation.

Suggestions to achieve this in some other way are appreciated. For e.g. one way could have been to create a subview, and modify that based on whenever props are set. However, that approach doesn't work very well for us because we are extending another native component, and then need to pass (set) all the props to that component as well and might cause layout issues as well.

I wanted to understand why that functionality hasn't been provided in RN so far. Is this whole design pattern incorrect?

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:



For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
[IOS] [ADDED] - Add props as an optional argument to view(). 
## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
