### PR TITLE
Export EmitterSubscription TypeScript Type

### DIFF
--- a/packages/react-native/types/__typetests__/index.tsx
+++ b/packages/react-native/types/__typetests__/index.tsx
@@ -40,6 +40,8 @@ import {
   DrawerLayoutAndroid,
   DrawerSlideEvent,
   DynamicColorIOS,
+  EmitterSubscription,
+  EventSubscription,
   FlatList,
   FlatListProps,
   GestureResponderEvent,

--- a/packages/react-native/types/index.d.ts
+++ b/packages/react-native/types/index.d.ts
@@ -147,6 +147,10 @@ export * from '../Libraries/Utilities/Platform';
 export * from '../Libraries/Vibration/Vibration';
 export * from '../Libraries/YellowBox/YellowBoxDeprecated';
 export * from '../Libraries/vendor/core/ErrorUtils';
+export {
+  EmitterSubscription,
+  EventSubscription,
+} from '../Libraries/vendor/emitter/EventEmitter';
 
 export * from './public/DeprecatedPropertiesAlias';
 export * from './public/Insets';


### PR DESCRIPTION
Summary:
Discovered when bumping the RN documentation to typecheck against 0.72, https://github.com/facebook/react-native/pull/36109 removed the `EmitterSubscription` type which should be kept public.

Changelog:
[General][Fixed] -  Export EmitterSubscription TypeScript Type

Differential Revision: D44375081

