### PR TITLE
[template] switch from `@types/jest` to `@jest/globals`

### DIFF
--- a/template/__tests__/App.test.tsx
+++ b/template/__tests__/App.test.tsx
@@ -4,6 +4,7 @@
 
 import 'react-native';
 import React from 'react';
+import {it} from "@jest/globals";
 import App from '../App';
 
 // Note: test renderer must be required after react-native.

--- a/template/__tests__/App.test.tsx
+++ b/template/__tests__/App.test.tsx
@@ -4,7 +4,7 @@
 
 import 'react-native';
 import React from 'react';
-import {it} from "@jest/globals";
+import {it} from '@jest/globals';
 import App from '../App';
 
 // Note: test renderer must be required after react-native.

--- a/template/package.json
+++ b/template/package.json
@@ -19,7 +19,6 @@
     "@babel/runtime": "^7.12.5",
     "@react-native/eslint-config": "^0.72.1",
     "@tsconfig/react-native": "^2.0.2",
-    "@types/jest": "^29.2.1",
     "@types/react": "^18.0.24",
     "@types/react-test-renderer": "^18.0.0",
     "babel-jest": "^29.2.1",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Originally proposed in https://github.com/react-native-community/discussions-and-proposals/discussions/592

Main changes are:
- Explicitly importing the global APIs in `App.test.tsx`
- Drop `@types/jest` from the devDependency list

Benefits of these changes will be:
- Keep in line with Jest's recommended practice
- Remove a dev-dependency to make dependencies slimmer

References:
- https://github.com/facebook/jest/pull/13133
- https://github.com/DefinitelyTyped/DefinitelyTyped/pull/62037

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

[GENERAL] [CHANGED] - Switch from `@types/jest` to `@jest/globals` for new react-native projects


## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

1. Create a new RN project from the modified template
2. Ensure yarn test passes
3. Ensure IDEs do not complain about `App.test.tsx`
