### PR TITLE
[General] [Fixed] - Fixes react-native-codegen location within script_phases.sh

### DIFF
--- a/scripts/react_native_pods_utils/script_phases.sh
+++ b/scripts/react_native_pods_utils/script_phases.sh
@@ -31,9 +31,9 @@ find_node () {
 }
 
 find_codegen () {
-    CODEGEN_CLI_PATH=$("$NODE_BINARY" --print "require('path').dirname(require.resolve('@react-native/codegen/package.json'))")
+    CODEGEN_CLI_PATH=$("$NODE_BINARY" --print "require('path').dirname(require.resolve('react-native-codegen/package.json'))")
     if ! [ -d "$CODEGEN_CLI_PATH" ]; then
-        error "error: Could not determine @react-native/codegen location, using node module resolution. Try running 'yarn install' or 'npm install' in your project root."
+        error "error: Could not determine react-native-codegen location, using node module resolution. Try running 'yarn install' or 'npm install' in your project root."
     fi
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

@byCedric did some amazing work to update the codegen location monorepo support. There was just 1 small issue which is in the name of the package: instead of `@react-native/codegen` it should be `react-native-codegen`

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

[General] [Fixed] - Fixes react-native-codegen location within script_phases.sh from `@react-native/codegen` to `react-native-codegen`

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan

Run `eas build --platform ios` within a monorepo like [Backpack](https://github.com/coral-xyz/backpack)
