### PR TITLE
[iOS] Build codegen package while using old architecture

### DIFF
--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -141,6 +141,9 @@ def use_react_native! (
   if fabric_enabled
     checkAndGenerateEmptyThirdPartyProvider!(prefix, new_arch_enabled, $CODEGEN_OUTPUT_DIR)
     setup_fabric!(:react_native_path => prefix)
+  else
+    relative_installation_root = Pod::Config.instance.installation_root.relative_path_from(Pathname.pwd)
+    build_codegen!(prefix, relative_installation_root)
   end
 
   # CocoaPods `configurations` option ensures that the target is copied only for the specified configurations,


### PR DESCRIPTION
## Summary

Fixes https://github.com/facebook/react-native/issues/36097

When building RNTester with the old architecture, we skip a call to `build_codegen`, which will build the JS package at `packages/react-native-codegen`. This is needed for the Xcode Script phase `Generate Specs`. This causes a build with fabric disabled to fail. We can fix this by ensuring we call `build_codegen` in both paper and fabric.

We've had this change in React Native macOS already since 0.68: https://github.com/microsoft/react-native-macos/commit/1175372ffecf6b4e18fa27b75b68f3ec7967a384

## Changelog

[IOS] [FIXED] - Build codegen package while using old architecture

## Test Plan

CI should suffice. Locally built RN-Tester without fabric with and without my change to show that disabling fabric will only succeed with this change included.
While running `pod install`, you should now see this extra line with the old architecture:
> [Codegen] building ./../../packages/react-native-codegen.