### PR TITLE
fix: remove unavailable EventEmitter TS export

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -147,7 +147,6 @@ export * from '../Libraries/Utilities/Platform';
 export * from '../Libraries/Vibration/Vibration';
 export * from '../Libraries/YellowBox/YellowBoxDeprecated';
 export * from '../Libraries/vendor/core/ErrorUtils';
-export * from '../Libraries/vendor/emitter/EventEmitter';
 
 export * from './public/DeprecatedPropertiesAlias';
 export * from './public/Insets';


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

currently, using TS, this is a valid import:

`import { EventEmitter } from 'react-native';`

However, looking at the [index file](https://github.com/facebook/react-native/blob/main/index.js) we can see that there is no such export.

I first thought I'd add the EventEmitter export in order to get the `index.js` in line with the types, but it appears that the Event Emitter will become a separate package at some point https://github.com/facebook/react-native/pull/34401 so removing it from the types seems to be better for future.


## Changelog

fix: remove unavailable EventEmitter TS export

Pick one each for the category and type tags:

[INTERNAL] [CHANGED] - remove unavailable EventEmitter TS export

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests

## Test Plan

tested locally: using `import { EventEmitter } from 'react-native';` correctly gives `TS2305: Module '"react-native"' has no exported member 'EventEmitter'.`
