### PR TITLE
brew should overwrite existing python links

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -593,6 +593,11 @@ jobs:
       - run:
           name: "Brew: Tap wix/brew"
           command: brew tap wix/brew >/dev/null
+      - run:
+          # Python 3.10 already exists in the environment, this is a workaround for:
+          # https://github.com/actions/setup-python/issues/577
+          name: "Unlink environment's Python 3.10"
+          command: brew unlink python@3.10
       - brew_install:
           package: applesimutils watchman
 


### PR DESCRIPTION
Summary:
Builds are failing on CI because brew bails out when it tries installing Python 3.1. The image already has an existing version of Python 3, which we should overwrite.

Changelog:
[General][Changed] - Brew overwrites system Python 3.

Differential Revision: D43391941

