### PR TITLE
Do not report "first-input" event type via Event Timing API

### DIFF
--- a/Libraries/WebPerformance/NativePerformanceObserver.cpp
+++ b/Libraries/WebPerformance/NativePerformanceObserver.cpp
@@ -18,8 +18,6 @@ static PerformanceEntryType stringToPerformanceEntryType(
     return PerformanceEntryType::MEASURE;
   } else if (entryType == "event") {
     return PerformanceEntryType::EVENT;
-  } else if (entryType == "first-input") {
-    return PerformanceEntryType::FIRST_INPUT;
   } else {
     return PerformanceEntryType::UNDEFINED;
   }

--- a/Libraries/WebPerformance/NativePerformanceObserver.js
+++ b/Libraries/WebPerformance/NativePerformanceObserver.js
@@ -17,7 +17,6 @@ export const RawPerformanceEntryTypeValues = {
   MARK: 1,
   MEASURE: 2,
   EVENT: 3,
-  FIRST_INPUT: 4,
 };
 
 export type RawPerformanceEntryType = number;

--- a/Libraries/WebPerformance/PerformanceEntry.js
+++ b/Libraries/WebPerformance/PerformanceEntry.js
@@ -9,7 +9,7 @@
  */
 
 export type HighResTimeStamp = number;
-export type PerformanceEntryType = 'mark' | 'measure' | 'event' | 'first-input';
+export type PerformanceEntryType = 'mark' | 'measure' | 'event';
 
 export class PerformanceEntry {
   name: string;

--- a/Libraries/WebPerformance/PerformanceEntryReporter.cpp
+++ b/Libraries/WebPerformance/PerformanceEntryReporter.cpp
@@ -170,15 +170,12 @@ void PerformanceEntryReporter::event(
     const std::string &name,
     double startTime,
     double duration,
-    bool isFirstInput,
     double processingStart,
     double processingEnd,
     uint32_t interactionId) {
   logEntry(
       {name,
-       static_cast<int>(
-           isFirstInput ? PerformanceEntryType::FIRST_INPUT
-                        : PerformanceEntryType::EVENT),
+       static_cast<int>(PerformanceEntryType::EVENT),
        startTime,
        duration,
        processingStart,
@@ -267,12 +264,10 @@ void PerformanceEntryReporter::onEventEnd(EventTag tag) {
     // TODO: Define the way to assign interaction IDs to the event chains
     // (T141358175)
     const uint32_t interactionId = 0;
-    bool firstInput = isFirstInput(name);
     event(
         std::move(name),
         entry.startTime,
         timeStamp - entry.startTime,
-        firstInput,
         entry.dispatchTime,
         timeStamp,
         interactionId);

--- a/Libraries/WebPerformance/PerformanceEntryReporter.h
+++ b/Libraries/WebPerformance/PerformanceEntryReporter.h
@@ -49,8 +49,7 @@ enum class PerformanceEntryType {
   MARK = 1,
   MEASURE = 2,
   EVENT = 3,
-  FIRST_INPUT = 4,
-  _COUNT = 5,
+  _COUNT = 4,
 };
 
 class PerformanceEntryReporter : public EventLogger {
@@ -95,7 +94,6 @@ class PerformanceEntryReporter : public EventLogger {
       const std::string &name,
       double startTime,
       double duration,
-      bool isFirstInput,
       double processingStart,
       double processingEnd,
       uint32_t interactionId);
@@ -112,16 +110,7 @@ class PerformanceEntryReporter : public EventLogger {
   void scheduleFlushBuffer();
 
   bool isReportingEvents() const {
-    return isReportingType(PerformanceEntryType::EVENT) ||
-        isReportingType(PerformanceEntryType::FIRST_INPUT);
-  }
-
-  bool isFirstInput(std::string name) {
-    if (firstInputs_.find(name) == firstInputs_.end()) {
-      firstInputs_.insert(std::move(name));
-      return true;
-    }
-    return false;
+    return isReportingType(PerformanceEntryType::EVENT);
   }
 
   std::optional<AsyncCallback<>> callback_;
@@ -147,7 +136,6 @@ class PerformanceEntryReporter : public EventLogger {
   // so a hash map should be just fine.
   std::unordered_map<EventTag, EventEntry> eventsInFlight_;
   std::mutex eventsInFlightMutex_;
-  std::unordered_set<std::string> firstInputs_;
 
   static EventTag sCurrentEventTag_;
 };

--- a/Libraries/WebPerformance/PerformanceEventTiming.js
+++ b/Libraries/WebPerformance/PerformanceEventTiming.js
@@ -24,11 +24,10 @@ export class PerformanceEventTiming extends PerformanceEntry {
     processingStart?: HighResTimeStamp,
     processingEnd?: HighResTimeStamp,
     interactionId?: number,
-    isFirstInput?: boolean,
   }) {
     super({
       name: init.name,
-      entryType: init.isFirstInput === true ? 'first-input' : 'event',
+      entryType: 'event',
       startTime: init.startTime ?? 0,
       duration: init.duration ?? 0,
     });

--- a/Libraries/WebPerformance/PerformanceObserver.js
+++ b/Libraries/WebPerformance/PerformanceObserver.js
@@ -31,8 +31,6 @@ function rawToPerformanceEntryType(
       return 'measure';
     case RawPerformanceEntryTypeValues.EVENT:
       return 'event';
-    case RawPerformanceEntryTypeValues.FIRST_INPUT:
-      return 'first-input';
     default:
       throw new TypeError(
         `unexpected performance entry type received: ${type}`,
@@ -41,10 +39,7 @@ function rawToPerformanceEntryType(
 }
 
 function rawToPerformanceEntry(entry: RawPerformanceEntry): PerformanceEntry {
-  if (
-    entry.entryType === RawPerformanceEntryTypeValues.EVENT ||
-    entry.entryType === RawPerformanceEntryTypeValues.FIRST_INPUT
-  ) {
+  if (entry.entryType === RawPerformanceEntryTypeValues.EVENT) {
     return new PerformanceEventTiming({
       name: entry.name,
       startTime: entry.startTime,
@@ -52,8 +47,6 @@ function rawToPerformanceEntry(entry: RawPerformanceEntry): PerformanceEntry {
       processingStart: entry.processingStart,
       processingEnd: entry.processingEnd,
       interactionId: entry.interactionId,
-      isFirstInput:
-        entry.entryType === RawPerformanceEntryTypeValues.FIRST_INPUT,
     });
   } else {
     return new PerformanceEntry({
@@ -298,7 +291,7 @@ export default class PerformanceObserver {
   }
 
   static supportedEntryTypes: $ReadOnlyArray<PerformanceEntryType> =
-    Object.freeze(['mark', 'measure', 'event', 'first-input']);
+    Object.freeze(['mark', 'measure', 'event']);
 }
 
 function union<T>(a: $ReadOnlySet<T>, b: $ReadOnlySet<T>): Set<T> {


### PR DESCRIPTION
Summary:
[Changelog][Internal]
Based on the internal discussion, we don't want to report `first-input` event types for RN (just use plain `event` instead), in the way that [Event Timing API standard suggests](https://www.w3.org/TR/event-timing), as this is doesn't have that clear semantics in the context of RN, also to keep it simpler.

Differential Revision: D42341923

