### PR TITLE
Add Appearance.setColorScheme support

### DIFF
--- a/Libraries/Utilities/Appearance.d.ts
+++ b/Libraries/Utilities/Appearance.d.ts
@@ -34,7 +34,7 @@ export namespace Appearance {
    * appearance of the system UI, only the appearance of the app.
    * Only available on iOS 13+ and Android 10+.
    */
-  export function setColorScheme(scheme: ColorSchemeName): void;
+  export function setColorScheme(scheme: ColorSchemeName | null | undefined): void;
 
   /**
    * Add an event handler that is fired when appearance preferences change.

--- a/Libraries/Utilities/Appearance.d.ts
+++ b/Libraries/Utilities/Appearance.d.ts
@@ -34,7 +34,9 @@ export namespace Appearance {
    * appearance of the system UI, only the appearance of the app.
    * Only available on iOS 13+ and Android 10+.
    */
-  export function setColorScheme(scheme: ColorSchemeName | null | undefined): void;
+  export function setColorScheme(
+    scheme: ColorSchemeName | null | undefined,
+  ): void;
 
   /**
    * Add an event handler that is fired when appearance preferences change.

--- a/Libraries/Utilities/Appearance.d.ts
+++ b/Libraries/Utilities/Appearance.d.ts
@@ -29,6 +29,14 @@ export namespace Appearance {
   export function getColorScheme(): ColorSchemeName;
 
   /**
+   * Set the color scheme preference. This is useful for overriding the default
+   * color scheme preference for the app. Note that this will not change the
+   * appearance of the system UI, only the appearance of the app.
+   * Only available on iOS 13+ and Android 10+.
+   */
+  export function setColorScheme(scheme: ColorSchemeName): void;
+
+  /**
    * Add an event handler that is fired when appearance preferences change.
    */
   export function addChangeListener(

--- a/Libraries/Utilities/Appearance.js
+++ b/Libraries/Utilities/Appearance.js
@@ -86,13 +86,10 @@ module.exports = {
   },
 
   setColorScheme(colorScheme: ?ColorSchemeName): void {
-    const nativeColorScheme =
-      colorScheme == null ? 'unspecified' : colorScheme;
+    const nativeColorScheme = colorScheme == null ? 'unspecified' : colorScheme;
 
     invariant(
-      colorScheme === 'dark' ||
-        colorScheme === 'light' ||
-        colorScheme == null,
+      colorScheme === 'dark' || colorScheme === 'light' || colorScheme == null,
       "Unrecognized color scheme. Did you mean 'dark', 'light' or null?",
     );
 

--- a/Libraries/Utilities/Appearance.js
+++ b/Libraries/Utilities/Appearance.js
@@ -86,7 +86,7 @@ module.exports = {
   },
 
   setColorScheme(colorScheme: ?ColorSchemeName): void {
-    const nativeColorScheme: ?string =
+    const nativeColorScheme =
       colorScheme == null ? 'unspecified' : colorScheme;
 
     invariant(

--- a/Libraries/Utilities/Appearance.js
+++ b/Libraries/Utilities/Appearance.js
@@ -85,7 +85,7 @@ module.exports = {
     return nativeColorScheme;
   },
 
-  setColorScheme(colorScheme: string): void {
+  setColorScheme(colorScheme: ?ColorSchemeName): void {
     const nativeColorScheme: ?string =
       colorScheme == null ? 'unspecified' : colorScheme;
 

--- a/Libraries/Utilities/Appearance.js
+++ b/Libraries/Utilities/Appearance.js
@@ -85,6 +85,22 @@ module.exports = {
     return nativeColorScheme;
   },
 
+  setColorScheme(colorScheme: string): void {
+    const nativeColorScheme: ?string =
+      colorScheme == null ? 'unspecified' : colorScheme;
+
+    invariant(
+      nativeColorScheme === 'dark' ||
+        nativeColorScheme === 'light' ||
+        nativeColorScheme == null,
+      "Unrecognized color scheme. Did you mean 'dark', 'light' or null?",
+    );
+
+    if (NativeAppearance != null) {
+      NativeAppearance.setColorScheme(nativeColorScheme);
+    }
+  },
+
   /**
    * Add an event handler that is fired when appearance preferences change.
    */

--- a/Libraries/Utilities/Appearance.js
+++ b/Libraries/Utilities/Appearance.js
@@ -90,9 +90,9 @@ module.exports = {
       colorScheme == null ? 'unspecified' : colorScheme;
 
     invariant(
-      nativeColorScheme === 'dark' ||
-        nativeColorScheme === 'light' ||
-        nativeColorScheme == null,
+      colorScheme === 'dark' ||
+        colorScheme === 'light' ||
+        colorScheme == null,
       "Unrecognized color scheme. Did you mean 'dark', 'light' or null?",
     );
 

--- a/Libraries/Utilities/NativeAppearance.js
+++ b/Libraries/Utilities/NativeAppearance.js
@@ -26,6 +26,7 @@ export interface Spec extends TurboModule {
   // types.
   /* 'light' | 'dark' */
   +getColorScheme: () => ?string;
+  +setColorScheme: (colorScheme: ?string) => void;
 
   // RCTEventEmitter
   +addListener: (eventName: string) => void;

--- a/Libraries/Utilities/NativeAppearance.js
+++ b/Libraries/Utilities/NativeAppearance.js
@@ -26,7 +26,7 @@ export interface Spec extends TurboModule {
   // types.
   /* 'light' | 'dark' */
   +getColorScheme: () => ?string;
-  +setColorScheme: (colorScheme: ?string) => void;
+  +setColorScheme: (colorScheme: string) => void;
 
   // RCTEventEmitter
   +addListener: (eventName: string) => void;

--- a/React/CoreModules/RCTAppearance.h
+++ b/React/CoreModules/RCTAppearance.h
@@ -7,6 +7,7 @@
 
 #import <UIKit/UIKit.h>
 
+#import <React/RCTConvert.h>
 #import <React/RCTBridgeModule.h>
 #import <React/RCTEventEmitter.h>
 

--- a/React/CoreModules/RCTAppearance.mm
+++ b/React/CoreModules/RCTAppearance.mm
@@ -68,6 +68,23 @@ NSString *RCTColorSchemePreference(UITraitCollection *traitCollection)
   return RCTAppearanceColorSchemeLight;
 }
 
+@implementation RCTConvert (UIUserInterfaceStyle)
+
+RCT_ENUM_CONVERTER(
+    UIUserInterfaceStyle,
+    (@{
+        @"light" : @(UIUserInterfaceStyleLight),
+        @"dark" : @(UIUserInterfaceStyleDark),
+        @"unspecified" : @(UIUserInterfaceStyleUnspecified)
+    }),
+    UIUserInterfaceStyleUnspecified,
+    integerValue);
+
+@end
+
+@interface RCTAppearance () <NativeAppearanceSpec>
+@end
+
 @interface RCTAppearance () <NativeAppearanceSpec>
 @end
 
@@ -90,6 +107,17 @@ RCT_EXPORT_MODULE(Appearance)
 - (std::shared_ptr<TurboModule>)getTurboModule:(const ObjCTurboModule::InitParams &)params
 {
   return std::make_shared<NativeAppearanceSpecJSI>(params);
+}
+
+RCT_EXPORT_METHOD(setColorScheme : (NSString *)style) {
+  UIUserInterfaceStyle userInterfaceStyle = [RCTConvert UIUserInterfaceStyle:style];
+  NSArray<__kindof UIWindow*>* windows = [[UIApplication sharedApplication] windows];
+  if (@available(iOS 13.0, *)) {
+    for (UIWindow *window in windows)
+    {
+      window.overrideUserInterfaceStyle = userInterfaceStyle;
+    }
+  }
 }
 
 RCT_EXPORT_SYNCHRONOUS_TYPED_METHOD(NSString *, getColorScheme)

--- a/React/CoreModules/RCTAppearance.mm
+++ b/React/CoreModules/RCTAppearance.mm
@@ -10,6 +10,7 @@
 #import <FBReactNativeSpec/FBReactNativeSpec.h>
 #import <React/RCTConstants.h>
 #import <React/RCTEventEmitter.h>
+#import <React/RCTUtils.h>
 
 #import "CoreModulesPlugins.h"
 
@@ -108,7 +109,7 @@ RCT_EXPORT_MODULE(Appearance)
 
 RCT_EXPORT_METHOD(setColorScheme : (NSString *)style) {
   UIUserInterfaceStyle userInterfaceStyle = [RCTConvert UIUserInterfaceStyle:style];
-  NSArray<__kindof UIWindow*>* windows = [[UIApplication sharedApplication] windows];
+  NSArray<__kindof UIWindow*>* windows = RCTSharedApplication().windows;
   if (@available(iOS 13.0, *)) {
     for (UIWindow *window in windows)
     {

--- a/React/CoreModules/RCTAppearance.mm
+++ b/React/CoreModules/RCTAppearance.mm
@@ -85,9 +85,6 @@ RCT_ENUM_CONVERTER(
 @interface RCTAppearance () <NativeAppearanceSpec>
 @end
 
-@interface RCTAppearance () <NativeAppearanceSpec>
-@end
-
 @implementation RCTAppearance {
   NSString *_currentColorScheme;
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/appearance/AppearanceModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/appearance/AppearanceModule.java
@@ -69,11 +69,11 @@ public class AppearanceModule extends NativeAppearanceSpec {
 
   @Override
   public void setColorScheme(String style) {
-    if ("dark".equals(style)) {
+    if (style == "dark") {
       AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES);
-    } else if ("light".equals(style)) {
+    } else if (style == "light") {
       AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO);
-    } else if ("unspecified".equals(style)) {
+    } else if (style == "unspecified") {
       AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM);
     }
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/appearance/AppearanceModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/appearance/AppearanceModule.java
@@ -11,6 +11,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.res.Configuration;
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatDelegate;
 import com.facebook.fbreact.specs.NativeAppearanceSpec;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -64,6 +65,17 @@ public class AppearanceModule extends NativeAppearanceSpec {
     }
 
     return "light";
+  }
+
+  @Override
+  public void setColorScheme(String style) {
+    if ("dark".equals(style)) {
+      AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES);
+    } else if ("light".equals(style)) {
+      AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO);
+    } else if ("unspecified".equals(style)) {
+      AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM);
+    }
   }
 
   @Override

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/appearance/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/appearance/BUCK
@@ -14,6 +14,7 @@ rn_android_library(
     deps = [
         react_native_dep("third-party/java/jsr-305:jsr-305"),
         react_native_dep("third-party/android/androidx:annotation"),
+        react_native_dep("third-party/android/androidx:appcompat"),
         react_native_target("java/com/facebook/react/bridge:bridge"),
         react_native_target("java/com/facebook/react/common:common"),
         react_native_target("java/com/facebook/react/module/annotations:annotations"),

--- a/ReactAndroid/src/main/java/com/facebook/react/shell/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/shell/BUCK
@@ -15,6 +15,7 @@ rn_android_library(
         react_native_dep("libraries/fresco/fresco-react-native:imagepipeline"),
         react_native_dep("libraries/soloader/java/com/facebook/soloader:soloader"),
         react_native_dep("third-party/android/androidx:annotation"),
+        react_native_dep("third-party/android/androidx:appcompat"),
         react_native_dep("third-party/android/androidx:core"),
         react_native_dep("third-party/android/androidx:fragment"),
         react_native_dep("third-party/android/androidx:legacy-support-core-utils"),


### PR DESCRIPTION

## Summary

Both Android and iOS allow you to set application specific user interface style, which is useful for applications that support both light and dark mode.

With the newly added `Appearance.setColorScheme`, you can natively manage the application's user interface style rather than keeping that preference in JavaScript. The benefit is that native dialogs like alert, keyboard, action sheets and more will also be affected by this change.

Implemented using Android X [AppCompatDelegate.setDefaultNightMode](https://developer.android.com/reference/androidx/appcompat/app/AppCompatDelegate#setDefaultNightMode(int)) and iOS 13+ [overrideUserInterfaceStyle](https://developer.apple.com/documentation/uikit/uiview/3238086-overrideuserinterfacestyle?language=objc)

## Changelog

[GENERAL] [ADDED] - Added `setColorScheme` to `Appearance` module

## Test Plan

This is a void function so testing is rather limited.

```tsx
// Lets assume a given device is set to **dark** mode.

Appearance.getColorScheme(); // `dark`

// Set the app's user interface to `light`
Appearance.setColorScheme('light');

Appearance.getColorScheme(); // `light`

// Set the app's user interface to `unspecified`
Appearance.setColorScheme(null);

Appearance.getColorScheme() // `dark`
 ```
