### PR TITLE
Fix FlatList ItemSeparatorComponent type

### DIFF
--- a/packages/virtualized-lists/Lists/VirtualizedList.d.ts
+++ b/packages/virtualized-lists/Lists/VirtualizedList.d.ts
@@ -142,7 +142,11 @@ export interface VirtualizedListWithoutRenderItemProps<ItemT>
   /**
    * Rendered in between each item, but not at the top or bottom
    */
-  ItemSeparatorComponent?: React.ComponentType<any> | null | undefined;
+  ItemSeparatorComponent?:
+    | React.ComponentType<any>
+    | React.ReactElement
+    | null
+    | undefined;
 
   /**
    * Rendered when the list is empty. Can be a React Component Class, a render function, or

--- a/packages/virtualized-lists/Lists/VirtualizedListProps.js
+++ b/packages/virtualized-lists/Lists/VirtualizedListProps.js
@@ -112,7 +112,7 @@ type OptionalProps = {|
    * which will update the `highlighted` prop, but you can also add custom props with
    * `separators.updateProps`.
    */
-  ItemSeparatorComponent?: ?React.ComponentType<any>,
+  ItemSeparatorComponent?: ?(React.ComponentType<any> | React.Element<any>),
   /**
    * Takes an item from `data` and renders it into the list. Example usage:
    *


### PR DESCRIPTION
## Summary
FlatList's ItemSeparatorComponent type did not support passing in react element as per documented in docs.

## Changelog
[GENERAL] [FIXED] - Fix FlatList ItemSeparatorComponent type

## Test Plan
None needed