### PR TITLE
Finish the JS-facing side of the TurboModule interop layer

### DIFF
--- a/packages/react-native/Libraries/TurboModule/TurboModuleRegistry.js
+++ b/packages/react-native/Libraries/TurboModule/TurboModuleRegistry.js
@@ -16,9 +16,12 @@ const NativeModules = require('../BatchedBridge/NativeModules');
 
 const turboModuleProxy = global.__turboModuleProxy;
 
+// TODO(148943970): Consider reversing the lookup here:
+// Lookup on __turboModuleProxy, then lookup on nativeModuleProxy
 function requireModule<T: TurboModule>(name: string): ?T {
-  // Bridgeless mode requires TurboModules
-  if (global.RN$Bridgeless !== true) {
+  const isBridgeless = global.RN$Bridgeless === true;
+  const isTurboModuleInteropEnabled = global.RN$TurboInterop === true;
+  if (!isBridgeless || isTurboModuleInteropEnabled) {
     // Backward compatibility layer during migration.
     const legacyModule = NativeModules[name];
     if (legacyModule != null) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackageTurboModuleManagerDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackageTurboModuleManagerDelegate.java
@@ -9,7 +9,6 @@ package com.facebook.react;
 
 import androidx.annotation.Nullable;
 import com.facebook.infer.annotation.Assertions;
-import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.bridge.CxxModuleWrapper;
 import com.facebook.react.bridge.ModuleSpec;
 import com.facebook.react.bridge.NativeModule;
@@ -142,36 +141,6 @@ public abstract class ReactPackageTurboModuleManagerDelegate extends TurboModule
   @Nullable
   @Override
   public TurboModule getModule(String moduleName) {
-    TurboModule module = resolveModule(moduleName);
-    if (module == null) {
-      return null;
-    }
-
-    if (module instanceof CxxModuleWrapper) {
-      return null;
-    }
-
-    return module;
-  }
-
-  @Nullable
-  @Override
-  @DoNotStrip
-  public CxxModuleWrapper getLegacyCxxModule(String moduleName) {
-    TurboModule module = resolveModule(moduleName);
-    if (module == null) {
-      return null;
-    }
-
-    if (!(module instanceof CxxModuleWrapper)) {
-      return null;
-    }
-
-    return (CxxModuleWrapper) module;
-  }
-
-  @Nullable
-  private TurboModule resolveModule(String moduleName) {
     NativeModule resolvedModule = null;
 
     for (final ModuleProvider moduleProvider : mModuleProviders) {
@@ -200,6 +169,13 @@ public abstract class ReactPackageTurboModuleManagerDelegate extends TurboModule
       return (TurboModule) resolvedModule;
     }
 
+    return null;
+  }
+
+  @Deprecated
+  @Nullable
+  @Override
+  public CxxModuleWrapper getLegacyCxxModule(String moduleName) {
     return null;
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java
@@ -28,7 +28,6 @@ import com.facebook.react.common.annotations.VisibleForTesting;
 import com.facebook.react.config.ReactFeatureFlags;
 import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.turbomodule.core.CallInvokerHolderImpl;
-import com.facebook.react.turbomodule.core.interfaces.TurboModule;
 import com.facebook.react.turbomodule.core.interfaces.TurboModuleRegistry;
 import com.facebook.systrace.Systrace;
 import com.facebook.systrace.TraceListener;
@@ -458,7 +457,7 @@ public class CatalystInstanceImpl implements CatalystInstance {
   @Override
   public <T extends NativeModule> boolean hasNativeModule(Class<T> nativeModuleInterface) {
     String moduleName = getNameFromAnnotation(nativeModuleInterface);
-    return getTurboModuleRegistry() != null && getTurboModuleRegistry().hasModule(moduleName)
+    return getTurboModuleRegistry() != null && getTurboModuleRegistry().hasNativeModule(moduleName)
         ? true
         : mNativeModuleRegistry.hasModule(moduleName);
   }
@@ -483,9 +482,9 @@ public class CatalystInstanceImpl implements CatalystInstance {
   @Nullable
   public NativeModule getNativeModule(String moduleName) {
     if (getTurboModuleRegistry() != null) {
-      TurboModule turboModule = getTurboModuleRegistry().getModule(moduleName);
-      if (turboModule != null) {
-        return (NativeModule) turboModule;
+      NativeModule module = getTurboModuleRegistry().getNativeModule(moduleName);
+      if (module != null) {
+        return module;
       }
     }
 
@@ -510,8 +509,8 @@ public class CatalystInstanceImpl implements CatalystInstance {
     nativeModules.addAll(mNativeModuleRegistry.getAllModules());
 
     if (getTurboModuleRegistry() != null) {
-      for (TurboModule turboModule : getTurboModuleRegistry().getModules()) {
-        nativeModules.add((NativeModule) turboModule);
+      for (NativeModule module : getTurboModuleRegistry().getNativeModules()) {
+        nativeModules.add(module);
       }
     }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/TurboModuleInteropUtils.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/TurboModuleInteropUtils.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.turbomodule.core;
+
+import androidx.annotation.Nullable;
+import com.facebook.proguard.annotations.DoNotStrip;
+import com.facebook.react.bridge.Callback;
+import com.facebook.react.bridge.Dynamic;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.ReactModuleWithSpec;
+import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.WritableArray;
+import com.facebook.react.bridge.WritableMap;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class TurboModuleInteropUtils {
+  public static class MethodDescriptor {
+    @DoNotStrip public final String methodName;
+    @DoNotStrip public final String jniSignature;
+    @DoNotStrip public final String jsiReturnKind;
+    @DoNotStrip public final int jsArgCount;
+
+    MethodDescriptor(String methodName, String jniSignature, String jsiReturnKind, int jsArgCount) {
+      this.methodName = methodName;
+      this.jniSignature = jniSignature;
+      this.jsiReturnKind = jsiReturnKind;
+      this.jsArgCount = jsArgCount;
+    }
+  }
+
+  public static class ParsingException extends RuntimeException {
+    public ParsingException(String moduleName, String message) {
+      super(
+          "Unable to parse @ReactMethod annotations from native module: "
+              + moduleName
+              + ". Details: "
+              + message);
+    }
+
+    public ParsingException(String moduleName, String methodName, String message) {
+      super(
+          "Unable to parse @ReactMethod annotation from native module method: "
+              + moduleName
+              + "."
+              + methodName
+              + "()"
+              + ". Details: "
+              + message);
+    }
+  }
+
+  public static List<MethodDescriptor> getMethodDescriptorsFromModule(NativeModule module) {
+    final Method[] methods = getMethodsFromModule(module);
+
+    List<MethodDescriptor> methodDescriptors = new ArrayList<>();
+    Set<String> methodNames = new HashSet<>();
+
+    for (Method method : methods) {
+      @Nullable ReactMethod annotation = method.getAnnotation(ReactMethod.class);
+      final String moduleName = module.getName();
+      final String methodName = method.getName();
+      if (annotation == null && !"getConstants".equals(methodName)) {
+        continue;
+      }
+
+      if (methodNames.contains(methodName)) {
+        throw new ParsingException(
+            moduleName,
+            "Module exports two methods to JavaScript with the same name: \"" + methodName);
+      }
+
+      methodNames.add(methodName);
+
+      Class[] paramClasses = method.getParameterTypes();
+      Class returnType = method.getReturnType();
+
+      if ("getConstants".equals(methodName)) {
+        if (returnType != Map.class) {
+          // TODO(T145105887) Output error. getConstants must always have a return type of Map
+        }
+      } else if (annotation.isBlockingSynchronousMethod() && returnType == void.class
+          || !annotation.isBlockingSynchronousMethod() && returnType != void.class) {
+        // TODO(T145105887): Output error. TurboModule system assumes returnType == void iff the
+        // method is synchronous.
+      }
+
+      methodDescriptors.add(
+          new MethodDescriptor(
+              methodName,
+              createJniSignature(moduleName, methodName, paramClasses, returnType),
+              createJSIReturnKind(moduleName, methodName, paramClasses, returnType),
+              getJsArgCount(moduleName, methodName, paramClasses)));
+    }
+
+    return methodDescriptors;
+  }
+
+  private static Method[] getMethodsFromModule(NativeModule module) {
+    Class<? extends NativeModule> classForMethods = module.getClass();
+    Class<? extends NativeModule> superClass =
+        (Class<? extends NativeModule>) classForMethods.getSuperclass();
+    if (ReactModuleWithSpec.class.isAssignableFrom(superClass)) {
+      // For java module that is based on generated flow-type spec, inspect the
+      // spec abstract class instead, which is the super class of the given java
+      // module.
+      classForMethods = superClass;
+    }
+    Method[] targetMethods = classForMethods.getDeclaredMethods();
+    return targetMethods;
+  }
+
+  private static String createJniSignature(
+      String moduleName, String methodName, Class[] paramClasses, Class returnClass) {
+    String jniSignature = "(";
+    for (Class paramClass : paramClasses) {
+      jniSignature += convertParamClassToJniType(moduleName, methodName, paramClass);
+    }
+    jniSignature += ")";
+    jniSignature += convertReturnClassToJniType(moduleName, methodName, returnClass);
+    return jniSignature;
+  }
+
+  private static String convertParamClassToJniType(
+      String moduleName, String methodName, Class paramClass) {
+    if (paramClass == boolean.class) {
+      return "Z";
+    }
+
+    if (paramClass == int.class) {
+      return "I";
+    }
+
+    if (paramClass == double.class) {
+      return "D";
+    }
+
+    if (paramClass == float.class) {
+      return "F";
+    }
+
+    if (paramClass == Boolean.class
+        || paramClass == Integer.class
+        || paramClass == Double.class
+        || paramClass == Float.class
+        || paramClass == String.class
+        || paramClass == Callback.class
+        || paramClass == Promise.class
+        || paramClass == ReadableMap.class
+        || paramClass == ReadableArray.class) {
+      return convertClassToJniType(paramClass);
+    }
+
+    if (paramClass == Dynamic.class) {
+      // TODO(T145105887): Output warnings that TurboModules doesn't yet support Dynamic arguments
+    }
+
+    throw new ParsingException(
+        moduleName,
+        methodName,
+        "Unable to parse JNI signature. Detected unsupported parameter class: "
+            + paramClass.getCanonicalName());
+  }
+
+  private static String convertReturnClassToJniType(
+      String moduleName, String methodName, Class returnClass) {
+    if (returnClass == boolean.class) {
+      return "Z";
+    }
+
+    if (returnClass == int.class) {
+      return "I";
+    }
+
+    if (returnClass == double.class) {
+      return "D";
+    }
+
+    if (returnClass == float.class) {
+      return "F";
+    }
+
+    if (returnClass == void.class) {
+      return "V";
+    }
+
+    if (returnClass == Boolean.class
+        || returnClass == Integer.class
+        || returnClass == Double.class
+        || returnClass == Float.class
+        || returnClass == String.class
+        || returnClass == WritableMap.class
+        || returnClass == WritableArray.class
+        || returnClass == Map.class) {
+      return convertClassToJniType(returnClass);
+    }
+
+    throw new ParsingException(
+        moduleName,
+        methodName,
+        "Unable to parse JNI signature. Detected unsupported return class: "
+            + returnClass.getCanonicalName());
+  }
+
+  private static String convertClassToJniType(Class cls) {
+    return 'L' + cls.getCanonicalName().replace('.', '/') + ';';
+  }
+
+  private static int getJsArgCount(String moduleName, String methodName, Class[] paramClasses) {
+    for (int i = 0; i < paramClasses.length; i += 1) {
+      if (paramClasses[i] == Promise.class) {
+        if (i != (paramClasses.length - 1)) {
+          throw new ParsingException(
+              moduleName,
+              methodName,
+              "Unable to parse JavaScript arg count. Promises must be used as last parameter only.");
+        }
+
+        return paramClasses.length - 1;
+      }
+    }
+
+    return paramClasses.length;
+  }
+
+  private static String createJSIReturnKind(
+      String moduleName, String methodName, Class[] paramClasses, Class returnClass) {
+    for (int i = 0; i < paramClasses.length; i += 1) {
+      if (paramClasses[i] == Promise.class) {
+        if (i != (paramClasses.length - 1)) {
+          throw new ParsingException(
+              moduleName,
+              methodName,
+              "Unable to parse JSI return kind. Promises must be used as last parameter only.");
+        }
+
+        return "PromiseKind";
+      }
+    }
+
+    if (returnClass == boolean.class || returnClass == Boolean.class) {
+      return "BooleanKind";
+    }
+
+    if (returnClass == double.class
+        || returnClass == Double.class
+        || returnClass == float.class
+        || returnClass == Float.class
+        || returnClass == int.class
+        || returnClass == Integer.class) {
+      return "NumberKind";
+    }
+
+    if (returnClass == String.class) {
+      return "StringKind";
+    }
+
+    if (returnClass == void.class) {
+      return "VoidKind";
+    }
+
+    if (returnClass == WritableMap.class || returnClass == Map.class) {
+      return "ObjectKind";
+    }
+
+    if (returnClass == WritableArray.class) {
+      return "ArrayKind";
+    }
+
+    throw new ParsingException(
+        moduleName,
+        methodName,
+        "Unable to parse JSI return kind. Detected unsupported return class: "
+            + returnClass.getCanonicalName());
+  }
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/TurboModuleManagerDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/TurboModuleManagerDelegate.java
@@ -39,9 +39,12 @@ public abstract class TurboModuleManagerDelegate {
   public abstract TurboModule getModule(String moduleName);
 
   /**
-   * Create an return a CxxModuleWrapper NativeModule with name `moduleName`. If `moduleName` isn't
-   * a CxxModule, return null.
+   * Create and return a CxxModuleWrapper NativeModule with name `moduleName`. If `moduleName` isn't
+   * a CxxModule, return null. CxxModuleWrapper must implement TurboModule.
+   *
+   * <p>Deprecated. Please just return your CxxModuleWrappers from getModule.
    */
+  @Deprecated
   @Nullable
   public abstract CxxModuleWrapper getLegacyCxxModule(String moduleName);
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/TurboModuleManagerDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/TurboModuleManagerDelegate.java
@@ -11,6 +11,7 @@ import androidx.annotation.Nullable;
 import com.facebook.jni.HybridData;
 import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.bridge.CxxModuleWrapper;
+import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.turbomodule.core.interfaces.TurboModule;
 import com.facebook.soloader.SoLoader;
 import java.util.ArrayList;
@@ -47,6 +48,15 @@ public abstract class TurboModuleManagerDelegate {
   @Deprecated
   @Nullable
   public abstract CxxModuleWrapper getLegacyCxxModule(String moduleName);
+
+  /**
+   * Create an return a legacy NativeModule with name `moduleName`. If `moduleName` is a
+   * TurboModule, return null.
+   */
+  @Nullable
+  public NativeModule getLegacyModule(String moduleName) {
+    return null;
+  }
 
   public List<String> getEagerInitModuleNames() {
     return new ArrayList<>();

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/interfaces/BUCK
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/interfaces/BUCK
@@ -1,4 +1,4 @@
-load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "rn_android_library")
+load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "react_native_target", "rn_android_library")
 
 rn_android_library(
     name = "interfaces",
@@ -15,6 +15,7 @@ rn_android_library(
         "PUBLIC",
     ],
     deps = [
+        react_native_target("java/com/facebook/react/bridge:interfaces"),
         react_native_dep("third-party/android/androidx:annotation"),
         react_native_dep("third-party/java/jsr-305:jsr-305"),
     ],

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/interfaces/TurboModuleRegistry.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/interfaces/TurboModuleRegistry.java
@@ -8,25 +8,47 @@
 package com.facebook.react.turbomodule.core.interfaces;
 
 import androidx.annotation.Nullable;
+import com.facebook.react.bridge.NativeModule;
 import java.util.Collection;
 import java.util.List;
 
-/** Interface to allow for creating and retrieving TurboModules. */
+/**
+ * Interface to allow for creating and retrieving NativeModules. Why is this this class prefixed
+ * with "Turbo", even though it supports both legacy NativeModules, and TurboModules? Because there
+ * already is a NativeModuleRegistry (a part of the legacy architecture). Once that class is
+ * deleted, we should rename this interface accordingly.
+ */
 public interface TurboModuleRegistry {
-
   /**
    * Return the TurboModule instance that has that name `moduleName`. If the `moduleName`
    * TurboModule hasn't been instantiated, instantiate it. If no TurboModule is registered under
    * `moduleName`, return null.
    */
+  @Deprecated
   @Nullable
   TurboModule getModule(String moduleName);
 
   /** Get all instantiated TurboModules. */
+  @Deprecated
   Collection<TurboModule> getModules();
 
   /** Has the TurboModule with name `moduleName` been instantiated? */
+  @Deprecated
   boolean hasModule(String moduleName);
+
+  /**
+   * Return the NativeModule instance that has that name `moduleName`. If the `moduleName`
+   * NativeModule hasn't been instantiated, instantiate it. If no NativeModule is registered under
+   * `moduleName`, return null.
+   */
+  @Nullable
+  NativeModule getNativeModule(String moduleName);
+
+  /** Get all instantiated NativeModule. */
+  Collection<NativeModule> getNativeModules();
+
+  /** Has the NativeModule with name `moduleName` been instantiated? */
+  boolean hasNativeModule(String moduleName);
 
   /**
    * Return the names of all the NativeModules that are supposed to be eagerly initialized. By

--- a/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManager.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManager.h
@@ -54,13 +54,16 @@ class TurboModuleManager : public jni::HybridClass<TurboModuleManager> {
    */
   std::shared_ptr<TurboModuleCache> turboModuleCache_;
 
-  void installJSIBindings();
+  void installJSIBindings(bool shouldCreateLegacyModules);
   explicit TurboModuleManager(
       jni::alias_ref<TurboModuleManager::jhybridobject> jThis,
       RuntimeExecutor runtimeExecutor,
       std::shared_ptr<CallInvoker> jsCallInvoker,
       std::shared_ptr<CallInvoker> nativeCallInvoker,
       jni::alias_ref<TurboModuleManagerDelegate::javaobject> delegate);
+
+  TurboModuleProviderFunctionType createTurboModuleProvider();
+  TurboModuleProviderFunctionType createLegacyModuleProvider();
 };
 
 } // namespace react

--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModule.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModule.cpp
@@ -15,21 +15,6 @@ TurboModule::TurboModule(
     std::shared_ptr<CallInvoker> jsInvoker)
     : name_(std::move(name)), jsInvoker_(std::move(jsInvoker)) {}
 
-jsi::Value TurboModule::createHostFunction(
-    jsi::Runtime &runtime,
-    const jsi::PropNameID &propName,
-    const MethodMetadata &meta) {
-  return jsi::Function::createFromHostFunction(
-      runtime,
-      propName,
-      static_cast<unsigned int>(meta.argCount),
-      [this, meta](
-          jsi::Runtime &rt,
-          const jsi::Value &thisVal,
-          const jsi::Value *args,
-          size_t count) { return meta.invoker(rt, *this, args, count); });
-}
-
 void TurboModule::emitDeviceEvent(
     jsi::Runtime &runtime,
     const std::string &eventName,

--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModule.h
@@ -60,7 +60,7 @@ class JSI_EXPORT TurboModule : public facebook::jsi::HostObject {
     }
   }
 
-  std::vector<facebook::jsi::PropNameID> getPropertyNames(
+  virtual std::vector<facebook::jsi::PropNameID> getPropertyNames(
       facebook::jsi::Runtime &runtime) override {
     std::vector<jsi::PropNameID> result;
     result.reserve(methodMap_.size());

--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.h
@@ -21,6 +21,8 @@ enum class TurboModuleBindingMode : uint8_t {
   Eager = 2,
 };
 
+class BridgelessNativeModuleProxy;
+
 /**
  * Represents the JavaScript binding for the TurboModule system.
  */
@@ -33,13 +35,16 @@ class TurboModuleBinding {
   static void install(
       jsi::Runtime &runtime,
       TurboModuleBindingMode bindingMode,
-      TurboModuleProviderFunctionType &&moduleProvider);
+      TurboModuleProviderFunctionType &&moduleProvider,
+      TurboModuleProviderFunctionType &&legacyModuleProvider = nullptr);
 
- private:
   TurboModuleBinding(
       TurboModuleBindingMode bindingMode,
       TurboModuleProviderFunctionType &&moduleProvider);
   virtual ~TurboModuleBinding();
+
+ private:
+  friend BridgelessNativeModuleProxy;
 
   /**
    * A lookup function exposed to JS to get an instance of a TurboModule

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaInteropTurboModule.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaInteropTurboModule.cpp
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "JavaInteropTurboModule.h"
+
+namespace facebook {
+namespace react {
+
+namespace {
+
+// This is used for generating short exception strings.
+std::string getType(jsi::Runtime &rt, const jsi::Value &v) {
+  if (v.isUndefined()) {
+    return "undefined";
+  } else if (v.isNull()) {
+    return "null";
+  } else if (v.isBool()) {
+    return v.getBool() ? "true" : "false";
+  } else if (v.isNumber()) {
+    return "number";
+  } else if (v.isString()) {
+    return "string";
+  } else if (v.isSymbol()) {
+    return "symbol";
+  } else if (v.isBigInt()) {
+    return "bigint";
+  } else if (v.isObject()) {
+    return v.getObject(rt).isFunction(rt) ? "function" : "object";
+  } else {
+    return "unknown";
+  }
+}
+} // namespace
+
+JavaInteropTurboModule::JavaInteropTurboModule(
+    const JavaTurboModule::InitParams &params,
+    std::vector<MethodDescriptor> methodDescriptors)
+    : JavaTurboModule(params),
+      methodDescriptors_(methodDescriptors),
+      methodIDs_(methodDescriptors.size()),
+      constantsCache_(jsi::Value::undefined()) {
+  for (const auto &methodDescriptor : methodDescriptors) {
+    methodMap_[methodDescriptor.methodName] = MethodMetadata{
+        static_cast<size_t>(methodDescriptor.jsArgCount), nullptr};
+  }
+}
+
+jsi::Value JavaInteropTurboModule::create(
+    jsi::Runtime &runtime,
+    const jsi::PropNameID &propName) {
+  for (size_t i = 0; i < methodDescriptors_.size(); i += 1) {
+    if (methodDescriptors_[i].methodName == propName.utf8(runtime)) {
+      if (propName.utf8(runtime) == "getConstants") {
+        return jsi::Function::createFromHostFunction(
+            runtime,
+            propName,
+            static_cast<unsigned int>(methodDescriptors_[i].jsArgCount),
+            [this, i](
+                jsi::Runtime &rt,
+                const jsi::Value &thisVal,
+                const jsi::Value *args,
+                size_t count) mutable {
+              if (!this->constantsCache_.isUndefined()) {
+                return jsi::Value(rt, this->constantsCache_);
+              }
+
+              jsi::Value ret = this->invokeJavaMethod(
+                  rt,
+                  this->methodDescriptors_[i].jsiReturnKind,
+                  this->methodDescriptors_[i].methodName,
+                  this->methodDescriptors_[i].jniSignature,
+                  args,
+                  count,
+                  this->methodIDs_[i]);
+
+              bool isRetValid = ret.isUndefined() || ret.isNull() ||
+                  (ret.isObject() && !ret.asObject(rt).isFunction(rt));
+
+              if (!isRetValid) {
+                throw new jsi::JSError(
+                    rt,
+                    "Expected NativeModule " + this->name_ +
+                        ".getConstants() to return: null, undefined, or an object. But, got: " +
+                        getType(rt, ret));
+              }
+
+              if (ret.isUndefined() || ret.isNull()) {
+                this->constantsCache_ = jsi::Object(rt);
+              } else {
+                this->constantsCache_ = jsi::Value(rt, ret);
+              }
+
+              return ret;
+            });
+      }
+
+      return jsi::Function::createFromHostFunction(
+          runtime,
+          propName,
+          static_cast<unsigned int>(methodDescriptors_[i].jsArgCount),
+          [this, i](
+              jsi::Runtime &rt,
+              const jsi::Value &thisVal,
+              const jsi::Value *args,
+              size_t count) {
+            return this->invokeJavaMethod(
+                rt,
+                this->methodDescriptors_[i].jsiReturnKind,
+                this->methodDescriptors_[i].methodName,
+                this->methodDescriptors_[i].jniSignature,
+                args,
+                count,
+                this->methodIDs_[i]);
+          });
+    }
+  }
+
+  jsi::Object constants = getConstants(runtime).asObject(runtime);
+  jsi::Value constant = constants.getProperty(runtime, propName);
+
+  if (!constant.isUndefined()) {
+    // TODO(T145105887): Output warning. Tried to access a constant as a
+    // property on the native module object. Please migrate to getConstants().
+  }
+
+  return constant;
+}
+
+bool JavaInteropTurboModule::exportsConstants() {
+  for (size_t i = 0; i < methodDescriptors_.size(); i += 1) {
+    if (methodDescriptors_[i].methodName == "getConstants") {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+const jsi::Value &JavaInteropTurboModule::getConstants(jsi::Runtime &runtime) {
+  if (!constantsCache_.isUndefined()) {
+    return constantsCache_;
+  }
+
+  if (!exportsConstants()) {
+    constantsCache_ = jsi::Object(runtime);
+    return constantsCache_;
+  }
+
+  jsi::Value getConstantsProp =
+      get(runtime, jsi::PropNameID::forAscii(runtime, "getConstants"));
+
+  if (getConstantsProp.isObject()) {
+    jsi::Object getConstantsObj = getConstantsProp.asObject(runtime);
+    if (getConstantsObj.isFunction(runtime)) {
+      jsi::Function getConstantsFn = getConstantsObj.asFunction(runtime);
+      getConstantsFn.call(runtime);
+      return constantsCache_;
+    }
+  }
+
+  // Unable to invoke the getConstants() method.
+  // Maybe the module didn't define a getConstants() method.
+  // Default constants to {}, so no constants are spread into the NativeModule
+  constantsCache_ = jsi::Object(runtime);
+  return constantsCache_;
+}
+
+std::vector<facebook::jsi::PropNameID> JavaInteropTurboModule::getPropertyNames(
+    facebook::jsi::Runtime &runtime) {
+  std::vector<facebook::jsi::PropNameID> propNames =
+      JavaTurboModule::getPropertyNames(runtime);
+
+  jsi::Object constants = getConstants(runtime).asObject(runtime);
+  jsi::Array constantNames = constants.getPropertyNames(runtime);
+
+  for (size_t i = 0; i < constantNames.size(runtime); i += 1) {
+    jsi::Value constantName = constantNames.getValueAtIndex(runtime, i);
+    if (constantName.isString()) {
+      propNames.push_back(
+          jsi::PropNameID::forString(runtime, constantName.asString(runtime)));
+    }
+  }
+
+  return propNames;
+}
+
+} // namespace react
+} // namespace facebook

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaInteropTurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaInteropTurboModule.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include <ReactCommon/TurboModule.h>
+#include <fbjni/fbjni.h>
+#include <jsi/jsi.h>
+
+#include "JavaTurboModule.h"
+
+namespace facebook {
+namespace react {
+
+class JSI_EXPORT JavaInteropTurboModule : public JavaTurboModule {
+ public:
+  struct MethodDescriptor {
+    std::string methodName;
+    std::string jniSignature;
+    TurboModuleMethodValueKind jsiReturnKind;
+    int jsArgCount;
+  };
+
+  JavaInteropTurboModule(
+      const JavaTurboModule::InitParams &params,
+      std::vector<MethodDescriptor> methodDescriptors);
+
+  std::vector<facebook::jsi::PropNameID> getPropertyNames(
+      facebook::jsi::Runtime &runtime) override;
+
+ protected:
+  jsi::Value create(jsi::Runtime &runtime, const jsi::PropNameID &propName)
+      override;
+
+ private:
+  std::vector<MethodDescriptor> methodDescriptors_;
+  std::vector<jmethodID> methodIDs_;
+  jsi::Value constantsCache_;
+
+  const jsi::Value &getConstants(jsi::Runtime &runtime);
+  bool exportsConstants();
+};
+
+} // namespace react
+} // namespace facebook


### PR DESCRIPTION
Summary:
## Changes
This diff hooks up global.nativeModuleProxy to the TurboModule interop layer.

Now, when you call NativeModules.Foo, the TurboModule system will create the Foo interop module, and return it to JavaScript.

|**Language**|**Abstraction**|**Description**|
|Java/C++|MethodDescriptor| The information needed by JavaTurboModule::invokeJavaMethod() to execute a module method: [example](https://www.internalfb.com/code/fbsource/[78577e97310db97c489e976168ca6ddf4cb894c3]/xplat/js/react-native-github/ReactCommon/react/nativemodule/samples/platform/android/ReactCommon/SampleTurboModuleSpec.cpp?lines=34-36).|
|Java|TurboModuleInteropUtils| Takes the interop module object, and parses out MethodDescriptors from the methods annotated with ReactMethod|
|C++|JavaInteropTurboModule| Facilitates JavaScript -> Java method dispatch for interop modules. Extends [JavaTurboModule](https://www.internalfb.com/code/fbsource/[6f0698784af39dd0e881d9a69087ae6ac5e9cdc4]/xplat/js/react-native-github/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaTurboModule.h?lines=28). Needs to be created with a list of MethodDescriptors.|

Shape of MethodDescriptor:
```
class MethodDescriptor {
    String methodName;
    String jniSignature;
    String jsiReturnKind;
    int jsArgCount;
}
```

## Example
global.nativeModuleProxy.Foo:
1. **Java:** Use TurboModuleManager to create the Java interop module for Foo
2. **Java:** Use TurboModuleInteropUtils to generate Foo's MethodDescriptors
3. **C++:** Use Foo's MethodDescriptors to create, cache, and return a JavaInteropTurboModule object to JavaScript.

NOTE: After this diff, **all** legacy cxx modules will go through global.nativeModuleProxy, even if their CxxModuleWrappers implement TurboModule.

Changelog: [Internal]

Reviewed By: cortinico

Differential Revision: D43918998

