### PR TITLE
Add minimum necessary .d.ts files to react-native-codegen

### DIFF
--- a/packages/react-native-codegen/src/CodegenSchema.d.ts
+++ b/packages/react-native-codegen/src/CodegenSchema.d.ts
@@ -1,0 +1,348 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export type PlatformType =
+  | 'iOS'
+  | 'android';
+
+export interface SchemaType {
+  readonly modules: {
+    [hasteModuleName: string]: ComponentSchema | NativeModuleSchema;
+  };
+}
+
+export interface DoubleTypeAnnotation {
+  readonly type: 'DoubleTypeAnnotation';
+}
+
+export interface FloatTypeAnnotation {
+  readonly type: 'FloatTypeAnnotation';
+}
+
+export interface BooleanTypeAnnotation {
+  readonly type: 'BooleanTypeAnnotation';
+}
+
+export interface Int32TypeAnnotation {
+  readonly type: 'Int32TypeAnnotation';
+}
+
+export interface StringTypeAnnotation {
+  readonly type: 'StringTypeAnnotation';
+}
+
+export interface StringEnumTypeAnnotation {
+  readonly type: 'StringEnumTypeAnnotation';
+  readonly options: readonly string[];
+}
+
+export interface VoidTypeAnnotation {
+  readonly type: 'VoidTypeAnnotation';
+}
+
+export interface ObjectTypeAnnotation<T> {
+  readonly type: 'ObjectTypeAnnotation';
+  readonly properties: readonly NamedShape<T>[];
+  readonly baseTypes?: readonly string[];
+}
+
+export interface FunctionTypeAnnotation<P, R> {
+  readonly type: 'FunctionTypeAnnotation';
+  readonly params: readonly NamedShape<P>[];
+  readonly returnTypeAnnotation: R;
+}
+
+export interface NamedShape<T> {
+  readonly name: string;
+  readonly optional: boolean;
+  readonly typeAnnotation: T;
+}
+
+export interface ComponentSchema {
+  readonly type: 'Component';
+  readonly components: {
+    [componentName: string]: ComponentShape;
+  };
+}
+
+export interface ComponentShape extends OptionsShape {
+  readonly extendsProps: readonly ExtendsPropsShape[];
+  readonly events: readonly EventTypeShape[];
+  readonly props: readonly NamedShape<PropTypeAnnotation>[];
+  readonly commands: readonly NamedShape<CommandTypeAnnotation>[];
+}
+
+export interface OptionsShape {
+  readonly interfaceOnly?: boolean;
+  readonly paperComponentName?: string;
+  readonly excludedPlatforms?: readonly PlatformType[];
+  readonly paperComponentNameDeprecated?: string;
+}
+
+export interface ExtendsPropsShape {
+  readonly type: 'ReactNativeBuiltInType';
+  readonly knownTypeName: 'ReactNativeCoreViewProps';
+}
+
+export interface EventTypeShape {
+  readonly name: string;
+  readonly bubblingType:
+    | 'direct'
+    | 'bubble';
+  readonly optional: boolean;
+  readonly paperTopLevelNameDeprecated?: string;
+  readonly typeAnnotation: {
+    readonly type: 'EventTypeAnnotation';
+    readonly argument?: ObjectTypeAnnotation<EventTypeAnnotation>;
+  };
+}
+
+export type EventTypeAnnotation =
+  | BooleanTypeAnnotation
+  | StringTypeAnnotation
+  | DoubleTypeAnnotation
+  | FloatTypeAnnotation
+  | Int32TypeAnnotation
+  | StringEnumTypeAnnotation
+  | ObjectTypeAnnotation<EventTypeAnnotation>;
+
+export type PropTypeAnnotation =
+  | {
+      readonly type: 'BooleanTypeAnnotation';
+      readonly default:
+        | boolean
+        | null;
+    }
+  | {
+      readonly type: 'StringTypeAnnotation';
+      readonly default:
+        | string
+        | null;
+    }
+  | {
+      readonly type: 'DoubleTypeAnnotation';
+      readonly default: number;
+    }
+  | {
+      readonly type: 'FloatTypeAnnotation';
+      readonly default:
+        | number
+        | null;
+    }
+  | {
+      readonly type: 'Int32TypeAnnotation';
+      readonly default: number;
+    }
+  | {
+      readonly type: 'StringEnumTypeAnnotation';
+      readonly default: string;
+      readonly options: readonly string[];
+    }
+  | {
+      readonly type: 'Int32EnumTypeAnnotation';
+      readonly default: number;
+      readonly options: readonly number[];
+    }
+  | ReservedPropTypeAnnotation
+  | ObjectTypeAnnotation<PropTypeAnnotation>
+  | {
+      readonly type: 'ArrayTypeAnnotation';
+      readonly elementType:
+        | BooleanTypeAnnotation
+        | StringTypeAnnotation
+        | DoubleTypeAnnotation
+        | FloatTypeAnnotation
+        | Int32TypeAnnotation
+        | {
+            readonly type: 'StringEnumTypeAnnotation';
+            readonly default: string;
+            readonly options: readonly string[];
+          }
+        | ObjectTypeAnnotation<PropTypeAnnotation>
+        | ReservedPropTypeAnnotation
+        | {
+            readonly type: 'ArrayTypeAnnotation';
+            readonly elementType: ObjectTypeAnnotation<PropTypeAnnotation>;
+          };
+    };
+
+export interface ReservedPropTypeAnnotation {
+  readonly type: 'ReservedPropTypeAnnotation';
+  readonly name:
+    | 'ColorPrimitive'
+    | 'ImageSourcePrimitive'
+    | 'PointPrimitive'
+    | 'EdgeInsetsPrimitive'
+    | 'ImageRequestPrimitive'
+    | 'DimensionPrimitive';
+}
+
+export type CommandTypeAnnotation = FunctionTypeAnnotation<CommandParamTypeAnnotation, VoidTypeAnnotation>;
+
+export type CommandParamTypeAnnotation =
+  | ReservedTypeAnnotation
+  | BooleanTypeAnnotation
+  | Int32TypeAnnotation
+  | DoubleTypeAnnotation
+  | FloatTypeAnnotation
+  | StringTypeAnnotation;
+
+export interface ReservedTypeAnnotation {
+  readonly type: 'ReservedTypeAnnotation';
+  readonly name: 'RootTag';
+}
+
+export type Nullable<T extends NativeModuleTypeAnnotation> =
+  | NullableTypeAnnotation<T>
+  | T;
+
+export interface NullableTypeAnnotation<T extends NativeModuleTypeAnnotation> {
+  readonly type: 'NullableTypeAnnotation';
+  readonly typeAnnotation: T;
+}
+
+export interface NativeModuleSchema {
+  readonly type: 'NativeModule';
+  readonly aliasMap: NativeModuleAliasMap;
+  readonly enumMap: NativeModuleEnumMap;
+  readonly spec: NativeModuleSpec;
+  readonly moduleName: string;
+  readonly excludedPlatforms?: readonly PlatformType[];
+}
+
+export interface NativeModuleSpec {
+  readonly properties: readonly NativeModulePropertyShape[];
+}
+
+export type NativeModulePropertyShape = NamedShape<Nullable<NativeModuleFunctionTypeAnnotation>>;
+
+export interface NativeModuleEnumMap {
+  readonly [enumName: string]: NativeModuleEnumDeclarationWithMembers;
+}
+
+export interface NativeModuleAliasMap {
+  readonly [aliasName: string]: NativeModuleObjectTypeAnnotation;
+}
+
+export type NativeModuleFunctionTypeAnnotation = FunctionTypeAnnotation<Nullable<NativeModuleParamTypeAnnotation>, Nullable<NativeModuleReturnTypeAnnotation>>;
+
+export type NativeModuleObjectTypeAnnotation = ObjectTypeAnnotation<Nullable<NativeModuleBaseTypeAnnotation>>;
+
+export interface NativeModuleArrayTypeAnnotation<T extends Nullable<NativeModuleBaseTypeAnnotation>> {
+  readonly type: 'ArrayTypeAnnotation';
+  readonly elementType?: T;
+}
+
+export interface NativeModuleStringTypeAnnotation {
+  readonly type: 'StringTypeAnnotation';
+}
+
+export interface NativeModuleNumberTypeAnnotation {
+  readonly type: 'NumberTypeAnnotation';
+}
+
+export interface NativeModuleInt32TypeAnnotation {
+  readonly type: 'Int32TypeAnnotation';
+}
+
+export interface NativeModuleDoubleTypeAnnotation {
+  readonly type: 'DoubleTypeAnnotation';
+}
+
+export interface NativeModuleFloatTypeAnnotation {
+  readonly type: 'FloatTypeAnnotation';
+}
+
+export interface NativeModuleBooleanTypeAnnotation {
+  readonly type: 'BooleanTypeAnnotation';
+}
+
+export type NativeModuleEnumMembers = readonly {
+  readonly name: string;
+  readonly value: string;
+}[];
+
+export type NativeModuleEnumMemberType =
+  | 'NumberTypeAnnotation'
+  | 'StringTypeAnnotation';
+
+export interface NativeModuleEnumDeclaration {
+  readonly name: string;
+  readonly type: 'EnumDeclaration';
+  readonly memberType: NativeModuleEnumMemberType;
+}
+
+export interface NativeModuleEnumDeclarationWithMembers {
+  name: string;
+  type: 'EnumDeclarationWithMembers';
+  memberType: NativeModuleEnumMemberType;
+  members: NativeModuleEnumMembers;
+}
+
+export interface NativeModuleGenericObjectTypeAnnotation {
+  readonly type: 'GenericObjectTypeAnnotation';
+}
+
+export interface NativeModuleTypeAliasTypeAnnotation {
+  readonly type: 'TypeAliasTypeAnnotation';
+  readonly name: string;
+}
+
+export interface NativeModulePromiseTypeAnnotation {
+  readonly type: 'PromiseTypeAnnotation';
+  readonly elementType?: Nullable<NativeModuleBaseTypeAnnotation>;
+}
+
+export type UnionTypeAnnotationMemberType =
+  | 'NumberTypeAnnotation'
+  | 'ObjectTypeAnnotation'
+  | 'StringTypeAnnotation';
+
+export interface NativeModuleUnionTypeAnnotation {
+  readonly type: 'UnionTypeAnnotation';
+  readonly memberType: UnionTypeAnnotationMemberType;
+}
+
+export interface NativeModuleMixedTypeAnnotation {
+  readonly type: 'MixedTypeAnnotation';
+}
+
+export type NativeModuleBaseTypeAnnotation =
+  | NativeModuleStringTypeAnnotation
+  | NativeModuleNumberTypeAnnotation
+  | NativeModuleInt32TypeAnnotation
+  | NativeModuleDoubleTypeAnnotation
+  | NativeModuleFloatTypeAnnotation
+  | NativeModuleBooleanTypeAnnotation
+  | NativeModuleEnumDeclaration
+  | NativeModuleGenericObjectTypeAnnotation
+  | ReservedTypeAnnotation
+  | NativeModuleTypeAliasTypeAnnotation
+  | NativeModuleArrayTypeAnnotation<Nullable<NativeModuleBaseTypeAnnotation>>
+  | NativeModuleObjectTypeAnnotation
+  | NativeModuleUnionTypeAnnotation
+  | NativeModuleMixedTypeAnnotation;
+
+export type NativeModuleParamTypeAnnotation =
+  | NativeModuleBaseTypeAnnotation
+  | NativeModuleParamOnlyTypeAnnotation;
+
+export type NativeModuleReturnTypeAnnotation =
+  | NativeModuleBaseTypeAnnotation
+  | NativeModuleReturnOnlyTypeAnnotation;
+
+export type NativeModuleTypeAnnotation =
+  | NativeModuleBaseTypeAnnotation
+  | NativeModuleParamOnlyTypeAnnotation
+  | NativeModuleReturnOnlyTypeAnnotation;
+
+export type NativeModuleParamOnlyTypeAnnotation = NativeModuleFunctionTypeAnnotation;
+
+export type NativeModuleReturnOnlyTypeAnnotation =
+  | NativeModulePromiseTypeAnnotation
+  | VoidTypeAnnotation;
+

