### PR TITLE
fix(Alert): throw when title or message aren't strings

### DIFF
--- a/Libraries/Alert/Alert.js
+++ b/Libraries/Alert/Alert.js
@@ -46,10 +46,12 @@ class Alert {
     buttons?: Buttons,
     options?: Options,
   ): void {
-    if (title && typeof title !== 'string')
+    if (title && typeof title !== 'string') {
       throw new TypeError('TypeError: title is not a string');
-    if (message && typeof message !== 'string')
+    }
+    if (message && typeof message !== 'string') {
       throw new TypeError('TypeError: message is not a string');
+    }
 
     if (Platform.OS === 'ios') {
       Alert.prompt(
@@ -128,10 +130,12 @@ class Alert {
     options?: Options,
   ): void {
     if (Platform.OS === 'ios') {
-      if (title && typeof title !== 'string')
+      if (title && typeof title !== 'string') {
         throw new TypeError('TypeError: title is not a string');
-      if (message && typeof message !== 'string')
+      }
+      if (message && typeof message !== 'string') {
         throw new TypeError('TypeError: message is not a string');
+      }
 
       let callbacks: Array<?any> = [];
       const buttons = [];

--- a/Libraries/Alert/Alert.js
+++ b/Libraries/Alert/Alert.js
@@ -46,6 +46,11 @@ class Alert {
     buttons?: Buttons,
     options?: Options,
   ): void {
+    if (title && typeof title !== 'string')
+      throw new TypeError('TypeError: title is not a string');
+    if (message && typeof message !== 'string')
+      throw new TypeError('TypeError: message is not a string');
+
     if (Platform.OS === 'ios') {
       Alert.prompt(
         title,
@@ -123,6 +128,11 @@ class Alert {
     options?: Options,
   ): void {
     if (Platform.OS === 'ios') {
+      if (title && typeof title !== 'string')
+        throw new TypeError('TypeError: title is not a string');
+      if (message && typeof message !== 'string')
+        throw new TypeError('TypeError: message is not a string');
+
       let callbacks: Array<?any> = [];
       const buttons = [];
       let cancelButtonKey;


### PR DESCRIPTION
## Summary

Throw a TypeError if `title` or `message` are not strings to avoid getting less obvious native error about casting.
Fixes #36085

## Changelog

[GENERAL] [FIXED] Fix crashing when Alert's title or message are not strings

## Test Plan

Tested on variety of Alert invokes, the issue has been resolved, no side effects (unable to test iOS though)