### PR TITLE
Add TraceUpdateOverlayComponentDescriptor to CoreComponentsRegistry

### DIFF
--- a/ReactAndroid/src/main/jni/react/fabric/CoreComponentsRegistry.cpp
+++ b/ReactAndroid/src/main/jni/react/fabric/CoreComponentsRegistry.cpp
@@ -66,6 +66,8 @@ CoreComponentsRegistry::sharedProviderRegistry() {
         concreteComponentDescriptorProvider<ParagraphComponentDescriptor>());
     providerRegistry->add(concreteComponentDescriptorProvider<
                           AndroidDrawerLayoutComponentDescriptor>());
+    providerRegistry->add(concreteComponentDescriptorProvider<
+                          TraceUpdateOverlayComponentDescriptor>());
 
     return providerRegistry;
   }();


### PR DESCRIPTION
Summary:
RN Tester is currently red as `TraceUpdateOverlay` is not registered in the Fabric Core Component Registry.

Changelog:
[Internal] [Changed] - Add TraceUpdateOverlayComponentDescriptor to CoreComponentsRegistry

Differential Revision: D43567915

