### PR TITLE
Reduce use of assertions in prop parsing

### DIFF
--- a/ReactCommon/react/debug/react_native_assert.h
+++ b/ReactCommon/react/debug/react_native_assert.h
@@ -12,6 +12,12 @@
 // test before moving on. When all issues have been found, maybe we can use
 // `UNDEBUG` flag to disable NDEBUG in debug builds on Android.
 
+// Asserting is appropriate for conditions that:
+//   1. May or may not be recoverable, and
+//   2. imply there is a bug in React Native when violated.
+// For recoverable conditions that can be violated by user mistake (e.g. JS
+// code passes an unexpected prop value), consider react_native_expect instead.
+
 #include "flags.h"
 
 #undef react_native_assert

--- a/ReactCommon/react/debug/react_native_expect.h
+++ b/ReactCommon/react/debug/react_native_expect.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// No header guards since it is legitimately possible to include this file more
+// than once with and without REACT_NATIVE_DEBUG.
+
+// react_native_expect is a non-fatal counterpart of react_native_assert.
+// In debug builds, when an expectation fails, we log and move on.
+// In release builds, react_native_expect is a noop.
+
+// react_native_expect is appropriate for recoverable conditions that can be
+// violated by user mistake (e.g. JS code passes an unexpected prop value).
+// To enforce invariants that are internal to React Native, consider
+// react_native_assert (or a stronger mechanism).
+// Calling react_native_expect does NOT, by itself, guarantee that the user
+// will see a helpful diagnostic (beyond a low level log). That concern is the
+// caller's responsibility.
+
+#include "flags.h"
+
+#undef react_native_expect
+
+#ifndef REACT_NATIVE_DEBUG
+
+#define react_native_expect(e) ((void)0)
+
+#else // REACT_NATIVE_DEBUG
+
+#include <glog/logging.h>
+#include <cassert>
+
+#define react_native_expect(cond)                           \
+  if (!(cond)) {                                            \
+    LOG(ERROR) << "react_native_expect failure: " << #cond; \
+  }
+
+#endif // REACT_NATIVE_DEBUG

--- a/ReactCommon/react/renderer/attributedstring/conversions.h
+++ b/ReactCommon/react/renderer/attributedstring/conversions.h
@@ -9,7 +9,7 @@
 
 #include <folly/Conv.h>
 #include <folly/dynamic.h>
-#include <react/debug/react_native_assert.h>
+#include <react/debug/react_native_expect.h>
 #include <react/renderer/attributedstring/AttributedString.h>
 #include <react/renderer/attributedstring/ParagraphAttributes.h>
 #include <react/renderer/attributedstring/TextAttributes.h>
@@ -60,7 +60,7 @@ inline std::string toString(const DynamicTypeRamp &dynamicTypeRamp) {
   }
 
   LOG(ERROR) << "Unsupported DynamicTypeRamp value";
-  react_native_assert(false);
+  react_native_expect(false);
 
   // Sane default in case of parsing errors
   return "body";
