### PR TITLE
Implement durationThreshold option for PerformanceObserver

### DIFF
--- a/Libraries/WebPerformance/NativePerformanceObserver.cpp
+++ b/Libraries/WebPerformance/NativePerformanceObserver.cpp
@@ -45,4 +45,10 @@ void NativePerformanceObserver::setOnPerformanceEntryCallback(
   PerformanceEntryReporter::getInstance().setReportingCallback(callback);
 }
 
+void NativePerformanceObserver::logRawEntry(
+    jsi::Runtime &rt,
+    RawPerformanceEntry entry) {
+  PerformanceEntryReporter::getInstance().logEntry(entry);
+}
+
 } // namespace facebook::react

--- a/Libraries/WebPerformance/NativePerformanceObserver.cpp
+++ b/Libraries/WebPerformance/NativePerformanceObserver.cpp
@@ -51,4 +51,12 @@ void NativePerformanceObserver::logRawEntry(
   PerformanceEntryReporter::getInstance().logEntry(entry);
 }
 
+void NativePerformanceObserver::setDurationThreshold(
+    jsi::Runtime &rt,
+    int32_t entryType,
+    double durationThreshold) {
+  PerformanceEntryReporter::getInstance().setDurationThreshold(
+      static_cast<PerformanceEntryType>(entryType), durationThreshold);
+}
+
 } // namespace facebook::react

--- a/Libraries/WebPerformance/NativePerformanceObserver.h
+++ b/Libraries/WebPerformance/NativePerformanceObserver.h
@@ -69,6 +69,8 @@ class NativePerformanceObserver
       jsi::Runtime &rt,
       std::optional<AsyncCallback<>> callback);
 
+  void logRawEntry(jsi::Runtime &rt, RawPerformanceEntry entry);
+
  private:
 };
 

--- a/Libraries/WebPerformance/NativePerformanceObserver.h
+++ b/Libraries/WebPerformance/NativePerformanceObserver.h
@@ -71,6 +71,11 @@ class NativePerformanceObserver
 
   void logRawEntry(jsi::Runtime &rt, RawPerformanceEntry entry);
 
+  void setDurationThreshold(
+      jsi::Runtime &rt,
+      int32_t entryType,
+      double durationThreshold);
+
  private:
 };
 

--- a/Libraries/WebPerformance/NativePerformanceObserver.js
+++ b/Libraries/WebPerformance/NativePerformanceObserver.js
@@ -12,13 +12,6 @@ import type {TurboModule} from '../TurboModule/RCTExport';
 
 import * as TurboModuleRegistry from '../TurboModule/TurboModuleRegistry';
 
