### PR TITLE
[ci][monorepo] bump package versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "@react-native/gradle-plugin": "^0.72.2",
     "@react-native/js-polyfills": "^0.72.0",
     "@react-native/normalize-colors": "^0.72.0",
-    "@react-native/virtualized-lists": "0.72.0",
+    "@react-native/virtualized-lists": "^0.72.0",
     "abort-controller": "^3.0.0",
     "anser": "^1.4.9",
     "base64-js": "^1.1.2",

--- a/packages/babel-plugin-codegen/package.json
+++ b/packages/babel-plugin-codegen/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.72.1",
+  "version": "0.72.2",
   "name": "@react-native/babel-plugin-codegen",
   "description": "Babel plugin to generate native module and view manager code for React Native.",
   "repository": {

--- a/packages/eslint-plugin-specs/package.json
+++ b/packages/eslint-plugin-specs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native/eslint-plugin-specs",
-  "version": "0.72.1",
+  "version": "0.72.2",
   "description": "ESLint rules to validate NativeModule and Component Specs",
   "main": "index.js",
   "repository": {

--- a/packages/polyfills/package.json
+++ b/packages/polyfills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native/js-polyfills",
-  "version": "0.72.0",
+  "version": "0.72.1",
   "description": "Polyfills for React Native.",
   "repository": {
     "type": "git",

--- a/packages/react-native-codegen/package.json
+++ b/packages/react-native-codegen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native/codegen",
-  "version": "0.72.1",
+  "version": "0.72.2",
   "description": "⚛️ Code generation tools for React Native",
   "homepage": "https://github.com/facebook/react-native/tree/HEAD/packages/react-native-codegen",
   "repository": {

--- a/packages/react-native-gradle-plugin/package.json
+++ b/packages/react-native-gradle-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native/gradle-plugin",
-  "version": "0.72.2",
+  "version": "0.72.3",
   "description": "⚛️ Gradle Plugin for React Native",
   "homepage": "https://github.com/facebook/react-native/tree/HEAD/packages/react-native-gradle-plugin",
   "repository": {

--- a/packages/virtualized-lists/package.json
+++ b/packages/virtualized-lists/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native/virtualized-lists",
-  "version": "0.72.0",
+  "version": "0.72.1",
   "description": "Virtualized lists for React Native.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

We do have a lot of changes on `main` to ship to nightlies. This change bump all the packages with pending changes.

## Changelog

[INTERNAL] [CHANGED] - [ci][monorepo] bump package versions

## Test Plan

Will rely on CI run.