### PR TITLE
Don't download hermes nightly tarball if it exists

### DIFF
--- a/sdks/hermes-engine/hermes-utils.rb
+++ b/sdks/hermes-engine/hermes-utils.rb
@@ -110,9 +110,13 @@ def download_nightly_hermes(react_native_path, version)
     tarball_url = nightly_tarball_url(version)
 
     destination_folder = "#{react_native_path}/sdks/downloads"
-    destination_path = "#{destination_folder}/hermes-ios.tar.gz"
+    destination_path = "#{destination_folder}/hermes-ios-#{version}.tar.gz"
 
-    `mkdir -p "#{destination_folder}" && curl "#{tarball_url}" -Lo "#{destination_path}"`
+    unless File.exist?(destination_path)
+      # Download to a temporary file first so we don't cache incomplete downloads.
+      tmp_file = "#{destination_folder}/hermes-ios.download"
+      `mkdir -p "#{destination_folder}" && curl "#{tarball_url}" -Lo "#{tmp_file}" && mv "#{tmp_file}" "#{destination_path}"`
+    end
     return destination_path
 end
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Currently the hermes tarball will be re-downloaded every time we run pod update even if the file already exists. This adds a check to avoid downloading it if it already exists. To avoid partial downloads causing issues (if the script is interrupted) we download first to a different file and rename it when done.

## Changelog

[IOS] [FIXED] - Don't download hermes nightly tarball if it exists

## Test Plan

Tested in an app using nightly builds that the download is only done once when running multiple pod update.
