### PR TITLE
fix(scripts): add logic for version scripts to account for local E2E test versioning

### DIFF
--- a/scripts/set-rn-version.js
+++ b/scripts/set-rn-version.js
@@ -38,7 +38,12 @@ let argv = yargs
 
 const buildType = argv.buildType;
 const version = argv.toVersion;
-validateBuildType(buildType);
+
+try {
+  validateBuildType(buildType);
+} catch (e) {
+  throw e;
+}
 
 let major,
   minor,
@@ -47,8 +52,7 @@ let major,
 try {
   ({major, minor, patch, prerelease} = parseVersion(version, buildType));
 } catch (e) {
-  echo(e.message);
-  exit(1);
+  throw e;
 }
 
 const tmpVersioningFolder = fs.mkdtempSync(

--- a/scripts/test-e2e-local.js
+++ b/scripts/test-e2e-local.js
@@ -174,7 +174,7 @@ if (argv.target === 'RNTester') {
   ).code;
 
   if (exitCode !== 0) {
-    console.error('Failed to set the RN version');
+    console.error(`Failed to set the RN version. Version ${releaseVersion} is not valid for ${buildType}`);
     process.exit(exitCode);
   }
 

--- a/scripts/test-e2e-local.js
+++ b/scripts/test-e2e-local.js
@@ -156,11 +156,9 @@ if (argv.target === 'RNTester') {
   // we need to add the unique timestamp to avoid npm/yarn to use some local caches
   const baseVersion = require('../package.json').version;
 
-  const branchName = getBranchName();
-  const buildType =
-    branchName.endsWith('-stable') && baseVersion !== '1000.0.0'
-      ? 'release'
-      : 'dry-run';
+  // in local testing, 1000.0.0 mean we are on main, every other case means we are
+  // working on a release version
+  const buildType = baseVersion !== '1000.0.0' ? 'release' : 'dry-run';
 
   const dateIdentifier = new Date()
     .toISOString()

--- a/scripts/test-e2e-local.js
+++ b/scripts/test-e2e-local.js
@@ -171,9 +171,14 @@ if (argv.target === 'RNTester') {
   const releaseVersion = `${baseVersion}-${dateIdentifier}`;
 
   // this is needed to generate the Android artifacts correctly
-  exec(
+  const exitCode = exec(
     `node scripts/set-rn-version.js --to-version ${releaseVersion} --build-type ${buildType}`,
   ).code;
+
+  if (exitCode !== 0) {
+    console.error('Failed to set the RN version');
+    process.exit(exitCode);
+  }
 
   // Generate native files for Android
   generateAndroidArtifacts(releaseVersion, tmpPublishingFolder);

--- a/scripts/test-e2e-local.js
+++ b/scripts/test-e2e-local.js
@@ -21,7 +21,6 @@ const yargs = require('yargs');
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
-const {getBranchName} = require('./scm-utils');
 
 const {
   launchAndroidEmulator,
@@ -174,7 +173,9 @@ if (argv.target === 'RNTester') {
   ).code;
 
   if (exitCode !== 0) {
-    console.error(`Failed to set the RN version. Version ${releaseVersion} is not valid for ${buildType}`);
+    console.error(
+      `Failed to set the RN version. Version ${releaseVersion} is not valid for ${buildType}`,
+    );
     process.exit(exitCode);
   }
 

--- a/scripts/version-utils.js
+++ b/scripts/version-utils.js
@@ -38,7 +38,11 @@ const VERSION_REGEX = /^v?((\d+)\.(\d+)\.(\d+)(?:-(.+))?)$/;
  *
  */
 function parseVersion(versionStr, buildType) {
-  validateBuildType(buildType);
+  try {
+    validateBuildType(buildType);
+  } catch (e) {
+    throw e;
+  }
 
   const match = extractMatchIfValid(versionStr);
   const [, version, major, minor, patch, prerelease] = match;
@@ -51,7 +55,11 @@ function parseVersion(versionStr, buildType) {
     prerelease,
   };
 
-  validateVersion(versionObject, buildType);
+  try {
+    validateVersion(versionObject, buildType);
+  } catch (e) {
+    throw e;
+  }
 
   return versionObject;
 }

--- a/scripts/version-utils.js
+++ b/scripts/version-utils.js
@@ -18,6 +18,7 @@ const VERSION_REGEX = /^v?((\d+)\.(\d+)\.(\d+)(?:-(.+))?)$/;
  * Some examples of valid versions are:
  * - stable: 0.68.1
  * - stable prerelease: 0.70.0-rc.0
+ * - e2e-test: X.Y.Z-20221116-2018
  * - nightly: 0.0.0-20221116-2018-0bc4547fc
  * - dryrun: 1000.0.0
  *
@@ -137,7 +138,8 @@ function isStablePrerelease(version) {
     version.patch === '0' &&
     version.prerelease != null &&
     (version.prerelease.startsWith('rc.') ||
-      version.prerelease.startsWith('rc-'))
+      version.prerelease.startsWith('rc-') ||
+      version.prerelease.match(/^(\d{8})-(\d{4})$/))
   );
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

While working on this PR https://github.com/facebook/react-native/pull/35786 I encountered a problem in testing locally. Basically, I was getting hit by a silent error caused by recent work https://github.com/facebook/react-native/pull/35296 that didn't account for the shape of E2E local script for the release, `0.71.0-20230116-1649`.

This scripts fixes both aspects: the error now gets thrown "better" and the logic accounts for the E2E shape.

---

This is the PR for 0.71-stable branch, the one for main can be found here: https://github.com/facebook/react-native/pull/35846


## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[INTERNAL] [FIXED] - add logic for version scripts to account for local E2E test versioning


## Test Plan

Tested in this PR; here's how it will error now:
<img width="983" alt="Screenshot 2023-01-16 at 16 59 07" src="https://user-images.githubusercontent.com/16104054/212732651-e2b6fcc1-57af-4cac-b0aa-f8f7a35c85d6.png">

and if you try running `yarn test-e2e-local -t RNTestProject -p Android` now it will go ahead and work 👍
