### PR TITLE
Add `borderCurve` style prop to ViewStyle types

### DIFF
--- a/Libraries/StyleSheet/StyleSheetTypes.d.ts
+++ b/Libraries/StyleSheet/StyleSheetTypes.d.ts
@@ -239,6 +239,7 @@ export interface ViewStyle extends FlexStyle, ShadowStyleIOS, TransformsStyle {
   borderBottomStartRadius?: number | undefined;
   borderBottomWidth?: number | undefined;
   borderColor?: ColorValue | undefined;
+  borderCurve?: 'circular' | 'continuous';
   borderEndColor?: ColorValue | undefined;
   borderEndEndRadius?: number | undefined;
   borderEndStartRadius?: number | undefined;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

This PR adds the missing style prop type `borderCurve` introduced in [8993ffc82e](https://github.com/facebook/react-native/commit/8993ffc82e8d4010d82dcb1d69c33a609bb2771a)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

[GENERAL] [FIXED] - Added the missing `borderCurve` style prop to `ViewStyle`


<!-- Help reviewers and the release process by writing your own changelog entry.



Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan

IPR

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
