### PR TITLE
[iOS] [Fixed] - fix multiple modal not working

### DIFF
--- a/React/Views/RCTModalHostViewManager.m
+++ b/React/Views/RCTModalHostViewManager.m
@@ -79,9 +79,15 @@ RCT_EXPORT_MODULE()
     if (self->_presentationBlock) {
       self->_presentationBlock([modalHostView reactViewController], viewController, animated, completionBlock);
     } else {
-      [[modalHostView reactViewController] presentViewController:viewController
-                                                        animated:animated
-                                                      completion:completionBlock];
+        UIViewController *modelParentVC = [modalHostView reactViewController];
+        CGSize curSize = modelParentVC.view.frame.size;
+        [modelParentVC addChildViewController:viewController];
+        viewController.view.frame = CGRectMake(0, 0, curSize.width, curSize.height);
+        [modelParentVC.view addSubview:viewController.view];
+        [viewController didMoveToParentViewController:modelParentVC];
+        !completionBlock ?: completionBlock();
+        !self.dismissWaitingBlock ?: self.dismissWaitingBlock();
+        self.dismissWaitingBlock = nil;
     }
   });
 }
@@ -99,7 +105,10 @@ RCT_EXPORT_MODULE()
     if (self->_dismissalBlock) {
       self->_dismissalBlock([modalHostView reactViewController], viewController, animated, completionBlock);
     } else {
-      [viewController.presentingViewController dismissViewControllerAnimated:animated completion:completionBlock];
+        [viewController.view removeFromSuperview];
+        [viewController removeFromParentViewController];
+        [viewController willMoveToParentViewController:nil];
+        completionBlock();
     }
   });
 }


### PR DESCRIPTION
Summary
When I need to pop up multiple modals at the same time in react native, it doesn't work properly on iOS. It is presented on the native code of react native, iOS native cannot present multiple controllers at the same time

This modification is mainly to change the present form to addChild to solve the problem of adding multiple VC

Changelog
[iOS] [Fixed] - fix multiple modal not working

Test Plan
This modification has been verified in our project and online appstore
