### PR TITLE
Kotlin to 1.7.22

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
   id("com.android.library") version "7.4.1" apply false
   id("com.android.application") version "7.4.1" apply false
   id("de.undercouch.download") version "5.0.1" apply false
-  kotlin("android") version "1.6.10" apply false
+  kotlin("android") version "1.7.22" apply false
 }
 
 val reactAndroidProperties = java.util.Properties()

--- a/packages/react-native-gradle-plugin/build.gradle.kts
+++ b/packages/react-native-gradle-plugin/build.gradle.kts
@@ -11,7 +11,7 @@ import org.gradle.configurationcache.extensions.serviceOf
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-  kotlin("jvm") version "1.6.10"
+  kotlin("jvm") version "1.7.22"
   id("java-gradle-plugin")
 }
 


### PR DESCRIPTION
Summary:
This is needed for the next Gradle major (8.x) and re-aligns us with the
Kotlin version in fbsource

Changelog:
[Android] [Changed] - Kotlin to 1.7.22

Differential Revision: D43445999

