### PR TITLE
Hotfix: Lock RN CLI to 11.0.0-alpha.0 in template

### DIFF
--- a/packages/react-native/template/package.json
+++ b/packages/react-native/template/package.json
@@ -31,5 +31,17 @@
   },
   "engines": {
     "node": ">=16"
+  },
+  "overrides": {
+    "@react-native-community/cli": "11.0.0-alpha.0",
+    "@react-native-community/cli-platform-android": "11.0.0-alpha.0",
+    "@react-native-community/cli-platform-ios": "11.0.0-alpha.0",
+    "@react-native-community/cli-plugin-metro": "11.0.0-alpha.0"
+  },
+  "resolutions": {
+    "@react-native-community/cli": "11.0.0-alpha.0",
+    "@react-native-community/cli-platform-android": "11.0.0-alpha.0",
+    "@react-native-community/cli-platform-ios": "11.0.0-alpha.0",
+    "@react-native-community/cli-plugin-metro": "11.0.0-alpha.0"
   }
 }


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Hotfix for `main` branch CI stability after RN CLI `11.0.0` — the template as bootstrapped in CI needs to reference an exact version.

There is no published version (any more) for `11.0.0-alpha.2` (or `11.0.0-alpha.1`).

This is a temporary hotfix (we are trying to land https://github.com/facebook/react-native/pull/36623, but are stuck on infra issues).

- `11.0.0-alpha.0` includes `metro@0.75.0` (compatible).

More info: https://github.com/facebook/react-native/pull/36623#issuecomment-1482745547

Reviewed By: NickGerleman

Differential Revision: D44371406

