### PR TITLE
Use emitDeviceEvent in core ReactAndroid code

### DIFF
--- a/ReactAndroid/src/androidTest/java/com/facebook/react/testing/network/NetworkRecordingModuleMock.java
+++ b/ReactAndroid/src/androidTest/java/com/facebook/react/testing/network/NetworkRecordingModuleMock.java
@@ -18,7 +18,6 @@ import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.module.annotations.ReactModule;
-import com.facebook.react.modules.core.DeviceEventManagerModule;
 
 /**
  * Mock Networking module that records last request received by {@link #sendRequest} method and
@@ -36,6 +35,7 @@ public class NetworkRecordingModuleMock extends ReactContextBaseJavaModule {
   public boolean mAbortedRequest;
 
   private boolean mCompleteRequest;
+  private ReactApplicationContext mContext;
 
   public NetworkRecordingModuleMock(ReactApplicationContext reactContext) {
     this(reactContext, true);
@@ -44,6 +44,7 @@ public class NetworkRecordingModuleMock extends ReactContextBaseJavaModule {
   public NetworkRecordingModuleMock(ReactApplicationContext reactContext, boolean completeRequest) {
     super(reactContext);
     mCompleteRequest = completeRequest;
+    mContext = reactContext;
   }
 
   public interface RequestListener {
@@ -120,7 +121,7 @@ public class NetworkRecordingModuleMock extends ReactContextBaseJavaModule {
     args.pushInt(requestId);
     args.pushString(data);
 
-    getEventEmitter().emit("didReceiveNetworkData", args);
+    mContext.emitDeviceEvent("didReceiveNetworkData", args);
   }
 
   private void onRequestComplete(int requestId, @Nullable String error) {
@@ -128,7 +129,7 @@ public class NetworkRecordingModuleMock extends ReactContextBaseJavaModule {
     args.pushInt(requestId);
     args.pushString(error);
 
-    getEventEmitter().emit("didCompleteNetworkResponse", args);
+    mContext.emitDeviceEvent("didCompleteNetworkResponse", args);
   }
 
   private void onResponseReceived(int requestId, int code, WritableMap headers) {
@@ -137,11 +138,6 @@ public class NetworkRecordingModuleMock extends ReactContextBaseJavaModule {
     args.pushInt(code);
     args.pushMap(headers);
 
-    getEventEmitter().emit("didReceiveNetworkResponse", args);
-  }
-
-  private DeviceEventManagerModule.RCTDeviceEventEmitter getEventEmitter() {
-    return getReactApplicationContext()
-        .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class);
+    mContext.emitDeviceEvent("didReceiveNetworkResponse", args);
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -554,9 +554,7 @@ public class ReactInstanceManager {
   private void toggleElementInspector() {
     ReactContext currentContext = getCurrentReactContext();
     if (currentContext != null && currentContext.hasActiveReactInstance()) {
-      currentContext
-          .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-          .emit("toggleElementInspector", null);
+      currentContext.emitDeviceEvent("toggleElementInspector");
     } else {
       ReactSoftExceptionLogger.logSoftException(
           TAG,

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -52,7 +52,6 @@ import com.facebook.react.bridge.WritableNativeMap;
 import com.facebook.react.common.annotations.VisibleForTesting;
 import com.facebook.react.config.ReactFeatureFlags;
 import com.facebook.react.modules.appregistry.AppRegistry;
-import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.facebook.react.modules.deviceinfo.DeviceInfoModule;
 import com.facebook.react.surface.ReactStage;
 import com.facebook.react.uimanager.DisplayMetricsHolder;
@@ -866,9 +865,7 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
 
   /* package */ void sendEvent(String eventName, @Nullable WritableMap params) {
     if (hasActiveReactInstance()) {
-      getCurrentReactContext()
-          .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-          .emit(eventName, params);
+      getCurrentReactContext().emitDeviceEvent(eventName, params);
     }
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedModule.java
@@ -26,7 +26,6 @@ import com.facebook.react.bridge.UIManagerListener;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.common.annotations.VisibleForTesting;
 import com.facebook.react.module.annotations.ReactModule;
-import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.facebook.react.modules.core.ReactChoreographer;
 import com.facebook.react.uimanager.GuardedFrameCallback;
 import com.facebook.react.uimanager.NativeViewHierarchyManager;
@@ -566,9 +565,7 @@ public class NativeAnimatedModule extends NativeAnimatedModuleSpec
             ReactApplicationContext reactApplicationContext =
                 getReactApplicationContextIfActiveOrWarn();
             if (reactApplicationContext != null) {
-              reactApplicationContext
-                  .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-                  .emit("onAnimatedValueUpdate", onAnimatedValueData);
+              reactApplicationContext.emitDeviceEvent("onAnimatedValueUpdate", onAnimatedValueData);
             }
           }
         };
