### PR TITLE
Move iOS executor to M1 machines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ references:
   #        Dependency Anchors
   # -------------------------
   dependency_versions:
-    xcode_version: &xcode_version "14.0.1"
+    xcode_version: &xcode_version "14.2.0"
     nodelts_image: &nodelts_image "cimg/node:18.12.1"
     nodeprevlts_image: &nodeprevlts_image "cimg/node:16.18.1"
 
@@ -128,7 +128,7 @@ executors:
     <<: *defaults
     macos:
       xcode: *xcode_version
-    resource_class: macos.x86.medium.gen2
+    resource_class: macos.m1.large.gen1
     environment:
       - BUILD_FROM_SOURCE: true
 
@@ -174,18 +174,17 @@ commands:
           name: Bundle Install
           command: |
             # Check if rbenv is installed. CircleCI is migrating to rbenv so we may not need to always install it.
-
-            if [[ "$(command -v rbenv &> /dev/null)" ]]; then
-              echo "rbenv found; Skipping installation"
-            else
+            if [[ -z "$(command -v rbenv)" ]]; then
               brew install rbenv ruby-build
-            fi
 
-            # Load and init rbenv
-            (rbenv init 2> /dev/null) || true
-            echo '' >>  ~/.bash_profile
-            echo 'eval "$(rbenv init - bash)"' >> ~/.bash_profile
-            source ~/.bash_profile
+              # Load and init rbenv
+              (rbenv init 2> /dev/null) || true
+              echo '' >>  ~/.bash_profile
+              echo 'eval "$(rbenv init - bash)"' >> ~/.bash_profile
+              source ~/.bash_profile
+            else
+              echo "rbenv found; Skipping installation"
+            fi
 
             # Install the right version of ruby
             if [[ -z "$(rbenv versions | grep << parameters.ruby_version >>)" ]]; then
@@ -194,6 +193,8 @@ commands:
 
             # Set ruby dependencies
             rbenv global << parameters.ruby_version >>
+
+            echo ">>> using bundler"
             bundle check || bundle install --path vendor/bundle --clean
       - save_cache:
           key: *rbenv_cache_key
@@ -216,6 +217,14 @@ commands:
             - << parameters.yarn_base_cache_key >>-{{ arch }}-{{ checksum "yarn.lock" }}
             - << parameters.yarn_base_cache_key >>-{{ arch }}
             - << parameters.yarn_base_cache_key >>
+      - run:
+          name: "Install Yarn if needed"
+          command: |
+            if [[ -z "$(command -v yarn)" ]]; then
+              npm install --global yarn
+            else
+              echo "Yarn installed; Skipping"
+            fi
       - run:
           name: "Yarn: Install Dependencies"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,7 @@ references:
     windows_yarn_cache_key: &windows_yarn_cache_key v1-win-yarn-cache-{{ arch }}-{{ checksum "yarn.lock" }}
     windows_choco_cache_key: &windows_choco_cache_key v1-win-choco-cache-{{ .Environment.CIRCLE_JOB }}
     yarn_cache_key: &yarn_cache_key v5-yarn-cache-{{ .Environment.CIRCLE_JOB }}
+    rbenv_cache_key: &rbenv_cache_key v1-rbenv-{{ checksum "/tmp/required_ruby" }}
 
   cache_paths:
     hermes_workspace_macos_cache_paths: &hermes_workspace_macos_cache_paths
@@ -157,14 +158,47 @@ commands:
           command: mkdir -p ./reports/{buck,build,junit,outputs}
 
   setup_ruby:
+    parameters:
+      ruby_version:
+        default: "2.6.10"
+        type: string
     steps:
       - restore_cache:
           key: *gems_cache_key
       - run:
+          name: Set Required Ruby
+          command: echo << parameters.ruby_version >> > /tmp/required_ruby
+      - restore_cache:
+          key: *rbenv_cache_key
+      - run:
           name: Bundle Install
           command: |
-            source /usr/local/share/chruby/auto.sh
+            # Check if rbenv is installed. CircleCI is migrating to rbenv so we may not need to always install it.
+
+            if [[ "$(command -v rbenv &> /dev/null)" ]]; then
+              echo "rbenv found; Skipping installation"
+            else
+              brew install rbenv ruby-build
+            fi
+
+            # Load and init rbenv
+            (rbenv init 2> /dev/null) || true
+            echo '' >>  ~/.bash_profile
+            echo 'eval "$(rbenv init - bash)"' >> ~/.bash_profile
+            source ~/.bash_profile
+
+            # Install the right version of ruby
+            if [[ -z "$(rbenv versions | grep << parameters.ruby_version >>)" ]]; then
+              rbenv install << parameters.ruby_version >>
+            fi
+
+            # Set ruby dependencies
+            rbenv global << parameters.ruby_version >>
             bundle check || bundle install --path vendor/bundle --clean
+      - save_cache:
+          key: *rbenv_cache_key
+          paths:
+            - ~/.rbenv
       - save_cache:
           key: *gems_cache_key
           paths:
@@ -614,7 +648,8 @@ jobs:
 
       - run:
           name: Setup the CocoaPods environment
-          command: bundle exec pod setup
+          command: |
+            bundle exec pod setup
 
       - with_hermes_tarball_cache_span:
           set_tarball_path: True
@@ -869,6 +904,7 @@ jobs:
       - attach_workspace:
           at: .
       - *attach_hermes_workspace
+      - setup_ruby
       - when:
           condition:
             equal: ["Hermes", << parameters.jsengine >>]
@@ -892,8 +928,6 @@ jobs:
           command: |
             cd /tmp/$PROJECT_NAME/ios
 
-            bundle install
-
             if [[ << parameters.flavor >> == "Release" ]]; then
               export PRODUCTION=1
             fi
@@ -916,6 +950,7 @@ jobs:
               export USE_FRAMEWORKS=dynamic
             fi
 
+            bundle install
             bundle exec pod install
       - run:
           name: Build template project
@@ -954,7 +989,7 @@ jobs:
           name: Delete iOS Simulators
           background: true
           command: sudo rm -rf /Library/Developer/CoreSimulator/Profiles/Runtimes/
-
+      - setup_ruby
       - with_hermes_tarball_cache_span:
           set_tarball_path: True
           steps:
@@ -972,6 +1007,7 @@ jobs:
                   fi
 
                   cd packages/rn-tester
+
                   bundle install
                   bundle exec pod install
 


### PR DESCRIPTION
## Summary

This change moves our Executor to M1 machines. This increase the class size (which can speedup the CI).

## Changelog

[iOS][Changed] - Use M1 machines in CI

## Test Plan

CircleCI should stay green
