### PR TITLE
Add missing type objectFit prop in image style type definition

### DIFF
--- a/Libraries/StyleSheet/StyleSheetTypes.d.ts
+++ b/Libraries/StyleSheet/StyleSheetTypes.d.ts
@@ -363,4 +363,5 @@ export interface ImageStyle extends FlexStyle, ShadowStyleIOS, TransformsStyle {
   overlayColor?: ColorValue | undefined;
   tintColor?: ColorValue | undefined;
   opacity?: number | undefined;
+  objectFit?: 'cover' | 'contain' | 'fill' | 'scale-down' | undefined;
 }


### PR DESCRIPTION
## Summary

Following the [`initial commit`](https://github.com/facebook/react-native/commit/b2452ab216e28e004dc625dd8e1ad32351a79be9), the `objectFit` property have been implemented. However, it is not declared in the Typescript type files, making it unknown to the typescript compiler. Thus, when using this property in Typescript, we have the following issue:

![Capture d’écran 2023-02-22 à 14 52 04](https://user-images.githubusercontent.com/29439916/220639885-947dddb1-5e6f-4f60-b423-882ade29ac5a.png)


Then, the purpose of this PR is to fix that by adding the missing property to the `ImageStyle` interface defined in the`StyleSheetTypes.d.ts` file.

## Changelog

[GENERAL][FIXED] Add objectFit to the ImageStyle interface located in the StyleSheetTypes.d.ts file 

## Test Plan

To test it, create/use a typescript file and call the `Image` component with a `style` property. Then, check if the autocompletion provides you the right properties with the right type. For example:

![Capture d’écran 2023-02-22 à 14 34 58](https://user-images.githubusercontent.com/29439916/220636819-4c0d80dc-bc3a-468d-bcfc-782e038918ca.png)
![Capture d’écran 2023-02-22 à 14 35 46](https://user-images.githubusercontent.com/29439916/220636863-76a84122-0cdb-4d5d-8edf-309ed7c876f7.png)

