### PR TITLE
Add missing C++ include for prop conversion of complex array type

### DIFF
--- a/packages/react-native-codegen/e2e/__test_fixtures__/components/ArrayPropsNativeComponent.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/components/ArrayPropsNativeComponent.js
@@ -37,6 +37,7 @@ type NativeProps = $ReadOnly<{|
   edgeInsets?: $ReadOnlyArray<EdgeInsetsValue>,
   sizes?: WithDefault<$ReadOnlyArray<'small' | 'large'>, 'small'>,
   object?: $ReadOnlyArray<$ReadOnly<{|prop: string|}>>,
+  arrayOfObjects?: $ReadOnlyArray<$ReadOnly<{|prop1: Float, prop2: Int32|}>>,
 |}>;
 
 export default (codegenNativeComponent<NativeProps>(

--- a/packages/react-native-codegen/e2e/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/e2e/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -34,7 +34,8 @@ ArrayPropsNativeComponentViewProps::ArrayPropsNativeComponentViewProps(
     points(convertRawProp(context, rawProps, \\"points\\", sourceProps.points, {})),
     edgeInsets(convertRawProp(context, rawProps, \\"edgeInsets\\", sourceProps.edgeInsets, {})),
     sizes(convertRawProp(context, rawProps, \\"sizes\\", sourceProps.sizes, {static_cast<ArrayPropsNativeComponentViewSizesMask>(ArrayPropsNativeComponentViewSizes::Small)})),
-    object(convertRawProp(context, rawProps, \\"object\\", sourceProps.object, {}))
+    object(convertRawProp(context, rawProps, \\"object\\", sourceProps.object, {})),
+    arrayOfObjects(convertRawProp(context, rawProps, \\"arrayOfObjects\\", sourceProps.arrayOfObjects, {}))
       {}
 
 } // namespace react

--- a/packages/react-native-codegen/e2e/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/e2e/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
@@ -17,6 +17,7 @@ Object {
 #include <jsi/jsi.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/core/propsConversions.h>
 #include <react/renderer/graphics/Color.h>
 #include <react/renderer/graphics/Point.h>
 #include <react/renderer/graphics/RectangleEdges.h>
@@ -107,6 +108,38 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
   }
 }
 
+
+struct ArrayPropsNativeComponentViewArrayOfObjectsStruct {
+  Float prop1;
+  int prop2;
+};
+
+static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ArrayPropsNativeComponentViewArrayOfObjectsStruct &result) {
+  auto map = (butter::map<std::string, RawValue>)value;
+
+  auto tmp_prop1 = map.find(\\"prop1\\");
+  if (tmp_prop1 != map.end()) {
+    fromRawValue(context, tmp_prop1->second, result.prop1);
+  }
+  auto tmp_prop2 = map.find(\\"prop2\\");
+  if (tmp_prop2 != map.end()) {
+    fromRawValue(context, tmp_prop2->second, result.prop2);
+  }
+}
+
+static inline std::string toString(const ArrayPropsNativeComponentViewArrayOfObjectsStruct &value) {
+  return \\"[Object ArrayPropsNativeComponentViewArrayOfObjectsStruct]\\";
+}
+
+static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, std::vector<ArrayPropsNativeComponentViewArrayOfObjectsStruct> &result) {
+  auto items = (std::vector<RawValue>)value;
+  for (const auto &item : items) {
+    ArrayPropsNativeComponentViewArrayOfObjectsStruct newItem;
+    fromRawValue(context, item, newItem);
+    result.emplace_back(newItem);
+  }
+}
+
 class JSI_EXPORT ArrayPropsNativeComponentViewProps final : public ViewProps {
  public:
   ArrayPropsNativeComponentViewProps() = default;
@@ -124,6 +157,7 @@ class JSI_EXPORT ArrayPropsNativeComponentViewProps final : public ViewProps {
   std::vector<EdgeInsets> edgeInsets{};
   ArrayPropsNativeComponentViewSizesMask sizes{static_cast<ArrayPropsNativeComponentViewSizesMask>(ArrayPropsNativeComponentViewSizes::Small)};
   std::vector<ArrayPropsNativeComponentViewObjectStruct> object{};
+  std::vector<ArrayPropsNativeComponentViewArrayOfObjectsStruct> arrayOfObjects{};
 };
 
 } // namespace react

