### PR TITLE
Fix/animated lists types

### DIFF
--- a/Libraries/Animated/Animated.d.ts
+++ b/Libraries/Animated/Animated.d.ts
@@ -17,7 +17,6 @@ import {
   SectionListComponent,
   SectionListProps,
 } from '../Lists/SectionList';
-import {NodeHandle} from '../ReactNative/RendererProxy';
 import {ColorValue} from '../StyleSheet/StyleSheet';
 import {Text} from '../Text/Text';
 import {NativeSyntheticEvent} from '../Types/CoreEventTypes';

--- a/Libraries/Animated/Animated.d.ts
+++ b/Libraries/Animated/Animated.d.ts
@@ -15,7 +15,12 @@ import {
 import {View} from '../Components/View/View';
 import {Image} from '../Image/Image';
 import {FlatListProps} from '../Lists/FlatList';
-import {DefaultSectionT, SectionListProps} from '../Lists/SectionList';
+import {
+  DefaultSectionT,
+  SectionListProps,
+  SectionListScrollParams,
+} from '../Lists/SectionList';
+import {NodeHandle} from '../ReactNative/RendererProxy';
 import {ColorValue} from '../StyleSheet/StyleSheet';
 import {Text} from '../Text/Text';
 import {NativeSyntheticEvent} from '../Types/CoreEventTypes';
@@ -675,7 +680,38 @@ export namespace Animated {
   export class SectionList<
     ItemT = any,
     SectionT = DefaultSectionT,
-  > extends React.Component<AnimatedProps<SectionListProps<ItemT, SectionT>>> {}
+  > extends React.Component<AnimatedProps<SectionListProps<ItemT, SectionT>>> {
+    /**
+     * Scrolls to the item at the specified sectionIndex and itemIndex (within the section)
+     * positioned in the viewable area such that viewPosition 0 places it at the top
+     * (and may be covered by a sticky header), 1 at the bottom, and 0.5 centered in the middle.
+     */
+    scrollToLocation(params: SectionListScrollParams): void;
+
+    /**
+     * Tells the list an interaction has occurred, which should trigger viewability calculations, e.g.
+     * if `waitForInteractions` is true and the user has not scrolled. This is typically called by
+     * taps on items or by navigation actions.
+     */
+    recordInteraction(): void;
+
+    /**
+     * Displays the scroll indicators momentarily.
+     *
+     * @platform ios
+     */
+    flashScrollIndicators(): void;
+
+    /**
+     * Provides a handle to the underlying scroll responder.
+     */
+    getScrollResponder(): ScrollView | undefined;
+
+    /**
+     * Provides a handle to the underlying scroll node.
+     */
+    getScrollableNode(): NodeHandle | undefined;
+  }
 }
 
 // We need to alias these views so we can reference them in the Animated

--- a/Libraries/Animated/Animated.d.ts
+++ b/Libraries/Animated/Animated.d.ts
@@ -16,7 +16,6 @@ import {
   DefaultSectionT,
   SectionListComponent,
   SectionListProps,
-  SectionListScrollParams,
 } from '../Lists/SectionList';
 import {NodeHandle} from '../ReactNative/RendererProxy';
 import {ColorValue} from '../StyleSheet/StyleSheet';

--- a/Libraries/Animated/Animated.d.ts
+++ b/Libraries/Animated/Animated.d.ts
@@ -8,15 +8,13 @@
  */
 
 import type * as React from 'react';
-import {
-  ScrollView,
-  ScrollViewComponent,
-} from '../Components/ScrollView/ScrollView';
+import {ScrollView} from '../Components/ScrollView/ScrollView';
 import {View} from '../Components/View/View';
 import {Image} from '../Image/Image';
-import {FlatListProps} from '../Lists/FlatList';
+import {FlatListComponent, FlatListProps} from '../Lists/FlatList';
 import {
   DefaultSectionT,
+  SectionListComponent,
   SectionListProps,
   SectionListScrollParams,
 } from '../Lists/SectionList';
@@ -606,112 +604,18 @@ export namespace Animated {
   /**
    * FlatList and SectionList infer generic Type defined under their `data` and `section` props.
    */
-  export class FlatList<ItemT = any> extends React.Component<
+
+  export class FlatList<ItemT = any> extends FlatListComponent<
+    ItemT,
     AnimatedProps<FlatListProps<ItemT>>
-  > {
-    /**
-     * Scrolls to the end of the content. May be janky without `getItemLayout` prop.
-     */
-    scrollToEnd: (params?: {animated?: boolean | null | undefined}) => void;
-
-    /**
-     * Scrolls to the item at the specified index such that it is positioned in the viewable area
-     * such that viewPosition 0 places it at the top, 1 at the bottom, and 0.5 centered in the middle.
-     * Cannot scroll to locations outside the render window without specifying the getItemLayout prop.
-     */
-    scrollToIndex: (params: {
-      animated?: boolean | null | undefined;
-      index: number;
-      viewOffset?: number | undefined;
-      viewPosition?: number | undefined;
-    }) => void;
-
-    /**
-     * Requires linear scan through data - use `scrollToIndex` instead if possible.
-     * May be janky without `getItemLayout` prop.
-     */
-    scrollToItem: (params: {
-      animated?: boolean | null | undefined;
-      item: ItemT;
-      viewOffset?: number | undefined;
-      viewPosition?: number | undefined;
-    }) => void;
-
-    /**
-     * Scroll to a specific content pixel offset, like a normal `ScrollView`.
-     */
-    scrollToOffset: (params: {
-      animated?: boolean | null | undefined;
-      offset: number;
-    }) => void;
-
-    /**
-     * Tells the list an interaction has occurred, which should trigger viewability calculations,
-     * e.g. if waitForInteractions is true and the user has not scrolled. This is typically called
-     * by taps on items or by navigation actions.
-     */
-    recordInteraction: () => void;
-
-    /**
-     * Displays the scroll indicators momentarily.
-     */
-    flashScrollIndicators: () => void;
-
-    /**
-     * Provides a handle to the underlying scroll responder.
-     */
-    getScrollResponder: () => JSX.Element | null | undefined;
-
-    /**
-     * Provides a reference to the underlying host component
-     */
-    getNativeScrollRef: () =>
-      | React.ElementRef<typeof View>
-      | React.ElementRef<typeof ScrollViewComponent>
-      | null
-      | undefined;
-
-    getScrollableNode: () => any;
-
-    // TODO: use `unknown` instead of `any` for Typescript >= 3.0
-    setNativeProps: (props: {[key: string]: any}) => void;
-  }
+  > {}
 
   export class SectionList<
     ItemT = any,
     SectionT = DefaultSectionT,
-  > extends React.Component<AnimatedProps<SectionListProps<ItemT, SectionT>>> {
-    /**
-     * Scrolls to the item at the specified sectionIndex and itemIndex (within the section)
-     * positioned in the viewable area such that viewPosition 0 places it at the top
-     * (and may be covered by a sticky header), 1 at the bottom, and 0.5 centered in the middle.
-     */
-    scrollToLocation(params: SectionListScrollParams): void;
-
-    /**
-     * Tells the list an interaction has occurred, which should trigger viewability calculations, e.g.
-     * if `waitForInteractions` is true and the user has not scrolled. This is typically called by
-     * taps on items or by navigation actions.
-     */
-    recordInteraction(): void;
-
-    /**
-     * Displays the scroll indicators momentarily.
-     *
-     * @platform ios
-     */
-    flashScrollIndicators(): void;
-
-    /**
-     * Provides a handle to the underlying scroll responder.
-     */
-    getScrollResponder(): ScrollView | undefined;
-
-    /**
-     * Provides a handle to the underlying scroll node.
-     */
-    getScrollableNode(): NodeHandle | undefined;
-  }
+  > extends SectionListComponent<
+    AnimatedProps<SectionListProps<ItemT, SectionT>>
+  > {}
 }
 
 // We need to alias these views so we can reference them in the Animated

--- a/Libraries/Animated/Animated.d.ts
+++ b/Libraries/Animated/Animated.d.ts
@@ -8,7 +8,10 @@
  */
 
 import type * as React from 'react';
-import {ScrollView} from '../Components/ScrollView/ScrollView';
+import {
+  ScrollView,
+  ScrollViewComponent,
+} from '../Components/ScrollView/ScrollView';
 import {View} from '../Components/View/View';
 import {Image} from '../Image/Image';
 import {FlatListProps} from '../Lists/FlatList';
@@ -600,7 +603,75 @@ export namespace Animated {
    */
   export class FlatList<ItemT = any> extends React.Component<
     AnimatedProps<FlatListProps<ItemT>>
-  > {}
+  > {
+    /**
+     * Scrolls to the end of the content. May be janky without `getItemLayout` prop.
+     */
+    scrollToEnd: (params?: {animated?: boolean | null | undefined}) => void;
+
+    /**
+     * Scrolls to the item at the specified index such that it is positioned in the viewable area
+     * such that viewPosition 0 places it at the top, 1 at the bottom, and 0.5 centered in the middle.
+     * Cannot scroll to locations outside the render window without specifying the getItemLayout prop.
+     */
+    scrollToIndex: (params: {
+      animated?: boolean | null | undefined;
+      index: number;
+      viewOffset?: number | undefined;
+      viewPosition?: number | undefined;
+    }) => void;
+
+    /**
+     * Requires linear scan through data - use `scrollToIndex` instead if possible.
+     * May be janky without `getItemLayout` prop.
+     */
+    scrollToItem: (params: {
+      animated?: boolean | null | undefined;
+      item: ItemT;
+      viewOffset?: number | undefined;
+      viewPosition?: number | undefined;
+    }) => void;
+
+    /**
+     * Scroll to a specific content pixel offset, like a normal `ScrollView`.
+     */
+    scrollToOffset: (params: {
+      animated?: boolean | null | undefined;
+      offset: number;
+    }) => void;
+
+    /**
+     * Tells the list an interaction has occurred, which should trigger viewability calculations,
+     * e.g. if waitForInteractions is true and the user has not scrolled. This is typically called
+     * by taps on items or by navigation actions.
+     */
+    recordInteraction: () => void;
+
+    /**
+     * Displays the scroll indicators momentarily.
+     */
+    flashScrollIndicators: () => void;
+
+    /**
+     * Provides a handle to the underlying scroll responder.
+     */
+    getScrollResponder: () => JSX.Element | null | undefined;
+
+    /**
+     * Provides a reference to the underlying host component
+     */
+    getNativeScrollRef: () =>
+      | React.ElementRef<typeof View>
+      | React.ElementRef<typeof ScrollViewComponent>
+      | null
+      | undefined;
+
+    getScrollableNode: () => any;
+
+    // TODO: use `unknown` instead of `any` for Typescript >= 3.0
+    setNativeProps: (props: {[key: string]: any}) => void;
+  }
+
   export class SectionList<
     ItemT = any,
     SectionT = DefaultSectionT,

--- a/Libraries/Lists/FlatList.d.ts
+++ b/Libraries/Lists/FlatList.d.ts
@@ -166,9 +166,10 @@ export interface FlatListProps<ItemT> extends VirtualizedListProps<ItemT> {
   fadingEdgeLength?: number | undefined;
 }
 
-export class FlatList<ItemT = any> extends React.Component<
-  FlatListProps<ItemT>
-> {
+export abstract class FlatListComponent<
+  ItemT,
+  Props,
+> extends React.Component<Props> {
   /**
    * Scrolls to the end of the content. May be janky without `getItemLayout` prop.
    */
@@ -236,3 +237,8 @@ export class FlatList<ItemT = any> extends React.Component<
   // TODO: use `unknown` instead of `any` for Typescript >= 3.0
   setNativeProps: (props: {[key: string]: any}) => void;
 }
+
+export class FlatList<ItemT = any> extends FlatListComponent<
+  ItemT,
+  FlatListProps<ItemT>
+> {}

--- a/Libraries/Lists/SectionList.d.ts
+++ b/Libraries/Lists/SectionList.d.ts
@@ -210,10 +210,9 @@ export interface SectionListScrollParams {
   viewPosition?: number | undefined;
 }
 
-export class SectionList<
-  ItemT = any,
-  SectionT = DefaultSectionT,
-> extends React.Component<SectionListProps<ItemT, SectionT>> {
+export abstract class SectionListComponent<
+  Props,
+> extends React.Component<Props> {
   /**
    * Scrolls to the item at the specified sectionIndex and itemIndex (within the section)
    * positioned in the viewable area such that viewPosition 0 places it at the top
@@ -245,6 +244,11 @@ export class SectionList<
    */
   getScrollableNode(): NodeHandle | undefined;
 }
+
+export class SectionList<
+  ItemT = any,
+  SectionT = DefaultSectionT,
+> extends SectionListComponent<SectionListProps<ItemT, SectionT>> {}
 
 /* This definition is deprecated because it extends the wrong base type */
 export interface SectionListStatic<ItemT, SectionT = DefaultSectionT>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

I was working on `Animated.FlatList` and found some types missing as below

![Screen Shot 2023-02-25 at 4 32 43 PM](https://user-images.githubusercontent.com/64301935/221345457-74252131-5207-4e17-ad96-92221a915305.png)

also `Animated.SectionList` 

![Screen Shot 2023-02-25 at 4 31 34 PM](https://user-images.githubusercontent.com/64301935/221345679-07ba862b-708e-400e-ac14-7d2156fcc1e8.png)

So I refactored type definition for `Animated.FlatList` and `Animated.SectionList` using `abstract class`.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

[GENERAL] [FIXED] - add missing FlatList types for Animated FlatList
[GENERAL] [FIXED] - add missing SectionList types for Animated SectionList

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Ran `yarn test-typescript` and `yarn test-typescript-offline` with no errors.

