### PR TITLE
[Codegen 91] Extract inner switch case 'TSTypereference' to function translateTypeReferenceAnnotation()

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/ReactPackageTurboModuleManagerDelegate.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactPackageTurboModuleManagerDelegate.java
@@ -67,11 +67,19 @@ public abstract class ReactPackageTurboModuleManagerDelegate extends TurboModule
           moduleSpecProviderMap.put(moduleSpec.getName(), moduleSpec.getProvider());
         }
 
+//         final ModuleProvider moduleProvider =
+//             (name) -> {
+//               Provider<? extends NativeModule> provider = moduleSpecProviderMap.get(name);
+//               return provider != null ? provider.get() : null;
+//             };
         final ModuleProvider moduleProvider =
-            (name) -> {
-              Provider<? extends NativeModule> provider = moduleSpecProviderMap.get(name);
+          new ModuleProvider() {
+            public NativeModule getModule(String moduleName) {
+              Provider<? extends NativeModule> provider = moduleSpecProviderMap.get(moduleName);
               return provider != null ? provider.get() : null;
-            };
+            }
+          };
+
 
         mModuleProviders.add(moduleProvider);
         mPackageModuleInfos.put(

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -124,6 +124,102 @@ function translateObjectTypeAnnotation(
   );
 }
 
