### PR TITLE
Implement reporting of events from native side to WebPerformance API

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -1477,5 +1477,7 @@ rn_apple_xplat_cxx_library(
     visibility = ["PUBLIC"],
     deps = [
         ":FBReactNativeSpecJSI",
+        react_native_xplat_target("react/renderer/core:core"),
+        react_native_xplat_target("cxxreact:bridge"),
     ],
 )

--- a/Libraries/WebPerformance/NativePerformanceObserver.cpp
+++ b/Libraries/WebPerformance/NativePerformanceObserver.cpp
@@ -6,7 +6,6 @@
  */
 
 #include "NativePerformanceObserver.h"
-#include <glog/logging.h>
 #include "PerformanceEntryReporter.h"
 
 namespace facebook::react {
@@ -28,7 +27,13 @@ static PerformanceEntryType stringToPerformanceEntryType(
 
 NativePerformanceObserver::NativePerformanceObserver(
     std::shared_ptr<CallInvoker> jsInvoker)
-    : NativePerformanceObserverCxxSpec(std::move(jsInvoker)) {}
+    : NativePerformanceObserverCxxSpec(std::move(jsInvoker)) {
+  setEventLogger(&PerformanceEntryReporter::getInstance());
+}
+
+NativePerformanceObserver::~NativePerformanceObserver() {
+  setEventLogger(nullptr);
+}
 
 void NativePerformanceObserver::startReporting(
     jsi::Runtime &rt,

--- a/Libraries/WebPerformance/NativePerformanceObserver.h
+++ b/Libraries/WebPerformance/NativePerformanceObserver.h
@@ -57,6 +57,7 @@ class NativePerformanceObserver
       std::enable_shared_from_this<NativePerformanceObserver> {
  public:
   NativePerformanceObserver(std::shared_ptr<CallInvoker> jsInvoker);
+  ~NativePerformanceObserver();
 
   void startReporting(jsi::Runtime &rt, std::string entryType);
 

--- a/Libraries/WebPerformance/PerformanceEventTiming.js
+++ b/Libraries/WebPerformance/PerformanceEventTiming.js
@@ -28,7 +28,7 @@ export class PerformanceEventTiming extends PerformanceEntry {
   }) {
     super({
       name: init.name,
-      entryType: init.isFirstInput === true ? 'first-input' : 'measure',
+      entryType: init.isFirstInput === true ? 'first-input' : 'event',
       startTime: init.startTime ?? 0,
       duration: init.duration ?? 0,
     });

--- a/ReactCommon/react/renderer/core/BUCK
+++ b/ReactCommon/react/renderer/core/BUCK
@@ -59,6 +59,7 @@ rn_xplat_cxx_library(
         react_native_xplat_target("react/utils:utils"),
         react_native_xplat_target("react/renderer/debug:debug"),
         react_native_xplat_target("react/renderer/graphics:graphics"),
+        react_native_xplat_target("cxxreact:bridge"),
     ],
 )
 
@@ -84,6 +85,7 @@ fb_xplat_cxx_test(
         react_native_xplat_target("react/renderer/components/text:text"),
         react_native_xplat_target("react/renderer/element:element"),
         react_native_xplat_target("react/renderer/components/view:view"),
+        react_native_xplat_target("cxxreact:bridge"),
     ],
 )
 

--- a/ReactCommon/react/renderer/core/EventDispatcher.cpp
+++ b/ReactCommon/react/renderer/core/EventDispatcher.cpp
@@ -6,8 +6,9 @@
  */
 
 #include "EventDispatcher.h"
-
+#include <cxxreact/JSExecutor.h>
 #include <react/renderer/core/StateUpdate.h>
+#include "EventLogger.h"
 
 #include "BatchedEventQueue.h"
 #include "RawEvent.h"
@@ -38,6 +39,11 @@ void EventDispatcher::dispatchEvent(RawEvent &&rawEvent, EventPriority priority)
   // Allows the event listener to interrupt default event dispatch
   if (eventListeners_.willDispatchEvent(rawEvent)) {
     return;
+  }
+
+  auto eventLogger = getEventLogger();
+  if (eventLogger != nullptr) {
+    rawEvent.loggingTag = eventLogger->onEventStart(rawEvent.type.c_str());
   }
   getEventQueue(priority).enqueueEvent(std::move(rawEvent));
 }

--- a/ReactCommon/react/renderer/core/EventLogger.cpp
+++ b/ReactCommon/react/renderer/core/EventLogger.cpp
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "EventLogger.h"
+
+namespace facebook::react {
+
+EventLogger *eventLogger;
+
+void setEventLogger(EventLogger *logger) {
+  eventLogger = logger;
+}
+
+EventLogger *getEventLogger() {
+  return eventLogger;
+}
+
+} // namespace facebook::react

--- a/ReactCommon/react/renderer/core/EventLogger.h
+++ b/ReactCommon/react/renderer/core/EventLogger.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace facebook::react {
+
+using EventTag = unsigned int;
+
+/*
+ * Interface for logging discrete events (such as pointerenter/leave),
+ * which can be used for implementing W3C Event Timing API standard,
+ * see https://www.w3.org/TR/event-timing
+ */
+class EventLogger {
+ public:
+  virtual ~EventLogger() = default;
+
+  /*
+   * Called when an event is first created, returns and unique tag for this
+   * event, which can be used to log further event processing stages.
+   */
+  virtual EventTag onEventStart(const char *name) = 0;
+
+  /*
+   * Called when event starts getting dispatched (processed by the handlers, if
+   * any)
+   */
+  virtual void onEventDispatch(EventTag tag) = 0;
+
+  /*
+   * Called when event finishes being dispatched
+   */
+  virtual void onEventEnd(EventTag tag) = 0;
+};
+
+void setEventLogger(EventLogger *eventLogger);
+EventLogger *getEventLogger();
+
+} // namespace facebook::react

--- a/ReactCommon/react/renderer/core/EventQueueProcessor.cpp
+++ b/ReactCommon/react/renderer/core/EventQueueProcessor.cpp
@@ -5,9 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "EventQueue.h"
-
+#include <cxxreact/JSExecutor.h>
 #include "EventEmitter.h"
+#include "EventLogger.h"
+#include "EventQueue.h"
 #include "ShadowNodeFamily.h"
 
 namespace facebook::react {
@@ -47,12 +48,21 @@ void EventQueueProcessor::flushEvents(
       reactPriority = ReactEventPriority::Discrete;
     }
 
+    auto eventLogger = getEventLogger();
+    if (eventLogger != nullptr) {
+      eventLogger->onEventDispatch(event.loggingTag);
+    }
+
     eventPipe_(
         runtime,
         event.eventTarget.get(),
         event.type,
         reactPriority,
         event.payloadFactory);
+
+    if (eventLogger != nullptr) {
+      eventLogger->onEventEnd(event.loggingTag);
+    }
 
     if (event.category == RawEvent::Category::ContinuousStart) {
       hasContinuousEventStarted_ = true;

--- a/ReactCommon/react/renderer/core/RawEvent.h
+++ b/ReactCommon/react/renderer/core/RawEvent.h
@@ -10,6 +10,7 @@
 #include <memory>
 #include <string>
 
+#include <react/renderer/core/EventLogger.h>
 #include <react/renderer/core/EventTarget.h>
 #include <react/renderer/core/ValueFactory.h>
 
@@ -68,6 +69,7 @@ struct RawEvent {
   ValueFactory payloadFactory;
   SharedEventTarget eventTarget;
   Category category;
+  EventTag loggingTag{0};
 };
 
 } // namespace react


### PR DESCRIPTION
Summary:
Changelog: [Internal]

This implements native side mechanics for reporting user events timing to JS  (PerformanceObserver API).

See the standard for more details: https://www.w3.org/TR/event-timing/

The events are only logged when there are any active subscriptions (via `PerformanceObserver.observe`), also we only log "discrete events" (i.e. no likes of mouse move), so the overhead is non-existing.

There are two main metrics of interest for an event lifecycle:
* Time the event is spent in the queue, i.e. the time between it's created and dispatched
* Time that is spend in the event handler on the JS side (event dispatch), or processing time

Both of these are measured, and the corresponding fields are populated.

Reviewed By: sammy-SC

Differential Revision: D42294947

