### PR TITLE
Migrate React Native and OSS pipeline to 13.4

### DIFF
--- a/Libraries/ActionSheetIOS/React-RCTActionSheet.podspec
+++ b/Libraries/ActionSheetIOS/React-RCTActionSheet.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
   s.documentation_url      = "https://reactnative.dev/docs/actionsheetios"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4" }
+  s.platforms              = { :ios => min_ios_version_supported }
   s.source                 = source
   s.source_files           = "*.{m}"
   s.preserve_paths         = "package.json", "LICENSE", "LICENSE-docs"

--- a/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -112,11 +112,8 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
   enableFabric = self.fabricEnabled;
 #endif
   UIView *rootView = RCTAppSetupDefaultRootView(bridge, moduleName, initProps, enableFabric);
-  if (@available(iOS 13.0, *)) {
-    rootView.backgroundColor = [UIColor systemBackgroundColor];
-  } else {
-    rootView.backgroundColor = [UIColor whiteColor];
-  }
+
+  rootView.backgroundColor = [UIColor systemBackgroundColor];
 
   return rootView;
 }

--- a/Libraries/AppDelegate/React-RCTAppDelegate.podspec
+++ b/Libraries/AppDelegate/React-RCTAppDelegate.podspec
@@ -57,7 +57,7 @@ Pod::Spec.new do |s|
   s.documentation_url      = "https://reactnative.dev/docs/actionsheetios"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4" }
+  s.platforms              = { :ios => min_ios_version_supported }
   s.source                 = source
   s.source_files            = "**/*.{c,h,m,mm,S,cpp}"
 

--- a/Libraries/Blob/React-RCTBlob.podspec
+++ b/Libraries/Blob/React-RCTBlob.podspec
@@ -39,7 +39,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4" }
+  s.platforms              = { :ios => min_ios_version_supported }
   s.compiler_flags         = folly_compiler_flags + ' -Wno-nullability-completeness'
   s.source                 = source
   s.source_files           = "*.{h,m,mm}"

--- a/Libraries/FBLazyVector/FBLazyVector.podspec
+++ b/Libraries/FBLazyVector/FBLazyVector.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4" }
+  s.platforms              = { :ios => min_ios_version_supported }
   s.source                 = source
   s.source_files           = "**/*.{c,h,m,mm,cpp}"
   s.header_dir             = "FBLazyVector"

--- a/Libraries/Image/RCTImageView.mm
+++ b/Libraries/Image/RCTImageView.mm
@@ -99,15 +99,12 @@ static NSDictionary *onLoadParamsForSource(RCTImageSource *source)
                selector:@selector(clearImageIfDetached)
                    name:UIApplicationDidEnterBackgroundNotification
                  object:nil];
-#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
-    if (@available(iOS 13.0, *)) {
-      [center addObserver:self
-                 selector:@selector(clearImageIfDetached)
 
-                     name:UISceneDidEnterBackgroundNotification
-                   object:nil];
-    }
-#endif
+    [center addObserver:self
+               selector:@selector(clearImageIfDetached)
+
+                   name:UISceneDidEnterBackgroundNotification
+                 object:nil];
   }
   return self;
 }

--- a/Libraries/Image/React-RCTImage.podspec
+++ b/Libraries/Image/React-RCTImage.podspec
@@ -40,7 +40,7 @@ Pod::Spec.new do |s|
   s.documentation_url      = "https://reactnative.dev/docs/image"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4" }
+  s.platforms              = { :ios => min_ios_version_supported }
   s.compiler_flags         = folly_compiler_flags + ' -Wno-nullability-completeness'
   s.source                 = source
   s.source_files           = "*.{m,mm}"

--- a/Libraries/LinkingIOS/RCTLinkingManager.h
+++ b/Libraries/LinkingIOS/RCTLinkingManager.h
@@ -5,11 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
-#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= 12000) /* __IPHONE_12_0 */
-#import <UIKit/UIUserActivity.h>
-#endif
 #import <React/RCTEventEmitter.h>
+#import <UIKit/UIKit.h>
+#import <UIKit/UIUserActivity.h>
 
 @interface RCTLinkingManager : RCTEventEmitter
 
@@ -24,11 +22,6 @@
 
 + (BOOL)application:(nonnull UIApplication *)application
     continueUserActivity:(nonnull NSUserActivity *)userActivity
-      restorationHandler:
-#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= 12000) /* __IPHONE_12_0 */
-          (nonnull void (^)(NSArray<id<UIUserActivityRestoring>> *_Nullable))restorationHandler;
-#else
-          (nonnull void (^)(NSArray *_Nullable))restorationHandler;
-#endif
+      restorationHandler:(nonnull void (^)(NSArray<id<UIUserActivityRestoring>> *_Nullable))restorationHandler;
 
 @end

--- a/Libraries/LinkingIOS/RCTLinkingManager.mm
+++ b/Libraries/LinkingIOS/RCTLinkingManager.mm
@@ -72,14 +72,8 @@ RCT_EXPORT_MODULE()
 
 + (BOOL)application:(UIApplication *)application
     continueUserActivity:(NSUserActivity *)userActivity
-      restorationHandler:
-#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= 12000) /* __IPHONE_12_0 */
-          (nonnull void (^)(NSArray<id<UIUserActivityRestoring>> *_Nullable))restorationHandler
+      restorationHandler:(nonnull void (^)(NSArray<id<UIUserActivityRestoring>> *_Nullable))restorationHandler
 {
-#else
-          (nonnull void (^)(NSArray *_Nullable))restorationHandler
-{
-#endif
   if ([userActivity.activityType isEqualToString:NSUserActivityTypeBrowsingWeb]) {
     NSDictionary *payload = @{@"url" : userActivity.webpageURL.absoluteString};
     [[NSNotificationCenter defaultCenter] postNotificationName:kOpenURLNotification object:self userInfo:payload];

--- a/Libraries/LinkingIOS/React-RCTLinking.podspec
+++ b/Libraries/LinkingIOS/React-RCTLinking.podspec
@@ -40,7 +40,7 @@ Pod::Spec.new do |s|
   s.documentation_url      = "https://reactnative.dev/docs/linking"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4" }
+  s.platforms              = { :ios => min_ios_version_supported }
   s.compiler_flags         = folly_compiler_flags + ' -Wno-nullability-completeness'
   s.source                 = source
   s.source_files           = "*.{m,mm}"

--- a/Libraries/NativeAnimation/React-RCTAnimation.podspec
+++ b/Libraries/NativeAnimation/React-RCTAnimation.podspec
@@ -39,7 +39,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4" }
+  s.platforms              = { :ios => min_ios_version_supported }
   s.compiler_flags         = folly_compiler_flags + ' -Wno-nullability-completeness'
   s.source                 = source
   s.source_files           = "**/*.{h,m,mm}"

--- a/Libraries/Network/React-RCTNetwork.podspec
+++ b/Libraries/Network/React-RCTNetwork.podspec
@@ -39,7 +39,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4" }
+  s.platforms              = { :ios => min_ios_version_supported }
   s.compiler_flags         = folly_compiler_flags + ' -Wno-nullability-completeness'
   s.source                 = source
   s.source_files           = "*.{m,mm}"

--- a/Libraries/PushNotificationIOS/React-RCTPushNotification.podspec
+++ b/Libraries/PushNotificationIOS/React-RCTPushNotification.podspec
@@ -40,7 +40,7 @@ Pod::Spec.new do |s|
   s.documentation_url      = "https://reactnative.dev/docs/pushnotificationios"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4" }
+  s.platforms              = { :ios => min_ios_version_supported }
   s.compiler_flags         = folly_compiler_flags + ' -Wno-nullability-completeness'
   s.source                 = source
   s.source_files           = "*.{m,mm}"

--- a/Libraries/RCTRequired/RCTRequired.podspec
+++ b/Libraries/RCTRequired/RCTRequired.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4" }
+  s.platforms              = { :ios => min_ios_version_supported }
   s.source                 = source
   s.source_files           = "**/*.{c,h,m,mm,cpp}"
   s.header_dir             = "RCTRequired"

--- a/Libraries/Settings/React-RCTSettings.podspec
+++ b/Libraries/Settings/React-RCTSettings.podspec
@@ -40,7 +40,7 @@ Pod::Spec.new do |s|
   s.documentation_url      = "https://reactnative.dev/docs/settings"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4" }
+  s.platforms              = { :ios => min_ios_version_supported }
   s.compiler_flags         = folly_compiler_flags + ' -Wno-nullability-completeness'
   s.source                 = source
   s.source_files           = "*.{m,mm}"

--- a/Libraries/Text/React-RCTText.podspec
+++ b/Libraries/Text/React-RCTText.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
   s.documentation_url      = "https://reactnative.dev/docs/text"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4" }
+  s.platforms              = { :ios => min_ios_version_supported }
   s.source                 = source
   s.source_files           = "**/*.{h,m}"
   s.preserve_paths         = "package.json", "LICENSE", "LICENSE-docs"

--- a/Libraries/Text/TextInput/Multiline/RCTUITextView.m
+++ b/Libraries/Text/TextInput/Multiline/RCTUITextView.m
@@ -170,7 +170,7 @@ static UIColor *defaultPlaceholderColor()
 }
 
 // Turn off scroll animation to fix flaky scrolling.
-// This is only necessary for iOS <= 13.
+// This is only necessary for iOS < 14.
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED < 140000
 - (void)setContentOffset:(CGPoint)contentOffset animated:(__unused BOOL)animated
 {

--- a/Libraries/Text/TextInput/RCTBaseTextInputView.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputView.m
@@ -261,17 +261,13 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
       @"password" : UITextContentTypePassword,
     };
 
-#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 120000 /* __IPHONE_12_0 */
-    if (@available(iOS 12.0, *)) {
-      NSDictionary<NSString *, NSString *> *iOS12extras =
-          @{@"newPassword" : UITextContentTypeNewPassword, @"oneTimeCode" : UITextContentTypeOneTimeCode};
+    NSDictionary<NSString *, NSString *> *iOS12extras =
+        @{@"newPassword" : UITextContentTypeNewPassword, @"oneTimeCode" : UITextContentTypeOneTimeCode};
 
-      NSMutableDictionary<NSString *, NSString *> *iOS12baseMap = [contentTypeMap mutableCopy];
-      [iOS12baseMap addEntriesFromDictionary:iOS12extras];
+    NSMutableDictionary<NSString *, NSString *> *iOS12baseMap = [contentTypeMap mutableCopy];
+    [iOS12baseMap addEntriesFromDictionary:iOS12extras];
 
-      contentTypeMap = [iOS12baseMap copy];
-    }
-#endif
+    contentTypeMap = [iOS12baseMap copy];
   });
 
   // Setting textContentType to an empty string will disable any
