### PR TITLE
[Codegen] Move language ternaries logic to FlowParser and TypeScriptParser

### DIFF
--- a/packages/react-native-codegen/src/parsers/flow/parser.js
+++ b/packages/react-native-codegen/src/parsers/flow/parser.js
@@ -103,6 +103,10 @@ class FlowParser implements Parser {
   ): $FlowFixMe {
     return parameter.name;
   }
+
+  getParameterName(parameter: $FlowFixMe): string {
+    return parameter.name.name;
+  }
 }
 
 module.exports = {

--- a/packages/react-native-codegen/src/parsers/flow/parser.js
+++ b/packages/react-native-codegen/src/parsers/flow/parser.js
@@ -111,6 +111,12 @@ class FlowParser implements Parser {
   getParameterTypeAnnotation(parameter: $FlowFixMe): $FlowFixMe {
     return parameter.typeAnnotation;
   }
+
+  getFunctionTypeAnnotationReturnType(
+    functionTypeAnnotation: $FlowFixMe,
+  ): $FlowFixMe {
+    return functionTypeAnnotation.returnType;
+  }
 }
 
 module.exports = {

--- a/packages/react-native-codegen/src/parsers/flow/parser.js
+++ b/packages/react-native-codegen/src/parsers/flow/parser.js
@@ -107,6 +107,10 @@ class FlowParser implements Parser {
   getParameterName(parameter: $FlowFixMe): string {
     return parameter.name.name;
   }
+
+  getParameterTypeAnnotation(parameter: $FlowFixMe): $FlowFixMe {
+    return parameter.typeAnnotation;
+  }
 }
 
 module.exports = {

--- a/packages/react-native-codegen/src/parsers/flow/parser.js
+++ b/packages/react-native-codegen/src/parsers/flow/parser.js
@@ -13,6 +13,9 @@
 import type {
   UnionTypeAnnotationMemberType,
   SchemaType,
+  NamedShape,
+  Nullable,
+  NativeModuleParamTypeAnnotation,
 } from '../../CodegenSchema';
 import type {ParserType} from '../errors';
 import type {Parser} from '../parser';
@@ -93,6 +96,12 @@ class FlowParser implements Parser {
     functionTypeAnnotation: $FlowFixMe,
   ): $ReadOnlyArray<$FlowFixMe> {
     return functionTypeAnnotation.params;
+  }
+
+  getFunctionNameFromParameter(
+    parameter: NamedShape<Nullable<NativeModuleParamTypeAnnotation>>,
+  ): $FlowFixMe {
+    return parameter.name;
   }
 }
 

--- a/packages/react-native-codegen/src/parsers/flow/parser.js
+++ b/packages/react-native-codegen/src/parsers/flow/parser.js
@@ -88,6 +88,12 @@ class FlowParser implements Parser {
 
     return buildSchema(contents, filename, this);
   }
+
+  getFunctionTypeAnnotationParameters(
+    functionTypeAnnotation: $FlowFixMe,
+  ): $ReadOnlyArray<$FlowFixMe> {
+    return functionTypeAnnotation.params;
+  }
 }
 
 module.exports = {

--- a/packages/react-native-codegen/src/parsers/parser.js
+++ b/packages/react-native-codegen/src/parsers/parser.js
@@ -101,4 +101,11 @@ export interface Parser {
   getFunctionNameFromParameter(
     parameter: NamedShape<Nullable<NativeModuleParamTypeAnnotation>>,
   ): $FlowFixMe;
+
+  /**
+   * Given a parameter, it returns its name.
+   * @parameter parameter: a parameter of a FunctionTypeAnnotation.
+   * @returns: the name of the parameter.
+   */
+  getParameterName(parameter: $FlowFixMe): string;
 }

--- a/packages/react-native-codegen/src/parsers/parser.js
+++ b/packages/react-native-codegen/src/parsers/parser.js
@@ -115,4 +115,13 @@ export interface Parser {
    * @returns: the typeAnnotation of the parameter.
    */
   getParameterTypeAnnotation(param: $FlowFixMe): $FlowFixMe;
+
+  /**
+   * Given a FunctionTypeAnnotation, it returns its returnType.
+   * @parameter functionTypeAnnotation: a FunctionTypeAnnotation
+   * @returns: the returnType of the FunctionTypeAnnotation.
+   */
+  getFunctionTypeAnnotationReturnType(
+    functionTypeAnnotation: $FlowFixMe,
+  ): $FlowFixMe;
 }

--- a/packages/react-native-codegen/src/parsers/parser.js
+++ b/packages/react-native-codegen/src/parsers/parser.js
@@ -10,7 +10,13 @@
 
 'use strict';
 
-import type {UnionTypeAnnotationMemberType, SchemaType} from '../CodegenSchema';
+import type {
+  UnionTypeAnnotationMemberType,
+  SchemaType,
+  NamedShape,
+  Nullable,
+  NativeModuleParamTypeAnnotation,
+} from '../CodegenSchema';
 import type {ParserType} from './errors';
 
 /**
@@ -86,4 +92,13 @@ export interface Parser {
   getFunctionTypeAnnotationParameters(
     functionTypeAnnotation: $FlowFixMe,
   ): $ReadOnlyArray<$FlowFixMe>;
+
+  /**
+   * Given a parameter, it returns the function name of the parameter.
+   * @parameter parameter: a parameter of a FunctionTypeAnnotation.
+   * @returns: the function name of the parameter.
+   */
+  getFunctionNameFromParameter(
+    parameter: NamedShape<Nullable<NativeModuleParamTypeAnnotation>>,
+  ): $FlowFixMe;
 }

--- a/packages/react-native-codegen/src/parsers/parser.js
+++ b/packages/react-native-codegen/src/parsers/parser.js
@@ -77,4 +77,13 @@ export interface Parser {
    * @returns: the AST of the file (given in program property for typescript).
    */
   parseFile(filename: string): SchemaType;
+
+  /**
+   * Given a FunctionTypeAnnotation, it returns an array of its parameters.
+   * @parameter functionTypeAnnotation: a FunctionTypeAnnotation
+   * @returns: the parameters of the FunctionTypeAnnotation.
+   */
+  getFunctionTypeAnnotationParameters(
+    functionTypeAnnotation: $FlowFixMe,
+  ): $ReadOnlyArray<$FlowFixMe>;
 }

--- a/packages/react-native-codegen/src/parsers/parser.js
+++ b/packages/react-native-codegen/src/parsers/parser.js
@@ -108,4 +108,11 @@ export interface Parser {
    * @returns: the name of the parameter.
    */
   getParameterName(parameter: $FlowFixMe): string;
+
+  /**
+   * Given a parameter, it returns its typeAnnotation.
+   * @parameter parameter: a parameter of a FunctionTypeAnnotation.
+   * @returns: the typeAnnotation of the parameter.
+   */
+  getParameterTypeAnnotation(param: $FlowFixMe): $FlowFixMe;
 }

--- a/packages/react-native-codegen/src/parsers/parserMock.js
+++ b/packages/react-native-codegen/src/parsers/parserMock.js
@@ -12,7 +12,13 @@
 
 import type {Parser} from './parser';
 import type {ParserType} from './errors';
-import type {UnionTypeAnnotationMemberType, SchemaType} from '../CodegenSchema';
+import type {
+  UnionTypeAnnotationMemberType,
+  SchemaType,
+  NamedShape,
+  Nullable,
+  NativeModuleParamTypeAnnotation,
+} from '../CodegenSchema';
 
 const {
   UnsupportedObjectPropertyTypeAnnotationParserError,
@@ -87,5 +93,11 @@ export class MockedParser implements Parser {
     functionTypeAnnotation: $FlowFixMe,
   ): $ReadOnlyArray<$FlowFixMe> {
     return functionTypeAnnotation.params;
+  }
+
+  getFunctionNameFromParameter(
+    parameter: NamedShape<Nullable<NativeModuleParamTypeAnnotation>>,
+  ): $FlowFixMe {
+    return parameter.name;
   }
 }

--- a/packages/react-native-codegen/src/parsers/parserMock.js
+++ b/packages/react-native-codegen/src/parsers/parserMock.js
@@ -100,4 +100,8 @@ export class MockedParser implements Parser {
   ): $FlowFixMe {
     return parameter.name;
   }
+
+  getParameterName(parameter: $FlowFixMe): string {
+    return parameter.name.name;
+  }
 }

