### PR TITLE
[Android] Improve consistency for overflowed TextInput

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -1070,9 +1070,12 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
 
     @Override
     public void afterTextChanged(Editable s) {
-      if (!mEditText.hasFocus()) {
-        mEditText.post(() -> mEditText.scrollTo(0,0));
-      }
+      mEditText.post(new Runnable() {
+        @Override
+        public void run() {
+          mEditText.scrollTo(0, 0);
+        }
+      });
     }
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -1070,12 +1070,14 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
 
     @Override
     public void afterTextChanged(Editable s) {
-      mEditText.post(new Runnable() {
-        @Override
-        public void run() {
-          mEditText.scrollTo(0, 0);
-        }
-      });
+      if (!mEditText.hasFocus()) {
+        mEditText.post(new Runnable() {
+          @Override
+          public void run() {
+            mEditText.scrollTo(0, 0);
+          }
+        });
+      }
     }
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -1069,7 +1069,11 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
     }
 
     @Override
-    public void afterTextChanged(Editable s) {}
+    public void afterTextChanged(Editable s) {
+      if (!mEditText.hasFocus()) {
+        mEditText.post(() -> mEditText.scrollTo(0,0));
+      }
+    }
   }
 
   @Override

--- a/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
@@ -1108,17 +1108,14 @@ module.exports = ([
   },
   {
     title: 'Overflowed text behavior on render',
-    name: 'overflowedOnRender',
-    render: function(): React.Node {
+    render: function (): React.Node {
       return (
-        <View>
-          <TextInput
-            style={[styles.default]}
-            value={'The quick brown fox expertly jumps over the lazy dog, lying still on the grass.'}
-          />
-        </View>
+        <TextInput
+          style={styles.default}
+          defaultValue="The quick brown fox expertly jumps over the lazy dog, lying still on the grass."
+        />
       );
-    }
+    },
   },
   {
     title: 'Uncontrolled component with layout changes',

--- a/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
@@ -1107,6 +1107,20 @@ module.exports = ([
     },
   },
   {
+    title: 'Overflowed text behavior on render',
+    name: 'overflowedOnRender',
+    render: function(): React.Node {
+      return (
+        <View>
+          <TextInput
+            style={[styles.default]}
+            value={'The quick brown fox expertly jumps over the lazy dog, lying still on the grass.'}
+          />
+        </View>
+      );
+    }
+  },
+  {
     title: 'Uncontrolled component with layout changes',
     name: 'uncontrolledComponent',
     render: () => <UncontrolledExample />,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

The purpose of this PR is to improve consistency in the behavior of overflowed TextInput components across supported platforms. 

Currently on Android, when a TextInput is rendered with a value that overflows the width of the TextInput, Android Native displays the end of the text line. Other platforms display the start and clip the end.  This also applies to setting text programatically (ie. by setting the value through state for an unfocused TextInput).

This PR aims to normalize the behavior by updating the Android Native implementation to display the start of the line and clip the end, bringing it in line with the behavior of other platforms.

To achieve this, we can invoke `scrollTo` in the `afterChangedText` event using the existing `TextWatcher` for detecting text changes for the Android widget.  To ensure this only applies to initial rendering and auto-filling, we condition on the field being unfocused.  When the field is focused, the behaviour will not apply and therefore not effect regular keyboarding events.

This problem was discussed more thoroughly in the longstanding issue here: https://github.com/facebook/react-native/issues/14845

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[ANDROID] [Fixed] - TextInput not displaying start of text on render like other platforms

## Test Plan

My submitted solution includes an example within the `rn-tester` package. Below I will provide videos displaying the behaviour both there, and within our production app where the issue was identified.

<details>
<summary>Before Change (RNTester)</summary>

https://user-images.githubusercontent.com/1311325/224181112-7b7fb4bd-ce43-421d-913f-4e3a62a2060b.mp4

</details>

<details>
<summary>After Change (RNTester)</summary>

https://user-images.githubusercontent.com/1311325/224181178-5c7bd56f-ff92-43ae-b6d8-8ac7f99d7423.mp4

</details>

<details>
<summary>Before Change (Production app)</summary>

https://user-images.githubusercontent.com/1311325/224181324-6c816afa-792c-441a-9b46-14fcd3d86898.mp4

</details>

<details>
<summary>After Change (Production app)</summary>

https://user-images.githubusercontent.com/1311325/224181342-335611b1-163d-46c8-96d7-24b8d7aa2a04.mp4

</details>
