### PR TITLE
Reduce use of Java exceptions in prop parsing

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/ColorPropConverter.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/ColorPropConverter.java
@@ -12,6 +12,8 @@ import android.content.res.Resources;
 import android.util.TypedValue;
 import androidx.annotation.Nullable;
 import androidx.core.content.res.ResourcesCompat;
+import com.facebook.common.logging.FLog;
+import com.facebook.react.common.ReactConstants;
 
 public class ColorPropConverter {
   private static final String JSON_KEY = "resource_paths";
@@ -59,6 +61,15 @@ public class ColorPropConverter {
 
     throw new JSApplicationCausedNativeException(
         "ColorValue: the value must be a number or Object.");
+  }
+
+  public static Integer getColor(Object value, Context context, int defaultInt) {
+    try {
+      return getColor(value, context);
+    } catch (JSApplicationCausedNativeException e) {
+      FLog.w(ReactConstants.TAG, e, "Error converting ColorValue");
+      return defaultInt;
+    }
   }
 
   public static Integer resolveResourcePath(Context context, @Nullable String resourcePath) {

--- a/ReactAndroid/src/main/java/com/facebook/react/processing/ReactPropertyProcessor.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/processing/ReactPropertyProcessor.java
@@ -363,11 +363,15 @@ public class ReactPropertyProcessor extends AbstractProcessor {
       ClassInfo classInfo, PropertyInfo info, CodeBlock.Builder builder) {
     TypeName propertyType = info.propertyType;
     if (propertyType.equals(STRING_TYPE)) {
-      return builder.add("($L)value", STRING_TYPE);
+      return builder.add("value instanceof $L ? ($L)value : null", STRING_TYPE, STRING_TYPE);
     } else if (propertyType.equals(READABLE_ARRAY_TYPE)) {
-      return builder.add("($L)value", READABLE_ARRAY_TYPE); // TODO: use real type but needs import
+      return builder.add(
+          "value instanceof $L ? ($L)value : null",
+          READABLE_ARRAY_TYPE,
+          READABLE_ARRAY_TYPE); // TODO: use real type but needs import
     } else if (propertyType.equals(READABLE_MAP_TYPE)) {
-      return builder.add("($L)value", READABLE_MAP_TYPE);
+      return builder.add(
+          "value instanceof $L ? ($L)value : null", READABLE_MAP_TYPE, READABLE_MAP_TYPE);
     } else if (propertyType.equals(DYNAMIC_TYPE)) {
       return builder.add("new $L(value)", DYNAMIC_FROM_OBJECT_TYPE);
     } else if (propertyType.equals(YOGA_VALUE_TYPE)) {
@@ -380,40 +384,46 @@ public class ReactPropertyProcessor extends AbstractProcessor {
     }
 
     if (propertyType.equals(TypeName.BOOLEAN)) {
-      return builder.add("value == null ? $L : (boolean) value", info.mProperty.defaultBoolean());
+      return builder.add(
+          "!(value instanceof Boolean) ? $L : (boolean)value", info.mProperty.defaultBoolean());
     }
     if (propertyType.equals(TypeName.DOUBLE)) {
       double defaultDouble = info.mProperty.defaultDouble();
       if (Double.isNaN(defaultDouble)) {
-        return builder.add("value == null ? $T.NaN : (double) value", Double.class);
+        return builder.add("!(value instanceof Double) ? $T.NaN : (double)value", Double.class);
       } else {
-        return builder.add("value == null ? $Lf : (double) value", defaultDouble);
+        return builder.add("!(value instanceof Double) ? $Lf : (double)value", defaultDouble);
       }
     }
     if (propertyType.equals(TypeName.FLOAT)) {
       float defaultFloat = info.mProperty.defaultFloat();
       if (Float.isNaN(defaultFloat)) {
-        return builder.add("value == null ? $T.NaN : ((Double)value).floatValue()", Float.class);
+        return builder.add(
+            "!(value instanceof Double) ? $T.NaN : ((Double)value).floatValue()", Float.class);
       } else {
-        return builder.add("value == null ? $Lf : ((Double)value).floatValue()", defaultFloat);
+        return builder.add(
+            "!(value instanceof Double) ? $Lf : ((Double)value).floatValue()", defaultFloat);
       }
     }
     if ("Color".equals(info.mProperty.customType())) {
       switch (classInfo.getType()) {
         case VIEW_MANAGER:
           return builder.add(
-              "value == null ? $L : $T.getColor(value, view.getContext())",
+              "value == null ? $L : $T.getColor(value, view.getContext(), $L)",
               info.mProperty.defaultInt(),
-              com.facebook.react.bridge.ColorPropConverter.class);
+              com.facebook.react.bridge.ColorPropConverter.class,
+              info.mProperty.defaultInt());
         case SHADOW_NODE:
           return builder.add(
-              "value == null ? $L : $T.getColor(value, node.getThemedContext())",
+              "value == null ? $L : $T.getColor(value, node.getThemedContext(), $L)",
               info.mProperty.defaultInt(),
-              com.facebook.react.bridge.ColorPropConverter.class);
+              com.facebook.react.bridge.ColorPropConverter.class,
+              info.mProperty.defaultInt());
       }
     } else if (propertyType.equals(TypeName.INT)) {
       return builder.add(
-          "value == null ? $L : ((Double)value).intValue()", info.mProperty.defaultInt());
+          "!(value instanceof Double) ? $L : ((Double)value).intValue()",
+          info.mProperty.defaultInt());
     }
 
     throw new IllegalArgumentException();

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/LayoutShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/LayoutShadowNode.java
@@ -8,9 +8,10 @@
 package com.facebook.react.uimanager;
 
 import androidx.annotation.Nullable;
+import com.facebook.common.logging.FLog;
 import com.facebook.react.bridge.Dynamic;
-import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
 import com.facebook.react.bridge.ReadableType;
+import com.facebook.react.common.ReactConstants;
 import com.facebook.react.modules.i18nmanager.I18nUtil;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.annotations.ReactPropGroup;
@@ -60,11 +61,14 @@ public class LayoutShadowNode extends ReactShadowNodeImpl {
           unit = YogaUnit.PERCENT;
           value = Float.parseFloat(s.substring(0, s.length() - 1));
         } else {
-          throw new IllegalArgumentException("Unknown value: " + s);
+          FLog.w(ReactConstants.TAG, "Unknown value: " + s);
         }
-      } else {
+      } else if (dynamic.getType() == ReadableType.Number) {
         unit = YogaUnit.POINT;
         value = PixelUtil.toPixelFromDIP(dynamic.asDouble());
+      } else {
+        unit = YogaUnit.UNDEFINED;
+        value = YogaConstants.UNDEFINED;
       }
     }
   }
