### PR TITLE
Fixes JSDoc in Cliapboard setString

### DIFF
--- a/Libraries/Components/Clipboard/Clipboard.js
+++ b/Libraries/Components/Clipboard/Clipboard.js
@@ -32,7 +32,7 @@ module.exports = {
    *   Clipboard.setString('hello world');
    * }
    * ```
-   * @param the content to be stored in the clipboard.
+   * @param content - the content to be stored in the clipboard.
    */
   setString(content: string) {
     NativeClipboard.setString(content);

--- a/Libraries/Components/Clipboard/Clipboard.js
+++ b/Libraries/Components/Clipboard/Clipboard.js
@@ -32,7 +32,7 @@ module.exports = {
    *   Clipboard.setString('hello world');
    * }
    * ```
-   * @param content - the content to be stored in the clipboard.
+   * @param {string} content the content to be stored in the clipboard.
    */
   setString(content: string) {
     NativeClipboard.setString(content);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
There was a JSDoc mismatch in `Cliapboard.setString` method, `the` was considered as a parameter name, not `content`. Added correct param name and kept the same description as before, separated with a hyphen. 

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
[GENERAL] [FIXED] - Fixes JSDoc in Cliapboard setString

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
No tests needed
