### PR TITLE
Enable unused-promise lint in xplat/js

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -63,6 +63,7 @@ nonstrict-import=warn
 deprecated-type=error
 unsafe-getters-setters=warn
 unnecessary-invariant=warn
+unused-promise=error
 
 [strict]
 deprecated-type

--- a/.flowconfig.android
+++ b/.flowconfig.android
@@ -63,6 +63,7 @@ nonstrict-import=warn
 deprecated-type=error
 unsafe-getters-setters=warn
 unnecessary-invariant=warn
+unused-promise=error
 
 [strict]
 deprecated-type


### PR DESCRIPTION
Summary:
Enable the unused-promise lint in xplat/js.

See https://flow.org/en/docs/linting/rule-reference/#toc-unused-promise for more details.

Changelog: [Internal]

Reviewed By: motiz88

Differential Revision: D44156206

