### PR TITLE
Fix TurboModuleRegistry TS type

### DIFF
--- a/Libraries/TurboModule/TurboModuleRegistry.d.ts
+++ b/Libraries/TurboModule/TurboModuleRegistry.d.ts
@@ -9,7 +9,5 @@
 
 import {TurboModule} from './RCTExport';
 
-export const TurboModuleRegistry: {
-  get<T extends TurboModule>(name: string): T | null;
-  getEnforcing<T extends TurboModule>(name: string): T;
-};
+export function get<T extends TurboModule>(name: string): T | null;
+export function getEnforcing<T extends TurboModule>(name: string): T;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -136,7 +136,7 @@ export * from '../Libraries/StyleSheet/StyleSheetTypes';
 export * from '../Libraries/StyleSheet/processColor';
 export * from '../Libraries/Text/Text';
 export * from '../Libraries/TurboModule/RCTExport';
-export * from '../Libraries/TurboModule/TurboModuleRegistry';
+export * as TurboModuleRegistry from '../Libraries/TurboModule/TurboModuleRegistry';
 export * from '../Libraries/Types/CoreEventTypes';
 export * from '../Libraries/Utilities/Appearance';
 export * from '../Libraries/Utilities/BackHandler';


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

TurboModuleRegistry export functions and not a TurboModuleRegistry object. See https://github.com/facebook/react-native/blob/main/Libraries/TurboModule/TurboModuleRegistry.js#L37

## Changelog

[GENERAL] [FIXED] - Fix TurboModuleRegistry TS type

## Test Plan

Tested that the import doesn't generate a type error when used correctly.

```ts
import * as TurboModuleRegistry from 'react-native/Libraries/TurboModule/TurboModuleRegistry';

export default TurboModuleRegistry.get<Spec>('RNCSafeAreaContext');
```
