### PR TITLE
feat: add initialProps property to RCTAppDelegate

### DIFF
--- a/Libraries/AppDelegate/RCTAppDelegate.h
+++ b/Libraries/AppDelegate/RCTAppDelegate.h
@@ -55,6 +55,7 @@
 @property (nonatomic, strong) UIWindow *window;
 @property (nonatomic, strong) RCTBridge *bridge;
 @property (nonatomic, strong) NSString *moduleName;
+@property (nonatomic, strong) NSDictionary *initialProps;
 
 /**
  * It creates a `RCTBridge` using a delegate and some launch options.

--- a/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -50,6 +50,7 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
                                                                contextContainer:_contextContainer];
   self.bridge.surfacePresenter = self.bridgeAdapter.surfacePresenter;
 #endif
+
   NSDictionary *initProps = [self prepareInitialProps];
   UIView *rootView = [self createRootViewWithBridge:self.bridge moduleName:self.moduleName initProps:initProps];
 

--- a/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -50,10 +50,8 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
                                                                contextContainer:_contextContainer];
   self.bridge.surfacePresenter = self.bridgeAdapter.surfacePresenter;
 #endif
-  if(!self.initialProps) {
-    self.initialProps = [self prepareInitialProps];
-  }
-  UIView *rootView = [self createRootViewWithBridge:self.bridge moduleName:self.moduleName initProps:self.initialProps];
+  NSDictionary *initProps = [self prepareInitialProps];
+  UIView *rootView = [self createRootViewWithBridge:self.bridge moduleName:self.moduleName initProps:initProps];
 
   if (@available(iOS 13.0, *)) {
     rootView.backgroundColor = [UIColor systemBackgroundColor];
@@ -85,7 +83,7 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
 
 - (NSDictionary *)prepareInitialProps
 {
-  NSMutableDictionary *initProps = [NSMutableDictionary new];
+  NSMutableDictionary *initProps = self.initialProps ? [self.initialProps mutableCopy] : [NSMutableDictionary new];
 
 #ifdef RCT_NEW_ARCH_ENABLED
   initProps[kRNConcurrentRoot] = @([self concurrentRootEnabled]);

--- a/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -50,9 +50,10 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
                                                                contextContainer:_contextContainer];
   self.bridge.surfacePresenter = self.bridgeAdapter.surfacePresenter;
 #endif
-
-  NSDictionary *initProps = [self prepareInitialProps];
-  UIView *rootView = [self createRootViewWithBridge:self.bridge moduleName:self.moduleName initProps:initProps];
+  if(!self.initialProps) {
+    self.initialProps = [self prepareInitialProps];
+  }
+  UIView *rootView = [self createRootViewWithBridge:self.bridge moduleName:self.moduleName initProps:self.initialProps];
 
   if (@available(iOS 13.0, *)) {
     rootView.backgroundColor = [UIColor systemBackgroundColor];

--- a/template/ios/HelloWorld/AppDelegate.mm
+++ b/template/ios/HelloWorld/AppDelegate.mm
@@ -7,6 +7,9 @@
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
   self.moduleName = @"HelloWorld";
+  // You can add your custom initial props in the dictionary below.
+  // They will be passed down to the ViewController used by React Native.
+  self.initialProps = @{}; 
   return [super application:application didFinishLaunchingWithOptions:launchOptions];
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Hi there, 

While upgrading to 0.71 we realised the RCTAppDelegate doesn't offer a way to set custom `initProps` that would depend on `launchOptions`. 

This PR adds an `initialProps` property to the RCTAppDelegate. This would let us set this property based on `launchOptions` in our implementation of `didFinishLaunchingWithOptions` before calling `[super didFinishLaunchingWithOptions]`

Thanks !

## Changelog

[IOS] [ADDED] - Add `initialProps` property to `RCTAppDelegate`

