### PR TITLE
[fix] Use RNTester init also in the old arch when Fabric is enabled

### DIFF
--- a/packages/rn-tester/RNTester/AppDelegate.mm
+++ b/packages/rn-tester/RNTester/AppDelegate.mm
@@ -88,7 +88,7 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
 
 @implementation AppDelegate
 
-#if RCT_NEW_ARCH_ENABLED
+#ifdef RN_FABRIC_ENABLED
 - (instancetype)init
 {
   if (self = [super init]) {


### PR DESCRIPTION
## Summary

This PR fixes the initialization path of RNTester when it is run with the Old Arch and Fabric enabled

## Changelog

[iOS][Fixed] - Make sure to initialize the contextContainer in the Old Arch with Fabric enabled

## Test Plan

Tested manually on RNTester
CircleCI is green
