### PR TITLE
[ci][monorepo] bump package versions

### DIFF
--- a/packages/react-native-gradle-plugin/package.json
+++ b/packages/react-native-gradle-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native/gradle-plugin",
-  "version": "0.72.3",
+  "version": "0.72.4",
   "description": "⚛️ Gradle Plugin for React Native",
   "homepage": "https://github.com/facebook/react-native/tree/HEAD/packages/react-native-gradle-plugin",
   "repository": {


### PR DESCRIPTION
## Summary

Bumping RNGP as build from source on nightlies is broken

## Changelog

[INTERNAL] - bump package versions

## Test Plan

n/a