### PR TITLE
Use Ruby 2.6.10 in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,7 @@ references:
     windows_yarn_cache_key: &windows_yarn_cache_key v1-win-yarn-cache-{{ arch }}-{{ checksum "yarn.lock" }}
     windows_choco_cache_key: &windows_choco_cache_key v1-win-choco-cache-{{ .Environment.CIRCLE_JOB }}
     yarn_cache_key: &yarn_cache_key v5-yarn-cache-{{ .Environment.CIRCLE_JOB }}
+    rbenv_cache_key: &rbenv_cache_key v1-rbenv-{{ checksum "/tmp/required_ruby" }}
 
   cache_paths:
     hermes_workspace_macos_cache_paths: &hermes_workspace_macos_cache_paths
@@ -157,14 +158,47 @@ commands:
           command: mkdir -p ./reports/{buck,build,junit,outputs}
 
   setup_ruby:
+    parameters:
+      ruby_version:
+        default: "2.6.10"
+        type: string
     steps:
       - restore_cache:
           key: *gems_cache_key
       - run:
+          name: Set Required Ruby
+          command: echo << parameters.ruby_version >> > /tmp/required_ruby
+      - restore_cache:
+          key: *rbenv_cache_key
+      - run:
           name: Bundle Install
           command: |
-            source /usr/local/share/chruby/auto.sh
+            # Check if rbenv is installed. CircleCI is migrating to rbenv so we may not need to always install it.
+
+            if [[ -z "$(command -v rbenv)" ]]; then
+              brew install rbenv ruby-build
+            else
+              echo "rbenv found; Skipping installation"
+            fi
+
+            # Load and init rbenv
+            (rbenv init 2> /dev/null) || true
+            echo '' >>  ~/.bash_profile
+            echo 'eval "$(rbenv init - bash)"' >> ~/.bash_profile
+            source ~/.bash_profile
+
+            # Install the right version of ruby
+            if [[ -z "$(rbenv versions | grep << parameters.ruby_version >>)" ]]; then
+              rbenv install << parameters.ruby_version >>
+            fi
+
+            # Set ruby dependencies
+            rbenv global << parameters.ruby_version >>
             bundle check || bundle install --path vendor/bundle --clean
+      - save_cache:
+          key: *rbenv_cache_key
+          paths:
+            - ~/.rbenv
       - save_cache:
           key: *gems_cache_key
           paths:
@@ -614,7 +648,8 @@ jobs:
 
       - run:
           name: Setup the CocoaPods environment
-          command: bundle exec pod setup
+          command: |
+            bundle exec pod setup
 
       - with_hermes_tarball_cache_span:
           set_tarball_path: True
@@ -869,6 +904,7 @@ jobs:
       - attach_workspace:
           at: .
       - *attach_hermes_workspace
+      - setup_ruby
       - when:
           condition:
             equal: ["Hermes", << parameters.jsengine >>]
@@ -892,8 +928,6 @@ jobs:
           command: |
             cd /tmp/$PROJECT_NAME/ios
 
-            bundle install
-
             if [[ << parameters.flavor >> == "Release" ]]; then
               export PRODUCTION=1
             fi
@@ -916,6 +950,7 @@ jobs:
               export USE_FRAMEWORKS=dynamic
             fi
 
+            bundle install
             bundle exec pod install
       - run:
           name: Build template project
@@ -954,7 +989,7 @@ jobs:
           name: Delete iOS Simulators
           background: true
           command: sudo rm -rf /Library/Developer/CoreSimulator/Profiles/Runtimes/
-
+      - setup_ruby
       - with_hermes_tarball_cache_span:
           set_tarball_path: True
           steps:
@@ -972,6 +1007,7 @@ jobs:
                   fi
 
                   cd packages/rn-tester
+
                   bundle install
                   bundle exec pod install
 


### PR DESCRIPTION
## Summary

Starting from RN 0.72, we would like to be more permissive in which version of Ruby our users can use. This means that we have to make sure that our pipeline works with various 
versions of Ruby, especially the lowest one, which is 2.6.10.

This change make sure that we run all the CI jobs with version 2.6.10

## Changelog

[IOS] [CHANGED] - Use Ruby 2.6.10 in CI

## Test Plan

CircleCI must be green
