### PR TITLE
Pre-suppress unused-promise lint errors in xplat/js

### DIFF
--- a/IntegrationTests/PromiseTest.js
+++ b/IntegrationTests/PromiseTest.js
@@ -22,6 +22,7 @@ class PromiseTest extends React.Component<{...}> {
   shouldThrowAsync: boolean = false;
 
   componentDidMount() {
+    // $FlowFixMe[unused-promise]
     Promise.all([
       this.testShouldResolve(),
       this.testShouldReject(),

--- a/packages/react-native/Libraries/LogBox/Data/__tests__/LogBoxSymbolication-test.js
+++ b/packages/react-native/Libraries/LogBox/Data/__tests__/LogBoxSymbolication-test.js
@@ -41,7 +41,9 @@ describe('LogBoxSymbolication', () => {
   });
 
   it('symbolicates different stacks', () => {
+    // $FlowFixMe[unused-promise]
     LogBoxSymbolication.symbolicate(createStack(['A', 'B', 'C']));
+    // $FlowFixMe[unused-promise]
     LogBoxSymbolication.symbolicate(createStack(['D', 'E', 'F']));
 
     expect(symbolicateStackTrace.mock.calls.length).toBe(2);
@@ -49,7 +51,9 @@ describe('LogBoxSymbolication', () => {
 
   it('batch symbolicates equivalent stacks', () => {
     const stack = createStack(['A', 'B', 'C']);
+    // $FlowFixMe[unused-promise]
     LogBoxSymbolication.symbolicate(stack);
+    // $FlowFixMe[unused-promise]
     LogBoxSymbolication.symbolicate(stack);
 
     expect(symbolicateStackTrace.mock.calls.length).toBe(1);

--- a/packages/rn-tester/js/examples/Accessibility/AccessibilityExample.js
+++ b/packages/rn-tester/js/examples/Accessibility/AccessibilityExample.js
@@ -1528,6 +1528,7 @@ function DisplayOptionStatusExample({
       notification,
       setStatusEnabled,
     );
+    // $FlowFixMe[unused-promise]
     optionChecker().then(isEnabled => {
       setStatusEnabled(isEnabled);
     });

--- a/packages/rn-tester/js/examples/Image/ImageExample.js
+++ b/packages/rn-tester/js/examples/Image/ImageExample.js
@@ -48,6 +48,7 @@ class BlobImage extends React.Component<BlobImageProps, BlobImageState> {
   };
 
   UNSAFE_componentWillMount() {
+    // $FlowFixMe[unused-promise]
     (async () => {
       const result = await fetch(this.props.url);
       const blob = await result.blob();
@@ -158,6 +159,7 @@ class NetworkImageCallbackExample extends React.Component<
                   this._loadEventFired(
                     `✔ Prefetch OK (+${Date.now() - mountTime}ms)`,
                   );
+                  // $FlowFixMe[unused-promise]
                   Image.queryCache([IMAGE_PREFETCH_URL]).then(map => {
                     const result = map[IMAGE_PREFETCH_URL];
                     if (result) {

--- a/packages/rn-tester/js/examples/ScrollView/ScrollViewExample.js
+++ b/packages/rn-tester/js/examples/ScrollView/ScrollViewExample.js
@@ -741,6 +741,7 @@ const RefreshControlExample = () => {
   const [refreshing, setRefreshing] = useState(false);
   const onRefresh = useCallback(() => {
     setRefreshing(true);
+    // $FlowFixMe[unused-promise]
     wait(2000).then(() => setRefreshing(false));
   }, []);
 

--- a/packages/rn-tester/js/examples/Share/ShareExample.js
+++ b/packages/rn-tester/js/examples/Share/ShareExample.js
@@ -15,6 +15,7 @@ const React = require('react');
 const {StyleSheet, View, Text, Button, Share} = require('react-native');
 
 const shareMessage = () => {
+  // $FlowFixMe[unused-promise]
   Share.share({
     message:
       ('Our top priority for React Native is to match the expectations people have for each platform. This is why React Native renders to platform primitives. We value native look-and-feel over cross-platform consistency.' +
@@ -23,6 +24,7 @@ const shareMessage = () => {
 };
 
 const shareText = () => {
+  // $FlowFixMe[unused-promise]
   Share.share(
     {
       title: 'Massive Scale',

--- a/packages/rn-tester/js/examples/XHR/XHRExampleBinaryUpload.js
+++ b/packages/rn-tester/js/examples/XHR/XHRExampleBinaryUpload.js
@@ -71,6 +71,7 @@ class XHRExampleBinaryUpload extends React.Component<{...}, $FlowFixMeState> {
     }
     const url = xhr.responseText.slice(index).split('\n')[0];
     console.log('Upload successful: ' + url);
+    // $FlowFixMe[unused-promise]
     Linking.openURL(url);
   }
 

--- a/packages/rn-tester/js/examples/XHR/XHRExampleFetch.js
+++ b/packages/rn-tester/js/examples/XHR/XHRExampleFetch.js
@@ -28,6 +28,7 @@ class XHRExampleFetch extends React.Component<any, any> {
   }
 
   submit(uri: string) {
+    // $FlowFixMe[unused-promise]
     fetch(uri)
       .then(response => {
         this.responseURL = response.url;


### PR DESCRIPTION
Summary:
Pre-suppress unused-promise lint errors in xplat/js. The next diff enables the lint.

See https://flow.org/en/docs/linting/rule-reference/#toc-unused-promise for more details.

Changelog: [Internal]

drop-conflicts
bypass-lint

Differential Revision: D43967290

