### PR TITLE
Align USE_FRAMEWORKS usage between RNTester and the Template

### DIFF
--- a/packages/rn-tester/Podfile
+++ b/packages/rn-tester/Podfile
@@ -5,14 +5,15 @@ platform :ios, min_ios_version_supported
 
 prepare_react_native_project!
 
-USE_FRAMEWORKS = ENV['USE_FRAMEWORKS'] == '1'
 IN_CI = ENV['CI'] == 'true'
 
 @prefix_path = "../.."
 
+linkage = ENV['USE_FRAMEWORKS']
+USE_FRAMEWORKS = linkage != nil
 if USE_FRAMEWORKS
-  puts "Installing pods with use_frameworks!"
-  use_frameworks!
+  Pod::UI.puts "Configuring Pod with #{linkage}ally linked Frameworks".green
+  use_frameworks! :linkage => linkage.to_sym
 end
 
 def pods(target_name, options = {}, use_flipper: !IN_CI && !USE_FRAMEWORKS)


### PR DESCRIPTION
Summary:
This diff apply to RNTester the same logic we have in the template to control the `use_framework!` setting

This is a preliminary change to solve the `use_frameworks!` problems in the New Architecture for both the Template and RNTester.

## Changelog:
[iOS][Changed] - Align RNTester usage of the USE_FRAMEWORKS flag to the template

Reviewed By: cortinico

Differential Revision: D42387701

