### PR TITLE
Remove unused .netrc file from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1495,10 +1495,6 @@ jobs:
               - equal: [ "nightly", << parameters.release_type >> ]
           steps:
             - run: echo "//registry.npmjs.org/:_authToken=${CIRCLE_NPM_TOKEN}" > ~/.npmrc
-            - run: |
-                git config --global user.email "react-native-bot@users.noreply.github.com"
-                git config --global user.name "npm Deployment Script"
-                echo "machine github.com login react-native-bot password $GITHUB_TOKEN" > ~/.netrc
       # END: Stables and nightlies
 
       - run: node ./scripts/publish-npm.js --<< parameters.release_type >>


### PR DESCRIPTION
## Summary

Removing a stale configuration that was configuring username/password before publishing to NPM. This is effectively unused + the Github Token there is invalid therefore can be removed.

## Changelog

[INTERNAL] - Remove unused .netrc file from CircleCI

## Test Plan

n/a