### PR TITLE
fix(35639): Empty Space added when using KeyboardAvoidingView

### DIFF
--- a/Libraries/Components/Keyboard/KeyboardAvoidingView.js
+++ b/Libraries/Components/Keyboard/KeyboardAvoidingView.js
@@ -23,7 +23,7 @@ import {type EventSubscription} from '../../vendor/emitter/EventEmitter';
 import AccessibilityInfo from '../AccessibilityInfo/AccessibilityInfo';
 import View from '../View/View';
 import Keyboard from './Keyboard';
-import Dimensions from '../../Utilities/Dimensions'
+import Dimensions from '../../Utilities/Dimensions';
 import * as React from 'react';
 
 type Props = $ReadOnly<{|
@@ -101,7 +101,7 @@ class KeyboardAvoidingView extends React.Component<Props, State> {
       );
     }
 
-    const deviceY = Dimensions.get('screen').height
+    const deviceY = Dimensions.get('screen').height;
 
     // Calculate the displacement needed for the view such that it
     // no longer overlaps with the keyboard

--- a/Libraries/Components/Keyboard/KeyboardAvoidingView.js
+++ b/Libraries/Components/Keyboard/KeyboardAvoidingView.js
@@ -23,6 +23,7 @@ import {type EventSubscription} from '../../vendor/emitter/EventEmitter';
 import AccessibilityInfo from '../AccessibilityInfo/AccessibilityInfo';
 import View from '../View/View';
 import Keyboard from './Keyboard';
+import Dimensions from '../../Utilities/Dimensions'
 import * as React from 'react';
 
 type Props = $ReadOnly<{|
@@ -100,9 +101,11 @@ class KeyboardAvoidingView extends React.Component<Props, State> {
       );
     }
 
+    const deviceY = Dimensions.get('screen').height
+
     // Calculate the displacement needed for the view such that it
     // no longer overlaps with the keyboard
-    return Math.max(frame.y + frame.height - keyboardY, 0);
+    return Math.max(frame.y + deviceY - keyboardY, 0);
   }
 
   _onKeyboardChange = (event: ?KeyboardEvent) => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Fix issue [35639](https://github.com/facebook/react-native/issues/35639)

Problem was Empty Space added at the end when we use KeyboardAvoidingView with ScrollView

### before

[before](https://user-images.githubusercontent.com/104626733/207559221-db1f85b3-8411-4d7b-ae08-43957588954d.mov)

### after

[1234](https://user-images.githubusercontent.com/34812887/217223440-752a5683-78c6-4ca1-8984-08a4be7028d2.mp4)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[IOS] [FIXED] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

Update last 2 lines of _relativeKeyboardHeight located in _/node_modules/react-native/Libraries/Components/Keyboard/KeyboardAvoidingView.js_

Not using `frame.height` which changed unpredictably but using fixed device height (`DeviceY`) when calculating paddingBottom

```javascript
    const deviceY = Dimensions.get('screen').height // <-- New Line
    return Math.max(frame.y + deviceY - keyboardY, 0); // <-- Update frame.height to deviceY
```

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
