### PR TITLE
Fix the Multiple Podfile warning

### DIFF
--- a/template/react-native.config.js
+++ b/template/react-native.config.js
@@ -1,0 +1,14 @@
+/**
+ * CLI configurations for ReactNative
+ * https://github.com/react-native-community/cli/blob/master/docs/configuration.md
+ *
+ * @format
+ */
+
+module.exports = {
+  project: {
+    ios: {
+      sourceDir: 'ios/',
+    },
+  },
+};


### PR DESCRIPTION
Summary:
This PR adds the `react-native.config.js` warning when installing an app from the template.

## Changelog:
[iOS][Changed] - Fix multiple Podfile warning

Differential Revision: D43159852

