### PR TITLE
Fix check of "reduce motion" setting on android

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/accessibilityinfo/AccessibilityInfoModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/accessibilityinfo/AccessibilityInfoModule.java
@@ -100,10 +100,15 @@ public class AccessibilityInfoModule extends NativeAccessibilityInfoSpec
 
   @TargetApi(Build.VERSION_CODES.LOLLIPOP)
   private boolean getIsReduceMotionEnabledValue() {
-    String value =
+    // Disabling animations in developer settings will set the animation scale to "0.0"
+    // but setting "reduce motion" / "disable animations" will set the animation scale to "0".
+    String rawValue =
         Settings.Global.getString(mContentResolver, Settings.Global.TRANSITION_ANIMATION_SCALE);
 
-    return value != null && value.equals("0.0");
+    // Parse the value as a float so we can check for a single value.
+    Float parsedValue = rawValue != null ? Float.parseFloat(rawValue) : 1f;
+
+    return parsedValue == 0f;
   }
 
   @Override


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

On Android `AccessibilityInfo.isReduceMotionEnabled()` returns false even when "Disable Animations" is enabled. This fixes #31221.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
[ANDROID] [FIXED] - Fix check of "reduce motion" setting on android

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Have some code logging the value of `AccessibilityInfo.isReduceMotionEnabled()` or using it to change the UI. Run that code on Android without and with "Disable Animations" enabled. See the value is always `false` without the fix, but changes to `true` when  "Disable Animations" is enabled with the fix.