### PR TITLE
Prepare Fabric for use_frameworks! changes

### DIFF
--- a/ReactCommon/React-Fabric.podspec
+++ b/ReactCommon/React-Fabric.podspec
@@ -43,295 +43,299 @@ Pod::Spec.new do |s|
   s.dependency "ReactCommon/turbomodule/core", version
   s.dependency "React-jsi", version
 
-  s.subspec "animations" do |ss|
-    ss.dependency             folly_dep_name, folly_version
-    ss.compiler_flags       = folly_compiler_flags
-    ss.source_files         = "react/renderer/animations/**/*.{m,mm,cpp,h}"
-    ss.exclude_files        = "react/renderer/animations/tests"
-    ss.header_dir           = "react/renderer/animations"
-    ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
-  end
-
-  s.subspec "attributedstring" do |ss|
-    ss.dependency             folly_dep_name, folly_version
-    ss.compiler_flags       = folly_compiler_flags
-    ss.source_files         = "react/renderer/attributedstring/**/*.{m,mm,cpp,h}"
-    ss.exclude_files        = "react/renderer/attributedstring/tests"
-    ss.header_dir           = "react/renderer/attributedstring"
-    ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
-  end
-
-  s.subspec "butter" do |ss|
-    ss.dependency             folly_dep_name, folly_version
-    ss.compiler_flags       = folly_compiler_flags
-    ss.source_files         = "butter/**/*.{m,mm,cpp,h}"
-    ss.exclude_files        = "butter/tests"
-    ss.header_dir           = "butter"
-    ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
-  end
-
-  s.subspec "config" do |ss|
-    ss.source_files         = "react/config/*.{m,mm,cpp,h}"
-    ss.header_dir           = "react/config"
-    ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\"" }
-  end
-
-  s.subspec "core" do |ss|
-    ss.dependency             folly_dep_name, folly_version
-    ss.compiler_flags       = folly_compiler_flags + ' ' + boost_compiler_flags
-    ss.source_files         = "react/renderer/core/**/*.{m,mm,cpp,h}"
-    ss.exclude_files        = "react/renderer/core/tests"
-    ss.header_dir           = "react/renderer/core"
-    ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\" \"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
-  end
-
-  s.subspec "componentregistry" do |ss|
-    ss.dependency             folly_dep_name, folly_version
-    ss.compiler_flags       = folly_compiler_flags
-    ss.source_files         = "react/renderer/componentregistry/**/*.{m,mm,cpp,h}"
-    ss.header_dir           = "react/renderer/componentregistry"
-    ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
-  end
-
-  s.subspec "componentregistrynative" do |ss|
-    ss.dependency             folly_dep_name, folly_version
-    ss.compiler_flags       = folly_compiler_flags
-    ss.source_files         = "react/renderer/componentregistry/native/**/*.{m,mm,cpp,h}"
-    ss.header_dir           = "react/renderer/componentregistry/native"
-    ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
-  end
-
-  s.subspec "components" do |ss|
-    ss.subspec "activityindicator" do |sss|
-      sss.dependency             folly_dep_name, folly_version
-      sss.compiler_flags       = folly_compiler_flags
-      sss.source_files         = "react/renderer/components/activityindicator/**/*.{m,mm,cpp,h}"
-      sss.exclude_files        = "react/renderer/components/activityindicator/tests"
-      sss.header_dir           = "react/renderer/components/activityindicator"
-      sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
+  # Fabric is not compatible with use_frameworks! due to these sub specs.
+  # We need to split them in separate pods when that option is used.
+  # This guard ensures that when use_frameworks! is not used, we do not break the Static Library setting and the internal setup.
+  unless ENV['USE_FRAMEWORKS']
+    s.subspec "animations" do |ss|
+      ss.dependency             folly_dep_name, folly_version
+      ss.compiler_flags       = folly_compiler_flags
+      ss.source_files         = "react/renderer/animations/**/*.{m,mm,cpp,h}"
+      ss.exclude_files        = "react/renderer/animations/tests"
+      ss.header_dir           = "react/renderer/animations"
+      ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
     end
 
