### PR TITLE
fix: EventEmitter ts definition file

### DIFF
--- a/Libraries/Components/TextInput/TextInput.d.ts
+++ b/Libraries/Components/TextInput/TextInput.d.ts
@@ -21,7 +21,7 @@ import {
   NativeTouchEvent,
   TargetedEvent,
 } from '../../Types/CoreEventTypes';
-import {EventEmitter} from '../../vendor/emitter/EventEmitter';
+import EventEmitter from '../../vendor/emitter/EventEmitter';
 import {AccessibilityProps} from '../View/ViewAccessibility';
 import {ViewProps} from '../View/ViewPropTypes';
 

--- a/Libraries/EventEmitter/NativeEventEmitter.d.ts
+++ b/Libraries/EventEmitter/NativeEventEmitter.d.ts
@@ -7,9 +7,8 @@
  * @format
  */
 
-import {
+import EventEmitter, {
   EmitterSubscription,
-  EventEmitter,
 } from '../vendor/emitter/EventEmitter';
 
 /**

--- a/Libraries/EventEmitter/RCTDeviceEventEmitter.d.ts
+++ b/Libraries/EventEmitter/RCTDeviceEventEmitter.d.ts
@@ -7,9 +7,8 @@
  * @format
  */
 
-import {
+import EventEmitter, {
   EmitterSubscription,
-  EventEmitter,
   EventSubscriptionVendor,
 } from '../vendor/emitter/EventEmitter';
 

--- a/Libraries/vendor/emitter/EventEmitter.d.ts
+++ b/Libraries/vendor/emitter/EventEmitter.d.ts
@@ -104,7 +104,7 @@ interface EmitterSubscription extends EventSubscription {
   remove(): void;
 }
 
-export declare class EventEmitter {
+export default class EventEmitter {
   /**
    *
    * @param subscriber - Optional subscriber instance


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

There's an error in the `d.ts` file for EventEmitter which causes the following error:

```
This expression is not constructable.
  Type 'typeof import(".../vendor/emitter/EventEmitter")' has no construct signatures.
const emitter = new EventEmitter();
                      ~~~~~~~~~~~~
```

See https://github.com/facebook/react-native/blob/dce9d8d5de381fe53760ddda0d6cbbdfb5be00e4/Libraries/vendor/emitter/EventEmitter.js#L63 

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[GENERAL] [FIXED] -Fixes an issue with the EventEmitter type definition file

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
