### PR TITLE
fix(eslint-plugin-specs): removes unnecessary `ENOENT` error check

### DIFF
--- a/packages/eslint-plugin-specs/with-babel-register/disk-cache.js
+++ b/packages/eslint-plugin-specs/with-babel-register/disk-cache.js
@@ -61,9 +61,6 @@ function save() {
     fs.writeFileSync(FILENAME, serialised);
   } catch (e) {
     switch (e.code) {
-      // workaround https://github.com/nodejs/node/issues/31481
-      // todo: remove the ENOENT error check when we drop node.js 13 support
-      case 'ENOENT':
       case 'EACCES':
       case 'EPERM':
         console.warn(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

```javascript
      // workaround https://github.com/nodejs/node/issues/31481
      // todo: remove the ENOENT error check when we drop node.js 13 support
      case 'ENOENT':
      case 'EACCES':
```

Well, there was a TODO comment asking to remove `ENOENT` error check when react native drop nodejs 13 support since nodejs 14 has fixed the bug that motivated this check. Now react native minimum nodejs version supported is nodejs 14, so this check is not needed anymore.

## Changelog

[Internal] [Fixed] - Removes `ENOENT` error check

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
