### PR TITLE
[RNTester] Support Slide Over and Split View on iPad

### DIFF
--- a/packages/rn-tester/RNTester/Info.plist
+++ b/packages/rn-tester/RNTester/Info.plist
@@ -2,16 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>LSApplicationQueriesSchemes</key>
-	<array>
-		<string>tel</string>
-		<string>telprompt</string>
-		<string>http</string>
-		<string>fb</string>
-		<string>geo</string>
-	</array>
-	<key>UIStatusBarStyle</key>
-	<string>UIStatusBarStyleBlackTranslucent</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>
@@ -60,9 +50,10 @@
 	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
-		<string>UIInterfaceOrientationPortrait</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>


### PR DESCRIPTION
## Summary

Context: We have been looking at more multi-window on iPad bugs and issues for React Native. One is that the default test app currently doesn't support SlideOver / Split View / MultiWindow. This change should support the first two of those configurations. 

This mirrors a change we had done in React Native Test App: https://github.com/microsoft/react-native-test-app/pull/1032/
In order to support Slide Over and Split View on iPad, the app must support all 4 orientations. 

Note, this does not support multi-window, which would require RNTester to be refactored to use a `SceneDelegate`. React Native Test app already does this: https://github.com/microsoft/react-native-test-app/blob/trunk/ios/ReactTestApp/SceneDelegate.swift

## Changelog

[INTERNAL] [CHANGED] - Support Slide Over and Split View on iPad for RNTester


## Test Plan

Ran RNTester and tested both configurations.

https://user-images.githubusercontent.com/6722175/220747910-9bf43d10-055e-4d46-a98c-5e3b24641700.mov




