### PR TITLE
Add labels to bypass stale bot

### DIFF
--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -18,6 +18,8 @@ jobs:
           stale-pr-message: 'This PR is stale because it has been open 180 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
           close-issue-message: 'This issue was closed because it has been stalled for 7 days with no activity.'
           close-pr-message: 'This PR was closed because it has been stalled for 7 days with no activity.'
+          exempt-issue-labels: Help Wanted :octocat:, Good first issue, Never gets stale
+          exempt-pr-labels: Help Wanted :octocat:, Good first issue, Never gets stale
   stale-asc:
     runs-on: ubuntu-latest
     if: github.repository == 'facebook/react-native'
@@ -34,6 +36,8 @@ jobs:
           stale-pr-message: 'This PR is stale because it has been open 180 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
           close-issue-message: 'This issue was closed because it has been stalled for 7 days with no activity.'
           close-pr-message: 'This PR was closed because it has been stalled for 7 days with no activity.'
+          exempt-issue-labels: Help Wanted :octocat:, Good first issue, Never gets stale
+          exempt-pr-labels: Help Wanted :octocat:, Good first issue, Never gets stale
   stale-needs-author-feedback:
     runs-on: ubuntu-latest
     if: github.repository == 'facebook/react-native'
@@ -50,6 +54,8 @@ jobs:
           stale-pr-message: "This PR is waiting for author's feedback since 24 days. Please provide the requested feedback or this will be closed in 7 days"
           close-issue-message: "This issue was closed because the author hasn't provided the requested feedback after 7 days."
           close-pr-message: "This PR was closed because the author hasn't provided the requested feedback after 7 days."
+          exempt-issue-labels: Help Wanted :octocat:, Good first issue, Never gets stale
+          exempt-pr-labels: Help Wanted :octocat:, Good first issue, Never gets stale
   stale-needs-author-feedback-asc:
     runs-on: ubuntu-latest
     if: github.repository == 'facebook/react-native'
@@ -67,3 +73,5 @@ jobs:
           stale-pr-message: "This PR is waiting for author's feedback since 24 days. Please provide the requested feedback or this will be closed in 7 days"
           close-issue-message: "This issue was closed because the author hasn't provided the requested feedback after 7 days."
           close-pr-message: "This PR was closed because the author hasn't provided the requested feedback after 7 days."
+          exempt-issue-labels: Help Wanted :octocat:, Good first issue, Never gets stale
+          exempt-pr-labels: Help Wanted :octocat:, Good first issue, Never gets stale


### PR DESCRIPTION
## Summary

Tweaking stale bot to have labels that bypass the stale bot.

## Changelog

[INTERNAL] - Add labels to bypass stale bot

## Test Plan

n/a