@@ -318,8 +322,9 @@ public class LayoutShadowNode extends ReactShadowNodeImpl {
         }
       default:
         {
-          throw new JSApplicationIllegalArgumentException(
-              "invalid value for flexDirection: " + flexDirection);
+          FLog.w(ReactConstants.TAG, "invalid value for flexDirection: " + flexDirection);
+          setFlexDirection(YogaFlexDirection.COLUMN);
+          break;
         }
     }
   }
@@ -353,8 +358,9 @@ public class LayoutShadowNode extends ReactShadowNodeImpl {
         }
       default:
         {
-          throw new JSApplicationIllegalArgumentException(
-              "invalid value for flexWrap: " + flexWrap);
+          FLog.w(ReactConstants.TAG, "invalid value for flexWrap: " + flexWrap);
+          setFlexWrap(YogaWrap.NO_WRAP);
+          break;
         }
     }
   }
@@ -413,8 +419,9 @@ public class LayoutShadowNode extends ReactShadowNodeImpl {
         }
       default:
         {
-          throw new JSApplicationIllegalArgumentException(
-              "invalid value for alignSelf: " + alignSelf);
+          FLog.w(ReactConstants.TAG, "invalid value for alignSelf: " + alignSelf);
+          setAlignSelf(YogaAlign.AUTO);
+          return;
         }
     }
   }
@@ -473,8 +480,9 @@ public class LayoutShadowNode extends ReactShadowNodeImpl {
         }
       default:
         {
-          throw new JSApplicationIllegalArgumentException(
-              "invalid value for alignItems: " + alignItems);
+          FLog.w(ReactConstants.TAG, "invalid value for alignItems: " + alignItems);
+          setAlignItems(YogaAlign.STRETCH);
+          return;
         }
     }
   }
@@ -533,8 +541,9 @@ public class LayoutShadowNode extends ReactShadowNodeImpl {
         }
       default:
         {
-          throw new JSApplicationIllegalArgumentException(
-              "invalid value for alignContent: " + alignContent);
+          FLog.w(ReactConstants.TAG, "invalid value for alignContent: " + alignContent);
+          setAlignContent(YogaAlign.FLEX_START);
+          return;
         }
     }
   }
@@ -583,8 +592,9 @@ public class LayoutShadowNode extends ReactShadowNodeImpl {
         }
       default:
         {
-          throw new JSApplicationIllegalArgumentException(
-              "invalid value for justifyContent: " + justifyContent);
+          FLog.w(ReactConstants.TAG, "invalid value for justifyContent: " + justifyContent);
+          setJustifyContent(YogaJustify.FLEX_START);
+          break;
         }
     }
   }
