### PR TITLE
Fix for resources not correctly bundlded on release appbundles

### DIFF
--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
@@ -61,9 +61,16 @@ class ReactPlugin : Plugin<Project> {
       // This registers the $buildDir/generated/res/react/<variant> folder as a
       // res folder to be consumed with the old AGP Apis which are not broken.
       project.extensions.getByType(AppExtension::class.java).apply {
-        this.applicationVariants.all {
-          it.registerGeneratedResFolders(
-              project.layout.buildDirectory.files("generated/res/react/${it.name}"))
+        this.applicationVariants.all { variant ->
+          val isDebuggableVariant =
+              extension.debuggableVariants.get().any { it.equals(variant.name, ignoreCase = true) }
+          val targetName = variant.name.replaceFirstChar { it.uppercase() }
+          val bundleTaskName = "createBundle${targetName}JsAndAssets"
+          if (!isDebuggableVariant) {
+            variant.registerGeneratedResFolders(
+                project.layout.buildDirectory.files("generated/res/react/${variant.name}"))
+            variant.mergeResourcesProvider.get().dependsOn(bundleTaskName)
+          }
         }
       }
       configureCodegen(project, extension, isLibrary = false)


### PR DESCRIPTION
Summary:
When downgrading from AGP 7.4 to 7.3 we were forced to resort to older APIs
to bundle resources. It seems like we haven't properly wired the task to make sure
resources generated by Metro are correctly accounted before the generation of
release app bundles/apks.

This fixes it. This fix can also be removed once we are on AGP 7.4
Fixes #35865

Changelog:
[Android] [Fixed] - Fix for resources not correctly bundlded on release appbundles

Differential Revision: D42573450

