### PR TITLE
Add tests with more recent Rubies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,7 @@ references:
     windows_yarn_cache_key: &windows_yarn_cache_key v1-win-yarn-cache-{{ arch }}-{{ checksum "yarn.lock" }}
     windows_choco_cache_key: &windows_choco_cache_key v1-win-choco-cache-{{ .Environment.CIRCLE_JOB }}
     yarn_cache_key: &yarn_cache_key v5-yarn-cache-{{ .Environment.CIRCLE_JOB }}
+    rbenv_cache_key: &rbenv_cache_key v1-rbenv-{{ checksum "/tmp/required_ruby" }}
 
   cache_paths:
     hermes_workspace_macos_cache_paths: &hermes_workspace_macos_cache_paths
@@ -157,14 +158,47 @@ commands:
           command: mkdir -p ./reports/{buck,build,junit,outputs}
 
   setup_ruby:
+    parameters:
+      ruby_version:
+        default: "2.6.10"
+        type: string
     steps:
       - restore_cache:
           key: *gems_cache_key
       - run:
+          name: Set Required Ruby
+          command: echo << parameters.ruby_version >> > /tmp/required_ruby
+      - restore_cache:
+          key: *rbenv_cache_key
+      - run:
           name: Bundle Install
           command: |
-            source /usr/local/share/chruby/auto.sh
+            # Check if rbenv is installed. CircleCI is migrating to rbenv so we may not need to always install it.
+
+            if [[ -z "$(command -v rbenv)" ]]; then
+              brew install rbenv ruby-build
+            else
+              echo "rbenv found; Skipping installation"
+            fi
+
+            # Load and init rbenv
+            (rbenv init 2> /dev/null) || true
+            echo '' >>  ~/.bash_profile
+            echo 'eval "$(rbenv init - bash)"' >> ~/.bash_profile
+            source ~/.bash_profile
+
+            # Install the right version of ruby
+            if [[ -z "$(rbenv versions | grep << parameters.ruby_version >>)" ]]; then
+              rbenv install << parameters.ruby_version >>
+            fi
+
+            # Set ruby dependencies
+            rbenv global << parameters.ruby_version >>
             bundle check || bundle install --path vendor/bundle --clean
+      - save_cache:
+          key: *rbenv_cache_key
+          paths:
+            - ~/.rbenv
       - save_cache:
           key: *gems_cache_key
           paths:
@@ -614,7 +648,8 @@ jobs:
 
       - run:
           name: Setup the CocoaPods environment
-          command: bundle exec pod setup
+          command: |
+            bundle exec pod setup
 
       - with_hermes_tarball_cache_span:
           set_tarball_path: True
@@ -869,6 +904,7 @@ jobs:
       - attach_workspace:
           at: .
       - *attach_hermes_workspace
+      - setup_ruby
       - when:
           condition:
             equal: ["Hermes", << parameters.jsengine >>]
@@ -892,8 +928,6 @@ jobs:
           command: |
             cd /tmp/$PROJECT_NAME/ios
 
-            bundle install
-
             if [[ << parameters.flavor >> == "Release" ]]; then
               export PRODUCTION=1
             fi
@@ -916,6 +950,7 @@ jobs:
               export USE_FRAMEWORKS=dynamic
             fi
 
+            bundle install
             bundle exec pod install
       - run:
           name: Build template project
@@ -954,7 +989,7 @@ jobs:
           name: Delete iOS Simulators
           background: true
           command: sudo rm -rf /Library/Developer/CoreSimulator/Profiles/Runtimes/
-
+      - setup_ruby
       - with_hermes_tarball_cache_span:
           set_tarball_path: True
           steps:
@@ -972,6 +1007,7 @@ jobs:
                   fi
 
                   cd packages/rn-tester
+
                   bundle install
                   bundle exec pod install
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -596,12 +596,17 @@ jobs:
         description: Which JavaScript engine to use. Must be one of "Hermes", "JSC".
         type: enum
         enum: ["Hermes", "JSC"]
+      ruby_version:
+        default: "2.6.10"
+        description: The version of ruby that must be used
+        type: string
     environment:
       - REPORTS_DIR: "./reports/junit"
     steps:
       - checkout_code_with_cache
       - setup_artifacts
-      - setup_ruby
+      - setup_ruby:
+          ruby_version: << parameters.ruby_version >>
       - brew_install:
           package: xcbeautify
       - run:
