### PR TITLE
Fix mapping of the "onResponderMove" event via props parsing

### DIFF
--- a/ReactCommon/react/renderer/components/view/ViewProps.cpp
+++ b/ReactCommon/react/renderer/components/view/ViewProps.cpp
@@ -334,7 +334,7 @@ void ViewProps::setProp(
     VIEW_EVENT_CASE(ViewEvents::Offset::ResponderStart, "onResponderStart");
     VIEW_EVENT_CASE(ViewEvents::Offset::ResponderEnd, "onResponderEnd");
     VIEW_EVENT_CASE(ViewEvents::Offset::ResponderRelease, "onResponderRelease");
-    VIEW_EVENT_CASE(ViewEvents::Offset::ResponderMove, "ResponderMove");
+    VIEW_EVENT_CASE(ViewEvents::Offset::ResponderMove, "onResponderMove");
     VIEW_EVENT_CASE(
         ViewEvents::Offset::ResponderTerminate, "onResponderTerminate");
     VIEW_EVENT_CASE(


### PR DESCRIPTION
Summary:
[Changelog][Internal]

This looks like a copy/paste error, presumably introduced in D37050215 (https://github.com/facebook/react-native/commit/47280de85e62f33f0b97bc1ed7c83bc6ca0dc7d4).

The correct even name is `onResponderMove`, as evident from all other places in code and the documentation.

Differential Revision: D42344715

