### PR TITLE
Fix Android linting using old minSdkVersion

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/AndroidManifest.xml
+++ b/packages/react-native/ReactAndroid/src/main/AndroidManifest.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:versionCode="1"
+    >
+
+  <!-- This is necessary to inform the linter about our min API version. The linter walk the tree
+   up from the file to lint until it find an AndroidManifest with a minSdkVersion. This is then used
+   as the min SDK to lint the file.-->
+  <uses-sdk
+      android:minSdkVersion="21"
+      android:targetSdkVersion="33"
+      />
+
+</manifest>

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/ForwardingCookieHandler.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/ForwardingCookieHandler.java
@@ -7,9 +7,7 @@
 
 package com.facebook.react.modules.network;
 
-import android.annotation.TargetApi;
 import android.content.Context;
-import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.Message;
@@ -76,7 +74,6 @@ public class ForwardingCookieHandler extends CookieHandler {
     clearCookiesAsync(callback);
   }
 
-  @TargetApi(Build.VERSION_CODES.LOLLIPOP)
   private void clearCookiesAsync(final Callback callback) {
     CookieManager cookieManager = getCookieManager();
     if (cookieManager != null) {
@@ -104,7 +101,6 @@ public class ForwardingCookieHandler extends CookieHandler {
     mCookieSaver.onCookiesModified();
   }
 
-  @TargetApi(Build.VERSION_CODES.LOLLIPOP)
   private void addCookieAsync(String url, String cookie) {
     CookieManager cookieManager = getCookieManager();
     if (cookieManager != null) {
@@ -199,7 +195,6 @@ public class ForwardingCookieHandler extends CookieHandler {
           });
     }
 
-    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     private void flush() {
       CookieManager cookieManager = getCookieManager();
       if (cookieManager != null) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/statusbar/StatusBarModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/statusbar/StatusBarModule.java
@@ -79,7 +79,6 @@ public class StatusBarModule extends NativeStatusBarManagerAndroidSpec {
 
     UiThreadUtil.runOnUiThread(
         new GuardedRunnable(getReactApplicationContext()) {
-          @TargetApi(Build.VERSION_CODES.LOLLIPOP)
           @Override
           public void runGuarded() {
             activity
@@ -118,7 +117,6 @@ public class StatusBarModule extends NativeStatusBarManagerAndroidSpec {
 
     UiThreadUtil.runOnUiThread(
         new GuardedRunnable(getReactApplicationContext()) {
-          @TargetApi(Build.VERSION_CODES.LOLLIPOP)
           @Override
           public void runGuarded() {
             // If the status bar is translucent hook into the window insets calculations

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/switchview/ReactSwitch.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/switchview/ReactSwitch.java
@@ -7,14 +7,12 @@
 
 package com.facebook.react.views.switchview;
 
-import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.res.ColorStateList;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.RippleDrawable;
-import android.os.Build;
 import androidx.annotation.Nullable;
 import androidx.appcompat.widget.SwitchCompat;
 
@@ -51,7 +49,6 @@ import androidx.appcompat.widget.SwitchCompat;
   }
 
   @Override
-  @TargetApi(Build.VERSION_CODES.LOLLIPOP)
   public void setBackgroundColor(int color) {
     setBackground(
         new RippleDrawable(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/CustomLetterSpacingSpan.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/CustomLetterSpacingSpan.java
@@ -7,8 +7,6 @@
 
 package com.facebook.react.views.text;
 
-import android.annotation.TargetApi;
-import android.os.Build;
 import android.text.TextPaint;
 import android.text.style.MetricAffectingSpan;
 
@@ -18,7 +16,6 @@ import android.text.style.MetricAffectingSpan;
  * <p>The letter spacing is specified in pixels, which are converted to ems at paint time; this span
  * must therefore be applied after any spans affecting font size.
  */
-@TargetApi(Build.VERSION_CODES.LOLLIPOP)
 public class CustomLetterSpacingSpan extends MetricAffectingSpan implements ReactSpan {
 
   private final float mLetterSpacing;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -706,12 +706,10 @@ public class ReactEditText extends AppCompatEditText
     stripSpansOfKind(
         sb, ReactUnderlineSpan.class, (span) -> (getPaintFlags() & Paint.UNDERLINE_TEXT_FLAG) != 0);
 
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-      stripSpansOfKind(
-          sb,
-          CustomLetterSpacingSpan.class,
-          (span) -> span.getSpacing() == mTextAttributes.getEffectiveLetterSpacing());
-    }
+    stripSpansOfKind(
+        sb,
+        CustomLetterSpacingSpan.class,
+        (span) -> span.getSpacing() == mTextAttributes.getEffectiveLetterSpacing());
 
     stripSpansOfKind(
         sb,
@@ -769,15 +767,10 @@ public class ReactEditText extends AppCompatEditText
       workingText.setSpan(new ReactUnderlineSpan(), 0, workingText.length(), spanFlags);
     }
 
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-      float effectiveLetterSpacing = mTextAttributes.getEffectiveLetterSpacing();
-      if (!Float.isNaN(effectiveLetterSpacing)) {
-        workingText.setSpan(
-            new CustomLetterSpacingSpan(effectiveLetterSpacing),
-            0,
-            workingText.length(),
-            spanFlags);
-      }
+    float effectiveLetterSpacing = mTextAttributes.getEffectiveLetterSpacing();
+    if (!Float.isNaN(effectiveLetterSpacing)) {
+      workingText.setSpan(
+          new CustomLetterSpacingSpan(effectiveLetterSpacing), 0, workingText.length(), spanFlags);
     }
 
     if (mFontStyle != UNSET
@@ -1087,9 +1080,7 @@ public class ReactEditText extends AppCompatEditText
 
     float effectiveLetterSpacing = mTextAttributes.getEffectiveLetterSpacing();
     if (!Float.isNaN(effectiveLetterSpacing)) {
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-        setLetterSpacing(effectiveLetterSpacing);
-      }
+      setLetterSpacing(effectiveLetterSpacing);
     }
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactDrawableHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactDrawableHelper.java
@@ -7,7 +7,6 @@
 
 package com.facebook.react.views.view;
 
-import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.res.ColorStateList;
 import android.graphics.Color;
@@ -31,7 +30,6 @@ public class ReactDrawableHelper {
 
   private static final TypedValue sResolveOutValue = new TypedValue();
 
-  @TargetApi(Build.VERSION_CODES.LOLLIPOP)
   public static Drawable createDrawableFromJSDescription(
       Context context, ReadableMap drawableDescriptionDict) {
     String type = drawableDescriptionDict.getString("type");
@@ -52,7 +50,6 @@ public class ReactDrawableHelper {
     }
   }
 
-  @TargetApi(Build.VERSION_CODES.LOLLIPOP)
   private static int getAttrId(Context context, String attr) {
     SoftAssertions.assertNotNull(attr);
     if ("selectableItemBackground".equals(attr)) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewBackgroundDrawable.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewBackgroundDrawable.java
@@ -7,9 +7,6 @@
 
 package com.facebook.react.views.view;
 
-import static android.os.Build.VERSION_CODES.LOLLIPOP;
-
-import android.annotation.TargetApi;
 import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Color;
@@ -1396,7 +1393,6 @@ public class ReactViewBackgroundDrawable extends Drawable {
     return ReactViewBackgroundDrawable.colorFromAlphaAndRGBComponents(alpha, rgb);
   }
 
-  @TargetApi(LOLLIPOP)
   public RectF getDirectionAwareBorderInsets() {
     final float borderWidth = getBorderWidthOrDefaultTo(0, Spacing.ALL);
     final float borderTopWidth = getBorderWidthOrDefaultTo(borderWidth, Spacing.TOP);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -19,7 +19,6 @@ import android.graphics.Rect;
 import android.graphics.RectF;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.LayerDrawable;
-import android.os.Build;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
@@ -58,7 +57,6 @@ import com.facebook.yoga.YogaConstants;
  * Backing for a React View. Has support for borders, but since borders aren't common, lazy
  * initializes most of the storage needed for them.
  */
-@TargetApi(Build.VERSION_CODES.LOLLIPOP)
 public class ReactViewGroup extends ViewGroup
     implements ReactInterceptingViewGroup,
         ReactClippingViewGroup,


### PR DESCRIPTION
Summary:
Right now an arc focus'd Android Studio (and presumably Android studio in OSS) will warn on any call incompatible with API 20 and later, but we only target API 21+ (Lollipop). See D24380233 for where we removed Lollipop and earlier code in October 2020.

https://pxl.cl/2xMGG

From searching, these warnings are controlled by the closest parent `AndroidManifest.xml`. We don't use this to control the actual SDK version, but we can add one for correct lint warning.

This change does that, then removes any extraneous version checks that were added since then.

Changelog:
[Internal]

Differential Revision: D44305441