@@ -617,8 +627,9 @@ public class LayoutShadowNode extends ReactShadowNodeImpl {
         }
       default:
         {
-          throw new JSApplicationIllegalArgumentException(
-              "invalid value for overflow: " + overflow);
+          FLog.w(ReactConstants.TAG, "invalid value for overflow: " + overflow);
+          setOverflow(YogaOverflow.VISIBLE);
+          break;
         }
     }
   }
@@ -647,7 +658,9 @@ public class LayoutShadowNode extends ReactShadowNodeImpl {
         }
       default:
         {
-          throw new JSApplicationIllegalArgumentException("invalid value for display: " + display);
+          FLog.w(ReactConstants.TAG, "invalid value for display: " + display);
+          setDisplay(YogaDisplay.FLEX);
+          break;
         }
     }
   }
@@ -820,8 +833,9 @@ public class LayoutShadowNode extends ReactShadowNodeImpl {
         }
       default:
         {
-          throw new JSApplicationIllegalArgumentException(
-              "invalid value for position: " + position);
+          FLog.w(ReactConstants.TAG, "invalid value for position: " + position);
+          setPositionType(YogaPositionType.RELATIVE);
+          break;
         }
     }
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/TouchTargetHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/TouchTargetHelper.java
@@ -17,8 +17,9 @@ import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import androidx.annotation.Nullable;
-import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
+import com.facebook.common.logging.FLog;
 import com.facebook.react.bridge.UiThreadUtil;
+import com.facebook.react.common.ReactConstants;
 import com.facebook.react.touch.ReactHitSlopView;
 import com.facebook.react.uimanager.common.ViewUtil;
 import java.util.ArrayList;
