### PR TITLE
Fix typing for TS AnimatableStringValue

### DIFF
--- a/Libraries/StyleSheet/StyleSheetTypes.d.ts
+++ b/Libraries/StyleSheet/StyleSheetTypes.d.ts
@@ -25,7 +25,7 @@ type DimensionValue =
   | Animated.AnimatedNode
   | null;
 type AnimatableNumericValue = number | Animated.AnimatedNode;
-type AnimatableStringValue = number | Animated.AnimatedNode;
+type AnimatableStringValue = string | Animated.AnimatedNode;
 
 /**
  * Flex Prop Types


### PR DESCRIPTION
Summary:
## Changelog:

[General][Fixed] -

https://github.com/facebook/react-native/pull/36346 added some typing improvements, however there was a typo in `AnimatableStringValue` type definition, that broke tests on CI.

Reviewed By: cortinico, cipolleschi, hoxyq

Differential Revision: D43770412

