### PR TITLE
Fix RCTPerfMonitor not showing up in scene based app

### DIFF
--- a/React/CoreModules/RCTPerfMonitor.mm
+++ b/React/CoreModules/RCTPerfMonitor.mm
@@ -340,7 +340,12 @@ RCT_EXPORT_MODULE()
 
   [self updateStats];
 
-  UIWindow *window = RCTSharedApplication().delegate.window;
+  UIWindow *window = [self getUIWindowFromScene];
+
+  if (!window) {
+    window = RCTSharedApplication().delegate.window;
+  }
+
   [window addSubview:self.container];
 
   _uiDisplayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(threadUpdate:)];
@@ -530,6 +535,22 @@ RCT_EXPORT_MODULE()
     i += 2;
   }
   _perfLoggerMarks = [data copy];
+}
+
+- (UIWindow *)getUIWindowFromScene
+{
+  if (@available(iOS 13.0, *)) {
+    for (UIScene *scene in RCTSharedApplication().connectedScenes) {
+      if (scene.activationState == UISceneActivationStateForegroundActive && [scene isKindOfClass:[UIWindowScene class]]) {
+        if (@available(iOS 15.0, *)) {
+          return ((UIWindowScene *)scene).keyWindow;
+        } else {
+          return ((UIWindowScene *)scene).windows.firstObject;
+        }
+      }
+    }
+  }
+  return nil;
 }
 
 #pragma mark - UITableViewDataSource


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Currently RCTPerfMonitor won't show up in scene based app, we should first try to extract the window from the connected scenes, and fallback to the window in `UIApplicationDelegate`.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[iOS] [Fixed] - Fix RCTPerfMonitor not showing up in scene based app

## Test Plan

- Test RCTPerfMonitor in app not using scenes;
- Test RCTPerfMonitor in app using scenes in iOS 12 (if we are still supporting this target version);
- Test RCTPerfMonitor in app using scenes in iOS 13 & 14;
- Test RCTPerfMonitor in app using scenes in iOS 15+.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
