### PR TITLE
refactor(bump-all-updated-packages): use tag instead of custom commit message

### DIFF
--- a/scripts/monorepo/__tests__/find-and-publish-all-bumped-packages-test.js
+++ b/scripts/monorepo/__tests__/find-and-publish-all-bumped-packages-test.js
@@ -9,7 +9,7 @@
 
 const {spawnSync} = require('child_process');
 
-const {BUMP_COMMIT_MESSAGE} = require('../constants');
+const {PUBLISH_PACKAGES_TAG} = require('../constants');
 const forEachPackage = require('../for-each-package');
 const findAndPublishAllBumpedPackages = require('../find-and-publish-all-bumped-packages');
 
@@ -31,7 +31,7 @@ describe('findAndPublishAllBumpedPackages', () => {
     }));
 
     spawnSync.mockImplementationOnce(() => ({
-      stdout: BUMP_COMMIT_MESSAGE,
+      stdout: `This is my commit message\n\n${PUBLISH_PACKAGES_TAG}`,
     }));
 
     expect(() => findAndPublishAllBumpedPackages()).toThrow(

--- a/scripts/monorepo/constants.js
+++ b/scripts/monorepo/constants.js
@@ -8,6 +8,6 @@
  * @format
  */
 
-const BUMP_COMMIT_MESSAGE = '[ci][monorepo] bump package versions';
+const PUBLISH_PACKAGES_TAG = '@publish-packages-to-npm';
 
-module.exports = {BUMP_COMMIT_MESSAGE};
+module.exports = {PUBLISH_PACKAGES_TAG};

--- a/scripts/monorepo/find-and-publish-all-bumped-packages.js
+++ b/scripts/monorepo/find-and-publish-all-bumped-packages.js
@@ -10,7 +10,7 @@
 const path = require('path');
 const {spawnSync} = require('child_process');
 
-const {BUMP_COMMIT_MESSAGE} = require('./constants');
+const {PUBLISH_PACKAGES_TAG} = require('./constants');
 const forEachPackage = require('./for-each-package');
 
 const ROOT_LOCATION = path.join(__dirname, '..', '..');
@@ -79,10 +79,10 @@ const findAndPublishAllBumpedPackages = () => {
         process.exit(1);
       }
 
-      const hasSpecificCommitMessage =
-        commitMessage.startsWith(BUMP_COMMIT_MESSAGE);
+      const hasSpecificPublishTag =
+        commitMessage.includes(PUBLISH_PACKAGES_TAG);
 
-      if (!hasSpecificCommitMessage) {
+      if (!hasSpecificPublishTag) {
         throw new Error(
           `Package ${packageManifest.name} was updated, but not through CI script`,
         );


### PR DESCRIPTION
## Summary
Having custom commit message script is not an option for `main` branch, because we have internal tooling, which strips `[x]` tags from commit messages before merging them into `main` branch.

Instead of constant commit message, we are now using a tag which will be concatenated with the commit message, which was entered via interactive commit dialog, see demo below.

## Changelog
[Internal] - updated validation in bumping packages script

## Test Plan
https://user-images.githubusercontent.com/28902667/220163767-015bf37b-6914-4df2-84d9-aa25fb2887d3.mov


