### PR TITLE
fix(ios): fix `pod install --project-directory=...`

### DIFF
--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -209,7 +209,8 @@ def react_native_post_install(installer, react_native_path = "../node_modules/re
     flipper_post_install(installer)
   end
 
-  package = JSON.parse(File.read(File.join(react_native_path, "package.json")))
+  package_path = File.join(Pod::Config.instance.installation_root, react_native_path, "package.json")
+  package = JSON.parse(File.read(package_path))
   version = package['version']
 
   if ReactNativePodsUtils.has_pod(installer, 'hermes-engine') && is_building_hermes_from_source(version, react_native_path)


### PR DESCRIPTION
## Summary

![image](https://user-images.githubusercontent.com/4123478/217618490-4f99e408-1a07-4acf-a05c-e8837562a931.png)

Jokes aside, I think the breaking change was only introduced on the `0.71-stable` branch. So no need to fix anything on `main`.

## Changelog

[IOS] [FIXED] - Fix `pod install --project-directory=...`
