### PR TITLE
Refactor BUCK file for WebPerformance (use TurboModule plugins)

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -20,6 +20,7 @@ load(
     "RCT_URL_REQUEST_HANDLER_SOCKET",
     "YOGA_CXX_TARGET",
     "get_react_native_ios_target_sdk_version",
+    "react_cxx_module_plugin_provider",
     "react_fabric_component_plugin_provider",
     "react_module_plugin_providers",
     "react_native_root_target",
@@ -28,6 +29,7 @@ load(
     "rn_apple_library",
     "rn_apple_xplat_cxx_library",
     "rn_extra_build_flags",
+    "rn_xplat_cxx_library",
     "subdir_glob",
 )
 load("//tools/build_defs/third_party:yarn_defs.bzl", "yarn_workspace")
@@ -1455,7 +1457,7 @@ rn_apple_xplat_cxx_library(
     ],
 )
 
-rn_apple_xplat_cxx_library(
+rn_xplat_cxx_library(
     name = "RCTWebPerformance",
     srcs = glob([
         "Libraries/WebPerformance/**/*.cpp",
@@ -1465,15 +1467,23 @@ rn_apple_xplat_cxx_library(
         [("Libraries/WebPerformance", "*.h")],
         prefix = "RCTWebPerformance",
     ),
-    fbandroid_compiler_flags = [
-        "-fexceptions",
-        "-frtti",
-    ],
+    compiler_flags_enable_exceptions = True,
+    compiler_flags_enable_rtti = True,
     labels = [
         "depslint_never_remove",
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
     ],
     platforms = (ANDROID, APPLE, CXX),
+    plugins = [
+        react_cxx_module_plugin_provider(
+            name = "NativePerformanceCxx",
+            function = "NativePerformanceModuleProvider",
+        ),
+        react_cxx_module_plugin_provider(
+            name = "NativePerformanceObserverCxx",
+            function = "NativePerformanceObserverModuleProvider",
+        ),
+    ],
     visibility = ["PUBLIC"],
     deps = [
         ":FBReactNativeSpecJSI",

--- a/Libraries/WebPerformance/NativePerformance.cpp
+++ b/Libraries/WebPerformance/NativePerformance.cpp
@@ -5,10 +5,19 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "NativePerformance.h"
-#include <glog/logging.h>
+#include <memory>
+
 #include <jsi/instrumentation.h>
+#include "NativePerformance.h"
 #include "PerformanceEntryReporter.h"
+
+#include "Plugins.h"
+
+std::shared_ptr<facebook::react::TurboModule> NativePerformanceModuleProvider(
+    std::shared_ptr<facebook::react::CallInvoker> jsInvoker) {
+  return std::make_shared<facebook::react::NativePerformance>(
+      std::move(jsInvoker));
+}
 
 namespace facebook::react {
 

--- a/Libraries/WebPerformance/NativePerformanceObserver.cpp
+++ b/Libraries/WebPerformance/NativePerformanceObserver.cpp
@@ -5,8 +5,19 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <memory>
+
 #include "NativePerformanceObserver.h"
 #include "PerformanceEntryReporter.h"
+
+#include "Plugins.h"
+
+std::shared_ptr<facebook::react::TurboModule>
+NativePerformanceObserverModuleProvider(
+    std::shared_ptr<facebook::react::CallInvoker> jsInvoker) {
+  return std::make_shared<facebook::react::NativePerformanceObserver>(
+      std::move(jsInvoker));
+}
 
 namespace facebook::react {
 

--- a/tools/build_defs/oss/rn_defs.bzl
+++ b/tools/build_defs/oss/rn_defs.bzl
@@ -424,6 +424,10 @@ def react_module_plugin_providers(*args, **kwargs):
 def react_fabric_component_plugin_provider(name, native_class_func):
     return None
 
+# C++ TurboModule plugins support (stubbed)
+def react_cxx_module_plugin_provider(name, function):
+    return None
+
 HERMES_BYTECODE_VERSION = -1
 
 RCT_IMAGE_DATA_DECODER_SOCKET = None


### PR DESCRIPTION
Summary:
[Changelog][Internal]

This turns NativePerformance* module dependencies into "TurboModule plugins", which allows for more streamlined client integration (as it makes them register automatically once the dependency is there).

Differential Revision: D43353204

