### PR TITLE
fix: border rendering problem in Android

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewBackgroundDrawable.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewBackgroundDrawable.java
@@ -911,7 +911,9 @@ public class ReactViewBackgroundDrawable extends Drawable {
     }
 
     mInnerBottomLeftCorner.x = mInnerClipTempRectForBorderRadius.left;
-    mInnerBottomLeftCorner.y = mInnerClipTempRectForBorderRadius.bottom * -2;
+    mInnerBottomLeftCorner.y = borderWidth.bottom != 0
+      ? mInnerClipTempRectForBorderRadius.bottom * -2
+      : mInnerClipTempRectForBorderRadius.bottom;
 
     getEllipseIntersectionWithLine(
         // Ellipse Bounds
@@ -963,7 +965,9 @@ public class ReactViewBackgroundDrawable extends Drawable {
     }
 
     mInnerBottomRightCorner.x = mInnerClipTempRectForBorderRadius.right;
-    mInnerBottomRightCorner.y = mInnerClipTempRectForBorderRadius.bottom * -2;
+    mInnerBottomRightCorner.y = borderWidth.bottom != 0
+      ? mInnerClipTempRectForBorderRadius.bottom * -2
+      : mInnerClipTempRectForBorderRadius.bottom;
 
     getEllipseIntersectionWithLine(
         // Ellipse Bounds

--- a/packages/rn-tester/js/examples/View/ViewExample.js
+++ b/packages/rn-tester/js/examples/View/ViewExample.js
@@ -431,7 +431,7 @@ exports.examples = [
     title: 'Rounded Borders',
     render(): React.Node {
       return (
-        <View style={{ flexDirection: 'row', flexWrap: "wrap" }}>
+        <View style={{flexDirection: 'row', flexWrap: 'wrap'}}>
           <View
             style={{
               width: 50,
@@ -480,7 +480,7 @@ exports.examples = [
               height: 50,
               borderLeftWidth: 6,
               borderTopWidth: 6,
-              borderTopLeftRadius: 20
+              borderTopLeftRadius: 20,
             }}
           />
           <View
@@ -489,7 +489,7 @@ exports.examples = [
               height: 50,
               borderRightWidth: 6,
               borderTopWidth: 6,
-              borderTopRightRadius: 20
+              borderTopRightRadius: 20,
             }}
           />
           <View
@@ -498,7 +498,7 @@ exports.examples = [
               height: 50,
               borderBottomWidth: 6,
               borderLeftWidth: 6,
-              borderBottomLeftRadius: 20
+              borderBottomLeftRadius: 20,
             }}
           />
           <View
@@ -507,7 +507,7 @@ exports.examples = [
               height: 50,
               borderBottomWidth: 6,
               borderRightWidth: 6,
-              borderBottomRightRadius: 20
+              borderBottomRightRadius: 20,
             }}
           />
         </View>

--- a/packages/rn-tester/js/examples/View/ViewExample.js
+++ b/packages/rn-tester/js/examples/View/ViewExample.js
@@ -431,7 +431,7 @@ exports.examples = [
     title: 'Rounded Borders',
     render(): React.Node {
       return (
-        <View style={{flexDirection: 'row'}}>
+        <View style={{ flexDirection: 'row', flexWrap: "wrap" }}>
           <View
             style={{
               width: 50,
@@ -472,6 +472,42 @@ exports.examples = [
               borderBottomLeftRadius: 50,
               borderWidth: 10,
               marginRight: 10,
+            }}
+          />
+          <View
+            style={{
+              width: 50,
+              height: 50,
+              borderLeftWidth: 6,
+              borderTopWidth: 6,
+              borderTopLeftRadius: 20
+            }}
+          />
+          <View
+            style={{
+              width: 50,
+              height: 50,
+              borderRightWidth: 6,
+              borderTopWidth: 6,
+              borderTopRightRadius: 20
+            }}
+          />
+          <View
+            style={{
+              width: 50,
+              height: 50,
+              borderBottomWidth: 6,
+              borderLeftWidth: 6,
+              borderBottomLeftRadius: 20
+            }}
+          />
+          <View
+            style={{
+              width: 50,
+              height: 50,
+              borderBottomWidth: 6,
+              borderRightWidth: 6,
+              borderBottomRightRadius: 20
             }}
           />
         </View>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Fixes https://github.com/facebook/react-native/issues/36036

The problem was in `ReactViewBackgroundDrawable.java` that was not accounting for adjacent borders that add width set to 0.

## Changelog

[Android] [Fixed] - Fix border rendering issue when bottom borders has no width

## Test Plan

| Previously | Now with the fix  |
| --------------- | --------------- |
| <img width="417" alt="image" src="https://user-images.githubusercontent.com/25725586/218149384-00e2145c-3c84-4590-87be-3258574489e5.png"> | <img width="414" alt="image" src="https://user-images.githubusercontent.com/25725586/218148215-a8d37158-0feb-47ae-874b-cba2f422d792.png">  |