@@ -282,11 +278,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
 
 - (void)setPasswordRules:(NSString *)descriptor
 {
-#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_12_0
-  if (@available(iOS 12.0, *)) {
-    self.backedTextInputView.passwordRules = [UITextInputPasswordRules passwordRulesWithDescriptor:descriptor];
-  }
-#endif
+  self.backedTextInputView.passwordRules = [UITextInputPasswordRules passwordRulesWithDescriptor:descriptor];
 }
 
 - (UIKeyboardType)keyboardType

--- a/Libraries/TypeSafety/RCTTypeSafety.podspec
+++ b/Libraries/TypeSafety/RCTTypeSafety.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4" }
+  s.platforms              = { :ios => min_ios_version_supported }
   s.source                 = source
   s.source_files           = "**/*.{c,h,m,mm,cpp}"
   s.header_dir             = "RCTTypeSafety"

--- a/Libraries/Vibration/React-RCTVibration.podspec
+++ b/Libraries/Vibration/React-RCTVibration.podspec
@@ -40,7 +40,7 @@ Pod::Spec.new do |s|
   s.documentation_url      = "https://reactnative.dev/docs/vibration"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4" }
+  s.platforms              = { :ios => min_ios_version_supported }
   s.compiler_flags         = folly_compiler_flags + ' -Wno-nullability-completeness'
   s.source                 = source
   s.source_files           = "*.{m,mm}"

--- a/React-Core.podspec
+++ b/React-Core.podspec
@@ -67,7 +67,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4" }
+  s.platforms              = { :ios => min_ios_version_supported }
   s.source                 = source
   s.resource_bundle        = { "AccessibilityResources" => ["React/AccessibilityResources/*.lproj"]}
   s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags

--- a/React.podspec
+++ b/React.podspec
@@ -36,7 +36,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4" }
+  s.platforms              = { :ios => min_ios_version_supported }
   s.source                 = source
   s.preserve_paths         = "package.json", "LICENSE", "LICENSE-docs"
   s.cocoapods_version      = ">= 1.10.1"

--- a/React/Base/RCTConvert.m
+++ b/React/Base/RCTConvert.m
@@ -947,31 +947,23 @@ static NSString *RCTSemanticColorNames()
       id highContrastDark = [appearances objectForKey:@"highContrastDark"];
       UIColor *highContrastDarkColor = [RCTConvert UIColor:highContrastDark];
       if (lightColor != nil && darkColor != nil) {
-#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
-        if (@available(iOS 13.0, *)) {
-          UIColor *color = [UIColor colorWithDynamicProvider:^UIColor *_Nonnull(
-                                        UITraitCollection *_Nonnull collection) {
-            if (collection.userInterfaceStyle == UIUserInterfaceStyleDark) {
-              if (collection.accessibilityContrast == UIAccessibilityContrastHigh && highContrastDarkColor != nil) {
-                return highContrastDarkColor;
-              } else {
-                return darkColor;
-              }
+        UIColor *color = [UIColor colorWithDynamicProvider:^UIColor *_Nonnull(UITraitCollection *_Nonnull collection) {
+          if (collection.userInterfaceStyle == UIUserInterfaceStyleDark) {
+            if (collection.accessibilityContrast == UIAccessibilityContrastHigh && highContrastDarkColor != nil) {
+              return highContrastDarkColor;
             } else {
-              if (collection.accessibilityContrast == UIAccessibilityContrastHigh && highContrastLightColor != nil) {
-                return highContrastLightColor;
-              } else {
-                return lightColor;
-              }
+              return darkColor;
             }
-          }];
-          return color;
-        } else {
-#endif
-          return lightColor;
-#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
-        }
-#endif
+          } else {
+            if (collection.accessibilityContrast == UIAccessibilityContrastHigh && highContrastLightColor != nil) {
+              return highContrastLightColor;
+            } else {
+              return lightColor;
+            }
+          }
+        }];
+        return color;
+
       } else {
         RCTLogConvertError(json, @"a UIColor. Expected an iOS dynamic appearance aware color.");
         return nil;

--- a/React/CoreModules/RCTAccessibilityManager.mm
+++ b/React/CoreModules/RCTAccessibilityManager.mm
@@ -305,19 +305,15 @@ RCT_EXPORT_METHOD(announceForAccessibilityWithOptions
                   : (NSString *)announcement options
                   : (JS::NativeAccessibilityManager::SpecAnnounceForAccessibilityWithOptionsOptions &)options)
 {
-  if (@available(iOS 11.0, *)) {
-    NSMutableDictionary<NSString *, NSNumber *> *attrsDictionary = [NSMutableDictionary new];
-    if (options.queue()) {
-      attrsDictionary[UIAccessibilitySpeechAttributeQueueAnnouncement] = @(*(options.queue()) ? YES : NO);
-    }
+  NSMutableDictionary<NSString *, NSNumber *> *attrsDictionary = [NSMutableDictionary new];
+  if (options.queue()) {
+    attrsDictionary[UIAccessibilitySpeechAttributeQueueAnnouncement] = @(*(options.queue()) ? YES : NO);
+  }
 
-    if (attrsDictionary.count > 0) {
-      NSAttributedString *announcementWithAttrs = [[NSAttributedString alloc] initWithString:announcement
-                                                                                  attributes:attrsDictionary];
-      UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, announcementWithAttrs);
-    } else {
-      UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, announcement);
-    }
+  if (attrsDictionary.count > 0) {
+    NSAttributedString *announcementWithAttrs = [[NSAttributedString alloc] initWithString:announcement
+                                                                                attributes:attrsDictionary];
+    UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, announcementWithAttrs);
   } else {
     UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, announcement);
   }

