### PR TITLE
Draft: Make ReactSpans Non-Parcelable

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/CustomLetterSpacingSpan.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/CustomLetterSpacingSpan.java
@@ -9,8 +9,10 @@ package com.facebook.react.views.text;
 
 import android.annotation.TargetApi;
 import android.os.Build;
+import android.text.ParcelableSpan;
 import android.text.TextPaint;
 import android.text.style.MetricAffectingSpan;
+import androidx.annotation.Nullable;
 
 /**
  * A {@link MetricAffectingSpan} that allows to set the letter spacing on the selected text span.
@@ -41,5 +43,11 @@ public class CustomLetterSpacingSpan extends MetricAffectingSpan implements Reac
     if (!Float.isNaN(mLetterSpacing)) {
       paint.setLetterSpacing(mLetterSpacing);
     }
+  }
+
+  @Nullable
+  @Override
+  public ParcelableSpan asParcelable() {
+    return null;
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/CustomLineHeightSpan.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/CustomLineHeightSpan.java
@@ -8,7 +8,9 @@
 package com.facebook.react.views.text;
 
 import android.graphics.Paint;
+import android.text.ParcelableSpan;
 import android.text.style.LineHeightSpan;
+import androidx.annotation.Nullable;
 
 /**
  * We use a custom {@link LineHeightSpan}, because `lineSpacingExtra` is broken. Details here:
@@ -59,5 +61,10 @@ public class CustomLineHeightSpan implements LineHeightSpan, ReactSpan {
       fm.ascent = fm.top;
       fm.descent = fm.bottom;
     }
+  }
+
+  @Override
+  public @Nullable ParcelableSpan asParcelable() {
+    return null;
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/CustomStyleSpan.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/CustomStyleSpan.java
@@ -10,6 +10,7 @@ package com.facebook.react.views.text;
 import android.content.res.AssetManager;
 import android.graphics.Paint;
 import android.graphics.Typeface;
+import android.text.ParcelableSpan;
 import android.text.TextPaint;
 import android.text.style.MetricAffectingSpan;
 import androidx.annotation.Nullable;
@@ -83,5 +84,11 @@ public class CustomStyleSpan extends MetricAffectingSpan implements ReactSpan {
     paint.setFontFeatureSettings(fontFeatureSettings);
     paint.setTypeface(typeface);
     paint.setSubpixelText(true);
+  }
+
+  @Nullable
+  @Override
+  public ParcelableSpan asParcelable() {
+    return null;
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactAbsoluteSizeSpan.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactAbsoluteSizeSpan.java
@@ -7,13 +7,39 @@
 
 package com.facebook.react.views.text;
 
+import android.text.ParcelableSpan;
+import android.text.TextPaint;
 import android.text.style.AbsoluteSizeSpan;
+import android.text.style.MetricAffectingSpan;
+import androidx.annotation.NonNull;
 
 /*
  * Wraps {@link AbsoluteSizeSpan} as a {@link ReactSpan}.
  */
