### PR TITLE
Hardcode concurrentRootEnabled to true when Fabric is enabled

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
@@ -34,7 +34,6 @@ public class ReactActivityDelegate {
   private @Nullable PermissionListener mPermissionListener;
   private @Nullable Callback mPermissionsCallback;
   private ReactDelegate mReactDelegate;
-  private boolean mConcurrentRootEnabled;
 
   @Deprecated
   public ReactActivityDelegate(Activity activity, @Nullable String mainComponentName) {
@@ -59,7 +58,7 @@ public class ReactActivityDelegate {
 
   private @NonNull Bundle composeLaunchOptions() {
     Bundle composedLaunchOptions = getLaunchOptions();
-    if (isConcurrentRootEnabled()) {
+    if (isFabricEnabled()) {
       if (composedLaunchOptions == null) {
         composedLaunchOptions = new Bundle();
       }
@@ -212,14 +211,12 @@ public class ReactActivityDelegate {
   }
 
   /**
-   * Override this method to enable Concurrent Root on the surface for this Activity. See:
-   * https://reactjs.org/blog/2022/03/29/react-v18.html
+   * Override this method if you wish to selectively toggle Fabric for a specific surface. This will
+   * also control if Concurrent Root (React 18) should be enabled or not.
    *
-   * <p>This requires to be rendering on Fabric (i.e. on the New Architecture).
-   *
-   * @return Wether you want to enable Concurrent Root for this surface or not.
+   * @return true if Fabric is enabled for this Activity, false otherwise.
    */
-  protected boolean isConcurrentRootEnabled() {
+  protected boolean isFabricEnabled() {
     return false;
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactActivityDelegate.kt
+++ b/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactActivityDelegate.kt
@@ -15,31 +15,18 @@ import com.facebook.react.ReactRootView
  * A utility class that allows you to simplify the setup of a [ReactActivityDelegate] for new apps
  * in Open Source.
  *
- * Specifically, with this class you can simply control if Fabric and Concurrent Root are enabled
- * for an Activity using the boolean flags in the constructor.
+ * Specifically, with this class you can simply control if Fabric is enabled for an Activity using
+ * the boolean flag in the constructor.
  *
  * @param fabricEnabled Whether Fabric should be enabled for the RootView of this Activity.
- * @param concurrentRootEnabled Whether ConcurrentRoot (aka React 18) should be enabled for the
- *   RootView of this Activity.
  */
 open class DefaultReactActivityDelegate(
     activity: ReactActivity,
     mainComponentName: String,
     private val fabricEnabled: Boolean = false,
-    private val concurrentRootEnabled: Boolean = false
 ) : ReactActivityDelegate(activity, mainComponentName) {
 
-  /**
-   * Override this method to enable Concurrent Root on the surface for this Activity. See:
-   * https://reactjs.org/blog/2022/03/29/react-v18.html
-   *
-   * This requires to be rendering on Fabric (i.e. on the New Architecture).
-   *
-   * @return Whether you want to enable Concurrent Root for this surface or not.
-   */
-  override fun isConcurrentRootEnabled(): Boolean {
-    return concurrentRootEnabled
-  }
+  override fun isFabricEnabled(): Boolean = fabricEnabled
 
   override fun createRootView(): ReactRootView =
       ReactRootView(context).apply { setIsFabric(fabricEnabled) }

--- a/ReactAndroid/src/test/java/com/facebook/react/ReactActivityDelegateTest.kt
+++ b/ReactAndroid/src/test/java/com/facebook/react/ReactActivityDelegateTest.kt
@@ -17,10 +17,10 @@ import org.robolectric.RobolectricTestRunner
 class ReactActivityDelegateTest {
 
   @Test
-  fun delegateWithConcurrentRoot_populatesInitialPropsCorrectly() {
+  fun delegateWithFabricEnabled_populatesInitialPropsCorrectly() {
     val delegate =
         object : ReactActivityDelegate(null, "test-delegate") {
-          override fun isConcurrentRootEnabled() = true
+          override fun isFabricEnabled() = true
           public val inspectLaunchOptions: Bundle?
             get() = getLaunchOptions()
         }
@@ -31,10 +31,10 @@ class ReactActivityDelegateTest {
   }
 
   @Test
-  fun delegateWithoutConcurrentRoot_hasNullInitialProperties() {
+  fun delegateWithoutFabricEnabled_hasNullInitialProperties() {
     val delegate =
         object : ReactActivityDelegate(null, "test-delegate") {
-          override fun isConcurrentRootEnabled() = false
+          override fun isFabricEnabled() = false
           public val inspectLaunchOptions: Bundle?
             get() = getLaunchOptions()
         }
@@ -43,10 +43,10 @@ class ReactActivityDelegateTest {
   }
 
   @Test
-  fun delegateWithConcurrentRoot_composesInitialPropertiesCorrectly() {
+  fun delegateWithFabricEnabled_composesInitialPropertiesCorrectly() {
     val delegate =
         object : ReactActivityDelegate(null, "test-delegate") {
-          override fun isConcurrentRootEnabled() = true
+          override fun isFabricEnabled() = true
           override fun getLaunchOptions(): Bundle =
               Bundle().apply { putString("test-property", "test-value") }
           public val inspectLaunchOptions: Bundle?

--- a/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterActivity.java
+++ b/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterActivity.java
@@ -21,12 +21,7 @@ public class RNTesterActivity extends ReactActivity {
     private final @Nullable ReactActivity mActivity;
 
     public RNTesterActivityDelegate(ReactActivity activity, String mainComponentName) {
-      super(
-          activity,
-          mainComponentName,
-          DefaultNewArchitectureEntryPoint.getFabricEnabled(), // fabricEnabled
-          DefaultNewArchitectureEntryPoint.getConcurrentReactEnabled() // concurrentRootEnabled
-          );
+      super(activity, mainComponentName, DefaultNewArchitectureEntryPoint.getFabricEnabled());
       this.mActivity = activity;
     }
 

--- a/template/android/app/src/main/java/com/helloworld/MainActivity.java
+++ b/template/android/app/src/main/java/com/helloworld/MainActivity.java
@@ -27,9 +27,6 @@ public class MainActivity extends ReactActivity {
         this,
         getMainComponentName(),
         // If you opted-in for the New Architecture, we enable the Fabric Renderer.
-        DefaultNewArchitectureEntryPoint.getFabricEnabled(), // fabricEnabled
-        // If you opted-in for the New Architecture, we enable Concurrent React (i.e. React 18).
-        DefaultNewArchitectureEntryPoint.getConcurrentReactEnabled() // concurrentRootEnabled
-        );
+        DefaultNewArchitectureEntryPoint.getFabricEnabled());
   }
 }


### PR DESCRIPTION
Summary:
Having concurrentRoot disabled when Fabric is enabled is not recommended.
This simplifies the setup and makes sure that both are either enabled or disabled.

Changelog:
[Android] [Breaking] - Hardcode concurrentRootEnabled to true when Fabric is enabled

Reviewed By: cipolleschi

Differential Revision: D43127625