--- a/React/CoreModules/RCTActionSheetManager.mm
+++ b/React/CoreModules/RCTActionSheetManager.mm
@@ -181,20 +181,16 @@ RCT_EXPORT_METHOD(showActionSheetWithOptions
   }
 
   alertController.view.tintColor = tintColor;
-#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
-    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
-  if (@available(iOS 13.0, *)) {
-    NSString *userInterfaceStyle = [RCTConvert NSString:options.userInterfaceStyle()];
 
-    if (userInterfaceStyle == nil || [userInterfaceStyle isEqualToString:@""]) {
-      alertController.overrideUserInterfaceStyle = UIUserInterfaceStyleUnspecified;
-    } else if ([userInterfaceStyle isEqualToString:@"dark"]) {
-      alertController.overrideUserInterfaceStyle = UIUserInterfaceStyleDark;
-    } else if ([userInterfaceStyle isEqualToString:@"light"]) {
-      alertController.overrideUserInterfaceStyle = UIUserInterfaceStyleLight;
-    }
+  NSString *userInterfaceStyle = [RCTConvert NSString:options.userInterfaceStyle()];
+
+  if (userInterfaceStyle == nil || [userInterfaceStyle isEqualToString:@""]) {
+    alertController.overrideUserInterfaceStyle = UIUserInterfaceStyleUnspecified;
+  } else if ([userInterfaceStyle isEqualToString:@"dark"]) {
+    alertController.overrideUserInterfaceStyle = UIUserInterfaceStyleDark;
+  } else if ([userInterfaceStyle isEqualToString:@"light"]) {
+    alertController.overrideUserInterfaceStyle = UIUserInterfaceStyleLight;
   }
-#endif
 
   [_alertControllers addObject:alertController];
   [self presentViewController:alertController onParentViewController:controller anchorViewTag:anchorViewTag];
@@ -274,20 +270,15 @@ RCT_EXPORT_METHOD(showShareActionSheetWithOptions
   NSNumber *anchorViewTag = [RCTConvert NSNumber:options.anchor() ? @(*options.anchor()) : nil];
   shareController.view.tintColor = [RCTConvert UIColor:options.tintColor() ? @(*options.tintColor()) : nil];
 
-#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
-    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
-  if (@available(iOS 13.0, *)) {
-    NSString *userInterfaceStyle = [RCTConvert NSString:options.userInterfaceStyle()];
+  NSString *userInterfaceStyle = [RCTConvert NSString:options.userInterfaceStyle()];
 
-    if (userInterfaceStyle == nil || [userInterfaceStyle isEqualToString:@""]) {
-      shareController.overrideUserInterfaceStyle = UIUserInterfaceStyleUnspecified;
-    } else if ([userInterfaceStyle isEqualToString:@"dark"]) {
-      shareController.overrideUserInterfaceStyle = UIUserInterfaceStyleDark;
-    } else if ([userInterfaceStyle isEqualToString:@"light"]) {
-      shareController.overrideUserInterfaceStyle = UIUserInterfaceStyleLight;
-    }
+  if (userInterfaceStyle == nil || [userInterfaceStyle isEqualToString:@""]) {
+    shareController.overrideUserInterfaceStyle = UIUserInterfaceStyleUnspecified;
+  } else if ([userInterfaceStyle isEqualToString:@"dark"]) {
+    shareController.overrideUserInterfaceStyle = UIUserInterfaceStyleDark;
+  } else if ([userInterfaceStyle isEqualToString:@"light"]) {
+    shareController.overrideUserInterfaceStyle = UIUserInterfaceStyleLight;
   }
-#endif
 
   [self presentViewController:shareController onParentViewController:controller anchorViewTag:anchorViewTag];
 }

--- a/React/CoreModules/RCTAlertController.m
+++ b/React/CoreModules/RCTAlertController.m
@@ -43,11 +43,10 @@
 
 - (void)show:(BOOL)animated completion:(void (^)(void))completion
 {
-  if (@available(iOS 13.0, *)) {
-    UIUserInterfaceStyle style =
-        RCTSharedApplication().delegate.window.overrideUserInterfaceStyle ?: UIUserInterfaceStyleUnspecified;
-    self.overrideUserInterfaceStyle = style;
-  }
+  UIUserInterfaceStyle style =
+      RCTSharedApplication().delegate.window.overrideUserInterfaceStyle ?: UIUserInterfaceStyleUnspecified;
+  self.overrideUserInterfaceStyle = style;
+
   [self.alertWindow makeKeyAndVisible];
   [self.alertWindow.rootViewController presentViewController:self animated:animated completion:completion];
 }
@@ -56,23 +55,20 @@
 {
   [_alertWindow setHidden:YES];
 
-  if (@available(iOS 13, *)) {
-    _alertWindow.windowScene = nil;
-  }
+  _alertWindow.windowScene = nil;
 
   _alertWindow = nil;
 }
 
 - (UIWindow *)getUIWindowFromScene
 {
-  if (@available(iOS 13.0, *)) {
-    for (UIScene *scene in RCTSharedApplication().connectedScenes) {
-      if (scene.activationState == UISceneActivationStateForegroundActive &&
-          [scene isKindOfClass:[UIWindowScene class]]) {
-        return [[UIWindow alloc] initWithWindowScene:(UIWindowScene *)scene];
-      }
+  for (UIScene *scene in RCTSharedApplication().connectedScenes) {
+    if (scene.activationState == UISceneActivationStateForegroundActive &&
+        [scene isKindOfClass:[UIWindowScene class]]) {
+      return [[UIWindow alloc] initWithWindowScene:(UIWindowScene *)scene];
     }
   }
+
   return nil;
 }
 

--- a/React/CoreModules/RCTAlertManager.mm
+++ b/React/CoreModules/RCTAlertManager.mm
@@ -105,13 +105,8 @@ RCT_EXPORT_METHOD(alertWithArgs : (JS::NativeAlertManager::Args &)args callback 
                                                                              message:nil
                                                                       preferredStyle:UIAlertControllerStyleAlert];
 
-#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
-    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
-  if (@available(iOS 13.0, *)) {
-    UIUserInterfaceStyle userInterfaceStyle = [RCTConvert UIUserInterfaceStyle:args.userInterfaceStyle()];
-    alertController.overrideUserInterfaceStyle = userInterfaceStyle;
-  }
-#endif
+  UIUserInterfaceStyle userInterfaceStyle = [RCTConvert UIUserInterfaceStyle:args.userInterfaceStyle()];
+  alertController.overrideUserInterfaceStyle = userInterfaceStyle;
 
   switch (type) {
     case RCTAlertViewStylePlainTextInput: {

--- a/React/CoreModules/RCTAppearance.mm
+++ b/React/CoreModules/RCTAppearance.mm
@@ -38,32 +38,27 @@ NSString *RCTCurrentOverrideAppearancePreference()
 
 NSString *RCTColorSchemePreference(UITraitCollection *traitCollection)
 {
-#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
-    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
-  if (@available(iOS 13.0, *)) {
-    static NSDictionary *appearances;
-    static dispatch_once_t onceToken;
+  static NSDictionary *appearances;
+  static dispatch_once_t onceToken;
 
-    if (sColorSchemeOverride) {
-      return sColorSchemeOverride;
-    }
-
-    dispatch_once(&onceToken, ^{
-      appearances = @{
-        @(UIUserInterfaceStyleLight) : RCTAppearanceColorSchemeLight,
-        @(UIUserInterfaceStyleDark) : RCTAppearanceColorSchemeDark
-      };
-    });
-
-    if (!sAppearancePreferenceEnabled) {
-      // Return the default if the app doesn't allow different color schemes.
-      return RCTAppearanceColorSchemeLight;
-    }
-
-    traitCollection = traitCollection ?: [UITraitCollection currentTraitCollection];
-    return appearances[@(traitCollection.userInterfaceStyle)] ?: RCTAppearanceColorSchemeLight;
+  if (sColorSchemeOverride) {
+    return sColorSchemeOverride;
   }
-#endif
+
+  dispatch_once(&onceToken, ^{
+    appearances = @{
+      @(UIUserInterfaceStyleLight) : RCTAppearanceColorSchemeLight,
+      @(UIUserInterfaceStyleDark) : RCTAppearanceColorSchemeDark
+    };
+  });
+
+  if (!sAppearancePreferenceEnabled) {
+    // Return the default if the app doesn't allow different color schemes.
+    return RCTAppearanceColorSchemeLight;
+  }
+
+  traitCollection = traitCollection ?: [UITraitCollection currentTraitCollection];
+  return appearances[@(traitCollection.userInterfaceStyle)] ?: RCTAppearanceColorSchemeLight;
 
   // Default to light on older OS version - same behavior as Android.
   return RCTAppearanceColorSchemeLight;
@@ -97,10 +92,9 @@ RCT_EXPORT_METHOD(setColorScheme : (NSString *)style)
 {
   UIUserInterfaceStyle userInterfaceStyle = [RCTConvert UIUserInterfaceStyle:style];
   NSArray<__kindof UIWindow *> *windows = RCTSharedApplication().windows;
-  if (@available(iOS 13.0, *)) {
-    for (UIWindow *window in windows) {
-      window.overrideUserInterfaceStyle = userInterfaceStyle;
-    }
+
+  for (UIWindow *window in windows) {
+    window.overrideUserInterfaceStyle = userInterfaceStyle;
   }
 }
 
@@ -135,19 +129,15 @@ RCT_EXPORT_SYNCHRONOUS_TYPED_METHOD(NSString *, getColorScheme)
 
 - (void)startObserving
 {
-  if (@available(iOS 13.0, *)) {
-    [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(appearanceChanged:)
-                                                 name:RCTUserInterfaceStyleDidChangeNotification
-                                               object:nil];
-  }
+  [[NSNotificationCenter defaultCenter] addObserver:self
+                                           selector:@selector(appearanceChanged:)
+                                               name:RCTUserInterfaceStyleDidChangeNotification
+                                             object:nil];
 }
 
 - (void)stopObserving
 {
-  if (@available(iOS 13.0, *)) {
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
-  }
+  [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
 @end

--- a/React/CoreModules/RCTDevLoadingView.mm
+++ b/React/CoreModules/RCTDevLoadingView.mm
@@ -150,13 +150,8 @@ RCT_EXPORT_MODULE()
     self->_window.backgroundColor = backgroundColor;
     self->_window.hidden = NO;
 
-#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
-    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
-    if (@available(iOS 13.0, *)) {
-      UIWindowScene *scene = (UIWindowScene *)RCTSharedApplication().connectedScenes.anyObject;
-      self->_window.windowScene = scene;
-    }
-#endif
+    UIWindowScene *scene = (UIWindowScene *)RCTSharedApplication().connectedScenes.anyObject;
+    self->_window.windowScene = scene;
   });
 }
 

--- a/React/CoreModules/RCTLogBoxView.mm
+++ b/React/CoreModules/RCTLogBoxView.mm
@@ -37,11 +37,7 @@
 {
   RCTErrorNewArchitectureValidation(RCTNotAllowedInFabricWithoutLegacy, @"RCTLogBoxView", nil);
 
-  if (@available(iOS 13.0, *)) {
-    self = [super initWithWindowScene:window.windowScene];
-  } else {
-    self = [super initWithFrame:window.frame];
-  }
+  self = [super initWithWindowScene:window.windowScene];
 
   self.windowLevel = UIWindowLevelStatusBar - 1;
   self.backgroundColor = [UIColor clearColor];
@@ -59,11 +55,7 @@
 
 - (instancetype)initWithWindow:(UIWindow *)window surfacePresenter:(id<RCTSurfacePresenterStub>)surfacePresenter
 {
-  if (@available(iOS 13.0, *)) {
-    self = [super initWithWindowScene:window.windowScene];
-  } else {
-    self = [super initWithFrame:window.frame];
-  }
+  self = [super initWithWindowScene:window.windowScene];
 
   id<RCTSurfaceProtocol> surface = [surfacePresenter createFabricSurfaceForModuleName:@"LogBox" initialProperties:@{}];
   [surface start];

--- a/React/CoreModules/RCTPerfMonitor.mm
+++ b/React/CoreModules/RCTPerfMonitor.mm
@@ -45,35 +45,7 @@ NSArray<NSString *> *LabelsForRCTPerformanceLoggerTags();
 
 static BOOL RCTJSCSetOption(const char *option)
 {
-  static RCTJSCSetOptionType setOption;
-  static dispatch_once_t onceToken;
-
-  // As of iOS 13.4, it is no longer possible to change the JavaScriptCore
-  // options at runtime. The options are protected and will cause an
-  // exception when you try to change them after the VM has been initialized.
-  // https://github.com/facebook/react-native/issues/28414
-  if (@available(iOS 13.4, *)) {
-    return NO;
-  }
-
-  dispatch_once(&onceToken, ^{
-    /**
-     * JSC private C++ static method to toggle options at runtime
-     *
-     * JSC::Options::setOptions - JavaScriptCore/runtime/Options.h
-     */
-    setOption = reinterpret_cast<RCTJSCSetOptionType>(dlsym(RTLD_DEFAULT, "_ZN3JSC7Options9setOptionEPKc"));
-
-    if (RCT_DEBUG && setOption == NULL) {
-      RCTLogWarn(@"The symbol used to enable JSC runtime options is not available in this iOS version");
-    }
-  });
-
-  if (setOption) {
-    return setOption(option);
-  } else {
-    return NO;
-  }
+  return NO;
 }
 
 static vm_size_t RCTGetResidentMemorySize(void)
@@ -218,12 +190,8 @@ RCT_EXPORT_MODULE()
     [_container addGestureRecognizer:[[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(tap)]];
 
     _container.backgroundColor = [UIColor whiteColor];
-#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
-    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
-    if (@available(iOS 13.0, *)) {
-      _container.backgroundColor = [UIColor systemBackgroundColor];
-    }
-#endif
+
+    _container.backgroundColor = [UIColor systemBackgroundColor];
   }
 
   return _container;

--- a/React/CoreModules/RCTRedBox.mm
+++ b/React/CoreModules/RCTRedBox.mm
@@ -328,13 +328,11 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)aDecoder)
     cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"msg-cell"];
     cell.textLabel.accessibilityIdentifier = @"redbox-error";
     cell.textLabel.textColor = [UIColor whiteColor];
-    if (@available(iOS 13.0, *)) {
-      // Prefer a monofont for formatting messages that were designed
-      // to be displayed in a terminal.
-      cell.textLabel.font = [UIFont monospacedSystemFontOfSize:14 weight:UIFontWeightBold];
-    } else {
-      cell.textLabel.font = [UIFont boldSystemFontOfSize:14];
-    }
+
+    // Prefer a monofont for formatting messages that were designed
+    // to be displayed in a terminal.
+    cell.textLabel.font = [UIFont monospacedSystemFontOfSize:14 weight:UIFontWeightBold];
+
     cell.textLabel.lineBreakMode = NSLineBreakByWordWrapping;
     cell.textLabel.numberOfLines = 0;
     cell.detailTextLabel.textColor = [UIColor whiteColor];

--- a/React/CoreModules/RCTStatusBarManager.mm
+++ b/React/CoreModules/RCTStatusBarManager.mm
@@ -21,25 +21,12 @@
   static NSDictionary *mapping;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
-    if (@available(iOS 13.0, *)) {
-      mapping = @{
-        @"default" : @(UIStatusBarStyleDefault),
-        @"light-content" : @(UIStatusBarStyleLightContent),
-#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
-    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
-        @"dark-content" : @(UIStatusBarStyleDarkContent)
-#else
-          @"dark-content": @(UIStatusBarStyleDefault)
-#endif
-      };
+    mapping = @{
+      @"default" : @(UIStatusBarStyleDefault),
+      @"light-content" : @(UIStatusBarStyleLightContent),
 
-    } else {
-      mapping = @{
-        @"default" : @(UIStatusBarStyleDefault),
-        @"light-content" : @(UIStatusBarStyleLightContent),
-        @"dark-content" : @(UIStatusBarStyleDefault)
-      };
-    }
+      @"dark-content" : @(UIStatusBarStyleDarkContent)
+    };
   });
   return _RCT_CAST(
       UIStatusBarStyle,

--- a/React/CoreModules/React-CoreModules.podspec
+++ b/React/CoreModules/React-CoreModules.podspec
@@ -39,7 +39,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4" }
+  s.platforms              = { :ios => min_ios_version_supported }
   s.compiler_flags         = folly_compiler_flags + ' -Wno-nullability-completeness'
   s.source                 = source
   s.source_files           = "**/*.{c,m,mm,cpp}"

--- a/React/FBReactNativeSpec/FBReactNativeSpec.podspec
+++ b/React/FBReactNativeSpec/FBReactNativeSpec.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4" }
+  s.platforms              = { :ios => min_ios_version_supported }
   s.compiler_flags         = folly_compiler_flags + ' -Wno-nullability-completeness'
   s.source                 = source
   # This podspec is used to trigger the codegen, and built files are generated in a different location.

--- a/React/Fabric/Mounting/ComponentViews/Modal/RCTFabricModalHostViewController.mm
+++ b/React/Fabric/Mounting/ComponentViews/Modal/RCTFabricModalHostViewController.mm
@@ -22,12 +22,7 @@
   }
   _touchHandler = [RCTSurfaceTouchHandler new];
 
-#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
-    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
-  if (@available(iOS 13.0, *)) {
-    self.modalInPresentation = YES;
-  }
-#endif
+  self.modalInPresentation = YES;
 
   return self;
 }

--- a/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -272,12 +272,9 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrol
     scrollView.snapToOffsets = snapToOffsets;
   }
 
-  if (@available(iOS 13.0, *)) {
-    if (oldScrollViewProps.automaticallyAdjustsScrollIndicatorInsets !=
-        newScrollViewProps.automaticallyAdjustsScrollIndicatorInsets) {
-      scrollView.automaticallyAdjustsScrollIndicatorInsets =
-          newScrollViewProps.automaticallyAdjustsScrollIndicatorInsets;
-    }
+  if (oldScrollViewProps.automaticallyAdjustsScrollIndicatorInsets !=
+      newScrollViewProps.automaticallyAdjustsScrollIndicatorInsets) {
+    scrollView.automaticallyAdjustsScrollIndicatorInsets = newScrollViewProps.automaticallyAdjustsScrollIndicatorInsets;
   }
 
   if ((oldScrollViewProps.contentInsetAdjustmentBehavior != newScrollViewProps.contentInsetAdjustmentBehavior) ||

--- a/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -178,10 +178,7 @@ using namespace facebook::react;
   }
 
   if (newTextInputProps.traits.passwordRules != oldTextInputProps.traits.passwordRules) {
-    if (@available(iOS 12.0, *)) {
-      _backedTextInputView.passwordRules =
-          RCTUITextInputPasswordRulesFromString(newTextInputProps.traits.passwordRules);
-    }
+    _backedTextInputView.passwordRules = RCTUITextInputPasswordRulesFromString(newTextInputProps.traits.passwordRules);
   }
 
   // Traits `blurOnSubmit`, `clearTextOnFocus`, and `selectTextOnFocus` were omitted intentially here

--- a/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.mm
+++ b/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.mm
@@ -44,9 +44,7 @@ void RCTCopyBackedTextInput(
   toTextInput.keyboardType = fromTextInput.keyboardType;
   toTextInput.textContentType = fromTextInput.textContentType;
 
-  if (@available(iOS 12.0, *)) {
-    toTextInput.passwordRules = fromTextInput.passwordRules;
-  }
+  toTextInput.passwordRules = fromTextInput.passwordRules;
 
   [toTextInput setSelectedTextRange:fromTextInput.selectedTextRange notifyDelegate:NO];
 }
@@ -213,12 +211,10 @@ UITextContentType RCTUITextContentTypeFromString(std::string const &contentType)
       @"password" : UITextContentTypePassword,
     } mutableCopy];
 
-    if (@available(iOS 12.0, *)) {
-      [mutableContentTypeMap addEntriesFromDictionary:@{
-        @"newPassword" : UITextContentTypeNewPassword,
-        @"oneTimeCode" : UITextContentTypeOneTimeCode
-      }];
-    }
+    [mutableContentTypeMap addEntriesFromDictionary:@{
+      @"newPassword" : UITextContentTypeNewPassword,
+      @"oneTimeCode" : UITextContentTypeOneTimeCode
+    }];
 
     contentTypeMap = [mutableContentTypeMap copy];
   });

