### PR TITLE
Hardcode concurrentRootEnabled to true when Fabric is enabled

### DIFF
--- a/Libraries/AppDelegate/RCTAppDelegate.h
+++ b/Libraries/AppDelegate/RCTAppDelegate.h
@@ -100,13 +100,6 @@
 @property (nonatomic, strong) RCTTurboModuleManager *turboModuleManager;
 @property (nonatomic, strong) RCTSurfacePresenterBridgeAdapter *bridgeAdapter;
 
-/// This method controls whether the `concurrentRoot` feature of React18 is turned on or off.
-///
-/// @see: https://reactjs.org/blog/2022/03/29/react-v18.html
-/// @note: This requires to be rendering on Fabric (i.e. on the New Architecture).
-/// @return: `true` if the `concurrentRoot` feature is enabled. Otherwise, it returns `false`.
-- (BOOL)concurrentRootEnabled;
-
 /// This method controls whether the `turboModules` feature of the New Architecture is turned on or off.
 ///
 /// @note: This is required to be rendering on Fabric (i.e. on the New Architecture).

--- a/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -75,19 +75,12 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
   return nil;
 }
 
-- (BOOL)concurrentRootEnabled
-{
-  [NSException raise:@"concurrentRootEnabled not implemented"
-              format:@"Subclasses must implement a valid concurrentRootEnabled method"];
-  return true;
-}
-
 - (NSDictionary *)prepareInitialProps
 {
   NSMutableDictionary *initProps = self.initialProps ? [self.initialProps mutableCopy] : [NSMutableDictionary new];
 
 #ifdef RCT_NEW_ARCH_ENABLED
-  initProps[kRNConcurrentRoot] = @([self concurrentRootEnabled]);
+  initProps[kRNConcurrentRoot] = @([self fabricEnabled]);
 #endif
 
   return initProps;

--- a/template/ios/HelloWorld/AppDelegate.mm
+++ b/template/ios/HelloWorld/AppDelegate.mm
@@ -23,14 +23,4 @@
 #endif
 }
 
-/// This method controls whether the `concurrentRoot` feature of React18 is turned on or off.
-///
-/// @see: https://reactjs.org/blog/2022/03/29/react-v18.html
-/// @note: This requires to be rendering on Fabric (i.e. on the New Architecture).
-/// @return: `true` if the `concurrentRoot` feature is enabled. Otherwise, it returns `false`.
-- (BOOL)concurrentRootEnabled
-{
-  return true;
-}
-
 @end


### PR DESCRIPTION
Summary:
Having `concurrentRoot` disabled when Fabric is enabled is not recommended.
This simplifies the setup and makes sure that both are either enabled or disabled.

## Changelog:
[iOS] [Breaking] - Hardcode concurrentRootEnabled to `true` when Fabric is enabled

Differential Revision: D43153402

