### PR TITLE
refactor: move buildPropsSchema to parser commons wip

### DIFF
--- a/packages/react-native-codegen/src/parsers/flow/components/componentsUtils.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/componentsUtils.js
@@ -34,7 +34,11 @@ function getTypeAnnotationForArray<+T>(
   typeAnnotation: $FlowFixMe,
   defaultValue: $FlowFixMe | null,
   types: TypeDeclarationMap,
-  buildSchema: (property: PropAST, types: TypeDeclarationMap) => ?NamedShape<T>,
+  buildSchema: (
+    property: PropAST,
+    types: TypeDeclarationMap,
+    language: $FlowFixMe,
+  ) => ?NamedShape<T>,
 ): $FlowFixMe {
   const extractedTypeAnnotation = getValueFromTypes(typeAnnotation, types);
   if (extractedTypeAnnotation.type === 'NullableTypeAnnotation') {
@@ -63,7 +67,7 @@ function getTypeAnnotationForArray<+T>(
           objectType.typeParameters.params[0].properties,
           types,
         )
-          .map(prop => buildSchema(prop, types))
+          .map(prop => buildSchema(prop, types, 'Flow'))
           .filter(Boolean),
       };
     }
@@ -84,7 +88,7 @@ function getTypeAnnotationForArray<+T>(
             nestedObjectType.typeParameters.params[0].properties,
             types,
           )
-            .map(prop => buildSchema(prop, types))
+            .map(prop => buildSchema(prop, types, 'Flow'))
             .filter(Boolean),
         },
       };
@@ -233,7 +237,11 @@ function getTypeAnnotation<+T>(
   defaultValue: $FlowFixMe | null,
   withNullDefault: boolean,
   types: TypeDeclarationMap,
-  buildSchema: (property: PropAST, types: TypeDeclarationMap) => ?NamedShape<T>,
+  buildSchema: (
+    property: PropAST,
+    types: TypeDeclarationMap,
+    language: $FlowFixMe,
+  ) => ?NamedShape<T>,
 ): $FlowFixMe {
   const typeAnnotation = getValueFromTypes(annotation, types);
 
@@ -263,7 +271,7 @@ function getTypeAnnotation<+T>(
         typeAnnotation.typeParameters.params[0].properties,
         types,
       )
-        .map(prop => buildSchema(prop, types))
+        .map(prop => buildSchema(prop, types, 'Flow'))
         .filter(Boolean),
     };
   }

--- a/packages/react-native-codegen/src/parsers/flow/components/componentsUtils.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/componentsUtils.js
@@ -34,11 +34,7 @@ function getTypeAnnotationForArray<+T>(
   typeAnnotation: $FlowFixMe,
   defaultValue: $FlowFixMe | null,
   types: TypeDeclarationMap,
-  buildSchema: (
-    property: PropAST,
-    types: TypeDeclarationMap,
-    language: $FlowFixMe,
-  ) => ?NamedShape<T>,
+  buildSchema: (property: PropAST, types: TypeDeclarationMap) => ?NamedShape<T>,
 ): $FlowFixMe {
   const extractedTypeAnnotation = getValueFromTypes(typeAnnotation, types);
   if (extractedTypeAnnotation.type === 'NullableTypeAnnotation') {
@@ -67,7 +63,9 @@ function getTypeAnnotationForArray<+T>(
           objectType.typeParameters.params[0].properties,
           types,
         )
-          .map(prop => buildSchema(prop, types, 'Flow'))
+          .map(prop =>
+            buildSchema(prop, types, getSchemaInfo, getTypeAnnotation),
+          )
           .filter(Boolean),
       };
     }
@@ -88,7 +86,9 @@ function getTypeAnnotationForArray<+T>(
             nestedObjectType.typeParameters.params[0].properties,
             types,
           )
-            .map(prop => buildSchema(prop, types, 'Flow'))
+            .map(prop =>
+              buildSchema(prop, types, getSchemaInfo, getTypeAnnotation),
+            )
             .filter(Boolean),
         },
       };
