### PR TITLE
[Codegen 84] Merge Parse-Module-Name `anon` fn of `Flow` & `TS` parsers'

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-commons-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-commons-test.js
@@ -19,6 +19,7 @@ import {
   unwrapNullable,
   buildSchemaFromConfigType,
   buildSchema,
+  parseModuleName,
 } from '../parsers-commons';
 import type {ParserType} from '../errors';
 
@@ -30,6 +31,11 @@ const {isModuleRegistryCall} = require('../utils.js');
 const {
   ParserError,
   UnsupportedObjectPropertyTypeAnnotationParserError,
+  UnusedModuleInterfaceParserError,
+  MoreThanOneModuleRegistryCallsParserError,
+  IncorrectModuleRegistryCallArityParserError,
+  IncorrectModuleRegistryCallArgumentTypeParserError,
+  UntypedModuleRegistryCallParserError,
 } = require('../errors');
 
 import {MockedParser} from '../parserMock';
@@ -780,6 +786,256 @@ describe('buildSchema', () => {
           },
         },
       });
+    });
+  });
+});
+
+describe('parseModuleName', () => {
+  const hasteModuleName = 'testModuleName';
+  const emptyFlowAst = parser.getAst('');
+  const moduleSpecs = [{name: 'Spec'}];
+  const flowAstWithOneCallExpression = parser.getAst(
+    "export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');",
+  );
+
+  describe('throwIfUnusedModuleInterfaceParserError', () => {
+    it("throws an 'UnusedModuleInterfaceParserError' error if 'callExpressions' array is 'empty'", () => {
+      const expected = new UnusedModuleInterfaceParserError(
+        hasteModuleName,
+        moduleSpecs[0],
+      );
+
+      expect(() =>
+        parseModuleName(hasteModuleName, moduleSpecs[0], emptyFlowAst, parser),
+      ).toThrow(expected);
+    });
+
+    it("doesn't throw an 'UnusedModuleInterfaceParserError' error if 'callExpressions' array is 'NOT empty'", () => {
+      expect(() =>
+        parseModuleName(
+          hasteModuleName,
+          moduleSpecs[0],
+          flowAstWithOneCallExpression,
+          parser,
+        ),
+      ).not.toThrow(UnusedModuleInterfaceParserError);
+    });
+  });
+
+  describe('throwIfMoreThanOneModuleRegistryCalls', () => {
+    it("throws an 'MoreThanOneModuleRegistryCallsParserError' error if 'callExpressions' array contains more than one 'callExpression'", () => {
+      const flowAstWithTwoCallExpressions = parser.getAst(
+        "export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule'); TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');",
+      );
+
+      const callExpressions: Array<$FlowFixMe> =
+        flowAstWithTwoCallExpressions.body;
+
+      const expected = new MoreThanOneModuleRegistryCallsParserError(
+        hasteModuleName,
+        callExpressions,
+        callExpressions.length,
+      );
+
+      expect(() =>
+        parseModuleName(
+          hasteModuleName,
+          moduleSpecs[0],
+          flowAstWithTwoCallExpressions,
+          parser,
+        ),
+      ).toThrow(expected);
+    });
+
+    it("doesn't throw an 'MoreThanOneModuleRegistryCallsParserError' error if 'callExpressions' array contains extactly one 'callExpression'", () => {
+      expect(() =>
+        parseModuleName(
+          hasteModuleName,
+          moduleSpecs[0],
+          flowAstWithOneCallExpression,
+          parser,
+        ),
+      ).not.toThrow(MoreThanOneModuleRegistryCallsParserError);
+    });
+  });
+
+  describe('throwIfWrongNumberOfCallExpressionArgs', () => {
+    it("throws an 'IncorrectModuleRegistryCallArityParserError' error if wrong number of call expression args is used", () => {
+      const flowAstWithZeroCallExpressionArgs = parser.getAst(
+        'export default TurboModuleRegistry.getEnforcing();',
+      );
+      const flowCallExpressionWithoutArgs =
+        flowAstWithZeroCallExpressionArgs.body[0].declaration;
+      const numberOfCallExpressionArgs =
+        flowCallExpressionWithoutArgs.arguments.length;
+      const flowCallExpressionWithoutArgsCallee =
+        flowCallExpressionWithoutArgs.callee.property.name;
+
+      const expected = new IncorrectModuleRegistryCallArityParserError(
+        hasteModuleName,
+        flowCallExpressionWithoutArgs,
+        flowCallExpressionWithoutArgsCallee,
+        numberOfCallExpressionArgs,
+      );
+
+      expect(() =>
+        parseModuleName(
+          hasteModuleName,
+          moduleSpecs[0],
+          flowAstWithZeroCallExpressionArgs,
+          parser,
+        ),
+      ).toThrow(expected);
+    });
+
+    it("doesn't throw an 'IncorrectModuleRegistryCallArityParserError' error if correct number of call expression args is used", () => {
+      expect(() =>
+        parseModuleName(
+          hasteModuleName,
+          moduleSpecs[0],
+          flowAstWithOneCallExpression,
+          parser,
+        ),
+      ).not.toThrow(IncorrectModuleRegistryCallArityParserError);
+    });
+  });
+
+  describe('throwIfIncorrectModuleRegistryCallArgument', () => {
+    it("throws an 'IncorrectModuleRegistryCallArgumentTypeParserError' error if call expression arg is NOT a string literal", () => {
+      const flowAstWithNonStringLiteralCallExpressionArg = parser.getAst(
+        'export default TurboModuleRegistry.getEnforcing(Spec);',
+      );
+      const flowCallExpression =
+        flowAstWithNonStringLiteralCallExpressionArg.body[0].declaration;
+      const flowCallExpressionCalllee = flowCallExpression.callee.property.name;
+      const flowCallExpressionArg = flowCallExpression.arguments[0];
+
+      const expected = new IncorrectModuleRegistryCallArgumentTypeParserError(
+        hasteModuleName,
+        flowCallExpressionArg,
+        flowCallExpressionCalllee,
+        flowCallExpressionArg.type,
+      );
+
+      expect(() =>
+        parseModuleName(
+          hasteModuleName,
+          moduleSpecs[0],
+          flowAstWithNonStringLiteralCallExpressionArg,
+          parser,
+        ),
+      ).toThrow(expected);
+    });
+
+    it("doesn't throw an 'IncorrectModuleRegistryCallArgumentTypeParserError' error if call expression arg is a string literal", () => {
+      expect(() =>
+        parseModuleName(
+          hasteModuleName,
+          moduleSpecs[0],
+          flowAstWithOneCallExpression,
+          parser,
+        ),
+      ).not.toThrow(IncorrectModuleRegistryCallArgumentTypeParserError);
+    });
+  });
+
+  describe('throwIfUntypedModule', () => {
+    it("throws an 'UntypedModuleRegistryCallParserError' error if call expression is untyped", () => {
+      const flowAstWithUntypedCallExpression = parser.getAst(
+        "export default TurboModuleRegistry.getEnforcing('SampleTurboModule');",
+      );
+      const flowCallExpression =
+        flowAstWithUntypedCallExpression.body[0].declaration;
+      const flowCallExpressionCallee = flowCallExpression.callee.property.name;
+      const moduleName = flowCallExpression.arguments[0].value;
+      const expected = new UntypedModuleRegistryCallParserError(
+        hasteModuleName,
+        flowCallExpression,
+        flowCallExpressionCallee,
+        moduleName,
+      );
+
+      expect(() =>
+        parseModuleName(
+          hasteModuleName,
+          moduleSpecs[0],
+          flowAstWithUntypedCallExpression,
+          parser,
+        ),
+      ).toThrow(expected);
+    });
+
+    it("doesn't throw an 'UntypedModuleRegistryCallParserError' error if call expression is typed", () => {
+      expect(() =>
+        parseModuleName(
+          hasteModuleName,
+          moduleSpecs[0],
+          flowAstWithOneCallExpression,
+          parser,
+        ),
+      ).not.toThrow(UntypedModuleRegistryCallParserError);
+    });
+  });
+
+  // TODO: add/complete the tests for 'IncorrectModuleRegistryCallTypeParameterParserError' error; using 'parseModuleName' function.
+  //
+  // describe('throwIfIncorrectModuleRegistryCallTypeParameterParserError', () => {
+  //    it("throws an 'IncorrectModuleRegistryCallTypeParameterParserError' error if Incorrect ...", () => {
+  //      ...
+  //
+  //     const expected = new IncorrectModuleRegistryCallTypeParameterParserError(
+  //       ...
+  //     );
+  //
+  //     expect(() =>
+  //       parseModuleName(
+  //         ...
+  //       ),
+  //     ).toThrow(expected);
+  //    });
+  //
+  //    it("doesn't throw an 'IncorrectModuleRegistryCallTypeParameterParserError' error if correct ...", () => {
+  //      ...
+  //
+  //     const expected = new IncorrectModuleRegistryCallTypeParameterParserError(
+  //       ...
+  //     );
+  //
+  //     expect(() =>
+  //       parseModuleName(
+  //         ...
+  //       ),
+  //     ).not.toThrow(IncorrectModuleRegistryCallTypeParameterParserError);
+  //    });
+  // });
+
+  describe('when flow ast with valid module is passed', () => {
+    it("returns the correct ModuleName and doesn't throw any error", () => {
+      const moduleType = 'Spec';
+      const moduleName = 'SampleTurboModule';
+      const flowAstWithValidModule = parser.getAst(
+        `export default TurboModuleRegistry.getEnforcing<${moduleType}>('${moduleName}');`,
+      );
+
+      const expected = moduleName;
+
+      expect(
+        parseModuleName(
+          hasteModuleName,
+          moduleSpecs[0],
+          flowAstWithValidModule,
+          parser,
+        ),
+      ).toEqual(expected);
+
+      expect(() =>
+        parseModuleName(
+          hasteModuleName,
+          moduleSpecs[0],
+          flowAstWithValidModule,
+          parser,
+        ),
+      ).not.toThrow();
     });
   });
 });

