### PR TITLE
[Codegen 83] Merge `Flow` and `TS` Parsers' `IncorrectModuleRegistryCallArgumentTypeParserError` error-emitting code

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
@@ -18,6 +18,7 @@ const {
   throwIfUnusedModuleInterfaceParserError,
   throwIfWrongNumberOfCallExpressionArgs,
   throwIfIncorrectModuleRegistryCallTypeParameterParserError,
+  throwIfIncorrectModuleRegistryCallArgument,
   throwIfUnsupportedFunctionReturnTypeAnnotationParserError,
   throwIfMoreThanOneModuleInterfaceParserError,
   throwIfModuleTypeIsUnsupported,
@@ -33,6 +34,7 @@ const {
   UnusedModuleInterfaceParserError,
   IncorrectModuleRegistryCallArityParserError,
   IncorrectModuleRegistryCallTypeParameterParserError,
+  IncorrectModuleRegistryCallArgumentTypeParserError,
   UnsupportedFunctionReturnTypeAnnotationParserError,
   UntypedModuleRegistryCallParserError,
   MoreThanOneModuleInterfaceParserError,
@@ -458,6 +460,55 @@ describe('throwIfIncorrectModuleRegistryCallTypeParameterParserError', () => {
         typescriptParser,
       );
     }).not.toThrow(IncorrectModuleRegistryCallTypeParameterParserError);
+  });
+});
+
+describe('throwIfIncorrectModuleRegistryCallArgument', () => {
+  const nativeModuleName = 'moduleName';
+  const methodName = 'methodName';
+
+  it('throw error if callExpressionArg type is unsupported in Flow', () => {
+    const callExpressionArg = {type: 'NotLiteral'};
+    expect(() => {
+      throwIfIncorrectModuleRegistryCallArgument(
+        nativeModuleName,
+        callExpressionArg,
+        methodName,
+      );
+    }).toThrow(IncorrectModuleRegistryCallArgumentTypeParserError);
+  });
+
+  it("don't throw error if callExpressionArg type is `Literal` in Flow", () => {
+    const callExpressionArg = {type: 'Literal'};
+    expect(() => {
+      throwIfIncorrectModuleRegistryCallArgument(
+        nativeModuleName,
+        callExpressionArg,
+        methodName,
+      );
+    }).not.toThrow(IncorrectModuleRegistryCallArgumentTypeParserError);
+  });
+
+  it('throw error if callExpressionArg type is unsupported in TypeScript', () => {
+    const callExpressionArg = {type: 'NotStringLiteral'};
+    expect(() => {
+      throwIfIncorrectModuleRegistryCallArgument(
+        nativeModuleName,
+        callExpressionArg,
+        methodName,
+      );
+    }).toThrow(IncorrectModuleRegistryCallArgumentTypeParserError);
+  });
+
+  it("don't throw error if callExpressionArg type is `StringLiteral` in TypeScript", () => {
+    const callExpressionArg = {type: 'StringLiteral'};
+    expect(() => {
+      throwIfIncorrectModuleRegistryCallArgument(
+        nativeModuleName,
+        callExpressionArg,
+        methodName,
+      );
+    }).not.toThrow(IncorrectModuleRegistryCallArgumentTypeParserError);
   });
 });
 

--- a/packages/react-native-codegen/src/parsers/error-utils.js
+++ b/packages/react-native-codegen/src/parsers/error-utils.js
@@ -22,6 +22,7 @@ const {
   UnusedModuleInterfaceParserError,
   IncorrectModuleRegistryCallArityParserError,
   IncorrectModuleRegistryCallTypeParameterParserError,
+  IncorrectModuleRegistryCallArgumentTypeParserError,
   UnsupportedObjectPropertyValueTypeAnnotationParserError,
   UntypedModuleRegistryCallParserError,
   UnsupportedModulePropertyParserError,
@@ -260,6 +261,25 @@ function throwIfArrayElementTypeAnnotationIsUnsupported(
   }
 }
 