@@ -366,7 +367,10 @@ public class TouchTargetHelper {
 
       return null;
 
-    } else if (pointerEvents == PointerEvents.AUTO) {
+    } else {
+      if (pointerEvents != PointerEvents.AUTO) {
+        FLog.w(ReactConstants.TAG, "Unknown pointer event type: " + pointerEvents.toString());
+      }
       // Either this view or one of its children is the target
       if (view instanceof ReactCompoundViewGroup
           && isTouchPointInView(eventCoords[0], eventCoords[1], view)
@@ -387,10 +391,6 @@ public class TouchTargetHelper {
         pathAccumulator.add(new ViewTarget(view.getId(), view));
       }
       return result;
-
-    } else {
-      throw new JSApplicationIllegalArgumentException(
-          "Unknown pointer event type: " + pointerEvents.toString());
     }
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/TransformHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/TransformHelper.java
@@ -7,10 +7,11 @@
 
 package com.facebook.react.uimanager;
 
-import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
+import com.facebook.common.logging.FLog;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableType;
+import com.facebook.react.common.ReactConstants;
 
 /**
  * Class providing helper methods for converting transformation list (as accepted by 'transform'
@@ -100,8 +101,7 @@ public class TransformHelper {
       } else if ("skewY".equals(transformType)) {
         MatrixMathHelper.applySkewY(helperMatrix, convertToRadians(transform, transformType));
       } else {
-        throw new JSApplicationIllegalArgumentException(
-            "Unsupported transform type: " + transformType);
+        FLog.w(ReactConstants.TAG, "Unsupported transform type: " + transformType);
       }
 
       MatrixMathHelper.multiplyInto(result, result, helperMatrix);

--- a/ReactAndroid/src/main/java/com/facebook/react/views/drawer/ReactDrawerLayoutManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/drawer/ReactDrawerLayoutManager.java
@@ -12,11 +12,13 @@ import android.view.View;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.drawerlayout.widget.DrawerLayout;
+import com.facebook.common.logging.FLog;
 import com.facebook.react.bridge.Dynamic;
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableType;
 import com.facebook.react.common.MapBuilder;
+import com.facebook.react.common.ReactConstants;
 import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.ThemedReactContext;
@@ -90,13 +92,14 @@ public class ReactDrawerLayoutManager extends ViewGroupManager<ReactDrawerLayout
       if (Gravity.START == drawerPositionNum || Gravity.END == drawerPositionNum) {
         view.setDrawerPosition(drawerPositionNum);
       } else {
-        throw new JSApplicationIllegalArgumentException(
-            "Unknown drawerPosition " + drawerPositionNum);
+        FLog.w(ReactConstants.TAG, "Unknown drawerPosition " + drawerPositionNum);
+        view.setDrawerPosition(Gravity.START);
       }
     } else if (drawerPosition.getType() == ReadableType.String) {
       setDrawerPositionInternal(view, drawerPosition.asString());
     } else {
-      throw new JSApplicationIllegalArgumentException("drawerPosition must be a string or int");
+      FLog.w(ReactConstants.TAG, "drawerPosition must be a string or int");
+      view.setDrawerPosition(Gravity.START);
     }
   }
 
@@ -106,8 +109,10 @@ public class ReactDrawerLayoutManager extends ViewGroupManager<ReactDrawerLayout
     } else if (drawerPosition.equals("right")) {
       view.setDrawerPosition(Gravity.END);
     } else {
-      throw new JSApplicationIllegalArgumentException(
+      FLog.w(
+          ReactConstants.TAG,
           "drawerPosition must be 'left' or 'right', received" + drawerPosition);
+      view.setDrawerPosition(Gravity.START);
     }
   }
 
@@ -139,7 +144,8 @@ public class ReactDrawerLayoutManager extends ViewGroupManager<ReactDrawerLayout
     } else if ("locked-open".equals(drawerLockMode)) {
       view.setDrawerLockMode(DrawerLayout.LOCK_MODE_LOCKED_OPEN);
     } else {
-      throw new JSApplicationIllegalArgumentException("Unknown drawerLockMode " + drawerLockMode);
+      FLog.w(ReactConstants.TAG, "Unknown drawerLockMode " + drawerLockMode);
+      view.setDrawerLockMode(DrawerLayout.LOCK_MODE_UNLOCKED);
     }
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/image/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/image/BUCK
@@ -41,6 +41,7 @@ rn_android_library(
     ],
     deps = [
         YOGA_TARGET,
+        react_native_dep("libraries/fbcore/src/main/java/com/facebook/common/logging:logging"),
         react_native_dep("libraries/fresco/fresco-react-native:fbcore"),
         react_native_dep("libraries/fresco/fresco-react-native:fresco-drawee"),
         react_native_dep("libraries/fresco/fresco-react-native:fresco-react-native"),

--- a/ReactAndroid/src/main/java/com/facebook/react/views/image/ImageResizeMode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/image/ImageResizeMode.java
@@ -9,8 +9,9 @@ package com.facebook.react.views.image;
 
 import android.graphics.Shader;
 import androidx.annotation.Nullable;
+import com.facebook.common.logging.FLog;
 import com.facebook.drawee.drawable.ScalingUtils;
-import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
+import com.facebook.react.common.ReactConstants;
 
 /** Converts JS resize modes into Android-specific scale type. */
 public class ImageResizeMode {
@@ -41,12 +42,11 @@ public class ImageResizeMode {
       // Handled via a combination of ScaleType and TileMode
       return ScaleTypeStartInside.INSTANCE;
     }
-    if (resizeModeValue == null) {
-      // Use the default. Never use null.
-      return defaultValue();
+    if (resizeModeValue != null) {
+      FLog.w(ReactConstants.TAG, "Invalid resize mode: '" + resizeModeValue + "'");
     }
-    throw new JSApplicationIllegalArgumentException(
-        "Invalid resize mode: '" + resizeModeValue + "'");
+    // Use the default. Never use null.
+    return defaultValue();
   }
 
   /** Converts JS resize modes into {@code Shader.TileMode}. See {@code ImageResizeMode.js}. */
@@ -61,12 +61,11 @@ public class ImageResizeMode {
       // Handled via a combination of ScaleType and TileMode
       return Shader.TileMode.REPEAT;
     }
-    if (resizeModeValue == null) {
-      // Use the default. Never use null.
-      return defaultTileMode();
+    if (resizeModeValue != null) {
+      FLog.w(ReactConstants.TAG, "Invalid resize mode: '" + resizeModeValue + "'");
     }
-    throw new JSApplicationIllegalArgumentException(
-        "Invalid resize mode: '" + resizeModeValue + "'");
+    // Use the default. Never use null.
+    return defaultTileMode();
   }
 
   /** This is the default as per web and iOS. We want to be consistent across platforms. */

--- a/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageManager.java
@@ -10,12 +10,13 @@ package com.facebook.react.views.image;
 import android.graphics.Color;
 import android.graphics.PorterDuff.Mode;
 import androidx.annotation.Nullable;
+import com.facebook.common.logging.FLog;
 import com.facebook.drawee.backends.pipeline.Fresco;
 import com.facebook.drawee.controller.AbstractDraweeControllerBuilder;
-import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.common.MapBuilder;
+import com.facebook.react.common.ReactConstants;
 import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.SimpleViewManager;
@@ -210,8 +211,8 @@ public class ReactImageManager extends SimpleViewManager<ReactImageView> {
     } else if ("scale".equals(resizeMethod)) {
       view.setResizeMethod(ImageResizeMethod.SCALE);
     } else {
-      throw new JSApplicationIllegalArgumentException(
-          "Invalid resize method: '" + resizeMethod + "'");
+      view.setResizeMethod(ImageResizeMethod.AUTO);
+      FLog.w(ReactConstants.TAG, "Invalid resize method: '" + resizeMethod + "'");
     }
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/progressbar/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/progressbar/BUCK
@@ -13,6 +13,7 @@ rn_android_library(
     ],
     deps = [
         YOGA_TARGET,
+        react_native_dep("libraries/fbcore/src/main/java/com/facebook/common/logging:logging"),
         react_native_dep("third-party/android/androidx:annotation"),
         react_native_dep("third-party/java/infer-annotations:infer-annotations"),
         react_native_dep("third-party/java/jsr-305:jsr-305"),

--- a/ReactAndroid/src/main/java/com/facebook/react/views/progressbar/ReactProgressBarViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/progressbar/ReactProgressBarViewManager.java
@@ -13,8 +13,9 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ProgressBar;
 import androidx.annotation.Nullable;
-import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
+import com.facebook.common.logging.FLog;
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.common.ReactConstants;
 import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.PixelUtil;
@@ -146,8 +147,8 @@ public class ReactProgressBarViewManager
 
   /* package */ static int getStyleFromString(@Nullable String styleStr) {
     if (styleStr == null) {
-      throw new JSApplicationIllegalArgumentException(
-          "ProgressBar needs to have a style, null received");
+      FLog.w(ReactConstants.TAG, "ProgressBar needs to have a style, null received");
+      return android.R.attr.progressBarStyle;
     } else if (styleStr.equals("Horizontal")) {
       return android.R.attr.progressBarStyleHorizontal;
     } else if (styleStr.equals("Small")) {
@@ -163,7 +164,8 @@ public class ReactProgressBarViewManager
     } else if (styleStr.equals("Normal")) {
       return android.R.attr.progressBarStyle;
     } else {
-      throw new JSApplicationIllegalArgumentException("Unknown ProgressBar style: " + styleStr);
+      FLog.w(ReactConstants.TAG, "Unknown ProgressBar style: " + styleStr);
+      return android.R.attr.progressBarStyle;
     }
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.java
@@ -17,10 +17,10 @@ import android.widget.OverScroller;
 import androidx.annotation.Nullable;
 import androidx.core.view.ViewCompat;
 import com.facebook.common.logging.FLog;
-import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableNativeMap;
+import com.facebook.react.common.ReactConstants;
 import com.facebook.react.common.build.ReactBuildConfig;
 import com.facebook.react.uimanager.FabricViewStateManager;
 import com.facebook.react.uimanager.PixelUtil;
@@ -153,7 +153,8 @@ public class ReactScrollViewHelper {
     } else if (jsOverScrollMode.equals(OVER_SCROLL_NEVER)) {
       return View.OVER_SCROLL_NEVER;
     } else {
-      throw new JSApplicationIllegalArgumentException("wrong overScrollMode: " + jsOverScrollMode);
+      FLog.w(ReactConstants.TAG, "wrong overScrollMode: " + jsOverScrollMode);
+      return View.OVER_SCROLL_IF_CONTENT_SCROLLS;
     }
   }
 
@@ -167,7 +168,8 @@ public class ReactScrollViewHelper {
     } else if ("end".equals(alignment)) {
       return SNAP_ALIGNMENT_END;
     } else {
-      throw new JSApplicationIllegalArgumentException("wrong snap alignment value: " + alignment);
+      FLog.w(ReactConstants.TAG, "wrong snap alignment value: " + alignment);
+      return SNAP_ALIGNMENT_DISABLED;
     }
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactBaseTextShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactBaseTextShadowNode.java
@@ -17,10 +17,11 @@ import android.text.SpannableStringBuilder;
 import android.text.TextUtils;
 import android.view.Gravity;
 import androidx.annotation.Nullable;
+import com.facebook.common.logging.FLog;
 import com.facebook.infer.annotation.Assertions;
-import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.common.ReactConstants;
 import com.facebook.react.uimanager.IllegalViewOperationException;
 import com.facebook.react.uimanager.LayoutShadowNode;
 import com.facebook.react.uimanager.NativeViewHierarchyOptimizer;
@@ -460,7 +461,8 @@ public abstract class ReactBaseTextShadowNode extends LayoutShadowNode {
       } else if ("center".equals(textAlign)) {
         mTextAlign = Gravity.CENTER_HORIZONTAL;
       } else {
-        throw new JSApplicationIllegalArgumentException("Invalid textAlign: " + textAlign);
+        FLog.w(ReactConstants.TAG, "Invalid textAlign: " + textAlign);
+        mTextAlign = Gravity.NO_GRAVITY;
       }
     }
     markUpdated();
@@ -572,8 +574,8 @@ public abstract class ReactBaseTextShadowNode extends LayoutShadowNode {
     } else if ("balanced".equals(textBreakStrategy)) {
       mTextBreakStrategy = Layout.BREAK_STRATEGY_BALANCED;
     } else {
-      throw new JSApplicationIllegalArgumentException(
-          "Invalid textBreakStrategy: " + textBreakStrategy);
+      FLog.w(ReactConstants.TAG, "Invalid textBreakStrategy: " + textBreakStrategy);
+      mTextBreakStrategy = Layout.BREAK_STRATEGY_HIGH_QUALITY;
     }
 
     markUpdated();
@@ -629,7 +631,8 @@ public abstract class ReactBaseTextShadowNode extends LayoutShadowNode {
     } else if ("capitalize".equals(textTransform)) {
       mTextAttributes.setTextTransform(TextTransform.CAPITALIZE);
     } else {
-      throw new JSApplicationIllegalArgumentException("Invalid textTransform: " + textTransform);
+      FLog.w(ReactConstants.TAG, "Invalid textTransform: " + textTransform);
+      mTextAttributes.setTextTransform(TextTransform.UNSET);
     }
     markUpdated();
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextAnchorViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextAnchorViewManager.java
@@ -16,7 +16,7 @@ import android.view.Gravity;
 import android.view.View;
 import androidx.annotation.Nullable;
 import com.facebook.common.logging.FLog;
-import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
+import com.facebook.react.common.ReactConstants;
 import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.Spacing;
@@ -65,7 +65,8 @@ public abstract class ReactTextAnchorViewManager<T extends View, C extends React
     } else if (ellipsizeMode.equals("clip")) {
       view.setEllipsizeLocation(null);
     } else {
-      throw new JSApplicationIllegalArgumentException("Invalid ellipsizeMode: " + ellipsizeMode);
+      FLog.w(ReactConstants.TAG, "Invalid ellipsizeMode: " + ellipsizeMode);
+      view.setEllipsizeLocation(TextUtils.TruncateAt.END);
     }
   }
 