@@ -237,11 +237,7 @@ function getTypeAnnotation<+T>(
   defaultValue: $FlowFixMe | null,
   withNullDefault: boolean,
   types: TypeDeclarationMap,
-  buildSchema: (
-    property: PropAST,
-    types: TypeDeclarationMap,
-    language: $FlowFixMe,
-  ) => ?NamedShape<T>,
+  buildSchema: (property: PropAST, types: TypeDeclarationMap) => ?NamedShape<T>,
 ): $FlowFixMe {
   const typeAnnotation = getValueFromTypes(annotation, types);
 
@@ -271,7 +267,7 @@ function getTypeAnnotation<+T>(
         typeAnnotation.typeParameters.params[0].properties,
         types,
       )
-        .map(prop => buildSchema(prop, types, 'Flow'))
+        .map(prop => buildSchema(prop, types, getSchemaInfo, getTypeAnnotation))
         .filter(Boolean),
     };
   }

--- a/packages/react-native-codegen/src/parsers/flow/components/props.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/props.js
@@ -10,11 +10,9 @@
 
 'use strict';
 
-const {
-  flattenProperties,
-  getSchemaInfo,
-  getTypeAnnotation,
-} = require('./componentsUtils.js');
+const {flattenProperties} = require('./componentsUtils.js');
+
+const {buildPropSchema} = require('../../parsers-commons.js');
 
 import type {NamedShape, PropTypeAnnotation} from '../../../CodegenSchema.js';
 import type {TypeDeclarationMap} from '../../utils';
@@ -22,36 +20,12 @@ import type {TypeDeclarationMap} from '../../utils';
 // $FlowFixMe[unclear-type] there's no flowtype for ASTs
 type PropAST = Object;
 
-function buildPropSchema(
-  property: PropAST,
-  types: TypeDeclarationMap,
-): ?NamedShape<PropTypeAnnotation> {
-  const info = getSchemaInfo(property, types);
-  if (info == null) {
-    return null;
-  }
-  const {name, optional, typeAnnotation, defaultValue, withNullDefault} = info;
-
-  return {
-    name,
-    optional,
-    typeAnnotation: getTypeAnnotation(
-      name,
-      typeAnnotation,
-      defaultValue,
-      withNullDefault,
-      types,
-      buildPropSchema,
-    ),
-  };
-}
-
 function getProps(
   typeDefinition: $ReadOnlyArray<PropAST>,
   types: TypeDeclarationMap,
 ): $ReadOnlyArray<NamedShape<PropTypeAnnotation>> {
   return flattenProperties(typeDefinition, types)
-    .map(property => buildPropSchema(property, types))
+    .map(property => buildPropSchema(property, types, 'Flow'))
     .filter(Boolean);
 }
 

--- a/packages/react-native-codegen/src/parsers/flow/components/props.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/props.js
@@ -10,8 +10,11 @@
 
 'use strict';
 
-const {flattenProperties} = require('./componentsUtils.js');
-
+const {
+  flattenProperties,
+  getSchemaInfo,
+  getTypeAnnotation,
+} = require('./componentsUtils.js');
 const {buildPropSchema} = require('../../parsers-commons.js');
 
 import type {NamedShape, PropTypeAnnotation} from '../../../CodegenSchema.js';
@@ -25,7 +28,9 @@ function getProps(
   types: TypeDeclarationMap,
 ): $ReadOnlyArray<NamedShape<PropTypeAnnotation>> {
   return flattenProperties(typeDefinition, types)
-    .map(property => buildPropSchema(property, types, 'Flow'))
+    .map(property =>
+      buildPropSchema(property, types, getSchemaInfo, getTypeAnnotation),
+    )
     .filter(Boolean);
 }
 

