### PR TITLE
Make enums to work as part of data structures for C++ TurboModules codegen

### DIFF
--- a/Libraries/WebPerformance/EventCounts.js
+++ b/Libraries/WebPerformance/EventCounts.js
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ * @format
+ */
+
+import NativePerformanceObserver from './NativePerformanceObserver';
+import {warnNoNativePerformanceObserver} from './PerformanceObserver';
+import {rawToPerformanceEntryType} from './RawPerformanceEntry';
+
+type EventCountsForEachCallbackType =
+  | (() => void)
+  | ((value: number) => void)
+  | ((value: number, key: string) => void)
+  | ((value: number, key: string, map: Map<string, number>) => void);
+
+/**
+ * Implementation of the EventCounts Web Performance API
+ * corresponding to the standard in
+ * https://www.w3.org/TR/event-timing/#eventcounts
+ */
+export interface EventCounts {
+  size: number;
+
+  +entries: () => Iterator<[string, number]>;
+  +forEach: (callback: EventCountsForEachCallbackType) => void;
+  +get: (key: string) => ?number;
+  +has: (key: string) => boolean;
+  +keys: () => Iterator<string>;
+  +values: () => Iterator<number>;
+}
+
+let cachedEventCounts: ?Map<string, number>;
+
+function getCachedEventCounts(): Map<string, number> {
+  if (cachedEventCounts) {
+    return cachedEventCounts;
+  }
+  if (!NativePerformanceObserver) {
+    warnNoNativePerformanceObserver();
+    return new Map();
+  }
+
+  cachedEventCounts = new Map<string, number>(
+    NativePerformanceObserver.getEventCounts(),
+  );
+  // $FlowFixMe[incompatible-call]
+  global.queueMicrotask(() => {
+    // To be consistent with the calls to the API from the same task,
+    // but also not to refetch the data from native too often,
+    // schedule to invalidate the cache later,
+    // after the current task is guaranteed to have finished.
+    cachedEventCounts = null;
+  });
+  return cachedEventCounts ?? new Map();
+}
+
+// flowlint unsafe-getters-setters:off
+export const EventCountsProxy: EventCounts = {
+  get size(): number {
+    return getCachedEventCounts().size;
+  },
+
+  set size(value: number) {
+    throw new TypeError('EventCounts.size property is read-only');
+  },
+
+  entries: (): Iterator<[string, number]> => {
+    return getCachedEventCounts().entries();
+  },
+
+  forEach: (callback: EventCountsForEachCallbackType) => {
+    return getCachedEventCounts().forEach(callback);
+  },
+
+  get: (key: string): ?number => {
+    return getCachedEventCounts().get(key);
+  },
+
+  has: (key: string): boolean => {
+    return getCachedEventCounts().has(key);
+  },
+
+  keys: (): Iterator<string> => {
+    return getCachedEventCounts().keys();
+  },
+
+  values: (): Iterator<number> => {
+    return getCachedEventCounts().values();
+  },
+};

--- a/Libraries/WebPerformance/NativePerformanceObserver.cpp
+++ b/Libraries/WebPerformance/NativePerformanceObserver.cpp
@@ -45,4 +45,10 @@ void NativePerformanceObserver::setOnPerformanceEntryCallback(
   PerformanceEntryReporter::getInstance().setReportingCallback(callback);
 }
 
+void NativePerformanceObserver::logRawEntry(
+    jsi::Runtime &rt,
+    RawPerformanceEntry entry) {
+  PerformanceEntryReporter::getInstance().logEntry(entry);
+}
+
 } // namespace facebook::react

--- a/Libraries/WebPerformance/NativePerformanceObserver.cpp
+++ b/Libraries/WebPerformance/NativePerformanceObserver.cpp
@@ -51,4 +51,12 @@ void NativePerformanceObserver::logRawEntry(
   PerformanceEntryReporter::getInstance().logEntry(entry);
 }
 
+void NativePerformanceObserver::setDurationThreshold(
+    jsi::Runtime &rt,
+    int32_t entryType,
+    double durationThreshold) {
+  PerformanceEntryReporter::getInstance().setDurationThreshold(
+      static_cast<PerformanceEntryType>(entryType), durationThreshold);
+}
+
 } // namespace facebook::react

--- a/Libraries/WebPerformance/NativePerformanceObserver.cpp
+++ b/Libraries/WebPerformance/NativePerformanceObserver.cpp
@@ -59,4 +59,12 @@ void NativePerformanceObserver::setDurationThreshold(
       static_cast<PerformanceEntryType>(entryType), durationThreshold);
 }
 
+std::vector<std::pair<std::string, uint32_t>>
+NativePerformanceObserver::getEventCounts(jsi::Runtime &rt) {
+  const auto &eventCounts =
+      PerformanceEntryReporter::getInstance().getEventCounts();
+  return std::vector<std::pair<std::string, uint32_t>>(
+      eventCounts.begin(), eventCounts.end());
+}
+
 } // namespace facebook::react

--- a/Libraries/WebPerformance/NativePerformanceObserver.h
+++ b/Libraries/WebPerformance/NativePerformanceObserver.h
@@ -69,6 +69,8 @@ class NativePerformanceObserver
       jsi::Runtime &rt,
       std::optional<AsyncCallback<>> callback);
 
+  void logRawEntry(jsi::Runtime &rt, RawPerformanceEntry entry);
+
  private:
 };
 

--- a/Libraries/WebPerformance/NativePerformanceObserver.h
+++ b/Libraries/WebPerformance/NativePerformanceObserver.h
@@ -76,6 +76,9 @@ class NativePerformanceObserver
       int32_t entryType,
       double durationThreshold);
 
+  std::vector<std::pair<std::string, uint32_t>> getEventCounts(
+      jsi::Runtime &rt);
+
  private:
 };
 

--- a/Libraries/WebPerformance/NativePerformanceObserver.h
+++ b/Libraries/WebPerformance/NativePerformanceObserver.h
@@ -71,6 +71,11 @@ class NativePerformanceObserver
 
   void logRawEntry(jsi::Runtime &rt, RawPerformanceEntry entry);
 
+  void setDurationThreshold(
+      jsi::Runtime &rt,
+      int32_t entryType,
+      double durationThreshold);
+
  private:
 };
 

--- a/Libraries/WebPerformance/NativePerformanceObserver.js
+++ b/Libraries/WebPerformance/NativePerformanceObserver.js
@@ -12,13 +12,6 @@ import type {TurboModule} from '../TurboModule/RCTExport';
 
 import * as TurboModuleRegistry from '../TurboModule/TurboModuleRegistry';
 
