### PR TITLE
[Upstream] Remove assumptions on super's description

### DIFF
--- a/Libraries/Text/Text/RCTTextView.m
+++ b/Libraries/Text/Text/RCTTextView.m
@@ -38,10 +38,8 @@
 
 - (NSString *)description
 {
-  NSString *superDescription = super.description;
-  NSRange replacementRange = [superDescription rangeOfString:@">"];
-  NSString *replacement = [NSString stringWithFormat:@"; reactTag: %@; text: %@>", self.reactTag, _textStorage.string];
-  return [superDescription stringByReplacingCharactersInRange:replacementRange withString:replacement];
+  NSString *stringToAppend = [NSString stringWithFormat:@" reactTag: %@; text: %@", self.reactTag, _textStorage.string];
+  return [[super description] stringByAppendingString:stringToAppend];
 }
 
 - (void)setSelectable:(BOOL)selectable

--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -452,10 +452,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
 
 - (NSString *)description
 {
-  NSString *superDescription = super.description;
-  NSRange semicolonRange = [superDescription rangeOfString:@";"];
-  NSString *replacement = [NSString stringWithFormat:@"; reactTag: %@;", self.reactTag];
-  return [superDescription stringByReplacingCharactersInRange:semicolonRange withString:replacement];
+  return [[super description] stringByAppendingFormat:@" reactTag: %@; frame = %@; layer = %@", self.reactTag, NSStringFromCGRect(self.frame), self.layer];
 }
 
 #pragma mark - Statics for dealing with layoutGuides


### PR DESCRIPTION
## Summary

This is a change upstreamed from our fork, React Native macOS: https://github.com/microsoft/react-native-macos/pull/1088

Original description:

>We hit some crashes where replacing the chars in the string in the description was happening at an invalid range. That caused investigation into what these description methods are doing. We shouldn't have code assuming super's description will return in a certain format. Instead, just append any additional info we want to add to the end of the description.

## Changelog

[IOS] [CHANGED] -Remove assumptions on super's description

## Test Plan

CI should pass