--- a/packages/react-native-codegen/src/parsers/parsers-commons.js
+++ b/packages/react-native-codegen/src/parsers/parsers-commons.js
@@ -48,16 +48,6 @@ const {
   UnnamedFunctionParamParserError,
 } = require('./errors');
 
-const {
-  getSchemaInfo: getTsSchemaInfo,
-  getTypeAnnotation: getTsTypeAnnotation,
-} = require('./typescript/components/componentsUtils');
-
-const {
-  getSchemaInfo: getFlowSchemaInfo,
-  getTypeAnnotation: getFlowTypeAnnotation,
-} = require('./flow/components/componentsUtils');
-
 const invariant = require('invariant');
 import type {NativeModuleEnumMap} from '../CodegenSchema';
 
@@ -446,12 +436,24 @@ function buildSchema(
 function buildPropSchema(
   property: Object,
   types: TypeDeclarationMap,
-  language: string,
+  getLanguageSchemaInfo: (
+    property: Object,
+    types: TypeDeclarationMap,
+  ) => $FlowFixMe,
+  getLanguageTypeAnnotation: (
+    name: string,
+    annotation: $FlowFixMe | Object,
+    defaultValue: $FlowFixMe | null,
+    withNullDefault: boolean,
+    types: TypeDeclarationMap,
+    buildSchema: (
+      property: Object,
+      types: TypeDeclarationMap,
+    ) => ?NamedShape<T>,
+  ) => $FlowFixMe,
 ): ?NamedShape<PropTypeAnnotation> {
-  const info =
-    language === 'Typescript'
-      ? getTsSchemaInfo(property, types)
-      : getFlowSchemaInfo(property, types);
+  const info = getLanguageSchemaInfo(property, types);
+
   if (info == null) {
     return null;
   }
@@ -460,24 +462,14 @@ function buildPropSchema(
   return {
     name,
     optional,
-    typeAnnotation:
-      language === 'Typescript'
-        ? getTsTypeAnnotation(
-            name,
-            typeAnnotation,
-            defaultValue,
-            withNullDefault,
-            types,
-            buildPropSchema,
-          )
-        : getFlowTypeAnnotation(
-            name,
-            typeAnnotation,
-            defaultValue,
-            withNullDefault,
-            types,
-            buildPropSchema,
-          ),
+    typeAnnotation: getLanguageTypeAnnotation(
+      name,
+      typeAnnotation,
+      defaultValue,
+      withNullDefault,
+      types,
+      buildPropSchema,
+    ),
   };
 }
 

--- a/packages/react-native-codegen/src/parsers/typescript/components/componentsUtils.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/componentsUtils.js
@@ -111,7 +111,11 @@ function detectArrayType<T>(
   typeAnnotation: $FlowFixMe | ASTNode,
   defaultValue: $FlowFixMe | void,
   types: TypeDeclarationMap,
-  buildSchema: (property: PropAST, types: TypeDeclarationMap) => ?NamedShape<T>,
+  buildSchema: (
+    property: PropAST,
+    types: TypeDeclarationMap,
+    language: $FlowFixMe,
+  ) => ?NamedShape<T>,
 ): $FlowFixMe {
   // Covers: readonly T[]
   if (
@@ -169,11 +173,15 @@ function detectArrayType<T>(
 function buildObjectType<T>(
   rawProperties: Array<$FlowFixMe>,
   types: TypeDeclarationMap,
-  buildSchema: (property: PropAST, types: TypeDeclarationMap) => ?NamedShape<T>,
+  buildSchema: (
+    property: PropAST,
+    types: TypeDeclarationMap,
+    language: $FlowFixMe,
+  ) => ?NamedShape<T>,
 ): $FlowFixMe {
   const flattenedProperties = flattenProperties(rawProperties, types);
   const properties = flattenedProperties
-    .map(prop => buildSchema(prop, types))
+    .map(prop => buildSchema(prop, types, 'Typescript'))
     .filter(Boolean);
 
   return {
@@ -189,7 +197,11 @@ function getCommonTypeAnnotation<T>(
   typeAnnotation: $FlowFixMe,
   defaultValue: $FlowFixMe | void,
   types: TypeDeclarationMap,
-  buildSchema: (property: PropAST, types: TypeDeclarationMap) => ?NamedShape<T>,
+  buildSchema: (
+    property: PropAST,
+    types: TypeDeclarationMap,
+    language: $FlowFixMe,
+  ) => ?NamedShape<T>,
 ): $FlowFixMe {
   switch (type) {
     case 'TSTypeLiteral':
@@ -272,7 +284,11 @@ function getTypeAnnotationForArray<T>(
   typeAnnotation: $FlowFixMe,
   defaultValue: $FlowFixMe | void,
   types: TypeDeclarationMap,
-  buildSchema: (property: PropAST, types: TypeDeclarationMap) => ?NamedShape<T>,
+  buildSchema: (
+    property: PropAST,
+    types: TypeDeclarationMap,
+    language: $FlowFixMe,
+  ) => ?NamedShape<T>,
 ): $FlowFixMe {
   // unpack WithDefault, (T) or T|U
   const topLevelType = parseTopLevelType(typeAnnotation, types);
@@ -367,7 +383,11 @@ function getTypeAnnotation<T>(
   annotation: $FlowFixMe | ASTNode,
   defaultValue: $FlowFixMe | void,
   types: TypeDeclarationMap,
-  buildSchema: (property: PropAST, types: TypeDeclarationMap) => ?NamedShape<T>,
+  buildSchema: (
+    property: PropAST,
+    types: TypeDeclarationMap,
+    language: $FlowFixMe,
+  ) => ?NamedShape<T>,
 ): $FlowFixMe {
   // unpack WithDefault, (T) or T|U
   const topLevelType = parseTopLevelType(annotation, types);

--- a/packages/react-native-codegen/src/parsers/typescript/components/componentsUtils.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/componentsUtils.js
@@ -111,11 +111,7 @@ function detectArrayType<T>(
   typeAnnotation: $FlowFixMe | ASTNode,
   defaultValue: $FlowFixMe | void,
   types: TypeDeclarationMap,
-  buildSchema: (
-    property: PropAST,
-    types: TypeDeclarationMap,
-    language: $FlowFixMe,
-  ) => ?NamedShape<T>,
+  buildSchema: (property: PropAST, types: TypeDeclarationMap) => ?NamedShape<T>,
 ): $FlowFixMe {
   // Covers: readonly T[]
   if (
@@ -173,15 +169,11 @@ function detectArrayType<T>(
 function buildObjectType<T>(
   rawProperties: Array<$FlowFixMe>,
   types: TypeDeclarationMap,
-  buildSchema: (
-    property: PropAST,
-    types: TypeDeclarationMap,
-    language: $FlowFixMe,
-  ) => ?NamedShape<T>,
+  buildSchema: (property: PropAST, types: TypeDeclarationMap) => ?NamedShape<T>,
 ): $FlowFixMe {
   const flattenedProperties = flattenProperties(rawProperties, types);
   const properties = flattenedProperties
-    .map(prop => buildSchema(prop, types, 'Typescript'))
+    .map(prop => buildSchema(prop, types, getSchemaInfo, getTypeAnnotation))
     .filter(Boolean);
 
   return {
@@ -197,11 +189,7 @@ function getCommonTypeAnnotation<T>(
   typeAnnotation: $FlowFixMe,
   defaultValue: $FlowFixMe | void,
   types: TypeDeclarationMap,
-  buildSchema: (
-    property: PropAST,
-    types: TypeDeclarationMap,
-    language: $FlowFixMe,
-  ) => ?NamedShape<T>,
+  buildSchema: (property: PropAST, types: TypeDeclarationMap) => ?NamedShape<T>,
 ): $FlowFixMe {
   switch (type) {
     case 'TSTypeLiteral':
@@ -284,11 +272,7 @@ function getTypeAnnotationForArray<T>(
   typeAnnotation: $FlowFixMe,
   defaultValue: $FlowFixMe | void,
   types: TypeDeclarationMap,
-  buildSchema: (
-    property: PropAST,
-    types: TypeDeclarationMap,
-    language: $FlowFixMe,
-  ) => ?NamedShape<T>,
+  buildSchema: (property: PropAST, types: TypeDeclarationMap) => ?NamedShape<T>,
 ): $FlowFixMe {
   // unpack WithDefault, (T) or T|U
   const topLevelType = parseTopLevelType(typeAnnotation, types);
@@ -383,11 +367,7 @@ function getTypeAnnotation<T>(
   annotation: $FlowFixMe | ASTNode,
   defaultValue: $FlowFixMe | void,
   types: TypeDeclarationMap,
-  buildSchema: (
-    property: PropAST,
-    types: TypeDeclarationMap,
-    language: $FlowFixMe,
-  ) => ?NamedShape<T>,
+  buildSchema: (property: PropAST, types: TypeDeclarationMap) => ?NamedShape<T>,
 ): $FlowFixMe {
   // unpack WithDefault, (T) or T|U
   const topLevelType = parseTopLevelType(annotation, types);

--- a/packages/react-native-codegen/src/parsers/typescript/components/props.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/props.js
@@ -10,6 +10,7 @@
 
 'use strict';
 
+const {getSchemaInfo, getTypeAnnotation} = require('./componentsUtils.js');
 const {buildPropSchema} = require('../../parsers-commons');
 
 import type {NamedShape, PropTypeAnnotation} from '../../../CodegenSchema.js';
@@ -23,7 +24,7 @@ function getProps(
   types: TypeDeclarationMap,
 ): $ReadOnlyArray<NamedShape<PropTypeAnnotation>> {
   return typeDefinition.map(property =>
-    buildPropSchema(property, types, 'Typescript'),
+    buildPropSchema(property, types, getSchemaInfo, getTypeAnnotation),
   );
 }
 

--- a/packages/react-native-codegen/src/parsers/typescript/components/props.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/props.js
@@ -9,7 +9,8 @@
  */
 
 'use strict';
-const {getSchemaInfo, getTypeAnnotation} = require('./componentsUtils.js');
+
+const {buildPropSchema} = require('../../parsers-commons');
 
 import type {NamedShape, PropTypeAnnotation} from '../../../CodegenSchema.js';
 import type {TypeDeclarationMap} from '../../utils';
@@ -17,30 +18,13 @@ import type {TypeDeclarationMap} from '../../utils';
 // $FlowFixMe[unclear-type] there's no flowtype for ASTs
 type PropAST = Object;
 
-function buildPropSchema(
-  property: PropAST,
-  types: TypeDeclarationMap,
-): NamedShape<PropTypeAnnotation> {
-  const info = getSchemaInfo(property, types);
-  const {name, optional, typeAnnotation, defaultValue} = info;
-  return {
-    name,
-    optional,
-    typeAnnotation: getTypeAnnotation(
-      name,
-      typeAnnotation,
-      defaultValue,
-      types,
-      buildPropSchema,
-    ),
-  };
-}
-
 function getProps(
   typeDefinition: $ReadOnlyArray<PropAST>,
   types: TypeDeclarationMap,
 ): $ReadOnlyArray<NamedShape<PropTypeAnnotation>> {
-  return typeDefinition.map(property => buildPropSchema(property, types));
+  return typeDefinition.map(property =>
+    buildPropSchema(property, types, 'Typescript'),
+  );
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary

Part of https://github.com/facebook/react-native/issues/34872

In this PR was moved the buildPropSchema function in `parsers/typescript/components/props.js` and `parsers/flow/components/props.js` is the same. move it in parser-commons and use it in the origina files

## Changelog

[Internal] [Changed] - Move the buildPropSchema invocation into the parser-commons

## Test Plan

-


