### PR TITLE
Add Tests in CircleCI to check dynamic frameworks with the old arch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -853,7 +853,7 @@ jobs:
         default: "StaticLibraries"
         description: Which kind of option we want to use for `use_frameworks!`
         type: enum
-        enum: ["StaticLibraries", "StaticFrameworks"] #TODO: Add "DynamicFrameworks"
+        enum: ["StaticLibraries", "StaticFrameworks", "DynamicFrameworks"]
     environment:
       - PROJECT_NAME: "iOSTemplateProject"
       - HERMES_WS_DIR: *hermes_workspace_root
@@ -906,6 +906,8 @@ jobs:
 
             if [[ << parameters.use_frameworks >> == "StaticFrameworks" ]]; then
               export USE_FRAMEWORKS=static
+            elif [[ << parameters.use_frameworks >> == "DynamicFrameworks" ]]; then
+              export USE_FRAMEWORKS=dynamic
             fi
 
             bundle exec pod install
@@ -1636,7 +1638,7 @@ workflows:
               flavor: ["Debug", "Release"]
               jsengine: ["Hermes", "JSC"]
               flipper: ["WithFlipper", "WithoutFlipper"]
-              use_frameworks: [ "StaticLibraries", "StaticFrameworks" ] #TODO: make it works with DynamicFrameworks
+              use_frameworks: ["StaticLibraries", "StaticFrameworks", "DynamicFrameworks"]
             exclude:
               - architecture: "NewArch"
                 flavor: "Release"
@@ -1651,8 +1653,18 @@ workflows:
               - architecture: "NewArch"
                 flavor: "Release"
                 jsengine: "Hermes"
+                flipper: "WithFlipper"
+                use_frameworks: "DynamicFrameworks"
+              - architecture: "NewArch"
+                flavor: "Release"
+                jsengine: "Hermes"
                 flipper: "WithoutFlipper"
                 use_frameworks: "StaticFrameworks"
+              - architecture: "NewArch"
+                flavor: "Release"
+                jsengine: "Hermes"
+                flipper: "WithoutFlipper"
+                use_frameworks: "DynamicFrameworks"
               - architecture: "NewArch"
                 flavor: "Release"
                 jsengine: "JSC"
@@ -1666,8 +1678,18 @@ workflows:
               - architecture: "NewArch"
                 flavor: "Release"
                 jsengine: "JSC"
+                flipper: "WithFlipper"
+                use_frameworks: "DynamicFrameworks"
+              - architecture: "NewArch"
+                flavor: "Release"
+                jsengine: "JSC"
                 flipper: "WithoutFlipper"
                 use_frameworks: "StaticFrameworks"
+              - architecture: "NewArch"
+                flavor: "Release"
+                jsengine: "JSC"
+                flipper: "WithoutFlipper"
+                use_frameworks: "DynamicFrameworks"
               - architecture: "OldArch"
                 flavor: "Release"
                 jsengine: "Hermes"
@@ -1680,6 +1702,11 @@ workflows:
                 use_frameworks: "StaticFrameworks"
               - architecture: "OldArch"
                 flavor: "Release"
+                jsengine: "Hermes"
+                flipper: "WithFlipper"
+                use_frameworks: "DynamicFrameworks"
+              - architecture: "OldArch"
+                flavor: "Release"
                 jsengine: "JSC"
                 flipper: "WithFlipper"
                 use_frameworks: "StaticLibraries"
@@ -1688,6 +1715,11 @@ workflows:
                 jsengine: "JSC"
                 flipper: "WithFlipper"
                 use_frameworks: "StaticFrameworks"
+              - architecture: "OldArch"
+                flavor: "Release"
+                jsengine: "JSC"
+                flipper: "WithFlipper"
+                use_frameworks: "DynamicFrameworks"
               - architecture: "NewArch"
                 flavor: "Debug"
                 jsengine: "Hermes"
@@ -1718,6 +1750,36 @@ workflows:
                 jsengine: "JSC"
                 flipper: "WithFlipper"
                 use_frameworks: "StaticFrameworks"
+              - architecture: "NewArch"
+                flavor: "Debug"
+                jsengine: "Hermes"
+                flipper: "WithFlipper"
+                use_frameworks: "DynamicFrameworks"
+              - architecture: "NewArch"
+                flavor: "Debug"
+                jsengine: "Hermes"
+                flipper: "WithoutFlipper"
+                use_frameworks: "DynamicFrameworks"
+              - architecture: "NewArch"
+                flavor: "Debug"
+                jsengine: "JSC"
+                flipper: "WithFlipper"
+                use_frameworks: "DynamicFrameworks"
+              - architecture: "NewArch"
+                flavor: "Debug"
+                jsengine: "JSC"
+                flipper: "WithoutFlipper"
+                use_frameworks: "DynamicFrameworks"
+              - architecture: "OldArch"
+                flavor: "Debug"
+                jsengine: "Hermes"
+                flipper: "WithFlipper"
+                use_frameworks: "DynamicFrameworks"
+              - architecture: "OldArch"
+                flavor: "Debug"
+                jsengine: "JSC"
+                flipper: "WithFlipper"
+                use_frameworks: "DynamicFrameworks"
       - test_ios_rntester:
           requires:
             - build_hermes_macos

--- a/Libraries/Blob/React-RCTBlob.podspec
+++ b/Libraries/Blob/React-RCTBlob.podspec
@@ -45,4 +45,8 @@ Pod::Spec.new do |s|
   s.dependency "React-Core/RCTBlobHeaders", version
   s.dependency "React-Core/RCTWebSocket", version
   s.dependency "React-RCTNetwork", version
