### PR TITLE
Install the RuntimeScheduler when the New Architecture is enabled

### DIFF
--- a/Libraries/AppDelegate/RCTAppSetupUtils.h
+++ b/Libraries/AppDelegate/RCTAppSetupUtils.h
@@ -31,11 +31,17 @@
 #endif
 
 #if RCT_NEW_ARCH_ENABLED
+// Forward declaration to decrease compilation coupling
+namespace facebook::react {
+class RuntimeScheduler;
+}
+
 RCT_EXTERN id<RCTTurboModule> RCTAppSetupDefaultModuleFromClass(Class moduleClass);
 
 std::unique_ptr<facebook::react::JSExecutorFactory> RCTAppSetupDefaultJsExecutorFactory(
     RCTBridge *bridge,
-    RCTTurboModuleManager *turboModuleManager);
+    RCTTurboModuleManager *turboModuleManager,
+    std::shared_ptr<facebook::react::RuntimeScheduler> const &runtimeScheduler);
 #endif
 
 #endif // __cplusplus

--- a/packages/rn-tester/RNTester/AppDelegate.mm
+++ b/packages/rn-tester/RNTester/AppDelegate.mm
@@ -15,6 +15,10 @@
 #endif
 #endif
 
+#ifdef RCT_NEW_ARCH_ENABLED
+#define RN_FABRIC_ENABLED
+#endif
+
 #if RCT_USE_HERMES
 #import <reacthermes/HermesExecutorFactory.h>
 #else
@@ -48,6 +52,9 @@
 #import <React/RCTSurfacePresenterBridgeAdapter.h>
 
 #import <react/config/ReactNativeConfig.h>
+#import <react/renderer/runtimescheduler/RuntimeScheduler.h>
+#import <react/renderer/runtimescheduler/RuntimeSchedulerBinding.h>
+#import <react/renderer/runtimescheduler/RuntimeSchedulerCallInvoker.h>
 #endif
 
 #if DEBUG
@@ -70,6 +77,7 @@
   RCTSurfacePresenterBridgeAdapter *_bridgeAdapter;
   std::shared_ptr<const facebook::react::ReactNativeConfig> _reactNativeConfig;
   facebook::react::ContextContainer::Shared _contextContainer;
+  std::shared_ptr<facebook::react::RuntimeScheduler> _runtimeScheduler;
 #endif
 
   RCTTurboModuleManager *_turboModuleManager;
