### PR TITLE
Update getDevServer.js

### DIFF
--- a/Libraries/Core/Devtools/getDevServer.js
+++ b/Libraries/Core/Devtools/getDevServer.js
@@ -28,7 +28,7 @@ type DevServerInfo = {
 function getDevServer(): DevServerInfo {
   if (_cachedDevServerURL === undefined) {
     const scriptUrl = NativeSourceCode.getConstants().scriptURL;
-    const match = scriptUrl.match(/^https?:\/\/.*?\//);
+    const match = scriptUrl?.match(/^https?:\/\/.*?\//);
     _cachedDevServerURL = match ? match[0] : null;
     _cachedFullBundleURL = match ? scriptUrl : null;
   }


### PR DESCRIPTION
## Summary

Unable to create simple automated tests with jest using expo 47. Here is an screenshot below that best exemplifies the case:

![Screenshot 2023-01-21 105113](https://user-images.githubusercontent.com/499567/213869954-0227bcec-9015-449f-9869-fd4667454b52.png)

## Changelog

[GENERAL] [FIXED] - Message

## Test Plan

Just follow official expo documentation here: https://docs.expo.dev/guides/testing-with-jest/