@@ -895,6 +900,10 @@ jobs:
         description: Which kind of option we want to use for `use_frameworks!`
         type: enum
         enum: ["StaticLibraries", "StaticFrameworks", "DynamicFrameworks"]
+      ruby_version:
+        default: "2.6.10"
+        description: The version of ruby that must be used
+        type: string
     environment:
       - PROJECT_NAME: "iOSTemplateProject"
       - HERMES_WS_DIR: *hermes_workspace_root
@@ -904,7 +913,8 @@ jobs:
       - attach_workspace:
           at: .
       - *attach_hermes_workspace
-      - setup_ruby
+      - setup_ruby:
+          ruby_version: << parameters.ruby_version >>
       - when:
           condition:
             equal: ["Hermes", << parameters.jsengine >>]
@@ -977,6 +987,10 @@ jobs:
         description: Which React Native architecture to use. Must be one of "OldArch", "NewArch".
         type: enum
         enum: ["NewArch", "OldArch"]
+      ruby_version:
+        default: "2.6.10"
+        description: The version of ruby that must be used
+        type: string
     steps:
       - checkout_code_with_cache
       - run_yarn
@@ -989,7 +1003,8 @@ jobs:
           name: Delete iOS Simulators
           background: true
           command: sudo rm -rf /Library/Developer/CoreSimulator/Profiles/Runtimes/
-      - setup_ruby
+      - setup_ruby:
+          ruby_version: << parameters.ruby_version >>
       - with_hermes_tarball_cache_span:
           set_tarball_path: True
           steps:
@@ -1676,6 +1691,20 @@ workflows:
       - test_ios_template:
           requires:
             - build_npm_package
+          name: "Test Template with Ruby 2.7.7"
+          ruby_version: "2.7.7"
+          architecture: "NewArch"
+          flavor: "Debug"
+      - test_ios_template:
+          requires:
+            - build_npm_package
+          name: "Test Template with Ruby 3.2.0"
+          ruby_version: "3.2.0"
+          architecture: "NewArch"
+          flavor: "Debug"
+      - test_ios_template:
+          requires:
+            - build_npm_package
           matrix:
             parameters:
               architecture: ["NewArch", "OldArch"]
@@ -1807,10 +1836,34 @@ workflows:
       - test_ios_rntester:
           requires:
             - build_hermes_macos
+          name: "Test RNTester with Ruby 2.7.7"
+          ruby_version: "2.7.7"
+          architecture: "NewArch"
+      - test_ios_rntester:
+          requires:
+            - build_hermes_macos
+          name: "Test RNTester with Ruby 3.2.0"
+          ruby_version: "3.2.0"
+          architecture: "NewArch"
+      - test_ios_rntester:
+          requires:
+            - build_hermes_macos
           matrix:
             parameters:
               architecture: ["NewArch", "OldArch"]
               jsengine: ["Hermes", "JSC"]
+      - test_ios:
+          name: "Test iOS with Ruby 2.7.7"
+          run_unit_tests: true
+          requires:
+            - build_hermes_macos
+          ruby_version: "2.7.7"
+      - test_ios:
+          name: "Test iOS with Ruby 3.2.0"
+          run_unit_tests: true
+          requires:
+            - build_hermes_macos
+          ruby_version: "3.2.0"
       - test_ios:
           run_unit_tests: true
           requires:

--- a/scripts/cocoapods/__tests__/codegen_utils-test.rb
+++ b/scripts/cocoapods/__tests__/codegen_utils-test.rb
@@ -402,9 +402,10 @@ class CodegenUtilsTests < Test::Unit::TestCase
         CodegenUtils.set_cleanup_done(true)
         codegen_dir = "build/generated/ios"
         ios_folder = '.'
+        rn_path = '../node_modules/react-native'
 
         # Act
-        CodegenUtils.clean_up_build_folder(@base_path, ios_folder, codegen_dir, dir_manager: DirMock, file_manager: FileMock)
+        CodegenUtils.clean_up_build_folder(rn_path, @base_path, ios_folder, codegen_dir, dir_manager: DirMock, file_manager: FileMock)
 
         # Assert
         assert_equal(FileUtils::FileUtilsStorage.rmrf_invocation_count, 0)


### PR DESCRIPTION
## Summary

This change add more tests for iOS, using different versions of Ruby

## Changelog
[iOS][Added] - Added smoke tests for iOS with Ruby 2.7.7 and 3.2.0

## Test Plan

CircleCI must be green.
