### PR TITLE
RN: add @react-native/tester as a workspace to xplat/js/public

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@types/react": "^18.0.18",
     "@typescript-eslint/parser": "^5.30.5",
     "async": "^3.2.2",
+    "babel-plugin-transform-flow-enums":"^0.0.2",
     "clang-format": "^1.8.0",
     "connect": "^3.6.5",
     "coveralls": "^3.1.1",

--- a/packages/rn-tester/package.json
+++ b/packages/rn-tester/package.json
@@ -28,11 +28,6 @@
     "react": "18.2.0",
     "react-native": "*"
   },
-  "devDependencies": {
-    "babel-plugin-transform-flow-enums":"^0.0.2",
-    "connect": "^3.6.5",
-    "ws": "^6.2.2"
-  },
   "codegenConfig": {
     "name": "AppSpecs",
     "type": "all",

--- a/tools/__tests__/no-dev-dependencies-in-tester-package.js
+++ b/tools/__tests__/no-dev-dependencies-in-tester-package.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+import path from 'path';
+import fs from 'fs';
+
+const CURRENT_DIR = __dirname;
+const PATH_TO_TESTER_PACKAGE_MANIFEST = path.join(
+  CURRENT_DIR,
+  '..',
+  '..',
+  'packages',
+  'rn-tester',
+  'package.json',
+);
+
+const manifest = JSON.parse(
+  fs.readFileSync(PATH_TO_TESTER_PACKAGE_MANIFEST).toString(),
+);
+
+describe('@react-native/tester package', () => {
+  it('expected not to list any devDependencies', () => {
+    expect(manifest).not.toHaveProperty('devDependencies');
+  });
+});


### PR DESCRIPTION
Summary:
Changelog: [Internal]

In order to make `react-native/tester` imports work, adding this package to `xplat/js/public`

Also moving devDependecies from `react-native/tester/package.json` to root package json to avoid checking in dev dependencies in `xplat/js/public/node_modules`

Reviewed By: cortinico

Differential Revision: D44030539

