### PR TITLE
feat: add invoking dev menu on iOS by pressing `d` in terminal

### DIFF
--- a/React/CoreModules/RCTDevSettings.mm
+++ b/React/CoreModules/RCTDevSettings.mm
@@ -225,6 +225,27 @@ RCT_EXPORT_MODULE()
   }
 #endif
 
+#if RCT_DEV_MENU
+  if (self.bridge) {
+    RCTBridge *__weak weakBridge = self.bridge;
+    _bridgeExecutorOverrideToken = [[RCTPackagerConnection sharedPackagerConnection]
+        addNotificationHandler:^(id params) {
+          if (params != (id)kCFNull && [params[@"debug"] boolValue]) {
+            weakBridge.executorClass = objc_lookUpClass("RCTWebSocketExecutor");
+          }
+        }
+                         queue:dispatch_get_main_queue()
+                     forMethod:@"devMenu"];
+  }
+    
+  reloadToken = [[RCTPackagerConnection sharedPackagerConnection]
+      addNotificationHandler:^(id params) {
+          [self.bridge.devMenu show];
+      }
+                        queue:dispatch_get_main_queue()
+                    forMethod:@"devMenu"];
+#endif
+    
   __weak __typeof(self) weakSelf = self;
   dispatch_async(dispatch_get_main_queue(), ^{
     [weakSelf _synchronizeAllSettings];

--- a/React/CoreModules/RCTDevSettings.mm
+++ b/React/CoreModules/RCTDevSettings.mm
@@ -181,7 +181,7 @@ RCT_EXPORT_MODULE()
     _bridgeExecutorOverrideToken = [[RCTPackagerConnection sharedPackagerConnection]
         addNotificationHandler:^(id params) {
           if (params != (id)kCFNull && [params[@"debug"] boolValue]) {
-            weakBridge.executorClass = objc_lookUpClass("RCTWebSocketExecutor");
+              weakBridge.executorClass = self.executorClass;
           }
         }
                          queue:dispatch_get_main_queue()
@@ -203,7 +203,7 @@ RCT_EXPORT_MODULE()
     _bridgeExecutorOverrideToken = [[RCTPackagerConnection sharedPackagerConnection]
         addNotificationHandler:^(id params) {
           if (params != (id)kCFNull && [params[@"debug"] boolValue]) {
-            weakBridge.executorClass = objc_lookUpClass("RCTWebSocketExecutor");
+              weakBridge.executorClass = self.executorClass;
           }
         }
                          queue:dispatch_get_main_queue()

--- a/React/CoreModules/RCTDevSettings.mm
+++ b/React/CoreModules/RCTDevSettings.mm
@@ -186,7 +186,7 @@ RCT_EXPORT_MODULE()
     _bridgeExecutorOverrideToken = [[RCTPackagerConnection sharedPackagerConnection]
         addNotificationHandler:^(id params) {
           if (params != (id)kCFNull && [params[@"debug"] boolValue]) {
-              weakBridge.executorClass = objc_lookUpClass("RCTWebSocketExecutor");
+            weakBridge.executorClass = objc_lookUpClass("RCTWebSocketExecutor");
           }
         }
                          queue:dispatch_get_main_queue()
@@ -195,7 +195,7 @@ RCT_EXPORT_MODULE()
        _bridgeExecutorOverrideTokenDevMenu = [[RCTPackagerConnection sharedPackagerConnection]
            addNotificationHandler:^(id params) {
              if (params != (id)kCFNull && [params[@"debug"] boolValue]) {
-                 weakBridge.executorClass = objc_lookUpClass("RCTWebSocketExecutor");
+               weakBridge.executorClass = objc_lookUpClass("RCTWebSocketExecutor");
              }
            }
                             queue:dispatch_get_main_queue()

--- a/React/CoreModules/RCTDevSettings.mm
+++ b/React/CoreModules/RCTDevSettings.mm
@@ -196,6 +196,27 @@ RCT_EXPORT_MODULE()
                          queue:dispatch_get_main_queue()
                      forMethod:@"reload"];
   }
+    
+#if RCT_DEV_MENU
+  if (self.bridge) {
+    RCTBridge *__weak weakBridge = self.bridge;
+    _bridgeExecutorOverrideToken = [[RCTPackagerConnection sharedPackagerConnection]
+        addNotificationHandler:^(id params) {
+          if (params != (id)kCFNull && [params[@"debug"] boolValue]) {
+            weakBridge.executorClass = objc_lookUpClass("RCTWebSocketExecutor");
+          }
+        }
+                         queue:dispatch_get_main_queue()
+                     forMethod:@"devMenu"];
+  }
+    
+  reloadToken = [[RCTPackagerConnection sharedPackagerConnection]
+      addNotificationHandler:^(id params) {
+          [self.bridge.devMenu show];
+      }
+                        queue:dispatch_get_main_queue()
+                    forMethod:@"devMenu"];
+#endif
 #endif
 
 #if RCT_ENABLE_INSPECTOR
@@ -225,27 +246,6 @@ RCT_EXPORT_MODULE()
   }
 #endif
 
-#if RCT_DEV_MENU
-  if (self.bridge) {
-    RCTBridge *__weak weakBridge = self.bridge;
-    _bridgeExecutorOverrideToken = [[RCTPackagerConnection sharedPackagerConnection]
-        addNotificationHandler:^(id params) {
-          if (params != (id)kCFNull && [params[@"debug"] boolValue]) {
-            weakBridge.executorClass = objc_lookUpClass("RCTWebSocketExecutor");
-          }
-        }
-                         queue:dispatch_get_main_queue()
-                     forMethod:@"devMenu"];
-  }
-    
-  reloadToken = [[RCTPackagerConnection sharedPackagerConnection]
-      addNotificationHandler:^(id params) {
-          [self.bridge.devMenu show];
-      }
-                        queue:dispatch_get_main_queue()
-                    forMethod:@"devMenu"];
-#endif
-    
   __weak __typeof(self) weakSelf = self;
   dispatch_async(dispatch_get_main_queue(), ^{
     [weakSelf _synchronizeAllSettings];

--- a/React/CoreModules/RCTDevSettings.mm
+++ b/React/CoreModules/RCTDevSettings.mm
@@ -125,10 +125,6 @@ static std::atomic<int> numInitializedModules{0};
   BOOL _isJSLoaded;
 #if RCT_DEV_SETTINGS_ENABLE_PACKAGER_CONNECTION
   RCTHandlerToken _bridgeExecutorOverrideToken;
-    
-#if RCT_DEV_MENU
-  RCTHandlerToken _bridgeExecutorOverrideTokenDevMenu;
-#endif
 #endif
 }
 
@@ -191,16 +187,6 @@ RCT_EXPORT_MODULE()
         }
                          queue:dispatch_get_main_queue()
                      forMethod:@"reload"];
-    #if RCT_DEV_MENU
-       _bridgeExecutorOverrideTokenDevMenu = [[RCTPackagerConnection sharedPackagerConnection]
-           addNotificationHandler:^(id params) {
-             if (params != (id)kCFNull && [params[@"debug"] boolValue]) {
-               weakBridge.executorClass = objc_lookUpClass("RCTWebSocketExecutor");
-             }
-           }
-                            queue:dispatch_get_main_queue()
-                        forMethod:@"devMenu"];
-    #endif
   }
 
     if (numInitializedModules++ == 0) {
@@ -265,9 +251,6 @@ RCT_EXPORT_MODULE()
 #if RCT_DEV_SETTINGS_ENABLE_PACKAGER_CONNECTION
   if (self.bridge) {
     [[RCTPackagerConnection sharedPackagerConnection] removeHandler:_bridgeExecutorOverrideToken];
-    #if RCT_DEV_MENU
-      [[RCTPackagerConnection sharedPackagerConnection] removeHandler:_bridgeExecutorOverrideTokenDevMenu];
-    #endif
   }
 
   if (--numInitializedModules == 0) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Inspired by @tido64's comment https://github.com/react-native-community/cli/issues/1820#issuecomment-1424270890 I'm adding missing implementation on iOS for invoking dev menu by pressing `d` in terminal while metro is launched.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
[IOS][ADDED] - Add invoking dev menu on iOS by pressing `d` in terminal.


## Test Plan
Press `d` in terminal while metro is launched - dev menu should appear.


https://user-images.githubusercontent.com/63900941/217936561-deea1390-221e-4f32-bbc4-e6fcfdf2a992.mp4

