### PR TITLE
Avoid property name conflicts in event-emitter codegen

### DIFF
--- a/packages/react-native-codegen/e2e/__tests__/components/__snapshots__/GenerateEventEmitterCpp-test.js.snap
+++ b/packages/react-native-codegen/e2e/__tests__/components/__snapshots__/GenerateEventEmitterCpp-test.js.snap
@@ -17,8 +17,6 @@ Object {
 namespace facebook {
 namespace react {
 
-
-
 } // namespace react
 } // namespace facebook
 ",
@@ -41,8 +39,6 @@ Object {
 
 namespace facebook {
 namespace react {
-
-
 
 } // namespace react
 } // namespace facebook
@@ -67,8 +63,6 @@ Object {
 namespace facebook {
 namespace react {
 
-
-
 } // namespace react
 } // namespace facebook
 ",
@@ -91,8 +85,6 @@ Object {
 
 namespace facebook {
 namespace react {
-
-
 
 } // namespace react
 } // namespace facebook
@@ -117,8 +109,6 @@ Object {
 namespace facebook {
 namespace react {
 
-
-
 } // namespace react
 } // namespace facebook
 ",
@@ -141,8 +131,6 @@ Object {
 
 namespace facebook {
 namespace react {
-
-
 
 } // namespace react
 } // namespace facebook
@@ -167,23 +155,21 @@ Object {
 namespace facebook {
 namespace react {
 
-void EventNestedObjectPropsNativeComponentViewEventEmitter::onChange(OnChange event) const {
-  dispatchEvent(\\"change\\", [event=std::move(event)](jsi::Runtime &runtime) {
-    auto payload = jsi::Object(runtime);
+void EventNestedObjectPropsNativeComponentViewEventEmitter::onChange(OnChange $event) const {
+  dispatchEvent(\\"change\\", [$event=std::move($event)](jsi::Runtime &runtime) {
+    auto $payload = jsi::Object(runtime);
     {
-              auto location = jsi::Object(runtime);
-              {
-              auto source = jsi::Object(runtime);
-              source.setProperty(runtime, \\"url\\", event.location.source.url);
-
-              location.setProperty(runtime, \\"source\\", source);
-            }
-location.setProperty(runtime, \\"x\\", event.location.x);
-location.setProperty(runtime, \\"y\\", event.location.y);
-
-              payload.setProperty(runtime, \\"location\\", location);
-            }
-    return payload;
+  auto location = jsi::Object(runtime);
+  {
+  auto source = jsi::Object(runtime);
+  source.setProperty(runtime, \\"url\\", $event.location.source.url);
+  location.setProperty(runtime, \\"source\\", source);
+}
+location.setProperty(runtime, \\"x\\", $event.location.x);
+location.setProperty(runtime, \\"y\\", $event.location.y);
+  $payload.setProperty(runtime, \\"location\\", location);
+}
+    return $payload;
   });
 }
 
@@ -210,49 +196,59 @@ Object {
 namespace facebook {
 namespace react {
 
-void EventPropsNativeComponentViewEventEmitter::onChange(OnChange event) const {
-  dispatchEvent(\\"change\\", [event=std::move(event)](jsi::Runtime &runtime) {
-    auto payload = jsi::Object(runtime);
-    payload.setProperty(runtime, \\"value\\", event.value);
-payload.setProperty(runtime, \\"source\\", event.source);
-payload.setProperty(runtime, \\"progress\\", event.progress);
-payload.setProperty(runtime, \\"scale\\", event.scale);
-    return payload;
+void EventPropsNativeComponentViewEventEmitter::onChange(OnChange $event) const {
+  dispatchEvent(\\"change\\", [$event=std::move($event)](jsi::Runtime &runtime) {
+    auto $payload = jsi::Object(runtime);
+    $payload.setProperty(runtime, \\"value\\", $event.value);
+$payload.setProperty(runtime, \\"source\\", $event.source);
+$payload.setProperty(runtime, \\"progress\\", $event.progress);
+$payload.setProperty(runtime, \\"scale\\", $event.scale);
+    return $payload;
   });
 }
-void EventPropsNativeComponentViewEventEmitter::onEventDirect(OnEventDirect event) const {
-  dispatchEvent(\\"eventDirect\\", [event=std::move(event)](jsi::Runtime &runtime) {
-    auto payload = jsi::Object(runtime);
-    payload.setProperty(runtime, \\"value\\", event.value);
-    return payload;
+
+
+void EventPropsNativeComponentViewEventEmitter::onEventDirect(OnEventDirect $event) const {
+  dispatchEvent(\\"eventDirect\\", [$event=std::move($event)](jsi::Runtime &runtime) {
+    auto $payload = jsi::Object(runtime);
+    $payload.setProperty(runtime, \\"value\\", $event.value);
+    return $payload;
   });
 }
-void EventPropsNativeComponentViewEventEmitter::onEventDirectWithPaperName(OnEventDirectWithPaperName event) const {
-  dispatchEvent(\\"eventDirectWithPaperName\\", [event=std::move(event)](jsi::Runtime &runtime) {
-    auto payload = jsi::Object(runtime);
-    payload.setProperty(runtime, \\"value\\", event.value);
-    return payload;
+
+
+void EventPropsNativeComponentViewEventEmitter::onEventDirectWithPaperName(OnEventDirectWithPaperName $event) const {
+  dispatchEvent(\\"eventDirectWithPaperName\\", [$event=std::move($event)](jsi::Runtime &runtime) {
+    auto $payload = jsi::Object(runtime);
+    $payload.setProperty(runtime, \\"value\\", $event.value);
+    return $payload;
   });
 }
-void EventPropsNativeComponentViewEventEmitter::onOrientationChange(OnOrientationChange event) const {
-  dispatchEvent(\\"orientationChange\\", [event=std::move(event)](jsi::Runtime &runtime) {
-    auto payload = jsi::Object(runtime);
-    payload.setProperty(runtime, \\"orientation\\", toString(event.orientation));
-    return payload;
+
+
+void EventPropsNativeComponentViewEventEmitter::onOrientationChange(OnOrientationChange $event) const {
+  dispatchEvent(\\"orientationChange\\", [$event=std::move($event)](jsi::Runtime &runtime) {
+    auto $payload = jsi::Object(runtime);
+    $payload.setProperty(runtime, \\"orientation\\", toString($event.orientation));
+    return $payload;
   });
 }
-void EventPropsNativeComponentViewEventEmitter::onEnd(OnEnd event) const {
+
+
+void EventPropsNativeComponentViewEventEmitter::onEnd(OnEnd $event) const {
   dispatchEvent(\\"end\\", [](jsi::Runtime &runtime) {
-    auto payload = jsi::Object(runtime);
+    auto $payload = jsi::Object(runtime);
     
-    return payload;
+    return $payload;
   });
 }
-void EventPropsNativeComponentViewEventEmitter::onEventBubblingWithPaperName(OnEventBubblingWithPaperName event) const {
+
+
+void EventPropsNativeComponentViewEventEmitter::onEventBubblingWithPaperName(OnEventBubblingWithPaperName $event) const {
   dispatchEvent(\\"eventBubblingWithPaperName\\", [](jsi::Runtime &runtime) {
-    auto payload = jsi::Object(runtime);
+    auto $payload = jsi::Object(runtime);
     
-    return payload;
+    return $payload;
   });
 }
 
@@ -279,8 +275,6 @@ Object {
 namespace facebook {
 namespace react {
 
-
-
 } // namespace react
 } // namespace facebook
 ",
@@ -303,8 +297,6 @@ Object {
 
 namespace facebook {
 namespace react {
-
-
 
 } // namespace react
 } // namespace facebook
@@ -329,8 +321,6 @@ Object {
 namespace facebook {
 namespace react {
 
-
-
 } // namespace react
 } // namespace facebook
 ",
@@ -354,11 +344,11 @@ Object {
 namespace facebook {
 namespace react {
 
-void InterfaceOnlyNativeComponentViewEventEmitter::onChange(OnChange event) const {
-  dispatchEvent(\\"change\\", [event=std::move(event)](jsi::Runtime &runtime) {
-    auto payload = jsi::Object(runtime);
-    payload.setProperty(runtime, \\"value\\", event.value);
-    return payload;
+void InterfaceOnlyNativeComponentViewEventEmitter::onChange(OnChange $event) const {
+  dispatchEvent(\\"change\\", [$event=std::move($event)](jsi::Runtime &runtime) {
+    auto $payload = jsi::Object(runtime);
+    $payload.setProperty(runtime, \\"value\\", $event.value);
+    return $payload;
   });
 }
 
@@ -385,8 +375,6 @@ Object {
 namespace facebook {
 namespace react {
 
-
-
 } // namespace react
 } // namespace facebook
 ",
@@ -409,8 +397,6 @@ Object {
 
 namespace facebook {
 namespace react {
-
-
 
 } // namespace react
 } // namespace facebook
@@ -435,8 +421,6 @@ Object {
 namespace facebook {
 namespace react {
 
-
-
 } // namespace react
 } // namespace facebook
 ",
@@ -459,8 +443,6 @@ Object {
 
 namespace facebook {
 namespace react {
-
-
 
 } // namespace react
 } // namespace facebook
@@ -485,8 +467,6 @@ Object {
 namespace facebook {
 namespace react {
 
-
-
 } // namespace react
 } // namespace facebook
 ",
@@ -509,8 +489,6 @@ Object {
 
 namespace facebook {
 namespace react {
-
-
 
 } // namespace react
 } // namespace facebook

--- a/packages/react-native-codegen/e2e/__tests__/components/__snapshots__/GenerateEventEmitterH-test.js.snap
+++ b/packages/react-native-codegen/e2e/__tests__/components/__snapshots__/GenerateEventEmitterH-test.js.snap
@@ -18,7 +18,6 @@ Object {
 
 namespace facebook {
 namespace react {
-
 class JSI_EXPORT ArrayPropsNativeComponentViewEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
@@ -27,7 +26,6 @@ class JSI_EXPORT ArrayPropsNativeComponentViewEventEmitter : public ViewEventEmi
 
   
 };
-
 } // namespace react
 } // namespace facebook
 ",
@@ -52,7 +50,6 @@ Object {
 
 namespace facebook {
 namespace react {
-
 class JSI_EXPORT BooleanPropNativeComponentViewEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
@@ -61,7 +58,6 @@ class JSI_EXPORT BooleanPropNativeComponentViewEventEmitter : public ViewEventEm
 
   
 };
-
 } // namespace react
 } // namespace facebook
 ",
@@ -86,7 +82,6 @@ Object {
 
 namespace facebook {
 namespace react {
-
 class JSI_EXPORT ColorPropNativeComponentViewEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
@@ -95,7 +90,6 @@ class JSI_EXPORT ColorPropNativeComponentViewEventEmitter : public ViewEventEmit
 
   
 };
-
 } // namespace react
 } // namespace facebook
 ",
@@ -120,7 +114,6 @@ Object {
 
 namespace facebook {
 namespace react {
-
 class JSI_EXPORT DimensionPropNativeComponentViewEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
@@ -129,7 +122,6 @@ class JSI_EXPORT DimensionPropNativeComponentViewEventEmitter : public ViewEvent
 
   
 };
-
 } // namespace react
 } // namespace facebook
 ",
@@ -154,7 +146,6 @@ Object {
 
 namespace facebook {
 namespace react {
-
 class JSI_EXPORT EdgeInsetsPropNativeComponentViewEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
@@ -163,7 +154,6 @@ class JSI_EXPORT EdgeInsetsPropNativeComponentViewEventEmitter : public ViewEven
 
   
 };
-
 } // namespace react
 } // namespace facebook
 ",
@@ -188,7 +178,6 @@ Object {
 
 namespace facebook {
 namespace react {
-
 class JSI_EXPORT EnumPropNativeComponentViewEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
@@ -197,7 +186,6 @@ class JSI_EXPORT EnumPropNativeComponentViewEventEmitter : public ViewEventEmitt
 
   
 };
-
 } // namespace react
 } // namespace facebook
 ",
@@ -222,7 +210,6 @@ Object {
 
 namespace facebook {
 namespace react {
-
 class JSI_EXPORT EventNestedObjectPropsNativeComponentViewEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
@@ -243,7 +230,6 @@ class JSI_EXPORT EventNestedObjectPropsNativeComponentViewEventEmitter : public 
 
   void onChange(OnChange value) const;
 };
-
 } // namespace react
 } // namespace facebook
 ",
@@ -268,7 +254,6 @@ Object {
 
 namespace facebook {
 namespace react {
-
 class JSI_EXPORT EventPropsNativeComponentViewEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
@@ -324,7 +309,6 @@ class JSI_EXPORT EventPropsNativeComponentViewEventEmitter : public ViewEventEmi
 
   void onEventBubblingWithPaperName(OnEventBubblingWithPaperName value) const;
 };
-
 } // namespace react
 } // namespace facebook
 ",
@@ -349,7 +333,6 @@ Object {
 
 namespace facebook {
 namespace react {
-
 class JSI_EXPORT FloatPropsNativeComponentViewEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
@@ -358,7 +341,6 @@ class JSI_EXPORT FloatPropsNativeComponentViewEventEmitter : public ViewEventEmi
 
   
 };
-
 } // namespace react
 } // namespace facebook
 ",
@@ -383,7 +365,6 @@ Object {
 
 namespace facebook {
 namespace react {
-
 class JSI_EXPORT ImagePropNativeComponentViewEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
@@ -392,7 +373,6 @@ class JSI_EXPORT ImagePropNativeComponentViewEventEmitter : public ViewEventEmit
 
   
 };
-
 } // namespace react
 } // namespace facebook
 ",
@@ -417,7 +397,6 @@ Object {
 
 namespace facebook {
 namespace react {
-
 class JSI_EXPORT IntegerPropNativeComponentViewEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
@@ -426,7 +405,6 @@ class JSI_EXPORT IntegerPropNativeComponentViewEventEmitter : public ViewEventEm
 
   
 };
-
 } // namespace react
 } // namespace facebook
 ",
@@ -451,7 +429,6 @@ Object {
 
 namespace facebook {
 namespace react {
-
 class JSI_EXPORT InterfaceOnlyNativeComponentViewEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
@@ -462,7 +439,6 @@ class JSI_EXPORT InterfaceOnlyNativeComponentViewEventEmitter : public ViewEvent
 
   void onChange(OnChange value) const;
 };
-
 } // namespace react
 } // namespace facebook
 ",
@@ -487,7 +463,6 @@ Object {
 
 namespace facebook {
 namespace react {
-
 class JSI_EXPORT MixedPropNativeComponentViewEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
@@ -496,7 +471,6 @@ class JSI_EXPORT MixedPropNativeComponentViewEventEmitter : public ViewEventEmit
 
   
 };
-
 } // namespace react
 } // namespace facebook
 ",
@@ -521,7 +495,6 @@ Object {
 
 namespace facebook {
 namespace react {
-
 class JSI_EXPORT MultiNativePropNativeComponentViewEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
@@ -530,7 +503,6 @@ class JSI_EXPORT MultiNativePropNativeComponentViewEventEmitter : public ViewEve
 
   
 };
-
 } // namespace react
 } // namespace facebook
 ",
@@ -555,7 +527,6 @@ Object {
 
 namespace facebook {
 namespace react {
-
 class JSI_EXPORT NoPropsNoEventsNativeComponentViewEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
@@ -564,7 +535,6 @@ class JSI_EXPORT NoPropsNoEventsNativeComponentViewEventEmitter : public ViewEve
 
   
 };
-
 } // namespace react
 } // namespace facebook
 ",
@@ -589,7 +559,6 @@ Object {
 
 namespace facebook {
 namespace react {
-
 class JSI_EXPORT ObjectPropsNativeComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
@@ -598,7 +567,6 @@ class JSI_EXPORT ObjectPropsNativeComponentEventEmitter : public ViewEventEmitte
 
   
 };
-
 } // namespace react
 } // namespace facebook
 ",
@@ -623,7 +591,6 @@ Object {
 
 namespace facebook {
 namespace react {
-
 class JSI_EXPORT PointPropNativeComponentViewEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
@@ -632,7 +599,6 @@ class JSI_EXPORT PointPropNativeComponentViewEventEmitter : public ViewEventEmit
 
   
 };
-
 } // namespace react
 } // namespace facebook
 ",
@@ -657,7 +623,6 @@ Object {
 
 namespace facebook {
 namespace react {
-
 class JSI_EXPORT StringPropNativeComponentViewEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
@@ -666,7 +631,6 @@ class JSI_EXPORT StringPropNativeComponentViewEventEmitter : public ViewEventEmi
 
   
 };
-
 } // namespace react
 } // namespace facebook
 ",

--- a/packages/react-native-codegen/src/generators/components/GenerateEventEmitterH.js
+++ b/packages/react-native-codegen/src/generators/components/GenerateEventEmitterH.js
@@ -51,9 +51,7 @@ const FileTemplate = ({componentEmitters}: {componentEmitters: string}) => `
 
 namespace facebook {
 namespace react {
-
 ${componentEmitters}
-
 } // namespace react
 } // namespace facebook
 `;

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GenerateEventEmitterCpp-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GenerateEventEmitterCpp-test.js.snap
@@ -17,8 +17,6 @@ Map {
 namespace facebook {
 namespace react {
 
-
-
 } // namespace react
 } // namespace facebook
 ",
@@ -41,8 +39,6 @@ Map {
 
 namespace facebook {
 namespace react {
-
-
 
 } // namespace react
 } // namespace facebook
@@ -67,8 +63,6 @@ Map {
 namespace facebook {
 namespace react {
 
-
-
 } // namespace react
 } // namespace facebook
 ",
@@ -91,8 +85,6 @@ Map {
 
 namespace facebook {
 namespace react {
-
-
 
 } // namespace react
 } // namespace facebook
@@ -117,8 +109,6 @@ Map {
 namespace facebook {
 namespace react {
 
-
-
 } // namespace react
 } // namespace facebook
 ",
@@ -141,8 +131,6 @@ Map {
 
 namespace facebook {
 namespace react {
-
-
 
 } // namespace react
 } // namespace facebook
@@ -167,8 +155,6 @@ Map {
 namespace facebook {
 namespace react {
 
-
-
 } // namespace react
 } // namespace facebook
 ",
@@ -191,8 +177,6 @@ Map {
 
 namespace facebook {
 namespace react {
-
-
 
 } // namespace react
 } // namespace facebook
@@ -217,23 +201,21 @@ Map {
 namespace facebook {
 namespace react {
 
-void EventsNestedObjectNativeComponentEventEmitter::onChange(OnChange event) const {
-  dispatchEvent(\\"change\\", [event=std::move(event)](jsi::Runtime &runtime) {
-    auto payload = jsi::Object(runtime);
+void EventsNestedObjectNativeComponentEventEmitter::onChange(OnChange $event) const {
+  dispatchEvent(\\"change\\", [$event=std::move($event)](jsi::Runtime &runtime) {
+    auto $payload = jsi::Object(runtime);
     {
-              auto location = jsi::Object(runtime);
-              {
-              auto source = jsi::Object(runtime);
-              source.setProperty(runtime, \\"url\\", event.location.source.url);
-
-              location.setProperty(runtime, \\"source\\", source);
-            }
-location.setProperty(runtime, \\"x\\", event.location.x);
-location.setProperty(runtime, \\"y\\", event.location.y);
-
-              payload.setProperty(runtime, \\"location\\", location);
-            }
-    return payload;
+  auto location = jsi::Object(runtime);
+  {
+  auto source = jsi::Object(runtime);
+  source.setProperty(runtime, \\"url\\", $event.location.source.url);
+  location.setProperty(runtime, \\"source\\", source);
+}
+location.setProperty(runtime, \\"x\\", $event.location.x);
+location.setProperty(runtime, \\"y\\", $event.location.y);
+  $payload.setProperty(runtime, \\"location\\", location);
+}
+    return $payload;
   });
 }
 
@@ -260,34 +242,38 @@ Map {
 namespace facebook {
 namespace react {
 
-void EventsNativeComponentEventEmitter::onChange(OnChange event) const {
-  dispatchEvent(\\"change\\", [event=std::move(event)](jsi::Runtime &runtime) {
-    auto payload = jsi::Object(runtime);
-    payload.setProperty(runtime, \\"value\\", event.value);
-payload.setProperty(runtime, \\"source\\", event.source);
-payload.setProperty(runtime, \\"progress\\", event.progress);
-payload.setProperty(runtime, \\"scale\\", event.scale);
-    return payload;
+void EventsNativeComponentEventEmitter::onChange(OnChange $event) const {
+  dispatchEvent(\\"change\\", [$event=std::move($event)](jsi::Runtime &runtime) {
+    auto $payload = jsi::Object(runtime);
+    $payload.setProperty(runtime, \\"value\\", $event.value);
+$payload.setProperty(runtime, \\"source\\", $event.source);
+$payload.setProperty(runtime, \\"progress\\", $event.progress);
+$payload.setProperty(runtime, \\"scale\\", $event.scale);
+    return $payload;
   });
 }
-void EventsNativeComponentEventEmitter::onEventDirect(OnEventDirect event) const {
-  dispatchEvent(\\"eventDirect\\", [event=std::move(event)](jsi::Runtime &runtime) {
-    auto payload = jsi::Object(runtime);
-    payload.setProperty(runtime, \\"value\\", event.value);
-    return payload;
+
+
+void EventsNativeComponentEventEmitter::onEventDirect(OnEventDirect $event) const {
+  dispatchEvent(\\"eventDirect\\", [$event=std::move($event)](jsi::Runtime &runtime) {
+    auto $payload = jsi::Object(runtime);
+    $payload.setProperty(runtime, \\"value\\", $event.value);
+    return $payload;
   });
 }
-void EventsNativeComponentEventEmitter::onOrientationChange(OnOrientationChange event) const {
-  dispatchEvent(\\"orientationChange\\", [event=std::move(event)](jsi::Runtime &runtime) {
-    auto payload = jsi::Object(runtime);
-    payload.setProperty(runtime, \\"orientation\\", toString(event.orientation));
-    return payload;
+
+
+void EventsNativeComponentEventEmitter::onOrientationChange(OnOrientationChange $event) const {
+  dispatchEvent(\\"orientationChange\\", [$event=std::move($event)](jsi::Runtime &runtime) {
+    auto $payload = jsi::Object(runtime);
+    $payload.setProperty(runtime, \\"orientation\\", toString($event.orientation));
+    return $payload;
   });
 }
+
 void EventsNativeComponentEventEmitter::onEnd() const {
   dispatchEvent(\\"end\\");
 }
-
 } // namespace react
 } // namespace facebook
 ",
@@ -311,18 +297,20 @@ Map {
 namespace facebook {
 namespace react {
 
-void InterfaceOnlyComponentEventEmitter::onChange(OnChange event) const {
-  dispatchEvent(\\"change\\", [event=std::move(event)](jsi::Runtime &runtime) {
-    auto payload = jsi::Object(runtime);
-    payload.setProperty(runtime, \\"value\\", event.value);
-    return payload;
+void InterfaceOnlyComponentEventEmitter::onChange(OnChange $event) const {
+  dispatchEvent(\\"change\\", [$event=std::move($event)](jsi::Runtime &runtime) {
+    auto $payload = jsi::Object(runtime);
+    $payload.setProperty(runtime, \\"value\\", $event.value);
+    return $payload;
   });
 }
-void InterfaceOnlyComponentEventEmitter::onDire tChange(OnDire tChange event) const {
-  dispatchEvent(\\"dire tChange\\", [event=std::move(event)](jsi::Runtime &runtime) {
-    auto payload = jsi::Object(runtime);
-    payload.setProperty(runtime, \\"value\\", event.value);
-    return payload;
+
+
+void InterfaceOnlyComponentEventEmitter::onDire tChange(OnDire tChange $event) const {
+  dispatchEvent(\\"dire tChange\\", [$event=std::move($event)](jsi::Runtime &runtime) {
+    auto $payload = jsi::Object(runtime);
+    $payload.setProperty(runtime, \\"value\\", $event.value);
+    return $payload;
   });
 }
 
@@ -349,8 +337,6 @@ Map {
 namespace facebook {
 namespace react {
 
-
-
 } // namespace react
 } // namespace facebook
 ",
@@ -373,8 +359,6 @@ Map {
 
 namespace facebook {
 namespace react {
-
-
 
 } // namespace react
 } // namespace facebook
@@ -400,8 +384,6 @@ namespace facebook {
 namespace react {
 
 
-
-
 } // namespace react
 } // namespace facebook
 ",
@@ -424,8 +406,6 @@ Map {
 
 namespace facebook {
 namespace react {
-
-
 
 } // namespace react
 } // namespace facebook
@@ -450,8 +430,6 @@ Map {
 namespace facebook {
 namespace react {
 
-
-
 } // namespace react
 } // namespace facebook
 ",
@@ -474,8 +452,6 @@ Map {
 
 namespace facebook {
 namespace react {
-
-
 
 } // namespace react
 } // namespace facebook
@@ -500,8 +476,6 @@ Map {
 namespace facebook {
 namespace react {
 
-
-
 } // namespace react
 } // namespace facebook
 ",
@@ -524,8 +498,6 @@ Map {
 
 namespace facebook {
 namespace react {
-
-
 
 } // namespace react
 } // namespace facebook
@@ -550,11 +522,11 @@ Map {
 namespace facebook {
 namespace react {
 
-void InterfaceOnlyComponentEventEmitter::onChange(OnChange event) const {
-  dispatchEvent(\\"change\\", [event=std::move(event)](jsi::Runtime &runtime) {
-    auto payload = jsi::Object(runtime);
-    payload.setProperty(runtime, \\"value\\", event.value);
-    return payload;
+void InterfaceOnlyComponentEventEmitter::onChange(OnChange $event) const {
+  dispatchEvent(\\"change\\", [$event=std::move($event)](jsi::Runtime &runtime) {
+    auto $payload = jsi::Object(runtime);
+    $payload.setProperty(runtime, \\"value\\", $event.value);
+    return $payload;
   });
 }
 
@@ -581,8 +553,6 @@ Map {
 namespace facebook {
 namespace react {
 
-
-
 } // namespace react
 } // namespace facebook
 ",
@@ -605,8 +575,6 @@ Map {
 
 namespace facebook {
 namespace react {
-
-
 
 } // namespace react
 } // namespace facebook
@@ -631,8 +599,6 @@ Map {
 namespace facebook {
 namespace react {
 
-
-
 } // namespace react
 } // namespace facebook
 ",
@@ -655,8 +621,6 @@ Map {
 
 namespace facebook {
 namespace react {
-
-
 
 } // namespace react
 } // namespace facebook
@@ -681,8 +645,6 @@ Map {
 namespace facebook {
 namespace react {
 
-
-
 } // namespace react
 } // namespace facebook
 ",
@@ -706,8 +668,6 @@ Map {
 namespace facebook {
 namespace react {
 
-
-
 } // namespace react
 } // namespace facebook
 ",
@@ -730,8 +690,6 @@ Map {
 
 namespace facebook {
 namespace react {
-
-
 
 } // namespace react
 } // namespace facebook
@@ -757,8 +715,6 @@ namespace facebook {
 namespace react {
 
 
-
-
 } // namespace react
 } // namespace facebook
 ",
@@ -781,8 +737,6 @@ Map {
 
 namespace facebook {
 namespace react {
-
-
 
 
 } // namespace react

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GenerateEventEmitterH-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GenerateEventEmitterH-test.js.snap
@@ -18,7 +18,6 @@ Map {
 
 namespace facebook {
 namespace react {
-
 class JSI_EXPORT ArrayPropsNativeComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
@@ -27,7 +26,6 @@ class JSI_EXPORT ArrayPropsNativeComponentEventEmitter : public ViewEventEmitter
 
   
 };
-
 } // namespace react
 } // namespace facebook
 ",
@@ -52,7 +50,6 @@ Map {
 
 namespace facebook {
 namespace react {
-
 class JSI_EXPORT ArrayPropsNativeComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
@@ -61,7 +58,6 @@ class JSI_EXPORT ArrayPropsNativeComponentEventEmitter : public ViewEventEmitter
 
   
 };
-
 } // namespace react
 } // namespace facebook
 ",
@@ -86,7 +82,6 @@ Map {
 
 namespace facebook {
 namespace react {
-
 class JSI_EXPORT BooleanPropNativeComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
@@ -95,7 +90,6 @@ class JSI_EXPORT BooleanPropNativeComponentEventEmitter : public ViewEventEmitte
 
   
 };
-
 } // namespace react
 } // namespace facebook
 ",
@@ -120,7 +114,6 @@ Map {
 
 namespace facebook {
 namespace react {
-
 class JSI_EXPORT ColorPropNativeComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
@@ -129,7 +122,6 @@ class JSI_EXPORT ColorPropNativeComponentEventEmitter : public ViewEventEmitter 
 
   
 };
-
 } // namespace react
 } // namespace facebook
 ",
@@ -154,7 +146,6 @@ Map {
 
 namespace facebook {
 namespace react {
-
 class JSI_EXPORT CommandNativeComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
@@ -163,7 +154,6 @@ class JSI_EXPORT CommandNativeComponentEventEmitter : public ViewEventEmitter {
 
   
 };
-
 } // namespace react
 } // namespace facebook
 ",
@@ -188,7 +178,6 @@ Map {
 
 namespace facebook {
 namespace react {
-
 class JSI_EXPORT CommandNativeComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
@@ -197,7 +186,6 @@ class JSI_EXPORT CommandNativeComponentEventEmitter : public ViewEventEmitter {
 
   
 };
-
 } // namespace react
 } // namespace facebook
 ",
@@ -222,7 +210,6 @@ Map {
 
 namespace facebook {
 namespace react {
-
 class JSI_EXPORT DimensionPropNativeComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
@@ -231,7 +218,6 @@ class JSI_EXPORT DimensionPropNativeComponentEventEmitter : public ViewEventEmit
 
   
 };
-
 } // namespace react
 } // namespace facebook
 ",
@@ -256,7 +242,6 @@ Map {
 
 namespace facebook {
 namespace react {
-
 class JSI_EXPORT DoublePropNativeComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
@@ -265,7 +250,6 @@ class JSI_EXPORT DoublePropNativeComponentEventEmitter : public ViewEventEmitter
 
   
 };
-
 } // namespace react
 } // namespace facebook
 ",
@@ -290,7 +274,6 @@ Map {
 
 namespace facebook {
 namespace react {
-
 class JSI_EXPORT EventsNestedObjectNativeComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
@@ -311,7 +294,6 @@ class JSI_EXPORT EventsNestedObjectNativeComponentEventEmitter : public ViewEven
 
   void onChange(OnChange value) const;
 };
-
 } // namespace react
 } // namespace facebook
 ",
@@ -336,7 +318,6 @@ Map {
 
 namespace facebook {
 namespace react {
-
 class JSI_EXPORT EventsNativeComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
@@ -376,7 +357,6 @@ class JSI_EXPORT EventsNativeComponentEventEmitter : public ViewEventEmitter {
 
   void onEnd() const;
 };
-
 } // namespace react
 } // namespace facebook
 ",
@@ -401,7 +381,6 @@ Map {
 
 namespace facebook {
 namespace react {
-
 class JSI_EXPORT InterfaceOnlyComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
@@ -418,7 +397,6 @@ class JSI_EXPORT InterfaceOnlyComponentEventEmitter : public ViewEventEmitter {
 
   void onDire tChange(OnDire tChange value) const;
 };
-
 } // namespace react
 } // namespace facebook
 ",
@@ -443,7 +421,6 @@ Map {
 
 namespace facebook {
 namespace react {
-
 class JSI_EXPORT ExcludedAndroidComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
@@ -452,7 +429,6 @@ class JSI_EXPORT ExcludedAndroidComponentEventEmitter : public ViewEventEmitter 
 
   
 };
-
 } // namespace react
 } // namespace facebook
 ",
@@ -477,7 +453,6 @@ Map {
 
 namespace facebook {
 namespace react {
-
 class JSI_EXPORT ExcludedAndroidIosComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
@@ -486,7 +461,6 @@ class JSI_EXPORT ExcludedAndroidIosComponentEventEmitter : public ViewEventEmitt
 
   
 };
-
 } // namespace react
 } // namespace facebook
 ",
@@ -511,7 +485,6 @@ Map {
 
 namespace facebook {
 namespace react {
-
 class JSI_EXPORT ExcludedIosComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
@@ -528,7 +501,6 @@ class JSI_EXPORT MultiFileIncludedNativeComponentEventEmitter : public ViewEvent
 
   
 };
-
 } // namespace react
 } // namespace facebook
 ",
@@ -553,7 +525,6 @@ Map {
 
 namespace facebook {
 namespace react {
-
 class JSI_EXPORT FloatPropNativeComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
@@ -562,7 +533,6 @@ class JSI_EXPORT FloatPropNativeComponentEventEmitter : public ViewEventEmitter 
 
   
 };
-
 } // namespace react
 } // namespace facebook
 ",
@@ -587,7 +557,6 @@ Map {
 
 namespace facebook {
 namespace react {
-
 class JSI_EXPORT ImagePropNativeComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
@@ -596,7 +565,6 @@ class JSI_EXPORT ImagePropNativeComponentEventEmitter : public ViewEventEmitter 
 
   
 };
-
 } // namespace react
 } // namespace facebook
 ",
@@ -621,7 +589,6 @@ Map {
 
 namespace facebook {
 namespace react {
-
 class JSI_EXPORT InsetsPropNativeComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
@@ -630,7 +597,6 @@ class JSI_EXPORT InsetsPropNativeComponentEventEmitter : public ViewEventEmitter
 
   
 };
-
 } // namespace react
 } // namespace facebook
 ",
@@ -655,7 +621,6 @@ Map {
 
 namespace facebook {
 namespace react {
-
 class JSI_EXPORT Int32EnumPropsNativeComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
@@ -664,7 +629,6 @@ class JSI_EXPORT Int32EnumPropsNativeComponentEventEmitter : public ViewEventEmi
 
   
 };
-
 } // namespace react
 } // namespace facebook
 ",
@@ -689,7 +653,6 @@ Map {
 
 namespace facebook {
 namespace react {
-
 class JSI_EXPORT IntegerPropNativeComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
@@ -698,7 +661,6 @@ class JSI_EXPORT IntegerPropNativeComponentEventEmitter : public ViewEventEmitte
 
   
 };
-
 } // namespace react
 } // namespace facebook
 ",
@@ -723,7 +685,6 @@ Map {
 
 namespace facebook {
 namespace react {
-
 class JSI_EXPORT InterfaceOnlyComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
@@ -734,7 +695,6 @@ class JSI_EXPORT InterfaceOnlyComponentEventEmitter : public ViewEventEmitter {
 
   void onChange(OnChange value) const;
 };
-
 } // namespace react
 } // namespace facebook
 ",
@@ -759,7 +719,6 @@ Map {
 
 namespace facebook {
 namespace react {
-
 class JSI_EXPORT MixedPropNativeComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
@@ -768,7 +727,6 @@ class JSI_EXPORT MixedPropNativeComponentEventEmitter : public ViewEventEmitter 
 
   
 };
-
 } // namespace react
 } // namespace facebook
 ",
@@ -793,7 +751,6 @@ Map {
 
 namespace facebook {
 namespace react {
-
 class JSI_EXPORT ImageColorPropNativeComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
@@ -802,7 +759,6 @@ class JSI_EXPORT ImageColorPropNativeComponentEventEmitter : public ViewEventEmi
 
   
 };
-
 } // namespace react
 } // namespace facebook
 ",
@@ -827,7 +783,6 @@ Map {
 
 namespace facebook {
 namespace react {
-
 class JSI_EXPORT NoPropsNoEventsComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
@@ -836,7 +791,6 @@ class JSI_EXPORT NoPropsNoEventsComponentEventEmitter : public ViewEventEmitter 
 
   
 };
-
 } // namespace react
 } // namespace facebook
 ",
@@ -861,7 +815,6 @@ Map {
 
 namespace facebook {
 namespace react {
-
 class JSI_EXPORT ObjectPropsEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
@@ -870,7 +823,6 @@ class JSI_EXPORT ObjectPropsEventEmitter : public ViewEventEmitter {
 
   
 };
-
 } // namespace react
 } // namespace facebook
 ",
@@ -895,7 +847,6 @@ Map {
 
 namespace facebook {
 namespace react {
-
 class JSI_EXPORT PointPropNativeComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
@@ -904,7 +855,6 @@ class JSI_EXPORT PointPropNativeComponentEventEmitter : public ViewEventEmitter 
 
   
 };
-
 } // namespace react
 } // namespace facebook
 ",
@@ -929,7 +879,6 @@ Map {
 
 namespace facebook {
 namespace react {
-
 class JSI_EXPORT StringEnumPropsNativeComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
@@ -938,7 +887,6 @@ class JSI_EXPORT StringEnumPropsNativeComponentEventEmitter : public ViewEventEm
 
   
 };
-
 } // namespace react
 } // namespace facebook
 ",
@@ -963,7 +911,6 @@ Map {
 
 namespace facebook {
 namespace react {
-
 class JSI_EXPORT StringPropComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
@@ -972,7 +919,6 @@ class JSI_EXPORT StringPropComponentEventEmitter : public ViewEventEmitter {
 
   
 };
-
 } // namespace react
 } // namespace facebook
 ",
@@ -997,7 +943,6 @@ Map {
 
 namespace facebook {
 namespace react {
-
 class JSI_EXPORT MultiFile1NativeComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
@@ -1014,7 +959,6 @@ class JSI_EXPORT MultiFile2NativeComponentEventEmitter : public ViewEventEmitter
 
   
 };
-
 } // namespace react
 } // namespace facebook
 ",
@@ -1039,7 +983,6 @@ Map {
 
 namespace facebook {
 namespace react {
-
 class JSI_EXPORT MultiComponent1NativeComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
@@ -1056,7 +999,6 @@ class JSI_EXPORT MultiComponent2NativeComponentEventEmitter : public ViewEventEm
 
   
 };
-
 } // namespace react
 } // namespace facebook
 ",


### PR DESCRIPTION
Summary: If any of the properties used in event-emitter codegen conflict with `event` or `payload`, the generated code will fail to build, even if this generated code isn't used. Since these are quite common keys, prefix them with `$` (still valid C++) to avoid conflicts.

Changelog: [General][Fixed] Resolved property name conflicts in event-emitter codegen

Differential Revision: D44274619

