### PR TITLE
Implement EventCounts Web Performance API for React Native

### DIFF
--- a/Libraries/WebPerformance/EventCounts.js
+++ b/Libraries/WebPerformance/EventCounts.js
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ * @format
+ */
+
+import NativePerformanceObserver from './NativePerformanceObserver';
+import {warnNoNativePerformanceObserver} from './PerformanceObserver';
+
+type EventCountsForEachCallbackType =
+  | (() => void)
+  | ((value: number) => void)
+  | ((value: number, key: string) => void)
+  | ((value: number, key: string, map: Map<string, number>) => void);
+
+let cachedEventCounts: ?Map<string, number>;
+
+function getCachedEventCounts(): Map<string, number> {
+  if (cachedEventCounts) {
+    return cachedEventCounts;
+  }
+  if (!NativePerformanceObserver) {
+    warnNoNativePerformanceObserver();
+    return new Map();
+  }
+
+  cachedEventCounts = new Map<string, number>(
+    NativePerformanceObserver.getEventCounts(),
+  );
+  // $FlowFixMe[incompatible-call]
+  global.queueMicrotask(() => {
+    // To be consistent with the calls to the API from the same task,
+    // but also not to refetch the data from native too often,
+    // schedule to invalidate the cache later,
+    // after the current task is guaranteed to have finished.
+    cachedEventCounts = null;
+  });
+  return cachedEventCounts ?? new Map();
+}
+/**
+ * Implementation of the EventCounts Web Performance API
+ * corresponding to the standard in
+ * https://www.w3.org/TR/event-timing/#eventcounts
+ */
+export default class EventCounts {
+  // flowlint unsafe-getters-setters:off
+  get size(): number {
+    return getCachedEventCounts().size;
+  }
+
+  entries(): Iterator<[string, number]> {
+    return getCachedEventCounts().entries();
+  }
+
+  forEach(callback: EventCountsForEachCallbackType): void {
+    return getCachedEventCounts().forEach(callback);
+  }
+
+  get(key: string): ?number {
+    return getCachedEventCounts().get(key);
+  }
+
+  has(key: string): boolean {
+    return getCachedEventCounts().has(key);
+  }
+
+  keys(): Iterator<string> {
+    return getCachedEventCounts().keys();
+  }
+
+  values(): Iterator<number> {
+    return getCachedEventCounts().values();
+  }
+}

--- a/Libraries/WebPerformance/NativePerformanceObserver.cpp
+++ b/Libraries/WebPerformance/NativePerformanceObserver.cpp
@@ -51,4 +51,12 @@ void NativePerformanceObserver::logRawEntry(
   PerformanceEntryReporter::getInstance().logEntry(entry);
 }
 
+std::vector<std::pair<std::string, uint32_t>>
+NativePerformanceObserver::getEventCounts(jsi::Runtime &rt) {
+  const auto &eventCounts =
+      PerformanceEntryReporter::getInstance().getEventCounts();
+  return std::vector<std::pair<std::string, uint32_t>>(
+      eventCounts.begin(), eventCounts.end());
+}
+
 } // namespace facebook::react

--- a/Libraries/WebPerformance/NativePerformanceObserver.h
+++ b/Libraries/WebPerformance/NativePerformanceObserver.h
@@ -71,6 +71,9 @@ class NativePerformanceObserver
 
   void logRawEntry(jsi::Runtime &rt, RawPerformanceEntry entry);
 
+  std::vector<std::pair<std::string, uint32_t>> getEventCounts(
+      jsi::Runtime &rt);
+
  private:
 };
 

