### PR TITLE
Reduce use of RCTLogError (redbox) in prop parsing

### DIFF
--- a/React/Base/RCTConvert.h
+++ b/React/Base/RCTConvert.h
@@ -173,7 +173,7 @@ RCT_EXTERN NSArray *RCTConvertArrayValue(SEL, id);
  * avoid repeating the same boilerplate for every error message.
  */
 #define RCTLogConvertError(json, typeName) \
-  RCTLogError(@"JSON value '%@' of type %@ cannot be converted to %@", json, [json classForCoder], typeName)
+  RCTLogInfo(@"JSON value '%@' of type %@ cannot be converted to %@", json, [json classForCoder], typeName)
 
 /**
  * This macro is used for creating simple converter functions that just call

--- a/React/Base/RCTConvert.m
+++ b/React/Base/RCTConvert.m
@@ -69,7 +69,7 @@ RCT_CUSTOM_CONVERTER(NSData *, NSData, [json dataUsingEncoding:NSUTF8StringEncod
   for (NSNumber *number in json) {
     NSInteger index = number.integerValue;
     if (RCT_DEBUG && index < 0) {
-      RCTLogError(@"Invalid index value %lld. Indices must be positive.", (long long)index);
+      RCTLogInfo(@"Invalid index value %lld. Indices must be positive.", (long long)index);
     }
     [indexSet addIndex:index];
   }
@@ -169,7 +169,7 @@ RCT_ENUM_CONVERTER(
       __block BOOL allHeadersAreStrings = YES;
       [headers enumerateKeysAndObjectsUsingBlock:^(NSString *key, id header, BOOL *stop) {
         if (![header isKindOfClass:[NSString class]]) {
-          RCTLogError(
+          RCTLogInfo(
               @"Values of HTTP headers passed must be  of type string. "
                "Value of header '%@' is not a string.",
               key);
@@ -200,11 +200,11 @@ RCT_ENUM_CONVERTER(
 {
   NSURL *fileURL = [self NSURL:json];
   if (!fileURL.fileURL) {
-    RCTLogError(@"URI must be a local file, '%@' isn't.", fileURL);
+    RCTLogInfo(@"URI must be a local file, '%@' isn't.", fileURL);
     return nil;
   }
   if (![[NSFileManager defaultManager] fileExistsAtPath:fileURL.path]) {
-    RCTLogError(@"File '%@' could not be found.", fileURL);
+    RCTLogInfo(@"File '%@' could not be found.", fileURL);
     return nil;
   }
   return fileURL;
@@ -225,7 +225,7 @@ RCT_ENUM_CONVERTER(
     });
     NSDate *date = [formatter dateFromString:json];
     if (!date) {
-      RCTLogError(
+      RCTLogInfo(
           @"JSON String '%@' could not be interpreted as a date. "
            "Expected format: YYYY-MM-DD'T'HH:mm:ss.sssZ",
           json);
@@ -242,7 +242,7 @@ RCT_ENUM_CONVERTER(
   if ([json isKindOfClass:[NSString class]]) {
     NSLocale *locale = [[NSLocale alloc] initWithLocaleIdentifier:json];
     if (!locale) {
-      RCTLogError(@"JSON String '%@' could not be interpreted as a valid locale. ", json);
+      RCTLogInfo(@"JSON String '%@' could not be interpreted as a valid locale. ", json);
     }
     return locale;
   } else if (json) {
@@ -267,15 +267,15 @@ NSNumber *RCTConvertEnumValue(const char *typeName, NSDictionary *mapping, NSNum
     if ([allValues containsObject:json] || [json isEqual:defaultValue]) {
       return json;
     }
-    RCTLogError(@"Invalid %s '%@'. should be one of: %@", typeName, json, allValues);
+    RCTLogInfo(@"Invalid %s '%@'. should be one of: %@", typeName, json, allValues);
     return defaultValue;
   }
   if (RCT_DEBUG && ![json isKindOfClass:[NSString class]]) {
-    RCTLogError(@"Expected NSNumber or NSString for %s, received %@: %@", typeName, [json classForCoder], json);
+    RCTLogInfo(@"Expected NSNumber or NSString for %s, received %@: %@", typeName, [json classForCoder], json);
   }
   id value = mapping[json];
   if (RCT_DEBUG && !value && [json description].length > 0) {
-    RCTLogError(
+    RCTLogInfo(
         @"Invalid %s '%@'. should be one of: %@",
         typeName,
         json,
@@ -541,7 +541,7 @@ static void convertCGStruct(const char *type, NSArray *fields, CGFloat *result, 
   NSUInteger count = fields.count;
   if ([json isKindOfClass:[NSArray class]]) {
     if (RCT_DEBUG && [json count] != count) {
-      RCTLogError(
+      RCTLogInfo(
           @"Expected array with count %llu, but count is %llu: %@",
           (unsigned long long)count,
           (unsigned long long)[json count],
@@ -1295,7 +1295,7 @@ RCT_ENUM_CONVERTER(
   }
 
   if (!CGSizeEqualToSize(imageSource.size, CGSizeZero) && !CGSizeEqualToSize(imageSource.size, image.size)) {
-    RCTLogError(
+    RCTLogInfo(
         @"Image source %@ size %@ does not match loaded image size %@.",
         URL.path.lastPathComponent,
         NSStringFromCGSize(imageSource.size),

--- a/React/Views/RCTConvert+Transform.m
+++ b/React/Views/RCTConvert+Transform.m
@@ -138,7 +138,7 @@ static const NSUInteger kMatrixArrayLength = 4 * 4;
       transform = CATransform3DConcat(next, transform);
 
     } else {
-      RCTLogError(@"Unsupported transform type for a CATransform3D: %@.", property);
+      RCTLogInfo(@"Unsupported transform type for a CATransform3D: %@.", property);
     }
   }
   return transform;

--- a/React/Views/RCTFont.mm
+++ b/React/Views/RCTFont.mm
@@ -332,7 +332,7 @@ typedef NSDictionary RCTFontVariantDescriptor;
   });
   RCTFontVariantDescriptor *value = mapping[json];
   if (RCT_DEBUG && !value && [json description].length > 0) {
-    RCTLogError(
+    RCTLogInfo(
         @"Invalid RCTFontVariantDescriptor '%@'. should be one of: %@",
         json,
         [[mapping allKeys] sortedArrayUsingSelector:@selector(caseInsensitiveCompare:)]);

--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -212,7 +212,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
     case RCTPointerEventsBoxNone:
       return hitSubview;
     default:
-      RCTLogError(@"Invalid pointer-events specified %lld on %@", (long long)_pointerEvents, self);
+      RCTLogInfo(@"Invalid pointer-events specified %lld on %@", (long long)_pointerEvents, self);
       return hitSubview ?: hitView;
   }
 }

--- a/React/Views/RCTViewManager.m
+++ b/React/Views/RCTViewManager.m
@@ -266,7 +266,7 @@ RCT_CUSTOM_VIEW_PROPERTY(pointerEvents, RCTPointerEvents, RCTView)
       view.userInteractionEnabled = NO;
       break;
     default:
-      RCTLogError(@"UIView base class does not support pointerEvent value: %@", json);
+      RCTLogInfo(@"UIView base class does not support pointerEvent value: %@", json);
   }
 }
 RCT_CUSTOM_VIEW_PROPERTY(removeClippedSubviews, BOOL, RCTView)


### PR DESCRIPTION
Summary:
Changelog:
[iOS][Fixed] - Invalid prop values no longer trigger redbox in the legacy renderer

## Context

We are changing React Native to behave more like a browser in the sense that **bad style values are not runtime errors**. (See e.g. D43159284 (https://github.com/facebook/react-native/commit/d6e9891577c81503407adaa85db8f5bf97557db0), D43184380.) The recommended way for developers to ensure they are passing correct style values is to use a typechecker (TypeScript or Flow) in conjunction with E2E tests and manual spot checks.

## This diff

This change is similar to D43184380, but here we target the legacy renderer on iOS by removing the redboxes from most of `RCTConvert`'s methods.

I'm intentionally going with the simplest possible improvement which is to downgrade the redboxes to `RCTLogInfo` ( = log to stdout but not the JS console). Leaving the call sites in place (as opposed to deleting them) will be helpful if we decide that we want to repurpose these checks for a new, more visible diagnostic (though we would likely only build such a diagnostic in Fabric at this point).

Differential Revision: D43184379