--- a/packages/react-native-codegen/src/SchemaValidator.d.ts
+++ b/packages/react-native-codegen/src/SchemaValidator.d.ts
@@ -7,5 +7,5 @@
 
 import type { SchemaType } from "./CodegenSchema";
 
-export function getErrors(schema: SchemaType): readonly string[];
-export function validate(schema: SchemaType): void;
+export declare function getErrors(schema: SchemaType): readonly string[];
+export declare function validate(schema: SchemaType): void;

--- a/packages/react-native-codegen/src/SchemaValidator.d.ts
+++ b/packages/react-native-codegen/src/SchemaValidator.d.ts
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import type { SchemaType } from "./CodegenSchema";
+
+export function getErrors(schema: SchemaType): readonly string[];
+export function validate(schema: SchemaType): void;

--- a/packages/react-native-codegen/src/parsers/errors.d.ts
+++ b/packages/react-native-codegen/src/parsers/errors.d.ts
@@ -9,4 +9,4 @@ import type { Parser } from './parser';
 
 export type ParserType = 'Flow' | 'TypeScript';
 
-export class ParserError extends Error {}
+export declare class ParserError extends Error {}

--- a/packages/react-native-codegen/src/parsers/errors.d.ts
+++ b/packages/react-native-codegen/src/parsers/errors.d.ts
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import type { Parser } from './parser';
+
+export type ParserType = 'Flow' | 'TypeScript';
+
+export class ParserError extends Error {}

