### PR TITLE
fix: make cursor center for different line height

### DIFF
--- a/packages/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.m
+++ b/packages/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.m
@@ -298,7 +298,12 @@ static UIColor *defaultPlaceholderColor()
     return CGRectZero;
   }
 
-  return [super caretRectForPosition:position];
+  CGRect rect = [super caretRectForPosition:position];
+  UIFont *font = self.font;
+  float prevHeight = rect.size.height;
+  rect.size.height = font.pointSize - font.descender;
+  rect.origin.y +=  (prevHeight - rect.size.height);
+  return rect;
 }
 
 #pragma mark - Utility Methods


### PR DESCRIPTION
## Summary
Currently in multiline input the cursor touches the previous line.
So this reduces its height sets its position so that I does not touch previous line.
This PR will also fix the issue https://github.com/facebook/react-native/issues/28012 (Problem with TextInput lineHeight on iOS)
This RP will fix the issue caused in 
[PR](https://github.com/facebook/react-native/pull/36484)

## Changelog
[IOS] [ADDED] - Fixed cursor height on multiline text input

## Test Plan
Tested for different cursor height 

https://user-images.githubusercontent.com/46092576/227004355-3886a0b5-7cdb-4fdc-a16b-3c4abb729737.mov


https://user-images.githubusercontent.com/46092576/227004361-48099f81-9f52-460d-8ae8-d0ddb09dc47d.mov

