### PR TITLE
Find and fix typos in yoga code (#935)

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaNative.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaNative.java
@@ -40,7 +40,7 @@ public class YogaNative {
   static native void jni_YGNodeRemoveChildJNI(long nativePointer, long childPointer);
   static native void jni_YGNodeCalculateLayoutJNI(long nativePointer, float width, float height, long[] nativePointers, YogaNodeJNIBase[] nodes);
   static native void jni_YGNodeMarkDirtyJNI(long nativePointer);
-  static native void jni_YGNodeMarkDirtyAndPropogateToDescendantsJNI(long nativePointer);
+  static native void jni_YGNodeMarkDirtyAndPropagateToDescendantsJNI(long nativePointer);
   static native boolean jni_YGNodeIsDirtyJNI(long nativePointer);
   static native void jni_YGNodeCopyStyleJNI(long dstNativePointer, long srcNativePointer);
   static native int jni_YGNodeStyleGetDirectionJNI(long nativePointer);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaNodeJNIBase.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaNodeJNIBase.java
@@ -232,7 +232,7 @@ public abstract class YogaNodeJNIBase extends YogaNode implements Cloneable {
   }
 
   public void dirtyAllDescendants() {
-    YogaNative.jni_YGNodeMarkDirtyAndPropogateToDescendantsJNI(mNativePointer);
+    YogaNative.jni_YGNodeMarkDirtyAndPropagateToDescendantsJNI(mNativePointer);
   }
 
   public boolean isDirty() {

--- a/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/ScopedGlobalRef.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/ScopedGlobalRef.h
@@ -37,7 +37,7 @@ namespace vanillajni {
  * unexpected conversions or unexpected ownership transfer. In practice, this
  * class acts as a unique pointer where the underying JNI reference can have one
  * and just one owner. Transferring ownership is allowed but it is an explicit
- * operation (implemneted via move semantics and also via explicity API calls).
+ * operation (implemented via move semantics and also via explicitly API calls).
  *
  * Note that this class doesn't receive an explicit JNIEnv at construction time.
  * At destruction time it uses vanillajni::getCurrentEnv() to retrieve the

--- a/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/ScopedLocalRef.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/ScopedLocalRef.h
@@ -39,7 +39,7 @@ namespace vanillajni {
  * unexpected conversions or unexpected ownership transfer. In practice, this
  * class acts as a unique pointer where the underying JNI reference can have one
  * and just one owner. Transferring ownership is allowed but it is an explicit
- * operation (implemneted via move semantics and also via explicity API calls).
+ * operation (implemented via move semantics and also via explicitly API calls).
  *
  * As with standard JNI local references it is not a valid operation to keep a
  * reference around between different native method calls.

--- a/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/YGJNIVanilla.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/YGJNIVanilla.cpp
@@ -389,11 +389,11 @@ static void jni_YGNodeMarkDirtyJNI(
   YGNodeMarkDirty(_jlong2YGNodeRef(nativePointer));
 }
 
-static void jni_YGNodeMarkDirtyAndPropogateToDescendantsJNI(
+static void jni_YGNodeMarkDirtyAndPropagateToDescendantsJNI(
     JNIEnv* env,
     jobject obj,
     jlong nativePointer) {
-  YGNodeMarkDirtyAndPropogateToDescendants(_jlong2YGNodeRef(nativePointer));
+  YGNodeMarkDirtyAndPropagateToDescendants(_jlong2YGNodeRef(nativePointer));
 }
 
 static jboolean jni_YGNodeIsDirtyJNI(
@@ -785,9 +785,9 @@ static JNINativeMethod methods[] = {
      "(JFF[J[Lcom/facebook/yoga/YogaNodeJNIBase;)V",
      (void*) jni_YGNodeCalculateLayoutJNI},
     {"jni_YGNodeMarkDirtyJNI", "(J)V", (void*) jni_YGNodeMarkDirtyJNI},
-    {"jni_YGNodeMarkDirtyAndPropogateToDescendantsJNI",
+    {"jni_YGNodeMarkDirtyAndPropagateToDescendantsJNI",
      "(J)V",
-     (void*) jni_YGNodeMarkDirtyAndPropogateToDescendantsJNI},
+     (void*) jni_YGNodeMarkDirtyAndPropagateToDescendantsJNI},
     {"jni_YGNodeIsDirtyJNI", "(J)Z", (void*) jni_YGNodeIsDirtyJNI},
     {"jni_YGNodeCopyStyleJNI", "(JJ)V", (void*) jni_YGNodeCopyStyleJNI},
     {"jni_YGNodeStyleGetDirectionJNI",

--- a/packages/react-native/ReactCommon/yoga/yoga/Utils.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/Utils.h
@@ -27,10 +27,10 @@
 //   the remaining space left for the flexible children.
 //
 // - totalFlexGrowFactors: total flex grow factors of flex items which are to be
-//   layed in the current line
+//   laid in the current line
 //
 // - totalFlexShrinkFactors: total flex shrink factors of flex items which are
-//   to be layed in the current line
+//   to be laid in the current line
 //
 // - endOfLineIndex: Its the end index of the last flex item which was examined
 //   and it may or may not be part of the current line(as it may be absolutely

--- a/packages/react-native/ReactCommon/yoga/yoga/YGMacros.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGMacros.h
@@ -32,7 +32,7 @@
 #ifdef NS_ENUM
 // Cannot use NSInteger as NSInteger has a different size than int (which is the
 // default type of a enum). Therefor when linking the Yoga C library into obj-c
-// the header is a missmatch for the Yoga ABI.
+// the header is a mismatch for the Yoga ABI.
 #define YG_ENUM_BEGIN(name) NS_ENUM(int, name)
 #define YG_ENUM_END(name)
 #else

--- a/packages/react-native/ReactCommon/yoga/yoga/YGNode.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGNode.cpp
@@ -448,20 +448,20 @@ void YGNode::cloneChildrenIfNeeded(void* cloneContext) {
   iterChildrenAfterCloningIfNeeded([](YGNodeRef, void*) {}, cloneContext);
 }
 
-void YGNode::markDirtyAndPropogate() {
+void YGNode::markDirtyAndPropagate() {
   if (!facebook::yoga::detail::getBooleanData(flags, isDirty_)) {
     setDirty(true);
     setLayoutComputedFlexBasis(YGFloatOptional());
     if (owner_) {
-      owner_->markDirtyAndPropogate();
+      owner_->markDirtyAndPropagate();
     }
   }
 }
 
-void YGNode::markDirtyAndPropogateDownwards() {
+void YGNode::markDirtyAndPropagateDownwards() {
   facebook::yoga::detail::setBooleanData(flags, isDirty_, true);
   for_each(children_.begin(), children_.end(), [](YGNodeRef childNode) {
-    childNode->markDirtyAndPropogateDownwards();
+    childNode->markDirtyAndPropagateDownwards();
   });
 }
 

--- a/packages/react-native/ReactCommon/yoga/yoga/YGNode.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGNode.h
@@ -327,7 +327,7 @@ public:
       const float mainSize,
       const float crossSize,
       const float ownerWidth);
-  void markDirtyAndPropogateDownwards();
+  void markDirtyAndPropagateDownwards();
 
   // Other methods
   YGValue marginLeadingValue(const YGFlexDirection axis) const;
@@ -345,7 +345,7 @@ public:
   void removeChild(uint32_t index);
 
   void cloneChildrenIfNeeded(void*);
-  void markDirtyAndPropogate();
+  void markDirtyAndPropagate();
   float resolveFlexGrow() const;
   float resolveFlexShrink() const;
   bool isNodeFlexible();

--- a/packages/react-native/ReactCommon/yoga/yoga/YGNodePrint.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGNodePrint.cpp
@@ -28,7 +28,7 @@ static bool areFourValuesEqual(const YGStyle::Edges& four) {
       YGValueEqual(four[0], four[3]);
 }
 
-static void appendFormatedString(string& str, const char* fmt, ...) {
+static void appendFormattedString(string& str, const char* fmt, ...) {
   va_list args;
   va_start(args, fmt);
   va_list argsCopy;
@@ -46,7 +46,7 @@ static void appendFloatOptionalIfDefined(
     const string key,
     const YGFloatOptional num) {
   if (!num.isUndefined()) {
-    appendFormatedString(base, "%s: %g; ", key.c_str(), num.unwrap());
+    appendFormattedString(base, "%s: %g; ", key.c_str(), num.unwrap());
   }
 }
 
@@ -59,7 +59,7 @@ static void appendNumberIfNotUndefined(
       base.append(key + ": auto; ");
     } else {
       string unit = number.unit == YGUnitPoint ? "px" : "%%";
-      appendFormatedString(
+      appendFormattedString(
           base, "%s: %g%s; ", key.c_str(), number.value, unit.c_str());
     }
   }
@@ -121,46 +121,46 @@ void YGNodeToString(
     YGPrintOptions options,
     uint32_t level) {
   indent(str, level);
-  appendFormatedString(str, "<div ");
+  appendFormattedString(str, "<div ");
 
   if (options & YGPrintOptionsLayout) {
-    appendFormatedString(str, "layout=\"");
-    appendFormatedString(
+    appendFormattedString(str, "layout=\"");
+    appendFormattedString(
         str, "width: %g; ", node->getLayout().dimensions[YGDimensionWidth]);
-    appendFormatedString(
+    appendFormattedString(
         str, "height: %g; ", node->getLayout().dimensions[YGDimensionHeight]);
-    appendFormatedString(
+    appendFormattedString(
         str, "top: %g; ", node->getLayout().position[YGEdgeTop]);
-    appendFormatedString(
+    appendFormattedString(
         str, "left: %g;", node->getLayout().position[YGEdgeLeft]);
-    appendFormatedString(str, "\" ");
+    appendFormattedString(str, "\" ");
   }
 
   if (options & YGPrintOptionsStyle) {
-    appendFormatedString(str, "style=\"");
+    appendFormattedString(str, "style=\"");
     const auto& style = node->getStyle();
     if (style.flexDirection() != YGNode().getStyle().flexDirection()) {
-      appendFormatedString(
+      appendFormattedString(
           str,
           "flex-direction: %s; ",
           YGFlexDirectionToString(style.flexDirection()));
     }
     if (style.justifyContent() != YGNode().getStyle().justifyContent()) {
-      appendFormatedString(
+      appendFormattedString(
           str,
           "justify-content: %s; ",
           YGJustifyToString(style.justifyContent()));
     }
     if (style.alignItems() != YGNode().getStyle().alignItems()) {
-      appendFormatedString(
+      appendFormattedString(
           str, "align-items: %s; ", YGAlignToString(style.alignItems()));
     }
     if (style.alignContent() != YGNode().getStyle().alignContent()) {
-      appendFormatedString(
+      appendFormattedString(
           str, "align-content: %s; ", YGAlignToString(style.alignContent()));
     }
     if (style.alignSelf() != YGNode().getStyle().alignSelf()) {
-      appendFormatedString(
+      appendFormattedString(
           str, "align-self: %s; ", YGAlignToString(style.alignSelf()));
     }
     appendFloatOptionalIfDefined(str, "flex-grow", style.flexGrow());
@@ -169,17 +169,17 @@ void YGNodeToString(
     appendFloatOptionalIfDefined(str, "flex", style.flex());
 
     if (style.flexWrap() != YGNode().getStyle().flexWrap()) {
-      appendFormatedString(
+      appendFormattedString(
           str, "flex-wrap: %s; ", YGWrapToString(style.flexWrap()));
     }
 
     if (style.overflow() != YGNode().getStyle().overflow()) {
-      appendFormatedString(
+      appendFormattedString(
           str, "overflow: %s; ", YGOverflowToString(style.overflow()));
     }
 
     if (style.display() != YGNode().getStyle().display()) {
-      appendFormatedString(
+      appendFormattedString(
           str, "display: %s; ", YGDisplayToString(style.display()));
     }
     appendEdges(str, "margin", style.margin());
@@ -212,7 +212,7 @@ void YGNodeToString(
         str, "min-height", style.minDimensions()[YGDimensionHeight]);
 
     if (style.positionType() != YGNode().getStyle().positionType()) {
-      appendFormatedString(
+      appendFormattedString(
           str, "position: %s; ", YGPositionTypeToString(style.positionType()));
     }
 
@@ -220,24 +220,24 @@ void YGNodeToString(
     appendEdgeIfNotUndefined(str, "right", style.position(), YGEdgeRight);
     appendEdgeIfNotUndefined(str, "top", style.position(), YGEdgeTop);
     appendEdgeIfNotUndefined(str, "bottom", style.position(), YGEdgeBottom);
-    appendFormatedString(str, "\" ");
+    appendFormattedString(str, "\" ");
 
     if (node->hasMeasureFunc()) {
-      appendFormatedString(str, "has-custom-measure=\"true\"");
+      appendFormattedString(str, "has-custom-measure=\"true\"");
     }
   }
-  appendFormatedString(str, ">");
+  appendFormattedString(str, ">");
 
   const uint32_t childCount = static_cast<uint32_t>(node->getChildren().size());
   if (options & YGPrintOptionsChildren && childCount > 0) {
     for (uint32_t i = 0; i < childCount; i++) {
-      appendFormatedString(str, "\n");
+      appendFormattedString(str, "\n");
       YGNodeToString(str, YGNodeGetChild(node, i), options, level + 1);
     }
-    appendFormatedString(str, "\n");
+    appendFormattedString(str, "\n");
     indent(str, level);
   }
-  appendFormatedString(str, "</div>");
+  appendFormattedString(str, "</div>");
 }
 } // namespace yoga
 } // namespace facebook

--- a/packages/react-native/ReactCommon/yoga/yoga/Yoga.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/Yoga.cpp
@@ -180,9 +180,9 @@ YOGA_EXPORT bool YGNodeIsDirty(YGNodeRef node) {
   return node->isDirty();
 }
 
-YOGA_EXPORT void YGNodeMarkDirtyAndPropogateToDescendants(
+YOGA_EXPORT void YGNodeMarkDirtyAndPropagateToDescendants(
     const YGNodeRef node) {
-  return node->markDirtyAndPropogateDownwards();
+  return node->markDirtyAndPropagateDownwards();
 }
 
 int32_t gConfigInstanceCount = 0;
@@ -290,7 +290,7 @@ YOGA_EXPORT void YGNodeSetIsReferenceBaseline(
     bool isReferenceBaseline) {
   if (node->isReferenceBaseline() != isReferenceBaseline) {
     node->setIsReferenceBaseline(isReferenceBaseline);
-    node->markDirtyAndPropogate();
+    node->markDirtyAndPropagate();
   }
 }
 
@@ -314,7 +314,7 @@ YOGA_EXPORT void YGNodeInsertChild(
 
   owner->insertChild(child, index);
   child->setOwner(owner);
-  owner->markDirtyAndPropogate();
+  owner->markDirtyAndPropagate();
 }
 
 YOGA_EXPORT void YGNodeSwapChild(
@@ -342,7 +342,7 @@ YOGA_EXPORT void YGNodeRemoveChild(
       excludedChild->setLayout({}); // layout is no longer valid
       excludedChild->setOwner(nullptr);
     }
-    owner->markDirtyAndPropogate();
+    owner->markDirtyAndPropagate();
   }
 }
 
@@ -362,13 +362,13 @@ YOGA_EXPORT void YGNodeRemoveAllChildren(const YGNodeRef owner) {
       oldChild->setOwner(nullptr);
     }
     owner->clearChildren();
-    owner->markDirtyAndPropogate();
+    owner->markDirtyAndPropagate();
     return;
   }
   // Otherwise, we are not the owner of the child set. We don't have to do
   // anything to clear it.
   owner->setChildren(YGVector());
-  owner->markDirtyAndPropogate();
+  owner->markDirtyAndPropagate();
 }
 
 static void YGNodeSetChildrenInternal(
@@ -384,7 +384,7 @@ static void YGNodeSetChildrenInternal(
         child->setOwner(nullptr);
       }
       owner->setChildren(YGVector());
-      owner->markDirtyAndPropogate();
+      owner->markDirtyAndPropagate();
     }
   } else {
     if (YGNodeGetChildCount(owner) > 0) {
@@ -402,7 +402,7 @@ static void YGNodeSetChildrenInternal(
     for (YGNodeRef child : children) {
       child->setOwner(owner);
     }
-    owner->markDirtyAndPropogate();
+    owner->markDirtyAndPropagate();
   }
 }
 
@@ -447,7 +447,7 @@ YOGA_EXPORT void YGNodeMarkDirty(const YGNodeRef node) {
       "Only leaf nodes with custom measure functions"
       "should manually mark themselves as dirty");
 
-  node->markDirtyAndPropogate();
+  node->markDirtyAndPropagate();
 }
 
 YOGA_EXPORT void YGNodeCopyStyle(
@@ -455,7 +455,7 @@ YOGA_EXPORT void YGNodeCopyStyle(
     const YGNodeRef srcNode) {
   if (!(dstNode->getStyle() == srcNode->getStyle())) {
     dstNode->setStyle(srcNode->getStyle());
-    dstNode->markDirtyAndPropogate();
+    dstNode->markDirtyAndPropagate();
   }
 }
 
@@ -482,7 +482,7 @@ void updateStyle(
     Update&& update) {
   if (needsUpdate(node->getStyle(), value)) {
     update(node->getStyle(), value);
-    node->markDirtyAndPropogate();
+    node->markDirtyAndPropagate();
   }
 }
 
@@ -514,7 +514,7 @@ void updateIndexedStyleProp(
 // MSVC has trouble inferring the return type of pointer to member functions
 // with const and non-const overloads, instead of preferring the non-const
 // overload like clang and GCC. For the purposes of updateStyle(), we can help
-// MSVC by specifying that return type explicitely. In combination with
+// MSVC by specifying that return type explicitly. In combination with
 // decltype, MSVC will prefer the non-const version.
 #define MSVC_HINT(PROP) decltype(YGStyle{}.PROP())
 
@@ -1835,7 +1835,7 @@ static bool YGNodeFixedSizeSetMeasuredDimensions(
   return false;
 }
 
-static void YGZeroOutLayoutRecursivly(
+static void YGZeroOutLayoutRecursively(
     const YGNodeRef node,
     void* layoutContext) {
   node->getLayout() = {};
@@ -1844,7 +1844,7 @@ static void YGZeroOutLayoutRecursivly(
   node->setHasNewLayout(true);
 
   node->iterChildrenAfterCloningIfNeeded(
-      YGZeroOutLayoutRecursivly, layoutContext);
+      YGZeroOutLayoutRecursively, layoutContext);
 }
 
 static float YGNodeCalculateAvailableInnerDim(
@@ -1920,7 +1920,7 @@ static float YGNodeComputeFlexBasisForChildren(
   for (auto child : children) {
     child->resolveDimension();
     if (child->getStyle().display() == YGDisplayNone) {
-      YGZeroOutLayoutRecursivly(child, layoutContext);
+      YGZeroOutLayoutRecursively(child, layoutContext);
       child->setHasNewLayout(true);
       child->setDirty(false);
       continue;

--- a/packages/react-native/ReactCommon/yoga/yoga/Yoga.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/Yoga.h
@@ -109,7 +109,7 @@ WIN_EXPORT void YGNodeMarkDirty(YGNodeRef node);
 //
 // Intended to be used for Yoga benchmarks. Don't use in production, as calling
 // `YGCalculateLayout` will cause the recalculation of each and every node.
-WIN_EXPORT void YGNodeMarkDirtyAndPropogateToDescendants(YGNodeRef node);
+WIN_EXPORT void YGNodeMarkDirtyAndPropagateToDescendants(YGNodeRef node);
 
 WIN_EXPORT void YGNodePrint(YGNodeRef node, YGPrintOptions options);
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/litho/pull/935

X-link: https://github.com/facebook/yoga/pull/1239

Changelog:
[Internal] -

A follow-up to D44172494, I've run a pass of [typos](https://github.com/crate-ci/typos) on the Yoga code to detect/fix typos in comments and identifiers (with a manual review afterwards).

Reviewed By: javache

Differential Revision: D44254911

