### PR TITLE
Ensure Pressability doesn't forward onClick to onPress when it receives a click via pointer events

### DIFF
--- a/packages/react-native/Libraries/Pressability/Pressability.js
+++ b/packages/react-native/Libraries/Pressability/Pressability.js
@@ -547,6 +547,12 @@ export default class Pressability {
       },
 
       onClick: (event: PressEvent): void => {
+        // If event has `pointerType`, it was emitted from a PointerEvent and
+        // we should ignore it to avoid triggering `onPress` twice.
+        if (event?.nativeEvent?.hasOwnProperty?.('pointerType')) {
+          return;
+        }
+
         const {onPress, disabled} = this._config;
         if (onPress != null && disabled !== true) {
           onPress(event);


### PR DESCRIPTION
Summary:
Changelog: [Internal] - Ensure Pressability doesn't forward onClick to onPress when it receives a click via pointer events.

This is a better version of D43128801 which ensures that click events which are triggered by the new pointer events event emitter don't trigger onPress in Pressability — avoiding the double onPress issue while ensuring all existing usecases of onClick continue to work.

Reviewed By: yungsters

Differential Revision: D44031433