-    ss.subspec "image" do |sss|
-      sss.dependency             folly_dep_name, folly_version
-      sss.compiler_flags       = folly_compiler_flags
-      sss.source_files         = "react/renderer/components/image/**/*.{m,mm,cpp,h}"
-      sss.exclude_files        = "react/renderer/components/image/tests"
-      sss.header_dir           = "react/renderer/components/image"
-      sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
+    s.subspec "attributedstring" do |ss|
+      ss.dependency             folly_dep_name, folly_version
+      ss.compiler_flags       = folly_compiler_flags
+      ss.source_files         = "react/renderer/attributedstring/**/*.{m,mm,cpp,h}"
+      ss.exclude_files        = "react/renderer/attributedstring/tests"
+      ss.header_dir           = "react/renderer/attributedstring"
+      ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
     end
 
-    ss.subspec "inputaccessory" do |sss|
-      sss.dependency             folly_dep_name, folly_version
-      sss.compiler_flags       = folly_compiler_flags
-      sss.source_files         = "react/renderer/components/inputaccessory/**/*.{m,mm,cpp,h}"
-      sss.exclude_files        = "react/renderer/components/inputaccessory/tests"
-      sss.header_dir           = "react/renderer/components/inputaccessory"
-      sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
+    s.subspec "butter" do |ss|
+      ss.dependency             folly_dep_name, folly_version
+      ss.compiler_flags       = folly_compiler_flags
+      ss.source_files         = "butter/**/*.{m,mm,cpp,h}"
+      ss.exclude_files        = "butter/tests"
+      ss.header_dir           = "butter"
+      ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
     end
 
-    ss.subspec "legacyviewmanagerinterop" do |sss|
-      sss.dependency             folly_dep_name, folly_version
-      sss.compiler_flags       = folly_compiler_flags
-      sss.source_files         = "react/renderer/components/legacyviewmanagerinterop/**/*.{m,mm,cpp,h}"
-      sss.exclude_files        = "react/renderer/components/legacyviewmanagerinterop/tests"
-      sss.header_dir           = "react/renderer/components/legacyviewmanagerinterop"
-      sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/Headers/Private/React-Core\"" }
+    s.subspec "config" do |ss|
+      ss.source_files         = "react/config/*.{m,mm,cpp,h}"
+      ss.header_dir           = "react/config"
+      ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\"" }
     end
 
-    ss.subspec "modal" do |sss|
-      sss.dependency             folly_dep_name, folly_version
-      sss.compiler_flags       = folly_compiler_flags
-      sss.source_files         = "react/renderer/components/modal/**/*.{m,mm,cpp,h}"
-      sss.exclude_files        = "react/renderer/components/modal/tests"
-      sss.header_dir           = "react/renderer/components/modal"
-      sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
+    s.subspec "core" do |ss|
+      ss.dependency             folly_dep_name, folly_version
+      ss.compiler_flags       = folly_compiler_flags + ' ' + boost_compiler_flags
+      ss.source_files         = "react/renderer/core/**/*.{m,mm,cpp,h}"
+      ss.exclude_files        = "react/renderer/core/tests"
+      ss.header_dir           = "react/renderer/core"
+      ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\" \"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
     end
 
-    ss.subspec "root" do |sss|
-      sss.dependency             folly_dep_name, folly_version
-      sss.compiler_flags       = folly_compiler_flags
-      sss.source_files         = "react/renderer/components/root/**/*.{m,mm,cpp,h}"
-      sss.exclude_files        = "react/renderer/components/root/tests"
-      sss.header_dir           = "react/renderer/components/root"
-      sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
+    s.subspec "componentregistry" do |ss|
+      ss.dependency             folly_dep_name, folly_version
+      ss.compiler_flags       = folly_compiler_flags
+      ss.source_files         = "react/renderer/componentregistry/**/*.{m,mm,cpp,h}"
+      ss.header_dir           = "react/renderer/componentregistry"
+      ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
     end
 
