### PR TITLE
fix: add custom request handlers on new arch

### DIFF
--- a/React/AppSetup/RCTAppSetupUtils.mm
+++ b/React/AppSetup/RCTAppSetupUtils.mm
@@ -83,11 +83,13 @@ id<RCTTurboModule> RCTAppSetupDefaultModuleFromClass(Class moduleClass)
   } else if (moduleClass == RCTNetworking.class) {
     return [[moduleClass alloc]
         initWithHandlersProvider:^NSArray<id<RCTURLRequestHandler>> *(RCTModuleRegistry *moduleRegistry) {
-          return @[
-            [RCTHTTPRequestHandler new],
-            [RCTDataRequestHandler new],
-            [RCTFileRequestHandler new],
-          ];
+          NSArray *handlers = [moduleRegistry modulesConformingToProtocol:@protocol(RCTURLRequestHandler)];
+          NSArray *handlersWithDefaultOnes = [handlers arrayByAddingObjectsFromArray: @[
+                        [RCTHTTPRequestHandler new],
+                        [RCTDataRequestHandler new],
+                        [RCTFileRequestHandler new],
+          ]];
+          return handlersWithDefaultOnes;
         }];
   }
   // No custom initializer here.

--- a/React/Base/RCTBridgeModule.h
+++ b/React/Base/RCTBridgeModule.h
@@ -390,6 +390,7 @@ RCT_EXTERN_C_END
 
 - (id)moduleForName:(const char *)moduleName;
 - (id)moduleForName:(const char *)moduleName lazilyLoadIfNecessary:(BOOL)lazilyLoad;
+- (NSArray *)modulesConformingToProtocol:(Protocol *)protocol;
 @end
 
 typedef UIView * (^RCTBridgelessComponentViewProvider)(NSNumber *);

--- a/React/Base/RCTModuleRegistry.m
+++ b/React/Base/RCTModuleRegistry.m
@@ -47,4 +47,16 @@
   return module;
 }
 
+- (NSArray *)modulesConformingToProtocol:(Protocol *)protocol
+{
+  NSMutableArray *modules = [NSMutableArray new];
+  RCTBridge *bridge = _bridge;
+  if (bridge) {
+    [modules addObjectsFromArray:[bridge modulesConformingToProtocol:protocol]];
+  }
+
+  // TODO: find a way to get the same information of turboModules
+  return [modules copy];
+}
+
 @end


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Right now modules conforming to `RCTURLRequestHandler` protocol are hardcoded on new arch and there is no way to add your own modules there. I added the first look on a method providing all such modules there. The work is connected with bringing new arch to `react-native-cameraroll`: https://github.com/react-native-cameraroll/react-native-cameraroll/pull/460. For now I didn't convert the `RNCAssetsLibraryRequestHandler` from that lib to `TurboModule` since there is no way to get it then.


## Changelog

[IOS] [ADDED] - custom `RCTURLRequestHandler` modules on new arch

## Test Plan

Try and register a custom module conforming to `RCTURLRequestHandler` on new arch.