### PR TITLE
Make sure not to override user background color

### DIFF
--- a/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -54,12 +54,6 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
   NSDictionary *initProps = [self prepareInitialProps];
   UIView *rootView = [self createRootViewWithBridge:self.bridge moduleName:self.moduleName initProps:initProps];
 
-  if (@available(iOS 13.0, *)) {
-    rootView.backgroundColor = [UIColor systemBackgroundColor];
-  } else {
-    rootView.backgroundColor = [UIColor whiteColor];
-  }
-
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
   UIViewController *rootViewController = [self createRootViewController];
   rootViewController.view = rootView;
@@ -101,7 +95,14 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
 #if RCT_NEW_ARCH_ENABLED
   enableFabric = self.fabricEnabled;
 #endif
-  return RCTAppSetupDefaultRootView(bridge, moduleName, initProps, enableFabric);
+  UIView *rootView = RCTAppSetupDefaultRootView(bridge, moduleName, initProps, enableFabric);
+  if (@available(iOS 13.0, *)) {
+    rootView.backgroundColor = [UIColor systemBackgroundColor];
+  } else {
+    rootView.backgroundColor = [UIColor whiteColor];
+  }
+
+  return rootView;
 }
 
 - (UIViewController *)createRootViewController


### PR DESCRIPTION
Summary:
When we introduced the RCTAppDelegate library, we prepared some template methods for the user to customise their views.

However, after they customized their view, we were chaing the background color to match the system background. This would actually override the background color they set in their own customisation step.

This change make sure that we set the background color before they apply their customisations. In this way, we set the background color and, if they want, they can change it and that changw would be honoured.

This change also fixes [this issue](https://github.com/facebook/react-native/issues/35937)

## Changelog
[iOS][Fixed] - Honour background color customisation in RCTAppDelegate

Differential Revision: D43435946

