### PR TITLE
Avoid using shared_ptr when forwarding arguments in AsyncCallback

### DIFF
--- a/ReactCommon/react/bridging/Function.h
+++ b/ReactCommon/react/bridging/Function.h
@@ -39,38 +39,41 @@ class AsyncCallback {
   }
 
   void call(Args... args) const {
-    auto wrapper = callback_->wrapper_.lock();
-    if (!wrapper) {
-      throw std::runtime_error("Failed to call invalidated async callback");
-    }
-
-    auto argsTuple = std::make_tuple(std::forward<Args>(args)...);
-
-    wrapper->jsInvoker().invokeAsync(
-        [callback = callback_,
-         argsPtr = std::make_shared<decltype(argsTuple)>(
-             std::move(argsTuple))] { callback->apply(std::move(*argsPtr)); });
+    callInternal(std::nullopt, std::forward<Args>(args)...);
   }
 
   void callWithPriority(SchedulerPriority priority, Args... args) const {
-    auto wrapper = callback_->wrapper_.lock();
-    if (!wrapper) {
-      throw std::runtime_error("Failed to call invalidated async callback");
-    }
-
-    auto argsTuple = std::make_tuple(std::forward<Args>(args)...);
-
-    wrapper->jsInvoker().invokeAsync(
-        priority,
-        [callback = callback_,
-         argsPtr = std::make_shared<decltype(argsTuple)>(
-             std::move(argsTuple))] { callback->apply(std::move(*argsPtr)); });
+    callInternal(priority, std::forward<Args>(args)...);
   }
 
  private:
   friend Bridging<AsyncCallback>;
 
   std::shared_ptr<SyncCallback<void(Args...)>> callback_;
+
+  void callInternal(std::optional<SchedulerPriority> priority, Args... args)
+      const {
+    auto wrapper = callback_->wrapper_.lock();
+    if (!wrapper) {
+      throw std::runtime_error("Failed to call invalidated async callback");
+    }
+
+    // NOTE: the args tuple is manually allocated/deleted on the heap in order
+    // to work around C++11 limitation of not yet being able to move-capture in
+    // lambdas, so e.g. unique_ptr couldn't be used.
+    auto argsPtr =
+        new std::tuple<Args...>(std::make_tuple(std::forward<Args>(args)...));
+    auto fn = [callback = callback_, argsPtr] {
+      callback->apply(std::move(*argsPtr));
+      delete argsPtr;
+    };
+
+    if (priority) {
+      wrapper->jsInvoker().invokeAsync(*priority, std::move(fn));
+    } else {
+      wrapper->jsInvoker().invokeAsync(std::move(fn));
+    }
+  }
 };
 
 template <typename R, typename... Args>


### PR DESCRIPTION
Summary:
[Changelog][Internal]

Removes usage of `shared_ptr` when forwarding arguments to an async callback invocation for C++ bridging.

The shared_ptr is not really required here, as we don't share the arguments beyond the current scope, so this is basically an incidental overhead/complexity.

Note that ideally we'd like to use e.g. `unique_ptr` instead, but since we are still using some older compilers, and [C++11 doesn't yet support capture of move-only types in lambdas](https://en.wikipedia.org/wiki/C%2B%2B14#Lambda_capture_expressions), I resorted to allocating the args tuple on the heap manually. I think this is OK in this case, since it's encapsulated/localized in one place (with one caveat that the code now implicitly assumes that the callback will be always called).

Differential Revision: D42265274

