### PR TITLE
Revert Changes to Libraries/Utilities to fix prerelease type

### DIFF
--- a/packages/react-native/Libraries/Utilities/NativePlatformConstantsAndroid.js
+++ b/packages/react-native/Libraries/Utilities/NativePlatformConstantsAndroid.js
@@ -19,7 +19,7 @@ export interface Spec extends TurboModule {
       major: number,
       minor: number,
       patch: number,
-      prerelease: ?string,
+      prerelease: ?number,
     |},
     Version: number,
     Release: string,

--- a/packages/react-native/Libraries/Utilities/NativePlatformConstantsIOS.js
+++ b/packages/react-native/Libraries/Utilities/NativePlatformConstantsIOS.js
@@ -19,7 +19,7 @@ export interface Spec extends TurboModule {
       major: number,
       minor: number,
       patch: number,
-      prerelease: ?string,
+      prerelease: ?number,
     |},
     forceTouchAvailable: boolean,
     osVersion: string,

--- a/packages/react-native/Libraries/Utilities/Platform.android.js
+++ b/packages/react-native/Libraries/Utilities/Platform.android.js
@@ -32,7 +32,7 @@ const Platform = {
       major: number,
       minor: number,
       patch: number,
-      prerelease: ?string,
+      prerelease: ?number,
     |},
     Version: number,
     Release: string,

--- a/packages/react-native/Libraries/Utilities/Platform.d.ts
+++ b/packages/react-native/Libraries/Utilities/Platform.d.ts
@@ -23,7 +23,7 @@ type PlatformConstants = {
     major: number;
     minor: number;
     patch: number;
-    prerelease?: string | null | undefined;
+    prerelease?: number | null | undefined;
   };
 };
 interface PlatformStatic {

--- a/packages/react-native/Libraries/Utilities/Platform.ios.js
+++ b/packages/react-native/Libraries/Utilities/Platform.ios.js
@@ -35,7 +35,7 @@ const Platform = {
       major: number,
       minor: number,
       patch: number,
-      prerelease: ?string,
+      prerelease: ?number,
     |},
     systemName: string,
   |} {


### PR DESCRIPTION
## Summary

This PR revert some changes on the Libraries/Utilities as they are the wrong fix

## Changelog:

[INTERNAL] [FIXED] - Revert changes to `prerelease` type 

## Test Plan

CircleCI should present an error when flow checks the Libraries/Utilities folder
