### PR TITLE
RFC: Add @react-native/metro-config package

### DIFF
--- a/packages/metro-config/index.js
+++ b/packages/metro-config/index.js
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @noformat
+ */
+
+/*:: import type {ConfigT} from 'metro-config'; */
+
+const {getDefaultConfig: getBaseConfig, mergeConfig} = require('metro-config');
+
+const INTERNAL_CALLSITES_REGEX = new RegExp(
+  [
+    '/Libraries/Renderer/implementations/.+\\.js$',
+    '/Libraries/BatchedBridge/MessageQueue\\.js$',
+    '/Libraries/YellowBox/.+\\.js$',
+    '/Libraries/LogBox/.+\\.js$',
+    '/Libraries/Core/Timers/.+\\.js$',
+    '/Libraries/WebSocket/.+\\.js$',
+    '/Libraries/vendor/.+\\.js$',
+    '/node_modules/react-devtools-core/.+\\.js$',
+    '/node_modules/react-refresh/.+\\.js$',
+    '/node_modules/scheduler/.+\\.js$',
+    '/node_modules/event-target-shim/.+\\.js$',
+    '/node_modules/invariant/.+\\.js$',
+    '/node_modules/react-native/index.js$',
+    '/metro-runtime/.+\\.js$',
+    '^\\[native code\\]$',
+  ].join('|'),
+);
+
+/**
+ * Get the base Metro configuration for a React Native project.
+ */
+function getDefaultConfig(
+  projectRoot /*: string */
+) /*: ConfigT */ {
+  const config = {
+    resolver: {
+      resolverMainFields: ['react-native', 'browser', 'main'],
+      platforms: ['android', 'ios'],
+      unstable_conditionNames: ['import', 'require', 'react-native'],
+    },
+    serializer: {
+      getPolyfills: () => require('@react-native/js-polyfills')(),
+    },
+    server: {
+      port: Number(process.env.RCT_METRO_PORT) || 8081,
+    },
+    symbolicator: {
+      customizeFrame: (frame /*: $ReadOnly<{file: ?string, ...}>*/) => {
+        const collapse = Boolean(
+          frame.file && INTERNAL_CALLSITES_REGEX.test(frame.file),
+        );
+        return {collapse};
+      },
+    },
+    transformer: {
+      allowOptionalDependencies: true,
+      assetRegistryPath: 'react-native/Libraries/Image/AssetRegistry',
+      asyncRequireModulePath: require.resolve(
+        'metro-runtime/src/modules/asyncRequire',
+      ),
+      babelTransformerPath: require.resolve(
+        'metro-react-native-babel-transformer',
+      ),
+      getTransformOptions: async () => ({
+        transform: {
+          experimentalImportSupport: false,
+          inlineRequires: true,
+        },
+      }),
+    },
+    watchFolders: [],
+  };
+
+  return mergeConfig(
+    getBaseConfig.getDefaultValues(projectRoot),
+    config,
+  );
+}
+
+module.exports = {getDefaultConfig};

--- a/packages/metro-config/package.json
+++ b/packages/metro-config/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@react-native/metro-config",
+  "version": "0.72.0",
+  "description": "Metro configuration for React Native.",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:facebook/react-native.git",
+    "directory": "packages/metro-config"
+  },
+  "license": "MIT",
+  "exports": "./index.js",
+  "dependencies": {
+    "@react-native/js-polyfills": "^0.72.1",
+    "metro-config": "0.75.1"
+  }
+}


### PR DESCRIPTION
Summary:
## Context

### React Native Metro config → React Native repo

We (the React Native team) are aiming to relocate the default Metro config for React Native out of `react-native-community/cli-plugin-metro` and **into the React Native repo + app template** as a new `react-native/metro-config` package.

This is the first (and minimum viable) phase we can ship to separate the release process of Metro from RN CLI in order to reduce coupling and iterate faster for our users.

### Motivation

Today, the Metro config required to use React Native is entangled within `react-native-community/cli-plugin-metro` and is not readable from within a project. We instead want to relocate the default Metro config into the React Native repo and have users explicitly inherit this config in their projects.

| Before | After |
|--------|--------|
| <img width="1043" alt="image" src="https://user-images.githubusercontent.com/2547783/225677077-0ea0ba1b-9a11-40dd-b7a1-872db5fc66b6.png"> | <img width="1102" alt="image" src="https://user-images.githubusercontent.com/2547783/225677447-f7299420-8df2-45cd-93c5-9b4971567959.png"> |
| | Note: CLI change will be breaking, to explicitly target React Native 0.72 and onwards |

**Benefits**