@@ -85,8 +86,8 @@ public abstract class ReactTextAnchorViewManager<T extends View, C extends React
     } else if ("center".equals(textAlignVertical)) {
       view.setGravityVertical(Gravity.CENTER_VERTICAL);
     } else {
-      throw new JSApplicationIllegalArgumentException(
-          "Invalid textAlignVertical: " + textAlignVertical);
+      FLog.w(ReactConstants.TAG, "Invalid textAlignVertical: " + textAlignVertical);
+      view.setGravityVertical(Gravity.NO_GRAVITY);
     }
   }
 
@@ -118,8 +119,8 @@ public abstract class ReactTextAnchorViewManager<T extends View, C extends React
     } else if (frequency.equals("normal")) {
       view.setHyphenationFrequency(Layout.HYPHENATION_FREQUENCY_NORMAL);
     } else {
-      throw new JSApplicationIllegalArgumentException(
-          "Invalid android_hyphenationFrequency: " + frequency);
+      FLog.w(ReactConstants.TAG, "Invalid android_hyphenationFrequency: " + frequency);
+      view.setHyphenationFrequency(Layout.HYPHENATION_FREQUENCY_NONE);
     }
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/TextAttributeProps.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/TextAttributeProps.java
@@ -13,9 +13,10 @@ import android.text.TextUtils;
 import android.util.LayoutDirection;
 import android.view.Gravity;
 import androidx.annotation.Nullable;
