### PR TITLE
Catch IndexOutOfBoundsException in ReactAccessibilityDelegate to prevent crash

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAccessibilityDelegate.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAccessibilityDelegate.java
@@ -636,9 +636,21 @@ public class ReactAccessibilityDelegate extends ExploreByTouchHelper {
       return;
     }
 
+    // Sometimes the range of accessibleTextSpan seems to not match the actual text, possibly
+    // by incorrect virtualViewId being passed in. In this case, we return an "empty" node to
+    // prevent the app from crashing.
+    final Rect boundsInParent;
+    try {
+      boundsInParent = getBoundsInParent(accessibleTextSpan);
+    } catch (IndexOutOfBoundsException e) {
+      node.setContentDescription("");
+      node.setBoundsInParent(new Rect(0, 0, 1, 1));
+      return;
+    }
+
     node.setContentDescription(accessibleTextSpan.description);
     node.addAction(AccessibilityNodeInfoCompat.ACTION_CLICK);
-    node.setBoundsInParent(getBoundsInParent(accessibleTextSpan));
+    node.setBoundsInParent(boundsInParent);
     node.setRoleDescription(mView.getResources().getString(R.string.link_description));
     node.setClassName(AccessibilityRole.getValue(AccessibilityRole.BUTTON));
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

On some devices we frequently got these crashes:
```
Fatal Exception: java.lang.IndexOutOfBoundsException: offset(114) should be less than line limit(52)
       at android.text.TextLine.measure(TextLine.java:389)
       at android.text.Layout.getHorizontal(Layout.java:1254)
       at android.text.Layout.getHorizontal(Layout.java:1230)
       at android.text.Layout.getPrimaryHorizontal(Layout.java:1200)
       at android.text.Layout.getPrimaryHorizontal(Layout.java:1189)
       at com.facebook.react.uimanager.ReactAccessibilityDelegate.getBoundsInParent(ReactAccessibilityDelegate.java:662)
       at com.facebook.react.uimanager.ReactAccessibilityDelegate.onPopulateNodeForVirtualView(ReactAccessibilityDelegate.java:641)
       at androidx.customview.widget.ExploreByTouchHelper.createNodeForChild(ExploreByTouchHelper.java:802)
       at androidx.customview.widget.ExploreByTouchHelper.obtainAccessibilityNodeInfo(ExploreByTouchHelper.java:723)
       at androidx.customview.widget.ExploreByTouchHelper$MyNodeProvider.createAccessibilityNodeInfo(ExploreByTouchHelper.java:1246)
       at androidx.core.view.accessibility.AccessibilityNodeProviderCompat$AccessibilityNodeProviderApi16.createAccessibilityNodeInfo(AccessibilityNodeProviderCompat.java:46)
       at android.view.AccessibilityInteractionController$AccessibilityNodePrefetcher.prefetchDescendantsOfVirtualNode(AccessibilityInteractionController.java:1638)
       at android.view.AccessibilityInteractionController$AccessibilityNodePrefetcher.prefetchDescendantsOfRealNode(AccessibilityInteractionController.java:1547)
       at android.view.AccessibilityInteractionController$AccessibilityNodePrefetcher.prefetchDescendantsOfRealNode(AccessibilityInteractionController.java:1543)
       at android.view.AccessibilityInteractionController$AccessibilityNodePrefetcher.prefetchDescendantsOfRealNode(AccessibilityInteractionController.java:1543)
       at android.view.AccessibilityInteractionController$AccessibilityNodePrefetcher.prefetchDescendantsOfRealNode(AccessibilityInteractionController.java:1543)
       at android.view.AccessibilityInteractionController$AccessibilityNodePrefetcher.prefetchDescendantsOfRealNode(AccessibilityInteractionController.java:1543)
       at android.view.AccessibilityInteractionController$AccessibilityNodePrefetcher.prefetchDescendantsOfRealNode(AccessibilityInteractionController.java:1543)
       at android.view.AccessibilityInteractionController$AccessibilityNodePrefetcher.prefetchAccessibilityNodeInfos(AccessibilityInteractionController.java:1309)
       at android.view.AccessibilityInteractionController.findAccessibilityNodeInfoByAccessibilityIdUiThread(AccessibilityInteractionController.java:416)
       at android.view.AccessibilityInteractionController.-$$Nest$mfindAccessibilityNodeInfoByAccessibilityIdUiThread()
       at android.view.AccessibilityInteractionController$PrivateHandler.handleMessage(AccessibilityInteractionController.java:1713)
       at android.os.Handler.dispatchMessage(Handler.java:106)
       at android.os.Looper.loopOnce(Looper.java:226)
       at android.os.Looper.loop(Looper.java:313)
       at android.app.ActivityThread.main(ActivityThread.java:8741)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:571)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1067)
```

It's unclear what exactly causes this or when. It appears to be random. The provided changes did solve the issue for us, though I'm not sure if that's just fixing the symptom rather than the cause.

## Changelog

[ANDROID] [FIXED] - Crash caused in ReactAccessibilityDelegate

## Test Plan

Can't be reproduced consistently.
