### PR TITLE
JavaTurboModule/LongLivedObject cleanup

### DIFF
--- a/ReactCommon/react/bridging/CallbackWrapper.h
+++ b/ReactCommon/react/bridging/CallbackWrapper.h
@@ -35,8 +35,8 @@ class CallbackWrapper : public LongLivedObject {
       jsi::Function &&callback,
       jsi::Runtime &runtime,
       std::shared_ptr<CallInvoker> jsInvoker) {
-    auto wrapper = std::shared_ptr<CallbackWrapper>(
-        new CallbackWrapper(std::move(callback), runtime, jsInvoker));
+    auto wrapper = std::shared_ptr<CallbackWrapper>(new CallbackWrapper(
+        std::move(callback), runtime, std::move(jsInvoker)));
     LongLivedObjectCollection::get().add(wrapper);
     return wrapper;
   }

--- a/ReactCommon/react/bridging/LongLivedObject.h
+++ b/ReactCommon/react/bridging/LongLivedObject.h
@@ -26,11 +26,11 @@ namespace react {
  */
 class LongLivedObject {
  public:
-  virtual void allowRelease();
+  void allowRelease();
 
  protected:
-  LongLivedObject();
-  virtual ~LongLivedObject();
+  LongLivedObject() = default;
+  virtual ~LongLivedObject() = default;
 };
 
 /**
@@ -40,17 +40,18 @@ class LongLivedObjectCollection {
  public:
   static LongLivedObjectCollection &get();
 
-  LongLivedObjectCollection();
   LongLivedObjectCollection(LongLivedObjectCollection const &) = delete;
   void operator=(LongLivedObjectCollection const &) = delete;
 
-  void add(std::shared_ptr<LongLivedObject> o) const;
-  void remove(const LongLivedObject *o) const;
-  void clear() const;
+  void add(std::shared_ptr<LongLivedObject> o);
+  void remove(const LongLivedObject *o);
+  void clear();
   size_t size() const;
 
  private:
-  mutable std::unordered_set<std::shared_ptr<LongLivedObject>> collection_;
+  LongLivedObjectCollection() = default;
+
+  std::unordered_set<std::shared_ptr<LongLivedObject>> collection_;
   mutable std::mutex collectionMutex_;
 };
 

--- a/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleUtils.cpp
+++ b/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleUtils.cpp
@@ -79,13 +79,13 @@ void Promise::reject(const std::string &message) {
 
 jsi::Value createPromiseAsJSIValue(
     jsi::Runtime &rt,
-    const PromiseSetupFunctionType func) {
+    PromiseSetupFunctionType &&func) {
   jsi::Function JSPromise = rt.global().getPropertyAsFunction(rt, "Promise");
   jsi::Function fn = jsi::Function::createFromHostFunction(
       rt,
       jsi::PropNameID::forAscii(rt, "fn"),
       2,
-      [func](
+      [func = std::move(func)](
           jsi::Runtime &rt2,
           const jsi::Value &thisVal,
           const jsi::Value *args,

--- a/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleUtils.h
+++ b/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleUtils.h
@@ -36,7 +36,7 @@ using PromiseSetupFunctionType =
     std::function<void(jsi::Runtime &rt, std::shared_ptr<Promise>)>;
 jsi::Value createPromiseAsJSIValue(
     jsi::Runtime &rt,
-    const PromiseSetupFunctionType func);
+    PromiseSetupFunctionType &&func);
 
 class RAIICallbackWrapperDestroyer {
  public:


### PR DESCRIPTION
Summary:
* Don't iterate over JSI Value to get args, convert each of the args individually instead
* Make LongLivedObjectCollection constructor private
* allowRelease does not need to be virtual
* Move away from const-ness as a thread-safety indicator

Changelog: [Internal]

Differential Revision: D43354535

