### PR TITLE
[Codegen 98] Extract getCommandTypeNameAndOptionsExpression from components folders to parsers-common

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-commons-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-commons-test.js
@@ -23,6 +23,7 @@ import {
   createComponentConfig,
   getCommandOptions,
   getOptions,
+  getCommandTypeNameAndOptionsExpression,
 } from '../parsers-commons';
 import type {ParserType} from '../errors';
 
@@ -1407,5 +1408,132 @@ describe('getOptions', () => {
     };
     const expectedOptions = {paperComponentNameDeprecated: 'RCTRefreshControl'};
     expect(getOptions(optionsExpression)).toEqual(expectedOptions);
+  });
+});
+
+describe('getCommandTypeNameAndOptionsExpression', () => {
+  it("returns undefined when namedExport isn't well formatted", () => {
+    expect(
+      getCommandTypeNameAndOptionsExpression(null, flowParser),
+    ).toBeUndefined();
+
+    expect(
+      getCommandTypeNameAndOptionsExpression(undefined, flowParser),
+    ).toBeUndefined();
+
+    expect(
+      getCommandTypeNameAndOptionsExpression({}, flowParser),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when the called expression name is not codegenNativeCommands', () => {
+    const namedExportMock = {
+      declaration: {
+        declarations: [
+          {
+            init: {
+              callee: {
+                name: 'notCodegenNativeCommands',
+              },
+            },
+          },
+        ],
+      },
+    };
+
+    expect(
+      getCommandTypeNameAndOptionsExpression(namedExportMock, flowParser),
+    ).toBeUndefined();
+  });
+
+  it("throws when the called expression doesn't have 1 argument", () => {
+    const namedExportMock = {
+      declaration: {
+        declarations: [
+          {
+            init: {
+              callee: {
+                name: 'codegenNativeCommands',
+              },
+              arguments: [],
+            },
+          },
+        ],
+      },
+    };
+
+    expect(() =>
+      getCommandTypeNameAndOptionsExpression(namedExportMock, flowParser),
+    ).toThrow(
+      new Error(
+        'codegenNativeCommands must be passed options including the supported commands',
+      ),
+    );
+  });
+
+  it('throws when the type of the argument is not a generic type annotation', () => {
+    const namedExportMock = {
+      declaration: {
+        declarations: [
+          {
+            init: {
+              callee: {
+                name: 'codegenNativeCommands',
+              },
+              arguments: [{}],
+              typeArguments: {params: [{type: 'StringTypeAnnotation'}]},
+            },
+          },
+        ],
+      },
+    };
+
+    expect(() =>
+      getCommandTypeNameAndOptionsExpression(namedExportMock, flowParser),
+    ).toThrow(
+      new Error(
+        "codegenNativeCommands doesn't support inline definitions. Specify a file local type alias",
+      ),
+    );
+  });
+
+  it('returns the command TypeName and options expression when the named export is valid', () => {
+    const commandTypeName = 'MyCommandType';
+    const commandOptionsExpression = {
+      type: 'ObjectExpression',
+      properties: [],
+    };
+
+    const namedExportMock = {
+      declaration: {
+        declarations: [
+          {
+            init: {
+              callee: {
+                name: 'codegenNativeCommands',
+              },
+              arguments: [commandOptionsExpression],
+              typeArguments: {
+                params: [
+                  {
+                    type: 'GenericTypeAnnotation',
+                    id: {
+                      name: commandTypeName,
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      },
+    };
+
+    expect(
+      getCommandTypeNameAndOptionsExpression(namedExportMock, flowParser),
+    ).toStrictEqual({
+      commandTypeName,
+      commandOptionsExpression,
+    });
   });
 });

--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-test.js
@@ -90,6 +90,20 @@ describe('FlowParser', () => {
     });
   });
 
+  describe('isGenericTypeAnnotation', () => {
+    it('returns true if it is a generic type annotation', () => {
+      expect(parser.isGenericTypeAnnotation('GenericTypeAnnotation')).toBe(
+        true,
+      );
+    });
+
+    it('returns false if it is not a generic type annotation', () => {
+      expect(parser.isGenericTypeAnnotation('StringTypeAnnotation')).toBe(
+        false,
+      );
+    });
+  });
+
   describe('callExpressionTypeParameters', () => {
     it('returns type arguments if it is a valid node', () => {
       const node = {
@@ -325,6 +339,18 @@ describe('TypeScriptParser', () => {
     it('returns false if it is a invalid node', () => {
       const node = {};
       expect(parser.isModuleInterface(node)).toBe(false);
+    });
+  });
+
+  describe('isGenericTypeAnnotation', () => {
+    it('returns true if it is a generic type annotation', () => {
+      expect(parser.isGenericTypeAnnotation('TSTypeReference')).toBe(true);
+    });
+
+    it('returns false if it is not a generic type annotation', () => {
+      expect(parser.isGenericTypeAnnotation('StringTypeAnnotation')).toBe(
+        false,
+      );
     });
   });
 

--- a/packages/react-native-codegen/src/parsers/flow/components/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/index.js
@@ -76,7 +76,7 @@ function findComponentConfig(ast: $FlowFixMe, parser: Parser) {
       const typeArgumentParam =
         parser.getTypeArgumentParamsFromDeclaration(callExpression)[0];
 
-      if (typeArgumentParam.type !== 'GenericTypeAnnotation') {
+      if (!parser.isGenericTypeAnnotation(typeArgumentParam.type)) {
         throw new Error(
           "codegenNativeCommands doesn't support inline definitions. Specify a file local type alias",
         );

--- a/packages/react-native-codegen/src/parsers/flow/components/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/index.js
@@ -73,7 +73,8 @@ function findComponentConfig(ast: $FlowFixMe, parser: Parser) {
         );
       }
 
-      const typeArgumentParam = callExpression.typeArguments.params[0];
+      const typeArgumentParam =
+        parser.getTypeArgumentParamsFromDeclaration(callExpression)[0];
 
       if (typeArgumentParam.type !== 'GenericTypeAnnotation') {
         throw new Error(

--- a/packages/react-native-codegen/src/parsers/flow/components/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/index.js
@@ -83,7 +83,7 @@ function findComponentConfig(ast: $FlowFixMe, parser: Parser) {
       }
 
       return {
-        commandTypeName: typeArgumentParam.id.name,
+        commandTypeName: parser.nameForGenericTypeAnnotation(typeArgumentParam),
         commandOptionsExpression: callExpression.arguments[0],
       };
     })

--- a/packages/react-native-codegen/src/parsers/flow/components/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/index.js
@@ -67,7 +67,6 @@ function findComponentConfig(ast: $FlowFixMe, parser: Parser) {
         return;
       }
 
-      // const statement.declaration.declarations[0].init
       if (callExpression.arguments.length !== 1) {
         throw new Error(
           'codegenNativeCommands must be passed options including the supported commands',

--- a/packages/react-native-codegen/src/parsers/flow/components/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/index.js
@@ -25,6 +25,7 @@ const {
   findNativeComponentType,
   getCommandOptions,
   getOptions,
+  getCommandTypeNameAndOptionsExpression,
 } = require('../../parsers-commons');
 
 // $FlowFixMe[signature-verification-failure] there's no flowtype for AST
@@ -53,40 +54,7 @@ function findComponentConfig(ast: $FlowFixMe, parser: Parser) {
   );
 
   const commandsTypeNames = namedExports
-    .map(statement => {
-      let callExpression;
-      let calleeName;
-      try {
-        callExpression = statement.declaration.declarations[0].init;
-        calleeName = callExpression.callee.name;
-      } catch (e) {
-        return;
-      }
-
-      if (calleeName !== 'codegenNativeCommands') {
-        return;
-      }
-
-      if (callExpression.arguments.length !== 1) {
-        throw new Error(
-          'codegenNativeCommands must be passed options including the supported commands',
-        );
-      }
-
-      const typeArgumentParam =
-        parser.getTypeArgumentParamsFromDeclaration(callExpression)[0];
-
-      if (!parser.isGenericTypeAnnotation(typeArgumentParam.type)) {
-        throw new Error(
-          "codegenNativeCommands doesn't support inline definitions. Specify a file local type alias",
-        );
-      }
-
-      return {
-        commandTypeName: parser.nameForGenericTypeAnnotation(typeArgumentParam),
-        commandOptionsExpression: callExpression.arguments[0],
-      };
-    })
+    .map(statement => getCommandTypeNameAndOptionsExpression(statement, parser))
     .filter(Boolean);
 
   throwIfMoreThanOneCodegenNativecommands(commandsTypeNames);

--- a/packages/react-native-codegen/src/parsers/flow/parser.js
+++ b/packages/react-native-codegen/src/parsers/flow/parser.js
@@ -214,6 +214,10 @@ class FlowParser implements Parser {
     );
   }
 
+  isGenericTypeAnnotation(type: $FlowFixMe): boolean {
+    return type === 'GenericTypeAnnotation';
+  }
+
   extractAnnotatedElement(
     typeAnnotation: $FlowFixMe,
     types: TypeDeclarationMap,

--- a/packages/react-native-codegen/src/parsers/parser.js
+++ b/packages/react-native-codegen/src/parsers/parser.js
@@ -162,6 +162,11 @@ export interface Parser {
   isModuleInterface(node: $FlowFixMe): boolean;
 
   /**
+   * Given a type name, it returns true if it is a generic type annotation
+   */
+  isGenericTypeAnnotation(type: $FlowFixMe): boolean;
+
+  /**
    * Given a typeAnnotation, it returns the annotated element.
    * @parameter typeAnnotation: the annotation for a type.
    * @parameter types: a map of type declarations.

--- a/packages/react-native-codegen/src/parsers/parserMock.js
+++ b/packages/react-native-codegen/src/parsers/parserMock.js
@@ -172,6 +172,10 @@ export class MockedParser implements Parser {
     );
   }
 
+  isGenericTypeAnnotation(type: $FlowFixMe): boolean {
+    return true;
+  }
+
   extractAnnotatedElement(
     typeAnnotation: $FlowFixMe,
     types: TypeDeclarationMap,

--- a/packages/react-native-codegen/src/parsers/typescript/components/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/index.js
@@ -84,7 +84,7 @@ function findComponentConfig(ast: $FlowFixMe, parser: Parser) {
       }
 
       return {
-        commandTypeName: typeArgumentParam.typeName.name,
+        commandTypeName: parser.nameForGenericTypeAnnotation(typeArgumentParam),
         commandOptionsExpression: callExpression.arguments[0],
       };
     })

--- a/packages/react-native-codegen/src/parsers/typescript/components/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/index.js
@@ -68,7 +68,6 @@ function findComponentConfig(ast: $FlowFixMe, parser: Parser) {
         return;
       }
 
-      // const statement.declaration.declarations[0].init
       if (callExpression.arguments.length !== 1) {
         throw new Error(
           'codegenNativeCommands must be passed options including the supported commands',

--- a/packages/react-native-codegen/src/parsers/typescript/components/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/index.js
@@ -74,7 +74,8 @@ function findComponentConfig(ast: $FlowFixMe, parser: Parser) {
         );
       }
 
-      const typeArgumentParam = callExpression.typeParameters.params[0];
+      const typeArgumentParam =
+        parser.getTypeArgumentParamsFromDeclaration(callExpression)[0];
 
       if (typeArgumentParam.type !== 'TSTypeReference') {
         throw new Error(

--- a/packages/react-native-codegen/src/parsers/typescript/components/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/index.js
@@ -26,6 +26,7 @@ const {
   findNativeComponentType,
   getCommandOptions,
   getOptions,
+  getCommandTypeNameAndOptionsExpression,
 } = require('../../parsers-commons');
 
 // $FlowFixMe[signature-verification-failure] TODO(T108222691): Use flow-types for @babel/parser
@@ -54,40 +55,7 @@ function findComponentConfig(ast: $FlowFixMe, parser: Parser) {
   );
 
   const commandsTypeNames = namedExports
-    .map(statement => {
-      let callExpression;
-      let calleeName;
-      try {
-        callExpression = statement.declaration.declarations[0].init;
-        calleeName = callExpression.callee.name;
-      } catch (e) {
-        return;
-      }
-
-      if (calleeName !== 'codegenNativeCommands') {
-        return;
-      }
-
-      if (callExpression.arguments.length !== 1) {
-        throw new Error(
-          'codegenNativeCommands must be passed options including the supported commands',
-        );
-      }
-
-      const typeArgumentParam =
-        parser.getTypeArgumentParamsFromDeclaration(callExpression)[0];
-
-      if (!parser.isGenericTypeAnnotation(typeArgumentParam.type)) {
-        throw new Error(
-          "codegenNativeCommands doesn't support inline definitions. Specify a file local type alias",
-        );
-      }
-
-      return {
-        commandTypeName: parser.nameForGenericTypeAnnotation(typeArgumentParam),
-        commandOptionsExpression: callExpression.arguments[0],
-      };
-    })
+    .map(statement => getCommandTypeNameAndOptionsExpression(statement, parser))
     .filter(Boolean);
 
   throwIfMoreThanOneCodegenNativecommands(commandsTypeNames);

--- a/packages/react-native-codegen/src/parsers/typescript/components/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/index.js
@@ -77,7 +77,7 @@ function findComponentConfig(ast: $FlowFixMe, parser: Parser) {
       const typeArgumentParam =
         parser.getTypeArgumentParamsFromDeclaration(callExpression)[0];
 
-      if (typeArgumentParam.type !== 'TSTypeReference') {
+      if (!parser.isGenericTypeAnnotation(typeArgumentParam.type)) {
         throw new Error(
           "codegenNativeCommands doesn't support inline definitions. Specify a file local type alias",
         );

--- a/packages/react-native-codegen/src/parsers/typescript/parser.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parser.js
@@ -210,6 +210,10 @@ class TypeScriptParser implements Parser {
     );
   }
 
+  isGenericTypeAnnotation(type: $FlowFixMe): boolean {
+    return type === 'TSTypeReference';
+  }
+
   extractAnnotatedElement(
     typeAnnotation: $FlowFixMe,
     types: TypeDeclarationMap,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

This PR aims to remove the duplicated logic in [flow|typescript]/components/index.js files to move it in parsers-commons. It is a task of #34872:
> [Codegen 98 - assigned to @MaeIg] Extract the namedExports.map(statement => ([Flow](https://github.com/facebook/react-native/blob/main/packages/react-native-codegen/src/parsers/flow/components/index.js#L76-L108), [TS](https://github.com/facebook/react-native/blob/main/packages/react-native-codegen/src/parsers/typescript/components/index.js#L77-L109)) function in parser-commons, so that it accept a Parser parameter to unify the behaviors between flow and typescript. The Parser object needs to be enriched with all the methods to extract the required information from the Node, if they are not there yet.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
[Internal] [Changed] - Extract getCommandTypeNameAndOptionsExpression from components folders to parsers-common

## Test Plan

yarn flow:
<img width="151" alt="image" src="https://user-images.githubusercontent.com/40902940/227719831-1a67f588-3bb2-48d7-8a43-4c5c8972155e.png">

yarn lint:
<img width="499" alt="image" src="https://user-images.githubusercontent.com/40902940/227719839-e5b591c3-9f3a-4da4-b3a5-67275c58584f.png">

yarn test
<img width="389" alt="image" src="https://user-images.githubusercontent.com/40902940/227719849-f3adfc4a-9215-4b1a-8807-c01801c54628.png">