-import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
+import com.facebook.common.logging.FLog;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.common.ReactConstants;
 import com.facebook.react.common.mapbuffer.MapBuffer;
 import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.ReactAccessibilityDelegate;
@@ -267,7 +268,8 @@ public class TextAttributeProps {
       } else if ("center".equals(textAlignPropValue)) {
         textAlignment = Gravity.CENTER_HORIZONTAL;
       } else {
-        throw new JSApplicationIllegalArgumentException("Invalid textAlign: " + textAlignPropValue);
+        FLog.w(ReactConstants.TAG, "Invalid textAlign: " + textAlignPropValue);
+        textAlignment = Gravity.NO_GRAVITY;
       }
     }
     return textAlignment;
@@ -563,8 +565,8 @@ public class TextAttributeProps {
     } else if ("ltr".equals(layoutDirection)) {
       androidLayoutDirection = LayoutDirection.LTR;
     } else {
-      throw new JSApplicationIllegalArgumentException(
-          "Invalid layoutDirection: " + layoutDirection);
+      FLog.w(ReactConstants.TAG, "Invalid layoutDirection: " + layoutDirection);
+      androidLayoutDirection = UNSET;
     }
     return androidLayoutDirection;
   }
@@ -595,7 +597,8 @@ public class TextAttributeProps {
     } else if ("capitalize".equals(textTransform)) {
       mTextTransform = TextTransform.CAPITALIZE;
     } else {
-      throw new JSApplicationIllegalArgumentException("Invalid textTransform: " + textTransform);
+      FLog.w(ReactConstants.TAG, "Invalid textTransform: " + textTransform);
+      mTextTransform = TextTransform.NONE;
     }
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/TextAttributes.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/TextAttributes.java
@@ -7,7 +7,8 @@
 
 package com.facebook.react.views.text;
 
