### PR TITLE
Forward-declare imports in Binding and FabricMountingManager

### DIFF
--- a/packages/react-native/React/Fabric/RCTScheduler.mm
+++ b/packages/react-native/React/Fabric/RCTScheduler.mm
@@ -24,10 +24,10 @@ class SchedulerDelegateProxy : public SchedulerDelegate {
  public:
   SchedulerDelegateProxy(void *scheduler) : scheduler_(scheduler) {}
 
-  void schedulerDidFinishTransaction(MountingCoordinator::Shared mountingCoordinator) override
+  void schedulerDidFinishTransaction(const MountingCoordinator::Shared &mountingCoordinator) override
   {
     RCTScheduler *scheduler = (__bridge RCTScheduler *)scheduler_;
-    [scheduler.delegate schedulerDidFinishTransaction:std::move(mountingCoordinator)];
+    [scheduler.delegate schedulerDidFinishTransaction:mountingCoordinator];
   }
 
   void schedulerDidRequestPreliminaryViewAllocation(SurfaceId surfaceId, const ShadowNode &shadowNode) override

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/Binding.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/Binding.java
@@ -40,7 +40,7 @@ public class Binding {
   private native void installFabricUIManager(
       RuntimeExecutor runtimeExecutor,
       RuntimeScheduler runtimeScheduler,
-      Object uiManager,
+      FabricUIManager uiManager,
       EventBeatManager eventBeatManager,
       ComponentFactory componentsRegistry,
       Object reactNativeConfig);

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.h
@@ -7,8 +7,6 @@
 
 #pragma once
 
-#include "FabricMountingManager.h"
-
 #include <memory>
 #include <shared_mutex>
 
@@ -16,20 +14,25 @@
 #include <react/jni/JRuntimeExecutor.h>
 #include <react/jni/JRuntimeScheduler.h>
 #include <react/jni/ReadableNativeMap.h>
-#include <react/renderer/animations/LayoutAnimationDriver.h>
-#include <react/renderer/scheduler/Scheduler.h>
 #include <react/renderer/scheduler/SchedulerDelegate.h>
+#include <react/renderer/scheduler/SurfaceHandler.h>
 #include <react/renderer/uimanager/LayoutAnimationStatusDelegate.h>
+#include <react/renderer/uimanager/primitives.h>
 
-#include "ComponentFactory.h"
-#include "EventBeatManager.h"
 #include "EventEmitterWrapper.h"
-#include "SurfaceHandlerBinding.h"
+#include "JFabricUIManager.h"
 
 namespace facebook {
 namespace react {
 
+class ComponentFactory;
+class EventBeatManager;
+class FabricMountingManager;
 class Instance;
+class LayoutAnimationDriver;
+class ReactNativeConfig;
+class Scheduler;
+class SurfaceHandlerBinding;
 
 class Binding : public jni::HybridClass<Binding>,
                 public SchedulerDelegate,
@@ -40,7 +43,7 @@ class Binding : public jni::HybridClass<Binding>,
 
   static void registerNatives();
 
-  std::shared_ptr<Scheduler> getScheduler();
+  const std::shared_ptr<Scheduler> &getScheduler();
 
  private:
   void setConstraints(
@@ -62,7 +65,7 @@ class Binding : public jni::HybridClass<Binding>,
   void installFabricUIManager(
       jni::alias_ref<JRuntimeExecutor::javaobject> runtimeExecutorHolder,
       jni::alias_ref<JRuntimeScheduler::javaobject> runtimeSchedulerHolder,
-      jni::alias_ref<jobject> javaUIManager,
+      jni::alias_ref<JFabricUIManager::javaobject> javaUIManager,
       EventBeatManager *eventBeatManager,
       ComponentFactory *componentsRegistry,
       jni::alias_ref<jobject> reactNativeConfig);
@@ -94,7 +97,7 @@ class Binding : public jni::HybridClass<Binding>,
   void unregisterSurface(SurfaceHandlerBinding *surfaceHandler);
 
   void schedulerDidFinishTransaction(
-      MountingCoordinator::Shared mountingCoordinator) override;
+      const MountingCoordinator::Shared &mountingCoordinator) override;
 
   void schedulerDidRequestPreliminaryViewAllocation(
       const SurfaceId surfaceId,
@@ -127,8 +130,8 @@ class Binding : public jni::HybridClass<Binding>,
   std::shared_ptr<FabricMountingManager> mountingManager_;
   std::shared_ptr<Scheduler> scheduler_;
 
-  std::shared_ptr<FabricMountingManager> verifyMountingManager(
-      std::string const &locationHint);
+  const std::shared_ptr<FabricMountingManager> &verifyMountingManager(
+      const char *locationHint);
 
   // LayoutAnimations
   void onAnimationStarted() override;

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.h
@@ -7,33 +7,25 @@
 
 #pragma once
 
-#include "FabricMountItem.h"
-
-#include <react/config/ReactNativeConfig.h>
-#include <react/renderer/animations/LayoutAnimationDriver.h>
-#include <react/renderer/mounting/MountingCoordinator.h>
-#include <react/renderer/mounting/ShadowView.h>
-#include <react/renderer/uimanager/LayoutAnimationStatusDelegate.h>
-#include <react/utils/ContextContainer.h>
-
-#include <fbjni/fbjni.h>
-
 #include <mutex>
+
+#include <butter/set.h>
+#include <fbjni/fbjni.h>
+#include <react/fabric/JFabricUIManager.h>
+#include <react/renderer/mounting/MountingCoordinator.h>
+#include <react/renderer/uimanager/primitives.h>
 
 namespace facebook {
 namespace react {
 
+class ReactNativeConfig;
+struct ShadowView;
+
 class FabricMountingManager final {
  public:
-  constexpr static auto UIManagerJavaDescriptor =
-      "com/facebook/react/fabric/FabricUIManager";
-
-  constexpr static auto ReactFeatureFlagsJavaDescriptor =
-      "com/facebook/react/config/ReactFeatureFlags";
-
   FabricMountingManager(
       std::shared_ptr<const ReactNativeConfig> &config,
-      jni::global_ref<jobject> &javaUIManager);
+      jni::global_ref<JFabricUIManager::javaobject> &javaUIManager);
 
   void onSurfaceStart(SurfaceId surfaceId);
 
@@ -41,7 +33,7 @@ class FabricMountingManager final {
 
   void preallocateShadowView(SurfaceId surfaceId, ShadowView const &shadowView);
 
-  void executeMount(MountingCoordinator::Shared mountingCoordinator);
+  void executeMount(const MountingCoordinator::Shared &mountingCoordinator);
 
   void dispatchCommand(
       ShadowView const &shadowView,
@@ -62,7 +54,7 @@ class FabricMountingManager final {
   void onAllAnimationsComplete();
 
  private:
-  jni::global_ref<jobject> javaUIManager_;
+  jni::global_ref<JFabricUIManager::javaobject> javaUIManager_;
 
   std::recursive_mutex commitMutex_;
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/JFabricUIManager.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/JFabricUIManager.cpp
@@ -7,6 +7,8 @@
 
 #include "JFabricUIManager.h"
 
+#include "Binding.h"
+
 namespace facebook::react {
 
 Binding *JFabricUIManager::getBinding() {

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/JFabricUIManager.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/JFabricUIManager.h
@@ -9,9 +9,9 @@
 
 #include <fbjni/fbjni.h>
 
-#include "Binding.h"
-
 namespace facebook::react {
+
+class Binding;
 
 class JFabricUIManager : public jni::JavaClass<JFabricUIManager> {
  public:

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
@@ -320,15 +320,13 @@ void Scheduler::uiManagerDidFinishTransaction(
             [delegate = delegate_,
              mountingCoordinator =
                  std::move(mountingCoordinator)](jsi::Runtime &) {
-              delegate->schedulerDidFinishTransaction(
-                  std::move(mountingCoordinator));
+              delegate->schedulerDidFinishTransaction(mountingCoordinator);
             });
       } else {
-        delegate_->schedulerDidFinishTransaction(
-            std::move(mountingCoordinator));
+        delegate_->schedulerDidFinishTransaction(mountingCoordinator);
       }
     } else {
-      delegate_->schedulerDidFinishTransaction(std::move(mountingCoordinator));
+      delegate_->schedulerDidFinishTransaction(mountingCoordinator);
     }
   }
 }

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SchedulerDelegate.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SchedulerDelegate.h
@@ -26,7 +26,7 @@ class SchedulerDelegate {
    * to construct a new one.
    */
   virtual void schedulerDidFinishTransaction(
-      MountingCoordinator::Shared mountingCoordinator) = 0;
+      const MountingCoordinator::Shared &mountingCoordinator) = 0;
 
   /*
    * Called right after a new ShadowNode was created.


### PR DESCRIPTION
Summary:
Some random cleanup as I prepare to make these classes a better injection point for future experiments.

* Forward-declare classes where possible to reduce header import
* Return references to shared_ptr instead of copies when there are no lifetime concerns
* Use a shared JClass instance in JFabricUIManager

Changelog: [Internal]

Reviewed By: rshest

Differential Revision: D44221018

