### PR TITLE
Fix off-by-one error in cxx codegen

### DIFF
--- a/packages/react-native-codegen/e2e/__tests__/modules/__snapshots__/GenerateModuleCpp-test.js.snap
+++ b/packages/react-native-codegen/e2e/__tests__/modules/__snapshots__/GenerateModuleCpp-test.js.snap
@@ -16,13 +16,23 @@ namespace facebook {
 namespace react {
 
 static jsi::Value __hostFunction_NativeArrayTurboModuleCxxSpecJSI_getArray(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeArrayTurboModuleCxxSpecJSI *>(&turboModule)->getArray(rt, args[0].asObject(rt).asArray(rt));
+  return static_cast<NativeArrayTurboModuleCxxSpecJSI *>(&turboModule)->getArray(
+    rt,
+    args[0].asObject(rt).asArray(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeArrayTurboModuleCxxSpecJSI_getReadOnlyArray(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeArrayTurboModuleCxxSpecJSI *>(&turboModule)->getReadOnlyArray(rt, args[0].asObject(rt).asArray(rt));
+  return static_cast<NativeArrayTurboModuleCxxSpecJSI *>(&turboModule)->getReadOnlyArray(
+    rt,
+    args[0].asObject(rt).asArray(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeArrayTurboModuleCxxSpecJSI_getArrayWithAlias(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeArrayTurboModuleCxxSpecJSI *>(&turboModule)->getArrayWithAlias(rt, args[0].asObject(rt).asArray(rt), args[1].asObject(rt).asArray(rt));
+  return static_cast<NativeArrayTurboModuleCxxSpecJSI *>(&turboModule)->getArrayWithAlias(
+    rt,
+    args[0].asObject(rt).asArray(rt),
+    args[1].asObject(rt).asArray(rt)
+  );
 }
 
 NativeArrayTurboModuleCxxSpecJSI::NativeArrayTurboModuleCxxSpecJSI(std::shared_ptr<CallInvoker> jsInvoker)
@@ -32,10 +42,16 @@ NativeArrayTurboModuleCxxSpecJSI::NativeArrayTurboModuleCxxSpecJSI(std::shared_p
   methodMap_[\\"getArrayWithAlias\\"] = MethodMetadata {2, __hostFunction_NativeArrayTurboModuleCxxSpecJSI_getArrayWithAlias};
 }
 static jsi::Value __hostFunction_NativeBooleanTurboModuleCxxSpecJSI_getBoolean(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeBooleanTurboModuleCxxSpecJSI *>(&turboModule)->getBoolean(rt, args[0].asBool());
+  return static_cast<NativeBooleanTurboModuleCxxSpecJSI *>(&turboModule)->getBoolean(
+    rt,
+    args[0].asBool()
+  );
 }
 static jsi::Value __hostFunction_NativeBooleanTurboModuleCxxSpecJSI_getBooleanWithAlias(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeBooleanTurboModuleCxxSpecJSI *>(&turboModule)->getBooleanWithAlias(rt, args[0].asBool());
+  return static_cast<NativeBooleanTurboModuleCxxSpecJSI *>(&turboModule)->getBooleanWithAlias(
+    rt,
+    args[0].asBool()
+  );
 }
 
 NativeBooleanTurboModuleCxxSpecJSI::NativeBooleanTurboModuleCxxSpecJSI(std::shared_ptr<CallInvoker> jsInvoker)
@@ -44,11 +60,17 @@ NativeBooleanTurboModuleCxxSpecJSI::NativeBooleanTurboModuleCxxSpecJSI(std::shar
   methodMap_[\\"getBooleanWithAlias\\"] = MethodMetadata {1, __hostFunction_NativeBooleanTurboModuleCxxSpecJSI_getBooleanWithAlias};
 }
 static jsi::Value __hostFunction_NativeCallbackTurboModuleCxxSpecJSI_getValueWithCallback(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  static_cast<NativeCallbackTurboModuleCxxSpecJSI *>(&turboModule)->getValueWithCallback(rt, args[0].asObject(rt).asFunction(rt));
+  static_cast<NativeCallbackTurboModuleCxxSpecJSI *>(&turboModule)->getValueWithCallback(
+    rt,
+    args[0].asObject(rt).asFunction(rt)
+  );
   return jsi::Value::undefined();
 }
 static jsi::Value __hostFunction_NativeCallbackTurboModuleCxxSpecJSI_getValueWithCallbackWithAlias(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  static_cast<NativeCallbackTurboModuleCxxSpecJSI *>(&turboModule)->getValueWithCallbackWithAlias(rt, args[0].asObject(rt).asFunction(rt));
+  static_cast<NativeCallbackTurboModuleCxxSpecJSI *>(&turboModule)->getValueWithCallbackWithAlias(
+    rt,
+    args[0].asObject(rt).asFunction(rt)
+  );
   return jsi::Value::undefined();
 }
 
@@ -58,22 +80,43 @@ NativeCallbackTurboModuleCxxSpecJSI::NativeCallbackTurboModuleCxxSpecJSI(std::sh
   methodMap_[\\"getValueWithCallbackWithAlias\\"] = MethodMetadata {1, __hostFunction_NativeCallbackTurboModuleCxxSpecJSI_getValueWithCallbackWithAlias};
 }
 static jsi::Value __hostFunction_NativeEnumTurboModuleCxxSpecJSI_getStatusRegular(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeEnumTurboModuleCxxSpecJSI *>(&turboModule)->getStatusRegular(rt, args[0].asObject(rt));
+  return static_cast<NativeEnumTurboModuleCxxSpecJSI *>(&turboModule)->getStatusRegular(
+    rt,
+    args[0].asObject(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeEnumTurboModuleCxxSpecJSI_getStatusStr(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeEnumTurboModuleCxxSpecJSI *>(&turboModule)->getStatusStr(rt, args[0].asObject(rt));
+  return static_cast<NativeEnumTurboModuleCxxSpecJSI *>(&turboModule)->getStatusStr(
+    rt,
+    args[0].asObject(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeEnumTurboModuleCxxSpecJSI_getStatusNum(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeEnumTurboModuleCxxSpecJSI *>(&turboModule)->getStatusNum(rt, args[0].asObject(rt));
+  return static_cast<NativeEnumTurboModuleCxxSpecJSI *>(&turboModule)->getStatusNum(
+    rt,
+    args[0].asObject(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeEnumTurboModuleCxxSpecJSI_getStatusFraction(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeEnumTurboModuleCxxSpecJSI *>(&turboModule)->getStatusFraction(rt, args[0].asObject(rt));
+  return static_cast<NativeEnumTurboModuleCxxSpecJSI *>(&turboModule)->getStatusFraction(
+    rt,
+    args[0].asObject(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeEnumTurboModuleCxxSpecJSI_getStateType(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeEnumTurboModuleCxxSpecJSI *>(&turboModule)->getStateType(rt, args[0].asString(rt), args[1].asString(rt), args[2].asNumber(), args[3].asNumber());
+  return static_cast<NativeEnumTurboModuleCxxSpecJSI *>(&turboModule)->getStateType(
+    rt,
+    args[0].asString(rt),
+    args[1].asString(rt),
+    args[2].asNumber(),
+    args[3].asNumber()
+  );
 }
 static jsi::Value __hostFunction_NativeEnumTurboModuleCxxSpecJSI_getStateTypeWithEnums(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeEnumTurboModuleCxxSpecJSI *>(&turboModule)->getStateTypeWithEnums(rt, args[0].asObject(rt));
+  return static_cast<NativeEnumTurboModuleCxxSpecJSI *>(&turboModule)->getStateTypeWithEnums(
+    rt,
+    args[0].asObject(rt)
+  );
 }
 
 NativeEnumTurboModuleCxxSpecJSI::NativeEnumTurboModuleCxxSpecJSI(std::shared_ptr<CallInvoker> jsInvoker)
@@ -86,27 +129,44 @@ NativeEnumTurboModuleCxxSpecJSI::NativeEnumTurboModuleCxxSpecJSI(std::shared_ptr
   methodMap_[\\"getStateTypeWithEnums\\"] = MethodMetadata {1, __hostFunction_NativeEnumTurboModuleCxxSpecJSI_getStateTypeWithEnums};
 }
 static jsi::Value __hostFunction_NativeNullableTurboModuleCxxSpecJSI_getBool(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  auto result = static_cast<NativeNullableTurboModuleCxxSpecJSI *>(&turboModule)->getBool(rt, args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asBool()));
+  auto result = static_cast<NativeNullableTurboModuleCxxSpecJSI *>(&turboModule)->getBool(
+    rt,
+    args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asBool())
+  );
   return result ? jsi::Value(std::move(*result)) : jsi::Value::null();
 }
 static jsi::Value __hostFunction_NativeNullableTurboModuleCxxSpecJSI_getNumber(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  auto result = static_cast<NativeNullableTurboModuleCxxSpecJSI *>(&turboModule)->getNumber(rt, args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asNumber()));
+  auto result = static_cast<NativeNullableTurboModuleCxxSpecJSI *>(&turboModule)->getNumber(
+    rt,
+    args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asNumber())
+  );
   return result ? jsi::Value(std::move(*result)) : jsi::Value::null();
 }
 static jsi::Value __hostFunction_NativeNullableTurboModuleCxxSpecJSI_getString(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  auto result = static_cast<NativeNullableTurboModuleCxxSpecJSI *>(&turboModule)->getString(rt, args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asNumber()));
+  auto result = static_cast<NativeNullableTurboModuleCxxSpecJSI *>(&turboModule)->getString(
+    rt,
+    args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asNumber())
+  );
   return result ? jsi::Value(std::move(*result)) : jsi::Value::null();
 }
 static jsi::Value __hostFunction_NativeNullableTurboModuleCxxSpecJSI_getArray(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  auto result = static_cast<NativeNullableTurboModuleCxxSpecJSI *>(&turboModule)->getArray(rt, args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt).asArray(rt)));
+  auto result = static_cast<NativeNullableTurboModuleCxxSpecJSI *>(&turboModule)->getArray(
+    rt,
+    args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt).asArray(rt))
+  );
   return result ? jsi::Value(std::move(*result)) : jsi::Value::null();
 }
 static jsi::Value __hostFunction_NativeNullableTurboModuleCxxSpecJSI_getObject(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  auto result = static_cast<NativeNullableTurboModuleCxxSpecJSI *>(&turboModule)->getObject(rt, args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt)));
+  auto result = static_cast<NativeNullableTurboModuleCxxSpecJSI *>(&turboModule)->getObject(
+    rt,
+    args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt))
+  );
   return result ? jsi::Value(std::move(*result)) : jsi::Value::null();
 }
 static jsi::Value __hostFunction_NativeNullableTurboModuleCxxSpecJSI_getValueWithPromise(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  auto result = static_cast<NativeNullableTurboModuleCxxSpecJSI *>(&turboModule)->getValueWithPromise(rt);
+  auto result = static_cast<NativeNullableTurboModuleCxxSpecJSI *>(&turboModule)->getValueWithPromise(
+    rt
+  );
   return result ? jsi::Value(std::move(*result)) : jsi::Value::null();
 }
 
@@ -120,10 +180,16 @@ NativeNullableTurboModuleCxxSpecJSI::NativeNullableTurboModuleCxxSpecJSI(std::sh
   methodMap_[\\"getValueWithPromise\\"] = MethodMetadata {0, __hostFunction_NativeNullableTurboModuleCxxSpecJSI_getValueWithPromise};
 }
 static jsi::Value __hostFunction_NativeNumberTurboModuleCxxSpecJSI_getNumber(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeNumberTurboModuleCxxSpecJSI *>(&turboModule)->getNumber(rt, args[0].asNumber());
+  return static_cast<NativeNumberTurboModuleCxxSpecJSI *>(&turboModule)->getNumber(
+    rt,
+    args[0].asNumber()
+  );
 }
 static jsi::Value __hostFunction_NativeNumberTurboModuleCxxSpecJSI_getNumberWithAlias(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeNumberTurboModuleCxxSpecJSI *>(&turboModule)->getNumberWithAlias(rt, args[0].asNumber());
+  return static_cast<NativeNumberTurboModuleCxxSpecJSI *>(&turboModule)->getNumberWithAlias(
+    rt,
+    args[0].asNumber()
+  );
 }
 
 NativeNumberTurboModuleCxxSpecJSI::NativeNumberTurboModuleCxxSpecJSI(std::shared_ptr<CallInvoker> jsInvoker)
@@ -132,19 +198,33 @@ NativeNumberTurboModuleCxxSpecJSI::NativeNumberTurboModuleCxxSpecJSI(std::shared
   methodMap_[\\"getNumberWithAlias\\"] = MethodMetadata {1, __hostFunction_NativeNumberTurboModuleCxxSpecJSI_getNumberWithAlias};
 }
 static jsi::Value __hostFunction_NativeObjectTurboModuleCxxSpecJSI_getGenericObject(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeObjectTurboModuleCxxSpecJSI *>(&turboModule)->getGenericObject(rt, args[0].asObject(rt));
+  return static_cast<NativeObjectTurboModuleCxxSpecJSI *>(&turboModule)->getGenericObject(
+    rt,
+    args[0].asObject(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeObjectTurboModuleCxxSpecJSI_getGenericObjectReadOnly(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeObjectTurboModuleCxxSpecJSI *>(&turboModule)->getGenericObjectReadOnly(rt, args[0].asObject(rt));
+  return static_cast<NativeObjectTurboModuleCxxSpecJSI *>(&turboModule)->getGenericObjectReadOnly(
+    rt,
+    args[0].asObject(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeObjectTurboModuleCxxSpecJSI_getGenericObjectWithAlias(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeObjectTurboModuleCxxSpecJSI *>(&turboModule)->getGenericObjectWithAlias(rt, args[0].asObject(rt));
+  return static_cast<NativeObjectTurboModuleCxxSpecJSI *>(&turboModule)->getGenericObjectWithAlias(
+    rt,
+    args[0].asObject(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeObjectTurboModuleCxxSpecJSI_difficultObject(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeObjectTurboModuleCxxSpecJSI *>(&turboModule)->difficultObject(rt, args[0].asObject(rt));
+  return static_cast<NativeObjectTurboModuleCxxSpecJSI *>(&turboModule)->difficultObject(
+    rt,
+    args[0].asObject(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeObjectTurboModuleCxxSpecJSI_getConstants(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeObjectTurboModuleCxxSpecJSI *>(&turboModule)->getConstants(rt);
+  return static_cast<NativeObjectTurboModuleCxxSpecJSI *>(&turboModule)->getConstants(
+    rt
+  );
 }
 
 NativeObjectTurboModuleCxxSpecJSI::NativeObjectTurboModuleCxxSpecJSI(std::shared_ptr<CallInvoker> jsInvoker)
@@ -156,7 +236,9 @@ NativeObjectTurboModuleCxxSpecJSI::NativeObjectTurboModuleCxxSpecJSI(std::shared
   methodMap_[\\"getConstants\\"] = MethodMetadata {0, __hostFunction_NativeObjectTurboModuleCxxSpecJSI_getConstants};
 }
 static jsi::Value __hostFunction_NativeOptionalObjectTurboModuleCxxSpecJSI_getConstants(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeOptionalObjectTurboModuleCxxSpecJSI *>(&turboModule)->getConstants(rt);
+  return static_cast<NativeOptionalObjectTurboModuleCxxSpecJSI *>(&turboModule)->getConstants(
+    rt
+  );
 }
 
 NativeOptionalObjectTurboModuleCxxSpecJSI::NativeOptionalObjectTurboModuleCxxSpecJSI(std::shared_ptr<CallInvoker> jsInvoker)
@@ -164,16 +246,27 @@ NativeOptionalObjectTurboModuleCxxSpecJSI::NativeOptionalObjectTurboModuleCxxSpe
   methodMap_[\\"getConstants\\"] = MethodMetadata {0, __hostFunction_NativeOptionalObjectTurboModuleCxxSpecJSI_getConstants};
 }
 static jsi::Value __hostFunction_NativePartialAnnotationTurboModuleCxxSpecJSI_getSomeObj(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativePartialAnnotationTurboModuleCxxSpecJSI *>(&turboModule)->getSomeObj(rt);
+  return static_cast<NativePartialAnnotationTurboModuleCxxSpecJSI *>(&turboModule)->getSomeObj(
+    rt
+  );
 }
 static jsi::Value __hostFunction_NativePartialAnnotationTurboModuleCxxSpecJSI_getPartialSomeObj(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativePartialAnnotationTurboModuleCxxSpecJSI *>(&turboModule)->getPartialSomeObj(rt);
+  return static_cast<NativePartialAnnotationTurboModuleCxxSpecJSI *>(&turboModule)->getPartialSomeObj(
+    rt
+  );
 }
 static jsi::Value __hostFunction_NativePartialAnnotationTurboModuleCxxSpecJSI_getSomeObjFromPartialSomeObj(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativePartialAnnotationTurboModuleCxxSpecJSI *>(&turboModule)->getSomeObjFromPartialSomeObj(rt, args[0].asObject(rt));
+  return static_cast<NativePartialAnnotationTurboModuleCxxSpecJSI *>(&turboModule)->getSomeObjFromPartialSomeObj(
+    rt,
+    args[0].asObject(rt)
+  );
 }
 static jsi::Value __hostFunction_NativePartialAnnotationTurboModuleCxxSpecJSI_getPartialPartial(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativePartialAnnotationTurboModuleCxxSpecJSI *>(&turboModule)->getPartialPartial(rt, args[0].asObject(rt), args[1].asObject(rt));
+  return static_cast<NativePartialAnnotationTurboModuleCxxSpecJSI *>(&turboModule)->getPartialPartial(
+    rt,
+    args[0].asObject(rt),
+    args[1].asObject(rt)
+  );
 }
 
 NativePartialAnnotationTurboModuleCxxSpecJSI::NativePartialAnnotationTurboModuleCxxSpecJSI(std::shared_ptr<CallInvoker> jsInvoker)
@@ -184,10 +277,16 @@ NativePartialAnnotationTurboModuleCxxSpecJSI::NativePartialAnnotationTurboModule
   methodMap_[\\"getPartialPartial\\"] = MethodMetadata {2, __hostFunction_NativePartialAnnotationTurboModuleCxxSpecJSI_getPartialPartial};
 }
 static jsi::Value __hostFunction_NativePromiseTurboModuleCxxSpecJSI_getValueWithPromise(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativePromiseTurboModuleCxxSpecJSI *>(&turboModule)->getValueWithPromise(rt, args[0].asBool());
+  return static_cast<NativePromiseTurboModuleCxxSpecJSI *>(&turboModule)->getValueWithPromise(
+    rt,
+    args[0].asBool()
+  );
 }
 static jsi::Value __hostFunction_NativePromiseTurboModuleCxxSpecJSI_getValueWithPromiseWithAlias(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativePromiseTurboModuleCxxSpecJSI *>(&turboModule)->getValueWithPromiseWithAlias(rt, args[0].asString(rt));
+  return static_cast<NativePromiseTurboModuleCxxSpecJSI *>(&turboModule)->getValueWithPromiseWithAlias(
+    rt,
+    args[0].asString(rt)
+  );
 }
 
 NativePromiseTurboModuleCxxSpecJSI::NativePromiseTurboModuleCxxSpecJSI(std::shared_ptr<CallInvoker> jsInvoker)
@@ -196,45 +295,84 @@ NativePromiseTurboModuleCxxSpecJSI::NativePromiseTurboModuleCxxSpecJSI(std::shar
   methodMap_[\\"getValueWithPromiseWithAlias\\"] = MethodMetadata {1, __hostFunction_NativePromiseTurboModuleCxxSpecJSI_getValueWithPromiseWithAlias};
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_getConstants(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getConstants(rt);
+  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getConstants(
+    rt
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_voidFunc(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->voidFunc(rt);
+  static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->voidFunc(
+    rt
+  );
   return jsi::Value::undefined();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_getBool(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getBool(rt, args[0].asBool());
+  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getBool(
+    rt,
+    args[0].asBool()
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_getNumber(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getNumber(rt, args[0].asNumber());
+  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getNumber(
+    rt,
+    args[0].asNumber()
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_getString(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getString(rt, args[0].asString(rt));
+  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getString(
+    rt,
+    args[0].asString(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_getArray(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getArray(rt, args[0].asObject(rt).asArray(rt));
+  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getArray(
+    rt,
+    args[0].asObject(rt).asArray(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_getObject(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getObject(rt, args[0].asObject(rt));
+  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getObject(
+    rt,
+    args[0].asObject(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_getObjectShape(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getObjectShape(rt, args[0].asObject(rt));
+  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getObjectShape(
+    rt,
+    args[0].asObject(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_getAlias(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getAlias(rt, args[0].asObject(rt));
+  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getAlias(
+    rt,
+    args[0].asObject(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_getRootTag(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getRootTag(rt, args[0].getNumber());
+  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getRootTag(
+    rt,
+    args[0].getNumber()
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_getValue(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getValue(rt, args[0].asNumber(), args[1].asString(rt), args[2].asObject(rt));
+  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getValue(
+    rt,
+    args[0].asNumber(),
+    args[1].asString(rt),
+    args[2].asObject(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_getValueWithCallback(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getValueWithCallback(rt, args[0].asObject(rt).asFunction(rt));
+  static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getValueWithCallback(
+    rt,
+    args[0].asObject(rt).asFunction(rt)
+  );
   return jsi::Value::undefined();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_getValueWithPromise(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getValueWithPromise(rt, args[0].asBool());
+  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getValueWithPromise(
+    rt,
+    args[0].asBool()
+  );
 }
 
 NativeSampleTurboModuleCxxSpecJSI::NativeSampleTurboModuleCxxSpecJSI(std::shared_ptr<CallInvoker> jsInvoker)
@@ -254,45 +392,84 @@ NativeSampleTurboModuleCxxSpecJSI::NativeSampleTurboModuleCxxSpecJSI(std::shared
   methodMap_[\\"getValueWithPromise\\"] = MethodMetadata {1, __hostFunction_NativeSampleTurboModuleCxxSpecJSI_getValueWithPromise};
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleArraysCxxSpecJSI_getConstants(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleArraysCxxSpecJSI *>(&turboModule)->getConstants(rt);
+  return static_cast<NativeSampleTurboModuleArraysCxxSpecJSI *>(&turboModule)->getConstants(
+    rt
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleArraysCxxSpecJSI_voidFunc(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  static_cast<NativeSampleTurboModuleArraysCxxSpecJSI *>(&turboModule)->voidFunc(rt);
+  static_cast<NativeSampleTurboModuleArraysCxxSpecJSI *>(&turboModule)->voidFunc(
+    rt
+  );
   return jsi::Value::undefined();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleArraysCxxSpecJSI_getBool(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleArraysCxxSpecJSI *>(&turboModule)->getBool(rt, args[0].asObject(rt).asArray(rt));
+  return static_cast<NativeSampleTurboModuleArraysCxxSpecJSI *>(&turboModule)->getBool(
+    rt,
+    args[0].asObject(rt).asArray(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleArraysCxxSpecJSI_getNumber(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleArraysCxxSpecJSI *>(&turboModule)->getNumber(rt, args[0].asObject(rt).asArray(rt));
+  return static_cast<NativeSampleTurboModuleArraysCxxSpecJSI *>(&turboModule)->getNumber(
+    rt,
+    args[0].asObject(rt).asArray(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleArraysCxxSpecJSI_getString(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleArraysCxxSpecJSI *>(&turboModule)->getString(rt, args[0].asObject(rt).asArray(rt));
+  return static_cast<NativeSampleTurboModuleArraysCxxSpecJSI *>(&turboModule)->getString(
+    rt,
+    args[0].asObject(rt).asArray(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleArraysCxxSpecJSI_getArray(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleArraysCxxSpecJSI *>(&turboModule)->getArray(rt, args[0].asObject(rt).asArray(rt));
+  return static_cast<NativeSampleTurboModuleArraysCxxSpecJSI *>(&turboModule)->getArray(
+    rt,
+    args[0].asObject(rt).asArray(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleArraysCxxSpecJSI_getObject(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleArraysCxxSpecJSI *>(&turboModule)->getObject(rt, args[0].asObject(rt).asArray(rt));
+  return static_cast<NativeSampleTurboModuleArraysCxxSpecJSI *>(&turboModule)->getObject(
+    rt,
+    args[0].asObject(rt).asArray(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleArraysCxxSpecJSI_getObjectShape(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleArraysCxxSpecJSI *>(&turboModule)->getObjectShape(rt, args[0].asObject(rt).asArray(rt));
+  return static_cast<NativeSampleTurboModuleArraysCxxSpecJSI *>(&turboModule)->getObjectShape(
+    rt,
+    args[0].asObject(rt).asArray(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleArraysCxxSpecJSI_getAlias(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleArraysCxxSpecJSI *>(&turboModule)->getAlias(rt, args[0].asObject(rt).asArray(rt));
+  return static_cast<NativeSampleTurboModuleArraysCxxSpecJSI *>(&turboModule)->getAlias(
+    rt,
+    args[0].asObject(rt).asArray(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleArraysCxxSpecJSI_getRootTag(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleArraysCxxSpecJSI *>(&turboModule)->getRootTag(rt, args[0].asObject(rt).asArray(rt));
+  return static_cast<NativeSampleTurboModuleArraysCxxSpecJSI *>(&turboModule)->getRootTag(
+    rt,
+    args[0].asObject(rt).asArray(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleArraysCxxSpecJSI_getValue(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleArraysCxxSpecJSI *>(&turboModule)->getValue(rt, args[0].asObject(rt).asArray(rt), args[1].asObject(rt).asArray(rt), args[2].asObject(rt).asArray(rt));
+  return static_cast<NativeSampleTurboModuleArraysCxxSpecJSI *>(&turboModule)->getValue(
+    rt,
+    args[0].asObject(rt).asArray(rt),
+    args[1].asObject(rt).asArray(rt),
+    args[2].asObject(rt).asArray(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleArraysCxxSpecJSI_getValueWithCallback(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  static_cast<NativeSampleTurboModuleArraysCxxSpecJSI *>(&turboModule)->getValueWithCallback(rt, args[0].asObject(rt).asFunction(rt));
+  static_cast<NativeSampleTurboModuleArraysCxxSpecJSI *>(&turboModule)->getValueWithCallback(
+    rt,
+    args[0].asObject(rt).asFunction(rt)
+  );
   return jsi::Value::undefined();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleArraysCxxSpecJSI_getValueWithPromise(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleArraysCxxSpecJSI *>(&turboModule)->getValueWithPromise(rt, args[0].asObject(rt).asArray(rt));
+  return static_cast<NativeSampleTurboModuleArraysCxxSpecJSI *>(&turboModule)->getValueWithPromise(
+    rt,
+    args[0].asObject(rt).asArray(rt)
+  );
 }
 
 NativeSampleTurboModuleArraysCxxSpecJSI::NativeSampleTurboModuleArraysCxxSpecJSI(std::shared_ptr<CallInvoker> jsInvoker)
@@ -312,54 +489,93 @@ NativeSampleTurboModuleArraysCxxSpecJSI::NativeSampleTurboModuleArraysCxxSpecJSI
   methodMap_[\\"getValueWithPromise\\"] = MethodMetadata {1, __hostFunction_NativeSampleTurboModuleArraysCxxSpecJSI_getValueWithPromise};
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleNullableCxxSpecJSI_getConstants(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleNullableCxxSpecJSI *>(&turboModule)->getConstants(rt);
+  return static_cast<NativeSampleTurboModuleNullableCxxSpecJSI *>(&turboModule)->getConstants(
+    rt
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleNullableCxxSpecJSI_voidFunc(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  static_cast<NativeSampleTurboModuleNullableCxxSpecJSI *>(&turboModule)->voidFunc(rt);
+  static_cast<NativeSampleTurboModuleNullableCxxSpecJSI *>(&turboModule)->voidFunc(
+    rt
+  );
   return jsi::Value::undefined();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleNullableCxxSpecJSI_getBool(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  auto result = static_cast<NativeSampleTurboModuleNullableCxxSpecJSI *>(&turboModule)->getBool(rt, args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asBool()));
+  auto result = static_cast<NativeSampleTurboModuleNullableCxxSpecJSI *>(&turboModule)->getBool(
+    rt,
+    args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asBool())
+  );
   return result ? jsi::Value(std::move(*result)) : jsi::Value::null();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleNullableCxxSpecJSI_getNumber(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  auto result = static_cast<NativeSampleTurboModuleNullableCxxSpecJSI *>(&turboModule)->getNumber(rt, args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asNumber()));
+  auto result = static_cast<NativeSampleTurboModuleNullableCxxSpecJSI *>(&turboModule)->getNumber(
+    rt,
+    args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asNumber())
+  );
   return result ? jsi::Value(std::move(*result)) : jsi::Value::null();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleNullableCxxSpecJSI_getString(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  auto result = static_cast<NativeSampleTurboModuleNullableCxxSpecJSI *>(&turboModule)->getString(rt, args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asString(rt)));
+  auto result = static_cast<NativeSampleTurboModuleNullableCxxSpecJSI *>(&turboModule)->getString(
+    rt,
+    args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asString(rt))
+  );
   return result ? jsi::Value(std::move(*result)) : jsi::Value::null();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleNullableCxxSpecJSI_getArray(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  auto result = static_cast<NativeSampleTurboModuleNullableCxxSpecJSI *>(&turboModule)->getArray(rt, args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt).asArray(rt)));
+  auto result = static_cast<NativeSampleTurboModuleNullableCxxSpecJSI *>(&turboModule)->getArray(
+    rt,
+    args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt).asArray(rt))
+  );
   return result ? jsi::Value(std::move(*result)) : jsi::Value::null();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleNullableCxxSpecJSI_getObject(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  auto result = static_cast<NativeSampleTurboModuleNullableCxxSpecJSI *>(&turboModule)->getObject(rt, args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt)));
+  auto result = static_cast<NativeSampleTurboModuleNullableCxxSpecJSI *>(&turboModule)->getObject(
+    rt,
+    args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt))
+  );
   return result ? jsi::Value(std::move(*result)) : jsi::Value::null();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleNullableCxxSpecJSI_getObjectShape(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  auto result = static_cast<NativeSampleTurboModuleNullableCxxSpecJSI *>(&turboModule)->getObjectShape(rt, args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt)));
+  auto result = static_cast<NativeSampleTurboModuleNullableCxxSpecJSI *>(&turboModule)->getObjectShape(
+    rt,
+    args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt))
+  );
   return result ? jsi::Value(std::move(*result)) : jsi::Value::null();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleNullableCxxSpecJSI_getAlias(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  auto result = static_cast<NativeSampleTurboModuleNullableCxxSpecJSI *>(&turboModule)->getAlias(rt, args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt)));
+  auto result = static_cast<NativeSampleTurboModuleNullableCxxSpecJSI *>(&turboModule)->getAlias(
+    rt,
+    args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt))
+  );
   return result ? jsi::Value(std::move(*result)) : jsi::Value::null();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleNullableCxxSpecJSI_getRootTag(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  auto result = static_cast<NativeSampleTurboModuleNullableCxxSpecJSI *>(&turboModule)->getRootTag(rt, args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].getNumber()));
+  auto result = static_cast<NativeSampleTurboModuleNullableCxxSpecJSI *>(&turboModule)->getRootTag(
+    rt,
+    args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].getNumber())
+  );
   return result ? jsi::Value(std::move(*result)) : jsi::Value::null();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleNullableCxxSpecJSI_getValue(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  auto result = static_cast<NativeSampleTurboModuleNullableCxxSpecJSI *>(&turboModule)->getValue(rt, args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asNumber()), args[1].isNull() || args[1].isUndefined() ? std::nullopt : std::make_optional(args[1].asString(rt)), args[2].isNull() || args[2].isUndefined() ? std::nullopt : std::make_optional(args[2].asObject(rt)));
+  auto result = static_cast<NativeSampleTurboModuleNullableCxxSpecJSI *>(&turboModule)->getValue(
+    rt,
+    args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asNumber()),
+    args[1].isNull() || args[1].isUndefined() ? std::nullopt : std::make_optional(args[1].asString(rt)),
+    args[2].isNull() || args[2].isUndefined() ? std::nullopt : std::make_optional(args[2].asObject(rt))
+  );
   return result ? jsi::Value(std::move(*result)) : jsi::Value::null();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleNullableCxxSpecJSI_getValueWithCallback(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  static_cast<NativeSampleTurboModuleNullableCxxSpecJSI *>(&turboModule)->getValueWithCallback(rt, args[0].asObject(rt).asFunction(rt));
+  static_cast<NativeSampleTurboModuleNullableCxxSpecJSI *>(&turboModule)->getValueWithCallback(
+    rt,
+    args[0].asObject(rt).asFunction(rt)
+  );
   return jsi::Value::undefined();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleNullableCxxSpecJSI_getValueWithPromise(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  auto result = static_cast<NativeSampleTurboModuleNullableCxxSpecJSI *>(&turboModule)->getValueWithPromise(rt, args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asBool()));
+  auto result = static_cast<NativeSampleTurboModuleNullableCxxSpecJSI *>(&turboModule)->getValueWithPromise(
+    rt,
+    args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asBool())
+  );
   return result ? jsi::Value(std::move(*result)) : jsi::Value::null();
 }
 
@@ -380,53 +596,92 @@ NativeSampleTurboModuleNullableCxxSpecJSI::NativeSampleTurboModuleNullableCxxSpe
   methodMap_[\\"getValueWithPromise\\"] = MethodMetadata {1, __hostFunction_NativeSampleTurboModuleNullableCxxSpecJSI_getValueWithPromise};
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI_getConstants(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI *>(&turboModule)->getConstants(rt);
+  return static_cast<NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI *>(&turboModule)->getConstants(
+    rt
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI_voidFunc(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  static_cast<NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI *>(&turboModule)->voidFunc(rt);
+  static_cast<NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI *>(&turboModule)->voidFunc(
+    rt
+  );
   return jsi::Value::undefined();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI_getBool(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  auto result = static_cast<NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI *>(&turboModule)->getBool(rt, count < 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asBool()));
+  auto result = static_cast<NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI *>(&turboModule)->getBool(
+    rt,
+    count <= 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asBool())
+  );
   return result ? jsi::Value(std::move(*result)) : jsi::Value::null();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI_getNumber(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  auto result = static_cast<NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI *>(&turboModule)->getNumber(rt, count < 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asNumber()));
+  auto result = static_cast<NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI *>(&turboModule)->getNumber(
+    rt,
+    count <= 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asNumber())
+  );
   return result ? jsi::Value(std::move(*result)) : jsi::Value::null();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI_getString(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  auto result = static_cast<NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI *>(&turboModule)->getString(rt, count < 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asString(rt)));
+  auto result = static_cast<NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI *>(&turboModule)->getString(
+    rt,
+    count <= 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asString(rt))
+  );
   return result ? jsi::Value(std::move(*result)) : jsi::Value::null();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI_getArray(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  auto result = static_cast<NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI *>(&turboModule)->getArray(rt, count < 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt).asArray(rt)));
+  auto result = static_cast<NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI *>(&turboModule)->getArray(
+    rt,
+    count <= 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt).asArray(rt))
+  );
   return result ? jsi::Value(std::move(*result)) : jsi::Value::null();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI_getObject(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  auto result = static_cast<NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI *>(&turboModule)->getObject(rt, count < 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt)));
+  auto result = static_cast<NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI *>(&turboModule)->getObject(
+    rt,
+    count <= 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt))
+  );
   return result ? jsi::Value(std::move(*result)) : jsi::Value::null();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI_getObjectShape(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI *>(&turboModule)->getObjectShape(rt, count < 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt)));
+  return static_cast<NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI *>(&turboModule)->getObjectShape(
+    rt,
+    count <= 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt))
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI_getAlias(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  auto result = static_cast<NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI *>(&turboModule)->getAlias(rt, count < 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt)));
+  auto result = static_cast<NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI *>(&turboModule)->getAlias(
+    rt,
+    count <= 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt))
+  );
   return result ? jsi::Value(std::move(*result)) : jsi::Value::null();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI_getRootTag(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  auto result = static_cast<NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI *>(&turboModule)->getRootTag(rt, count < 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].getNumber()));
+  auto result = static_cast<NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI *>(&turboModule)->getRootTag(
+    rt,
+    count <= 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].getNumber())
+  );
   return result ? jsi::Value(std::move(*result)) : jsi::Value::null();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI_getValue(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  auto result = static_cast<NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI *>(&turboModule)->getValue(rt, count < 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asNumber()), count < 1 || args[1].isNull() || args[1].isUndefined() ? std::nullopt : std::make_optional(args[1].asString(rt)), count < 2 || args[2].isNull() || args[2].isUndefined() ? std::nullopt : std::make_optional(args[2].asObject(rt)));
+  auto result = static_cast<NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI *>(&turboModule)->getValue(
+    rt,
+    count <= 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asNumber()),
+    count <= 1 || args[1].isNull() || args[1].isUndefined() ? std::nullopt : std::make_optional(args[1].asString(rt)),
+    count <= 2 || args[2].isNull() || args[2].isUndefined() ? std::nullopt : std::make_optional(args[2].asObject(rt))
+  );
   return result ? jsi::Value(std::move(*result)) : jsi::Value::null();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI_getValueWithCallback(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  static_cast<NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI *>(&turboModule)->getValueWithCallback(rt, count < 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt).asFunction(rt)));
+  static_cast<NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI *>(&turboModule)->getValueWithCallback(
+    rt,
+    count <= 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt).asFunction(rt))
+  );
   return jsi::Value::undefined();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI_getValueWithPromise(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  auto result = static_cast<NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI *>(&turboModule)->getValueWithPromise(rt, count < 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asBool()));
+  auto result = static_cast<NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI *>(&turboModule)->getValueWithPromise(
+    rt,
+    count <= 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asBool())
+  );
   return result ? jsi::Value(std::move(*result)) : jsi::Value::null();
 }
 
@@ -447,45 +702,84 @@ NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI::NativeSampleTurboModuleNul
   methodMap_[\\"getValueWithPromise\\"] = MethodMetadata {1, __hostFunction_NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI_getValueWithPromise};
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleOptionalCxxSpecJSI_getConstants(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleOptionalCxxSpecJSI *>(&turboModule)->getConstants(rt);
+  return static_cast<NativeSampleTurboModuleOptionalCxxSpecJSI *>(&turboModule)->getConstants(
+    rt
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleOptionalCxxSpecJSI_voidFunc(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  static_cast<NativeSampleTurboModuleOptionalCxxSpecJSI *>(&turboModule)->voidFunc(rt);
+  static_cast<NativeSampleTurboModuleOptionalCxxSpecJSI *>(&turboModule)->voidFunc(
+    rt
+  );
   return jsi::Value::undefined();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleOptionalCxxSpecJSI_getBool(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleOptionalCxxSpecJSI *>(&turboModule)->getBool(rt, count < 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asBool()));
+  return static_cast<NativeSampleTurboModuleOptionalCxxSpecJSI *>(&turboModule)->getBool(
+    rt,
+    count <= 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asBool())
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleOptionalCxxSpecJSI_getNumber(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleOptionalCxxSpecJSI *>(&turboModule)->getNumber(rt, count < 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asNumber()));
+  return static_cast<NativeSampleTurboModuleOptionalCxxSpecJSI *>(&turboModule)->getNumber(
+    rt,
+    count <= 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asNumber())
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleOptionalCxxSpecJSI_getString(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleOptionalCxxSpecJSI *>(&turboModule)->getString(rt, count < 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asString(rt)));
+  return static_cast<NativeSampleTurboModuleOptionalCxxSpecJSI *>(&turboModule)->getString(
+    rt,
+    count <= 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asString(rt))
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleOptionalCxxSpecJSI_getArray(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleOptionalCxxSpecJSI *>(&turboModule)->getArray(rt, count < 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt).asArray(rt)));
+  return static_cast<NativeSampleTurboModuleOptionalCxxSpecJSI *>(&turboModule)->getArray(
+    rt,
+    count <= 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt).asArray(rt))
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleOptionalCxxSpecJSI_getObject(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleOptionalCxxSpecJSI *>(&turboModule)->getObject(rt, count < 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt)));
+  return static_cast<NativeSampleTurboModuleOptionalCxxSpecJSI *>(&turboModule)->getObject(
+    rt,
+    count <= 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt))
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleOptionalCxxSpecJSI_getObjectShape(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleOptionalCxxSpecJSI *>(&turboModule)->getObjectShape(rt, count < 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt)));
+  return static_cast<NativeSampleTurboModuleOptionalCxxSpecJSI *>(&turboModule)->getObjectShape(
+    rt,
+    count <= 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt))
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleOptionalCxxSpecJSI_getAlias(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleOptionalCxxSpecJSI *>(&turboModule)->getAlias(rt, count < 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt)));
+  return static_cast<NativeSampleTurboModuleOptionalCxxSpecJSI *>(&turboModule)->getAlias(
+    rt,
+    count <= 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt))
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleOptionalCxxSpecJSI_getRootTag(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleOptionalCxxSpecJSI *>(&turboModule)->getRootTag(rt, count < 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].getNumber()));
+  return static_cast<NativeSampleTurboModuleOptionalCxxSpecJSI *>(&turboModule)->getRootTag(
+    rt,
+    count <= 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].getNumber())
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleOptionalCxxSpecJSI_getValue(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleOptionalCxxSpecJSI *>(&turboModule)->getValue(rt, count < 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asNumber()), count < 1 || args[1].isNull() || args[1].isUndefined() ? std::nullopt : std::make_optional(args[1].asString(rt)), count < 2 || args[2].isNull() || args[2].isUndefined() ? std::nullopt : std::make_optional(args[2].asObject(rt)));
+  return static_cast<NativeSampleTurboModuleOptionalCxxSpecJSI *>(&turboModule)->getValue(
+    rt,
+    count <= 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asNumber()),
+    count <= 1 || args[1].isNull() || args[1].isUndefined() ? std::nullopt : std::make_optional(args[1].asString(rt)),
+    count <= 2 || args[2].isNull() || args[2].isUndefined() ? std::nullopt : std::make_optional(args[2].asObject(rt))
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleOptionalCxxSpecJSI_getValueWithCallback(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  static_cast<NativeSampleTurboModuleOptionalCxxSpecJSI *>(&turboModule)->getValueWithCallback(rt, count < 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt).asFunction(rt)));
+  static_cast<NativeSampleTurboModuleOptionalCxxSpecJSI *>(&turboModule)->getValueWithCallback(
+    rt,
+    count <= 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt).asFunction(rt))
+  );
   return jsi::Value::undefined();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleOptionalCxxSpecJSI_getValueWithPromise(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleOptionalCxxSpecJSI *>(&turboModule)->getValueWithPromise(rt, count < 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asBool()));
+  return static_cast<NativeSampleTurboModuleOptionalCxxSpecJSI *>(&turboModule)->getValueWithPromise(
+    rt,
+    count <= 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asBool())
+  );
 }
 
 NativeSampleTurboModuleOptionalCxxSpecJSI::NativeSampleTurboModuleOptionalCxxSpecJSI(std::shared_ptr<CallInvoker> jsInvoker)
@@ -505,10 +799,16 @@ NativeSampleTurboModuleOptionalCxxSpecJSI::NativeSampleTurboModuleOptionalCxxSpe
   methodMap_[\\"getValueWithPromise\\"] = MethodMetadata {1, __hostFunction_NativeSampleTurboModuleOptionalCxxSpecJSI_getValueWithPromise};
 }
 static jsi::Value __hostFunction_NativeStringTurboModuleCxxSpecJSI_getString(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeStringTurboModuleCxxSpecJSI *>(&turboModule)->getString(rt, args[0].asString(rt));
+  return static_cast<NativeStringTurboModuleCxxSpecJSI *>(&turboModule)->getString(
+    rt,
+    args[0].asString(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeStringTurboModuleCxxSpecJSI_getStringWithAlias(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeStringTurboModuleCxxSpecJSI *>(&turboModule)->getStringWithAlias(rt, args[0].asString(rt));
+  return static_cast<NativeStringTurboModuleCxxSpecJSI *>(&turboModule)->getStringWithAlias(
+    rt,
+    args[0].asString(rt)
+  );
 }
 
 NativeStringTurboModuleCxxSpecJSI::NativeStringTurboModuleCxxSpecJSI(std::shared_ptr<CallInvoker> jsInvoker)
@@ -539,13 +839,23 @@ namespace facebook {
 namespace react {
 
 static jsi::Value __hostFunction_NativeArrayTurboModuleCxxSpecJSI_getArray(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeArrayTurboModuleCxxSpecJSI *>(&turboModule)->getArray(rt, args[0].asObject(rt).asArray(rt));
+  return static_cast<NativeArrayTurboModuleCxxSpecJSI *>(&turboModule)->getArray(
+    rt,
+    args[0].asObject(rt).asArray(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeArrayTurboModuleCxxSpecJSI_getReadOnlyArray(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeArrayTurboModuleCxxSpecJSI *>(&turboModule)->getReadOnlyArray(rt, args[0].asObject(rt).asArray(rt));
+  return static_cast<NativeArrayTurboModuleCxxSpecJSI *>(&turboModule)->getReadOnlyArray(
+    rt,
+    args[0].asObject(rt).asArray(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeArrayTurboModuleCxxSpecJSI_getArrayWithAlias(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeArrayTurboModuleCxxSpecJSI *>(&turboModule)->getArrayWithAlias(rt, args[0].asObject(rt).asArray(rt), args[1].asObject(rt).asArray(rt));
+  return static_cast<NativeArrayTurboModuleCxxSpecJSI *>(&turboModule)->getArrayWithAlias(
+    rt,
+    args[0].asObject(rt).asArray(rt),
+    args[1].asObject(rt).asArray(rt)
+  );
 }
 
 NativeArrayTurboModuleCxxSpecJSI::NativeArrayTurboModuleCxxSpecJSI(std::shared_ptr<CallInvoker> jsInvoker)
@@ -555,10 +865,16 @@ NativeArrayTurboModuleCxxSpecJSI::NativeArrayTurboModuleCxxSpecJSI(std::shared_p
   methodMap_[\\"getArrayWithAlias\\"] = MethodMetadata {2, __hostFunction_NativeArrayTurboModuleCxxSpecJSI_getArrayWithAlias};
 }
 static jsi::Value __hostFunction_NativeBooleanTurboModuleCxxSpecJSI_getBoolean(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeBooleanTurboModuleCxxSpecJSI *>(&turboModule)->getBoolean(rt, args[0].asBool());
+  return static_cast<NativeBooleanTurboModuleCxxSpecJSI *>(&turboModule)->getBoolean(
+    rt,
+    args[0].asBool()
+  );
 }
 static jsi::Value __hostFunction_NativeBooleanTurboModuleCxxSpecJSI_getBooleanWithAlias(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeBooleanTurboModuleCxxSpecJSI *>(&turboModule)->getBooleanWithAlias(rt, args[0].asBool());
+  return static_cast<NativeBooleanTurboModuleCxxSpecJSI *>(&turboModule)->getBooleanWithAlias(
+    rt,
+    args[0].asBool()
+  );
 }
 
 NativeBooleanTurboModuleCxxSpecJSI::NativeBooleanTurboModuleCxxSpecJSI(std::shared_ptr<CallInvoker> jsInvoker)
@@ -567,11 +883,17 @@ NativeBooleanTurboModuleCxxSpecJSI::NativeBooleanTurboModuleCxxSpecJSI(std::shar
   methodMap_[\\"getBooleanWithAlias\\"] = MethodMetadata {1, __hostFunction_NativeBooleanTurboModuleCxxSpecJSI_getBooleanWithAlias};
 }
 static jsi::Value __hostFunction_NativeCallbackTurboModuleCxxSpecJSI_getValueWithCallback(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  static_cast<NativeCallbackTurboModuleCxxSpecJSI *>(&turboModule)->getValueWithCallback(rt, args[0].asObject(rt).asFunction(rt));
+  static_cast<NativeCallbackTurboModuleCxxSpecJSI *>(&turboModule)->getValueWithCallback(
+    rt,
+    args[0].asObject(rt).asFunction(rt)
+  );
   return jsi::Value::undefined();
 }
 static jsi::Value __hostFunction_NativeCallbackTurboModuleCxxSpecJSI_getValueWithCallbackWithAlias(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  static_cast<NativeCallbackTurboModuleCxxSpecJSI *>(&turboModule)->getValueWithCallbackWithAlias(rt, args[0].asObject(rt).asFunction(rt));
+  static_cast<NativeCallbackTurboModuleCxxSpecJSI *>(&turboModule)->getValueWithCallbackWithAlias(
+    rt,
+    args[0].asObject(rt).asFunction(rt)
+  );
   return jsi::Value::undefined();
 }
 
@@ -581,22 +903,43 @@ NativeCallbackTurboModuleCxxSpecJSI::NativeCallbackTurboModuleCxxSpecJSI(std::sh
   methodMap_[\\"getValueWithCallbackWithAlias\\"] = MethodMetadata {1, __hostFunction_NativeCallbackTurboModuleCxxSpecJSI_getValueWithCallbackWithAlias};
 }
 static jsi::Value __hostFunction_NativeEnumTurboModuleCxxSpecJSI_getStatusRegular(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeEnumTurboModuleCxxSpecJSI *>(&turboModule)->getStatusRegular(rt, args[0].asObject(rt));
+  return static_cast<NativeEnumTurboModuleCxxSpecJSI *>(&turboModule)->getStatusRegular(
+    rt,
+    args[0].asObject(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeEnumTurboModuleCxxSpecJSI_getStatusStr(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeEnumTurboModuleCxxSpecJSI *>(&turboModule)->getStatusStr(rt, args[0].asObject(rt));
+  return static_cast<NativeEnumTurboModuleCxxSpecJSI *>(&turboModule)->getStatusStr(
+    rt,
+    args[0].asObject(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeEnumTurboModuleCxxSpecJSI_getStatusNum(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeEnumTurboModuleCxxSpecJSI *>(&turboModule)->getStatusNum(rt, args[0].asObject(rt));
+  return static_cast<NativeEnumTurboModuleCxxSpecJSI *>(&turboModule)->getStatusNum(
+    rt,
+    args[0].asObject(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeEnumTurboModuleCxxSpecJSI_getStatusFraction(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeEnumTurboModuleCxxSpecJSI *>(&turboModule)->getStatusFraction(rt, args[0].asObject(rt));
+  return static_cast<NativeEnumTurboModuleCxxSpecJSI *>(&turboModule)->getStatusFraction(
+    rt,
+    args[0].asObject(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeEnumTurboModuleCxxSpecJSI_getStateType(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeEnumTurboModuleCxxSpecJSI *>(&turboModule)->getStateType(rt, args[0].asString(rt), args[1].asString(rt), args[2].asNumber(), args[3].asNumber());
+  return static_cast<NativeEnumTurboModuleCxxSpecJSI *>(&turboModule)->getStateType(
+    rt,
+    args[0].asString(rt),
+    args[1].asString(rt),
+    args[2].asNumber(),
+    args[3].asNumber()
+  );
 }
 static jsi::Value __hostFunction_NativeEnumTurboModuleCxxSpecJSI_getStateTypeWithEnums(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeEnumTurboModuleCxxSpecJSI *>(&turboModule)->getStateTypeWithEnums(rt, args[0].asObject(rt));
+  return static_cast<NativeEnumTurboModuleCxxSpecJSI *>(&turboModule)->getStateTypeWithEnums(
+    rt,
+    args[0].asObject(rt)
+  );
 }
 
 NativeEnumTurboModuleCxxSpecJSI::NativeEnumTurboModuleCxxSpecJSI(std::shared_ptr<CallInvoker> jsInvoker)
@@ -609,27 +952,44 @@ NativeEnumTurboModuleCxxSpecJSI::NativeEnumTurboModuleCxxSpecJSI(std::shared_ptr
   methodMap_[\\"getStateTypeWithEnums\\"] = MethodMetadata {1, __hostFunction_NativeEnumTurboModuleCxxSpecJSI_getStateTypeWithEnums};
 }
 static jsi::Value __hostFunction_NativeNullableTurboModuleCxxSpecJSI_getBool(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  auto result = static_cast<NativeNullableTurboModuleCxxSpecJSI *>(&turboModule)->getBool(rt, args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asBool()));
+  auto result = static_cast<NativeNullableTurboModuleCxxSpecJSI *>(&turboModule)->getBool(
+    rt,
+    args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asBool())
+  );
   return result ? jsi::Value(std::move(*result)) : jsi::Value::null();
 }
 static jsi::Value __hostFunction_NativeNullableTurboModuleCxxSpecJSI_getNumber(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  auto result = static_cast<NativeNullableTurboModuleCxxSpecJSI *>(&turboModule)->getNumber(rt, args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asNumber()));
+  auto result = static_cast<NativeNullableTurboModuleCxxSpecJSI *>(&turboModule)->getNumber(
+    rt,
+    args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asNumber())
+  );
   return result ? jsi::Value(std::move(*result)) : jsi::Value::null();
 }
 static jsi::Value __hostFunction_NativeNullableTurboModuleCxxSpecJSI_getString(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  auto result = static_cast<NativeNullableTurboModuleCxxSpecJSI *>(&turboModule)->getString(rt, args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asNumber()));
+  auto result = static_cast<NativeNullableTurboModuleCxxSpecJSI *>(&turboModule)->getString(
+    rt,
+    args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asNumber())
+  );
   return result ? jsi::Value(std::move(*result)) : jsi::Value::null();
 }
 static jsi::Value __hostFunction_NativeNullableTurboModuleCxxSpecJSI_getArray(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  auto result = static_cast<NativeNullableTurboModuleCxxSpecJSI *>(&turboModule)->getArray(rt, args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt).asArray(rt)));
+  auto result = static_cast<NativeNullableTurboModuleCxxSpecJSI *>(&turboModule)->getArray(
+    rt,
+    args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt).asArray(rt))
+  );
   return result ? jsi::Value(std::move(*result)) : jsi::Value::null();
 }
 static jsi::Value __hostFunction_NativeNullableTurboModuleCxxSpecJSI_getObject(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  auto result = static_cast<NativeNullableTurboModuleCxxSpecJSI *>(&turboModule)->getObject(rt, args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt)));
+  auto result = static_cast<NativeNullableTurboModuleCxxSpecJSI *>(&turboModule)->getObject(
+    rt,
+    args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt))
+  );
   return result ? jsi::Value(std::move(*result)) : jsi::Value::null();
 }
 static jsi::Value __hostFunction_NativeNullableTurboModuleCxxSpecJSI_getValueWithPromise(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  auto result = static_cast<NativeNullableTurboModuleCxxSpecJSI *>(&turboModule)->getValueWithPromise(rt);
+  auto result = static_cast<NativeNullableTurboModuleCxxSpecJSI *>(&turboModule)->getValueWithPromise(
+    rt
+  );
   return result ? jsi::Value(std::move(*result)) : jsi::Value::null();
 }
 
@@ -643,10 +1003,16 @@ NativeNullableTurboModuleCxxSpecJSI::NativeNullableTurboModuleCxxSpecJSI(std::sh
   methodMap_[\\"getValueWithPromise\\"] = MethodMetadata {0, __hostFunction_NativeNullableTurboModuleCxxSpecJSI_getValueWithPromise};
 }
 static jsi::Value __hostFunction_NativeNumberTurboModuleCxxSpecJSI_getNumber(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeNumberTurboModuleCxxSpecJSI *>(&turboModule)->getNumber(rt, args[0].asNumber());
+  return static_cast<NativeNumberTurboModuleCxxSpecJSI *>(&turboModule)->getNumber(
+    rt,
+    args[0].asNumber()
+  );
 }
 static jsi::Value __hostFunction_NativeNumberTurboModuleCxxSpecJSI_getNumberWithAlias(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeNumberTurboModuleCxxSpecJSI *>(&turboModule)->getNumberWithAlias(rt, args[0].asNumber());
+  return static_cast<NativeNumberTurboModuleCxxSpecJSI *>(&turboModule)->getNumberWithAlias(
+    rt,
+    args[0].asNumber()
+  );
 }
 
 NativeNumberTurboModuleCxxSpecJSI::NativeNumberTurboModuleCxxSpecJSI(std::shared_ptr<CallInvoker> jsInvoker)
@@ -655,19 +1021,33 @@ NativeNumberTurboModuleCxxSpecJSI::NativeNumberTurboModuleCxxSpecJSI(std::shared
   methodMap_[\\"getNumberWithAlias\\"] = MethodMetadata {1, __hostFunction_NativeNumberTurboModuleCxxSpecJSI_getNumberWithAlias};
 }
 static jsi::Value __hostFunction_NativeObjectTurboModuleCxxSpecJSI_getGenericObject(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeObjectTurboModuleCxxSpecJSI *>(&turboModule)->getGenericObject(rt, args[0].asObject(rt));
+  return static_cast<NativeObjectTurboModuleCxxSpecJSI *>(&turboModule)->getGenericObject(
+    rt,
+    args[0].asObject(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeObjectTurboModuleCxxSpecJSI_getGenericObjectReadOnly(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeObjectTurboModuleCxxSpecJSI *>(&turboModule)->getGenericObjectReadOnly(rt, args[0].asObject(rt));
+  return static_cast<NativeObjectTurboModuleCxxSpecJSI *>(&turboModule)->getGenericObjectReadOnly(
+    rt,
+    args[0].asObject(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeObjectTurboModuleCxxSpecJSI_getGenericObjectWithAlias(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeObjectTurboModuleCxxSpecJSI *>(&turboModule)->getGenericObjectWithAlias(rt, args[0].asObject(rt));
+  return static_cast<NativeObjectTurboModuleCxxSpecJSI *>(&turboModule)->getGenericObjectWithAlias(
+    rt,
+    args[0].asObject(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeObjectTurboModuleCxxSpecJSI_difficultObject(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeObjectTurboModuleCxxSpecJSI *>(&turboModule)->difficultObject(rt, args[0].asObject(rt));
+  return static_cast<NativeObjectTurboModuleCxxSpecJSI *>(&turboModule)->difficultObject(
+    rt,
+    args[0].asObject(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeObjectTurboModuleCxxSpecJSI_getConstants(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeObjectTurboModuleCxxSpecJSI *>(&turboModule)->getConstants(rt);
+  return static_cast<NativeObjectTurboModuleCxxSpecJSI *>(&turboModule)->getConstants(
+    rt
+  );
 }
 
 NativeObjectTurboModuleCxxSpecJSI::NativeObjectTurboModuleCxxSpecJSI(std::shared_ptr<CallInvoker> jsInvoker)
@@ -679,7 +1059,9 @@ NativeObjectTurboModuleCxxSpecJSI::NativeObjectTurboModuleCxxSpecJSI(std::shared
   methodMap_[\\"getConstants\\"] = MethodMetadata {0, __hostFunction_NativeObjectTurboModuleCxxSpecJSI_getConstants};
 }
 static jsi::Value __hostFunction_NativeOptionalObjectTurboModuleCxxSpecJSI_getConstants(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeOptionalObjectTurboModuleCxxSpecJSI *>(&turboModule)->getConstants(rt);
+  return static_cast<NativeOptionalObjectTurboModuleCxxSpecJSI *>(&turboModule)->getConstants(
+    rt
+  );
 }
 
 NativeOptionalObjectTurboModuleCxxSpecJSI::NativeOptionalObjectTurboModuleCxxSpecJSI(std::shared_ptr<CallInvoker> jsInvoker)
@@ -687,16 +1069,27 @@ NativeOptionalObjectTurboModuleCxxSpecJSI::NativeOptionalObjectTurboModuleCxxSpe
   methodMap_[\\"getConstants\\"] = MethodMetadata {0, __hostFunction_NativeOptionalObjectTurboModuleCxxSpecJSI_getConstants};
 }
 static jsi::Value __hostFunction_NativePartialAnnotationTurboModuleCxxSpecJSI_getSomeObj(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativePartialAnnotationTurboModuleCxxSpecJSI *>(&turboModule)->getSomeObj(rt);
+  return static_cast<NativePartialAnnotationTurboModuleCxxSpecJSI *>(&turboModule)->getSomeObj(
+    rt
+  );
 }
 static jsi::Value __hostFunction_NativePartialAnnotationTurboModuleCxxSpecJSI_getPartialSomeObj(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativePartialAnnotationTurboModuleCxxSpecJSI *>(&turboModule)->getPartialSomeObj(rt);
+  return static_cast<NativePartialAnnotationTurboModuleCxxSpecJSI *>(&turboModule)->getPartialSomeObj(
+    rt
+  );
 }
 static jsi::Value __hostFunction_NativePartialAnnotationTurboModuleCxxSpecJSI_getSomeObjFromPartialSomeObj(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativePartialAnnotationTurboModuleCxxSpecJSI *>(&turboModule)->getSomeObjFromPartialSomeObj(rt, args[0].asObject(rt));
+  return static_cast<NativePartialAnnotationTurboModuleCxxSpecJSI *>(&turboModule)->getSomeObjFromPartialSomeObj(
+    rt,
+    args[0].asObject(rt)
+  );
 }
 static jsi::Value __hostFunction_NativePartialAnnotationTurboModuleCxxSpecJSI_getPartialPartial(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativePartialAnnotationTurboModuleCxxSpecJSI *>(&turboModule)->getPartialPartial(rt, args[0].asObject(rt), args[1].asObject(rt));
+  return static_cast<NativePartialAnnotationTurboModuleCxxSpecJSI *>(&turboModule)->getPartialPartial(
+    rt,
+    args[0].asObject(rt),
+    args[1].asObject(rt)
+  );
 }
 
 NativePartialAnnotationTurboModuleCxxSpecJSI::NativePartialAnnotationTurboModuleCxxSpecJSI(std::shared_ptr<CallInvoker> jsInvoker)
@@ -707,10 +1100,16 @@ NativePartialAnnotationTurboModuleCxxSpecJSI::NativePartialAnnotationTurboModule
   methodMap_[\\"getPartialPartial\\"] = MethodMetadata {2, __hostFunction_NativePartialAnnotationTurboModuleCxxSpecJSI_getPartialPartial};
 }
 static jsi::Value __hostFunction_NativePromiseTurboModuleCxxSpecJSI_getValueWithPromise(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativePromiseTurboModuleCxxSpecJSI *>(&turboModule)->getValueWithPromise(rt, args[0].asBool());
+  return static_cast<NativePromiseTurboModuleCxxSpecJSI *>(&turboModule)->getValueWithPromise(
+    rt,
+    args[0].asBool()
+  );
 }
 static jsi::Value __hostFunction_NativePromiseTurboModuleCxxSpecJSI_getValueWithPromiseWithAlias(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativePromiseTurboModuleCxxSpecJSI *>(&turboModule)->getValueWithPromiseWithAlias(rt, args[0].asString(rt));
+  return static_cast<NativePromiseTurboModuleCxxSpecJSI *>(&turboModule)->getValueWithPromiseWithAlias(
+    rt,
+    args[0].asString(rt)
+  );
 }
 
 NativePromiseTurboModuleCxxSpecJSI::NativePromiseTurboModuleCxxSpecJSI(std::shared_ptr<CallInvoker> jsInvoker)
@@ -719,45 +1118,84 @@ NativePromiseTurboModuleCxxSpecJSI::NativePromiseTurboModuleCxxSpecJSI(std::shar
   methodMap_[\\"getValueWithPromiseWithAlias\\"] = MethodMetadata {1, __hostFunction_NativePromiseTurboModuleCxxSpecJSI_getValueWithPromiseWithAlias};
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_getConstants(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getConstants(rt);
+  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getConstants(
+    rt
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_voidFunc(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->voidFunc(rt);
+  static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->voidFunc(
+    rt
+  );
   return jsi::Value::undefined();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_getBool(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getBool(rt, args[0].asBool());
+  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getBool(
+    rt,
+    args[0].asBool()
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_getNumber(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getNumber(rt, args[0].asNumber());
+  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getNumber(
+    rt,
+    args[0].asNumber()
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_getString(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getString(rt, args[0].asString(rt));
+  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getString(
+    rt,
+    args[0].asString(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_getArray(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getArray(rt, args[0].asObject(rt).asArray(rt));
+  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getArray(
+    rt,
+    args[0].asObject(rt).asArray(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_getObject(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getObject(rt, args[0].asObject(rt));
+  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getObject(
+    rt,
+    args[0].asObject(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_getObjectShape(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getObjectShape(rt, args[0].asObject(rt));
+  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getObjectShape(
+    rt,
+    args[0].asObject(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_getAlias(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getAlias(rt, args[0].asObject(rt));
+  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getAlias(
+    rt,
+    args[0].asObject(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_getRootTag(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getRootTag(rt, args[0].getNumber());
+  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getRootTag(
+    rt,
+    args[0].getNumber()
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_getValue(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getValue(rt, args[0].asNumber(), args[1].asString(rt), args[2].asObject(rt));
+  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getValue(
+    rt,
+    args[0].asNumber(),
+    args[1].asString(rt),
+    args[2].asObject(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_getValueWithCallback(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getValueWithCallback(rt, args[0].asObject(rt).asFunction(rt));
+  static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getValueWithCallback(
+    rt,
+    args[0].asObject(rt).asFunction(rt)
+  );
   return jsi::Value::undefined();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_getValueWithPromise(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getValueWithPromise(rt, args[0].asBool());
+  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getValueWithPromise(
+    rt,
+    args[0].asBool()
+  );
 }
 
 NativeSampleTurboModuleCxxSpecJSI::NativeSampleTurboModuleCxxSpecJSI(std::shared_ptr<CallInvoker> jsInvoker)
@@ -777,45 +1215,84 @@ NativeSampleTurboModuleCxxSpecJSI::NativeSampleTurboModuleCxxSpecJSI(std::shared
   methodMap_[\\"getValueWithPromise\\"] = MethodMetadata {1, __hostFunction_NativeSampleTurboModuleCxxSpecJSI_getValueWithPromise};
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleArraysCxxSpecJSI_getConstants(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleArraysCxxSpecJSI *>(&turboModule)->getConstants(rt);
+  return static_cast<NativeSampleTurboModuleArraysCxxSpecJSI *>(&turboModule)->getConstants(
+    rt
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleArraysCxxSpecJSI_voidFunc(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  static_cast<NativeSampleTurboModuleArraysCxxSpecJSI *>(&turboModule)->voidFunc(rt);
+  static_cast<NativeSampleTurboModuleArraysCxxSpecJSI *>(&turboModule)->voidFunc(
+    rt
+  );
   return jsi::Value::undefined();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleArraysCxxSpecJSI_getBool(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleArraysCxxSpecJSI *>(&turboModule)->getBool(rt, args[0].asObject(rt).asArray(rt));
+  return static_cast<NativeSampleTurboModuleArraysCxxSpecJSI *>(&turboModule)->getBool(
+    rt,
+    args[0].asObject(rt).asArray(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleArraysCxxSpecJSI_getNumber(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleArraysCxxSpecJSI *>(&turboModule)->getNumber(rt, args[0].asObject(rt).asArray(rt));
+  return static_cast<NativeSampleTurboModuleArraysCxxSpecJSI *>(&turboModule)->getNumber(
+    rt,
+    args[0].asObject(rt).asArray(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleArraysCxxSpecJSI_getString(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleArraysCxxSpecJSI *>(&turboModule)->getString(rt, args[0].asObject(rt).asArray(rt));
+  return static_cast<NativeSampleTurboModuleArraysCxxSpecJSI *>(&turboModule)->getString(
+    rt,
+    args[0].asObject(rt).asArray(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleArraysCxxSpecJSI_getArray(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleArraysCxxSpecJSI *>(&turboModule)->getArray(rt, args[0].asObject(rt).asArray(rt));
+  return static_cast<NativeSampleTurboModuleArraysCxxSpecJSI *>(&turboModule)->getArray(
+    rt,
+    args[0].asObject(rt).asArray(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleArraysCxxSpecJSI_getObject(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleArraysCxxSpecJSI *>(&turboModule)->getObject(rt, args[0].asObject(rt).asArray(rt));
+  return static_cast<NativeSampleTurboModuleArraysCxxSpecJSI *>(&turboModule)->getObject(
+    rt,
+    args[0].asObject(rt).asArray(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleArraysCxxSpecJSI_getObjectShape(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleArraysCxxSpecJSI *>(&turboModule)->getObjectShape(rt, args[0].asObject(rt).asArray(rt));
+  return static_cast<NativeSampleTurboModuleArraysCxxSpecJSI *>(&turboModule)->getObjectShape(
+    rt,
+    args[0].asObject(rt).asArray(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleArraysCxxSpecJSI_getAlias(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleArraysCxxSpecJSI *>(&turboModule)->getAlias(rt, args[0].asObject(rt).asArray(rt));
+  return static_cast<NativeSampleTurboModuleArraysCxxSpecJSI *>(&turboModule)->getAlias(
+    rt,
+    args[0].asObject(rt).asArray(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleArraysCxxSpecJSI_getRootTag(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleArraysCxxSpecJSI *>(&turboModule)->getRootTag(rt, args[0].asObject(rt).asArray(rt));
+  return static_cast<NativeSampleTurboModuleArraysCxxSpecJSI *>(&turboModule)->getRootTag(
+    rt,
+    args[0].asObject(rt).asArray(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleArraysCxxSpecJSI_getValue(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleArraysCxxSpecJSI *>(&turboModule)->getValue(rt, args[0].asObject(rt).asArray(rt), args[1].asObject(rt).asArray(rt), args[2].asObject(rt).asArray(rt));
+  return static_cast<NativeSampleTurboModuleArraysCxxSpecJSI *>(&turboModule)->getValue(
+    rt,
+    args[0].asObject(rt).asArray(rt),
+    args[1].asObject(rt).asArray(rt),
+    args[2].asObject(rt).asArray(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleArraysCxxSpecJSI_getValueWithCallback(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  static_cast<NativeSampleTurboModuleArraysCxxSpecJSI *>(&turboModule)->getValueWithCallback(rt, args[0].asObject(rt).asFunction(rt));
+  static_cast<NativeSampleTurboModuleArraysCxxSpecJSI *>(&turboModule)->getValueWithCallback(
+    rt,
+    args[0].asObject(rt).asFunction(rt)
+  );
   return jsi::Value::undefined();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleArraysCxxSpecJSI_getValueWithPromise(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleArraysCxxSpecJSI *>(&turboModule)->getValueWithPromise(rt, args[0].asObject(rt).asArray(rt));
+  return static_cast<NativeSampleTurboModuleArraysCxxSpecJSI *>(&turboModule)->getValueWithPromise(
+    rt,
+    args[0].asObject(rt).asArray(rt)
+  );
 }
 
 NativeSampleTurboModuleArraysCxxSpecJSI::NativeSampleTurboModuleArraysCxxSpecJSI(std::shared_ptr<CallInvoker> jsInvoker)
@@ -835,54 +1312,93 @@ NativeSampleTurboModuleArraysCxxSpecJSI::NativeSampleTurboModuleArraysCxxSpecJSI
   methodMap_[\\"getValueWithPromise\\"] = MethodMetadata {1, __hostFunction_NativeSampleTurboModuleArraysCxxSpecJSI_getValueWithPromise};
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleNullableCxxSpecJSI_getConstants(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleNullableCxxSpecJSI *>(&turboModule)->getConstants(rt);
+  return static_cast<NativeSampleTurboModuleNullableCxxSpecJSI *>(&turboModule)->getConstants(
+    rt
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleNullableCxxSpecJSI_voidFunc(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  static_cast<NativeSampleTurboModuleNullableCxxSpecJSI *>(&turboModule)->voidFunc(rt);
+  static_cast<NativeSampleTurboModuleNullableCxxSpecJSI *>(&turboModule)->voidFunc(
+    rt
+  );
   return jsi::Value::undefined();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleNullableCxxSpecJSI_getBool(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  auto result = static_cast<NativeSampleTurboModuleNullableCxxSpecJSI *>(&turboModule)->getBool(rt, args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asBool()));
+  auto result = static_cast<NativeSampleTurboModuleNullableCxxSpecJSI *>(&turboModule)->getBool(
+    rt,
+    args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asBool())
+  );
   return result ? jsi::Value(std::move(*result)) : jsi::Value::null();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleNullableCxxSpecJSI_getNumber(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  auto result = static_cast<NativeSampleTurboModuleNullableCxxSpecJSI *>(&turboModule)->getNumber(rt, args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asNumber()));
+  auto result = static_cast<NativeSampleTurboModuleNullableCxxSpecJSI *>(&turboModule)->getNumber(
+    rt,
+    args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asNumber())
+  );
   return result ? jsi::Value(std::move(*result)) : jsi::Value::null();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleNullableCxxSpecJSI_getString(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  auto result = static_cast<NativeSampleTurboModuleNullableCxxSpecJSI *>(&turboModule)->getString(rt, args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asString(rt)));
+  auto result = static_cast<NativeSampleTurboModuleNullableCxxSpecJSI *>(&turboModule)->getString(
+    rt,
+    args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asString(rt))
+  );
   return result ? jsi::Value(std::move(*result)) : jsi::Value::null();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleNullableCxxSpecJSI_getArray(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  auto result = static_cast<NativeSampleTurboModuleNullableCxxSpecJSI *>(&turboModule)->getArray(rt, args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt).asArray(rt)));
+  auto result = static_cast<NativeSampleTurboModuleNullableCxxSpecJSI *>(&turboModule)->getArray(
+    rt,
+    args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt).asArray(rt))
+  );
   return result ? jsi::Value(std::move(*result)) : jsi::Value::null();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleNullableCxxSpecJSI_getObject(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  auto result = static_cast<NativeSampleTurboModuleNullableCxxSpecJSI *>(&turboModule)->getObject(rt, args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt)));
+  auto result = static_cast<NativeSampleTurboModuleNullableCxxSpecJSI *>(&turboModule)->getObject(
+    rt,
+    args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt))
+  );
   return result ? jsi::Value(std::move(*result)) : jsi::Value::null();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleNullableCxxSpecJSI_getObjectShape(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  auto result = static_cast<NativeSampleTurboModuleNullableCxxSpecJSI *>(&turboModule)->getObjectShape(rt, args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt)));
+  auto result = static_cast<NativeSampleTurboModuleNullableCxxSpecJSI *>(&turboModule)->getObjectShape(
+    rt,
+    args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt))
+  );
   return result ? jsi::Value(std::move(*result)) : jsi::Value::null();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleNullableCxxSpecJSI_getAlias(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  auto result = static_cast<NativeSampleTurboModuleNullableCxxSpecJSI *>(&turboModule)->getAlias(rt, args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt)));
+  auto result = static_cast<NativeSampleTurboModuleNullableCxxSpecJSI *>(&turboModule)->getAlias(
+    rt,
+    args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt))
+  );
   return result ? jsi::Value(std::move(*result)) : jsi::Value::null();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleNullableCxxSpecJSI_getRootTag(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  auto result = static_cast<NativeSampleTurboModuleNullableCxxSpecJSI *>(&turboModule)->getRootTag(rt, args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].getNumber()));
+  auto result = static_cast<NativeSampleTurboModuleNullableCxxSpecJSI *>(&turboModule)->getRootTag(
+    rt,
+    args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].getNumber())
+  );
   return result ? jsi::Value(std::move(*result)) : jsi::Value::null();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleNullableCxxSpecJSI_getValue(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  auto result = static_cast<NativeSampleTurboModuleNullableCxxSpecJSI *>(&turboModule)->getValue(rt, args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asNumber()), args[1].isNull() || args[1].isUndefined() ? std::nullopt : std::make_optional(args[1].asString(rt)), args[2].isNull() || args[2].isUndefined() ? std::nullopt : std::make_optional(args[2].asObject(rt)));
+  auto result = static_cast<NativeSampleTurboModuleNullableCxxSpecJSI *>(&turboModule)->getValue(
+    rt,
+    args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asNumber()),
+    args[1].isNull() || args[1].isUndefined() ? std::nullopt : std::make_optional(args[1].asString(rt)),
+    args[2].isNull() || args[2].isUndefined() ? std::nullopt : std::make_optional(args[2].asObject(rt))
+  );
   return result ? jsi::Value(std::move(*result)) : jsi::Value::null();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleNullableCxxSpecJSI_getValueWithCallback(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  static_cast<NativeSampleTurboModuleNullableCxxSpecJSI *>(&turboModule)->getValueWithCallback(rt, args[0].asObject(rt).asFunction(rt));
+  static_cast<NativeSampleTurboModuleNullableCxxSpecJSI *>(&turboModule)->getValueWithCallback(
+    rt,
+    args[0].asObject(rt).asFunction(rt)
+  );
   return jsi::Value::undefined();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleNullableCxxSpecJSI_getValueWithPromise(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  auto result = static_cast<NativeSampleTurboModuleNullableCxxSpecJSI *>(&turboModule)->getValueWithPromise(rt, args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asBool()));
+  auto result = static_cast<NativeSampleTurboModuleNullableCxxSpecJSI *>(&turboModule)->getValueWithPromise(
+    rt,
+    args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asBool())
+  );
   return result ? jsi::Value(std::move(*result)) : jsi::Value::null();
 }
 
@@ -903,53 +1419,92 @@ NativeSampleTurboModuleNullableCxxSpecJSI::NativeSampleTurboModuleNullableCxxSpe
   methodMap_[\\"getValueWithPromise\\"] = MethodMetadata {1, __hostFunction_NativeSampleTurboModuleNullableCxxSpecJSI_getValueWithPromise};
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI_getConstants(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI *>(&turboModule)->getConstants(rt);
+  return static_cast<NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI *>(&turboModule)->getConstants(
+    rt
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI_voidFunc(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  static_cast<NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI *>(&turboModule)->voidFunc(rt);
+  static_cast<NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI *>(&turboModule)->voidFunc(
+    rt
+  );
   return jsi::Value::undefined();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI_getBool(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  auto result = static_cast<NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI *>(&turboModule)->getBool(rt, count < 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asBool()));
+  auto result = static_cast<NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI *>(&turboModule)->getBool(
+    rt,
+    count <= 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asBool())
+  );
   return result ? jsi::Value(std::move(*result)) : jsi::Value::null();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI_getNumber(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  auto result = static_cast<NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI *>(&turboModule)->getNumber(rt, count < 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asNumber()));
+  auto result = static_cast<NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI *>(&turboModule)->getNumber(
+    rt,
+    count <= 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asNumber())
+  );
   return result ? jsi::Value(std::move(*result)) : jsi::Value::null();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI_getString(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  auto result = static_cast<NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI *>(&turboModule)->getString(rt, count < 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asString(rt)));
+  auto result = static_cast<NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI *>(&turboModule)->getString(
+    rt,
+    count <= 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asString(rt))
+  );
   return result ? jsi::Value(std::move(*result)) : jsi::Value::null();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI_getArray(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  auto result = static_cast<NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI *>(&turboModule)->getArray(rt, count < 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt).asArray(rt)));
+  auto result = static_cast<NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI *>(&turboModule)->getArray(
+    rt,
+    count <= 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt).asArray(rt))
+  );
   return result ? jsi::Value(std::move(*result)) : jsi::Value::null();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI_getObject(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  auto result = static_cast<NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI *>(&turboModule)->getObject(rt, count < 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt)));
+  auto result = static_cast<NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI *>(&turboModule)->getObject(
+    rt,
+    count <= 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt))
+  );
   return result ? jsi::Value(std::move(*result)) : jsi::Value::null();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI_getObjectShape(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI *>(&turboModule)->getObjectShape(rt, count < 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt)));
+  return static_cast<NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI *>(&turboModule)->getObjectShape(
+    rt,
+    count <= 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt))
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI_getAlias(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  auto result = static_cast<NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI *>(&turboModule)->getAlias(rt, count < 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt)));
+  auto result = static_cast<NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI *>(&turboModule)->getAlias(
+    rt,
+    count <= 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt))
+  );
   return result ? jsi::Value(std::move(*result)) : jsi::Value::null();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI_getRootTag(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  auto result = static_cast<NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI *>(&turboModule)->getRootTag(rt, count < 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].getNumber()));
+  auto result = static_cast<NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI *>(&turboModule)->getRootTag(
+    rt,
+    count <= 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].getNumber())
+  );
   return result ? jsi::Value(std::move(*result)) : jsi::Value::null();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI_getValue(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  auto result = static_cast<NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI *>(&turboModule)->getValue(rt, count < 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asNumber()), count < 1 || args[1].isNull() || args[1].isUndefined() ? std::nullopt : std::make_optional(args[1].asString(rt)), count < 2 || args[2].isNull() || args[2].isUndefined() ? std::nullopt : std::make_optional(args[2].asObject(rt)));
+  auto result = static_cast<NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI *>(&turboModule)->getValue(
+    rt,
+    count <= 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asNumber()),
+    count <= 1 || args[1].isNull() || args[1].isUndefined() ? std::nullopt : std::make_optional(args[1].asString(rt)),
+    count <= 2 || args[2].isNull() || args[2].isUndefined() ? std::nullopt : std::make_optional(args[2].asObject(rt))
+  );
   return result ? jsi::Value(std::move(*result)) : jsi::Value::null();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI_getValueWithCallback(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  static_cast<NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI *>(&turboModule)->getValueWithCallback(rt, count < 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt).asFunction(rt)));
+  static_cast<NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI *>(&turboModule)->getValueWithCallback(
+    rt,
+    count <= 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt).asFunction(rt))
+  );
   return jsi::Value::undefined();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI_getValueWithPromise(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  auto result = static_cast<NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI *>(&turboModule)->getValueWithPromise(rt, count < 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asBool()));
+  auto result = static_cast<NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI *>(&turboModule)->getValueWithPromise(
+    rt,
+    count <= 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asBool())
+  );
   return result ? jsi::Value(std::move(*result)) : jsi::Value::null();
 }
 
@@ -970,45 +1525,84 @@ NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI::NativeSampleTurboModuleNul
   methodMap_[\\"getValueWithPromise\\"] = MethodMetadata {1, __hostFunction_NativeSampleTurboModuleNullableAndOptionalCxxSpecJSI_getValueWithPromise};
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleOptionalCxxSpecJSI_getConstants(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleOptionalCxxSpecJSI *>(&turboModule)->getConstants(rt);
+  return static_cast<NativeSampleTurboModuleOptionalCxxSpecJSI *>(&turboModule)->getConstants(
+    rt
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleOptionalCxxSpecJSI_voidFunc(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  static_cast<NativeSampleTurboModuleOptionalCxxSpecJSI *>(&turboModule)->voidFunc(rt);
+  static_cast<NativeSampleTurboModuleOptionalCxxSpecJSI *>(&turboModule)->voidFunc(
+    rt
+  );
   return jsi::Value::undefined();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleOptionalCxxSpecJSI_getBool(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleOptionalCxxSpecJSI *>(&turboModule)->getBool(rt, count < 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asBool()));
+  return static_cast<NativeSampleTurboModuleOptionalCxxSpecJSI *>(&turboModule)->getBool(
+    rt,
+    count <= 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asBool())
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleOptionalCxxSpecJSI_getNumber(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleOptionalCxxSpecJSI *>(&turboModule)->getNumber(rt, count < 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asNumber()));
+  return static_cast<NativeSampleTurboModuleOptionalCxxSpecJSI *>(&turboModule)->getNumber(
+    rt,
+    count <= 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asNumber())
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleOptionalCxxSpecJSI_getString(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleOptionalCxxSpecJSI *>(&turboModule)->getString(rt, count < 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asString(rt)));
+  return static_cast<NativeSampleTurboModuleOptionalCxxSpecJSI *>(&turboModule)->getString(
+    rt,
+    count <= 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asString(rt))
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleOptionalCxxSpecJSI_getArray(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleOptionalCxxSpecJSI *>(&turboModule)->getArray(rt, count < 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt).asArray(rt)));
+  return static_cast<NativeSampleTurboModuleOptionalCxxSpecJSI *>(&turboModule)->getArray(
+    rt,
+    count <= 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt).asArray(rt))
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleOptionalCxxSpecJSI_getObject(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleOptionalCxxSpecJSI *>(&turboModule)->getObject(rt, count < 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt)));
+  return static_cast<NativeSampleTurboModuleOptionalCxxSpecJSI *>(&turboModule)->getObject(
+    rt,
+    count <= 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt))
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleOptionalCxxSpecJSI_getObjectShape(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleOptionalCxxSpecJSI *>(&turboModule)->getObjectShape(rt, count < 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt)));
+  return static_cast<NativeSampleTurboModuleOptionalCxxSpecJSI *>(&turboModule)->getObjectShape(
+    rt,
+    count <= 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt))
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleOptionalCxxSpecJSI_getAlias(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleOptionalCxxSpecJSI *>(&turboModule)->getAlias(rt, count < 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt)));
+  return static_cast<NativeSampleTurboModuleOptionalCxxSpecJSI *>(&turboModule)->getAlias(
+    rt,
+    count <= 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt))
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleOptionalCxxSpecJSI_getRootTag(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleOptionalCxxSpecJSI *>(&turboModule)->getRootTag(rt, count < 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].getNumber()));
+  return static_cast<NativeSampleTurboModuleOptionalCxxSpecJSI *>(&turboModule)->getRootTag(
+    rt,
+    count <= 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].getNumber())
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleOptionalCxxSpecJSI_getValue(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleOptionalCxxSpecJSI *>(&turboModule)->getValue(rt, count < 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asNumber()), count < 1 || args[1].isNull() || args[1].isUndefined() ? std::nullopt : std::make_optional(args[1].asString(rt)), count < 2 || args[2].isNull() || args[2].isUndefined() ? std::nullopt : std::make_optional(args[2].asObject(rt)));
+  return static_cast<NativeSampleTurboModuleOptionalCxxSpecJSI *>(&turboModule)->getValue(
+    rt,
+    count <= 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asNumber()),
+    count <= 1 || args[1].isNull() || args[1].isUndefined() ? std::nullopt : std::make_optional(args[1].asString(rt)),
+    count <= 2 || args[2].isNull() || args[2].isUndefined() ? std::nullopt : std::make_optional(args[2].asObject(rt))
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleOptionalCxxSpecJSI_getValueWithCallback(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  static_cast<NativeSampleTurboModuleOptionalCxxSpecJSI *>(&turboModule)->getValueWithCallback(rt, count < 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt).asFunction(rt)));
+  static_cast<NativeSampleTurboModuleOptionalCxxSpecJSI *>(&turboModule)->getValueWithCallback(
+    rt,
+    count <= 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt).asFunction(rt))
+  );
   return jsi::Value::undefined();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleOptionalCxxSpecJSI_getValueWithPromise(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleOptionalCxxSpecJSI *>(&turboModule)->getValueWithPromise(rt, count < 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asBool()));
+  return static_cast<NativeSampleTurboModuleOptionalCxxSpecJSI *>(&turboModule)->getValueWithPromise(
+    rt,
+    count <= 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asBool())
+  );
 }
 
 NativeSampleTurboModuleOptionalCxxSpecJSI::NativeSampleTurboModuleOptionalCxxSpecJSI(std::shared_ptr<CallInvoker> jsInvoker)
@@ -1028,10 +1622,16 @@ NativeSampleTurboModuleOptionalCxxSpecJSI::NativeSampleTurboModuleOptionalCxxSpe
   methodMap_[\\"getValueWithPromise\\"] = MethodMetadata {1, __hostFunction_NativeSampleTurboModuleOptionalCxxSpecJSI_getValueWithPromise};
 }
 static jsi::Value __hostFunction_NativeStringTurboModuleCxxSpecJSI_getString(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeStringTurboModuleCxxSpecJSI *>(&turboModule)->getString(rt, args[0].asString(rt));
+  return static_cast<NativeStringTurboModuleCxxSpecJSI *>(&turboModule)->getString(
+    rt,
+    args[0].asString(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeStringTurboModuleCxxSpecJSI_getStringWithAlias(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeStringTurboModuleCxxSpecJSI *>(&turboModule)->getStringWithAlias(rt, args[0].asString(rt));
+  return static_cast<NativeStringTurboModuleCxxSpecJSI *>(&turboModule)->getStringWithAlias(
+    rt,
+    args[0].asString(rt)
+  );
 }
 
 NativeStringTurboModuleCxxSpecJSI::NativeStringTurboModuleCxxSpecJSI(std::shared_ptr<CallInvoker> jsInvoker)

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleCpp.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleCpp.js
@@ -40,8 +40,8 @@ const HostFunctionTemplate = ({
 }>) => {
   const isNullable = returnTypeAnnotation.type === 'NullableTypeAnnotation';
   const isVoid = returnTypeAnnotation.type === 'VoidTypeAnnotation';
-  const methodCallArgs = ['rt', ...args].join(', ');
-  const methodCall = `static_cast<${hasteModuleName}CxxSpecJSI *>(&turboModule)->${methodName}(${methodCallArgs})`;
+  const methodCallArgs = ['    rt', ...args].join(',\n    ');
+  const methodCall = `static_cast<${hasteModuleName}CxxSpecJSI *>(&turboModule)->${methodName}(\n${methodCallArgs}\n  )`;
 
   return `static jsi::Value __hostFunction_${hasteModuleName}CxxSpecJSI_${methodName}(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {${
     isVoid
@@ -139,7 +139,7 @@ function serializeArg(
     } else {
       let condition = `${val}.isNull() || ${val}.isUndefined()`;
       if (optional) {
-        condition = `count < ${index} || ${condition}`;
+        condition = `count <= ${index} || ${condition}`;
       }
       return `${condition} ? std::nullopt : std::make_optional(${expression})`;
     }

--- a/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleCpp-test.js.snap
+++ b/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleCpp-test.js.snap
@@ -47,30 +47,50 @@ namespace facebook {
 namespace react {
 
 static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_difficult(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->difficult(rt, args[0].asObject(rt));
+  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->difficult(
+    rt,
+    args[0].asObject(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_optionals(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->optionals(rt, args[0].asObject(rt));
+  static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->optionals(
+    rt,
+    args[0].asObject(rt)
+  );
   return jsi::Value::undefined();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_optionalMethod(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->optionalMethod(rt, args[0].asObject(rt), args[1].asObject(rt).asFunction(rt), count < 2 || args[2].isNull() || args[2].isUndefined() ? std::nullopt : std::make_optional(args[2].asObject(rt).asArray(rt)));
+  static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->optionalMethod(
+    rt,
+    args[0].asObject(rt),
+    args[1].asObject(rt).asFunction(rt),
+    count <= 2 || args[2].isNull() || args[2].isUndefined() ? std::nullopt : std::make_optional(args[2].asObject(rt).asArray(rt))
+  );
   return jsi::Value::undefined();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_getArrays(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getArrays(rt, args[0].asObject(rt));
+  static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getArrays(
+    rt,
+    args[0].asObject(rt)
+  );
   return jsi::Value::undefined();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_getNullableObject(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  auto result = static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getNullableObject(rt);
+  auto result = static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getNullableObject(
+    rt
+  );
   return result ? jsi::Value(std::move(*result)) : jsi::Value::null();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_getNullableGenericObject(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  auto result = static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getNullableGenericObject(rt);
+  auto result = static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getNullableGenericObject(
+    rt
+  );
   return result ? jsi::Value(std::move(*result)) : jsi::Value::null();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_getNullableArray(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  auto result = static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getNullableArray(rt);
+  auto result = static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getNullableArray(
+    rt
+  );
   return result ? jsi::Value(std::move(*result)) : jsi::Value::null();
 }
 
@@ -109,20 +129,39 @@ namespace facebook {
 namespace react {
 
 static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_getMixed(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getMixed(rt, jsi::Value(rt, args[0]));
+  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getMixed(
+    rt,
+    jsi::Value(rt, args[0])
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_getNullableNumberFromNullableAlias(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  auto result = static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getNullableNumberFromNullableAlias(rt, args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt)));
+  auto result = static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getNullableNumberFromNullableAlias(
+    rt,
+    args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt))
+  );
   return result ? jsi::Value(std::move(*result)) : jsi::Value::null();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_getEnums(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getEnums(rt, args[0].asNumber(), args[1].asNumber(), args[2].asString(rt));
+  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getEnums(
+    rt,
+    args[0].asNumber(),
+    args[1].asNumber(),
+    args[2].asString(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_getUnion(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getUnion(rt, args[0].asNumber(), args[1].asNumber(), args[2].asObject(rt), args[3].asString(rt));
+  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getUnion(
+    rt,
+    args[0].asNumber(),
+    args[1].asNumber(),
+    args[2].asObject(rt),
+    args[3].asString(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_getEnumReturn(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getEnumReturn(rt);
+  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getEnumReturn(
+    rt
+  );
 }
 
 NativeSampleTurboModuleCxxSpecJSI::NativeSampleTurboModuleCxxSpecJSI(std::shared_ptr<CallInvoker> jsInvoker)
@@ -188,10 +227,15 @@ namespace facebook {
 namespace react {
 
 static jsi::Value __hostFunction_AliasTurboModuleCxxSpecJSI_getConstants(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<AliasTurboModuleCxxSpecJSI *>(&turboModule)->getConstants(rt);
+  return static_cast<AliasTurboModuleCxxSpecJSI *>(&turboModule)->getConstants(
+    rt
+  );
 }
 static jsi::Value __hostFunction_AliasTurboModuleCxxSpecJSI_cropImage(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  static_cast<AliasTurboModuleCxxSpecJSI *>(&turboModule)->cropImage(rt, args[0].asObject(rt));
+  static_cast<AliasTurboModuleCxxSpecJSI *>(&turboModule)->cropImage(
+    rt,
+    args[0].asObject(rt)
+  );
   return jsi::Value::undefined();
 }
 
@@ -225,16 +269,28 @@ namespace facebook {
 namespace react {
 
 static jsi::Value __hostFunction_NativeCameraRollManagerCxxSpecJSI_getConstants(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeCameraRollManagerCxxSpecJSI *>(&turboModule)->getConstants(rt);
+  return static_cast<NativeCameraRollManagerCxxSpecJSI *>(&turboModule)->getConstants(
+    rt
+  );
 }
 static jsi::Value __hostFunction_NativeCameraRollManagerCxxSpecJSI_getPhotos(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeCameraRollManagerCxxSpecJSI *>(&turboModule)->getPhotos(rt, args[0].asObject(rt));
+  return static_cast<NativeCameraRollManagerCxxSpecJSI *>(&turboModule)->getPhotos(
+    rt,
+    args[0].asObject(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeCameraRollManagerCxxSpecJSI_saveToCameraRoll(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeCameraRollManagerCxxSpecJSI *>(&turboModule)->saveToCameraRoll(rt, args[0].asString(rt), args[1].asString(rt));
+  return static_cast<NativeCameraRollManagerCxxSpecJSI *>(&turboModule)->saveToCameraRoll(
+    rt,
+    args[0].asString(rt),
+    args[1].asString(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeCameraRollManagerCxxSpecJSI_deletePhotos(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeCameraRollManagerCxxSpecJSI *>(&turboModule)->deletePhotos(rt, args[0].asObject(rt).asArray(rt));
+  return static_cast<NativeCameraRollManagerCxxSpecJSI *>(&turboModule)->deletePhotos(
+    rt,
+    args[0].asObject(rt).asArray(rt)
+  );
 }
 
 NativeCameraRollManagerCxxSpecJSI::NativeCameraRollManagerCxxSpecJSI(std::shared_ptr<CallInvoker> jsInvoker)
@@ -245,23 +301,43 @@ NativeCameraRollManagerCxxSpecJSI::NativeCameraRollManagerCxxSpecJSI(std::shared
   methodMap_[\\"deletePhotos\\"] = MethodMetadata {1, __hostFunction_NativeCameraRollManagerCxxSpecJSI_deletePhotos};
 }
 static jsi::Value __hostFunction_NativeExceptionsManagerCxxSpecJSI_reportFatalException(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  static_cast<NativeExceptionsManagerCxxSpecJSI *>(&turboModule)->reportFatalException(rt, args[0].asString(rt), args[1].asObject(rt).asArray(rt), args[2].asNumber());
+  static_cast<NativeExceptionsManagerCxxSpecJSI *>(&turboModule)->reportFatalException(
+    rt,
+    args[0].asString(rt),
+    args[1].asObject(rt).asArray(rt),
+    args[2].asNumber()
+  );
   return jsi::Value::undefined();
 }
 static jsi::Value __hostFunction_NativeExceptionsManagerCxxSpecJSI_reportSoftException(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  static_cast<NativeExceptionsManagerCxxSpecJSI *>(&turboModule)->reportSoftException(rt, args[0].asString(rt), args[1].asObject(rt).asArray(rt), args[2].asNumber());
+  static_cast<NativeExceptionsManagerCxxSpecJSI *>(&turboModule)->reportSoftException(
+    rt,
+    args[0].asString(rt),
+    args[1].asObject(rt).asArray(rt),
+    args[2].asNumber()
+  );
   return jsi::Value::undefined();
 }
 static jsi::Value __hostFunction_NativeExceptionsManagerCxxSpecJSI_reportException(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  static_cast<NativeExceptionsManagerCxxSpecJSI *>(&turboModule)->reportException(rt, args[0].asObject(rt));
+  static_cast<NativeExceptionsManagerCxxSpecJSI *>(&turboModule)->reportException(
+    rt,
+    args[0].asObject(rt)
+  );
   return jsi::Value::undefined();
 }
 static jsi::Value __hostFunction_NativeExceptionsManagerCxxSpecJSI_updateExceptionMessage(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  static_cast<NativeExceptionsManagerCxxSpecJSI *>(&turboModule)->updateExceptionMessage(rt, args[0].asString(rt), args[1].asObject(rt).asArray(rt), args[2].asNumber());
+  static_cast<NativeExceptionsManagerCxxSpecJSI *>(&turboModule)->updateExceptionMessage(
+    rt,
+    args[0].asString(rt),
+    args[1].asObject(rt).asArray(rt),
+    args[2].asNumber()
+  );
   return jsi::Value::undefined();
 }
 static jsi::Value __hostFunction_NativeExceptionsManagerCxxSpecJSI_dismissRedbox(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  static_cast<NativeExceptionsManagerCxxSpecJSI *>(&turboModule)->dismissRedbox(rt);
+  static_cast<NativeExceptionsManagerCxxSpecJSI *>(&turboModule)->dismissRedbox(
+    rt
+  );
   return jsi::Value::undefined();
 }
 
@@ -298,48 +374,91 @@ namespace facebook {
 namespace react {
 
 static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_getConstants(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getConstants(rt);
+  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getConstants(
+    rt
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_voidFunc(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->voidFunc(rt);
+  static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->voidFunc(
+    rt
+  );
   return jsi::Value::undefined();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_getBool(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getBool(rt, args[0].asBool());
+  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getBool(
+    rt,
+    args[0].asBool()
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_getNumber(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getNumber(rt, args[0].asNumber());
+  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getNumber(
+    rt,
+    args[0].asNumber()
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_getString(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getString(rt, args[0].asString(rt));
+  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getString(
+    rt,
+    args[0].asString(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_getArray(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getArray(rt, args[0].asObject(rt).asArray(rt));
+  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getArray(
+    rt,
+    args[0].asObject(rt).asArray(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_getObject(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getObject(rt, args[0].asObject(rt));
+  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getObject(
+    rt,
+    args[0].asObject(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_getRootTag(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getRootTag(rt, args[0].getNumber());
+  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getRootTag(
+    rt,
+    args[0].getNumber()
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_getValue(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getValue(rt, args[0].asNumber(), args[1].asString(rt), args[2].asObject(rt));
+  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getValue(
+    rt,
+    args[0].asNumber(),
+    args[1].asString(rt),
+    args[2].asObject(rt)
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_getEnumReturn(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getEnumReturn(rt);
+  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getEnumReturn(
+    rt
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_getValueWithCallback(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getValueWithCallback(rt, args[0].asObject(rt).asFunction(rt));
+  static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getValueWithCallback(
+    rt,
+    args[0].asObject(rt).asFunction(rt)
+  );
   return jsi::Value::undefined();
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_getValueWithPromise(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getValueWithPromise(rt, args[0].asBool());
+  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getValueWithPromise(
+    rt,
+    args[0].asBool()
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_getValueWithOptionalArg(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getValueWithOptionalArg(rt, count < 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt)));
+  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getValueWithOptionalArg(
+    rt,
+    count <= 0 || args[0].isNull() || args[0].isUndefined() ? std::nullopt : std::make_optional(args[0].asObject(rt))
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_getEnums(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getEnums(rt, args[0].asNumber(), args[1].asNumber(), args[2].asString(rt));
+  return static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->getEnums(
+    rt,
+    args[0].asNumber(),
+    args[1].asNumber(),
+    args[2].asString(rt)
+  );
 }
 
 NativeSampleTurboModuleCxxSpecJSI::NativeSampleTurboModuleCxxSpecJSI(std::shared_ptr<CallInvoker> jsInvoker)
@@ -384,7 +503,9 @@ namespace facebook {
 namespace react {
 
 static jsi::Value __hostFunction_NativeSampleTurboModuleCxxSpecJSI_voidFunc(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->voidFunc(rt);
+  static_cast<NativeSampleTurboModuleCxxSpecJSI *>(&turboModule)->voidFunc(
+    rt
+  );
   return jsi::Value::undefined();
 }
 
@@ -393,10 +514,14 @@ NativeSampleTurboModuleCxxSpecJSI::NativeSampleTurboModuleCxxSpecJSI(std::shared
   methodMap_[\\"voidFunc\\"] = MethodMetadata {0, __hostFunction_NativeSampleTurboModuleCxxSpecJSI_voidFunc};
 }
 static jsi::Value __hostFunction_NativeSampleTurboModule2CxxSpecJSI_getConstants(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboModule2CxxSpecJSI *>(&turboModule)->getConstants(rt);
+  return static_cast<NativeSampleTurboModule2CxxSpecJSI *>(&turboModule)->getConstants(
+    rt
+  );
 }
 static jsi::Value __hostFunction_NativeSampleTurboModule2CxxSpecJSI_voidFunc(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  static_cast<NativeSampleTurboModule2CxxSpecJSI *>(&turboModule)->voidFunc(rt);
+  static_cast<NativeSampleTurboModule2CxxSpecJSI *>(&turboModule)->voidFunc(
+    rt
+  );
   return jsi::Value::undefined();
 }
 

--- a/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.cpp
+++ b/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.cpp
@@ -117,6 +117,12 @@ AsyncPromise<std::string> NativeCxxModuleExample::getValueWithPromise(
   return promise;
 }
 
+bool NativeCxxModuleExample::getWithWithOptionalArgs(
+    jsi::Runtime &rt,
+    std::optional<bool> optionalArg) {
+  return optionalArg.value_or(false);
+}
+
 void NativeCxxModuleExample::voidFunc(jsi::Runtime &rt) {
   // Nothing to do
 }

--- a/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.h
+++ b/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.h
@@ -120,6 +120,10 @@ class NativeCxxModuleExample
 
   AsyncPromise<std::string> getValueWithPromise(jsi::Runtime &rt, bool error);
 
+  bool getWithWithOptionalArgs(
+      jsi::Runtime &rt,
+      std::optional<bool> optionalArg);
+
   void voidFunc(jsi::Runtime &rt);
 
   void emitCustomDeviceEvent(jsi::Runtime &rt, jsi::String eventName);

--- a/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.js
+++ b/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.js
@@ -70,6 +70,7 @@ export interface Spec extends TurboModule {
   +getValue: (x: number, y: string, z: ObjectStruct) => ValueStruct;
   +getValueWithCallback: (callback: (value: string) => void) => void;
   +getValueWithPromise: (error: boolean) => Promise<string>;
+  +getWithWithOptionalArgs: (optionalArg?: boolean) => boolean;
   +voidFunc: () => void;
   +emitCustomDeviceEvent: (eventName: string) => void;
 }

--- a/packages/rn-tester/js/examples/TurboModule/NativeCxxModuleExampleExample.js
+++ b/packages/rn-tester/js/examples/TurboModule/NativeCxxModuleExampleExample.js
@@ -55,6 +55,7 @@ type Examples =
   | 'promise'
   | 'rejectPromise'
   | 'voidFunc'
+  | 'optionalArgs'
   | 'emitDeviceEvent';
 
 class NativeCxxModuleExampleExample extends React.Component<{||}, State> {
@@ -99,6 +100,7 @@ class NativeCxxModuleExampleExample extends React.Component<{||}, State> {
         .then(() => {})
         .catch(e => this._setResult('rejectPromise', e.message)),
     voidFunc: () => NativeCxxModuleExample?.voidFunc(),
+    optionalArgs: () => NativeCxxModuleExample?.getWithWithOptionalArgs(),
     emitDeviceEvent: () => {
       const CUSTOM_EVENT_TYPE = 'myCustomDeviceEvent';
       DeviceEventEmitter.removeAllListeners(CUSTOM_EVENT_TYPE);


### PR DESCRIPTION
Summary:
We would previously generate the following codegen for optional args

```
return static_cast<NativeAudioModuleCxxSpecJSI *>(&turboModule)->playAudio(
    rt,
    args[0].asString(rt),
    args[1].isNull() || args[1].isUndefined() ? std::nullopt : std::make_optional(args[1].asString(rt)),
    args[2].isNull() || args[2].isUndefined() ? std::nullopt : std::make_optional(args[2].asString(rt)),
    args[3].asNumber(),
    count < 4 || args[4].isNull() || args[4].isUndefined() ? std::nullopt : std::make_optional(args[4].asObject(rt)),
    count < 5 || args[5].isNull() || args[5].isUndefined() ? std::nullopt : std::make_optional(args[5].asObject(rt)),
    count < 6 || args[6].isNull() || args[6].isUndefined() ? std::nullopt : std::make_optional(args[6].asBool())
);
```

However, the counts checked are off-by-one, causing us to incorrectly process args.

Changelog: [General][Fixed] Issue with TurboModule C++ codegen with optional args

Differential Revision: D44299193

