### PR TITLE
Run commit hooks before layout calculation

### DIFF
--- a/ReactCommon/react/renderer/mounting/ShadowTree.cpp
+++ b/ReactCommon/react/renderer/mounting/ShadowTree.cpp
@@ -351,6 +351,10 @@ CommitStatus ShadowTree::tryCommit(
     }
   }
 
+  // Run commit hooks.
+  newRootShadowNode = delegate_.shadowTreeWillCommit(
+      *this, oldRootShadowNode, newRootShadowNode);
+
   // Layout nodes.
   std::vector<LayoutableShadowNode const *> affectedLayoutableNodes{};
   affectedLayoutableNodes.reserve(1024);
@@ -373,9 +377,6 @@ CommitStatus ShadowTree::tryCommit(
     }
 
     auto newRevisionNumber = oldRevision.number + 1;
-
-    newRootShadowNode = delegate_.shadowTreeWillCommit(
-        *this, oldRootShadowNode, newRootShadowNode);
 
     if (!newRootShadowNode ||
         (commitOptions.shouldYield && commitOptions.shouldYield())) {


### PR DESCRIPTION
## Summary

I've noticed that `UIManagerCommitHooks` are applied after calling `layoutIfNeeded`, meaning that if a commit hook makes some changes to the tree, it needs to calculate the layout again, effectively making the first calculation redundant.

This PR swaps the order of these two operations and moves `shadowTreeWillCommit` call before `layoutIfNeeded`. Thanks to this change, commit hooks don't need to manually trigger layout calculations as well as can potentially operate on unsealed nodes which can make it more efficient in some cases.

Finally, this PR eliminates a crash on `emitLayoutEvents(affectedLayoutableNodes);` when commit hook actually modifies the tree and thus de-allocates old shadow nodes.

cc @sammy-SC 

## Changelog

[GENERAL] [CHANGED] - Run commit hooks before layout calculation

## Test Plan

The only `UIManagerCommitHook` I could find in the OSS repo is [`TimelineController`](https://github.com/facebook/react-native/blob/8bd3edec88148d0ab1f225d2119435681fbbba33/ReactCommon/react/renderer/timeline/TimelineController.h#L26).
