### PR TITLE
Use FileMock and DirMock instead of Monkey Patching

### DIFF
--- a/scripts/cocoapods/__tests__/codegen-test.rb
+++ b/scripts/cocoapods/__tests__/codegen-test.rb
@@ -20,8 +20,6 @@ class CodegenTests < Test::Unit::TestCase
     :tmp_schema_list_file
 
     def setup
-        File.enable_testing_mode!
-        Dir.enable_testing_mode!
         Pod::Config.reset()
 
         @prefix = "../.."
@@ -38,8 +36,8 @@ class CodegenTests < Test::Unit::TestCase
         Pod::UI.reset()
         Pod::Executable.reset()
         Pathname.reset()
-        File.reset()
-        Dir.reset()
+        FileMock.reset()
+        DirMock.reset()
     end
 
     # ============================================== #
@@ -48,90 +46,90 @@ class CodegenTests < Test::Unit::TestCase
     def testCheckAndGenerateEmptyThirdPartyProvider_whenFileAlreadyExists_doNothing()
 
         # Arrange
-        File.mocked_existing_files([
+        FileMock.mocked_existing_files([
             @base_path + "/build/" + @third_party_provider_header,
             @base_path + "/build/" + @third_party_provider_implementation,
         ])
 
         # Act
-        checkAndGenerateEmptyThirdPartyProvider!(@prefix, false, 'build')
+        checkAndGenerateEmptyThirdPartyProvider!(@prefix, false, 'build', dir_manager: DirMock, file_manager: FileMock)
 
         # Assert
         assert_equal(Pathname.pwd_invocation_count, 1)
         assert_equal(Pod::Config.instance.installation_root.relative_path_from_invocation_count, 1)
-        assert_equal(File.exist_invocation_params, [
+        assert_equal(FileMock.exist_invocation_params, [
             @base_path + "/build/" + @third_party_provider_header,
             @base_path + "/build/" + @third_party_provider_implementation,
         ])
-        assert_equal(Dir.exist_invocation_params, [])
+        assert_equal(DirMock.exist_invocation_params, [])
         assert_equal(Pod::UI.collected_messages, [])
         assert_equal($collected_commands, [])
-        assert_equal(File.open_files.length, 0)
+        assert_equal(FileMock.open_files.length, 0)
         assert_equal(Pod::Executable.executed_commands.length, 0)
     end
 
     def testCheckAndGenerateEmptyThirdPartyProvider_whenHeaderMissingAndCodegenMissing_raiseError()
 
         # Arrange
-        File.mocked_existing_files([
+        FileMock.mocked_existing_files([
             @base_path + "/build/" + @third_party_provider_implementation,
         ])
 
         # Act
         assert_raise {
-            checkAndGenerateEmptyThirdPartyProvider!(@prefix, false, 'build')
+            checkAndGenerateEmptyThirdPartyProvider!(@prefix, false, 'build', dir_manager: DirMock, file_manager: FileMock)
         }
 
         # Assert
         assert_equal(Pathname.pwd_invocation_count, 1)
         assert_equal(Pod::Config.instance.installation_root.relative_path_from_invocation_count, 1)
-        assert_equal(File.exist_invocation_params, [
+        assert_equal(FileMock.exist_invocation_params, [
             @base_path + "/build/" + @third_party_provider_header
         ])
-        assert_equal(Dir.exist_invocation_params, [
+        assert_equal(DirMock.exist_invocation_params, [
             @base_path + "/"+ @prefix + "/packages/react-native-codegen",
             @base_path + "/"+ @prefix + "/../@react-native/codegen",
         ])
         assert_equal(Pod::UI.collected_messages, [])
         assert_equal($collected_commands, [])
-        assert_equal(File.open_files.length, 0)
+        assert_equal(FileMock.open_files.length, 0)
         assert_equal(Pod::Executable.executed_commands.length, 0)
     end
 
     def testCheckAndGenerateEmptyThirdPartyProvider_whenImplementationMissingAndCodegenrepoExists_dontBuildCodegen()
 
         # Arrange
-        File.mocked_existing_files([
+        FileMock.mocked_existing_files([
             @base_path + "/build/" + @third_party_provider_header,
             @base_path + "/build/tmpSchemaList.txt"
         ])
 
-        Dir.mocked_existing_dirs([
+        DirMock.mocked_existing_dirs([
             @base_path + "/"+ @prefix + "/packages/react-native-codegen",
             @base_path + "/"+ @prefix + "/packages/react-native-codegen/lib"
         ])
 
         # Act
-        checkAndGenerateEmptyThirdPartyProvider!(@prefix, false, 'build')
+        checkAndGenerateEmptyThirdPartyProvider!(@prefix, false, 'build', dir_manager: DirMock, file_manager: FileMock)
 
         # Assert
         assert_equal(Pathname.pwd_invocation_count, 1)
         assert_equal(Pod::Config.instance.installation_root.relative_path_from_invocation_count, 1)
-        assert_equal(File.exist_invocation_params, [
+        assert_equal(FileMock.exist_invocation_params, [
             @base_path + "/build/" + @third_party_provider_header,
             @base_path + "/build/" + @third_party_provider_implementation,
             @base_path + "/build/tmpSchemaList.txt",
         ])
-        assert_equal(Dir.exist_invocation_params, [
+        assert_equal(DirMock.exist_invocation_params, [
             @base_path + "/"+ @prefix + "/packages/react-native-codegen",
             @base_path + "/"+ @prefix + "/packages/react-native-codegen/lib",
         ])
         assert_equal(Pod::UI.collected_messages, ["[Codegen] generating an empty RCTThirdPartyFabricComponentsProvider"])
         assert_equal($collected_commands, [])
-        assert_equal(File.open_invocation_count, 1)
-        assert_equal(File.open_files_with_mode[@base_path + "/build/tmpSchemaList.txt"], 'w')
-        assert_equal(File.open_files[0].collected_write, ["[]"])
-        assert_equal(File.open_files[0].fsync_invocation_count, 1)
+        assert_equal(FileMock.open_invocation_count, 1)
+        assert_equal(FileMock.open_files_with_mode[@base_path + "/build/tmpSchemaList.txt"], 'w')
+        assert_equal(FileMock.open_files[0].collected_write, ["[]"])
+        assert_equal(FileMock.open_files[0].fsync_invocation_count, 1)
         assert_equal(Pod::Executable.executed_commands[0], {
             "command" => "node",
             "arguments" => [
@@ -141,27 +139,27 @@ class CodegenTests < Test::Unit::TestCase
                 "--outputDir", @base_path + "/build"
             ]
         })
-        assert_equal(File.delete_invocation_count, 1)
-        assert_equal(File.deleted_files, [@base_path + "/build/tmpSchemaList.txt"])
+        assert_equal(FileMock.delete_invocation_count, 1)
+        assert_equal(FileMock.deleted_files, [@base_path + "/build/tmpSchemaList.txt"])
     end
 
     def testCheckAndGenerateEmptyThirdPartyProvider_whenBothMissing_buildCodegen()
         # Arrange
         codegen_cli_path = @base_path + "/" + @prefix + "/../@react-native/codegen"
-        Dir.mocked_existing_dirs([
+        DirMock.mocked_existing_dirs([
             codegen_cli_path,
         ])
         # Act
-        checkAndGenerateEmptyThirdPartyProvider!(@prefix, false, 'build')
+        checkAndGenerateEmptyThirdPartyProvider!(@prefix, false, 'build', dir_manager: DirMock, file_manager: FileMock)
 
         # Assert
         assert_equal(Pathname.pwd_invocation_count, 1)
         assert_equal(Pod::Config.instance.installation_root.relative_path_from_invocation_count, 1)
-        assert_equal(File.exist_invocation_params, [
+        assert_equal(FileMock.exist_invocation_params, [
             @base_path + "/build/" + @third_party_provider_header,
             @base_path + "/build/" + @tmp_schema_list_file
         ])
-        assert_equal(Dir.exist_invocation_params, [
+        assert_equal(DirMock.exist_invocation_params, [
             @base_path + "/" + @prefix + "/packages/react-native-codegen",
             codegen_cli_path,
             codegen_cli_path + "/lib",
@@ -171,8 +169,8 @@ class CodegenTests < Test::Unit::TestCase
             "[Codegen] generating an empty RCTThirdPartyFabricComponentsProvider"
         ])
         assert_equal($collected_commands, ["~/app/ios/../../../@react-native/codegen/scripts/oss/build.sh"])
-        assert_equal(File.open_files[0].collected_write, ["[]"])
-        assert_equal(File.open_files[0].fsync_invocation_count, 1)
+        assert_equal(FileMock.open_files[0].collected_write, ["[]"])
+        assert_equal(FileMock.open_files[0].fsync_invocation_count, 1)
         assert_equal(Pod::Executable.executed_commands[0], {
             "command" => "node",
             "arguments" => [

--- a/scripts/cocoapods/__tests__/jsengine-test.rb
+++ b/scripts/cocoapods/__tests__/jsengine-test.rb
@@ -14,7 +14,6 @@ class JSEngineTests < Test::Unit::TestCase
     :react_native_path
 
     def setup
-        File.enable_testing_mode!
         @react_native_path = "../.."
         podSpy_cleanUp()
 
@@ -28,7 +27,6 @@ class JSEngineTests < Test::Unit::TestCase
         podSpy_cleanUp()
         ENV['USE_HERMES'] = '1'
         ENV['CI'] = nil
-        File.reset()
     end
 
     # =============== #

--- a/scripts/cocoapods/__tests__/local_podspec_patch-test.rb
+++ b/scripts/cocoapods/__tests__/local_podspec_patch-test.rb
@@ -12,14 +12,10 @@ require_relative "./test_utils/PodMock.rb"
 require_relative "./test_utils/LocalPodspecPatchMock.rb"
 
 class LocalPodspecPatchTests < Test::Unit::TestCase
-    def setup
-        File.enable_testing_mode!
-        Dir.enable_testing_mode!
-    end
 
     def teardown
-        File.reset()
-        Dir.reset()
+        FileMock.reset()
+        DirMock.reset()
     end
 
     # =================== #
@@ -31,18 +27,18 @@ class LocalPodspecPatchTests < Test::Unit::TestCase
         react_native_path = "../node_modules/react-native"
         globs = ["a/path/to/boost.podspec", "a/path/to/DoubleConversion.podspec"]
         mocked_pwd = "a/path/to"
-        Dir.mocked_existing_globs(globs, "#{react_native_path}/third-party-podspecs/*")
-        Dir.set_pwd(mocked_pwd)
+        DirMock.mocked_existing_globs(globs, "#{react_native_path}/third-party-podspecs/*")
+        DirMock.set_pwd(mocked_pwd)
 
         # Act
-        local_podspec = LocalPodspecPatch.pods_to_update(:react_native_path => react_native_path)
+        local_podspec = LocalPodspecPatch.pods_to_update(:react_native_path => react_native_path, dir_manager: DirMock, file_manager: FileMock)
 
         # Assert
         assert_equal(local_podspec, [])
-        assert_equal(Dir.glob_invocation, ["#{react_native_path}/third-party-podspecs/*"])
-        assert_equal(File.exist_invocation_params, [
-            File.join(mocked_pwd, "Pods/Local Podspecs", "boost.podspec.json"),
-            File.join(mocked_pwd, "Pods/Local Podspecs", "DoubleConversion.podspec.json"),
+        assert_equal(DirMock.glob_invocation, ["#{react_native_path}/third-party-podspecs/*"])
+        assert_equal(FileMock.exist_invocation_params, [
+            FileMock.join(mocked_pwd, "Pods/Local Podspecs", "boost.podspec.json"),
+            FileMock.join(mocked_pwd, "Pods/Local Podspecs", "DoubleConversion.podspec.json"),
         ])
     end
 
@@ -54,14 +50,14 @@ class LocalPodspecPatchTests < Test::Unit::TestCase
         prepare_PodsToUpdate_test_withMatchingVersions(react_native_path, globs, mocked_pwd)
 
         # Act
-        local_podspec = LocalPodspecPatch.pods_to_update(:react_native_path => react_native_path)
+        local_podspec = LocalPodspecPatch.pods_to_update(:react_native_path => react_native_path, dir_manager: DirMock, file_manager: FileMock)
 
         # Assert
         assert_equal(local_podspec, [])
-        assert_equal(Dir.glob_invocation, ["#{react_native_path}/third-party-podspecs/*"])
-        assert_equal(File.exist_invocation_params, [
-            File.join(mocked_pwd, "Pods/Local Podspecs", "boost.podspec.json"),
-            File.join(mocked_pwd, "Pods/Local Podspecs", "DoubleConversion.podspec.json"),
+        assert_equal(DirMock.glob_invocation, ["#{react_native_path}/third-party-podspecs/*"])
+        assert_equal(FileMock.exist_invocation_params, [
+            FileMock.join(mocked_pwd, "Pods/Local Podspecs", "boost.podspec.json"),
+            FileMock.join(mocked_pwd, "Pods/Local Podspecs", "DoubleConversion.podspec.json"),
         ])
     end
 
@@ -73,17 +69,17 @@ class LocalPodspecPatchTests < Test::Unit::TestCase
         prepare_PodsToUpdate_test_withDifferentVersions(react_native_path, globs, mocked_pwd)
 
         # Act
-        local_podspec = LocalPodspecPatch.pods_to_update(:react_native_path => react_native_path)
+        local_podspec = LocalPodspecPatch.pods_to_update(:react_native_path => react_native_path, dir_manager: DirMock, file_manager: FileMock)
 
         # Assert
         assert_equal(local_podspec, [
             "boost",
             "DoubleConversion"
         ])
-        assert_equal(Dir.glob_invocation, ["#{react_native_path}/third-party-podspecs/*"])
-        assert_equal(File.exist_invocation_params, [
-            File.join(mocked_pwd, "Pods/Local Podspecs", "boost.podspec.json"),
-            File.join(mocked_pwd, "Pods/Local Podspecs", "DoubleConversion.podspec.json"),
+        assert_equal(DirMock.glob_invocation, ["#{react_native_path}/third-party-podspecs/*"])
+        assert_equal(FileMock.exist_invocation_params, [
+            FileMock.join(mocked_pwd, "Pods/Local Podspecs", "boost.podspec.json"),
+            FileMock.join(mocked_pwd, "Pods/Local Podspecs", "DoubleConversion.podspec.json"),
         ])
     end
 
@@ -136,16 +132,16 @@ class LocalPodspecPatchTests < Test::Unit::TestCase
     # Utilities #
     # ========= #
     def prepare_PodsToUpdate_test_withMatchingVersions(react_native_path, globs, mocked_pwd)
-        File.mocked_existing_files([
+        FileMock.mocked_existing_files([
             "a/path/to/Pods/Local Podspecs/boost.podspec.json",
             "a/path/to/Pods/Local Podspecs/DoubleConversion.podspec.json"
         ])
-        File.files_to_read({
+        FileMock.files_to_read({
             "a/path/to/Pods/Local Podspecs/boost.podspec.json" => "{ \"version\": \"0.0.1\"}",
             "a/path/to/Pods/Local Podspecs/DoubleConversion.podspec.json" => "{ \"version\": \"1.0.1\"}",
         })
-        Dir.mocked_existing_globs(globs, "#{react_native_path}/third-party-podspecs/*")
-        Dir.set_pwd(mocked_pwd)
+        DirMock.mocked_existing_globs(globs, "#{react_native_path}/third-party-podspecs/*")
+        DirMock.set_pwd(mocked_pwd)
         Pod::Specification.specs_from_file({
             "../node_modules/react-native/third-party-podspecs/boost.podspec" => Pod::PodSpecMock.new(:version => "0.0.1"),
             "../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec" => Pod::PodSpecMock.new(:version => "1.0.1"),
@@ -153,16 +149,16 @@ class LocalPodspecPatchTests < Test::Unit::TestCase
     end
 
     def prepare_PodsToUpdate_test_withDifferentVersions(react_native_path, globs, mocked_pwd)
-        File.mocked_existing_files([
+        FileMock.mocked_existing_files([
             "a/path/to/Pods/Local Podspecs/boost.podspec.json",
             "a/path/to/Pods/Local Podspecs/DoubleConversion.podspec.json"
         ])
-        File.files_to_read({
+        FileMock.files_to_read({
             "a/path/to/Pods/Local Podspecs/boost.podspec.json" => "{ \"version\": \"0.0.1\"}",
             "a/path/to/Pods/Local Podspecs/DoubleConversion.podspec.json" => "{ \"version\": \"1.0.1\"}",
         })
-        Dir.mocked_existing_globs(globs, "#{react_native_path}/third-party-podspecs/*")
-        Dir.set_pwd(mocked_pwd)
+        DirMock.mocked_existing_globs(globs, "#{react_native_path}/third-party-podspecs/*")
+        DirMock.set_pwd(mocked_pwd)
         Pod::Specification.specs_from_file({
             "../node_modules/react-native/third-party-podspecs/boost.podspec" => Pod::PodSpecMock.new(:version => "0.1.1"),
             "../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec" => Pod::PodSpecMock.new(:version => "1.1.1"),

--- a/scripts/cocoapods/__tests__/test_utils/CodegenUtilsMock.rb
+++ b/scripts/cocoapods/__tests__/test_utils/CodegenUtilsMock.rb
@@ -93,7 +93,7 @@ class CodegenUtilsMock
         codegen_output_dir: 'build/generated/ios',
         config_key: 'codegenConfig',
         folly_version: "2021.07.22.00",
-        codegen_utils: CodegenUtils.new()
+        codegen_utils: CodegenUtilsMock.new()
     )
         @use_react_native_codegen_discovery_params.push({
             codegen_disabled: codegen_disabled,

--- a/scripts/cocoapods/__tests__/test_utils/DirMock.rb
+++ b/scripts/cocoapods/__tests__/test_utils/DirMock.rb
@@ -3,9 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-class Dir
-
-    @@is_testing = false
+class DirMock < Dir
     @@exist_invocation_params = []
     @@mocked_existing_dirs = []
 
@@ -19,10 +17,6 @@ class Dir
     # To use this, invoke the `is_testing` method before starting your test.
     # Remember to invoke `reset` after the test.
     def self.exist?(path)
-        if !@@is_testing
-            return exists?(path)
-        end
-
         @@exist_invocation_params.push(path)
         return @@mocked_existing_dirs.include?(path)
     end
@@ -67,16 +61,10 @@ class Dir
         return pwd
     end
 
-    # Turn on the mocking features of the File mock
-    def self.enable_testing_mode!()
-        @@is_testing = true
-    end
-
     # Resets all the settings for the File mock
     def self.reset()
         @@pwd = nil
         @@mocked_existing_dirs = []
-        @@is_testing = false
         @@exist_invocation_params = []
         @@glob_invocation = []
         @@mocked_existing_globs = {}

--- a/scripts/cocoapods/__tests__/test_utils/FileMock.rb
+++ b/scripts/cocoapods/__tests__/test_utils/FileMock.rb
@@ -3,9 +3,132 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-class File
+# class File
+#     @@is_testing = false
+#     @@exist_invocation_params = []
+#     @@mocked_existing_files = []
 
-    @@is_testing = false
+#     @@delete_invocation_count = 0
+#     @@deleted_files = []
+
+#     @@open_files_with_mode = {}
+#     @@open_invocation_count = 0
+
+#     @@open_files = []
+
+#     @@files_to_read = {}
+#     attr_reader :collected_write
+#     attr_reader :fsync_invocation_count
+
+#     def initialize()
+#         @collected_write = []
+#         @fsync_invocation_count = 0
+#     end
+
+#     # Monkey patched exists? method.
+#     # It is used also by the test runner, so it can't start monkey patched
+#     # To use this, invoke the `is_testing` method before starting your test.
+#     # Remember to invoke `reset` after the test.
+#     def self.exist?(path)
+#         if !@@is_testing
+#             return exists?(path)
+#         end
+
+#         @@exist_invocation_params.push(path)
+#         return @@mocked_existing_files.include?(path)
+#     end
+
+#     def self.delete(path)
+#         if !@@is_testing
+#             delete(path)
+#             return
+#         end
+
+#         @@delete_invocation_count += 1
+#         @@deleted_files.push(path)
+#     end
+
+#     def self.delete_invocation_count
+#         return @@delete_invocation_count
+#     end
+
+#     def self.deleted_files
+#         return @@deleted_files
+#     end
+
+#     # Getter for the `exist_invocation_params` to check that the exist method
+#     # is invoked the right number of times with the right parameters
+#     def self.exist_invocation_params()
+#         return @@exist_invocation_params
+#     end
+
+#     # Set the list of files the test must return as existing
+#     def self.mocked_existing_files(files)
+#         @@mocked_existing_files = files
+#     end
+
+#     # Turn on the mocking features of the File mock
+#     def self.enable_testing_mode!()
+#         @@is_testing = true
+#     end
+
+#     def self.open(path, mode, &block)
+#         @@open_files_with_mode[path] = mode
+#         @@open_invocation_count += 1
+#         file = File.new()
+#         @@open_files.push(file)
+#         yield(file)
+#     end
+
+#     def self.open_files_with_mode
+#         return @@open_files_with_mode
+#     end
+
+#     def self.open_invocation_count
+#         return @@open_invocation_count
+#     end
+
+#     def self.open_files
+#         return @@open_files
+#     end
+
+#     def self.file_invocation_params
+#         return @@file_invocation_params
+#     end
+
+#     def write(text)
+#         @collected_write.push(text.to_s)
+#     end
+
+#     def fsync()
+#         @fsync_invocation_count += 1
+#     end
+
+
+#     def self.files_to_read(files)
+#         @@files_to_read = files
+#     end
+
+#     def self.read(filepath)
+#         return @@files_to_read[filepath]
+#     end
+
+#     # Resets all the settings for the File mock
+#     def self.reset()
+#         @@delete_invocation_count = 0
+#         @@deleted_files = []
+#         @@open_files = []
+#         @@open_files_with_mode = {}
+#         @@open_invocation_count = 0
+#         @@mocked_existing_files = []
+#         @@is_testing = false
+#         @@file_invocation_params = []
+#         @@exist_invocation_params = []
+#         @@files_to_read = {}
+#     end
+# end
+
+class FileMock < File
     @@exist_invocation_params = []
     @@mocked_existing_files = []
 
@@ -31,20 +154,11 @@ class File
     # To use this, invoke the `is_testing` method before starting your test.
     # Remember to invoke `reset` after the test.
     def self.exist?(path)
-        if !@@is_testing
-            return exists?(path)
-        end
-
         @@exist_invocation_params.push(path)
         return @@mocked_existing_files.include?(path)
     end
 
     def self.delete(path)
-        if !@@is_testing
-            delete(path)
-            return
-        end
-
         @@delete_invocation_count += 1
         @@deleted_files.push(path)
     end
@@ -68,15 +182,10 @@ class File
         @@mocked_existing_files = files
     end
 
-    # Turn on the mocking features of the File mock
-    def self.enable_testing_mode!()
-        @@is_testing = true
-    end
-
     def self.open(path, mode, &block)
         @@open_files_with_mode[path] = mode
         @@open_invocation_count += 1
-        file = File.new()
+        file = FileMock.new()
         @@open_files.push(file)
         yield(file)
     end
@@ -122,11 +231,8 @@ class File
         @@open_files_with_mode = {}
         @@open_invocation_count = 0
         @@mocked_existing_files = []
-        @@is_testing = false
         @@file_invocation_params = []
         @@exist_invocation_params = []
         @@files_to_read = {}
     end
-
-
 end

--- a/scripts/cocoapods/__tests__/test_utils/FileUtilsMock.rb
+++ b/scripts/cocoapods/__tests__/test_utils/FileUtilsMock.rb
@@ -35,6 +35,6 @@ module FileUtils
     def self.rm_rf(path)
         FileUtilsStorage.push_rmrf_path(path)
         FileUtilsStorage.increase_rmrfi_invocation_count
-        Dir.remove_mocked_paths(path)
+        DirMock.remove_mocked_paths(path)
     end
 end

--- a/scripts/cocoapods/__tests__/utils-test.rb
+++ b/scripts/cocoapods/__tests__/utils-test.rb
@@ -19,11 +19,10 @@ class UtilsTests < Test::Unit::TestCase
     def setup
         @base_path = "~/app/ios"
         Pathname.pwd!(@base_path)
-        File.enable_testing_mode!
     end
 
     def teardown
-        File.reset()
+        FileMock.reset()
         Pod::UI.reset()
         Pathname.reset()
         Pod::Config.reset()
@@ -466,11 +465,11 @@ class UtilsTests < Test::Unit::TestCase
     # =================================== #
     def test_createXcodeEnvIfMissing_whenItIsPresent_doNothing
         # Arrange
-        File.mocked_existing_files("/.xcode.env")
+        FileMock.mocked_existing_files("/.xcode.env")
         # Act
-        ReactNativePodsUtils.create_xcode_env_if_missing
+        ReactNativePodsUtils.create_xcode_env_if_missing(file_manager: FileMock)
         # Assert
-        assert_equal(File.exist_invocation_params, ["/.xcode.env"])
+        assert_equal(FileMock.exist_invocation_params, ["/.xcode.env"])
         assert_equal($collected_commands, [])
     end
 
@@ -478,9 +477,9 @@ class UtilsTests < Test::Unit::TestCase
         # Arrange
 
         # Act
-        ReactNativePodsUtils.create_xcode_env_if_missing
+        ReactNativePodsUtils.create_xcode_env_if_missing(file_manager: FileMock)
         # Assert
-        assert_equal(File.exist_invocation_params, ["/.xcode.env"])
+        assert_equal(FileMock.exist_invocation_params, ["/.xcode.env"])
         assert_equal($collected_commands, ["echo 'export NODE_BINARY=$(command -v node)' > /.xcode.env"])
     end
 

--- a/scripts/cocoapods/codegen.rb
+++ b/scripts/cocoapods/codegen.rb
@@ -5,23 +5,26 @@
 
 # It builds the codegen CLI if it is not present
 #
-# @parameter react_native_path: the path to the react native installation
-# @parameter relative_installation_root: the path to the relative installation root of the pods
+# Parameters:
+# - react_native_path: the path to the react native installation
+# - relative_installation_root: the path to the relative installation root of the pods
+# - dir_manager: a class that implements the `Dir` interface. Defaults to `Dir`, the Dependency can be injected for testing purposes.
+# - file_manager: a class that implements the `File` interface. Defaults to `File`, the Dependency can be injected for testing purposes.
 # @throws an error if it could not find the codegen folder.
-def build_codegen!(react_native_path, relative_installation_root)
+def build_codegen!(react_native_path, relative_installation_root, dir_manager: Dir)
     codegen_repo_path = "#{relative_installation_root}/#{react_native_path}/packages/react-native-codegen";
     codegen_npm_path = "#{relative_installation_root}/#{react_native_path}/../@react-native/codegen";
     codegen_cli_path = ""
 
-    if Dir.exist?(codegen_repo_path)
+    if dir_manager.exist?(codegen_repo_path)
       codegen_cli_path = codegen_repo_path
-    elsif Dir.exist?(codegen_npm_path)
+    elsif dir_manager.exist?(codegen_npm_path)
       codegen_cli_path = codegen_npm_path
     else
       raise "[codegen] Couldn't not find react-native-codegen."
     end
 
-    if !Dir.exist?("#{codegen_cli_path}/lib")
+    if !dir_manager.exist?("#{codegen_cli_path}/lib")
       Pod::UI.puts "[Codegen] building #{codegen_cli_path}."
       system("#{codegen_cli_path}/scripts/oss/build.sh")
     end
@@ -29,10 +32,13 @@ def build_codegen!(react_native_path, relative_installation_root)
 
 # It generates an empty `ThirdPartyProvider`, required by Fabric to load the components
 #
-# @parameter react_native_path: path to the react native framework
-# @parameter new_arch_enabled: whether the New Architecture is enabled or not
-# @parameter codegen_output_dir: the output directory for the codegen
-def checkAndGenerateEmptyThirdPartyProvider!(react_native_path, new_arch_enabled, codegen_output_dir)
+# Parameters:
+# - react_native_path: path to the react native framework
+# - new_arch_enabled: whether the New Architecture is enabled or not
+# - codegen_output_dir: the output directory for the codegen
+# - dir_manager: a class that implements the `Dir` interface. Defaults to `Dir`, the Dependency can be injected for testing purposes.
+# - file_manager: a class that implements the `File` interface. Defaults to `File`, the Dependency can be injected for testing purposes.
+def checkAndGenerateEmptyThirdPartyProvider!(react_native_path, new_arch_enabled, codegen_output_dir, dir_manager: Dir, file_manager: File)
     return if new_arch_enabled
 
     relative_installation_root = Pod::Config.instance.installation_root.relative_path_from(Pathname.pwd)
@@ -42,13 +48,13 @@ def checkAndGenerateEmptyThirdPartyProvider!(react_native_path, new_arch_enabled
     provider_h_path = "#{output_dir}/RCTThirdPartyFabricComponentsProvider.h"
     provider_cpp_path ="#{output_dir}/RCTThirdPartyFabricComponentsProvider.cpp"
 
-    if(!File.exist?(provider_h_path) || !File.exist?(provider_cpp_path))
+    if(!file_manager.exist?(provider_h_path) || !file_manager.exist?(provider_cpp_path))
         # build codegen
-        build_codegen!(react_native_path, relative_installation_root)
+        build_codegen!(react_native_path, relative_installation_root, dir_manager: dir_manager)
 
         # Just use a temp empty schema list.
         temp_schema_list_path = "#{output_dir}/tmpSchemaList.txt"
-        File.open(temp_schema_list_path, 'w') do |f|
+        file_manager.open(temp_schema_list_path, 'w') do |f|
             f.write('[]')
             f.fsync
         end
@@ -62,7 +68,7 @@ def checkAndGenerateEmptyThirdPartyProvider!(react_native_path, new_arch_enabled
             "--schemaListPath", temp_schema_list_path,
             "--outputDir", "#{output_dir}"
         ])
-        File.delete(temp_schema_list_path) if File.exist?(temp_schema_list_path)
+        file_manager.delete(temp_schema_list_path) if file_manager.exist?(temp_schema_list_path)
     end
 end
 

--- a/scripts/cocoapods/local_podspec_patch.rb
+++ b/scripts/cocoapods/local_podspec_patch.rb
@@ -7,19 +7,19 @@
 # This is necessary because local podspec dependencies must be otherwise manually updated.
 module LocalPodspecPatch
     # Returns local podspecs whose versions differ from the one in the `react-native` package.
-    def self.pods_to_update(react_native_path: "../node_modules/react-native")
-        @@local_podspecs = Dir.glob("#{react_native_path}/third-party-podspecs/*").map { |file| File.basename(file, ".podspec") }
+    def self.pods_to_update(react_native_path: "../node_modules/react-native", dir_manager: Dir, file_manager: File)
+        @@local_podspecs = dir_manager.glob("#{react_native_path}/third-party-podspecs/*").map { |file| file_manager.basename(file, ".podspec") }
         @@local_podspecs = @@local_podspecs.select do |podspec_name|
 
             # Read local podspec to determine the cached version
-            local_podspec_path = File.join(
-                Dir.pwd, "Pods/Local Podspecs/#{podspec_name}.podspec.json"
+            local_podspec_path = file_manager.join(
+                dir_manager.pwd, "Pods/Local Podspecs/#{podspec_name}.podspec.json"
             )
 
             # Local podspec cannot be outdated if it does not exist, yet
-            next unless File.exist?(local_podspec_path)
+            next unless file_manager.exist?(local_podspec_path)
 
-            local_podspec = File.read(local_podspec_path)
+            local_podspec = file_manager.read(local_podspec_path)
             local_podspec_json = JSON.parse(local_podspec)
             local_version = local_podspec_json["version"]
 

--- a/scripts/cocoapods/utils.rb
+++ b/scripts/cocoapods/utils.rb
@@ -154,10 +154,10 @@ class ReactNativePodsUtils
         end
     end
 
-    def self.create_xcode_env_if_missing
+    def self.create_xcode_env_if_missing(file_manager: File)
         relative_path = Pod::Config.instance.installation_root.relative_path_from(Pathname.pwd)
-        file_path = File.join(relative_path, '.xcode.env')
-        if File.exist?(file_path)
+        file_path = file_manager.join(relative_path, '.xcode.env')
+        if file_manager.exist?(file_path)
             return
         end
 


### PR DESCRIPTION
Summary:
This Diff fixes a problem we have when running Ruby tests.

The previous approach was monkey-patching the Ruby File and Dir classes to override some behaviours we needed during tests. However, these classes are also used by the test runners to properly read and run the tests, therefore when the tests were failing, the stream weren't closed properly and we received the wrong errors.

This problem was also preventing us from adopting other Ruby tools like SimpleCov to compute code coverage.

## Changelog:
[internal] - refactor Ruby tests not to monkey patch Dir and File

Differential Revision: D42414717

