### PR TITLE
chore: Add functionTypeAnnotation to codegen Parser class

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
@@ -554,9 +554,11 @@ describe('throwIfUntypedModule', () => {
 describe('throwIfModuleTypeIsUnsupported', () => {
   const hasteModuleName = 'moduleName';
   const property = {value: 'value', key: {name: 'name'}};
+  const flowParser = new FlowParser();
+  const typescriptParser = new TypeScriptParser();
+
   it("don't throw error if module type is FunctionTypeAnnotation in Flow", () => {
     const value = {type: 'FunctionTypeAnnotation'};
-    const language = 'Flow';
 
     expect(() => {
       throwIfModuleTypeIsUnsupported(
@@ -564,13 +566,12 @@ describe('throwIfModuleTypeIsUnsupported', () => {
         property.value,
         property.key.name,
         value.type,
-        language,
+        flowParser,
       );
     }).not.toThrow(UnsupportedModulePropertyParserError);
   });
   it('throw error if module type is unsupported in Flow', () => {
     const value = {type: ''};
-    const language = 'Flow';
 
     expect(() => {
       throwIfModuleTypeIsUnsupported(
@@ -578,13 +579,12 @@ describe('throwIfModuleTypeIsUnsupported', () => {
         property.value,
         property.key.name,
         value.type,
-        language,
+        flowParser,
       );
     }).toThrow(UnsupportedModulePropertyParserError);
   });
   it("don't throw error if module type is TSFunctionType in TypeScript", () => {
     const value = {type: 'TSFunctionType'};
-    const language = 'TypeScript';
 
     expect(() => {
       throwIfModuleTypeIsUnsupported(
@@ -592,13 +592,12 @@ describe('throwIfModuleTypeIsUnsupported', () => {
         property.value,
         property.key.name,
         value.type,
-        language,
+        typescriptParser,
       );
     }).not.toThrow(UnsupportedModulePropertyParserError);
   });
   it("don't throw error if module type is TSMethodSignature in TypeScript", () => {
     const value = {type: 'TSMethodSignature'};
-    const language = 'TypeScript';
 
     expect(() => {
       throwIfModuleTypeIsUnsupported(
@@ -606,13 +605,12 @@ describe('throwIfModuleTypeIsUnsupported', () => {
         property.value,
         property.key.name,
         value.type,
-        language,
+        typescriptParser,
       );
     }).not.toThrow(UnsupportedModulePropertyParserError);
   });
   it('throw error if module type is unsupported in TypeScript', () => {
     const value = {type: ''};
-    const language = 'TypeScript';
 
     expect(() => {
       throwIfModuleTypeIsUnsupported(
@@ -620,7 +618,7 @@ describe('throwIfModuleTypeIsUnsupported', () => {
         property.value,
         property.key.name,
         value.type,
-        language,
+        typescriptParser,
       );
     }).toThrow(UnsupportedModulePropertyParserError);
   });

--- a/packages/react-native-codegen/src/parsers/error-utils.js
+++ b/packages/react-native-codegen/src/parsers/error-utils.js
@@ -160,27 +160,15 @@ function throwIfModuleTypeIsUnsupported(
   propertyValue: $FlowFixMe,
   propertyName: string,
   propertyValueType: string,
-  language: ParserType,
+  parser: Parser,
 ) {
-  if (language === 'Flow' && propertyValueType !== 'FunctionTypeAnnotation') {
+  if (!parser.functionTypeAnnotation(propertyValueType)) {
     throw new UnsupportedModulePropertyParserError(
       nativeModuleName,
       propertyValue,
       propertyName,
       propertyValueType,
-      language,
-    );
-  } else if (
-    language === 'TypeScript' &&
-    propertyValueType !== 'TSFunctionType' &&
-    propertyValueType !== 'TSMethodSignature'
-  ) {
-    throw new UnsupportedModulePropertyParserError(
-      nativeModuleName,
-      propertyValue,
-      propertyName,
-      propertyValueType,
-      language,
+      parser.language(),
     );
   }
 }

--- a/packages/react-native-codegen/src/parsers/flow/parser.js
+++ b/packages/react-native-codegen/src/parsers/flow/parser.js
@@ -291,6 +291,10 @@ class FlowParser implements Parser {
       };
     });
   }
+
+  functionTypeAnnotation(propertyValueType: string): boolean {
+    return propertyValueType === 'FunctionTypeAnnotation';
+  }
 }
 
 module.exports = {

--- a/packages/react-native-codegen/src/parsers/parser.js
+++ b/packages/react-native-codegen/src/parsers/parser.js
@@ -204,4 +204,11 @@ export interface Parser {
     tryParse: ParserErrorCapturer,
     cxxOnly: boolean,
   ): Array<$FlowFixMe>;
+
+  /**
+   * Given a propertyValueType, it returns a boolean specifying if the property is a function type annotation.
+   * @parameter propertyValueType: the propertyValueType.
+   * @returns: a boolean specifying if the property is a function type annotation.
+   */
+  functionTypeAnnotation(propertyValueType: string): boolean;
 }

--- a/packages/react-native-codegen/src/parsers/parserMock.js
+++ b/packages/react-native-codegen/src/parsers/parserMock.js
@@ -209,4 +209,8 @@ export class MockedParser implements Parser {
       },
     ];
   }
+
+  functionTypeAnnotation(propertyValueType: string): boolean {
+    return propertyValueType === 'FunctionTypeAnnotation';
+  }
 }

--- a/packages/react-native-codegen/src/parsers/parsers-commons.js
+++ b/packages/react-native-codegen/src/parsers/parsers-commons.js
@@ -328,7 +328,7 @@ function buildPropertySchema(
     property.value,
     key.name,
     value.type,
-    parser.language(),
+    parser,
   );
 
   return {

--- a/packages/react-native-codegen/src/parsers/typescript/parser.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parser.js
@@ -277,6 +277,13 @@ class TypeScriptParser implements Parser {
       };
     });
   }
+
+  functionTypeAnnotation(propertyValueType: string): boolean {
+    return (
+      propertyValueType === 'TSFunctionType' ||
+      propertyValueType === 'TSMethodSignature'
+    );
+  }
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary
 
This PR adds a  `functionTypeAnnotation`  function to the codegen Parser class and implements it in the Flow and TypeScript parsers as requested on https://github.com/facebook/react-native/issues/34872, refactoring the `throwIfModuleTypeIsUnsupported`  function to accept a `Parser` instead of a `ParserType` and use the newly created function instead of the `if (language)` logic. 

## Changelog

[Internal] [Added] - Add `functionTypeAnnotation` to codegen Parser class

## Test Plan

Run `yarn jest react-native-codegen` and ensure CI is green

![image](https://user-images.githubusercontent.com/11707729/224882017-2c31f326-047d-4c21-91e0-3396203ce1c5.png)
