### PR TITLE
Add jsinspector prefab target

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -215,6 +215,10 @@ final def preparePrefab = tasks.register("preparePrefab", PreparePrefabHeadersTa
                     new Pair("../ReactCommon/cxxreact/", "cxxreact/"),
                 ]
             ),
+            new PrefabPreprocessingEntry(
+                "jsinspector",
+                new Pair("../ReactCommon/jsinspector/", "jsinspector/"),
+            ),
         ]
     )
     it.outputDir.set(prefabHeadersDir)
@@ -472,7 +476,8 @@ android {
                     "react_render_scheduler",
                     "react_render_mounting",
                     "hermes_executor",
-                    "jscexecutor"
+                    "jscexecutor",
+                    "jsinspector"
             }
         }
         ndk {
@@ -597,6 +602,9 @@ android {
         }
         jscexecutor {
             headers(new File(prefabHeadersDir, "jscexecutor").absolutePath)
+        }
+        jsinspector {
+            headers(new File(prefabHeadersDir, "jsinspector").absolutePath)
         }
     }
 


### PR DESCRIPTION
## Summary

react-native-v8 requires the `jsinspector` for its js inspector feature. this pr adds the `jsinspector` to the prefab target list.

## Changelog

[ANDROID][ADDED] - Add `jsinspector` to the prefab target

## Test Plan

```
$ ./gradlew :ReactAndroid:installArchives

# check prefab files in aar

$ unzip -l android/com/facebook/react/react-android/1000.0.0/react-android-1000.0.0-release.aar | grep 'prefab\/modules\/jsinspector'
$ unzip -l android/com/facebook/react/react-android/1000.0.0/react-android-1000.0.0-debug.aar | grep 'prefab\/modules\/jsinspector'
```
