### PR TITLE
[Codegen 100] Unify findComponentConfig return statement

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-commons-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-commons-test.js
@@ -20,6 +20,7 @@ import {
   buildSchemaFromConfigType,
   buildSchema,
   parseModuleName,
+  createComponentConfig,
 } from '../parsers-commons';
 import type {ParserType} from '../errors';
 
@@ -1229,5 +1230,49 @@ describe('buildModuleSchema', () => {
     );
 
     expect(schema).toEqual(schmeaMock);
+  });
+});
+
+describe('createComponentConfig', () => {
+  const foundConfig = {
+    propsTypeName: 'testPropsTypeName',
+    componentName: 'testComponentName',
+  };
+
+  describe('when commandTypeNames contains an object as first element', () => {
+    it('returns expected config', () => {
+      const commandsTypeNames = [
+        {
+          commandTypeName: 'testTypeName',
+          commandOptionsExpression: 'testOptionsExpression',
+        },
+      ];
+
+      const expectedConfig = {
+        propsTypeName: 'testPropsTypeName',
+        componentName: 'testComponentName',
+        commandTypeName: 'testTypeName',
+        commandOptionsExpression: 'testOptionsExpression',
+      };
+
+      const configs = createComponentConfig(foundConfig, commandsTypeNames);
+      expect(configs).toEqual(expectedConfig);
+    });
+  });
+
+  describe('when commandTypeNames is an empty array', () => {
+    it('returns the foundConfig and null for the command parameters', () => {
+      const commandsTypeNames = [];
+
+      const expectedConfig = {
+        propsTypeName: 'testPropsTypeName',
+        componentName: 'testComponentName',
+        commandTypeName: null,
+        commandOptionsExpression: null,
+      };
+
+      const configs = createComponentConfig(foundConfig, commandsTypeNames);
+      expect(configs).toEqual(expectedConfig);
+    });
   });
 });

--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-commons-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-commons-test.js
@@ -1262,6 +1262,7 @@ describe('createComponentConfig', () => {
 
   describe('when commandTypeNames is an empty array', () => {
     it('returns the foundConfig and null for the command parameters', () => {
+      // $FlowFixMe[missing-empty-array-annot]
       const commandsTypeNames = [];
 
       const expectedConfig = {

--- a/packages/react-native-codegen/src/parsers/flow/components/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/index.js
@@ -20,6 +20,7 @@ const {getExtendsProps, removeKnownExtends} = require('./extends');
 const {getCommandOptions, getOptions} = require('./options');
 const {getProps} = require('./props');
 const {getProperties} = require('./componentsUtils.js');
+const {createComponentConfig} = require('../../parsers-commons');
 
 /* $FlowFixMe[missing-local-annot] The type annotation(s) required by Flow's
  * LTI update could not be added via codemod */
@@ -112,17 +113,7 @@ function findComponentConfig(ast) {
     throw new Error('codegenNativeCommands may only be called once in a file');
   }
 
-  return {
-    ...foundConfig,
-    commandTypeName:
-      commandsTypeNames[0] == null
-        ? null
-        : commandsTypeNames[0].commandTypeName,
-    commandOptionsExpression:
-      commandsTypeNames[0] == null
-        ? null
-        : commandsTypeNames[0].commandOptionsExpression,
-  };
+  return createComponentConfig(foundConfig, commandsTypeNames);
 }
 
 function getCommandProperties(

--- a/packages/react-native-codegen/src/parsers/parsers-commons.js
+++ b/packages/react-native-codegen/src/parsers/parsers-commons.js
@@ -466,6 +466,23 @@ function buildSchema(
   );
 }
 
+function createComponentConfig(
+  foundConfig: $FlowFixMe,
+  commandsTypeNames: $FlowFixMe,
+) {
+  return {
+    ...foundConfig,
+    commandTypeName:
+      commandsTypeNames[0] == null
+        ? null
+        : commandsTypeNames[0].commandTypeName,
+    commandOptionsExpression:
+      commandsTypeNames[0] == null
+        ? null
+        : commandsTypeNames[0].commandOptionsExpression,
+  };
+}
+
 const parseModuleName = (
   hasteModuleName: string,
   moduleSpec: $FlowFixMe,
@@ -651,6 +668,7 @@ module.exports = {
   buildPropertySchema,
   buildSchemaFromConfigType,
   buildSchema,
+  createComponentConfig,
   parseModuleName,
   buildModuleSchema,
 };

--- a/packages/react-native-codegen/src/parsers/parsers-commons.js
+++ b/packages/react-native-codegen/src/parsers/parsers-commons.js
@@ -469,7 +469,7 @@ function buildSchema(
 function createComponentConfig(
   foundConfig: $FlowFixMe,
   commandsTypeNames: $FlowFixMe,
-) {
+): $FlowFixMe {
   return {
     ...foundConfig,
     commandTypeName:

--- a/packages/react-native-codegen/src/parsers/typescript/components/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/index.js
@@ -21,6 +21,7 @@ const {categorizeProps} = require('./extends');
 const {getCommandOptions, getOptions} = require('./options');
 const {getProps} = require('./props');
 const {getProperties} = require('./componentsUtils.js');
+const {createComponentConfig} = require('../../parsers-commons');
 
 /* $FlowFixMe[missing-local-annot] The type annotation(s) required by Flow's
  * LTI update could not be added via codemod */
@@ -113,17 +114,7 @@ function findComponentConfig(ast) {
     throw new Error('codegenNativeCommands may only be called once in a file');
   }
 
-  return {
-    ...foundConfig,
-    commandTypeName:
-      commandsTypeNames[0] == null
-        ? null
-        : commandsTypeNames[0].commandTypeName,
-    commandOptionsExpression:
-      commandsTypeNames[0] == null
-        ? null
-        : commandsTypeNames[0].commandOptionsExpression,
-  };
+  return createComponentConfig(foundConfig, commandsTypeNames);
 }
 
 function getCommandProperties(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

> [Codegen 100] Create a createComponentConfig function in the parser-commons.js file. It takes the foundConfig and the commandTypeNames as parameters and returns the component config object. Extract the return statements ([Flow](https://github.com/facebook/react-native/blob/main/packages/react-native-codegen/src/parsers/flow/components/index.js#L115-L126) [TS](https://github.com/facebook/react-native/blob/main/packages/react-native-codegen/src/parsers/typescript/components/index.js#L116-L127)) and use those implementations in that function.

Part of Issue https://github.com/facebook/react-native/issues/34872

In case I should already add better typing I can update the PR while clarifying the type definitions.

## Changelog

[INTERNAL] [CHANGED] - Move the return statement of `findComponentConfig` to `parsers-commons.js` merging Flow and TS implementation.

## Test Plan

`yarn lint && yarn run flow && yarn test react-native-codegen`