--- a/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -591,9 +591,9 @@ static RCTBorderStyle RCTBorderStyleFromBorderStyle(BorderStyle borderStyle)
     layer.borderColor = borderColor;
     CGColorRelease(borderColor);
     layer.cornerRadius = (CGFloat)borderMetrics.borderRadii.topLeft;
-    if (@available(iOS 13.0, *)) {
-      layer.cornerCurve = CornerCurveFromBorderCurve(borderMetrics.borderCurves.topLeft);
-    }
+
+    layer.cornerCurve = CornerCurveFromBorderCurve(borderMetrics.borderCurves.topLeft);
+
     layer.backgroundColor = _backgroundColor.CGColor;
   } else {
     if (!_borderLayer) {

--- a/React/React-RCTFabric.podspec
+++ b/React/React-RCTFabric.podspec
@@ -50,7 +50,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4" }
+  s.platforms              = { :ios => min_ios_version_supported }
   s.source                 = source
   s.source_files           = "Fabric/**/*.{c,h,m,mm,S,cpp}"
   s.exclude_files          = "**/tests/*",

--- a/React/Views/RCTModalHostView.m
+++ b/React/Views/RCTModalHostView.m
@@ -182,9 +182,9 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : coder)
     if (self.presentationStyle != UIModalPresentationNone) {
       _modalViewController.modalPresentationStyle = self.presentationStyle;
     }
-    if (@available(iOS 13.0, *)) {
-      _modalViewController.presentationController.delegate = self;
-    }
+
+    _modalViewController.presentationController.delegate = self;
+
     [_delegate presentModalHostView:self withViewController:_modalViewController animated:[self hasAnimationType]];
     _isPresented = YES;
   }

