### PR TITLE
[Android]fix memory leak in Android

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java
@@ -667,6 +667,15 @@ public class NativeViewHierarchyManager {
   }
 
   /**
+   * Return root view num
+   *
+   * @return The num of root view
+   */
+  public synchronized int getRootViewNum() {
+    return mRootTags.size();
+  }
+
+  /**
    * Returns true on success, false on failure. If successful, after calling, output buffer will be
    * {x, y, width, height}.
    */

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIImplementation.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIImplementation.java
@@ -170,6 +170,15 @@ public class UIImplementation {
     mOperationsQueue.enqueueRemoveRootView(rootViewTag);
   }
 
+  /**
+   * Return root view num
+   *
+   * @return The num of root view
+   */
+  public int getRootViewNum() {
+    return mOperationsQueue.getNativeViewHierarchyManager().getRootViewNum();
+  }
+
   /** Unregisters a root node with a given tag from the shadow node registry */
   public void removeRootShadowNode(int rootViewTag) {
     synchronized (uiImplementationThreadLock) {

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIImplementation.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIImplementation.java
@@ -175,7 +175,7 @@ public class UIImplementation {
    *
    * @return The num of root view
    */
-  public int getRootViewNum() {
+  private int getRootViewNum() {
     return mOperationsQueue.getNativeViewHierarchyManager().getRootViewNum();
   }
 
@@ -608,6 +608,12 @@ public class UIImplementation {
 
   /** Invoked at the end of the transaction to commit any updates to the node hierarchy. */
   public void dispatchViewUpdates(int batchId) {
+    if (getRootViewNum() <= 0) {
+      // If there are no RootViews registered, there will be no View updates to dispatch.
+      // This is a hack to prevent this from being called when Fabric is used everywhere.
+      // This should no longer be necessary in Bridgeless Mode.
+      return;
+    }
     SystraceMessage.beginSection(
             Systrace.TRACE_TAG_REACT_JAVA_BRIDGE, "UIImplementation.dispatchViewUpdates")
         .arg("batchId", batchId)

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
@@ -765,12 +765,7 @@ public class UIManagerModule extends ReactContextBaseJavaModule
       listener.willDispatchViewUpdates(this);
     }
     try {
-      // If there are no RootViews registered, there will be no View updates to dispatch.
-      // This is a hack to prevent this from being called when Fabric is used everywhere.
-      // This should no longer be necessary in Bridgeless Mode.
-      if (mUIImplementation.getRootViewNum() > 0) {
-        mUIImplementation.dispatchViewUpdates(batchId);
-      }
+      mUIImplementation.dispatchViewUpdates(batchId);
     } finally {
       Systrace.endSection(Systrace.TRACE_TAG_REACT_JAVA_BRIDGE);
     }

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
@@ -113,7 +113,6 @@ public class UIManagerModule extends ReactContextBaseJavaModule
   private volatile int mViewManagerConstantsCacheSize;
 
   private int mBatchId = 0;
-  private int mNumRootViews = 0;
 
   public UIManagerModule(
       ReactApplicationContext reactContext,
@@ -403,7 +402,6 @@ public class UIManagerModule extends ReactContextBaseJavaModule
             -1);
 
     mUIImplementation.registerRootView(rootView, tag, themedRootContext);
-    mNumRootViews++;
     Systrace.endSection(Systrace.TRACE_TAG_REACT_JAVA_BRIDGE);
     return tag;
   }
@@ -427,7 +425,6 @@ public class UIManagerModule extends ReactContextBaseJavaModule
   @ReactMethod
   public void removeRootView(int rootViewTag) {
     mUIImplementation.removeRootView(rootViewTag);
-    mNumRootViews--;
   }
 
   public void updateNodeSize(int nodeViewTag, int newWidth, int newHeight) {
@@ -771,7 +768,7 @@ public class UIManagerModule extends ReactContextBaseJavaModule
       // If there are no RootViews registered, there will be no View updates to dispatch.
       // This is a hack to prevent this from being called when Fabric is used everywhere.
       // This should no longer be necessary in Bridgeless Mode.
-      if (mNumRootViews > 0) {
+      if (mUIImplementation.getRootViewNum() > 0) {
         mUIImplementation.dispatchViewUpdates(batchId);
       }
     } finally {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
fix memory leak in Android
The issues link: #35890 
Explain Defect
since 0.65, when call dispatchViewUpdates, we add judge mNumRootViews>0 
<img width="531" alt="image" src="https://user-images.githubusercontent.com/20136688/213394240-4c284df4-27de-494e-8eed-8e5f30796cce.png">
When we call removeRootView, it will decrease the mNumRootViews before dispatchViewUpdates
<img width="430" alt="image" src="https://user-images.githubusercontent.com/20136688/213394611-d47ab49f-fc7a-4dd1-9836-fe667d655660.png">
So when we remove the last rootview, it will skip call dispatchViewUpdates and do not remove it, it will cause memory leak
Explain Fix
We should use the original root view num to judge, we can get it from NativeViewHierarchyManager
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog
[ANDROID] [FIXED] - fix memory leak in Android
<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
