### PR TITLE
Use modern Podfile syntax to avoid polluting application build settings

### DIFF
--- a/sdks/hermes-engine/hermes-engine.podspec
+++ b/sdks/hermes-engine/hermes-engine.podspec
@@ -39,7 +39,7 @@ Pod::Spec.new do |spec|
   spec.preserve_paths      = '**/*.*'
   spec.source_files        = ''
 
-  spec.xcconfig = {
+  spec.pod_target_xcconfig = {
                     "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",
                     "CLANG_CXX_LIBRARY" => "compiler-default"
                   }.merge!(build_type == :debug ? { "GCC_PREPROCESSOR_DEFINITIONS" => "HERMES_ENABLE_DEBUGGER=1" } : {})


### PR DESCRIPTION
## Summary

Fixes conflicts in pod build settings like the one below:

Example warning
> Can't merge user_target_xcconfig for pod targets: ["RNReanimated", "hermes-engine"]. Singular build setting CLANG_CXX_LANGUAGE_STANDARD has different values.


Background:

> The former attribute xcconfig is deprecated and will cause a linter error when pushing new versions to trunk. The new attributes are available as pod_target_xcconfig and user_target_xcconfig, which makes their effects more clear. The latter attribute (user_target_xcconfig) should be used with great care, because well designed Pods should be self-contained and make as few assumptions about their environment as possible. Furthermore, this attribute can cause conflicts when different values are specified by two Pods for a build setting which doesn't allow multiple values and so cannot be merged.
- https://blog.cocoapods.org/CocoaPods-0.38/

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[IOS] [FIXED] - Fix cocoapods warning about merging user_target_xcconfig

-->

## Test Plan

- Run in example app

## Related PR

- https://github.com/facebook/hermes/pull/903