-export const RawPerformanceEntryTypeValues = {
-  UNDEFINED: 0,
-  MARK: 1,
-  MEASURE: 2,
-  EVENT: 3,
-};
-
 export type RawPerformanceEntryType = number;
 
 export type RawPerformanceEntry = {|

--- a/Libraries/WebPerformance/NativePerformanceObserver.js
+++ b/Libraries/WebPerformance/NativePerformanceObserver.js
@@ -40,6 +40,7 @@ export interface Spec extends TurboModule {
     entryType: RawPerformanceEntryType,
     durationThreshold: number,
   ) => void;
+  +getEventCounts: () => $ReadOnlyArray<[string, number]>;
 }
 
 export default (TurboModuleRegistry.get<Spec>(

--- a/Libraries/WebPerformance/NativePerformanceObserver.js
+++ b/Libraries/WebPerformance/NativePerformanceObserver.js
@@ -35,6 +35,11 @@ export interface Spec extends TurboModule {
   +stopReporting: (entryType: RawPerformanceEntryType) => void;
   +popPendingEntries: () => GetPendingEntriesResult;
   +setOnPerformanceEntryCallback: (callback?: () => void) => void;
+  +logRawEntry: (entry: RawPerformanceEntry) => void;
+  +setDurationThreshold: (
+    entryType: RawPerformanceEntryType,
+    durationThreshold: number,
+  ) => void;
 }
 
 export default (TurboModuleRegistry.get<Spec>(

--- a/Libraries/WebPerformance/Performance.js
+++ b/Libraries/WebPerformance/Performance.js
@@ -8,9 +8,11 @@
  * @flow strict
  */
 
+import type {EventCounts} from './EventCounts';
 import type {HighResTimeStamp} from './PerformanceEntry';
 
 import warnOnce from '../Utilities/warnOnce';
+import {EventCountsProxy} from './EventCounts';
 import NativePerformance from './NativePerformance';
 import {PerformanceEntry} from './PerformanceEntry';
 
@@ -83,9 +85,11 @@ function warnNoNativePerformance() {
 /**
  * Partial implementation of the Performance interface for RN,
  * corresponding to the standard in
- *  https://www.w3.org/TR/user-timing/#extensions-performance-interface
+ * https://www.w3.org/TR/user-timing/#extensions-performance-interface
  */
 export default class Performance {
+  eventCounts: EventCounts = EventCountsProxy;
+
   mark(
     markName: string,
     markOptions?: PerformanceMarkOptions,

--- a/Libraries/WebPerformance/PerformanceEntryReporter.cpp
+++ b/Libraries/WebPerformance/PerformanceEntryReporter.cpp
@@ -31,8 +31,17 @@ void PerformanceEntryReporter::setReportingCallback(
 }
 
 void PerformanceEntryReporter::startReporting(PerformanceEntryType entryType) {
-  reportingType_[static_cast<int>(entryType)] = true;
+  int entryTypeIdx = static_cast<int>(entryType);
+  reportingType_[entryTypeIdx] = true;
+  durationThreshold_[entryTypeIdx] = DEFAULT_DURATION_THRESHOLD;
 }
+
+void PerformanceEntryReporter::setDurationThreshold(
+    PerformanceEntryType entryType,
+    double durationThreshold) {
+  durationThreshold_[static_cast<int>(entryType)] = durationThreshold;
+}
+
 void PerformanceEntryReporter::stopReporting(PerformanceEntryType entryType) {
   reportingType_[static_cast<int>(entryType)] = false;
 }
@@ -48,6 +57,11 @@ GetPendingEntriesResult PerformanceEntryReporter::popPendingEntries() {
 
 void PerformanceEntryReporter::logEntry(const RawPerformanceEntry &entry) {
   if (!isReportingType(static_cast<PerformanceEntryType>(entry.entryType))) {
+    return;
+  }
+
+  if (entry.duration < durationThreshold_[entry.entryType]) {
+    // The entries duration is lower than the desired reporting threshold, skip
     return;
   }
 

--- a/Libraries/WebPerformance/PerformanceEntryReporter.cpp
+++ b/Libraries/WebPerformance/PerformanceEntryReporter.cpp
@@ -56,7 +56,12 @@ GetPendingEntriesResult PerformanceEntryReporter::popPendingEntries() {
 }
 
 void PerformanceEntryReporter::logEntry(const RawPerformanceEntry &entry) {
-  if (!isReportingType(static_cast<PerformanceEntryType>(entry.entryType))) {
+  const auto entryType = static_cast<PerformanceEntryType>(entry.entryType);
+  if (entryType == PerformanceEntryType::EVENT) {
+    eventCounts_[entry.name]++;
+  }
+
+  if (!isReportingType(entryType)) {
     return;
   }
 

--- a/Libraries/WebPerformance/PerformanceEntryReporter.h
+++ b/Libraries/WebPerformance/PerformanceEntryReporter.h
@@ -44,6 +44,8 @@ using PerformanceMarkRegistryType = std::
 // memory for the sake of the "Performance.measure" mark name lookup
 constexpr size_t MARKS_BUFFER_SIZE = 1024;
 
+constexpr double DEFAULT_DURATION_THRESHOLD = 0.0;
+
 enum class PerformanceEntryType {
   UNDEFINED = 0,
   MARK = 1,
@@ -66,6 +68,9 @@ class PerformanceEntryReporter : public EventLogger {
   void setReportingCallback(std::optional<AsyncCallback<>> callback);
   void startReporting(PerformanceEntryType entryType);
   void stopReporting(PerformanceEntryType entryType);
+  void setDurationThreshold(
+      PerformanceEntryType entryType,
+      double durationThreshold);
 
   GetPendingEntriesResult popPendingEntries();
   void logEntry(const RawPerformanceEntry &entry);
@@ -117,6 +122,8 @@ class PerformanceEntryReporter : public EventLogger {
   std::vector<RawPerformanceEntry> entries_;
   std::mutex entriesMutex_;
   std::array<bool, (size_t)PerformanceEntryType::_COUNT> reportingType_{false};
+  std::array<double, (size_t)PerformanceEntryType::_COUNT> durationThreshold_{
+      DEFAULT_DURATION_THRESHOLD};
 
   // Mark registry for "measure" lookup
   PerformanceMarkRegistryType marksRegistry_;

--- a/Libraries/WebPerformance/PerformanceEntryReporter.h
+++ b/Libraries/WebPerformance/PerformanceEntryReporter.h
@@ -107,6 +107,10 @@ class PerformanceEntryReporter : public EventLogger {
   void onEventDispatch(EventTag tag) override;
   void onEventEnd(EventTag tag) override;
 
+  const std::unordered_map<std::string, uint32_t> &getEventCounts() const {
+    return eventCounts_;
+  }
+
  private:
   PerformanceEntryReporter() {}
 
@@ -124,6 +128,7 @@ class PerformanceEntryReporter : public EventLogger {
   std::array<bool, (size_t)PerformanceEntryType::_COUNT> reportingType_{false};
   std::array<double, (size_t)PerformanceEntryType::_COUNT> durationThreshold_{
       DEFAULT_DURATION_THRESHOLD};
+  std::unordered_map<std::string, uint32_t> eventCounts_;
 
   // Mark registry for "measure" lookup
   PerformanceMarkRegistryType marksRegistry_;

--- a/Libraries/WebPerformance/PerformanceObserver.js
+++ b/Libraries/WebPerformance/PerformanceObserver.js
@@ -8,74 +8,15 @@
  * @flow strict
  */
 
-import type {
-  RawPerformanceEntry,
-  RawPerformanceEntryType,
-} from './NativePerformanceObserver';
 import type {PerformanceEntryType} from './PerformanceEntry';
 
 import warnOnce from '../Utilities/warnOnce';
-import NativePerformanceObserver, {
-  RawPerformanceEntryTypeValues,
-} from './NativePerformanceObserver';
+import NativePerformanceObserver from './NativePerformanceObserver';
 import {PerformanceEntry} from './PerformanceEntry';
-import {PerformanceEventTiming} from './PerformanceEventTiming';
-
-function rawToPerformanceEntryType(
-  type: RawPerformanceEntryType,
-): PerformanceEntryType {
-  switch (type) {
-    case RawPerformanceEntryTypeValues.MARK:
-      return 'mark';
-    case RawPerformanceEntryTypeValues.MEASURE:
-      return 'measure';
-    case RawPerformanceEntryTypeValues.EVENT:
-      return 'event';
-    default:
-      throw new TypeError(
-        `rawToPerformanceEntryType: unexpected performance entry type received: ${type}`,
-      );
-  }
-}
-
-function performanceEntryTypeToRaw(
-  type: PerformanceEntryType,
-): RawPerformanceEntryType {
-  switch (type) {
-    case 'mark':
-      return RawPerformanceEntryTypeValues.MARK;
-    case 'measure':
-      return RawPerformanceEntryTypeValues.MEASURE;
-    case 'event':
-      return RawPerformanceEntryTypeValues.EVENT;
-    default:
-      // Verify exhaustive check with Flow
-      (type: empty);
-      throw new TypeError(
-        `performanceEntryTypeToRaw: unexpected performance entry type received: ${type}`,
-      );
-  }
-}
-
-function rawToPerformanceEntry(entry: RawPerformanceEntry): PerformanceEntry {
-  if (entry.entryType === RawPerformanceEntryTypeValues.EVENT) {
-    return new PerformanceEventTiming({
-      name: entry.name,
-      startTime: entry.startTime,
-      duration: entry.duration,
-      processingStart: entry.processingStart,
-      processingEnd: entry.processingEnd,
-      interactionId: entry.interactionId,
-    });
-  } else {
-    return new PerformanceEntry({
-      name: entry.name,
-      entryType: rawToPerformanceEntryType(entry.entryType),
-      startTime: entry.startTime,
-      duration: entry.duration,
-    });
-  }
-}
+import {
+  performanceEntryTypeToRaw,
+  rawToPerformanceEntry,
+} from './RawPerformanceEntry';
 
 export type PerformanceEntryList = $ReadOnlyArray<PerformanceEntry>;
 

--- a/Libraries/WebPerformance/PerformanceObserver.js
+++ b/Libraries/WebPerformance/PerformanceObserver.js
@@ -104,7 +104,7 @@ const onPerformanceEntry = () => {
   }
 };
 
-function warnNoNativePerformanceObserver() {
+export function warnNoNativePerformanceObserver() {
   warnOnce(
     'missing-native-performance-observer',
     'Missing native implementation of PerformanceObserver',

--- a/Libraries/WebPerformance/PerformanceObserver.js
+++ b/Libraries/WebPerformance/PerformanceObserver.js
@@ -8,7 +8,7 @@
  * @flow strict
  */
 
-import type {PerformanceEntryType} from './PerformanceEntry';
+import type {HighResTimeStamp, PerformanceEntryType} from './PerformanceEntry';
 
 import warnOnce from '../Utilities/warnOnce';
 import NativePerformanceObserver from './NativePerformanceObserver';
@@ -62,11 +62,13 @@ export type PerformanceObserverInit =
     }
   | {
       type: PerformanceEntryType,
+      durationThreshold?: HighResTimeStamp,
     };
 
 type PerformanceObserverConfig = {|
   callback: PerformanceObserverCallback,
-  entryTypes: $ReadOnlySet<PerformanceEntryType>,
+  // Map of {entryType: durationThreshold}
+  entryTypes: $ReadOnlyMap<PerformanceEntryType, ?number>,
 |};
 
 const observerCountPerEntryType: Map<PerformanceEntryType, number> = new Map();
@@ -87,9 +89,13 @@ const onPerformanceEntry = () => {
   }
   const entries = rawEntries.map(rawToPerformanceEntry);
   for (const [observer, observerConfig] of registeredObservers.entries()) {
-    const entriesForObserver: PerformanceEntryList = entries.filter(
-      entry => observerConfig.entryTypes.has(entry.entryType) !== -1,
-    );
+    const entriesForObserver: PerformanceEntryList = entries.filter(entry => {
+      if (!observerConfig.entryTypes.has(entry.entryType)) {
+        return false;
+      }
+      const durationThreshold = observerConfig.entryTypes.get(entry.entryType);
+      return entry.duration >= (durationThreshold ?? 0);
+    });
     observerConfig.callback(
       new PerformanceObserverEntryList(entriesForObserver),
       observer,
@@ -103,6 +109,24 @@ function warnNoNativePerformanceObserver() {
     'missing-native-performance-observer',
     'Missing native implementation of PerformanceObserver',
   );
+}
+
+function applyDurationThresholds() {
+  const durationThresholds: Map<PerformanceEntryType, ?number> = Array.from(
+    registeredObservers.values(),
+  )
+    .map(config => config.entryTypes)
+    .reduce(
+      (accumulator, currentValue) => union(accumulator, currentValue),
+      new Map(),
+    );
+
+  for (const [entryType, durationThreshold] of durationThresholds) {
+    NativePerformanceObserver?.setDurationThreshold(
+      performanceEntryTypeToRaw(entryType),
+      durationThreshold ?? 0,
+    );
+  }
 }
 
 /**
@@ -145,10 +169,14 @@ export default class PerformanceObserver {
 
     if (options.entryTypes) {
       this._type = 'multiple';
-      requestedEntryTypes = new Set(options.entryTypes);
+      requestedEntryTypes = new Map(
+        options.entryTypes.map(t => [t, undefined]),
+      );
     } else {
       this._type = 'single';
-      requestedEntryTypes = new Set([options.type]);
+      requestedEntryTypes = new Map([
+        [options.type, options.durationThreshold],
+      ]);
     }
 
     // The same observer may receive multiple calls to "observe", so we need
@@ -178,19 +206,22 @@ export default class PerformanceObserver {
     // We only need to start listenening to new entry types being observed in
     // this observer.
     const newEntryTypes = currentEntryTypes
-      ? difference(requestedEntryTypes, currentEntryTypes)
-      : requestedEntryTypes;
+      ? difference(
+          new Set(requestedEntryTypes.keys()),
+          new Set(currentEntryTypes.keys()),
+        )
+      : new Set(requestedEntryTypes.keys());
     for (const type of newEntryTypes) {
       if (!observerCountPerEntryType.has(type)) {
-        NativePerformanceObserver.startReporting(
-          performanceEntryTypeToRaw(type),
-        );
+        const rawType = performanceEntryTypeToRaw(type);
+        NativePerformanceObserver.startReporting(rawType);
       }
       observerCountPerEntryType.set(
         type,
         (observerCountPerEntryType.get(type) ?? 0) + 1,
       );
     }
+    applyDurationThresholds();
   }
 
   disconnect(): void {
@@ -205,7 +236,7 @@ export default class PerformanceObserver {
     }
 
     // Disconnect this observer
-    for (const type of observerConfig.entryTypes) {
+    for (const type of observerConfig.entryTypes.keys()) {
       const numberOfObserversForThisType =
         observerCountPerEntryType.get(type) ?? 0;
       if (numberOfObserversForThisType === 1) {
@@ -224,10 +255,12 @@ export default class PerformanceObserver {
       NativePerformanceObserver.setOnPerformanceEntryCallback(undefined);
       isOnPerformanceEntryCallbackSet = false;
     }
+
+    applyDurationThresholds();
   }
 
   _validateObserveOptions(options: PerformanceObserverInit): void {
-    const {type, entryTypes} = options;
+    const {type, entryTypes, durationThreshold} = options;
 
     if (!type && !entryTypes) {
       throw new TypeError(
@@ -252,14 +285,32 @@ export default class PerformanceObserver {
         "Failed to execute 'observe' on 'PerformanceObserver': This PerformanceObserver has performed observe({type:...}, therefore it cannot perform observe({entryTypes:...})",
       );
     }
+
+    if (entryTypes && durationThreshold !== undefined) {
+      throw new TypeError(
+        "Failed to execute 'observe' on 'PerformanceObserver': An observe() call must not include both entryTypes and durationThreshold arguments.",
+      );
+    }
   }
 
   static supportedEntryTypes: $ReadOnlyArray<PerformanceEntryType> =
     Object.freeze(['mark', 'measure', 'event']);
 }
 
-function union<T>(a: $ReadOnlySet<T>, b: $ReadOnlySet<T>): Set<T> {
-  return new Set([...a, ...b]);
+// As a Set union, except if value exists in both, we take minimum
+function union<T>(
+  a: $ReadOnlyMap<T, ?number>,
+  b: $ReadOnlyMap<T, ?number>,
+): Map<T, ?number> {
+  const res = new Map<T, ?number>();
+  for (const [k, v] of a) {
+    if (!b.has(k)) {
+      res.set(k, v);
+    } else {
+      res.set(k, Math.min(v ?? 0, b.get(k) ?? 0));
+    }
+  }
+  return res;
 }
 
 function difference<T>(a: $ReadOnlySet<T>, b: $ReadOnlySet<T>): Set<T> {

--- a/Libraries/WebPerformance/RawPerformanceEntry.js
+++ b/Libraries/WebPerformance/RawPerformanceEntry.js
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow strict
+ */
+
+import type {
+  RawPerformanceEntry,
+  RawPerformanceEntryType,
+} from './NativePerformanceObserver';
+import type {PerformanceEntryType} from './PerformanceEntry';
+
+import {PerformanceEntry} from './PerformanceEntry';
+import {PerformanceEventTiming} from './PerformanceEventTiming';
+
+export const RawPerformanceEntryTypeValues = {
+  UNDEFINED: 0,
+  MARK: 1,
+  MEASURE: 2,
+  EVENT: 3,
+};
+
+export function rawToPerformanceEntry(
+  entry: RawPerformanceEntry,
+): PerformanceEntry {
+  if (entry.entryType === RawPerformanceEntryTypeValues.EVENT) {
+    return new PerformanceEventTiming({
+      name: entry.name,
+      startTime: entry.startTime,
+      duration: entry.duration,
+      processingStart: entry.processingStart,
+      processingEnd: entry.processingEnd,
+      interactionId: entry.interactionId,
+    });
+  } else {
+    return new PerformanceEntry({
+      name: entry.name,
+      entryType: rawToPerformanceEntryType(entry.entryType),
+      startTime: entry.startTime,
+      duration: entry.duration,
+    });
+  }
+}
+
+export function rawToPerformanceEntryType(
+  type: RawPerformanceEntryType,
+): PerformanceEntryType {
+  switch (type) {
+    case RawPerformanceEntryTypeValues.MARK:
+      return 'mark';
+    case RawPerformanceEntryTypeValues.MEASURE:
+      return 'measure';
+    case RawPerformanceEntryTypeValues.EVENT:
+      return 'event';
+    default:
+      throw new TypeError(
+        `rawToPerformanceEntryType: unexpected performance entry type received: ${type}`,
+      );
+  }
+}
+
+export function performanceEntryTypeToRaw(
+  type: PerformanceEntryType,
+): RawPerformanceEntryType {
+  switch (type) {
+    case 'mark':
+      return RawPerformanceEntryTypeValues.MARK;
+    case 'measure':
+      return RawPerformanceEntryTypeValues.MEASURE;
+    case 'event':
+      return RawPerformanceEntryTypeValues.EVENT;
+    default:
+      // Verify exhaustive check with Flow
+      (type: empty);
+      throw new TypeError(
+        `performanceEntryTypeToRaw: unexpected performance entry type received: ${type}`,
+      );
+  }
+}

--- a/Libraries/WebPerformance/__mocks__/NativePerformanceObserver.js
+++ b/Libraries/WebPerformance/__mocks__/NativePerformanceObserver.js
@@ -15,8 +15,11 @@ import type {
   Spec as NativePerformanceObserver,
 } from '../NativePerformanceObserver';
 
+import {RawPerformanceEntryTypeValues} from '../RawPerformanceEntry';
+
 const reportingType: Set<RawPerformanceEntryType> = new Set();
 const durationThresholds: Map<RawPerformanceEntryType, number> = new Map();
+const eventCounts: Map<string, number> = new Map();
 let entries: Array<RawPerformanceEntry> = [];
 let onPerformanceEntryCallback: ?() => void;
 
@@ -55,6 +58,9 @@ export const NativePerformanceObserverMock: NativePerformanceObserver = {
       entries.push(entry);
       onPerformanceEntryCallback?.();
     }
+    if (entry.entryType === RawPerformanceEntryTypeValues.EVENT) {
+      eventCounts.set(entry.name, (eventCounts.get(entry.name) ?? 0) + 1);
+    }
   },
 
   setDurationThreshold: (
@@ -62,6 +68,10 @@ export const NativePerformanceObserverMock: NativePerformanceObserver = {
     durationThreshold: number,
   ) => {
     durationThresholds.set(entryType, durationThreshold);
+  },
+
+  getEventCounts: (): $ReadOnlyArray<[string, number]> => {
+    return Array.from(eventCounts.entries());
   },
 };
 

--- a/Libraries/WebPerformance/__mocks__/NativePerformanceObserver.js
+++ b/Libraries/WebPerformance/__mocks__/NativePerformanceObserver.js
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ * @format
+ */
+
+import type {
+  GetPendingEntriesResult,
+  RawPerformanceEntry,
+  RawPerformanceEntryType,
+  Spec as NativePerformanceObserver,
+} from '../NativePerformanceObserver';
+
+const reportingType: Set<RawPerformanceEntryType> = new Set();
+let entries: Array<RawPerformanceEntry> = [];
+let onPerformanceEntryCallback: ?() => void;
+
+export const NativePerformanceObserverMock: NativePerformanceObserver = {
+  startReporting: (entryType: RawPerformanceEntryType) => {
+    reportingType.add(entryType);
+  },
+
+  stopReporting: (entryType: RawPerformanceEntryType) => {
+    reportingType.delete(entryType);
+  },
+
+  popPendingEntries: (): GetPendingEntriesResult => {
+    const res = entries;
+    entries = [];
+    return {
+      droppedEntriesCount: 0,
+      entries: res,
+    };
+  },
+
+  setOnPerformanceEntryCallback: (callback?: () => void) => {
+    onPerformanceEntryCallback = callback;
+  },
+
+  logRawEntry: (entry: RawPerformanceEntry) => {
+    if (reportingType.has(entry.entryType)) {
+      entries.push(entry);
+      onPerformanceEntryCallback?.();
+    }
+  },
+};
+
+export default NativePerformanceObserverMock;

--- a/Libraries/WebPerformance/__tests__/EventCounts-test.js
+++ b/Libraries/WebPerformance/__tests__/EventCounts-test.js
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @oncall react_native
+ */
+
+import {RawPerformanceEntryTypeValues} from '../RawPerformanceEntry';
+
+// NOTE: Jest mocks of transitive dependencies don't appear to work with
+// ES6 module imports, therefore forced to use commonjs style imports here.
+const NativePerformanceObserver = require('../NativePerformanceObserver');
+const Performance = require('../Performance').default;
+
+jest.mock(
+  '../NativePerformanceObserver',
+  () => require('../__mocks__/NativePerformanceObserver').default,
+);
+
+describe('EventCounts', () => {
+  it('consistently implements the API for EventCounts', async () => {
+    NativePerformanceObserver.logRawEntry({
+      name: 'click',
+      entryType: RawPerformanceEntryTypeValues.EVENT,
+    });
+
+    NativePerformanceObserver.logRawEntry({
+      name: 'input',
+      entryType: RawPerformanceEntryTypeValues.EVENT,
+    });
+
+    NativePerformanceObserver.logRawEntry({
+      name: 'input',
+      entryType: RawPerformanceEntryTypeValues.EVENT,
+    });
+
+    NativePerformanceObserver.logRawEntry({
+      name: 'keyup',
+      entryType: RawPerformanceEntryTypeValues.EVENT,
+    });
+
+    NativePerformanceObserver.logRawEntry({
+      name: 'keyup',
+      entryType: RawPerformanceEntryTypeValues.EVENT,
+    });
+
+    NativePerformanceObserver.logRawEntry({
+      name: 'keyup',
+      entryType: RawPerformanceEntryTypeValues.EVENT,
+    });
+
+    const eventCounts = new Performance().eventCounts;
+
+    expect(eventCounts).not.toBeUndefined();
+    expect(eventCounts.size).toBe(3);
+    expect(Array.from(eventCounts.entries())).toStrictEqual([
+      ['click', 1],
+      ['input', 2],
+      ['keyup', 3],
+    ]);
+
+    expect(eventCounts.get('click')).toEqual(1);
+    expect(eventCounts.get('input')).toEqual(2);
+    expect(eventCounts.get('keyup')).toEqual(3);
+
+    expect(eventCounts.has('click')).toEqual(true);
+    expect(eventCounts.has('input')).toEqual(true);
+    expect(eventCounts.has('keyup')).toEqual(true);
+
+    expect(Array.from(eventCounts.keys())).toStrictEqual([
+      'click',
+      'input',
+      'keyup',
+    ]);
+    expect(Array.from(eventCounts.values())).toStrictEqual([1, 2, 3]);
+  });
+});

--- a/Libraries/WebPerformance/__tests__/NativePerformanceObserverMock-test.js
+++ b/Libraries/WebPerformance/__tests__/NativePerformanceObserverMock-test.js
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @oncall react_native
+ */
+
+import {NativePerformanceObserverMock} from '../__mocks__/NativePerformanceObserver';
+import {RawPerformanceEntryTypeValues} from '../RawPerformanceEntry';
+
+describe('NativePerformanceObserver', () => {
+  it('correctly starts and stops listening to entries in a nominal scenario', async () => {
+    NativePerformanceObserverMock.startReporting(
+      RawPerformanceEntryTypeValues.MARK,
+    );
+
+    NativePerformanceObserverMock.logRawEntry({
+      name: 'mark1',
+      entryType: RawPerformanceEntryTypeValues.MARK,
+      startTime: 0,
+      duration: 10,
+    });
+
+    NativePerformanceObserverMock.logRawEntry({
+      name: 'mark2',
+      entryType: RawPerformanceEntryTypeValues.MARK,
+      startTime: 0,
+      duration: 20,
+    });
+
+    NativePerformanceObserverMock.logRawEntry({
+      name: 'event1',
+      entryType: RawPerformanceEntryTypeValues.EVENT,
+      startTime: 0,
+      duration: 20,
+    });
+
+    const entriesResult = NativePerformanceObserverMock.popPendingEntries();
+    expect(entriesResult).not.toBe(undefined);
+    const entries = entriesResult.entries;
+
+    expect(entries.length).toBe(2);
+    expect(entries[0].name).toBe('mark1');
+    expect(entries[1].name).toBe('mark2');
+
+    const entriesResult1 = NativePerformanceObserverMock.popPendingEntries();
+    expect(entriesResult1).not.toBe(undefined);
+    const entries1 = entriesResult1.entries;
+    expect(entries1.length).toBe(0);
+
+    NativePerformanceObserverMock.stopReporting('mark');
+  });
+});

--- a/Libraries/WebPerformance/__tests__/PerformanceObserver-test.js
+++ b/Libraries/WebPerformance/__tests__/PerformanceObserver-test.js
@@ -26,6 +26,7 @@ describe('PerformanceObserver', () => {
 
     let totalEntries = 0;
     const observer = new PerformanceObserver((list, _observer) => {
+      expect(_observer).toBe(observer);
       const entries = list.getEntries();
       expect(entries).toHaveLength(1);
       const entry = entries[0];
@@ -44,5 +45,156 @@ describe('PerformanceObserver', () => {
 
     expect(totalEntries).toBe(1);
     observer.disconnect();
+  });
+
+  it('handles durationThreshold argument as expected', async () => {
+    let entries = [];
+    const observer = new PerformanceObserver((list, _observer) => {
+      entries = [...entries, ...list.getEntries()];
+    });
+
+    // durationThreshold can't be used together with entryTypes
+    expect(() =>
+      observer.observe({entryTypes: ['mark'], durationThreshold: 100}),
+    ).toThrow();
+
+    observer.observe({type: 'mark', durationThreshold: 100});
+
+    NativePerformanceObserver.logRawEntry({
+      name: 'mark1',
+      entryType: RawPerformanceEntryTypeValues.MARK,
+      startTime: 0,
+      duration: 200,
+    });
+
+    NativePerformanceObserver.logRawEntry({
+      name: 'mark2',
+      entryType: RawPerformanceEntryTypeValues.MARK,
+      startTime: 0,
+      duration: 20,
+    });
+
+    NativePerformanceObserver.logRawEntry({
+      name: 'mark3',
+      entryType: RawPerformanceEntryTypeValues.MARK,
+      startTime: 0,
+      duration: 100,
+    });
+
+    NativePerformanceObserver.logRawEntry({
+      name: 'mark4',
+      entryType: RawPerformanceEntryTypeValues.MARK,
+      startTime: 0,
+      duration: 500,
+    });
+
+    expect(entries).toHaveLength(3);
+    expect(entries.map(e => e.name)).toStrictEqual(['mark1', 'mark3', 'mark4']);
+  });
+
+  it('correctly works with multiple PerformanceObservers with durationThreshold', async () => {
+    let entries1 = [];
+    const observer1 = new PerformanceObserver((list, _observer) => {
+      entries1 = [...entries1, ...list.getEntries()];
+    });
+
+    let entries2 = [];
+    const observer2 = new PerformanceObserver((list, _observer) => {
+      entries2 = [...entries2, ...list.getEntries()];
+    });
+
+    let entries3 = [];
+    const observer3 = new PerformanceObserver((list, _observer) => {
+      entries3 = [...entries3, ...list.getEntries()];
+    });
+
+    let entries4 = [];
+    const observer4 = new PerformanceObserver((list, _observer) => {
+      entries4 = [...entries4, ...list.getEntries()];
+    });
+
+    observer2.observe({type: 'mark', durationThreshold: 200});
+    observer1.observe({type: 'mark', durationThreshold: 100});
+    observer3.observe({type: 'mark', durationThreshold: 300});
+    observer3.observe({type: 'measure', durationThreshold: 500});
+    observer4.observe({entryTypes: ['mark', 'measure']});
+
+    NativePerformanceObserver.logRawEntry({
+      name: 'mark1',
+      entryType: RawPerformanceEntryTypeValues.MARK,
+      startTime: 0,
+      duration: 200,
+    });
+
+    NativePerformanceObserver.logRawEntry({
+      name: 'mark2',
+      entryType: RawPerformanceEntryTypeValues.MARK,
+      startTime: 0,
+      duration: 20,
+    });
+
+    NativePerformanceObserver.logRawEntry({
+      name: 'mark3',
+      entryType: RawPerformanceEntryTypeValues.MARK,
+      startTime: 0,
+      duration: 100,
+    });
+
+    NativePerformanceObserver.logRawEntry({
+      name: 'mark4',
+      entryType: RawPerformanceEntryTypeValues.MARK,
+      startTime: 0,
+      duration: 500,
+    });
+
+    observer1.disconnect();
+
+    NativePerformanceObserver.logRawEntry({
+      name: 'mark5',
+      entryType: RawPerformanceEntryTypeValues.MARK,
+      startTime: 0,
+      duration: 200,
+    });
+
+    NativePerformanceObserver.logRawEntry({
+      name: 'mark6',
+      entryType: RawPerformanceEntryTypeValues.MARK,
+      startTime: 0,
+      duration: 300,
+    });
+
+    observer3.disconnect();
+
+    NativePerformanceObserver.logRawEntry({
+      name: 'mark7',
+      entryType: RawPerformanceEntryTypeValues.MARK,
+      startTime: 0,
+      duration: 200,
+    });
+
+    observer4.disconnect();
+
+    expect(entries1.map(e => e.name)).toStrictEqual([
+      'mark1',
+      'mark3',
+      'mark4',
+    ]);
+    expect(entries2.map(e => e.name)).toStrictEqual([
+      'mark1',
+      'mark4',
+      'mark5',
+      'mark6',
+      'mark7',
+    ]);
+    expect(entries3.map(e => e.name)).toStrictEqual(['mark4', 'mark6']);
+    expect(entries4.map(e => e.name)).toStrictEqual([
+      'mark1',
+      'mark2',
+      'mark3',
+      'mark4',
+      'mark5',
+      'mark6',
+      'mark7',
+    ]);
   });
 });

--- a/Libraries/WebPerformance/__tests__/PerformanceObserver-test.js
+++ b/Libraries/WebPerformance/__tests__/PerformanceObserver-test.js
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @oncall react_native
+ */
+
+import {RawPerformanceEntryTypeValues} from '../RawPerformanceEntry';
+
+// NOTE: Jest mocks of transitive dependencies don't appear to work with
+// ES6 module imports, therefore forced to use commonjs style imports here.
+const NativePerformanceObserver = require('../NativePerformanceObserver');
+const PerformanceObserver = require('../PerformanceObserver').default;
+
+jest.mock(
+  '../NativePerformanceObserver',
+  () => require('../__mocks__/NativePerformanceObserver').default,
+);
+
+describe('PerformanceObserver', () => {
+  it('can be mocked by a reference NativePerformanceObserver implementation', async () => {
+    expect(NativePerformanceObserver).not.toBe(undefined);
+
+    let totalEntries = 0;
+    const observer = new PerformanceObserver((list, _observer) => {
+      const entries = list.getEntries();
+      expect(entries).toHaveLength(1);
+      const entry = entries[0];
+      expect(entry.name).toBe('mark1');
+      expect(entry.entryType).toBe('mark');
+      totalEntries += entries.length;
+    });
+    expect(() => observer.observe({entryTypes: ['mark']})).not.toThrow();
+
+    NativePerformanceObserver.logRawEntry({
+      name: 'mark1',
+      entryType: RawPerformanceEntryTypeValues.MARK,
+      startTime: 0,
+      duration: 0,
+    });
+
+    expect(totalEntries).toBe(1);
+    observer.disconnect();
+  });
+});

--- a/packages/react-native-codegen/e2e/__tests__/modules/__snapshots__/GenerateModuleH-test.js.snap
+++ b/packages/react-native-codegen/e2e/__tests__/modules/__snapshots__/GenerateModuleH-test.js.snap
@@ -193,7 +193,19 @@ enum NativeEnumTurboModuleStatusRegularEnum { Active, Paused, Off };
 
 template <>
 struct Bridging<NativeEnumTurboModuleStatusRegularEnum> {
-  static NativeEnumTurboModuleStatusRegularEnum fromJs(jsi::Runtime &rt, const jsi::String &rawValue) {
+  static jsi::String toJs(jsi::Runtime &rt, NativeEnumTurboModuleStatusRegularEnum value, const std::shared_ptr<CallInvoker> &jsInvoker) {
+    if (value == NativeEnumTurboModuleStatusRegularEnum::Active) {
+      return bridging::toJs(rt, \\"Active\\");
+    } else if (value == NativeEnumTurboModuleStatusRegularEnum::Paused) {
+      return bridging::toJs(rt, \\"Paused\\");
+    } else if (value == NativeEnumTurboModuleStatusRegularEnum::Off) {
+      return bridging::toJs(rt, \\"Off\\");
+    } else {
+      throw jsi::JSError(rt, \\"No appropriate enum member found for enum value\\");
+    }
+  }
+
+  static NativeEnumTurboModuleStatusRegularEnum fromJs(jsi::Runtime &rt, const jsi::String &rawValue, const std::shared_ptr<CallInvoker> &jsInvoker) {
     std::string value = rawValue.utf8(rt);
     if (value == \\"Active\\") {
       return NativeEnumTurboModuleStatusRegularEnum::Active;
@@ -205,18 +217,6 @@ struct Bridging<NativeEnumTurboModuleStatusRegularEnum> {
       throw jsi::JSError(rt, \\"No appropriate enum member found for value\\");
     }
   }
-
-  static jsi::String toJs(jsi::Runtime &rt, NativeEnumTurboModuleStatusRegularEnum value) {
-    if (value == NativeEnumTurboModuleStatusRegularEnum::Active) {
-      return bridging::toJs(rt, \\"Active\\");
-    } else if (value == NativeEnumTurboModuleStatusRegularEnum::Paused) {
-      return bridging::toJs(rt, \\"Paused\\");
-    } else if (value == NativeEnumTurboModuleStatusRegularEnum::Off) {
-      return bridging::toJs(rt, \\"Off\\");
-    } else {
-      throw jsi::JSError(rt, \\"No appropriate enum member found for enum value\\");
-    }
-  }
 };
 
 #pragma mark - NativeEnumTurboModuleStatusStrEnum
@@ -225,7 +225,19 @@ enum NativeEnumTurboModuleStatusStrEnum { Active, Paused, Off };
 
 template <>
 struct Bridging<NativeEnumTurboModuleStatusStrEnum> {
-  static NativeEnumTurboModuleStatusStrEnum fromJs(jsi::Runtime &rt, const jsi::String &rawValue) {
+  static jsi::String toJs(jsi::Runtime &rt, NativeEnumTurboModuleStatusStrEnum value, const std::shared_ptr<CallInvoker> &jsInvoker) {
+    if (value == NativeEnumTurboModuleStatusStrEnum::Active) {
+      return bridging::toJs(rt, \\"active\\");
+    } else if (value == NativeEnumTurboModuleStatusStrEnum::Paused) {
+      return bridging::toJs(rt, \\"paused\\");
+    } else if (value == NativeEnumTurboModuleStatusStrEnum::Off) {
+      return bridging::toJs(rt, \\"off\\");
+    } else {
+      throw jsi::JSError(rt, \\"No appropriate enum member found for enum value\\");
+    }
+  }
+
+  static NativeEnumTurboModuleStatusStrEnum fromJs(jsi::Runtime &rt, const jsi::String &rawValue, const std::shared_ptr<CallInvoker> &jsInvoker) {
     std::string value = rawValue.utf8(rt);
     if (value == \\"active\\") {
       return NativeEnumTurboModuleStatusStrEnum::Active;
@@ -237,18 +249,6 @@ struct Bridging<NativeEnumTurboModuleStatusStrEnum> {
       throw jsi::JSError(rt, \\"No appropriate enum member found for value\\");
     }
   }
-
-  static jsi::String toJs(jsi::Runtime &rt, NativeEnumTurboModuleStatusStrEnum value) {
-    if (value == NativeEnumTurboModuleStatusStrEnum::Active) {
-      return bridging::toJs(rt, \\"active\\");
-    } else if (value == NativeEnumTurboModuleStatusStrEnum::Paused) {
-      return bridging::toJs(rt, \\"paused\\");
-    } else if (value == NativeEnumTurboModuleStatusStrEnum::Off) {
-      return bridging::toJs(rt, \\"off\\");
-    } else {
-      throw jsi::JSError(rt, \\"No appropriate enum member found for enum value\\");
-    }
-  }
 };
 
 #pragma mark - NativeEnumTurboModuleStatusNumEnum
@@ -257,20 +257,7 @@ enum NativeEnumTurboModuleStatusNumEnum { Active, Paused, Off };
 
 template <>
 struct Bridging<NativeEnumTurboModuleStatusNumEnum> {
-  static NativeEnumTurboModuleStatusNumEnum fromJs(jsi::Runtime &rt, int32_t value) {
-    
-    if (value == 2) {
-      return NativeEnumTurboModuleStatusNumEnum::Active;
-    } else if (value == 1) {
-      return NativeEnumTurboModuleStatusNumEnum::Paused;
-    } else if (value == 0) {
-      return NativeEnumTurboModuleStatusNumEnum::Off;
-    } else {
-      throw jsi::JSError(rt, \\"No appropriate enum member found for value\\");
-    }
-  }
-
-  static jsi::Value toJs(jsi::Runtime &rt, NativeEnumTurboModuleStatusNumEnum value) {
+  static jsi::Value toJs(jsi::Runtime &rt, NativeEnumTurboModuleStatusNumEnum value, const std::shared_ptr<CallInvoker> &jsInvoker) {
     if (value == NativeEnumTurboModuleStatusNumEnum::Active) {
       return bridging::toJs(rt, 2);
     } else if (value == NativeEnumTurboModuleStatusNumEnum::Paused) {
@@ -281,6 +268,19 @@ struct Bridging<NativeEnumTurboModuleStatusNumEnum> {
       throw jsi::JSError(rt, \\"No appropriate enum member found for enum value\\");
     }
   }
+
+  static NativeEnumTurboModuleStatusNumEnum fromJs(jsi::Runtime &rt, const jsi::Value &rawValue, const std::shared_ptr<CallInvoker> &jsInvoker) {
+    double value = (double)rawValue.asNumber();
+    if (value == 2) {
+      return NativeEnumTurboModuleStatusNumEnum::Active;
+    } else if (value == 1) {
+      return NativeEnumTurboModuleStatusNumEnum::Paused;
+    } else if (value == 0) {
+      return NativeEnumTurboModuleStatusNumEnum::Off;
+    } else {
+      throw jsi::JSError(rt, \\"No appropriate enum member found for value\\");
+    }
+  }
 };
 
 #pragma mark - NativeEnumTurboModuleStatusFractionEnum
@@ -289,20 +289,7 @@ enum NativeEnumTurboModuleStatusFractionEnum { Active, Paused, Off };
 
 template <>
 struct Bridging<NativeEnumTurboModuleStatusFractionEnum> {
-  static NativeEnumTurboModuleStatusFractionEnum fromJs(jsi::Runtime &rt, float value) {
-    
-    if (value == 0.2f) {
-      return NativeEnumTurboModuleStatusFractionEnum::Active;
-    } else if (value == 0.1f) {
-      return NativeEnumTurboModuleStatusFractionEnum::Paused;
-    } else if (value == 0f) {
-      return NativeEnumTurboModuleStatusFractionEnum::Off;
-    } else {
-      throw jsi::JSError(rt, \\"No appropriate enum member found for value\\");
-    }
-  }
-
-  static jsi::Value toJs(jsi::Runtime &rt, NativeEnumTurboModuleStatusFractionEnum value) {
+  static jsi::Value toJs(jsi::Runtime &rt, NativeEnumTurboModuleStatusFractionEnum value, const std::shared_ptr<CallInvoker> &jsInvoker) {
     if (value == NativeEnumTurboModuleStatusFractionEnum::Active) {
       return bridging::toJs(rt, 0.2f);
     } else if (value == NativeEnumTurboModuleStatusFractionEnum::Paused) {
@@ -311,6 +298,19 @@ struct Bridging<NativeEnumTurboModuleStatusFractionEnum> {
       return bridging::toJs(rt, 0f);
     } else {
       throw jsi::JSError(rt, \\"No appropriate enum member found for enum value\\");
+    }
+  }
+
+  static NativeEnumTurboModuleStatusFractionEnum fromJs(jsi::Runtime &rt, const jsi::Value &rawValue, const std::shared_ptr<CallInvoker> &jsInvoker) {
+    double value = (double)rawValue.asNumber();
+    if (value == 0.2f) {
+      return NativeEnumTurboModuleStatusFractionEnum::Active;
+    } else if (value == 0.1f) {
+      return NativeEnumTurboModuleStatusFractionEnum::Paused;
+    } else if (value == 0f) {
+      return NativeEnumTurboModuleStatusFractionEnum::Off;
+    } else {
+      throw jsi::JSError(rt, \\"No appropriate enum member found for value\\");
     }
   }
 };
@@ -2136,7 +2136,19 @@ enum NativeEnumTurboModuleStatusRegularEnum { Active, Paused, Off };
 
 template <>
 struct Bridging<NativeEnumTurboModuleStatusRegularEnum> {
-  static NativeEnumTurboModuleStatusRegularEnum fromJs(jsi::Runtime &rt, const jsi::String &rawValue) {
+  static jsi::String toJs(jsi::Runtime &rt, NativeEnumTurboModuleStatusRegularEnum value, const std::shared_ptr<CallInvoker> &jsInvoker) {
+    if (value == NativeEnumTurboModuleStatusRegularEnum::Active) {
+      return bridging::toJs(rt, \\"Active\\");
+    } else if (value == NativeEnumTurboModuleStatusRegularEnum::Paused) {
+      return bridging::toJs(rt, \\"Paused\\");
+    } else if (value == NativeEnumTurboModuleStatusRegularEnum::Off) {
+      return bridging::toJs(rt, \\"Off\\");
+    } else {
+      throw jsi::JSError(rt, \\"No appropriate enum member found for enum value\\");
+    }
+  }
+
+  static NativeEnumTurboModuleStatusRegularEnum fromJs(jsi::Runtime &rt, const jsi::String &rawValue, const std::shared_ptr<CallInvoker> &jsInvoker) {
     std::string value = rawValue.utf8(rt);
     if (value == \\"Active\\") {
       return NativeEnumTurboModuleStatusRegularEnum::Active;
@@ -2148,18 +2160,6 @@ struct Bridging<NativeEnumTurboModuleStatusRegularEnum> {
       throw jsi::JSError(rt, \\"No appropriate enum member found for value\\");
     }
   }
-
-  static jsi::String toJs(jsi::Runtime &rt, NativeEnumTurboModuleStatusRegularEnum value) {
-    if (value == NativeEnumTurboModuleStatusRegularEnum::Active) {
-      return bridging::toJs(rt, \\"Active\\");
-    } else if (value == NativeEnumTurboModuleStatusRegularEnum::Paused) {
-      return bridging::toJs(rt, \\"Paused\\");
-    } else if (value == NativeEnumTurboModuleStatusRegularEnum::Off) {
-      return bridging::toJs(rt, \\"Off\\");
-    } else {
-      throw jsi::JSError(rt, \\"No appropriate enum member found for enum value\\");
-    }
-  }
 };
 
 #pragma mark - NativeEnumTurboModuleStatusStrEnum
@@ -2168,7 +2168,19 @@ enum NativeEnumTurboModuleStatusStrEnum { Active, Paused, Off };
 
 template <>
 struct Bridging<NativeEnumTurboModuleStatusStrEnum> {
-  static NativeEnumTurboModuleStatusStrEnum fromJs(jsi::Runtime &rt, const jsi::String &rawValue) {
+  static jsi::String toJs(jsi::Runtime &rt, NativeEnumTurboModuleStatusStrEnum value, const std::shared_ptr<CallInvoker> &jsInvoker) {
+    if (value == NativeEnumTurboModuleStatusStrEnum::Active) {
+      return bridging::toJs(rt, \\"active\\");
+    } else if (value == NativeEnumTurboModuleStatusStrEnum::Paused) {
+      return bridging::toJs(rt, \\"paused\\");
+    } else if (value == NativeEnumTurboModuleStatusStrEnum::Off) {
+      return bridging::toJs(rt, \\"off\\");
+    } else {
+      throw jsi::JSError(rt, \\"No appropriate enum member found for enum value\\");
+    }
+  }
+
+  static NativeEnumTurboModuleStatusStrEnum fromJs(jsi::Runtime &rt, const jsi::String &rawValue, const std::shared_ptr<CallInvoker> &jsInvoker) {
     std::string value = rawValue.utf8(rt);
     if (value == \\"active\\") {
       return NativeEnumTurboModuleStatusStrEnum::Active;
@@ -2180,18 +2192,6 @@ struct Bridging<NativeEnumTurboModuleStatusStrEnum> {
       throw jsi::JSError(rt, \\"No appropriate enum member found for value\\");
     }
   }
-
-  static jsi::String toJs(jsi::Runtime &rt, NativeEnumTurboModuleStatusStrEnum value) {
-    if (value == NativeEnumTurboModuleStatusStrEnum::Active) {
-      return bridging::toJs(rt, \\"active\\");
-    } else if (value == NativeEnumTurboModuleStatusStrEnum::Paused) {
-      return bridging::toJs(rt, \\"paused\\");
-    } else if (value == NativeEnumTurboModuleStatusStrEnum::Off) {
-      return bridging::toJs(rt, \\"off\\");
-    } else {
-      throw jsi::JSError(rt, \\"No appropriate enum member found for enum value\\");
-    }
-  }
 };
 
 #pragma mark - NativeEnumTurboModuleStatusNumEnum
@@ -2200,20 +2200,7 @@ enum NativeEnumTurboModuleStatusNumEnum { Active, Paused, Off };
 
 template <>
 struct Bridging<NativeEnumTurboModuleStatusNumEnum> {
-  static NativeEnumTurboModuleStatusNumEnum fromJs(jsi::Runtime &rt, int32_t value) {
-    
-    if (value == 2) {
-      return NativeEnumTurboModuleStatusNumEnum::Active;
-    } else if (value == 1) {
-      return NativeEnumTurboModuleStatusNumEnum::Paused;
-    } else if (value == 0) {
-      return NativeEnumTurboModuleStatusNumEnum::Off;
-    } else {
-      throw jsi::JSError(rt, \\"No appropriate enum member found for value\\");
-    }
-  }
-
-  static jsi::Value toJs(jsi::Runtime &rt, NativeEnumTurboModuleStatusNumEnum value) {
+  static jsi::Value toJs(jsi::Runtime &rt, NativeEnumTurboModuleStatusNumEnum value, const std::shared_ptr<CallInvoker> &jsInvoker) {
     if (value == NativeEnumTurboModuleStatusNumEnum::Active) {
       return bridging::toJs(rt, 2);
     } else if (value == NativeEnumTurboModuleStatusNumEnum::Paused) {
@@ -2224,6 +2211,19 @@ struct Bridging<NativeEnumTurboModuleStatusNumEnum> {
       throw jsi::JSError(rt, \\"No appropriate enum member found for enum value\\");
     }
   }
+
+  static NativeEnumTurboModuleStatusNumEnum fromJs(jsi::Runtime &rt, const jsi::Value &rawValue, const std::shared_ptr<CallInvoker> &jsInvoker) {
+    double value = (double)rawValue.asNumber();
+    if (value == 2) {
+      return NativeEnumTurboModuleStatusNumEnum::Active;
+    } else if (value == 1) {
+      return NativeEnumTurboModuleStatusNumEnum::Paused;
+    } else if (value == 0) {
+      return NativeEnumTurboModuleStatusNumEnum::Off;
+    } else {
+      throw jsi::JSError(rt, \\"No appropriate enum member found for value\\");
+    }
+  }
 };
 
 #pragma mark - NativeEnumTurboModuleStatusFractionEnum
@@ -2232,20 +2232,7 @@ enum NativeEnumTurboModuleStatusFractionEnum { Active, Paused, Off };
 
 template <>
 struct Bridging<NativeEnumTurboModuleStatusFractionEnum> {
-  static NativeEnumTurboModuleStatusFractionEnum fromJs(jsi::Runtime &rt, float value) {
-    
-    if (value == 0.2f) {
-      return NativeEnumTurboModuleStatusFractionEnum::Active;
-    } else if (value == 0.1f) {
-      return NativeEnumTurboModuleStatusFractionEnum::Paused;
-    } else if (value == 0f) {
-      return NativeEnumTurboModuleStatusFractionEnum::Off;
-    } else {
-      throw jsi::JSError(rt, \\"No appropriate enum member found for value\\");
-    }
-  }
-
-  static jsi::Value toJs(jsi::Runtime &rt, NativeEnumTurboModuleStatusFractionEnum value) {
+  static jsi::Value toJs(jsi::Runtime &rt, NativeEnumTurboModuleStatusFractionEnum value, const std::shared_ptr<CallInvoker> &jsInvoker) {
     if (value == NativeEnumTurboModuleStatusFractionEnum::Active) {
       return bridging::toJs(rt, 0.2f);
     } else if (value == NativeEnumTurboModuleStatusFractionEnum::Paused) {
@@ -2254,6 +2241,19 @@ struct Bridging<NativeEnumTurboModuleStatusFractionEnum> {
       return bridging::toJs(rt, 0f);
     } else {
       throw jsi::JSError(rt, \\"No appropriate enum member found for enum value\\");
+    }
+  }
+
+  static NativeEnumTurboModuleStatusFractionEnum fromJs(jsi::Runtime &rt, const jsi::Value &rawValue, const std::shared_ptr<CallInvoker> &jsInvoker) {
+    double value = (double)rawValue.asNumber();
+    if (value == 0.2f) {
+      return NativeEnumTurboModuleStatusFractionEnum::Active;
+    } else if (value == 0.1f) {
+      return NativeEnumTurboModuleStatusFractionEnum::Paused;
+    } else if (value == 0f) {
+      return NativeEnumTurboModuleStatusFractionEnum::Off;
+    } else {
+      throw jsi::JSError(rt, \\"No appropriate enum member found for value\\");
     }
   }
 };

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleH.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleH.js
@@ -318,18 +318,18 @@ const EnumTemplate = ({
   toCases: string,
   nativeEnumMemberType: NativeEnumMemberValueType,
 }) => {
-  const fromValue =
+  const [fromValue, fromValueConversion, toValue] =
     nativeEnumMemberType === 'std::string'
-      ? 'const jsi::String &rawValue'
-      : `${nativeEnumMemberType} value`;
-
-  const fromValueConvertion =
-    nativeEnumMemberType === 'std::string'
-      ? 'std::string value = rawValue.utf8(rt);'
-      : '';
-
-  const toValue =
-    nativeEnumMemberType === 'std::string' ? 'jsi::String' : 'jsi::Value';
+      ? [
+          'const jsi::String &rawValue',
+          'std::string value = rawValue.utf8(rt);',
+          'jsi::String',
+        ]
+      : [
+          'const jsi::Value &rawValue',
+          'double value = (double)rawValue.asNumber();',
+          'jsi::Value',
+        ];
 
   return `
 #pragma mark - ${enumName}
@@ -338,13 +338,13 @@ enum ${enumName} { ${values} };
 
 template <>
 struct Bridging<${enumName}> {
-  static ${enumName} fromJs(jsi::Runtime &rt, ${fromValue}) {
-    ${fromValueConvertion}
-    ${fromCases}
+  static ${toValue} toJs(jsi::Runtime &rt, ${enumName} value, const std::shared_ptr<CallInvoker> &jsInvoker) {
+    ${toCases}
   }
 
-  static ${toValue} toJs(jsi::Runtime &rt, ${enumName} value) {
-    ${toCases}
+  static ${enumName} fromJs(jsi::Runtime &rt, ${fromValue}, const std::shared_ptr<CallInvoker> &jsInvoker) {
+    ${fromValueConversion}
+    ${fromCases}
   }
 };`;
 };

--- a/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleH-test.js.snap
+++ b/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleH-test.js.snap
@@ -211,24 +211,24 @@ enum SampleTurboModuleCxxNumEnum { ONE, TWO };
 
 template <>
 struct Bridging<SampleTurboModuleCxxNumEnum> {
-  static SampleTurboModuleCxxNumEnum fromJs(jsi::Runtime &rt, int32_t value) {
-    
-    if (value == 1) {
-      return SampleTurboModuleCxxNumEnum::ONE;
-    } else if (value == 2) {
-      return SampleTurboModuleCxxNumEnum::TWO;
-    } else {
-      throw jsi::JSError(rt, \\"No appropriate enum member found for value\\");
-    }
-  }
-
-  static jsi::Value toJs(jsi::Runtime &rt, SampleTurboModuleCxxNumEnum value) {
+  static jsi::Value toJs(jsi::Runtime &rt, SampleTurboModuleCxxNumEnum value, const std::shared_ptr<CallInvoker> &jsInvoker) {
     if (value == SampleTurboModuleCxxNumEnum::ONE) {
       return bridging::toJs(rt, 1);
     } else if (value == SampleTurboModuleCxxNumEnum::TWO) {
       return bridging::toJs(rt, 2);
     } else {
       throw jsi::JSError(rt, \\"No appropriate enum member found for enum value\\");
+    }
+  }
+
+  static SampleTurboModuleCxxNumEnum fromJs(jsi::Runtime &rt, const jsi::Value &rawValue, const std::shared_ptr<CallInvoker> &jsInvoker) {
+    double value = (double)rawValue.asNumber();
+    if (value == 1) {
+      return SampleTurboModuleCxxNumEnum::ONE;
+    } else if (value == 2) {
+      return SampleTurboModuleCxxNumEnum::TWO;
+    } else {
+      throw jsi::JSError(rt, \\"No appropriate enum member found for value\\");
     }
   }
 };
@@ -239,20 +239,7 @@ enum SampleTurboModuleCxxFloatEnum { POINT_ZERO, POINT_ONE, POINT_TWO };
 
 template <>
 struct Bridging<SampleTurboModuleCxxFloatEnum> {
-  static SampleTurboModuleCxxFloatEnum fromJs(jsi::Runtime &rt, float value) {
-    
-    if (value == 0.0f) {
-      return SampleTurboModuleCxxFloatEnum::POINT_ZERO;
-    } else if (value == 0.1f) {
-      return SampleTurboModuleCxxFloatEnum::POINT_ONE;
-    } else if (value == 0.2f) {
-      return SampleTurboModuleCxxFloatEnum::POINT_TWO;
-    } else {
-      throw jsi::JSError(rt, \\"No appropriate enum member found for value\\");
-    }
-  }
-
-  static jsi::Value toJs(jsi::Runtime &rt, SampleTurboModuleCxxFloatEnum value) {
+  static jsi::Value toJs(jsi::Runtime &rt, SampleTurboModuleCxxFloatEnum value, const std::shared_ptr<CallInvoker> &jsInvoker) {
     if (value == SampleTurboModuleCxxFloatEnum::POINT_ZERO) {
       return bridging::toJs(rt, 0.0f);
     } else if (value == SampleTurboModuleCxxFloatEnum::POINT_ONE) {
@@ -263,6 +250,19 @@ struct Bridging<SampleTurboModuleCxxFloatEnum> {
       throw jsi::JSError(rt, \\"No appropriate enum member found for enum value\\");
     }
   }
+
+  static SampleTurboModuleCxxFloatEnum fromJs(jsi::Runtime &rt, const jsi::Value &rawValue, const std::shared_ptr<CallInvoker> &jsInvoker) {
+    double value = (double)rawValue.asNumber();
+    if (value == 0.0f) {
+      return SampleTurboModuleCxxFloatEnum::POINT_ZERO;
+    } else if (value == 0.1f) {
+      return SampleTurboModuleCxxFloatEnum::POINT_ONE;
+    } else if (value == 0.2f) {
+      return SampleTurboModuleCxxFloatEnum::POINT_TWO;
+    } else {
+      throw jsi::JSError(rt, \\"No appropriate enum member found for value\\");
+    }
+  }
 };
 
 #pragma mark - SampleTurboModuleCxxStringEnum
@@ -271,7 +271,17 @@ enum SampleTurboModuleCxxStringEnum { HELLO, GoodBye };
 
 template <>
 struct Bridging<SampleTurboModuleCxxStringEnum> {
-  static SampleTurboModuleCxxStringEnum fromJs(jsi::Runtime &rt, const jsi::String &rawValue) {
+  static jsi::String toJs(jsi::Runtime &rt, SampleTurboModuleCxxStringEnum value, const std::shared_ptr<CallInvoker> &jsInvoker) {
+    if (value == SampleTurboModuleCxxStringEnum::HELLO) {
+      return bridging::toJs(rt, \\"hello\\");
+    } else if (value == SampleTurboModuleCxxStringEnum::GoodBye) {
+      return bridging::toJs(rt, \\"goodbye\\");
+    } else {
+      throw jsi::JSError(rt, \\"No appropriate enum member found for enum value\\");
+    }
+  }
+
+  static SampleTurboModuleCxxStringEnum fromJs(jsi::Runtime &rt, const jsi::String &rawValue, const std::shared_ptr<CallInvoker> &jsInvoker) {
     std::string value = rawValue.utf8(rt);
     if (value == \\"hello\\") {
       return SampleTurboModuleCxxStringEnum::HELLO;
@@ -279,16 +289,6 @@ struct Bridging<SampleTurboModuleCxxStringEnum> {
       return SampleTurboModuleCxxStringEnum::GoodBye;
     } else {
       throw jsi::JSError(rt, \\"No appropriate enum member found for value\\");
-    }
-  }
-
-  static jsi::String toJs(jsi::Runtime &rt, SampleTurboModuleCxxStringEnum value) {
-    if (value == SampleTurboModuleCxxStringEnum::HELLO) {
-      return bridging::toJs(rt, \\"hello\\");
-    } else if (value == SampleTurboModuleCxxStringEnum::GoodBye) {
-      return bridging::toJs(rt, \\"goodbye\\");
-    } else {
-      throw jsi::JSError(rt, \\"No appropriate enum member found for enum value\\");
     }
   }
 };
@@ -1209,24 +1209,24 @@ enum SampleTurboModuleNumEnum { ONE, TWO };
 
 template <>
 struct Bridging<SampleTurboModuleNumEnum> {
-  static SampleTurboModuleNumEnum fromJs(jsi::Runtime &rt, int32_t value) {
-    
-    if (value == 1) {
-      return SampleTurboModuleNumEnum::ONE;
-    } else if (value == 2) {
-      return SampleTurboModuleNumEnum::TWO;
-    } else {
-      throw jsi::JSError(rt, \\"No appropriate enum member found for value\\");
-    }
-  }
-
-  static jsi::Value toJs(jsi::Runtime &rt, SampleTurboModuleNumEnum value) {
+  static jsi::Value toJs(jsi::Runtime &rt, SampleTurboModuleNumEnum value, const std::shared_ptr<CallInvoker> &jsInvoker) {
     if (value == SampleTurboModuleNumEnum::ONE) {
       return bridging::toJs(rt, 1);
     } else if (value == SampleTurboModuleNumEnum::TWO) {
       return bridging::toJs(rt, 2);
     } else {
       throw jsi::JSError(rt, \\"No appropriate enum member found for enum value\\");
+    }
+  }
+
+  static SampleTurboModuleNumEnum fromJs(jsi::Runtime &rt, const jsi::Value &rawValue, const std::shared_ptr<CallInvoker> &jsInvoker) {
+    double value = (double)rawValue.asNumber();
+    if (value == 1) {
+      return SampleTurboModuleNumEnum::ONE;
+    } else if (value == 2) {
+      return SampleTurboModuleNumEnum::TWO;
+    } else {
+      throw jsi::JSError(rt, \\"No appropriate enum member found for value\\");
     }
   }
 };
@@ -1237,20 +1237,7 @@ enum SampleTurboModuleFloatEnum { POINT_ZERO, POINT_ONE, POINT_TWO };
 
 template <>
 struct Bridging<SampleTurboModuleFloatEnum> {
-  static SampleTurboModuleFloatEnum fromJs(jsi::Runtime &rt, float value) {
-    
-    if (value == 0.0f) {
-      return SampleTurboModuleFloatEnum::POINT_ZERO;
-    } else if (value == 0.1f) {
-      return SampleTurboModuleFloatEnum::POINT_ONE;
-    } else if (value == 0.2f) {
-      return SampleTurboModuleFloatEnum::POINT_TWO;
-    } else {
-      throw jsi::JSError(rt, \\"No appropriate enum member found for value\\");
-    }
-  }
-
-  static jsi::Value toJs(jsi::Runtime &rt, SampleTurboModuleFloatEnum value) {
+  static jsi::Value toJs(jsi::Runtime &rt, SampleTurboModuleFloatEnum value, const std::shared_ptr<CallInvoker> &jsInvoker) {
     if (value == SampleTurboModuleFloatEnum::POINT_ZERO) {
       return bridging::toJs(rt, 0.0f);
     } else if (value == SampleTurboModuleFloatEnum::POINT_ONE) {
@@ -1261,6 +1248,19 @@ struct Bridging<SampleTurboModuleFloatEnum> {
       throw jsi::JSError(rt, \\"No appropriate enum member found for enum value\\");
     }
   }
+
+  static SampleTurboModuleFloatEnum fromJs(jsi::Runtime &rt, const jsi::Value &rawValue, const std::shared_ptr<CallInvoker> &jsInvoker) {
+    double value = (double)rawValue.asNumber();
+    if (value == 0.0f) {
+      return SampleTurboModuleFloatEnum::POINT_ZERO;
+    } else if (value == 0.1f) {
+      return SampleTurboModuleFloatEnum::POINT_ONE;
+    } else if (value == 0.2f) {
+      return SampleTurboModuleFloatEnum::POINT_TWO;
+    } else {
+      throw jsi::JSError(rt, \\"No appropriate enum member found for value\\");
+    }
+  }
 };
 
 #pragma mark - SampleTurboModuleStringEnum
@@ -1269,7 +1269,17 @@ enum SampleTurboModuleStringEnum { HELLO, GoodBye };
 
 template <>
 struct Bridging<SampleTurboModuleStringEnum> {
-  static SampleTurboModuleStringEnum fromJs(jsi::Runtime &rt, const jsi::String &rawValue) {
+  static jsi::String toJs(jsi::Runtime &rt, SampleTurboModuleStringEnum value, const std::shared_ptr<CallInvoker> &jsInvoker) {
+    if (value == SampleTurboModuleStringEnum::HELLO) {
+      return bridging::toJs(rt, \\"hello\\");
+    } else if (value == SampleTurboModuleStringEnum::GoodBye) {
+      return bridging::toJs(rt, \\"goodbye\\");
+    } else {
+      throw jsi::JSError(rt, \\"No appropriate enum member found for enum value\\");
+    }
+  }
+
+  static SampleTurboModuleStringEnum fromJs(jsi::Runtime &rt, const jsi::String &rawValue, const std::shared_ptr<CallInvoker> &jsInvoker) {
     std::string value = rawValue.utf8(rt);
     if (value == \\"hello\\") {
       return SampleTurboModuleStringEnum::HELLO;
@@ -1277,16 +1287,6 @@ struct Bridging<SampleTurboModuleStringEnum> {
       return SampleTurboModuleStringEnum::GoodBye;
     } else {
       throw jsi::JSError(rt, \\"No appropriate enum member found for value\\");
-    }
-  }
-
-  static jsi::String toJs(jsi::Runtime &rt, SampleTurboModuleStringEnum value) {
-    if (value == SampleTurboModuleStringEnum::HELLO) {
-      return bridging::toJs(rt, \\"hello\\");
-    } else if (value == SampleTurboModuleStringEnum::GoodBye) {
-      return bridging::toJs(rt, \\"goodbye\\");
-    } else {
-      throw jsi::JSError(rt, \\"No appropriate enum member found for enum value\\");
     }
   }
 };


### PR DESCRIPTION
Summary:
[Changelog][Internal]

The PR  https://github.com/facebook/react-native/pull/36030 (diff D42884147 (https://github.com/facebook/react-native/commit/ceb1d0dea694739f357d86296b94f5834e5ee7f7)) added support for enum types in JS to C++ bridging in C++ TurboModules.

This only worked for enums as argument types for exposed methods, but not for the cases when enums are members of complex data structures that are also exposed through a codegen.

This diff fixes this problem, so that codegen now correctly works both with enum types as method arguments, but also as data structure members.

Some part of the change is the same as D42008724 (https://github.com/facebook/react-native/commit/963e45afd1c69771d1d26df8282774c948f762e3), but there are also some changes related to the types, that were required.

Differential Revision: D43292254