+function translateTypeReferenceAnnotation(
+  typeName: string,//typeAnnotation.typeName.name
+  nullable: boolean,
+  typeAnnotation: $FlowFixMe,
+  hasteModuleName: string,
+  types: TypeDeclarationMap,
+  aliasMap: {...NativeModuleAliasMap},
+  enumMap: {...NativeModuleEnumMap},
+  tryParse: ParserErrorCapturer,
+  cxxOnly: boolean,
+  parser: Parser,
+): Nullable<NativeModuleTypeAnnotation> {
+  switch (typeName) {
+    case 'RootTag': {
+      return emitRootTag(nullable);
+    }
+    case 'Promise': {
+      return emitPromise(
+        hasteModuleName,
+        typeAnnotation,
+        parser,
+        nullable,
+        types,
+        aliasMap,
+        enumMap,
+        tryParse,
+        cxxOnly,
+        translateTypeAnnotation,
+      );
+    }
+    case 'Array':
+    case 'ReadonlyArray': {
+      return emitArrayType(
+        hasteModuleName,
+        typeAnnotation,
+        parser,
+        types,
+        aliasMap,
+        enumMap,
+        cxxOnly,
+        nullable,
+        translateTypeAnnotation,
+      );
+    }
+    case 'Stringish': {
+      return emitStringish(nullable);
+    }
+    case 'Int32': {
+      return emitInt32(nullable);
+    }
+    case 'Double': {
+      return emitDouble(nullable);
+    }
+    case 'Float': {
+      return emitFloat(nullable);
+    }
+    case 'UnsafeObject':
+    case 'Object': {
+      return emitGenericObject(nullable);
+    }
+    case 'Partial': {
+      throwIfPartialWithMoreParameter(typeAnnotation);
+
+      const annotatedElement = parser.extractAnnotatedElement(
+        typeAnnotation,
+        types,
+      );
+
+      throwIfPartialNotAnnotatingTypeParameter(
+        typeAnnotation,
+        types,
+        parser,
+      );
+
+      const properties = parser.computePartialProperties(
+        annotatedElement.typeAnnotation.members,
+        hasteModuleName,
+        types,
+        aliasMap,
+        enumMap,
+        tryParse,
+        cxxOnly,
+      );
+
+      return emitObject(nullable, properties);
+    }
+    default: {
+      throw new UnsupportedGenericParserError(
+        hasteModuleName,
+        typeAnnotation,
+        parser,
+      );
+    }
+  }
+}
+
 function translateTypeAnnotation(
   hasteModuleName: string,
   /**
@@ -181,88 +277,18 @@ function translateTypeAnnotation(
       }
     }
     case 'TSTypeReference': {
-      switch (typeAnnotation.typeName.name) {
-        case 'RootTag': {
-          return emitRootTag(nullable);
-        }
-        case 'Promise': {
-          return emitPromise(
-            hasteModuleName,
-            typeAnnotation,
-            parser,
-            nullable,
-            types,
-            aliasMap,
-            enumMap,
-            tryParse,
-            cxxOnly,
-            translateTypeAnnotation,
-          );
-        }
-        case 'Array':
-        case 'ReadonlyArray': {
-          return emitArrayType(
-            hasteModuleName,
-            typeAnnotation,
-            parser,
-            types,
-            aliasMap,
-            enumMap,
-            cxxOnly,
-            nullable,
-            translateTypeAnnotation,
-          );
-        }
-        case 'Stringish': {
-          return emitStringish(nullable);
-        }
-        case 'Int32': {
-          return emitInt32(nullable);
-        }
-        case 'Double': {
-          return emitDouble(nullable);
-        }
-        case 'Float': {
-          return emitFloat(nullable);
-        }
-        case 'UnsafeObject':
-        case 'Object': {
-          return emitGenericObject(nullable);
-        }
-        case 'Partial': {
-          throwIfPartialWithMoreParameter(typeAnnotation);
-
-          const annotatedElement = parser.extractAnnotatedElement(
-            typeAnnotation,
-            types,
-          );
-
-          throwIfPartialNotAnnotatingTypeParameter(
-            typeAnnotation,
-            types,
-            parser,
-          );
-
-          const properties = parser.computePartialProperties(
-            annotatedElement.typeAnnotation.members,
-            hasteModuleName,
-            types,
-            aliasMap,
-            enumMap,
-            tryParse,
-            cxxOnly,
-          );
-
-          return emitObject(nullable, properties);
-        }
-        default: {
-          throw new UnsupportedGenericParserError(
-            hasteModuleName,
-            typeAnnotation,
-            parser,
-          );
-        }
-      }
+      return translateTypeReferenceAnnotation(
+        typeAnnotation.typeName.name,
+        nullable,
+        typeAnnotation,
+        hasteModuleName,
+        types,
+        aliasMap,
+        enumMap,
+        tryParse,
+        cxxOnly,
+        parser
+      );
     }
     case 'TSInterfaceDeclaration': {
       const baseTypes = (typeAnnotation.extends ?? []).map(

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -125,7 +125,7 @@ function translateObjectTypeAnnotation(
 }
 
 function translateTypeReferenceAnnotation(
-  typeName: string,//typeAnnotation.typeName.name
+  typeName: string,
   nullable: boolean,
   typeAnnotation: $FlowFixMe,
   hasteModuleName: string,
@@ -192,11 +192,7 @@ function translateTypeReferenceAnnotation(
         types,
       );
 
-      throwIfPartialNotAnnotatingTypeParameter(
-        typeAnnotation,
-        types,
-        parser,
-      );
+      throwIfPartialNotAnnotatingTypeParameter(typeAnnotation, types, parser);
 
       const properties = parser.computePartialProperties(
         annotatedElement.typeAnnotation.members,
@@ -287,7 +283,7 @@ function translateTypeAnnotation(
         enumMap,
         tryParse,
         cxxOnly,
-        parser
+        parser,
       );
     }
     case 'TSInterfaceDeclaration': {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

> [Codegen 91] Extract the inner switch in typescript/modules/index.js at line to parse the case TSTypereference ([lines](https://github.com/facebook/react-native/blob/main/packages/react-native-codegen/src/parsers/typescript/modules/index.js#L194-L275))into a function translateTypeReferenceAnnotation() (the goal is to try and get a simpler switch statement and to spot structural similiarities between the flow and typescript index.js files)

Part of Issue #34872 

Also modified lambda function at the 70th line of ReactAndroid/src/main/java/com/facebook/react/ReactPackageTurboModuleManagerDelegate.java, for that CircleCI tests failed due to unsupported lambda function in old Java versions.

I saw it implemented without lambda (as it is now in this PR) in commit a09a6d4, but didn't find out since when it has been changed into lambda. I commented out the original lambda version just in case that you don't actually expect this change.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry.

[INTERNAL] [CHANGED] - Extract case 'TSTypereference' in the switch statement into a separate function translateTypeReferenceAnnotation() for clearer structure; Replaced lambda function for compatibility.


## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

- yarn lint 
- yarn run flow 
- yarn test react-native-codegen
