### PR TITLE
Remove API_AVAILABLE(ios(10.0)) / API_AVAILABLE(ios(12.0))

### DIFF
--- a/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.h
+++ b/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.h
@@ -35,10 +35,8 @@ UIKeyboardType RCTUIKeyboardTypeFromKeyboardType(facebook::react::KeyboardType k
 
 UIReturnKeyType RCTUIReturnKeyTypeFromReturnKeyType(facebook::react::ReturnKeyType returnKeyType);
 
-API_AVAILABLE(ios(10.0))
 UITextContentType RCTUITextContentTypeFromString(std::string const &contentType);
 
-API_AVAILABLE(ios(12.0))
 UITextInputPasswordRules *RCTUITextInputPasswordRulesFromString(std::string const &passwordRules);
 
 NS_ASSUME_NONNULL_END

--- a/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.mm
+++ b/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.mm
@@ -177,7 +177,6 @@ UIReturnKeyType RCTUIReturnKeyTypeFromReturnKeyType(ReturnKeyType returnKeyType)
   }
 }
 
-API_AVAILABLE(ios(10.0))
 UITextContentType RCTUITextContentTypeFromString(std::string const &contentType)
 {
   static dispatch_once_t onceToken;
@@ -227,7 +226,6 @@ UITextContentType RCTUITextContentTypeFromString(std::string const &contentType)
   return contentTypeMap[RCTNSStringFromString(contentType)] ?: @"";
 }
 
-API_AVAILABLE(ios(12.0))
 UITextInputPasswordRules *RCTUITextInputPasswordRulesFromString(std::string const &passwordRules)
 {
   return [UITextInputPasswordRules passwordRulesWithDescriptor:RCTNSStringFromStringNilIfEmpty(passwordRules)];


### PR DESCRIPTION
Summary:
The minimum iOS version for react-native-macOS is 12.4 at this time.
These checks can be removed.
See: https://github.com/microsoft/react-native-macos/issues/1605

Changelog: [Internal]

Differential Revision: D42523417