-    ss.subspec "safeareaview" do |sss|
-      sss.dependency             folly_dep_name, folly_version
-      sss.compiler_flags       = folly_compiler_flags
-      sss.source_files         = "react/renderer/components/safeareaview/**/*.{m,mm,cpp,h}"
-      sss.exclude_files        = "react/renderer/components/safeareaview/tests"
-      sss.header_dir           = "react/renderer/components/safeareaview"
-      sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
+    s.subspec "componentregistrynative" do |ss|
+      ss.dependency             folly_dep_name, folly_version
+      ss.compiler_flags       = folly_compiler_flags
+      ss.source_files         = "react/renderer/componentregistry/native/**/*.{m,mm,cpp,h}"
+      ss.header_dir           = "react/renderer/componentregistry/native"
+      ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
     end
 
-    ss.subspec "scrollview" do |sss|
-      sss.dependency             folly_dep_name, folly_version
-      sss.compiler_flags       = folly_compiler_flags
-      sss.source_files         = "react/renderer/components/scrollview/**/*.{m,mm,cpp,h}"
-      sss.exclude_files        = "react/renderer/components/scrollview/tests"
-      sss.header_dir           = "react/renderer/components/scrollview"
-      sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
+    s.subspec "components" do |ss|
+      ss.subspec "activityindicator" do |sss|
+        sss.dependency             folly_dep_name, folly_version
+        sss.compiler_flags       = folly_compiler_flags
+        sss.source_files         = "react/renderer/components/activityindicator/**/*.{m,mm,cpp,h}"
+        sss.exclude_files        = "react/renderer/components/activityindicator/tests"
+        sss.header_dir           = "react/renderer/components/activityindicator"
+        sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
+      end
+
+      ss.subspec "image" do |sss|
+        sss.dependency             folly_dep_name, folly_version
+        sss.compiler_flags       = folly_compiler_flags
+        sss.source_files         = "react/renderer/components/image/**/*.{m,mm,cpp,h}"
+        sss.exclude_files        = "react/renderer/components/image/tests"
+        sss.header_dir           = "react/renderer/components/image"
+        sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
+      end
+
+      ss.subspec "inputaccessory" do |sss|
+        sss.dependency             folly_dep_name, folly_version
+        sss.compiler_flags       = folly_compiler_flags
+        sss.source_files         = "react/renderer/components/inputaccessory/**/*.{m,mm,cpp,h}"
+        sss.exclude_files        = "react/renderer/components/inputaccessory/tests"
+        sss.header_dir           = "react/renderer/components/inputaccessory"
+        sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
+      end
+
+      ss.subspec "legacyviewmanagerinterop" do |sss|
+        sss.dependency             folly_dep_name, folly_version
+        sss.compiler_flags       = folly_compiler_flags
+        sss.source_files         = "react/renderer/components/legacyviewmanagerinterop/**/*.{m,mm,cpp,h}"
+        sss.exclude_files        = "react/renderer/components/legacyviewmanagerinterop/tests"
+        sss.header_dir           = "react/renderer/components/legacyviewmanagerinterop"
+        sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/Headers/Private/React-Core\"" }
+      end
+
+      ss.subspec "modal" do |sss|
+        sss.dependency             folly_dep_name, folly_version
+        sss.compiler_flags       = folly_compiler_flags
+        sss.source_files         = "react/renderer/components/modal/**/*.{m,mm,cpp,h}"
+        sss.exclude_files        = "react/renderer/components/modal/tests"
+        sss.header_dir           = "react/renderer/components/modal"
+        sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
+      end
+
+      ss.subspec "root" do |sss|
+        sss.dependency             folly_dep_name, folly_version
+        sss.compiler_flags       = folly_compiler_flags
+        sss.source_files         = "react/renderer/components/root/**/*.{m,mm,cpp,h}"
+        sss.exclude_files        = "react/renderer/components/root/tests"
+        sss.header_dir           = "react/renderer/components/root"
+        sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
+      end
+
+      ss.subspec "safeareaview" do |sss|
+        sss.dependency             folly_dep_name, folly_version
+        sss.compiler_flags       = folly_compiler_flags
+        sss.source_files         = "react/renderer/components/safeareaview/**/*.{m,mm,cpp,h}"
+        sss.exclude_files        = "react/renderer/components/safeareaview/tests"
+        sss.header_dir           = "react/renderer/components/safeareaview"
+        sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
+      end
+
+      ss.subspec "scrollview" do |sss|
+        sss.dependency             folly_dep_name, folly_version
+        sss.compiler_flags       = folly_compiler_flags
+        sss.source_files         = "react/renderer/components/scrollview/**/*.{m,mm,cpp,h}"
+        sss.exclude_files        = "react/renderer/components/scrollview/tests"
+        sss.header_dir           = "react/renderer/components/scrollview"
+        sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
+      end
+
+      ss.subspec "text" do |sss|
+        sss.dependency             folly_dep_name, folly_version
+        sss.compiler_flags       = folly_compiler_flags
+        sss.source_files         = "react/renderer/components/text/**/*.{m,mm,cpp,h}"
+        sss.exclude_files        = "react/renderer/components/text/tests"
+        sss.header_dir           = "react/renderer/components/text"
+        sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
+      end
+
+      ss.subspec "textinput" do |sss|
+        sss.dependency             folly_dep_name, folly_version
+        sss.compiler_flags       = folly_compiler_flags
+        sss.source_files         = "react/renderer/components/textinput/iostextinput/**/*.{m,mm,cpp,h}"
+        sss.exclude_files        = "react/renderer/components/textinput/iostextinput/tests"
+        sss.header_dir           = "react/renderer/components/iostextinput"
+        sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
+      end
+
+      ss.subspec "unimplementedview" do |sss|
+        sss.dependency             folly_dep_name, folly_version
+        sss.compiler_flags       = folly_compiler_flags
+        sss.source_files         = "react/renderer/components/unimplementedview/**/*.{m,mm,cpp,h}"
+        sss.exclude_files        = "react/renderer/components/unimplementedview/tests"
+        sss.header_dir           = "react/renderer/components/unimplementedview"
+        sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
+      end
+
+      ss.subspec "view" do |sss|
+        sss.dependency             folly_dep_name, folly_version
+        sss.dependency             "Yoga"
+        sss.compiler_flags       = folly_compiler_flags
+        sss.source_files         = "react/renderer/components/view/**/*.{m,mm,cpp,h}"
+        sss.exclude_files        = "react/renderer/components/view/tests"
+        sss.header_dir           = "react/renderer/components/view"
+        sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
+      end
     end
 
