### PR TITLE
[CI] Switch to xcbeautify

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -568,6 +568,8 @@ jobs:
       - checkout_code_with_cache
       - setup_artifacts
       - setup_ruby
+      - brew_install:
+          package: xcbeautify
       - run:
           name: Run Ruby Tests
           command: |

--- a/scripts/objc-test.sh
+++ b/scripts/objc-test.sh
@@ -91,7 +91,7 @@ buildProject() {
     -sdk iphonesimulator
 }
 
-xcprettyFormat() {
+xcbeautifyFormat() {
   if [ "$CI" ]; then
     # Circle CI expects JUnit reports to be available here
     REPORTS_DIR="$HOME/react-native/reports/junit"
@@ -102,7 +102,7 @@ xcprettyFormat() {
     REPORTS_DIR="$THIS_DIR/../build/reports"
   fi
 
-  xcpretty --report junit --output "$REPORTS_DIR/ios/results.xml"
+  xcbeautify --report junit --report-path "$REPORTS_DIR/ios/results.xml"
 }
 
 preloadBundles() {
@@ -131,16 +131,16 @@ main() {
     preloadBundles
 
     # Build and run tests.
-    if [ -x "$(command -v xcpretty)" ]; then
-      runTests | xcprettyFormat && exit "${PIPESTATUS[0]}"
+    if [ -x "$(command -v xcbeautify)" ]; then
+      runTests | xcbeautifyFormat && exit "${PIPESTATUS[0]}"
     else
-      echo 'Warning: xcpretty is not installed. Install xcpretty to generate JUnit reports.'
+      echo 'Warning: xcbeautify is not installed. Install xcbeautify to generate JUnit reports.'
       runTests
     fi
   else
     # Build without running tests.
-    if [ -x "$(command -v xcpretty)" ]; then
-      buildProject | xcprettyFormat && exit "${PIPESTATUS[0]}"
+    if [ -x "$(command -v xcbeautify)" ]; then
+      buildProject | xcbeautifyFormat && exit "${PIPESTATUS[0]}"
     else
       buildProject
     fi

--- a/scripts/run-ci-e2e-tests.js
+++ b/scripts/run-ci-e2e-tests.js
@@ -234,10 +234,10 @@ try {
             ].join(' ') +
               ' | ' +
               [
-                'xcpretty',
+                'xcbeautify',
                 '--report',
                 'junit',
-                '--output',
+                '--reportPath',
                 '"~/react-native/reports/junit/iOS-e2e/results.xml"',
               ].join(' ') +
               ' && exit ${PIPESTATUS[0]}',


### PR DESCRIPTION
## Summary

`xcpretty` is no longer maintained. Let's switch to `xcbeautify`, which is faster and is maintained. I'm also biased because `xcpretty` hid an error from me that `xcbeautify` did not.

## Changelog

[INTERNAL] [CHANGED] - Move CI from `xcpretty` to `xcbeautify`

## Test Plan

Locally yarn `yarn test-ios` and got output that looks like this:

<img width="1245" alt="Screenshot 2023-02-11 at 9 34 07 PM" src="https://user-images.githubusercontent.com/6722175/218291538-07760f94-7e52-4919-b603-8a35a623fc9a.png">

I also confirmed a junit report that looks like this was generated:
```xml
<testsuites name="Selected tests" tests="193" failures="0">
    <testsuite name="RCTLoggingTests" tests="1" failures="0">
        <testcase classname="RCTLoggingTests" name="testLogging" time="0.175" />
    </testsuite>
    <testsuite name="RCTUIManagerScenarioTests" tests="3" failures="0">
        <testcase classname="RCTUIManagerScenarioTests" name="testManagingChildrenToAddRemoveAndMove" time="0.001" />
        <testcase classname="RCTUIManagerScenarioTests" name="testManagingChildrenToAddViews" time="0.000" />
        <testcase classname="RCTUIManagerScenarioTests" name="testManagingChildrenToRemoveViews" time="0.001" />
    </testsuite>
    ...
```


