### PR TITLE
Fix: Remove installation of Python 3 in CI for Windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1368,8 +1368,8 @@ jobs:
             if (-not(Test-Path -Path $Env:HERMES_WS_DIR\win64-bin\hermesc.exe)) {
               choco install --no-progress cmake --version 3.14.7
               if (-not $?) { throw "Failed to install CMake" }
-              choco install --no-progress python3
-              if (-not $?) { throw "Failed to install Python" }
+              # choco install --no-progress python3
+              # if (-not $?) { throw "Failed to install Python" }
 
               cd $Env:HERMES_WS_DIR\icu
               # If Invoke-WebRequest shows a progress bar, it will fail with

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1368,8 +1368,6 @@ jobs:
             if (-not(Test-Path -Path $Env:HERMES_WS_DIR\win64-bin\hermesc.exe)) {
               choco install --no-progress cmake --version 3.14.7
               if (-not $?) { throw "Failed to install CMake" }
-              # choco install --no-progress python3
-              # if (-not $?) { throw "Failed to install Python" }
 
               cd $Env:HERMES_WS_DIR\icu
               # If Invoke-WebRequest shows a progress bar, it will fail with


### PR DESCRIPTION
## Summary
We used to have to install python 3 on windows. Starting from yesterday (22/03/2023) the `build_hermesc_window` job started failing because Python3 is already installed on the default machine. 

## Changelog:

[INTERNAL] [FIXED] - Skip installing python 3 on Windows as it's already there.

## Test Plan

CircleCI must be green