--- a/packages/react-native-codegen/src/parsers/flow/parser.d.ts
+++ b/packages/react-native-codegen/src/parsers/flow/parser.d.ts
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import type {Parser} from '../parser';
+
+export class FlowParser implements Parser{}

--- a/packages/react-native-codegen/src/parsers/flow/parser.d.ts
+++ b/packages/react-native-codegen/src/parsers/flow/parser.d.ts
@@ -7,4 +7,4 @@
 
 import type {Parser} from '../parser';
 
-export class FlowParser implements Parser{}
+export declare class FlowParser implements Parser{}

--- a/packages/react-native-codegen/src/parsers/parser.d.ts
+++ b/packages/react-native-codegen/src/parsers/parser.d.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import type { SchemaType } from "../CodegenSchema";
+import type { ParserType } from "./errors";
+
+// useful members only for downstream
+export interface Parser {
+    language(): ParserType;
+    parseFile(filename: string): SchemaType;
+    parseString(contents: string, filename?: string): SchemaType;
+    parseModuleFixture(filename: string): SchemaType;
+}

--- a/packages/react-native-codegen/src/parsers/schema/index.d.ts
+++ b/packages/react-native-codegen/src/parsers/schema/index.d.ts
@@ -5,6 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-export type ParserType = 'Flow' | 'TypeScript';
+import type { SchemaType } from "../../CodegenSchema";
 
-export declare class ParserError extends Error {}
+export declare function parse(filename: string): SchemaType | undefined;

--- a/packages/react-native-codegen/src/parsers/typescript/parser.d.ts
+++ b/packages/react-native-codegen/src/parsers/typescript/parser.d.ts
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import type {Parser} from '../parser';
+
+export class TypeScriptParser implements Parser{}

--- a/packages/react-native-codegen/src/parsers/typescript/parser.d.ts
+++ b/packages/react-native-codegen/src/parsers/typescript/parser.d.ts
@@ -7,4 +7,4 @@
 
 import type {Parser} from '../parser';
 
-export class TypeScriptParser implements Parser{}
+export declare class TypeScriptParser implements Parser{}


### PR DESCRIPTION
## Summary

Add minimum necessary .d.ts files to react-native-codegen.

I found .d.ts files will be copied to `lib` so I guess no additional script is needed.

## Changelog

[GENERAL] [CHANGED] - Add minimum necessary .d.ts files to react-native-codegen

## Test Plan

`npm run build` in `packages/react-native-codegen` and see all .d.ts files appear in `lib`.
