### PR TITLE
save registry auth token before bootstrapping verdaccio

### DIFF
--- a/scripts/setup-verdaccio.js
+++ b/scripts/setup-verdaccio.js
@@ -28,6 +28,10 @@ function setupVerdaccio(
     );
   }
 
+  execSync('echo "//localhost:4873/:_authToken=secretToken" > .npmrc', {
+    cwd: reactNativeRootPath,
+  });
+
   const verdaccioProcess = spawn(
     'npx',
     ['verdaccio@5.16.3', '--config', verdaccioConfigPath],
@@ -37,11 +41,7 @@ function setupVerdaccio(
   const VERDACCIO_PID = verdaccioProcess.pid;
 
   execSync('npx wait-on@6.0.1 http://localhost:4873');
-
   execSync('npm set registry http://localhost:4873');
-  execSync('echo "//localhost:4873/:_authToken=secretToken" > .npmrc', {
-    cwd: reactNativeRootPath,
-  });
 
   return VERDACCIO_PID;
 }


### PR DESCRIPTION
Summary:
Changelog: [Internal]

While cherry-picking all this logic to `0.71-stable` branch, we've discovered several issues where some packages were failing to be published on Verdaccio proxy

This was failing only on node v16+, after some research, I've noticed that there might be a race-condition and npm unable to grab this token before first `npm publish` executes

Although this still work well on `main` branch, I am backporting it to keep aligned with `0.71-stable`

Differential Revision: D42806081

