### PR TITLE
Blob#slice end <= size (fixes #35959)

### DIFF
--- a/Libraries/Blob/Blob.js
+++ b/Libraries/Blob/Blob.js
@@ -98,6 +98,10 @@ class Blob {
           // $FlowFixMe[reassign-const]
           end = this.size + end;
         }
+        if (end > this.size) {
+          // $FlowFixMe[reassign-const]
+          end = this.size;
+        }
         size = end - start;
       }
     }

--- a/Libraries/Blob/__tests__/Blob-test.js
+++ b/Libraries/Blob/__tests__/Blob-test.js
@@ -71,6 +71,11 @@ describe('Blob', function () {
     expect(sliceB.data.offset).toBe(2384);
     expect(sliceB.size).toBe(7621 - 2384);
     expect(sliceB.type).toBe('');
+
+    const sliceC = blob.slice(34543, 34569);
+
+    expect(sliceC.data.offset).toBe(34543);
+    expect(sliceC.size).toBe(Math.min(blob.data.size, 34569) - 34543);
   });
 
   it('should close a blob', () => {


### PR DESCRIPTION
## Summary

See #35959 .  Potentially fixes other issues including #34988

## Changelog

[INTERNAL] [FIXED] - Blob#slice end check avoids overflow

## Test Plan

Added a test which fails against current release but passes after code changes.