--- a/packages/react-native-codegen/src/parsers/parserMock.js
+++ b/packages/react-native-codegen/src/parsers/parserMock.js
@@ -82,4 +82,10 @@ export class MockedParser implements Parser {
       },
     };
   }
+
+  getFunctionTypeAnnotationParameters(
+    functionTypeAnnotation: $FlowFixMe,
+  ): $ReadOnlyArray<$FlowFixMe> {
+    return functionTypeAnnotation.params;
+  }
 }

--- a/packages/react-native-codegen/src/parsers/parserMock.js
+++ b/packages/react-native-codegen/src/parsers/parserMock.js
@@ -108,4 +108,10 @@ export class MockedParser implements Parser {
   getParameterTypeAnnotation(parameter: $FlowFixMe): $FlowFixMe {
     return parameter.typeAnnotation;
   }
+
+  getFunctionTypeAnnotationReturnType(
+    functionTypeAnnotation: $FlowFixMe,
+  ): $FlowFixMe {
+    return functionTypeAnnotation.returnType;
+  }
 }

--- a/packages/react-native-codegen/src/parsers/parserMock.js
+++ b/packages/react-native-codegen/src/parsers/parserMock.js
@@ -104,4 +104,8 @@ export class MockedParser implements Parser {
   getParameterName(parameter: $FlowFixMe): string {
     return parameter.name.name;
   }
+
+  getParameterTypeAnnotation(parameter: $FlowFixMe): $FlowFixMe {
+    return parameter.typeAnnotation;
+  }
 }

