### PR TITLE
Refactor creation of MountItems

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -59,10 +59,9 @@ import com.facebook.react.fabric.mounting.MountItemDispatcher;
 import com.facebook.react.fabric.mounting.MountingManager;
 import com.facebook.react.fabric.mounting.SurfaceMountingManager;
 import com.facebook.react.fabric.mounting.SurfaceMountingManager.ViewEvent;
-import com.facebook.react.fabric.mounting.mountitems.DispatchIntCommandMountItem;
-import com.facebook.react.fabric.mounting.mountitems.DispatchStringCommandMountItem;
 import com.facebook.react.fabric.mounting.mountitems.IntBufferBatchMountItem;
 import com.facebook.react.fabric.mounting.mountitems.MountItem;
+import com.facebook.react.fabric.mounting.mountitems.MountItemFactory;
 import com.facebook.react.fabric.mounting.mountitems.PreAllocateViewMountItem;
 import com.facebook.react.fabric.mounting.mountitems.SendAccessibilityEvent;
 import com.facebook.react.modules.core.ReactChoreographer;
@@ -1021,7 +1020,8 @@ public class FabricUIManager implements UIManager, LifecycleEventListener {
       final int commandId,
       @Nullable final ReadableArray commandArgs) {
     mMountItemDispatcher.dispatchCommandMountItem(
-        new DispatchIntCommandMountItem(surfaceId, reactTag, commandId, commandArgs));
+        MountItemFactory.createDispatchCommandMountItem(
+            surfaceId, reactTag, commandId, commandArgs));
   }
 
   @AnyThread
@@ -1032,7 +1032,8 @@ public class FabricUIManager implements UIManager, LifecycleEventListener {
       final String commandId,
       @Nullable final ReadableArray commandArgs) {
     mMountItemDispatcher.dispatchCommandMountItem(
-        new DispatchStringCommandMountItem(surfaceId, reactTag, commandId, commandArgs));
+        MountItemFactory.createDispatchCommandMountItem(
+            surfaceId, reactTag, commandId, commandArgs));
   }
 
   @Override

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/DispatchIntCommandMountItem.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/DispatchIntCommandMountItem.java
@@ -12,7 +12,7 @@ import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.fabric.mounting.MountingManager;
 
-public class DispatchIntCommandMountItem extends DispatchCommandMountItem {
+class DispatchIntCommandMountItem extends DispatchCommandMountItem {
 
   private final int mSurfaceId;
   private final int mReactTag;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/DispatchStringCommandMountItem.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/DispatchStringCommandMountItem.java
@@ -12,7 +12,7 @@ import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.fabric.mounting.MountingManager;
 
-public class DispatchStringCommandMountItem extends DispatchCommandMountItem {
+class DispatchStringCommandMountItem extends DispatchCommandMountItem {
 
   private final int mSurfaceId;
   private final int mReactTag;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/MountItemFactory.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/MountItemFactory.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.fabric.mounting.mountitems;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import com.facebook.react.bridge.ReadableArray;
+
+/** Factory class that expose creation of {@link MountItem} */
+public class MountItemFactory {
+
+  /** @return a {@link DispatchCommandMountItem} for commands identified by an int */
+  public static DispatchCommandMountItem createDispatchCommandMountItem(
+      int surfaceId, int reactTag, int commandId, @Nullable ReadableArray commandArgs) {
+    return new DispatchIntCommandMountItem(surfaceId, reactTag, commandId, commandArgs);
+  }
+
+  /** @return a {@link DispatchCommandMountItem} for commands identified by a String */
+  public static DispatchCommandMountItem createDispatchCommandMountItem(
+      int surfaceId, int reactTag, @NonNull String commandId, @Nullable ReadableArray commandArgs) {
+    return new DispatchStringCommandMountItem(surfaceId, reactTag, commandId, commandArgs);
+  }
+}


### PR DESCRIPTION
Summary:
This diff introduces the class MountItemFactory that will be used to create MountItems in Fabric.
The purpose of this refactor is to reduce visibility for custom implementations of MountItems

This should not be a breaking change, because nobody should be using these classes

changelog: [internal] internal

Reviewed By: javache

Differential Revision: D44115053

