### PR TITLE
fix(EventEmitter) only apply if listener #35577

### DIFF
--- a/Libraries/vendor/emitter/EventEmitter.js
+++ b/Libraries/vendor/emitter/EventEmitter.js
@@ -105,7 +105,7 @@ export default class EventEmitter<TEventToArgsMap: {...}>
     > = this._registry[eventType];
     if (registrations != null) {
       for (const registration of [...registrations]) {
-        registration.listener.apply(registration.context, args);
+        registration.listener?.apply(registration.context, args);
       }
     }
   }

--- a/Libraries/vendor/emitter/EventEmitter.js
+++ b/Libraries/vendor/emitter/EventEmitter.js
@@ -74,6 +74,9 @@ export default class EventEmitter<TEventToArgsMap: {...}>
     listener: (...args: $ElementType<TEventToArgsMap, TEvent>) => mixed,
     context: mixed,
   ): EventSubscription {
+    if (typeof listener !== 'function') {
+      throw new TypeError('EventEmitter.addListener(…): 2nd argument must be a function.');
+    }
     const registrations = allocate<_, _, TEventToArgsMap[TEvent]>(
       this._registry,
       eventType,

--- a/Libraries/vendor/emitter/EventEmitter.js
+++ b/Libraries/vendor/emitter/EventEmitter.js
@@ -75,7 +75,9 @@ export default class EventEmitter<TEventToArgsMap: {...}>
     context: mixed,
   ): EventSubscription {
     if (typeof listener !== 'function') {
-      throw new TypeError('EventEmitter.addListener(…): 2nd argument must be a function.');
+      throw new TypeError(
+        'EventEmitter.addListener(…): 2nd argument must be a function.'
+      );
     }
     const registrations = allocate<_, _, TEventToArgsMap[TEvent]>(
       this._registry,

--- a/Libraries/vendor/emitter/EventEmitter.js
+++ b/Libraries/vendor/emitter/EventEmitter.js
@@ -76,7 +76,7 @@ export default class EventEmitter<TEventToArgsMap: {...}>
   ): EventSubscription {
     if (typeof listener !== 'function') {
       throw new TypeError(
-        'EventEmitter.addListener(…): 2nd argument must be a function.'
+        'EventEmitter.addListener(…): 2nd argument must be a function.',
       );
     }
     const registrations = allocate<_, _, TEventToArgsMap[TEvent]>(

--- a/Libraries/vendor/emitter/EventEmitter.js
+++ b/Libraries/vendor/emitter/EventEmitter.js
@@ -108,7 +108,7 @@ export default class EventEmitter<TEventToArgsMap: {...}>
     > = this._registry[eventType];
     if (registrations != null) {
       for (const registration of [...registrations]) {
-        registration.listener?.apply(registration.context, args);
+        registration.listener.apply(registration.context, args);
       }
     }
   }

--- a/Libraries/vendor/emitter/__tests__/EventEmitter-test.js
+++ b/Libraries/vendor/emitter/__tests__/EventEmitter-test.js
@@ -78,6 +78,13 @@ describe('listeners', () => {
     expect(results).toEqual(['A', 'B', 'C']);
   });
 
+  it('registers an event with an illegal argument', () => {
+    const emitter = new EventEmitter<{A: []}>();
+    const fakeFunction = ({}: any);
+
+    expect(() => emitter.addListener('A', fakeFunction)).toThrow('EventEmitter.addListener(…): 2nd argument must be a function.');
+  });
+
   it('invokes the same listener registered multiple times', () => {
     const emitter = new EventEmitter<{A: []}>();
 

--- a/Libraries/vendor/emitter/__tests__/EventEmitter-test.js
+++ b/Libraries/vendor/emitter/__tests__/EventEmitter-test.js
@@ -82,7 +82,9 @@ describe('listeners', () => {
     const emitter = new EventEmitter<{A: []}>();
     const fakeFunction = ({}: any);
 
-    expect(() => emitter.addListener('A', fakeFunction)).toThrow('EventEmitter.addListener(…): 2nd argument must be a function.');
+    expect(() => emitter.addListener('A', fakeFunction)).toThrow(
+      'EventEmitter.addListener(…): 2nd argument must be a function.',
+    );
   });
 
   it('invokes the same listener registered multiple times', () => {

--- a/Libraries/vendor/emitter/__tests__/EventEmitter-test.js
+++ b/Libraries/vendor/emitter/__tests__/EventEmitter-test.js
@@ -80,9 +80,8 @@ describe('listeners', () => {
 
   it('registers an event with an illegal argument', () => {
     const emitter = new EventEmitter<{A: []}>();
-    const fakeFunction = ({}: any);
 
-    expect(() => emitter.addListener('A', fakeFunction)).toThrow(
+    expect(() => emitter.addListener('A', null)).toThrow(
       'EventEmitter.addListener(…): 2nd argument must be a function.',
     );
   });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

During the rewrite of the event listeners in e5c5dcd a check was removed if the listener exists.
This change now checks that the listener is registred correctly.

## Changelog

[INTERNAL] [FIXED] - make sure the event listener is registred correctly

## Test Plan

Try to add an event listener without a proper func as parameter

