### PR TITLE
Bump Flipper to 0.174.0

### DIFF
--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -10,9 +10,8 @@ PODS:
     - React-Core (= 1000.0.0)
     - React-jsi (= 1000.0.0)
     - ReactCommon/turbomodule/core (= 1000.0.0)
-  - Flipper (0.125.0):
+  - Flipper (0.174.0):
     - Flipper-Folly (~> 2.6)
-    - Flipper-RSocket (~> 1.4)
   - Flipper-Boost-iOSX (1.76.0.1.11)
   - Flipper-DoubleConversion (3.2.0.1)
   - Flipper-Fmt (7.1.7)
@@ -25,50 +24,48 @@ PODS:
     - OpenSSL-Universal (= 1.1.1100)
   - Flipper-Glog (0.5.0.5)
   - Flipper-PeerTalk (0.0.4)
-  - Flipper-RSocket (1.4.3):
-    - Flipper-Folly (~> 2.6)
-  - FlipperKit (0.125.0):
-    - FlipperKit/Core (= 0.125.0)
-  - FlipperKit/Core (0.125.0):
-    - Flipper (~> 0.125.0)
+  - FlipperKit (0.174.0):
+    - FlipperKit/Core (= 0.174.0)
+  - FlipperKit/Core (0.174.0):
+    - Flipper (~> 0.174.0)
     - FlipperKit/CppBridge
     - FlipperKit/FBCxxFollyDynamicConvert
     - FlipperKit/FBDefines
     - FlipperKit/FKPortForwarding
     - SocketRocket (~> 0.6.0)
-  - FlipperKit/CppBridge (0.125.0):
-    - Flipper (~> 0.125.0)
-  - FlipperKit/FBCxxFollyDynamicConvert (0.125.0):
+  - FlipperKit/CppBridge (0.174.0):
+    - Flipper (~> 0.174.0)
+  - FlipperKit/FBCxxFollyDynamicConvert (0.174.0):
     - Flipper-Folly (~> 2.6)
-  - FlipperKit/FBDefines (0.125.0)
-  - FlipperKit/FKPortForwarding (0.125.0):
+  - FlipperKit/FBDefines (0.174.0)
+  - FlipperKit/FKPortForwarding (0.174.0):
     - CocoaAsyncSocket (~> 7.6)
     - Flipper-PeerTalk (~> 0.0.4)
-  - FlipperKit/FlipperKitHighlightOverlay (0.125.0)
-  - FlipperKit/FlipperKitLayoutHelpers (0.125.0):
+  - FlipperKit/FlipperKitHighlightOverlay (0.174.0)
+  - FlipperKit/FlipperKitLayoutHelpers (0.174.0):
     - FlipperKit/Core
     - FlipperKit/FlipperKitHighlightOverlay
     - FlipperKit/FlipperKitLayoutTextSearchable
-  - FlipperKit/FlipperKitLayoutIOSDescriptors (0.125.0):
+  - FlipperKit/FlipperKitLayoutIOSDescriptors (0.174.0):
     - FlipperKit/Core
     - FlipperKit/FlipperKitHighlightOverlay
     - FlipperKit/FlipperKitLayoutHelpers
     - YogaKit (~> 1.18)
-  - FlipperKit/FlipperKitLayoutPlugin (0.125.0):
+  - FlipperKit/FlipperKitLayoutPlugin (0.174.0):
     - FlipperKit/Core
     - FlipperKit/FlipperKitHighlightOverlay
     - FlipperKit/FlipperKitLayoutHelpers
     - FlipperKit/FlipperKitLayoutIOSDescriptors
     - FlipperKit/FlipperKitLayoutTextSearchable
     - YogaKit (~> 1.18)
-  - FlipperKit/FlipperKitLayoutTextSearchable (0.125.0)
-  - FlipperKit/FlipperKitNetworkPlugin (0.125.0):
+  - FlipperKit/FlipperKitLayoutTextSearchable (0.174.0)
+  - FlipperKit/FlipperKitNetworkPlugin (0.174.0):
     - FlipperKit/Core
-  - FlipperKit/FlipperKitReactPlugin (0.125.0):
+  - FlipperKit/FlipperKitReactPlugin (0.174.0):
     - FlipperKit/Core
-  - FlipperKit/FlipperKitUserDefaultsPlugin (0.125.0):
+  - FlipperKit/FlipperKitUserDefaultsPlugin (0.174.0):
     - FlipperKit/Core
-  - FlipperKit/SKIOSNetworkPlugin (0.125.0):
+  - FlipperKit/SKIOSNetworkPlugin (0.174.0):
     - FlipperKit/Core
     - FlipperKit/FlipperKitNetworkPlugin
   - fmt (6.2.1)
