### PR TITLE
RNGP - Properly set the `jsRootDir` default value

### DIFF
--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactExtension.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactExtension.kt
@@ -129,9 +129,9 @@ abstract class ReactExtension @Inject constructor(project: Project) {
   /**
    * The root directory for all JS files for the app.
    *
-   * Default: [root] (i.e. ${rootProject.dir}/../)
+   * Default: the parent folder of the `/android` folder.
    */
-  val jsRootDir: DirectoryProperty = objects.directoryProperty().convention(root.get())
+  val jsRootDir: DirectoryProperty = objects.directoryProperty()
 
   /**
    * The library name that will be used for the codegen artifacts.

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
@@ -110,6 +110,15 @@ class ReactPlugin : Plugin<Project> {
     // First, we set up the output dir for the codegen.
     val generatedSrcDir = File(project.buildDir, "generated/source/codegen")
 
+    // We specify the default value (convention) for jsRootDir.
+    // It's the root folder for apps (so ../../ from the Gradle project)
+    // and the package folder for library (so ../ from the Gradle project)
+    if (isLibrary) {
+      extension.jsRootDir.convention(project.layout.projectDirectory.dir("../"))
+    } else {
+      extension.jsRootDir.convention(extension.root)
+    }
+
     val buildCodegenTask =
         project.tasks.register("buildCodegenCLI", BuildCodegenCLITask::class.java) {
           it.codegenDir.set(extension.codegenDir)


### PR DESCRIPTION
Summary:
Fixes https://github.com/software-mansion/react-native-gesture-handler/issues/2382

I've just realized that the default value fo `jsRootDir` is not entirely correct.
That's the root of the folder where the codegen should run.

For apps, it should be defaulted to `root` (i.e. ../../)
For libraries, it should be defaulted to `../` (currently is root).

This causes a problem where libraries without either a `codegenConfig` or a `react{ jsRootDir = ... }`
specified in the build.gradle will be invoking the codegen and generating duplicated symbols.

Changelog:
[Android] [Fixed] - RNGP - Properly set the `jsRootDir` default value

Differential Revision: D42806411

