### PR TITLE
Gradle 8.x prep - specify task dependency between mergeNativeLibs and external native builds

### DIFF
--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/GenerateCodegenSchemaTask.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/GenerateCodegenSchemaTask.kt
@@ -38,13 +38,10 @@ abstract class GenerateCodegenSchemaTask : Exec() {
         // Those are known build paths where the source map or other
         // .js files could be stored/generated. We want to make sure we don't pick them up
         // for execution avoidance.
-        it.exclude("**/generated/source/codegen/**/*")
         it.exclude("**/build/ASSETS/**/*")
         it.exclude("**/build/RES/**/*")
-        it.exclude("**/build/generated/assets/react/**/*")
-        it.exclude("**/build/generated/res/react/**/*")
-        it.exclude("**/build/generated/sourcemaps/react/**/*")
-        it.exclude("**/build/intermediates/sourcemaps/react/**/*")
+        it.exclude("**/build/generated/**/*")
+        it.exclude("**/build/intermediates/**/*")
       }
 
   @get:OutputFile

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/GenerateCodegenSchemaTaskTest.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/GenerateCodegenSchemaTaskTest.kt
@@ -51,7 +51,7 @@ class GenerateCodegenSchemaTaskTest {
         tempFolder.newFolder("js").apply {
           File(this, "afolder/includedfile.js").createFileAndPath()
           // Those files should be excluded due to their filepath
-          File(this, "afolder/generated/source/codegen/anotherfolder/excludedfile.js")
+          File(this, "afolder/build/generated/source/codegen/anotherfolder/excludedfile.js")
               .createFileAndPath()
           File(this, "afolder/build/generated/assets/react/anotherfolder/excludedfile.js")
               .createFileAndPath()
@@ -68,13 +68,10 @@ class GenerateCodegenSchemaTaskTest {
     assertEquals(jsRootDir, task.jsInputFiles.dir)
     assertEquals(
         setOf(
-            "**/generated/source/codegen/**/*",
             "**/build/ASSETS/**/*",
             "**/build/RES/**/*",
-            "**/build/generated/assets/react/**/*",
-            "**/build/generated/res/react/**/*",
-            "**/build/generated/sourcemaps/react/**/*",
-            "**/build/intermediates/sourcemaps/react/**/*",
+            "**/build/generated/**/*",
+            "**/build/intermediates/**/*",
         ),
         task.jsInputFiles.excludes)
     assertEquals(1, task.jsInputFiles.files.size)

--- a/packages/rn-tester/android/app/build.gradle
+++ b/packages/rn-tester/android/app/build.gradle
@@ -206,4 +206,12 @@ afterEvaluate {
     // As we're consuming Hermes from source, we want to make sure
     // `hermesc` is built before we actually invoke the `emit*HermesResource` task
     createBundleHermesReleaseJsAndAssets.dependsOn(":ReactAndroid:hermes-engine:buildHermes")
+
+    // As we're building 4 native flavors in parallel, there is clash on the `.cxx/Debug` and
+    // `.cxx/Release` folder where the CMake intermediates are stored.
+    // We fixing this by instructing Gradle to always mergeLibs after they've been built.
+    mergeHermesDebugNativeLibs.mustRunAfter(externalNativeBuildJscDebug)
+    mergeHermesReleaseNativeLibs.mustRunAfter(externalNativeBuildJscRelease)
+    mergeJscDebugNativeLibs.mustRunAfter(externalNativeBuildHermesDebug)
+    mergeJscReleaseNativeLibs.mustRunAfter(externalNativeBuildHermesRelease)
 }


### PR DESCRIPTION
Summary:
Another build warning that got converted into a failure in Gradle 8.x
Specifically here as we're running 4 native builds in parallel for RN Tester, but they all originate
from 2 CMake intermediates files (one set for Debug and one for Release), Gradle raises a warning.

Here I'm fixing this warning by specifying an explicit ordering between those tasks.

Changelog:
[Internal] [Changed] - Gradle 8.x prep - specify task dependency between mergeNativeLibs and external native builds

Reviewed By: cipolleschi

Differential Revision: D43501128

