### PR TITLE
Provide timestamp as argument to rAF callbacks when running Jest tests

### DIFF
--- a/jest/setup.js
+++ b/jest/setup.js
@@ -25,7 +25,7 @@ global.regeneratorRuntime = jest.requireActual('regenerator-runtime/runtime');
 global.window = global;
 
 global.requestAnimationFrame = function (callback) {
-  return setTimeout(callback, 0);
+  return setTimeout(() => callback(performance.now()), 0);
 };
 global.cancelAnimationFrame = function (id) {
   clearTimeout(id);

--- a/jest/setup.js
+++ b/jest/setup.js
@@ -25,7 +25,7 @@ global.regeneratorRuntime = jest.requireActual('regenerator-runtime/runtime');
 global.window = global;
 
 global.requestAnimationFrame = function (callback) {
-  return setTimeout(() => callback(performance.now()), 0);
+  return setTimeout(() => callback(jest.now()), 0);
 };
 global.cancelAnimationFrame = function (id) {
   clearTimeout(id);


### PR DESCRIPTION
## Summary

This change aligns requestAnimationFrame implementation used in Jest environment with web standard, and with the implementation that runs in the application environment. 

As per specification https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame#parameters – requestAnimationFrame callback gets a single parameter, which represents the current frame timestamp. The current polyfill maps requestAnimationFrame directly to setTimeout which makes the callback execute without any parameters.

## Changelog

[General] [Fixed] - Jest mocked requestAnimationFrame callbacks now receive a timestamp parameter

## Test Plan

1. execute jest test suite to make sure nothing breaks
2. add the below code to one of the tests:
```
jest.useFakeTimers();
requestAnimationFrame((timestamp) => console.log("rAF", timestamp));
jest.runOnlyPendingTimers();
jest.useRealTimers();
```
this code will print `undefined` before and numer `0` representing the mocked frame time after this change.