--- a/React/Views/RCTModalHostViewController.m
+++ b/React/Views/RCTModalHostViewController.m
@@ -22,12 +22,7 @@
     return nil;
   }
 
-#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
-    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
-  if (@available(iOS 13.0, *)) {
-    self.modalInPresentation = YES;
-  }
-#endif
+  self.modalInPresentation = YES;
 
   _preferredStatusBarStyle = [RCTSharedApplication() statusBarStyle];
   _preferredStatusBarHidden = [RCTSharedApplication() isStatusBarHidden];

--- a/React/Views/RCTSegmentedControl.m
+++ b/React/Views/RCTSegmentedControl.m
@@ -37,38 +37,19 @@
   super.selectedSegmentIndex = selectedIndex;
 }
 
-- (void)setBackgroundColor:(UIColor *)backgroundColor
-{
-#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
-    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
-  if (@available(iOS 13.0, *)) {
-    [super setBackgroundColor:backgroundColor];
-  }
-#endif
-}
-
 - (void)setTextColor:(UIColor *)textColor
 {
-#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
-    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
-  if (@available(iOS 13.0, *)) {
-    [self setTitleTextAttributes:@{NSForegroundColorAttributeName : textColor} forState:UIControlStateNormal];
-  }
-#endif
+  [self setTitleTextAttributes:@{NSForegroundColorAttributeName : textColor} forState:UIControlStateNormal];
 }
 
 - (void)setTintColor:(UIColor *)tintColor
 {
   [super setTintColor:tintColor];
-#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
-    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
-  if (@available(iOS 13.0, *)) {
-    [self setSelectedSegmentTintColor:tintColor];
-    [self setTitleTextAttributes:@{NSForegroundColorAttributeName : [UIColor whiteColor]}
-                        forState:UIControlStateSelected];
-    [self setTitleTextAttributes:@{NSForegroundColorAttributeName : tintColor} forState:UIControlStateNormal];
-  }
-#endif
+
+  [self setSelectedSegmentTintColor:tintColor];
+  [self setTitleTextAttributes:@{NSForegroundColorAttributeName : [UIColor whiteColor]}
+                      forState:UIControlStateSelected];
+  [self setTitleTextAttributes:@{NSForegroundColorAttributeName : tintColor} forState:UIControlStateNormal];
 }
 
 - (void)didChange