-import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
+import com.facebook.common.logging.FLog;
+import com.facebook.react.common.ReactConstants;
 import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.ViewDefaults;
 
@@ -98,8 +99,9 @@ public class TextAttributes {
 
   public void setMaxFontSizeMultiplier(float maxFontSizeMultiplier) {
     if (maxFontSizeMultiplier != 0 && maxFontSizeMultiplier < 1) {
-      throw new JSApplicationIllegalArgumentException(
-          "maxFontSizeMultiplier must be NaN, 0, or >= 1");
+      FLog.w(ReactConstants.TAG, "maxFontSizeMultiplier must be NaN, 0, or >= 1");
+      mMaxFontSizeMultiplier = Float.NaN;
+      return;
     }
     mMaxFontSizeMultiplier = maxFontSizeMultiplier;
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/frescosupport/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/frescosupport/BUCK
@@ -14,6 +14,7 @@ rn_android_library(
     deps = [
         YOGA_TARGET,
         react_native_dep("third-party/android/androidx:annotation"),
+        react_native_dep("libraries/fbcore/src/main/java/com/facebook/common/logging:logging"),
         react_native_dep("libraries/fresco/fresco-react-native:fbcore"),
         react_native_dep("libraries/fresco/fresco-react-native:fresco-drawee"),
         react_native_dep("libraries/fresco/fresco-react-native:fresco-react-native"),

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/frescosupport/FrescoBasedReactTextInlineImageShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/frescosupport/FrescoBasedReactTextInlineImageShadowNode.java
@@ -11,13 +11,14 @@ import android.content.Context;
 import android.content.res.Resources;
 import android.net.Uri;
 import androidx.annotation.Nullable;
+import com.facebook.common.logging.FLog;
 import com.facebook.common.util.UriUtil;
 import com.facebook.drawee.controller.AbstractDraweeControllerBuilder;
 import com.facebook.react.bridge.Dynamic;
-import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableType;
+import com.facebook.react.common.ReactConstants;
 import com.facebook.react.uimanager.ViewProps;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.views.text.ReactTextInlineImageShadowNode;
@@ -84,8 +85,8 @@ public class FrescoBasedReactTextInlineImageShadowNode extends ReactTextInlineIm
     if (width.getType() == ReadableType.Number) {
       mWidth = (float) width.asDouble();
     } else {
-      throw new JSApplicationIllegalArgumentException(
-          "Inline images must not have percentage based width");
+      FLog.w(ReactConstants.TAG, "Inline images must not have percentage based width");
+      mWidth = YogaConstants.UNDEFINED;
     }
   }
 
@@ -94,8 +95,8 @@ public class FrescoBasedReactTextInlineImageShadowNode extends ReactTextInlineIm
     if (height.getType() == ReadableType.Number) {
       mHeight = (float) height.asDouble();
     } else {
-      throw new JSApplicationIllegalArgumentException(
-          "Inline images must not have percentage based height");
+      FLog.w(ReactConstants.TAG, "Inline images must not have percentage based height");
+      mHeight = YogaConstants.UNDEFINED;
     }
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -35,7 +35,6 @@ import androidx.core.content.ContextCompat;
 import com.facebook.common.logging.FLog;
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.bridge.Dynamic;
-import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReactSoftExceptionLogger;
 import com.facebook.react.bridge.ReadableArray;
@@ -45,6 +44,7 @@ import com.facebook.react.bridge.ReadableType;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableNativeMap;
 import com.facebook.react.common.MapBuilder;
+import com.facebook.react.common.ReactConstants;
 import com.facebook.react.common.mapbuffer.MapBuffer;
 import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.uimanager.BaseViewManager;
@@ -691,7 +691,8 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
       } else if ("center".equals(textAlign)) {
         view.setGravityHorizontal(Gravity.CENTER_HORIZONTAL);
       } else {
-        throw new JSApplicationIllegalArgumentException("Invalid textAlign: " + textAlign);
+        FLog.w(ReactConstants.TAG, "Invalid textAlign: " + textAlign);
+        view.setGravityHorizontal(Gravity.NO_GRAVITY);
       }
     }
   }
@@ -707,8 +708,8 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
     } else if ("center".equals(textAlignVertical)) {
       view.setGravityVertical(Gravity.CENTER_VERTICAL);
     } else {
-      throw new JSApplicationIllegalArgumentException(
-          "Invalid textAlignVertical: " + textAlignVertical);
+      FLog.w(ReactConstants.TAG, "Invalid textAlignVertical: " + textAlignVertical);
+      view.setGravityVertical(Gravity.NO_GRAVITY);
     }
   }
 
