### PR TITLE
Reduce visibility of FabricComponentName mappings

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -9,7 +9,6 @@ package com.facebook.react.fabric;
 
 import static com.facebook.infer.annotation.ThreadConfined.ANY;
 import static com.facebook.infer.annotation.ThreadConfined.UI;
-import static com.facebook.react.fabric.FabricComponents.getFabricComponentName;
 import static com.facebook.react.fabric.mounting.LayoutMetricsConversions.getMaxSize;
 import static com.facebook.react.fabric.mounting.LayoutMetricsConversions.getMinSize;
 import static com.facebook.react.fabric.mounting.LayoutMetricsConversions.getYogaMeasureMode;
@@ -716,7 +715,7 @@ public class FabricUIManager implements UIManager, LifecycleEventListener {
         new PreAllocateViewMountItem(
             rootTag,
             reactTag,
-            getFabricComponentName(componentName),
+            componentName,
             props,
             (StateWrapper) stateWrapper,
             (EventEmitterWrapper) eventEmitterWrapper,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/FabricNameComponentMapping.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/FabricNameComponentMapping.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.fabric.mounting.mountitems;
+
+import androidx.annotation.NonNull;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Utility class for Fabric components, this will be removed
+ *
+ * <p>TODO T97384889: remove this class when the component names are unified between JS - Android -
+ * iOS - C++
+ */
+class FabricNameComponentMapping {
+
+  private static @NonNull final Map<String, String> sComponentNames = new HashMap<>();
+
+  static {
+    // TODO T97384889: unify component names between JS - Android - iOS - C++
+    sComponentNames.put("View", "RCTView");
+    sComponentNames.put("Image", "RCTImageView");
+    sComponentNames.put("ScrollView", "RCTScrollView");
+    sComponentNames.put("Slider", "RCTSlider");
+    sComponentNames.put("ModalHostView", "RCTModalHostView");
+    sComponentNames.put("Paragraph", "RCTText");
+    sComponentNames.put("Text", "RCText");
+    sComponentNames.put("RawText", "RCTRawText");
+    sComponentNames.put("ActivityIndicatorView", "AndroidProgressBar");
+    sComponentNames.put("ShimmeringView", "RKShimmeringView");
+    sComponentNames.put("TemplateView", "RCTTemplateView");
+    sComponentNames.put("AxialGradientView", "RCTAxialGradientView");
+    sComponentNames.put("Video", "RCTVideo");
+    sComponentNames.put("Map", "RCTMap");
+    sComponentNames.put("WebView", "RCTWebView");
+    sComponentNames.put("Keyframes", "RCTKeyframes");
+    sComponentNames.put("ImpressionTrackingView", "RCTImpressionTrackingView");
+  }
+
+  /** @return the name of component in the Fabric environment */
+  static String getFabricComponentName(String componentName) {
+    String component = sComponentNames.get(componentName);
+    return component != null ? component : componentName;
+  }
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/IntBufferBatchMountItem.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/IntBufferBatchMountItem.java
@@ -7,9 +7,9 @@
 
 package com.facebook.react.fabric.mounting.mountitems;
 
-import static com.facebook.react.fabric.FabricComponents.getFabricComponentName;
 import static com.facebook.react.fabric.FabricUIManager.ENABLE_FABRIC_LOGS;
 import static com.facebook.react.fabric.FabricUIManager.IS_DEVELOPMENT_ENVIRONMENT;
+import static com.facebook.react.fabric.mounting.mountitems.FabricNameComponentMapping.getFabricComponentName;
 
 import androidx.annotation.NonNull;
 import com.facebook.common.logging.FLog;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/PreAllocateViewMountItem.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/PreAllocateViewMountItem.java
@@ -9,6 +9,7 @@ package com.facebook.react.fabric.mounting.mountitems;
 
 import static com.facebook.react.fabric.FabricUIManager.IS_DEVELOPMENT_ENVIRONMENT;
 import static com.facebook.react.fabric.FabricUIManager.TAG;
+import static com.facebook.react.fabric.mounting.mountitems.FabricNameComponentMapping.getFabricComponentName;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -37,7 +38,7 @@ public class PreAllocateViewMountItem implements MountItem {
       @NonNull StateWrapper stateWrapper,
       @Nullable EventEmitterWrapper eventEmitterWrapper,
       boolean isLayoutable) {
-    mComponent = component;
+    mComponent = getFabricComponentName(component);
     mSurfaceId = surfaceId;
     mProps = props;
     mStateWrapper = stateWrapper;


### PR DESCRIPTION
Summary:
This diff refactors and reduces visibility of the legacy class FabricComponents. This should not be a breaking change because nobody should be using it (there is no purpose to be used externally)

changelog: [internal] internal change on the APIs

Reviewed By: javache

Differential Revision: D44112418

