### PR TITLE
Adding AlertOptions to ts Alert.prompt function

### DIFF
--- a/Libraries/Alert/Alert.d.ts
+++ b/Libraries/Alert/Alert.d.ts
@@ -77,6 +77,7 @@ export interface AlertStatic {
     type?: AlertType,
     defaultValue?: string,
     keyboardType?: string,
+    options?: AlertOptions,
   ) => void;
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Bringing the typescript function signature in-line with the js code.

## Changelog

[GENERAL] [FIXED] - Added AlertOptions argument to the type definition for Alert.prompt to bring it into parity with the js code.

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Before the change, VS Code would show a typescript error when I pass AlertOptions to Alert.prompt (even though the js would execute successfully and respect the options I passed. After the change, when I use an Alert.prompt in VS code the function signature was recognized without errors.
