### PR TITLE
Add device event emit test for the sample C++ TurboModule

### DIFF
--- a/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.cpp
+++ b/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.cpp
@@ -121,4 +121,19 @@ void NativeCxxModuleExample::voidFunc(jsi::Runtime &rt) {
   // Nothing to do
 }
 
+void NativeCxxModuleExample::emitCustomDeviceEvent(
+    jsi::Runtime &rt,
+    jsi::String eventName) {
+  // Test emitting device events (RCTDeviceEventEmitter.emit) from C++
+  // TurboModule with arbitrary arguments
+  emitDeviceEvent(
+      rt,
+      eventName.utf8(rt).c_str(),
+      [](jsi::Runtime &rt, std::vector<jsi::Value> &args) {
+        args.emplace_back(jsi::Value(true));
+        args.emplace_back(jsi::Value(42));
+        args.emplace_back(jsi::String::createFromAscii(rt, "stringArg"));
+      });
+}
+
 } // namespace facebook::react

--- a/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.h
+++ b/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.h
@@ -121,6 +121,8 @@ class NativeCxxModuleExample
   AsyncPromise<std::string> getValueWithPromise(jsi::Runtime &rt, bool error);
 
   void voidFunc(jsi::Runtime &rt);
+
+  void emitCustomDeviceEvent(jsi::Runtime &rt, jsi::String eventName);
 };
 
 } // namespace facebook::react

--- a/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.js
+++ b/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.js
@@ -71,6 +71,7 @@ export interface Spec extends TurboModule {
   +getValueWithCallback: (callback: (value: string) => void) => void;
   +getValueWithPromise: (error: boolean) => Promise<string>;
   +voidFunc: () => void;
+  +emitCustomDeviceEvent: (eventName: string) => void;
 }
 
 export default (TurboModuleRegistry.get<Spec>(

--- a/packages/rn-tester/js/examples/TurboModule/NativeCxxModuleExampleExample.js
+++ b/packages/rn-tester/js/examples/TurboModule/NativeCxxModuleExampleExample.js
@@ -11,6 +11,7 @@
 import type {RootTag} from 'react-native/Libraries/ReactNative/RootTag';
 
 import {
+  DeviceEventEmitter,
   StyleSheet,
   Text,
   View,
@@ -53,7 +54,8 @@ type Examples =
   | 'getValue'
   | 'promise'
   | 'rejectPromise'
-  | 'voidFunc';
+  | 'voidFunc'
+  | 'emitCustomDeviceEvent';
 
 class NativeCxxModuleExampleExample extends React.Component<{||}, State> {
   static contextType: React$Context<RootTag> = RootTagContext;
@@ -97,6 +99,17 @@ class NativeCxxModuleExampleExample extends React.Component<{||}, State> {
         .then(() => {})
         .catch(e => this._setResult('rejectPromise', e.message)),
     voidFunc: () => NativeCxxModuleExample?.voidFunc(),
+    emitCustomDeviceEvent: () => {
+      const CUSTOM_EVENT_TYPE = 'myCustomDeviceEvent';
+      DeviceEventEmitter.removeAllListeners(CUSTOM_EVENT_TYPE);
+      DeviceEventEmitter.addListener(CUSTOM_EVENT_TYPE, (...args) => {
+        this._setResult(
+          'emitCustomDeviceEvent',
+          `${CUSTOM_EVENT_TYPE}(${args.map(s => `${s}`).join(', ')})`,
+        );
+      });
+      NativeCxxModuleExample?.emitCustomDeviceEvent(CUSTOM_EVENT_TYPE);
+    },
   };
 
   _setResult(


### PR DESCRIPTION
Summary:
[Changelog][Internal]

The diff creates a test clause for [TurboModule::emitDeviceEvent C++ API for TurboModules](https://www.internalfb.com/code/fbsource/[929870c905c8fe68cb330ce96bda7eb703bb6ae6]/xplat/js/react-native-github/ReactCommon/react/nativemodule/core/ReactCommon/TurboModule.h?lines=90), which can be seen in either Catalyst or RNTester.

Reviewed By: cipolleschi

Differential Revision: D43466327

