### PR TITLE
Fix hermes and jsc pods for test targets

### DIFF
--- a/React-Core.podspec
+++ b/React-Core.podspec
@@ -112,6 +112,7 @@ Pod::Spec.new do |s|
   s.dependency "React-perflogger", version
   s.dependency "React-jsi", version
   s.dependency "React-jsiexecutor", version
+  s.dependency "React-#{use_hermes ? "hermes" : "jsc"}", version
   s.dependency "Yoga"
   s.dependency "glog"
 end

--- a/ReactCommon/jsc/React-jsc.podspec
+++ b/ReactCommon/jsc/React-jsc.podspec
@@ -28,6 +28,7 @@ Pod::Spec.new do |s|
   s.source_files           = "JSCRuntime.{cpp,h}"
   s.exclude_files          = "**/test/*"
   s.framework              = "JavaScriptCore"
+  s.header_dir             = "jsc"
 
   s.dependency "React-jsi", version
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

I'm maintaining a library that includes iOS tests (https://github.com/DataDog/dd-sdk-reactnative).

To run these tests, I'm adding the test target to a simple application, from where I am able to run the tests:
![image](https://user-images.githubusercontent.com/8973379/215448714-b06029b8-b7ae-4d24-8202-c16cb790dee9.png)

Since React Native 0.71, the build for the test target fails with the following errors (depending on whether hermes is enabled or not):

Without hermes:
```
Undefined symbols for architecture arm64:
  "facebook::jsc::makeJSCRuntime()", referenced from:
      facebook::react::JSCExecutorFactory::createJSExecutor(std::__1::shared_ptr<facebook::react::ExecutorDelegate>, std::__1::shared_ptr<facebook::react::MessageQueueThread>) in libReact-Core.a(JSCExecutorFactory.o)

```

With hermes:
```
Undefined symbols for architecture arm64:
  "facebook::react::HermesExecutorFactory::defaultRuntimeConfig()", referenced from:
      std::__1::__shared_ptr_emplace<facebook::react::HermesExecutorFactory, std::__1::allocator<facebook::react::HermesExecutorFactory> >::__shared_ptr_emplace<std::__1::function<void (facebook::jsi::Runtime&)>&>(std::__1::allocator<facebook::react::HermesExecutorFactory>, std::__1::function<void (facebook::jsi::Runtime&)>&) in libReact-Core.a(RCTCxxBridge.o)
  "vtable for facebook::react::HermesExecutorFactory", referenced from:
      facebook::react::HermesExecutorFactory::HermesExecutorFactory(std::__1::function<void (facebook::jsi::Runtime&)>, std::__1::function<void (std::__1::function<void ()> const&, std::__1::function<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > ()>)> const&, hermes::vm::RuntimeConfig) in libReact-Core.a(RCTCxxBridge.o)
  NOTE: a missing vtable usually means the first non-inline virtual member function has no definition.
```

When I investigated into the testing target for my pod, I realized that `React-jsc` (or `React-hermes` if hermes is enabled) were missing from the following Build Settings:
- other linker flags
- header search paths
- library search paths

See screenshots below (with hermes):
![image](https://user-images.githubusercontent.com/8973379/215447121-6fe95bb1-f684-48e0-a7cc-b8d766f8b46a.png)
![Screenshot 2023-01-30 at 11 05 01](https://user-images.githubusercontent.com/8973379/215447373-2419be7f-5b29-400a-a7c7-d7b7b802fc04.png)
![image](https://user-images.githubusercontent.com/8973379/215447308-5580769a-9951-493e-b88b-2b227a9ec569.png)

After comparing with other pods that were included in these locations, I noticed that the difference was that they were not in the dependencies of `React-Core` and that `React-jsc` is missing a `header_dir` property in its podspec.

After adding both changes, I was able to build the test target again, and there was no regression on my simple application.

I am not sure this is the best way to achieve this, I don't understand fully how header search paths etc. are defined for Pods targets, so feel free to point me to a better solution if you can think of one.

This could also potentially fix https://github.com/facebook/react-native/issues/34344


## Changelog


[IOS] [FIXED] - Fix builds for pods testing targets

## Test Plan

I am still able to build a simple RN 0.71 application.
With the changes, my test target builds and tests are passing.