-public class ReactAbsoluteSizeSpan extends AbsoluteSizeSpan implements ReactSpan {
+public class ReactAbsoluteSizeSpan extends MetricAffectingSpan implements ReactSpan {
+  private AbsoluteSizeSpan mSpan;
+
   public ReactAbsoluteSizeSpan(int size) {
-    super(size);
+    mSpan = new AbsoluteSizeSpan(size);
+  }
+
+  public int getSize() {
+    return mSpan.getSize();
+  }
+
+  @Override
+  public void updateMeasureState(@NonNull TextPaint textPaint) {
+    mSpan.updateMeasureState(textPaint);
+  }
+
+  @Override
+  public void updateDrawState(TextPaint textPaint) {
+    mSpan.updateDrawState(textPaint);
+  }
+
+  @NonNull
+  @Override
+  public ParcelableSpan asParcelable() {
+    return mSpan;
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactBackgroundColorSpan.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactBackgroundColorSpan.java
@@ -7,13 +7,32 @@
 
 package com.facebook.react.views.text;
 
+import android.text.ParcelableSpan;
+import android.text.TextPaint;
 import android.text.style.BackgroundColorSpan;
+import android.text.style.CharacterStyle;
+import android.text.style.UpdateAppearance;
+import androidx.annotation.NonNull;
 
 /*
  * Wraps {@link BackgroundColorSpan} as a {@link ReactSpan}.
  */
-public class ReactBackgroundColorSpan extends BackgroundColorSpan implements ReactSpan {
+public class ReactBackgroundColorSpan extends CharacterStyle
+    implements ReactSpan, UpdateAppearance {
+  private BackgroundColorSpan mSpan;
+
   public ReactBackgroundColorSpan(int color) {
-    super(color);
+    mSpan = new BackgroundColorSpan(color);
+  }
+
+  @NonNull
+  @Override
+  public ParcelableSpan asParcelable() {
+    return mSpan;
+  }
+
+  @Override
+  public void updateDrawState(TextPaint textPaint) {
+    mSpan.updateDrawState(textPaint);
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactBaseTextShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactBaseTextShadowNode.java
@@ -12,6 +12,7 @@ import android.graphics.Color;
 import android.graphics.Typeface;
 import android.os.Build;
 import android.text.Layout;
+import android.text.ParcelableSpan;
 import android.text.Spannable;
 import android.text.SpannableStringBuilder;
 import android.text.TextUtils;
@@ -73,6 +74,13 @@ public abstract class ReactBaseTextShadowNode extends LayoutShadowNode {
     protected ReactSpan what;
 
     SetSpanOperation(int start, int end, ReactSpan what) {
+      // Avoid making ReactSpans Parcelable by default to prevent the Samsung
+      // keyboard from infinitely cloning them.
+      // See https://github.com/facebook/react-native/issues/35936 (S318090)
+      if (what instanceof ParcelableSpan) {
+        throw new IllegalArgumentException("ReactSpans should not be Parcelable");
+      }
+
       this.start = start;
       this.end = end;
       this.what = what;

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactClickableSpan.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactClickableSpan.java
@@ -7,10 +7,12 @@
 
 package com.facebook.react.views.text;
 
+import android.text.ParcelableSpan;
 import android.text.TextPaint;
 import android.text.style.ClickableSpan;
 import android.view.View;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.uimanager.UIManagerHelper;
 import com.facebook.react.uimanager.events.EventDispatcher;
@@ -63,5 +65,11 @@ class ReactClickableSpan extends ClickableSpan implements ReactSpan {
 
   public int getReactTag() {
     return mReactTag;
+  }
+
+  @Nullable
+  @Override
+  public ParcelableSpan asParcelable() {
+    return null;
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactForegroundColorSpan.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactForegroundColorSpan.java
@@ -7,13 +7,32 @@
 
 package com.facebook.react.views.text;
 
+import android.text.ParcelableSpan;
+import android.text.TextPaint;
+import android.text.style.CharacterStyle;
 import android.text.style.ForegroundColorSpan;
+import android.text.style.UpdateAppearance;
+import androidx.annotation.NonNull;
 
 /*
  * Wraps {@link ForegroundColorSpan} as a {@link ReactSpan}.
  */
-public class ReactForegroundColorSpan extends ForegroundColorSpan implements ReactSpan {
+public class ReactForegroundColorSpan extends CharacterStyle
+    implements ReactSpan, UpdateAppearance {
+  private ForegroundColorSpan mSpan;
+
   public ReactForegroundColorSpan(int color) {
-    super(color);
+    mSpan = new ForegroundColorSpan(color);
+  }
+
+  @Override
+  public void updateDrawState(TextPaint textPaint) {
+    mSpan.updateDrawState(textPaint);
+  }
+
+  @NonNull
+  @Override
+  public ParcelableSpan asParcelable() {
+    return mSpan;
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactSpan.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactSpan.java
@@ -7,8 +7,17 @@
 
 package com.facebook.react.views.text;
 
+import android.text.ParcelableSpan;
+import androidx.annotation.Nullable;
+
 /*
  * Enables us to distinguish between spans that were added by React Native and spans that were
  * added by something else. All spans that React Native adds should implement this interface.
+ *
+ * ReactSpans should not directly extend system provided spans which implement ParcelableSpan.
  */
-public interface ReactSpan {}
+public interface ReactSpan {
+  /** Returns a system-provided ParcelableSpan to represent the span when copied to clipboard. */
+  @Nullable
+  ParcelableSpan asParcelable();
+}

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactStrikethroughSpan.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactStrikethroughSpan.java
@@ -7,9 +7,31 @@
 
 package com.facebook.react.views.text;
 
+import android.text.ParcelableSpan;
+import android.text.TextPaint;
+import android.text.style.CharacterStyle;
 import android.text.style.StrikethroughSpan;
+import android.text.style.UpdateAppearance;
+import androidx.annotation.NonNull;
 
 /*
  * Wraps {@link StrikethroughSpan} as a {@link ReactSpan}.
  */
-public class ReactStrikethroughSpan extends StrikethroughSpan implements ReactSpan {}
+public class ReactStrikethroughSpan extends CharacterStyle implements ReactSpan, UpdateAppearance {
+  private StrikethroughSpan mSpan;
+
+  public ReactStrikethroughSpan() {
+    mSpan = new StrikethroughSpan();
+  }
+
+  @Override
+  public void updateDrawState(TextPaint textPaint) {
+    mSpan.updateDrawState(textPaint);
+  }
+
+  @NonNull
+  @Override
+  public ParcelableSpan asParcelable() {
+    return mSpan;
+  }
+}

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTagSpan.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTagSpan.java
@@ -7,6 +7,9 @@
 
 package com.facebook.react.views.text;
 
+import android.text.ParcelableSpan;
+import androidx.annotation.Nullable;
+
 /**
  * Instances of this class are used to place reactTag information of nested text react nodes into
  * spannable text rendered by single {@link TextView}
@@ -21,5 +24,11 @@ public class ReactTagSpan implements ReactSpan {
 
   public int getReactTag() {
     return mReactTag;
+  }
+
+  @Nullable
+  @Override
+  public ParcelableSpan asParcelable() {
+    return null;
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
@@ -15,6 +15,7 @@ import android.text.Spannable;
 import android.text.Spanned;
 import android.text.StaticLayout;
 import android.text.TextPaint;
+import android.text.style.AbsoluteSizeSpan;
 import android.view.Gravity;
 import android.widget.TextView;
 import androidx.annotation.Nullable;
@@ -90,12 +91,11 @@ public class ReactTextShadowNode extends ReactBaseTextShadowNode {
               currentFontSize = currentFontSize - (int) PixelUtil.toPixelFromDIP(1);
 
               float ratio = (float) currentFontSize / (float) initialFontSize;
-              ReactAbsoluteSizeSpan[] sizeSpans =
-                  text.getSpans(0, text.length(), ReactAbsoluteSizeSpan.class);
-              for (ReactAbsoluteSizeSpan span : sizeSpans) {
+              AbsoluteSizeSpan[] sizeSpans =
+                  text.getSpans(0, text.length(), AbsoluteSizeSpan.class);
+              for (AbsoluteSizeSpan span : sizeSpans) {
                 text.setSpan(
-                    new ReactAbsoluteSizeSpan(
-                        (int) Math.max((span.getSize() * ratio), minimumFontSize)),
+                    new AbsoluteSizeSpan((int) Math.max((span.getSize() * ratio), minimumFontSize)),
                     text.getSpanStart(span),
                     text.getSpanEnd(span),
                     text.getSpanFlags(span));

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactUnderlineSpan.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactUnderlineSpan.java
@@ -7,9 +7,31 @@
 
 package com.facebook.react.views.text;
 
+import android.text.ParcelableSpan;
+import android.text.TextPaint;
+import android.text.style.CharacterStyle;
 import android.text.style.UnderlineSpan;
+import android.text.style.UpdateAppearance;
+import androidx.annotation.NonNull;
 
 /*
  * Wraps {@link UnderlineSpan} as a {@link ReactSpan}.
  */
-public class ReactUnderlineSpan extends UnderlineSpan implements ReactSpan {}
+public class ReactUnderlineSpan extends CharacterStyle implements ReactSpan, UpdateAppearance {
+  private UnderlineSpan mSpan;
+
+  ReactUnderlineSpan() {
+    mSpan = new UnderlineSpan();
+  }
+
+  @Override
+  public void updateDrawState(TextPaint textPaint) {
+    mSpan.updateDrawState(textPaint);
+  }
+
+  @NonNull
+  @Override
+  public ParcelableSpan asParcelable() {
+    return mSpan;
+  }
+}

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ShadowStyleSpan.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ShadowStyleSpan.java
@@ -7,10 +7,13 @@
 
 package com.facebook.react.views.text;
 
+import android.text.ParcelableSpan;
 import android.text.TextPaint;
 import android.text.style.CharacterStyle;
+import android.text.style.UpdateAppearance;
+import androidx.annotation.Nullable;
 
-public class ShadowStyleSpan extends CharacterStyle implements ReactSpan {
+public class ShadowStyleSpan extends CharacterStyle implements ReactSpan, UpdateAppearance {
   private final float mDx, mDy, mRadius;
   private final int mColor;
 
@@ -24,5 +27,11 @@ public class ShadowStyleSpan extends CharacterStyle implements ReactSpan {
   @Override
   public void updateDrawState(TextPaint textPaint) {
     textPaint.setShadowLayer(mRadius, mDx, mDy, mColor);
+  }
+
+  @Nullable
+  @Override
+  public ParcelableSpan asParcelable() {
+    return null;
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/TextInlineViewPlaceholderSpan.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/TextInlineViewPlaceholderSpan.java
@@ -9,7 +9,9 @@ package com.facebook.react.views.text;
 
 import android.graphics.Canvas;
 import android.graphics.Paint;
+import android.text.ParcelableSpan;
 import android.text.style.ReplacementSpan;
+import androidx.annotation.Nullable;
 
 /**
  * TextInlineViewPlaceholderSpan is a span for inlined views that are inside <Text/>. It computes
@@ -64,4 +66,10 @@ public class TextInlineViewPlaceholderSpan extends ReplacementSpan implements Re
       int y,
       int bottom,
       Paint paint) {}
+
+  @Nullable
+  @Override
+  public ParcelableSpan asParcelable() {
+    return null;
+  }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
@@ -13,6 +13,7 @@ import android.content.Context;
 import android.os.Build;
 import android.text.BoringLayout;
 import android.text.Layout;
+import android.text.ParcelableSpan;
 import android.text.Spannable;
 import android.text.SpannableStringBuilder;
 import android.text.Spanned;
@@ -559,6 +560,13 @@ public class TextLayoutManager {
     protected ReactSpan what;
 
     public SetSpanOperation(int start, int end, ReactSpan what) {
+      // Avoid making ReactSpans Parcelable by default to prevent the Samsung
+      // keyboard from infinitely cloning them.
+      // See https://github.com/facebook/react-native/issues/35936 (S318090)
+      if (what instanceof ParcelableSpan) {
+        throw new IllegalArgumentException("ReactSpans should not be Parcelable");
+      }
+
       this.start = start;
       this.end = end;
       this.what = what;

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManagerMapBuffer.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManagerMapBuffer.java
@@ -13,6 +13,7 @@ import android.content.Context;
 import android.os.Build;
 import android.text.BoringLayout;
 import android.text.Layout;
+import android.text.ParcelableSpan;
 import android.text.Spannable;
 import android.text.SpannableStringBuilder;
 import android.text.Spanned;
@@ -584,6 +585,13 @@ public class TextLayoutManagerMapBuffer {
     protected ReactSpan what;
 
     public SetSpanOperation(int start, int end, ReactSpan what) {
+      // Avoid making ReactSpans Parcelable by default to prevent the Samsung
+      // keyboard from infinitely cloning them.
+      // See https://github.com/facebook/react-native/issues/35936 (S318090)
+      if (what instanceof ParcelableSpan) {
+        throw new IllegalArgumentException("ReactSpans should not be Parcelable");
+      }
+
       this.start = start;
       this.end = end;
       this.what = what;

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/frescosupport/FrescoBasedReactTextInlineImageSpan.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/frescosupport/FrescoBasedReactTextInlineImageSpan.java
@@ -13,6 +13,7 @@ import android.graphics.Paint;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
+import android.text.ParcelableSpan;
 import android.widget.TextView;
 import androidx.annotation.Nullable;
 import com.facebook.drawee.controller.AbstractDraweeControllerBuilder;
@@ -180,5 +181,11 @@ public class FrescoBasedReactTextInlineImageSpan extends TextInlineImageSpan {
   @Override
   public int getHeight() {
     return mHeight;
+  }
+
+  @Nullable
+  @Override
+  public ParcelableSpan asParcelable() {
+    return null;
   }
 }


### PR DESCRIPTION
Summary:
In https://github.com/facebook/react-native/issues/35936 we saw behavior where built-in spans seem to be continuously cloned when using the Samsung keyboard. Notably, ReactAbsoluteSizeSpan, etc, become AbsoluteSizeSpan. This seems to be cloned by parceling. E.g. as the CharSequence is serialized across a process and makes it way back.

Making our own spans non-parcelable effectively hides them from any cross-process mechanisms, and they are not infinitely cloned like the system spans are. We can add a hook, so that spans can separately customize how they are parceled for the purpose of cut/copy/paste.

Turning a React Span into a non-ReactSpan also creates some general issues for controlled components which assume everything added by React remains a ReactSpan. This change should circumvent that as well.

TODO: Pasting text into the EditText with formatting (including text copied from the EditText) may introduce parcelable spans again. So we would need to hook paste with a mechanism to go from Parcelable back to non-parcelable spans.

Changelog:
[Android][Fixed] - Make ReactSpans Non-Parcelable

Differential Revision: D42919034

