### PR TITLE
Speed up Hermes builds in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1207,6 +1207,11 @@ jobs:
         description: The Hermes build type. Must be one of "Debug", "Release".
         type: enum
         enum: ["Debug", "Release"]
+      target:
+        default: "iphoneos"
+        description: "The target to build. Allowed values: iphoneos, iphonesimulator, catalyst, macos"
+        type: enum
+        enum: ["iphoneos", "iphonesimulator", "catalyst", "macos"]
     executor: reactnativeios
     environment:
       - HERMES_WS_DIR: *hermes_workspace_root
@@ -1244,16 +1249,100 @@ jobs:
             - with_hermesc_span:
                 flavor: << parameters.flavor >>
                 steps:
+                  - when:
+                      condition:
+                        equal: ["macos", << parameters.target >> ]
+                      steps:
+                        - run:
+                            name: Build the Hermes Mac frameworks
+                            command: |
+                              cd ./sdks/hermes || exit 1
+                              BUILD_TYPE="<< parameters.flavor >>" ./utils/build-mac-framework.sh
+                  - when:
+                      condition:
+                        not:
+                          equal: ["macos", << parameters.target >> ]
+                      steps:
+                        - run:
+                            name: Build the Hermes iOS frameworks
+                            command: |
+                              cd ./sdks/hermes || exit 1
+                              BUILD_TYPE="<< parameters.flavor >>" ./utils/build-ios-framework.sh << parameters.target >>
+            - when:
+                condition:
+                  equal: [ "macos", << parameters.target >> ]
+                steps:
+                  - persist_to_workspace:
+                      root: ~/react-native/sdks/hermes
+                      paths:
+                        - destroot
+                        - build_macosx
+            - when:
+                condition:
+                  not:
+                    equal: [ "macos", << parameters.target >> ]
+                steps:
+                  - persist_to_workspace:
+                      root: ~/react-native/sdks/hermes
+                      paths:
+                        - destroot/Library
+                        - build_macosx/Library
+
+
+
+  package_hermes_macos:
+    parameters:
+      flavor:
+        default: "Debug"
+        description: The Hermes build type. Must be one of "Debug", "Release".
+        type: enum
+        enum: ["Debug", "Release"]
+    executor: reactnativeios
+    environment:
+      - HERMES_WS_DIR: *hermes_workspace_root
+      - HERMES_TARBALL_ARTIFACTS_DIR: *hermes_tarball_artifacts_dir
+      - HERMES_OSXBIN_ARTIFACTS_DIR: *hermes_osxbin_artifacts_dir
+    steps:
+      - checkout_code_with_cache
+      - run_yarn
+      - *attach_hermes_workspace
+      - run:
+          name: "Move destroot to the proper folder"
+          command: |
+            mkdir -p ~/react-native/sdks/hermes/destroot
+            mkdir -p ~/react-native/sdks/hermes/build_macosx
+            cp -R /tmp/hermes/destroot ~/react-native/sdks/hermes
+            cp -R /tmp/hermes/build_macosx ~/react-native/sdks/hermes
+      - get_react_native_version
+      - when:
+          condition:
+            equal: [ << parameters.flavor >>, "Debug"]
+          steps:
+            - restore_cache:
+                keys:
+                  - *hermes_workspace_debug_cache_key
+      - when:
+          condition:
+            equal: [ << parameters.flavor >>, "Release"]
+          steps:
+            - restore_cache:
+                keys:
+                  - *hermes_workspace_release_cache_key
+      - brew_install:
+          package: cmake
+      - with_hermes_tarball_cache_span:
+          flavor: << parameters.flavor >>
+          steps:
+            - with_hermesc_span:
+                flavor: << parameters.flavor >>
+                steps:
                   - run:
-                      name: Build the Hermes Mac frameworks
+                      name: "Create XCFramework"
                       command: |
