### PR TITLE
Turbo module codegen support interface with inheritance in module

### DIFF
--- a/packages/react-native-codegen/src/CodegenSchema.js
+++ b/packages/react-native-codegen/src/CodegenSchema.js
@@ -53,6 +53,8 @@ export type VoidTypeAnnotation = $ReadOnly<{
 export type ObjectTypeAnnotation<+T> = $ReadOnly<{
   type: 'ObjectTypeAnnotation',
   properties: $ReadOnlyArray<NamedShape<T>>,
+
+  // metadata for objects that generated from interfaces
   baseTypes?: $ReadOnlyArray<string>,
 }>;
 

--- a/packages/react-native-codegen/src/CodegenSchema.js
+++ b/packages/react-native-codegen/src/CodegenSchema.js
@@ -53,6 +53,7 @@ export type VoidTypeAnnotation = $ReadOnly<{
 export type ObjectTypeAnnotation<+T> = $ReadOnly<{
   type: 'ObjectTypeAnnotation',
   properties: $ReadOnlyArray<NamedShape<T>>,
+  baseTypes?: $ReadOnlyArray<string>,
 }>;
 
 type FunctionTypeAnnotation<+P, +R> = $ReadOnly<{

--- a/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/__snapshots__/typescript-module-parser-snapshot-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/__snapshots__/typescript-module-parser-snapshot-test.js.snap
@@ -1521,6 +1521,53 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_NE
             }
           ]
         },
+        'Base1': {
+          'type': 'ObjectTypeAnnotation',
+          'properties': [
+            {
+              'name': 'bar1',
+              'optional': false,
+              'typeAnnotation': {
+                'type': 'TypeAliasTypeAnnotation',
+                'name': 'Bar'
+              }
+            }
+          ]
+        },
+        'Base2': {
+          'type': 'ObjectTypeAnnotation',
+          'properties': [
+            {
+              'name': 'bar2',
+              'optional': false,
+              'typeAnnotation': {
+                'type': 'TypeAliasTypeAnnotation',
+                'name': 'Bar'
+              }
+            }
+          ]
+        },
+        'Base3': {
+          'type': 'ObjectTypeAnnotation',
+          'properties': [
+            {
+              'name': 'bar2',
+              'optional': false,
+              'typeAnnotation': {
+                'type': 'TypeAliasTypeAnnotation',
+                'name': 'Bar'
+              }
+            },
+            {
+              'name': 'bar3',
+              'optional': false,
+              'typeAnnotation': {
+                'type': 'TypeAliasTypeAnnotation',
+                'name': 'Bar'
+              }
+            }
+          ]
+        },
         'Foo': {
           'type': 'ObjectTypeAnnotation',
           'properties': [

--- a/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/__snapshots__/typescript-module-parser-snapshot-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/__snapshots__/typescript-module-parser-snapshot-test.js.snap
@@ -1566,6 +1566,9 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_NE
                 'name': 'Bar'
               }
             }
+          ],
+          'baseTypes': [
+            'Base2'
           ]
         },
         'Foo': {
@@ -1603,6 +1606,10 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_NE
                 'name': 'Bar'
               }
             }
+          ],
+          'baseTypes': [
+            'Base1',
+            'Base3'
           ]
         }
       },

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -268,7 +268,7 @@ function translateTypeAnnotation(
         baseTypes,
       };
 
-      if (objectTypeAnnotation.baseTypes.length == 0) {
+      if (objectTypeAnnotation.baseTypes.length === 0) {
         // The flow checker does not allow adding a member after an object literal is created
         // so here I do it in a reverse way
         delete objectTypeAnnotation.baseTypes;

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -221,6 +221,20 @@ function translateTypeAnnotation(
       }
     }
     case 'TSInterfaceDeclaration': {
+      const baseTypes = (typeAnnotation.extends ?? []).map((extend)=>extend.expression.name);
+      for(const baseType of baseTypes) {
+        // ensure base types exist and appear in aliasMap
+        translateTypeAnnotation(
+          hasteModuleName,
+          {type:'TSTypeReference',typeName:{type:'Identifier',name:baseType}},
+          types,
+          aliasMap,
+          tryParse,
+          cxxOnly,
+          parser,
+        );
+      }
+
       const objectTypeAnnotation = {
         type: 'ObjectTypeAnnotation',
         // $FlowFixMe[missing-type-arg]

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -221,12 +221,17 @@ function translateTypeAnnotation(
       }
     }
     case 'TSInterfaceDeclaration': {
-      const baseTypes = (typeAnnotation.extends ?? []).map((extend)=>extend.expression.name);
-      for(const baseType of baseTypes) {
+      const baseTypes = (typeAnnotation.extends ?? []).map(
+        extend => extend.expression.name,
+      );
+      for (const baseType of baseTypes) {
         // ensure base types exist and appear in aliasMap
         translateTypeAnnotation(
           hasteModuleName,
-          {type:'TSTypeReference',typeName:{type:'Identifier',name:baseType}},
+          {
+            type: 'TSTypeReference',
+            typeName: {type: 'Identifier', name: baseType},
+          },
           types,
           aliasMap,
           tryParse,
@@ -260,10 +265,13 @@ function translateTypeAnnotation(
             },
           )
           .filter(Boolean),
+        baseTypes,
       };
 
-      if(baseTypes.length>0){
-        objectTypeAnnotation.baseTypes = baseTypes;
+      if (objectTypeAnnotation.baseTypes.length == 0) {
+        // The flow checker does not allow adding a member after an object literal is created
+        // so here I do it in a reverse way
+        delete objectTypeAnnotation.baseTypes;
       }
 
       return typeAliasResolution(

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -235,7 +235,7 @@ function translateTypeAnnotation(
         );
       }
 
-      const objectTypeAnnotation = {
+      let objectTypeAnnotation = {
         type: 'ObjectTypeAnnotation',
         // $FlowFixMe[missing-type-arg]
         properties: (flattenProperties(
@@ -261,6 +261,10 @@ function translateTypeAnnotation(
           )
           .filter(Boolean),
       };
+
+      if(baseTypes.length>0){
+        objectTypeAnnotation.baseTypes = baseTypes;
+      }
 
       return typeAliasResolution(
         typeAliasResolutionStatus,


### PR DESCRIPTION
## Summary

The [previous pull request](https://github.com/facebook/react-native/pull/35812) enables defining interfaces and using them in a turbo module, but all members are flattened, this is not the best option for codegen for object oriented languages.

In this pull request, an optional member `baseTypes` is added to aliased objects. Members are still flattened for backward compatibility, if a codegen doesn't care about that nothing needs to be changed.

### Example

```typescript
interface A {
  a : string;
}

interface B extends A {
  b : number;
}
```

#### Before the previous pull request

`interface` is not allowed here, you must use type alias.

#### At the previous pull request

`interface` is allowed, but it is translated to

```typescript
type A = {a : string};
type B = {a : string, b : number};
```

#### At this pull request

Extra information is provided so that you know `B` extends `A`. By comparing `B` to `A` it is easy to know that `B::a` is obtained from `A`.

## Changelog

[GENERAL] [CHANGED] - Turbo module codegen support interface with inheritance in module

## Test Plan

`yarn jest react-native-codegen` passed
