### PR TITLE
Getting rid of Toast in Dev Loading View post Native Module is released

### DIFF
--- a/Libraries/Utilities/LoadingView.android.js
+++ b/Libraries/Utilities/LoadingView.android.js
@@ -8,13 +8,9 @@
  * @flow strict-local
  */
 
-import ToastAndroid from '../Components/ToastAndroid/ToastAndroid';
 import processColor from '../StyleSheet/processColor';
 import Appearance from './Appearance';
 import NativeDevLoadingView from './NativeDevLoadingView';
-
-const TOAST_SHORT_DELAY = 2000;
-let isVisible = false;
 
 module.exports = {
   showMessage(message: string, type: 'load' | 'refresh') {
@@ -40,12 +36,6 @@ module.exports = {
         typeof textColor === 'number' ? textColor : null,
         typeof backgroundColor === 'number' ? backgroundColor : null,
       );
-    } else if (!isVisible) {
-      ToastAndroid.show(message, ToastAndroid.SHORT);
-      isVisible = true;
-      setTimeout(() => {
-        isVisible = false;
-      }, TOAST_SHORT_DELAY);
     }
   },
   hide() {


### PR DESCRIPTION
Summary:
Changelog:
[Android][Removed] - For supporting Dev Loading View across multiple platforms, changed the Loading View of Android to rely on the native implementation instead of Toast. Getting rid of the JS changes relying on Toast for Dev Loading View now that the native module is released.

Differential Revision: D42599220

