### PR TITLE
ci: Add `unsupported-version` label action

### DIFF
--- a/.github/workflows/on-issue-labeled.yml
+++ b/.github/workflows/on-issue-labeled.yml
@@ -163,3 +163,22 @@ jobs:
               repo: context.repo.repo,
               labels: ['Needs: Author Feedback']
             })
+  unsupported-version:
+    runs-on: ubuntu-latest
+    if: "${{ contains(github.event.label.name, 'Type: Unsupported Version') }}"
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `It looks like your issue or the example you provided uses an [unsupported version of React Native](https://github.com/reactwg/react-native-releases/blob/main/README.md#releases-support-policy). Due to the amount of issues we receive, we're currently accepting only new issues against one of the supported version. Please open your issue on [StackOverflow](https://stackoverflow.com/questions/tagged/react-native) to get further community support.`,
+            })
+            await github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['Needs: Author Feedback']
+            })

--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -17,3 +17,18 @@ jobs:
           stale-pr-message: 'This PR is stale because it has been open 180 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
           close-issue-message: 'This issue was closed because it has been stalled for 7 days with no activity.'
           close-pr-message: 'This PR was closed because it has been stalled for 7 days with no activity.'
+  stale-versions:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          any-of-labels: 'Needs: Author Feedback'
+          days-before-stale: 24
+          stale-issue-message: 'This issue is stale because it has been open 24 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
+          stale-pr-message: 'This PR is stale because it has been open 24 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
+          close-issue-message: 'This issue was closed because it has been stalled for 7 days with no activity.'
+          close-pr-message: 'This PR was closed because it has been stalled for 7 days with no activity.'


### PR DESCRIPTION
Summary:
Users will provide issues or examples that use unsupported versions of React Native. Provide label to track and ask them to update example / issue to currently mainted version.

Changelog:

[Internal] - Support 'unsupported version' tag comment

Differential Revision: D42531703


![image](https://user-images.githubusercontent.com/49578/212873816-aa9523c2-5bab-48fc-8525-899c4dd6c44d.png)