### PR TITLE
fix: fix virtualizedList scrollToEnd for 0 items

### DIFF
--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -167,6 +167,9 @@ export default class VirtualizedList extends StateSafePureComponent<
   scrollToEnd(params?: ?{animated?: ?boolean, ...}) {
     const animated = params ? params.animated : true;
     const veryLast = this.props.getItemCount(this.props.data) - 1;
+    if (veryLast < 0) {
+      return;
+    }
     const frame = this.__getFrameMetricsApprox(veryLast, this.props);
     const offset = Math.max(
       0,

--- a/Libraries/Lists/__tests__/FlatList-test.js
+++ b/Libraries/Lists/__tests__/FlatList-test.js
@@ -74,17 +74,6 @@ describe('FlatList', () => {
     );
     expect(component).toMatchSnapshot();
   });
-  it('scrollToEnd works with null list', () => {
-    const listRef = React.createRef(null);
-    ReactTestRenderer.create(
-      <FlatList
-        data={undefined}
-        renderItem={({item}) => <item value={item.key} />}
-        ref={listRef}
-      />,
-    );
-    listRef.current.scrollToEnd();
-  });
   it('renders all the bells and whistles', () => {
     const component = ReactTestRenderer.create(
       <FlatList

--- a/Libraries/Lists/__tests__/FlatList-test.js
+++ b/Libraries/Lists/__tests__/FlatList-test.js
@@ -74,6 +74,17 @@ describe('FlatList', () => {
     );
     expect(component).toMatchSnapshot();
   });
+  it('scrollToEnd works with null list', () => {
+    const listRef = React.createRef(null);
+    ReactTestRenderer.create(
+      <FlatList
+        data={undefined}
+        renderItem={({item}) => <item value={item.key} />}
+        ref={listRef}
+      />,
+    );
+    listRef.current.scrollToEnd();
+  });
   it('renders all the bells and whistles', () => {
     const component = ReactTestRenderer.create(
       <FlatList

--- a/Libraries/Lists/__tests__/VirtualizedList-test.js
+++ b/Libraries/Lists/__tests__/VirtualizedList-test.js
@@ -137,6 +137,20 @@ describe('VirtualizedList', () => {
     expect(component).toMatchSnapshot();
   });
 
+  it('scrollToEnd works with null list', () => {
+    const listRef = React.createRef(null);
+    ReactTestRenderer.create(
+      <VirtualizedList
+        data={undefined}
+        renderItem={({item}) => <item value={item.key} />}
+        getItem={(data, index) => data[index]}
+        getItemCount={data => 0}
+        ref={listRef}
+      />,
+    );
+    listRef.current.scrollToEnd();
+  });
+
   it('renders empty list with empty component', () => {
     const component = ReactTestRenderer.create(
       <VirtualizedList


### PR DESCRIPTION
## Summary

Fixes https://github.com/facebook/react-native/issues/36066

## Changelog

[GENERAL] [FIXED] - VirtualizedList scrollToEnd with no data

## Test Plan

Run `yarn test VirtualizedList-test`