### PR TITLE
Downgrade CLI to `alpha.0` to get Metro working again in CI

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -79,9 +79,9 @@
   },
   "dependencies": {
     "@jest/create-cache-key-function": "^29.2.1",
-    "@react-native-community/cli": "11.0.0-alpha.2",
-    "@react-native-community/cli-platform-android": "11.0.0-alpha.2",
-    "@react-native-community/cli-platform-ios": "11.0.0-alpha.2",
+    "@react-native-community/cli": "11.0.0-alpha.0",
+    "@react-native-community/cli-platform-android": "11.0.0-alpha.0",
+    "@react-native-community/cli-platform-ios": "11.0.0-alpha.0",
     "@react-native/assets-registry": "^0.72.0",
     "@react-native/codegen": "^0.72.4",
     "@react-native/gradle-plugin": "^0.72.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2248,27 +2248,34 @@
   optionalDependencies:
     npmlog "2 || ^3.1.0 || ^4.0.0"
 
-"@react-native-community/cli-clean@^11.0.0-alpha.2":
-  version "11.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-clean/-/cli-clean-11.0.0-alpha.2.tgz#31e9a896df86dd11de06c1daced00142126c8ec0"
-  integrity sha512-IdZj/2CZYME/iWY4cAxKBWAr/pQTfj5I2NZp8Z4+u6/KrjP2PuoMkUcb+ONvwQCLpd9R62EnuaPzXVomH43d8A==
+"@react-native-community/cli-clean@^11.0.0-alpha.0":
+  version "11.0.0"
+  resolved "http://localhost:4873/@react-native-community%2fcli-clean/-/cli-clean-11.0.0.tgz#7225f8df011893de1cb740a0cad3dd2670574da5"
+  integrity sha512-CWulRz6Ey2ntr3Ml/bMgSXhcE2yWj3R/Vrho2D00Y3wuU6p4cK/Af7YIidyn5E0NI/CMtXZ0cE1l5WME0o4wsA==
   dependencies:
-    "@react-native-community/cli-tools" "^11.0.0-alpha.2"
+    "@react-native-community/cli-tools" "^11.0.0"
     chalk "^4.1.2"
     execa "^1.0.0"
     prompts "^2.4.0"
 
-"@react-native-community/cli-config@^11.0.0-alpha.2":
-  version "11.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-config/-/cli-config-11.0.0-alpha.2.tgz#640373580782a23bdb53eedbd4084f485d2e0113"
-  integrity sha512-ZlRbsEoi/DdrQdX+j0YLkhjdsYTENHBeqdPXhLsGp3OWdf7t4yRlsBDElXP8VhHuUeBBQ0tWaXGPiaZbPjLi6A==
+"@react-native-community/cli-config@^11.0.0", "@react-native-community/cli-config@^11.0.0-alpha.0":
+  version "11.0.0"
+  resolved "http://localhost:4873/@react-native-community%2fcli-config/-/cli-config-11.0.0.tgz#c41acda2ff7aa2a4f1b5cdd895e341f27009ff8f"
+  integrity sha512-aKjv/lG7rr2WSN7MSP/P2HUJwoUI94Zct9eyxWEPBV5d48dVR4u7UXcGPRJSJTwVl7+RGNVThnGH8Gh55e1+Lw==
   dependencies:
-    "@react-native-community/cli-tools" "^11.0.0-alpha.2"
+    "@react-native-community/cli-tools" "^11.0.0"
     chalk "^4.1.2"
     cosmiconfig "^5.1.0"
-    deepmerge "^3.2.0"
+    deepmerge "^4.3.0"
     glob "^7.1.3"
     joi "^17.2.1"
+
+"@react-native-community/cli-debugger-ui@^10.0.0":
+  version "10.0.0"
+  resolved "http://localhost:4873/@react-native-community%2fcli-debugger-ui/-/cli-debugger-ui-10.0.0.tgz#4bb6d41c7e46449714dc7ba5d9f5b41ef0ea7c57"
+  integrity sha512-8UKLcvpSNxnUTRy8CkCl27GGLqZunQ9ncGYhSrWyKrU9SWBJJGeZwi2k2KaoJi5FvF2+cD0t8z8cU6lsq2ZZmA==
+  dependencies:
+    serve-static "^1.13.1"
 
 "@react-native-community/cli-debugger-ui@^11.0.0-alpha.2":
   version "11.0.0-alpha.2"
@@ -2277,14 +2284,15 @@
   dependencies:
     serve-static "^1.13.1"
 
-"@react-native-community/cli-doctor@^11.0.0-alpha.2":
-  version "11.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-doctor/-/cli-doctor-11.0.0-alpha.2.tgz#dcca2f8249cff3bab12bd784ebca75866df3f074"
-  integrity sha512-mjpUc6gjxtkfgBan0TQLch0FEck7gweB0xVt+jcSY12En58o37hlrClCg/Grk3Kl0abGa79Ve61C5bwknTXdLA==
+"@react-native-community/cli-doctor@^11.0.0-alpha.0":
+  version "11.0.0"
+  resolved "http://localhost:4873/@react-native-community%2fcli-doctor/-/cli-doctor-11.0.0.tgz#bf4c8993cc0439c8347803e01aeafbd40bb3f69f"
+  integrity sha512-eOvQw6YTDJXSPMYV7lM2bIKi80Ccwj+EAvYIYBHy77NwpL06MXNGUdNPuH/NgkYTR53gfJIMawddUm4qQN1b3w==
   dependencies:
-    "@react-native-community/cli-config" "^11.0.0-alpha.2"
-    "@react-native-community/cli-platform-ios" "^11.0.0-alpha.2"
-    "@react-native-community/cli-tools" "^11.0.0-alpha.2"
+    "@react-native-community/cli-config" "^11.0.0"
+    "@react-native-community/cli-platform-android" "^11.0.0"
+    "@react-native-community/cli-platform-ios" "^11.0.0"
+    "@react-native-community/cli-tools" "^11.0.0"
     chalk "^4.1.2"
     command-exists "^1.2.8"
     envinfo "^7.7.2"
@@ -2299,76 +2307,97 @@
     sudo-prompt "^9.0.0"
     wcwidth "^1.0.1"
 
-"@react-native-community/cli-hermes@^11.0.0-alpha.2":
-  version "11.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-hermes/-/cli-hermes-11.0.0-alpha.2.tgz#62833e17f01ad1b36fccc96cf752edea1cd171a8"
-  integrity sha512-JU5r7y+TOXFFG6tq6nG5bgOTG1kGwSdJkYvt87cBmQA+Y7b7vUdWijxedwJGexMs6PR3xU/iI7f8ZDKpLhlMpQ==
+"@react-native-community/cli-hermes@^11.0.0-alpha.0":
+  version "11.0.0"
+  resolved "http://localhost:4873/@react-native-community%2fcli-hermes/-/cli-hermes-11.0.0.tgz#0586e8a923174d81342f629abcd03ffab2020292"
+  integrity sha512-HNkiFnW/U9laf1ekvGfWhfX6N9OzZFd5oFK0BTolvETAZt4qFWFbP7BqkpHhA7iaxs76sCnE/VEAwQQndQWKWg==
   dependencies:
-    "@react-native-community/cli-platform-android" "^11.0.0-alpha.2"
-    "@react-native-community/cli-tools" "^11.0.0-alpha.2"
+    "@react-native-community/cli-platform-android" "^11.0.0"
+    "@react-native-community/cli-tools" "^11.0.0"
     chalk "^4.1.2"
     hermes-profile-transformer "^0.0.6"
     ip "^1.1.5"
 
-"@react-native-community/cli-platform-android@11.0.0-alpha.2", "@react-native-community/cli-platform-android@^11.0.0-alpha.2":
-  version "11.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-android/-/cli-platform-android-11.0.0-alpha.2.tgz#207d27ff535a92895aa512556a7c26e2f103d86c"
-  integrity sha512-CmVxlROf03r+811jATYk9x8eQ6YU0nIGw7qy8CI/ggDypI3HpPsh9sGx34uysUHxh5QsjYGjcCOTvRePehqXOQ==
+"@react-native-community/cli-platform-android@11.0.0-alpha.0":
+  version "11.0.0-alpha.0"
+  resolved "http://localhost:4873/@react-native-community%2fcli-platform-android/-/cli-platform-android-11.0.0-alpha.0.tgz#c4a4cd2104e67d78fbce72a9af75ea1941505110"
+  integrity sha512-4yaXpxxbQGoNOvrg7+bHaF22FT4jSEv4rDwC6/B7G9aQ2LkCW/45xpOaAwV8yk2HjjWyRXIhaHDc9dEg8T4BmA==
   dependencies:
-    "@react-native-community/cli-tools" "^11.0.0-alpha.2"
+    "@react-native-community/cli-tools" "^11.0.0-alpha.0"
     chalk "^4.1.2"
     execa "^1.0.0"
     glob "^7.1.3"
     logkitty "^0.7.1"
 
-"@react-native-community/cli-platform-ios@11.0.0-alpha.2", "@react-native-community/cli-platform-ios@^11.0.0-alpha.2":
-  version "11.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-ios/-/cli-platform-ios-11.0.0-alpha.2.tgz#c003737bbac966432b17a16877935b9bbae78485"
-  integrity sha512-wrNZS+59DgB0BjPTah81CUWu1wTiE5VPC/RRU34aPd2hhs3mEkwWB+CI0iVg0rHDd/dDEg9qDQXPpIqGwPjgMQ==
+"@react-native-community/cli-platform-android@^11.0.0":
+  version "11.0.0"
+  resolved "http://localhost:4873/@react-native-community%2fcli-platform-android/-/cli-platform-android-11.0.0.tgz#ef08118e3aac4cc02422109a8204afc4277d1714"
+  integrity sha512-1jhP/1qONcAsIa7yoI6t+S4rW3Ctevv2W89uVgzNxyOK6GNSD0WWM1awO83iWo3YU+iknluUmHampq+nIiirNA==
   dependencies:
-    "@react-native-community/cli-tools" "^11.0.0-alpha.2"
+    "@react-native-community/cli-tools" "^11.0.0"
+    chalk "^4.1.2"
+    execa "^1.0.0"
+    glob "^7.1.3"
+    logkitty "^0.7.1"
+
+"@react-native-community/cli-platform-ios@11.0.0-alpha.0":
+  version "11.0.0-alpha.0"
+  resolved "http://localhost:4873/@react-native-community%2fcli-platform-ios/-/cli-platform-ios-11.0.0-alpha.0.tgz#cc7c7c828c25dd8d0e134ce95fb1e50de1ff572a"
+  integrity sha512-dyycqtRnhU1ktgQBsvmie3RdlxtpIHCQ5uUQIW+ZCsnigkl6pC/ulyLxOFwAJmczEuH1RIj9kl/hJ81sxv5CjQ==
+  dependencies:
+    "@react-native-community/cli-tools" "^11.0.0-alpha.0"
     chalk "^4.1.2"
     execa "^1.0.0"
     fast-xml-parser "^4.0.12"
     glob "^7.1.3"
     ora "^5.4.1"
 
-"@react-native-community/cli-plugin-metro@^11.0.0-alpha.2":
-  version "11.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-plugin-metro/-/cli-plugin-metro-11.0.0-alpha.2.tgz#73c5656879d9589911861e88f3ec777d99239a53"
-  integrity sha512-ICb5HJoiwaIFiFMWkUzZcVYXp+8ePjRImUxG4sq/fG6ZZKjUl2Ylk6XBzuhOfOyFFKeVNYYJ8h2U6uCmFG0PIw==
+"@react-native-community/cli-platform-ios@^11.0.0":
+  version "11.0.0"
+  resolved "http://localhost:4873/@react-native-community%2fcli-platform-ios/-/cli-platform-ios-11.0.0.tgz#4c7bbcdeffe3307566a6183b5c50d6403b87c9f3"
+  integrity sha512-xGWmmifNiZG0auKe2sCAhQ46yHAUZDNyAfPP3m4zXGYP3jaSAi01KldnBaboC9ZNNrjUNOmkKh4v6IrXXxxCXg==
   dependencies:
-    "@react-native-community/cli-server-api" "^11.0.0-alpha.2"
-    "@react-native-community/cli-tools" "^11.0.0-alpha.2"
+    "@react-native-community/cli-tools" "^11.0.0"
     chalk "^4.1.2"
     execa "^1.0.0"
-    metro "0.75.1"
-    metro-config "0.75.1"
-    metro-core "0.75.1"
-    metro-react-native-babel-transformer "0.75.1"
-    metro-resolver "0.75.1"
-    metro-runtime "0.75.1"
+    fast-xml-parser "^4.0.12"
+    glob "^7.1.3"
+    ora "^5.4.1"
+
+"@react-native-community/cli-plugin-metro@^11.0.0-alpha.0":
+  version "11.0.0"
+  resolved "http://localhost:4873/@react-native-community%2fcli-plugin-metro/-/cli-plugin-metro-11.0.0.tgz#00fe753f8fe8b1294a0c08653a42ddb4961f60d7"
+  integrity sha512-ekPZEhB6LP7OhiIw73UbEbwlgsHcISW1jCO6ZKwlv5gFxP7kZaq6yzh4dirbxFUECa28O4VmceKwTeicCsU0EQ==
+  dependencies:
+    "@react-native-community/cli-server-api" "^11.0.0"
+    "@react-native-community/cli-tools" "^11.0.0"
+    chalk "^4.1.2"
+    execa "^1.0.0"
+    metro "0.76.0"
+    metro-config "0.76.0"
+    metro-core "0.76.0"
+    metro-resolver "0.76.0"
     readline "^1.3.0"
 
-"@react-native-community/cli-server-api@^11.0.0-alpha.2":
-  version "11.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-server-api/-/cli-server-api-11.0.0-alpha.2.tgz#45ebbb6b3c46b667f3aa65fe715c914ce446d968"
-  integrity sha512-pK/13Z9OIi8Qjdx70n1EZn5bxvJ9LIRaSsOLep2B62nRWCsQ9y8rBhITUeXXfw3hBurdBJZgxcFBlENaNcbcPg==
+"@react-native-community/cli-server-api@^11.0.0", "@react-native-community/cli-server-api@^11.0.0-alpha.0":
+  version "11.0.0"
+  resolved "http://localhost:4873/@react-native-community%2fcli-server-api/-/cli-server-api-11.0.0.tgz#ab6d46e5f243edb05b170b7007d531b853a2bc15"
+  integrity sha512-9EcqWDp65GBF3qtXsoyCcHd7RLrl2BEBXcBqN/f6pBSsqHkwJFUNalEdL832Pd7aGnSnQ6TrFX/3AFJWXAd06A==
   dependencies:
     "@react-native-community/cli-debugger-ui" "^11.0.0-alpha.2"
-    "@react-native-community/cli-tools" "^11.0.0-alpha.2"
+    "@react-native-community/cli-tools" "^11.0.0"
     compression "^1.7.1"
     connect "^3.6.5"
-    errorhandler "^1.5.0"
+    errorhandler "^1.5.1"
     nocache "^3.0.1"
     pretty-format "^26.6.2"
     serve-static "^1.13.1"
     ws "^7.5.1"
 
-"@react-native-community/cli-tools@^11.0.0-alpha.2":
-  version "11.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-tools/-/cli-tools-11.0.0-alpha.2.tgz#6e79d5ace5fa218892d9c6a8534f634e12af2b49"
-  integrity sha512-KPlS5YIjEaYrbOeoMcAM/P7H09V+nw/oja1nrIn0bSJCG9tc4IXwHnCadXo1qDmsAcu9if6ZUC+AThYqOPly/A==
+"@react-native-community/cli-tools@^11.0.0", "@react-native-community/cli-tools@^11.0.0-alpha.0":
+  version "11.0.0"
+  resolved "http://localhost:4873/@react-native-community%2fcli-tools/-/cli-tools-11.0.0.tgz#6a9e2c8577fc45bb16bded694cf9cec902d18840"
+  integrity sha512-WfybGk4jK/QUIe+lA2zKyKd3ifjVBxjqZ10onfXYHxjqf02MXK4n1utOnzLfarS4WrbHSmLtHlzO7ytJAeQjFw==
   dependencies:
     appdirsjs "^1.2.4"
     chalk "^4.1.2"
@@ -2380,27 +2409,27 @@
     semver "^6.3.0"
     shell-quote "^1.7.3"
 
-"@react-native-community/cli-types@^11.0.0-alpha.2":
-  version "11.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-types/-/cli-types-11.0.0-alpha.2.tgz#3d2563a0b43adfd38d12f4f303eab767f5002912"
-  integrity sha512-rT3f6hJajlGwK/eqTUCDMH0g/tj5yezwWTO87bjxniUTbL2X3v8oYZxRWO8SxC6ifNtpUssUkXXzM1hUtJcmOw==
+"@react-native-community/cli-types@^11.0.0-alpha.0":
+  version "11.0.0"
+  resolved "http://localhost:4873/@react-native-community%2fcli-types/-/cli-types-11.0.0.tgz#8ad65b1d969e24e163b68bff4e8c0dac67f7804e"
+  integrity sha512-w+1hOzV6VKqpCcO6/LF6lxrcl47tQ6ojlMCmhrB4Ah92gSbcmAluSWgb+kbzPIhsGxW0h/YnLR/4RXM9lnknDA==
   dependencies:
     joi "^17.2.1"
 
-"@react-native-community/cli@11.0.0-alpha.2":
-  version "11.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli/-/cli-11.0.0-alpha.2.tgz#27336b0a4e4cb14ae20a42e1a8373f28f279ea67"
-  integrity sha512-lpW+7MNFYHTZLvQjMO+6nQYrkpDSOuQa6pZcz3dTC+n7OL5GmmXIRB2iklJID76hNIZPca/27RPwfkMsW3eBGg==
+"@react-native-community/cli@11.0.0-alpha.0":
+  version "11.0.0-alpha.0"
+  resolved "http://localhost:4873/@react-native-community%2fcli/-/cli-11.0.0-alpha.0.tgz#8e9f920a0c90348e71c85ef0867a0d306f62cc24"
+  integrity sha512-zd1p/FC1xVUnn5AxHRfy2GH1y72MV4W7uL23K7YJxqpegBuU2odggfKUsYTT5jIgiXsZYdaQvOFMLdBW0s5ejQ==
   dependencies:
-    "@react-native-community/cli-clean" "^11.0.0-alpha.2"
-    "@react-native-community/cli-config" "^11.0.0-alpha.2"
-    "@react-native-community/cli-debugger-ui" "^11.0.0-alpha.2"
-    "@react-native-community/cli-doctor" "^11.0.0-alpha.2"
-    "@react-native-community/cli-hermes" "^11.0.0-alpha.2"
-    "@react-native-community/cli-plugin-metro" "^11.0.0-alpha.2"
-    "@react-native-community/cli-server-api" "^11.0.0-alpha.2"
-    "@react-native-community/cli-tools" "^11.0.0-alpha.2"
-    "@react-native-community/cli-types" "^11.0.0-alpha.2"
+    "@react-native-community/cli-clean" "^11.0.0-alpha.0"
+    "@react-native-community/cli-config" "^11.0.0-alpha.0"
+    "@react-native-community/cli-debugger-ui" "^10.0.0"
+    "@react-native-community/cli-doctor" "^11.0.0-alpha.0"
+    "@react-native-community/cli-hermes" "^11.0.0-alpha.0"
+    "@react-native-community/cli-plugin-metro" "^11.0.0-alpha.0"
+    "@react-native-community/cli-server-api" "^11.0.0-alpha.0"
+    "@react-native-community/cli-tools" "^11.0.0-alpha.0"
+    "@react-native-community/cli-types" "^11.0.0-alpha.0"
     chalk "^4.1.2"
     commander "^9.4.1"
     execa "^1.0.0"
@@ -2801,18 +2830,21 @@ abort-controller@^3.0.0:
   dependencies:
     event-target-shim "^5.0.0"
 
-absolute-path@^0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/absolute-path/-/absolute-path-0.0.0.tgz#a78762fbdadfb5297be99b15d35a785b2f095bf7"
-  integrity sha1-p4di+9rftSl76ZsV01p4Wy8JW/c=
-
-accepts@^1.3.7, accepts@~1.3.3, accepts@~1.3.5:
+accepts@^1.3.7, accepts@~1.3.5:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.7.tgz#531bc726517a3b2b41f850021c6cc15eaab507cd"
   integrity sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==
   dependencies:
     mime-types "~2.1.24"
     negotiator "0.6.2"
+
+accepts@~1.3.7:
+  version "1.3.8"
+  resolved "http://localhost:4873/accepts/-/accepts-1.3.8.tgz#0bf0be125b67014adcb0b0921e62db7bffe16b2e"
+  integrity sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==
+  dependencies:
+    mime-types "~2.1.34"
+    negotiator "0.6.3"
 
 acorn-jsx@^5.3.2:
   version "5.3.2"
@@ -3835,15 +3867,15 @@ deep-is@^0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
-deepmerge@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-3.2.0.tgz#58ef463a57c08d376547f8869fdc5bcee957f44e"
-  integrity sha512-6+LuZGU7QCNUnAJyX8cIrlzoEgggTM6B7mm+znKOX4t5ltluT9KLjN6g61ECMS0LTsLW7yDpNoxhix5FZcrIow==
-
 deepmerge@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
   integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
+
+deepmerge@^4.3.0:
+  version "4.3.1"
+  resolved "http://localhost:4873/deepmerge/-/deepmerge-4.3.1.tgz#44b5f2147cd3b00d4b56137685966f26fd25dd4a"
+  integrity sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==
 
 defaults@^1.0.3:
   version "1.0.3"
@@ -4016,12 +4048,12 @@ error-stack-parser@^2.0.6:
   dependencies:
     stackframe "^1.1.1"
 
-errorhandler@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/errorhandler/-/errorhandler-1.5.0.tgz#eaba64ca5d542a311ac945f582defc336165d9f4"
-  integrity sha1-6rpkyl1UKjEayUX1gt78M2Fl2fQ=
+errorhandler@^1.5.1:
+  version "1.5.1"
+  resolved "http://localhost:4873/errorhandler/-/errorhandler-1.5.1.tgz#b9ba5d17cf90744cd1e851357a6e75bf806a9a91"
+  integrity sha512-rcOwbfvP1WTViVoUjcfZicVzjhjTuhSMntHh6mW3IrEiyE6mJyXvsToJUJGlGlw/2xU9P5whlWNGlIDVeCiT4A==
   dependencies:
-    accepts "~1.3.3"
+    accepts "~1.3.7"
     escape-html "~1.0.3"
 
 es-abstract@^1.19.0, es-abstract@^1.19.1, es-abstract@^1.19.2, es-abstract@^1.19.5:
@@ -6369,43 +6401,53 @@ metro-babel-transformer@0.75.1:
     metro-source-map "0.75.1"
     nullthrows "^1.1.1"
 
-metro-cache-key@0.75.1:
-  version "0.75.1"
-  resolved "https://registry.yarnpkg.com/metro-cache-key/-/metro-cache-key-0.75.1.tgz#c27fde127e2278b544d7db7196f6d33d8dcde004"
-  integrity sha512-SUC+vBhsE/I9lA9l42wsGsFj3bK3h11GLiePaIZueyh5qD16Y5X+9iC+vmgZT3rAsqFyF04Ty5RBxh+sErJmsg==
-
-metro-cache@0.75.1:
-  version "0.75.1"
-  resolved "https://registry.yarnpkg.com/metro-cache/-/metro-cache-0.75.1.tgz#5f664127f9571816521c32179e3ec3583c4c4273"
-  integrity sha512-uWfQRtEdUYIsKcfwGHU//eTKdxUQCyjjq0GCsZwMOvfipT5bihpam1VPEFk3W+UEFB+qQ3cZp2DvUX1WoEi+Mw==
+metro-babel-transformer@0.76.0:
+  version "0.76.0"
+  resolved "http://localhost:4873/metro-babel-transformer/-/metro-babel-transformer-0.76.0.tgz#cb3854ee74a1ecba40680af1b6625aa46928c3c0"
+  integrity sha512-yBF8eJluya2iofhu8nZDXr9It/7bUcgXiKpFPrkiOWcMFY/jqzEbcavQ8uK3lFeXNRyvj0iaKaFs7Qo+2QJfow==
   dependencies:
-    metro-core "0.75.1"
+    "@babel/core" "^7.20.0"
+    hermes-parser "0.8.0"
+    metro-source-map "0.76.0"
+    nullthrows "^1.1.1"
+
+metro-cache-key@0.76.0:
+  version "0.76.0"
+  resolved "http://localhost:4873/metro-cache-key/-/metro-cache-key-0.76.0.tgz#0ab9513c8fc0392e7fde5d4473f220a9352e2cf0"
+  integrity sha512-Oyz+Yo/CG56kMXsDuioLf80MHwUqRzhOjaFsDvam3+gpc9rIGhnFL4ODhc6Qlum5auPRMT9XsksScErouft2tA==
+
+metro-cache@0.76.0:
+  version "0.76.0"
+  resolved "http://localhost:4873/metro-cache/-/metro-cache-0.76.0.tgz#b68d284fa46e74fe6cc7b822a9f3028f8824f952"
+  integrity sha512-J+OkOcIWrJisoXw6fXwWzeR1q4IuysMIKG8v/DWmKUOy8VI2c0gKXUW0mBfEWq6y3w0Czl94/xh1x7X0YLsTNg==
+  dependencies:
+    metro-core "0.76.0"
     rimraf "^3.0.2"
 
-metro-config@0.75.1:
-  version "0.75.1"
-  resolved "https://registry.yarnpkg.com/metro-config/-/metro-config-0.75.1.tgz#1fbfdb491eb211327ccfecff026ca499503f4bcb"
-  integrity sha512-zF1DLIxjS/LpJJtr7PhrMS+d4sPQsoMVgFFHv270sNOHNbltLa1Em8Epk/JGOozBzX4ijQOsL4PkBVyJN8WsEg==
+metro-config@0.76.0:
+  version "0.76.0"
+  resolved "http://localhost:4873/metro-config/-/metro-config-0.76.0.tgz#fe38e555faa1c6fa7eb2fbe9fa504844b1156154"
+  integrity sha512-5bfOtovHM7qjSobGBGRWXGh9+wMJlXHgot1LhjL3YTaNLUY42umbzdNC7dPcrGNLHH3MXTlG4cyNeCWZxtm6Hg==
   dependencies:
     cosmiconfig "^5.0.5"
     jest-validate "^26.5.2"
-    metro "0.75.1"
-    metro-cache "0.75.1"
-    metro-core "0.75.1"
-    metro-runtime "0.75.1"
+    metro "0.76.0"
+    metro-cache "0.76.0"
+    metro-core "0.76.0"
+    metro-runtime "0.76.0"
 
-metro-core@0.75.1:
-  version "0.75.1"
-  resolved "https://registry.yarnpkg.com/metro-core/-/metro-core-0.75.1.tgz#6ed853160a28a9815d4220081d0bf9e5157d469a"
-  integrity sha512-TGTBqqM3lZ4IA83HTNOsWXZ+sr/4Gi2RgTO9svJ0O1rYNc4UdDpe99EurYmbU709RJ8C7+zl3t8kHMB+1RNyuw==
+metro-core@0.76.0:
+  version "0.76.0"
+  resolved "http://localhost:4873/metro-core/-/metro-core-0.76.0.tgz#16f8a73d40173ffe659a2de8b727bb2c84a2846e"
+  integrity sha512-LRNWBpvHWcMeK+LZ74VZRo6QfU8izh6BmmqeW57HnZec69JQ1uODV6e7gQig6PWH89aMzhq8QKQr0dPDUGDYIg==
   dependencies:
     lodash.throttle "^4.1.1"
-    metro-resolver "0.75.1"
+    metro-resolver "0.76.0"
 
-metro-file-map@0.75.1:
-  version "0.75.1"
-  resolved "https://registry.yarnpkg.com/metro-file-map/-/metro-file-map-0.75.1.tgz#43d7c84168a7f8db2a7e7fd75159191c7f7e1396"
-  integrity sha512-fwXHBVe0ABihNvyvhFRU/tGz1N/yVkyrd1X9kOB6IP4/XQllt8GlxUV0aHvjYPYgxCjk+PzrVAbT65WBYYfEMA==
+metro-file-map@0.76.0:
+  version "0.76.0"
+  resolved "http://localhost:4873/metro-file-map/-/metro-file-map-0.76.0.tgz#a27586bd4e22112864e76ba49bda6bb851bf5e49"
+  integrity sha512-ifhMf75SlkSR8QcRBK1ecDwt9APZNEMWG7U8RIhtoDAtBYKuTbjjHNJiAwAU8UPE78m/Aryz6A+5cwpuAvSGrA==
   dependencies:
     abort-controller "^3.0.0"
     anymatch "^3.0.3"
@@ -6423,15 +6465,15 @@ metro-file-map@0.75.1:
   optionalDependencies:
     fsevents "^2.3.2"
 
-metro-hermes-compiler@0.75.1:
-  version "0.75.1"
-  resolved "https://registry.yarnpkg.com/metro-hermes-compiler/-/metro-hermes-compiler-0.75.1.tgz#5c5a6f71f1a06599a77f973986dbaea06f205f4a"
-  integrity sha512-5JYhUrKaEfQnU3N/RFmne/cM8sl98Y8EzJEiBOKZkhumtx7381ajK+M1jO/pAgpHlsgGNQn3/0snh+7xsveyRQ==
+metro-hermes-compiler@0.76.0:
+  version "0.76.0"
+  resolved "http://localhost:4873/metro-hermes-compiler/-/metro-hermes-compiler-0.76.0.tgz#2c4cca498011cab799434527544c0303eb12b806"
+  integrity sha512-ZW1jHtErMp327aPEkhHP69dLmtbzGj7ajsNFEwayoz/tZtyrTXT+f/8j6QVynIBMMpnAJkSIlinNo9fgIbE08w==
 
-metro-inspector-proxy@0.75.1:
-  version "0.75.1"
-  resolved "https://registry.yarnpkg.com/metro-inspector-proxy/-/metro-inspector-proxy-0.75.1.tgz#0e54802c8e4786341ec62cfb5c1e2efc00487e79"
-  integrity sha512-OzrP5eNZnO9/bu3RrWObC/PMCu0xm1svTolt2vgQjatt+Rf0JU6P8kqoyFB9F6WsV/9oieiHhtHecfXNb1PR+g==
+metro-inspector-proxy@0.76.0:
+  version "0.76.0"
+  resolved "http://localhost:4873/metro-inspector-proxy/-/metro-inspector-proxy-0.76.0.tgz#01af31de7cd09d9ec5a204b73fc786e3f4ddc793"
+  integrity sha512-1RCMmXzcvDsFvJyfRqzUl2B3r0FTgxW37WlH2c2tMhqVtGxobDGHn5cFySeaCLvKSHps0NELeB+1SF7MB9scxA==
   dependencies:
     connect "^3.6.5"
     debug "^2.2.0"
@@ -6444,17 +6486,17 @@ metro-memory-fs@0.75.1:
   resolved "https://registry.yarnpkg.com/metro-memory-fs/-/metro-memory-fs-0.75.1.tgz#4f19ad6ed45f28af900d4684a02ea54c024c62ab"
   integrity sha512-cxyrdPfc/eHWRo4sTCAsLDjS+CztW7zRodtjBeMpm+m+VZOk1ntB/0ZSM7mPCOzVDUAZjUupuXte18TGo4/EXw==
 
-metro-minify-terser@0.75.1:
-  version "0.75.1"
-  resolved "https://registry.yarnpkg.com/metro-minify-terser/-/metro-minify-terser-0.75.1.tgz#0a940cac616930b6449838040016d42b2136893b"
-  integrity sha512-SLJpthrK5cowVgxckb0f+aEvFQIwGoJxHq8BE+QCZgfRfkuu5Yvf+lt0koWPFXG6r8ztU2eZE4j/QE429BGq5A==
+metro-minify-terser@0.76.0:
+  version "0.76.0"
+  resolved "http://localhost:4873/metro-minify-terser/-/metro-minify-terser-0.76.0.tgz#49cef5fc0c2ae9b2ed76a8832132934c3a10de4c"
+  integrity sha512-dxaE/pvFDFEvXoNHuiXbA2Tw/jT1MD3B4a9AM+aYPWJBh3PdT9XM1HdzumyJldtZpCn5yka4maYSrtuebKgOyw==
   dependencies:
     terser "^5.15.0"
 
-metro-minify-uglify@0.75.1:
-  version "0.75.1"
-  resolved "https://registry.yarnpkg.com/metro-minify-uglify/-/metro-minify-uglify-0.75.1.tgz#311665b15c1a49f54b0a1bb9df3d2b0bbbcf5c23"
-  integrity sha512-964Ft6eyXp+LVXJHn4B32mU3TyG8r8C4c3k1RlRQSuHqtTH//C/8J44c3ruyvAZnT2CuYMRl5xqmJge/gZODug==
+metro-minify-uglify@0.76.0:
+  version "0.76.0"
+  resolved "http://localhost:4873/metro-minify-uglify/-/metro-minify-uglify-0.76.0.tgz#a34a64614b5abd364674dc6c0ff567d43d2b525c"
+  integrity sha512-Fuoxr5wLw/2/BUmhJqmIsfNZK+x8BK/DDXID5CZvHmZj5PdN4MN2WGWkM/F4EOw2t1YxbJ1hFSXM8skfSZ7jkw==
   dependencies:
     uglify-es "^3.1.9"
 
@@ -6462,6 +6504,51 @@ metro-react-native-babel-preset@0.75.1:
   version "0.75.1"
   resolved "https://registry.yarnpkg.com/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.75.1.tgz#370bb3bba3ca83b3be1d8b0ab628271c864491cd"
   integrity sha512-a4Se/koIVsH+wmfWsSOiRpFLBSICJcbd6o1wv37QRoFSnH7mYXDOfYxNBZYX46PwN1QwmgR49Iwsef79JOaJMg==
+  dependencies:
+    "@babel/core" "^7.20.0"
+    "@babel/plugin-proposal-async-generator-functions" "^7.0.0"
+    "@babel/plugin-proposal-class-properties" "^7.0.0"
+    "@babel/plugin-proposal-export-default-from" "^7.0.0"
+    "@babel/plugin-proposal-nullish-coalescing-operator" "^7.0.0"
+    "@babel/plugin-proposal-numeric-separator" "^7.0.0"
+    "@babel/plugin-proposal-object-rest-spread" "^7.0.0"
+    "@babel/plugin-proposal-optional-catch-binding" "^7.0.0"
+    "@babel/plugin-proposal-optional-chaining" "^7.0.0"
+    "@babel/plugin-syntax-dynamic-import" "^7.0.0"
+    "@babel/plugin-syntax-export-default-from" "^7.0.0"
+    "@babel/plugin-syntax-flow" "^7.18.0"
+    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.0.0"
+    "@babel/plugin-syntax-optional-chaining" "^7.0.0"
+    "@babel/plugin-transform-arrow-functions" "^7.0.0"
+    "@babel/plugin-transform-async-to-generator" "^7.0.0"
+    "@babel/plugin-transform-block-scoping" "^7.0.0"
+    "@babel/plugin-transform-classes" "^7.0.0"
+    "@babel/plugin-transform-computed-properties" "^7.0.0"
+    "@babel/plugin-transform-destructuring" "^7.0.0"
+    "@babel/plugin-transform-flow-strip-types" "^7.0.0"
+    "@babel/plugin-transform-function-name" "^7.0.0"
+    "@babel/plugin-transform-literals" "^7.0.0"
+    "@babel/plugin-transform-modules-commonjs" "^7.0.0"
+    "@babel/plugin-transform-named-capturing-groups-regex" "^7.0.0"
+    "@babel/plugin-transform-parameters" "^7.0.0"
+    "@babel/plugin-transform-react-display-name" "^7.0.0"
+    "@babel/plugin-transform-react-jsx" "^7.0.0"
+    "@babel/plugin-transform-react-jsx-self" "^7.0.0"
+    "@babel/plugin-transform-react-jsx-source" "^7.0.0"
+    "@babel/plugin-transform-runtime" "^7.0.0"
+    "@babel/plugin-transform-shorthand-properties" "^7.0.0"
+    "@babel/plugin-transform-spread" "^7.0.0"
+    "@babel/plugin-transform-sticky-regex" "^7.0.0"
+    "@babel/plugin-transform-typescript" "^7.5.0"
+    "@babel/plugin-transform-unicode-regex" "^7.0.0"
+    "@babel/template" "^7.0.0"
+    babel-plugin-transform-flow-enums "^0.0.2"
+    react-refresh "^0.4.0"
+
+metro-react-native-babel-preset@0.76.0:
+  version "0.76.0"
+  resolved "http://localhost:4873/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.76.0.tgz#440a0e8965b2eb01afa391ef95575faeed67636b"
+  integrity sha512-2sM6dy9uAbuQlg7l/VOdiudUUMFRkABJ1YLkZU6Fpqi/rJCXn4fbF0pO+TwCFbBYNIQBY50clv9RPvD2n64hXg==
   dependencies:
     "@babel/core" "^7.20.0"
     "@babel/plugin-proposal-async-generator-functions" "^7.0.0"
@@ -6516,18 +6603,23 @@ metro-react-native-babel-transformer@0.75.1:
     metro-source-map "0.75.1"
     nullthrows "^1.1.1"
 
-metro-resolver@0.75.1:
-  version "0.75.1"
-  resolved "https://registry.yarnpkg.com/metro-resolver/-/metro-resolver-0.75.1.tgz#f54f410774f9b58ea766c65c3096ef3a399185e8"
-  integrity sha512-zKhRcfTi5G9jcVFh2VPH1WFuabTl0WaZq5WJNK24Y3xVBTOfgr4MIN0iSz1XLwffPCqj3J8D8w6BPteID3DEoQ==
-  dependencies:
-    absolute-path "^0.0.0"
-    invariant "^2.2.4"
+metro-resolver@0.76.0:
+  version "0.76.0"
+  resolved "http://localhost:4873/metro-resolver/-/metro-resolver-0.76.0.tgz#3fa778adbab30859023a89e7a1241f4eb68171f2"
+  integrity sha512-bU6HvKzPJOHGoe9na+tUa0g3pZqMUaSGE+noFx2qeSMtoIgOYkDzmuU9ZOAGcUOz0qJJtGs+QmgM+nBqfSS/pQ==
 
 metro-runtime@0.75.1:
   version "0.75.1"
   resolved "https://registry.yarnpkg.com/metro-runtime/-/metro-runtime-0.75.1.tgz#e34936400ef4af28aa4e5f43c7fd7b6fbad68c1b"
   integrity sha512-AbmDCLPV2efz/LD3+k7bHTchUYmwEzB1L99UJYLYQksLlV1aoW+ri9hurXc/0mc55Jw6h4uKKe1nlAKJYZLJEg==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    react-refresh "^0.4.0"
+
+metro-runtime@0.76.0:
+  version "0.76.0"
+  resolved "http://localhost:4873/metro-runtime/-/metro-runtime-0.76.0.tgz#ccc4721010a24d4919bf50e9146d06d28266efb3"
+  integrity sha512-mEt1uWCYVwyvHYhCfsRXp7mqIBgOAYkocgousH5jwi07MwSAAvaDCvyRBUgtFohDQpL4j4N/QxNYExDDqUuuQw==
   dependencies:
     "@babel/runtime" "^7.0.0"
     react-refresh "^0.4.0"
@@ -6546,6 +6638,20 @@ metro-source-map@0.75.1:
     source-map "^0.5.6"
     vlq "^1.0.0"
 
+metro-source-map@0.76.0:
+  version "0.76.0"
+  resolved "http://localhost:4873/metro-source-map/-/metro-source-map-0.76.0.tgz#0f05263dc4648f654feaab36dae799b7118b36c0"
+  integrity sha512-tAXlHI6EOtRTkhXynZbe/as7pBDBxDaHftq/7pV3QCGyLeSaTNy6wzXI5ewr3kTuZxtBXktQH/Zl0rhKO8DGMA==
+  dependencies:
+    "@babel/traverse" "^7.20.0"
+    "@babel/types" "^7.20.0"
+    invariant "^2.2.4"
+    metro-symbolicate "0.76.0"
+    nullthrows "^1.1.1"
+    ob1 "0.76.0"
+    source-map "^0.5.6"
+    vlq "^1.0.0"
+
 metro-symbolicate@0.75.1:
   version "0.75.1"
   resolved "https://registry.yarnpkg.com/metro-symbolicate/-/metro-symbolicate-0.75.1.tgz#29fd71175d1607187ee2522c3702e4cc27050279"
@@ -6558,10 +6664,22 @@ metro-symbolicate@0.75.1:
     through2 "^2.0.1"
     vlq "^1.0.0"
 
-metro-transform-plugins@0.75.1:
-  version "0.75.1"
-  resolved "https://registry.yarnpkg.com/metro-transform-plugins/-/metro-transform-plugins-0.75.1.tgz#5e4b338dbbf80a13c0d22e2bed33211c7ea2560a"
-  integrity sha512-XiurTRKY570ZEbEr7kY4vyX11uYXRKmUTVCVQ7+j4SHA6p6RS23d/2cHMUgwtzch6K9vk1zPT5GK3/eYRglWYw==
+metro-symbolicate@0.76.0:
+  version "0.76.0"
+  resolved "http://localhost:4873/metro-symbolicate/-/metro-symbolicate-0.76.0.tgz#3745875473d4fab544d054b90522df6779b41d37"
+  integrity sha512-duq4RbeHDUzYQu4nzU2zWfBdG1YEXpaMqpLSvsXn5WJF3KK+v+BbtBvmo0zrEvzeA7kczNMxtZ97Yev9rqeYrw==
+  dependencies:
+    invariant "^2.2.4"
+    metro-source-map "0.76.0"
+    nullthrows "^1.1.1"
+    source-map "^0.5.6"
+    through2 "^2.0.1"
+    vlq "^1.0.0"
+
+metro-transform-plugins@0.76.0:
+  version "0.76.0"
+  resolved "http://localhost:4873/metro-transform-plugins/-/metro-transform-plugins-0.76.0.tgz#dbab337561444cd9cd0882365a5b13b03bb92433"
+  integrity sha512-Pl84l7LZAI+RXVP3+Hv+vLQwv4I3dHE91lM+Lw1EVFSep6jvraVVbER5+5/lnb5j1OTEW4EtHXmFus3nnTckeg==
   dependencies:
     "@babel/core" "^7.20.0"
     "@babel/generator" "^7.20.0"
@@ -6569,29 +6687,29 @@ metro-transform-plugins@0.75.1:
     "@babel/traverse" "^7.20.0"
     nullthrows "^1.1.1"
 
-metro-transform-worker@0.75.1:
-  version "0.75.1"
-  resolved "https://registry.yarnpkg.com/metro-transform-worker/-/metro-transform-worker-0.75.1.tgz#72cad162d6421e1365d5872685ca9112b922d326"
-  integrity sha512-at96L4h3/OIUIB1MRIm/jvYPk2J27tRZNEjzSnbTgTzR0329RVHySmblJmgBvWj7F8uqOAUepjuVGkRM50USYg==
+metro-transform-worker@0.76.0:
+  version "0.76.0"
+  resolved "http://localhost:4873/metro-transform-worker/-/metro-transform-worker-0.76.0.tgz#b53ae1d7033b9dae550384afcedeec46905cc6f9"
+  integrity sha512-diV1gXL+/5R/LFPH3UwuU+dNlzT59c0qCHZm2iFqJYaVHuXUgAjyw48gVfOGDbytXLLcswQQD6C594Sc0QNnPA==
   dependencies:
     "@babel/core" "^7.20.0"
     "@babel/generator" "^7.20.0"
     "@babel/parser" "^7.20.0"
     "@babel/types" "^7.20.0"
     babel-preset-fbjs "^3.4.0"
-    metro "0.75.1"
-    metro-babel-transformer "0.75.1"
-    metro-cache "0.75.1"
-    metro-cache-key "0.75.1"
-    metro-hermes-compiler "0.75.1"
-    metro-source-map "0.75.1"
-    metro-transform-plugins "0.75.1"
+    metro "0.76.0"
+    metro-babel-transformer "0.76.0"
+    metro-cache "0.76.0"
+    metro-cache-key "0.76.0"
+    metro-hermes-compiler "0.76.0"
+    metro-source-map "0.76.0"
+    metro-transform-plugins "0.76.0"
     nullthrows "^1.1.1"
 
-metro@0.75.1:
-  version "0.75.1"
-  resolved "https://registry.yarnpkg.com/metro/-/metro-0.75.1.tgz#795b6466a5c4a65dd6816d1a2d7cefa22c25d453"
-  integrity sha512-0Hlm3t99bIVie4bWqAZZTKqAFj1OgzAaaYZ0VqCyfeFfo0dyd86Ipaz8XlKSwpMPLiG/3LbG+pZJ5Z9ERV1nIw==
+metro@0.76.0:
+  version "0.76.0"
+  resolved "http://localhost:4873/metro/-/metro-0.76.0.tgz#eedb7a48c79a222faa953de902f3d81e529eb4c2"
+  integrity sha512-Pm9eMGyNQKnAaDOCmG+26YnodCh34gyl9ZD4UMKSBZA0ent2uUIZWGfZ5Bznljx1WH7JvPvn48VuZVJhctAhLQ==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     "@babel/core" "^7.20.0"
@@ -6600,7 +6718,6 @@ metro@0.75.1:
     "@babel/template" "^7.0.0"
     "@babel/traverse" "^7.20.0"
     "@babel/types" "^7.20.0"
-    absolute-path "^0.0.0"
     accepts "^1.3.7"
     async "^3.2.2"
     chalk "^4.0.0"
@@ -6615,23 +6732,23 @@ metro@0.75.1:
     invariant "^2.2.4"
     jest-worker "^27.2.0"
     lodash.throttle "^4.1.1"
-    metro-babel-transformer "0.75.1"
-    metro-cache "0.75.1"
-    metro-cache-key "0.75.1"
-    metro-config "0.75.1"
-    metro-core "0.75.1"
-    metro-file-map "0.75.1"
-    metro-hermes-compiler "0.75.1"
-    metro-inspector-proxy "0.75.1"
-    metro-minify-terser "0.75.1"
-    metro-minify-uglify "0.75.1"
-    metro-react-native-babel-preset "0.75.1"
-    metro-resolver "0.75.1"
-    metro-runtime "0.75.1"
-    metro-source-map "0.75.1"
-    metro-symbolicate "0.75.1"
-    metro-transform-plugins "0.75.1"
-    metro-transform-worker "0.75.1"
+    metro-babel-transformer "0.76.0"
+    metro-cache "0.76.0"
+    metro-cache-key "0.76.0"
+    metro-config "0.76.0"
+    metro-core "0.76.0"
+    metro-file-map "0.76.0"
+    metro-hermes-compiler "0.76.0"
+    metro-inspector-proxy "0.76.0"
+    metro-minify-terser "0.76.0"
+    metro-minify-uglify "0.76.0"
+    metro-react-native-babel-preset "0.76.0"
+    metro-resolver "0.76.0"
+    metro-runtime "0.76.0"
+    metro-source-map "0.76.0"
+    metro-symbolicate "0.76.0"
+    metro-transform-plugins "0.76.0"
+    metro-transform-worker "0.76.0"
     mime-types "^2.1.27"
     node-fetch "^2.2.0"
     nullthrows "^1.1.1"
@@ -6657,12 +6774,24 @@ mime-db@1.51.0, "mime-db@>= 1.36.0 < 2":
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.51.0.tgz#d9ff62451859b18342d960850dc3cfb77e63fb0c"
   integrity sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==
 
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "http://localhost:4873/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
 mime-types@^2.1.12, mime-types@^2.1.27, mime-types@~2.1.19, mime-types@~2.1.24:
   version "2.1.34"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.34.tgz#5a712f9ec1503511a945803640fafe09d3793c24"
   integrity sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==
   dependencies:
     mime-db "1.51.0"
+
+mime-types@~2.1.34:
+  version "2.1.35"
+  resolved "http://localhost:4873/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
 
 mime@1.4.1:
   version "1.4.1"
@@ -6762,6 +6891,11 @@ negotiator@0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
   integrity sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==
+
+negotiator@0.6.3:
+  version "0.6.3"
+  resolved "http://localhost:4873/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
+  integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
 
 neo-async@^2.5.0:
   version "2.6.0"
@@ -6884,6 +7018,11 @@ ob1@0.75.1:
   version "0.75.1"
   resolved "https://registry.yarnpkg.com/ob1/-/ob1-0.75.1.tgz#ee1ee0ef0ebc14548ab6b945399299e4062d049a"
   integrity sha512-JEUNCFtUL4uhgg9++Q8jB9EqQBjFHiAZa/cb9fBWUHmalWH/VMI8zWt7ty0z/Z7IsrV0EK+RO1O9lLA7/gIuGA==
+
+ob1@0.76.0:
+  version "0.76.0"
+  resolved "http://localhost:4873/ob1/-/ob1-0.76.0.tgz#d36e1a2f2e7ff4534cf25aaf2ab27b48161a408f"
+  integrity sha512-ZLPDN2wCuFRAno0S2BSitMse+l0ipfjQQCDlYZMjZn9YnOGsRneifMlvN+3mWgTA8TOHsoAMYQdciBylgsfAmA==
 
 object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"


### PR DESCRIPTION
## Summary

This PR is part of the work @huntie is doing to fix the CLI-Metro situation. For the time being, this local commit should bring back CircleCI to a green state.

## Changelog
[General][Fixed] - Downgrade CLI to alpha.0 to make Metro work again

## Test Plan
- CircleCI must be green