--- a/Libraries/WebPerformance/NativePerformanceObserver.js
+++ b/Libraries/WebPerformance/NativePerformanceObserver.js
@@ -35,6 +35,8 @@ export interface Spec extends TurboModule {
   +stopReporting: (entryType: RawPerformanceEntryType) => void;
   +popPendingEntries: () => GetPendingEntriesResult;
   +setOnPerformanceEntryCallback: (callback?: () => void) => void;
+  +logRawEntry: (entry: RawPerformanceEntry) => void;
+  +getEventCounts: () => $ReadOnlyArray<[string, number]>;
 }
 
 export default (TurboModuleRegistry.get<Spec>(

--- a/Libraries/WebPerformance/Performance.js
+++ b/Libraries/WebPerformance/Performance.js
@@ -14,6 +14,7 @@ import type {HighResTimeStamp} from './PerformanceEntry';
 
 import warnOnce from '../Utilities/warnOnce';
 import MemoryInfo from './MemoryInfo';
+import EventCounts from './EventCounts';
 import NativePerformance from './NativePerformance';
 import {PerformanceEntry} from './PerformanceEntry';
 
@@ -86,9 +87,11 @@ function warnNoNativePerformance() {
 /**
  * Partial implementation of the Performance interface for RN,
  * corresponding to the standard in
- *  https://www.w3.org/TR/user-timing/#extensions-performance-interface
+ * https://www.w3.org/TR/user-timing/#extensions-performance-interface
  */
 export default class Performance {
+  eventCounts: EventCounts = new EventCounts();
+
   // Get the current JS memory information.
   get memory(): MemoryInfo {
     if (NativePerformance?.getSimpleMemoryInfo) {

--- a/Libraries/WebPerformance/PerformanceEntryReporter.cpp
+++ b/Libraries/WebPerformance/PerformanceEntryReporter.cpp
@@ -47,7 +47,12 @@ GetPendingEntriesResult PerformanceEntryReporter::popPendingEntries() {
 }
 
 void PerformanceEntryReporter::logEntry(const RawPerformanceEntry &entry) {
-  if (!isReportingType(static_cast<PerformanceEntryType>(entry.entryType))) {
+  const auto entryType = static_cast<PerformanceEntryType>(entry.entryType);
+  if (entryType == PerformanceEntryType::EVENT) {
+    eventCounts_[entry.name]++;
+  }
+
+  if (!isReportingType(entryType)) {
     return;
   }
 

--- a/Libraries/WebPerformance/PerformanceEntryReporter.h
+++ b/Libraries/WebPerformance/PerformanceEntryReporter.h
@@ -102,6 +102,10 @@ class PerformanceEntryReporter : public EventLogger {
   void onEventDispatch(EventTag tag) override;
   void onEventEnd(EventTag tag) override;
 
+  const std::unordered_map<std::string, uint32_t> &getEventCounts() const {
+    return eventCounts_;
+  }
+
  private:
   PerformanceEntryReporter() {}
 
@@ -117,6 +121,7 @@ class PerformanceEntryReporter : public EventLogger {
   std::vector<RawPerformanceEntry> entries_;
   std::mutex entriesMutex_;
   std::array<bool, (size_t)PerformanceEntryType::_COUNT> reportingType_{false};
+  std::unordered_map<std::string, uint32_t> eventCounts_;
 
   // Mark registry for "measure" lookup
   PerformanceMarkRegistryType marksRegistry_;

--- a/Libraries/WebPerformance/PerformanceObserver.js
+++ b/Libraries/WebPerformance/PerformanceObserver.js
@@ -98,7 +98,7 @@ const onPerformanceEntry = () => {
   }
 };
 
-function warnNoNativePerformanceObserver() {
+export function warnNoNativePerformanceObserver() {
   warnOnce(
     'missing-native-performance-observer',
     'Missing native implementation of PerformanceObserver',

--- a/Libraries/WebPerformance/__mocks__/NativePerformanceObserver.js
+++ b/Libraries/WebPerformance/__mocks__/NativePerformanceObserver.js
@@ -15,7 +15,10 @@ import type {
   Spec as NativePerformanceObserver,
 } from '../NativePerformanceObserver';
 
+import {RawPerformanceEntryTypeValues} from '../RawPerformanceEntry';
+
 const reportingType: Set<RawPerformanceEntryType> = new Set();
+const eventCounts: Map<string, number> = new Map();
 let entries: Array<RawPerformanceEntry> = [];
 let onPerformanceEntryCallback: ?() => void;
 
@@ -50,6 +53,13 @@ const NativePerformanceObserverMock: NativePerformanceObserver = {
         onPerformanceEntryCallback?.();
       });
     }
+    if (entry.entryType === RawPerformanceEntryTypeValues.EVENT) {
+      eventCounts.set(entry.name, (eventCounts.get(entry.name) ?? 0) + 1);
+    }
+  },
+
+  getEventCounts: (): $ReadOnlyArray<[string, number]> => {
+    return Array.from(eventCounts.entries());
   },
 };
 

--- a/Libraries/WebPerformance/__tests__/EventCounts-test.js
+++ b/Libraries/WebPerformance/__tests__/EventCounts-test.js
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @oncall react_native
+ */
+
+import {RawPerformanceEntryTypeValues} from '../RawPerformanceEntry';
+
+// NOTE: Jest mocks of transitive dependencies don't appear to work with
+// ES6 module imports, therefore forced to use commonjs style imports here.
+const NativePerformanceObserver = require('../NativePerformanceObserver');
+const Performance = require('../Performance').default;
+
+jest.mock(
+  '../NativePerformanceObserver',
+  () => require('../__mocks__/NativePerformanceObserver').default,
+);
+
+describe('EventCounts', () => {
+  it('defines EventCounts for Performance', () => {
+    const eventCounts = new Performance().eventCounts;
+    expect(eventCounts).not.toBeUndefined();
+  });
+
+  it('consistently implements the API for EventCounts', async () => {
+    NativePerformanceObserver.logRawEntry({
+      name: 'click',
+      entryType: RawPerformanceEntryTypeValues.EVENT,
+    });
+
+    NativePerformanceObserver.logRawEntry({
+      name: 'input',
+      entryType: RawPerformanceEntryTypeValues.EVENT,
+    });
+
+    NativePerformanceObserver.logRawEntry({
+      name: 'input',
+      entryType: RawPerformanceEntryTypeValues.EVENT,
+    });
+
+    NativePerformanceObserver.logRawEntry({
+      name: 'keyup',
+      entryType: RawPerformanceEntryTypeValues.EVENT,
+    });
+
+    NativePerformanceObserver.logRawEntry({
+      name: 'keyup',
+      entryType: RawPerformanceEntryTypeValues.EVENT,
+    });
+
+    NativePerformanceObserver.logRawEntry({
+      name: 'keyup',
+      entryType: RawPerformanceEntryTypeValues.EVENT,
+    });
+
+    const eventCounts = new Performance().eventCounts;
+    expect(eventCounts.size).toBe(3);
+    expect(Array.from(eventCounts.entries())).toStrictEqual([
+      ['click', 1],
+      ['input', 2],
+      ['keyup', 3],
+    ]);
+
+    expect(eventCounts.get('click')).toEqual(1);
+    expect(eventCounts.get('input')).toEqual(2);
+    expect(eventCounts.get('keyup')).toEqual(3);
+
+    expect(eventCounts.has('click')).toEqual(true);
+    expect(eventCounts.has('input')).toEqual(true);
+    expect(eventCounts.has('keyup')).toEqual(true);
+
+    expect(Array.from(eventCounts.keys())).toStrictEqual([
+      'click',
+      'input',
+      'keyup',
+    ]);
+    expect(Array.from(eventCounts.values())).toStrictEqual([1, 2, 3]);
+
+    await jest.runAllTicks();
+    NativePerformanceObserver.logRawEntry({
+      name: 'input',
+      entryType: RawPerformanceEntryTypeValues.EVENT,
+    });
+
+    NativePerformanceObserver.logRawEntry({
+      name: 'keyup',
+      entryType: RawPerformanceEntryTypeValues.EVENT,
+    });
+
+    NativePerformanceObserver.logRawEntry({
+      name: 'keyup',
+      entryType: RawPerformanceEntryTypeValues.EVENT,
+    });
+    expect(Array.from(eventCounts.values())).toStrictEqual([1, 3, 5]);
+
+    await jest.runAllTicks();
+
+    NativePerformanceObserver.logRawEntry({
+      name: 'click',
+      entryType: RawPerformanceEntryTypeValues.EVENT,
+    });
+
+    await jest.runAllTicks();
+
+    NativePerformanceObserver.logRawEntry({
+      name: 'keyup',
+      entryType: RawPerformanceEntryTypeValues.EVENT,
+    });
+
+    expect(Array.from(eventCounts.values())).toStrictEqual([2, 3, 6]);
+  });
+});


### PR DESCRIPTION
Summary:
[Changelog][Internal]

Implements EventCounts API (`Performance.eventCounts`) for Web Performance, according to the W3C standard, see the specs here: https://www.w3.org/TR/event-timing/#eventcounts

The rationale for why we need it is to support some advanced metrics computations, such as a ratio of "slow events" to total event count, per event type.

Reviewed By: rubennorte

Differential Revision: D43285073

