### PR TITLE
fix: fix animated components ref types

### DIFF
--- a/Libraries/Animated/Animated.d.ts
+++ b/Libraries/Animated/Animated.d.ts
@@ -564,7 +564,9 @@ export namespace Animated {
   type NonAnimatedProps = 'key' | 'ref';
 
   type TAugmentRef<T> = T extends React.Ref<infer R>
-    ? React.Ref<R | LegacyRef<R>>
+    ? unknown extends R
+      ? never
+      : React.Ref<R | LegacyRef<R>>
     : never;
 
   export type AnimatedProps<T> = {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

I found Animated components like `View`, `Text`, `ScrollView`, `Image` ref type inferred as `any` when ref callback used. 

![Screen Shot 2023-03-14 at 7 32 53 PM](https://user-images.githubusercontent.com/64301935/224975295-21047dab-7bd1-4023-93d4-a6ee5c47f1e5.png)

this is happening because of `unknown` type is included as union type as below. 

![Screen Shot 2023-03-14 at 7 33 01 PM](https://user-images.githubusercontent.com/64301935/224975937-6ee49f7e-55f7-4391-a752-c52c5171ec02.png)

So I excluded `unknown` type inferring via fixing `TAugmentRef` utility type. 

Result below! 

![Screen Shot 2023-03-14 at 7 33 36 PM](https://user-images.githubusercontent.com/64301935/224976685-da66e5ec-3ef0-41dd-9e1f-2bb8bfcdf598.png)


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

[GENERAL] [FIXED] - fix animated components ref type inferred `any`

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan

Ran `yarn test-typescript` and `yarn test-typescript-offline` with no errors.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
