### PR TITLE
add-coverage-to-gitignore

### DIFF
--- a/template/_gitignore
+++ b/template/_gitignore
@@ -61,3 +61,6 @@ yarn-error.log
 
 # Temporary files created by Metro to check the health of the file watcher
 .metro-health-check*
+
+# testing
+/coverage


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

There is a large amount of autogenerated files in the coverage folder when running `jest --coverage`.

This folder is also in .gitignore for react projects created with `create-react-app`

Originally suggested here: https://github.com/react-native-community/discussions-and-proposals/discussions/569

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[GENERAL] [ADDED] - Added "coverage" folder generated på `jest --coverage` to .gitignore

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

1. cd template
2. yarn
3. yarn test --coverage

Im not sure why many of the files in the template folder have an underscore(_) in the filenames instead of a dot(.). When creating a react-native project they have a dot. So if you run the above commands, the coverage folder will not be ignored since its not in `.gitingore` but in `_gitignore`. However, if you temporarily create a `.gitignore` file, you will see that the coverage folder is ignored.

4. Temporarily create `.gitignore` file to verify that coverage folder is ignored