@@ -84,17 +92,18 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
 {
   RCTEnableTurboModule(YES);
 
+#ifdef RN_FABRIC_ENABLED
+  _contextContainer = std::make_shared<facebook::react::ContextContainer const>();
+  _reactNativeConfig = std::make_shared<facebook::react::EmptyReactNativeConfig const>();
+  _contextContainer->insert("ReactNativeConfig", _reactNativeConfig);
+#endif
+
   _bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
 
   // Appetizer.io params check
   NSDictionary *initProps = [self prepareInitialProps];
 
 #ifdef RN_FABRIC_ENABLED
-  _contextContainer = std::make_shared<facebook::react::ContextContainer const>();
-  _reactNativeConfig = std::make_shared<facebook::react::EmptyReactNativeConfig const>();
-
-  _contextContainer->insert("ReactNativeConfig", _reactNativeConfig);
-
   _bridgeAdapter = [[RCTSurfacePresenterBridgeAdapter alloc] initWithBridge:_bridge contextContainer:_contextContainer];
 
   _bridge.surfacePresenter = _bridgeAdapter.surfacePresenter;
@@ -174,11 +183,19 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
 
 #pragma mark - RCTCxxBridgeDelegate
 
+// This function is called during
+// `[[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];`
 - (std::unique_ptr<facebook::react::JSExecutorFactory>)jsExecutorFactoryForBridge:(RCTBridge *)bridge
 {
-  _turboModuleManager = [[RCTTurboModuleManager alloc] initWithBridge:bridge
-                                                             delegate:self
-                                                            jsInvoker:bridge.jsCallInvoker];
+  std::shared_ptr<facebook::react::CallInvoker> callInvoker = bridge.jsCallInvoker;
+
+#ifdef RCT_NEW_ARCH_ENABLED
+  _runtimeScheduler = std::make_shared<facebook::react::RuntimeScheduler>(RCTRuntimeExecutorFromBridge(bridge));
+  _contextContainer->erase("RuntimeScheduler");
+  _contextContainer->insert("RuntimeScheduler", _runtimeScheduler);
+  callInvoker = std::make_shared<facebook::react::RuntimeSchedulerCallInvoker>(_runtimeScheduler);
+#endif
+  _turboModuleManager = [[RCTTurboModuleManager alloc] initWithBridge:bridge delegate:self jsInvoker:callInvoker];
   [bridge setRCTTurboModuleRegistry:_turboModuleManager];
 
 #if RCT_DEV
@@ -190,6 +207,7 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
 #endif
 
   __weak __typeof(self) weakSelf = self;
+
 #if RCT_USE_HERMES
   return std::make_unique<facebook::react::HermesExecutorFactory>(
 #else
@@ -200,6 +218,9 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
           return;
         }
         __typeof(self) strongSelf = weakSelf;
+        if (strongSelf && strongSelf->_runtimeScheduler) {
+          facebook::react::RuntimeSchedulerBinding::createAndInstallIfNeeded(runtime, strongSelf->_runtimeScheduler);
+        }
         if (strongSelf) {
           facebook::react::RuntimeExecutor syncRuntimeExecutor =
               [&](std::function<void(facebook::jsi::Runtime & runtime_)> &&callback) { callback(runtime); };

--- a/scripts/cocoapods/utils.rb
+++ b/scripts/cocoapods/utils.rb
@@ -131,6 +131,28 @@ class ReactNativePodsUtils
         end
     end
 
+    def self.apply_flags_for_fabric(installer, fabric_enabled: false)
+        return if !fabric_enabled
+
+        fabric_flag = "-DRN_FABRIC_ENABLED"
+        projects = installer.aggregate_targets
+            .map{ |t| t.user_project }
+            .uniq{ |p| p.path }
+            .push(installer.pods_project)
+
+        projects.each do |project|
+            project.build_configurations.each do |config|
+                cflags = config.build_settings["OTHER_CFLAGS"] ? config.build_settings["OTHER_CFLAGS"] : "$(inherited)"
+
+                if !cflags.include?(fabric_flag)
+                    cflags = "#{cflags} #{fabric_flag}"
+                end
+                config.build_settings["OTHER_CFLAGS"] = cflags
+            end
+            project.save()
+        end
+    end
+
     private
 
     def self.fix_library_search_path(config)

--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -212,10 +212,13 @@ def react_native_post_install(installer, react_native_path = "../node_modules/re
     flipper_post_install(installer)
   end
 
+  fabric_enabled = ReactNativePodsUtils.has_pod(installer, 'React-Fabric')
+
   ReactNativePodsUtils.exclude_i386_architecture_while_using_hermes(installer)
   ReactNativePodsUtils.fix_library_search_paths(installer)
   ReactNativePodsUtils.update_search_paths(installer)
   ReactNativePodsUtils.set_node_modules_user_settings(installer, react_native_path)
+  ReactNativePodsUtils.apply_flags_for_fabric(installer, fabric_enabled: fabric_enabled)
 
   NewArchitectureHelper.set_clang_cxx_language_standard_if_needed(installer)
   is_new_arch_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == "1"


### PR DESCRIPTION
Summary:
ThisChange automatically enable the RuntimeScheduler when the new architecture is enabled, both on RNester and in the Template app.

Note that no migration steps are required.

## Changelog
[iOS][Changed] - Automatically install the RuntimeScheduler

Differential Revision: D43392059