-    ss.subspec "text" do |sss|
-      sss.dependency             folly_dep_name, folly_version
-      sss.compiler_flags       = folly_compiler_flags
-      sss.source_files         = "react/renderer/components/text/**/*.{m,mm,cpp,h}"
-      sss.exclude_files        = "react/renderer/components/text/tests"
-      sss.header_dir           = "react/renderer/components/text"
-      sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
+    s.subspec "debug_core" do |ss|
+      ss.dependency             folly_dep_name, folly_version
+      ss.compiler_flags       = folly_compiler_flags
+      ss.source_files         = "react/debug/**/*.{m,mm,cpp,h}"
+      ss.exclude_files        = "react/debug/tests"
+      ss.header_dir           = "react/debug"
+      ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
     end
 
-    ss.subspec "textinput" do |sss|
-      sss.dependency             folly_dep_name, folly_version
-      sss.compiler_flags       = folly_compiler_flags
-      sss.source_files         = "react/renderer/components/textinput/iostextinput/**/*.{m,mm,cpp,h}"
-      sss.exclude_files        = "react/renderer/components/textinput/iostextinput/tests"
-      sss.header_dir           = "react/renderer/components/iostextinput"
-      sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
+    s.subspec "debug_renderer" do |ss|
+      ss.dependency             folly_dep_name, folly_version
+      ss.compiler_flags       = folly_compiler_flags
+      ss.source_files         = "react/renderer/debug/**/*.{m,mm,cpp,h}"
+      ss.exclude_files        = "react/renderer/debug/tests"
+      ss.header_dir           = "react/renderer/debug"
+      ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
     end
 
