### PR TITLE
[Codegen 77] Extract the functions to compute partial properties in the Flow and TypeScript parsers.

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-test.js
@@ -110,6 +110,61 @@ describe('FlowParser', () => {
       expect(parser.callExpressionTypeParameters(node)).toBe(null);
     });
   });
+
+  describe('computePartialProperties', () => {
+    it('returns partial properties', () => {
+      const properties = [
+        {
+          type: 'ObjectTypeProperty',
+          key: {
+            type: 'Identifier',
+            name: 'a',
+          },
+          value: {
+            type: 'StringTypeAnnotation',
+            range: [],
+          },
+        },
+        {
+          type: 'ObjectTypeProperty',
+          key: {
+            type: 'Identifier',
+            name: 'b',
+          },
+          optional: true,
+          value: {
+            type: 'BooleanTypeAnnotation',
+            range: [],
+          },
+        },
+      ];
+
+      const expected = [
+        {
+          name: 'a',
+          optional: true,
+          typeAnnotation: {type: 'StringTypeAnnotation'},
+        },
+        {
+          name: 'b',
+          optional: true,
+          typeAnnotation: {type: 'BooleanTypeAnnotation'},
+        },
+      ];
+
+      expect(
+        parser.computePartialProperties(
+          properties,
+          'hasteModuleName',
+          {},
+          {},
+          {},
+          () => null,
+          false,
+        ),
+      ).toEqual(expected);
+    });
+  });
 });
 
 describe('TypeScriptParser', () => {
@@ -200,6 +255,75 @@ describe('TypeScriptParser', () => {
     it('returns null if it is a invalid node', () => {
       const node = {};
       expect(parser.callExpressionTypeParameters(node)).toBe(null);
+    });
+  });
+
+  describe('computePartialProperties', () => {
+    it('returns partial properties', () => {
+      const properties = [
+        {
+          type: 'TSPropertySignature',
+          key: {
+            type: 'Identifier',
+            name: 'a',
+          },
+          typeAnnotation: {
+            type: 'TSTypeAnnotation',
+            typeAnnotation: {
+              type: 'TSTypeLiteral',
+              key: {
+                type: 'Identifier',
+                name: 'a',
+              },
+              members: [],
+            },
+          },
+        },
+        {
+          type: 'TSPropertySignature',
+          key: {
+            type: 'Identifier',
+            name: 'b',
+          },
+          optional: true,
+          typeAnnotation: {
+            type: 'TSTypeAnnotation',
+            typeAnnotation: {
+              type: 'TSStringKeyword',
+              key: {
+                type: 'Identifier',
+                name: 'b',
+              },
+              members: [],
+            },
+          },
+        },
+      ];
+
+      const expected = [
+        {
+          name: 'a',
+          optional: true,
+          typeAnnotation: {properties: [], type: 'ObjectTypeAnnotation'},
+        },
+        {
+          name: 'b',
+          optional: true,
+          typeAnnotation: {type: 'StringTypeAnnotation'},
+        },
+      ];
+
+      expect(
+        parser.computePartialProperties(
+          properties,
+          'hasteModuleName',
+          {},
+          {},
+          {},
+          () => null,
+          false,
+        ),
+      ).toEqual(expected);
     });
   });
 });

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -172,22 +172,15 @@ function translateTypeAnnotation(
             parser,
           );
 
-          const properties = annotatedElement.right.properties.map(prop => {
-            return {
-              name: prop.key.name,
-              optional: true,
-              typeAnnotation: translateTypeAnnotation(
-                hasteModuleName,
-                prop.value,
-                types,
-                aliasMap,
-                enumMap,
-                tryParse,
-                cxxOnly,
-                parser,
-              ),
-            };
-          });
+          const properties = parser.computePartialProperties(
+            annotatedElement.right.properties,
+            hasteModuleName,
+            types,
+            aliasMap,
+            enumMap,
+            tryParse,
+            cxxOnly,
+          );
 
           return emitObject(nullable, properties);
         }

--- a/packages/react-native-codegen/src/parsers/flow/parser.js
+++ b/packages/react-native-codegen/src/parsers/flow/parser.js
@@ -18,10 +18,14 @@ import type {
   NativeModuleParamTypeAnnotation,
   NativeModuleEnumMemberType,
   NativeModuleEnumMembers,
+  NativeModuleAliasMap,
+  NativeModuleEnumMap,
 } from '../../CodegenSchema';
 import type {ParserType} from '../errors';
 import type {Parser} from '../parser';
