### PR TITLE
Implement Performance.getEntries* W3C extension for Performance Timeline API

### DIFF
--- a/Libraries/WebPerformance/NativePerformanceObserver.cpp
+++ b/Libraries/WebPerformance/NativePerformanceObserver.cpp
@@ -87,4 +87,14 @@ void NativePerformanceObserver::clearEntries(
       entryName ? entryName->c_str() : nullptr);
 }
 
+std::vector<RawPerformanceEntry> NativePerformanceObserver::getEntries(
+    jsi::Runtime &rt,
+    std::optional<int32_t> entryType,
+    std::optional<std::string> entryName) {
+  return PerformanceEntryReporter::getInstance().getEntries(
+      entryType ? static_cast<PerformanceEntryType>(*entryType)
+                : PerformanceEntryType::UNDEFINED,
+      entryName ? entryName->c_str() : nullptr);
+}
+
 } // namespace facebook::react

--- a/Libraries/WebPerformance/NativePerformanceObserver.h
+++ b/Libraries/WebPerformance/NativePerformanceObserver.h
@@ -84,6 +84,11 @@ class NativePerformanceObserver
       int32_t entryType,
       std::optional<std::string> entryName);
 
+  std::vector<RawPerformanceEntry> getEntries(
+      jsi::Runtime &rt,
+      std::optional<int32_t> entryType,
+      std::optional<std::string> entryName);
+
  private:
 };
 

--- a/Libraries/WebPerformance/NativePerformanceObserver.js
+++ b/Libraries/WebPerformance/NativePerformanceObserver.js
@@ -45,6 +45,10 @@ export interface Spec extends TurboModule {
     entryType: RawPerformanceEntryType,
     entryName?: string,
   ) => void;
+  +getEntries: (
+    entryType?: RawPerformanceEntryType,
+    entryName?: string,
+  ) => $ReadOnlyArray<RawPerformanceEntry>;
 }
 
 export default (TurboModuleRegistry.get<Spec>(

--- a/Libraries/WebPerformance/Performance.js
+++ b/Libraries/WebPerformance/Performance.js
@@ -10,7 +10,8 @@
 
 // flowlint unsafe-getters-setters:off
 
-import type {HighResTimeStamp} from './PerformanceEntry';
+import type {HighResTimeStamp, PerformanceEntryType} from './PerformanceEntry';
+import type {PerformanceEntryList} from './PerformanceObserver';
 
 import warnOnce from '../Utilities/warnOnce';
 import EventCounts from './EventCounts';
@@ -19,6 +20,10 @@ import NativePerformance from './NativePerformance';
 import NativePerformanceObserver from './NativePerformanceObserver';
 import {PerformanceEntry} from './PerformanceEntry';
 import {warnNoNativePerformanceObserver} from './PerformanceObserver';
+import {
+  performanceEntryTypeToRaw,
+  rawToPerformanceEntry,
+} from './RawPerformanceEntry';
 import {RawPerformanceEntryTypeValues} from './RawPerformanceEntry';
 
 type DetailType = mixed;
@@ -236,5 +241,62 @@ export default class Performance {
    */
   now(): HighResTimeStamp {
     return getCurrentTimeStamp();
+  }
+
+  /**
+   * An extension that allows to get back to JS all currently logged marks/measures
+   * (in our case, be it from JS or native), see
+   * https://www.w3.org/TR/performance-timeline/#extensions-to-the-performance-interface
+   */
+  getEntries(): PerformanceEntryList {
+    if (!NativePerformanceObserver?.clearEntries) {
+      warnNoNativePerformanceObserver();
+      return [];
+    }
+    return NativePerformanceObserver.getEntries().map(rawToPerformanceEntry);
+  }
+
+  getEntriesByType(entryType: PerformanceEntryType): PerformanceEntryList {
+    if (entryType !== 'mark' && entryType !== 'measure') {
+      warnOnce(
+        'performance-get-entries-by-type-' + entryType,
+        `Performance.getEntriesByType: Only valid for 'mark' and 'measure' entry types, got ${entryType}`,
+      );
+      return [];
+    }
+
+    if (!NativePerformanceObserver?.clearEntries) {
+      warnNoNativePerformanceObserver();
+      return [];
+    }
+    return NativePerformanceObserver.getEntries(
+      performanceEntryTypeToRaw(entryType),
+    ).map(rawToPerformanceEntry);
+  }
+
+  getEntriesByName(
+    entryName: string,
+    entryType?: PerformanceEntryType,
+  ): PerformanceEntryList {
+    if (
+      entryType !== undefined &&
+      entryType !== 'mark' &&
+      entryType !== 'measure'
+    ) {
+      warnOnce(
+        'performance-get-entries-by-name-' + entryType,
+        `Performance.getEntriesByName: Only valid for 'mark' and 'measure' entry types, got ${entryType}`,
+      );
+      return [];
+    }
+
+    if (!NativePerformanceObserver?.clearEntries) {
+      warnNoNativePerformanceObserver();
+      return [];
+    }
+    return NativePerformanceObserver.getEntries(
+      entryType ? performanceEntryTypeToRaw(entryType) : undefined,
+      entryName,
+    ).map(rawToPerformanceEntry);
   }
 }

--- a/Libraries/WebPerformance/__mocks__/NativePerformanceObserver.js
+++ b/Libraries/WebPerformance/__mocks__/NativePerformanceObserver.js
@@ -85,6 +85,17 @@ const NativePerformanceObserverMock: NativePerformanceObserver = {
         (entryName == null || e.name === entryName),
     );
   },
+
+  getEntries: (
+    entryType?: RawPerformanceEntryType,
+    entryName?: string,
+  ): $ReadOnlyArray<RawPerformanceEntry> => {
+    return entries.filter(
+      e =>
+        (entryType === undefined || e.entryType === entryType) &&
+        (entryName === undefined || e.name === entryName),
+    );
+  },
 };
 
 export default NativePerformanceObserverMock;


### PR DESCRIPTION
Summary:
## Changelog

[Internal] - Added support for W3C Performance API extension (Performance,getEntries*)

See [here for the details](https://www.w3.org/TR/performance-timeline/#extensions-to-the-performance-interface).

This only supports `mark` and `measure` performance entry types (not `events`, as those are not supported by browsers either, they recommend using the `PerformanceObserver` API instead).

From the implementation perspective, we already maintained persistent buffer for `mark` entry types, which was required in order to look up measures.

The buffer is circular, limited to 1K entries by default.

I basically mimic the same behavior for `measure` entry types as well, since it's the simplest way of doing it at this point,

If we happen to want adding some other entry types that would be available via `Performance.getEntries*` API in the future, we may want to iterate on the internal data structures representation inside `PerformanceEntryReporter`, but for now I believe this approach should work just fine.

Differential Revision: D43625488

