### PR TITLE
Change PerformanceApiExample to use ModulePathing

### DIFF
--- a/packages/rn-tester/js/examples/Performance/PerformanceApiExample.js
+++ b/packages/rn-tester/js/examples/Performance/PerformanceApiExample.js
@@ -10,13 +10,13 @@
  */
 
 'use strict';
-import type MemoryInfo from '../../../../../Libraries/WebPerformance/MemoryInfo';
-import type ReactNativeStartupTiming from '../../../../../Libraries/WebPerformance/ReactNativeStartupTiming';
+import type MemoryInfo from 'react-native/Libraries/WebPerformance/MemoryInfo';
+import type ReactNativeStartupTiming from 'react-native/Libraries/WebPerformance/ReactNativeStartupTiming';
 
 import * as React from 'react';
 import {StyleSheet, View, Text, Button} from 'react-native';
 import RNTesterPage from '../../components/RNTesterPage';
-import Performance from '../../../../../Libraries/WebPerformance/Performance';
+import Performance from 'react-native/Libraries/WebPerformance/Performance';
 
 const {useState, useCallback} = React;
 const performance = new Performance();


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Recent integration from Windows brought in PerformanceApiExample that uses relative pathing to access react-native library. This causes us to have to override the file since our file structure is different. https://github.com/microsoft/react-native-windows/issues/11373

This PR changes the example to use module pathing instead. 

## Changelog

[GENERAL] [CHANGED] - Change PerformanceApiExample to use ModulePathing

## Test Plan

Tested and passed Windows tests
