### PR TITLE
[Upstream] fix (iOS): Only try to make the alert window key if the app recognizes it

### DIFF
--- a/React/CoreModules/RCTAlertController.m
+++ b/React/CoreModules/RCTAlertController.m
@@ -60,6 +60,7 @@
   } else {
     // When using Scenes, we must present the alert from a view controller associated with a window in the Scene. A fresh window (i.e. _alertWindow) cannot show the alert.
     [RCTPresentedViewController() presentViewController:self animated:animated completion:completion];
+  }
 }
 
 - (void)hide

--- a/React/CoreModules/RCTAlertController.m
+++ b/React/CoreModules/RCTAlertController.m
@@ -48,8 +48,18 @@
         RCTSharedApplication().delegate.window.overrideUserInterfaceStyle ?: UIUserInterfaceStyleUnspecified;
     self.overrideUserInterfaceStyle = style;
   }
-  [self.alertWindow makeKeyAndVisible];
-  [self.alertWindow.rootViewController presentViewController:self animated:animated completion:completion];
+  // Call self.alertWindow to ensure that it gets populated
+  UIWindow *alertWindow = self.alertWindow;
+
+  // If the window is tracked by our application then it will show the alert
+  if ([[[UIApplication sharedApplication] windows] containsObject:alertWindow]) {
+    // On iOS 14, makeKeyAndVisible should only be called if alertWindow is tracked by the application.
+    // Later versions of iOS appear to already do this check for us behind the scenes.
+    [alertWindow makeKeyAndVisible];
+    [alertWindow.rootViewController presentViewController:self animated:animated completion:completion];
+  } else {
+    // When using Scenes, we must present the alert from a view controller associated with a window in the Scene. A fresh window (i.e. _alertWindow) cannot show the alert.
+    [RCTPresentedViewController() presentViewController:self animated:animated completion:completion];
 }
 
 - (void)hide


### PR DESCRIPTION
## Summary

This is a [change](https://github.com/microsoft/react-native-macos/pull/1008) we made in our fork (React Native macOS) that we are now upstreaming to reduce the number of diffs between React Native Core and React Native macOS. Also.. one less crash 🥳!

Resolves https://github.com/microsoft/react-native-macos/issues/1675

Original PR Notes:
> In iOS 14, if we call `-[UIWindow makeKeyAndVisible]` from a `UIWindow` that isn't part of the app, the current key window gets made non-key. This can result in `RCTKeyWindow()`, and thusly, `RCTPresentedViewController()`, to come back as `nil`, which means that the alert never shows up.
>
> The fix here is to ensure that we don't try to make the alert window key unless it's actually tracked by the application.

## Changelog

[IOS] [FIXED] - Only try to make the alert window key if the app recognizes it

## Test Plan

Build should pass. This change has been running in our fork in production for a while so we're fairly confident of it.
