### PR TITLE
Degrade debugging log to avoid confusion over warning

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
@@ -97,7 +97,7 @@ public class ReactContext extends ContextWrapper {
 
   /** Initialize message queue threads using a ReactQueueConfiguration. */
   public synchronized void initializeMessageQueueThreads(ReactQueueConfiguration queueConfig) {
-    FLog.w(TAG, "initializeMessageQueueThreads() is called.");
+    FLog.d(TAG, "initializeMessageQueueThreads() is called.");
     if (mUiMessageQueueThread != null
         || mNativeModulesMessageQueueThread != null
         || mJSMessageQueueThread != null) {


### PR DESCRIPTION
Summary:
To avoid unnecessary confusion caused by the warning here. Context https://fb.workplace.com/groups/rn.support/permalink/24454205640868054/

Changelog:
[Internal][Changed] - Degrade debugging log to avoid confusion

Reviewed By: genkikondo

Differential Revision: D44293359

