### PR TITLE
[Android] Fix possible `ConcurrentModificationException` when accessing the list of view managers

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -923,10 +923,11 @@ public class ReactInstanceManager {
       if (mViewManagers == null) {
         synchronized (mPackages) {
           if (mViewManagers == null) {
-            mViewManagers = new ArrayList<>();
+            ArrayList<ViewManager> viewManagers = new ArrayList<>();
             for (ReactPackage reactPackage : mPackages) {
-              mViewManagers.addAll(reactPackage.createViewManagers(catalystApplicationContext));
+              viewManagers.addAll(reactPackage.createViewManagers(catalystApplicationContext));
             }
+            mViewManagers = viewManagers;
             return mViewManagers;
           }
         }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

With the current implementation, it's possible to get a reference to the list of view managers while it's being populated, which in some cases results in `ConcurrentModificationException` thrown [here](https://github.com/facebook/react-native/blob/9c57a7f20925765da69590256ca8755b71735cdb/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModuleConstantsHelper.java#L80). This PR updates the logic, so the reference to the list is updated (and returned) only when it's ready.

## Changelog

[ANDROID] [FIXED] - Fix possible `ConcurrentModificationException` in `UIManagerModuleConstantsHelper::createConstants`

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
