### PR TITLE
Fix ScrollView momentum not stopping when calling scrollTo programmatically

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -1076,6 +1076,7 @@ public class ReactScrollView extends ScrollView
    */
   @Override
   public void scrollTo(int x, int y) {
+    mScroller.abortAnimation();
     super.scrollTo(x, y);
     ReactScrollViewHelper.updateFabricScrollState(this);
     setPendingContentOffsets(x, y);


### PR DESCRIPTION
## Summary

Fixes #32235.

See https://github.com/facebook/react-native/issues/32235#issuecomment-1420826665 for details.

Here's what I did:
1. Set a breakpoint in method `scrollTo` in class `android.view.View` (make sure the API level of your emulator matches `compileSdkVersion` so the sources are aligned with the bytecode)
2. Try to scroll the ScrollView, make sure the breakpoint is hit, continue execution
3. Add condition `y == 0` to the breakpoint so it doesn't pause execution when scrolling
4. Scroll the ScrollView again so that it still scrolls with its momentum
5. Click the button that calls `scrollTo` command with `y = 0`
6. Breakpoint should be hit, see `ReactScrollViewCommandHelper` in the stack trace 
7. Remove condition `y == 0` from the breakpoint, continue execution
8. Breakpoint is hit again with `y != 0` (in my case 49153 or something) &ndash; this is incorrect behavior as it overwrites the effect of the previous call
9. Notice the stack trace goes through a series of native calls, probably there's some mechanism that kicks in here
10. Add `mScroller.abortAnimation();` just out of curiosity
11. It actually works!
12. Submit this PR

Before:

https://user-images.githubusercontent.com/20516055/217268275-7ec9a228-bbd6-4294-aa1f-a43c4268984c.mov

After:

https://user-images.githubusercontent.com/20516055/217786242-f44b008f-6c6d-4f11-a7bd-b7a01150f3fb.mov

## Changelog

[ANDROID] [FIXED] - Fixed ScrollView momentum not stopping when calling scrollTo programmatically

## Test Plan

Reproducer: https://github.com/tomekzaw/Issue32235/blob/master/App.tsx
