### PR TITLE
Fix VirtualizedList with maintainVisibleContentPosition

### DIFF
--- a/packages/react-native/Libraries/Lists/__tests__/__snapshots__/FlatList-test.js.snap
+++ b/packages/react-native/Libraries/Lists/__tests__/__snapshots__/FlatList-test.js.snap
@@ -111,6 +111,7 @@ exports[`FlatList renders all the bells and whistles 1`] = `
   <RCTRefreshControl />
   <View>
     <View
+      collapsable={false}
       onLayout={[Function]}
     >
       <header />

--- a/packages/react-native/Libraries/Lists/__tests__/__snapshots__/SectionList-test.js.snap
+++ b/packages/react-native/Libraries/Lists/__tests__/__snapshots__/SectionList-test.js.snap
@@ -243,6 +243,7 @@ exports[`SectionList renders all the bells and whistles 1`] = `
   <RCTRefreshControl />
   <View>
     <View
+      collapsable={false}
       onLayout={[Function]}
     >
       <header

--- a/packages/rn-tester/js/components/ListExampleShared.js
+++ b/packages/rn-tester/js/components/ListExampleShared.js
@@ -13,6 +13,7 @@
 const React = require('react');
 
 const {
+  ActivityIndicator,
   Animated,
   Image,
   Platform,
@@ -33,16 +34,28 @@ export type Item = {
   ...
 };
 
-function genItemData(count: number, start: number = 0): Array<Item> {
+function genItemData(i: number): Item {
+  const itemHash = Math.abs(hashCode('Item ' + i));
+  return {
+    title: 'Item ' + i,
+    text: LOREM_IPSUM.substr(0, (itemHash % 301) + 20),
+    key: String(i),
+    pressed: false,
+  };
+}
+
+function genNewerItems(count: number, start: number = 0): Array<Item> {
   const dataBlob = [];
-  for (let ii = start; ii < count + start; ii++) {
-    const itemHash = Math.abs(hashCode('Item ' + ii));
-    dataBlob.push({
-      title: 'Item ' + ii,
-      text: LOREM_IPSUM.substr(0, (itemHash % 301) + 20),
-      key: String(ii),
-      pressed: false,
-    });
+  for (let i = start; i < count + start; i++) {
+    dataBlob.push(genItemData(i));
+  }
+  return dataBlob;
+}
+
+function genOlderItems(count: number, start: number = 0): Array<Item> {
+  const dataBlob = [];
+  for (let i = count; i > 0; i--) {
+    dataBlob.push(genItemData(start - i));
   }
   return dataBlob;
 }
@@ -146,6 +159,12 @@ class SeparatorComponent extends React.PureComponent<{...}> {
     return <View style={styles.separator} />;
   }
 }
+
+const LoadingComponent: React.ComponentType<{}> = React.memo(() => (
+  <View style={styles.loadingContainer}>
+    <ActivityIndicator />
+  </View>
+));
 
 class ItemSeparatorComponent extends React.PureComponent<$FlowFixMeProps> {
   render(): React.Node {
@@ -352,6 +371,13 @@ const styles = StyleSheet.create({
   text: {
     flex: 1,
   },
+  loadingContainer: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: 100,
+    borderTopWidth: 1,
+    borderTopColor: 'rgb(200, 199, 204)',
+  },
 });
 
 module.exports = {
@@ -362,8 +388,10 @@ module.exports = {
   ItemSeparatorComponent,
   PlainInput,
   SeparatorComponent,
+  LoadingComponent,
   Spindicator,
-  genItemData,
+  genNewerItems,
+  genOlderItems,
   getItemLayout,
   pressItem,
   renderSmallSwitchOption,

--- a/packages/rn-tester/js/examples/FlatList/FlatList-basic.js
+++ b/packages/rn-tester/js/examples/FlatList/FlatList-basic.js
@@ -35,14 +35,21 @@ import {
   ItemSeparatorComponent,
   PlainInput,
   SeparatorComponent,
+  LoadingComponent,
   Spindicator,
-  genItemData,
+  genNewerItems,
+  genOlderItems,
   getItemLayout,
   pressItem,
   renderSmallSwitchOption,
 } from '../../components/ListExampleShared';
 
 import type {Item} from '../../components/ListExampleShared';
+
+const PAGE_SIZE = 100;
+const NUM_PAGES = 10;
+const INITIAL_PAGE_OFFSET = Math.floor(NUM_PAGES / 2);
+const LOAD_TIME = 2000;
 
 const VIEWABILITY_CONFIG = {
   minimumViewTime: 3000,
@@ -53,6 +60,8 @@ const VIEWABILITY_CONFIG = {
 type Props = $ReadOnly<{||}>;
 type State = {|
   data: Array<Item>,
+  first: number,
+  last: number,
   debug: boolean,
   horizontal: boolean,
   inverted: boolean,
@@ -66,13 +75,18 @@ type State = {|
   onPressDisabled: boolean,
   textSelectable: boolean,
   isRTL: boolean,
+  maintainVisibleContentPosition: boolean,
+  previousLoading: boolean,
+  nextLoading: boolean,
 |};
 
 const IS_RTL = I18nManager.isRTL;
 
 class FlatListExample extends React.PureComponent<Props, State> {
   state: State = {
-    data: genItemData(100),
+    data: genNewerItems(PAGE_SIZE, PAGE_SIZE * INITIAL_PAGE_OFFSET),
+    first: PAGE_SIZE * INITIAL_PAGE_OFFSET,
+    last: PAGE_SIZE + PAGE_SIZE * INITIAL_PAGE_OFFSET,
     debug: false,
     horizontal: false,
     inverted: false,
@@ -86,6 +100,9 @@ class FlatListExample extends React.PureComponent<Props, State> {
     onPressDisabled: false,
     textSelectable: true,
     isRTL: IS_RTL,
+    maintainVisibleContentPosition: true,
+    previousLoading: false,
+    nextLoading: false,
   };
 
   /* $FlowFixMe[missing-local-annot] The type annotation(s) required by Flow's
@@ -206,6 +223,11 @@ class FlatListExample extends React.PureComponent<Props, State> {
                 this.state.isRTL,
                 this._setIsRTL,
               )}
+              {renderSmallSwitchOption(
+                'Maintain content position',
+                this.state.maintainVisibleContentPosition,
+                this._setBooleanValue('maintainVisibleContentPosition'),
+              )}
               {Platform.OS === 'android' && (
                 <View>
                   <TextInput
@@ -227,8 +249,12 @@ class FlatListExample extends React.PureComponent<Props, State> {
           <Animated.FlatList
             fadingEdgeLength={this.state.fadingEdgeLength}
             ItemSeparatorComponent={ItemSeparatorComponent}
-            ListHeaderComponent={<HeaderComponent />}
-            ListFooterComponent={FooterComponent}
+            ListHeaderComponent={
+              this.state.previousLoading ? LoadingComponent : HeaderComponent
+            }
+            ListFooterComponent={
+              this.state.nextLoading ? LoadingComponent : FooterComponent
+            }
             ListEmptyComponent={ListEmptyComponent}
             // $FlowFixMe[missing-empty-array-annot]
             data={this.state.empty ? [] : filteredData}
@@ -247,6 +273,8 @@ class FlatListExample extends React.PureComponent<Props, State> {
             keyboardShouldPersistTaps="always"
             keyboardDismissMode="on-drag"
             numColumns={1}
+            onStartReached={this._onStartReached}
+            initialScrollIndex={Math.floor(PAGE_SIZE / 2)}
             onEndReached={this._onEndReached}
             onRefresh={this._onRefresh}
             onScroll={
@@ -257,6 +285,11 @@ class FlatListExample extends React.PureComponent<Props, State> {
             refreshing={false}
             contentContainerStyle={styles.list}
             viewabilityConfig={VIEWABILITY_CONFIG}
+            maintainVisibleContentPosition={
+              this.state.maintainVisibleContentPosition
+                ? {minIndexForVisible: 0}
+                : undefined
+            }
             {...flatListItemRendererProps}
           />
         </View>
@@ -277,13 +310,33 @@ class FlatListExample extends React.PureComponent<Props, State> {
   _getItemLayout = (data: any, index: number) => {
     return getItemLayout(data, index, this.state.horizontal);
   };
-  _onEndReached = () => {
-    if (this.state.data.length >= 1000) {
+  _onStartReached = () => {
+    if (this.state.first <= 0 || this.state.previousLoading) {
       return;
     }
-    this.setState(state => ({
-      data: state.data.concat(genItemData(100, state.data.length)),
-    }));
+
+    this.setState({previousLoading: true});
+    setTimeout(() => {
+      this.setState(state => ({
+        previousLoading: false,
+        data: genOlderItems(PAGE_SIZE, state.first).concat(state.data),
+        first: state.first - PAGE_SIZE,
+      }));
+    }, LOAD_TIME);
+  };
+  _onEndReached = () => {
+    if (this.state.last >= PAGE_SIZE * NUM_PAGES || this.state.nextLoading) {
+      return;
+    }
+
+    this.setState({nextLoading: true});
+    setTimeout(() => {
+      this.setState(state => ({
+        nextLoading: false,
+        data: state.data.concat(genNewerItems(PAGE_SIZE, state.last)),
+        last: state.last + PAGE_SIZE,
+      }));
+    }, LOAD_TIME);
   };
   // $FlowFixMe[missing-local-annot]
   _onPressCallback = () => {
@@ -340,7 +393,7 @@ class FlatListExample extends React.PureComponent<Props, State> {
 
   _pressItem = (key: string) => {
     this._listRef?.recordInteraction();
-    const index = Number(key);
+    const index = this.state.data.findIndex(item => item.key === key);
     const itemState = pressItem(this.state.data[index]);
     this.setState(state => ({
       ...state,

--- a/packages/rn-tester/js/examples/FlatList/FlatList-multiColumn.js
+++ b/packages/rn-tester/js/examples/FlatList/FlatList-multiColumn.js
@@ -23,7 +23,7 @@ const {
   ItemComponent,
   PlainInput,
   SeparatorComponent,
-  genItemData,
+  genNewerItems,
   getItemLayout,
   pressItem,
   renderSmallSwitchOption,
@@ -46,7 +46,7 @@ class MultiColumnExample extends React.PureComponent<
         numColumns: number,
         virtualized: boolean,
       |} = {
-    data: genItemData(1000),
+    data: genNewerItems(1000),
     filterText: '',
     fixedHeight: true,
     logViewable: false,

--- a/packages/rn-tester/js/examples/SectionList/SectionList-scrollable.js
+++ b/packages/rn-tester/js/examples/SectionList/SectionList-scrollable.js
@@ -22,7 +22,7 @@ const {
   PlainInput,
   SeparatorComponent,
   Spindicator,
-  genItemData,
+  genNewerItems,
   pressItem,
   renderSmallSwitchOption,
   renderStackedItem,
@@ -170,7 +170,7 @@ export function SectionList_scrollable(Props: {
   const [logViewable, setLogViewable] = React.useState(false);
   const [debug, setDebug] = React.useState(false);
   const [inverted, setInverted] = React.useState(false);
-  const [data, setData] = React.useState(genItemData(1000));
+  const [data, setData] = React.useState(genNewerItems(1000));
 
   const filterRegex = new RegExp(String(filterText), 'i');
   const filter = (item: Item) =>

--- a/packages/virtualized-lists/Lists/VirtualizedList.js
+++ b/packages/virtualized-lists/Lists/VirtualizedList.js
@@ -891,6 +891,10 @@ class VirtualizedList extends StateSafePureComponent<Props, State> {
           cellKey={this._getCellKey() + '-header'}
           key="$header">
           <View
+            // We expect that header component will be a single native view so make it
+            // not collapsable to avoid this view being flattened and make this assumption
+            // no longer true.
+            collapsable={false}
             onLayout={this._onLayoutHeader}
             style={StyleSheet.compose(
               inversionStyle,

--- a/packages/virtualized-lists/Lists/__tests__/VirtualizedList-test.js
+++ b/packages/virtualized-lists/Lists/__tests__/VirtualizedList-test.js
@@ -2225,7 +2225,7 @@ function simulateContentLayout(component, dimensions) {
 
 function simulateCellLayout(component, items, itemIndex, dimensions) {
   const instance = component.getInstance();
-  const cellKey = instance._keyExtractor(
+  const cellKey = VirtualizedList._keyExtractor(
     items[itemIndex],
     itemIndex,
     instance.props,

--- a/packages/virtualized-lists/Lists/__tests__/VirtualizedList-test.js
+++ b/packages/virtualized-lists/Lists/__tests__/VirtualizedList-test.js
@@ -2164,10 +2164,70 @@ it('virtualizes away last focused index if item removed', () => {
   expect(component).toMatchSnapshot();
 });
 
-function generateItems(count) {
+it('handles maintainVisibleContentPosition', () => {
+  const items = generateItems(20);
+  const ITEM_HEIGHT = 10;
+
+  let component;
+  ReactTestRenderer.act(() => {
+    component = ReactTestRenderer.create(
+      <VirtualizedList
+        initialNumToRender={1}
+        windowSize={1}
+        maintainVisibleContentPosition={{minIndexForVisible: 0}}
+        {...baseItemProps(items)}
+        {...fixedHeightItemLayoutProps(ITEM_HEIGHT)}
+      />,
+    );
+  });
+
+  ReactTestRenderer.act(() => {
+    simulateLayout(component, {
+      viewport: {width: 10, height: 50},
+      content: {width: 10, height: items.length * ITEM_HEIGHT},
+    });
+
+    performAllBatches();
+  });
+
+  // Initial render.
+  expect(component).toMatchSnapshot();
+
+  // Add new items at the start of the list to trigger the maintainVisibleContentPosition adjustment.
+  const newItems = [...generateItems(10, items.length), ...items];
+  ReactTestRenderer.act(() => {
+    component.update(
+      <VirtualizedList
+        initialNumToRender={1}
+        windowSize={1}
+        maintainVisibleContentPosition={{minIndexForVisible: 0}}
+        {...baseItemProps(newItems)}
+        {...fixedHeightItemLayoutProps(ITEM_HEIGHT)}
+      />,
+    );
+  });
+
+  // Previously rendered cells should be rendered still.
+  expect(component).toMatchSnapshot();
+
+  // Simulate scroll adjustment from native maintainVisibleContentPosition.
+  ReactTestRenderer.act(() => {
+    simulateContentLayout(component, {
+      width: 10,
+      height: newItems.length * ITEM_HEIGHT,
+    });
+    simulateScroll(component, {x: 0, y: 10 * ITEM_HEIGHT});
+    performAllBatches();
+  });
+
+  // Previously rendered cells should be rendered still + starting to render new cells ahead.
+  expect(component).toMatchSnapshot();
+});
+
+function generateItems(count, startKey = 0) {
   return Array(count)
     .fill()
-    .map((_, i) => ({key: i}));
+    .map((_, i) => ({key: i + startKey}));
 }
 
 function generateItemsStickyEveryN(count, n) {

--- a/packages/virtualized-lists/Lists/__tests__/__snapshots__/VirtualizedList-test.js.snap
+++ b/packages/virtualized-lists/Lists/__tests__/__snapshots__/VirtualizedList-test.js.snap
@@ -1837,45 +1837,12 @@ exports[`adjusts render area with non-zero initialScrollIndex 1`] = `
       />
     </View>
     <View
-      onFocusCapture={[Function]}
-      style={null}
-    >
-      <MockCellItem
-        value={15}
-      />
-    </View>
-    <View
-      onFocusCapture={[Function]}
-      style={null}
-    >
-      <MockCellItem
-        value={16}
-      />
-    </View>
-    <View
-      onFocusCapture={[Function]}
-      style={null}
-    >
-      <MockCellItem
-        value={17}
-      />
-    </View>
-    <View
-      onFocusCapture={[Function]}
-      style={null}
-    >
-      <MockCellItem
-        value={18}
-      />
-    </View>
-    <View
-      onFocusCapture={[Function]}
-      style={null}
-    >
-      <MockCellItem
-        value={19}
-      />
-    </View>
+      style={
+        Object {
+          "height": 50,
+        }
+      }
+    />
   </View>
 </RCTScrollView>
 `;
@@ -3628,10 +3595,18 @@ exports[`handles maintainVisibleContentPosition 3`] = `
     <View
       style={
         Object {
-          "height": 90,
+          "height": 80,
         }
       }
     />
+    <View
+      onFocusCapture={[Function]}
+      style={null}
+    >
+      <MockCellItem
+        value={29}
+      />
+    </View>
     <View
       onFocusCapture={[Function]}
       style={null}
@@ -4623,21 +4598,12 @@ exports[`renders new items when data is updated with non-zero initialScrollIndex
       />
     </View>
     <View
-      onFocusCapture={[Function]}
-      style={null}
-    >
-      <MockCellItem
-        value={2}
-      />
-    </View>
-    <View
-      onFocusCapture={[Function]}
-      style={null}
-    >
-      <MockCellItem
-        value={3}
-      />
-    </View>
+      style={
+        Object {
+          "height": 20,
+        }
+      }
+    />
   </View>
 </RCTScrollView>
 `;

--- a/packages/virtualized-lists/Lists/__tests__/__snapshots__/VirtualizedList-test.js.snap
+++ b/packages/virtualized-lists/Lists/__tests__/__snapshots__/VirtualizedList-test.js.snap
@@ -3176,6 +3176,513 @@ exports[`gracefully handles negative initialScrollIndex 1`] = `
 </RCTScrollView>
 `;
 
+exports[`handles maintainVisibleContentPosition 1`] = `
+<RCTScrollView
+  data={
+    Array [
+      Object {
+        "key": 0,
+      },
+      Object {
+        "key": 1,
+      },
+      Object {
+        "key": 2,
+      },
+      Object {
+        "key": 3,
+      },
+      Object {
+        "key": 4,
+      },
+      Object {
+        "key": 5,
+      },
+      Object {
+        "key": 6,
+      },
+      Object {
+        "key": 7,
+      },
+      Object {
+        "key": 8,
+      },
+      Object {
+        "key": 9,
+      },
+      Object {
+        "key": 10,
+      },
+      Object {
+        "key": 11,
+      },
+      Object {
+        "key": 12,
+      },
+      Object {
+        "key": 13,
+      },
+      Object {
+        "key": 14,
+      },
+      Object {
+        "key": 15,
+      },
+      Object {
+        "key": 16,
+      },
+      Object {
+        "key": 17,
+      },
+      Object {
+        "key": 18,
+      },
+      Object {
+        "key": 19,
+      },
+    ]
+  }
+  getItem={[Function]}
+  getItemCount={[Function]}
+  getItemLayout={[Function]}
+  initialNumToRender={1}
+  maintainVisibleContentPosition={
+    Object {
+      "minIndexForVisible": 0,
+    }
+  }
+  onContentSizeChange={[Function]}
+  onLayout={[Function]}
+  onMomentumScrollBegin={[Function]}
+  onMomentumScrollEnd={[Function]}
+  onScroll={[Function]}
+  onScrollBeginDrag={[Function]}
+  onScrollEndDrag={[Function]}
+  renderItem={[Function]}
+  scrollEventThrottle={50}
+  stickyHeaderIndices={Array []}
+  windowSize={1}
+>
+  <View>
+    <View
+      onFocusCapture={[Function]}
+      style={null}
+    >
+      <MockCellItem
+        value={0}
+      />
+    </View>
+    <View
+      onFocusCapture={[Function]}
+      style={null}
+    >
+      <MockCellItem
+        value={1}
+      />
+    </View>
+    <View
+      onFocusCapture={[Function]}
+      style={null}
+    >
+      <MockCellItem
+        value={2}
+      />
+    </View>
+    <View
+      onFocusCapture={[Function]}
+      style={null}
+    >
+      <MockCellItem
+        value={3}
+      />
+    </View>
+    <View
+      onFocusCapture={[Function]}
+      style={null}
+    >
+      <MockCellItem
+        value={4}
+      />
+    </View>
+    <View
+      style={
+        Object {
+          "height": 150,
+        }
+      }
+    />
+  </View>
+</RCTScrollView>
+`;
+
+exports[`handles maintainVisibleContentPosition 2`] = `
+<RCTScrollView
+  data={
+    Array [
+      Object {
+        "key": 20,
+      },
+      Object {
+        "key": 21,
+      },
+      Object {
+        "key": 22,
+      },
+      Object {
+        "key": 23,
+      },
+      Object {
+        "key": 24,
+      },
+      Object {
+        "key": 25,
+      },
+      Object {
+        "key": 26,
+      },
+      Object {
+        "key": 27,
+      },
+      Object {
+        "key": 28,
+      },
+      Object {
+        "key": 29,
+      },
+      Object {
+        "key": 0,
+      },
+      Object {
+        "key": 1,
+      },
+      Object {
+        "key": 2,
+      },
+      Object {
+        "key": 3,
+      },
+      Object {
+        "key": 4,
+      },
+      Object {
+        "key": 5,
+      },
+      Object {
+        "key": 6,
+      },
+      Object {
+        "key": 7,
+      },
+      Object {
+        "key": 8,
+      },
+      Object {
+        "key": 9,
+      },
+      Object {
+        "key": 10,
+      },
+      Object {
+        "key": 11,
+      },
+      Object {
+        "key": 12,
+      },
+      Object {
+        "key": 13,
+      },
+      Object {
+        "key": 14,
+      },
+      Object {
+        "key": 15,
+      },
+      Object {
+        "key": 16,
+      },
+      Object {
+        "key": 17,
+      },
+      Object {
+        "key": 18,
+      },
+      Object {
+        "key": 19,
+      },
+    ]
+  }
+  getItem={[Function]}
+  getItemCount={[Function]}
+  getItemLayout={[Function]}
+  initialNumToRender={1}
+  maintainVisibleContentPosition={
+    Object {
+      "minIndexForVisible": 0,
+    }
+  }
+  onContentSizeChange={[Function]}
+  onLayout={[Function]}
+  onMomentumScrollBegin={[Function]}
+  onMomentumScrollEnd={[Function]}
+  onScroll={[Function]}
+  onScrollBeginDrag={[Function]}
+  onScrollEndDrag={[Function]}
+  renderItem={[Function]}
+  scrollEventThrottle={50}
+  stickyHeaderIndices={Array []}
+  windowSize={1}
+>
+  <View>
+    <View
+      onFocusCapture={[Function]}
+      style={null}
+    >
+      <MockCellItem
+        value={20}
+      />
+    </View>
+    <View
+      style={
+        Object {
+          "height": 90,
+        }
+      }
+    />
+    <View
+      onFocusCapture={[Function]}
+      style={null}
+    >
+      <MockCellItem
+        value={0}
+      />
+    </View>
+    <View
+      onFocusCapture={[Function]}
+      style={null}
+    >
+      <MockCellItem
+        value={1}
+      />
+    </View>
+    <View
+      onFocusCapture={[Function]}
+      style={null}
+    >
+      <MockCellItem
+        value={2}
+      />
+    </View>
+    <View
+      onFocusCapture={[Function]}
+      style={null}
+    >
+      <MockCellItem
+        value={3}
+      />
+    </View>
+    <View
+      onFocusCapture={[Function]}
+      style={null}
+    >
+      <MockCellItem
+        value={4}
+      />
+    </View>
+    <View
+      style={
+        Object {
+          "height": 150,
+        }
+      }
+    />
+  </View>
+</RCTScrollView>
+`;
+
+exports[`handles maintainVisibleContentPosition 3`] = `
+<RCTScrollView
+  data={
+    Array [
+      Object {
+        "key": 20,
+      },
+      Object {
+        "key": 21,
+      },
+      Object {
+        "key": 22,
+      },
+      Object {
+        "key": 23,
+      },
+      Object {
+        "key": 24,
+      },
+      Object {
+        "key": 25,
+      },
+      Object {
+        "key": 26,
+      },
+      Object {
+        "key": 27,
+      },
+      Object {
+        "key": 28,
+      },
+      Object {
+        "key": 29,
+      },
+      Object {
+        "key": 0,
+      },
+      Object {
+        "key": 1,
+      },
+      Object {
+        "key": 2,
+      },
+      Object {
+        "key": 3,
+      },
+      Object {
+        "key": 4,
+      },
+      Object {
+        "key": 5,
+      },
+      Object {
+        "key": 6,
+      },
+      Object {
+        "key": 7,
+      },
+      Object {
+        "key": 8,
+      },
+      Object {
+        "key": 9,
+      },
+      Object {
+        "key": 10,
+      },
+      Object {
+        "key": 11,
+      },
+      Object {
+        "key": 12,
+      },
+      Object {
+        "key": 13,
+      },
+      Object {
+        "key": 14,
+      },
+      Object {
+        "key": 15,
+      },
+      Object {
+        "key": 16,
+      },
+      Object {
+        "key": 17,
+      },
+      Object {
+        "key": 18,
+      },
+      Object {
+        "key": 19,
+      },
+    ]
+  }
+  getItem={[Function]}
+  getItemCount={[Function]}
+  getItemLayout={[Function]}
+  initialNumToRender={1}
+  maintainVisibleContentPosition={
+    Object {
+      "minIndexForVisible": 0,
+    }
+  }
+  onContentSizeChange={[Function]}
+  onLayout={[Function]}
+  onMomentumScrollBegin={[Function]}
+  onMomentumScrollEnd={[Function]}
+  onScroll={[Function]}
+  onScrollBeginDrag={[Function]}
+  onScrollEndDrag={[Function]}
+  renderItem={[Function]}
+  scrollEventThrottle={50}
+  stickyHeaderIndices={Array []}
+  windowSize={1}
+>
+  <View>
+    <View
+      onFocusCapture={[Function]}
+      style={null}
+    >
+      <MockCellItem
+        value={20}
+      />
+    </View>
+    <View
+      style={
+        Object {
+          "height": 90,
+        }
+      }
+    />
+    <View
+      onFocusCapture={[Function]}
+      style={null}
+    >
+      <MockCellItem
+        value={0}
+      />
+    </View>
+    <View
+      onFocusCapture={[Function]}
+      style={null}
+    >
+      <MockCellItem
+        value={1}
+      />
+    </View>
+    <View
+      onFocusCapture={[Function]}
+      style={null}
+    >
+      <MockCellItem
+        value={2}
+      />
+    </View>
+    <View
+      onFocusCapture={[Function]}
+      style={null}
+    >
+      <MockCellItem
+        value={3}
+      />
+    </View>
+    <View
+      onFocusCapture={[Function]}
+      style={null}
+    >
+      <MockCellItem
+        value={4}
+      />
+    </View>
+    <View
+      style={
+        Object {
+          "height": 150,
+        }
+      }
+    />
+  </View>
+</RCTScrollView>
+`;
+
 exports[`initially renders nothing when initialNumToRender is 0 1`] = `
 <RCTScrollView
   data={

--- a/packages/virtualized-lists/Lists/__tests__/__snapshots__/VirtualizedList-test.js.snap
+++ b/packages/virtualized-lists/Lists/__tests__/__snapshots__/VirtualizedList-test.js.snap
@@ -65,6 +65,7 @@ exports[`VirtualizedList forwards correct stickyHeaderIndices when ListHeaderCom
 >
   <View>
     <View
+      collapsable={false}
       onLayout={[Function]}
     >
       <Header />
@@ -1048,6 +1049,7 @@ exports[`VirtualizedList renders all the bells and whistles 1`] = `
   <RCTRefreshControl />
   <View>
     <View
+      collapsable={false}
       onLayout={[Function]}
       style={
         Object {
@@ -1249,6 +1251,7 @@ exports[`VirtualizedList renders empty list with empty component 1`] = `
 >
   <View>
     <View
+      collapsable={false}
       onLayout={[Function]}
     >
       <header />

--- a/packages/virtualized-lists/Lists/__tests__/__snapshots__/VirtualizedSectionList-test.js.snap
+++ b/packages/virtualized-lists/Lists/__tests__/__snapshots__/VirtualizedSectionList-test.js.snap
@@ -831,6 +831,7 @@ exports[`VirtualizedSectionList renders all the bells and whistles 1`] = `
   <RCTRefreshControl />
   <View>
     <View
+      collapsable={false}
       onLayout={[Function]}
       style={
         Object {
@@ -1056,6 +1057,7 @@ exports[`VirtualizedSectionList renders empty list with empty component 1`] = `
 >
   <View>
     <View
+      collapsable={false}
       onLayout={[Function]}
     >
       <header />


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

`maintainVisibleContentPosition` is broken when using virtualization and the new content pushes visible content outside its "window". This can be reproduced in the example from this diff. When using a large page size it will always push visible content outside of the list "window" which will cause currently visible views to be unmounted so the implementation of `maintainVisibleContentPosition` can't adjust the content inset since the visible views no longer exist.

The first illustration shows the working case, when the new content doesn't push visible content outside the window. The red box represents the window, all views outside the box are not mounted, which means the native implementation of `maintainVisibleContentPosition`  has no way to know it exists. In that case the first visible view is #2, after new content is added #2 is still inside the window so there's not problem adjusting content offset to maintain position. As you can see Step 1 and 3 result in the same position for all initial views.

The second illustation shows the broken case, when new content is added and pushes the first visible view outside the window. As you can see in step 2 the view #2 is no longer rendered so there's no way to maintain its position.

#### Illustration 1

![image](https://user-images.githubusercontent.com/2677334/163263472-eaf7342a-9b94-4c49-9a34-17bf8ef4ffb9.png)

#### Illustration 2

![image](https://user-images.githubusercontent.com/2677334/163263528-a8172341-137e-417e-a0c7-929d1e4e6791.png)

To fix `maintainVisibleContentPosition` when using `VirtualizedList` we need to make sure the visible items stay rendered when new items are added at the start of the list.

In order to do that we need to do the following:

- Detect new items that will cause content to be adjusted
- Add cells to render mask so that previously visible cells stay rendered
- Ignore certain updates while scroll metrics are invalid

### Detect new items that will cause content to be adjusted

The goal here is to know that scroll position will be updated natively by the `maintainVisibleContentPosition` implementation. The problem is that the native code uses layout heuristics which are not easily available to JS to do so. In order to approximate the native heuristic we can assume that if new items are added at the start of the list, it will cause `maintainVisibleContentPosition` to be triggered. This simplifies JS logic a lot as we don't have to track visible items. In the worst case if for some reason our JS heuristic is wrong, it will cause extra cells to be rendered until the next scroll event, or content position will not be maintained (what happens all the time currently). I think this is a good compromise between complexity and accuracy.

We need to find how many items have been added before the first one. To do that we save the key of the first item in state `firstItemKey`. When data changes we can find the index of `firstItemKey` in the new data and that will be the amount we need to adjust the window state by.

Note that this means that keys need to be stable, and using index won't work.

### Add cells to render mask so that previously visible cells stay rendered

Once we have the adjusted number we can save this in a new state value `maintainVisibleContentPositionAdjustment` and add the adjusted cells to the render mask.

This state is then cleared when we receive updated scroll metrics, once the native implementation is done adding the new items and adjusting the content offset.

This value is also only set when `maintainVisibleContentPosition` is set so this makes sure this maintains the currently behavior when that prop is not set.

### Ignore certain updates while scroll metrics are invalid

While the `maintainVisibleContentPositionAdjustment` state is set we know that the current scroll metrics are invalid since they will be updated in the native `ScrollView` implementation. In that case we want to prevent certain code from running.

One example is `onStartReached` that will be called incorrectly while we are waiting for updated scroll metrics.

## Changelog

[General] [Fixed] - Fix VirtualizedList with maintainVisibleContentPosition

## Test Plan

Added bidirectional paging to RN tester FlatList example. Note that for this to work RN tester need to be run using old architecture on iOS, to use new architecture it requires https://github.com/facebook/react-native/pull/35319

Using debug mode we can see that virtualization is still working properly, and content position is being maintained.

https://user-images.githubusercontent.com/2677334/163294404-e2eeae5b-e079-4dba-8664-ad280c171ae6.mov

