### PR TITLE
Fix typos (RCTCustomRefreshControlProtocol)

### DIFF
--- a/React/Views/RefreshControl/RCTRefreshControl.h
+++ b/React/Views/RefreshControl/RCTRefreshControl.h
@@ -10,7 +10,7 @@
 #import <React/RCTComponent.h>
 #import <React/RCTScrollableProtocol.h>
 
-@interface RCTRefreshControl : UIRefreshControl <RCTCustomRefreshContolProtocol>
+@interface RCTRefreshControl : UIRefreshControl <RCTCustomRefreshControlProtocol>
 
 @property (nonatomic, copy) NSString *title;
 @property (nonatomic, copy) RCTDirectEventBlock onRefresh;

--- a/React/Views/ScrollView/RCTScrollView.m
+++ b/React/Views/ScrollView/RCTScrollView.m
@@ -29,7 +29,7 @@
 @interface RCTCustomScrollView : UIScrollView <UIGestureRecognizerDelegate>
 
 @property (nonatomic, assign) BOOL centerContent;
-@property (nonatomic, strong) UIView<RCTCustomRefreshContolProtocol> *customRefreshControl;
+@property (nonatomic, strong) UIView<RCTCustomRefreshControlProtocol> *customRefreshControl;
 @property (nonatomic, assign) BOOL pinchGestureEnabled;
 
 @end
@@ -215,14 +215,14 @@
   }
 }
 
-- (void)setCustomRefreshControl:(UIView<RCTCustomRefreshContolProtocol> *)refreshControl
+- (void)setCustomRefreshControl:(UIView<RCTCustomRefreshControlProtocol> *)refreshControl
 {
   if (_customRefreshControl) {
     [_customRefreshControl removeFromSuperview];
   }
   _customRefreshControl = refreshControl;
   // We have to set this because we can't always guarantee the
-  // `RCTCustomRefreshContolProtocol`'s superview will always be of class
+  // `RCTCustomRefreshControlProtocol`'s superview will always be of class
   // `UIScrollView` like we were previously
   if ([_customRefreshControl respondsToSelector:@selector(setScrollView:)]) {
     _customRefreshControl.scrollView = self;
@@ -412,8 +412,8 @@ static inline void RCTApplyTransformationAccordingLayoutDirection(
 - (void)insertReactSubview:(UIView *)view atIndex:(NSInteger)atIndex
 {
   [super insertReactSubview:view atIndex:atIndex];
-  if ([view conformsToProtocol:@protocol(RCTCustomRefreshContolProtocol)]) {
-    [_scrollView setCustomRefreshControl:(UIView<RCTCustomRefreshContolProtocol> *)view];
+  if ([view conformsToProtocol:@protocol(RCTCustomRefreshControlProtocol)]) {
+    [_scrollView setCustomRefreshControl:(UIView<RCTCustomRefreshControlProtocol> *)view];
     if (![view isKindOfClass:[UIRefreshControl class]] && [view conformsToProtocol:@protocol(UIScrollViewDelegate)]) {
       [self addScrollListener:(UIView<UIScrollViewDelegate> *)view];
     }
@@ -431,7 +431,7 @@ static inline void RCTApplyTransformationAccordingLayoutDirection(
 - (void)removeReactSubview:(UIView *)subview
 {
   [super removeReactSubview:subview];
-  if ([subview conformsToProtocol:@protocol(RCTCustomRefreshContolProtocol)]) {
+  if ([subview conformsToProtocol:@protocol(RCTCustomRefreshControlProtocol)]) {
     [_scrollView setCustomRefreshControl:nil];
     if (![subview isKindOfClass:[UIRefreshControl class]] &&
         [subview conformsToProtocol:@protocol(UIScrollViewDelegate)]) {
@@ -486,7 +486,7 @@ static inline void RCTApplyTransformationAccordingLayoutDirection(
 
 #if !TARGET_OS_TV
   // Adjust the refresh control frame if the scrollview layout changes.
-  UIView<RCTCustomRefreshContolProtocol> *refreshControl = _scrollView.customRefreshControl;
+  UIView<RCTCustomRefreshControlProtocol> *refreshControl = _scrollView.customRefreshControl;
   if (refreshControl && refreshControl.isRefreshing && ![refreshControl isKindOfClass:UIRefreshControl.class]) {
     refreshControl.frame =
         (CGRect){_scrollView.contentOffset, {_scrollView.frame.size.width, refreshControl.frame.size.height}};

--- a/React/Views/ScrollView/RCTScrollableProtocol.h
+++ b/React/Views/ScrollView/RCTScrollableProtocol.h
@@ -42,3 +42,7 @@
 @property (nonatomic, weak) UIScrollView *scrollView;
 
 @end
+
+ __attribute__ ((deprecated("Use RCTCustomRefreshControlProtocol instead")))
+@protocol RCTCustomRefreshContolProtocol <RCTCustomRefreshControlProtocol>
+@end

--- a/React/Views/ScrollView/RCTScrollableProtocol.h
+++ b/React/Views/ScrollView/RCTScrollableProtocol.h
@@ -33,7 +33,7 @@
 /**
  * Denotes a view which implements custom pull to refresh functionality.
  */
-@protocol RCTCustomRefreshContolProtocol
+@protocol RCTCustomRefreshControlProtocol
 
 @property (nonatomic, copy) RCTDirectEventBlock onRefresh;
 @property (nonatomic, readonly, getter=isRefreshing) BOOL refreshing;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Fix typo `RCTCustomRefreshContolProtocol` > `RCTCustomRefreshControlProtocol`

## Changelog

[INTERNAL] [FIXED] - Fixed typo RCTCustomRefreshControlProtocol

## Test Plan

none