### PR TITLE
Use `?string` instead of `?number` as `prerelease` type

### DIFF
--- a/packages/react-native/Libraries/Utilities/NativePlatformConstantsAndroid.js
+++ b/packages/react-native/Libraries/Utilities/NativePlatformConstantsAndroid.js
@@ -19,7 +19,7 @@ export interface Spec extends TurboModule {
       major: number,
       minor: number,
       patch: number,
-      prerelease: ?number,
+      prerelease: ?string | ?number,
     |},
     Version: number,
     Release: string,

--- a/packages/react-native/Libraries/Utilities/NativePlatformConstantsIOS.js
+++ b/packages/react-native/Libraries/Utilities/NativePlatformConstantsIOS.js
@@ -19,7 +19,7 @@ export interface Spec extends TurboModule {
       major: number,
       minor: number,
       patch: number,
-      prerelease: ?number,
+      prerelease: ?string | ?number,
     |},
     forceTouchAvailable: boolean,
     osVersion: string,

--- a/packages/react-native/Libraries/Utilities/Platform.android.js
+++ b/packages/react-native/Libraries/Utilities/Platform.android.js
@@ -32,7 +32,7 @@ const Platform = {
       major: number,
       minor: number,
       patch: number,
-      prerelease: ?number,
+      prerelease: ?string | ?number,
     |},
     Version: number,
     Release: string,

--- a/packages/react-native/Libraries/Utilities/Platform.d.ts
+++ b/packages/react-native/Libraries/Utilities/Platform.d.ts
@@ -23,7 +23,7 @@ type PlatformConstants = {
     major: number;
     minor: number;
     patch: number;
-    prerelease?: number | null | undefined;
+    prerelease?: number | string | null | undefined;
   };
 };
 interface PlatformStatic {

--- a/packages/react-native/Libraries/Utilities/Platform.ios.js
+++ b/packages/react-native/Libraries/Utilities/Platform.ios.js
@@ -35,7 +35,7 @@ const Platform = {
       major: number,
       minor: number,
       patch: number,
-      prerelease: ?number,
+      prerelease: ?string | ?number,
     |},
     systemName: string,
   |} {


### PR DESCRIPTION
Summary:
CircleCI in the 0.72-stable branch was read because we used `?number` as type for the prerelease, when, instead, it should be `?string`. The prerelease value can be anything and we typically use `rc.W`, where `W` is a number, as `prerelease` value

## Changelog:
[Internal][Fixed] - Use `?string` instead of `?number` as `prerelease` type

Reviewed By: cortinico

Differential Revision: D44419259