--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -599,13 +599,10 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
 - (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection
 {
   [super traitCollectionDidChange:previousTraitCollection];
-#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
-  if (@available(iOS 13.0, *)) {
-    if ([self.traitCollection hasDifferentColorAppearanceComparedToTraitCollection:previousTraitCollection]) {
-      [self.layer setNeedsDisplay];
-    }
+
+  if ([self.traitCollection hasDifferentColorAppearanceComparedToTraitCollection:previousTraitCollection]) {
+    [self.layer setNeedsDisplay];
   }
-#endif
 }
 
 #pragma mark - Borders
@@ -756,17 +753,12 @@ static CGFloat RCTDefaultIfNegativeTo(CGFloat defaultValue, CGFloat x)
     borderTopColor = _borderBlockStartColor;
   }
 
-#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
-  if (@available(iOS 13.0, *)) {
-    borderColor = [borderColor resolvedColorWithTraitCollection:self.traitCollection];
-    borderTopColor = [borderTopColor resolvedColorWithTraitCollection:self.traitCollection];
-    directionAwareBorderLeftColor =
-        [directionAwareBorderLeftColor resolvedColorWithTraitCollection:self.traitCollection];
-    borderBottomColor = [borderBottomColor resolvedColorWithTraitCollection:self.traitCollection];
-    directionAwareBorderRightColor =
-        [directionAwareBorderRightColor resolvedColorWithTraitCollection:self.traitCollection];
-  }
-#endif
+  borderColor = [borderColor resolvedColorWithTraitCollection:self.traitCollection];
+  borderTopColor = [borderTopColor resolvedColorWithTraitCollection:self.traitCollection];
+  directionAwareBorderLeftColor = [directionAwareBorderLeftColor resolvedColorWithTraitCollection:self.traitCollection];
+  borderBottomColor = [borderBottomColor resolvedColorWithTraitCollection:self.traitCollection];
+  directionAwareBorderRightColor =
+      [directionAwareBorderRightColor resolvedColorWithTraitCollection:self.traitCollection];
 
   return (RCTBorderColors){
       (borderTopColor ?: borderColor).CGColor,
@@ -814,15 +806,8 @@ static CGFloat RCTDefaultIfNegativeTo(CGFloat defaultValue, CGFloat x)
   // correctly clip the subviews.
 
   CGColorRef backgroundColor;
-#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
-  if (@available(iOS 13.0, *)) {
-    backgroundColor = [_backgroundColor resolvedColorWithTraitCollection:self.traitCollection].CGColor;
-  } else {
-    backgroundColor = _backgroundColor.CGColor;
-  }
-#else
-  backgroundColor = _backgroundColor.CGColor;
-#endif
+
+  backgroundColor = [_backgroundColor resolvedColorWithTraitCollection:self.traitCollection].CGColor;
 
   if (useIOSBorderRendering) {
     layer.cornerRadius = cornerRadii.topLeft;

--- a/React/Views/RCTViewManager.m
+++ b/React/Views/RCTViewManager.m
@@ -277,15 +277,13 @@ RCT_CUSTOM_VIEW_PROPERTY(removeClippedSubviews, BOOL, RCTView)
 }
 RCT_CUSTOM_VIEW_PROPERTY(borderCurve, RCTBorderCurve, RCTView)
 {
-  if (@available(iOS 13.0, *)) {
-    switch ([RCTConvert RCTBorderCurve:json]) {
-      case RCTBorderCurveContinuous:
-        view.layer.cornerCurve = kCACornerCurveContinuous;
-        break;
-      case RCTBorderCurveCircular:
-        view.layer.cornerCurve = kCACornerCurveCircular;
-        break;
-    }
+  switch ([RCTConvert RCTBorderCurve:json]) {
+    case RCTBorderCurveContinuous:
+      view.layer.cornerCurve = kCACornerCurveContinuous;
+      break;
+    case RCTBorderCurveCircular:
+      view.layer.cornerCurve = kCACornerCurveCircular;
+      break;
   }
 }
 RCT_CUSTOM_VIEW_PROPERTY(borderRadius, CGFloat, RCTView)

--- a/React/Views/ScrollView/RCTScrollView.m
+++ b/React/Views/ScrollView/RCTScrollView.m
@@ -1015,17 +1015,13 @@ RCT_SET_AND_PRESERVE_OFFSET(setShowsVerticalScrollIndicator, showsVerticalScroll
 RCT_SET_AND_PRESERVE_OFFSET(setZoomScale, zoomScale, CGFloat);
 RCT_SET_AND_PRESERVE_OFFSET(setScrollIndicatorInsets, scrollIndicatorInsets, UIEdgeInsets);
 
-#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000 /* __IPHONE_13_0 */
 - (void)setAutomaticallyAdjustsScrollIndicatorInsets:(BOOL)automaticallyAdjusts API_AVAILABLE(ios(13.0))
 {
   // `automaticallyAdjustsScrollIndicatorInsets` is available since iOS 13.
   if ([_scrollView respondsToSelector:@selector(setAutomaticallyAdjustsScrollIndicatorInsets:)]) {
-    if (@available(iOS 13.0, *)) {
-      _scrollView.automaticallyAdjustsScrollIndicatorInsets = automaticallyAdjusts;
-    }
+    _scrollView.automaticallyAdjustsScrollIndicatorInsets = automaticallyAdjusts;
   }
 }
-#endif
 
 - (void)setContentInsetAdjustmentBehavior:(UIScrollViewContentInsetAdjustmentBehavior)behavior
 {

--- a/React/Views/ScrollView/RCTScrollViewManager.m
+++ b/React/Views/ScrollView/RCTScrollViewManager.m
@@ -98,9 +98,7 @@ RCT_EXPORT_VIEW_PROPERTY(onScrollEndDrag, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onMomentumScrollBegin, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onMomentumScrollEnd, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(inverted, BOOL)
-#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000 /* __IPHONE_13_0 */
 RCT_EXPORT_VIEW_PROPERTY(automaticallyAdjustsScrollIndicatorInsets, BOOL)
-#endif
 RCT_EXPORT_VIEW_PROPERTY(contentInsetAdjustmentBehavior, UIScrollViewContentInsetAdjustmentBehavior)
 
 // overflow is used both in css-layout as well as by react-native. In css-layout

--- a/ReactCommon/React-Fabric.podspec
+++ b/ReactCommon/React-Fabric.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4" }
+  s.platforms              = { :ios => min_ios_version_supported }
   s.source                 = source
   s.source_files           = "dummyFile.cpp"
   s.pod_target_xcconfig = { "USE_HEADERMAP" => "YES",

--- a/ReactCommon/React-rncore.podspec
+++ b/ReactCommon/React-rncore.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4" }
+  s.platforms              = { :ios => min_ios_version_supported }
   s.source                 = source
   s.source_files           = "dummyFile.cpp"
   s.pod_target_xcconfig = { "USE_HEADERMAP" => "YES",

--- a/ReactCommon/ReactCommon.podspec
+++ b/ReactCommon/ReactCommon.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4" }
+  s.platforms              = { :ios => min_ios_version_supported }
   s.source                 = source
   s.header_dir             = "ReactCommon" # Use global header_dir for all subspecs for use_frameworks! compatibility
   s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags

--- a/ReactCommon/callinvoker/React-callinvoker.podspec
+++ b/ReactCommon/callinvoker/React-callinvoker.podspec
@@ -27,7 +27,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4" }
+  s.platforms              = { :ios => min_ios_version_supported }
   s.source                 = source
   s.source_files           = "**/*.{cpp,h}"
   s.header_dir             = "ReactCommon"

--- a/ReactCommon/cxxreact/React-cxxreact.podspec
+++ b/ReactCommon/cxxreact/React-cxxreact.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4" }
+  s.platforms              = { :ios => min_ios_version_supported }
   s.source                 = source
   s.source_files           = "*.{cpp,h}"
   s.exclude_files          = "SampleCxxModule.*"

--- a/ReactCommon/hermes/React-hermes.podspec
+++ b/ReactCommon/hermes/React-hermes.podspec
@@ -31,7 +31,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package['license']
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :osx => "10.14", :ios => "12.4" }
+  s.platforms              = { :osx => "10.14", :ios => min_ios_version_supported }
   s.source                 = source
   s.source_files           = "executor/*.{cpp,h}",
                              "inspector/*.{cpp,h}",

--- a/ReactCommon/jsc/React-jsc.podspec
+++ b/ReactCommon/jsc/React-jsc.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4" }
+  s.platforms              = { :ios => min_ios_version_supported }
   s.source                 = source
   s.source_files           = "JSCRuntime.{cpp,h}"
   s.exclude_files          = "**/test/*"

--- a/ReactCommon/jsi/React-jsi.podspec
+++ b/ReactCommon/jsi/React-jsi.podspec
@@ -31,7 +31,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4" }
+  s.platforms              = { :ios => min_ios_version_supported }
   s.source                 = source
 
   s.header_dir    = "jsi"

--- a/ReactCommon/jsiexecutor/React-jsiexecutor.podspec
+++ b/ReactCommon/jsiexecutor/React-jsiexecutor.podspec
@@ -27,7 +27,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4" }
+  s.platforms              = { :ios => min_ios_version_supported }
   s.source                 = source
   s.source_files         = "jsireact/*.{cpp,h}"
   s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags

--- a/ReactCommon/jsinspector/React-jsinspector.podspec
+++ b/ReactCommon/jsinspector/React-jsinspector.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4" }
+  s.platforms              = { :ios => min_ios_version_supported }
   s.source                 = source
   s.source_files           = "*.{cpp,h}"
   s.header_dir             = 'jsinspector'

--- a/ReactCommon/logger/React-logger.podspec
+++ b/ReactCommon/logger/React-logger.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4" }
+  s.platforms              = { :ios => min_ios_version_supported }
   s.source                 = source
   s.source_files           = "*.{cpp,h}"
   s.exclude_files          = "SampleCxxModule.*"

--- a/ReactCommon/react/nativemodule/core/platform/ios/React-NativeModulesApple.podspec
+++ b/ReactCommon/react/nativemodule/core/platform/ios/React-NativeModulesApple.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |s|
     s.homepage               = "https://reactnative.dev/"
     s.license                = package["license"]
     s.author                 = "Meta Platforms, Inc. and its affiliates"
-    s.platforms              = { :ios => "12.4" }
+    s.platforms              = { :ios => min_ios_version_supported }
     s.source                 = source
     s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
     s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/Headers/Private/React-Core\"",

--- a/ReactCommon/react/nativemodule/samples/ReactCommon-Samples.podspec
+++ b/ReactCommon/react/nativemodule/samples/ReactCommon-Samples.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4" }
+  s.platforms              = { :ios => min_ios_version_supported }
   s.source                 = source
   s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
   s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/Headers/Private/React-Core\" \"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon-Samples/ReactCommon_Samples.framework/Headers\"",

--- a/ReactCommon/react/renderer/graphics/React-graphics.podspec
+++ b/ReactCommon/react/renderer/graphics/React-graphics.podspec
@@ -34,7 +34,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4" }
+  s.platforms              = { :ios => min_ios_version_supported }
   s.source                 = source
   s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
   s.source_files           = source_files

--- a/ReactCommon/react/renderer/imagemanager/platform/ios/React-ImageManager.podspec
+++ b/ReactCommon/react/renderer/imagemanager/platform/ios/React-ImageManager.podspec
@@ -34,7 +34,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4" }
+  s.platforms              = { :ios => min_ios_version_supported }
   s.source                 = source
   s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
   s.source_files           = source_files

--- a/ReactCommon/reactperflogger/React-perflogger.podspec
+++ b/ReactCommon/reactperflogger/React-perflogger.podspec
@@ -27,7 +27,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4" }
+  s.platforms              = { :ios => min_ios_version_supported }
   s.source                 = source
   s.source_files           = "**/*.{cpp,h}"
   s.header_dir             = "reactperflogger"

--- a/ReactCommon/runtimeexecutor/React-runtimeexecutor.podspec
+++ b/ReactCommon/runtimeexecutor/React-runtimeexecutor.podspec
@@ -27,7 +27,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4" }
+  s.platforms              = { :ios => min_ios_version_supported }
   s.source                 = source
   s.source_files           = "**/*.{cpp,h}"
   s.header_dir             = "ReactCommon"

--- a/ReactCommon/yoga/Yoga.podspec
+++ b/ReactCommon/yoga/Yoga.podspec
@@ -43,7 +43,7 @@ Pod::Spec.new do |spec|
   ]
 
   # Pinning to the same version as React.podspec.
-  spec.platforms = { :ios => "12.4" }
+  spec.platforms = { :ios => min_ios_version_supported }
 
   # Set this environment variable when *not* using the `:path` option to install the pod.
   # E.g. when publishing this spec to a spec repo.

--- a/packages/rn-tester/NativeComponentExample/MyNativeView.podspec
+++ b/packages/rn-tester/NativeComponentExample/MyNativeView.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.description     = "my-native-view"
   s.homepage        = "https://github.com/sota000/my-native-view.git"
   s.license         = "MIT"
-  s.platforms       = { :ios => "12.4" }
+  s.platforms       = { :ios => min_ios_version_supported }
   s.compiler_flags  = boost_compiler_flags + ' -Wno-nullability-completeness'
   s.author          = "Meta Platforms, Inc. and its affiliates"
   s.source          = { :git => "https://github.com/facebook/my-native-view.git", :tag => "#{s.version}" }

--- a/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.podspec
+++ b/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.description     = "NativeCxxModuleExample"
   s.homepage        = "https://github.com/facebook/react-native.git"
   s.license         = "MIT"
-  s.platforms       = { :ios => "12.4" }
+  s.platforms       = { :ios => min_ios_version_supported }
   s.compiler_flags  = '-Wno-nullability-completeness'
   s.author          = "Meta Platforms, Inc. and its affiliates"
   s.source          = { :git => "https://github.com/facebook/react-native.git", :tag => "#{s.version}" }

--- a/packages/rn-tester/NativeModuleExample/ScreenshotManager.podspec
+++ b/packages/rn-tester/NativeModuleExample/ScreenshotManager.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.description     = "ScreenshotManager"
   s.homepage        = "https://github.com/facebook/react-native.git"
   s.license         = "MIT"
-  s.platforms       = { :ios => "12.4" }
+  s.platforms       = { :ios => min_ios_version_supported }
   s.compiler_flags  = '-Wno-nullability-completeness'
   s.author          = "Meta Platforms, Inc. and its affiliates"
   s.source          = { :git => "https://github.com/facebook/react-native.git", :tag => "#{s.version}" }

--- a/packages/rn-tester/RCTTest/React-RCTTest.podspec
+++ b/packages/rn-tester/RCTTest/React-RCTTest.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
-  s.platforms              = { :ios => "12.4" }
+  s.platforms              = { :ios => min_ios_version_supported }
   s.compiler_flags         = folly_compiler_flags + ' -Wno-nullability-completeness'
   s.source                 = source
   s.source_files           = "**/*.{h,m,mm}"

--- a/packages/rn-tester/RNTesterUnitTests/RCTConvert_UIColorTests.m
+++ b/packages/rn-tester/RNTesterUnitTests/RCTConvert_UIColorTests.m
@@ -75,30 +75,26 @@ static BOOL CGColorsAreEqual(CGColorRef color1, CGColorRef color2)
   UIColor *value = [RCTConvert UIColor:json];
   XCTAssertNotNil(value);
 
-#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
-  if (@available(iOS 13.0, *)) {
-    id savedTraitCollection = [UITraitCollection currentTraitCollection];
+  id savedTraitCollection = [UITraitCollection currentTraitCollection];
 
-    [UITraitCollection
-        setCurrentTraitCollection:[UITraitCollection traitCollectionWithUserInterfaceStyle:UIUserInterfaceStyleLight]];
-    CGFloat rgba[4];
-    RCTGetRGBAColorComponents([value CGColor], rgba);
-    XCTAssertEqual(rgba[0], 0);
-    XCTAssertEqual(rgba[1], 0);
-    XCTAssertEqual(rgba[2], 0);
-    XCTAssertEqual(rgba[3], 0);
+  [UITraitCollection
+      setCurrentTraitCollection:[UITraitCollection traitCollectionWithUserInterfaceStyle:UIUserInterfaceStyleLight]];
+  CGFloat rgba[4];
+  RCTGetRGBAColorComponents([value CGColor], rgba);
+  XCTAssertEqual(rgba[0], 0);
+  XCTAssertEqual(rgba[1], 0);
+  XCTAssertEqual(rgba[2], 0);
+  XCTAssertEqual(rgba[3], 0);
 
-    [UITraitCollection
-        setCurrentTraitCollection:[UITraitCollection traitCollectionWithUserInterfaceStyle:UIUserInterfaceStyleDark]];
-    RCTGetRGBAColorComponents([value CGColor], rgba);
-    XCTAssertEqual(rgba[0], 1);
-    XCTAssertEqual(rgba[1], 1);
-    XCTAssertEqual(rgba[2], 1);
-    XCTAssertEqual(rgba[3], 0);
+  [UITraitCollection
+      setCurrentTraitCollection:[UITraitCollection traitCollectionWithUserInterfaceStyle:UIUserInterfaceStyleDark]];
+  RCTGetRGBAColorComponents([value CGColor], rgba);
+  XCTAssertEqual(rgba[0], 1);
+  XCTAssertEqual(rgba[1], 1);
+  XCTAssertEqual(rgba[2], 1);
+  XCTAssertEqual(rgba[3], 0);
 
-    [UITraitCollection setCurrentTraitCollection:savedTraitCollection];
-  }
-#endif
+  [UITraitCollection setCurrentTraitCollection:savedTraitCollection];
 }
 
 - (void)testCompositeDynamicColor
@@ -109,23 +105,19 @@ static BOOL CGColorsAreEqual(CGColorRef color1, CGColorRef color2)
   UIColor *value = [RCTConvert UIColor:json];
   XCTAssertNotNil(value);
 
-#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
-  if (@available(iOS 13.0, *)) {
-    id savedTraitCollection = [UITraitCollection currentTraitCollection];
+  id savedTraitCollection = [UITraitCollection currentTraitCollection];
 
-    [UITraitCollection
-        setCurrentTraitCollection:[UITraitCollection traitCollectionWithUserInterfaceStyle:UIUserInterfaceStyleLight]];
+  [UITraitCollection
+      setCurrentTraitCollection:[UITraitCollection traitCollectionWithUserInterfaceStyle:UIUserInterfaceStyleLight]];
 
-    XCTAssertTrue(CGColorsAreEqual([value CGColor], [[UIColor systemRedColor] CGColor]));
+  XCTAssertTrue(CGColorsAreEqual([value CGColor], [[UIColor systemRedColor] CGColor]));
 
-    [UITraitCollection
-        setCurrentTraitCollection:[UITraitCollection traitCollectionWithUserInterfaceStyle:UIUserInterfaceStyleDark]];
+  [UITraitCollection
+      setCurrentTraitCollection:[UITraitCollection traitCollectionWithUserInterfaceStyle:UIUserInterfaceStyleDark]];
 
-    XCTAssertTrue(CGColorsAreEqual([value CGColor], [[UIColor systemBlueColor] CGColor]));
+  XCTAssertTrue(CGColorsAreEqual([value CGColor], [[UIColor systemBlueColor] CGColor]));
 
-    [UITraitCollection setCurrentTraitCollection:savedTraitCollection];
-  }
-#endif
+  [UITraitCollection setCurrentTraitCollection:savedTraitCollection];
 }
 
 - (void)testGenerateFallbacks
@@ -171,15 +163,12 @@ static BOOL CGColorsAreEqual(CGColorRef color1, CGColorRef color2)
     @"clearColor" : @(0x00000000),
   };
 
-#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
   id savedTraitCollection = nil;
-  if (@available(iOS 13.0, *)) {
-    savedTraitCollection = [UITraitCollection currentTraitCollection];
 
-    [UITraitCollection
-        setCurrentTraitCollection:[UITraitCollection traitCollectionWithUserInterfaceStyle:UIUserInterfaceStyleLight]];
-  }
-#endif
+  savedTraitCollection = [UITraitCollection currentTraitCollection];
+
+  [UITraitCollection
+      setCurrentTraitCollection:[UITraitCollection traitCollectionWithUserInterfaceStyle:UIUserInterfaceStyleLight]];
 
   for (NSString *semanticColor in semanticColors) {
     id json = RCTJSONParse([NSString stringWithFormat:@"{ \"semantic\": \"%@\" }", semanticColor], nil);
@@ -206,11 +195,7 @@ static BOOL CGColorsAreEqual(CGColorRef color1, CGColorRef color2)
     XCTAssertEqual(alpha1, alpha2);
   }
 
-#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
-  if (@available(iOS 13.0, *)) {
-    [UITraitCollection setCurrentTraitCollection:savedTraitCollection];
-  }
-#endif
+  [UITraitCollection setCurrentTraitCollection:savedTraitCollection];
 }
 
 @end

--- a/scripts/cocoapods/codegen_utils.rb
+++ b/scripts/cocoapods/codegen_utils.rb
@@ -111,7 +111,7 @@ class CodegenUtils
           'source' => { :git => '' },
           'header_mappings_dir' => './',
           'platforms' => {
-            'ios' => '11.0',
+            'ios' => min_ios_version_supported,
           },
           'source_files' => "**/*.{h,mm,cpp}",
           'pod_target_xcconfig' => {

--- a/scripts/react_native_pods.rb
+++ b/scripts/react_native_pods.rb
@@ -27,7 +27,7 @@ $START_TIME = Time.now.to_i
 # By using this function, you won't have to manualy change your Podfile
 # when we change the minimum version supported by the framework.
 def min_ios_version_supported
-  return '12.4'
+  return '13.4'
 end
 
 # This function prepares the project for React Native, before processing

--- a/sdks/hermes-engine/hermes-engine.podspec
+++ b/sdks/hermes-engine/hermes-engine.podspec
@@ -34,7 +34,7 @@ Pod::Spec.new do |spec|
   spec.license     = package['license']
   spec.author      = "Facebook"
   spec.source      = source
-  spec.platforms   = { :osx => "10.13", :ios => "12.4" }
+  spec.platforms   = { :osx => "10.13", :ios => min_ios_version_supported }
 
   spec.preserve_paths      = '**/*.*'
   spec.source_files        = ''

--- a/third-party-podspecs/DoubleConversion.podspec
+++ b/third-party-podspecs/DoubleConversion.podspec
@@ -21,6 +21,6 @@ Pod::Spec.new do |spec|
   spec.user_target_xcconfig = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/DoubleConversion\"" }
 
   # Pinning to the same version as React.podspec.
-  spec.platforms = { :ios => "12.4" }
+  spec.platforms = { :ios => min_ios_version_supported }
 
 end

--- a/third-party-podspecs/RCT-Folly.podspec
+++ b/third-party-podspecs/RCT-Folly.podspec
@@ -152,5 +152,5 @@ Pod::Spec.new do |spec|
 
   # Folly has issues when compiled with iOS 10 set as deployment target
   # See https://github.com/facebook/folly/issues/1470 for details
-  spec.platforms = { :ios => "9.0" }
+  spec.platforms = { :ios => min_ios_version_supported }
 end

--- a/third-party-podspecs/boost.podspec
+++ b/third-party-podspecs/boost.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |spec|
                   :sha256 => 'f0397ba6e982c4450f27bf32a2a83292aba035b827a5623a14636ea583318c41' }
 
   # Pinning to the same version as React.podspec.
-  spec.platforms = { :ios => '11.0' }
+  spec.platforms = { :ios => min_ios_version_supported }
   spec.requires_arc = false
 
   spec.module_name = 'boost'

--- a/third-party-podspecs/glog.podspec
+++ b/third-party-podspecs/glog.podspec
@@ -33,6 +33,6 @@ Pod::Spec.new do |spec|
                                "HEADER_SEARCH_PATHS" => "$(PODS_TARGET_SRCROOT)/src" }
 
   # Pinning to the same version as React.podspec.
-  spec.platforms = { :ios => "12.4" }
+  spec.platforms = { :ios => min_ios_version_supported }
 
 end


### PR DESCRIPTION
Summary:
Internally, FBApp moved already to iOS 13.4, since several months already. React Native is still using 12.4 as minimum version.

This set of changes moves RN to 13.4, following the company directives.

## Changelog
[iOS][Breaking] - Move minimum version of RN to 13.4

Differential Revision: D44135295

