### PR TITLE
Update `react-native-xcode.sh` to use `PROJECT_DIR` from Xcode

### DIFF
--- a/scripts/react-native-xcode.sh
+++ b/scripts/react-native-xcode.sh
@@ -58,9 +58,8 @@ esac
 
 # Path to react-native folder inside node_modules
 REACT_NATIVE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-# The project should be located next to where react-native is installed
-# in node_modules.
-PROJECT_ROOT=${PROJECT_ROOT:-"$REACT_NATIVE_DIR/../.."}
+# Most projects have their project root, one level up from their Xcode project dir (the "ios" directory)
+PROJECT_ROOT=${PROJECT_ROOT:-"$PROJECT_DIR/.."}
 
 cd "$PROJECT_ROOT" || exit
 


### PR DESCRIPTION
## Summary

In a mono-repo the `react-native` package could be hoisted compared to the app directory, in which case it's not a good strategy for the `react-native-xcode.sh` script to guess the app project root relative to the location of itself. Instead I suggest to relying on a build setting provided by Xcode to derive the default app path.

I could have use the `SRCROOT` instead. According to https://stackoverflow.com/questions/36323031/what-the-different-between-srcroot-and-project-dir this is equivalent and also a bit less ambiguous as I see it. I.e. I would expect most Xcode projects to be located in the `ios` directory of the app.

As a workaround, before this merge, users can add the following to their "Bundle React Native code and images" build phase or `ios/.xcode.env` file:

```shell
export PROJECT_ROOT="$PROJECT_DIR/.."
```

This build phase can also be used for users wanting to revert this default behaviour once merged.

## Changelog

[iOS] [Changed] - Changed default `PROJECT_ROOT` (used in when bundling for iOS) to rely on the `PROJECT_DIR` build setting.

## Test Plan

I've updated this locally and verified this does indeed pick up the correct app path - even in a mono-repo.

To verify this:
- Instantiate the template with this patch applied.
- Update the "Run scheme"'s "Build Configuration" to "Release".
- Build the app without errors.
