### PR TITLE
build: remove deprecated File.exists() method from Hermes podspec.

### DIFF
--- a/sdks/hermes-engine/hermes-utils.rb
+++ b/sdks/hermes-engine/hermes-utils.rb
@@ -36,7 +36,7 @@ def compute_hermes_source(build_from_source, hermestag_file, git, version, build
     if ENV.has_key?('HERMES_ENGINE_TARBALL_PATH')
         use_tarball(source)
     elsif build_from_source
-        if File.exists?(hermestag_file)
+        if File.exist?(hermestag_file)
             build_from_tagfile(source, git, hermestag_file)
         else
             build_hermes_from_source(source, git)


### PR DESCRIPTION
## Summary

Remove deprecated `File.exists` method which was removed in later Ruby versions. Spotted during a brew upgrade [here](https://github.com/software-mansion/react-native-reanimated/pull/3919).

https://rubyapi.org/2.5/o/file#method-c-exist-3F

```
Fetching podspec for `hermes-engine` from `../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec`
[!] Failed to load 'hermes-engine' podspec: 
[!] Invalid `hermes-engine.podspec` file: undefined method `exists?' for File:Class.
 #  from [..]/node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec:46
 ```

## Changelog

[IOS] [FIXED] - Migrated `File.exists` from Hermes podspec for non-deprecated `File.exist`.

## Test Plan

Valid CI via CircleCI.
