### PR TITLE
fix(ios): fix nullability warnings

### DIFF
--- a/React/Base/RCTJSScriptLoaderModule.h
+++ b/React/Base/RCTJSScriptLoaderModule.h
@@ -7,12 +7,16 @@
 
 @class RCTSource;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * This protocol should be adopted when a turbo module needs to tell React Native to load a script.
  * In bridge-less React Native, it is a replacement for [_bridge loadAndExecuteSplitBundleURL:].
  */
 @protocol RCTJSScriptLoaderModule <NSObject>
 
-@property (nonatomic, copy, nonnull) void (^loadScript)(RCTSource *source);
+@property (nonatomic, copy) void (^loadScript)(RCTSource *source);
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/React/CoreModules/RCTTiming.h
+++ b/React/CoreModules/RCTTiming.h
@@ -12,21 +12,25 @@
 #import <React/RCTInitializing.h>
 #import <React/RCTInvalidating.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @protocol RCTTimingDelegate
 
 - (void)callTimers:(NSArray<NSNumber *> *)timers;
-- (void)immediatelyCallTimer:(nonnull NSNumber *)callbackID;
-- (void)callIdleCallbacks:(nonnull NSNumber *)absoluteFrameStartMS;
+- (void)immediatelyCallTimer:(NSNumber *)callbackID;
+- (void)callIdleCallbacks:(NSNumber *)absoluteFrameStartMS;
 
 @end
 
 @interface RCTTiming : NSObject <RCTBridgeModule, RCTInvalidating, RCTFrameUpdateObserver, RCTInitializing>
 
 - (instancetype)initWithDelegate:(id<RCTTimingDelegate>)delegate;
-- (void)createTimerForNextFrame:(nonnull NSNumber *)callbackID
+- (void)createTimerForNextFrame:(NSNumber *)callbackID
                        duration:(NSTimeInterval)jsDuration
                jsSchedulingTime:(NSDate *)jsSchedulingTime
                         repeats:(BOOL)repeats;
 - (void)deleteTimer:(double)timerID;
 
 @end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
## Summary

While testing `use_frameworks! :linkage => :static`, I encountered nullability warnings that were previously suppressed because we always build with `-Werror`. I'm not sure why the suppressions no longer work, but they should just be fixed.

## Changelog

[IOS] [FIXED] - Fix nullability warnings

## Test Plan

iOS build should succeed.