### PR TITLE
Introduce the DefaultReactDelegate to simplify enabling/disabling Fabric for ReactFragment.

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
@@ -11,6 +11,7 @@ import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.KeyEvent;
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.devsupport.DoubleTapReloadRecognizer;
@@ -40,7 +41,7 @@ public class ReactDelegate {
       @Nullable Bundle launchOptions) {
     mActivity = activity;
     mMainComponentName = appKey;
-    mLaunchOptions = launchOptions;
+    mLaunchOptions = composeLaunchOptions(launchOptions);
     mDoubleTapReloadRecognizer = new DoubleTapReloadRecognizer();
     mReactNativeHost = reactNativeHost;
   }
@@ -143,5 +144,25 @@ public class ReactDelegate {
 
   public ReactInstanceManager getReactInstanceManager() {
     return getReactNativeHost().getReactInstanceManager();
+  }
+
+  /**
+    * Override this method if you wish to selectively toggle Fabric for a specific surface. This will
+    * also control if Concurrent Root (React 18) should be enabled or not.
+    *
+    * @return true if Fabric is enabled for this Activity, false otherwise.
+    */
+  protected boolean isFabricEnabled() {
+    return false;
+  }
+
+  private @NonNull Bundle composeLaunchOptions(Bundle composedLaunchOptions) {
+    if (isFabricEnabled()) {
+      if (composedLaunchOptions == null) {
+        composedLaunchOptions = new Bundle();
+      }
+      composedLaunchOptions.putBoolean("concurrentRoot", true);
+    }
+    return composedLaunchOptions;
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactFragment.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactFragment.java
@@ -20,6 +20,7 @@ import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import com.facebook.react.modules.core.PermissionAwareActivity;
 import com.facebook.react.modules.core.PermissionListener;
+import com.facebook.react.defaults.DefaultReactDelegate
 
 /**
  * Fragment for creating a React View. This allows the developer to "embed" a React Application
@@ -29,6 +30,7 @@ public class ReactFragment extends Fragment implements PermissionAwareActivity {
 
   protected static final String ARG_COMPONENT_NAME = "arg_component_name";
   protected static final String ARG_LAUNCH_OPTIONS = "arg_launch_options";
+  protected static final String FABRIC_ENABLED = "fabric_enabled";
 
   private ReactDelegate mReactDelegate;
 
@@ -40,13 +42,15 @@ public class ReactFragment extends Fragment implements PermissionAwareActivity {
 
   /**
    * @param componentName The name of the react native component
+   * @param fabricEnabled
    * @return A new instance of fragment ReactFragment.
    */
-  private static ReactFragment newInstance(String componentName, Bundle launchOptions) {
+  private static ReactFragment newInstance(String componentName, Bundle launchOptions, Boolean fabricEnabled) {
     ReactFragment fragment = new ReactFragment();
     Bundle args = new Bundle();
     args.putString(ARG_COMPONENT_NAME, componentName);
     args.putBundle(ARG_LAUNCH_OPTIONS, launchOptions);
+    args.putBoolean(FABRIC_ENABLED, fabricEnabled);
     fragment.setArguments(args);
     return fragment;
   }
@@ -57,15 +61,17 @@ public class ReactFragment extends Fragment implements PermissionAwareActivity {
     super.onCreate(savedInstanceState);
     String mainComponentName = null;
     Bundle launchOptions = null;
+    Boolean fabricEnabled = null;
     if (getArguments() != null) {
       mainComponentName = getArguments().getString(ARG_COMPONENT_NAME);
       launchOptions = getArguments().getBundle(ARG_LAUNCH_OPTIONS);
+      fabricEnabled = getArguments().getBoolean(FABRIC_ENABLED);
     }
     if (mainComponentName == null) {
       throw new IllegalStateException("Cannot loadApp if component name is null");
     }
     mReactDelegate =
-        new ReactDelegate(getActivity(), getReactNativeHost(), mainComponentName, launchOptions);
+        new DefaultReactDelegate(getActivity(), getReactNativeHost(), mainComponentName, launchOptions, fabricEnabled);
   }
 
   /**
@@ -172,10 +178,12 @@ public class ReactFragment extends Fragment implements PermissionAwareActivity {
 
     String mComponentName;
     Bundle mLaunchOptions;
+    Boolean mFabricEnabled;
 
     public Builder() {
       mComponentName = null;
       mLaunchOptions = null;
+      mFabricEnabled = null;
     }
 
     /**
@@ -201,7 +209,12 @@ public class ReactFragment extends Fragment implements PermissionAwareActivity {
     }
 
     public ReactFragment build() {
-      return ReactFragment.newInstance(mComponentName, mLaunchOptions);
+      return ReactFragment.newInstance(mComponentName, mLaunchOptions, mFabricEnabled);
+    }
+
+    public Builder fabricEnabled(boolean fabricEnabled) {
+      mFabricEnabled = fabricEnabled;
+      return this;
     }
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactDelegate.kt
+++ b/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactDelegate.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.defaults
+
+import android.app.Activity
+import android.os.Bundle
+import com.facebook.react.ReactNativeHost
+import com.facebook.react.ReactRootView
+
+/**
+ * A utility class that allows you to simplify the setup of a [ReactDelegate] for new apps
+ * in Open Source.
+ *
+ * Specifically, with this class you can simply control if Fabric is enabled for an Activity using
+ * the boolean flag in the constructor.
+ *
+ * @param fabricEnabled Whether Fabric should be enabled for the RootView of this Activity.
+ */
+open class DefaultReactDelegate(
+    activity: Activity,
+    reactNativeHost: ReactNativeHost,
+    appKey: String?,
+    launchOptions: Bundle?,
+    private val fabricEnabled: Boolean = false,
+) : ReactDelegate(activity, reactNativeHost, appKey, launchOptions) {
+
+    override fun isFabricEnabled(): Boolean = fabricEnabled
+
+    override fun createRootView(): ReactRootView =
+        ReactRootView(context).apply { setIsFabric(fabricEnabled) }
+}


### PR DESCRIPTION
## Summary

New Architecture Support missing in React Native Fragment, added same.

## Changelog

[ANDROID] [ADDED] - Introduce the DefaultReactDelegate to simplify enabling/disabling Fabric for ReactFragment.


## Test Plan

Kotlin Code Snippet to test:
`supportFragmentManager
    .beginTransaction()
    .add(android.R.id.content, 
        ReactFragment.Builder()
            .setComponentName("hyperSwitch")
            .fabricEnabled(true))
            .build())
    .commit()`