### PR TITLE
Hotfix for Jest preset changes in 0a3c555

### DIFF
--- a/jest/react-native-env.js
+++ b/jest/react-native-env.js
@@ -12,5 +12,5 @@
 const NodeEnv = require('jest-environment-node').TestEnvironment;
 
 module.exports = class ReactNativeEnv extends NodeEnv {
-  customExportConditions = ['import', 'require', 'react-native'];
+  customExportConditions = ['require', 'react-native'];
 };


### PR DESCRIPTION
Summary:
It looks like Jest is not running `@babel/transform-modules-commonjs` on all files, and therefore when including `"import"` as a Package Exports condition in Jest, this misbehaved (https://github.com/facebook/react-native/commit/0a3c55562b5ba43b00c21ca4d7b2cba0c8eb6206).

This is a hotfix to restore CI stability.

Changelog:
[Fix][Internal] Hotfix adjusting Jest changes added in https://github.com/facebook/react-native/commit/0a3c55562b5ba43b00c21ca4d7b2cba0c8eb6206

Reviewed By: hoxyq

Differential Revision: D44130442

