### PR TITLE
fix(viewabilityHelper): clear timeouts during onUpdate when minimumViewTime is present

### DIFF
--- a/Libraries/Lists/ViewabilityHelper.js
+++ b/Libraries/Lists/ViewabilityHelper.js
@@ -246,6 +246,7 @@ class ViewabilityHelper {
           createViewToken,
         );
       }, this._config.minimumViewTime);
+      this.dispose();
       /* $FlowFixMe[incompatible-call] (>=0.63.0 site=react_native_fb) This
        * comment suppresses an error found when Flow v0.63 was deployed. To see
        * the error delete this comment and run Flow. */

--- a/Libraries/Lists/__tests__/ViewabilityHelper-test.js
+++ b/Libraries/Lists/__tests__/ViewabilityHelper-test.js
@@ -170,6 +170,10 @@ describe('computeViewableItems', function () {
 });
 
 describe('onUpdate', function () {
+  beforeEach(() => {
+    jest.useFakeTimers({legacyFakeTimers: true});
+  });
+
   it('returns 1 visible row as viewable then scrolls away', function () {
     const helper = new ViewabilityHelper();
     rowFrames = {
@@ -440,5 +444,39 @@ describe('onUpdate', function () {
       viewabilityConfig: {viewAreaCoveragePercentThreshold: 0},
       viewableItems: [{isViewable: true, key: 'c'}],
     });
+  });
+
+  it('should call onViewableItemsChanged once in minimumViewTime when onUpdate is called multiple times', function () {
+    const helper = new ViewabilityHelper({
+      minimumViewTime: 1000,
+      itemVisiblePercentThreshold: 90,
+    });
+    const itemHeight = 250;
+    const keys = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'];
+    rowFrames = keys.reduce((acc, curVal, i) => {
+      acc[curVal] = {
+        y: itemHeight * i,
+        height: itemHeight,
+      };
+
+      return acc;
+    }, {});
+    data = keys.map(key => ({key}));
+    const onViewableItemsChanged = jest.fn();
+
+    Array.from({length: 4}).forEach((v, i) => {
+      helper.onUpdate(
+        props,
+        150 * i,
+        800,
+        getFrameMetrics,
+        createViewToken,
+        onViewableItemsChanged,
+      );
+    });
+
+    jest.runAllTimers();
+
+    expect(onViewableItemsChanged.mock.calls.length).toBe(1);
   });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
This fixes [the issue](https://github.com/facebook/react-native/issues/35682) with onViewableItemsChanged being called multiple time during the minimumViewTime window.

To sum up the problem, the onViewableItemsChanged callback is called multiple times during scroll event, kind of ignoring the minimumViewTime setting. So e.g. if there is FlatList with a few items, and the viewport allows 3 items to be simultaneously visible, user will scroll, and the callback will be called with [1], [1, 2] and [1, 2, 3] items. By clearing the intervals, we omit running the callback too many times.

## Technical note

I haven't changed the existing unit tests for the ViewabilityHelper, but I was left a bit confused by this:

```
rowFrames = {
      a: {y: 0, height: 250},
      b: {y: 250, height: 200},
    };
helper.onUpdate(
      props,
      0,
      200,
      getFrameMetrics,
      createViewToken,
      onViewableItemsChanged,
    );
```

The `200` parameter in onUpdate is the viewportHeight. So there are few questions I don't understand completely, which makes me a bit uncertain about my change:
- if the viewport height is set to 200, it means that there is always only one visible item on screen. I think that's the assumption that missed this edge case I'm trying to fix
- the parameter is called viewportHeight. I'm not sure what's the impact here in case of a horizontal flatList 🤔 

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
[GENERAL][FIXED] - fix onViewableItemsChanged called multiple times during minimumViewTime window

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
I've added a unit test that covers the change
