### PR TITLE
feat: font variation settings (wip)

### DIFF
--- a/Libraries/Components/View/ReactNativeStyleAttributes.js
+++ b/Libraries/Components/View/ReactNativeStyleAttributes.js
@@ -150,6 +150,7 @@ const ReactNativeStyleAttributes: {[string]: AnyAttributeType, ...} = {
    */
   color: colorAttributes,
   fontFamily: true,
+  fontVariationSettings: true,
   fontSize: true,
   fontStyle: true,
   fontVariant: {process: processFontVariant},

--- a/Libraries/StyleSheet/StyleSheetTypes.d.ts
+++ b/Libraries/StyleSheet/StyleSheetTypes.d.ts
@@ -310,6 +310,7 @@ export interface TextStyleAndroid extends ViewStyle {
 export interface TextStyle extends TextStyleIOS, TextStyleAndroid, ViewStyle {
   color?: ColorValue | undefined;
   fontFamily?: string | undefined;
+  fontVariationSettings?: string | undefined;
   fontSize?: number | undefined;
   fontStyle?: 'normal' | 'italic' | undefined;
   /**

--- a/Libraries/StyleSheet/StyleSheetTypes.js
+++ b/Libraries/StyleSheet/StyleSheetTypes.js
@@ -815,6 +815,7 @@ export type ____TextStyle_InternalCore = $ReadOnly<{
   ...$Exact<____ViewStyle_Internal>,
   color?: ____ColorValue_Internal,
   fontFamily?: string,
+  fontVariationSettings?: string,
   fontSize?: number,
   fontStyle?: 'normal' | 'italic',
   fontWeight?: ____FontWeight_Internal,

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewProps.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewProps.java
@@ -91,6 +91,7 @@ public class ViewProps {
   public static final String FONT_WEIGHT = "fontWeight";
   public static final String FONT_STYLE = "fontStyle";
   public static final String FONT_VARIANT = "fontVariant";
+  public static final String FONT_VARIATION_SETTINGS = "fontVariationSettings";
   public static final String FONT_FAMILY = "fontFamily";
   public static final String LINE_HEIGHT = "lineHeight";
   public static final String LETTER_SPACING = "letterSpacing";

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/CustomStyleSpan.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/CustomStyleSpan.java
@@ -10,6 +10,7 @@ package com.facebook.react.views.text;
 import android.content.res.AssetManager;
 import android.graphics.Paint;
 import android.graphics.Typeface;
+import android.os.Build;
 import android.text.TextPaint;
 import android.text.style.MetricAffectingSpan;
 import androidx.annotation.Nullable;
@@ -33,30 +34,34 @@ public class CustomStyleSpan extends MetricAffectingSpan implements ReactSpan {
 
   private final int mStyle;
   private final int mWeight;
+
+  private final String mFontVariationSettings;
   private final @Nullable String mFeatureSettings;
   private final @Nullable String mFontFamily;
 
   public CustomStyleSpan(
       int fontStyle,
       int fontWeight,
+      String fontVariationSettings,
       @Nullable String fontFeatureSettings,
       @Nullable String fontFamily,
       AssetManager assetManager) {
     mStyle = fontStyle;
     mWeight = fontWeight;
     mFeatureSettings = fontFeatureSettings;
+    mFontVariationSettings = fontVariationSettings;
     mFontFamily = fontFamily;
     mAssetManager = assetManager;
   }
 
   @Override
   public void updateDrawState(TextPaint ds) {
-    apply(ds, mStyle, mWeight, mFeatureSettings, mFontFamily, mAssetManager);
+    apply(ds, mStyle, mWeight, mFontVariationSettings, mFeatureSettings, mFontFamily, mAssetManager);
   }
 
   @Override
   public void updateMeasureState(TextPaint paint) {
-    apply(paint, mStyle, mWeight, mFeatureSettings, mFontFamily, mAssetManager);
+    apply(paint, mStyle, mWeight, mFontVariationSettings, mFeatureSettings, mFontFamily, mAssetManager);
   }
 
   public int getStyle() {
@@ -75,12 +80,16 @@ public class CustomStyleSpan extends MetricAffectingSpan implements ReactSpan {
       Paint paint,
       int style,
       int weight,
+      String fontVariationSettings,
       @Nullable String fontFeatureSettings,
       @Nullable String family,
       AssetManager assetManager) {
     Typeface typeface =
         ReactTypefaceUtils.applyStyles(paint.getTypeface(), style, weight, family, assetManager);
     paint.setFontFeatureSettings(fontFeatureSettings);
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      paint.setFontVariationSettings(fontVariationSettings);
+    }
     paint.setTypeface(typeface);
     paint.setSubpixelText(true);
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactBaseTextShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactBaseTextShadowNode.java
@@ -201,6 +201,7 @@ public abstract class ReactBaseTextShadowNode extends LayoutShadowNode {
       }
       if (textShadowNode.mFontStyle != UNSET
           || textShadowNode.mFontWeight != UNSET
+          || textShadowNode.mFontVariationSettings != null
           || textShadowNode.mFontFamily != null) {
         ops.add(
             new SetSpanOperation(
@@ -358,7 +359,7 @@ public abstract class ReactBaseTextShadowNode extends LayoutShadowNode {
   /**
    * mFontVariationSettings can be used for variable font features e.g: 'wght' 850
    */
-  protected String mFontVariationSettings = "";
+  protected String mFontVariationSettings;
   
   protected int mFontWeight = UNSET;
   /**

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactBaseTextShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactBaseTextShadowNode.java
@@ -15,6 +15,7 @@ import android.text.Layout;
 import android.text.Spannable;
 import android.text.SpannableStringBuilder;
 import android.text.TextUtils;
+import android.util.Log;
 import android.view.Gravity;
 import androidx.annotation.Nullable;
 import com.facebook.common.logging.FLog;
@@ -208,6 +209,7 @@ public abstract class ReactBaseTextShadowNode extends LayoutShadowNode {
                 new CustomStyleSpan(
                     textShadowNode.mFontStyle,
                     textShadowNode.mFontWeight,
+                    textShadowNode.mFontVariationSettings,
                     textShadowNode.mFontFeatureSettings,
                     textShadowNode.mFontFamily,
                     textShadowNode.getThemedContext().getAssets())));
@@ -353,6 +355,11 @@ public abstract class ReactBaseTextShadowNode extends LayoutShadowNode {
    */
   protected int mFontStyle = UNSET;
 
+  /**
+   * mFontVariationSettings can be used for variable font features e.g: 'wght' 850
+   */
+  protected String mFontVariationSettings = "";
+  
   protected int mFontWeight = UNSET;
   /**
    * NB: If a font family is used that does not have a style in a certain Android version (ie.
@@ -527,6 +534,15 @@ public abstract class ReactBaseTextShadowNode extends LayoutShadowNode {
 
     if (!TextUtils.equals(fontFeatureSettings, mFontFeatureSettings)) {
       mFontFeatureSettings = fontFeatureSettings;
+      markUpdated();
+    }
+  }
+
+  @ReactProp(name = ViewProps.FONT_VARIATION_SETTINGS)
+  public void setFontVariationSettings(@Nullable String fontVariationSettings) {
+    Log.d("ReactBaseTextShadowNode", "fontVariationSettings: " + fontVariationSettings);
+    if(fontVariationSettings != mFontVariationSettings) {
+      mFontVariationSettings = fontVariationSettings;
       markUpdated();
     }
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactBaseTextShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactBaseTextShadowNode.java
@@ -521,6 +521,7 @@ public abstract class ReactBaseTextShadowNode extends LayoutShadowNode {
 
   @ReactProp(name = ViewProps.FONT_WEIGHT)
   public void setFontWeight(@Nullable String fontWeightString) {
+    Log.d("ReactBaseTextShadowNode", "Font weight: " + fontWeightString);
     int fontWeight = ReactTypefaceUtils.parseFontWeight(fontWeightString);
     if (fontWeight != mFontWeight) {
       mFontWeight = fontWeight;

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/TextAttributeProps.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/TextAttributeProps.java
@@ -12,9 +12,7 @@ import android.text.Layout;
 import android.text.TextUtils;
 import android.util.LayoutDirection;
 import android.view.Gravity;
-
 import androidx.annotation.Nullable;
-
 import com.facebook.common.logging.FLog;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
@@ -24,7 +22,6 @@ import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.ReactAccessibilityDelegate;
 import com.facebook.react.uimanager.ReactStylesDiffMap;
 import com.facebook.react.uimanager.ViewProps;
-
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -110,11 +107,6 @@ public class TextAttributeProps {
   protected boolean mIsAccessibilityRoleSet = false;
   protected boolean mIsAccessibilityLink = false;
 
-  /**
-   * mFontVariationSettings can be used for variable font features e.g: 'wght' 850
-   */
-  protected String mFontVariationSettings = "";
-
   protected int mFontStyle = UNSET;
   protected int mFontWeight = UNSET;
   /**
@@ -141,18 +133,19 @@ public class TextAttributeProps {
   protected @Nullable String mFontFamily = null;
 
   /**
-   * @see android.graphics.Paint#setFontFeatureSettings
+   * mFontVariationSettings can be used for variable font features e.g: 'wght' 850
    */
+  protected String mFontVariationSettings = "";
+
+  /** @see android.graphics.Paint#setFontFeatureSettings */
   protected @Nullable String mFontFeatureSettings = null;
+
   protected boolean mContainsImages = false;
   protected float mHeightOfTallestInlineImage = Float.NaN;
 
-  private TextAttributeProps() {
-  }
+  private TextAttributeProps() {}
 
-  /**
-   * Build a TextAttributeProps using data from the {@link MapBuffer} received as a parameter.
-   */
+  /** Build a TextAttributeProps using data from the {@link MapBuffer} received as a parameter. */
   public static TextAttributeProps fromMapBuffer(MapBuffer props) {
     TextAttributeProps result = new TextAttributeProps();
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/TextAttributeProps.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/TextAttributeProps.java
@@ -69,11 +69,11 @@ public class TextAttributeProps {
 
   private static final int DEFAULT_TEXT_SHADOW_COLOR = 0x55000000;
   private static final int DEFAULT_JUSTIFICATION_MODE =
-    (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) ? 0 : Layout.JUSTIFICATION_MODE_NONE;
+      (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) ? 0 : Layout.JUSTIFICATION_MODE_NONE;
   private static final int DEFAULT_BREAK_STRATEGY =
-    (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) ? 0 : Layout.BREAK_STRATEGY_HIGH_QUALITY;
+      (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) ? 0 : Layout.BREAK_STRATEGY_HIGH_QUALITY;
   private static final int DEFAULT_HYPHENATION_FREQUENCY =
-    (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) ? 0 : Layout.HYPHENATION_FREQUENCY_NONE;
+      (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) ? 0 : Layout.HYPHENATION_FREQUENCY_NONE;
 
   protected float mLineHeight = Float.NaN;
   protected boolean mIsColorSet = false;
@@ -131,11 +131,11 @@ public class TextAttributeProps {
    * </pre>
    */
   protected @Nullable String mFontFamily = null;
-
+  
   /**
    * mFontVariationSettings can be used for variable font features e.g: 'wght' 850
    */
-  protected String mFontVariationSettings = "";
+  protected String mFontVariationSettings = null;
 
   /** @see android.graphics.Paint#setFontFeatureSettings */
   protected @Nullable String mFontFeatureSettings = null;
@@ -213,11 +213,11 @@ public class TextAttributeProps {
         case TA_KEY_ACCESSIBILITY_ROLE:
           result.setAccessibilityRole(entry.getStringValue());
           break;
-        case TA_KEY_FONT_VARIATION_SETTINGS:
-          result.setFontVariationSettings(entry.getStringValue());
-          break;
         case TA_KEY_LINE_BREAK_STRATEGY:
           // TODO: add line break strategy
+          break;
+        case TA_KEY_FONT_VARIATION_SETTINGS:
+          result.setFontVariationSettings(entry.getStringValue());
           break;
       }
     }
@@ -240,22 +240,22 @@ public class TextAttributeProps {
     result.setFontSize(getFloatProp(props, ViewProps.FONT_SIZE, UNSET));
     result.setColor(props.hasKey(ViewProps.COLOR) ? props.getInt(ViewProps.COLOR, 0) : null);
     result.setColor(
-      props.hasKey(ViewProps.FOREGROUND_COLOR)
-        ? props.getInt(ViewProps.FOREGROUND_COLOR, 0)
-        : null);
+        props.hasKey(ViewProps.FOREGROUND_COLOR)
+            ? props.getInt(ViewProps.FOREGROUND_COLOR, 0)
+            : null);
     result.setBackgroundColor(
-      props.hasKey(ViewProps.BACKGROUND_COLOR)
-        ? props.getInt(ViewProps.BACKGROUND_COLOR, 0)
-        : null);
+        props.hasKey(ViewProps.BACKGROUND_COLOR)
+            ? props.getInt(ViewProps.BACKGROUND_COLOR, 0)
+            : null);
     result.setFontFamily(getStringProp(props, ViewProps.FONT_FAMILY));
+    result.setFontVariationSettings(getStringProp(props, ViewProps.FONT_VARIATION_SETTINGS));
     result.setFontWeight(getStringProp(props, ViewProps.FONT_WEIGHT));
     result.setFontStyle(getStringProp(props, ViewProps.FONT_STYLE));
-    result.setFontVariationSettings(getStringProp(props, ViewProps.FONT_VARIATION_SETTINGS));
     result.setFontVariant(getArrayProp(props, ViewProps.FONT_VARIANT));
     result.setIncludeFontPadding(getBooleanProp(props, ViewProps.INCLUDE_FONT_PADDING, true));
     result.setTextDecorationLine(getStringProp(props, ViewProps.TEXT_DECORATION_LINE));
     result.setTextShadowOffset(
-      props.hasKey(PROP_SHADOW_OFFSET) ? props.getMap(PROP_SHADOW_OFFSET) : null);
+        props.hasKey(PROP_SHADOW_OFFSET) ? props.getMap(PROP_SHADOW_OFFSET) : null);
     result.setTextShadowRadius(getFloatProp(props, PROP_SHADOW_RADIUS, 1));
     result.setTextShadowColor(getIntProp(props, PROP_SHADOW_COLOR, DEFAULT_TEXT_SHADOW_COLOR));
     result.setTextTransform(getStringProp(props, PROP_TEXT_TRANSFORM));
@@ -301,7 +301,7 @@ public class TextAttributeProps {
   }
 
   private static boolean getBooleanProp(
-    ReactStylesDiffMap mProps, String name, boolean defaultValue) {
+      ReactStylesDiffMap mProps, String name, boolean defaultValue) {
     if (mProps.hasKey(name)) {
       return mProps.getBoolean(name, defaultValue);
     } else {
@@ -345,9 +345,9 @@ public class TextAttributeProps {
   // and the height of the inline images.
   public float getEffectiveLineHeight() {
     boolean useInlineViewHeight =
-      !Float.isNaN(mLineHeight)
-        && !Float.isNaN(mHeightOfTallestInlineImage)
-        && mHeightOfTallestInlineImage > mLineHeight;
+        !Float.isNaN(mLineHeight)
+            && !Float.isNaN(mHeightOfTallestInlineImage)
+            && mHeightOfTallestInlineImage > mLineHeight;
     return useInlineViewHeight ? mHeightOfTallestInlineImage : mLineHeight;
   }
 
@@ -361,9 +361,9 @@ public class TextAttributeProps {
       mLineHeight = Float.NaN;
     } else {
       mLineHeight =
-        mAllowFontScaling
-          ? PixelUtil.toPixelFromSP(lineHeight)
-          : PixelUtil.toPixelFromDIP(lineHeight);
+          mAllowFontScaling
+              ? PixelUtil.toPixelFromSP(lineHeight)
+              : PixelUtil.toPixelFromDIP(lineHeight);
     }
   }
 
@@ -373,13 +373,13 @@ public class TextAttributeProps {
 
   public float getLetterSpacing() {
     float letterSpacingPixels =
-      mAllowFontScaling
-        ? PixelUtil.toPixelFromSP(mLetterSpacingInput)
-        : PixelUtil.toPixelFromDIP(mLetterSpacingInput);
+        mAllowFontScaling
+            ? PixelUtil.toPixelFromSP(mLetterSpacingInput)
+            : PixelUtil.toPixelFromDIP(mLetterSpacingInput);
 
     if (mFontSize <= 0) {
       throw new IllegalArgumentException(
-        "FontSize should be a positive value. Current value: " + mFontSize);
+          "FontSize should be a positive value. Current value: " + mFontSize);
     }
     // `letterSpacingPixels` and `mFontSize` are both in pixels,
     // yielding an accurate em value.
@@ -399,9 +399,9 @@ public class TextAttributeProps {
     mFontSizeInput = fontSize;
     if (fontSize != UNSET) {
       fontSize =
-        mAllowFontScaling
-          ? (float) Math.ceil(PixelUtil.toPixelFromSP(fontSize))
-          : (float) Math.ceil(PixelUtil.toPixelFromDIP(fontSize));
+          mAllowFontScaling
+              ? (float) Math.ceil(PixelUtil.toPixelFromSP(fontSize))
+              : (float) Math.ceil(PixelUtil.toPixelFromDIP(fontSize));
     }
     mFontSize = (int) fontSize;
   }
@@ -428,6 +428,10 @@ public class TextAttributeProps {
     mFontFamily = fontFamily;
   }
 
+  private void setFontVariationSettings(String fontVariationSettings) {
+    mFontVariationSettings = fontVariationSettings;
+  }
+  
   private void setFontVariant(@Nullable ReadableArray fontVariant) {
     mFontFeatureSettings = ReactTypefaceUtils.parseFontVariant(fontVariant);
   }
@@ -526,10 +530,6 @@ public class TextAttributeProps {
     mFontFeatureSettings = TextUtils.join(", ", features);
   }
 
-  private void setFontVariationSettings(String fontVariationSettings) {
-    mFontVariationSettings = fontVariationSettings;
-  }
-
   private void setFontWeight(@Nullable String fontWeightString) {
     mFontWeight = ReactTypefaceUtils.parseFontWeight(fontWeightString);
   }
@@ -562,14 +562,14 @@ public class TextAttributeProps {
 
     if (offsetMap != null) {
       if (offsetMap.hasKey(PROP_SHADOW_OFFSET_WIDTH)
-        && !offsetMap.isNull(PROP_SHADOW_OFFSET_WIDTH)) {
+          && !offsetMap.isNull(PROP_SHADOW_OFFSET_WIDTH)) {
         mTextShadowOffsetDx =
-          PixelUtil.toPixelFromDIP(offsetMap.getDouble(PROP_SHADOW_OFFSET_WIDTH));
+            PixelUtil.toPixelFromDIP(offsetMap.getDouble(PROP_SHADOW_OFFSET_WIDTH));
       }
       if (offsetMap.hasKey(PROP_SHADOW_OFFSET_HEIGHT)
-        && !offsetMap.isNull(PROP_SHADOW_OFFSET_HEIGHT)) {
+          && !offsetMap.isNull(PROP_SHADOW_OFFSET_HEIGHT)) {
         mTextShadowOffsetDy =
-          PixelUtil.toPixelFromDIP(offsetMap.getDouble(PROP_SHADOW_OFFSET_HEIGHT));
+            PixelUtil.toPixelFromDIP(offsetMap.getDouble(PROP_SHADOW_OFFSET_HEIGHT));
       }
     }
   }
@@ -624,9 +624,9 @@ public class TextAttributeProps {
     if (accessibilityRole != null) {
       mIsAccessibilityRoleSet = true;
       mAccessibilityRole =
-        ReactAccessibilityDelegate.AccessibilityRole.fromValue(accessibilityRole);
+          ReactAccessibilityDelegate.AccessibilityRole.fromValue(accessibilityRole);
       mIsAccessibilityLink =
-        mAccessibilityRole.equals(ReactAccessibilityDelegate.AccessibilityRole.LINK);
+          mAccessibilityRole.equals(ReactAccessibilityDelegate.AccessibilityRole.LINK);
     }
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
@@ -146,6 +146,7 @@ public class TextLayoutManager {
             new SetSpanOperation(start, end, new ReactAbsoluteSizeSpan(textAttributes.mFontSize)));
         if (textAttributes.mFontStyle != UNSET
             || textAttributes.mFontWeight != UNSET
+            || textAttributes.mFontVariationSettings != null
             || textAttributes.mFontFamily != null) {
           ops.add(
               new SetSpanOperation(

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
@@ -154,6 +154,7 @@ public class TextLayoutManager {
                   new CustomStyleSpan(
                       textAttributes.mFontStyle,
                       textAttributes.mFontWeight,
+                      textAttributes.mFontVariationSettings,
                       textAttributes.mFontFeatureSettings,
                       textAttributes.mFontFamily,
                       context.getAssets())));

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManagerMapBuffer.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManagerMapBuffer.java
@@ -170,6 +170,7 @@ public class TextLayoutManagerMapBuffer {
                   new CustomStyleSpan(
                       textAttributes.mFontStyle,
                       textAttributes.mFontWeight,
+                      textAttributes.mFontVariationSettings,
                       textAttributes.mFontFeatureSettings,
                       textAttributes.mFontFamily,
                       context.getAssets())));

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManagerMapBuffer.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManagerMapBuffer.java
@@ -162,6 +162,7 @@ public class TextLayoutManagerMapBuffer {
             new SetSpanOperation(start, end, new ReactAbsoluteSizeSpan(textAttributes.mFontSize)));
         if (textAttributes.mFontStyle != UNSET
             || textAttributes.mFontWeight != UNSET
+            || textAttributes.mFontVariationSettings != null
             || textAttributes.mFontFamily != null) {
           ops.add(
               new SetSpanOperation(

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -822,6 +822,7 @@ public class ReactEditText extends AppCompatEditText
               new CustomStyleSpan(
                   mFontStyle,
                   mFontWeight,
+                  "",
                   null, // TODO: do we need to support FontFeatureSettings / fontVariant?
                   mFontFamily,
                   getReactContext(ReactEditText.this).getAssets())));

--- a/ReactCommon/react/renderer/attributedstring/TextAttributes.cpp
+++ b/ReactCommon/react/renderer/attributedstring/TextAttributes.cpp
@@ -31,6 +31,10 @@ void TextAttributes::apply(TextAttributes textAttributes) {
   // Font
   fontFamily = !textAttributes.fontFamily.empty() ? textAttributes.fontFamily
                                                   : fontFamily;
+
+  fontVariationSettings = !textAttributes.fontVariationSettings.empty() ? textAttributes.fontVariationSettings
+                                                  : fontVariationSettings;
+
   fontSize =
       !std::isnan(textAttributes.fontSize) ? textAttributes.fontSize : fontSize;
   fontSizeMultiplier = !std::isnan(textAttributes.fontSizeMultiplier)
@@ -110,6 +114,7 @@ bool TextAttributes::operator==(const TextAttributes &rhs) const {
              foregroundColor,
              backgroundColor,
              fontFamily,
+             fontVariationSettings,
              fontWeight,
              fontStyle,
              fontVariant,
@@ -131,6 +136,7 @@ bool TextAttributes::operator==(const TextAttributes &rhs) const {
              rhs.foregroundColor,
              rhs.backgroundColor,
              rhs.fontFamily,
+             rhs.fontVariationSettings,
              rhs.fontWeight,
              rhs.fontStyle,
              rhs.fontVariant,
@@ -168,6 +174,7 @@ TextAttributes TextAttributes::defaultTextAttributes() {
     textAttributes.backgroundColor = clearColor();
     textAttributes.fontSize = 14.0;
     textAttributes.fontSizeMultiplier = 1.0;
+    textAttributes.fontVariationSettings = "";
     return textAttributes;
   }();
   return textAttributes;
@@ -190,6 +197,7 @@ SharedDebugStringConvertibleList TextAttributes::getDebugProps() const {
       debugStringConvertibleItem("fontWeight", fontWeight),
       debugStringConvertibleItem("fontStyle", fontStyle),
       debugStringConvertibleItem("fontVariant", fontVariant),
+      debugStringConvertibleItem("fontVariationSettings", fontVariationSettings),
       debugStringConvertibleItem("allowFontScaling", allowFontScaling),
       debugStringConvertibleItem("dynamicTypeRamp", dynamicTypeRamp),
       debugStringConvertibleItem("letterSpacing", letterSpacing),

--- a/ReactCommon/react/renderer/attributedstring/TextAttributes.h
+++ b/ReactCommon/react/renderer/attributedstring/TextAttributes.h
@@ -45,6 +45,7 @@ class TextAttributes : public DebugStringConvertible {
 
   // Font
   std::string fontFamily{""};
+  std::string fontVariationSettings{""};
   Float fontSize{std::numeric_limits<Float>::quiet_NaN()};
   Float fontSizeMultiplier{std::numeric_limits<Float>::quiet_NaN()};
   std::optional<FontWeight> fontWeight{};
@@ -113,6 +114,7 @@ struct hash<facebook::react::TextAttributes> {
         textAttributes.backgroundColor,
         textAttributes.opacity,
         textAttributes.fontFamily,
+        textAttributes.fontVariationSettings,
         textAttributes.fontSize,
         textAttributes.fontSizeMultiplier,
         textAttributes.fontWeight,

--- a/ReactCommon/react/renderer/attributedstring/conversions.h
+++ b/ReactCommon/react/renderer/attributedstring/conversions.h
@@ -962,6 +962,9 @@ inline folly::dynamic toDynamic(const TextAttributes &textAttributes) {
   if (!textAttributes.fontFamily.empty()) {
     _textAttributes("fontFamily", textAttributes.fontFamily);
   }
+  if (!textAttributes.fontVariationSettings.empty()) {
+    _textAttributes("fontVariationSettings", textAttributes.fontVariationSettings);
+  }
   if (!std::isnan(textAttributes.fontSize)) {
     _textAttributes("fontSize", textAttributes.fontSize);
   }
@@ -1110,6 +1113,7 @@ constexpr static MapBuffer::Key TA_KEY_IS_HIGHLIGHTED = 20;
 constexpr static MapBuffer::Key TA_KEY_LAYOUT_DIRECTION = 21;
 constexpr static MapBuffer::Key TA_KEY_ACCESSIBILITY_ROLE = 22;
 constexpr static MapBuffer::Key TA_KEY_LINE_BREAK_STRATEGY = 23;
+constexpr static MapBuffer::Key TA_KEY_FONT_VARIATION_SETTINGS = 24;
 
 // constants for ParagraphAttributes serialization
 constexpr static MapBuffer::Key PA_KEY_MAX_NUMBER_OF_LINES = 0;
@@ -1176,6 +1180,9 @@ inline MapBuffer toMapBuffer(const TextAttributes &textAttributes) {
   }
   if (!textAttributes.fontFamily.empty()) {
     builder.putString(TA_KEY_FONT_FAMILY, textAttributes.fontFamily);
+  }
+  if (!textAttributes.fontVariationSettings.empty()) {
+    builder.putString(TA_KEY_FONT_VARIATION_SETTINGS, textAttributes.fontVariationSettings);
   }
   if (!std::isnan(textAttributes.fontSize)) {
     builder.putDouble(TA_KEY_FONT_SIZE, textAttributes.fontSize);

--- a/ReactCommon/react/renderer/components/text/BaseTextProps.cpp
+++ b/ReactCommon/react/renderer/components/text/BaseTextProps.cpp
@@ -37,6 +37,12 @@ static TextAttributes convertRawProp(
       "fontFamily",
       sourceTextAttributes.fontFamily,
       defaultTextAttributes.fontFamily);
+  textAttributes.fontVariationSettings = convertRawProp(
+      context,
+      rawProps,
+      "fontVariationSettings",
+      sourceTextAttributes.fontVariationSettings,
+      defaultTextAttributes.fontVariationSettings);
   textAttributes.fontSize = convertRawProp(
       context,
       rawProps,
@@ -297,6 +303,8 @@ void BaseTextProps::setProp(
         defaults, value, textAttributes, opacity, "opacity");
     REBUILD_FIELD_SWITCH_CASE(
         defaults, value, textAttributes, backgroundColor, "backgroundColor");
+    REBUILD_FIELD_SWITCH_CASE(
+        defaults, value, textAttributes, fontVariationSettings, "fontVariationSettings");
   }
 }
 

--- a/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
+++ b/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
@@ -204,6 +204,8 @@ AndroidTextInputProps::AndroidTextInputProps(
           convertRawProp(context, rawProps, "fontWeight", sourceProps.fontWeight, {})),
       fontFamily(CoreFeatures::enablePropIteratorSetter? sourceProps.fontFamily :
           convertRawProp(context, rawProps, "fontFamily", sourceProps.fontFamily, {})),
+      fontVariationSettings(CoreFeatures::enablePropIteratorSetter? sourceProps.fontVariationSettings :
+          convertRawProp(context, rawProps, "fontVariationSettings", sourceProps.fontVariationSettings, {})),
       textAlignVertical(CoreFeatures::enablePropIteratorSetter? sourceProps.textAlignVertical : convertRawProp(context, rawProps,
           "textAlignVertical",
           sourceProps.textAlignVertical,
@@ -373,6 +375,7 @@ void AndroidTextInputProps::setProp(
     RAW_SET_PROP_SWITCH_CASE_BASIC(includeFontPadding);
     RAW_SET_PROP_SWITCH_CASE_BASIC(fontWeight);
     RAW_SET_PROP_SWITCH_CASE_BASIC(fontFamily);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(fontVariationSettings);
     RAW_SET_PROP_SWITCH_CASE_BASIC(textAlignVertical);
     RAW_SET_PROP_SWITCH_CASE_BASIC(cursorColor);
     RAW_SET_PROP_SWITCH_CASE_BASIC(mostRecentEventCount);
@@ -475,6 +478,7 @@ folly::dynamic AndroidTextInputProps::getDynamic() const {
   props["includeFontPadding"] = includeFontPadding;
   props["fontWeight"] = fontWeight;
   props["fontFamily"] = fontFamily;
+  props["fontVariationSettings"] = fontVariationSettings;
   props["textAlignVertical"] = textAlignVertical;
   props["cursorColor"] = toAndroidRepr(cursorColor);
   props["mostRecentEventCount"] = mostRecentEventCount;

--- a/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputProps.h
+++ b/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputProps.h
@@ -160,6 +160,7 @@ class AndroidTextInputProps final : public ViewProps, public BaseTextProps {
   bool includeFontPadding{false};
   std::string fontWeight{};
   std::string fontFamily{};
+  std::string fontVariationSettings{};
   std::string textAlignVertical{};
   SharedColor cursorColor{};
   int mostRecentEventCount{0};

--- a/ReactCommon/react/renderer/textlayoutmanager/TextMeasureCache.h
+++ b/ReactCommon/react/renderer/textlayoutmanager/TextMeasureCache.h
@@ -91,6 +91,7 @@ inline bool areTextAttributesEquivalentLayoutWise(
   // colors).
   return std::tie(
              lhs.fontFamily,
+             lhs.fontVariationSettings,
              lhs.fontWeight,
              lhs.fontStyle,
              lhs.fontVariant,
@@ -99,6 +100,7 @@ inline bool areTextAttributesEquivalentLayoutWise(
              lhs.alignment) ==
       std::tie(
              rhs.fontFamily,
+             rhs.fontVariationSettings,
              rhs.fontWeight,
              rhs.fontStyle,
              rhs.fontVariant,
@@ -118,6 +120,7 @@ inline size_t textAttributesHashLayoutWise(
   return folly::hash::hash_combine(
       0,
       textAttributes.fontFamily,
+      textAttributes.fontVariationSettings,
       textAttributes.fontSize,
       textAttributes.fontSizeMultiplier,
       textAttributes.fontWeight,

--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -977,8 +977,8 @@ SPEC CHECKSUMS:
   boost: 57d2868c099736d80fcd648bf211b4431e51a558
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
-  FBLazyVector: d68947eddece25638eb0f642d1b957c90388afd1
-  FBReactNativeSpec: bfaf9508748c07260662ac4f7d773617856c3d45
+  FBLazyVector: 7f5b14c87d59cbd3f61dacc91e42c46d0fc1835f
+  FBReactNativeSpec: f317ccfd096eee7e4c7d460a7e4ebcef2ab2fe01
   Flipper: 6edb735e6c3e332975d1b17956bcc584eccf5818
   Flipper-Boost-iOSX: fd1e2b8cbef7e662a122412d7ac5f5bea715403c
   Flipper-DoubleConversion: 2dc99b02f658daf147069aad9dbd29d8feb06d30
@@ -989,47 +989,47 @@ SPEC CHECKSUMS:
   FlipperKit: 2efad7007d6745a3f95e4034d547be637f89d3f6
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
-  hermes-engine: 9dd16fe1cfa47002229300b94e89fc661e198b10
+  hermes-engine: 3dcfb57ed37db96fde5bc562cd10ce06d2505321
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OCMock: 9491e4bec59e0b267d52a9184ff5605995e74be8
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1
-  RCTRequired: 54a4f03dbbebb0cfdb4e2ba8d3b1d0b1258f8c08
-  RCTTypeSafety: a41e253b4ed644708899857d912b2f50c7b6214d
-  React: 2fc6c4c656cccd6753016528ad41199c16fd558e
-  React-callinvoker: a7d5e883a83bb9bd3985b08be832c5e76451d18f
+  RCTRequired: 341e124c7aeaa740095b710865c51651a01e2174
+  RCTTypeSafety: 0270d4f34052b1df9641d65bf95a4c8b7c8c2917
+  React: 4dd22759ab9729ea9dee7b314ead6010f2433bce
+  React-callinvoker: 881e975b0c4ea29532599aa0aed9a0378fb0d2e0
   React-Codegen: 1d5974f7b1384b458c5e38f1aad902d0bfce1c80
-  React-Core: 279a6e5ee79e88faa99157169b560c49635973d7
-  React-CoreModules: d3ee40954b381edc514301341e8b895febfc1848
-  React-cxxreact: aff243750dad852080636e615d7ae5639381735b
-  React-Fabric: 6b5c30b6e60a85446cc5d3702fa262fd1fc15619
-  React-graphics: e70886fff4b79bec3745de761900a770029591f2
-  React-hermes: 7f0e87d44b1c7cfbdd11aa3c070d04435fe75d57
-  React-ImageManager: 9fd3521fb8871cd5bea83d2d282da27d6ef91199
-  React-jsi: e4c75a1cf727c8761908ac2eeb1084e47ba88a26
-  React-jsiexecutor: 8361f78286021782d885e0888bb059a4045c59b9
-  React-jsinspector: 9b56a373a6797114e1d89a7dffa98ee98af67a8f
-  React-logger: 07c9b44040a6f948b8e2033207b23cb623f0b9b4
-  React-perflogger: b4b9fb2ddd856b78003708ab3cf66ce03e6bc7c4
-  React-RCTActionSheet: 1b1501ef80928be10702cd0ce09120358094cd82
-  React-RCTAnimation: 6741f7be3e269e057c1426074cc70f34b56e114b
-  React-RCTAppDelegate: 0b3b2c1e02c02f952f5033535ddb23d690e3b890
-  React-RCTBlob: fd1ee93e48aa67b0183346a59754375de93de63d
-  React-RCTFabric: 179b2203e1b8b89b6ec8fa6104071beb553b1684
-  React-RCTImage: 055685a12c88939437f6520d9e7c120cd666cbf1
-  React-RCTLinking: b149b3ff1f96fa93fc445230b9c171adb0e5572c
-  React-RCTNetwork: 21abb4231182651f48b7035beaa011b1ab7ae8f4
-  React-RCTPushNotification: f3af966de34c1fe2df8860625d225fb2f581d15e
-  React-RCTSettings: 64b6acabfddf7f96796229b101bd91f46d14391b
-  React-RCTTest: 81ebfa8c2e1b0b482effe12485e6486dc0ff70d7
-  React-RCTText: 4e5ae05b778a0ed2b22b012af025da5e1a1c4e54
-  React-RCTVibration: ecfd04c1886a9c9a4e31a466c0fbcf6b36e92fde
-  React-rncore: 3ef1d281e86300d2c8f97625f4a2fcea6602c5d5
-  React-runtimeexecutor: c7b2cd6babf6cc50340398bfbb7a9da13c93093f
-  ReactCommon: fdc30b91d89bfd2ed919c2cbccb460435f1f43f4
+  React-Core: 3b427ca257653b3c8367edf7c59acb143102b29b
+  React-CoreModules: 7c8adcf54a63a270454727cf0b7d2093922d1fed
+  React-cxxreact: 961d2d840ae5aa4a1f376898c54205752d4d995e
+  React-Fabric: 1655c0c8ca74023b252e5abebc8f7848bd2372ef
+  React-graphics: e0bb6d65cea68ec44dfdce5b68e441aa2b2bf5e9
+  React-hermes: 5b6da5580452e8ff9eab2a99ba608097ca11e932
+  React-ImageManager: 63ca6dd489078633db3d65b03092f167d659b080
+  React-jsi: 87eebc68ac1db5d67858c911277e92ad194fa2fe
+  React-jsiexecutor: efd5ec285a16a902127d755d6272ff55014f61fa
+  React-jsinspector: da7c5e80c8103d594397e8b66d49b61d4b634c57
+  React-logger: f0844097ffaa1b20a4c3c8f87411e81b43ad5a18
+  React-perflogger: 92344b30fa4eeb307b76278939bcc7569f5b840d
+  React-RCTActionSheet: 1be7fd68ffd36d23194c4e1168f93a4bafca3773
+  React-RCTAnimation: 11b1eca0972026d26cf03b1ab7fe7800bba13631
+  React-RCTAppDelegate: 6b4bd71937d1e0aae3588994a634773ad246a50f
+  React-RCTBlob: b2a7736a758071b61193965bdac219337db7a79b
+  React-RCTFabric: 3d777492812c530914e9079aefbfbc94689f0d31
+  React-RCTImage: f928320ef53f29a7bd5342d3114b3fc3d3f5aaba
+  React-RCTLinking: 1d75a2c2ee34361c8b09dd3d49ee3982ab26550c
+  React-RCTNetwork: d902618db27b9c3ceebc69875475aae48dc49a99
+  React-RCTPushNotification: df3fb162740e5e1aa1dc866f52a1e63903e756f7
+  React-RCTSettings: e62244e32a7f22580b0dbc127e7ef04cddbf76ba
+  React-RCTTest: 3f5ee495092f348c840561c1bbef26adaafcfb33
+  React-RCTText: 85ddee7f221352dc1dc08d3428aa6e842f9f1777
+  React-RCTVibration: d2ab1c9bf67ff685d7d3e1b814381c7c386b5ff4
+  React-rncore: ef0d20706b095a6209c20501db744a21cc6b6a85
+  React-runtimeexecutor: e120409bcfdc321ccd92f3605788b682cacd4674
+  ReactCommon: 57c33e91e642d7e39ce5265fdc78185b30cce3b8
   ScreenshotManager: fb68e0677077569df974c9cbeaeb54f764d002ba
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
-  Yoga: 1b1a12ff3d86a10565ea7cbe057d42f5e5fb2a07
+  Yoga: 80f0459cdd947d8ed9e81c0596e5df7a55e51602
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
 PODFILE CHECKSUM: 041d77a36c7a31e8cd4f62ad87890e1436d3e1a9

--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -977,8 +977,8 @@ SPEC CHECKSUMS:
   boost: 57d2868c099736d80fcd648bf211b4431e51a558
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
-  FBLazyVector: 7f5b14c87d59cbd3f61dacc91e42c46d0fc1835f
-  FBReactNativeSpec: f317ccfd096eee7e4c7d460a7e4ebcef2ab2fe01
+  FBLazyVector: d68947eddece25638eb0f642d1b957c90388afd1
+  FBReactNativeSpec: bfaf9508748c07260662ac4f7d773617856c3d45
   Flipper: 6edb735e6c3e332975d1b17956bcc584eccf5818
   Flipper-Boost-iOSX: fd1e2b8cbef7e662a122412d7ac5f5bea715403c
   Flipper-DoubleConversion: 2dc99b02f658daf147069aad9dbd29d8feb06d30
@@ -989,47 +989,47 @@ SPEC CHECKSUMS:
   FlipperKit: 2efad7007d6745a3f95e4034d547be637f89d3f6
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
-  hermes-engine: 3dcfb57ed37db96fde5bc562cd10ce06d2505321
+  hermes-engine: 7907a32084d03d32827639c9d977a4581ab0ef71
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OCMock: 9491e4bec59e0b267d52a9184ff5605995e74be8
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1
-  RCTRequired: 341e124c7aeaa740095b710865c51651a01e2174
-  RCTTypeSafety: 0270d4f34052b1df9641d65bf95a4c8b7c8c2917
-  React: 4dd22759ab9729ea9dee7b314ead6010f2433bce
-  React-callinvoker: 881e975b0c4ea29532599aa0aed9a0378fb0d2e0
+  RCTRequired: 54a4f03dbbebb0cfdb4e2ba8d3b1d0b1258f8c08
+  RCTTypeSafety: a41e253b4ed644708899857d912b2f50c7b6214d
+  React: 2fc6c4c656cccd6753016528ad41199c16fd558e
+  React-callinvoker: a7d5e883a83bb9bd3985b08be832c5e76451d18f
   React-Codegen: 1d5974f7b1384b458c5e38f1aad902d0bfce1c80
-  React-Core: 3b427ca257653b3c8367edf7c59acb143102b29b
-  React-CoreModules: 7c8adcf54a63a270454727cf0b7d2093922d1fed
-  React-cxxreact: 961d2d840ae5aa4a1f376898c54205752d4d995e
-  React-Fabric: 1655c0c8ca74023b252e5abebc8f7848bd2372ef
-  React-graphics: e0bb6d65cea68ec44dfdce5b68e441aa2b2bf5e9
-  React-hermes: 5b6da5580452e8ff9eab2a99ba608097ca11e932
-  React-ImageManager: 63ca6dd489078633db3d65b03092f167d659b080
-  React-jsi: 87eebc68ac1db5d67858c911277e92ad194fa2fe
-  React-jsiexecutor: efd5ec285a16a902127d755d6272ff55014f61fa
-  React-jsinspector: da7c5e80c8103d594397e8b66d49b61d4b634c57
-  React-logger: f0844097ffaa1b20a4c3c8f87411e81b43ad5a18
-  React-perflogger: 92344b30fa4eeb307b76278939bcc7569f5b840d
-  React-RCTActionSheet: 1be7fd68ffd36d23194c4e1168f93a4bafca3773
-  React-RCTAnimation: 11b1eca0972026d26cf03b1ab7fe7800bba13631
-  React-RCTAppDelegate: 6b4bd71937d1e0aae3588994a634773ad246a50f
-  React-RCTBlob: b2a7736a758071b61193965bdac219337db7a79b
-  React-RCTFabric: 3d777492812c530914e9079aefbfbc94689f0d31
-  React-RCTImage: f928320ef53f29a7bd5342d3114b3fc3d3f5aaba
-  React-RCTLinking: 1d75a2c2ee34361c8b09dd3d49ee3982ab26550c
-  React-RCTNetwork: d902618db27b9c3ceebc69875475aae48dc49a99
-  React-RCTPushNotification: df3fb162740e5e1aa1dc866f52a1e63903e756f7
-  React-RCTSettings: e62244e32a7f22580b0dbc127e7ef04cddbf76ba
-  React-RCTTest: 3f5ee495092f348c840561c1bbef26adaafcfb33
-  React-RCTText: 85ddee7f221352dc1dc08d3428aa6e842f9f1777
-  React-RCTVibration: d2ab1c9bf67ff685d7d3e1b814381c7c386b5ff4
-  React-rncore: ef0d20706b095a6209c20501db744a21cc6b6a85
-  React-runtimeexecutor: e120409bcfdc321ccd92f3605788b682cacd4674
-  ReactCommon: 57c33e91e642d7e39ce5265fdc78185b30cce3b8
+  React-Core: 279a6e5ee79e88faa99157169b560c49635973d7
+  React-CoreModules: d3ee40954b381edc514301341e8b895febfc1848
+  React-cxxreact: aff243750dad852080636e615d7ae5639381735b
+  React-Fabric: 6b5c30b6e60a85446cc5d3702fa262fd1fc15619
+  React-graphics: e70886fff4b79bec3745de761900a770029591f2
+  React-hermes: 7f0e87d44b1c7cfbdd11aa3c070d04435fe75d57
+  React-ImageManager: 9fd3521fb8871cd5bea83d2d282da27d6ef91199
+  React-jsi: e4c75a1cf727c8761908ac2eeb1084e47ba88a26
+  React-jsiexecutor: 8361f78286021782d885e0888bb059a4045c59b9
+  React-jsinspector: 9b56a373a6797114e1d89a7dffa98ee98af67a8f
+  React-logger: 07c9b44040a6f948b8e2033207b23cb623f0b9b4
+  React-perflogger: b4b9fb2ddd856b78003708ab3cf66ce03e6bc7c4
+  React-RCTActionSheet: 1b1501ef80928be10702cd0ce09120358094cd82
+  React-RCTAnimation: 6741f7be3e269e057c1426074cc70f34b56e114b
+  React-RCTAppDelegate: 0b3b2c1e02c02f952f5033535ddb23d690e3b890
+  React-RCTBlob: fd1ee93e48aa67b0183346a59754375de93de63d
+  React-RCTFabric: 179b2203e1b8b89b6ec8fa6104071beb553b1684
+  React-RCTImage: 055685a12c88939437f6520d9e7c120cd666cbf1
+  React-RCTLinking: b149b3ff1f96fa93fc445230b9c171adb0e5572c
+  React-RCTNetwork: 21abb4231182651f48b7035beaa011b1ab7ae8f4
+  React-RCTPushNotification: f3af966de34c1fe2df8860625d225fb2f581d15e
+  React-RCTSettings: 64b6acabfddf7f96796229b101bd91f46d14391b
+  React-RCTTest: 81ebfa8c2e1b0b482effe12485e6486dc0ff70d7
+  React-RCTText: 4e5ae05b778a0ed2b22b012af025da5e1a1c4e54
+  React-RCTVibration: ecfd04c1886a9c9a4e31a466c0fbcf6b36e92fde
+  React-rncore: 3ef1d281e86300d2c8f97625f4a2fcea6602c5d5
+  React-runtimeexecutor: c7b2cd6babf6cc50340398bfbb7a9da13c93093f
+  ReactCommon: fdc30b91d89bfd2ed919c2cbccb460435f1f43f4
   ScreenshotManager: fb68e0677077569df974c9cbeaeb54f764d002ba
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
-  Yoga: 80f0459cdd947d8ed9e81c0596e5df7a55e51602
+  Yoga: 1b1a12ff3d86a10565ea7cbe057d42f5e5fb2a07
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
 PODFILE CHECKSUM: 041d77a36c7a31e8cd4f62ad87890e1436d3e1a9

--- a/packages/rn-tester/js/examples/Text/TextExample.android.js
+++ b/packages/rn-tester/js/examples/Text/TextExample.android.js
@@ -204,6 +204,24 @@ class TextExample extends React.Component<{...}> {
   render(): React.Node {
     return (
       <RNTesterPage title="<Text>">
+        <RNTesterBlock title="Font Variation Settings">
+          <Text
+            style={{
+              fontFamily: 'MaterialSymbolsSharp',
+              fontVariationSettings: "'wght' 100, 'FILL' 0",
+              fontSize: 64,
+            }}>
+            {String.fromCodePoint(59576)}
+          </Text>
+          <Text
+            style={{
+              fontFamily: 'MaterialSymbolsSharp',
+              fontVariationSettings: "'wght' 600, 'FILL' 1",
+              fontSize: 64,
+            }}>
+            {String.fromCodePoint(59576)}
+          </Text>
+        </RNTesterBlock>
         <RNTesterBlock title="Dynamic Font Size Adjustment">
           <AdjustingFontSize />
         </RNTesterBlock>


### PR DESCRIPTION
## Summary

This PR adds font variation settings feature for variable fonts in react native. The `fontVariationSettings` property provides low-level control over [variable font](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Fonts/Variable_Fonts_Guide) characteristics, by specifying the four letter axis names of the characteristics you want to vary, along with their values.

Registered axes are the most commonly encountered — common enough that the authors of the specification felt they were worth standardizing. Note that this doesn't mean that the author has to include all of these in their font.

Custom axes can be anything the font designer wants to vary in their font, for example ascender or descender heights, the size of serifs, or anything else they can imagine. Any axis can be used as long as it is given a unique 4-character axis. Some will end up becoming more common, and may even become registered over time.


Example:

```ts
<Text
  style={{
    fontFamily: 'MaterialSymbolsSharp',
    fontVariationSettings: "'wght' 100, 'FILL' 0",
  }}>
  {String.fromCodePoint(59576)}
</Text>
```

Font characteristics set using `fontVariationSettings` will always override those set using the corresponding basic font properties, e.g. `fontWeight` regardless of the order. 

Android reference: https://developer.android.com/reference/android/graphics/fonts/FontVariationAxis
iOS reference: https://developer.apple.com/documentation/coretext/kctfontvariationattribute
MDN reference: https://developer.mozilla.org/en-US/docs/Web/CSS/font-variation-settings
Spec: https://learn.microsoft.com/en-us/typography/opentype/spec/otvaroverview

## Changelog

[General] [Added] - add fontVariationSettings support for variable font 

## Test Plan

TBD