-import type {TypeDeclarationMap} from '../utils';
+import type {ParserErrorCapturer, TypeDeclarationMap} from '../utils';
+
+const {flowTranslateTypeAnnotation} = require('./modules');
 
 // $FlowFixMe[untyped-import] there's no flowtype flow-parser
 const flowParser = require('flow-parser');
@@ -256,6 +260,33 @@ class FlowParser implements Parser {
 
   callExpressionTypeParameters(callExpression: $FlowFixMe): $FlowFixMe | null {
     return callExpression.typeArguments || null;
+  }
+
+  computePartialProperties(
+    properties: Array<$FlowFixMe>,
+    hasteModuleName: string,
+    types: TypeDeclarationMap,
+    aliasMap: {...NativeModuleAliasMap},
+    enumMap: {...NativeModuleEnumMap},
+    tryParse: ParserErrorCapturer,
+    cxxOnly: boolean,
+  ): Array<$FlowFixMe> {
+    return properties.map(prop => {
+      return {
+        name: prop.key.name,
+        optional: true,
+        typeAnnotation: flowTranslateTypeAnnotation(
+          hasteModuleName,
+          prop.value,
+          types,
+          aliasMap,
+          enumMap,
+          tryParse,
+          cxxOnly,
+          this,
+        ),
+      };
+    });
   }
 }
 

--- a/packages/react-native-codegen/src/parsers/parser.js
+++ b/packages/react-native-codegen/src/parsers/parser.js
@@ -18,9 +18,11 @@ import type {
   NativeModuleParamTypeAnnotation,
   NativeModuleEnumMemberType,
   NativeModuleEnumMembers,
+  NativeModuleAliasMap,
+  NativeModuleEnumMap,
 } from '../CodegenSchema';
 import type {ParserType} from './errors';
-import type {TypeDeclarationMap} from './utils';
+import type {ParserErrorCapturer, TypeDeclarationMap} from './utils';
 
 /**
  * This is the main interface for Parsers of various languages.
@@ -181,4 +183,25 @@ export interface Parser {
    * @returns: the typeParameters of the callExpression or null if it does not exist.
    */
   callExpressionTypeParameters(callExpression: $FlowFixMe): $FlowFixMe | null;
+
+  /**
+   * Given an array of properties from a Partial type, it returns an array of remaped properties.
+   * @paramater properties: properties from a Partial types.
+   * @parameter hasteModuleName: a string with the native module name.
+   * @paramater types: a map of type declarations.
+   * @paramater aliasMap: a map of type aliases.
+   * @paramater enumMap: a map of type enums.
+   * @paramater tryParse: a parser error capturer.
+   * @paramater cxxOnly: a boolean specifying if the module is Cxx only.
+   * @returns: an array of remaped properties
+   */
+  computePartialProperties(
+    properties: Array<$FlowFixMe>,
+    hasteModuleName: string,
+    types: TypeDeclarationMap,
+    aliasMap: {...NativeModuleAliasMap},
+    enumMap: {...NativeModuleEnumMap},
+    tryParse: ParserErrorCapturer,
+    cxxOnly: boolean,
+  ): Array<$FlowFixMe>;
 }

--- a/packages/react-native-codegen/src/parsers/parserMock.js
+++ b/packages/react-native-codegen/src/parsers/parserMock.js
@@ -20,8 +20,10 @@ import type {
   NativeModuleParamTypeAnnotation,
   NativeModuleEnumMemberType,
   NativeModuleEnumMembers,
+  NativeModuleAliasMap,
+  NativeModuleEnumMap,
 } from '../CodegenSchema';
-import type {TypeDeclarationMap} from './utils';
+import type {ParserErrorCapturer, TypeDeclarationMap} from './utils';
 
 // $FlowFixMe[untyped-import] there's no flowtype flow-parser
 const flowParser = require('flow-parser');
