### PR TITLE
Fix typo in Dynamic Type docs

### DIFF
--- a/Libraries/Text/Text.d.ts
+++ b/Libraries/Text/Text.d.ts
@@ -27,7 +27,7 @@ export interface TextPropsIOS {
   adjustsFontSizeToFit?: boolean | undefined;
 
   /**
-   * The Dynamic Text scale ramp to apply to this element on iOS.
+   * The Dynamic Type scale ramp to apply to this element on iOS.
    */
   dynamicTypeRamp?:
     | 'caption2'

--- a/Libraries/Text/TextProps.js
+++ b/Libraries/Text/TextProps.js
@@ -229,7 +229,7 @@ export type TextProps = $ReadOnly<{|
   adjustsFontSizeToFit?: ?boolean,
 
   /**
-   * The Dynamic Text scale ramp to apply to this element on iOS.
+   * The Dynamic Type scale ramp to apply to this element on iOS.
    */
   dynamicTypeRamp?: ?(
     | 'caption2'


### PR DESCRIPTION
## Summary

When working on Dynamic Type, I accidentally referred to it as "Dynamic Text" in some of the documentation. This is just a minor cleanup bit.

## Changelog

[IOS] [FIXED] - Fix typo in documentation

## Test Plan

Non-functional change, no testing should be needed :-)