### PR TITLE
RN [refactor]: bump and realign package versions by running a single script

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "test-typescript": "dtslint packages/react-native/types",
     "test-typescript-offline": "dtslint --localTs node_modules/typescript/lib  packages/react-native/types",
     "bump-all-updated-packages": "node ./scripts/monorepo/bump-all-updated-packages",
-    "align-package-versions": "node ./scripts/monorepo/align-package-versions.js"
+    "align-package-versions": "node -e \"require('./scripts/monorepo/align-package-versions')()\""
   },
   "workspaces": [
     "packages/*"

--- a/scripts/monorepo/align-package-versions.js
+++ b/scripts/monorepo/align-package-versions.js
@@ -7,17 +7,17 @@
  * @format
  */
 
-const {spawnSync} = require('child_process');
 const {writeFileSync, readFileSync} = require('fs');
 const path = require('path');
 
-const checkForGitChanges = require('./check-for-git-changes');
 const forEachPackage = require('./for-each-package');
 
 const ROOT_LOCATION = path.join(__dirname, '..', '..');
 const TEMPLATE_LOCATION = path.join(
   ROOT_LOCATION,
-  'packages/react-native/template',
+  'packages',
+  'react-native',
+  'template',
 );
 
 const readJSONFile = pathToFile => JSON.parse(readFileSync(pathToFile));
@@ -93,14 +93,6 @@ const checkIfShouldUpdateDependencyPackageVersion = (
 };
 
 const alignPackageVersions = () => {
-  if (checkForGitChanges()) {
-    console.log(
-      '\u274c Found uncommitted changes. Please commit or stash them before running this script',
-    );
-
-    process.exit(1);
-  }
-
   forEachPackage((_, __, packageManifest) => {
     checkIfShouldUpdateDependencyPackageVersion(
       ROOT_LOCATION,
@@ -124,21 +116,6 @@ const alignPackageVersions = () => {
       {includeReactNative: true},
     );
   });
-
-  if (!checkForGitChanges()) {
-    console.log(
-      '\u2705 There were no changes. Every consumer package uses the actual version of dependency package.',
-    );
-    return;
-  }
-
-  console.log('Running yarn to update lock file...');
-  spawnSync('yarn', ['install'], {
-    cwd: ROOT_LOCATION,
-    shell: true,
-    stdio: 'inherit',
-    encoding: 'utf-8',
-  });
 };
 
-alignPackageVersions();
+module.exports = alignPackageVersions;


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Okay, so before the monorepo migration we had to use two scripts separately:
1. Bumping every package with `npm run bump-all-updated-packages`
2. Aligning other packages versions with `npm run align-package-versions`

The reason for it is that *before the monorepo* in a release branch cutoff process we had a step, which was removing `workspaces` keyword from `react-native` package. Without this keyword all new versions of packages will be resolved from npm (where they will be not available yet, because we have to publish them prior to it)

This is not the case for our current setup, and we can actually bump packages versions and they will be resolved as a workspaces successfully

Differential Revision: D44261057

Demo: 

https://user-images.githubusercontent.com/28902667/226952772-fb13b1e1-aced-479a-9885-2c6a54699140.mov



