### PR TITLE
fix: use relative paths for gradle exec invocations

### DIFF
--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/BundleHermesCTask.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/BundleHermesCTask.kt
@@ -89,7 +89,7 @@ abstract class BundleHermesCTask : DefaultTask() {
     runCommand(bundleCommand)
 
     if (hermesEnabled.get()) {
-      val detectedHermesCommand = detectOSAwareHermesCommand(root.get().asFile, hermesCommand.get())
+      val detectedHermesCommand = File(detectOSAwareHermesCommand(root.get().asFile, hermesCommand.get())).relativeTo(root.get().asFile).path
       val bytecodeFile = File("${bundleFile}.hbc")
       val outputSourceMap = resolveOutputSourceMap(bundleAssetFilename)
       val compilerSourceMap = resolveCompilerSourceMap(bundleAssetFilename)
@@ -136,7 +136,7 @@ abstract class BundleHermesCTask : DefaultTask() {
       windowsAwareCommandLine(
           buildList {
             addAll(nodeExecutableAndArgs.get())
-            add(cliFile.get().asFile.absolutePath)
+            add(cliFile.get().asFile.relativeTo(root.get().asFile).path)
             add(bundleCommand.get())
             add("--platform")
             add("android")
@@ -144,16 +144,16 @@ abstract class BundleHermesCTask : DefaultTask() {
             add(devEnabled.get().toString())
             add("--reset-cache")
             add("--entry-file")
-            add(entryFile.get().asFile.toString())
+            add(entryFile.get().asFile.relativeTo(root.get().asFile).path)
             add("--bundle-output")
-            add(bundleFile.toString())
+            add(bundleFile.relativeTo(root.get().asFile).path)
             add("--assets-dest")
-            add(resourcesDir.get().asFile.toString())
+            add(resourcesDir.get().asFile.relativeTo(root.get().asFile).path)
             add("--sourcemap-output")
-            add(sourceMapFile.toString())
+            add(sourceMapFile.relativeTo(root.get().asFile).path)
             if (bundleConfig.isPresent) {
               add("--config")
-              add(bundleConfig.get().asFile.absolutePath)
+              add(bundleConfig.get().asFile.relativeTo(root.get().asFile).path)
             }
             add("--minify")
             add(minifyEnabled.get().toString())
@@ -170,8 +170,8 @@ abstract class BundleHermesCTask : DefaultTask() {
           hermesCommand,
           "-emit-binary",
           "-out",
-          bytecodeFile.absolutePath,
-          bundleFile.absolutePath,
+          bytecodeFile.relativeTo(root.get().asFile).path,
+          bundleFile.relativeTo(root.get().asFile).path,
           *hermesFlags.get().toTypedArray())
 
   internal fun getComposeSourceMapsCommand(
@@ -182,9 +182,9 @@ abstract class BundleHermesCTask : DefaultTask() {
   ): List<Any> =
       windowsAwareCommandLine(
           *nodeExecutableAndArgs.get().toTypedArray(),
-          composeScript.absolutePath,
-          packagerSourceMap.toString(),
-          compilerSourceMap.toString(),
+          composeScript.relativeTo(root.get().asFile).path,
+          packagerSourceMap.relativeTo(root.get().asFile).path,
+          compilerSourceMap.relativeTo(root.get().asFile).path,
           "-o",
-          outputSourceMap.toString())
+          outputSourceMap.relativeTo(root.get().asFile).path)
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

For Android release builds on Windows, gradle release build fails if there are spaces in path (#34878). This is due to gradle improperly handling arguments with spaces (this is also [an open issue](https://github.com/gradle/gradle/issues/6072) on Gradle). Since the Hermes compilation and other Gradle exec invocations involve arguments which will contain spaces (if there are spaces in your path), this also means it is hard to get around this by simply escaping the spaces (eg: by using double quotes), since these arguments are not properly handled by Gradle itself.

As a workaround, this PR uses relative paths for all Gradle commands invoked for Android. As long as there aren't any spaces in the react-native directory structure (i.e this repo), this fix should work.

## Changelog

[Android][Fixed] - Used relative paths for gradle commands

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

`npx react-native run-android` builds and runs the app successfully on Android device, when run inside an RN0711 project with a path containing spaces (and with the changes in this PR applied) on Windows. This includes release builds (i.e with the `--variant=release` flag).
