### PR TITLE
FileReader#readAsArrayBuffer

### DIFF
--- a/Libraries/Blob/FileReader.js
+++ b/Libraries/Blob/FileReader.js
@@ -11,6 +11,7 @@
 import type Blob from './Blob';
 
 import NativeFileReaderModule from './NativeFileReaderModule';
+import {toByteArray} from 'base64-js';
 
 const EventTarget = require('event-target-shim');
 
@@ -74,8 +75,35 @@ class FileReader extends (EventTarget(...READER_EVENTS): any) {
     }
   }
 
-  readAsArrayBuffer(): any {
-    throw new Error('FileReader.readAsArrayBuffer is not implemented');
+  readAsArrayBuffer(blob: ?Blob): void {
+    this._aborted = false;
+
+    if (blob == null) {
+      throw new TypeError(
+        "Failed to execute 'readAsArrayBuffer' on 'FileReader': parameter 1 is not of type 'Blob'",
+      );
+    }
+
+    NativeFileReaderModule.readAsDataURL(blob.data).then(
+      (text: string) => {
+        if (this._aborted) {
+          return;
+        }
+
+        const base64 = text.split(',')[1];
+        const typedArray = toByteArray(base64);
+
+        this._result = typedArray.buffer;
+        this._setReadyState(DONE);
+      },
+      error => {
+        if (this._aborted) {
+          return;
+        }
+        this._error = error;
+        this._setReadyState(DONE);
+      },
+    );
   }
 
   readAsDataURL(blob: ?Blob): void {

--- a/Libraries/Blob/__tests__/FileReader-test.js
+++ b/Libraries/Blob/__tests__/FileReader-test.js
@@ -38,4 +38,16 @@ describe('FileReader', function () {
     });
     expect(e.target.result).toBe('data:text/plain;base64,NDI=');
   });
+
+  it('should read blob as ArrayBuffer', async () => {
+    const e = await new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = resolve;
+      reader.onerror = reject;
+      reader.readAsArrayBuffer(new Blob());
+    });
+    const ab = e.target.result;
+    expect(ab.byteLength).toBe(2);
+    expect(new TextDecoder().decode(ab)).toBe('42');
+  });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Fixes a number of issues with third party libraries that use `Blob#arrayBuffer` or `FileReader#readAsArrayBuffer`, including #30769 #34402 #20091 #21209

## Changelog

[INTERNAL] [FIXED] - Implemented FileReader#readAsArrayBuffer

## Test Plan

Added a test which fails against current release but passes after code changes.