-    ss.subspec "unimplementedview" do |sss|
-      sss.dependency             folly_dep_name, folly_version
-      sss.compiler_flags       = folly_compiler_flags
-      sss.source_files         = "react/renderer/components/unimplementedview/**/*.{m,mm,cpp,h}"
-      sss.exclude_files        = "react/renderer/components/unimplementedview/tests"
-      sss.header_dir           = "react/renderer/components/unimplementedview"
-      sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
+    s.subspec "imagemanager" do |ss|
+      ss.dependency             "React-RCTImage", version
+      ss.dependency             folly_dep_name, folly_version
+      ss.compiler_flags       = folly_compiler_flags
+      ss.source_files         = "react/renderer/imagemanager/**/*.{m,mm,cpp,h}"
+      ss.exclude_files        = "react/renderer/imagemanager/tests",
+                                "react/renderer/imagemanager/platform/android",
+                                "react/renderer/imagemanager/platform/cxx"
+      ss.header_dir           = "react/renderer/imagemanager"
+      ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
     end
 
-    ss.subspec "view" do |sss|
-      sss.dependency             folly_dep_name, folly_version
-      sss.dependency             "Yoga"
-      sss.compiler_flags       = folly_compiler_flags
-      sss.source_files         = "react/renderer/components/view/**/*.{m,mm,cpp,h}"
-      sss.exclude_files        = "react/renderer/components/view/tests"
-      sss.header_dir           = "react/renderer/components/view"
-      sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
+    s.subspec "mapbuffer" do |ss|
+      ss.dependency             folly_dep_name, folly_version
+      ss.compiler_flags       = folly_compiler_flags
+      ss.source_files         = "react/renderer/mapbuffer/**/*.{m,mm,cpp,h}"
+      ss.exclude_files        = "react/renderer/mapbuffer/tests"
+      ss.header_dir           = "react/renderer/mapbuffer"
+      ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
     end
-  end
 
-  s.subspec "debug_core" do |ss|
-    ss.dependency             folly_dep_name, folly_version
-    ss.compiler_flags       = folly_compiler_flags
-    ss.source_files         = "react/debug/**/*.{m,mm,cpp,h}"
-    ss.exclude_files        = "react/debug/tests"
-    ss.header_dir           = "react/debug"
-    ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
-  end
+    s.subspec "mounting" do |ss|
+      ss.dependency             folly_dep_name, folly_version
+      ss.compiler_flags       = folly_compiler_flags
+      ss.source_files         = "react/renderer/mounting/**/*.{m,mm,cpp,h}"
+      ss.exclude_files        = "react/renderer/mounting/tests"
+      ss.header_dir           = "react/renderer/mounting"
+      ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
+    end
 
-  s.subspec "debug_renderer" do |ss|
-    ss.dependency             folly_dep_name, folly_version
-    ss.compiler_flags       = folly_compiler_flags
-    ss.source_files         = "react/renderer/debug/**/*.{m,mm,cpp,h}"
-    ss.exclude_files        = "react/renderer/debug/tests"
-    ss.header_dir           = "react/renderer/debug"
-    ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
-  end
+    s.subspec "scheduler" do |ss|
+      ss.dependency             folly_dep_name, folly_version
+      ss.compiler_flags       = folly_compiler_flags
+      ss.source_files         = "react/renderer/scheduler/**/*.{m,mm,cpp,h}"
+      ss.header_dir           = "react/renderer/scheduler"
+      ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
+    end
 
-  s.subspec "imagemanager" do |ss|
-    ss.dependency             "React-RCTImage", version
-    ss.dependency             folly_dep_name, folly_version
-    ss.compiler_flags       = folly_compiler_flags
-    ss.source_files         = "react/renderer/imagemanager/**/*.{m,mm,cpp,h}"
-    ss.exclude_files        = "react/renderer/imagemanager/tests",
-                              "react/renderer/imagemanager/platform/android",
-                              "react/renderer/imagemanager/platform/cxx"
-    ss.header_dir           = "react/renderer/imagemanager"
-    ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
-  end
+    s.subspec "templateprocessor" do |ss|
+      ss.dependency             folly_dep_name, folly_version
+      ss.compiler_flags       = folly_compiler_flags
+      ss.source_files         = "react/renderer/templateprocessor/**/*.{m,mm,cpp,h}"
+      ss.exclude_files        = "react/renderer/templateprocessor/tests"
+      ss.header_dir           = "react/renderer/templateprocessor"
+      ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
+    end
 
