### PR TITLE
Fix cxx codegen handling of optional return types

### DIFF
--- a/packages/react-native/ReactCommon/react/bridging/Class.h
+++ b/packages/react-native/ReactCommon/react/bridging/Class.h
@@ -50,7 +50,7 @@ T callFromJs(
             rt, fromJs<Args>(rt, std::forward<JSArgs>(args), jsInvoker)...),
         jsInvoker);
 
-  } else if constexpr (is_optional_v<T>) {
+  } else if constexpr (is_optional_jsi_v<T>) {
     static_assert(
         is_optional_v<R>
             ? supportsToJs<typename R::value_type, typename T::value_type>
@@ -70,10 +70,8 @@ T callFromJs(
     }
 
     return convert(rt, std::move(result));
-
   } else {
     static_assert(std::is_convertible_v<R, T>, "Incompatible return type");
-
     return (instance->*method)(
         rt, fromJs<Args>(rt, std::forward<JSArgs>(args), jsInvoker)...);
   }

--- a/packages/react-native/ReactCommon/react/bridging/Convert.h
+++ b/packages/react-native/ReactCommon/react/bridging/Convert.h
@@ -33,6 +33,14 @@ struct is_optional<std::optional<T>> : std::true_type {};
 template <typename T>
 inline constexpr bool is_optional_v = is_optional<T>::value;
 
+template <typename T, typename = void>
+inline constexpr bool is_optional_jsi_v = false;
+
+template <typename T>
+inline constexpr bool
+    is_optional_jsi_v<T, typename std::enable_if_t<is_optional_v<T>>> =
+        is_jsi_v<typename T::value_type>;
+
 template <typename T>
 struct Converter;
 

--- a/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.cpp
+++ b/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.cpp
@@ -117,10 +117,10 @@ AsyncPromise<std::string> NativeCxxModuleExample::getValueWithPromise(
   return promise;
 }
 
-bool NativeCxxModuleExample::getWithWithOptionalArgs(
+std::optional<bool> NativeCxxModuleExample::getWithWithOptionalArgs(
     jsi::Runtime &rt,
     std::optional<bool> optionalArg) {
-  return optionalArg.value_or(false);
+  return optionalArg;
 }
 
 void NativeCxxModuleExample::voidFunc(jsi::Runtime &rt) {

--- a/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.h
+++ b/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.h
@@ -120,7 +120,7 @@ class NativeCxxModuleExample
 
   AsyncPromise<std::string> getValueWithPromise(jsi::Runtime &rt, bool error);
 
-  bool getWithWithOptionalArgs(
+  std::optional<bool> getWithWithOptionalArgs(
       jsi::Runtime &rt,
       std::optional<bool> optionalArg);
 

--- a/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.js
+++ b/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.js
@@ -70,7 +70,7 @@ export interface Spec extends TurboModule {
   +getValue: (x: number, y: string, z: ObjectStruct) => ValueStruct;
   +getValueWithCallback: (callback: (value: string) => void) => void;
   +getValueWithPromise: (error: boolean) => Promise<string>;
-  +getWithWithOptionalArgs: (optionalArg?: boolean) => boolean;
+  +getWithWithOptionalArgs: (optionalArg?: boolean) => ?boolean;
   +voidFunc: () => void;
   +emitCustomDeviceEvent: (eventName: string) => void;
 }


### PR DESCRIPTION
Summary:
Found that the current codegen did not properly handle a return type of `?bool` because the branch of `constexpr (is_optional_v<T>)` assumed that T was always a JSI value that needed conversion, and `supportsToJs<bool, bool>` is false.

Changelog: [General][Fixed] Issue with TurboModule C++ codegen with optional return types

Differential Revision: D44302352

