### PR TITLE
fix: dont mess up `EXCLUDED_ARCHS[sdk=iphonesimulator*]` after `pod install`

### DIFF
--- a/scripts/cocoapods/utils.rb
+++ b/scripts/cocoapods/utils.rb
@@ -65,7 +65,11 @@ class ReactNativePodsUtils
 
         projects.each do |project|
             project.build_configurations.each do |config|
-                config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"] = excluded_archs_default
+                if arm_value == 1 then
+                    config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"] = excluded_archs_default
+                else
+                    config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"] = "arm64 " + excluded_archs_default
+                end
             end
 
             project.save()


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

https://github.com/facebook/react-native/issues/31118

When running `pod install` on an M1 machine, the xcodeproj file is messed up and while it works for M1 machines, it doesn't on other non-M1 machines, and also doesn't work on ci, since usually they don't use M1s.

This change makes sure that it will not mess with the xcodeproj file.

some real world usage:
- https://github.com/artsy/eigen/blob/main/patches/react-native%2B0.66.5.patch#L150-L154
- https://github.com/artsy/eigen/blob/main/HACKS.md#react-native-patch-package-excluded_archs-part-only

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[IOS] [FIXED] - Not messing with `EXCLUDED_ARCHS[sdk=iphonesimulator*]` on M1 machines.

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

You can try to run `pod install` on an m1 and a non-m1, and see that the `EXCLUDED_ARCHS[sdk=iphonesimulator*]` don't change.
