### PR TITLE
RNGP - Bump AGP to 7.4.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,7 @@ buildscript {
     gradlePluginPortal()
   }
   dependencies {
-    classpath("com.android.tools.build:gradle:7.3.1")
+    classpath("com.android.tools.build:gradle:7.4.1")
     classpath("de.undercouch:gradle-download-task:5.0.1")
   }
 }

--- a/packages/react-native-gradle-plugin/build.gradle.kts
+++ b/packages/react-native-gradle-plugin/build.gradle.kts
@@ -33,7 +33,7 @@ group = "com.facebook.react"
 
 dependencies {
   implementation(gradleApi())
-  implementation("com.android.tools.build:gradle:7.3.1")
+  implementation("com.android.tools.build:gradle:7.4.1")
   implementation("com.google.code.gson:gson:2.8.9")
   implementation("com.google.guava:guava:31.0.1-jre")
   implementation("com.squareup:javapoet:1.13.0")

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
@@ -8,7 +8,6 @@
 package com.facebook.react
 
 import com.android.build.api.variant.AndroidComponentsExtension
-import com.android.build.gradle.AppExtension
 import com.android.build.gradle.internal.tasks.factory.dependsOn
 import com.facebook.react.tasks.BuildCodegenCLITask
 import com.facebook.react.tasks.GenerateCodegenArtifactsTask
@@ -53,24 +52,6 @@ class ReactPlugin : Plugin<Project> {
       project.extensions.getByType(AndroidComponentsExtension::class.java).apply {
         onVariants(selector().all()) { variant ->
           project.configureReactTasks(variant = variant, config = extension)
-        }
-      }
-
-      // This is a legacy AGP api. Needed as AGP 7.3 is not consuming generated resources correctly.
-      // Can be removed as we bump to AGP 7.4 stable.
-      // This registers the $buildDir/generated/res/react/<variant> folder as a
-      // res folder to be consumed with the old AGP Apis which are not broken.
-      project.extensions.getByType(AppExtension::class.java).apply {
-        this.applicationVariants.all { variant ->
-          val isDebuggableVariant =
-              extension.debuggableVariants.get().any { it.equals(variant.name, ignoreCase = true) }
-          val targetName = variant.name.replaceFirstChar { it.uppercase() }
-          val bundleTaskName = "createBundle${targetName}JsAndAssets"
-          if (!isDebuggableVariant) {
-            variant.registerGeneratedResFolders(
-                project.layout.buildDirectory.files("generated/res/react/${variant.name}"))
-            variant.mergeResourcesProvider.get().dependsOn(bundleTaskName)
-          }
         }
       }
       configureCodegen(project, extension, isLibrary = false)

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/TaskConfiguration.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/TaskConfiguration.kt
@@ -72,9 +72,7 @@ internal fun Project.configureReactTasks(variant: Variant, config: ReactExtensio
           it.hermesFlags.set(config.hermesFlags)
           it.reactNativeDir.set(config.reactNativeDir)
         }
-    // Currently broken inside AGP 7.3 We need to wait for a release of AGP 7.4 in order to use
-    // the addGeneratedSourceDirectory API.
-    // variant.sources.res?.addGeneratedSourceDirectory(bundleTask, BundleHermesCTask::resourcesDir)
+    variant.sources.res?.addGeneratedSourceDirectory(bundleTask, BundleHermesCTask::resourcesDir)
     variant.sources.assets?.addGeneratedSourceDirectory(bundleTask, BundleHermesCTask::jsBundleDir)
   }
 }

--- a/template/android/build.gradle
+++ b/template/android/build.gradle
@@ -15,7 +15,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:7.3.1")
+        classpath("com.android.tools.build:gradle")
         classpath("com.facebook.react:react-native-gradle-plugin")
     }
 }


### PR DESCRIPTION
Summary:
This change bumps AGP to 7.4.1 so we can remove a lot of the unnecessary changes
we had to do to support AGP 7.3.x

I've also removed the explicit version in the template as now the AGP version
is provided by RNGP. That means that the user will get the correct version they need.

This also bumps the default CMake version in user space to 3.22 which resolves a lot
of warning when users are building with the New Architecture enabled.

Changelog:
[Android] [Changed] - Bump AGP to 7.4.1

Differential Revision: D42960353

