### PR TITLE
[Codegen 76] create throwIfPartialNotAnnotatingTypeParameter and add extractAnnotatedElement method in parsers

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
@@ -25,6 +25,7 @@ const {
   throwIfUntypedModule,
   throwIfUnsupportedFunctionParamTypeAnnotationParserError,
   throwIfArrayElementTypeAnnotationIsUnsupported,
+  throwIfPartialNotAnnotatingTypeParameter,
 } = require('../error-utils');
 const {
   UnsupportedModulePropertyParserError,
@@ -718,5 +719,80 @@ describe('throwIfArrayElementTypeAnnotationIsUnsupported', () => {
         'StringTypeAnnotation',
       );
     }).not.toThrow(UnsupportedArrayElementTypeAnnotationParserError);
+  });
+});
+
+describe('throwIfPartialNotAnnotatingTypeParameter', () => {
+  const flowParser = new FlowParser();
+  const typescriptParser = new TypeScriptParser();
+  const typerscriptTypeAnnotation = {
+    typeParameters: {
+      params: [
+        {
+          typeName: {
+            name: 'TypeDeclaration',
+          },
+        },
+      ],
+    },
+  };
+  const flowTypeAnnotation = {
+    typeParameters: {
+      params: [
+        {
+          id: {
+            name: 'TypeDeclaration',
+          },
+        },
+      ],
+    },
+  };
+
+  it('throw error if Partial Not Annotating Type Parameter in Flow', () => {
+    const types = {};
+
+    expect(() => {
+      throwIfPartialNotAnnotatingTypeParameter(
+        flowTypeAnnotation,
+        types,
+        flowParser,
+      );
+    }).toThrowError('Partials only support annotating a type parameter.');
+  });
+
+  it('throw error if Partial Not Annotating Type Parameter in TypeScript', () => {
+    const types = {};
+
+    expect(() => {
+      throwIfPartialNotAnnotatingTypeParameter(
+        typerscriptTypeAnnotation,
+        types,
+        typescriptParser,
+      );
+    }).toThrowError('Partials only support annotating a type parameter.');
+  });
+
+  it('does not throw error if Partial Annotating Type Parameter in Flow', () => {
+    const types = {TypeDeclaration: {}};
+
+    expect(() => {
+      throwIfPartialNotAnnotatingTypeParameter(
+        flowTypeAnnotation,
+        types,
+        flowParser,
+      );
+    }).not.toThrowError();
+  });
+
+  it('does not throw error if Partial Annotating Type Parameter in TypeScript', () => {
+    const types = {TypeDeclaration: {}};
+
+    expect(() => {
+      throwIfPartialNotAnnotatingTypeParameter(
+        typerscriptTypeAnnotation,
+        types,
+        typescriptParser,
+      );
+    }).not.toThrowError();
   });
 });

--- a/packages/react-native-codegen/src/parsers/error-utils.js
+++ b/packages/react-native-codegen/src/parsers/error-utils.js
@@ -13,6 +13,7 @@
 import type {NativeModuleTypeAnnotation} from '../CodegenSchema';
 import type {ParserType} from './errors';
 import type {Parser} from './parser';
+import type {TypeDeclarationMap} from '../parsers/utils';
 
 const {
   MisnamedModuleInterfaceParserError,
@@ -280,6 +281,21 @@ function throwIfIncorrectModuleRegistryCallArgument(
   }
 }
 
+function throwIfPartialNotAnnotatingTypeParameter(
+  typeAnnotation: $FlowFixMe,
+  types: TypeDeclarationMap,
+  parser: Parser,
+) {
+  const annotatedElement = parser.extractAnnotatedElement(
+    typeAnnotation,
+    types,
+  );
+
+  if (!annotatedElement) {
+    throw new Error('Partials only support annotating a type parameter.');
+  }
+}
+
 module.exports = {
   throwIfModuleInterfaceIsMisnamed,
   throwIfUnsupportedFunctionReturnTypeAnnotationParserError,
@@ -295,4 +311,5 @@ module.exports = {
   throwIfUnsupportedFunctionParamTypeAnnotationParserError,
   throwIfArrayElementTypeAnnotationIsUnsupported,
   throwIfIncorrectModuleRegistryCallArgument,
+  throwIfPartialNotAnnotatingTypeParameter,
 };

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -69,6 +69,7 @@ const {
   throwIfIncorrectModuleRegistryCallArgument,
   throwIfUntypedModule,
   throwIfMoreThanOneModuleInterfaceParserError,
+  throwIfPartialNotAnnotatingTypeParameter,
 } = require('../../error-utils');
 
 const language = 'Flow';
@@ -168,14 +169,16 @@ function translateTypeAnnotation(
             );
           }
 
-          const annotatedElement =
-            types[typeAnnotation.typeParameters.params[0].id.name];
+          const annotatedElement = parser.extractAnnotatedElement(
+            typeAnnotation,
+            types,
+          );
 
