### PR TITLE
Add Examples for Direct Manipulation in the Interop Layer

### DIFF
--- a/packages/react-native/Libraries/ReactNative/UIManager.js
+++ b/packages/react-native/Libraries/ReactNative/UIManager.js
@@ -175,6 +175,33 @@ const UIManager = {
       );
     }
   },
+
+  dispatchViewManagerCommand(
+    reactTag: number,
+    commandName: number | string,
+    commandArgs: any[],
+  ) {
+    if (isFabricReactTag(reactTag)) {
+      const FabricUIManager = nullthrows(getFabricUIManager());
+      const shadowNode =
+        FabricUIManager.findShadowNodeByTag_DEPRECATED(reactTag);
+      if (shadowNode) {
+        // Transform the accidental CommandID into a CommandName which is the stringified number.
+        // The interop layer knows how to convert this number into the right method name.
+        // Stringify a string is a no-op, so it's safe.
+        commandName = `${commandName}`;
+        FabricUIManager.dispatchCommand(shadowNode, commandName, commandArgs);
+      }
+    } else {
+      UIManagerImpl.dispatchViewManagerCommand(
+        reactTag,
+        // We have some legacy components that are actually already using strings. ¯\_(ツ)_/¯
+        // $FlowFixMe[incompatible-call]
+        commandName,
+        commandArgs,
+      );
+    }
+  },
 };
 
 module.exports = UIManager;

--- a/packages/react-native/Libraries/ReactNative/UIManager.js
+++ b/packages/react-native/Libraries/ReactNative/UIManager.js
@@ -9,7 +9,6 @@
  */
 
 import type {RootTag} from '../Types/RootTagTypes';
-import type {Spec as FabricUIManagerSpec} from './FabricUIManager';
 import type {Spec} from './NativeUIManager';
 
 import {getFabricUIManager} from './FabricUIManager';

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropCoordinatorAdapter.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropCoordinatorAdapter.mm
@@ -50,7 +50,7 @@
 
 - (void)handleCommand:(NSString *)commandName args:(NSArray *)args
 {
-  [_coordinator handleCommand:commandName args:args reactTag:_tag];
+  [_coordinator handleCommand:commandName args:args reactTag:_tag paperView:self.paperView];
 }
 
 @end

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/RCTLegacyViewManagerInteropCoordinator.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/RCTLegacyViewManagerInteropCoordinator.h
@@ -33,7 +33,10 @@ typedef void (^InterceptorBlock)(std::string eventName, folly::dynamic event);
 
 - (NSString *)componentViewName;
 
-- (void)handleCommand:(NSString *)commandName args:(NSArray *)args reactTag:(NSInteger)tag;
+- (void)handleCommand:(NSString *)commandName
+                 args:(NSArray *)args
+             reactTag:(NSInteger)tag
+            paperView:(UIView *)paperView;
 
 @end
 

--- a/packages/rn-tester/NativeComponentExample/ios/RNTMyLegacyNativeViewManager.mm
+++ b/packages/rn-tester/NativeComponentExample/ios/RNTMyLegacyNativeViewManager.mm
@@ -30,6 +30,13 @@ RCT_REMAP_VIEW_PROPERTY(opacity, alpha, CGFloat)
 
 RCT_EXPORT_VIEW_PROPERTY(onColorChanged, RCTBubblingEventBlock)
 
