### PR TITLE
logbox footer buttons fix safearea

### DIFF
--- a/Libraries/LogBox/UI/LogBoxInspectorFooter.js
+++ b/Libraries/LogBox/UI/LogBoxInspectorFooter.js
@@ -10,10 +10,10 @@
 
 import type {LogLevel} from '../Data/LogBoxLog';
 
+import SafeAreaView from "../../Components/SafeAreaView/SafeAreaView";
 import View from '../../Components/View/View';
 import StyleSheet from '../../StyleSheet/StyleSheet';
 import Text from '../../Text/Text';
-import DeviceInfo from '../../Utilities/DeviceInfo';
 import LogBoxButton from './LogBoxButton';
 import * as LogBoxStyle from './LogBoxStyle';
 import * as React from 'react';
@@ -52,25 +52,24 @@ type ButtonProps = $ReadOnly<{|
 
 function FooterButton(props: ButtonProps): React.Node {
   return (
-    <LogBoxButton
-      backgroundColor={{
-        default: 'transparent',
-        pressed: LogBoxStyle.getBackgroundDarkColor(),
-      }}
-      onPress={props.onPress}
-      style={buttonStyles.safeArea}>
-      <View style={buttonStyles.content}>
-        <Text style={buttonStyles.label}>{props.text}</Text>
-      </View>
-    </LogBoxButton>
+    <SafeAreaView style={buttonStyles.safeArea}>
+      <LogBoxButton
+        backgroundColor={{
+          default: 'transparent',
+          pressed: LogBoxStyle.getBackgroundDarkColor(),
+        }}
+        onPress={props.onPress}>
+        <View style={buttonStyles.content}>
+          <Text style={buttonStyles.label}>{props.text}</Text>
+        </View>
+      </LogBoxButton>
+    </SafeAreaView>
   );
 }
 
 const buttonStyles = StyleSheet.create({
   safeArea: {
     flex: 1,
-    // $FlowFixMe[sketchy-null-bool]
-    paddingBottom: DeviceInfo.getConstants().isIPhoneX_deprecated ? 30 : 0,
   },
   content: {
     alignItems: 'center',


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

The logbox buttons on iOS are not easy to reach since they draw in the safe area. This pr should fix that.

## Changelog

[IOS] [FIXED] - logbox footer buttons respect safe area 

## Test Plan

| after  | before  |
|---|---|
| ![IMG_3296](https://user-images.githubusercontent.com/3705499/224150030-b2637977-9fbc-4a5e-9efb-86a42a62b31a.PNG) | ![IMG_9BF70BD03E1B-1](https://user-images.githubusercontent.com/3705499/224150681-dc84295b-134a-4840-9773-23c601b24e01.jpeg)
