### PR TITLE
Fix crash by conditional value of aspectRatio style value (#35858)

### DIFF
--- a/Libraries/StyleSheet/__tests__/__snapshots__/processAspectRatio-test.js.snap
+++ b/Libraries/StyleSheet/__tests__/__snapshots__/processAspectRatio-test.js.snap
@@ -1,7 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`processAspectRatio should not accept invalid formats 1`] = `"aspectRatio must either be a number, a ratio or \`auto\`. You passed: 0a"`;
+exports[`processAspectRatio should not accept invalid formats 1`] = `"aspectRatio must either be a number, a ratio string or \`auto\`. You passed: 0a"`;
 
-exports[`processAspectRatio should not accept invalid formats 2`] = `"aspectRatio must either be a number, a ratio or \`auto\`. You passed: 1 / 1 1"`;
+exports[`processAspectRatio should not accept invalid formats 2`] = `"aspectRatio must either be a number, a ratio string or \`auto\`. You passed: 1 / 1 1"`;
 
-exports[`processAspectRatio should not accept invalid formats 3`] = `"aspectRatio must either be a number, a ratio or \`auto\`. You passed: auto 1/1"`;
+exports[`processAspectRatio should not accept invalid formats 3`] = `"aspectRatio must either be a number, a ratio string or \`auto\`. You passed: auto 1/1"`;
+
+exports[`processAspectRatio should not accept non string truthy types 1`] = `"aspectRatio must either be a number, a ratio string or \`auto\`. You passed: function () {}"`;
+
+exports[`processAspectRatio should not accept non string truthy types 2`] = `"aspectRatio must either be a number, a ratio string or \`auto\`. You passed: 1,2,3"`;
+
+exports[`processAspectRatio should not accept non string truthy types 3`] = `"aspectRatio must either be a number, a ratio string or \`auto\`. You passed: [object Object]"`;

--- a/Libraries/StyleSheet/__tests__/processAspectRatio-test.js
+++ b/Libraries/StyleSheet/__tests__/processAspectRatio-test.js
@@ -49,7 +49,7 @@ describe('processAspectRatio', () => {
   });
 
   it('should not accept non number | string type', () => {
-    const invalidThings = [undefined, null];
+    const invalidThings = [undefined, null, () => {}, [1, 2, 3]];
     invalidThings.forEach(thing => {
       expect(processAspectRatio(thing)).toBe(undefined);
     });

--- a/Libraries/StyleSheet/__tests__/processAspectRatio-test.js
+++ b/Libraries/StyleSheet/__tests__/processAspectRatio-test.js
@@ -48,10 +48,17 @@ describe('processAspectRatio', () => {
     expect(() => processAspectRatio('auto 1/1')).toThrowErrorMatchingSnapshot();
   });
 
-  it('should not accept non number | string type', () => {
-    const invalidThings = [undefined, null, () => {}, [1, 2, 3]];
+  it('should not accept non string falsy types', () => {
+    const invalidThings = [undefined, null, false];
     invalidThings.forEach(thing => {
       expect(processAspectRatio(thing)).toBe(undefined);
+    });
+  });
+
+  it('should not accept non string truthy types', () => {
+    const invalidThings = [() => {}, [1, 2, 3], {}];
+    invalidThings.forEach(thing => {
+      expect(() => processAspectRatio(thing)).toThrowErrorMatchingSnapshot();
     });
   });
 });

--- a/Libraries/StyleSheet/__tests__/processAspectRatio-test.js
+++ b/Libraries/StyleSheet/__tests__/processAspectRatio-test.js
@@ -47,4 +47,11 @@ describe('processAspectRatio', () => {
     expect(() => processAspectRatio('1 / 1 1')).toThrowErrorMatchingSnapshot();
     expect(() => processAspectRatio('auto 1/1')).toThrowErrorMatchingSnapshot();
   });
+
+  it('should not accept non number | string type', () => {
+    const invalidThings = [undefined, null];
+    invalidThings.forEach(thing => {
+      expect(processAspectRatio(thing)).toBe(undefined);
+    });
+  });
 });

