### PR TITLE
[Upstream] Pull out CGContext early in UIImage+Diff

### DIFF
--- a/packages/rn-tester/RCTTest/FBSnapshotTestCase/UIImage+Diff.m
+++ b/packages/rn-tester/RCTTest/FBSnapshotTestCase/UIImage+Diff.m
@@ -22,7 +22,7 @@
                                                                                    format:rendererFormat];
 
   return [renderer imageWithActions:^(UIGraphicsImageRendererContext *_Nonnull rendererContext) {
-    CGCotextRef context = rendererContext.CGContext;
+    const CGContextRef context = rendererContext.CGContext;
     [self drawInRect:CGRectMake(0, 0, self.size.width, self.size.height)];
     CGContextSetAlpha(context, 0.5f);
     CGContextBeginTransparencyLayer(context, NULL);

--- a/packages/rn-tester/RCTTest/FBSnapshotTestCase/UIImage+Diff.m
+++ b/packages/rn-tester/RCTTest/FBSnapshotTestCase/UIImage+Diff.m
@@ -21,15 +21,16 @@
   UIGraphicsImageRenderer *const renderer = [[UIGraphicsImageRenderer alloc] initWithSize:imageSize
                                                                                    format:rendererFormat];
 
-  return [renderer imageWithActions:^(UIGraphicsImageRendererContext *_Nonnull context) {
+  return [renderer imageWithActions:^(UIGraphicsImageRendererContext *_Nonnull rendererContext) {
+    CGCotextRef context = rendererContext.CGContext;
     [self drawInRect:CGRectMake(0, 0, self.size.width, self.size.height)];
-    CGContextSetAlpha(context.CGContext, 0.5f);
-    CGContextBeginTransparencyLayer(context.CGContext, NULL);
+    CGContextSetAlpha(context, 0.5f);
+    CGContextBeginTransparencyLayer(context, NULL);
     [image drawInRect:CGRectMake(0, 0, image.size.width, image.size.height)];
-    CGContextSetBlendMode(context.CGContext, kCGBlendModeDifference);
-    CGContextSetFillColorWithColor(context.CGContext, [UIColor whiteColor].CGColor);
-    CGContextFillRect(context.CGContext, CGRectMake(0, 0, self.size.width, self.size.height));
-    CGContextEndTransparencyLayer(context.CGContext);
+    CGContextSetBlendMode(context, kCGBlendModeDifference);
+    CGContextSetFillColorWithColor(context, [UIColor whiteColor].CGColor);
+    CGContextFillRect(context, CGRectMake(0, 0, self.size.width, self.size.height));
+    CGContextEndTransparencyLayer(context);
   }];
 }
 


### PR DESCRIPTION
## Summary

This is a small refactor designed to make future merges for React Native macOS easier. It was found while merging React Native 0.71 into React Native macOS.

In React Native macOS, we ifdef iOS  out API's and replace them with macOS APIs, reusing as much code as possible. `CGContext` is a type that is available on both iOS and macOS, but `UIGraphicsImageRendererContext` is not. A simple refactor makes it easier to reuse this code in React Native macOS without affecting iOS :) 

Resolves https://github.com/microsoft/react-native-macos/issues/1676

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[IOS] [CHANGED] - Pull out CGContext early in UIImage+Diff

## Test Plan

Build should pass.
