### PR TITLE
Remove 'import' from default Package Exports conditions

### DIFF
--- a/packages/metro-config/index.js
+++ b/packages/metro-config/index.js
@@ -42,7 +42,7 @@ function getDefaultConfig(
     resolver: {
       resolverMainFields: ['react-native', 'browser', 'main'],
       platforms: ['android', 'ios'],
-      unstable_conditionNames: ['import', 'require', 'react-native'],
+      unstable_conditionNames: ['require', 'react-native'],
     },
     serializer: {
       getPolyfills: () => require('@react-native/js-polyfills')(),


### PR DESCRIPTION
Summary:
The [Exports RFC](https://github.com/react-native-community/discussions-and-proposals/blob/main/proposals/0534-metro-package-exports-support.md) had assumed that supporting the `"import"` condition was a syntax-only difference, given we are not in a Node.js environment — and so was worthwhile to support for maximal ecosystem compatibility.

<img width="1090" alt="image" src="https://user-images.githubusercontent.com/2547783/226997557-818da648-2b0e-4838-a304-f94bc1cc8069.png">

This assumption is similar to [`--moduleResolution bundler` in TypeScript 5.0](https://github.com/microsoft/TypeScript/pull/51669):

> bundlers and runtimes that include a range of Node-like resolution features and ESM syntax, but do not enforce the strict resolution rules that accompany ES modules in Node or in the browser
> -- https://github.com/microsoft/TypeScript/pull/51669#issue-1467004047

However, @robhogan has rightly pointed out that **we should not do this!**

- ESM (once transpiled) is **not** simply a stricter subset of in-scope features supported by CJS. For example, it supports top-level async, which would be breaking at runtime.
- We recently made the same change for our Jest environment:
    - https://github.com/facebook/react-native/commit/681d7f8113d2b5e9d6966255ee6c72b50a7d488a

As such, we are erring on the side of correctness and supporting only `['require', 'react-native']` in our defaults. At runtime, all code run by React Native is anticipated to be CommonJS. `"exports"` will instead allow React Native to correctly select the CommonJS versions of modules from all npm packages.

- Metro will require future extended behaviour in order to dynamically set `'import'` based on how the module is `import`ed/`require()`d. For now this is not in scope.

Changelog:
[General][Changed] - Default condition set for experimental Package Exports is now `['require', 'react-native']`

Metro changelog: [Experimental] Package Exports `unstable_conditionNames` now defaults to `['require']`

Differential Revision: D44303559

