### PR TITLE
fix: use properly exclude parameter of matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -862,35 +862,6 @@ jobs:
       - PROJECT_NAME: "iOSTemplateProject"
       - HERMES_WS_DIR: *hermes_workspace_root
     steps:
-      # Early exit in case of Release and WithFlipper. The two does not make sense together.
-      # Unfortunately, the `exclude` parameter of `matrix` does not work, so we have to do it manually.
-      - when:
-          condition:
-            and:
-              - equal: [ << parameters.flavor >>, "Release"]
-              - equal: [ << parameters.flipper >>, "WithFlipper" ]
-          steps:
-            - run:
-                command: circleci-agent step halt # this interrupts the job successfully.
-      # use_frameworks! does not works with Flipper enabled
-      - when:
-          condition:
-            and:
-              - equal: [ << parameters.use_frameworks >>, "StaticFrameworks"]
-              - equal: [ << parameters.flipper >>, "WithFlipper" ]
-          steps:
-            - run:
-                command: circleci-agent step halt # this interrupts the job successfully.
-      # use_frameworks! does not works with the New Architecture enabled
-      - when:
-          condition:
-            and:
-              - equal: [ << parameters.use_frameworks >>, "StaticFrameworks"]
-              - equal: [ << parameters.architecture >>, "NewArch" ]
-          steps:
-            - run:
-                command: circleci-agent step halt # this interrupts the job successfully.
-      # Valid configuration, we can continue
       - checkout_code_with_cache
       - run_yarn
       - attach_workspace:
@@ -1657,6 +1628,87 @@ workflows:
               jsengine: ["Hermes", "JSC"]
               flipper: ["WithFlipper", "WithoutFlipper"]
               use_frameworks: [ "StaticLibraries", "StaticFrameworks" ] #TODO: make it works with DynamicFrameworks
+            exclude:
+              - architecture: "NewArch"
+                flavor: "Release"
+                jsengine: "Hermes"
+                flipper: "WithFlipper"
+                use_frameworks: "StaticLibraries"
+              - architecture: "NewArch"
+                flavor: "Release"
+                jsengine: "Hermes"
+                flipper: "WithFlipper"
+                use_frameworks: "StaticFrameworks"
+              - architecture: "NewArch"
+                flavor: "Release"
+                jsengine: "Hermes"
+                flipper: "WithoutFlipper"
+                use_frameworks: "StaticFrameworks"
+              - architecture: "NewArch"
+                flavor: "Release"
+                jsengine: "JSC"
+                flipper: "WithFlipper"
+                use_frameworks: "StaticLibraries"
+              - architecture: "NewArch"
+                flavor: "Release"
+                jsengine: "JSC"
+                flipper: "WithFlipper"
+                use_frameworks: "StaticFrameworks"
+              - architecture: "NewArch"
+                flavor: "Release"
+                jsengine: "JSC"
+                flipper: "WithoutFlipper"
+                use_frameworks: "StaticFrameworks"
+              - architecture: "OldArch"
+                flavor: "Release"
+                jsengine: "Hermes"
+                flipper: "WithFlipper"
+                use_frameworks: "StaticLibraries"
+              - architecture: "OldArch"
+                flavor: "Release"
+                jsengine: "Hermes"
+                flipper: "WithFlipper"
+                use_frameworks: "StaticFrameworks"
+              - architecture: "OldArch"
+                flavor: "Release"
+                jsengine: "JSC"
+                flipper: "WithFlipper"
+                use_frameworks: "StaticLibraries"
+              - architecture: "OldArch"
+                flavor: "Release"
+                jsengine: "JSC"
+                flipper: "WithFlipper"
+                use_frameworks: "StaticFrameworks"
+              - architecture: "NewArch"
+                flavor: "Debug"
+                jsengine: "Hermes"
+                flipper: "WithFlipper"
+                use_frameworks: "StaticFrameworks"
+              - architecture: "NewArch"
+                flavor: "Debug"
+                jsengine: "Hermes"
+                flipper: "WithoutFlipper"
+                use_frameworks: "StaticFrameworks"
+              - architecture: "NewArch"
+                flavor: "Debug"
+                jsengine: "JSC"
+                flipper: "WithFlipper"
+                use_frameworks: "StaticFrameworks"
+              - architecture: "NewArch"
+                flavor: "Debug"
+                jsengine: "JSC"
+                flipper: "WithoutFlipper"
+                use_frameworks: "StaticFrameworks"
+              - architecture: "OldArch"
+                flavor: "Debug"
+                jsengine: "Hermes"
+                flipper: "WithFlipper"
+                use_frameworks: "StaticFrameworks"
+              - architecture: "OldArch"
+                flavor: "Debug"
+                jsengine: "JSC"
+                flipper: "WithFlipper"
+                use_frameworks: "StaticFrameworks"
       - test_ios_rntester:
           requires:
             - build_hermes_macos


### PR DESCRIPTION
## Summary

Update the CircleCI configuration to use the proper `exclude` parameter of matrix rather then bootstrap a machine and then kill it.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
## Changelog
[Internal] - Use the `exclude` parameter of matrices to avoid spinning up unnecessary machines

## Test Plan

The number of jobs on CircleCI should decrease.
