### PR TITLE
Remove references to `coveralls` NPM package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1148,7 +1148,7 @@ jobs:
   # Collect JavaScript test coverage
   js_coverage:
     executor: nodelts
-    environment: p
+    environment:
       - CI_BRANCH: $CIRCLE_BRANCH
       - CI_PULL_REQUEST: $CIRCLE_PULL_REQUEST
       - CI_BUILD_NUMBER: $CIRCLE_BUILD_NUM

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1148,7 +1148,7 @@ jobs:
   # Collect JavaScript test coverage
   js_coverage:
     executor: nodelts
-    environment:
+    environment: p
       - CI_BRANCH: $CIRCLE_BRANCH
       - CI_PULL_REQUEST: $CIRCLE_PULL_REQUEST
       - CI_BUILD_NUMBER: $CIRCLE_BUILD_NUM
@@ -1161,9 +1161,6 @@ jobs:
           name: Collect test coverage information
           command: |
             scripts/circleci/exec_swallow_error.sh yarn test --coverage --maxWorkers=2
-            if [[ -e ./coverage/lcov.info ]]; then
-              cat ./coverage/lcov.info | scripts/circleci/exec_swallow_error.sh ./node_modules/.bin/coveralls
-            fi
       - store_artifacts:
           path: ~/react-native/coverage/
 

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "async": "^3.2.2",
     "clang-format": "^1.8.0",
     "connect": "^3.6.5",
-    "coveralls": "^3.1.1",
     "eslint": "^8.19.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-babel": "^5.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3698,17 +3698,6 @@ cosmiconfig@^5.0.5, cosmiconfig@^5.1.0:
     js-yaml "^3.13.0"
     parse-json "^4.0.0"
 
-coveralls@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/coveralls/-/coveralls-3.1.1.tgz#f5d4431d8b5ae69c5079c8f8ca00d64ac77cf081"
-  integrity sha512-+dxnG2NHncSD1NrqbSM3dn/lE57O6Qf/koe9+I7c+wzkqRmEvcp0kgJdxKInzYzkICKkFMZsX3Vct3++tsF9ww==
-  dependencies:
-    js-yaml "^3.13.1"
-    lcov-parse "^1.0.0"
-    log-driver "^1.2.7"
-    minimist "^1.2.5"
-    request "^2.88.2"
-
 cross-spawn@^6.0.0:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -6136,11 +6125,6 @@ language-tags@^1.0.5:
   dependencies:
     language-subtag-registry "~0.3.2"
 
-lcov-parse@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/lcov-parse/-/lcov-parse-1.0.0.tgz#eb0d46b54111ebc561acb4c408ef9363bdc8f7e0"
-  integrity sha1-6w1GtUER68VhrLTECO+TY73I9+A=
-
 leven@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"
@@ -6247,11 +6231,6 @@ lodash@^4.17.19, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
-
-log-driver@^1.2.7:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/log-driver/-/log-driver-1.2.7.tgz#63b95021f0702fedfa2c9bb0a24e7797d71871d8"
-  integrity sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==
 
 log-symbols@^4.1.0:
   version "4.1.0"
@@ -6696,7 +6675,7 @@ minimatch@^3.0.2, minimatch@^3.0.4, minimatch@^3.1.1, minimatch@^3.1.2:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
+minimist@^1.2.0, minimist@^1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==


### PR DESCRIPTION
## Summary

In our fork React Native macOS, the NPM package `coveralls` generates a security warning. This is (partially) because it depends on the deprecated package `request`, which we can see here has been end of life for 2+ years: https://github.com/request/request/issues/3142 . React Native depends on it to parse some code coverage output in CircleCI. Let's remove it entirely because:

1) The parsing wasn't working. Both locally and in CI , I see this error when I run the bit that uses `coveralls`:
```
sanajmi@saads-mac-mini react-native % cat ./coverage/lcov.info | scripts/circleci/exec_swallow_error.sh ./node_modules/.bin/coveralls

/Users/sanajmi/workspace/react-native/node_modules/coveralls/bin/coveralls.js:19
      throw err;
      ^
Bad response: 422 {"message":"Couldn't find a repository matching this job.","error":true}
(Use `node --trace-uncaught ...` to show where the exception was thrown)
Command  ./node_modules/.bin/coveralls  exited with error status 1
```
Here's a link to another PR's CI job where it's failing with the same error: https://app.circleci.com/pipelines/github/facebook/react-native/20462/workflows/d0ae15f6-557b-47df-a9d3-ef978b055b0a/jobs/483714/parallel-runs/0/steps/0-106

2) We upload the entire `coverage/` folder as a CI artifact anyway. So we're not losing info. 

## Changelog

[INTERNAL] [SECURITY] - Remove references to `coveralls` NPM package

## Test Plan

CI should pass. 