@@ -751,27 +748,26 @@ DEPENDENCIES:
   - DoubleConversion (from `../../third-party-podspecs/DoubleConversion.podspec`)
   - FBLazyVector (from `../../Libraries/FBLazyVector`)
   - FBReactNativeSpec (from `../../React/FBReactNativeSpec`)
-  - Flipper (= 0.125.0)
+  - Flipper (= 0.174.0)
   - Flipper-Boost-iOSX (= 1.76.0.1.11)
   - Flipper-DoubleConversion (= 3.2.0.1)
   - Flipper-Fmt (= 7.1.7)
   - Flipper-Folly (= 2.6.10)
   - Flipper-Glog (= 0.5.0.5)
   - Flipper-PeerTalk (= 0.0.4)
-  - Flipper-RSocket (= 1.4.3)
-  - FlipperKit (= 0.125.0)
-  - FlipperKit/Core (= 0.125.0)
-  - FlipperKit/CppBridge (= 0.125.0)
-  - FlipperKit/FBCxxFollyDynamicConvert (= 0.125.0)
-  - FlipperKit/FBDefines (= 0.125.0)
-  - FlipperKit/FKPortForwarding (= 0.125.0)
-  - FlipperKit/FlipperKitHighlightOverlay (= 0.125.0)
-  - FlipperKit/FlipperKitLayoutPlugin (= 0.125.0)
-  - FlipperKit/FlipperKitLayoutTextSearchable (= 0.125.0)
-  - FlipperKit/FlipperKitNetworkPlugin (= 0.125.0)
-  - FlipperKit/FlipperKitReactPlugin (= 0.125.0)
-  - FlipperKit/FlipperKitUserDefaultsPlugin (= 0.125.0)
-  - FlipperKit/SKIOSNetworkPlugin (= 0.125.0)
+  - FlipperKit (= 0.174.0)
+  - FlipperKit/Core (= 0.174.0)
+  - FlipperKit/CppBridge (= 0.174.0)
+  - FlipperKit/FBCxxFollyDynamicConvert (= 0.174.0)
+  - FlipperKit/FBDefines (= 0.174.0)
+  - FlipperKit/FKPortForwarding (= 0.174.0)
+  - FlipperKit/FlipperKitHighlightOverlay (= 0.174.0)
+  - FlipperKit/FlipperKitLayoutPlugin (= 0.174.0)
+  - FlipperKit/FlipperKitLayoutTextSearchable (= 0.174.0)
+  - FlipperKit/FlipperKitNetworkPlugin (= 0.174.0)
+  - FlipperKit/FlipperKitReactPlugin (= 0.174.0)
+  - FlipperKit/FlipperKitUserDefaultsPlugin (= 0.174.0)
+  - FlipperKit/SKIOSNetworkPlugin (= 0.174.0)
   - glog (from `../../third-party-podspecs/glog.podspec`)
   - hermes-engine (from `../../sdks/hermes/hermes-engine.podspec`)
   - libevent (~> 2.1.12)
@@ -826,7 +822,6 @@ SPEC REPOS:
     - Flipper-Folly
     - Flipper-Glog
     - Flipper-PeerTalk
-    - Flipper-RSocket
     - FlipperKit
     - fmt
     - libevent
@@ -924,18 +919,17 @@ SPEC CHECKSUMS:
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   FBLazyVector: d68947eddece25638eb0f642d1b957c90388afd1
   FBReactNativeSpec: c530d2df977f98d0d72ce4440c074cb73bff6289
-  Flipper: 26fc4b7382499f1281eb8cb921e5c3ad6de91fe0
+  Flipper: 186214d97e5c24edd706f39faf933e5acaaa8644
   Flipper-Boost-iOSX: fd1e2b8cbef7e662a122412d7ac5f5bea715403c
   Flipper-DoubleConversion: 2dc99b02f658daf147069aad9dbd29d8feb06d30
   Flipper-Fmt: 60cbdd92fc254826e61d669a5d87ef7015396a9b
   Flipper-Folly: 584845625005ff068a6ebf41f857f468decd26b3
   Flipper-Glog: 70c50ce58ddaf67dc35180db05f191692570f446
   Flipper-PeerTalk: 116d8f857dc6ef55c7a5a75ea3ceaafe878aadc9
-  Flipper-RSocket: d9d9ade67cbecf6ac10730304bf5607266dd2541
-  FlipperKit: cbdee19bdd4e7f05472a66ce290f1b729ba3cb86
+  FlipperKit: b353b63cb4048a5747529412524407d6efa68336
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
-  hermes-engine: 41b1b184a76a464385ebd97d798f6ee2468ebbae
+  hermes-engine: 3734586d093eb030823a66ae7da7abe549acf522
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1

