### PR TITLE
Remove UIKit import from RCTDevLoadingView.h

### DIFF
--- a/React/CoreModules/RCTDevLoadingView.h
+++ b/React/CoreModules/RCTDevLoadingView.h
@@ -7,7 +7,6 @@
 
 #import <React/RCTBridgeModule.h>
 #import <React/RCTDevLoadingViewProtocol.h>
-#import <UIKit/UIKit.h>
 
 @interface RCTDevLoadingView : NSObject <RCTDevLoadingViewProtocol, RCTBridgeModule>
 @end


### PR DESCRIPTION
Summary:
See: https://github.com/microsoft/react-native-macos/issues/1604

Changelog:
[iOS][Fixed]: Remove UIKit import from RCTDevLoadingView.h

Differential Revision: D42529787

