### PR TITLE
RCTBridge add init with Delegate and with bundle URL

### DIFF
--- a/React/Base/RCTBridge.h
+++ b/React/Base/RCTBridge.h
@@ -95,6 +95,12 @@ RCT_EXTERN void RCTSetTurboModuleCleanupMode(RCTTurboModuleCleanupMode mode);
                    moduleProvider:(RCTBridgeModuleListProvider)block
                     launchOptions:(NSDictionary *)launchOptions;
 
+
+- (instancetype)initWithDelegateWithBundleURL:(id<RCTBridgeDelegate>)delegate
+                          bundleURL:(NSURL *)bundleURL
+                     moduleProvider:(RCTBridgeModuleListProvider)block
+                      launchOptions:(NSDictionary *)launchOptions;
+
 /**
  * This method is used to call functions in the JavaScript application context.
  * It is primarily intended for use by modules that require two-way communication

--- a/React/Base/RCTBridge.m
+++ b/React/Base/RCTBridge.m
@@ -162,6 +162,14 @@ static RCTBridge *RCTCurrentBridgeInstance = nil;
   return [self initWithDelegate:nil bundleURL:bundleURL moduleProvider:block launchOptions:launchOptions];
 }
 
+- (instancetype)initWithDelegateAndBundleURL:(id<RCTBridgeDelegate>)delegate
+                       bundleURL:(NSURL *)bundleURL
+                  moduleProvider:(RCTBridgeModuleListProvider)block
+                   launchOptions:(NSDictionary *)launchOptions
+{
+    return [self initWithDelegate:delegate bundleURL:bundleURL moduleProvider:block launchOptions:launchOptions];
+}
+
 - (instancetype)initWithDelegate:(id<RCTBridgeDelegate>)delegate
                        bundleURL:(NSURL *)bundleURL
                   moduleProvider:(RCTBridgeModuleListProvider)block


### PR DESCRIPTION

## Summary
 not possible to do init RCTBridge with Delegate and with bundle URL also

#36401 


## Changelog

expose a method to do that

Pick one each for the category and type tags:

[iOS] [ADDED|] - expose a method 

## Test Plan

