### PR TITLE
Replace "facebook.proguard.annotations" with "facebook.yoga.annotations"

### DIFF
--- a/ReactAndroid/proguard-rules.pro
+++ b/ReactAndroid/proguard-rules.pro
@@ -60,3 +60,10 @@
 -dontwarn java.nio.file.*
 -dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
 -dontwarn okio.**
+
+# yoga
+-keep,allowobfuscation @interface com.facebook.yoga.annotations.DoNotStrip
+-keep @com.facebook.yoga.annotations.DoNotStrip class *
+-keepclassmembers class * {
+    @com.facebook.yoga.annotations.DoNotStrip *;
+}

--- a/ReactAndroid/src/main/java/com/facebook/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/BUCK
@@ -2,7 +2,7 @@ load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "rn_android_libra
 
 rn_android_library(
     name = "yoga",
-    srcs = glob(["yoga/*.java"]),
+    srcs = glob(["yoga/**/*.java"]),
     autoglob = False,
     language = "JAVA",
     visibility = ["PUBLIC"],

--- a/ReactAndroid/src/main/java/com/facebook/yoga/YogaLogLevel.java
+++ b/ReactAndroid/src/main/java/com/facebook/yoga/YogaLogLevel.java
@@ -9,7 +9,7 @@
 
 package com.facebook.yoga;
 
-import com.facebook.proguard.annotations.DoNotStrip;
+import com.facebook.yoga.annotations.DoNotStrip;
 
 @DoNotStrip
 public enum YogaLogLevel {

--- a/ReactAndroid/src/main/java/com/facebook/yoga/YogaLogger.java
+++ b/ReactAndroid/src/main/java/com/facebook/yoga/YogaLogger.java
@@ -7,7 +7,7 @@
 
 package com.facebook.yoga;
 
-import com.facebook.proguard.annotations.DoNotStrip;
+import com.facebook.yoga.annotations.DoNotStrip;
 
 /**
  * Interface for receiving logs from native layer. Use by setting YogaNode.setLogger(myLogger);

--- a/ReactAndroid/src/main/java/com/facebook/yoga/YogaNative.java
+++ b/ReactAndroid/src/main/java/com/facebook/yoga/YogaNative.java
@@ -7,7 +7,7 @@
 
 package com.facebook.yoga;
 
-import com.facebook.proguard.annotations.DoNotStrip;
+import com.facebook.yoga.annotations.DoNotStrip;
 import com.facebook.soloader.SoLoader;
 
 @DoNotStrip

--- a/ReactAndroid/src/main/java/com/facebook/yoga/YogaNodeJNIBase.java
+++ b/ReactAndroid/src/main/java/com/facebook/yoga/YogaNodeJNIBase.java
@@ -7,7 +7,7 @@
 
 package com.facebook.yoga;
 
-import com.facebook.proguard.annotations.DoNotStrip;
+import com.facebook.yoga.annotations.DoNotStrip;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nullable;

--- a/ReactAndroid/src/main/java/com/facebook/yoga/annotations/DoNotStrip.java
+++ b/ReactAndroid/src/main/java/com/facebook/yoga/annotations/DoNotStrip.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.yoga.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.CLASS;
+
+@Target({ ElementType.TYPE, ElementType.FIELD, ElementType.METHOD, ElementType.CONSTRUCTOR })
+@Retention(CLASS)
+public @interface DoNotStrip { }


### PR DESCRIPTION
Summary:
The Yoga JNI bindings use Reflection, so we need to let ProGuard know not to strip certain annotated fields.

This is done internally using a single copy of `com.facebook.proguard.annotations` from fbandroid (sometimes), which is then repackaged externally, and published as its own whole Yoga specific package. We never actually inform the stock Gradle project of the rules for the annotations though, so apps must add these manually.

This simplifies the setup, where Yoga has its own self-contained annotations/rules. The rules are exposed for Gradle/Buck dependencies, but RN and Litho both consume Yoga via dirsync + custom Gradle logic, so we need to duplicate the proguard rules to them instead of them being propagated automatically.

Changelog: [Internal]

Reviewed By: rshest

Differential Revision: D42406641