--- a/scripts/cocoapods/__tests__/flipper-test.rb
+++ b/scripts/cocoapods/__tests__/flipper-test.rb
@@ -39,7 +39,7 @@ class FlipperTests < Test::Unit::TestCase
         # Assert
         check_all_flipper_pods($flipper_default_versions, configurations)
         # the number of times the `pod` function has been invoked to install a dependency
-        assert_equal($podInvocationCount, 22)
+        assert_equal($podInvocationCount, 21)
     end
 
     def test_UseFlipperPods_WithCustomValues_InstallsPods
@@ -52,7 +52,6 @@ class FlipperTests < Test::Unit::TestCase
             "Flipper-Folly" => "2.1.1",
             "Flipper-Glog" => "0.1.2",
             "Flipper-PeerTalk" => "0.0.1",
-            "Flipper-RSocket" => "0.1.4",
             "OpenSSL-Universal" => "2.2.2200",
         }
         configurations = ['Debug', 'CI']
@@ -63,7 +62,7 @@ class FlipperTests < Test::Unit::TestCase
         # Assert
         check_all_flipper_pods(versions, configurations)
         # the number of times the `pod` function has been invoked to install a dependency
-        assert_equal($podInvocationCount, 22)
+        assert_equal($podInvocationCount, 21)
     end
 
     # ================= #
@@ -118,7 +117,6 @@ class FlipperTests < Test::Unit::TestCase
         check_flipper_pod('Flipper-Folly', versions['Flipper-Folly'], configurations)
         check_flipper_pod('Flipper-Glog', versions['Flipper-Glog'], configurations)
         check_flipper_pod('Flipper-PeerTalk', versions['Flipper-PeerTalk'], configurations)
-        check_flipper_pod('Flipper-RSocket', versions['Flipper-RSocket'], configurations)
         check_flipper_pod('OpenSSL-Universal', versions['OpenSSL-Universal'], configurations)
     end
 

--- a/scripts/cocoapods/flipper.rb
+++ b/scripts/cocoapods/flipper.rb
@@ -6,14 +6,13 @@
 # Default versions of Flipper and related dependencies.
 # Update this map to bump the dependencies.
 $flipper_default_versions = {
-    'Flipper' => '0.125.0',
+    'Flipper' => '0.174.0',
     'Flipper-Boost-iOSX' => '1.76.0.1.11',
     'Flipper-DoubleConversion' => '3.2.0.1',
     'Flipper-Fmt' => '7.1.7',
     'Flipper-Folly' => '2.6.10',
     'Flipper-Glog' => '0.5.0.5',
     'Flipper-PeerTalk' => '0.0.4',
-    'Flipper-RSocket' => '1.4.3',
     'OpenSSL-Universal' => '1.1.1100',
 }
 
@@ -39,7 +38,6 @@ def use_flipper_pods(versions = {}, configurations: ['Debug'])
     versions['Flipper-Folly'] ||= $flipper_default_versions['Flipper-Folly']
     versions['Flipper-Glog'] ||= $flipper_default_versions['Flipper-Glog']
     versions['Flipper-PeerTalk'] ||= $flipper_default_versions['Flipper-PeerTalk']
-    versions['Flipper-RSocket'] ||= $flipper_default_versions['Flipper-RSocket']
     versions['OpenSSL-Universal'] ||= $flipper_default_versions['OpenSSL-Universal']
     pod 'FlipperKit', versions['Flipper'], :configurations => configurations
     pod 'FlipperKit/FlipperKitLayoutPlugin', versions['Flipper'], :configurations => configurations
@@ -55,7 +53,6 @@ def use_flipper_pods(versions = {}, configurations: ['Debug'])
     pod 'Flipper-Folly', versions['Flipper-Folly'], :configurations => configurations
     pod 'Flipper-Glog', versions['Flipper-Glog'], :configurations => configurations
     pod 'Flipper-PeerTalk', versions['Flipper-PeerTalk'], :configurations => configurations
-    pod 'Flipper-RSocket', versions['Flipper-RSocket'], :configurations => configurations
     pod 'FlipperKit/Core', versions['Flipper'], :configurations => configurations
     pod 'FlipperKit/CppBridge', versions['Flipper'], :configurations => configurations
     pod 'FlipperKit/FBCxxFollyDynamicConvert', versions['Flipper'], :configurations => configurations


### PR DESCRIPTION
Summary:
As Flipper version is a bit old, let's bump it to the latest stable: 0.174.0.

This is a follow-up from D41492705 (https://github.com/facebook/react-native/commit/db3ac93001f65bad84b748ec257fe79b79432976).

At the time, it wasn't possible to update to the latest stable Flipper as crashes were observed due to NDK mismatch.

Changelog:
[iOS] [Changed] - Bump Flipper to 0.174.0

Differential Revision: D42345736

