### PR TITLE
Remove duplication of default field values in iterator-based prop parsing

### DIFF
--- a/ReactCommon/react/renderer/components/image/ImageProps.cpp
+++ b/ReactCommon/react/renderer/components/image/ImageProps.cpp
@@ -87,14 +87,16 @@ void ImageProps::setProp(
   // reuse the same values.
   ViewProps::setProp(context, hash, propName, value);
 
+  static auto defaults = ImageProps{};
+
   switch (hash) {
-    RAW_SET_PROP_SWITCH_CASE(sources, "source", {});
-    RAW_SET_PROP_SWITCH_CASE(defaultSources, "defaultSource", {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(resizeMode, ImageResizeMode::Stretch);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(blurRadius, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(capInsets, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(tintColor, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(internal_analyticTag, {});
+    RAW_SET_PROP_SWITCH_CASE(sources, "source");
+    RAW_SET_PROP_SWITCH_CASE(defaultSources, "defaultSource");
+    RAW_SET_PROP_SWITCH_CASE_BASIC(resizeMode);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(blurRadius);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(capInsets);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(tintColor);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(internal_analyticTag);
   }
 }
 

--- a/ReactCommon/react/renderer/components/scrollview/ScrollViewProps.cpp
+++ b/ReactCommon/react/renderer/components/scrollview/ScrollViewProps.cpp
@@ -322,42 +322,42 @@ void ScrollViewProps::setProp(
   // reuse the same values.
   ViewProps::setProp(context, hash, propName, value);
 
+  static auto defaults = ScrollViewProps{};
+
   switch (hash) {
-    RAW_SET_PROP_SWITCH_CASE_BASIC(alwaysBounceHorizontal, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(alwaysBounceVertical, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(bounces, true);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(bouncesZoom, true);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(canCancelContentTouches, true);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(centerContent, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(automaticallyAdjustContentInsets, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(
-        automaticallyAdjustsScrollIndicatorInsets, true);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(decelerationRate, (Float)0.998);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(directionalLockEnabled, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(indicatorStyle, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(keyboardDismissMode, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(maximumZoomScale, (Float)1.0);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(minimumZoomScale, (Float)1.0);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(scrollEnabled, true);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(pagingEnabled, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(pinchGestureEnabled, true);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(scrollsToTop, true);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(showsHorizontalScrollIndicator, true);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(showsVerticalScrollIndicator, true);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(scrollEventThrottle, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(zoomScale, (Float)1.0);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(contentInset, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(contentOffset, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(scrollIndicatorInsets, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(snapToInterval, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(snapToAlignment, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(disableIntervalMomentum, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(snapToOffsets, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(snapToStart, true);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(snapToEnd, true);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(
-        contentInsetAdjustmentBehavior, ContentInsetAdjustmentBehavior::Never);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(scrollToOverflowEnabled, {});
+    RAW_SET_PROP_SWITCH_CASE_BASIC(alwaysBounceHorizontal);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(alwaysBounceVertical);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(bounces);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(bouncesZoom);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(canCancelContentTouches);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(centerContent);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(automaticallyAdjustContentInsets);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(automaticallyAdjustsScrollIndicatorInsets);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(decelerationRate);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(directionalLockEnabled);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(indicatorStyle);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(keyboardDismissMode);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(maximumZoomScale);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(minimumZoomScale);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(scrollEnabled);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(pagingEnabled);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(pinchGestureEnabled);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(scrollsToTop);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(showsHorizontalScrollIndicator);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(showsVerticalScrollIndicator);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(scrollEventThrottle);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(zoomScale);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(contentInset);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(contentOffset);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(scrollIndicatorInsets);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(snapToInterval);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(snapToAlignment);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(disableIntervalMomentum);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(snapToOffsets);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(snapToStart);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(snapToEnd);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(contentInsetAdjustmentBehavior);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(scrollToOverflowEnabled);
   }
 }
 

--- a/ReactCommon/react/renderer/components/text/ParagraphProps.cpp
+++ b/ReactCommon/react/renderer/components/text/ParagraphProps.cpp
@@ -66,6 +66,8 @@ void ParagraphProps::setProp(
   ViewProps::setProp(context, hash, propName, value);
   BaseTextProps::setProp(context, hash, propName, value);
 
+  static auto defaults = ParagraphProps{};
+
   // ParagraphAttributes has its own switch statement - to keep all
   // of these fields together, and because there are some collisions between
   // propnames parsed here and outside of ParagraphAttributes.
@@ -119,8 +121,8 @@ void ParagraphProps::setProp(
   }
 
   switch (hash) {
-    RAW_SET_PROP_SWITCH_CASE_BASIC(isSelectable, false);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(onTextLayout, {});
+    RAW_SET_PROP_SWITCH_CASE_BASIC(isSelectable);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(onTextLayout);
   }
 
   /*

--- a/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
+++ b/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
@@ -269,6 +269,8 @@ void AndroidTextInputProps::setProp(
   ViewProps::setProp(context, hash, propName, value);
   BaseTextProps::setProp(context, hash, propName, value);
 
+  static auto defaults = AndroidTextInputProps{};
+
   // ParagraphAttributes has its own switch statement - to keep all
   // of these fields together, and because there are some collisions between
   // propnames parsed here and outside of ParagraphAttributes. For example,
@@ -323,55 +325,59 @@ void AndroidTextInputProps::setProp(
   }
 
   switch (hash) {
-    RAW_SET_PROP_SWITCH_CASE_BASIC(autoComplete, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(returnKeyLabel, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(numberOfLines, 0);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(disableFullscreenUI, false);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(textBreakStrategy, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(underlineColorAndroid, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(inlineImageLeft, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(inlineImagePadding, 0);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(importantForAutofill, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(showSoftInputOnFocus, false);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(autoCapitalize, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(autoCorrect, false);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(autoFocus, false);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(allowFontScaling, false);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(maxFontSizeMultiplier, (Float)0.0);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(editable, false);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(keyboardType, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(returnKeyType, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(maxLength, 0);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(multiline, false);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(placeholder, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(placeholderTextColor, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(secureTextEntry, false);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(selectionColor, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(selection, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(this->value, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(defaultValue, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(selectTextOnFocus, false);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(submitBehavior, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(caretHidden, false);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(contextMenuHidden, false);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(textShadowColor, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(textShadowRadius, (Float)0.0);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(textDecorationLine, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(fontStyle, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(textShadowOffset, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(lineHeight, (Float)0.0);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(textTransform, {});
-    // RAW_SET_PROP_SWITCH_CASE_BASIC(color, {0}); // currently not being parsed
-    RAW_SET_PROP_SWITCH_CASE_BASIC(letterSpacing, (Float)0.0);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(fontSize, (Float)0.0);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(textAlign, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(includeFontPadding, false);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(fontWeight, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(fontFamily, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(textAlignVertical, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(cursorColor, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(mostRecentEventCount, 0);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(text, {});
+    RAW_SET_PROP_SWITCH_CASE_BASIC(autoComplete);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(returnKeyLabel);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(numberOfLines);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(disableFullscreenUI);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(textBreakStrategy);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(underlineColorAndroid);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(inlineImageLeft);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(inlineImagePadding);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(importantForAutofill);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(showSoftInputOnFocus);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(autoCapitalize);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(autoCorrect);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(autoFocus);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(allowFontScaling);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(maxFontSizeMultiplier);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(editable);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(keyboardType);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(returnKeyType);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(maxLength);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(multiline);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(placeholder);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(placeholderTextColor);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(secureTextEntry);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(selectionColor);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(selection);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(defaultValue);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(selectTextOnFocus);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(submitBehavior);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(caretHidden);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(contextMenuHidden);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(textShadowColor);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(textShadowRadius);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(textDecorationLine);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(fontStyle);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(textShadowOffset);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(lineHeight);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(textTransform);
+    // RAW_SET_PROP_SWITCH_CASE_BASIC(color);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(letterSpacing);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(fontSize);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(textAlign);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(includeFontPadding);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(fontWeight);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(fontFamily);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(textAlignVertical);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(cursorColor);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(mostRecentEventCount);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(text);
+
+    case CONSTEXPR_RAW_PROPS_KEY_HASH("value"): {
+      fromRawValue(context, value, this->value, {});
+      return;
+    }
 
     // Paddings are not parsed at this level of the component (they're parsed in
     // ViewProps) but we do need to know if they're present or not. See

--- a/ReactCommon/react/renderer/components/view/AccessibilityProps.cpp
+++ b/ReactCommon/react/renderer/components/view/AccessibilityProps.cpp
@@ -208,25 +208,26 @@ void AccessibilityProps::setProp(
     RawPropsPropNameHash hash,
     const char * /*propName*/,
     RawValue const &value) {
+  static auto defaults = AccessibilityProps{};
+
   switch (hash) {
-    RAW_SET_PROP_SWITCH_CASE_BASIC(accessible, false);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(accessibilityState, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(accessibilityLabel, std::string{""});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(accessibilityLabelledBy, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(accessibilityHint, std::string{""});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(accessibilityLanguage, std::string{""});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(accessibilityValue, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(accessibilityActions, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(accessibilityViewIsModal, false);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(accessibilityElementsHidden, false);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(accessibilityIgnoresInvertColors, false);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(onAccessibilityTap, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(onAccessibilityMagicTap, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(onAccessibilityEscape, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(onAccessibilityAction, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(
-        importantForAccessibility, ImportantForAccessibility::Auto);
-    RAW_SET_PROP_SWITCH_CASE(testId, "testID", std::string{""});
+    RAW_SET_PROP_SWITCH_CASE_BASIC(accessible);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(accessibilityState);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(accessibilityLabel);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(accessibilityLabelledBy);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(accessibilityHint);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(accessibilityLanguage);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(accessibilityValue);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(accessibilityActions);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(accessibilityViewIsModal);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(accessibilityElementsHidden);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(accessibilityIgnoresInvertColors);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(onAccessibilityTap);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(onAccessibilityMagicTap);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(onAccessibilityEscape);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(onAccessibilityAction);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(importantForAccessibility);
+    RAW_SET_PROP_SWITCH_CASE(testId, "testID");
     case CONSTEXPR_RAW_PROPS_KEY_HASH("accessibilityRole"): {
       AccessibilityTraits traits = AccessibilityTraits::None;
       std::string roleString;

--- a/ReactCommon/react/renderer/components/view/ViewProps.cpp
+++ b/ReactCommon/react/renderer/components/view/ViewProps.cpp
@@ -291,23 +291,25 @@ void ViewProps::setProp(
   YogaStylableProps::setProp(context, hash, propName, value);
   AccessibilityProps::setProp(context, hash, propName, value);
 
+  static auto defaults = ViewProps{};
+
   switch (hash) {
-    RAW_SET_PROP_SWITCH_CASE_BASIC(opacity, (Float)1.0);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(foregroundColor, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(backgroundColor, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(shadowColor, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(shadowOffset, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(shadowOpacity, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(shadowRadius, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(transform, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(backfaceVisibility, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(shouldRasterize, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(zIndex, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(pointerEvents, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(hitSlop, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(onLayout, {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(collapsable, true);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(removeClippedSubviews, false);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(opacity);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(foregroundColor);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(backgroundColor);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(shadowColor);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(shadowOffset);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(shadowOpacity);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(shadowRadius);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(transform);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(backfaceVisibility);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(shouldRasterize);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(zIndex);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(pointerEvents);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(hitSlop);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(onLayout);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(collapsable);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(removeClippedSubviews);
     // events field
     VIEW_EVENT_CASE(PointerEnter);
     VIEW_EVENT_CASE(PointerEnterCapture);
@@ -335,13 +337,13 @@ void ViewProps::setProp(
     VIEW_EVENT_CASE(TouchEnd);
     VIEW_EVENT_CASE(TouchCancel);
 #ifdef ANDROID
-    RAW_SET_PROP_SWITCH_CASE_BASIC(elevation, {});
-    RAW_SET_PROP_SWITCH_CASE(nativeBackground, "nativeBackgroundAndroid", {});
-    RAW_SET_PROP_SWITCH_CASE(nativeForeground, "nativeForegroundAndroid", {});
-    RAW_SET_PROP_SWITCH_CASE_BASIC(focusable, false);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(hasTVPreferredFocus, false);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(needsOffscreenAlphaCompositing, false);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(renderToHardwareTextureAndroid, false);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(elevation);
+    RAW_SET_PROP_SWITCH_CASE(nativeBackground, "nativeBackgroundAndroid");
+    RAW_SET_PROP_SWITCH_CASE(nativeForeground, "nativeForegroundAndroid");
+    RAW_SET_PROP_SWITCH_CASE_BASIC(focusable);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(hasTVPreferredFocus);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(needsOffscreenAlphaCompositing);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(renderToHardwareTextureAndroid);
 #endif
     // BorderRadii
     SET_CASCADED_RECTANGLE_CORNERS(borderRadii, "border", "Radius", value);

--- a/ReactCommon/react/renderer/components/view/YogaStylableProps.cpp
+++ b/ReactCommon/react/renderer/components/view/YogaStylableProps.cpp
@@ -48,10 +48,10 @@ static inline T const getFieldValue(
   return defaultValue;
 }
 
-#define REBUILD_FIELD_SWITCH_CASE2(field, fieldName)                     \
-  case CONSTEXPR_RAW_PROPS_KEY_HASH(fieldName): {                        \
-    yogaStyle.field() = getFieldValue(context, value, defaults.field()); \
-    return;                                                              \
+#define REBUILD_FIELD_SWITCH_CASE2(field, fieldName)                       \
+  case CONSTEXPR_RAW_PROPS_KEY_HASH(fieldName): {                          \
+    yogaStyle.field() = getFieldValue(context, value, ygDefaults.field()); \
+    return;                                                                \
   }
 
 // @lint-ignore CLANGTIDY cppcoreguidelines-macro-usage
@@ -61,7 +61,7 @@ static inline T const getFieldValue(
 #define REBUILD_YG_FIELD_SWITCH_CASE_INDEXED(field, index, fieldName) \
   case CONSTEXPR_RAW_PROPS_KEY_HASH(fieldName): {                     \
     yogaStyle.field()[index] =                                        \
-        getFieldValue(context, value, defaults.field()[index]);       \
+        getFieldValue(context, value, ygDefaults.field()[index]);     \
     return;                                                           \
   }
 
@@ -104,7 +104,7 @@ void YogaStylableProps::setProp(
     RawPropsPropNameHash hash,
     const char *propName,
     RawValue const &value) {
-  static const auto defaults = YGStyle{};
+  static const auto ygDefaults = YGStyle{};
 
   Props::setProp(context, hash, propName, value);
 
@@ -133,44 +133,28 @@ void YogaStylableProps::setProp(
     REBUILD_FIELD_YG_EDGES(padding, "padding", "");
     REBUILD_FIELD_YG_EDGES(border, "border", "Width");
 
+    static const auto defaults = YogaStylableProps{};
+
     // Aliases
-    RAW_SET_PROP_SWITCH_CASE(inset, "inset", CompactValue::ofUndefined());
-    RAW_SET_PROP_SWITCH_CASE(
-        insetBlock, "insetBlock", CompactValue::ofUndefined());
-    RAW_SET_PROP_SWITCH_CASE(
-        insetBlockEnd, "insetBlockEnd", CompactValue::ofUndefined());
-    RAW_SET_PROP_SWITCH_CASE(
-        insetBlockStart, "insetBlockStart", CompactValue::ofUndefined());
-    RAW_SET_PROP_SWITCH_CASE(
-        insetInline, "insetInline", CompactValue::ofUndefined());
-    RAW_SET_PROP_SWITCH_CASE(
-        insetInlineEnd, "insetInlineEnd", CompactValue::ofUndefined());
-    RAW_SET_PROP_SWITCH_CASE(
-        insetInlineStart, "insetInlineStart", CompactValue::ofUndefined());
-    RAW_SET_PROP_SWITCH_CASE(
-        marginInline, "marginInline", CompactValue::ofUndefined());
-    RAW_SET_PROP_SWITCH_CASE(
-        marginInlineStart, "marginInlineStart", CompactValue::ofUndefined());
-    RAW_SET_PROP_SWITCH_CASE(
-        marginInlineEnd, "marginInlineEnd", CompactValue::ofUndefined());
-    RAW_SET_PROP_SWITCH_CASE(
-        marginBlock, "marginBlock", CompactValue::ofUndefined());
-    RAW_SET_PROP_SWITCH_CASE(
-        marginBlockStart, "marginBlockStart", CompactValue::ofUndefined());
-    RAW_SET_PROP_SWITCH_CASE(
-        marginBlockEnd, "marginBlockEnd", CompactValue::ofUndefined());
-    RAW_SET_PROP_SWITCH_CASE(
-        paddingInline, "paddingInline", CompactValue::ofUndefined());
-    RAW_SET_PROP_SWITCH_CASE(
-        paddingInlineStart, "paddingInlineStart", CompactValue::ofUndefined());
-    RAW_SET_PROP_SWITCH_CASE(
-        paddingInlineEnd, "paddingInlineEnd", CompactValue::ofUndefined());
-    RAW_SET_PROP_SWITCH_CASE(
-        paddingBlock, "paddingBlock", CompactValue::ofUndefined());
-    RAW_SET_PROP_SWITCH_CASE(
-        paddingBlockStart, "paddingBlockStart", CompactValue::ofUndefined());
-    RAW_SET_PROP_SWITCH_CASE(
-        paddingBlockEnd, "paddingBlockEnd", CompactValue::ofUndefined());
+    RAW_SET_PROP_SWITCH_CASE(inset, "inset");
+    RAW_SET_PROP_SWITCH_CASE(insetBlock, "insetBlock");
+    RAW_SET_PROP_SWITCH_CASE(insetBlockEnd, "insetBlockEnd");
+    RAW_SET_PROP_SWITCH_CASE(insetBlockStart, "insetBlockStart");
+    RAW_SET_PROP_SWITCH_CASE(insetInline, "insetInline");
+    RAW_SET_PROP_SWITCH_CASE(insetInlineEnd, "insetInlineEnd");
+    RAW_SET_PROP_SWITCH_CASE(insetInlineStart, "insetInlineStart");
+    RAW_SET_PROP_SWITCH_CASE(marginInline, "marginInline");
+    RAW_SET_PROP_SWITCH_CASE(marginInlineStart, "marginInlineStart");
+    RAW_SET_PROP_SWITCH_CASE(marginInlineEnd, "marginInlineEnd");
+    RAW_SET_PROP_SWITCH_CASE(marginBlock, "marginBlock");
+    RAW_SET_PROP_SWITCH_CASE(marginBlockStart, "marginBlockStart");
+    RAW_SET_PROP_SWITCH_CASE(marginBlockEnd, "marginBlockEnd");
+    RAW_SET_PROP_SWITCH_CASE(paddingInline, "paddingInline");
+    RAW_SET_PROP_SWITCH_CASE(paddingInlineStart, "paddingInlineStart");
+    RAW_SET_PROP_SWITCH_CASE(paddingInlineEnd, "paddingInlineEnd");
+    RAW_SET_PROP_SWITCH_CASE(paddingBlock, "paddingBlock");
+    RAW_SET_PROP_SWITCH_CASE(paddingBlockStart, "paddingBlockStart");
+    RAW_SET_PROP_SWITCH_CASE(paddingBlockEnd, "paddingBlockEnd");
   }
 }
 

--- a/ReactCommon/react/renderer/core/PropsMacros.h
+++ b/ReactCommon/react/renderer/core/PropsMacros.h
@@ -31,15 +31,15 @@
 // Convenience for building setProps switch statements.
 // This injects `fromRawValue` into source; each file that uses
 // this macro must import the proper, respective headers required.
-#define RAW_SET_PROP_SWITCH_CASE(field, jsPropName, defaultValue) \
-  case CONSTEXPR_RAW_PROPS_KEY_HASH(jsPropName):                  \
-    fromRawValue(context, value, field, defaultValue);            \
+#define RAW_SET_PROP_SWITCH_CASE(field, jsPropName)      \
+  case CONSTEXPR_RAW_PROPS_KEY_HASH(jsPropName):         \
+    fromRawValue(context, value, field, defaults.field); \
     return;
 
 // Convenience for building setProps switch statements where the field name is
 // the same as the string identifier
-#define RAW_SET_PROP_SWITCH_CASE_BASIC(field, defaultValue) \
-  RAW_SET_PROP_SWITCH_CASE(field, #field, defaultValue)
+#define RAW_SET_PROP_SWITCH_CASE_BASIC(field) \
+  RAW_SET_PROP_SWITCH_CASE(field, #field)
 
 #define CASE_STATEMENT_SET_FIELD_VALUE_INDEXED(         \
     struct, field, fieldNameString, value)              \


### PR DESCRIPTION
Summary:
[Changelog][Internal]

This has been on my backlog for some time, submitting the diff to get it out of the way.

It makes the macro-based code in the "iterator-based property parsing" branch somewhat less horrible and less error prone (by removing duplication vs the default values in the class declaration).

Differential Revision: D42990595

