### PR TITLE
RNGP - Fix RNTester crashing for JSC and safeguard against fetching JSC from Maven Central

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,13 +43,6 @@ nexusPublishing {
   }
 }
 
-allprojects {
-  repositories {
-    google()
-    mavenCentral()
-  }
-}
-
 tasks.register("cleanAll", Delete::class.java) {
   description = "Remove all the build files and intermediate build outputs"
   dependsOn(gradle.includedBuild("react-native-gradle-plugin").task(":clean"))

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/DependencyUtils.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/DependencyUtils.kt
@@ -28,7 +28,10 @@ internal object DependencyUtils {
         }
         // We add the snapshot for users on nightlies.
         mavenRepoFromUrl("https://oss.sonatype.org/content/repositories/snapshots/")
-        repositories.mavenCentral()
+        repositories.mavenCentral { repo ->
+          // We don't want to fetch JSC from Maven Central as there are older versions there.
+          repo.content { it.excludeModule("org.webkit", "android-jsc") }
+        }
         // Android JSC is installed from npm
         mavenRepoFromURI(File(reactNativeDir, "../jsc-android/dist").toURI())
         repositories.google()

--- a/packages/rn-tester/android/app/build.gradle
+++ b/packages/rn-tester/android/app/build.gradle
@@ -90,6 +90,12 @@ def reactNativeArchitectures() {
     return value ? value.split(",") : ["armeabi-v7a", "x86", "x86_64", "arm64-v8a"]
 }
 
+repositories {
+    maven {
+        url rootProject.file("node_modules/jsc-android/dist")
+    }
+}
+
 android {
     buildToolsVersion = "33.0.0"
     compileSdkVersion 33


### PR DESCRIPTION
Summary:
Seems like RN Tester is crashing for JSC debug/release.

This happens because RN Tester ends up fetching JSC from Maven Central which contains older versions
of the artifacts (r17) which are not compatible with our setup AND are missing `libjsc.so`.

This is happening as our file layout is a bit different than a regular NPM project so
the repository declaration for JSC, being `../jsc-android/dist` from React Native root ends
in the wrong folder.

In this specifically I:
- Add an excludeModule for "org.webkit:android-jsc" on Maven Central inside RNGP
- Remove the allproject{repositories{}} block which was overriding RNGP configuration
- Add a specific repository declaration inside RN Tester to point to where JSC effectively lives

Changelog:
[Internal] [Changed] - RNGP - Fix RNTester crashing for JSC and safeguard against fetching JSC from Maven Central

Reviewed By: sshic

Differential Revision: D43462015

