### PR TITLE
Missing src, srcSet, referrerPolicy, tintColor on Image.d.ts

### DIFF
--- a/Libraries/Image/Image.d.ts
+++ b/Libraries/Image/Image.d.ts
@@ -226,6 +226,14 @@ export interface ImagePropsBase
   source: ImageSourcePropType;
 
   /**
+   * A string representing the resource identifier for the image. Similar to
+   * src from HTML.
+   *
+   * See https://reactnative.dev/docs/image#src
+   */
+  src?: string | undefined,
+
+  /**
    * similarly to `source`, this property represents the resource used to render
    * the loading indicator for the image, displayed until image is ready to be
    * displayed, typically after when it got downloaded from network.

--- a/Libraries/Image/Image.d.ts
+++ b/Libraries/Image/Image.d.ts
@@ -12,7 +12,7 @@ import {Constructor} from '../../types/private/Utilities';
 import {AccessibilityProps} from '../Components/View/ViewAccessibility';
 import {Insets} from '../../types/public/Insets';
 import {NativeMethods} from '../../types/public/ReactNativeTypes';
-import {StyleProp} from '../StyleSheet/StyleSheet';
+import {ColorValue, StyleProp} from '../StyleSheet/StyleSheet';
 import {ImageStyle, ViewStyle} from '../StyleSheet/StyleSheetTypes';
 import {LayoutChangeEvent, NativeSyntheticEvent} from '../Types/CoreEventTypes';
 import {ImageResizeMode} from './ImageResizeMode';
@@ -276,6 +276,13 @@ export interface ImagePropsBase
    * See https://reactnative.dev/docs/image#crossorigin
    */
   crossOrigin?: 'anonymous' | 'use-credentials';
+
+  /**
+   * Changes the color of all the non-transparent pixels to the tintColor.
+   *
+   * See https://reactnative.dev/docs/image#tintcolor
+   */
+  tintColor?: ColorValue | undefined,
 }
 
 export interface ImageProps extends ImagePropsBase {

--- a/Libraries/Image/Image.d.ts
+++ b/Libraries/Image/Image.d.ts
@@ -283,6 +283,21 @@ export interface ImagePropsBase
    * See https://reactnative.dev/docs/image#tintcolor
    */
   tintColor?: ColorValue | undefined,
+
+  /**
+   * A string indicating which referrer to use when fetching the resource.
+   * Similar to referrerpolicy from HTML.
+   *
+   * See https://reactnative.dev/docs/image#referrerpolicy
+   */
+  referrerPolicy?: 'no-referrer'
+    | 'no-referrer-when-downgrade'
+    | 'origin'
+    | 'origin-when-cross-origin'
+    | 'same-origin' | 'strict-origin'
+    | 'strict-origin-when-cross-origin'
+    | 'unsafe-url'
+    | undefined,
 }
 
 export interface ImageProps extends ImagePropsBase {

--- a/Libraries/Image/Image.d.ts
+++ b/Libraries/Image/Image.d.ts
@@ -234,6 +234,13 @@ export interface ImagePropsBase
   src?: string | undefined,
 
   /**
+   * Similar to srcset from HTML.
+   *
+   * See https://reactnative.dev/docs/image#srcset
+   */
+  srcSet?: string | undefined,
+
+  /**
    * similarly to `source`, this property represents the resource used to render
    * the loading indicator for the image, displayed until image is ready to be
    * displayed, typically after when it got downloaded from network.


### PR DESCRIPTION
## Summary

After reviewing the doc [`Image`](https://reactnative.dev/docs/image), the typescript compiler doesn't know the following properties:
- src
- srcSet
- referrerPolicy
- tintColor
- objectFit

But after reviewing the source code and this [`commit`](https://github.com/facebook/react-native/commit/b2452ab216e28e004dc625dd8e1ad32351a79be9), the `objectFit` property isn't one related to the Image component but to the `style` props, making the official doc outdated. So, an [`issue in the react-native-website repo`](https://github.com/facebook/react-native-website/issues/3579) have been created and I decided to not include the objectFit prop in this PR.  

So, this PR includes those properties: sec, secSet, referrerPolicy and tintColor

## Changelog

[GENERAL][FIXED] Add src, srcSet, referrerPolicy, tintColor to Image.d.ts declaration file

## Test Plan

To test it, create/use a typescript file and call the `Image` component. Then, check if the autocompletion provides you the right properties with the right type. For example, for the referrerPolicy one:

![Capture d’écran 2023-02-20 à 20 50 34](https://user-images.githubusercontent.com/29439916/220188855-0ae4217b-b16a-4aaf-a15d-263e1cc9b999.jpg)

