### PR TITLE
fix(deps): expose yarn peer dependencies

### DIFF
--- a/packages/react-native-codegen/package.json
+++ b/packages/react-native-codegen/package.json
@@ -41,5 +41,8 @@
     "mkdirp": "^0.5.1",
     "prettier": "^2.4.1",
     "rimraf": "^3.0.2"
+  },
+  "peerDependencies": {
+    "@babel/preset-env": "^7.1.6"
   }
 }


### PR DESCRIPTION
## Summary

Fixes #35913

## CHANGELOG

[General] [Fixed] - Peer dependency warnings for Yarn 3

## Test Plan

```bash
yarn set version berry
yarn add react-native-changelog
```