### PR TITLE
setUpPerformance not to redirect to WebPerformance before the API is public

### DIFF
--- a/Libraries/Core/setUpPerformance.js
+++ b/Libraries/Core/setUpPerformance.js
@@ -8,8 +8,17 @@
  * @format
  */
 
-import Performance from '../WebPerformance/Performance';
-
 if (!global.performance) {
-  global.performance = new Performance();
+  global.performance = ({}: {now?: () => number});
+}
+
+/**
+ * Returns a double, measured in milliseconds.
+ * https://developer.mozilla.org/en-US/docs/Web/API/Performance/now
+ */
+if (typeof global.performance.now !== 'function') {
+  global.performance.now = function () {
+    const performanceNow = global.nativePerformanceNow || Date.now;
+    return performanceNow();
+  };
 }

--- a/Libraries/Core/setUpWebPerformance.js
+++ b/Libraries/Core/setUpWebPerformance.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ * @format
+ */
+
+import Performance from '../WebPerformance/Performance';
+
+// TODO: Replace setUpPerformance with this once the WebPerformance API is stable (T143070419)
+export default function setUpPerformance() {
+  global.performance = new Performance();
+}


### PR DESCRIPTION
Summary:
[Changelog][Internal]
Partially reverts the change that was redirecting `performance` instance to the new implementation in WebPerformance, until the actual implementation becomes public and native modules are included by default.

Differential Revision: D42607379