-  s.subspec "mapbuffer" do |ss|
-    ss.dependency             folly_dep_name, folly_version
-    ss.compiler_flags       = folly_compiler_flags
-    ss.source_files         = "react/renderer/mapbuffer/**/*.{m,mm,cpp,h}"
-    ss.exclude_files        = "react/renderer/mapbuffer/tests"
-    ss.header_dir           = "react/renderer/mapbuffer"
-    ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
-  end
+    s.subspec "textlayoutmanager" do |ss|
+      ss.dependency             folly_dep_name, folly_version
+      ss.dependency             "React-Fabric/uimanager"
+      ss.compiler_flags       = folly_compiler_flags
+      ss.source_files         = "react/renderer/textlayoutmanager/platform/ios/**/*.{m,mm,cpp,h}",
+                                "react/renderer/textlayoutmanager/*.{m,mm,cpp,h}"
+      ss.exclude_files        = "react/renderer/textlayoutmanager/tests",
+                                "react/renderer/textlayoutmanager/platform/android",
+                                "react/renderer/textlayoutmanager/platform/cxx"
+      ss.header_dir           = "react/renderer/textlayoutmanager"
+      ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
+    end
 
-  s.subspec "mounting" do |ss|
-    ss.dependency             folly_dep_name, folly_version
-    ss.compiler_flags       = folly_compiler_flags
-    ss.source_files         = "react/renderer/mounting/**/*.{m,mm,cpp,h}"
-    ss.exclude_files        = "react/renderer/mounting/tests"
-    ss.header_dir           = "react/renderer/mounting"
-    ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
-  end
+    s.subspec "uimanager" do |ss|
+      ss.dependency             folly_dep_name, folly_version
+      ss.compiler_flags       = folly_compiler_flags
+      ss.source_files         = "react/renderer/uimanager/**/*.{m,mm,cpp,h}"
+      ss.exclude_files        = "react/renderer/uimanager/tests"
+      ss.header_dir           = "react/renderer/uimanager"
+      ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
+    end
 
-  s.subspec "scheduler" do |ss|
-    ss.dependency             folly_dep_name, folly_version
-    ss.compiler_flags       = folly_compiler_flags
-    ss.source_files         = "react/renderer/scheduler/**/*.{m,mm,cpp,h}"
-    ss.header_dir           = "react/renderer/scheduler"
-    ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
-  end
+    s.subspec "telemetry" do |ss|
+      ss.dependency             folly_dep_name, folly_version
+      ss.compiler_flags       = folly_compiler_flags
+      ss.source_files         = "react/renderer/telemetry/**/*.{m,mm,cpp,h}"
+      ss.exclude_files        = "react/renderer/telemetry/tests"
+      ss.header_dir           = "react/renderer/telemetry"
+      ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
+    end
 
-  s.subspec "templateprocessor" do |ss|
-    ss.dependency             folly_dep_name, folly_version
-    ss.compiler_flags       = folly_compiler_flags
-    ss.source_files         = "react/renderer/templateprocessor/**/*.{m,mm,cpp,h}"
-    ss.exclude_files        = "react/renderer/templateprocessor/tests"
-    ss.header_dir           = "react/renderer/templateprocessor"
-    ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
-  end
+    s.subspec "leakchecker" do |ss|
+      ss.dependency             folly_dep_name, folly_version
+      ss.compiler_flags       = folly_compiler_flags
+      ss.source_files         = "react/renderer/leakchecker/**/*.{cpp,h}"
+      ss.exclude_files        = "react/renderer/leakchecker/tests"
+      ss.header_dir           = "react/renderer/leakchecker"
+      ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"",
+                                  "GCC_WARN_PEDANTIC" => "YES" }
+    end
 