- Allows projects to clearly understand, extend, and override options within their `metro.config.js` file as the source of truth.
- Logically, locates the config for using Metro with React Native within the React Native repo — where we can set baseline defaults that are inherited by other tooling (e.g. both RN CLI and Expo).
- The previous setup meant that the resolved Metro configuration was hidden, preventing standalone Metro CLI commands from being runnable.
   - e.g. [`metro get-dependencies`](https://facebook.github.io/metro/docs/cli/#get-dependencies-entryfile), which currently fails in a default React Native or Expo project.
- Removes existing [noise](https://github.com/facebook/react-native/blob/main/template/metro.config.js#L12-L13) from the template config.
- Moves us closer to shipping Metro updates and bugfixes independent of the CLI.

**User-side change: Default `metro.config.js` file in a new React Native project**

We will also signal the need to update existing `metro.config.js` files in the release blog post.

| Before | After |
|--------|--------|
| <img width="630" alt="image" src="https://user-images.githubusercontent.com/2547783/225653497-5b62e653-5abb-4146-9f8e-897ecfb76bd8.png"> | <img width="603" alt="image" src="https://user-images.githubusercontent.com/2547783/225653202-ef9c7649-7dc9-4383-b949-1b754b89be87.png"> |
| ⚠️ Config contains user overrides only, will be overridden by defaults set by React Native CLI. | ✅ Complete Metro config is defined by extending `react-native/metro-config`.  |
| ⚠️ Config contains stale defaults that were split across the template and RN CLI. | ✅ Both RN CLI and `metro` CLI will read the same config. |
|  | ✅ Dynamic/extended config will continue to be applied by RN CLI on top of these. |
|  | ✅ User-defined config object is cleaned up. |

### Plan

1. ➡️ **This PR**: Create a new package within [facebook/react-native](https://github.com/facebook/react-native), `@react-native/metro-config`, to contain the default Metro config for React Native projects going forward.
2. Update React Native app template to define an updated `metro.config.js` extending the new config package.
3. (Depends on the above two changes) https://github.com/react-native-community/cli/pull/1875

Note: Changes in this repo (1, 2) will be compatible with the current version of RN CLI on `main` — the only breaking change is that the new CLI will not be able to support RN projects without these changes.

## Changes

- This PR adds the new `@react-native/metro-config` package which reproduces all static values previously defined in RN CLI.
    - The values not included, [which remain in RN CLI](https://github.com/react-native-community/cli/pull/1875), are dynamic values derived from CLI options passed by the user.

## Test Plan (all PRs + incoming changes)

**E2E expectation**: _The new config is non-breaking against old CLI, the new CLI is breaking against old config_.

**Pre-steps**

With the relevant repos cloned:

```
.
└── Development/forks
    ├── react-native     # huntie/react-native@export-D44099692
    └── react-native-cli # huntie/react-native-cli@c53e49b
```

1. `cd Development/forks/react-native/packages/rn-tester/`
2. Copy over `metro.config.js` and `package.json` changes from `react-native/template/` (next commit in stack).
3. Run `yarn`.

**[Base case] React Native @ `main` (this stack, before new CLI is merged — non-breaking)**
(template = new, CLI = old)

```
yarn start
```

✅ Works (new complete Metro config is read into RN CLI, and overridden by its previous defaults — for this reason we can't delete `./rn-get-polyfills.js` yet!)

```
yarn metro get-dependencies --entry-file js/RNTesterApp.android.js --platform android
```

✅ Works (new complete Metro config is available to Metro CLI)

**[Release state] React Native 0.72 (new CLI, new config required)**
(template = new, CLI = new)

1.  Use `(cd ../..; yarn link @react-native-community/cli-plugin-metro)` to substitute version of `@react-native-community/cli-plugin-metro` using cloned `react-native-cli` directory.
2. Run `yarn`.
3. Update `watchFolders` (see [Metro Local Development Setup](https://facebook.github.io/metro/docs/local-development)).

```
yarn start
```

<img width="2192" alt="image" src="https://user-images.githubusercontent.com/2547783/226422585-4fb299da-f166-46b7-bf35-277d2124e494.png">

✅ Works (new complete Metro config is read into RN CLI, and merged with sparser defaults in https://github.com/react-native-community/cli/pull/1875)
    - (Note console logs)
    - Note: At the point this test was run, found a small unrelated bug (post monorepo land) where `rn-tester` would look for a `metro.config.js` at the repo root and not inside `packages/rn-tester/` — hence an extra `/metro.config.js` file was added in the above screenshot. This will be re-tested in the commit when we bump RN CLI.

Changelog:
[General][Added] Add `react-native/metro-config` package

Differential Revision: D44099692

