### PR TITLE
chore(stalebot): set the stale bot to start from oldest

### DIFF
--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -12,6 +12,21 @@ jobs:
     steps:
       - uses: actions/stale@v5
         with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-stale: 180
+          stale-issue-message: 'This issue is stale because it has been open 180 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
+          stale-pr-message: 'This PR is stale because it has been open 180 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
+          close-issue-message: 'This issue was closed because it has been stalled for 7 days with no activity.'
+          close-pr-message: 'This PR was closed because it has been stalled for 7 days with no activity.'
+  stale-asc:
+    runs-on: ubuntu-latest
+    if: github.repository == 'facebook/react-native'
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v5
+        with:
           ascending: true
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-stale: 180
@@ -20,6 +35,22 @@ jobs:
           close-issue-message: 'This issue was closed because it has been stalled for 7 days with no activity.'
           close-pr-message: 'This PR was closed because it has been stalled for 7 days with no activity.'
   stale-needs-author-feedback:
+    runs-on: ubuntu-latest
+    if: github.repository == 'facebook/react-native'
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          any-of-labels: 'Needs: Author Feedback'
+          days-before-stale: 24
+          stale-issue-message: "This issue is waiting for author's feedback since 24 days. Please provide the requested feedback or this will be closed in 7 days."
+          stale-pr-message: "This PR is waiting for author's feedback since 24 days. Please provide the requested feedback or this will be closed in 7 days"
+          close-issue-message: "This issue was closed because the author hasn't provided the requested feedback after 7 days."
+          close-pr-message: "This PR was closed because the author hasn't provided the requested feedback after 7 days."
+  stale-needs-author-feedback-asc:
     runs-on: ubuntu-latest
     if: github.repository == 'facebook/react-native'
     permissions:

--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -12,6 +12,7 @@ jobs:
     steps:
       - uses: actions/stale@v5
         with:
+          ascending: true
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-stale: 180
           stale-issue-message: 'This issue is stale because it has been open 180 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
@@ -27,6 +28,7 @@ jobs:
     steps:
       - uses: actions/stale@v5
         with:
+          ascending: true
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           any-of-labels: 'Needs: Author Feedback'
           days-before-stale: 24


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

We realized lately that the bot has "too much to eat" and because by default it starts from the most recent things ([see default here](https://github.com/actions/stale#ascending)), I'm fixing the settings so that it would start from oldest.

This should make it start from [very old and inactive issues](https://github.com/facebook/react-native/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-asc+) such as such as https://github.com/facebook/react-native/issues/1693 (last comment from Aug 2020) or https://github.com/facebook/react-native/issues/10027 (last activity in May 2019) and make it do significant progress on the repo clean up :)

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[INTERNAL] [CHANGED] - set the stale bot to start from oldest

## Test Plan

N/A
