### PR TITLE
Unify measuring and rendering of text and text input using mapbuffer

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -77,7 +77,6 @@ import com.facebook.react.uimanager.ViewManagerRegistry;
 import com.facebook.react.uimanager.events.EventCategoryDef;
 import com.facebook.react.uimanager.events.EventDispatcher;
 import com.facebook.react.uimanager.events.EventDispatcherImpl;
-import com.facebook.react.views.text.TextLayoutManager;
 import com.facebook.react.views.text.TextLayoutManagerMapBuffer;
 import java.util.HashMap;
 import java.util.Map;
@@ -433,17 +432,6 @@ public class FabricUIManager implements UIManager, LifecycleEventListener {
     if (!ReactFeatureFlags.enableBridgelessArchitecture) {
       mEventDispatcher.onCatalystInstanceDestroyed();
     }
-  }
-
-  @SuppressWarnings("unused")
-  private NativeArray measureLines(
-      ReadableMap attributedString, ReadableMap paragraphAttributes, float width, float height) {
-    return (NativeArray)
-        TextLayoutManager.measureLines(
-            mReactApplicationContext,
-            attributedString,
-            paragraphAttributes,
-            PixelUtil.toPixelFromDIP(width));
   }
 
   @SuppressWarnings("unused")

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.java
@@ -14,7 +14,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.facebook.react.R;
 import com.facebook.react.bridge.ReadableMap;
-import com.facebook.react.bridge.ReadableNativeMap;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.common.annotations.VisibleForTesting;
 import com.facebook.react.common.mapbuffer.MapBuffer;
@@ -24,7 +23,6 @@ import com.facebook.react.uimanager.ReactAccessibilityDelegate;
 import com.facebook.react.uimanager.ReactStylesDiffMap;
 import com.facebook.react.uimanager.StateWrapper;
 import com.facebook.react.uimanager.ThemedReactContext;
-import com.facebook.react.uimanager.ViewProps;
 import com.facebook.yoga.YogaMeasureMode;
 import java.util.HashMap;
 import java.util.Map;
@@ -133,40 +131,7 @@ public class ReactTextViewManager
   @Override
   public Object updateState(
       ReactTextView view, ReactStylesDiffMap props, StateWrapper stateWrapper) {
-    MapBuffer stateMapBuffer = stateWrapper.getStateDataMapBuffer();
-    if (stateMapBuffer != null) {
-      return getReactTextUpdate(view, props, stateMapBuffer);
-    }
-    ReadableNativeMap state = stateWrapper.getStateData();
-    if (state == null) {
-      return null;
-    }
-
-    ReadableMap attributedString = state.getMap("attributedString");
-    ReadableMap paragraphAttributes = state.getMap("paragraphAttributes");
-    Spannable spanned =
-        TextLayoutManager.getOrCreateSpannableForText(
-            view.getContext(), attributedString, mReactTextViewManagerCallback);
-    view.setSpanned(spanned);
-
-    int textBreakStrategy =
-        TextAttributeProps.getTextBreakStrategy(
-            paragraphAttributes.getString(ViewProps.TEXT_BREAK_STRATEGY));
-    int currentJustificationMode =
-        Build.VERSION.SDK_INT < Build.VERSION_CODES.O ? 0 : view.getJustificationMode();
-
-    return new ReactTextUpdate(
-        spanned,
-        state.hasKey("mostRecentEventCount") ? state.getInt("mostRecentEventCount") : -1,
-        false, // TODO add this into local Data
-        TextAttributeProps.getTextAlignment(
-            props, TextLayoutManager.isRTL(attributedString), view.getGravityHorizontal()),
-        textBreakStrategy,
-        TextAttributeProps.getJustificationMode(props, currentJustificationMode));
-  }
-
-  private Object getReactTextUpdate(ReactTextView view, ReactStylesDiffMap props, MapBuffer state) {
-
+    MapBuffer state = stateWrapper.getStateDataMapBuffer();
     MapBuffer attributedString = state.getMapBuffer(TX_STATE_KEY_ATTRIBUTED_STRING);
     MapBuffer paragraphAttributes = state.getMapBuffer(TX_STATE_KEY_PARAGRAPH_ATTRIBUTES);
     Spannable spanned =
@@ -214,16 +179,7 @@ public class ReactTextViewManager
       float height,
       YogaMeasureMode heightMode,
       @Nullable float[] attachmentsPositions) {
-    return TextLayoutManager.measureText(
-        context,
-        localData,
-        props,
-        width,
-        widthMode,
-        height,
-        heightMode,
-        mReactTextViewManagerCallback,
-        attachmentsPositions);
+    throw new UnsupportedOperationException("use mapbuffer");
   }
 
   @Override

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -62,7 +62,7 @@ import com.facebook.react.views.text.ReactTypefaceUtils;
 import com.facebook.react.views.text.ReactUnderlineSpan;
 import com.facebook.react.views.text.TextAttributes;
 import com.facebook.react.views.text.TextInlineImageSpan;
-import com.facebook.react.views.text.TextLayoutManager;
+import com.facebook.react.views.text.TextLayoutManagerMapBuffer;
 import com.facebook.react.views.view.ReactViewBackgroundManager;
 import java.util.ArrayList;
 import java.util.Objects;
@@ -187,7 +187,7 @@ public class ReactEditText extends AppCompatEditText
     if (DEBUG_MODE) {
       FLog.e(TAG, "finalize[" + getId() + "] delete cached spannable");
     }
-    TextLayoutManager.deleteCachedSpannableForTag(getId());
+    TextLayoutManagerMapBuffer.deleteCachedSpannableForTag(getId());
   }
 
   // After the text changes inside an EditText, TextView checks if a layout() has been requested.
