### PR TITLE
feat: Add Android Paper implementation of inset logical properties

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/LayoutShadowNode.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/LayoutShadowNode.java
@@ -76,6 +76,7 @@ public class LayoutShadowNode extends ReactShadowNodeImpl {
   }
 
   private final MutableYogaValue mTempYogaValue;
+  private final Dynamic[] mPosition = new Dynamic[Spacing.INLINE_START + 1];
 
   public LayoutShadowNode() {
     mTempYogaValue = new MutableYogaValue();
@@ -786,15 +787,62 @@ public class LayoutShadowNode extends ReactShadowNodeImpl {
       Spacing.TOP,
       Spacing.BOTTOM,
       Spacing.ALL,
-      Spacing.VERTICAL,
-      Spacing.BOTTOM,
-      Spacing.TOP,
-      Spacing.HORIZONTAL,
-      Spacing.START,
-      Spacing.END
+      Spacing.BLOCK,
+      Spacing.BLOCK_END,
+      Spacing.BLOCK_START,
+      Spacing.INLINE,
+      Spacing.INLINE_END,
+      Spacing.INLINE_START
     };
 
-    int spacingType = maybeTransformLeftRightToStartEnd(POSITION_SPACING_TYPES[index]);
+    mPosition[POSITION_SPACING_TYPES[index]] = position;
+    updatePositionValues();
+  }
+
+  private void updatePositionValues() {
+    setYogaPosition(Spacing.TOP, mPosition[Spacing.TOP]);
+    setYogaPosition(Spacing.BOTTOM, mPosition[Spacing.BOTTOM]);
+    setYogaPosition(Spacing.START, mPosition[Spacing.START]);
+    setYogaPosition(Spacing.END, mPosition[Spacing.END]);
+
+    if (!I18nUtil.getInstance().doLeftAndRightSwapInRTL(getThemedContext())) {
+      setYogaPosition(Spacing.LEFT, mPosition[Spacing.LEFT]);
+      setYogaPosition(Spacing.RIGHT, mPosition[Spacing.RIGHT]);
+    } else {
+      setYogaPosition(Spacing.START, mPosition[Spacing.LEFT]);
+      setYogaPosition(Spacing.END, mPosition[Spacing.RIGHT]);
+    }
+
+    // Aliases with precedence
+    if (mPosition[Spacing.ALL] != null && !mPosition[Spacing.ALL].isNull()) {
+      setYogaPosition(Spacing.ALL, mPosition[Spacing.ALL]);
+    }
+    if (mPosition[Spacing.BLOCK] != null && !mPosition[Spacing.BLOCK].isNull()) {
+      setYogaPosition(Spacing.VERTICAL, mPosition[Spacing.BLOCK]);
+    }
+    if (mPosition[Spacing.INLINE] != null && !mPosition[Spacing.INLINE].isNull()) {
+      setYogaPosition(Spacing.HORIZONTAL, mPosition[Spacing.INLINE]);
+    }
+    if (mPosition[Spacing.INLINE_END] != null && !mPosition[Spacing.INLINE_END].isNull()) {
+      setYogaPosition(Spacing.END, mPosition[Spacing.INLINE_END]);
+    }
+    if (mPosition[Spacing.INLINE_START] != null && !mPosition[Spacing.INLINE_START].isNull()) {
+      setYogaPosition(Spacing.START, mPosition[Spacing.INLINE_START]);
+    }
+
+    // Aliases without precedence
+    if (mPosition[Spacing.BOTTOM] == null || mPosition[Spacing.BOTTOM].isNull()) {
+      setYogaPosition(Spacing.BOTTOM, mPosition[Spacing.BLOCK_END]);
+    }
+    if (mPosition[Spacing.TOP] == null || mPosition[Spacing.TOP].isNull()) {
+      setYogaPosition(Spacing.TOP, mPosition[Spacing.BLOCK_START]);
+    }
+  }
+
+  private void setYogaPosition(int spacingType, Dynamic position) {
+    if(position == null){
+      return;
+    }
 
     mTempYogaValue.setFromDynamic(position);
     switch (mTempYogaValue.unit) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/LayoutShadowNode.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/LayoutShadowNode.java
@@ -765,6 +765,13 @@ public class LayoutShadowNode extends ReactShadowNodeImpl {
         ViewProps.RIGHT,
         ViewProps.TOP,
         ViewProps.BOTTOM,
+        ViewProps.INSET,
+        ViewProps.INSET_BLOCK,
+        ViewProps.INSET_BLOCK_END,
+        ViewProps.INSET_BLOCK_START,
+        ViewProps.INSET_INLINE,
+        ViewProps.INSET_INLINE_END,
+        ViewProps.INSET_INLINE_START,
       })
   public void setPositionValues(int index, Dynamic position) {
     if (isVirtual()) {
@@ -772,7 +779,19 @@ public class LayoutShadowNode extends ReactShadowNodeImpl {
     }
 
     final int[] POSITION_SPACING_TYPES = {
-      Spacing.START, Spacing.END, Spacing.LEFT, Spacing.RIGHT, Spacing.TOP, Spacing.BOTTOM
+      Spacing.START,
+      Spacing.END,
+      Spacing.LEFT,
+      Spacing.RIGHT,
+      Spacing.TOP,
+      Spacing.BOTTOM,
+      Spacing.ALL,
+      Spacing.VERTICAL,
+      Spacing.BOTTOM,
+      Spacing.TOP,
+      Spacing.HORIZONTAL,
+      Spacing.START,
+      Spacing.END
     };
 
     int spacingType = maybeTransformLeftRightToStartEnd(POSITION_SPACING_TYPES[index]);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/LayoutShadowNode.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/LayoutShadowNode.java
@@ -786,7 +786,7 @@ public class LayoutShadowNode extends ReactShadowNodeImpl {
       Spacing.RIGHT,
       Spacing.TOP,
       Spacing.BOTTOM,
-      Spacing.ALL,
+      Spacing.ALL_EDGES,
       Spacing.BLOCK,
       Spacing.BLOCK_END,
       Spacing.BLOCK_START,
@@ -814,8 +814,8 @@ public class LayoutShadowNode extends ReactShadowNodeImpl {
     }
 
     // Aliases with precedence
-    if (mPosition[Spacing.ALL] != null && !mPosition[Spacing.ALL].isNull()) {
-      setYogaPosition(Spacing.ALL, mPosition[Spacing.ALL]);
+    if (mPosition[Spacing.ALL_EDGES] != null && !mPosition[Spacing.ALL_EDGES].isNull()) {
+      setYogaPosition(Spacing.ALL_EDGES, mPosition[Spacing.ALL_EDGES]);
     }
     if (mPosition[Spacing.BLOCK] != null && !mPosition[Spacing.BLOCK].isNull()) {
       setYogaPosition(Spacing.VERTICAL, mPosition[Spacing.BLOCK]);
@@ -840,7 +840,7 @@ public class LayoutShadowNode extends ReactShadowNodeImpl {
   }
 
   private void setYogaPosition(int spacingType, Dynamic position) {
-    if(position == null){
+    if (position == null){
       return;
     }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactShadowNodeImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactShadowNodeImpl.java
@@ -82,8 +82,8 @@ public class ReactShadowNodeImpl implements ReactShadowNode<ReactShadowNodeImpl>
   private int mScreenWidth;
   private int mScreenHeight;
   private final Spacing mDefaultPadding;
-  private final float[] mPadding = new float[Spacing.ALL + 1];
-  private final boolean[] mPaddingIsPercent = new boolean[Spacing.ALL + 1];
+  private final float[] mPadding = new float[Spacing.ALL_EDGES + 1];
+  private final boolean[] mPaddingIsPercent = new boolean[Spacing.ALL_EDGES + 1];
   private YogaNode mYogaNode;
   private Integer mWidthMeasureSpec;
   private Integer mHeightMeasureSpec;
@@ -921,21 +921,21 @@ public class ReactShadowNodeImpl implements ReactShadowNode<ReactShadowNodeImpl>
   }
 
   private void updatePadding() {
-    for (int spacingType = Spacing.LEFT; spacingType <= Spacing.ALL; spacingType++) {
+    for (int spacingType = Spacing.LEFT; spacingType <= Spacing.ALL_EDGES; spacingType++) {
       if (spacingType == Spacing.LEFT
           || spacingType == Spacing.RIGHT
           || spacingType == Spacing.START
           || spacingType == Spacing.END) {
         if (YogaConstants.isUndefined(mPadding[spacingType])
             && YogaConstants.isUndefined(mPadding[Spacing.HORIZONTAL])
-            && YogaConstants.isUndefined(mPadding[Spacing.ALL])) {
+            && YogaConstants.isUndefined(mPadding[Spacing.ALL_EDGES])) {
           mYogaNode.setPadding(YogaEdge.fromInt(spacingType), mDefaultPadding.getRaw(spacingType));
           continue;
         }
       } else if (spacingType == Spacing.TOP || spacingType == Spacing.BOTTOM) {
         if (YogaConstants.isUndefined(mPadding[spacingType])
             && YogaConstants.isUndefined(mPadding[Spacing.VERTICAL])
-            && YogaConstants.isUndefined(mPadding[Spacing.ALL])) {
+            && YogaConstants.isUndefined(mPadding[Spacing.ALL_EDGES])) {
           mYogaNode.setPadding(YogaEdge.fromInt(spacingType), mDefaultPadding.getRaw(spacingType));
           continue;
         }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/Spacing.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/Spacing.java
@@ -55,10 +55,23 @@ public class Spacing {
    * Spacing type that represents the block start direction (top). E.g. {@code marginBlockStart}.
    */
   public static final int BLOCK_START = 11;
+  /** Spacing type that represents inline directions (left, right). E.g. {@code marginInline}. */
+  public static final int INLINE = 12;
+  /**
+   * Spacing type that represents the inline end direction (right in left-to-right, left in
+   * right-to-left). E.g. {@code marginInlineEnd}.
+   */
+  public static final int INLINE_END = 13;
+  /**
+   * Spacing type that represents the inline start direction (left in left-to-right, right in
+   * right-to-left). E.g. {@code marginInlineStart}.
+   */
+  public static final int INLINE_START = 14;
 
   private static final int[] sFlagsMap = {
     1, /*LEFT*/ 2, /*TOP*/ 4, /*RIGHT*/ 8, /*BOTTOM*/ 16, /*START*/ 32, /*END*/ 64, /*HORIZONTAL*/
     128, /*VERTICAL*/ 256, /*ALL*/ 512, /*BLOCK*/ 1024, /*BLOCK_END*/ 2048, /*BLOCK_START*/
+    4096, /*INLINE*/ 8192, /*INLINE_END*/ 16384, /*INLINE_START*/
   };
 
   private final float[] mSpacing;
@@ -105,7 +118,8 @@ public class Spacing {
           (mValueFlags & sFlagsMap[ALL]) != 0
               || (mValueFlags & sFlagsMap[VERTICAL]) != 0
               || (mValueFlags & sFlagsMap[HORIZONTAL]) != 0
-              || (mValueFlags & sFlagsMap[BLOCK]) != 0;
+              || (mValueFlags & sFlagsMap[BLOCK]) != 0
+              || (mValueFlags & sFlagsMap[INLINE]) != 0;
 
       return true;
     }
@@ -125,6 +139,9 @@ public class Spacing {
                 || spacingType == BLOCK
                 || spacingType == BLOCK_END
                 || spacingType == BLOCK_START
+                || spacingType == INLINE
+                || spacingType == INLINE_END
+                || spacingType == INLINE_START
             ? YogaConstants.UNDEFINED
             : mDefaultValue);
 
@@ -180,6 +197,9 @@ public class Spacing {
 
   private static float[] newFullSpacingArray() {
     return new float[] {
+      YogaConstants.UNDEFINED,
+      YogaConstants.UNDEFINED,
+      YogaConstants.UNDEFINED,
       YogaConstants.UNDEFINED,
       YogaConstants.UNDEFINED,
       YogaConstants.UNDEFINED,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/Spacing.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/Spacing.java
@@ -44,9 +44,9 @@ public class Spacing {
    */
   public static final int VERTICAL = 7;
   /**
-   * Spacing type that represents all directions (left, top, right, bottom). E.g. {@code margin}.
+   * Spacing type that represents all edge directions (left, top, right, bottom). E.g. {@code margin}.
    */
-  public static final int ALL = 8;
+  public static final int ALL_EDGES = 8;
   /** Spacing type that represents block directions (top, bottom). E.g. {@code marginBlock}. */
   public static final int BLOCK = 9;
   /** Spacing type that represents the block end direction (bottom). E.g. {@code marginBlockEnd}. */
@@ -67,11 +67,15 @@ public class Spacing {
    * right-to-left). E.g. {@code marginInlineStart}.
    */
   public static final int INLINE_START = 14;
+  /**
+   * Spacing type that represents all directions E.g. {@code margin}.
+   */
+  public static final int ALL = 15;
 
   private static final int[] sFlagsMap = {
     1, /*LEFT*/ 2, /*TOP*/ 4, /*RIGHT*/ 8, /*BOTTOM*/ 16, /*START*/ 32, /*END*/ 64, /*HORIZONTAL*/
-    128, /*VERTICAL*/ 256, /*ALL*/ 512, /*BLOCK*/ 1024, /*BLOCK_END*/ 2048, /*BLOCK_START*/
-    4096, /*INLINE*/ 8192, /*INLINE_END*/ 16384, /*INLINE_START*/
+    128, /*VERTICAL*/ 256, /*ALL_EDGES*/ 512, /*BLOCK*/ 1024, /*BLOCK_END*/ 2048, /*BLOCK_START*/
+    4096, /*INLINE*/ 8192, /*INLINE_END*/ 16384, /*INLINE_START*/ 32768, /*ALL*/
   };
 
   private final float[] mSpacing;
@@ -99,7 +103,7 @@ public class Spacing {
    * Set a spacing value.
    *
    * @param spacingType one of {@link #LEFT}, {@link #TOP}, {@link #RIGHT}, {@link #BOTTOM}, {@link
-   *     #VERTICAL}, {@link #HORIZONTAL}, {@link #ALL}
+   *     #VERTICAL}, {@link #HORIZONTAL}, {@link #ALL_EDGES}
    * @param value the value for this direction
    * @return {@code true} if the spacing has changed, or {@code false} if the same value was already
    *     set
@@ -115,7 +119,7 @@ public class Spacing {
       }
 
       mHasAliasesSet =
-          (mValueFlags & sFlagsMap[ALL]) != 0
+          (mValueFlags & sFlagsMap[ALL_EDGES]) != 0
               || (mValueFlags & sFlagsMap[VERTICAL]) != 0
               || (mValueFlags & sFlagsMap[HORIZONTAL]) != 0
               || (mValueFlags & sFlagsMap[BLOCK]) != 0
@@ -157,8 +161,8 @@ public class Spacing {
       int secondType = spacingType == TOP || spacingType == BOTTOM ? VERTICAL : HORIZONTAL;
       if ((mValueFlags & sFlagsMap[secondType]) != 0) {
         return mSpacing[secondType];
-      } else if ((mValueFlags & sFlagsMap[ALL]) != 0) {
-        return mSpacing[ALL];
+      } else if ((mValueFlags & sFlagsMap[ALL_EDGES]) != 0) {
+        return mSpacing[ALL_EDGES];
       }
     }
 
@@ -170,7 +174,7 @@ public class Spacing {
    * any default values.
    *
    * @param spacingType one of {@link #LEFT}, {@link #TOP}, {@link #RIGHT}, {@link #BOTTOM}, {@link
-   *     #VERTICAL}, {@link #HORIZONTAL}, {@link #ALL}
+   *     #VERTICAL}, {@link #HORIZONTAL}, {@link #ALL_EDGES}
    */
   public float getRaw(int spacingType) {
     return mSpacing[spacingType];
@@ -197,6 +201,7 @@ public class Spacing {
 
   private static float[] newFullSpacingArray() {
     return new float[] {
+      YogaConstants.UNDEFINED,
       YogaConstants.UNDEFINED,
       YogaConstants.UNDEFINED,
       YogaConstants.UNDEFINED,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewProps.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewProps.java
@@ -38,6 +38,14 @@ public class ViewProps {
   public static final String HEIGHT = "height";
   public static final String JUSTIFY_CONTENT = "justifyContent";
   public static final String LEFT = "left";
+  public static final String INSET = "inset";
+  public static final String INSET_BLOCK = "insetBlock";
+  public static final String INSET_BLOCK_END = "insetBlockEnd";
+  public static final String INSET_BLOCK_START = "insetBlockStart";
+  public static final String INSET_INLINE = "insetInline";
+  public static final String INSET_INLINE_END = "insetInlineEnd";
+  public static final String INSET_INLINE_START = "insetInlineStart";
+
 
   public static final String MARGIN = "margin";
   public static final String MARGIN_VERTICAL = "marginVertical";
@@ -230,6 +238,13 @@ public class ViewProps {
               LEFT,
               START,
               END,
+              INSET,
+              INSET_BLOCK,
+              INSET_BLOCK_END,
+              INSET_BLOCK_START,
+              INSET_INLINE,
+              INSET_INLINE_END,
+              INSET_INLINE_START,
 
               /* dimensions */
               WIDTH,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewProps.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewProps.java
@@ -188,7 +188,7 @@ public class ViewProps {
   public static final String NATIVE_ID = "nativeID";
 
   public static final int[] BORDER_SPACING_TYPES = {
-    Spacing.ALL,
+    Spacing.ALL_EDGES,
     Spacing.START,
     Spacing.END,
     Spacing.TOP,
@@ -197,7 +197,7 @@ public class ViewProps {
     Spacing.RIGHT
   };
   public static final int[] PADDING_MARGIN_SPACING_TYPES = {
-    Spacing.ALL,
+    Spacing.ALL_EDGES,
     Spacing.VERTICAL,
     Spacing.HORIZONTAL,
     Spacing.START,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
@@ -43,7 +43,7 @@ public class ReactHorizontalScrollViewManager extends ViewGroupManager<ReactHori
   public static final String REACT_CLASS = "AndroidHorizontalScrollView";
 
   private static final int[] SPACING_TYPES = {
-    Spacing.ALL, Spacing.LEFT, Spacing.RIGHT, Spacing.TOP, Spacing.BOTTOM,
+    Spacing.ALL_EDGES, Spacing.LEFT, Spacing.RIGHT, Spacing.TOP, Spacing.BOTTOM,
   };
 
   private @Nullable FpsListener mFpsListener = null;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.java
@@ -46,7 +46,7 @@ public class ReactScrollViewManager extends ViewGroupManager<ReactScrollView>
   public static final String REACT_CLASS = "RCTScrollView";
 
   private static final int[] SPACING_TYPES = {
-    Spacing.ALL, Spacing.LEFT, Spacing.RIGHT, Spacing.TOP, Spacing.BOTTOM,
+    Spacing.ALL_EDGES, Spacing.LEFT, Spacing.RIGHT, Spacing.TOP, Spacing.BOTTOM,
   };
 
   private @Nullable FpsListener mFpsListener = null;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextAnchorViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextAnchorViewManager.java
@@ -39,7 +39,7 @@ public abstract class ReactTextAnchorViewManager<T extends View, C extends React
     extends BaseViewManager<T, C> {
 
   private static final int[] SPACING_TYPES = {
-    Spacing.ALL, Spacing.LEFT, Spacing.RIGHT, Spacing.TOP, Spacing.BOTTOM,
+    Spacing.ALL_EDGES, Spacing.LEFT, Spacing.RIGHT, Spacing.TOP, Spacing.BOTTOM,
   };
   private static final String TAG = "ReactTextAnchorViewManager";
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -95,7 +95,7 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
   private static final short TX_STATE_KEY_MOST_RECENT_EVENT_COUNT = 3;
 
   private static final int[] SPACING_TYPES = {
-    Spacing.ALL, Spacing.LEFT, Spacing.RIGHT, Spacing.TOP, Spacing.BOTTOM,
+    Spacing.ALL_EDGES, Spacing.LEFT, Spacing.RIGHT, Spacing.TOP, Spacing.BOTTOM,
   };
   private static final Map<String, String> REACT_PROPS_AUTOFILL_HINTS_MAP =
       new HashMap<String, String>() {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactMapBufferPropSetter.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactMapBufferPropSetter.kt
@@ -90,6 +90,9 @@ object ReactMapBufferPropSetter {
   private const val EDGE_BLOCK = 7
   private const val EDGE_BLOCK_END = 8
   private const val EDGE_BLOCK_START = 9
+  private const val EDGE_INLINE = 10
+  private const val EDGE_INLINE_END = 11
+  private const val EDGE_INLINE_START = 12
 
   private const val CORNER_TOP_LEFT = 0
   private const val CORNER_TOP_RIGHT = 1
@@ -355,6 +358,9 @@ object ReactMapBufferPropSetter {
             EDGE_BLOCK -> 7
             EDGE_BLOCK_END -> 8
             EDGE_BLOCK_START -> 9
+            EDGE_INLINE -> 10
+            EDGE_INLINE_END -> 11
+            EDGE_INLINE_START -> 12
             else -> throw IllegalArgumentException("Unknown key for border color: $key")
           }
       val colorValue = entry.intValue

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewBackgroundDrawable.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewBackgroundDrawable.java
@@ -80,7 +80,7 @@ public class ReactViewBackgroundDrawable extends Drawable {
     }
   };
 
-  /* Value at Spacing.ALL index used for rounded borders, whole array used by rectangular borders */
+  /* Value at Spacing.ALL_EDGES index used for rounded borders, whole array used by rectangular borders */
   private @Nullable Spacing mBorderWidth;
   private @Nullable Spacing mBorderRGB;
   private @Nullable Spacing mBorderAlpha;
@@ -214,7 +214,7 @@ public class ReactViewBackgroundDrawable extends Drawable {
     if (!FloatUtil.floatsEqual(mBorderWidth.getRaw(position), width)) {
       mBorderWidth.set(position, width);
       switch (position) {
-        case Spacing.ALL:
+        case Spacing.ALL_EDGES:
         case Spacing.LEFT:
         case Spacing.BOTTOM:
         case Spacing.RIGHT:
@@ -381,7 +381,7 @@ public class ReactViewBackgroundDrawable extends Drawable {
 
       // If it's a full and even border draw inner rect path with stroke
       final float fullBorderWidth = getFullBorderWidth();
-      int borderColor = getBorderColor(Spacing.ALL);
+      int borderColor = getBorderColor(Spacing.ALL_EDGES);
       if (borderWidth.top == fullBorderWidth
           && borderWidth.bottom == fullBorderWidth
           && borderWidth.left == fullBorderWidth
@@ -566,7 +566,7 @@ public class ReactViewBackgroundDrawable extends Drawable {
     int colorTop = getBorderColor(Spacing.TOP);
     int colorRight = getBorderColor(Spacing.RIGHT);
     int colorBottom = getBorderColor(Spacing.BOTTOM);
-    int borderColor = getBorderColor(Spacing.ALL);
+    int borderColor = getBorderColor(Spacing.ALL_EDGES);
     int colorBlock = getBorderColor(Spacing.BLOCK);
     int colorBlockStart = getBorderColor(Spacing.BLOCK_START);
     int colorBlockEnd = getBorderColor(Spacing.BLOCK_END);
@@ -745,7 +745,7 @@ public class ReactViewBackgroundDrawable extends Drawable {
     float extraRadiusForOutline = 0;
 
     if (mBorderWidth != null) {
-      extraRadiusForOutline = mBorderWidth.get(Spacing.ALL) / 2f;
+      extraRadiusForOutline = mBorderWidth.get(Spacing.ALL_EDGES) / 2f;
     }
 
     mPathForBorderRadiusOutline.addRoundRect(
@@ -1094,8 +1094,8 @@ public class ReactViewBackgroundDrawable extends Drawable {
 
   /** For rounded borders we use default "borderWidth" property. */
   public float getFullBorderWidth() {
-    return (mBorderWidth != null && !YogaConstants.isUndefined(mBorderWidth.getRaw(Spacing.ALL)))
-        ? mBorderWidth.getRaw(Spacing.ALL)
+    return (mBorderWidth != null && !YogaConstants.isUndefined(mBorderWidth.getRaw(Spacing.ALL_EDGES)))
+        ? mBorderWidth.getRaw(Spacing.ALL_EDGES)
         : 0f;
   }
 
@@ -1398,7 +1398,7 @@ public class ReactViewBackgroundDrawable extends Drawable {
 
   @TargetApi(LOLLIPOP)
   public RectF getDirectionAwareBorderInsets() {
-    final float borderWidth = getBorderWidthOrDefaultTo(0, Spacing.ALL);
+    final float borderWidth = getBorderWidthOrDefaultTo(0, Spacing.ALL_EDGES);
     final float borderTopWidth = getBorderWidthOrDefaultTo(borderWidth, Spacing.TOP);
     final float borderBottomWidth = getBorderWidthOrDefaultTo(borderWidth, Spacing.BOTTOM);
     float borderLeftWidth = getBorderWidthOrDefaultTo(borderWidth, Spacing.LEFT);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
@@ -42,7 +42,7 @@ public class ReactViewManager extends ReactClippingViewManager<ReactViewGroup> {
   @VisibleForTesting public static final String REACT_CLASS = ViewProps.VIEW_CLASS_NAME;
 
   private static final int[] SPACING_TYPES = {
-    Spacing.ALL,
+    Spacing.ALL_EDGES,
     Spacing.LEFT,
     Spacing.RIGHT,
     Spacing.TOP,

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/LayoutPropertyApplicatorTest.java
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/LayoutPropertyApplicatorTest.java
@@ -140,7 +140,7 @@ public class LayoutPropertyApplicatorTest {
     ReactStylesDiffMap map = spy(buildStyles("margin", 10.0));
 
     reactShadowNode.updateProperties(map);
-    verify(reactShadowNode).setMargin(eq(Spacing.ALL), anyFloat());
+    verify(reactShadowNode).setMargin(eq(Spacing.ALL_EDGES), anyFloat());
     verify(map).getFloat("margin", YogaConstants.UNDEFINED);
 
     // marginVertical
@@ -207,7 +207,7 @@ public class LayoutPropertyApplicatorTest {
     ReactStylesDiffMap map = spy(buildStyles("padding", 10.0));
 
     reactShadowNode.updateProperties(map);
-    verify(reactShadowNode).setPadding(eq(Spacing.ALL), anyFloat());
+    verify(reactShadowNode).setPadding(eq(Spacing.ALL_EDGES), anyFloat());
     verify(map).getFloat("padding", YogaConstants.UNDEFINED);
 
     // paddingVertical
@@ -343,7 +343,7 @@ public class LayoutPropertyApplicatorTest {
     verify(reactShadowNode).setPosition(Spacing.START, 10.f);
     verify(reactShadowNode).setPosition(Spacing.TOP, 10.f);
     verify(reactShadowNode).setFlex(1.0f);
-    verify(reactShadowNode).setPadding(Spacing.ALL, 10.f);
+    verify(reactShadowNode).setPadding(Spacing.ALL_EDGES, 10.f);
     verify(reactShadowNode).setMargin(Spacing.START, 10.f);
     verify(reactShadowNode).setBorder(Spacing.TOP, 10.f);
     verify(reactShadowNode).setFlexDirection(YogaFlexDirection.ROW);
@@ -388,7 +388,7 @@ public class LayoutPropertyApplicatorTest {
     verify(reactShadowNode).setPosition(Spacing.START, YogaConstants.UNDEFINED);
     verify(reactShadowNode).setPosition(Spacing.TOP, YogaConstants.UNDEFINED);
     verify(reactShadowNode).setFlex(0.f);
-    verify(reactShadowNode).setPadding(Spacing.ALL, YogaConstants.UNDEFINED);
+    verify(reactShadowNode).setPadding(Spacing.ALL_EDGES, YogaConstants.UNDEFINED);
     verify(reactShadowNode).setMargin(Spacing.START, YogaConstants.UNDEFINED);
     verify(reactShadowNode).setBorder(Spacing.TOP, YogaConstants.UNDEFINED);
     verify(reactShadowNode).setFlexDirection(YogaFlexDirection.COLUMN);


### PR DESCRIPTION
## Summary:


This PR adds Paper support to `inset` logical properties on Android as requested on https://github.com/facebook/react-native/issues/34425. This implementation includes the addition of the following style properties 

- `inset`, equivalent to `top`, `bottom`, `right` and `left`.
- `insetBlock`, equivalent to `top` and `bottom`.
- `insetBlockEnd`, equivalent to `bottom`.
- `insetBlockStart`, equivalent to `top`.
- `insetInline`, equivalent to `right` and `left`.
- `insetInlineEnd`, equivalent to `right` or `left`.
- `insetInlineStart`, equivalent to `right` or `left`.

One thing that still needs to be figured out is how to respect the same precedence as [here](https://github.com/facebook/react-native/blob/9669c10afceef65626c82149210afc07d47df98b/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp#L335-L375) when using Paper (cc @NickGerleman)

iOS changes are in a separate PR to facilitate code review https://github.com/facebook/react-native/pull/36241

## Changelog:
 
[ANDROID] [ADDED] - Add Paper implementation of inset logical properties
 

## Test Plan:

1. Open the RNTester app and navigate to the `View` page
2. Test the new style properties through the `Insets` section

![image](https://user-images.githubusercontent.com/11707729/220522453-04903c48-d163-457d-90c5-283268f7271e.png)


