### PR TITLE
Expose `rrc_root` via prefab

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -113,6 +113,10 @@ final def preparePrefab = tasks.register("preparePrefab", PreparePrefabHeadersTa
                 ]
             ),
             new PrefabPreprocessingEntry(
+                "rrc_root",
+                new Pair("../ReactCommon/react/renderer/components/root/", "react/renderer/components/root/")
+            ),
+            new PrefabPreprocessingEntry(
                 "rrc_view",
                 new Pair("../ReactCommon/react/renderer/components/view/", "react/renderer/components/view/")
             ),
@@ -471,6 +475,7 @@ android {
                     "react_render_core",
                     "react_render_graphics",
                     "rrc_image",
+                    "rrc_root",
                     "rrc_view",
                     "jsi",
                     "glog",
@@ -566,6 +571,9 @@ android {
         }
         rrc_image {
             headers(new File(prefabHeadersDir, "rrc_image").absolutePath)
+        }
+        rrc_root {
+            headers(new File(prefabHeadersDir, "rrc_root").absolutePath)
         }
         rrc_view {
             headers(new File(prefabHeadersDir, "rrc_view").absolutePath)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

The `rrc_root` was not exposed via prefab. I'm adding it to make possible for Reanimated to integrate on top of React Native via prefab. Based on #35643.

## Changelog

[ANDROID] [CHANGED] - Expose `rrc_root` via prefab.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