+RCT_CUSTOM_VIEW_PROPERTY(cornerRadius, CGFloat, RNTLegacyView)
+{
+  view.clipsToBounds = true;
+  NSNumber *cornerRadius = (NSNumber *)json;
+  view.layer.cornerRadius = [cornerRadius floatValue];
+}
+
 RCT_EXPORT_METHOD(changeBackgroundColor : (nonnull NSNumber *)reactTag color : (NSString *)color)
 {
   [self.bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {

--- a/packages/rn-tester/NativeComponentExample/ios/RNTMyLegacyNativeViewManager.mm
+++ b/packages/rn-tester/NativeComponentExample/ios/RNTMyLegacyNativeViewManager.mm
@@ -30,9 +30,34 @@ RCT_REMAP_VIEW_PROPERTY(opacity, alpha, CGFloat)
 
 RCT_EXPORT_VIEW_PROPERTY(onColorChanged, RCTBubblingEventBlock)
 
+RCT_EXPORT_METHOD(changeBackgroundColor : (nonnull NSNumber *)reactTag color : (NSString *)color)
+{
+  [self.bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
+    UIView *view = viewRegistry[reactTag];
+    if (!view || ![view isKindOfClass:[RNTLegacyView class]]) {
+      RCTLogError(@"Cannot find RNTLegacyView with tag #%@", reactTag);
+      return;
+    }
+
+    unsigned rgbValue = 0;
+    NSString *colorString = [NSString stringWithCString:std::string([color UTF8String]).c_str()
+                                               encoding:[NSString defaultCStringEncoding]];
+    NSScanner *scanner = [NSScanner scannerWithString:colorString];
+    [scanner setScanLocation:1]; // bypass '#' character
+    [scanner scanHexInt:&rgbValue];
+
+    UIColor *newColor = [UIColor colorWithRed:((rgbValue & 0xFF0000) >> 16) / 255.0
+                                        green:((rgbValue & 0xFF00) >> 8) / 255.0
+                                         blue:(rgbValue & 0xFF) / 255.0
+                                        alpha:1.0];
+    view.backgroundColor = newColor;
+  }];
+}
+
 - (UIView *)view
 {
   RNTLegacyView *view = [[RNTLegacyView alloc] init];
+  view.backgroundColor = UIColor.redColor;
   return view;
 }
 

--- a/packages/rn-tester/NativeComponentExample/js/MyLegacyViewNativeComponent.js
+++ b/packages/rn-tester/NativeComponentExample/js/MyLegacyViewNativeComponent.js
@@ -8,9 +8,11 @@
  * @format
  */
 
+import * as React from 'react';
 import type {HostComponent} from 'react-native';
 import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
-import {requireNativeComponent} from 'react-native';
+import {requireNativeComponent, UIManager} from 'react-native';
+import ReactNative from '../../../react-native/Libraries/Renderer/shims/ReactNative';
 
 type ColorChangedEvent = {
   nativeEvent: {
@@ -31,6 +33,22 @@ type NativeProps = $ReadOnly<{|
 |}>;
 
 export type MyLegacyViewType = HostComponent<NativeProps>;
+
+export function callNativeMethodToChangeBackgroundColor(
+  viewRef: React.ElementRef<MyLegacyViewType> | null,
+  color: string,
+) {
+  if (!viewRef) {
+    console.log('viewRef is null');
+    return;
+  }
+  UIManager.dispatchViewManagerCommand(
+    ReactNative.findNodeHandle(viewRef),
+    UIManager.getViewManagerConfig('RNTMyLegacyNativeView').Commands
+      .changeBackgroundColor,
+    [color],
+  );
+}
 
 export default (requireNativeComponent(
   'RNTMyLegacyNativeView',

--- a/packages/rn-tester/NativeComponentExample/js/MyNativeView.js
+++ b/packages/rn-tester/NativeComponentExample/js/MyNativeView.js
@@ -27,6 +27,8 @@ const colors = [
   '#000033',
 ];
 
+const cornerRadiuses = [0, 20, 40, 60, 80, 100, 120];
+
 class HSBA {
   hue: number;
   saturation: number;
@@ -50,14 +52,51 @@ class HSBA {
   }
 }
 
+function beautify(number: number): string {
+  if (number % 1 === 0) {
+    return number.toFixed();
+  }
+  return number.toFixed(2);
+}
+
+type MeasureStruct = {
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+};
+
+const MeasureStructZero: MeasureStruct = {
+  x: 0,
+  y: 0,
+  width: 0,
+  height: 0,
+};
+
+function getTextFor(measureStruct: MeasureStruct): string {
+  return `x: ${beautify(measureStruct.x)}, y: ${beautify(
+    measureStruct.y,
+  )}, width: ${beautify(measureStruct.width)}, height: ${beautify(
+    measureStruct.height,
+  )}`;
+}
+
 // This is an example component that migrates to use the new architecture.
 export default function MyNativeView(props: {}): React.Node {
+  const containerRef = useRef<typeof View | null>(null);
   const ref = useRef<React.ElementRef<MyNativeViewType> | null>(null);
   const legacyRef = useRef<React.ElementRef<MyLegacyViewType> | null>(null);
   const [opacity, setOpacity] = useState(1.0);
   const [hsba, setHsba] = useState<HSBA>(new HSBA());
+  const [cornerRadiusIndex, setCornerRadiusIndex] = useState<number>(0);
+  const [legacyMeasure, setLegacyMeasure] =
+    useState<MeasureStruct>(MeasureStructZero);
+  const [legacyMeasureInWindow, setLegacyMeasureInWindow] =
+    useState<MeasureStruct>(MeasureStructZero);
+  const [legacyMeasureLayout, setLegacyMeasureLayout] =
+    useState<MeasureStruct>(MeasureStructZero);
   return (
-    <View style={{flex: 1}}>
+    <View ref={containerRef} style={{flex: 1}}>
       <Text style={{color: 'red'}}>Fabric View</Text>
       <RNTMyNativeView ref={ref} style={{flex: 1}} opacity={opacity} />
       <Text style={{color: 'red'}}>Legacy View</Text>
@@ -76,8 +115,10 @@ export default function MyNativeView(props: {}): React.Node {
           )
         }
       />
-      <Text style={{color: 'green'}}>HSBA: {hsba.toString()}</Text>
-      <Text style={{color: 'green'}}>
+      <Text style={{color: 'green', textAlign: 'center'}}>
+        HSBA: {hsba.toString()}
+      </Text>
+      <Text style={{color: 'green', textAlign: 'center'}}>
         Constants From Interop Layer:{' '}
         {UIManager.RNTMyLegacyNativeView.Constants.PI}
       </Text>
@@ -105,6 +146,49 @@ export default function MyNativeView(props: {}): React.Node {
         onPress={() => {
           ref.current?.measure((x, y, width, height) => {
             console.log(x, y, width, height);
+          });
+
+          legacyRef.current?.measure((x, y, width, height) => {
+            setLegacyMeasure({x, y, width, height});
+          });
+          legacyRef.current?.measureInWindow((x, y, width, height) => {
+            setLegacyMeasureInWindow({x, y, width, height});
+          });
+
+          if (containerRef.current) {
+            legacyRef.current?.measureLayout(
+              // $FlowFixMe[incompatible-call]
+              containerRef.current,
+              (x, y, width, height) => {
+                setLegacyMeasureLayout({x, y, width, height});
+              },
+            );
+          }
+        }}
+      />
+
+      <Text style={{textAlign: 'center'}}>
+        &gt; Interop Layer Measurements &lt;
+      </Text>
+      <Text style={{textAlign: 'center'}}>
+        measure {getTextFor(legacyMeasure)}
+      </Text>
+      <Text style={{textAlign: 'center'}}>
+        InWindow {getTextFor(legacyMeasureInWindow)}
+      </Text>
+      <Text style={{textAlign: 'center'}}>
+        InLayout {getTextFor(legacyMeasureLayout)}
+      </Text>
+      <Button
+        title="Test setNativeProps"
+        onPress={() => {
+          const newCRIndex =
+            cornerRadiusIndex + 1 >= cornerRadiuses.length
+              ? 0
+              : cornerRadiusIndex + 1;
+          setCornerRadiusIndex(newCRIndex);
+          legacyRef.current?.setNativeProps({
+            cornerRadius: cornerRadiuses[newCRIndex],
           });
         }}
       />

--- a/packages/rn-tester/NativeComponentExample/js/MyNativeView.js
+++ b/packages/rn-tester/NativeComponentExample/js/MyNativeView.js
@@ -15,8 +15,9 @@ import RNTMyNativeView, {
   Commands as RNTMyNativeViewCommands,
 } from './MyNativeViewNativeComponent';
 import RNTMyLegacyNativeView from './MyLegacyViewNativeComponent';
+import type {MyLegacyViewType} from './MyLegacyViewNativeComponent';
 import type {MyNativeViewType} from './MyNativeViewNativeComponent';
-
+import {callNativeMethodToChangeBackgroundColor} from './MyLegacyViewNativeComponent';
 const colors = [
   '#0000FF',
   '#FF0000',
@@ -52,8 +53,8 @@ class HSBA {
 // This is an example component that migrates to use the new architecture.
 export default function MyNativeView(props: {}): React.Node {
   const ref = useRef<React.ElementRef<MyNativeViewType> | null>(null);
+  const legacyRef = useRef<React.ElementRef<MyLegacyViewType> | null>(null);
   const [opacity, setOpacity] = useState(1.0);
-  const [color, setColor] = useState('#FF0000');
   const [hsba, setHsba] = useState<HSBA>(new HSBA());
   return (
     <View style={{flex: 1}}>
@@ -61,9 +62,9 @@ export default function MyNativeView(props: {}): React.Node {
       <RNTMyNativeView ref={ref} style={{flex: 1}} opacity={opacity} />
       <Text style={{color: 'red'}}>Legacy View</Text>
       <RNTMyLegacyNativeView
+        ref={legacyRef}
         style={{flex: 1}}
         opacity={opacity}
-        color={color}
         onColorChanged={event =>
           setHsba(
             new HSBA(
@@ -84,12 +85,13 @@ export default function MyNativeView(props: {}): React.Node {
         title="Change Background"
         onPress={() => {
           let newColor = colors[Math.floor(Math.random() * 5)];
-          setColor(newColor);
           RNTMyNativeViewCommands.callNativeMethodToChangeBackgroundColor(
             // $FlowFixMe[incompatible-call]
             ref.current,
             newColor,
           );
+
+          callNativeMethodToChangeBackgroundColor(legacyRef.current, newColor);
         }}
       />
       <Button


### PR DESCRIPTION
Summary:
This change add to RNTester examples of a legacy Native Component, loaded in the New Architecture through the Interop Layer, that uses the APIs described in the [Direct Manipulation](https://reactnative.dev/docs/direct-manipulation) sectioon of the website.

## Changelog:
[iOS][Added] - Added examples of direct manipulation

Differential Revision: D43978674

