### PR TITLE
[Codegen 80] Convert the emitCommonTypes implementation from a switch based implementation to a dictionary based one

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-primitives-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-primitives-test.js
@@ -1263,6 +1263,7 @@ describe('emitPartial', () => {
     nullable: boolean,
   ): $FlowFixMe {
     return emitPartial(
+      nullable,
       hasteModuleName,
       typeAnnotation,
       /* types: TypeDeclarationMap */
@@ -1278,7 +1279,6 @@ describe('emitPartial', () => {
       },
       /* cxxOnly: boolean */
       false,
-      nullable,
       parser,
     );
   }
@@ -1492,6 +1492,17 @@ describe('emitCommonTypes', () => {
 
     it("returns 'GenericObjectTypeAnnotation'", () => {
       expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when typeAnnotation is invalid', () => {
+    const typeAnnotation = {
+      id: {
+        name: 'InvalidName',
+      },
+    };
+    it('returns null', () => {
+      expect(emitCommonTypesForUnitTest(typeAnnotation, false)).toBeNull();
     });
   });
 });


### PR DESCRIPTION
## Summary

Task from #34872 
> [Codegen 80] Convert the emitCommonTypes implementation from a switch based implementation to a dictionary based one

## Changelog

[Internal] [Changed] - Convert the emitCommonTypes implementation from a switch based implementation to a dictionary based one

## Test Plan

`yarn test react-native-codegen`