+function throwIfIncorrectModuleRegistryCallArgument(
+  nativeModuleName: string,
+  callExpressionArg: $FlowFixMe,
+  methodName: string,
+) {
+  if (
+    callExpressionArg.type !== 'StringLiteral' &&
+    callExpressionArg.type !== 'Literal'
+  ) {
+    const {type} = callExpressionArg;
+    throw new IncorrectModuleRegistryCallArgumentTypeParserError(
+      nativeModuleName,
+      callExpressionArg,
+      methodName,
+      type,
+    );
+  }
+}
+
 module.exports = {
   throwIfModuleInterfaceIsMisnamed,
   throwIfUnsupportedFunctionReturnTypeAnnotationParserError,
@@ -274,4 +294,5 @@ module.exports = {
   throwIfMoreThanOneModuleInterfaceParserError,
   throwIfUnsupportedFunctionParamTypeAnnotationParserError,
   throwIfArrayElementTypeAnnotationIsUnsupported,
+  throwIfIncorrectModuleRegistryCallArgument,
 };

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -56,7 +56,6 @@ const {
 
 const {
   UnsupportedTypeAnnotationParserError,
-  IncorrectModuleRegistryCallArgumentTypeParserError,
   UnsupportedGenericParserError,
 } = require('../../errors');
 
@@ -67,6 +66,7 @@ const {
   throwIfWrongNumberOfCallExpressionArgs,
   throwIfMoreThanOneModuleRegistryCalls,
   throwIfIncorrectModuleRegistryCallTypeParameterParserError,
+  throwIfIncorrectModuleRegistryCallArgument,
   throwIfUntypedModule,
   throwIfMoreThanOneModuleInterfaceParserError,
 } = require('../../error-utils');
@@ -404,15 +404,11 @@ function buildModuleSchema(
       callExpression.arguments.length,
     );
 
-    if (callExpression.arguments[0].type !== 'Literal') {
-      const {type} = callExpression.arguments[0];
-      throw new IncorrectModuleRegistryCallArgumentTypeParserError(
-        hasteModuleName,
-        callExpression.arguments[0],
-        methodName,
-        type,
-      );
-    }
+    throwIfIncorrectModuleRegistryCallArgument(
+      hasteModuleName,
+      callExpression.arguments[0],
+      methodName,
+    );
 
     const $moduleName = callExpression.arguments[0].value;
 

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -63,7 +63,6 @@ const {
 const {
   UnsupportedGenericParserError,
   UnsupportedTypeAnnotationParserError,
-  IncorrectModuleRegistryCallArgumentTypeParserError,
 } = require('../../errors');
 
 const {
@@ -75,6 +74,7 @@ const {
   throwIfMoreThanOneModuleRegistryCalls,
   throwIfMoreThanOneModuleInterfaceParserError,
   throwIfIncorrectModuleRegistryCallTypeParameterParserError,
+  throwIfIncorrectModuleRegistryCallArgument,
 } = require('../../error-utils');
 
 const language = 'TypeScript';
@@ -510,15 +510,11 @@ function buildModuleSchema(
       callExpression.arguments.length,
     );
 
-    if (callExpression.arguments[0].type !== 'StringLiteral') {
-      const {type} = callExpression.arguments[0];
-      throw new IncorrectModuleRegistryCallArgumentTypeParserError(
-        hasteModuleName,
-        callExpression.arguments[0],
-        methodName,
-        type,
-      );
-    }
+    throwIfIncorrectModuleRegistryCallArgument(
+      hasteModuleName,
+      callExpression.arguments[0],
+      methodName,
+    );
 
     const $moduleName = callExpression.arguments[0].value;
 


### PR DESCRIPTION
## Summary

> [Codegen 83 - assigned to @Pranav-yadav] Create a function throwIfIncorrectModuleRegistryCallArgumnent function in the errors.js file and factor together the code from [Flow](https://github.com/facebook/react-native/blob/main/packages/react-native-codegen/src/parsers/flow/modules/index.js#L407-L415) and [TypeScript](https://github.com/facebook/react-native/blob/main/packages/react-native-codegen/src/parsers/typescript/modules/index.js#L513-L521). Update the Parsers to return the right Literl type

Merged `Flow` and `TS` Parsers' `IncorrectModuleRegistryCallArgumentTypeParserError` error-emitting code

- into `throwIfIncorrectModuleRegistryCallArgument` fun in `error-utils.js`


## Changelog

[INTERNAL] [CHANGED] -  Merge `Flow` and `TS` Parsers' `IncorrectModuleRegistryCallArgumentTypeParserError` error-emitting code

## Test Plan

- `yarn test`

