### PR TITLE
Fix invalid context cast in ReactRootView

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -14,6 +14,7 @@ import static com.facebook.systrace.Systrace.TRACE_TAG_REACT_JAVA_BRIDGE;
 
 import android.app.Activity;
 import android.content.Context;
+import android.content.ContextWrapper;
 import android.graphics.Canvas;
 import android.graphics.Insets;
 import android.graphics.Point;
@@ -918,6 +919,14 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
       checkForDeviceDimensionsChanges();
     }
 
+    private Activity getActivity() {
+      Context context = getContext();
+      while (!(context instanceof Activity) && context instanceof ContextWrapper) {
+        context = ((ContextWrapper) context).getBaseContext();
+      }
+      return (Activity) context;
+    }
+
     @RequiresApi(api = Build.VERSION_CODES.R)
     private void checkForKeyboardEvents() {
       getRootView().getWindowVisibleDisplayFrame(mVisibleViewArea);
@@ -935,7 +944,7 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
           Insets barInsets = rootInsets.getInsets(WindowInsets.Type.systemBars());
           int height = imeInsets.bottom - barInsets.bottom;
 
-          int softInputMode = ((Activity) getContext()).getWindow().getAttributes().softInputMode;
+          int softInputMode = getActivity().getWindow().getAttributes().softInputMode;
           int screenY =
               softInputMode == WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING
                   ? mVisibleViewArea.bottom - height


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Hi 👋 

I'm one of the  Expo contributors. When upgrading the Stripe dependency in Expo for SDK48 release on Android, we noticed the following error:
```java.lang.ClassCastException: android.view.ContextThemeWrapper cannot be cast to android.app.Activity```

With @Kudo we narrowed it down to an underlying issue in the following cast in `ReactRootView` done during checking for keyboard events:
```((Activity) getContext())``` 

The `getContext()` is actually a `ContextThemeWrapper` for `ExperienceActivity`, so we should not cast it to an `Activity` directly - instead, we unwrap it using `getBaseContext()`.


Implementing the following fix into the Expo fork fixed the crash for us:
https://github.com/expo/react-native/commit/0e2c9cada120a3709e8285ab4bcdaa1c5c446732





<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

[ANDROID] [FIXED] - Fixed crash occurring in certain native views when handling keyboard events.

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Tested manually by comparing two builds before and after this change. The main branch build crashes when the [Stripe 0.23.1](https://github.com/stripe/stripe-react-native) Card Element from the example app is mounted on screen. Applying the change fixed the issue.

Happy to make a more isolated reproduction if necessary.

---
Full stack trace:
```
         AndroidRuntime  D  Shutting down VM
                         E  FATAL EXCEPTION: main
                         E  Process: host.exp.exponent, PID: 8849
                         E  java.lang.ClassCastException: android.view.ContextThemeWrapper cannot be cast to android.app.Activity
                         E      at com.facebook.react.ReactRootView$CustomGlobalLayoutListener.checkForKeyboardEvents(ReactRootView.java:937)
                         E      at com.facebook.react.ReactRootView$CustomGlobalLayoutListener.onGlobalLayout(ReactRootView.java:913)
                         E      at android.view.ViewTreeObserver.dispatchOnGlobalLayout(ViewTreeObserver.java:1061)
                         E      at android.view.ViewRootImpl.performTraversals(ViewRootImpl.java:3352)
                         E      at android.view.ViewRootImpl.doTraversal(ViewRootImpl.java:2286)
                         E      at android.view.ViewRootImpl$TraversalRunnable.run(ViewRootImpl.java:8948)
                         E      at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1231)
                         E      at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1239)
                         E      at android.view.Choreographer.doCallbacks(Choreographer.java:899)
                         E      at android.view.Choreographer.doFrame(Choreographer.java:832)
                         E      at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:1214)
                         E      at android.os.Handler.handleCallback(Handler.java:942)
                         E      at android.os.Handler.dispatchMessage(Handler.java:99)
                         E      at android.os.Looper.loopOnce(Looper.java:201)
                         E      at android.os.Looper.loop(Looper.java:288)
                         E      at android.app.ActivityThread.main(ActivityThread.java:7898)
                         E      at java.lang.reflect.Method.invoke(Native Method)
                         E      at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
                         E      at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:936)
```