### PR TITLE
fix: add width, height and crossOrigin props on Image type declaration file

### DIFF
--- a/Libraries/Image/Image.d.ts
+++ b/Libraries/Image/Image.d.ts
@@ -254,6 +254,20 @@ export interface ImagePropsBase
    * See https://reactnative.dev/docs/image#alt
    */
   alt?: string | undefined;
+
+  /**
+   * Height of the image component.
+   *
+   * See https://reactnative.dev/docs/image#height
+   */
+  height?: number | undefined;
+
+  /**
+   * Width of the image component.
+   *
+   * See https://reactnative.dev/docs/image#width
+   */
+  width?: number | undefined;
 }
 
 export interface ImageProps extends ImagePropsBase {

--- a/Libraries/Image/Image.d.ts
+++ b/Libraries/Image/Image.d.ts
@@ -268,6 +268,14 @@ export interface ImagePropsBase
    * See https://reactnative.dev/docs/image#width
    */
   width?: number | undefined;
+
+  /**
+   * Adds the CORS related header to the request.
+   * Similar to crossorigin from HTML.
+   *
+   * See https://reactnative.dev/docs/image#crossorigin
+   */
+  crossOrigin?: 'anonymous' | 'use-credentials',
 }
 
 export interface ImageProps extends ImagePropsBase {


### PR DESCRIPTION
## Summary

According this Issue [`#36182`](https://github.com/facebook/react-native/issues/36182), the typescript compiler doesn't know the `width`, `height` and `crossOrigin` props for the `Image` component although they are taken in account in the code, [docs](https://reactnative.dev/docs/image#crossorigin) and the flow types.

## Changelog

[GENERAL] [FIXED] - Fix missing `height`, `width`, `crossOrigin` props on Typescript Image.d.ts file
