### PR TITLE
Reduce breaking changes with DefaultReactActivityDelegate

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
+++ b/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
@@ -27,23 +27,45 @@ object DefaultNewArchitectureEntryPoint {
   fun load(
       turboModulesEnabled: Boolean = true,
       fabricEnabled: Boolean = true,
-      concurrentReactEnabled: Boolean = true,
       dynamicLibraryName: String = "appmodules",
   ) {
     ReactFeatureFlags.useTurboModules = turboModulesEnabled
     ReactFeatureFlags.enableFabricRenderer = fabricEnabled
 
-    this.fabricEnabled = fabricEnabled
-    this.turboModulesEnabled = turboModulesEnabled
-    this.concurrentReactEnabled = concurrentReactEnabled
+    this.privateFabricEnabled = fabricEnabled
+    this.privateTurboModulesEnabled = turboModulesEnabled
+    this.privateConcurrentReactEnabled = fabricEnabled
 
     SoLoader.loadLibrary("react_newarchdefaults")
     SoLoader.loadLibrary(dynamicLibraryName)
   }
 
-  @JvmStatic var fabricEnabled: Boolean = false
+  @Deprecated(
+      message =
+          "Calling DefaultNewArchitectureEntryPoint.load() with different fabricEnabled and concurrentReactEnabled is deprecated. Please use a single flag for both Fabric and Concurrent React",
+      replaceWith = ReplaceWith("load(turboModulesEnabled, fabricEnabled, dynamicLibraryName)"),
+      level = DeprecationLevel.WARNING)
+  fun load(
+      turboModulesEnabled: Boolean = true,
+      fabricEnabled: Boolean = true,
+      @Suppress("UNUSED_PARAMETER") concurrentReactEnabled: Boolean = true,
+      dynamicLibraryName: String = "appmodules",
+  ) {
+    load(turboModulesEnabled, fabricEnabled, dynamicLibraryName)
+  }
 
-  @JvmStatic var turboModulesEnabled: Boolean = false
+  private var privateFabricEnabled: Boolean = false
+  @JvmStatic
+  val fabricEnabled: Boolean
+    get() = privateFabricEnabled
 
-  @JvmStatic var concurrentReactEnabled: Boolean = false
+  private var privateTurboModulesEnabled: Boolean = false
+  @JvmStatic
+  val turboModulesEnabled: Boolean
+    get() = privateTurboModulesEnabled
+
+  private var privateConcurrentReactEnabled: Boolean = false
+  @JvmStatic
+  val concurrentReactEnabled: Boolean
+    get() = privateConcurrentReactEnabled
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactActivityDelegate.kt
+++ b/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactActivityDelegate.kt
@@ -26,6 +26,19 @@ open class DefaultReactActivityDelegate(
     private val fabricEnabled: Boolean = false,
 ) : ReactActivityDelegate(activity, mainComponentName) {
 
+  @Deprecated(
+      message =
+          "Creating DefaultReactActivityDelegate with both fabricEnabled and concurrentReactEnabled is deprecated. Please pass only one boolean value that will be used for both flags",
+      level = DeprecationLevel.WARNING,
+      replaceWith =
+          ReplaceWith("DefaultReactActivityDelegate(activity, mainComponentName, fabricEnabled)"))
+  constructor(
+      activity: ReactActivity,
+      mainComponentName: String,
+      fabricEnabled: Boolean,
+      @Suppress("UNUSED_PARAMETER") concurrentReactEnabled: Boolean,
+  ) : this(activity, mainComponentName, fabricEnabled)
+
   override fun isFabricEnabled(): Boolean = fabricEnabled
 
   override fun createRootView(): ReactRootView =


### PR DESCRIPTION
Summary:
As part of the preparation for 0.72, this reduces the amount of breaking changes we expose in the template for the user.
Specifically it re-introduces the 4 param ctor for `DefaultReactActivityDelegate` and marking it with Deprecated,
so the build log and the IDE will instruct the user to move away from it (if they forgot to follow the upgrade helper).

Changelog:
[Internal] [Changed] - Reduce breaking changes with DefaultReactActivityDelegate

Reviewed By: cipolleschi

Differential Revision: D43619184