@@ -70,7 +70,7 @@ inline void fromRawValue(
     const PropsParserContext &context,
     const RawValue &value,
     DynamicTypeRamp &result) {
-  react_native_assert(value.hasType<std::string>());
+  react_native_expect(value.hasType<std::string>());
   if (value.hasType<std::string>()) {
     auto string = (std::string)value;
     if (string == "caption2") {
@@ -98,14 +98,14 @@ inline void fromRawValue(
     } else {
       // sane default
       LOG(ERROR) << "Unsupported DynamicTypeRamp value: " << string;
-      react_native_assert(false);
+      react_native_expect(false);
       result = DynamicTypeRamp::Body;
     }
     return;
   }
 
   LOG(ERROR) << "Unsupported DynamicTypeRamp type";
-  react_native_assert(false);
+  react_native_expect(false);
 
   // Sane default in case of parsing errors
   result = DynamicTypeRamp::Body;
@@ -124,7 +124,7 @@ inline std::string toString(const EllipsizeMode &ellipsisMode) {
   }
 
   LOG(ERROR) << "Unsupported EllipsizeMode value";
-  react_native_assert(false);
+  react_native_expect(false);
 
   // Sane default in case of parsing errors
   return "tail";
@@ -134,7 +134,7 @@ inline void fromRawValue(
     const PropsParserContext &context,
     const RawValue &value,
     EllipsizeMode &result) {
-  react_native_assert(value.hasType<std::string>());
+  react_native_expect(value.hasType<std::string>());
   if (value.hasType<std::string>()) {
     auto string = (std::string)value;
     if (string == "clip") {
@@ -148,14 +148,14 @@ inline void fromRawValue(
     } else {
       // sane default
       LOG(ERROR) << "Unsupported EllipsizeMode value: " << string;
-      react_native_assert(false);
+      react_native_expect(false);
       result = EllipsizeMode::Tail;
     }
     return;
   }
 
   LOG(ERROR) << "Unsupported EllipsizeMode type";
-  react_native_assert(false);
+  react_native_expect(false);
 
   // Sane default in case of parsing errors
   result = EllipsizeMode::Tail;
@@ -172,7 +172,7 @@ inline std::string toString(const TextBreakStrategy &textBreakStrategy) {
   }
 
   LOG(ERROR) << "Unsupported TextBreakStrategy value";
-  react_native_assert(false);
+  react_native_expect(false);
   return "highQuality";
 }
 
@@ -180,7 +180,7 @@ inline void fromRawValue(
     const PropsParserContext &context,
     const RawValue &value,
     TextBreakStrategy &result) {
-  react_native_assert(value.hasType<std::string>());
+  react_native_expect(value.hasType<std::string>());
   if (value.hasType<std::string>()) {
     auto string = (std::string)value;
     if (string == "simple") {
@@ -192,14 +192,14 @@ inline void fromRawValue(
     } else {
       // sane default
       LOG(ERROR) << "Unsupported TextBreakStrategy value: " << string;
-      react_native_assert(false);
+      react_native_expect(false);
       result = TextBreakStrategy::HighQuality;
     }
     return;
   }
 
   LOG(ERROR) << "Unsupported TextBreakStrategy type";
-  react_native_assert(false);
+  react_native_expect(false);
   result = TextBreakStrategy::HighQuality;
 }
 
@@ -207,7 +207,7 @@ inline void fromRawValue(
     const PropsParserContext &context,
     const RawValue &value,
     FontWeight &result) {
-  react_native_assert(value.hasType<std::string>());
+  react_native_expect(value.hasType<std::string>());
   if (value.hasType<std::string>()) {
     auto string = (std::string)value;
     if (string == "normal") {
@@ -236,7 +236,7 @@ inline void fromRawValue(
       result = FontWeight::Weight900;
     } else {
       LOG(ERROR) << "Unsupported FontWeight value: " << string;
-      react_native_assert(false);
+      react_native_expect(false);
       // sane default for prod
       result = FontWeight::Regular;
     }
@@ -244,7 +244,7 @@ inline void fromRawValue(
   }
 
   LOG(ERROR) << "Unsupported FontWeight type";
-  react_native_assert(false);
+  react_native_expect(false);
   result = FontWeight::Regular;
 }
 
@@ -256,7 +256,7 @@ inline void fromRawValue(
     const PropsParserContext &context,
     const RawValue &value,
     FontStyle &result) {
-  react_native_assert(value.hasType<std::string>());
+  react_native_expect(value.hasType<std::string>());
   if (value.hasType<std::string>()) {
     auto string = (std::string)value;
     if (string == "normal") {
@@ -267,7 +267,7 @@ inline void fromRawValue(
       result = FontStyle::Oblique;
     } else {
       LOG(ERROR) << "Unsupported FontStyle value: " << string;
-      react_native_assert(false);
+      react_native_expect(false);
       // sane default for prod
       result = FontStyle::Normal;
     }
@@ -275,7 +275,7 @@ inline void fromRawValue(
   }
 
   LOG(ERROR) << "Unsupported FontStyle type";
-  react_native_assert(false);
+  react_native_expect(false);
   // sane default for prod
   result = FontStyle::Normal;
 }
@@ -291,7 +291,7 @@ inline std::string toString(const FontStyle &fontStyle) {
   }
 
   LOG(ERROR) << "Unsupported FontStyle value";
-  react_native_assert(false);
+  react_native_expect(false);
   // sane default for prod
   return "normal";
 }
@@ -300,7 +300,7 @@ inline void fromRawValue(
     const PropsParserContext &context,
     const RawValue &value,
     FontVariant &result) {
-  react_native_assert(value.hasType<std::vector<std::string>>());
+  react_native_expect(value.hasType<std::vector<std::string>>());
   result = FontVariant::Default;
   if (value.hasType<std::vector<std::string>>()) {
     auto items = std::vector<std::string>{value};
@@ -318,7 +318,7 @@ inline void fromRawValue(
             (FontVariant)((int)result | (int)FontVariant::ProportionalNums);
       } else {
         LOG(ERROR) << "Unsupported FontVariant value: " << item;
-        react_native_assert(false);
+        react_native_expect(false);
       }
       continue;
     }
@@ -357,7 +357,7 @@ inline void fromRawValue(
     const PropsParserContext &context,
     const RawValue &value,
     TextTransform &result) {
-  react_native_assert(value.hasType<std::string>());
+  react_native_expect(value.hasType<std::string>());
   if (value.hasType<std::string>()) {
     auto string = (std::string)value;
     if (string == "none") {
@@ -372,7 +372,7 @@ inline void fromRawValue(
       result = TextTransform::Unset;
     } else {
       LOG(ERROR) << "Unsupported TextTransform value: " << string;
-      react_native_assert(false);
+      react_native_expect(false);
       // sane default for prod
       result = TextTransform::None;
     }
@@ -380,7 +380,7 @@ inline void fromRawValue(
   }
 
   LOG(ERROR) << "Unsupported TextTransform type";
-  react_native_assert(false);
+  react_native_expect(false);
   // sane default for prod
   result = TextTransform::None;
 }
@@ -400,7 +400,7 @@ inline std::string toString(const TextTransform &textTransform) {
   }
 
   LOG(ERROR) << "Unsupported TextTransform value";
-  react_native_assert(false);
+  react_native_expect(false);
   // sane default for prod
   return "none";
 }
@@ -409,7 +409,7 @@ inline void fromRawValue(
     const PropsParserContext &context,
     const RawValue &value,
     TextAlignment &result) {
-  react_native_assert(value.hasType<std::string>());
+  react_native_expect(value.hasType<std::string>());
   if (value.hasType<std::string>()) {
     auto string = (std::string)value;
     if (string == "auto") {
@@ -424,7 +424,7 @@ inline void fromRawValue(
       result = TextAlignment::Justified;
     } else {
       LOG(ERROR) << "Unsupported TextAlignment value: " << string;
-      react_native_assert(false);
+      react_native_expect(false);
       // sane default for prod
       result = TextAlignment::Natural;
     }
@@ -459,7 +459,7 @@ inline void fromRawValue(
     const PropsParserContext &context,
     const RawValue &value,
     WritingDirection &result) {
-  react_native_assert(value.hasType<std::string>());
+  react_native_expect(value.hasType<std::string>());
   if (value.hasType<std::string>()) {
     auto string = (std::string)value;
     if (string == "natural" || string == "auto") {
@@ -470,7 +470,7 @@ inline void fromRawValue(
       result = WritingDirection::RightToLeft;
     } else {
       LOG(ERROR) << "Unsupported WritingDirection value: " << string;
-      react_native_assert(false);
+      react_native_expect(false);
       // sane default for prod
       result = WritingDirection::Natural;
     }
@@ -501,7 +501,7 @@ inline void fromRawValue(
     const PropsParserContext &context,
     const RawValue &value,
     LineBreakStrategy &result) {
-  react_native_assert(value.hasType<std::string>());
+  react_native_expect(value.hasType<std::string>());
   if (value.hasType<std::string>()) {
     auto string = (std::string)value;
     if (string == "none") {
@@ -514,7 +514,7 @@ inline void fromRawValue(
       result = LineBreakStrategy::Standard;
     } else {
       LOG(ERROR) << "Unsupported LineBreakStrategy value: " << string;
-      react_native_assert(false);
+      react_native_expect(false);
       // sane default for prod
       result = LineBreakStrategy::None;
     }
@@ -547,7 +547,7 @@ inline void fromRawValue(
     const PropsParserContext &context,
     const RawValue &value,
     TextDecorationLineType &result) {
-  react_native_assert(value.hasType<std::string>());
+  react_native_expect(value.hasType<std::string>());
   if (value.hasType<std::string>()) {
     auto string = (std::string)value;
     if (string == "none") {
@@ -564,7 +564,7 @@ inline void fromRawValue(
       result = TextDecorationLineType::UnderlineStrikethrough;
     } else {
       LOG(ERROR) << "Unsupported TextDecorationLineType value: " << string;
-      react_native_assert(false);
+      react_native_expect(false);
       // sane default for prod
       result = TextDecorationLineType::None;
     }
@@ -590,7 +590,7 @@ inline std::string toString(
   }
 
   LOG(ERROR) << "Unsupported TextDecorationLineType value";
-  react_native_assert(false);
+  react_native_expect(false);
   // sane default for prod
   return "none";
 }
@@ -599,7 +599,7 @@ inline void fromRawValue(
     const PropsParserContext &context,
     const RawValue &value,
     TextDecorationStyle &result) {
-  react_native_assert(value.hasType<std::string>());
+  react_native_expect(value.hasType<std::string>());
   if (value.hasType<std::string>()) {
     auto string = (std::string)value;
     if (string == "solid") {
@@ -612,7 +612,7 @@ inline void fromRawValue(
       result = TextDecorationStyle::Dashed;
     } else {
       LOG(ERROR) << "Unsupported TextDecorationStyle value: " << string;
-      react_native_assert(false);
+      react_native_expect(false);
       // sane default for prod
       result = TextDecorationStyle::Solid;
     }
@@ -637,7 +637,7 @@ inline std::string toString(const TextDecorationStyle &textDecorationStyle) {
   }
 
   LOG(ERROR) << "Unsupported TextDecorationStyle value";
-  react_native_assert(false);
+  react_native_expect(false);
   // sane default for prod
   return "solid";
 }
@@ -703,7 +703,7 @@ inline std::string toString(const AccessibilityRole &accessibilityRole) {
   }
 
   LOG(ERROR) << "Unsupported AccessibilityRole value";
-  react_native_assert(false);
+  react_native_expect(false);
   // sane default for prod
   return "none";
 }
@@ -712,7 +712,7 @@ inline void fromRawValue(
     const PropsParserContext &context,
     const RawValue &value,
     AccessibilityRole &result) {
-  react_native_assert(value.hasType<std::string>());
+  react_native_expect(value.hasType<std::string>());
   if (value.hasType<std::string>()) {
     auto string = (std::string)value;
     if (string == "none") {
@@ -773,7 +773,7 @@ inline void fromRawValue(
       result = AccessibilityRole::Toolbar;
     } else {
       LOG(ERROR) << "Unsupported AccessibilityRole value: " << string;
-      react_native_assert(false);
+      react_native_expect(false);
       // sane default for prod
       result = AccessibilityRole::None;
     }
@@ -781,7 +781,7 @@ inline void fromRawValue(
   }
 
   LOG(ERROR) << "Unsupported AccessibilityRole type";
-  react_native_assert(false);
+  react_native_expect(false);
   // sane default for prod
   result = AccessibilityRole::None;
 }
@@ -797,7 +797,7 @@ inline std::string toString(const HyphenationFrequency &hyphenationFrequency) {
   }
 
   LOG(ERROR) << "Unsupported HyphenationFrequency value";
-  react_native_assert(false);
+  react_native_expect(false);
   return "none";
 }
 
@@ -805,7 +805,7 @@ inline void fromRawValue(
     const PropsParserContext &context,
     const RawValue &value,
     HyphenationFrequency &result) {
-  react_native_assert(value.hasType<std::string>());
+  react_native_expect(value.hasType<std::string>());
   if (value.hasType<std::string>()) {
     auto string = (std::string)value;
     if (string == "none") {
@@ -817,14 +817,14 @@ inline void fromRawValue(
     } else {
       // sane default
       LOG(ERROR) << "Unsupported HyphenationFrequency value: " << string;
-      react_native_assert(false);
+      react_native_expect(false);
       result = HyphenationFrequency::None;
     }
     return;
   }
 
   LOG(ERROR) << "Unsupported HyphenationFrequency type";
-  react_native_assert(false);
+  react_native_expect(false);
   result = HyphenationFrequency::None;
 }
 

--- a/ReactCommon/react/renderer/components/image/conversions.h
+++ b/ReactCommon/react/renderer/components/image/conversions.h
@@ -10,7 +10,7 @@
 #include <butter/map.h>
 #include <folly/dynamic.h>
 #include <glog/logging.h>
-#include <react/debug/react_native_assert.h>
+#include <react/debug/react_native_expect.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/graphics/conversions.h>
 #include <react/renderer/imagemanager/primitives.h>
@@ -97,7 +97,7 @@ inline void fromRawValue(
     const PropsParserContext &context,
     const RawValue &value,
     ImageResizeMode &result) {
-  react_native_assert(value.hasType<std::string>());
+  react_native_expect(value.hasType<std::string>());
   if (!value.hasType<std::string>()) {
     LOG(ERROR) << "Unsupported ImageResizeMode type";
     // "cover" is default in non-Fabric web and iOS
@@ -118,7 +118,7 @@ inline void fromRawValue(
     result = ImageResizeMode::Repeat;
   } else {
     LOG(ERROR) << "Unsupported ImageResizeMode value: " << stringValue;
-    react_native_assert(false);
+    react_native_expect(false);
     // "cover" is default in non-Fabric web and iOS
     result = ImageResizeMode::Cover;
   }

--- a/ReactCommon/react/renderer/components/textinput/iostextinput/propsConversions.h
+++ b/ReactCommon/react/renderer/components/textinput/iostextinput/propsConversions.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <react/debug/react_native_expect.h>
 #include <react/renderer/components/iostextinput/primitives.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/core/propsConversions.h>
@@ -158,16 +159,16 @@ inline void fromRawValue(
         result.end = pair.second;
       } else {
         LOG(ERROR) << "Unsupported Selection map key: " << pair.first;
-        react_native_assert(false);
+        react_native_expect(false);
       }
     }
     return;
   }
 
-  react_native_assert(value.hasType<std::vector<int>>());
+  react_native_expect(value.hasType<std::vector<int>>());
   if (value.hasType<std::vector<int>>()) {
     auto array = (std::vector<int>)value;
-    react_native_assert(array.size() == 2);
+    react_native_expect(array.size() == 2);
     if (array.size() >= 2) {
       result = {array.at(0), array.at(1)};
     } else {

--- a/ReactCommon/react/renderer/components/view/conversions.h
+++ b/ReactCommon/react/renderer/components/view/conversions.h
@@ -12,7 +12,7 @@
 #include <folly/dynamic.h>
 #include <glog/logging.h>
 #include <react/config/ReactNativeConfig.h>
-#include <react/debug/react_native_assert.h>
+#include <react/debug/react_native_expect.h>
 #include <react/renderer/components/view/primitives.h>
 #include <react/renderer/core/LayoutMetrics.h>
 #include <react/renderer/core/PropsParserContext.h>
@@ -169,7 +169,7 @@ inline void fromRawValue(
     const PropsParserContext &context,
     const RawValue &value,
     YGDirection &result) {
-  react_native_assert(value.hasType<std::string>());
+  react_native_expect(value.hasType<std::string>());
   auto stringValue = (std::string)value;
   if (stringValue == "inherit") {
     result = YGDirectionInherit;
@@ -184,14 +184,14 @@ inline void fromRawValue(
     return;
   }
   LOG(FATAL) << "Could not parse YGDirection:" << stringValue;
-  react_native_assert(false);
+  react_native_expect(false);
 }
 
 inline void fromRawValue(
     const PropsParserContext &context,
     const RawValue &value,
     YGFlexDirection &result) {
-  react_native_assert(value.hasType<std::string>());
+  react_native_expect(value.hasType<std::string>());
   auto stringValue = (std::string)value;
   if (stringValue == "row") {
     result = YGFlexDirectionRow;
@@ -210,14 +210,14 @@ inline void fromRawValue(
     return;
   }
   LOG(FATAL) << "Could not parse YGFlexDirection:" << stringValue;
-  react_native_assert(false);
+  react_native_expect(false);
 }
 
 inline void fromRawValue(
     const PropsParserContext &context,
     const RawValue &value,
     YGJustify &result) {
-  react_native_assert(value.hasType<std::string>());
+  react_native_expect(value.hasType<std::string>());
   auto stringValue = (std::string)value;
   if (stringValue == "flex-start") {
     result = YGJustifyFlexStart;
@@ -244,14 +244,14 @@ inline void fromRawValue(
     return;
   }
   LOG(FATAL) << "Could not parse YGJustify:" << stringValue;
-  react_native_assert(false);
+  react_native_expect(false);
 }
 
 inline void fromRawValue(
     const PropsParserContext &context,
     const RawValue &value,
     YGAlign &result) {
-  react_native_assert(value.hasType<std::string>());
+  react_native_expect(value.hasType<std::string>());
   auto stringValue = (std::string)value;
   if (stringValue == "auto") {
     result = YGAlignAuto;
@@ -286,14 +286,14 @@ inline void fromRawValue(
     return;
   }
   LOG(FATAL) << "Could not parse YGAlign:" << stringValue;
-  react_native_assert(false);
+  react_native_expect(false);
 }
 
 inline void fromRawValue(
     const PropsParserContext &context,
     const RawValue &value,
     YGPositionType &result) {
-  react_native_assert(value.hasType<std::string>());
+  react_native_expect(value.hasType<std::string>());
   auto stringValue = (std::string)value;
   if (stringValue == "static") {
     result = YGPositionTypeStatic;
@@ -308,14 +308,14 @@ inline void fromRawValue(
     return;
   }
   LOG(FATAL) << "Could not parse YGPositionType:" << stringValue;
-  react_native_assert(false);
+  react_native_expect(false);
 }
 
 inline void fromRawValue(
     const PropsParserContext &context,
     const RawValue &value,
     YGWrap &result) {
-  react_native_assert(value.hasType<std::string>());
+  react_native_expect(value.hasType<std::string>());
   auto stringValue = (std::string)value;
   if (stringValue == "nowrap") {
     result = YGWrapNoWrap;
@@ -330,14 +330,14 @@ inline void fromRawValue(
     return;
   }
   LOG(FATAL) << "Could not parse YGWrap:" << stringValue;
-  react_native_assert(false);
+  react_native_expect(false);
 }
 
 inline void fromRawValue(
     const PropsParserContext &context,
     const RawValue &value,
     YGOverflow &result) {
-  react_native_assert(value.hasType<std::string>());
+  react_native_expect(value.hasType<std::string>());
   auto stringValue = (std::string)value;
   if (stringValue == "visible") {
     result = YGOverflowVisible;
@@ -352,14 +352,14 @@ inline void fromRawValue(
     return;
   }
   LOG(FATAL) << "Could not parse YGOverflow:" << stringValue;
-  react_native_assert(false);
+  react_native_expect(false);
 }
 
 inline void fromRawValue(
     const PropsParserContext &context,
     const RawValue &value,
     YGDisplay &result) {
-  react_native_assert(value.hasType<std::string>());
+  react_native_expect(value.hasType<std::string>());
   auto stringValue = (std::string)value;
   if (stringValue == "flex") {
     result = YGDisplayFlex;
@@ -370,7 +370,7 @@ inline void fromRawValue(
     return;
   }
   LOG(FATAL) << "Could not parse YGDisplay:" << stringValue;
-  react_native_assert(false);
+  react_native_expect(false);
 }
 
 inline void fromRawValue(
@@ -433,14 +433,14 @@ inline void fromRawValue(
     }
   }
   LOG(FATAL) << "Could not parse YGFloatOptional";
-  react_native_assert(false);
+  react_native_expect(false);
 }
 
 inline Float toRadians(const RawValue &value) {
   if (value.hasType<Float>()) {
     return (Float)value;
   }
-  react_native_assert(value.hasType<std::string>());
+  react_native_expect(value.hasType<std::string>());
   auto stringValue = (std::string)value;
   char *suffixStart;
   double num = strtod(
@@ -456,7 +456,7 @@ inline void fromRawValue(
     const PropsParserContext &context,
     const RawValue &value,
     Transform &result) {
-  react_native_assert(value.hasType<std::vector<RawValue>>());
+  react_native_expect(value.hasType<std::vector<RawValue>>());
   auto transformMatrix = Transform{};
   auto configurations = static_cast<std::vector<RawValue>>(value);
 
@@ -474,9 +474,9 @@ inline void fromRawValue(
     auto &parameters = pair->second;
 
     if (operation == "matrix") {
-      react_native_assert(parameters.hasType<std::vector<Float>>());
+      react_native_expect(parameters.hasType<std::vector<Float>>());
       auto numbers = (std::vector<Float>)parameters;
-      react_native_assert(numbers.size() == transformMatrix.matrix.size());
+      react_native_expect(numbers.size() == transformMatrix.matrix.size());
       auto i = 0;
       for (auto number : numbers) {
         transformMatrix.matrix[i++] = number;
@@ -534,7 +534,7 @@ inline void fromRawValue(
     const PropsParserContext &context,
     const RawValue &value,
     PointerEventsMode &result) {
-  react_native_assert(value.hasType<std::string>());
+  react_native_expect(value.hasType<std::string>());
   auto stringValue = (std::string)value;
   if (stringValue == "auto") {
     result = PointerEventsMode::Auto;
@@ -553,14 +553,14 @@ inline void fromRawValue(
     return;
   }
   LOG(FATAL) << "Could not parse PointerEventsMode:" << stringValue;
-  react_native_assert(false);
+  react_native_expect(false);
 }
 
 inline void fromRawValue(
     const PropsParserContext &context,
     const RawValue &value,
     BackfaceVisibility &result) {
-  react_native_assert(value.hasType<std::string>());
+  react_native_expect(value.hasType<std::string>());
   auto stringValue = (std::string)value;
   if (stringValue == "auto") {
     result = BackfaceVisibility::Auto;
@@ -575,14 +575,14 @@ inline void fromRawValue(
     return;
   }
   LOG(FATAL) << "Could not parse BackfaceVisibility:" << stringValue;
-  react_native_assert(false);
+  react_native_expect(false);
 }
 
 inline void fromRawValue(
     const PropsParserContext &context,
     const RawValue &value,
     BorderCurve &result) {
-  react_native_assert(value.hasType<std::string>());
+  react_native_expect(value.hasType<std::string>());
   auto stringValue = (std::string)value;
   if (stringValue == "circular") {
     result = BorderCurve::Circular;
@@ -593,14 +593,14 @@ inline void fromRawValue(
     return;
   }
   LOG(FATAL) << "Could not parse BorderCurve:" << stringValue;
-  react_native_assert(false);
+  react_native_expect(false);
 }
 
 inline void fromRawValue(
     const PropsParserContext &context,
     const RawValue &value,
     BorderStyle &result) {
-  react_native_assert(value.hasType<std::string>());
+  react_native_expect(value.hasType<std::string>());
   auto stringValue = (std::string)value;
   if (stringValue == "solid") {
     result = BorderStyle::Solid;
@@ -615,7 +615,7 @@ inline void fromRawValue(
     return;
   }
   LOG(FATAL) << "Could not parse BorderStyle:" << stringValue;
-  react_native_assert(false);
+  react_native_expect(false);
 }
 
 inline std::string toString(

--- a/ReactCommon/react/renderer/components/view/propsConversions.h
+++ b/ReactCommon/react/renderer/components/view/propsConversions.h
@@ -724,13 +724,13 @@ static inline void fromRawValue(
   auto map = (butter::map<std::string, RawValue>)rawValue;
 
   auto typeIterator = map.find("type");
-  react_native_assert(
+  react_native_expect(
       typeIterator != map.end() && typeIterator->second.hasType<std::string>());
   std::string type = (std::string)typeIterator->second;
 
   if (type == "ThemeAttrAndroid") {
     auto attrIterator = map.find("attribute");
-    react_native_assert(
+    react_native_expect(
         attrIterator != map.end() &&
         attrIterator->second.hasType<std::string>());
 
@@ -761,7 +761,7 @@ static inline void fromRawValue(
     };
   } else {
     LOG(ERROR) << "Unknown native drawable type: " << type;
-    react_native_assert(false);
+    react_native_expect(false);
   }
 }
 

--- a/ReactCommon/react/renderer/graphics/conversions.h
+++ b/ReactCommon/react/renderer/graphics/conversions.h
@@ -9,7 +9,7 @@
 
 #include <butter/map.h>
 #include <glog/logging.h>
-#include <react/debug/react_native_assert.h>
+#include <react/debug/react_native_expect.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/core/RawProps.h>
 #include <react/renderer/graphics/Color.h>
@@ -41,7 +41,7 @@ inline void fromRawValue(
   } else if (value.hasType<std::vector<float>>()) {
     auto items = (std::vector<float>)value;
     auto length = items.size();
-    react_native_assert(length == 3 || length == 4);
+    react_native_expect(length == 3 || length == 4);
     colorComponents.red = items.at(0);
     colorComponents.green = items.at(1);
     colorComponents.blue = items.at(2);
@@ -86,10 +86,10 @@ inline void fromRawValue(
     return;
   }
 
-  react_native_assert(value.hasType<std::vector<Float>>());
+  react_native_expect(value.hasType<std::vector<Float>>());
   if (value.hasType<std::vector<Float>>()) {
     auto array = (std::vector<Float>)value;
-    react_native_assert(array.size() == 2);
+    react_native_expect(array.size() == 2);
     if (array.size() >= 2) {
       result = {array.at(0), array.at(1)};
     } else {
@@ -114,16 +114,16 @@ inline void fromRawValue(
         result.height = pair.second;
       } else {
         LOG(ERROR) << "Unsupported Size map key: " << pair.first;
-        react_native_assert(false);
+        react_native_expect(false);
       }
     }
     return;
   }
 
-  react_native_assert(value.hasType<std::vector<Float>>());
+  react_native_expect(value.hasType<std::vector<Float>>());
   if (value.hasType<std::vector<Float>>()) {
     auto array = (std::vector<Float>)value;
-    react_native_assert(array.size() == 2);
+    react_native_expect(array.size() == 2);
     if (array.size() >= 2) {
       result = {array.at(0), array.at(1)};
     } else {
@@ -158,16 +158,16 @@ inline void fromRawValue(
         result.right = pair.second;
       } else {
         LOG(ERROR) << "Unsupported EdgeInsets map key: " << pair.first;
-        react_native_assert(false);
+        react_native_expect(false);
       }
     }
     return;
   }
 
-  react_native_assert(value.hasType<std::vector<Float>>());
+  react_native_expect(value.hasType<std::vector<Float>>());
   if (value.hasType<std::vector<Float>>()) {
     auto array = (std::vector<Float>)value;
-    react_native_assert(array.size() == 4);
+    react_native_expect(array.size() == 4);
     if (array.size() >= 4) {
       result = {array.at(0), array.at(1), array.at(2), array.at(3)};
     } else {
@@ -202,16 +202,16 @@ inline void fromRawValue(
         result.bottomRight = pair.second;
       } else {
         LOG(ERROR) << "Unsupported CornerInsets map key: " << pair.first;
-        react_native_assert(false);
+        react_native_expect(false);
       }
     }
     return;
   }
 
-  react_native_assert(value.hasType<std::vector<Float>>());
+  react_native_expect(value.hasType<std::vector<Float>>());
   if (value.hasType<std::vector<Float>>()) {
     auto array = (std::vector<Float>)value;
-    react_native_assert(array.size() == 4);
+    react_native_expect(array.size() == 4);
     if (array.size() >= 4) {
       result = {array.at(0), array.at(1), array.at(2), array.at(3)};
     } else {

--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -135,36 +135,44 @@ PODS:
     - ReactCommon/turbomodule/core
   - React-Core (1000.0.0):
     - glog
+    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default (= 1000.0.0)
     - React-cxxreact (= 1000.0.0)
+    - React-hermes
     - React-jsi (= 1000.0.0)
     - React-jsiexecutor (= 1000.0.0)
     - React-perflogger (= 1000.0.0)
     - Yoga
   - React-Core/CoreModulesHeaders (1000.0.0):
     - glog
+    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
     - React-cxxreact (= 1000.0.0)
+    - React-hermes
     - React-jsi (= 1000.0.0)
     - React-jsiexecutor (= 1000.0.0)
     - React-perflogger (= 1000.0.0)
     - Yoga
   - React-Core/Default (1000.0.0):
     - glog
+    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-cxxreact (= 1000.0.0)
+    - React-hermes
     - React-jsi (= 1000.0.0)
     - React-jsiexecutor (= 1000.0.0)
     - React-perflogger (= 1000.0.0)
     - Yoga
   - React-Core/DevSupport (1000.0.0):
     - glog
+    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default (= 1000.0.0)
     - React-Core/RCTWebSocket (= 1000.0.0)
     - React-cxxreact (= 1000.0.0)
+    - React-hermes
     - React-jsi (= 1000.0.0)
     - React-jsiexecutor (= 1000.0.0)
     - React-jsinspector (= 1000.0.0)
@@ -172,99 +180,121 @@ PODS:
     - Yoga
   - React-Core/RCTActionSheetHeaders (1000.0.0):
     - glog
+    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
     - React-cxxreact (= 1000.0.0)
+    - React-hermes
     - React-jsi (= 1000.0.0)
     - React-jsiexecutor (= 1000.0.0)
     - React-perflogger (= 1000.0.0)
     - Yoga
   - React-Core/RCTAnimationHeaders (1000.0.0):
     - glog
+    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
     - React-cxxreact (= 1000.0.0)
+    - React-hermes
     - React-jsi (= 1000.0.0)
     - React-jsiexecutor (= 1000.0.0)
     - React-perflogger (= 1000.0.0)
     - Yoga
   - React-Core/RCTBlobHeaders (1000.0.0):
     - glog
+    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
     - React-cxxreact (= 1000.0.0)
+    - React-hermes
     - React-jsi (= 1000.0.0)
     - React-jsiexecutor (= 1000.0.0)
     - React-perflogger (= 1000.0.0)
     - Yoga
   - React-Core/RCTImageHeaders (1000.0.0):
     - glog
+    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
     - React-cxxreact (= 1000.0.0)
+    - React-hermes
     - React-jsi (= 1000.0.0)
     - React-jsiexecutor (= 1000.0.0)
     - React-perflogger (= 1000.0.0)
     - Yoga
   - React-Core/RCTLinkingHeaders (1000.0.0):
     - glog
+    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
     - React-cxxreact (= 1000.0.0)
+    - React-hermes
     - React-jsi (= 1000.0.0)
     - React-jsiexecutor (= 1000.0.0)
     - React-perflogger (= 1000.0.0)
     - Yoga
   - React-Core/RCTNetworkHeaders (1000.0.0):
     - glog
+    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
     - React-cxxreact (= 1000.0.0)
+    - React-hermes
     - React-jsi (= 1000.0.0)
     - React-jsiexecutor (= 1000.0.0)
     - React-perflogger (= 1000.0.0)
     - Yoga
   - React-Core/RCTPushNotificationHeaders (1000.0.0):
     - glog
+    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
     - React-cxxreact (= 1000.0.0)
+    - React-hermes
     - React-jsi (= 1000.0.0)
     - React-jsiexecutor (= 1000.0.0)
     - React-perflogger (= 1000.0.0)
     - Yoga
   - React-Core/RCTSettingsHeaders (1000.0.0):
     - glog
+    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
     - React-cxxreact (= 1000.0.0)
+    - React-hermes
     - React-jsi (= 1000.0.0)
     - React-jsiexecutor (= 1000.0.0)
     - React-perflogger (= 1000.0.0)
     - Yoga
   - React-Core/RCTTextHeaders (1000.0.0):
     - glog
+    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
     - React-cxxreact (= 1000.0.0)
+    - React-hermes
     - React-jsi (= 1000.0.0)
     - React-jsiexecutor (= 1000.0.0)
     - React-perflogger (= 1000.0.0)
     - Yoga
   - React-Core/RCTVibrationHeaders (1000.0.0):
     - glog
+    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
     - React-cxxreact (= 1000.0.0)
+    - React-hermes
     - React-jsi (= 1000.0.0)
     - React-jsiexecutor (= 1000.0.0)
     - React-perflogger (= 1000.0.0)
     - Yoga
   - React-Core/RCTWebSocket (1000.0.0):
     - glog
+    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default (= 1000.0.0)
     - React-cxxreact (= 1000.0.0)
+    - React-hermes
     - React-jsi (= 1000.0.0)
     - React-jsiexecutor (= 1000.0.0)
     - React-perflogger (= 1000.0.0)
@@ -275,12 +305,14 @@ PODS:
     - React-Codegen (= 1000.0.0)
     - React-Core/CoreModulesHeaders (= 1000.0.0)
     - React-jsi (= 1000.0.0)
+    - React-RCTBlob
     - React-RCTImage (= 1000.0.0)
     - ReactCommon/turbomodule/core (= 1000.0.0)
   - React-cxxreact (1000.0.0):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
+    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-callinvoker (= 1000.0.0)
     - React-jsi (= 1000.0.0)
@@ -606,6 +638,7 @@ PODS:
     - RCT-Folly (= 2021.07.22.00)
     - RCT-Folly/Futures (= 2021.07.22.00)
     - React-cxxreact (= 1000.0.0)
+    - React-jsi
     - React-jsiexecutor (= 1000.0.0)
     - React-jsinspector (= 1000.0.0)
     - React-perflogger (= 1000.0.0)
@@ -618,6 +651,7 @@ PODS:
   - React-jsiexecutor (1000.0.0):
     - DoubleConversion
     - glog
+    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-cxxreact (= 1000.0.0)
     - React-jsi (= 1000.0.0)
@@ -642,6 +676,7 @@ PODS:
     - React-Core
     - ReactCommon/turbomodule/core
   - React-RCTBlob (1000.0.0):
+    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Codegen (= 1000.0.0)
     - React-Core/RCTBlobHeaders (= 1000.0.0)
@@ -707,6 +742,7 @@ PODS:
   - ReactCommon/turbomodule/bridging (1000.0.0):
     - DoubleConversion
     - glog
+    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-callinvoker (= 1000.0.0)
     - React-Core (= 1000.0.0)
@@ -717,6 +753,7 @@ PODS:
   - ReactCommon/turbomodule/core (1000.0.0):
     - DoubleConversion
     - glog
+    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-callinvoker (= 1000.0.0)
     - React-Core (= 1000.0.0)
@@ -727,6 +764,7 @@ PODS:
   - ReactCommon/turbomodule/samples (1000.0.0):
     - DoubleConversion
     - glog
+    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-callinvoker (= 1000.0.0)
     - React-Core (= 1000.0.0)
@@ -929,7 +967,7 @@ SPEC CHECKSUMS:
   FlipperKit: b353b63cb4048a5747529412524407d6efa68336
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
-  hermes-engine: 094454894cb46a8522d3f72e803e634f86536889
+  hermes-engine: a111c64414009c85d78d574ab1ae9b95316c2c6f
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1
@@ -938,21 +976,21 @@ SPEC CHECKSUMS:
   React: 2fc6c4c656cccd6753016528ad41199c16fd558e
   React-callinvoker: a7d5e883a83bb9bd3985b08be832c5e76451d18f
   React-Codegen: 4f1e911c128928e425e11698ad7859dfd0f92e20
-  React-Core: 719bec4b41c93b1affb1e2c3a43956ec482ecb9f
-  React-CoreModules: feaa45c54c58e1420981f6dd544c8b3d01200caa
-  React-cxxreact: 97903bdac0fb53409663fd312e2183ae1dd730e5
+  React-Core: 279a6e5ee79e88faa99157169b560c49635973d7
+  React-CoreModules: d3ee40954b381edc514301341e8b895febfc1848
+  React-cxxreact: aff243750dad852080636e615d7ae5639381735b
   React-Fabric: 62b9929a7345f941d8833630f37d9440b2dda438
   React-graphics: cb8a85648695c60f33a00d732b985f734d1470d8
-  React-hermes: e35ea664b36773a2ce84c583febf1396080e59f7
+  React-hermes: 7f0e87d44b1c7cfbdd11aa3c070d04435fe75d57
   React-jsi: e4c75a1cf727c8761908ac2eeb1084e47ba88a26
-  React-jsiexecutor: dcc8c2b89b6e0b5abb9bbbfb6df86adf44e3e877
+  React-jsiexecutor: 8361f78286021782d885e0888bb059a4045c59b9
   React-jsinspector: 9b56a373a6797114e1d89a7dffa98ee98af67a8f
   React-logger: 07c9b44040a6f948b8e2033207b23cb623f0b9b4
   React-perflogger: b4b9fb2ddd856b78003708ab3cf66ce03e6bc7c4
   React-RCTActionSheet: 1b1501ef80928be10702cd0ce09120358094cd82
   React-RCTAnimation: 6741f7be3e269e057c1426074cc70f34b56e114b
   React-RCTAppDelegate: 0b3b2c1e02c02f952f5033535ddb23d690e3b890
-  React-RCTBlob: 94feb99abafd0527a78f6caaa17a0bcec9ce3167
+  React-RCTBlob: fd1ee93e48aa67b0183346a59754375de93de63d
   React-RCTFabric: db1d7fe55db4811b63ae4060078e7048ebb4a918
   React-RCTImage: 055685a12c88939437f6520d9e7c120cd666cbf1
   React-RCTLinking: b149b3ff1f96fa93fc445230b9c171adb0e5572c
@@ -962,14 +1000,14 @@ SPEC CHECKSUMS:
   React-RCTTest: 81ebfa8c2e1b0b482effe12485e6486dc0ff70d7
   React-RCTText: 4e5ae05b778a0ed2b22b012af025da5e1a1c4e54
   React-RCTVibration: ecfd04c1886a9c9a4e31a466c0fbcf6b36e92fde
-  React-rncore: ec7a711a56a4a64d122be8572b37a67572d5de60
+  React-rncore: 1235cadc4feaa607c9af12ca157b8ae991ade3a5
   React-runtimeexecutor: c7b2cd6babf6cc50340398bfbb7a9da13c93093f
-  ReactCommon: a11d5523be510a2d75e50e435de607297072172a
+  ReactCommon: fdc30b91d89bfd2ed919c2cbccb460435f1f43f4
   ScreenshotManager: 37152a3841a53f2de5c0013c58835b8738894553
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
   Yoga: 1b1a12ff3d86a10565ea7cbe057d42f5e5fb2a07
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: 8da43cb75927abd2bbb2fc21dcebfebb05b89963
+PODFILE CHECKSUM: 920fb3b0e3c9dbdf8d86707f80cf0e7f2dc85c70
 
 COCOAPODS: 1.11.3


### PR DESCRIPTION
Summary:
Changelog:
[General][Fixed] - Invalid prop values no longer trigger assertion failures in Fabric

## Context

Fabric has historically been very strict about prop parsing. It originally `abort()`ed on any prop value that failed to parse according to the expected type; this was replaced with dev-only assertions in D27540903 (https://github.com/facebook/react-native/commit/cb37562f8355b624e271c5b74416c257b0e62a00). We've received feedback that C++ assertions (and other similar mechanisms in the legacy renderer) are still too aggressive and disruptive as a diagnostic for developers working on JS code.

We are changing React Native to behave more like a browser in this regard, reflecting a new principle that **bad style values are not runtime errors**. (See e.g. D43159284 (https://github.com/facebook/react-native/commit/d6e9891577c81503407adaa85db8f5bf97557db0).) The recommended way for developers to ensure they are passing correct style values is to use a typechecker (TypeScript or Flow) in conjunction with E2E tests and manual spot checks.

More broadly, values passed from JS product code should not be able to crash the app, which is why we're not strictly limiting this change to style props. From now on, if a JS developer can trigger an internal assertion in React Native simply by writing normal application code, that is a bug.

## This diff

This diff introduces a new macro called `react_native_expect` which serves as a drop-in replacement for `react_native_assert`, but logs (to glog / logcat / stdout) instead of asserting. This way we don't need to fully delete the existing call sites. This will be helpful if we decide that we want to repurpose these checks for a new, more visible diagnostic.

I'm *intentionally* opting for the simplest possible improvement here, which is to silence the assertions - not to print them to the JS console, not to convert them to LogBox warnings, etc. The hypothesis is that this is already strictly an improvement over the previous behaviour, will help us get to feature parity between renderers faster, and allow us to design improved diagnostics that are consistent and helpful.

## Next steps

1. There are still places where Fabric can hit an unguarded assertion in prop conversion code (e.g. unchecked casts from `RawValue` with no fallback code path). I will fix those in a separate diff.
2. Paper on iOS needs a similar treatment as it calls `RCTLogError` liberally during prop parsing (resulting in a native redbox experience that is nearly as bad as an outright crash). I will fix that in a separate diff.
3. I'll add some manual test cases to RNTester to cover these scenarios.
4. We will eventually need to take a clear stance on PropTypes, but since they provide reasonable, non-breaking diagnostics (recoverable JS LogBox + component stack) it is less urgent to do so.

Reviewed By: sammy-SC

Differential Revision: D43184380

