### PR TITLE
fix: update publishing packages tag message prefix

### DIFF
--- a/scripts/monorepo/constants.js
+++ b/scripts/monorepo/constants.js
@@ -8,6 +8,6 @@
  * @format
  */
 
-const PUBLISH_PACKAGES_TAG = '@publish-packages-to-npm';
+const PUBLISH_PACKAGES_TAG = '#publish-packages-to-npm';
 
 module.exports = {PUBLISH_PACKAGES_TAG};


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Turns out that Phabricator strips `@` symbol from `@...` tags when exports commits to GitHub. Proposing to use `#` instead.

#publish-packages-to-npm

Differential Revision: D43712415

