### PR TITLE
[Codegen 92] move getCommandOptions to parsers-commons

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-commons-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-commons-test.js
@@ -21,6 +21,7 @@ import {
   buildSchema,
   parseModuleName,
   createComponentConfig,
+  getCommandOptions,
 } from '../parsers-commons';
 import type {ParserType} from '../errors';
 
@@ -1275,5 +1276,48 @@ describe('createComponentConfig', () => {
       const configs = createComponentConfig(foundConfig, commandsTypeNames);
       expect(configs).toEqual(expectedConfig);
     });
+  });
+});
+
+describe('getCommandOptions', () => {
+  it('returns null when commandOptionsExpression is null', () => {
+    const result = getCommandOptions(null);
+    expect(result).toBeNull();
+  });
+
+  it('parses and returns command options correctly', () => {
+    const commandOptionsExpression = {
+      properties: [
+        {
+          range: [],
+          loc: {},
+          type: '',
+          key: {
+            name: 'hotspotUpdate',
+            loc: {},
+          },
+          value: {
+            elements: [
+              {
+                value: 'value',
+              },
+            ],
+          },
+        },
+      ],
+    };
+    const result = getCommandOptions(commandOptionsExpression);
+    expect(result).toEqual({
+      hotspotUpdate: ['value'],
+    });
+  });
+
+  it('should throw an error if command options are not defined correctly', () => {
+    const commandOptionsExpression = {
+      properties: null,
+    };
+    expect(() => getCommandOptions(commandOptionsExpression)).toThrowError(
+      'Failed to parse command options, please check that they are defined correctly',
+    );
   });
 });

--- a/packages/react-native-codegen/src/parsers/flow/components/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/index.js
@@ -11,16 +11,19 @@
 'use strict';
 import type {Parser} from '../../parser';
 import type {TypeDeclarationMap} from '../../utils';
-import type {CommandOptions} from './options';
+import type {CommandOptions} from '../../parsers-commons';
 import type {ComponentSchemaBuilderConfig} from '../../schema.js';
 
 const {getCommands} = require('./commands');
 const {getEvents} = require('./events');
 const {getExtendsProps, removeKnownExtends} = require('./extends');
-const {getCommandOptions, getOptions} = require('./options');
+const {getOptions} = require('./options');
 const {getProps} = require('./props');
 const {getProperties} = require('./componentsUtils.js');
-const {createComponentConfig} = require('../../parsers-commons');
+const {
+  createComponentConfig,
+  getCommandOptions,
+} = require('../../parsers-commons');
 
 /* $FlowFixMe[missing-local-annot] The type annotation(s) required by Flow's
  * LTI update could not be added via codemod */

--- a/packages/react-native-codegen/src/parsers/flow/components/options.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/options.js
@@ -15,38 +15,6 @@ import type {OptionsShape} from '../../../CodegenSchema.js';
 // $FlowFixMe[unclear-type] there's no flowtype for ASTs
 type OptionsAST = Object;
 
-export type CommandOptions = $ReadOnly<{
-  supportedCommands: $ReadOnlyArray<string>,
-}>;
-
-function getCommandOptions(
-  commandOptionsExpression: OptionsAST,
-): ?CommandOptions {
-  if (commandOptionsExpression == null) {
-    return null;
-  }
-
-  let foundOptions;
-  try {
-    foundOptions = commandOptionsExpression.properties.reduce(
-      (options, prop) => {
-        options[prop.key.name] = (
-          (prop && prop.value && prop.value.elements) ||
-          []
-        ).map(element => element && element.value);
-        return options;
-      },
-      {},
-    );
-  } catch (e) {
-    throw new Error(
-      'Failed to parse command options, please check that they are defined correctly',
-    );
-  }
-
-  return foundOptions;
-}
-
 function getOptions(optionsExpression: OptionsAST): ?OptionsShape {
   if (!optionsExpression) {
     return null;
@@ -82,6 +50,5 @@ function getOptions(optionsExpression: OptionsAST): ?OptionsShape {
 }
 
 module.exports = {
-  getCommandOptions,
   getOptions,
 };

--- a/packages/react-native-codegen/src/parsers/typescript/components/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/index.js
@@ -12,16 +12,19 @@
 import type {ExtendsPropsShape} from '../../../CodegenSchema.js';
 import type {Parser} from '../../parser';
 import type {TypeDeclarationMap} from '../../utils';
-import type {CommandOptions} from './options';
+import type {CommandOptions} from '../../parsers-commons';
 import type {ComponentSchemaBuilderConfig} from '../../schema.js';
 
 const {getCommands} = require('./commands');
 const {getEvents} = require('./events');
 const {categorizeProps} = require('./extends');
-const {getCommandOptions, getOptions} = require('./options');
+const {getOptions} = require('./options');
 const {getProps} = require('./props');
 const {getProperties} = require('./componentsUtils.js');
-const {createComponentConfig} = require('../../parsers-commons');
+const {
+  createComponentConfig,
+  getCommandOptions,
+} = require('../../parsers-commons');
 
 /* $FlowFixMe[missing-local-annot] The type annotation(s) required by Flow's
  * LTI update could not be added via codemod */

--- a/packages/react-native-codegen/src/parsers/typescript/components/options.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/options.js
@@ -15,38 +15,6 @@ import type {OptionsShape} from '../../../CodegenSchema.js';
 // $FlowFixMe[unclear-type] TODO(T108222691): Use flow-types for @babel/parser
 type OptionsAST = Object;
 
-export type CommandOptions = $ReadOnly<{
-  supportedCommands: $ReadOnlyArray<string>,
-}>;
-
-function getCommandOptions(
-  commandOptionsExpression: OptionsAST,
-): ?CommandOptions {
-  if (commandOptionsExpression == null) {
-    return null;
-  }
-
-  let foundOptions;
-  try {
-    foundOptions = commandOptionsExpression.properties.reduce(
-      (options, prop) => {
-        options[prop.key.name] = (
-          (prop && prop.value && prop.value.elements) ||
-          []
-        ).map(element => element && element.value);
-        return options;
-      },
-      {},
-    );
-  } catch (e) {
-    throw new Error(
-      'Failed to parse command options, please check that they are defined correctly',
-    );
-  }
-
-  return foundOptions;
-}
-
 function getOptions(optionsExpression: OptionsAST): ?OptionsShape {
   if (!optionsExpression) {
     return null;
@@ -82,6 +50,5 @@ function getOptions(optionsExpression: OptionsAST): ?OptionsShape {
 }
 
 module.exports = {
-  getCommandOptions,
   getOptions,
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Part of Codegen Umbrella Issue: #34872

> [Codegen 92] The getCommandOptions function in parsers/typescript/components/options.js and parsers/flow/components/options.js is the same. move it in parser-commons and use it in the original files. If the file two options.js files are empty, delete them.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
[Internal][Changed] - Move getCommandOptions from both parsers components options file
## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
`
yarn jest react-native-codegen`