--- a/Libraries/StyleSheet/__tests__/processAspectRatio-test.js
+++ b/Libraries/StyleSheet/__tests__/processAspectRatio-test.js
@@ -48,7 +48,7 @@ describe('processAspectRatio', () => {
     expect(() => processAspectRatio('auto 1/1')).toThrowErrorMatchingSnapshot();
   });
 
-  it('should not accept non string falsy types', () => {
+  it('should ignone non string falsy types', () => {
     const invalidThings = [undefined, null, false];
     invalidThings.forEach(thing => {
       expect(processAspectRatio(thing)).toBe(undefined);

--- a/Libraries/StyleSheet/__tests__/processAspectRatio-test.js
+++ b/Libraries/StyleSheet/__tests__/processAspectRatio-test.js
@@ -48,7 +48,7 @@ describe('processAspectRatio', () => {
     expect(() => processAspectRatio('auto 1/1')).toThrowErrorMatchingSnapshot();
   });
 
-  it('should ignone non string falsy types', () => {
+  it('should ignore non string falsy types', () => {
     const invalidThings = [undefined, null, false];
     invalidThings.forEach(thing => {
       expect(processAspectRatio(thing)).toBe(undefined);

--- a/Libraries/StyleSheet/processAspectRatio.js
+++ b/Libraries/StyleSheet/processAspectRatio.js
@@ -12,9 +12,12 @@
 
 const invariant = require('invariant');
 
-function processAspectRatio(aspectRatio: number | string): ?number {
+function processAspectRatio(aspectRatio?: number | string): ?number {
   if (typeof aspectRatio === 'number') {
     return aspectRatio;
+  }
+  if (typeof aspectRatio !== 'string') {
+    return;
   }
 
   const matches = aspectRatio.split('/').map(s => s.trim());

--- a/Libraries/StyleSheet/processAspectRatio.js
+++ b/Libraries/StyleSheet/processAspectRatio.js
@@ -16,7 +16,7 @@ function processAspectRatio(aspectRatio?: number | string): ?number {
   if (typeof aspectRatio === 'number') {
     return aspectRatio;
   }
-  if (typeof aspectRatio !== 'string') {
+  if (typeof aspectRatio !== 'string' && !aspectRatio) {
     return;
   }
 

--- a/Libraries/StyleSheet/processAspectRatio.js
+++ b/Libraries/StyleSheet/processAspectRatio.js
@@ -16,7 +16,14 @@ function processAspectRatio(aspectRatio?: number | string): ?number {
   if (typeof aspectRatio === 'number') {
     return aspectRatio;
   }
-  if (typeof aspectRatio !== 'string' && !aspectRatio) {
+  if (typeof aspectRatio !== 'string') {
+    if (__DEV__) {
+      invariant(
+        !aspectRatio,
+        'aspectRatio must either be a number, a ratio string or `auto`. You passed: %s',
+        aspectRatio,
+      );
+    }
     return;
   }
 
@@ -37,7 +44,7 @@ function processAspectRatio(aspectRatio?: number | string): ?number {
   if (__DEV__) {
     invariant(
       !hasNonNumericValues && (matches.length === 1 || matches.length === 2),
-      'aspectRatio must either be a number, a ratio or `auto`. You passed: %s',
+      'aspectRatio must either be a number, a ratio string or `auto`. You passed: %s',
       aspectRatio,
     );
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

fix #35858 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

1. Handle not `number` | `string` value passed to `aspectRatio`
2. Add some tests

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[GENERAL] [FIXED] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

## Sample
[Sample Repository](https://github.com/mym0404/rn-aspect-ratio-crash-sample)

Video

![1](https://user-images.githubusercontent.com/33388801/212956921-94b21cda-d841-4588-a05a-d604a82e204c.gif)

