### PR TITLE
chore: Create Codegen throwIfPartialWithMoreParameter function

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
@@ -26,6 +26,7 @@ const {
   throwIfUnsupportedFunctionParamTypeAnnotationParserError,
   throwIfArrayElementTypeAnnotationIsUnsupported,
   throwIfPartialNotAnnotatingTypeParameter,
+  throwIfPartialWithMoreParameter,
 } = require('../error-utils');
 const {
   UnsupportedModulePropertyParserError,
@@ -793,6 +794,29 @@ describe('throwIfPartialNotAnnotatingTypeParameter', () => {
         types,
         typescriptParser,
       );
+    }).not.toThrowError();
+  });
+});
+
+describe('throwIfPartialWithMoreParameter', () => {
+  it('throw error if Partial does not have exactly one parameter', () => {
+    const typeAnnotation = {
+      type: '',
+      typeParameters: {params: [{}, {}]},
+    };
+    expect(() => {
+      throwIfPartialWithMoreParameter(typeAnnotation);
+    }).toThrowError('Partials only support annotating exactly one parameter.');
+  });
+
+  it('does not throw error if Partial has exactly one parameter', () => {
+    const typeAnnotation = {
+      type: '',
+      typeParameters: {params: [{}]},
+    };
+
+    expect(() => {
+      throwIfPartialWithMoreParameter(typeAnnotation);
     }).not.toThrowError();
   });
 });

--- a/packages/react-native-codegen/src/parsers/error-utils.js
+++ b/packages/react-native-codegen/src/parsers/error-utils.js
@@ -296,6 +296,12 @@ function throwIfPartialNotAnnotatingTypeParameter(
   }
 }
 
+function throwIfPartialWithMoreParameter(typeAnnotation: $FlowFixMe) {
+  if (typeAnnotation.typeParameters.params.length !== 1) {
+    throw new Error('Partials only support annotating exactly one parameter.');
+  }
+}
+
 module.exports = {
   throwIfModuleInterfaceIsMisnamed,
   throwIfUnsupportedFunctionReturnTypeAnnotationParserError,
@@ -312,4 +318,5 @@ module.exports = {
   throwIfArrayElementTypeAnnotationIsUnsupported,
   throwIfIncorrectModuleRegistryCallArgument,
   throwIfPartialNotAnnotatingTypeParameter,
+  throwIfPartialWithMoreParameter,
 };

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -70,6 +70,7 @@ const {
   throwIfUntypedModule,
   throwIfMoreThanOneModuleInterfaceParserError,
   throwIfPartialNotAnnotatingTypeParameter,
+  throwIfPartialWithMoreParameter,
 } = require('../../error-utils');
 
 const language = 'Flow';
@@ -163,11 +164,7 @@ function translateTypeAnnotation(
           return emitGenericObject(nullable);
         }
         case '$Partial': {
-          if (typeAnnotation.typeParameters.params.length !== 1) {
-            throw new Error(
-              'Partials only support annotating exactly one parameter.',
-            );
-          }
+          throwIfPartialWithMoreParameter(typeAnnotation);
 
           const annotatedElement = parser.extractAnnotatedElement(
             typeAnnotation,

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -76,6 +76,7 @@ const {
   throwIfIncorrectModuleRegistryCallTypeParameterParserError,
   throwIfIncorrectModuleRegistryCallArgument,
   throwIfPartialNotAnnotatingTypeParameter,
+  throwIfPartialWithMoreParameter,
 } = require('../../error-utils');
 
 const language = 'TypeScript';
@@ -244,11 +245,7 @@ function translateTypeAnnotation(
           return emitGenericObject(nullable);
         }
         case 'Partial': {
-          if (typeAnnotation.typeParameters.params.length !== 1) {
-            throw new Error(
-              'Partials only support annotating exactly one parameter.',
-            );
-          }
+          throwIfPartialWithMoreParameter(typeAnnotation);
 
           const annotatedElement = parser.extractAnnotatedElement(
             typeAnnotation,


### PR DESCRIPTION
## Summary

This PR creates a Codegen `throwIfPartialWithMoreParameter` function and extracts the error-emitting code from [Flow](https://github.com/facebook/react-native/blob/main/packages/react-native-codegen/src/parsers/flow/modules/index.js#L165-L169) and [Typescript](https://github.com/facebook/react-native/blob/main/packages/react-native-codegen/src/parsers/typescript/modules/index.js#L246-L250) index files as requested on https://github.com/facebook/react-native/issues/34872. This also adds unit tests to the new function.

## Changelog

[Internal] [Changed]  - Create codegen `throwIfPartialWithMoreParameter` function and extract the `error-emitting` code from Flow and Typescript index files.

## Test Plan

Run `yarn jest react-native-codegen` and ensure CI is green
![image](https://user-images.githubusercontent.com/11707729/221445922-b2c21ad2-012e-4266-9456-6c781b0de7f0.png)