@@ -1090,9 +1087,8 @@ public class NativeAnimatedModule extends NativeAnimatedModuleSpec
                           ReactApplicationContext reactApplicationContext =
                               getReactApplicationContextIfActiveOrWarn();
                           if (reactApplicationContext != null) {
-                            reactApplicationContext
-                                .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-                                .emit("onAnimatedValueUpdate", onAnimatedValueData);
+                            reactApplicationContext.emitDeviceEvent(
+                                "onAnimatedValueUpdate", onAnimatedValueData);
                           }
                         }
                       };

--- a/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedNodesManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedNodesManager.java
@@ -23,7 +23,6 @@ import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.UIManager;
 import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.bridge.WritableMap;
-import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.facebook.react.uimanager.UIManagerHelper;
 import com.facebook.react.uimanager.common.UIManagerType;
 import com.facebook.react.uimanager.events.Event;
@@ -308,9 +307,8 @@ public class NativeAnimatedNodesManager implements EventDispatcherListener {
           WritableMap params = Arguments.createMap();
           params.putInt("animationId", animation.mId);
           params.putBoolean("finished", false);
-          mReactApplicationContext
-              .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-              .emit("onNativeAnimatedModuleAnimationFinished", params);
+          mReactApplicationContext.emitDeviceEvent(
+              "onNativeAnimatedModuleAnimationFinished", params);
         }
         mActiveAnimations.removeAt(i);
         i--;
@@ -339,9 +337,8 @@ public class NativeAnimatedNodesManager implements EventDispatcherListener {
           WritableMap params = Arguments.createMap();
           params.putInt("animationId", animation.mId);
           params.putBoolean("finished", false);
-          mReactApplicationContext
-              .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-              .emit("onNativeAnimatedModuleAnimationFinished", params);
+          mReactApplicationContext.emitDeviceEvent(
+              "onNativeAnimatedModuleAnimationFinished", params);
         }
         mActiveAnimations.removeAt(i);
         return;
@@ -474,9 +471,7 @@ public class NativeAnimatedNodesManager implements EventDispatcherListener {
     WritableMap params = Arguments.createMap();
     params.putInt("tag", tag);
     params.putDouble("value", value);
-    mReactApplicationContext
-        .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-        .emit("onNativeAnimatedModuleGetValue", params);
+    mReactApplicationContext.emitDeviceEvent("onNativeAnimatedModuleGetValue", params);
   }
 
   @UiThread
@@ -653,12 +648,8 @@ public class NativeAnimatedNodesManager implements EventDispatcherListener {
             WritableMap params = Arguments.createMap();
             params.putInt("animationId", animation.mId);
             params.putBoolean("finished", true);
-            DeviceEventManagerModule.RCTDeviceEventEmitter eventEmitter =
-                mReactApplicationContext.getJSModule(
-                    DeviceEventManagerModule.RCTDeviceEventEmitter.class);
-            if (eventEmitter != null) {
-              eventEmitter.emit("onNativeAnimatedModuleAnimationFinished", params);
-            }
+            mReactApplicationContext.emitDeviceEvent(
+                "onNativeAnimatedModuleAnimationFinished", params);
           }
           mActiveAnimations.removeAt(i);
         }

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
@@ -15,10 +15,12 @@ import android.content.ContextWrapper;
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.LayoutInflater;
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.facebook.common.logging.FLog;
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.infer.annotation.ThreadConfined;
+import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.bridge.queue.MessageQueueThread;
 import com.facebook.react.bridge.queue.ReactQueueConfiguration;
 import com.facebook.react.common.LifecycleState;
