### PR TITLE
[Codegen 99] Extract throwIfMoreThanOneCodegenNativecommands error in error-utils

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
@@ -27,6 +27,7 @@ const {
   throwIfArrayElementTypeAnnotationIsUnsupported,
   throwIfPartialNotAnnotatingTypeParameter,
   throwIfPartialWithMoreParameter,
+  throwIfMoreThanOneCodegenNativecommands,
 } = require('../error-utils');
 const {
   UnsupportedModulePropertyParserError,
@@ -818,5 +819,35 @@ describe('throwIfPartialWithMoreParameter', () => {
     expect(() => {
       throwIfPartialWithMoreParameter(typeAnnotation);
     }).not.toThrowError();
+  });
+});
+
+describe('throwIfMoreThanOneCodegenNativecommands', () => {
+  it('throws an error if given more than one codegenNativeCommands', () => {
+    const commandsTypeNames = [
+      {
+        commandTypeName: '',
+        commandOptionsExpression: {},
+      },
+      {
+        commandTypeName: '',
+        commandOptionsExpression: {},
+      },
+    ];
+    expect(() => {
+      throwIfMoreThanOneCodegenNativecommands(commandsTypeNames);
+    }).toThrowError('codegenNativeCommands may only be called once in a file');
+  });
+
+  it('does not throw an error if given exactly one codegenNativeCommand', () => {
+    const commandsTypeNames = [
+      {
+        commandTypeName: '',
+        commandOptionsExpression: {},
+      },
+    ];
+    expect(() => {
+      throwIfMoreThanOneCodegenNativecommands(commandsTypeNames);
+    }).not.toThrow();
   });
 });

--- a/packages/react-native-codegen/src/parsers/error-utils.js
+++ b/packages/react-native-codegen/src/parsers/error-utils.js
@@ -302,6 +302,14 @@ function throwIfPartialWithMoreParameter(typeAnnotation: $FlowFixMe) {
   }
 }
 
+function throwIfMoreThanOneCodegenNativecommands(
+  commandsTypeNames: $ReadOnlyArray<$FlowFixMe>,
+) {
+  if (commandsTypeNames.length > 1) {
+    throw new Error('codegenNativeCommands may only be called once in a file');
+  }
+}
+
 module.exports = {
   throwIfModuleInterfaceIsMisnamed,
   throwIfUnsupportedFunctionReturnTypeAnnotationParserError,
@@ -319,4 +327,5 @@ module.exports = {
   throwIfIncorrectModuleRegistryCallArgument,
   throwIfPartialNotAnnotatingTypeParameter,
   throwIfPartialWithMoreParameter,
+  throwIfMoreThanOneCodegenNativecommands,
 };

--- a/packages/react-native-codegen/src/parsers/flow/components/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/index.js
@@ -21,6 +21,7 @@ const {getCommandOptions, getOptions} = require('./options');
 const {getProps} = require('./props');
 const {getProperties} = require('./componentsUtils.js');
 const {createComponentConfig} = require('../../parsers-commons');
+const {throwIfMoreThanOneCodegenNativecommands} = require('../../error-utils');
 
 /* $FlowFixMe[missing-local-annot] The type annotation(s) required by Flow's
  * LTI update could not be added via codemod */
@@ -109,9 +110,7 @@ function findComponentConfig(ast) {
     })
     .filter(Boolean);
 
-  if (commandsTypeNames.length > 1) {
-    throw new Error('codegenNativeCommands may only be called once in a file');
-  }
+  throwIfMoreThanOneCodegenNativecommands(commandsTypeNames);
 
   return createComponentConfig(foundConfig, commandsTypeNames);
 }

--- a/packages/react-native-codegen/src/parsers/typescript/components/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/index.js
@@ -22,6 +22,7 @@ const {getCommandOptions, getOptions} = require('./options');
 const {getProps} = require('./props');
 const {getProperties} = require('./componentsUtils.js');
 const {createComponentConfig} = require('../../parsers-commons');
+const {throwIfMoreThanOneCodegenNativecommands} = require('../../error-utils');
 
 /* $FlowFixMe[missing-local-annot] The type annotation(s) required by Flow's
  * LTI update could not be added via codemod */
@@ -110,9 +111,7 @@ function findComponentConfig(ast) {
     })
     .filter(Boolean);
 
-  if (commandsTypeNames.length > 1) {
-    throw new Error('codegenNativeCommands may only be called once in a file');
-  }
+  throwIfMoreThanOneCodegenNativecommands(commandsTypeNames);
 
   return createComponentConfig(foundConfig, commandsTypeNames);
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Part of Codegen Umbrella Issue: #34872
> [Codegen 99] Extract the throwIfMoreThanOneCodegenNativecommands error in the error-utils.js file and extract the error code from [Flow](https://github.com/facebook/react-native/blob/main/packages/react-native-codegen/src/parsers/flow/components/index.js#L111-L133) and [TS](https://github.com/facebook/react-native/blob/main/packages/react-native-codegen/src/parsers/typescript/components/index.js#L112-L114)

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
[Internal] [Changed] - Extract throwIfMoreThanOneCodegenNativecommands error in error-utils

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

`yarn jest react-native-codegen`
