### PR TITLE
remove duplicate role grid from RCTViewManager

### DIFF
--- a/React/Views/RCTViewManager.m
+++ b/React/Views/RCTViewManager.m
@@ -64,7 +64,6 @@ RCT_MULTI_ENUM_CONVERTER(
       @"tablist" : @(UIAccessibilityTraitNone),
       @"timer" : @(UIAccessibilityTraitNone),
       @"toolbar" : @(UIAccessibilityTraitNone),
-      @"grid" : @(UIAccessibilityTraitNone),
       @"pager" : @(UIAccessibilityTraitNone),
       @"scrollview" : @(UIAccessibilityTraitNone),
       @"horizontalscrollview" : @(UIAccessibilityTraitNone),
@@ -74,6 +73,7 @@ RCT_MULTI_ENUM_CONVERTER(
       @"slidingdrawer" : @(UIAccessibilityTraitNone),
       @"iconmenu" : @(UIAccessibilityTraitNone),
       @"list" : @(UIAccessibilityTraitNone),
+      @"grid" : @(UIAccessibilityTraitNone),
     }),
     UIAccessibilityTraitNone,
     unsignedLongLongValue)

--- a/React/Views/RCTViewManager.m
+++ b/React/Views/RCTViewManager.m
@@ -74,7 +74,6 @@ RCT_MULTI_ENUM_CONVERTER(
       @"slidingdrawer" : @(UIAccessibilityTraitNone),
       @"iconmenu" : @(UIAccessibilityTraitNone),
       @"list" : @(UIAccessibilityTraitNone),
-      @"grid" : @(UIAccessibilityTraitNone),
     }),
     UIAccessibilityTraitNone,
     unsignedLongLongValue)


### PR DESCRIPTION
## Summary

Fix warning: duplicate key in dictionary literal. Different PRs tried to fix this issue at the same time and introduced a duplicate. Related https://github.com/fabriziobertoglio1987/react-native/commit/55c0df43b9859853e41b6e2ef271b78b783538f0 https://github.com/fabriziobertoglio1987/react-native/commit/f3d9f2ea233304870bd4ab67d9682af6eb0ae16f

## Changelog

[IOS] [FIXED] - remove duplicate role grid from RCTViewManager

## Test Plan

<img width="1920" alt="duplicated grid role on iOS" src="https://user-images.githubusercontent.com/24992535/214054716-d79dec11-2b5c-4780-a4af-08d50be4a1a2.png">