-export const RawPerformanceEntryTypeValues = {
-  UNDEFINED: 0,
-  MARK: 1,
-  MEASURE: 2,
-  EVENT: 3,
-};
-
 export type RawPerformanceEntryType = number;
 
 export type RawPerformanceEntry = {|

--- a/Libraries/WebPerformance/NativePerformanceObserver.js
+++ b/Libraries/WebPerformance/NativePerformanceObserver.js
@@ -35,6 +35,11 @@ export interface Spec extends TurboModule {
   +stopReporting: (entryType: RawPerformanceEntryType) => void;
   +popPendingEntries: () => GetPendingEntriesResult;
   +setOnPerformanceEntryCallback: (callback?: () => void) => void;
+  +logRawEntry: (entry: RawPerformanceEntry) => void;
+  +setDurationThreshold: (
+    entryType: RawPerformanceEntryType,
+    durationThreshold: number,
+  ) => void;
 }
 
 export default (TurboModuleRegistry.get<Spec>(

--- a/Libraries/WebPerformance/PerformanceEntryReporter.cpp
+++ b/Libraries/WebPerformance/PerformanceEntryReporter.cpp
@@ -31,8 +31,17 @@ void PerformanceEntryReporter::setReportingCallback(
 }
 
 void PerformanceEntryReporter::startReporting(PerformanceEntryType entryType) {
-  reportingType_[static_cast<int>(entryType)] = true;
+  int entryTypeIdx = static_cast<int>(entryType);
+  reportingType_[entryTypeIdx] = true;
+  durationThreshold_[entryTypeIdx] = DEFAULT_DURATION_THRESHOLD;
 }
+
+void PerformanceEntryReporter::setDurationThreshold(
+    PerformanceEntryType entryType,
+    double durationThreshold) {
+  durationThreshold_[static_cast<int>(entryType)] = durationThreshold;
+}
+
 void PerformanceEntryReporter::stopReporting(PerformanceEntryType entryType) {
   reportingType_[static_cast<int>(entryType)] = false;
 }
@@ -48,6 +57,11 @@ GetPendingEntriesResult PerformanceEntryReporter::popPendingEntries() {
 
 void PerformanceEntryReporter::logEntry(const RawPerformanceEntry &entry) {
   if (!isReportingType(static_cast<PerformanceEntryType>(entry.entryType))) {
+    return;
+  }
+
+  if (entry.duration < durationThreshold_[entry.entryType]) {
+    // The entries duration is lower than the desired reporting threshold, skip
     return;
   }
 

--- a/Libraries/WebPerformance/PerformanceEntryReporter.h
+++ b/Libraries/WebPerformance/PerformanceEntryReporter.h
@@ -44,6 +44,8 @@ using PerformanceMarkRegistryType = std::
 // memory for the sake of the "Performance.measure" mark name lookup
 constexpr size_t MARKS_BUFFER_SIZE = 1024;
 
+constexpr double DEFAULT_DURATION_THRESHOLD = 0.0;
+
 enum class PerformanceEntryType {
   UNDEFINED = 0,
   MARK = 1,
@@ -66,6 +68,9 @@ class PerformanceEntryReporter : public EventLogger {
   void setReportingCallback(std::optional<AsyncCallback<>> callback);
   void startReporting(PerformanceEntryType entryType);
   void stopReporting(PerformanceEntryType entryType);
+  void setDurationThreshold(
+      PerformanceEntryType entryType,
+      double durationThreshold);
 
   GetPendingEntriesResult popPendingEntries();
   void logEntry(const RawPerformanceEntry &entry);
@@ -117,6 +122,8 @@ class PerformanceEntryReporter : public EventLogger {
   std::vector<RawPerformanceEntry> entries_;
   std::mutex entriesMutex_;
   std::array<bool, (size_t)PerformanceEntryType::_COUNT> reportingType_{false};
+  std::array<double, (size_t)PerformanceEntryType::_COUNT> durationThreshold_{
+      DEFAULT_DURATION_THRESHOLD};
 
   // Mark registry for "measure" lookup
   PerformanceMarkRegistryType marksRegistry_;

--- a/Libraries/WebPerformance/PerformanceObserver.js
+++ b/Libraries/WebPerformance/PerformanceObserver.js
@@ -8,74 +8,15 @@
  * @flow strict
  */
 
-import type {
-  RawPerformanceEntry,
-  RawPerformanceEntryType,
-} from './NativePerformanceObserver';
 import type {PerformanceEntryType} from './PerformanceEntry';
 
 import warnOnce from '../Utilities/warnOnce';
-import NativePerformanceObserver, {
-  RawPerformanceEntryTypeValues,
-} from './NativePerformanceObserver';
+import NativePerformanceObserver from './NativePerformanceObserver';
 import {PerformanceEntry} from './PerformanceEntry';
-import {PerformanceEventTiming} from './PerformanceEventTiming';
-
-function rawToPerformanceEntryType(
-  type: RawPerformanceEntryType,
-): PerformanceEntryType {
-  switch (type) {
-    case RawPerformanceEntryTypeValues.MARK:
-      return 'mark';
-    case RawPerformanceEntryTypeValues.MEASURE:
-      return 'measure';
-    case RawPerformanceEntryTypeValues.EVENT:
-      return 'event';
-    default:
-      throw new TypeError(
-        `rawToPerformanceEntryType: unexpected performance entry type received: ${type}`,
-      );
-  }
-}
-
-function performanceEntryTypeToRaw(
-  type: PerformanceEntryType,
-): RawPerformanceEntryType {
-  switch (type) {
-    case 'mark':
-      return RawPerformanceEntryTypeValues.MARK;
-    case 'measure':
-      return RawPerformanceEntryTypeValues.MEASURE;
-    case 'event':
-      return RawPerformanceEntryTypeValues.EVENT;
-    default:
-      // Verify exhaustive check with Flow
-      (type: empty);
-      throw new TypeError(
-        `performanceEntryTypeToRaw: unexpected performance entry type received: ${type}`,
-      );
-  }
-}
-
-function rawToPerformanceEntry(entry: RawPerformanceEntry): PerformanceEntry {
-  if (entry.entryType === RawPerformanceEntryTypeValues.EVENT) {
-    return new PerformanceEventTiming({
-      name: entry.name,
-      startTime: entry.startTime,
-      duration: entry.duration,
-      processingStart: entry.processingStart,
-      processingEnd: entry.processingEnd,
-      interactionId: entry.interactionId,
-    });
-  } else {
-    return new PerformanceEntry({
-      name: entry.name,
-      entryType: rawToPerformanceEntryType(entry.entryType),
-      startTime: entry.startTime,
-      duration: entry.duration,
-    });
-  }
-}
+import {
+  performanceEntryTypeToRaw,
+  rawToPerformanceEntry,
+} from './RawPerformanceEntry';
 
 export type PerformanceEntryList = $ReadOnlyArray<PerformanceEntry>;
 

--- a/Libraries/WebPerformance/PerformanceObserver.js
+++ b/Libraries/WebPerformance/PerformanceObserver.js
@@ -8,7 +8,7 @@
  * @flow strict
  */
 
-import type {PerformanceEntryType} from './PerformanceEntry';
+import type {HighResTimeStamp, PerformanceEntryType} from './PerformanceEntry';
 
 import warnOnce from '../Utilities/warnOnce';
 import NativePerformanceObserver from './NativePerformanceObserver';
@@ -62,11 +62,13 @@ export type PerformanceObserverInit =
     }
   | {
       type: PerformanceEntryType,
+      durationThreshold?: HighResTimeStamp,
     };
 
 type PerformanceObserverConfig = {|
   callback: PerformanceObserverCallback,
-  entryTypes: $ReadOnlySet<PerformanceEntryType>,
+  // Map of {entryType: durationThreshold}
+  entryTypes: $ReadOnlyMap<PerformanceEntryType, ?number>,
 |};
 
 const observerCountPerEntryType: Map<PerformanceEntryType, number> = new Map();
@@ -87,9 +89,13 @@ const onPerformanceEntry = () => {
   }
   const entries = rawEntries.map(rawToPerformanceEntry);
   for (const [observer, observerConfig] of registeredObservers.entries()) {
-    const entriesForObserver: PerformanceEntryList = entries.filter(
-      entry => observerConfig.entryTypes.has(entry.entryType) !== -1,
-    );
+    const entriesForObserver: PerformanceEntryList = entries.filter(entry => {
+      if (!observerConfig.entryTypes.has(entry.entryType)) {
+        return false;
+      }
+      const durationThreshold = observerConfig.entryTypes.get(entry.entryType);
+      return entry.duration >= (durationThreshold ?? 0);
+    });
     observerConfig.callback(
       new PerformanceObserverEntryList(entriesForObserver),
       observer,
@@ -103,6 +109,24 @@ function warnNoNativePerformanceObserver() {
     'missing-native-performance-observer',
     'Missing native implementation of PerformanceObserver',
   );
+}
+
+function applyDurationThresholds() {
+  const durationThresholds: Map<PerformanceEntryType, ?number> = Array.from(
+    registeredObservers.values(),
+  )
+    .map(config => config.entryTypes)
+    .reduce(
+      (accumulator, currentValue) => union(accumulator, currentValue),
+      new Map(),
+    );
+
+  for (const [entryType, durationThreshold] of durationThresholds) {
+    NativePerformanceObserver?.setDurationThreshold(
+      performanceEntryTypeToRaw(entryType),
+      durationThreshold ?? 0,
+    );
+  }
 }
 
 /**
@@ -145,10 +169,14 @@ export default class PerformanceObserver {
 
     if (options.entryTypes) {
       this._type = 'multiple';
-      requestedEntryTypes = new Set(options.entryTypes);
+      requestedEntryTypes = new Map(
+        options.entryTypes.map(t => [t, undefined]),
+      );
     } else {
       this._type = 'single';
-      requestedEntryTypes = new Set([options.type]);
+      requestedEntryTypes = new Map([
+        [options.type, options.durationThreshold],
+      ]);
     }
 
     // The same observer may receive multiple calls to "observe", so we need
@@ -178,19 +206,22 @@ export default class PerformanceObserver {
     // We only need to start listenening to new entry types being observed in
     // this observer.
     const newEntryTypes = currentEntryTypes
-      ? difference(requestedEntryTypes, currentEntryTypes)
-      : requestedEntryTypes;
+      ? difference(
+          new Set(requestedEntryTypes.keys()),
+          new Set(currentEntryTypes.keys()),
+        )
+      : new Set(requestedEntryTypes.keys());
     for (const type of newEntryTypes) {
       if (!observerCountPerEntryType.has(type)) {
-        NativePerformanceObserver.startReporting(
-          performanceEntryTypeToRaw(type),
-        );
+        const rawType = performanceEntryTypeToRaw(type);
+        NativePerformanceObserver.startReporting(rawType);
       }
       observerCountPerEntryType.set(
         type,
         (observerCountPerEntryType.get(type) ?? 0) + 1,
       );
     }
+    applyDurationThresholds();
   }
 
   disconnect(): void {
@@ -205,7 +236,7 @@ export default class PerformanceObserver {
     }
 
     // Disconnect this observer
-    for (const type of observerConfig.entryTypes) {
+    for (const type of observerConfig.entryTypes.keys()) {
       const numberOfObserversForThisType =
         observerCountPerEntryType.get(type) ?? 0;
       if (numberOfObserversForThisType === 1) {
@@ -224,10 +255,12 @@ export default class PerformanceObserver {
       NativePerformanceObserver.setOnPerformanceEntryCallback(undefined);
       isOnPerformanceEntryCallbackSet = false;
     }
+
+    applyDurationThresholds();
   }
 
   _validateObserveOptions(options: PerformanceObserverInit): void {
-    const {type, entryTypes} = options;
+    const {type, entryTypes, durationThreshold} = options;
 
     if (!type && !entryTypes) {
       throw new TypeError(
@@ -252,14 +285,32 @@ export default class PerformanceObserver {
         "Failed to execute 'observe' on 'PerformanceObserver': This PerformanceObserver has performed observe({type:...}, therefore it cannot perform observe({entryTypes:...})",
       );
     }
+
+    if (entryTypes && durationThreshold !== undefined) {
+      throw new TypeError(
+        "Failed to execute 'observe' on 'PerformanceObserver': An observe() call must not include both entryTypes and durationThreshold arguments.",
+      );
+    }
   }
 
   static supportedEntryTypes: $ReadOnlyArray<PerformanceEntryType> =
     Object.freeze(['mark', 'measure', 'event']);
 }
 
-function union<T>(a: $ReadOnlySet<T>, b: $ReadOnlySet<T>): Set<T> {
-  return new Set([...a, ...b]);
+// As a Set union, except if value exists in both, we take minimum
+function union<T>(
+  a: $ReadOnlyMap<T, ?number>,
+  b: $ReadOnlyMap<T, ?number>,
+): Map<T, ?number> {
+  const res = new Map<T, ?number>();
+  for (const [k, v] of a) {
+    if (!b.has(k)) {
+      res.set(k, v);
+    } else {
+      res.set(k, Math.min(v ?? 0, b.get(k) ?? 0));
+    }
+  }
+  return res;
 }
 
 function difference<T>(a: $ReadOnlySet<T>, b: $ReadOnlySet<T>): Set<T> {

--- a/Libraries/WebPerformance/RawPerformanceEntry.js
+++ b/Libraries/WebPerformance/RawPerformanceEntry.js
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow strict
+ */
+
+import type {
+  RawPerformanceEntry,
+  RawPerformanceEntryType,
+} from './NativePerformanceObserver';
+import type {PerformanceEntryType} from './PerformanceEntry';
+
+import {PerformanceEntry} from './PerformanceEntry';
+import {PerformanceEventTiming} from './PerformanceEventTiming';
+
+export const RawPerformanceEntryTypeValues = {
+  UNDEFINED: 0,
+  MARK: 1,
+  MEASURE: 2,
+  EVENT: 3,
+};
+
+export function rawToPerformanceEntry(
+  entry: RawPerformanceEntry,
+): PerformanceEntry {
+  if (entry.entryType === RawPerformanceEntryTypeValues.EVENT) {
+    return new PerformanceEventTiming({
+      name: entry.name,
+      startTime: entry.startTime,
+      duration: entry.duration,
+      processingStart: entry.processingStart,
+      processingEnd: entry.processingEnd,
+      interactionId: entry.interactionId,
+    });
+  } else {
+    return new PerformanceEntry({
+      name: entry.name,
+      entryType: rawToPerformanceEntryType(entry.entryType),
+      startTime: entry.startTime,
+      duration: entry.duration,
+    });
+  }
+}
+
+export function rawToPerformanceEntryType(
+  type: RawPerformanceEntryType,
+): PerformanceEntryType {
+  switch (type) {
+    case RawPerformanceEntryTypeValues.MARK:
+      return 'mark';
+    case RawPerformanceEntryTypeValues.MEASURE:
+      return 'measure';
+    case RawPerformanceEntryTypeValues.EVENT:
+      return 'event';
+    default:
+      throw new TypeError(
+        `rawToPerformanceEntryType: unexpected performance entry type received: ${type}`,
+      );
+  }
+}
+
+export function performanceEntryTypeToRaw(
+  type: PerformanceEntryType,
+): RawPerformanceEntryType {
+  switch (type) {
+    case 'mark':
+      return RawPerformanceEntryTypeValues.MARK;
+    case 'measure':
+      return RawPerformanceEntryTypeValues.MEASURE;
+    case 'event':
+      return RawPerformanceEntryTypeValues.EVENT;
+    default:
+      // Verify exhaustive check with Flow
+      (type: empty);
+      throw new TypeError(
+        `performanceEntryTypeToRaw: unexpected performance entry type received: ${type}`,
+      );
+  }
+}

--- a/Libraries/WebPerformance/__mocks__/NativePerformanceObserver.js
+++ b/Libraries/WebPerformance/__mocks__/NativePerformanceObserver.js
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ * @format
+ */
+
+import type {
+  GetPendingEntriesResult,
+  RawPerformanceEntry,
+  RawPerformanceEntryType,
+  Spec as NativePerformanceObserver,
+} from '../NativePerformanceObserver';
+
+const reportingType: Set<RawPerformanceEntryType> = new Set();
+let entries: Array<RawPerformanceEntry> = [];
+let onPerformanceEntryCallback: ?() => void;
+
+export const NativePerformanceObserverMock: NativePerformanceObserver = {
+  startReporting: (entryType: RawPerformanceEntryType) => {
+    reportingType.add(entryType);
+  },
+
+  stopReporting: (entryType: RawPerformanceEntryType) => {
+    reportingType.delete(entryType);
+  },
+
+  popPendingEntries: (): GetPendingEntriesResult => {
+    const res = entries;
+    entries = [];
+    return {
+      droppedEntriesCount: 0,
+      entries: res,
+    };
+  },
+
+  setOnPerformanceEntryCallback: (callback?: () => void) => {
+    onPerformanceEntryCallback = callback;
+  },
+
+  logRawEntry: (entry: RawPerformanceEntry) => {
+    if (reportingType.has(entry.entryType)) {
+      entries.push(entry);
+      onPerformanceEntryCallback?.();
+    }
+  },
+};
+
+export default NativePerformanceObserverMock;

--- a/Libraries/WebPerformance/__tests__/NativePerformanceObserverMock-test.js
+++ b/Libraries/WebPerformance/__tests__/NativePerformanceObserverMock-test.js
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @oncall react_native
+ */
+
+import {NativePerformanceObserverMock} from '../__mocks__/NativePerformanceObserver';
+import {RawPerformanceEntryTypeValues} from '../RawPerformanceEntry';
+
+describe('NativePerformanceObserver', () => {
+  it('correctly starts and stops listening to entries in a nominal scenario', async () => {
+    NativePerformanceObserverMock.startReporting(
+      RawPerformanceEntryTypeValues.MARK,
+    );
+
+    NativePerformanceObserverMock.logRawEntry({
+      name: 'mark1',
+      entryType: RawPerformanceEntryTypeValues.MARK,
+      startTime: 0,
+      duration: 10,
+    });
+
+    NativePerformanceObserverMock.logRawEntry({
+      name: 'mark2',
+      entryType: RawPerformanceEntryTypeValues.MARK,
+      startTime: 0,
+      duration: 20,
+    });
+
+    NativePerformanceObserverMock.logRawEntry({
+      name: 'event1',
+      entryType: RawPerformanceEntryTypeValues.EVENT,
+      startTime: 0,
+      duration: 20,
+    });
+
+    const entriesResult = NativePerformanceObserverMock.popPendingEntries();
+    expect(entriesResult).not.toBe(undefined);
+    const entries = entriesResult.entries;
+
+    expect(entries.length).toBe(2);
+    expect(entries[0].name).toBe('mark1');
+    expect(entries[1].name).toBe('mark2');
+
+    const entriesResult1 = NativePerformanceObserverMock.popPendingEntries();
+    expect(entriesResult1).not.toBe(undefined);
+    const entries1 = entriesResult1.entries;
+    expect(entries1.length).toBe(0);
+
+    NativePerformanceObserverMock.stopReporting('mark');
+  });
+});

--- a/Libraries/WebPerformance/__tests__/PerformanceObserver-test.js
+++ b/Libraries/WebPerformance/__tests__/PerformanceObserver-test.js
@@ -26,6 +26,7 @@ describe('PerformanceObserver', () => {
 
     let totalEntries = 0;
     const observer = new PerformanceObserver((list, _observer) => {
+      expect(_observer).toBe(observer);
       const entries = list.getEntries();
       expect(entries).toHaveLength(1);
       const entry = entries[0];
@@ -44,5 +45,156 @@ describe('PerformanceObserver', () => {
 
     expect(totalEntries).toBe(1);
     observer.disconnect();
+  });
+
+  it('handles durationThreshold argument as expected', async () => {
+    let entries = [];
+    const observer = new PerformanceObserver((list, _observer) => {
+      entries = [...entries, ...list.getEntries()];
+    });
+
+    // durationThreshold can't be used together with entryTypes
+    expect(() =>
+      observer.observe({entryTypes: ['mark'], durationThreshold: 100}),
+    ).toThrow();
+
+    observer.observe({type: 'mark', durationThreshold: 100});
+
+    NativePerformanceObserver.logRawEntry({
+      name: 'mark1',
+      entryType: RawPerformanceEntryTypeValues.MARK,
+      startTime: 0,
+      duration: 200,
+    });
+
+    NativePerformanceObserver.logRawEntry({
+      name: 'mark2',
+      entryType: RawPerformanceEntryTypeValues.MARK,
+      startTime: 0,
+      duration: 20,
+    });
+
+    NativePerformanceObserver.logRawEntry({
+      name: 'mark3',
+      entryType: RawPerformanceEntryTypeValues.MARK,
+      startTime: 0,
+      duration: 100,
+    });
+
+    NativePerformanceObserver.logRawEntry({
+      name: 'mark4',
+      entryType: RawPerformanceEntryTypeValues.MARK,
+      startTime: 0,
+      duration: 500,
+    });
+
+    expect(entries).toHaveLength(3);
+    expect(entries.map(e => e.name)).toStrictEqual(['mark1', 'mark3', 'mark4']);
+  });
+
+  it('correctly works with multiple PerformanceObservers with durationThreshold', async () => {
+    let entries1 = [];
+    const observer1 = new PerformanceObserver((list, _observer) => {
+      entries1 = [...entries1, ...list.getEntries()];
+    });
+
+    let entries2 = [];
+    const observer2 = new PerformanceObserver((list, _observer) => {
+      entries2 = [...entries2, ...list.getEntries()];
+    });
+
+    let entries3 = [];
+    const observer3 = new PerformanceObserver((list, _observer) => {
+      entries3 = [...entries3, ...list.getEntries()];
+    });
+
+    let entries4 = [];
+    const observer4 = new PerformanceObserver((list, _observer) => {
+      entries4 = [...entries4, ...list.getEntries()];
+    });
+
+    observer2.observe({type: 'mark', durationThreshold: 200});
+    observer1.observe({type: 'mark', durationThreshold: 100});
+    observer3.observe({type: 'mark', durationThreshold: 300});
+    observer3.observe({type: 'measure', durationThreshold: 500});
+    observer4.observe({entryTypes: ['mark', 'measure']});
+
+    NativePerformanceObserver.logRawEntry({
+      name: 'mark1',
+      entryType: RawPerformanceEntryTypeValues.MARK,
+      startTime: 0,
+      duration: 200,
+    });
+
+    NativePerformanceObserver.logRawEntry({
+      name: 'mark2',
+      entryType: RawPerformanceEntryTypeValues.MARK,
+      startTime: 0,
+      duration: 20,
+    });
+
+    NativePerformanceObserver.logRawEntry({
+      name: 'mark3',
+      entryType: RawPerformanceEntryTypeValues.MARK,
+      startTime: 0,
+      duration: 100,
+    });
+
+    NativePerformanceObserver.logRawEntry({
+      name: 'mark4',
+      entryType: RawPerformanceEntryTypeValues.MARK,
+      startTime: 0,
+      duration: 500,
+    });
+
+    observer1.disconnect();
+
+    NativePerformanceObserver.logRawEntry({
+      name: 'mark5',
+      entryType: RawPerformanceEntryTypeValues.MARK,
+      startTime: 0,
+      duration: 200,
+    });
+
+    NativePerformanceObserver.logRawEntry({
+      name: 'mark6',
+      entryType: RawPerformanceEntryTypeValues.MARK,
+      startTime: 0,
+      duration: 300,
+    });
+
+    observer3.disconnect();
+
+    NativePerformanceObserver.logRawEntry({
+      name: 'mark7',
+      entryType: RawPerformanceEntryTypeValues.MARK,
+      startTime: 0,
+      duration: 200,
+    });
+
+    observer4.disconnect();
+
+    expect(entries1.map(e => e.name)).toStrictEqual([
+      'mark1',
+      'mark3',
+      'mark4',
+    ]);
+    expect(entries2.map(e => e.name)).toStrictEqual([
+      'mark1',
+      'mark4',
+      'mark5',
+      'mark6',
+      'mark7',
+    ]);
+    expect(entries3.map(e => e.name)).toStrictEqual(['mark4', 'mark6']);
+    expect(entries4.map(e => e.name)).toStrictEqual([
+      'mark1',
+      'mark2',
+      'mark3',
+      'mark4',
+      'mark5',
+      'mark6',
+      'mark7',
+    ]);
   });
 });

--- a/Libraries/WebPerformance/__tests__/PerformanceObserver-test.js
+++ b/Libraries/WebPerformance/__tests__/PerformanceObserver-test.js
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @oncall react_native
+ */
+
+import {RawPerformanceEntryTypeValues} from '../RawPerformanceEntry';
+
+// NOTE: Jest mocks of transitive dependencies don't appear to work with
+// ES6 module imports, therefore forced to use commonjs style imports here.
+const NativePerformanceObserver = require('../NativePerformanceObserver');
+const PerformanceObserver = require('../PerformanceObserver').default;
+
+jest.mock(
+  '../NativePerformanceObserver',
+  () => require('../__mocks__/NativePerformanceObserver').default,
+);
+
+describe('PerformanceObserver', () => {
+  it('can be mocked by a reference NativePerformanceObserver implementation', async () => {
+    expect(NativePerformanceObserver).not.toBe(undefined);
+
+    let totalEntries = 0;
+    const observer = new PerformanceObserver((list, _observer) => {
+      const entries = list.getEntries();
+      expect(entries).toHaveLength(1);
+      const entry = entries[0];
+      expect(entry.name).toBe('mark1');
+      expect(entry.entryType).toBe('mark');
+      totalEntries += entries.length;
+    });
+    expect(() => observer.observe({entryTypes: ['mark']})).not.toThrow();
+
+    NativePerformanceObserver.logRawEntry({
+      name: 'mark1',
+      entryType: RawPerformanceEntryTypeValues.MARK,
+      startTime: 0,
+      duration: 0,
+    });
+
+    expect(totalEntries).toBe(1);
+    observer.disconnect();
+  });
+});


### PR DESCRIPTION
Summary:
[Changelog][Internal]

By [the W3C standard](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceObserver/observe), `PerformanceObserver.observer` can optionally take a `durationThreshold` option, so that only entries with duration larger than the threshold are reported.

This diff adds support for this on the RN side, as well as unit tests for this feature on the JS side.

NOTE: The standard suggests that default value for this is 104s. I left it at 0 for now, as for the RN use cases t may be to too high (needs discussion).

Differential Revision: D43154319

