### PR TITLE
Remove unneeded deps from OSS Yoga Buck Build

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/BUCK
@@ -7,8 +7,6 @@ rn_android_library(
     language = "JAVA",
     visibility = ["PUBLIC"],
     deps = [
-        react_native_dep("libraries/fbjni:java"),
-        react_native_dep("java/com/facebook/proguard/annotations:annotations"),
         react_native_dep("libraries/soloader/java/com/facebook/soloader:soloader"),
         react_native_dep("third-party/java/infer-annotations:infer-annotations"),
         react_native_dep("third-party/java/jsr-305:jsr-305"),


### PR DESCRIPTION
Summary:
Yoga moved away from fbjni, to use vanilla JNI. This removes fbjni, and proguard annotations (see last stack) as Yoga dependencies from the OSS RN Buck build.

Changelog: [Internal]

Differential Revision: D42538671