--- a/packages/react-native-codegen/e2e/__tests__/components/__snapshots__/GeneratePropsJavaDelegate-test.js.snap
+++ b/packages/react-native-codegen/e2e/__tests__/components/__snapshots__/GeneratePropsJavaDelegate-test.js.snap
@@ -56,6 +56,9 @@ public class ArrayPropsNativeComponentViewManagerDelegate<T extends View, U exte
       case \\"object\\":
         mViewManager.setObject(view, (ReadableArray) value);
         break;
+      case \\"arrayOfObjects\\":
+        mViewManager.setArrayOfObjects(view, (ReadableArray) value);
+        break;
       default:
         super.setProperty(view, propName, value);
     }

--- a/packages/react-native-codegen/e2e/__tests__/components/__snapshots__/GeneratePropsJavaInterface-test.js.snap
+++ b/packages/react-native-codegen/e2e/__tests__/components/__snapshots__/GeneratePropsJavaInterface-test.js.snap
@@ -28,6 +28,7 @@ public interface ArrayPropsNativeComponentViewManagerInterface<T extends View> {
   void setEdgeInsets(T view, @Nullable ReadableArray value);
   void setSizes(T view, @Nullable ReadableArray value);
   void setObject(T view, @Nullable ReadableArray value);
+  void setArrayOfObjects(T view, @Nullable ReadableArray value);
 }
 ",
 }

--- a/packages/react-native-codegen/e2e/__tests__/components/__snapshots__/GenerateViewConfigJs-test.js.snap
+++ b/packages/react-native-codegen/e2e/__tests__/components/__snapshots__/GenerateViewConfigJs-test.js.snap
@@ -39,6 +39,7 @@ export const __INTERNAL_VIEW_CONFIG = {
     edgeInsets: true,
     sizes: true,
     object: true,
+    arrayOfObjects: true,
   },
 };
 

--- a/packages/react-native-codegen/src/generators/components/ComponentsGeneratorUtils.js
+++ b/packages/react-native-codegen/src/generators/components/ComponentsGeneratorUtils.js
@@ -270,8 +270,11 @@ function getLocalImports(
       typeAnnotation.type === 'ArrayTypeAnnotation' &&
       typeAnnotation.elementType.type === 'ObjectTypeAnnotation'
     ) {
+      imports.add('#include <react/renderer/core/propsConversions.h>');
       const objectProps = typeAnnotation.elementType.properties;
+      // $FlowFixMe[incompatible-call] the type is guaranteed to be ObjectTypeAnnotation<PropTypeAnnotation>
       const objectImports = getImports(objectProps);
+      // $FlowFixMe[incompatible-call] the type is guaranteed to be ObjectTypeAnnotation<PropTypeAnnotation>
       const localImports = getLocalImports(objectProps);
       // $FlowFixMe[method-unbinding] added when improving typing for this parameters
       objectImports.forEach(imports.add, imports);

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsH-test.js.snap
@@ -17,6 +17,7 @@ Map {
 #include <jsi/jsi.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/core/propsConversions.h>
 #include <react/renderer/graphics/Color.h>
 #include <react/renderer/graphics/Point.h>
 #include <react/renderer/imagemanager/primitives.h>
@@ -234,6 +235,7 @@ Map {
 #include <react/renderer/components/image/conversions.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/core/propsConversions.h>
 #include <react/renderer/graphics/Color.h>
 #include <react/renderer/graphics/Point.h>
 #include <react/renderer/imagemanager/primitives.h>


### PR DESCRIPTION
Summary:
[Changelog][Internal]

Codegen for props parsing was failing to add a required include for the case when the type is an array of objects, which in turn use non-trivial types.

Something like:
```
export type NativeProps = $ReadOnly<{
  ...ViewProps,
  bounds: $ReadOnlyArray<
    $ReadOnly<{
      height?: Float,
      left?: Float,
      top?: Float,
      width?: Float,
    }>,
  >,
}>;
```

would cause compilation errors on C++ side, since the required header for the `Float` conversion wasn't included.

Reviewed By: cipolleschi

Differential Revision: D42781128

