### PR TITLE
Codemod long deprecated `*` type to `any`

### DIFF
--- a/packages/react-native/flow/jest.js
+++ b/packages/react-native/flow/jest.js
@@ -673,7 +673,7 @@ interface JestExpectType {
    * Use .toBeInstanceOf(Class) to check that an object is an instance of a
    * class.
    */
-  toBeInstanceOf(cls: Class<*>): void;
+  toBeInstanceOf(cls: Class<any>): void;
   /**
    * .toBeNull() is the same as .toBe(null) but the error messages are a bit
    * nicer.


### PR DESCRIPTION
Summary:
The existential type `*` has been deprecated and just an alias for `any` since version 0.163. Codemod usage of it to `any`.
This helps with diff D44276187, which makes it always an error to use `*`.

Changelog: [internal]

Reviewed By: pieterv, SamChou19815

Differential Revision: D44358809