@@ -1092,8 +1092,8 @@ public class ReactEditText extends AppCompatEditText
   /**
    * Update the cached Spannable used in TextLayoutManager to measure the text in Fabric. This is
    * mostly copied from ReactTextInputShadowNode.java (the non-Fabric version) and
-   * TextLayoutManager.java with some very minor modifications. There's some duplication between
-   * here and TextLayoutManager, so there might be an opportunity for refactor.
+   * TextLayoutManagerMapBuffer.java with some very minor modifications. There's some duplication
+   * between here and TextLayoutManager, so there might be an opportunity for refactor.
    */
   private void updateCachedSpannable() {
     // Noops in non-Fabric
@@ -1165,7 +1165,7 @@ public class ReactEditText extends AppCompatEditText
     }
 
     addSpansFromStyleAttributes(sb);
-    TextLayoutManager.setCachedSpannabledForTag(getId(), sb);
+    TextLayoutManagerMapBuffer.setCachedSpannabledForTag(getId(), sb);
   }
 
   void setEventDispatcher(@Nullable EventDispatcher eventDispatcher) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -39,8 +39,6 @@ import com.facebook.react.bridge.Dynamic;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReactSoftExceptionLogger;
 import com.facebook.react.bridge.ReadableArray;
-import com.facebook.react.bridge.ReadableMap;
-import com.facebook.react.bridge.ReadableNativeMap;
 import com.facebook.react.bridge.ReadableType;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableNativeMap;
@@ -72,7 +70,6 @@ import com.facebook.react.views.text.ReactTextViewManagerCallback;
 import com.facebook.react.views.text.ReactTypefaceUtils;
 import com.facebook.react.views.text.TextAttributeProps;
 import com.facebook.react.views.text.TextInlineImageSpan;
-import com.facebook.react.views.text.TextLayoutManager;
 import com.facebook.react.views.text.TextLayoutManagerMapBuffer;
 import com.facebook.react.views.text.TextTransform;
 import com.facebook.yoga.YogaConstants;
@@ -1327,42 +1324,8 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
       // TODO T58784068: move this constructor once Fabric is shipped
       view.setPadding(0, 0, 0, 0);
     }
-
     stateManager.setStateWrapper(stateWrapper);
-
-    MapBuffer stateMapBuffer = stateWrapper.getStateDataMapBuffer();
-    if (stateMapBuffer != null) {
-      return getReactTextUpdate(view, props, stateMapBuffer);
-    }
-
-    ReadableNativeMap state = stateWrapper.getStateData();
-    if (state == null || !state.hasKey("attributedString")) {
-      return null;
-    }
-
-    ReadableMap attributedString = state.getMap("attributedString");
-    ReadableMap paragraphAttributes = state.getMap("paragraphAttributes");
-    if (attributedString == null || paragraphAttributes == null) {
-      throw new IllegalArgumentException("Invalid TextInput State was received as a parameters");
-    }
-
-    Spannable spanned =
-        TextLayoutManager.getOrCreateSpannableForText(
-            view.getContext(), attributedString, mReactTextViewManagerCallback);
-
-    int textBreakStrategy =
-        TextAttributeProps.getTextBreakStrategy(
-            paragraphAttributes.getString(ViewProps.TEXT_BREAK_STRATEGY));
-    int currentJustificationMode =
-        Build.VERSION.SDK_INT < Build.VERSION_CODES.O ? 0 : view.getJustificationMode();
-
-    return ReactTextUpdate.buildReactTextUpdateFromState(
-        spanned,
-        state.getInt("mostRecentEventCount"),
-        TextAttributeProps.getTextAlignment(
-            props, TextLayoutManager.isRTL(attributedString), view.getGravityHorizontal()),
-        textBreakStrategy,
-        TextAttributeProps.getJustificationMode(props, currentJustificationMode));
+    return getReactTextUpdate(view, props, stateWrapper.getStateDataMapBuffer());
   }
 
   public Object getReactTextUpdate(ReactEditText view, ReactStylesDiffMap props, MapBuffer state) {

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/conversions.h
@@ -1266,6 +1266,12 @@ inline MapBuffer toMapBuffer(const TextAttributes &textAttributes) {
   return builder.build();
 }
 
+inline MapBuffer cacheIdToMapBuffer(int64_t cacheId) {
+  auto builder = MapBufferBuilder();
+  builder.putInt(AS_KEY_CACHE_ID, (int32_t)cacheId);
+  return builder.build();
+}
+
 inline MapBuffer toMapBuffer(const AttributedString &attributedString) {
   auto fragmentsBuilder = MapBufferBuilder();
 

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/android/react/renderer/textlayoutmanager/TextLayoutManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/android/react/renderer/textlayoutmanager/TextLayoutManager.h
@@ -78,11 +78,6 @@ class TextLayoutManager {
   void *getNativeTextLayoutManager() const;
 
  private:
-  TextMeasurement doMeasure(
-      AttributedString attributedString,
-      ParagraphAttributes const &paragraphAttributes,
-      LayoutConstraints layoutConstraints) const;
-
   TextMeasurement doMeasureMapBuffer(
       AttributedString attributedString,
       ParagraphAttributes const &paragraphAttributes,


### PR DESCRIPTION
Summary:
We currently have 2 classes to measure text (TextLayoutManagerMapBuffer and TextLayoutManager)
This diff unifies all rendering in TextLayoutManagerMapBuffer

changelog: [internal] internal

Reviewed By: NickGerleman, sammy-SC

Differential Revision: D43982142

