### PR TITLE
fix: ReactRootView checkForKeyboardEvents to check if rootInsets are set

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -923,38 +923,40 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
     private void checkForKeyboardEvents() {
       getRootView().getWindowVisibleDisplayFrame(mVisibleViewArea);
       WindowInsets rootInsets = getRootView().getRootWindowInsets();
-      WindowInsetsCompat compatRootInsets = WindowInsetsCompat.toWindowInsetsCompat(rootInsets);
+      if (rootInsets != null) {
+        WindowInsetsCompat compatRootInsets = WindowInsetsCompat.toWindowInsetsCompat(rootInsets);
 
-      boolean keyboardIsVisible = compatRootInsets.isVisible(WindowInsetsCompat.Type.ime());
-      if (keyboardIsVisible != mKeyboardIsVisible) {
-        mKeyboardIsVisible = keyboardIsVisible;
+        boolean keyboardIsVisible = compatRootInsets.isVisible(WindowInsetsCompat.Type.ime());
+        if (keyboardIsVisible != mKeyboardIsVisible) {
+          mKeyboardIsVisible = keyboardIsVisible;
 
-        if (keyboardIsVisible) {
-          Insets imeInsets = compatRootInsets.getInsets(WindowInsetsCompat.Type.ime());
-          Insets barInsets = compatRootInsets.getInsets(WindowInsetsCompat.Type.systemBars());
-          int height = imeInsets.bottom - barInsets.bottom;
+          if (keyboardIsVisible) {
+            Insets imeInsets = compatRootInsets.getInsets(WindowInsetsCompat.Type.ime());
+            Insets barInsets = compatRootInsets.getInsets(WindowInsetsCompat.Type.systemBars());
+            int height = imeInsets.bottom - barInsets.bottom;
 
-          int softInputMode = ((Activity) getContext()).getWindow().getAttributes().softInputMode;
-          int screenY =
-              softInputMode == WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING
-                  ? mVisibleViewArea.bottom - height
-                  : mVisibleViewArea.bottom;
+            int softInputMode = ((Activity) getContext()).getWindow().getAttributes().softInputMode;
+            int screenY =
+                    softInputMode == WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING
+                            ? mVisibleViewArea.bottom - height
+                            : mVisibleViewArea.bottom;
 
-          sendEvent(
-              "keyboardDidShow",
-              createKeyboardEventPayload(
-                  PixelUtil.toDIPFromPixel(screenY),
-                  PixelUtil.toDIPFromPixel(mVisibleViewArea.left),
-                  PixelUtil.toDIPFromPixel(mVisibleViewArea.width()),
-                  PixelUtil.toDIPFromPixel(height)));
-        } else {
-          sendEvent(
-              "keyboardDidHide",
-              createKeyboardEventPayload(
-                  PixelUtil.toDIPFromPixel(mLastHeight),
-                  0,
-                  PixelUtil.toDIPFromPixel(mVisibleViewArea.width()),
-                  0));
+            sendEvent(
+                    "keyboardDidShow",
+                    createKeyboardEventPayload(
+                            PixelUtil.toDIPFromPixel(screenY),
+                            PixelUtil.toDIPFromPixel(mVisibleViewArea.left),
+                            PixelUtil.toDIPFromPixel(mVisibleViewArea.width()),
+                            PixelUtil.toDIPFromPixel(height)));
+          } else {
+            sendEvent(
+                    "keyboardDidHide",
+                    createKeyboardEventPayload(
+                            PixelUtil.toDIPFromPixel(mLastHeight),
+                            0,
+                            PixelUtil.toDIPFromPixel(mVisibleViewArea.width()),
+                            0));
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary

react-native-navigation allows to register React components to be included in the navigation top bar as buttons, the way this work is by using the AppRegistry. When the ViewTreeObserver executes the `CustomGlobalLayout` we are checking for the RootWindowInsets in the `checkKeyboardEvents` which in the case for the top bar component it returns null and the **WindowInsetsCompat.toWindowInsetsCompat** function throws if the insets are null causing the app to crash.

Interestingly in the function `checkForKeyboardEventsLegacy` the null value is being checked, so I guess it was overlooked in the newer function.

## Changelog

[ANDROID] [FIXED] - Fix ReactRootView crash when root view window insets are null

## Test Plan

The following videos show how the app crashes as soon as we attempt to pop a screen that contains a react component as a button in the navigation top bar and how it correctly pops to the previous screen after applying the fix

| Crash | Fix |
| -- | -- |
| https://user-images.githubusercontent.com/6757047/213116971-fe693989-f978-438c-b8f9-fc56f2a477c8.mp4 | https://user-images.githubusercontent.com/6757047/213118352-fe258f28-07aa-4d17-98d2-97136464ffd5.mp4 |
