### PR TITLE
fix(publishing-bumped-packages): look for status code instaead of stderr

### DIFF
--- a/scripts/monorepo/find-and-publish-all-bumped-packages.js
+++ b/scripts/monorepo/find-and-publish-all-bumped-packages.js
@@ -103,15 +103,15 @@ const findAndPublishAllBumpedPackages = () => {
 
       const npmOTPFlag = NPM_CONFIG_OTP ? `--otp ${NPM_CONFIG_OTP}` : '';
 
-      const {stderr} = spawnSync('npm', ['publish', `${npmOTPFlag}`], {
+      const {status, stderr} = spawnSync('npm', ['publish', `${npmOTPFlag}`], {
         cwd: packageAbsolutePath,
         shell: true,
         stdio: 'pipe',
         encoding: 'utf-8',
       });
-      if (stderr) {
+      if (status !== 0) {
         console.log(
-          `\u274c Failed to publish version ${nextVersion} of ${packageManifest.name}:`,
+          `\u274c Failed to publish version ${nextVersion} of ${packageManifest.name}. npm publish exited with code ${status}:`,
         );
         console.log(stderr);
 


### PR DESCRIPTION
Summary:
Changelog: [Internal]

This fixes CircleCI job, which is responsible for publishing bumped packages. We should not check for `stderr`, apparently `npm` uses it to store debug information:
- https://github.com/npm/npm/issues/118#issuecomment-325440

So we've tried to use this on 0.71-stable before and it succesfully published one package, but have exited right after it because `stderr` was not empty

Differential Revision: D42836212

