### PR TITLE
Remove PAT_TOKEN and PAT_USERNAME from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1556,7 +1556,7 @@ jobs:
                 command: |
                   curl -X POST https://api.github.com/repos/react-native-community/rn-diff-purge/dispatches \
                     -H "Accept: application/vnd.github.v3+json" \
-                    -u "$PAT_USERNAME:$PAT_TOKEN" \
+                    -H "Authorization: Bearer $REACT_NATIVE_BOT_GITHUB_TOKEN" \
                     -d "{\"event_type\": \"publish\", \"client_payload\": { \"version\": \"${CIRCLE_TAG:1}\" }}"
       # END: Stable releases
 


### PR DESCRIPTION
## Summary

This is a cleanup change needed after the CircleCI security incident.
We should be using the `Authorization: Bearer` header to trigger `rn-diff-purge` instead of using username & password authentication.

Source: https://docs.github.com/rest/reference/repos#create-a-repository-dispatch-event

## Changelog

[INTERNAL] - Remove PAT_TOKEN and PAT_USERNAME from CircleCI

## Test Plan

I've tested this locally with:

```
curl -X POST https://api.github.com/repos/react-native-community/rn-diff-purge/dispatches \
                    -H "Accept: application/vnd.github.v3+json" \
                    -H "Authorization: Bearer [...]" \
                    -d "{\"event_type\": \"publish\", \"client_payload\": { \"version\": \"test.test.test\" }}"
```

and the run was succesfully fired by @react-native-bot:
https://github.com/react-native-community/rn-diff-purge/actions/runs/3894079133