### PR TITLE
Fix missing node error message not printed correctly

### DIFF
--- a/scripts/xcode/with-environment.sh
+++ b/scripts/xcode/with-environment.sh
@@ -32,7 +32,7 @@ fi
 if [ -n "$NODE_BINARY" ]; then
     echo "Node found at: ${NODE_BINARY}"
 else
-      echo '[Warning] You need to configure your node path in the `".xcode.env" file` environment. ' \
+    echo '[Warning] You need to configure your node path in the `".xcode.env" file` environment. ' \
        'You can set it up quickly by running: ' \
        '`echo export NODE_BINARY=$(command -v node) > .xcode.env` ' \
        'in the ios folder. This is needed by React Native to work correctly. ' \

--- a/scripts/xcode/with-environment.sh
+++ b/scripts/xcode/with-environment.sh
@@ -32,12 +32,12 @@ fi
 if [ -n "$NODE_BINARY" ]; then
     echo "Node found at: ${NODE_BINARY}"
 else
-    echo "[Warning] You need to configure your node path in the `'.xcode.env' file` environment. " \
-       "You can set it up quickly by running: " \
-       "echo 'export NODE_BINARY=$(command -v node)' > .xcode.env " \
-       "in the ios folder. This is needed by React Native to work correctly. " \
-       "We fallback to the DEPRECATED behavior of finding `node`. This will be REMOVED in a future version. " \
-       "You can read more about this here: https://reactnative.dev/docs/environment-setup#optional-configuring-your-environment" >&2
+      echo '[Warning] You need to configure your node path in the `".xcode.env" file` environment. ' \
+       'You can set it up quickly by running: ' \
+       '`echo export NODE_BINARY=$(command -v node) > .xcode.env` ' \
+       'in the ios folder. This is needed by React Native to work correctly. ' \
+       'We fallback to the DEPRECATED behavior of finding `node`. This will be REMOVED in a future version. ' \
+       'You can read more about this here: https://reactnative.dev/docs/environment-setup#optional-configuring-your-environment' >&2
     source "${REACT_NATIVE_PATH}/scripts/find-node-for-xcode.sh"
 fi
 


### PR DESCRIPTION
## Summary

When the node version could not be found there is an error message shown to help what can be done to fix this issue (for example in the error logs in xcode)

The problem was that the backtick symbol is interpreted as running commands in terminals so the parts that were in backticks were run and the error message was printed incompletely. Also there were other errors added (.xcode.env command not found, for example) which makes it harder to understand what is going on.

In bash / zsh single quotes does not expand commands and variables unlike double quotes which does this.

## Changelog

[IOS] [FIXED] - Fix missing node error message not printed correctly when deprecated `find-node-for-xcode.sh` is used.


## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

I just ran the xcode build again after updating it manually in the node_modules folder.

The log output changed from this
```
[Warning] You need to configure your node path in the  environment.  You can set it up quickly by running:  echo 'export NODE_BINARY=/Users/uloco/Library/Caches/fnm_multishells/78434_1676301546457/bin/node' > .xcode.env  in the ios folder. This is needed by React Native to work correctly.  We fallback to the DEPRECATED behavior of finding . This will be REMOVED in a future version.  You can read more about this here: https://reactnative.dev/docs/environment-setup#optional-configuring-your-environment
```

to this
```
[Warning] You need to configure your node path in the `".xcode.env" file` environment.  You can set it up quickly by running:  `echo export NODE_BINARY=$(command -v node) > .xcode.env`  in the ios folder. This is needed by React Native to work correctly.  We fallback to the DEPRECATED behavior of finding `node`. This will be REMOVED in a future version.  You can read more about this here: https://reactnative.dev/docs/environment-setup#optional-configuring-your-environment
```
