### PR TITLE
Fix platform Typings

### DIFF
--- a/packages/react-native/Libraries/Utilities/NativePlatformConstantsAndroid.js
+++ b/packages/react-native/Libraries/Utilities/NativePlatformConstantsAndroid.js
@@ -19,7 +19,7 @@ export interface Spec extends TurboModule {
       major: number,
       minor: number,
       patch: number,
-      prerelease: ?number,
+      prerelease: ?string,
     |},
     Version: number,
     Release: string,

--- a/packages/react-native/Libraries/Utilities/NativePlatformConstantsIOS.js
+++ b/packages/react-native/Libraries/Utilities/NativePlatformConstantsIOS.js
@@ -19,7 +19,7 @@ export interface Spec extends TurboModule {
       major: number,
       minor: number,
       patch: number,
-      prerelease: ?number,
+      prerelease: ?string,
     |},
     forceTouchAvailable: boolean,
     osVersion: string,

--- a/packages/react-native/Libraries/Utilities/Platform.android.js
+++ b/packages/react-native/Libraries/Utilities/Platform.android.js
@@ -32,7 +32,7 @@ const Platform = {
       major: number,
       minor: number,
       patch: number,
-      prerelease: ?number,
+      prerelease: ?string,
     |},
     Version: number,
     Release: string,

--- a/packages/react-native/Libraries/Utilities/Platform.d.ts
+++ b/packages/react-native/Libraries/Utilities/Platform.d.ts
@@ -23,7 +23,7 @@ type PlatformConstants = {
     major: number;
     minor: number;
     patch: number;
-    prerelease?: number | null | undefined;
+    prerelease?: string | null | undefined;
   };
 };
 interface PlatformStatic {

--- a/packages/react-native/Libraries/Utilities/Platform.ios.js
+++ b/packages/react-native/Libraries/Utilities/Platform.ios.js
@@ -35,7 +35,7 @@ const Platform = {
       major: number,
       minor: number,
       patch: number,
-      prerelease: ?number,
+      prerelease: ?string,
     |},
     systemName: string,
   |} {


### PR DESCRIPTION
## Summary

This PR fixes some typings in the platform files. The `prerelease` value is actually a string as it can assume various values, not just numbers. We typically use `rc.W`, where only `W` is a number, but for local testing, for example, we use completely different strings.

## Changelog

[INTERNAL] [FIXED] - Use `?string` as `prerelease` type.

## Test Plan

- CircleCI must be green on the job that were failing for this problem.