### PR TITLE
Support PNPM and workspace setups with pod install

### DIFF
--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -23,6 +23,17 @@ $FOLLY_VERSION = '2021.07.22.00'
 
 $START_TIME = Time.now.to_i
 
+# `@react-native-community/cli-platform-ios/native_modules` defines
+# use_native_modules. We use node to resolve its path to allow for
+# different packager and workspace setups. This is reliant on
+# `@react-native-community/cli-platform-ios` being a direct dependency
+# of `react-native`.
+require Pod::Executable.execute_command('node', ['-p',
+  'require.resolve(
+    "@react-native-community/cli-platform-ios/native_modules.rb",
+    {paths: [process.argv[1]]},
+  )', __dir__]).strip
+
 # This function returns the min iOS version supported by React Native
 # By using this function, you won't have to manualy change your Podfile
 # when we change the minimum version supported by the framework.

--- a/packages/react-native/template/ios/Podfile
+++ b/packages/react-native/template/ios/Podfile
@@ -1,5 +1,9 @@
-require_relative '../node_modules/react-native/scripts/react_native_pods'
-require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
+# Resolve react_native_pods.rb with node to allow for hoisting
+require Pod::Executable.execute_command('node', ['-p',
+  'require.resolve(
+    "react-native/scripts/react_native_pods.rb",
+    {paths: [process.argv[1]]},
+  )', __dir__]).strip
 
 platform :ios, min_ios_version_supported
 prepare_react_native_project!
@@ -50,6 +54,7 @@ target 'HelloWorld' do
     # https://github.com/facebook/react-native/blob/main/scripts/react_native_pods.rb#L197-L202
     react_native_post_install(
       installer,
+      config[:reactNativePath],
       :mac_catalyst_enabled => false
     )
     __apply_Xcode_12_5_M1_post_install_workaround(installer)


### PR DESCRIPTION
## Summary

With Metro symlink support coming soon, users will expect isolated `node_modules` resolution and hoisted `react-native` to work. Currently, we make some fragile assumptions in Ruby scripts about the location of `node_modules` packages - in particular `react-native` and `@react-native-community/cli-platform-ios`.

This change invokes `node` to resolve those paths, which should allow these scripts to work in any Node JS-compliant setup.

There's a small (sub-second) performance penalty involved in invoking node, but two of these in the context of `pod install` seems reasonable. Also, these scripts [already invoke `node`](https://github.com/react-native-community/cli/blob/fb78fe8ea2fabe8e6d43f5042ecbb92e8e484e12/packages/cli-platform-ios/native_modules.rb#L26), so this isn't an additional dependency or point of failure.

*This is probably the first Ruby I've written in >10 years, review suggestions welcome!*

## Changelog

[ios][fixed] - Support workspace setups with pod install

## Test Plan
`pod install` succeeds on a PNPM workspace setup where `@react-native-community/cli` was not at the path previously expected by this script.