### PR TITLE
Addition of overCurrentContext in Modal presentationStyle property for iOS

### DIFF
--- a/Libraries/Modal/Modal.js
+++ b/Libraries/Modal/Modal.js
@@ -77,6 +77,7 @@ export type Props = $ReadOnly<{|
     | 'pageSheet'
     | 'formSheet'
     | 'overFullScreen'
+    | 'overCurrentContext'
   ),
 
   /**
@@ -163,7 +164,7 @@ function confirmProps(props: Props) {
   if (__DEV__) {
     if (
       props.presentationStyle &&
-      props.presentationStyle !== 'overFullScreen' &&
+      (props.presentationStyle !== 'overFullScreen' || props.presentationStyle !== 'overCurrentContext') &&
       props.transparent === true
     ) {
       console.warn(

--- a/React/Views/RCTModalHostViewManager.m
+++ b/React/Views/RCTModalHostViewManager.m
@@ -23,6 +23,7 @@ RCT_ENUM_CONVERTER(
       @"pageSheet" : @(UIModalPresentationPageSheet),
       @"formSheet" : @(UIModalPresentationFormSheet),
       @"overFullScreen" : @(UIModalPresentationOverFullScreen),
+      @"overCurrentContext" : @(UIModalPresentationOverCurrentContext)
     }),
     UIModalPresentationFullScreen,
     integerValue)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

With the current options provided in react-native modal component there is no option to open a bottomsheet with a transparent background where context of the previous screen is still visible more than half-way in iOS. Adding the option of UIModalPresentationStyle of "overCurrentContext" in the presentationStyle property allows developers to make bottom sheets that have flexible content height and transparent empty space with visible background context.  


## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[IOS] [ADDED] - Added overCurrentContext option in Modal presentationStyle property, which is only applicable for iOS.

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

In order to check the changes, I executed comment "npm start" to run the node server and ran my iOS app from Xcode which contains react native containers.

Please find attached a screenshot of my bottomsheet with transparent background and partially visible background context.
(https://user-images.githubusercontent.com/68434231/209869482-b2f0b2d0-b24d-4816-b469-204208cddb56.png)
Simulator Screen Shot - iPhone 14 - 2022-12-29 at 02.02.03.png…]()