--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-commons-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-commons-test.js
@@ -977,38 +977,6 @@ describe('parseModuleName', () => {
     });
   });
 
-  // TODO: add/complete the tests for 'IncorrectModuleRegistryCallTypeParameterParserError' error; using 'parseModuleName' function.
-  //
-  // describe('throwIfIncorrectModuleRegistryCallTypeParameterParserError', () => {
-  //    it("throws an 'IncorrectModuleRegistryCallTypeParameterParserError' error if Incorrect ...", () => {
-  //      ...
-  //
-  //     const expected = new IncorrectModuleRegistryCallTypeParameterParserError(
-  //       ...
-  //     );
-  //
-  //     expect(() =>
-  //       parseModuleName(
-  //         ...
-  //       ),
-  //     ).toThrow(expected);
-  //    });
-  //
-  //    it("doesn't throw an 'IncorrectModuleRegistryCallTypeParameterParserError' error if correct ...", () => {
-  //      ...
-  //
-  //     const expected = new IncorrectModuleRegistryCallTypeParameterParserError(
-  //       ...
-  //     );
-  //
-  //     expect(() =>
-  //       parseModuleName(
-  //         ...
-  //       ),
-  //     ).not.toThrow(IncorrectModuleRegistryCallTypeParameterParserError);
-  //    });
-  // });
-
   describe('when flow ast with valid module is passed', () => {
     it("returns the correct ModuleName and doesn't throw any error", () => {
       const moduleType = 'Spec';

--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-test.js
@@ -89,6 +89,27 @@ describe('FlowParser', () => {
       expect(parser.isModuleInterface(node)).toBe(false);
     });
   });
+
+  describe('callExpressionTypeParameters', () => {
+    it('returns type arguments if it is a valid node', () => {
+      const node = {
+        type: 'CallExpression',
+        typeArguments: {
+          type: 'TypeParameterInstantiation',
+          params: [],
+        },
+      };
+      expect(parser.callExpressionTypeParameters(node)).toEqual({
+        type: 'TypeParameterInstantiation',
+        params: [],
+      });
+    });
+
+    it('returns null if it is a invalid node', () => {
+      const node = {};
+      expect(parser.callExpressionTypeParameters(node)).toBe(null);
+    });
+  });
 });
 
 describe('TypeScriptParser', () => {
@@ -158,6 +179,27 @@ describe('TypeScriptParser', () => {
     it('returns false if it is a invalid node', () => {
       const node = {};
       expect(parser.isModuleInterface(node)).toBe(false);
+    });
+  });
+
+  describe('callExpressionTypeParameters', () => {
+    it('returns type parameters if it is a valid node', () => {
+      const node = {
+        type: 'CallExpression',
+        typeParameters: {
+          type: 'TypeParameterInstantiation',
+          params: [],
+        },
+      };
+      expect(parser.callExpressionTypeParameters(node)).toEqual({
+        type: 'TypeParameterInstantiation',
+        params: [],
+      });
+    });
+
+    it('returns null if it is a invalid node', () => {
+      const node = {};
+      expect(parser.callExpressionTypeParameters(node)).toBe(null);
     });
   });
 });

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -24,14 +24,15 @@ import type {
 import type {Parser} from '../../parser';
 import type {ParserErrorCapturer, TypeDeclarationMap} from '../../utils';
 
-const {visit, isModuleRegistryCall, verifyPlatforms} = require('../../utils');
-const {resolveTypeAnnotation} = require('../utils');
+const {verifyPlatforms} = require('../../utils');
+const {resolveTypeAnnotation, getTypes} = require('../utils');
 const {
   unwrapNullable,
   wrapNullable,
   assertGenericTypeAnnotationHasExactlyOneTypeParameter,
   parseObjectProperty,
   buildPropertySchema,
+  parseModuleName,
 } = require('../../parsers-commons');
 const {
   emitArrayType,
@@ -62,12 +63,6 @@ const {
 const {
   throwIfModuleInterfaceNotFound,
   throwIfModuleInterfaceIsMisnamed,
-  throwIfUnusedModuleInterfaceParserError,
-  throwIfWrongNumberOfCallExpressionArgs,
-  throwIfMoreThanOneModuleRegistryCalls,
-  throwIfIncorrectModuleRegistryCallTypeParameterParserError,
-  throwIfIncorrectModuleRegistryCallArgument,
-  throwIfUntypedModule,
   throwIfMoreThanOneModuleInterfaceParserError,
   throwIfPartialNotAnnotatingTypeParameter,
   throwIfPartialWithMoreParameter,
@@ -362,65 +357,14 @@ function buildModuleSchema(
   throwIfModuleInterfaceIsMisnamed(hasteModuleName, moduleSpec.id, language);
 
   // Parse Module Name
-  const moduleName = ((): string => {
-    const callExpressions = [];
-    visit(ast, {
-      CallExpression(node) {
-        if (isModuleRegistryCall(node)) {
-          callExpressions.push(node);
-        }
-      },
-    });
-
-    throwIfUnusedModuleInterfaceParserError(
-      hasteModuleName,
-      moduleSpec,
-      callExpressions,
-    );
-
-    throwIfMoreThanOneModuleRegistryCalls(
-      hasteModuleName,
-      callExpressions,
-      callExpressions.length,
-    );
-
-    const [callExpression] = callExpressions;
-    const {typeArguments} = callExpression;
-    const methodName = callExpression.callee.property.name;
-
-    throwIfWrongNumberOfCallExpressionArgs(
-      hasteModuleName,
-      callExpression,
-      methodName,
-      callExpression.arguments.length,
-    );
-
-    throwIfIncorrectModuleRegistryCallArgument(
-      hasteModuleName,
-      callExpression.arguments[0],
-      methodName,
-    );
-
-    const $moduleName = callExpression.arguments[0].value;
-
-    throwIfUntypedModule(
-      typeArguments,
-      hasteModuleName,
-      callExpression,
-      methodName,
-      $moduleName,
-    );
-
-    throwIfIncorrectModuleRegistryCallTypeParameterParserError(
-      hasteModuleName,
-      typeArguments,
-      methodName,
-      $moduleName,
-      parser,
-    );
-
-    return $moduleName;
-  })();
+  // Also checks and throws error if:
+  // - Module Interface is Unused
+  // - More than 1 Module Registry Calls
+  // - Wrong number of Call Expression Args
+  // - Module Registry Call Args are Incorrect
+  // - Module is Untyped
+  // - Module Registry Call Type Parameter is Icorrect
+  const moduleName = parseModuleName(hasteModuleName, moduleSpec, ast, parser);
 
   // Some module names use platform suffix to indicate platform-exclusive modules.
   // Eventually this should be made explicit in the Flow type itself.

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -25,7 +25,7 @@ import type {Parser} from '../../parser';
 import type {ParserErrorCapturer, TypeDeclarationMap} from '../../utils';
 
 const {verifyPlatforms} = require('../../utils');
-const {resolveTypeAnnotation, getTypes} = require('../utils');
+const {resolveTypeAnnotation} = require('../utils');
 const {
   unwrapNullable,
   wrapNullable,

--- a/packages/react-native-codegen/src/parsers/flow/parser.js
+++ b/packages/react-native-codegen/src/parsers/flow/parser.js
@@ -253,6 +253,10 @@ class FlowParser implements Parser {
       return types;
     }, {});
   }
+
+  callExpressionTypeParameters(callExpression: $FlowFixMe): $FlowFixMe | null {
+    return callExpression.typeArguments || null;
+  }
 }
 
 module.exports = {

--- a/packages/react-native-codegen/src/parsers/parser.js
+++ b/packages/react-native-codegen/src/parsers/parser.js
@@ -174,4 +174,11 @@ export interface Parser {
    * Given the AST, returns the TypeDeclarationMap
    */
   getTypes(ast: $FlowFixMe): TypeDeclarationMap;
+
+  /**
+   * Given a callExpression, it returns the typeParameters of the callExpression.
+   * @paramater callExpression: the callExpression.
+   * @returns: the typeParameters of the callExpression or null if it does not exist.
+   */
+  callExpressionTypeParameters(callExpression: $FlowFixMe): $FlowFixMe | null;
 }

--- a/packages/react-native-codegen/src/parsers/parserMock.js
+++ b/packages/react-native-codegen/src/parsers/parserMock.js
@@ -180,4 +180,8 @@ export class MockedParser implements Parser {
   getTypes(ast: $FlowFixMe): TypeDeclarationMap {
     return {};
   }
+
+  callExpressionTypeParameters(callExpression: $FlowFixMe): $FlowFixMe | null {
+    return callExpression.typeArguments || null;
+  }
 }

--- a/packages/react-native-codegen/src/parsers/parsers-commons.js
+++ b/packages/react-native-codegen/src/parsers/parsers-commons.js
@@ -473,12 +473,7 @@ const parseModuleName = (
   );
 
   const [callExpression] = callExpressions;
-  let typeParameters;
-  if (parser.language() === 'TypeScript') {
-    typeParameters = callExpression.typeParameters;
-  } else {
-    typeParameters = callExpression.typeArguments;
-  }
+  const typeParameters = parser.callExpressionTypeParameters(callExpression);
   const methodName = callExpression.callee.property.name;
 
   throwIfWrongNumberOfCallExpressionArgs(

--- a/packages/react-native-codegen/src/parsers/parsers-commons.js
+++ b/packages/react-native-codegen/src/parsers/parsers-commons.js
@@ -32,13 +32,20 @@ const {
   getConfigType,
   extractNativeModuleName,
   createParserErrorCapturer,
+  visit,
+  isModuleRegistryCall,
 } = require('./utils');
-
 const {
   throwIfPropertyValueTypeIsUnsupported,
   throwIfUnsupportedFunctionParamTypeAnnotationParserError,
   throwIfUnsupportedFunctionReturnTypeAnnotationParserError,
   throwIfModuleTypeIsUnsupported,
+  throwIfUnusedModuleInterfaceParserError,
+  throwIfMoreThanOneModuleRegistryCalls,
+  throwIfWrongNumberOfCallExpressionArgs,
+  throwIfUntypedModule,
+  throwIfIncorrectModuleRegistryCallTypeParameterParserError,
+  throwIfIncorrectModuleRegistryCallArgument,
 } = require('./error-utils');
 
 const {
@@ -438,6 +445,71 @@ function buildSchema(
   );
 }
 
+const parseModuleName = (
+  hasteModuleName: string,
+  moduleSpec: $FlowFixMe,
+  ast: $FlowFixMe,
+  parser: Parser,
+): string => {
+  const callExpressions = [];
+  visit(ast, {
+    CallExpression(node) {
+      if (isModuleRegistryCall(node)) {
+        callExpressions.push(node);
+      }
+    },
+  });
+
+  throwIfUnusedModuleInterfaceParserError(
+    hasteModuleName,
+    moduleSpec,
+    callExpressions,
+  );
+
+  throwIfMoreThanOneModuleRegistryCalls(
+    hasteModuleName,
+    callExpressions,
+    callExpressions.length,
+  );
+
+  const [callExpression] = callExpressions;
+  const {typeArguments} = callExpression;
+  const methodName = callExpression.callee.property.name;
+
+  throwIfWrongNumberOfCallExpressionArgs(
+    hasteModuleName,
+    callExpression,
+    methodName,
+    callExpression.arguments.length,
+  );
+
+  throwIfIncorrectModuleRegistryCallArgument(
+    hasteModuleName,
+    callExpression.arguments[0],
+    methodName,
+  );
+
+  const $moduleName = callExpression.arguments[0].value;
+
+  throwIfUntypedModule(
+    typeArguments,
+    hasteModuleName,
+    callExpression,
+    methodName,
+    $moduleName,
+  );
+
+  throwIfIncorrectModuleRegistryCallTypeParameterParserError(
+    hasteModuleName,
+    typeArguments,
+    methodName,
+    $moduleName,
+    parser,
+  );
+
+  return $moduleName;
+};
+
 module.exports = {
   wrapModuleSchema,
   unwrapNullable,
@@ -449,4 +521,5 @@ module.exports = {
   buildPropertySchema,
   buildSchemaFromConfigType,
   buildSchema,
+  parseModuleName,
 };

--- a/packages/react-native-codegen/src/parsers/parsers-commons.js
+++ b/packages/react-native-codegen/src/parsers/parsers-commons.js
@@ -473,7 +473,12 @@ const parseModuleName = (
   );
 
   const [callExpression] = callExpressions;
-  const {typeArguments} = callExpression;
+  let typeParameters;
+  if (parser.language() === 'TypeScript') {
+    typeParameters = callExpression.typeParameters;
+  } else {
+    typeParameters = callExpression.typeArguments;
+  }
   const methodName = callExpression.callee.property.name;
 
   throwIfWrongNumberOfCallExpressionArgs(
@@ -492,7 +497,7 @@ const parseModuleName = (
   const $moduleName = callExpression.arguments[0].value;
 
   throwIfUntypedModule(
-    typeArguments,
+    typeParameters,
     hasteModuleName,
     callExpression,
     methodName,
@@ -501,7 +506,7 @@ const parseModuleName = (
 
   throwIfIncorrectModuleRegistryCallTypeParameterParserError(
     hasteModuleName,
-    typeArguments,
+    typeParameters,
     methodName,
     $moduleName,
     parser,

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -30,12 +30,13 @@ import type {
 const {flattenIntersectionType} = require('../parseTopLevelType');
 const {flattenProperties} = require('../components/componentsUtils');
 
-const {visit, isModuleRegistryCall, verifyPlatforms} = require('../../utils');
-const {resolveTypeAnnotation} = require('../utils');
+const {verifyPlatforms} = require('../../utils');
+const {resolveTypeAnnotation, getTypes} = require('../utils');
 
 const {
   parseObjectProperty,
   buildPropertySchema,
+  parseModuleName,
 } = require('../../parsers-commons');
 const {typeEnumResolution} = require('../../parsers-primitives');
 
@@ -66,15 +67,9 @@ const {
 } = require('../../errors');
 
 const {
-  throwIfUntypedModule,
-  throwIfUnusedModuleInterfaceParserError,
   throwIfModuleInterfaceNotFound,
   throwIfModuleInterfaceIsMisnamed,
-  throwIfWrongNumberOfCallExpressionArgs,
-  throwIfMoreThanOneModuleRegistryCalls,
   throwIfMoreThanOneModuleInterfaceParserError,
-  throwIfIncorrectModuleRegistryCallTypeParameterParserError,
-  throwIfIncorrectModuleRegistryCallArgument,
   throwIfPartialNotAnnotatingTypeParameter,
   throwIfPartialWithMoreParameter,
 } = require('../../error-utils');
@@ -468,65 +463,14 @@ function buildModuleSchema(
   throwIfModuleInterfaceIsMisnamed(hasteModuleName, moduleSpec.id, language);
 
   // Parse Module Name
-  const moduleName = ((): string => {
-    const callExpressions = [];
-    visit(ast, {
-      CallExpression(node) {
-        if (isModuleRegistryCall(node)) {
-          callExpressions.push(node);
-        }
-      },
-    });
-
-    throwIfUnusedModuleInterfaceParserError(
-      hasteModuleName,
-      moduleSpec,
-      callExpressions,
-    );
-
-    throwIfMoreThanOneModuleRegistryCalls(
-      hasteModuleName,
-      callExpressions,
-      callExpressions.length,
-    );
-
-    const [callExpression] = callExpressions;
-    const {typeParameters} = callExpression;
-    const methodName = callExpression.callee.property.name;
-
-    throwIfWrongNumberOfCallExpressionArgs(
-      hasteModuleName,
-      callExpression,
-      methodName,
-      callExpression.arguments.length,
-    );
-
-    throwIfIncorrectModuleRegistryCallArgument(
-      hasteModuleName,
-      callExpression.arguments[0],
-      methodName,
-    );
-
-    const $moduleName = callExpression.arguments[0].value;
-
-    throwIfUntypedModule(
-      typeParameters,
-      hasteModuleName,
-      callExpression,
-      methodName,
-      $moduleName,
-    );
-
-    throwIfIncorrectModuleRegistryCallTypeParameterParserError(
-      hasteModuleName,
-      typeParameters,
-      methodName,
-      $moduleName,
-      parser,
-    );
-
-    return $moduleName;
-  })();
+  // Also checks and throws error if:
+  // - Module Interface is Unused
+  // - More than 1 Module Registry Calls
+  // - Wrong number of Call Expression Args
+  // - Module Registry Call Args are Incorrect
+  // - Module is Untyped
+  // - Module Registry Call Type Parameter is Icorrect
+  const moduleName = parseModuleName(hasteModuleName, moduleSpec, ast, parser);
 
   // Some module names use platform suffix to indicate platform-exclusive modules.
   // Eventually this should be made explicit in the Flow type itself.

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -31,7 +31,7 @@ const {flattenIntersectionType} = require('../parseTopLevelType');
 const {flattenProperties} = require('../components/componentsUtils');
 
 const {verifyPlatforms} = require('../../utils');
-const {resolveTypeAnnotation, getTypes} = require('../utils');
+const {resolveTypeAnnotation} = require('../utils');
 
 const {
   parseObjectProperty,

--- a/packages/react-native-codegen/src/parsers/typescript/parser.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parser.js
@@ -239,6 +239,10 @@ class TypeScriptParser implements Parser {
       return types;
     }, {});
   }
+
+  callExpressionTypeParameters(callExpression: $FlowFixMe): $FlowFixMe | null {
+    return callExpression.typeParameters || null;
+  }
 }
 module.exports = {
   TypeScriptParser,


### PR DESCRIPTION
## Summary
Part of Umbrella #34872  
> [**Codegen 84** - assigned to @Pranav-yadav] It depends on [Codegen 83] export the parseModuleName anonymous function (Flow, TypeScript) in a common parseModuleName function in the parsers-commons.js file.

- merged Parse Module-Name _**anon**_ fn of `Flow` & `TS` parsers; into a common `parseModuleName` fn in the `parsers-commons.js`
- added **tests** for `parseModuleName` fn from `parsers-commons.js`
- added `callExpressionTypeParameters` method to **_parsers_**
- added **tests** for `callExpressionTypeParameters` method of _parsers_
- used `parser.callExpressionTypeParameters` method in `parseModuleName` fn

PS: fixed merge conflicts several times :(

Overall :)

## Changelog

[INTERNAL] [CHANGED] - Merge Parse-Module-Name anon fn of `Flow` & `TS` and add `callExpressionTypeParameters` method to **_parsers_**
## Test Plan

- `yarn lint && yarn run flow && yarn test react-native-codegen`  ==> ✅ 