+                        mkdir -p ./sdks/hermes/utils
+                        cp -R ./sdks/hermes-engine/utils ./sdks/hermes
                         cd ./sdks/hermes || exit 1
-                        BUILD_TYPE="<< parameters.flavor >>" ./utils/build-mac-framework.sh
-                  - run:
-                      name: Build the Hermes iOS frameworks
-                      command: |
-                        cd ./sdks/hermes || exit 1
-                        BUILD_TYPE="<< parameters.flavor >>" ./utils/build-ios-framework.sh
+                        BUILD_TYPE="<< parameters.flavor >>" ./utils/build-ios-framework.sh "build_framework"
             - run:
                 name: Package the Hermes Apple frameworks
                 command: |
@@ -1298,6 +1387,7 @@ jobs:
                 paths:
                   - hermes-runtime-darwin
                   - osx-bin
+
 
   build_hermesc_windows:
     executor:
@@ -1601,6 +1691,13 @@ workflows:
           matrix:
             parameters:
               flavor: ["Debug", "Release"]
+              target: ["iphoneos", "iphonesimulator", "catalyst", "macos"]
+      - package_hermes_macos:
+          requires:
+            - build_hermes_macos
+          matrix:
+            parameters:
+              flavor: ["Debug", "Release"]
       - build_hermesc_windows:
           requires:
             - prepare_hermes_workspace
@@ -1609,7 +1706,7 @@ workflows:
           release_type: "dry-run"
           requires:
             - build_hermesc_linux
-            - build_hermes_macos
+            - package_hermes_macos
             - build_hermesc_windows
       - test_js:
           run_disabled_tests: false
@@ -1778,7 +1875,7 @@ workflows:
                 use_frameworks: "DynamicFrameworks"
       - test_ios_rntester:
           requires:
-            - build_hermes_macos
+            - package_hermes_macos
           matrix:
             parameters:
               architecture: ["NewArch", "OldArch"]
@@ -1786,7 +1883,7 @@ workflows:
       - test_ios:
           run_unit_tests: true
           requires:
-            - build_hermes_macos
+            - package_hermes_macos
           matrix:
             parameters:
               jsengine: ["Hermes", "JSC"]
@@ -1829,6 +1926,13 @@ workflows:
           matrix:
             parameters:
               flavor: ["Debug", "Release"]
+              target: ["iphoneos", "iphonesimulator", "catalyst", "macos"]
+      - package_hermes_macos:
+          requires:
+            - build_hermes_macos
+          matrix:
+            parameters:
+              flavor: ["Debug", "Release"]
       - build_hermesc_windows:
           filters: *only_release_tags
           requires:
@@ -1840,7 +1944,7 @@ workflows:
           filters: *only_release_tags
           requires:
             - build_hermesc_linux
-            - build_hermes_macos
+            - package_hermes_macos
             - build_hermesc_windows
 
   package_and_publish_release_dryrun:
@@ -1866,6 +1970,13 @@ workflows:
           matrix:
             parameters:
               flavor: ["Debug", "Release"]
+              target: ["iphoneos", "iphonesimulator", "catalyst", "macos"]
+      - package_hermes_macos:
+          requires:
+            - build_hermes_macos
+          matrix:
+            parameters:
+              flavor: ["Debug", "Release"]
       - build_hermesc_windows:
           requires:
             - prepare_hermes_workspace
@@ -1874,7 +1985,7 @@ workflows:
           release_type: "dry-run"
           requires:
             - build_hermesc_linux
-            - build_hermes_macos
+            - package_hermes_macos
             - build_hermesc_windows
 
   analysis:
@@ -1906,6 +2017,13 @@ workflows:
           matrix:
             parameters:
               flavor: ["Debug", "Release"]
+              target: ["iphoneos", "iphonesimulator", "catalyst", "macos"]
+      - package_hermes_macos:
+          requires:
+            - build_hermes_macos
+          matrix:
+            parameters:
+              flavor: ["Debug", "Release"]
       - build_hermesc_windows:
           requires:
             - prepare_hermes_workspace
