### PR TITLE
Support HermesAPILeanOrFull in react native apps

### DIFF
--- a/ReactAndroid/src/main/jni/react/hermes/instrumentation/BUCK
+++ b/ReactAndroid/src/main/jni/react/hermes/instrumentation/BUCK
@@ -22,6 +22,6 @@ rn_xplat_cxx_library(
     deps = [
         react_native_target("jni/react/jni:jni"),
         FBJNI_TARGET,
-        react_native_xplat_dep("hermes/API:HermesAPI"),
+        react_native_xplat_dep("hermes/API:HermesAPIFullOrLean"),
     ],
 )

--- a/ReactCommon/hermes/inspector/BUCK
+++ b/ReactCommon/hermes/inspector/BUCK
@@ -62,7 +62,7 @@ fb_xplat_cxx_library(
         ":inspectorlib",
         "//third-party/glog:glog",
         "//xplat/folly:futures",
-        "//xplat/hermes/API:HermesAPI",
+        "//xplat/hermes/API:HermesAPIFullOrLean",
         "//xplat/jsi:JSIDynamic",
         "//xplat/jsi:jsi",
     ],
@@ -164,7 +164,7 @@ fb_xplat_cxx_binary(
     deps = [
         ":chrome",
         ":inspectorlib",
-        "//xplat/hermes/API:HermesAPI",
+        "//xplat/hermes/API:HermesAPIFullOrLean",
     ],
 )
 
@@ -203,7 +203,7 @@ fb_xplat_cxx_library(
         ":detail",
         "//third-party/glog:glog",
         "//xplat/folly:futures",
-        "//xplat/hermes/API:HermesAPI",
+        "//xplat/hermes/API:HermesAPIFullOrLean",
         "//xplat/jsi:jsi",
     ],
 )


### PR DESCRIPTION
Summary:
This changes all of the in-built dependencies in react native app components upon hermes from HermesAPI to HermesAPIFullOrLean.

HermesAPI (full) includes the bytecode compiler and thus has support for eval().
HermesAPILean does not include the bytecode compiler. It throws at runtime if eval is called. The native dependencies are significantly smaller without the bytecode compiler.

The HermesAPIFullOrLean target toggles between full and lean modes based on the value of buckconfig field `hermes.lean_vm` (default is false). Therefore, without overriding this config option, this change is a no-op and should result in react native apps being built with exactly the same dependencies as before.

If you do specify it, you lose eval support at runtime and gain an apk size savings of a few hundred kB after compression.

Differential Revision: D43283200

## Changelog [Android] [Changed] - Updated build configuration to depend on HermesAPIFullOrLean instead of HermesAPI, to enable slimmer builds via a mode change