### PR TITLE
Fix default shadow radius in TextAttributeProps

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextAttributeProps.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextAttributeProps.java
@@ -96,7 +96,7 @@ public class TextAttributeProps {
 
   protected float mTextShadowOffsetDx = 0;
   protected float mTextShadowOffsetDy = 0;
-  protected float mTextShadowRadius = 1;
+  protected float mTextShadowRadius = 0;
   protected int mTextShadowColor = DEFAULT_TEXT_SHADOW_COLOR;
 
   protected boolean mIsUnderlineTextDecorationSet = false;


### PR DESCRIPTION
Summary:
After D44302691 enabled textShadow, there was a subtle 1px shadow on any new text which I did't that I didn't spot, but screenshot tests did (yay). This is because unlike `ReactBaseTextShadowNode` in paper, `TextAttributes` defaults to a radius of 1 (previously not shown).

Before:
https://pxl.cl/2z2wX

After:
https://pxl.cl/2z2x0

This changes the default to zero, which will cause us to skip adding the shadow, and matches previous behavior in Paper.

I double-checked the other props are defaulted the same way between `BaseTextShadowNode` (Paper) and `TextAttributes` (Fabric).

Changelog:
[Android][Fixed] - Fix default mTextShadowRadius in `TextProps`

Differential Revision: D44364446

