### PR TITLE
Improve robustness of iOS CircleCI Pipelines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,6 +192,10 @@ commands:
 
             # Install the right version of ruby
             if [[ -z "$(rbenv versions | grep << parameters.ruby_version >>)" ]]; then
+              # ensure that `ruby-build` can see all the available versions of Ruby
+              # some PRs received machines in a weird state, this should make the pipelines
+              # more robust.
+              brew update && brew upgrade ruby-build
               rbenv install << parameters.ruby_version >>
             fi
 


### PR DESCRIPTION
Summary:
After migrating to Xcode 14.2.0, some contributors were receiving CircleCI Machines that were not able to install Ruby 3.2.0.

This change should improve the robustness of the pipelines, ensuring that `ruby-build` can always find the version of Ruby it needs

## Changelog:
[internal] - Make sure CircleCI always find the right version of Ruby

Differential Revision: D43944878