@@ -1913,7 +2031,7 @@ workflows:
           release_type: "nightly"
           requires:
             - build_hermesc_linux
-            - build_hermes_macos
+            - package_hermes_macos
             - build_hermesc_windows
 
   publish_bumped_packages:

--- a/sdks/hermes-engine/utils/build-ios-framework.sh
+++ b/sdks/hermes-engine/utils/build-ios-framework.sh
@@ -4,18 +4,68 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+# Given a specific target, retrieve the right architecture for it
+# $1 the target you want to build. Allowed values: iphoneos, iphonesimulator, catalyst
+function get_architecture {
+    if [[ $1 == "iphoneos" ]]; then
+      echo "arm64"
+    elif [[ $1 == "iphonesimulator" ]]; then
+      echo "x86_64;arm64"
+    elif [[ $1 == "catalyst" ]]; then
+      echo "x86_64;arm64"
+    else
+      echo "Error: unknown arkitecture passed $1"
+      exit -1
+    fi
+}
+
+# build a single framework
+# $1 is the target to build
+function build_framework {
+  if [ ! -d destroot/Library/Frameworks/universal/hermes.xcframework ]; then
+    ios_deployment_target=$(get_ios_deployment_target)
+
+    architecture=$(get_architecture $1)
+
+    build_apple_framework "$1" "$architecture" "$ios_deployment_target"
+  else
+    echo "Skipping; Clean \"destroot\" to rebuild".
+  fi
+}
+
+# group the frameworks together to create a universal framework
+function build_universal_framework {
+    if [ ! -d destroot/Library/Frameworks/universal/hermes.xcframework ]; then
+        create_universal_framework "iphoneos" "iphonesimulator" "catalyst"
+    else
+        echo "Skipping; Clean \"destroot\" to rebuild".
+    fi
+}
+
+# single function that builds sequentially iphoneos, iphonesimulator and catalyst
+# this is used to preserve backward compatibility
+function create_framework {
+    if [ ! -d destroot/Library/Frameworks/universal/hermes.xcframework ]; then
+        ios_deployment_target=$(get_ios_deployment_target)
+
+        build_framework "iphoneos"
+        build_framework "iphonesimulator"
+        build_framework "catalyst"
+
+        build_universal_framework
+    else
+        echo "Skipping; Clean \"destroot\" to rebuild".
+    fi
+}
+
 # shellcheck source=xplat/js/react-native-github/sdks/hermes-engine/utils/build-apple-framework.sh
 CURR_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 . "${CURR_SCRIPT_DIR}/build-apple-framework.sh"
 
-if [ ! -d destroot/Library/Frameworks/universal/hermes.xcframework ]; then
-    ios_deployment_target=$(get_ios_deployment_target)
-
-    build_apple_framework "iphoneos" "arm64" "$ios_deployment_target"
-    build_apple_framework "iphonesimulator" "x86_64;arm64" "$ios_deployment_target"
-    build_apple_framework "catalyst" "x86_64;arm64" "$ios_deployment_target"
-
-    create_universal_framework "iphoneos" "iphonesimulator" "catalyst"
+if [[ -z $1 ]]; then
+  create_framework
+elif [[ $1 == "build_framework" ]]; then
+  build_universal_framework
 else
-    echo "Skipping; Clean \"destroot\" to rebuild".
+  build_framework $1
 fi


### PR DESCRIPTION
## Summary

The build_hermes_macos jobs builds four architecture sequentially: iphoneos, iphonesimulator, catalyst and macos. Then, it creates a universal frameworks with all those architectures.
This PR tries to split the build process on 4 machines and then to collect the output on a following job. 

This could  ~75% of the time spent by the CI when building hermes.

## Changelog

[internal] - Speedup hermes builds

## Test Plan

Wait for CircleCI. It should be green and Hermes builds should take about 10 minutes rather then 40 minutes.
