### PR TITLE
fix: update executor for packages publishing workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1537,9 +1537,10 @@ jobs:
             echo "Nightly build run"
 
   find_and_publish_bumped_packages:
-    executor: reactnativeandroid
+    executor: nodelts
     steps:
       - checkout
+      - run_yarn
       - run:
           name: Set NPM auth token
           command: echo "//registry.npmjs.org/:_authToken=${CIRCLE_NPM_TOKEN}" > ~/.npmrc


### PR DESCRIPTION
Summary:
Changelog: [Internal]

- While working on 0.71.3, it was discovered that `react-native-codegen` package is being published almost empty (without `lib` folder)
- The reason for it is that `prepare` script is not being executed
- The main reason for it is npm v6, which requires adding `unsafe-perm` flag for it: https://www.vinayraghu.com/blog/npm-unsafe-perm
- Instead of using this flag, changing executor to `nodelts`, which has node v18 and npm v8
- Also adding `run_yarn` before running the script, because `react-native/codegen` uses external dependencies (such as rimraf) for its build scripts

Differential Revision: D43248175