@@ -183,5 +185,28 @@ export class MockedParser implements Parser {
 
   callExpressionTypeParameters(callExpression: $FlowFixMe): $FlowFixMe | null {
     return callExpression.typeArguments || null;
+  }
+
+  computePartialProperties(
+    properties: Array<$FlowFixMe>,
+    hasteModuleName: string,
+    types: TypeDeclarationMap,
+    aliasMap: {...NativeModuleAliasMap},
+    enumMap: {...NativeModuleEnumMap},
+    tryParse: ParserErrorCapturer,
+    cxxOnly: boolean,
+  ): Array<$FlowFixMe> {
+    return [
+      {
+        name: 'a',
+        optional: true,
+        typeAnnotation: {type: 'StringTypeAnnotation'},
+      },
+      {
+        name: 'b',
+        optional: true,
+        typeAnnotation: {type: 'BooleanTypeAnnotation'},
+      },
+    ];
   }
 }

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -253,23 +253,14 @@ function translateTypeAnnotation(
             parser,
           );
 
-          const properties = annotatedElement.typeAnnotation.members.map(
-            member => {
-              return {
-                name: member.key.name,
-                optional: true,
-                typeAnnotation: translateTypeAnnotation(
-                  hasteModuleName,
-                  member.typeAnnotation.typeAnnotation,
-                  types,
-                  aliasMap,
-                  enumMap,
-                  tryParse,
-                  cxxOnly,
-                  parser,
-                ),
-              };
-            },
+          const properties = parser.computePartialProperties(
+            annotatedElement.typeAnnotation.members,
+            hasteModuleName,
+            types,
+            aliasMap,
+            enumMap,
+            tryParse,
+            cxxOnly,
           );
 
           return emitObject(nullable, properties);

--- a/packages/react-native-codegen/src/parsers/typescript/parser.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parser.js
@@ -18,10 +18,14 @@ import type {
   NativeModuleParamTypeAnnotation,
   NativeModuleEnumMembers,
   NativeModuleEnumMemberType,
+  NativeModuleAliasMap,
+  NativeModuleEnumMap,
 } from '../../CodegenSchema';
 import type {ParserType} from '../errors';
 import type {Parser} from '../parser';
-import type {TypeDeclarationMap} from '../utils';
+import type {ParserErrorCapturer, TypeDeclarationMap} from '../utils';
+
+const {typeScriptTranslateTypeAnnotation} = require('./modules');
 
 // $FlowFixMe[untyped-import] Use flow-types for @babel/parser
 const babelParser = require('@babel/parser');
@@ -243,7 +247,35 @@ class TypeScriptParser implements Parser {
   callExpressionTypeParameters(callExpression: $FlowFixMe): $FlowFixMe | null {
     return callExpression.typeParameters || null;
   }
+
+  computePartialProperties(
+    properties: Array<$FlowFixMe>,
+    hasteModuleName: string,
+    types: TypeDeclarationMap,
+    aliasMap: {...NativeModuleAliasMap},
+    enumMap: {...NativeModuleEnumMap},
+    tryParse: ParserErrorCapturer,
+    cxxOnly: boolean,
+  ): Array<$FlowFixMe> {
+    return properties.map(prop => {
+      return {
+        name: prop.key.name,
+        optional: true,
+        typeAnnotation: typeScriptTranslateTypeAnnotation(
+          hasteModuleName,
+          prop.typeAnnotation.typeAnnotation,
+          types,
+          aliasMap,
+          enumMap,
+          tryParse,
+          cxxOnly,
+          this,
+        ),
+      };
+    });
+  }
 }
+
 module.exports = {
   TypeScriptParser,
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

This PR aims to extract  the switch(configType) block from the buildSchema function into a separate function in a shared file between typescript and flow. It is a task of #34872:
> [Codegen 77 - assigned to @MaeIg] Extract the functions to compute partial properties from the index.js file ([Flow](https://github.com/facebook/react-native/blob/main/packages/react-native-codegen/src/parsers/flow/modules/index.js#L180-L194) and [TypeScript](https://github.com/facebook/react-native/blob/main/packages/react-native-codegen/src/parsers/typescript/modules/index.js#L261-L278))in the Flow and TypeScript parsers.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
[Internal] [Changed] - Extract the functions to compute partial properties in the Flow and TypeScript parsers.

## Test Plan

yarn flow:
<img width="560" alt="image" src="https://user-images.githubusercontent.com/40902940/222934040-97e88691-c1d6-44a1-b7ee-e500b4698cd2.png">

yarn lint:
<img width="509" alt="image" src="https://user-images.githubusercontent.com/40902940/222934137-05b6f1fd-a755-4323-baac-5954d36fd613.png">

yarn test
<img width="388" alt="image" src="https://user-images.githubusercontent.com/40902940/222934145-76a2bc38-7469-4c30-9301-bc21cfadded4.png">
