### PR TITLE
Fix paths in objc-test.sh, temporarily exclude /IntegrationTests

### DIFF
--- a/packages/rn-tester/RNTester/RNTester.xctestplan
+++ b/packages/rn-tester/RNTester/RNTester.xctestplan
@@ -28,6 +28,7 @@
   },
   "testTargets" : [
     {
+      "enabled": false,
       "target" : {
         "containerPath" : "container:RNTesterPods.xcodeproj",
         "identifier" : "E7DB215222B2F332005AC45F",

--- a/packages/rn-tester/package.json
+++ b/packages/rn-tester/package.json
@@ -11,7 +11,7 @@
     "directory": "packages/rn-tester"
   },
   "scripts": {
-    "start": "../react-native/scripts/packager.sh",
+    "start": "react-native start",
     "install-android-jsc": "../../gradlew :packages:rn-tester:android:app:installJscDebug",
     "install-android-hermes": "../../gradlew :packages:rn-tester:android:app:installHermesDebug",
     "clean-android": "rm -rf android/app/build",


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Blocker for https://github.com/facebook/react-native/pull/36623. The `test-ios` job in CI was misconfigured following the monorepo migration — and becomes load-bearing with the incoming version of React Native CLI.

- Update `objc-test.sh` to run in `packages/rn-tester`, and exclude tests under `/IntegrationTests` which are outside of a Metro project directory (before the monorepo changes, this was logically inside `packages/react-native`).
    - **This is temporary** — a task has been created to move/split up/otherwise restore tests in `IntegrationTests`, which @cipolleschi is following up (thanks!).
- Also fix `yarn start` script in `packages/rn-tester`.

Differential Revision: D44416533

