### PR TITLE
fix: update Hermes dSYM path for Catalyst

### DIFF
--- a/sdks/hermes-engine/utils/build-apple-framework.sh
+++ b/sdks/hermes-engine/utils/build-apple-framework.sh
@@ -129,11 +129,19 @@ function create_universal_framework {
   echo "Creating universal framework for platforms: ${platforms[*]}"
 
   for i in "${!platforms[@]}"; do
-    local hermes_framework_path="${platforms[$i]}/hermes.framework"
+    local platform="${platforms[$i]}"
+    local hermes_framework_path="${platform}/hermes.framework"
+    local dSYM_path="${platform}/hermes.framework"
+
+    # TODO: remove this when the hermes team fixes the dSYM issue
+    if [[ "$platform" == "catalyst" ]]; then
+      dSYM_path="${platform}/0"
+    fi
+
     args+="-framework $hermes_framework_path "
 
     # Path to dSYM must be absolute
-    args+="-debug-symbols $HERMES_PATH/destroot/Library/Frameworks/$hermes_framework_path.dSYM "
+    args+="-debug-symbols $HERMES_PATH/destroot/Library/Frameworks/$dSYM_path.dSYM "
   done
 
   mkdir -p universal


### PR DESCRIPTION
## Summary

After a [change](https://github.com/facebook/hermes/commit/4ff7c31fb43f534947cca591e1f156d8c45aef9c) that landed on Hermes, the build script for Hermes generated an invalid dSYM name for Catalyst builds, which make our CI fail. 
This PR aims to patch it while the Hermes team works on a long term fix for it.

The CI will go back to red as soon as that happen, but in that case, we will just need to revert this change. But, at least, we can go back to a green state for CircleCI.

## Changelog

[Internal] - update Hermes build script to be more resilient from dSYM names

## Test Plan

CircleCI is green
