### PR TITLE
Set size of `Modal` only once on Android

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostManager.kt
@@ -135,9 +135,13 @@ public class ReactModalHostManager :
       props: ReactStylesDiffMap,
       stateWrapper: StateWrapper
   ): Any? {
+    val isInitialState = view.stateWrapper == null
+
     view.stateWrapper = stateWrapper
-    val modalSize = getModalHostSize(view.context)
-    view.updateState(modalSize.x, modalSize.y)
+    if (isInitialState) {
+      val modalSize = getModalHostSize(view.context)
+      view.updateState(modalSize.x, modalSize.y)
+    }
     return null
   }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

On the old architecture, when using a `Modal` with no animation and translucent status bar, a layout flash is noticeable when the modal is opened. Here's the video of this happening (it's visible for one frame):

https://user-images.githubusercontent.com/21055725/211768547-d3ff49b9-2ce6-4f36-9f0f-91ad102fab28.mov

On the new architecture, the issue is more problematic as the modal keeps the wrong height:

https://user-images.githubusercontent.com/21055725/211768801-df57b295-fa04-4bd8-af35-0057553bf15b.mov

This PR updates the logic related to setting modal size, to set only the initial state based on the helper method, and the following updates will be based on the dimensions received in `onSizeChanged` method.

Issue relevant to this PR (with more details): #35804

## Changelog

[Android] [Fixed] - Fixed wrong modal height when `statusBarTranslucent` is set to `true`
<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:



For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan

I've tested the changes on the following snippet:

```jsx
import React, {useState} from 'react';
import {View, Button, Modal} from 'react-native';

const App = () => {
  const [open, setOpen] = useState(false);

  return (
    <View style={{flex: 1, backgroundColor: 'yellow'}}>
      <Button
        title="Open"
        onPress={() => {
          setOpen(true);
        }}
      />

      <Modal
        visible={open}
        animationType="none"
        statusBarTranslucent={true}>
        <View style={{flex: 1, backgroundColor: 'red'}}>
          <Button
            title="Close"
            onPress={() => {
              setOpen(false);
            }}
          />
        </View>
      </Modal>
    </View>
  );
};

export default App;
```
