### PR TITLE
fix(script): handle patch versions after the .0 for set version

### DIFF
--- a/scripts/__tests__/version-utils-test.js
+++ b/scripts/__tests__/version-utils-test.js
@@ -141,15 +141,6 @@ describe('version-utils', () => {
       expect(prerelease).toBe('rc.4');
     });
 
-    it('should reject pre-release version with patch != 0', () => {
-      function testInvalidVersion() {
-        parseVersion('0.66.3-rc.4', 'release');
-      }
-      expect(testInvalidVersion).toThrowErrorMatchingInlineSnapshot(
-        `"Version 0.66.3-rc.4 is not valid for Release"`,
-      );
-    });
-
     it('should reject pre-release version from tag with random prerelease pattern', () => {
       function testInvalidVersion() {
         parseVersion('v0.66.0-something_invalid', 'release');
@@ -233,15 +224,6 @@ describe('version-utils', () => {
       expect(prerelease).toBe('rc.0');
     });
 
-    it('should reject dryrun with prerelease . version with patch different from 0', () => {
-      function testInvalidFunction() {
-        parseVersion('0.20.3-rc.0', 'dry-run');
-      }
-      expect(testInvalidFunction).toThrowErrorMatchingInlineSnapshot(
-        `"Version 0.20.3-rc.0 is not valid for dry-runs"`,
-      );
-    });
-
     it('should parse dryrun with prerelease - version', () => {
       const {version, major, minor, patch, prerelease} = parseVersion(
         '0.20.0-rc-0',
@@ -252,15 +234,6 @@ describe('version-utils', () => {
       expect(minor).toBe('20');
       expect(patch).toBe('0');
       expect(prerelease).toBe('rc-0');
-    });
-
-    it('should reject dryrun with prerelease - version with patch different from 0', () => {
-      function testInvalidFunction() {
-        parseVersion('0.20.3-rc-0', 'dry-run');
-      }
-      expect(testInvalidFunction).toThrowErrorMatchingInlineSnapshot(
-        `"Version 0.20.3-rc-0 is not valid for dry-runs"`,
-      );
     });
 
     it('should parse dryrun with main version', () => {

--- a/scripts/version-utils.js
+++ b/scripts/version-utils.js
@@ -131,7 +131,7 @@ function isStablePrerelease(version) {
   return (
     version.major === '0' &&
     version.minor !== '0' &&
-    version.patch === '0' &&
+    version.patch.match(/^\d+$/) &&
     version.prerelease != null &&
     (version.prerelease.startsWith('rc.') ||
       version.prerelease.startsWith('rc-') ||


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

A small backport to main of a local fix done in 0.71 to account for the logic for releases 0.Y.1,2,3-prerelease (meaning, not just strictly 0).

I could have done like the other logics and just remove the check for patch, but decided to at least make sure it's a digit 😅

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:


For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[INTERNAL] [FIXED] - handle patch versions after the .0 for set version

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Tested in 0.71-stable, without it we can't test RNTestProject.
