### PR TITLE
fix: format template location following prettier rules

### DIFF
--- a/scripts/monorepo/align-package-versions.js
+++ b/scripts/monorepo/align-package-versions.js
@@ -15,7 +15,12 @@ const checkForGitChanges = require('./check-for-git-changes');
 const forEachPackage = require('./for-each-package');
 
 const ROOT_LOCATION = path.join(__dirname, '..', '..');
-const TEMPLATE_LOCATION = path.join(ROOT_LOCATION, 'packages/react-native/template');
+const TEMPLATE_LOCATION = path.join(
+  ROOT_LOCATION,
+  'packages',
+  'react-native',
+  'template',
+);
 
 const readJSONFile = pathToFile => JSON.parse(readFileSync(pathToFile));
 


### PR DESCRIPTION
Initial change was force-pushed while working on a branch cut, thats why we have missed linter errors