@@ -784,7 +785,8 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
     } else if (REACT_PROPS_AUTOFILL_HINTS_MAP.containsKey(autoComplete)) {
       setAutofillHints(view, REACT_PROPS_AUTOFILL_HINTS_MAP.get(autoComplete));
     } else {
-      throw new JSApplicationIllegalArgumentException("Invalid autoComplete: " + autoComplete);
+      FLog.w(ReactConstants.TAG, "Invalid autoComplete: " + autoComplete);
+      setImportantForAutofill(view, View.IMPORTANT_FOR_AUTOFILL_NO);
     }
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputShadowNode.java
@@ -15,9 +15,10 @@ import android.view.ViewGroup;
 import android.widget.EditText;
 import androidx.annotation.Nullable;
 import androidx.core.view.ViewCompat;
+import com.facebook.common.logging.FLog;
 import com.facebook.infer.annotation.Assertions;
-import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.common.ReactConstants;
 import com.facebook.react.common.annotations.VisibleForTesting;
 import com.facebook.react.uimanager.Spacing;
 import com.facebook.react.uimanager.ThemedReactContext;
@@ -218,8 +219,8 @@ public class ReactTextInputShadowNode extends ReactBaseTextShadowNode
     } else if ("balanced".equals(textBreakStrategy)) {
       mTextBreakStrategy = Layout.BREAK_STRATEGY_BALANCED;
     } else {
-      throw new JSApplicationIllegalArgumentException(
-          "Invalid textBreakStrategy: " + textBreakStrategy);
+      FLog.w(ReactConstants.TAG, "Invalid textBreakStrategy: " + textBreakStrategy);
+      mTextBreakStrategy = Layout.BREAK_STRATEGY_SIMPLE;
     }
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
@@ -13,12 +13,14 @@ import android.os.Build;
 import android.view.View;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import com.facebook.common.logging.FLog;
 import com.facebook.react.bridge.Dynamic;
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.common.MapBuilder;
+import com.facebook.react.common.ReactConstants;
 import com.facebook.react.common.annotations.VisibleForTesting;
 import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.uimanager.PixelUtil;
@@ -152,9 +154,6 @@ public class ReactViewManager extends ReactClippingViewManager<ReactViewGroup> {
   @ReactProp(name = "hitSlop")
   public void setHitSlop(final ReactViewGroup view, Dynamic hitSlop) {
     switch (hitSlop.getType()) {
-      case Null:
-        view.setHitSlopRect(null);
-        break;
       case Map:
         ReadableMap hitSlopMap = hitSlop.asMap();
         view.setHitSlopRect(
@@ -177,8 +176,11 @@ public class ReactViewManager extends ReactClippingViewManager<ReactViewGroup> {
         view.setHitSlopRect(new Rect(hitSlopValue, hitSlopValue, hitSlopValue, hitSlopValue));
         break;
       default:
-        throw new JSApplicationIllegalArgumentException(
-            "Invalid type for 'hitSlop' value " + hitSlop.getType());
+        FLog.w(ReactConstants.TAG, "Invalid type for 'hitSlop' value " + hitSlop.getType());
+        /* falls through */
+      case Null:
+        view.setHitSlopRect(null);
+        break;
     }
   }
 

--- a/ReactAndroid/src/test/java/com/facebook/react/views/image/ReactImagePropertyTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/views/image/ReactImagePropertyTest.java
@@ -101,13 +101,6 @@ public class ReactImagePropertyTest {
     return new ReactStylesDiffMap(JavaOnlyMap.of(keysAndValues));
   }
 
-  @Test(expected = JSApplicationIllegalArgumentException.class)
-  public void testImageInvalidResizeMode() {
-    ReactImageManager viewManager = new ReactImageManager();
-    ReactImageView view = viewManager.createViewInstance(mThemeContext);
-    viewManager.updateProperties(view, buildStyles("resizeMode", "pancakes"));
-  }
-
   @Test
   public void testBorderColor() {
     ReactImageManager viewManager = new ReactImageManager();


### PR DESCRIPTION
Summary:
Changelog:
[Android][Fixed] - Invalid prop values no longer trigger Java exceptions in the legacy renderer

## Context

We are changing React Native to behave more like a browser in the sense that **bad style values are not runtime errors**. (See e.g. D43159284 (https://github.com/facebook/react-native/commit/d6e9891577c81503407adaa85db8f5bf97557db0), D43184380.) The recommended way for developers to ensure they are passing correct style values is to use a typechecker (TypeScript or Flow) in conjunction with E2E tests and manual spot checks.

## This diff

This change is similar to D43184380, but here we target the legacy renderer on Android by (1) replacing exceptions with logging calls, (2) adding fallback values (equivalent to resetting the respective props to `null`) where needed, and (3) replacing `null` checks in `ReactProp` converters with `instanceof` checks.

Leaving the logging call sites in place (as opposed to deleting them) will be helpful if we decide that we want to repurpose these checks for a new, more visible diagnostic (though we would likely only build such a diagnostic in Fabric at this point).

Differential Revision: D43274525

