### PR TITLE
Do not attempt to comment on PRs when on forks

### DIFF
--- a/.github/workflows/apply-version-label-issue.yml
+++ b/.github/workflows/apply-version-label-issue.yml
@@ -13,6 +13,7 @@ jobs:
       issues: write  # for react-native-community/actions-apply-version-label to label issues
     runs-on: ubuntu-latest
     continue-on-error: true
+    if: github.repository == 'facebook/react-native'
 
     steps:
       - uses: react-native-community/actions-apply-version-label@v0.0.3

--- a/.github/workflows/close_pr.yml
+++ b/.github/workflows/close_pr.yml
@@ -9,6 +9,7 @@ permissions:
 jobs:
   comment-and-label:
     runs-on: ubuntu-latest
+    if: github.repository == 'facebook/react-native'
     steps:
       - uses: actions/github-script@v6
         with:

--- a/.github/workflows/danger_pr.yml
+++ b/.github/workflows/danger_pr.yml
@@ -15,6 +15,7 @@ permissions:
 jobs:
   danger:
     runs-on: ubuntu-latest
+    if: github.repository == 'facebook/react-native'
     steps:
       - uses: actions/checkout@v3
       - name: Run Yarn Install on Root

--- a/.github/workflows/needs-attention.yml
+++ b/.github/workflows/needs-attention.yml
@@ -14,6 +14,7 @@ jobs:
       issues: write  # for hramos/needs-attention to label issues
     name: Apply Needs Attention Label
     runs-on: ubuntu-latest
+    if: github.repository == 'facebook/react-native'
     steps:
       - uses: actions/checkout@v3
       - name: Apply Needs Attention Label

--- a/.github/workflows/on-issue-labeled.yml
+++ b/.github/workflows/on-issue-labeled.yml
@@ -13,7 +13,7 @@ jobs:
   # then invokes actOnLabel to react to any added labels
   triage-issue:
     runs-on: ubuntu-latest
-    if: "${{ contains(github.event.label.name, 'Needs: Triage :mag:') }}"
+    if: "${{ github.repository == 'facebook/react-native' && contains(github.event.label.name, 'Needs: Triage :mag:') }}"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/github-script@v6
@@ -36,6 +36,7 @@ jobs:
   # Reacts to the label that triggered this workflow (added manually or via other workflows)
   act-on-label:
     runs-on: ubuntu-latest
+    if: github.repository == 'facebook/react-native'
     steps:
       - uses: actions/checkout@v3
       - uses: actions/github-script@v6

--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -5,6 +5,7 @@ on:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    if: github.repository == 'facebook/react-native'
     permissions:
       issues: write
       pull-requests: write
@@ -19,6 +20,7 @@ jobs:
           close-pr-message: 'This PR was closed because it has been stalled for 7 days with no activity.'
   stale-needs-author-feedback:
     runs-on: ubuntu-latest
+    if: github.repository == 'facebook/react-native'
     permissions:
       issues: write
       pull-requests: write


### PR DESCRIPTION
## Summary

I'm gating this workflow to run only upstream as I'm receiving notifications that it fails on my fork. We don't want to run this workflow on forks at all hence we can add a `if:` there.

## Changelog

[INTERNAL] - Do not attempt to comment on PRs when on forks

## Test Plan

If Github Actions UI is green, we're good to go