### PR TITLE
Fix incorrect touchable hitSlop and pressRetentionOffset type

### DIFF
--- a/Libraries/Components/Touchable/TouchableWithoutFeedback.d.ts
+++ b/Libraries/Components/Touchable/TouchableWithoutFeedback.d.ts
@@ -69,7 +69,7 @@ export interface TouchableWithoutFeedbackProps
    * the Z-index of sibling views always takes precedence if a touch hits
    * two overlapping views.
    */
-  hitSlop?: Insets | undefined;
+  hitSlop?: null | Insets | number | undefined;
 
   /**
    * Used to reference react managed views from native code.

--- a/Libraries/Components/Touchable/TouchableWithoutFeedback.d.ts
+++ b/Libraries/Components/Touchable/TouchableWithoutFeedback.d.ts
@@ -121,7 +121,7 @@ export interface TouchableWithoutFeedbackProps
    * while the scroll view is disabled. Ensure you pass in a constant
    * to reduce memory allocations.
    */
-  pressRetentionOffset?: Insets | undefined;
+  pressRetentionOffset?: null | Insets | number | undefined;
 
   /**
    * Used to locate this view in end-to-end tests.

--- a/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+++ b/Libraries/Components/Touchable/TouchableWithoutFeedback.js
@@ -15,7 +15,7 @@ import type {
   AccessibilityState,
   AccessibilityValue,
 } from '../../Components/View/ViewAccessibility';
-import type {EdgeInsetsProp} from '../../StyleSheet/EdgeInsetsPropType';
+import type {EdgeInsetsOrSizeProp} from '../../StyleSheet/EdgeInsetsPropType';
 import type {
   BlurEvent,
   FocusEvent,
@@ -67,7 +67,7 @@ type Props = $ReadOnly<{|
   delayPressOut?: ?number,
   disabled?: ?boolean,
   focusable?: ?boolean,
-  hitSlop?: ?EdgeInsetsProp,
+  hitSlop?: ?EdgeInsetsOrSizeProp,
   id?: string,
   importantForAccessibility?: ?('auto' | 'yes' | 'no' | 'no-hide-descendants'),
   nativeID?: ?string,
@@ -79,7 +79,7 @@ type Props = $ReadOnly<{|
   onPress?: ?(event: PressEvent) => mixed,
   onPressIn?: ?(event: PressEvent) => mixed,
   onPressOut?: ?(event: PressEvent) => mixed,
-  pressRetentionOffset?: ?EdgeInsetsProp,
+  pressRetentionOffset?: ?EdgeInsetsOrSizeProp,
   rejectResponderTermination?: ?boolean,
   testID?: ?string,
   touchSoundDisabled?: ?boolean,


### PR DESCRIPTION
## Summary
Incorrect TS type disallows use of `hitSlop={number}`. Fixed by using Pressable's hitSlop type.

NOTE: I did not bother to change Flow types in the `.js` file, please add a commit doing that if required.

## Changelog
[GENERAL] [FIXED] - Fix touchable hitSlop type

## Test Plan
None needed