@@ -32,6 +34,10 @@ import java.util.concurrent.CopyOnWriteArraySet;
  * CatalystInstance}
  */
 public class ReactContext extends ContextWrapper {
+  @DoNotStrip
+  public interface RCTDeviceEventEmitter extends JavaScriptModule {
+    void emit(@NonNull String eventName, @Nullable Object data);
+  }
 
   private static final String TAG = "ReactContext";
   private static final String EARLY_JS_ACCESS_EXCEPTION_MESSAGE =
@@ -181,6 +187,21 @@ public class ReactContext extends ContextWrapper {
       raiseCatalystInstanceMissingException();
     }
     return mCatalystInstance.getNativeModule(nativeModuleInterface);
+  }
+
+  /**
+   * Calls RCTDeviceEventEmitter.emit to JavaScript, with given event name and an optional list of
+   * arguments.
+   */
+  public void emitDeviceEvent(String eventName, @Nullable Object args) {
+    RCTDeviceEventEmitter eventEmitter = getJSModule(RCTDeviceEventEmitter.class);
+    if (eventEmitter != null) {
+      eventEmitter.emit(eventName, args);
+    }
+  }
+
+  public void emitDeviceEvent(String eventName) {
+    emitDeviceEvent(eventName, null);
   }
 
   public CatalystInstance getCatalystInstance() {

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/accessibilityinfo/AccessibilityInfoModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/accessibilityinfo/AccessibilityInfoModule.java
@@ -24,7 +24,6 @@ import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.module.annotations.ReactModule;
-import com.facebook.react.modules.core.DeviceEventManagerModule;
 
 /**
  * Module that monitors and provides information about the state of Touch Exploration service on the
@@ -130,9 +129,7 @@ public class AccessibilityInfoModule extends NativeAccessibilityInfoSpec
 
       ReactApplicationContext reactApplicationContext = getReactApplicationContextIfActiveOrWarn();
       if (reactApplicationContext != null) {
-        reactApplicationContext
-            .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-            .emit(REDUCE_MOTION_EVENT_NAME, mReduceMotionEnabled);
+        reactApplicationContext.emitDeviceEvent(REDUCE_MOTION_EVENT_NAME, mReduceMotionEnabled);
       }
     }
   }
@@ -144,8 +141,7 @@ public class AccessibilityInfoModule extends NativeAccessibilityInfoSpec
       ReactApplicationContext reactApplicationContext = getReactApplicationContextIfActiveOrWarn();
       if (reactApplicationContext != null) {
         getReactApplicationContext()
-            .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-            .emit(TOUCH_EXPLORATION_EVENT_NAME, mTouchExplorationEnabled);
+            .emitDeviceEvent(TOUCH_EXPLORATION_EVENT_NAME, mTouchExplorationEnabled);
       }
     }
   }
@@ -157,8 +153,7 @@ public class AccessibilityInfoModule extends NativeAccessibilityInfoSpec
       ReactApplicationContext reactApplicationContext = getReactApplicationContextIfActiveOrWarn();
       if (reactApplicationContext != null) {
         getReactApplicationContext()
-            .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-            .emit(ACCESSIBILITY_SERVICE_EVENT_NAME, mAccessibilityServiceEnabled);
+            .emitDeviceEvent(ACCESSIBILITY_SERVICE_EVENT_NAME, mAccessibilityServiceEnabled);
       }
     }
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/appearance/AppearanceModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/appearance/AppearanceModule.java
@@ -16,7 +16,6 @@ import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.module.annotations.ReactModule;
-import com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEmitter;
 
 /** Module that exposes the user's preferred color scheme. */
 @ReactModule(name = NativeAppearanceSpec.NAME)
@@ -108,9 +107,7 @@ public class AppearanceModule extends NativeAppearanceSpec {
     ReactApplicationContext reactApplicationContext = getReactApplicationContextIfActiveOrWarn();
 
     if (reactApplicationContext != null) {
-      reactApplicationContext
-          .getJSModule(RCTDeviceEventEmitter.class)
-          .emit(APPEARANCE_CHANGED_EVENT_NAME, appearancePreferences);
+      reactApplicationContext.emitDeviceEvent(APPEARANCE_CHANGED_EVENT_NAME, appearancePreferences);
     }
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/appstate/AppStateModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/appstate/AppStateModule.java
@@ -16,7 +16,6 @@ import com.facebook.react.bridge.WindowFocusChangeListener;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.common.LifecycleState;
 import com.facebook.react.module.annotations.ReactModule;
-import com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEmitter;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -96,7 +95,7 @@ public class AppStateModule extends NativeAppStateSpec
     if (!reactApplicationContext.hasActiveReactInstance()) {
       return;
     }
-    reactApplicationContext.getJSModule(RCTDeviceEventEmitter.class).emit(eventName, data);
+    reactApplicationContext.emitDeviceEvent(eventName, data);
   }
 
   private void sendAppStateChangeEvent() {

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/core/DeviceEventManagerModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/core/DeviceEventManagerModule.java
@@ -47,9 +47,7 @@ public class DeviceEventManagerModule extends NativeDeviceEventManagerSpec {
     ReactApplicationContext reactApplicationContext = getReactApplicationContextIfActiveOrWarn();
 
     if (reactApplicationContext != null) {
-      reactApplicationContext
-          .getJSModule(RCTDeviceEventEmitter.class)
-          .emit("hardwareBackPress", null);
+      reactApplicationContext.emitDeviceEvent("hardwareBackPress", null);
     }
   }
 
@@ -60,7 +58,7 @@ public class DeviceEventManagerModule extends NativeDeviceEventManagerSpec {
     if (reactApplicationContext != null) {
       WritableMap map = Arguments.createMap();
       map.putString("url", uri.toString());
-      reactApplicationContext.getJSModule(RCTDeviceEventEmitter.class).emit("url", map);
+      reactApplicationContext.emitDeviceEvent("url", map);
     }
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/debug/DevSettingsModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/debug/DevSettingsModule.java
@@ -15,7 +15,6 @@ import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.devsupport.interfaces.DevOptionHandler;
 import com.facebook.react.devsupport.interfaces.DevSupportManager;
 import com.facebook.react.module.annotations.ReactModule;
-import com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEmitter;
 
 /**
  * Module that exposes the URL to the source code map (used for exception stack trace parsing) to JS
@@ -89,9 +88,7 @@ public class DevSettingsModule extends NativeDevSettingsSpec {
                 getReactApplicationContextIfActiveOrWarn();
 
             if (reactApplicationContext != null) {
-              reactApplicationContext
-                  .getJSModule(RCTDeviceEventEmitter.class)
-                  .emit("didPressMenuItem", data);
+              reactApplicationContext.emitDeviceEvent("didPressMenuItem", data);
             }
           }
         });

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/deviceinfo/DeviceInfoModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/deviceinfo/DeviceInfoModule.java
@@ -17,7 +17,6 @@ import com.facebook.react.bridge.ReactSoftExceptionLogger;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.module.annotations.ReactModule;
-import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.facebook.react.uimanager.DisplayMetricsHolder;
 import java.util.HashMap;
 import java.util.Map;
@@ -89,9 +88,7 @@ public class DeviceInfoModule extends NativeDeviceInfoSpec implements LifecycleE
         mPreviousDisplayMetrics = displayMetrics.copy();
       } else if (!displayMetrics.equals(mPreviousDisplayMetrics)) {
         mPreviousDisplayMetrics = displayMetrics.copy();
-        mReactApplicationContext
-            .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-            .emit("didUpdateDimensions", displayMetrics);
+        mReactApplicationContext.emitDeviceEvent("didUpdateDimensions", displayMetrics);
       }
     } else {
       ReactSoftExceptionLogger.logSoftException(

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/network/ResponseUtil.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/network/ResponseUtil.java
@@ -9,26 +9,26 @@ package com.facebook.react.modules.network;
 
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
-import com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEmitter;
 import java.net.SocketTimeoutException;
 
 /** Util methods to send network responses to JS. */
 public class ResponseUtil {
   public static void onDataSend(
-      @Nullable RCTDeviceEventEmitter eventEmitter, int requestId, long progress, long total) {
+      @Nullable ReactApplicationContext reactContext, int requestId, long progress, long total) {
     WritableArray args = Arguments.createArray();
     args.pushInt(requestId);
     args.pushInt((int) progress);
     args.pushInt((int) total);
-    if (eventEmitter != null) {
-      eventEmitter.emit("didSendNetworkData", args);
+    if (reactContext != null) {
+      reactContext.emitDeviceEvent("didSendNetworkData", args);
     }
   }
 
   public static void onIncrementalDataReceived(
-      @Nullable RCTDeviceEventEmitter eventEmitter,
+      @Nullable ReactApplicationContext reactContext,
       int requestId,
       String data,
       long progress,
@@ -39,47 +39,47 @@ public class ResponseUtil {
     args.pushInt((int) progress);
     args.pushInt((int) total);
 
-    if (eventEmitter != null) {
-      eventEmitter.emit("didReceiveNetworkIncrementalData", args);
+    if (reactContext != null) {
+      reactContext.emitDeviceEvent("didReceiveNetworkIncrementalData", args);
     }
   }
 
   public static void onDataReceivedProgress(
-      @Nullable RCTDeviceEventEmitter eventEmitter, int requestId, long progress, long total) {
+      @Nullable ReactApplicationContext reactContext, int requestId, long progress, long total) {
     WritableArray args = Arguments.createArray();
     args.pushInt(requestId);
     args.pushInt((int) progress);
     args.pushInt((int) total);
 
-    if (eventEmitter != null) {
-      eventEmitter.emit("didReceiveNetworkDataProgress", args);
+    if (reactContext != null) {
+      reactContext.emitDeviceEvent("didReceiveNetworkDataProgress", args);
     }
   }
 
   public static void onDataReceived(
-      @Nullable RCTDeviceEventEmitter eventEmitter, int requestId, String data) {
+      @Nullable ReactApplicationContext reactContext, int requestId, String data) {
     WritableArray args = Arguments.createArray();
     args.pushInt(requestId);
     args.pushString(data);
 
-    if (eventEmitter != null) {
-      eventEmitter.emit("didReceiveNetworkData", args);
+    if (reactContext != null) {
+      reactContext.emitDeviceEvent("didReceiveNetworkData", args);
     }
   }
 
   public static void onDataReceived(
-      @Nullable RCTDeviceEventEmitter eventEmitter, int requestId, WritableMap data) {
+      @Nullable ReactApplicationContext reactContext, int requestId, WritableMap data) {
     WritableArray args = Arguments.createArray();
     args.pushInt(requestId);
     args.pushMap(data);
 
-    if (eventEmitter != null) {
-      eventEmitter.emit("didReceiveNetworkData", args);
+    if (reactContext != null) {
+      reactContext.emitDeviceEvent("didReceiveNetworkData", args);
     }
   }
 
   public static void onRequestError(
-      @Nullable RCTDeviceEventEmitter eventEmitter, int requestId, String error, Throwable e) {
+      @Nullable ReactApplicationContext reactContext, int requestId, String error, Throwable e) {
     WritableArray args = Arguments.createArray();
     args.pushInt(requestId);
     args.pushString(error);
@@ -88,23 +88,24 @@ public class ResponseUtil {
       args.pushBoolean(true); // last argument is a time out boolean
     }
 
-    if (eventEmitter != null) {
-      eventEmitter.emit("didCompleteNetworkResponse", args);
+    if (reactContext != null) {
+      reactContext.emitDeviceEvent("didCompleteNetworkResponse", args);
     }
   }
 
-  public static void onRequestSuccess(@Nullable RCTDeviceEventEmitter eventEmitter, int requestId) {
+  public static void onRequestSuccess(
+      @Nullable ReactApplicationContext reactContext, int requestId) {
     WritableArray args = Arguments.createArray();
     args.pushInt(requestId);
     args.pushNull();
 
-    if (eventEmitter != null) {
-      eventEmitter.emit("didCompleteNetworkResponse", args);
+    if (reactContext != null) {
+      reactContext.emitDeviceEvent("didCompleteNetworkResponse", args);
     }
   }
 
   public static void onResponseReceived(
-      @Nullable RCTDeviceEventEmitter eventEmitter,
+      @Nullable ReactApplicationContext reactContext,
       int requestId,
       int statusCode,
       WritableMap headers,
@@ -115,8 +116,8 @@ public class ResponseUtil {
     args.pushMap(headers);
     args.pushString(url);
 
-    if (eventEmitter != null) {
-      eventEmitter.emit("didReceiveNetworkResponse", args);
+    if (reactContext != null) {
+      reactContext.emitDeviceEvent("didReceiveNetworkResponse", args);
     }
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java
@@ -19,7 +19,6 @@ import com.facebook.react.bridge.ReadableType;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.common.ReactConstants;
 import com.facebook.react.module.annotations.ReactModule;
-import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.facebook.react.modules.network.ForwardingCookieHandler;
 import java.io.IOException;
 import java.net.URI;
@@ -66,9 +65,7 @@ public final class WebSocketModule extends NativeWebSocketModuleSpec {
   private void sendEvent(String eventName, WritableMap params) {
     ReactApplicationContext reactApplicationContext = getReactApplicationContext();
     if (reactApplicationContext.hasActiveReactInstance()) {
-      reactApplicationContext
-          .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-          .emit(eventName, params);
+      reactApplicationContext.emitDeviceEvent(eventName, params);
     }
   }
 

--- a/ReactAndroid/src/test/java/com/facebook/react/RootViewTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/RootViewTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -28,7 +29,6 @@ import com.facebook.react.bridge.ReactTestHelper;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.common.SystemClock;
-import com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEmitter;
 import com.facebook.react.uimanager.DisplayMetricsHolder;
 import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.events.Event;
@@ -91,7 +91,7 @@ public class RootViewTest {
             });
 
     mCatalystInstanceMock = ReactTestHelper.createMockCatalystInstance();
-    mReactContext = new ReactApplicationContext(RuntimeEnvironment.application);
+    mReactContext = spy(new ReactApplicationContext(RuntimeEnvironment.application));
     mReactContext.initializeWithInstance(mCatalystInstanceMock);
     DisplayMetricsHolder.initDisplayMetricsIfNotInitialized(mReactContext);
 
@@ -217,11 +217,8 @@ public class RootViewTest {
   @Test
   public void testCheckForKeyboardEvents() {
     ReactInstanceManager instanceManager = mock(ReactInstanceManager.class);
-    RCTDeviceEventEmitter eventEmitterModuleMock = mock(RCTDeviceEventEmitter.class);
 
     when(instanceManager.getCurrentReactContext()).thenReturn(mReactContext);
-    when(mReactContext.getJSModule(RCTDeviceEventEmitter.class)).thenReturn(eventEmitterModuleMock);
-
     ReactRootView rootView =
         new ReactRootView(mReactContext) {
           @Override
@@ -250,6 +247,6 @@ public class RootViewTest {
     params.putMap("endCoordinates", endCoordinates);
     params.putString("easing", "keyboard");
 
-    verify(eventEmitterModuleMock, Mockito.times(1)).emit("keyboardDidShow", params);
+    verify(mReactContext, Mockito.times(1)).emitDeviceEvent("keyboardDidShow", params);
   }
 }


### PR DESCRIPTION
Summary:
[Changelog][Internal]

As a follow-up to adding `ReactContext.emitDeviceEvent` (D43534174) this makes it used in the OSS part of RN.

Reviewed By: NickGerleman

Differential Revision: D43494167

