### PR TITLE
Restore object with prerelease as string to unblock 0.72

### DIFF
--- a/packages/react-native/Libraries/Core/ReactNativeVersionCheck.js
+++ b/packages/react-native/Libraries/Core/ReactNativeVersionCheck.js
@@ -39,8 +39,12 @@ exports.checkVersions = function checkVersions(): void {
   }
 };
 
+// Note: in OSS, the prerelease version is usually 0.Y.0-rc.W, so it is a string and not a number
+// Then we need to keep supporting that object shape.
 function _formatVersion(
-  version: (typeof Platform)['constants']['reactNativeVersion'],
+  version:
+    | (typeof Platform)['constants']['reactNativeVersion']
+    | {major: number, minor: number, patch: number, prerelease: ?string},
 ): string {
   return (
     `${version.major}.${version.minor}.${version.patch}` +


### PR DESCRIPTION
## Summary

Before 0.72, a change landed that enforced the version to have a `number` as prerelease version (https://github.com/facebook/react-native/commit/8a59153bd7325055dcca33571ee0484f8f00fb30). 
However, this breaks the CI when we prepare the releases in OSS. This PR restore that possibility. 

## Changelog:

[INTERNAL] [FIXED] - Restore Prerelease as string for OSS

## Test Plan

- CircleCI must be green
