### PR TITLE
Add fabric support for maintainVisibleContentPosition on Android

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedModule.java
@@ -298,6 +298,16 @@ public class NativeAnimatedModule extends NativeAnimatedModuleSpec
     mCurrentFrameNumber++;
   }
 
+  @Override
+  public void willMountItems(UIManager uiManager) {
+    // noop
+  }
+
+  @Override
+  public void didMountItems(UIManager uiManager) {
+    // noop
+  }
+
   // For FabricUIManager only
   @Override
   @UiThread

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/UIManagerListener.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/UIManagerListener.java
@@ -12,10 +12,33 @@ public interface UIManagerListener {
   /**
    * Called right before view updates are dispatched at the end of a batch. This is useful if a
    * module needs to add UIBlocks to the queue before it is flushed.
+   *
+   * This is called by Paper only.
    */
   void willDispatchViewUpdates(UIManager uiManager);
-  /* Called right after view updates are dispatched for a frame. */
+  /**
+   * Called on UIThread right before view updates are executed.
+   *
+   * This is called by Fabric only.
+   */
+  void willMountItems(UIManager uiManager);
+  /**
+   * Called on UIThread right after view updates are executed.
+   *
+   * This is called by Fabric only.
+   */
+  void didMountItems(UIManager uiManager);
+  /**
+   * Called on UIThread right after view updates are dispatched for a frame. Note that this will be called
+   * for every frame even if there are no updates.
+   *
+   * This is called by Fabric only.
+   */
   void didDispatchMountItems(UIManager uiManager);
-  /* Called right after scheduleMountItems is called in Fabric, after a new tree is committed. */
+  /**
+   * Called right after scheduleMountItems is called in Fabric, after a new tree is committed.
+   *
+   * This is called by Fabric only.
+   */
   void didScheduleMountItems(UIManager uiManager);
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -1203,6 +1203,20 @@ public class FabricUIManager implements UIManager, LifecycleEventListener {
 
   private class MountItemDispatchListener implements MountItemDispatcher.ItemDispatchListener {
     @Override
+    public void willMountItems() {
+      for (UIManagerListener listener : mListeners) {
+        listener.willMountItems(FabricUIManager.this);
+      }
+    }
+
+    @Override
+    public void didMountItems() {
+      for (UIManagerListener listener : mListeners) {
+        listener.didMountItems(FabricUIManager.this);
+      }
+    }
+
+    @Override
     public void didDispatchMountItems() {
       for (UIManagerListener listener : mListeners) {
         listener.didDispatchMountItems(FabricUIManager.this);

--- a/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountItemDispatcher.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountItemDispatcher.java
@@ -193,6 +193,8 @@ public class MountItemDispatcher {
       return false;
     }
 
+    mItemDispatchListener.willMountItems();
+
     // As an optimization, execute all ViewCommands first
     // This should be:
     // 1) Performant: ViewCommands are often a replacement for SetNativeProps, which we've always
@@ -299,6 +301,9 @@ public class MountItemDispatcher {
       }
       mBatchedExecutionTime += SystemClock.uptimeMillis() - batchedExecutionStartTime;
     }
+
+    mItemDispatchListener.didMountItems();
+
     Systrace.endSection(Systrace.TRACE_TAG_REACT_JAVA_BRIDGE);
 
     return true;
@@ -415,6 +420,8 @@ public class MountItemDispatcher {
   }
 
   public interface ItemDispatchListener {
+    void willMountItems();
+    void didMountItems();
     void didDispatchMountItems();
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/MaintainVisibleScrollPositionHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/MaintainVisibleScrollPositionHelper.java
@@ -18,6 +18,7 @@ import com.facebook.react.bridge.UIManager;
 import com.facebook.react.bridge.UIManagerListener;
 import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.uimanager.UIManagerHelper;
+import com.facebook.react.uimanager.common.UIManagerType;
 import com.facebook.react.uimanager.common.ViewUtil;
 import com.facebook.react.views.scroll.ReactScrollViewHelper.HasSmoothScroll;
 import com.facebook.react.views.view.ReactViewGroup;
@@ -89,6 +90,14 @@ public class MaintainVisibleScrollPositionHelper<ScrollViewT extends ViewGroup &
    * been updated.
    */
   public void updateScrollPosition() {
+    // On Fabric this will be called internally in `didMountItems`.
+    if (ViewUtil.getUIManagerType(mScrollView.getId()) == UIManagerType.FABRIC) {
+      return;
+    }
+    updateScrollPositionInternal();
+  }
+
+  private void updateScrollPositionInternal() {
     if (mConfig == null || mFirstVisibleView == null || mPrevFirstVisibleFrame == null) {
       return;
     }
@@ -167,6 +176,16 @@ public class MaintainVisibleScrollPositionHelper<ScrollViewT extends ViewGroup &
             computeTargetView();
           }
         });
+  }
+
+  @Override
+  public void willMountItems(UIManager uiManager) {
+    computeTargetView();
+  }
+
+  @Override
+  public void didMountItems(UIManager uiManager) {
+    updateScrollPositionInternal();
   }
 
   @Override


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Implement a few missing bits for `maintainVisibleContentPosition` to work with fabric. The main thing needed is to add 2 fabric renderer listener methods to allow to hook into specific parts of the rendering process. We need some code to execute before view updates are executed and after view updates are executed. The current methods that are exposed do not work for this case. `willDispatchViewUpdates` is called from JS thread, and there doesn't seem to be a way to add UI blocks that will be executed at the right time like we do in paper. `didDispatchMountItems` is called for every frame which we don't want and will cause lots of overhead.

After that we simply need to call the right methods in the new renderer listener methods.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID] [ADDED] - Add fabric support for maintainVisibleContentPosition on Android

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan

Tested in RN tester maintainVisibleContentPosition example on Android with fabric enabled.