-          if (!annotatedElement) {
-            throw new Error(
-              'Partials only support annotating a type parameter.',
-            );
-          }
+          throwIfPartialNotAnnotatingTypeParameter(
+            typeAnnotation,
+            types,
+            parser,
+          );
 
           const properties = annotatedElement.right.properties.map(prop => {
             return {

--- a/packages/react-native-codegen/src/parsers/flow/parser.js
+++ b/packages/react-native-codegen/src/parsers/flow/parser.js
@@ -21,6 +21,7 @@ import type {
 } from '../../CodegenSchema';
 import type {ParserType} from '../errors';
 import type {Parser} from '../parser';
+import type {TypeDeclarationMap} from '../utils';
 
 // $FlowFixMe[untyped-import] there's no flowtype flow-parser
 const flowParser = require('flow-parser');
@@ -204,6 +205,13 @@ class FlowParser implements Parser {
       node.extends[0].type === 'InterfaceExtends' &&
       node.extends[0].id.name === 'TurboModule'
     );
+  }
+
+  extractAnnotatedElement(
+    typeAnnotation: $FlowFixMe,
+    types: TypeDeclarationMap,
+  ): $FlowFixMe {
+    return types[typeAnnotation.typeParameters.params[0].id.name];
   }
 }
 

--- a/packages/react-native-codegen/src/parsers/parser.js
+++ b/packages/react-native-codegen/src/parsers/parser.js
@@ -20,6 +20,7 @@ import type {
   NativeModuleEnumMembers,
 } from '../CodegenSchema';
 import type {ParserType} from './errors';
+import type {TypeDeclarationMap} from './utils';
 
 /**
  * This is the main interface for Parsers of various languages.
@@ -157,4 +158,15 @@ export interface Parser {
    * Given a node, it returns true if it is a module interface
    */
   isModuleInterface(node: $FlowFixMe): boolean;
+
+  /**
+   * Given a typeAnnotation, it returns the annotated element.
+   * @paramater typeAnnotation: the annotation for a type.
+   * @paramater types: a map of type declarations.
+   * @returns: the annotated element.
+   */
+  extractAnnotatedElement(
+    typeAnnotation: $FlowFixMe,
+    types: TypeDeclarationMap,
+  ): $FlowFixMe;
 }

--- a/packages/react-native-codegen/src/parsers/parserMock.js
+++ b/packages/react-native-codegen/src/parsers/parserMock.js
@@ -22,6 +22,8 @@ import type {
   NativeModuleEnumMembers,
 } from '../CodegenSchema';
 
+import type {TypeDeclarationMap} from './utils';
+
 // $FlowFixMe[untyped-import] there's no flowtype flow-parser
 const flowParser = require('flow-parser');
 const {
@@ -167,5 +169,12 @@ export class MockedParser implements Parser {
       node.extends[0].type === 'InterfaceExtends' &&
       node.extends[0].id.name === 'TurboModule'
     );
+  }
+
+  extractAnnotatedElement(
+    typeAnnotation: $FlowFixMe,
+    types: TypeDeclarationMap,
+  ): $FlowFixMe {
+    return types[typeAnnotation.typeParameters.params[0].id.name];
   }
 }

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -75,6 +75,7 @@ const {
   throwIfMoreThanOneModuleInterfaceParserError,
   throwIfIncorrectModuleRegistryCallTypeParameterParserError,
   throwIfIncorrectModuleRegistryCallArgument,
+  throwIfPartialNotAnnotatingTypeParameter,
 } = require('../../error-utils');
 
 const language = 'TypeScript';
@@ -249,14 +250,16 @@ function translateTypeAnnotation(
             );
           }
 
-          const annotatedElement =
-            types[typeAnnotation.typeParameters.params[0].typeName.name];
+          const annotatedElement = parser.extractAnnotatedElement(
+            typeAnnotation,
+            types,
+          );
 
-          if (!annotatedElement) {
-            throw new Error(
-              'Partials only support annotating a type parameter.',
-            );
-          }
+          throwIfPartialNotAnnotatingTypeParameter(
+            typeAnnotation,
+            types,
+            parser,
+          );
 
           const properties = annotatedElement.typeAnnotation.members.map(
             member => {

--- a/packages/react-native-codegen/src/parsers/typescript/parser.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parser.js
@@ -21,6 +21,7 @@ import type {
 } from '../../CodegenSchema';
 import type {ParserType} from '../errors';
 import type {Parser} from '../parser';
+import type {TypeDeclarationMap} from '../utils';
 
 // $FlowFixMe[untyped-import] Use flow-types for @babel/parser
 const babelParser = require('@babel/parser');
@@ -200,6 +201,13 @@ class TypeScriptParser implements Parser {
       node.extends[0].type === 'TSExpressionWithTypeArguments' &&
       node.extends[0].expression.name === 'TurboModule'
     );
+  }
+
+  extractAnnotatedElement(
+    typeAnnotation: $FlowFixMe,
+    types: TypeDeclarationMap,
+  ): $FlowFixMe {
+    return types[typeAnnotation.typeParameters.params[0].typeName.name];
   }
 }
 module.exports = {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

> Create a throwIfPartialNotAnnotatingTypeParameter function in the error-utils.js file and extract the error-emitting code from [Flow](https://github.com/facebook/react-native/blob/main/packages/react-native-codegen/src/parsers/flow/modules/index.js#L174-L178) and [Typescript](https://github.com/facebook/react-native/blob/main/packages/react-native-codegen/src/parsers/typescript/modules/index.js#L252-L259) index files. Notice that the way in which the annotatedElement is computed is different, therefore we should add an extractAnnotatedElement function to the Flow and TypeScript parsers.

Part of the Codegen ☂️ Issue https://github.com/facebook/react-native/issues/34872


## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
[Internal] [Changed] - create throwIfPartialNotAnnotatingTypeParameter and add extractAnnotatedElement method in parsers

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

`yarn jest react-native-codegen`
