### PR TITLE
[Codegen] Remove unused language argument in codegen errors

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
@@ -481,7 +481,6 @@ describe('throwIfUntypedModule', () => {
 
   it('should throw error if module does not have a type', () => {
     const typeArguments = null;
-    const language = 'Flow';
     expect(() =>
       throwIfUntypedModule(
         typeArguments,
@@ -489,7 +488,6 @@ describe('throwIfUntypedModule', () => {
         callExpressions,
         methodName,
         moduleName,
-        language,
       ),
     ).toThrowError(UntypedModuleRegistryCallParserError);
   });
@@ -500,7 +498,6 @@ describe('throwIfUntypedModule', () => {
       params: [],
     };
 
-    const language = 'TypeScript';
     expect(() =>
       throwIfUntypedModule(
         typeArguments,
@@ -508,7 +505,6 @@ describe('throwIfUntypedModule', () => {
         callExpressions,
         methodName,
         moduleName,
-        language,
       ),
     ).not.toThrowError(UntypedModuleRegistryCallParserError);
   });

--- a/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
@@ -91,28 +91,24 @@ describe('throwIfMoreThanOneModuleRegistryCalls', () => {
       {name: 'callExpression1'},
       {name: 'callExpression2'},
     ];
-    const parserType = 'Flow';
 
     expect(() => {
       throwIfMoreThanOneModuleRegistryCalls(
         nativeModuleName,
         callExpressions,
         callExpressions.length,
-        parserType,
       );
     }).toThrow(MoreThanOneModuleRegistryCallsParserError);
   });
   it("don't throw error if single module registry call", () => {
     const nativeModuleName = 'moduleName';
     const callExpressions = [{name: 'callExpression1'}];
-    const parserType = 'TypeScript';
 
     expect(() => {
       throwIfMoreThanOneModuleRegistryCalls(
         nativeModuleName,
         callExpressions,
         callExpressions.length,
-        parserType,
       );
     }).not.toThrow(MoreThanOneModuleRegistryCallsParserError);
   });

--- a/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
@@ -119,13 +119,11 @@ describe('throwIfUnusedModuleInterfaceParserError', () => {
     const nativeModuleName = 'moduleName';
     const callExpressions: Array<$FlowFixMe> = [];
     const spec = {name: 'Spec'};
-    const parserType = 'Flow';
     expect(() => {
       throwIfUnusedModuleInterfaceParserError(
         nativeModuleName,
         spec,
         callExpressions,
-        parserType,
       );
     }).toThrow(UnusedModuleInterfaceParserError);
   });
@@ -134,13 +132,11 @@ describe('throwIfUnusedModuleInterfaceParserError', () => {
     const nativeModuleName = 'moduleName';
     const callExpressions = [{name: 'callExpression1'}];
     const spec = {name: 'Spec'};
-    const parserType = 'TypeScript';
     expect(() => {
       throwIfUnusedModuleInterfaceParserError(
         nativeModuleName,
         spec,
         callExpressions,
-        parserType,
       );
     }).not.toThrow(UnusedModuleInterfaceParserError);
   });

--- a/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
@@ -179,8 +179,7 @@ describe('throwIfUnsupportedFunctionReturnTypeAnnotationParserError', () => {
       returnType: '',
     },
     nativeModuleName = 'moduleName',
-    invalidReturnType = 'FunctionTypeAnnotation',
-    language = 'Flow';
+    invalidReturnType = 'FunctionTypeAnnotation';
 
   it('do not throw error if cxxOnly is true', () => {
     const cxxOnly = true,
@@ -191,7 +190,6 @@ describe('throwIfUnsupportedFunctionReturnTypeAnnotationParserError', () => {
         nativeModuleName,
         returnTypeAnnotation,
         invalidReturnType,
-        language,
         cxxOnly,
         returnType,
       );
@@ -207,7 +205,6 @@ describe('throwIfUnsupportedFunctionReturnTypeAnnotationParserError', () => {
         nativeModuleName,
         returnTypeAnnotation,
         invalidReturnType,
-        language,
         cxxOnly,
         returnType,
       );
@@ -223,7 +220,6 @@ describe('throwIfUnsupportedFunctionReturnTypeAnnotationParserError', () => {
         nativeModuleName,
         returnTypeAnnotation,
         invalidReturnType,
-        language,
         cxxOnly,
         returnType,
       );

--- a/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
@@ -624,7 +624,6 @@ describe('throwIfArrayElementTypeAnnotationIsUnsupported', () => {
     UnsupportedArrayElementTypeAnnotationParserError,
   } = require('../errors.js');
   const moduleName = 'moduleName';
-  const language = 'Flow';
 
   it('throws the error if it is the type is void type annotation', () => {
     expect(() => {
@@ -633,7 +632,6 @@ describe('throwIfArrayElementTypeAnnotationIsUnsupported', () => {
         undefined,
         'Array',
         'VoidTypeAnnotation',
-        language,
       );
     }).toThrow(UnsupportedArrayElementTypeAnnotationParserError);
   });
@@ -645,7 +643,6 @@ describe('throwIfArrayElementTypeAnnotationIsUnsupported', () => {
         undefined,
         'Array',
         'PromiseTypeAnnotation',
-        language,
       );
     }).toThrow(UnsupportedArrayElementTypeAnnotationParserError);
   });
@@ -657,7 +654,6 @@ describe('throwIfArrayElementTypeAnnotationIsUnsupported', () => {
         undefined,
         'Array',
         'FunctionTypeAnnotation',
-        language,
       );
     }).toThrow(UnsupportedArrayElementTypeAnnotationParserError);
   });
@@ -669,7 +665,6 @@ describe('throwIfArrayElementTypeAnnotationIsUnsupported', () => {
         undefined,
         'Array',
         'StringTypeAnnotation',
-        language,
       );
     }).not.toThrow(UnsupportedArrayElementTypeAnnotationParserError);
   });

--- a/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
@@ -156,14 +156,12 @@ describe('throwErrorIfWrongNumberOfCallExpressionArgs', () => {
     const flowCallExpression: {argument: Array<$FlowFixMe>} = {argument: []};
     const methodName = 'methodName';
     const numberOfCallExpressionArgs = flowCallExpression.argument.length;
-    const language = 'Flow';
     expect(() => {
       throwIfWrongNumberOfCallExpressionArgs(
         nativeModuleName,
         flowCallExpression,
         methodName,
         numberOfCallExpressionArgs,
-        language,
       );
     }).toThrow(IncorrectModuleRegistryCallArityParserError);
   });
@@ -173,14 +171,12 @@ describe('throwErrorIfWrongNumberOfCallExpressionArgs', () => {
     const flowCallExpression = {argument: ['argument']};
     const methodName = 'methodName';
     const numberOfCallExpressionArgs = flowCallExpression.argument.length;
-    const language = 'Flow';
     expect(() => {
       throwIfWrongNumberOfCallExpressionArgs(
         nativeModuleName,
         flowCallExpression,
         methodName,
         numberOfCallExpressionArgs,
-        language,
       );
     }).not.toThrow(IncorrectModuleRegistryCallArityParserError);
   });

--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-primitives-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-primitives-test.js
@@ -672,7 +672,6 @@ describe('emitUnion', () => {
             hasteModuleName,
             typeAnnotation,
             unionTypes,
-            flowParser.language(),
           );
 
           expect(() => {
@@ -687,7 +686,6 @@ describe('emitUnion', () => {
             hasteModuleName,
             typeAnnotation,
             unionTypes,
-            flowParser.language(),
           );
 
           expect(() => {
@@ -887,7 +885,6 @@ describe('emitUnion', () => {
             hasteModuleName,
             typeAnnotation,
             unionTypes,
-            typeScriptParser.language(),
           );
 
           expect(() => {
@@ -902,7 +899,6 @@ describe('emitUnion', () => {
             hasteModuleName,
             typeAnnotation,
             unionTypes,
-            typeScriptParser.language(),
           );
 
           expect(() => {

--- a/packages/react-native-codegen/src/parsers/error-utils.js
+++ b/packages/react-native-codegen/src/parsers/error-utils.js
@@ -240,7 +240,6 @@ function throwIfArrayElementTypeAnnotationIsUnsupported(
   flowElementType: $FlowFixMe,
   flowArrayType: 'Array' | '$ReadOnlyArray' | 'ReadonlyArray',
   type: string,
-  language: ParserType,
 ) {
   const TypeMap = {
     FunctionTypeAnnotation: 'FunctionTypeAnnotation',
@@ -257,7 +256,6 @@ function throwIfArrayElementTypeAnnotationIsUnsupported(
       flowElementType,
       flowArrayType,
       TypeMap[type],
-      language,
     );
   }
 }

--- a/packages/react-native-codegen/src/parsers/error-utils.js
+++ b/packages/react-native-codegen/src/parsers/error-utils.js
@@ -77,14 +77,9 @@ function throwIfUnusedModuleInterfaceParserError(
   nativeModuleName: string,
   moduleSpec: $FlowFixMe,
   callExpressions: $FlowFixMe,
-  language: ParserType,
 ) {
   if (callExpressions.length === 0) {
-    throw new UnusedModuleInterfaceParserError(
-      nativeModuleName,
-      moduleSpec,
-      language,
-    );
+    throw new UnusedModuleInterfaceParserError(nativeModuleName, moduleSpec);
   }
 }
 

--- a/packages/react-native-codegen/src/parsers/error-utils.js
+++ b/packages/react-native-codegen/src/parsers/error-utils.js
@@ -63,14 +63,12 @@ function throwIfMoreThanOneModuleRegistryCalls(
   hasteModuleName: string,
   callExpressions: $FlowFixMe,
   callExpressionsLength: number,
-  language: ParserType,
 ) {
   if (callExpressions.length > 1) {
     throw new MoreThanOneModuleRegistryCallsParserError(
       hasteModuleName,
       callExpressions,
       callExpressionsLength,
-      language,
     );
   }
 }

--- a/packages/react-native-codegen/src/parsers/error-utils.js
+++ b/packages/react-native-codegen/src/parsers/error-utils.js
@@ -194,7 +194,6 @@ function throwIfPropertyValueTypeIsUnsupported(
   propertyValue: $FlowFixMe,
   propertyKey: string,
   type: string,
-  language: ParserType,
 ) {
   const invalidPropertyValueType =
     UnsupportedObjectPropertyTypeToInvalidPropertyValueTypeMap[type];
@@ -204,7 +203,6 @@ function throwIfPropertyValueTypeIsUnsupported(
     propertyValue,
     propertyKey,
     invalidPropertyValueType,
-    language,
   );
 }
 

--- a/packages/react-native-codegen/src/parsers/error-utils.js
+++ b/packages/react-native-codegen/src/parsers/error-utils.js
@@ -95,7 +95,6 @@ function throwIfWrongNumberOfCallExpressionArgs(
   flowCallExpression: $FlowFixMe,
   methodName: string,
   numberOfCallExpressionArgs: number,
-  language: ParserType,
 ) {
   if (numberOfCallExpressionArgs !== 1) {
     throw new IncorrectModuleRegistryCallArityParserError(
@@ -103,7 +102,6 @@ function throwIfWrongNumberOfCallExpressionArgs(
       flowCallExpression,
       methodName,
       numberOfCallExpressionArgs,
-      language,
     );
   }
 }

--- a/packages/react-native-codegen/src/parsers/error-utils.js
+++ b/packages/react-native-codegen/src/parsers/error-utils.js
@@ -119,7 +119,6 @@ function throwIfIncorrectModuleRegistryCallTypeParameterParserError(
       typeArguments,
       methodName,
       moduleName,
-      parser.language(),
     );
   }
 

--- a/packages/react-native-codegen/src/parsers/error-utils.js
+++ b/packages/react-native-codegen/src/parsers/error-utils.js
@@ -151,7 +151,6 @@ function throwIfUntypedModule(
   callExpression: $FlowFixMe,
   methodName: string,
   moduleName: string,
-  language: ParserType,
 ) {
   if (typeArguments == null) {
     throw new UntypedModuleRegistryCallParserError(
@@ -159,7 +158,6 @@ function throwIfUntypedModule(
       callExpression,
       methodName,
       moduleName,
-      language,
     );
   }
 }

--- a/packages/react-native-codegen/src/parsers/error-utils.js
+++ b/packages/react-native-codegen/src/parsers/error-utils.js
@@ -124,7 +124,6 @@ function throwIfUnsupportedFunctionReturnTypeAnnotationParserError(
   nativeModuleName: string,
   returnTypeAnnotation: $FlowFixMe,
   invalidReturnType: string,
-  language: ParserType,
   cxxOnly: boolean,
   returnType: string,
 ) {
@@ -133,7 +132,6 @@ function throwIfUnsupportedFunctionReturnTypeAnnotationParserError(
       nativeModuleName,
       returnTypeAnnotation.returnType,
       'FunctionTypeAnnotation',
-      language,
     );
   }
 }

--- a/packages/react-native-codegen/src/parsers/errors.js
+++ b/packages/react-native-codegen/src/parsers/errors.js
@@ -337,7 +337,6 @@ class MoreThanOneModuleRegistryCallsParserError extends ParserError {
     nativeModuleName: string,
     flowCallExpressions: $FlowFixMe,
     numCalls: number,
-    language: ParserType,
   ) {
     super(
       nativeModuleName,

--- a/packages/react-native-codegen/src/parsers/errors.js
+++ b/packages/react-native-codegen/src/parsers/errors.js
@@ -302,7 +302,6 @@ class UnsupportedUnionTypeAnnotationParserError extends ParserError {
     nativeModuleName: string,
     arrayElementTypeAST: $FlowFixMe,
     types: UnionTypeAnnotationMemberType[],
-    language: ParserType,
   ) {
     super(
       nativeModuleName,

--- a/packages/react-native-codegen/src/parsers/errors.js
+++ b/packages/react-native-codegen/src/parsers/errors.js
@@ -231,11 +231,7 @@ class UnsupportedObjectPropertyValueTypeAnnotationParserError extends ParserErro
  */
 
 class UnnamedFunctionParamParserError extends ParserError {
-  constructor(
-    functionParam: $FlowFixMe,
-    nativeModuleName: string,
-    language: ParserType,
-  ) {
+  constructor(functionParam: $FlowFixMe, nativeModuleName: string) {
     super(
       nativeModuleName,
       functionParam,

--- a/packages/react-native-codegen/src/parsers/errors.js
+++ b/packages/react-native-codegen/src/parsers/errors.js
@@ -353,7 +353,6 @@ class UntypedModuleRegistryCallParserError extends ParserError {
     flowCallExpression: $FlowFixMe,
     methodName: string,
     moduleName: string,
-    language: ParserType,
   ) {
     super(
       nativeModuleName,

--- a/packages/react-native-codegen/src/parsers/errors.js
+++ b/packages/react-native-codegen/src/parsers/errors.js
@@ -283,7 +283,6 @@ class UnsupportedEnumDeclarationParserError extends ParserError {
     nativeModuleName: string,
     arrayElementTypeAST: $FlowFixMe,
     memberType: string,
-    language: ParserType,
   ) {
     super(
       nativeModuleName,

--- a/packages/react-native-codegen/src/parsers/errors.js
+++ b/packages/react-native-codegen/src/parsers/errors.js
@@ -369,7 +369,6 @@ class IncorrectModuleRegistryCallTypeParameterParserError extends ParserError {
     flowTypeArguments: $FlowFixMe,
     methodName: string,
     moduleName: string,
-    language: ParserType,
   ) {
     super(
       nativeModuleName,

--- a/packages/react-native-codegen/src/parsers/errors.js
+++ b/packages/react-native-codegen/src/parsers/errors.js
@@ -176,7 +176,6 @@ class UnsupportedArrayElementTypeAnnotationParserError extends ParserError {
     arrayElementTypeAST: $FlowFixMe,
     arrayType: 'Array' | '$ReadOnlyArray' | 'ReadonlyArray',
     invalidArrayElementType: string,
-    language: ParserType,
   ) {
     super(
       nativeModuleName,

--- a/packages/react-native-codegen/src/parsers/errors.js
+++ b/packages/react-native-codegen/src/parsers/errors.js
@@ -264,7 +264,6 @@ class UnsupportedFunctionReturnTypeAnnotationParserError extends ParserError {
     nativeModuleName: string,
     flowReturnTypeAnnotation: $FlowFixMe,
     invalidReturnType: string,
-    language: ParserType,
   ) {
     super(
       nativeModuleName,

--- a/packages/react-native-codegen/src/parsers/errors.js
+++ b/packages/react-native-codegen/src/parsers/errors.js
@@ -401,7 +401,6 @@ class IncorrectModuleRegistryCallArgumentTypeParserError extends ParserError {
     flowArgument: $FlowFixMe,
     methodName: string,
     type: string,
-    language: ParserType,
   ) {
     const a = /[aeiouy]/.test(type.toLowerCase()) ? 'an' : 'a';
     super(

--- a/packages/react-native-codegen/src/parsers/errors.js
+++ b/packages/react-native-codegen/src/parsers/errors.js
@@ -319,11 +319,7 @@ class UnsupportedUnionTypeAnnotationParserError extends ParserError {
  */
 
 class UnusedModuleInterfaceParserError extends ParserError {
-  constructor(
-    nativeModuleName: string,
-    flowInterface: $FlowFixMe,
-    language: ParserType,
-  ) {
+  constructor(nativeModuleName: string, flowInterface: $FlowFixMe) {
     super(
       nativeModuleName,
       flowInterface,

--- a/packages/react-native-codegen/src/parsers/errors.js
+++ b/packages/react-native-codegen/src/parsers/errors.js
@@ -385,7 +385,6 @@ class IncorrectModuleRegistryCallArityParserError extends ParserError {
     flowCallExpression: $FlowFixMe,
     methodName: string,
     incorrectArity: number,
-    language: ParserType,
   ) {
     super(
       nativeModuleName,

--- a/packages/react-native-codegen/src/parsers/errors.js
+++ b/packages/react-native-codegen/src/parsers/errors.js
@@ -216,7 +216,6 @@ class UnsupportedObjectPropertyValueTypeAnnotationParserError extends ParserErro
     propertyValueAST: $FlowFixMe,
     propertyName: string,
     invalidPropertyValueType: string,
-    language: ParserType,
   ) {
     super(
       nativeModuleName,

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -370,7 +370,6 @@ function buildModuleSchema(
       callExpression,
       methodName,
       $moduleName,
-      language,
     );
 
     throwIfIncorrectModuleRegistryCallTypeParameterParserError(

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -350,7 +350,6 @@ function buildModuleSchema(
       callExpression,
       methodName,
       callExpression.arguments.length,
-      language,
     );
 
     if (callExpression.arguments[0].type !== 'Literal') {

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -338,7 +338,6 @@ function buildModuleSchema(
       hasteModuleName,
       callExpressions,
       callExpressions.length,
-      language,
     );
 
     const [callExpression] = callExpressions;

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -360,7 +360,6 @@ function buildModuleSchema(
         callExpression.arguments[0],
         methodName,
         type,
-        language,
       );
     }
 

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -331,7 +331,6 @@ function buildModuleSchema(
       hasteModuleName,
       moduleSpec,
       callExpressions,
-      language,
     );
 
     throwIfMoreThanOneModuleRegistryCalls(

--- a/packages/react-native-codegen/src/parsers/parsers-commons.js
+++ b/packages/react-native-codegen/src/parsers/parsers-commons.js
@@ -273,11 +273,7 @@ function translateFunctionTypeAnnotation(
   )) {
     const parsedParam = tryParse(() => {
       if (getFunctionNameFromParameter(param, parser.language()) == null) {
-        throw new UnnamedFunctionParamParserError(
-          param,
-          hasteModuleName,
-          parser.language(),
-        );
+        throw new UnnamedFunctionParamParserError(param, hasteModuleName);
       }
 
       const paramName = getParameterName(param, parser.language());

--- a/packages/react-native-codegen/src/parsers/parsers-commons.js
+++ b/packages/react-native-codegen/src/parsers/parsers-commons.js
@@ -339,7 +339,6 @@ function translateFunctionTypeAnnotation(
     hasteModuleName,
     typeAnnotation,
     'FunctionTypeAnnotation',
-    parser.language(),
     cxxOnly,
     returnTypeAnnotation.type,
   );

--- a/packages/react-native-codegen/src/parsers/parsers-commons.js
+++ b/packages/react-native-codegen/src/parsers/parsers-commons.js
@@ -203,7 +203,6 @@ function translateDefault(
         hasteModuleName,
         typeAnnotation,
         memberType,
-        parser.language(),
       );
     }
   }

--- a/packages/react-native-codegen/src/parsers/parsers-commons.js
+++ b/packages/react-native-codegen/src/parsers/parsers-commons.js
@@ -166,7 +166,6 @@ function parseObjectProperty(
       languageTypeAnnotation,
       property.key,
       propertyTypeAnnotation.type,
-      language,
     );
   }
 

--- a/packages/react-native-codegen/src/parsers/parsers-primitives.js
+++ b/packages/react-native-codegen/src/parsers/parsers-primitives.js
@@ -267,7 +267,6 @@ function emitUnion(
       hasteModuleName,
       typeAnnotation,
       unionTypes,
-      parser.language(),
     );
   }
 

--- a/packages/react-native-codegen/src/parsers/parsers-primitives.js
+++ b/packages/react-native-codegen/src/parsers/parsers-primitives.js
@@ -318,7 +318,6 @@ function translateArrayTypeAnnotation(
       elementType,
       arrayType,
       _elementType.type,
-      parser.language(),
     );
 
     return wrapNullable(nullable, {

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -355,7 +355,6 @@ function buildModuleSchema(
       callExpression,
       methodName,
       callExpression.arguments.length,
-      language,
     );
 
     if (callExpression.arguments[0].type !== 'StringLiteral') {

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -343,7 +343,6 @@ function buildModuleSchema(
       hasteModuleName,
       callExpressions,
       callExpressions.length,
-      language,
     );
 
     const [callExpression] = callExpressions;

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -336,7 +336,6 @@ function buildModuleSchema(
       hasteModuleName,
       moduleSpec,
       callExpressions,
-      language,
     );
 
     throwIfMoreThanOneModuleRegistryCalls(

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -365,7 +365,6 @@ function buildModuleSchema(
         callExpression.arguments[0],
         methodName,
         type,
-        language,
       );
     }
 

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -375,7 +375,6 @@ function buildModuleSchema(
       callExpression,
       methodName,
       $moduleName,
-      language,
     );
 
     throwIfIncorrectModuleRegistryCallTypeParameterParserError(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This is not a task from https://github.com/facebook/react-native/issues/34872 but I noticed that we were passing `language` arguments that were never used for several errors so I removed them.


## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[INTERNAL] [CHANGED] - Remove unused language argument in Codegen errors

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

I tested using Flow and Jest.