-  s.subspec "textlayoutmanager" do |ss|
-    ss.dependency             folly_dep_name, folly_version
-    ss.dependency             "React-Fabric/uimanager"
-    ss.compiler_flags       = folly_compiler_flags
-    ss.source_files         = "react/renderer/textlayoutmanager/platform/ios/**/*.{m,mm,cpp,h}",
-                              "react/renderer/textlayoutmanager/*.{m,mm,cpp,h}"
-    ss.exclude_files        = "react/renderer/textlayoutmanager/tests",
-                              "react/renderer/textlayoutmanager/platform/android",
-                              "react/renderer/textlayoutmanager/platform/cxx"
-    ss.header_dir           = "react/renderer/textlayoutmanager"
-    ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
-  end
-
-  s.subspec "uimanager" do |ss|
-    ss.dependency             folly_dep_name, folly_version
-    ss.compiler_flags       = folly_compiler_flags
-    ss.source_files         = "react/renderer/uimanager/**/*.{m,mm,cpp,h}"
-    ss.exclude_files        = "react/renderer/uimanager/tests"
-    ss.header_dir           = "react/renderer/uimanager"
-    ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
-  end
-
-  s.subspec "telemetry" do |ss|
-    ss.dependency             folly_dep_name, folly_version
-    ss.compiler_flags       = folly_compiler_flags
-    ss.source_files         = "react/renderer/telemetry/**/*.{m,mm,cpp,h}"
-    ss.exclude_files        = "react/renderer/telemetry/tests"
-    ss.header_dir           = "react/renderer/telemetry"
-    ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
-  end
-
-  s.subspec "leakchecker" do |ss|
-    ss.dependency             folly_dep_name, folly_version
-    ss.compiler_flags       = folly_compiler_flags
-    ss.source_files         = "react/renderer/leakchecker/**/*.{cpp,h}"
-    ss.exclude_files        = "react/renderer/leakchecker/tests"
-    ss.header_dir           = "react/renderer/leakchecker"
-    ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"",
+    s.subspec "runtimescheduler" do |ss|
+      ss.dependency             folly_dep_name, folly_version
+      ss.compiler_flags       = folly_compiler_flags
+      ss.source_files         = "react/renderer/runtimescheduler/**/*.{cpp,h}"
+      ss.exclude_files        = "react/renderer/runtimescheduler/tests"
+      ss.header_dir           = "react/renderer/runtimescheduler"
+      ss.pod_target_xcconfig  = {"HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"",
                                 "GCC_WARN_PEDANTIC" => "YES" }
-  end
+    end
 
-  s.subspec "runtimescheduler" do |ss|
-    ss.dependency             folly_dep_name, folly_version
-    ss.compiler_flags       = folly_compiler_flags
-    ss.source_files         = "react/renderer/runtimescheduler/**/*.{cpp,h}"
-    ss.exclude_files        = "react/renderer/runtimescheduler/tests"
-    ss.header_dir           = "react/renderer/runtimescheduler"
-    ss.pod_target_xcconfig  = {"HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"",
-                               "GCC_WARN_PEDANTIC" => "YES" }
+    s.subspec "utils" do |ss|
+      ss.source_files         = "react/utils/*.{m,mm,cpp,h}"
+      ss.header_dir           = "react/utils"
+      ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\""}
+    end
   end
-
-  s.subspec "utils" do |ss|
-    ss.source_files         = "react/utils/*.{m,mm,cpp,h}"
-    ss.header_dir           = "react/utils"
-    ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\""}
-  end
-
 end

--- a/packages/rn-tester/Podfile
+++ b/packages/rn-tester/Podfile
@@ -5,14 +5,15 @@ platform :ios, min_ios_version_supported
 
 prepare_react_native_project!
 
-USE_FRAMEWORKS = ENV['USE_FRAMEWORKS'] == '1'
 IN_CI = ENV['CI'] == 'true'
 
 @prefix_path = "../.."
 
+linkage = ENV['USE_FRAMEWORKS']
+USE_FRAMEWORKS = linkage != nil
 if USE_FRAMEWORKS
-  puts "Installing pods with use_frameworks!"
-  use_frameworks!
+  Pod::UI.puts "Configuring Pod with #{linkage}ally linked Frameworks".green
+  use_frameworks! :linkage => linkage.to_sym
 end
 
 def pods(target_name, options = {}, use_flipper: !IN_CI && !USE_FRAMEWORKS)


### PR DESCRIPTION
Summary:
This diff prepares the React-Fabric podspec to support use_frameworks!

To fix the issues we currently have with use_framework, without renaming any file, we have to split the Fabric subspecs in different pods only when use_frameworks! is turned on.

## Changelog:
[internal] - Add guard to prepare theFabric pod to be split in different pods.

Differential Revision: D42388541

