### PR TITLE
update type definitions for unstable_batchedUpdates

### DIFF
--- a/types/public/ReactNativeRenderer.d.ts
+++ b/types/public/ReactNativeRenderer.d.ts
@@ -140,10 +140,5 @@ export interface GestureResponderHandlers {
 /**
  * React Native also implements unstable_batchedUpdates
  */
-export function unstable_batchedUpdates<A, B>(
-  callback: (a: A, b: B) => any,
-  a: A,
-  b: B,
-): void;
-export function unstable_batchedUpdates<A>(callback: (a: A) => any, a: A): void;
-export function unstable_batchedUpdates(callback: () => any): void;
+export function unstable_batchedUpdates<A, R>(callback: (a: A) => R, a: A): R;
+export function unstable_batchedUpdates<R>(callback: () => R): R;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

This PR fixes the type definitions for `unstable_batchedUpdates`. The same change was recently made on DefinitelyTyped - see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/63517 for a more detailed explanation

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

[General] [Fixed] - fix type definition for `unstable_batchedUpdates`


## Test Plan

Note how the typescript defintions now match [the flow definitions](https://github.com/facebook/react-native/blob/43636267011a97490ed7495b08e500c5d0d54872/Libraries/ReactNative/RendererImplementation.js#L99), and note how [the tests in DefinitelyTyped](https://github.com/k-yle/DefinitelyTyped/blob/a4e15e3c2b9c6d689918cbbfa98c02cd26fe7681/types/react-dom/test/react-dom-tests.tsx#L231-L238) are passing.