### PR TITLE
Get rid of unneeded iOS platfrom dependency when running core C++ unit tests in RN

### DIFF
--- a/ReactCommon/react/utils/BUCK
+++ b/ReactCommon/react/utils/BUCK
@@ -19,7 +19,6 @@ rn_xplat_cxx_library(
     srcs = glob(
         [
             "**/*.cpp",
-            "**/*.mm",
         ],
         exclude = glob(["tests/**/*.cpp"]),
     ),
@@ -42,6 +41,11 @@ rn_xplat_cxx_library(
     fbobjc_compiler_flags = APPLE_COMPILER_FLAGS,
     fbobjc_frameworks = ["Foundation"],
     fbobjc_preprocessor_flags = get_preprocessor_flags_for_build_mode() + get_apple_inspector_flags(),
+    fbobjc_srcs = glob(
+        [
+            "**/*.mm",
+        ],
+    ),
     force_static = True,
     labels = [
         "pfh:ReactNative_CommonInfrastructurePlaceholder",


### PR DESCRIPTION
Summary:
## Changelog

[Internal] -

Fixes dependencies, so we don't pull in unneeded iOS ones when we don't care about them (in this case, when running C++ tests for the RN core).

The iOS dependencies came from the `ReactCommon/react/utils` library, that was including ObjectiveC files unconditionally.

Differential Revision: D43769718