--- a/packages/react-native-codegen/src/parsers/parsers-commons.js
+++ b/packages/react-native-codegen/src/parsers/parsers-commons.js
@@ -213,15 +213,6 @@ function translateDefault(
   );
 }
 
-function getTypeAnnotationParameters(
-  typeAnnotation: $FlowFixMe,
-  language: ParserType,
-): $ReadOnlyArray<$FlowFixMe> {
-  return language === 'Flow'
-    ? typeAnnotation.params
-    : typeAnnotation.parameters;
-}
-
 function getFunctionNameFromParameter(
   param: NamedShape<Nullable<NativeModuleParamTypeAnnotation>>,
   language: ParserType,
@@ -255,7 +246,7 @@ function translateFunctionTypeAnnotation(
   hasteModuleName: string,
   // TODO(T108222691): Use flow-types for @babel/parser
   // TODO(T71778680): This is a FunctionTypeAnnotation. Type this.
-  typeAnnotation: $FlowFixMe,
+  functionTypeAnnotation: $FlowFixMe,
   types: TypeDeclarationMap,
   aliasMap: {...NativeModuleAliasMap},
   tryParse: ParserErrorCapturer,
@@ -266,9 +257,8 @@ function translateFunctionTypeAnnotation(
   type Param = NamedShape<Nullable<NativeModuleParamTypeAnnotation>>;
   const params: Array<Param> = [];
 
-  for (const param of getTypeAnnotationParameters(
-    typeAnnotation,
-    parser.language(),
+  for (const param of parser.getFunctionTypeAnnotationParameters(
+    functionTypeAnnotation,
   )) {
     const parsedParam = tryParse(() => {
       if (getFunctionNameFromParameter(param, parser.language()) == null) {
@@ -321,7 +311,7 @@ function translateFunctionTypeAnnotation(
     unwrapNullable<$FlowFixMe>(
       translateTypeAnnotation(
         hasteModuleName,
-        getTypeAnnotationReturnType(typeAnnotation, parser.language()),
+        getTypeAnnotationReturnType(functionTypeAnnotation, parser.language()),
         types,
         aliasMap,
         tryParse,
@@ -332,7 +322,7 @@ function translateFunctionTypeAnnotation(
 
   throwIfUnsupportedFunctionReturnTypeAnnotationParserError(
     hasteModuleName,
-    typeAnnotation,
+    functionTypeAnnotation,
     'FunctionTypeAnnotation',
     cxxOnly,
     returnTypeAnnotation.type,

--- a/packages/react-native-codegen/src/parsers/parsers-commons.js
+++ b/packages/react-native-codegen/src/parsers/parsers-commons.js
@@ -213,15 +213,6 @@ function translateDefault(
   );
 }
 
-function getParameterTypeAnnotation(
-  param: $FlowFixMe,
-  language: ParserType,
-): $FlowFixMe {
-  return language === 'Flow'
-    ? param.typeAnnotation
-    : param.typeAnnotation.typeAnnotation;
-}
-
 function getTypeAnnotationReturnType(
   typeAnnotation: $FlowFixMe,
   language: ParserType,
@@ -260,7 +251,7 @@ function translateFunctionTypeAnnotation(
         unwrapNullable<$FlowFixMe>(
           translateTypeAnnotation(
             hasteModuleName,
-            getParameterTypeAnnotation(param, parser.language()),
+            parser.getParameterTypeAnnotation(param),
             types,
             aliasMap,
             tryParse,

--- a/packages/react-native-codegen/src/parsers/parsers-commons.js
+++ b/packages/react-native-codegen/src/parsers/parsers-commons.js
@@ -261,7 +261,7 @@ function translateFunctionTypeAnnotation(
     functionTypeAnnotation,
   )) {
     const parsedParam = tryParse(() => {
-      if (getFunctionNameFromParameter(param, parser.language()) == null) {
+      if (parser.getFunctionNameFromParameter(param) == null) {
         throw new UnnamedFunctionParamParserError(param, hasteModuleName);
       }
 

--- a/packages/react-native-codegen/src/parsers/parsers-commons.js
+++ b/packages/react-native-codegen/src/parsers/parsers-commons.js
@@ -213,17 +213,6 @@ function translateDefault(
   );
 }
 
-function getFunctionNameFromParameter(
-  param: NamedShape<Nullable<NativeModuleParamTypeAnnotation>>,
-  language: ParserType,
-): $FlowFixMe {
-  return language === 'Flow' ? param.name : param.typeAnnotation;
-}
-
-function getParameterName(param: $FlowFixMe, language: ParserType): string {
-  return language === 'Flow' ? param.name.name : param.name;
-}
-
 function getParameterTypeAnnotation(
   param: $FlowFixMe,
   language: ParserType,
@@ -265,7 +254,7 @@ function translateFunctionTypeAnnotation(
         throw new UnnamedFunctionParamParserError(param, hasteModuleName);
       }
 
-      const paramName = getParameterName(param, parser.language());
+      const paramName = parser.getParameterName(param);
 
       const [paramTypeAnnotation, isParamTypeAnnotationNullable] =
         unwrapNullable<$FlowFixMe>(

--- a/packages/react-native-codegen/src/parsers/parsers-commons.js
+++ b/packages/react-native-codegen/src/parsers/parsers-commons.js
@@ -213,15 +213,6 @@ function translateDefault(
   );
 }
 
-function getTypeAnnotationReturnType(
-  typeAnnotation: $FlowFixMe,
-  language: ParserType,
-): $FlowFixMe {
-  return language === 'Flow'
-    ? typeAnnotation.returnType
-    : typeAnnotation.typeAnnotation.typeAnnotation;
-}
-
 function translateFunctionTypeAnnotation(
   hasteModuleName: string,
   // TODO(T108222691): Use flow-types for @babel/parser
@@ -291,7 +282,7 @@ function translateFunctionTypeAnnotation(
     unwrapNullable<$FlowFixMe>(
       translateTypeAnnotation(
         hasteModuleName,
-        getTypeAnnotationReturnType(functionTypeAnnotation, parser.language()),
+        parser.getFunctionTypeAnnotationReturnType(functionTypeAnnotation),
         types,
         aliasMap,
         tryParse,

--- a/packages/react-native-codegen/src/parsers/typescript/parser.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parser.js
@@ -109,6 +109,10 @@ class TypeScriptParser implements Parser {
   ): $FlowFixMe {
     return parameter.typeAnnotation;
   }
+
+  getParameterName(parameter: $FlowFixMe): string {
+    return parameter.name;
+  }
 }
 module.exports = {
   TypeScriptParser,

--- a/packages/react-native-codegen/src/parsers/typescript/parser.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parser.js
@@ -117,6 +117,12 @@ class TypeScriptParser implements Parser {
   getParameterTypeAnnotation(parameter: $FlowFixMe): $FlowFixMe {
     return parameter.typeAnnotation.typeAnnotation;
   }
+
+  getFunctionTypeAnnotationReturnType(
+    functionTypeAnnotation: $FlowFixMe,
+  ): $FlowFixMe {
+    return functionTypeAnnotation.typeAnnotation.typeAnnotation;
+  }
 }
 module.exports = {
   TypeScriptParser,

--- a/packages/react-native-codegen/src/parsers/typescript/parser.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parser.js
@@ -94,6 +94,12 @@ class TypeScriptParser implements Parser {
 
     return buildSchema(contents, filename, this);
   }
+
+  getFunctionTypeAnnotationParameters(
+    functionTypeAnnotation: $FlowFixMe,
+  ): $ReadOnlyArray<$FlowFixMe> {
+    return functionTypeAnnotation.parameters;
+  }
 }
 module.exports = {
   TypeScriptParser,

--- a/packages/react-native-codegen/src/parsers/typescript/parser.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parser.js
@@ -13,6 +13,9 @@
 import type {
   UnionTypeAnnotationMemberType,
   SchemaType,
+  NamedShape,
+  Nullable,
+  NativeModuleParamTypeAnnotation,
 } from '../../CodegenSchema';
 import type {ParserType} from '../errors';
 import type {Parser} from '../parser';
@@ -99,6 +102,12 @@ class TypeScriptParser implements Parser {
     functionTypeAnnotation: $FlowFixMe,
   ): $ReadOnlyArray<$FlowFixMe> {
     return functionTypeAnnotation.parameters;
+  }
+
+  getFunctionNameFromParameter(
+    parameter: NamedShape<Nullable<NativeModuleParamTypeAnnotation>>,
+  ): $FlowFixMe {
+    return parameter.typeAnnotation;
   }
 }
 module.exports = {

--- a/packages/react-native-codegen/src/parsers/typescript/parser.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parser.js
@@ -113,6 +113,10 @@ class TypeScriptParser implements Parser {
   getParameterName(parameter: $FlowFixMe): string {
     return parameter.name;
   }
+
+  getParameterTypeAnnotation(parameter: $FlowFixMe): $FlowFixMe {
+    return parameter.typeAnnotation.typeAnnotation;
+  }
 }
 module.exports = {
   TypeScriptParser,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This is not a task from https://github.com/facebook/react-native/issues/34872 but it goes towards the same goal: removing language-specific logic from shared code and moving it to the FlowParser and TypeScriptParser.

I'm not sure about the documentation of the functions. It's been quite difficult for me to understand what the arguments are and what is returned by the functions because I find the naming quite confusing and nothing is typed.


## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[INTERNAL] [CHANGED] - [Codegen] Move language ternaries logic to FlowParser and TypeScriptParser

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

I tested using Flow and Jest commands. I made sure that tests were broken when Flow and TypeScript implementations were reversed.
