### PR TITLE
RNGP - ENTRY_FILE should resolve relative paths from root

### DIFF
--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/TaskConfiguration.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/TaskConfiguration.kt
@@ -51,13 +51,14 @@ internal fun Project.configureReactTasks(variant: Variant, config: ReactExtensio
   configureJsEnginePackagingOptions(config, variant, isHermesEnabledInThisVariant)
 
   if (!isDebuggableVariant) {
+    val entryFileEnvVariable = System.getenv("ENTRY_FILE")
     val bundleTask =
         tasks.register("createBundle${targetName}JsAndAssets", BundleHermesCTask::class.java) {
           it.root.set(config.root)
           it.nodeExecutableAndArgs.set(config.nodeExecutableAndArgs)
           it.cliFile.set(cliFile)
           it.bundleCommand.set(config.bundleCommand)
-          it.entryFile.set(detectedEntryFile(config))
+          it.entryFile.set(detectedEntryFile(config, entryFileEnvVariable))
           it.extraPackagerArgs.set(config.extraPackagerArgs)
           it.bundleConfig.set(config.bundleConfig)
           it.bundleAssetName.set(config.bundleAssetName)

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/PathUtils.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/PathUtils.kt
@@ -25,9 +25,11 @@ import org.gradle.api.file.DirectoryProperty
  *
  * @param config The [ReactExtension] configured for this project
  */
-internal fun detectedEntryFile(config: ReactExtension): File =
+internal fun detectedEntryFile(config: ReactExtension, envVariableOverride: String? = null): File =
     detectEntryFile(
-        entryFile = config.entryFile.orNull?.asFile, reactRoot = config.root.get().asFile)
+        entryFile = config.entryFile.orNull?.asFile,
+        reactRoot = config.root.get().asFile,
+        envVariableOverride = envVariableOverride)
 
 /**
  * Computes the CLI file for React Native. The Algo follows this order:
@@ -54,9 +56,13 @@ internal fun detectedCliFile(config: ReactExtension): File =
 internal fun detectedHermesCommand(config: ReactExtension): String =
     detectOSAwareHermesCommand(config.root.get().asFile, config.hermesCommand.get())
 
-private fun detectEntryFile(entryFile: File?, reactRoot: File): File =
+private fun detectEntryFile(
+    entryFile: File?,
+    reactRoot: File,
+    envVariableOverride: String? = null
+): File =
     when {
-      System.getenv("ENTRY_FILE") != null -> File(System.getenv("ENTRY_FILE"))
+      envVariableOverride != null -> File(reactRoot, envVariableOverride)
       entryFile != null -> entryFile
       File(reactRoot, "index.android.js").exists() -> File(reactRoot, "index.android.js")
       else -> File(reactRoot, "index.js")

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/PathUtilsTest.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/PathUtilsTest.kt
@@ -58,6 +58,20 @@ class PathUtilsTest {
   }
 
   @Test
+  fun detectedEntryFile_withEnvironmentVariable() {
+    val extension = TestReactExtension(ProjectBuilder.builder().build())
+    val expected = tempFolder.newFile("./fromenv.index.js")
+    // As we can't override env variable for tests, we're going to emulate them here.
+    val envVariable = "./fromenv.index.js"
+
+    extension.root.set(tempFolder.root)
+
+    val actual = detectedEntryFile(extension, envVariable)
+
+    assertEquals(expected, actual)
+  }
+
+  @Test
   fun detectedCliPath_withCliPathFromExtensionAndFileExists_returnsIt() {
     val project = ProjectBuilder.builder().build()
     val cliFile = tempFolder.newFile("cli.js").apply { createNewFile() }


### PR DESCRIPTION
Summary:
Fixes #36186

Changelog:
[Android] [Fixed] - ENTRY_FILE should resolve relative paths from root

Differential Revision: D43392121

