### PR TITLE
Bail on realizing region around last focused cell if we don't know where it is

### DIFF
--- a/packages/virtualized-lists/Lists/VirtualizedList.js
+++ b/packages/virtualized-lists/Lists/VirtualizedList.js
@@ -1886,6 +1886,19 @@ class VirtualizedList extends StateSafePureComponent<Props, State> {
     const focusedCellIndex = lastFocusedCellRenderer.props.index;
     const itemCount = props.getItemCount(props.data);
 
+    // The last cell we rendered may be at a new index. Bail if we don't know
+    // where it is.
+    if (
+      focusedCellIndex >= itemCount ||
+      this._keyExtractor(
+        props.getItem(props.data, focusedCellIndex),
+        focusedCellIndex,
+        props,
+      ) !== this._lastFocusedCellKey
+    ) {
+      return [];
+    }
+
     let first = focusedCellIndex;
     let heightOfCellsBeforeFocused = 0;
     for (


### PR DESCRIPTION
Summary:
We only know where the last focused cell lives after it is rendered. Apart from dead refs handled in D43835135, this means items added or removed before the focused cell will lead to a stale last index for the next state update.

We don't have a good way to correlate cells after data change. This effects the implementation for [`maintainVisibleContentPosition`](https://github.com/facebook/react-native/pull/35993) as well, but needs some thought on the right way to handle it. For now, we bail when we don't know where the last focused cell lives.

Changelog:
[General][Fixed] - Bail on realizing region around last focused cell if we don't know where it is

Differential Revision: D44221162

