### PR TITLE
rename module exports from "aliases" to "aliasMap" (#36028)

### DIFF
--- a/packages/react-native-codegen/src/CodegenSchema.js
+++ b/packages/react-native-codegen/src/CodegenSchema.js
@@ -222,7 +222,7 @@ export type NullableTypeAnnotation<+T: NativeModuleTypeAnnotation> = $ReadOnly<{
 
 export type NativeModuleSchema = $ReadOnly<{
   type: 'NativeModule',
-  aliases: NativeModuleAliasMap,
+  aliasMap: NativeModuleAliasMap,
   spec: NativeModuleSpec,
   moduleName: string,
   // Use for modules that are not used on other platforms.

--- a/packages/react-native-codegen/src/generators/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/generators/__test_fixtures__/fixtures.js
@@ -41,7 +41,7 @@ const SCHEMA_WITH_TM_AND_FC: SchemaType = {
     },
     NativeCalculator: {
       type: 'NativeModule',
-      aliases: {},
+      aliasMap: {},
       spec: {
         properties: [
           {

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleCpp.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleCpp.js
@@ -238,11 +238,11 @@ module.exports = {
       .map((hasteModuleName: string) => {
         const nativeModule = nativeModules[hasteModuleName];
         const {
-          aliases,
+          aliasMap,
           spec: {properties},
           moduleName,
         } = nativeModule;
-        const resolveAlias = createAliasResolver(aliases);
+        const resolveAlias = createAliasResolver(aliasMap);
         const hostFunctions = properties.map(property =>
           serializePropertyIntoHostFunction(
             hasteModuleName,

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleH.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleH.js
@@ -341,12 +341,12 @@ module.exports = {
 
     const modules = Object.keys(nativeModules).flatMap(hasteModuleName => {
       const {
-        aliases,
+        aliasMap,
         spec: {properties},
         moduleName,
       } = nativeModules[hasteModuleName];
-      const resolveAlias = createAliasResolver(aliases);
-      const structs = createStructs(moduleName, aliases, resolveAlias);
+      const resolveAlias = createAliasResolver(aliasMap);
+      const structs = createStructs(moduleName, aliasMap, resolveAlias);
 
       return [
         ModuleClassDeclarationTemplate({

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleJavaSpec.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleJavaSpec.js
@@ -447,7 +447,7 @@ module.exports = {
 
     Object.keys(nativeModules).forEach(hasteModuleName => {
       const {
-        aliases,
+        aliasMap,
         excludedPlatforms,
         moduleName,
         spec: {properties},
@@ -455,7 +455,7 @@ module.exports = {
       if (excludedPlatforms != null && excludedPlatforms.includes('android')) {
         return;
       }
-      const resolveAlias = createAliasResolver(aliases);
+      const resolveAlias = createAliasResolver(aliasMap);
       const className = `${hasteModuleName}Spec`;
 
       const imports: Set<string> = new Set([

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleJniCpp.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleJniCpp.js
@@ -438,10 +438,10 @@ module.exports = {
       .sort()
       .map(hasteModuleName => {
         const {
-          aliases,
+          aliasMap,
           spec: {properties},
         } = nativeModules[hasteModuleName];
-        const resolveAlias = createAliasResolver(aliases);
+        const resolveAlias = createAliasResolver(aliasMap);
 
         const translatedMethods = properties
           .map(property =>

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/index.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/index.js
@@ -132,14 +132,14 @@ module.exports = {
     const hasteModuleNames: Array<string> = Object.keys(nativeModules).sort();
     for (const hasteModuleName of hasteModuleNames) {
       const {
-        aliases,
+        aliasMap,
         excludedPlatforms,
         spec: {properties},
       } = nativeModules[hasteModuleName];
       if (excludedPlatforms != null && excludedPlatforms.includes('iOS')) {
         continue;
       }
-      const resolveAlias = createAliasResolver(aliases);
+      const resolveAlias = createAliasResolver(aliasMap);
       const structCollector = new StructCollector();
 
       const methodSerializations: Array<MethodSerializationOutput> = [];

--- a/packages/react-native-codegen/src/generators/modules/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/generators/modules/__test_fixtures__/fixtures.js
@@ -16,7 +16,7 @@ const EMPTY_NATIVE_MODULES: SchemaType = {
   modules: {
     NativeSampleTurboModule: {
       type: 'NativeModule',
-      aliases: {},
+      aliasMap: {},
       spec: {
         properties: [],
       },
@@ -29,7 +29,7 @@ const SIMPLE_NATIVE_MODULES: SchemaType = {
   modules: {
     NativeSampleTurboModule: {
       type: 'NativeModule',
-      aliases: {},
+      aliasMap: {},
       spec: {
         properties: [
           {
@@ -341,7 +341,7 @@ const TWO_MODULES_DIFFERENT_FILES: SchemaType = {
   modules: {
     NativeSampleTurboModule: {
       type: 'NativeModule',
-      aliases: {},
+      aliasMap: {},
       spec: {
         properties: [
           {
@@ -361,7 +361,7 @@ const TWO_MODULES_DIFFERENT_FILES: SchemaType = {
     },
     NativeSampleTurboModule2: {
       type: 'NativeModule',
-      aliases: {},
+      aliasMap: {},
       spec: {
         properties: [
           {
@@ -398,7 +398,7 @@ const COMPLEX_OBJECTS: SchemaType = {
   modules: {
     NativeSampleTurboModule: {
       type: 'NativeModule',
-      aliases: {},
+      aliasMap: {},
       spec: {
         properties: [
           {
@@ -764,7 +764,7 @@ const NATIVE_MODULES_WITH_TYPE_ALIASES: SchemaType = {
   modules: {
     AliasTurboModule: {
       type: 'NativeModule',
-      aliases: {
+      aliasMap: {
         Options: {
           type: 'ObjectTypeAnnotation',
           properties: [
@@ -899,7 +899,7 @@ const REAL_MODULE_EXAMPLE: SchemaType = {
   modules: {
     NativeCameraRollManager: {
       type: 'NativeModule',
-      aliases: {
+      aliasMap: {
         PhotoIdentifierImage: {
           type: 'ObjectTypeAnnotation',
           properties: [
@@ -1226,7 +1226,7 @@ const REAL_MODULE_EXAMPLE: SchemaType = {
     },
     NativeExceptionsManager: {
       type: 'NativeModule',
-      aliases: {
+      aliasMap: {
         StackFrame: {
           properties: [
             {
@@ -1494,7 +1494,7 @@ const CXX_ONLY_NATIVE_MODULES: SchemaType = {
   modules: {
     NativeSampleTurboModule: {
       type: 'NativeModule',
-      aliases: {
+      aliasMap: {
         ObjectAlias: {
           type: 'ObjectTypeAnnotation',
           properties: [
@@ -1648,7 +1648,7 @@ const SAMPLE_WITH_UPPERCASE_NAME: SchemaType = {
   modules: {
     NativeSampleTurboModule: {
       type: 'NativeModule',
-      aliases: {},
+      aliasMap: {},
       spec: {
         properties: [],
       },

--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-commons-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-commons-test.js
@@ -374,7 +374,7 @@ describe('buildSchemaFromConfigType', () => {
 
   const moduleSchemaMock = {
     type: 'NativeModule',
-    aliases: {},
+    aliasMap: {},
     spec: {properties: []},
     moduleName: '',
   };
@@ -657,13 +657,13 @@ describe('buildSchema', () => {
     const contents = `
       import type {ViewProps} from 'ViewPropTypes';
       import type {HostComponent} from 'react-native';
-      
+
       const codegenNativeComponent = require('codegenNativeComponent');
-      
+
       export type ModuleProps = $ReadOnly<{|
         ...ViewProps,
       |}>;
-      
+
       export default (codegenNativeComponent<ModuleProps>(
         'Module',
       ): HostComponent<ModuleProps>);
@@ -712,11 +712,11 @@ describe('buildSchema', () => {
     const contents = `
       import type {TurboModule} from 'react-native/Libraries/TurboModule/RCTExport';
       import * as TurboModuleRegistry from 'react-native/Libraries/TurboModule/TurboModuleRegistry';
-      
+
       export interface Spec extends TurboModule {
         +getArray: (a: Array<any>) => Array<string>;
       }
-      
+
       export default (TurboModuleRegistry.getEnforcing<Spec>(
         'SampleTurboModule',
       ): Spec);
@@ -742,7 +742,7 @@ describe('buildSchema', () => {
         modules: {
           fileName: {
             type: 'NativeModule',
-            aliases: {},
+            aliasMap: {},
             spec: {
               properties: [
                 {

--- a/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap
@@ -21,7 +21,7 @@ exports[`RN Codegen Flow Parser can generate fixture ANDROID_ONLY_NATIVE_MODULE 
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {},
+      'aliasMap': {},
       'spec': {
         'properties': []
       },
@@ -39,7 +39,7 @@ exports[`RN Codegen Flow Parser can generate fixture CXX_ONLY_NATIVE_MODULE 1`] 
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {},
+      'aliasMap': {},
       'spec': {
         'properties': [
           {
@@ -220,7 +220,7 @@ exports[`RN Codegen Flow Parser can generate fixture EMPTY_NATIVE_MODULE 1`] = `
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {},
+      'aliasMap': {},
       'spec': {
         'properties': []
       },
@@ -235,7 +235,7 @@ exports[`RN Codegen Flow Parser can generate fixture IOS_ONLY_NATIVE_MODULE 1`] 
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {},
+      'aliasMap': {},
       'spec': {
         'properties': [
           {
@@ -298,7 +298,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_ALIASES 
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {
+      'aliasMap': {
         'ObjectAlias': {
           'type': 'ObjectTypeAnnotation',
           'properties': [
@@ -495,7 +495,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_ARRAY_WI
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {},
+      'aliasMap': {},
       'spec': {
         'properties': [
           {
@@ -536,7 +536,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_ARRAY_WI
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {},
+      'aliasMap': {},
       'spec': {
         'properties': [
           {
@@ -571,7 +571,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_BASIC_AR
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {},
+      'aliasMap': {},
       'spec': {
         'properties': [
           {
@@ -637,7 +637,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_BASIC_PA
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {},
+      'aliasMap': {},
       'spec': {
         'properties': [
           {
@@ -729,7 +729,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_CALLBACK
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {},
+      'aliasMap': {},
       'spec': {
         'properties': [
           {
@@ -789,7 +789,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_COMPLEX_
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {},
+      'aliasMap': {},
       'spec': {
         'properties': [
           {
@@ -848,7 +848,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_COMPLEX_
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {},
+      'aliasMap': {},
       'spec': {
         'properties': [
           {
@@ -1060,7 +1060,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_COMPLEX_
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {},
+      'aliasMap': {},
       'spec': {
         'properties': [
           {
@@ -1164,7 +1164,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_FLOAT_AN
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {},
+      'aliasMap': {},
       'spec': {
         'properties': [
           {
@@ -1218,7 +1218,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_NESTED_A
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {
+      'aliasMap': {
         'Bar': {
           'type': 'ObjectTypeAnnotation',
           'properties': [
@@ -1309,7 +1309,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_NULLABLE
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {},
+      'aliasMap': {},
       'spec': {
         'properties': [
           {
@@ -1347,7 +1347,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_OBJECT_W
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {
+      'aliasMap': {
         'DisplayMetricsAndroid': {
           'type': 'ObjectTypeAnnotation',
           'properties': [
@@ -1436,7 +1436,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_PARTIALS
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {
+      'aliasMap': {
         'SomeObj': {
           'type': 'ObjectTypeAnnotation',
           'properties': [
@@ -1547,7 +1547,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_PARTIALS
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {
+      'aliasMap': {
         'SomeObj': {
           'type': 'ObjectTypeAnnotation',
           'properties': [
@@ -1642,7 +1642,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_PROMISE 
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {
+      'aliasMap': {
         'SomeObj': {
           'type': 'ObjectTypeAnnotation',
           'properties': [
@@ -1714,7 +1714,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_ROOT_TAG
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {},
+      'aliasMap': {},
       'spec': {
         'properties': [
           {
@@ -1751,7 +1751,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_SIMPLE_O
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {},
+      'aliasMap': {},
       'spec': {
         'properties': [
           {
@@ -1786,7 +1786,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_UNION 1`
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {},
+      'aliasMap': {},
       'spec': {
         'properties': [
           {
@@ -1847,7 +1847,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_UNSAFE_O
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {},
+      'aliasMap': {},
       'spec': {
         'properties': [
           {
@@ -1882,7 +1882,7 @@ exports[`RN Codegen Flow Parser can generate fixture PROMISE_WITH_COMMONLY_USED_
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {
+      'aliasMap': {
         'CustomObject': {
           'type': 'ObjectTypeAnnotation',
           'properties': [

--- a/packages/react-native-codegen/src/parsers/flow/modules/__tests__/module-parser-e2e-test.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__tests__/module-parser-e2e-test.js
@@ -60,7 +60,7 @@ type AnimalPointer = Animal;
 `;
 
 function expectAnimalTypeAliasToExist(module: NativeModuleSchema) {
-  const animalAlias = module.aliases.Animal;
+  const animalAlias = module.aliasMap.Animal;
 
   expect(animalAlias).not.toBe(null);
   invariant(animalAlias != null, '');

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -452,7 +452,7 @@ function buildModuleSchema(
     .reduce(
       (moduleSchema: NativeModuleSchema, {aliasMap, propertyShape}) => ({
         type: 'NativeModule',
-        aliases: {...moduleSchema.aliases, ...aliasMap},
+        aliasMap: {...moduleSchema.aliasMap, ...aliasMap},
         spec: {
           properties: [...moduleSchema.spec.properties, propertyShape],
         },
@@ -461,7 +461,7 @@ function buildModuleSchema(
       }),
       {
         type: 'NativeModule',
-        aliases: {},
+        aliasMap: {},
         spec: {properties: []},
         moduleName,
         excludedPlatforms:

--- a/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/__snapshots__/typescript-module-parser-snapshot-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/__snapshots__/typescript-module-parser-snapshot-test.js.snap
@@ -19,7 +19,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture ANDROID_ONLY_NATIVE_M
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {},
+      'aliasMap': {},
       'spec': {
         'properties': []
       },
@@ -37,7 +37,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture CXX_ONLY_NATIVE_MODUL
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {},
+      'aliasMap': {},
       'spec': {
         'properties': [
           {
@@ -218,7 +218,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EMPTY_NATIVE_MODULE 1
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {},
+      'aliasMap': {},
       'spec': {
         'properties': []
       },
@@ -233,7 +233,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture IOS_ONLY_NATIVE_MODUL
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {},
+      'aliasMap': {},
       'spec': {
         'properties': [
           {
@@ -296,7 +296,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_AL
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {
+      'aliasMap': {
         'ObjectAlias': {
           'type': 'ObjectTypeAnnotation',
           'properties': [
@@ -493,7 +493,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_AR
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {},
+      'aliasMap': {},
       'spec': {
         'properties': [
           {
@@ -534,7 +534,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_AR
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {},
+      'aliasMap': {},
       'spec': {
         'properties': [
           {
@@ -569,7 +569,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_AR
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {},
+      'aliasMap': {},
       'spec': {
         'properties': [
           {
@@ -610,7 +610,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_AR
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {},
+      'aliasMap': {},
       'spec': {
         'properties': [
           {
@@ -645,7 +645,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_BA
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {},
+      'aliasMap': {},
       'spec': {
         'properties': [
           {
@@ -711,7 +711,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_BA
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {},
+      'aliasMap': {},
       'spec': {
         'properties': [
           {
@@ -777,7 +777,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_BA
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {},
+      'aliasMap': {},
       'spec': {
         'properties': [
           {
@@ -869,7 +869,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_CA
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {},
+      'aliasMap': {},
       'spec': {
         'properties': [
           {
@@ -929,7 +929,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_CO
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {},
+      'aliasMap': {},
       'spec': {
         'properties': [
           {
@@ -988,7 +988,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_CO
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {},
+      'aliasMap': {},
       'spec': {
         'properties': [
           {
@@ -1047,7 +1047,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_CO
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {},
+      'aliasMap': {},
       'spec': {
         'properties': [
           {
@@ -1259,7 +1259,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_CO
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {},
+      'aliasMap': {},
       'spec': {
         'properties': [
           {
@@ -1363,7 +1363,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_FL
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {},
+      'aliasMap': {},
       'spec': {
         'properties': [
           {
@@ -1417,7 +1417,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_NE
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {
+      'aliasMap': {
         'Bar': {
           'type': 'ObjectTypeAnnotation',
           'properties': [
@@ -1508,7 +1508,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_NE
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {
+      'aliasMap': {
         'Bar': {
           'type': 'ObjectTypeAnnotation',
           'properties': [
@@ -1669,7 +1669,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_NU
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {},
+      'aliasMap': {},
       'spec': {
         'properties': [
           {
@@ -1707,7 +1707,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_OB
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {
+      'aliasMap': {
         'DisplayMetricsAndroid': {
           'type': 'ObjectTypeAnnotation',
           'properties': [
@@ -1796,7 +1796,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_PA
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {
+      'aliasMap': {
         'SomeObj': {
           'type': 'ObjectTypeAnnotation',
           'properties': [
@@ -1907,7 +1907,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_PA
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {
+      'aliasMap': {
         'SomeObj': {
           'type': 'ObjectTypeAnnotation',
           'properties': [
@@ -2002,7 +2002,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_PR
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {
+      'aliasMap': {
         'SomeObj': {
           'type': 'ObjectTypeAnnotation',
           'properties': [
@@ -2074,7 +2074,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_RO
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {},
+      'aliasMap': {},
       'spec': {
         'properties': [
           {
@@ -2111,7 +2111,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_SI
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {},
+      'aliasMap': {},
       'spec': {
         'properties': [
           {
@@ -2146,7 +2146,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_UN
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {},
+      'aliasMap': {},
       'spec': {
         'properties': [
           {
@@ -2207,7 +2207,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_UN
   'modules': {
     'NativeSampleTurboModule': {
       'type': 'NativeModule',
-      'aliases': {},
+      'aliasMap': {},
       'spec': {
         'properties': [
           {

--- a/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/typescript-module-parser-e2e-test.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/typescript-module-parser-e2e-test.js
@@ -60,7 +60,7 @@ type AnimalPointer = Animal;
 `;
 
 function expectAnimalTypeAliasToExist(module: NativeModuleSchema) {
-  const animalAlias = module.aliases.Animal;
+  const animalAlias = module.aliasMap.Animal;
 
   expect(animalAlias).not.toBe(null);
   invariant(animalAlias != null, '');

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -527,7 +527,7 @@ function buildModuleSchema(
       (moduleSchema: NativeModuleSchema, {aliasMap, propertyShape}) => {
         return {
           type: 'NativeModule',
-          aliases: {...moduleSchema.aliases, ...aliasMap},
+          aliasMap: {...moduleSchema.aliasMap, ...aliasMap},
           spec: {
             properties: [...moduleSchema.spec.properties, propertyShape],
           },
@@ -537,7 +537,7 @@ function buildModuleSchema(
       },
       {
         type: 'NativeModule',
-        aliases: {},
+        aliasMap: {},
         spec: {properties: []},
         moduleName: moduleName,
         excludedPlatforms:


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebook/react-native/pull/36028

Use aliasMap both in parsers and generators instead of using aliasMap in half of the places and aliases in the other.

This would also allow us to introduce "enumMap" more easily in the next commit.

Changelog: [Internal] rename module exports from "aliases" to "aliasMap"

Reviewed By: christophpurrer, cipolleschi

Differential Revision: D42888752

