### PR TITLE
[iOS] expose keyCode in onKeyPress event (TextInput)

### DIFF
--- a/Libraries/Text/TextInput/RCTBaseTextInputView.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputView.m
@@ -378,10 +378,10 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
   if (@available(iOS 13.4, *)) {
     if(firstPress != nil){
       UIKey* key = firstPress.key;
-      CFIndex keyCode = (CFIndex) key.keyCode;
-      NSInteger *iosKeyCode = (NSInteger*) keyCode;
       
       if(key != nil){
+        CFIndex keyCode = (CFIndex) key.keyCode;
+        NSInteger *iosKeyCode = (NSInteger*) keyCode;
         [_eventDispatcher sendTextEventWithType:RCTTextEventTypeKeyPress
                                        reactTag:self.reactTag
                                            text:nil

--- a/Libraries/Text/TextInput/RCTBaseTextInputView.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputView.m
@@ -346,6 +346,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
                                  reactTag:self.reactTag
                                      text:[self.backedTextInputView.attributedText.string copy]
                                       key:nil
+                               iosKeyCode:nil
                                eventCount:_nativeEventCount];
 }
 
@@ -360,13 +361,37 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
                                  reactTag:self.reactTag
                                      text:[self.backedTextInputView.attributedText.string copy]
                                       key:nil
+                               iosKeyCode:nil
                                eventCount:_nativeEventCount];
 
   [_eventDispatcher sendTextEventWithType:RCTTextEventTypeBlur
                                  reactTag:self.reactTag
                                      text:[self.backedTextInputView.attributedText.string copy]
                                       key:nil
+                               iosKeyCode:nil
                                eventCount:_nativeEventCount];
+}
+
+- (void)pressesBegan:(NSSet<UIPress *> *)presses withEvent:(UIPressesEvent *)event{
+  UIPress* firstPress = [[presses allObjects] objectAtIndex:0];
+  
+  if (@available(iOS 13.4, *)) {
+    if(firstPress != nil){
+      UIKey* key = firstPress.key;
+      CFIndex keyCode = (CFIndex) key.keyCode;
+      NSInteger *iosKeyCode = (NSInteger*) keyCode;
+      
+      if(key != nil){
+        [_eventDispatcher sendTextEventWithType:RCTTextEventTypeKeyPress
+                                       reactTag:self.reactTag
+                                           text:nil
+                                            key:key.characters
+                                     iosKeyCode:iosKeyCode
+                                     eventCount:_nativeEventCount];
+      }
+    }
+  }
+  [super pressesBegan:presses withEvent:event];
 }
 
 - (BOOL)textInputShouldSubmitOnReturn
@@ -383,6 +408,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
                                    reactTag:self.reactTag
                                        text:[self.backedTextInputView.attributedText.string copy]
                                         key:nil
+                                 iosKeyCode:nil
                                  eventCount:_nativeEventCount];
   }
   return shouldSubmit;
@@ -403,11 +429,16 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
   id<RCTBackedTextInputViewProtocol> backedTextInputView = self.backedTextInputView;
 
   if (!backedTextInputView.textWasPasted) {
-    [_eventDispatcher sendTextEventWithType:RCTTextEventTypeKeyPress
+    if (@available(iOS 13.4, *)) {
+
+    } else {
+      [_eventDispatcher sendTextEventWithType:RCTTextEventTypeKeyPress
                                    reactTag:self.reactTag
                                        text:nil
                                         key:text
+                                 iosKeyCode:nil
                                  eventCount:_nativeEventCount];
+    }
   }
 
   if (_maxLength) {

--- a/React/Base/RCTEventDispatcherProtocol.h
+++ b/React/Base/RCTEventDispatcherProtocol.h
@@ -100,6 +100,7 @@ typedef NS_ENUM(NSInteger, RCTTextEventType) {
                      reactTag:(NSNumber *)reactTag
                          text:(NSString *)text
                           key:(NSString *)key
+                   iosKeyCode:(NSInteger *)iosKeyCode
                    eventCount:(NSInteger)eventCount;
 
 /**

--- a/React/CoreModules/RCTEventDispatcher.mm
+++ b/React/CoreModules/RCTEventDispatcher.mm
@@ -77,6 +77,7 @@ RCT_EXPORT_MODULE()
                      reactTag:(NSNumber *)reactTag
                          text:(NSString *)text
                           key:(NSString *)key
+                   iosKeyCode:(NSInteger *)iosKeyCode
                    eventCount:(NSInteger)eventCount
 {
   static NSString *events[] = {@"focus", @"blur", @"change", @"submitEditing", @"endEditing", @"keyPress"};


### PR DESCRIPTION
## Summary

This exposes the ios keyCode to onKeyPress events. This makes it possible to support richer keyboard interactions, like in [react-native-hotkeys](https://github.com/Kingstinct/react-native-hotkeys/blob/main/src/utils/mapIosKeyCode.ts) which provides a uniform interface for both web and iOS.

## Changelog

[IOS] [ADDED] - Added iosKeyCode to onKeyPress events for iOS 13.4+

## Test Plan

This is used live in conjunction (with patch-package) with react-native-hotkeys in https://www.schedulist.app/. All it does is expose an additional property containing the iOS key code to onKeyPress events.