### PR TITLE
[Codegen 89 & 90] Remove hardcoded language from modules/index.js

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-primitives-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-primitives-test.js
@@ -358,7 +358,6 @@ describe('typeEnumResolution', () => {
           {successful: true, type: 'enum', name: 'Foo'},
           true /* nullable */,
           'SomeModule' /* name */,
-          'Flow',
           enumMap,
           parser,
         );
@@ -402,7 +401,6 @@ describe('typeEnumResolution', () => {
           {successful: true, type: 'enum', name: 'Foo'},
           true /* nullable */,
           'SomeModule' /* name */,
-          'Flow',
           enumMap,
           parser,
         );

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -295,7 +295,6 @@ function translateTypeAnnotation(
         typeResolutionStatus,
         nullable,
         hasteModuleName,
-        language,
         enumMap,
         parser,
       );

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -60,8 +60,6 @@ const {
   throwIfPartialWithMoreParameter,
 } = require('../../error-utils');
 
-const language = 'Flow';
-
 function translateTypeAnnotation(
   hasteModuleName: string,
   /**
@@ -303,7 +301,7 @@ function translateTypeAnnotation(
       throw new UnsupportedTypeAnnotationParserError(
         hasteModuleName,
         typeAnnotation,
-        language,
+        parser.language(),
       );
     }
   }

--- a/packages/react-native-codegen/src/parsers/parsers-primitives.js
+++ b/packages/react-native-codegen/src/parsers/parsers-primitives.js
@@ -34,7 +34,6 @@ import type {
   NativeModuleObjectTypeAnnotation,
   NativeModuleEnumDeclaration,
 } from '../CodegenSchema';
-import type {ParserType} from './errors';
 import type {Parser} from './parser';
 import type {
   ParserErrorCapturer,
@@ -204,7 +203,6 @@ function typeEnumResolution(
   typeResolution: TypeResolutionStatus,
   nullable: boolean,
   hasteModuleName: string,
-  language: ParserType,
   enumMap: {...NativeModuleEnumMap},
   parser: Parser,
 ): Nullable<NativeModuleEnumDeclaration> {
@@ -212,7 +210,7 @@ function typeEnumResolution(
     throw new UnsupportedTypeAnnotationParserError(
       hasteModuleName,
       typeAnnotation,
-      language,
+      parser.language(),
     );
   }
 

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -64,8 +64,6 @@ const {
   throwIfPartialWithMoreParameter,
 } = require('../../error-utils');
 
-const language = 'TypeScript';
-
 function translateObjectTypeAnnotation(
   hasteModuleName: string,
   /**
@@ -405,7 +403,7 @@ function translateTypeAnnotation(
       throw new UnsupportedTypeAnnotationParserError(
         hasteModuleName,
         typeAnnotation,
-        language,
+        parser.language(),
       );
     }
   }

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -362,7 +362,6 @@ function translateTypeAnnotation(
         typeResolutionStatus,
         nullable,
         hasteModuleName,
-        language,
         enumMap,
         parser,
       );


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

This PR aims to remove the hardcoded language constants to use common parser instead. It is a task of #34872:
> [Codegen 89 - Assigned to @MaeIg] Remove the const language variable from flow/modules/index.js and replace its usage with parser.language()
> [Codegen 90 - Assigned to @MaeIg] Remove the const language variable from typescript/modules/index.js and replace its usage with parser.language()

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
[Internal] [Changed] - Remove hardcoded language from modules/index.js to use common parser instead

## Test Plan

yarn flow:
<img width="145" alt="image" src="https://user-images.githubusercontent.com/40902940/224333480-600cefd0-9dc6-4142-8e88-db20785e49e6.png">

yarn lint:
<img width="504" alt="image" src="https://user-images.githubusercontent.com/40902940/224333852-d510594f-053e-4866-8ceb-5e3e3d074bc2.png">

yarn test
<img width="383" alt="image" src="https://user-images.githubusercontent.com/40902940/224333600-8c772829-2362-4943-895d-1949a0d88918.png">

