### PR TITLE
Enable NDEBUG in production builds

### DIFF
--- a/scripts/cocoapods/__tests__/new_architecture-test.rb
+++ b/scripts/cocoapods/__tests__/new_architecture-test.rb
@@ -111,6 +111,42 @@ class NewArchitectureTests < Test::Unit::TestCase
         assert_equal(yoga_release_config.build_settings["OTHER_CPLUSPLUSFLAGS"], "$(inherited)")
     end
 
+    def test_modifyFlagsForNewArch_whenOnNewArchAndIsRelease_updateFlags
+        # Arrange
+        first_xcconfig = prepare_xcconfig("First")
+        second_xcconfig = prepare_xcconfig("Second")
+        react_core_debug_config = prepare_CXX_Flags_build_configuration("Debug")
+        react_core_release_config = prepare_CXX_Flags_build_configuration("Release")
+        yoga_debug_config = prepare_CXX_Flags_build_configuration("Debug")
+        yoga_release_config = prepare_CXX_Flags_build_configuration("Release")
+
+        installer = prepare_installer_for_cpp_flags(
+            [ first_xcconfig, second_xcconfig ],
+            {
+                "React-Core" => [ react_core_debug_config, react_core_release_config ],
+                "Yoga" => [ yoga_debug_config, yoga_release_config ],
+            }
+        )
+        # Act
+        NewArchitectureHelper.modify_flags_for_new_architecture(installer, true, is_release: true)
+
+        # Assert
+        assert_equal(first_xcconfig.attributes["OTHER_CPLUSPLUSFLAGS"], "$(inherited) -DRCT_NEW_ARCH_ENABLED=1 -DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DNDEBUG")
+        assert_equal(first_xcconfig.attributes["OTHER_CFLAGS"], "$(inherited) -DNDEBUG")
+        assert_equal(first_xcconfig.save_as_invocation, ["a/path/First.xcconfig"])
+        assert_equal(second_xcconfig.attributes["OTHER_CPLUSPLUSFLAGS"], "$(inherited) -DRCT_NEW_ARCH_ENABLED=1 -DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DNDEBUG")
+        assert_equal(second_xcconfig.attributes["OTHER_CFLAGS"], "$(inherited) -DNDEBUG")
+        assert_equal(second_xcconfig.save_as_invocation, ["a/path/Second.xcconfig"])
+        assert_equal(react_core_debug_config.build_settings["OTHER_CPLUSPLUSFLAGS"], "$(inherited) -DRCT_NEW_ARCH_ENABLED=1 -DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DNDEBUG")
+        assert_equal(react_core_debug_config.build_settings["OTHER_CFLAGS"], "$(inherited) -DNDEBUG")
+        assert_equal(react_core_release_config.build_settings["OTHER_CPLUSPLUSFLAGS"], "$(inherited) -DRCT_NEW_ARCH_ENABLED=1 -DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DNDEBUG")
+        assert_equal(react_core_release_config.build_settings["OTHER_CFLAGS"], "$(inherited) -DNDEBUG")
+        assert_equal(yoga_debug_config.build_settings["OTHER_CPLUSPLUSFLAGS"], "$(inherited) -DNDEBUG")
+        assert_equal(yoga_debug_config.build_settings["OTHER_CFLAGS"], "$(inherited) -DNDEBUG")
+        assert_equal(yoga_release_config.build_settings["OTHER_CPLUSPLUSFLAGS"], "$(inherited) -DNDEBUG")
+        assert_equal(yoga_release_config.build_settings["OTHER_CFLAGS"], "$(inherited) -DNDEBUG")
+    end
+
     # =================================== #
     # Test - install Modules Dependencies #
     # =================================== #

--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -218,7 +218,7 @@ def react_native_post_install(installer, react_native_path = "../node_modules/re
 
   NewArchitectureHelper.set_clang_cxx_language_standard_if_needed(installer)
   is_new_arch_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == "1"
-  NewArchitectureHelper.modify_flags_for_new_architecture(installer, is_new_arch_enabled)
+  NewArchitectureHelper.modify_flags_for_new_architecture(installer, is_new_arch_enabled, is_release: ENV['PRODUCTION'] == "1")
 
   Pod::UI.puts "Pod install took #{Time.now.to_i - $START_TIME} [s] to run".green
 end


### PR DESCRIPTION
Summary:
This change is the iOS equivalent of D43344120 (https://github.com/facebook/react-native/commit/8486e191a170d9eae4d1d628a7539dc9e3d13ea4), but for iOS.

## Changelog:
[iOS][Fixed] - Turn on NDEBUG when pods are installed for production.

Reviewed By: cortinico

Differential Revision: D43388881

