### PR TITLE
Improve error messages for invalid function types in react-native-codegen

### DIFF
--- a/packages/react-native-codegen/src/parsers/typescript/components/componentsUtils.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/componentsUtils.js
@@ -416,6 +416,10 @@ function getTypeAnnotation<T>(
       throw new Error(
         `Cannot use "${type}" type annotation for "${name}": must use a specific numeric type like Int32, Double, or Float`,
       );
+    case 'TSFunctionType':
+      throw new Error(
+        `Cannot use "${type}" type annotation for "${name}": must use a specific function type like BubblingEventHandler, or DirectEventHandler`
+      );
     default:
       (type: empty);
       throw new Error(`Unknown prop type for "${name}": "${type}"`);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
The supported `CodegenTypes` aren't provided in the docs, which leads to many issues for developers working to transition native components to support Fabric.
However, explicit error messages are provided in many cases (e.g., to use specific numeric types instead of `number` attributes or to remove nested optionals in arrays).
This isn't the case for the common use-case of TypeScript functions, which are very commonly used for event handlers in native components (such as `onChange`), forcing devs to search their way through the `react-native` codebase until they find [this file](https://github.com/facebook/react-native/blob/681d7f8113d2b5e9d6966255ee6c72b50a7d488a/Libraries/Types/CodegenTypes.js#L18).

By providing an explicit error message, we can significantly improve developer experience while transitioning libraries/components, leading to higher Fabric adoption.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
[GENERAL] [ADDED] - Create explicit error message for TypeScript functions used as props in Codegen components, redirecting devs to the supported function types `BubblingEventHandler` and `DirectEventHandler`.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
* `yarn run lint` shows no errors
* no impact on `yarn && yarn jest react-native-codegen`, which failed 362 tests before and after my changes.