+
+  if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
+    s.dependency "hermes-engine"
+  end
 end

--- a/React-Core.podspec
+++ b/React-Core.podspec
@@ -75,12 +75,20 @@ Pod::Spec.new do |s|
 
   s.subspec "Default" do |ss|
     ss.source_files           = "React/**/*.{c,h,m,mm,S,cpp}"
-    ss.exclude_files          = "React/CoreModules/**/*",
-                                "React/DevSupport/**/*",
-                                "React/Fabric/**/*",
-                                "React/FBReactNativeSpec/**/*",
-                                "React/Tests/**/*",
-                                "React/Inspector/**/*"
+    exclude_files = [
+      "React/CoreModules/**/*",
+      "React/DevSupport/**/*",
+      "React/Fabric/**/*",
+      "React/FBReactNativeSpec/**/*",
+      "React/Tests/**/*",
+      "React/Inspector/**/*"
+    ]
+    # If we are using Hermes (the default is use hermes, so USE_HERMES can be nil), we don't have jsc installed
+    # So we have to exclude the JSCExecutorFactory
+    if ENV['USE_HERMES'] == nil || ENV['USE_HERMES'] == "1"
+      exclude_files = exclude_files.append("React/CxxBridge/JSCExecutorFactory.{h,mm}")
+    end
+    ss.exclude_files = exclude_files
     ss.private_header_files   = "React/Cxx*/*.h"
   end
 
@@ -117,5 +125,8 @@ Pod::Spec.new do |s|
 
   if ENV['USE_HERMES'] == "0"
     s.dependency 'React-jsc'
+  else
+    s.dependency 'React-hermes'
+    s.dependency 'hermes-engine'
   end
 end

--- a/React-Core.podspec
+++ b/React-Core.podspec
@@ -114,4 +114,8 @@ Pod::Spec.new do |s|
   s.dependency "React-jsiexecutor", version
   s.dependency "Yoga"
   s.dependency "glog"
+
+  if ENV['USE_HERMES'] == "0"
+    s.dependency 'React-jsc'
+  end
 end

--- a/React/CoreModules/React-CoreModules.podspec
+++ b/React/CoreModules/React-CoreModules.podspec
@@ -44,4 +44,5 @@ Pod::Spec.new do |s|
   s.dependency "React-RCTImage", version
   s.dependency "ReactCommon/turbomodule/core", version
   s.dependency "React-jsi", version
+  s.dependency 'React-RCTBlob'
 end

--- a/ReactCommon/ReactCommon.podspec
+++ b/ReactCommon/ReactCommon.podspec
@@ -19,7 +19,7 @@ end
 folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32 -Wno-gnu-zero-variadic-macro-arguments'
 folly_version = '2021.07.22.00'
 boost_compiler_flags = '-Wno-documentation'
-
+using_hermes = ENV['USE_HERMES'] == nil || ENV['USE_HERMES'] == "1"
 Pod::Spec.new do |s|
   s.name                   = "ReactCommon"
   s.module_name            = "ReactCommon"
@@ -49,6 +49,9 @@ Pod::Spec.new do |s|
     s.dependency "React-logger", version
     ss.dependency "DoubleConversion"
     ss.dependency "glog"
+    if using_hermes
+      ss.dependency "hermes-engine"
+    end
 
     ss.subspec "bridging" do |sss|
       sss.dependency           "React-jsi", version
@@ -56,6 +59,9 @@ Pod::Spec.new do |s|
       sss.exclude_files        = "react/bridging/tests"
       sss.header_dir           = "react/bridging"
       sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
+      if using_hermes
+        sss.dependency "hermes-engine"
+      end
     end
 
     ss.subspec "core" do |sss|

--- a/ReactCommon/cxxreact/React-cxxreact.podspec
+++ b/ReactCommon/cxxreact/React-cxxreact.podspec
@@ -47,4 +47,8 @@ Pod::Spec.new do |s|
   s.dependency "React-perflogger", version
   s.dependency "React-jsi", version
   s.dependency "React-logger", version
+
+  if ENV['USE_HERMES'] == nil || ENV['USE_HERMES'] == "1"
+    s.dependency 'hermes-engine'
+  end
 end

--- a/ReactCommon/hermes/React-hermes.podspec
+++ b/ReactCommon/hermes/React-hermes.podspec
@@ -53,4 +53,5 @@ Pod::Spec.new do |s|
   s.dependency "glog"
   s.dependency "RCT-Folly/Futures", folly_version
   s.dependency "hermes-engine"
+  s.dependency "React-jsi"
 end

--- a/ReactCommon/jsiexecutor/React-jsiexecutor.podspec
+++ b/ReactCommon/jsiexecutor/React-jsiexecutor.podspec
@@ -41,4 +41,8 @@ Pod::Spec.new do |s|
   s.dependency "RCT-Folly", folly_version
   s.dependency "DoubleConversion"
   s.dependency "glog"
+
+  if ENV['USE_HERMES'] == nil || ENV['USE_HERMES'] == "1"
+    s.dependency 'hermes-engine'
+  end
 end


### PR DESCRIPTION
Summary:
This diff adds 4 tests in CircleCI to make sure we don't regress in the support of Dynamic Frameworks for the old architecture.

## Changelog
[iOS][Fixed] - Add CircleCI tests for dynamic frameworks with the Old Architecture.

Differential Revision: D42829895

