### PR TITLE
Finish the Java-facing side of the TurboModule interop layer

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackageTurboModuleManagerDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackageTurboModuleManagerDelegate.java
@@ -9,7 +9,6 @@ package com.facebook.react;
 
 import androidx.annotation.Nullable;
 import com.facebook.infer.annotation.Assertions;
-import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.bridge.CxxModuleWrapper;
 import com.facebook.react.bridge.ModuleSpec;
 import com.facebook.react.bridge.NativeModule;
@@ -142,36 +141,6 @@ public abstract class ReactPackageTurboModuleManagerDelegate extends TurboModule
   @Nullable
   @Override
   public TurboModule getModule(String moduleName) {
-    TurboModule module = resolveModule(moduleName);
-    if (module == null) {
-      return null;
-    }
-
-    if (module instanceof CxxModuleWrapper) {
-      return null;
-    }
-
-    return module;
-  }
-
-  @Nullable
-  @Override
-  @DoNotStrip
-  public CxxModuleWrapper getLegacyCxxModule(String moduleName) {
-    TurboModule module = resolveModule(moduleName);
-    if (module == null) {
-      return null;
-    }
-
-    if (!(module instanceof CxxModuleWrapper)) {
-      return null;
-    }
-
-    return (CxxModuleWrapper) module;
-  }
-
-  @Nullable
-  private TurboModule resolveModule(String moduleName) {
     NativeModule resolvedModule = null;
 
     for (final ModuleProvider moduleProvider : mModuleProviders) {
@@ -200,6 +169,13 @@ public abstract class ReactPackageTurboModuleManagerDelegate extends TurboModule
       return (TurboModule) resolvedModule;
     }
 
+    return null;
+  }
+
+  @Deprecated
+  @Nullable
+  @Override
+  public CxxModuleWrapper getLegacyCxxModule(String moduleName) {
     return null;
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java
@@ -28,7 +28,6 @@ import com.facebook.react.common.annotations.VisibleForTesting;
 import com.facebook.react.config.ReactFeatureFlags;
 import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.turbomodule.core.CallInvokerHolderImpl;
-import com.facebook.react.turbomodule.core.interfaces.TurboModule;
 import com.facebook.react.turbomodule.core.interfaces.TurboModuleRegistry;
 import com.facebook.systrace.Systrace;
 import com.facebook.systrace.TraceListener;
@@ -458,7 +457,7 @@ public class CatalystInstanceImpl implements CatalystInstance {
   @Override
   public <T extends NativeModule> boolean hasNativeModule(Class<T> nativeModuleInterface) {
     String moduleName = getNameFromAnnotation(nativeModuleInterface);
-    return getTurboModuleRegistry() != null && getTurboModuleRegistry().hasModule(moduleName)
+    return getTurboModuleRegistry() != null && getTurboModuleRegistry().hasNativeModule(moduleName)
         ? true
         : mNativeModuleRegistry.hasModule(moduleName);
   }
@@ -483,9 +482,9 @@ public class CatalystInstanceImpl implements CatalystInstance {
   @Nullable
   public NativeModule getNativeModule(String moduleName) {
     if (getTurboModuleRegistry() != null) {
-      TurboModule turboModule = getTurboModuleRegistry().getModule(moduleName);
-      if (turboModule != null) {
-        return (NativeModule) turboModule;
+      NativeModule module = getTurboModuleRegistry().getNativeModule(moduleName);
+      if (module != null) {
+        return module;
       }
     }
 
@@ -510,8 +509,8 @@ public class CatalystInstanceImpl implements CatalystInstance {
     nativeModules.addAll(mNativeModuleRegistry.getAllModules());
 
     if (getTurboModuleRegistry() != null) {
-      for (TurboModule turboModule : getTurboModuleRegistry().getModules()) {
-        nativeModules.add((NativeModule) turboModule);
+      for (NativeModule module : getTurboModuleRegistry().getNativeModules()) {
+        nativeModules.add(module);
       }
     }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/TurboModuleManagerDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/TurboModuleManagerDelegate.java
@@ -39,9 +39,12 @@ public abstract class TurboModuleManagerDelegate {
   public abstract TurboModule getModule(String moduleName);
 
   /**
-   * Create an return a CxxModuleWrapper NativeModule with name `moduleName`. If `moduleName` isn't
-   * a CxxModule, return null.
+   * Create and return a CxxModuleWrapper NativeModule with name `moduleName`. If `moduleName` isn't
+   * a CxxModule, return null. CxxModuleWrapper must implement TurboModule.
+   *
+   * <p>Deprecated. Please just return your CxxModuleWrappers from getModule.
    */
+  @Deprecated
   @Nullable
   public abstract CxxModuleWrapper getLegacyCxxModule(String moduleName);
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/TurboModuleManagerDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/TurboModuleManagerDelegate.java
@@ -11,6 +11,7 @@ import androidx.annotation.Nullable;
 import com.facebook.jni.HybridData;
 import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.bridge.CxxModuleWrapper;
+import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.turbomodule.core.interfaces.TurboModule;
 import com.facebook.soloader.SoLoader;
 import java.util.ArrayList;
@@ -47,6 +48,15 @@ public abstract class TurboModuleManagerDelegate {
   @Deprecated
   @Nullable
   public abstract CxxModuleWrapper getLegacyCxxModule(String moduleName);
+
+  /**
+   * Create an return a legacy NativeModule with name `moduleName`. If `moduleName` is a
+   * TurboModule, return null.
+   */
+  @Nullable
+  public NativeModule getLegacyModule(String moduleName) {
+    return null;
+  }
 
   public List<String> getEagerInitModuleNames() {
     return new ArrayList<>();

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/interfaces/BUCK
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/interfaces/BUCK
@@ -1,4 +1,4 @@
-load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "rn_android_library")
+load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "react_native_target", "rn_android_library")
 
 rn_android_library(
     name = "interfaces",
@@ -15,6 +15,7 @@ rn_android_library(
         "PUBLIC",
     ],
     deps = [
+        react_native_target("java/com/facebook/react/bridge:interfaces"),
         react_native_dep("third-party/android/androidx:annotation"),
         react_native_dep("third-party/java/jsr-305:jsr-305"),
     ],

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/interfaces/TurboModuleRegistry.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/interfaces/TurboModuleRegistry.java
@@ -8,25 +8,47 @@
 package com.facebook.react.turbomodule.core.interfaces;
 
 import androidx.annotation.Nullable;
+import com.facebook.react.bridge.NativeModule;
 import java.util.Collection;
 import java.util.List;
 
-/** Interface to allow for creating and retrieving TurboModules. */
+/**
+ * Interface to allow for creating and retrieving NativeModules. Why is this this class prefixed
+ * with "Turbo", even though it supports both legacy NativeModules, and TurboModules? Because there
+ * already is a NativeModuleRegistry (a part of the legacy architecture). Once that class is
+ * deleted, we should rename this interface accordingly.
+ */
 public interface TurboModuleRegistry {
-
   /**
    * Return the TurboModule instance that has that name `moduleName`. If the `moduleName`
    * TurboModule hasn't been instantiated, instantiate it. If no TurboModule is registered under
    * `moduleName`, return null.
    */
+  @Deprecated
   @Nullable
   TurboModule getModule(String moduleName);
 
   /** Get all instantiated TurboModules. */
+  @Deprecated
   Collection<TurboModule> getModules();
 
   /** Has the TurboModule with name `moduleName` been instantiated? */
+  @Deprecated
   boolean hasModule(String moduleName);
+
+  /**
+   * Return the NativeModule instance that has that name `moduleName`. If the `moduleName`
+   * NativeModule hasn't been instantiated, instantiate it. If no NativeModule is registered under
+   * `moduleName`, return null.
+   */
+  @Nullable
+  NativeModule getNativeModule(String moduleName);
+
+  /** Get all instantiated NativeModule. */
+  Collection<NativeModule> getNativeModules();
+
+  /** Has the NativeModule with name `moduleName` been instantiated? */
+  boolean hasNativeModule(String moduleName);
 
   /**
    * Return the names of all the NativeModules that are supposed to be eagerly initialized. By

--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModule.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModule.cpp
@@ -15,21 +15,6 @@ TurboModule::TurboModule(
     std::shared_ptr<CallInvoker> jsInvoker)
     : name_(std::move(name)), jsInvoker_(std::move(jsInvoker)) {}
 
-jsi::Value TurboModule::createHostFunction(
-    jsi::Runtime &runtime,
-    const jsi::PropNameID &propName,
-    const MethodMetadata &meta) {
-  return jsi::Function::createFromHostFunction(
-      runtime,
-      propName,
-      static_cast<unsigned int>(meta.argCount),
-      [this, meta](
-          jsi::Runtime &rt,
-          const jsi::Value &thisVal,
-          const jsi::Value *args,
-          size_t count) { return meta.invoker(rt, *this, args, count); });
-}
-
 void TurboModule::emitDeviceEvent(
     jsi::Runtime &runtime,
     const std::string &eventName,


### PR DESCRIPTION
Summary:
## Changes
Now, when you call TurboModuleManager.getModule(interopModuleName), the TurboModuleManager will create and return that interop module to you.

Changes in this diff:
1. Forward interop NativeModules from app's ReactPackages to the TurboModuleManager
2. Extend TurboModule system's module creation algorithm to create interop NativeModules.

## Details
TurboModuleManagerDelegate's capabilities:
||API| Without Interop | With Interop |
|same|getModule()|Java [NativeModule](https://www.internalfb.com/code/fbsource/[e5db2a0dc412f0656f7eeec1db9d2da4aab61f40]/xplat/js/react-native-github/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeModule.java?lines=21) that also implements [TurboModule](https://www.internalfb.com/code/fbsource/[c7089c1408eda109f342a1f33252533e743614ed]/xplat/js/react-native-github/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/interfaces/TurboModule.java?lines=11) |Java [NativeModule](https://www.internalfb.com/code/fbsource/[e5db2a0dc412f0656f7eeec1db9d2da4aab61f40]/xplat/js/react-native-github/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeModule.java?lines=21) that also implements [TurboModule](https://www.internalfb.com/code/fbsource/[c7089c1408eda109f342a1f33252533e743614ed]/xplat/js/react-native-github/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/interfaces/TurboModule.java?lines=11) |
|changed|getLegacyCxxModule()|Java [CxxModuleWrapper](https://www.internalfb.com/code/fbsource/[386e8104f66a0eb75a5f5137ba40a855047678c9]/xplat/js/react-native-github/ReactAndroid/src/main/java/com/facebook/react/bridge/CxxModuleWrapper.java?lines=16) that implements [TurboModule](https://www.internalfb.com/code/fbsource/[c7089c1408eda109f342a1f33252533e743614ed]/xplat/js/react-native-github/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/interfaces/TurboModule.java?lines=11) |Java [CxxModuleWrapper](https://www.internalfb.com/code/fbsource/[386e8104f66a0eb75a5f5137ba40a855047678c9]/xplat/js/react-native-github/ReactAndroid/src/main/java/com/facebook/react/bridge/CxxModuleWrapper.java?lines=16) that **doesn't *necessarily*** implement [TurboModule](https://www.internalfb.com/code/fbsource/[c7089c1408eda109f342a1f33252533e743614ed]/xplat/js/react-native-github/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/interfaces/TurboModule.java?lines=11)|
|new|getLegacyJavaModule()| |Java [NativeModule](https://www.internalfb.com/code/fbsource/[e5db2a0dc412f0656f7eeec1db9d2da4aab61f40]/xplat/js/react-native-github/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeModule.java?lines=21) that **doesn't** implement [TurboModule](https://www.internalfb.com/code/fbsource/[c7089c1408eda109f342a1f33252533e743614ed]/xplat/js/react-native-github/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/interfaces/TurboModule.java?lines=11)|

Changelog: [Internal]

Reviewed By: cortinico

Differential Revision: D43751055

