### PR TITLE
Fix crash when accessing weak reference

### DIFF
--- a/Libraries/Text/Text/RCTTextViewManager.m
+++ b/Libraries/Text/Text/RCTTextViewManager.m
@@ -68,7 +68,9 @@ RCT_EXPORT_VIEW_PROPERTY(selectable, BOOL)
 - (void)uiManagerWillPerformMounting:(__unused RCTUIManager *)uiManager
 {
   for (RCTTextShadowView *shadowView in _shadowViews) {
-    [shadowView uiManagerWillPerformMounting];
+    if (shadowView) {
+      [shadowView uiManagerWillPerformMounting];
+    }
   }
 }
 


### PR DESCRIPTION
Crash with message `uiManagerWillPerformMounting: Attempted to dereference garbage pointer <address>`

![image](https://user-images.githubusercontent.com/895369/217678767-3eaf1430-80f9-4824-bb24-0812f0b6a339.png)

## Summary

We are seeing multiple crashes in production apps where uiManagerWillPerformMounting is mentioned in the context of a PHPicker controller being shown. While it's not clear how to reliable reproduce the issue, after reviewing the culprit, it does seem like an issue that a weak reference hash map is being used to access shadow views. Between being added to the map and being called they could be freed, causing this crash.

## Changelog

[IOS] [FIXED] - Fixed "uiManagerWillPerformMounting" native crash while another UIViewController is active.

## Test Plan

Code was NOT tested. Reproducibility is an issue, and I was not able to gather any feedback on this proposal outside of a GH PR. I would like some feedback before we merge.
However, it's clear that weak references should always be checked so it seems fine to do this.
