### PR TITLE
fix: pod install with --project-directory

### DIFF
--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -209,9 +209,6 @@ def react_native_post_install(installer, react_native_path = "../node_modules/re
     flipper_post_install(installer)
   end
 
-  package = JSON.parse(File.read(File.join(react_native_path, "package.json")))
-  version = package['version']
-
   ReactNativePodsUtils.exclude_i386_architecture_while_using_hermes(installer)
   ReactNativePodsUtils.fix_library_search_paths(installer)
   ReactNativePodsUtils.set_node_modules_user_settings(installer, react_native_path)


### PR DESCRIPTION
## Summary
The variable `version` is previously used but in https://github.com/facebook/react-native/commit/234486068e7f547450829d17e8d5db111a1571bc#diff-adcf572f001c2b710d14f409c14763f1a50b08369b3034548f1602685d21f67f, its usage have been removed the but the variable is kept.

It also raises an error when using `bundle exec pod install --project-directory=ios` which works on `0.70.X` and below.

```txt
No such file or directory @ rb_sysopen - ../node_modules/react-native/package.json

/Users/davidangulo/Desktop/mobile/myapp/node_modules/react-native/scripts/react_native_pods.rb:212:in `read'
/Users/davidangulo/Desktop/mobile/myapp/node_modules/react-native/scripts/react_native_pods.rb:212:in `react_native_post_install'
```

## Changelog
[IOS] [FIXED] - pod install with --project-directory

## Test Plan
`bundle exec pod install --project-directory=ios` should not raise an error.
