### PR TITLE
[0.72-stable] Fix localhost references in yarn.lock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2250,7 +2250,7 @@
 
 "@react-native-community/cli-clean@^11.0.0-alpha.0":
   version "11.0.0"
-  resolved "http://localhost:4873/@react-native-community%2fcli-clean/-/cli-clean-11.0.0.tgz#7225f8df011893de1cb740a0cad3dd2670574da5"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-clean/-/cli-clean-11.0.0.tgz#7225f8df011893de1cb740a0cad3dd2670574da5"
   integrity sha512-CWulRz6Ey2ntr3Ml/bMgSXhcE2yWj3R/Vrho2D00Y3wuU6p4cK/Af7YIidyn5E0NI/CMtXZ0cE1l5WME0o4wsA==
   dependencies:
     "@react-native-community/cli-tools" "^11.0.0"
@@ -2260,7 +2260,7 @@
 
 "@react-native-community/cli-config@^11.0.0", "@react-native-community/cli-config@^11.0.0-alpha.0":
   version "11.0.0"
-  resolved "http://localhost:4873/@react-native-community%2fcli-config/-/cli-config-11.0.0.tgz#c41acda2ff7aa2a4f1b5cdd895e341f27009ff8f"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-config/-/cli-config-11.0.0.tgz#c41acda2ff7aa2a4f1b5cdd895e341f27009ff8f"
   integrity sha512-aKjv/lG7rr2WSN7MSP/P2HUJwoUI94Zct9eyxWEPBV5d48dVR4u7UXcGPRJSJTwVl7+RGNVThnGH8Gh55e1+Lw==
   dependencies:
     "@react-native-community/cli-tools" "^11.0.0"
@@ -2272,7 +2272,7 @@
 
 "@react-native-community/cli-debugger-ui@^10.0.0":
   version "10.0.0"
-  resolved "http://localhost:4873/@react-native-community%2fcli-debugger-ui/-/cli-debugger-ui-10.0.0.tgz#4bb6d41c7e46449714dc7ba5d9f5b41ef0ea7c57"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-10.0.0.tgz#4bb6d41c7e46449714dc7ba5d9f5b41ef0ea7c57"
   integrity sha512-8UKLcvpSNxnUTRy8CkCl27GGLqZunQ9ncGYhSrWyKrU9SWBJJGeZwi2k2KaoJi5FvF2+cD0t8z8cU6lsq2ZZmA==
   dependencies:
     serve-static "^1.13.1"
@@ -2286,7 +2286,7 @@
 
 "@react-native-community/cli-doctor@^11.0.0-alpha.0":
   version "11.0.0"
-  resolved "http://localhost:4873/@react-native-community%2fcli-doctor/-/cli-doctor-11.0.0.tgz#bf4c8993cc0439c8347803e01aeafbd40bb3f69f"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-doctor/-/cli-doctor-11.0.0.tgz#bf4c8993cc0439c8347803e01aeafbd40bb3f69f"
   integrity sha512-eOvQw6YTDJXSPMYV7lM2bIKi80Ccwj+EAvYIYBHy77NwpL06MXNGUdNPuH/NgkYTR53gfJIMawddUm4qQN1b3w==
   dependencies:
     "@react-native-community/cli-config" "^11.0.0"
@@ -2309,7 +2309,7 @@
 
 "@react-native-community/cli-hermes@^11.0.0-alpha.0":
   version "11.0.0"
-  resolved "http://localhost:4873/@react-native-community%2fcli-hermes/-/cli-hermes-11.0.0.tgz#0586e8a923174d81342f629abcd03ffab2020292"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-hermes/-/cli-hermes-11.0.0.tgz#0586e8a923174d81342f629abcd03ffab2020292"
   integrity sha512-HNkiFnW/U9laf1ekvGfWhfX6N9OzZFd5oFK0BTolvETAZt4qFWFbP7BqkpHhA7iaxs76sCnE/VEAwQQndQWKWg==
   dependencies:
     "@react-native-community/cli-platform-android" "^11.0.0"
@@ -2320,7 +2320,7 @@
 
 "@react-native-community/cli-platform-android@11.0.0-alpha.0":
   version "11.0.0-alpha.0"
-  resolved "http://localhost:4873/@react-native-community%2fcli-platform-android/-/cli-platform-android-11.0.0-alpha.0.tgz#c4a4cd2104e67d78fbce72a9af75ea1941505110"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-android/-/cli-platform-android-11.0.0-alpha.0.tgz#c4a4cd2104e67d78fbce72a9af75ea1941505110"
   integrity sha512-4yaXpxxbQGoNOvrg7+bHaF22FT4jSEv4rDwC6/B7G9aQ2LkCW/45xpOaAwV8yk2HjjWyRXIhaHDc9dEg8T4BmA==
   dependencies:
     "@react-native-community/cli-tools" "^11.0.0-alpha.0"
@@ -2331,7 +2331,7 @@
 
 "@react-native-community/cli-platform-android@^11.0.0":
   version "11.0.0"
-  resolved "http://localhost:4873/@react-native-community%2fcli-platform-android/-/cli-platform-android-11.0.0.tgz#ef08118e3aac4cc02422109a8204afc4277d1714"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-android/-/cli-platform-android-11.0.0.tgz#ef08118e3aac4cc02422109a8204afc4277d1714"
   integrity sha512-1jhP/1qONcAsIa7yoI6t+S4rW3Ctevv2W89uVgzNxyOK6GNSD0WWM1awO83iWo3YU+iknluUmHampq+nIiirNA==
   dependencies:
     "@react-native-community/cli-tools" "^11.0.0"
@@ -2342,7 +2342,7 @@
 
 "@react-native-community/cli-platform-ios@11.0.0-alpha.0":
   version "11.0.0-alpha.0"
-  resolved "http://localhost:4873/@react-native-community%2fcli-platform-ios/-/cli-platform-ios-11.0.0-alpha.0.tgz#cc7c7c828c25dd8d0e134ce95fb1e50de1ff572a"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-ios/-/cli-platform-ios-11.0.0-alpha.0.tgz#cc7c7c828c25dd8d0e134ce95fb1e50de1ff572a"
   integrity sha512-dyycqtRnhU1ktgQBsvmie3RdlxtpIHCQ5uUQIW+ZCsnigkl6pC/ulyLxOFwAJmczEuH1RIj9kl/hJ81sxv5CjQ==
   dependencies:
     "@react-native-community/cli-tools" "^11.0.0-alpha.0"
@@ -2354,7 +2354,7 @@
 
 "@react-native-community/cli-platform-ios@^11.0.0":
   version "11.0.0"
-  resolved "http://localhost:4873/@react-native-community%2fcli-platform-ios/-/cli-platform-ios-11.0.0.tgz#4c7bbcdeffe3307566a6183b5c50d6403b87c9f3"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-ios/-/cli-platform-ios-11.0.0.tgz#4c7bbcdeffe3307566a6183b5c50d6403b87c9f3"
   integrity sha512-xGWmmifNiZG0auKe2sCAhQ46yHAUZDNyAfPP3m4zXGYP3jaSAi01KldnBaboC9ZNNrjUNOmkKh4v6IrXXxxCXg==
   dependencies:
     "@react-native-community/cli-tools" "^11.0.0"
@@ -2366,7 +2366,7 @@
 
 "@react-native-community/cli-plugin-metro@^11.0.0-alpha.0":
   version "11.0.0"
-  resolved "http://localhost:4873/@react-native-community%2fcli-plugin-metro/-/cli-plugin-metro-11.0.0.tgz#00fe753f8fe8b1294a0c08653a42ddb4961f60d7"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-plugin-metro/-/cli-plugin-metro-11.0.0.tgz#00fe753f8fe8b1294a0c08653a42ddb4961f60d7"
   integrity sha512-ekPZEhB6LP7OhiIw73UbEbwlgsHcISW1jCO6ZKwlv5gFxP7kZaq6yzh4dirbxFUECa28O4VmceKwTeicCsU0EQ==
   dependencies:
     "@react-native-community/cli-server-api" "^11.0.0"
@@ -2381,7 +2381,7 @@
 
 "@react-native-community/cli-server-api@^11.0.0", "@react-native-community/cli-server-api@^11.0.0-alpha.0":
   version "11.0.0"
-  resolved "http://localhost:4873/@react-native-community%2fcli-server-api/-/cli-server-api-11.0.0.tgz#ab6d46e5f243edb05b170b7007d531b853a2bc15"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-server-api/-/cli-server-api-11.0.0.tgz#ab6d46e5f243edb05b170b7007d531b853a2bc15"
   integrity sha512-9EcqWDp65GBF3qtXsoyCcHd7RLrl2BEBXcBqN/f6pBSsqHkwJFUNalEdL832Pd7aGnSnQ6TrFX/3AFJWXAd06A==
   dependencies:
     "@react-native-community/cli-debugger-ui" "^11.0.0-alpha.2"
@@ -2396,7 +2396,7 @@
 
 "@react-native-community/cli-tools@^11.0.0", "@react-native-community/cli-tools@^11.0.0-alpha.0":
   version "11.0.0"
-  resolved "http://localhost:4873/@react-native-community%2fcli-tools/-/cli-tools-11.0.0.tgz#6a9e2c8577fc45bb16bded694cf9cec902d18840"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-tools/-/cli-tools-11.0.0.tgz#6a9e2c8577fc45bb16bded694cf9cec902d18840"
   integrity sha512-WfybGk4jK/QUIe+lA2zKyKd3ifjVBxjqZ10onfXYHxjqf02MXK4n1utOnzLfarS4WrbHSmLtHlzO7ytJAeQjFw==
   dependencies:
     appdirsjs "^1.2.4"
@@ -2411,14 +2411,14 @@
 
 "@react-native-community/cli-types@^11.0.0-alpha.0":
   version "11.0.0"
-  resolved "http://localhost:4873/@react-native-community%2fcli-types/-/cli-types-11.0.0.tgz#8ad65b1d969e24e163b68bff4e8c0dac67f7804e"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-types/-/cli-types-11.0.0.tgz#8ad65b1d969e24e163b68bff4e8c0dac67f7804e"
   integrity sha512-w+1hOzV6VKqpCcO6/LF6lxrcl47tQ6ojlMCmhrB4Ah92gSbcmAluSWgb+kbzPIhsGxW0h/YnLR/4RXM9lnknDA==
   dependencies:
     joi "^17.2.1"
 
 "@react-native-community/cli@11.0.0-alpha.0":
   version "11.0.0-alpha.0"
-  resolved "http://localhost:4873/@react-native-community%2fcli/-/cli-11.0.0-alpha.0.tgz#8e9f920a0c90348e71c85ef0867a0d306f62cc24"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli/-/cli-11.0.0-alpha.0.tgz#8e9f920a0c90348e71c85ef0867a0d306f62cc24"
   integrity sha512-zd1p/FC1xVUnn5AxHRfy2GH1y72MV4W7uL23K7YJxqpegBuU2odggfKUsYTT5jIgiXsZYdaQvOFMLdBW0s5ejQ==
   dependencies:
     "@react-native-community/cli-clean" "^11.0.0-alpha.0"
@@ -2840,7 +2840,7 @@ accepts@^1.3.7, accepts@~1.3.5:
 
 accepts@~1.3.7:
   version "1.3.8"
-  resolved "http://localhost:4873/accepts/-/accepts-1.3.8.tgz#0bf0be125b67014adcb0b0921e62db7bffe16b2e"
+  resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.8.tgz#0bf0be125b67014adcb0b0921e62db7bffe16b2e"
   integrity sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==
   dependencies:
     mime-types "~2.1.34"
@@ -3874,7 +3874,7 @@ deepmerge@^4.2.2:
 
 deepmerge@^4.3.0:
   version "4.3.1"
-  resolved "http://localhost:4873/deepmerge/-/deepmerge-4.3.1.tgz#44b5f2147cd3b00d4b56137685966f26fd25dd4a"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.3.1.tgz#44b5f2147cd3b00d4b56137685966f26fd25dd4a"
   integrity sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==
 
 defaults@^1.0.3:
@@ -4050,7 +4050,7 @@ error-stack-parser@^2.0.6:
 
 errorhandler@^1.5.1:
   version "1.5.1"
-  resolved "http://localhost:4873/errorhandler/-/errorhandler-1.5.1.tgz#b9ba5d17cf90744cd1e851357a6e75bf806a9a91"
+  resolved "https://registry.yarnpkg.com/errorhandler/-/errorhandler-1.5.1.tgz#b9ba5d17cf90744cd1e851357a6e75bf806a9a91"
   integrity sha512-rcOwbfvP1WTViVoUjcfZicVzjhjTuhSMntHh6mW3IrEiyE6mJyXvsToJUJGlGlw/2xU9P5whlWNGlIDVeCiT4A==
   dependencies:
     accepts "~1.3.7"
@@ -6403,7 +6403,7 @@ metro-babel-transformer@0.75.1:
 
 metro-babel-transformer@0.76.0:
   version "0.76.0"
-  resolved "http://localhost:4873/metro-babel-transformer/-/metro-babel-transformer-0.76.0.tgz#cb3854ee74a1ecba40680af1b6625aa46928c3c0"
+  resolved "https://registry.yarnpkg.com/metro-babel-transformer/-/metro-babel-transformer-0.76.0.tgz#cb3854ee74a1ecba40680af1b6625aa46928c3c0"
   integrity sha512-yBF8eJluya2iofhu8nZDXr9It/7bUcgXiKpFPrkiOWcMFY/jqzEbcavQ8uK3lFeXNRyvj0iaKaFs7Qo+2QJfow==
   dependencies:
     "@babel/core" "^7.20.0"
@@ -6413,12 +6413,12 @@ metro-babel-transformer@0.76.0:
 
 metro-cache-key@0.76.0:
   version "0.76.0"
-  resolved "http://localhost:4873/metro-cache-key/-/metro-cache-key-0.76.0.tgz#0ab9513c8fc0392e7fde5d4473f220a9352e2cf0"
+  resolved "https://registry.yarnpkg.com/metro-cache-key/-/metro-cache-key-0.76.0.tgz#0ab9513c8fc0392e7fde5d4473f220a9352e2cf0"
   integrity sha512-Oyz+Yo/CG56kMXsDuioLf80MHwUqRzhOjaFsDvam3+gpc9rIGhnFL4ODhc6Qlum5auPRMT9XsksScErouft2tA==
 
 metro-cache@0.76.0:
   version "0.76.0"
-  resolved "http://localhost:4873/metro-cache/-/metro-cache-0.76.0.tgz#b68d284fa46e74fe6cc7b822a9f3028f8824f952"
+  resolved "https://registry.yarnpkg.com/metro-cache/-/metro-cache-0.76.0.tgz#b68d284fa46e74fe6cc7b822a9f3028f8824f952"
   integrity sha512-J+OkOcIWrJisoXw6fXwWzeR1q4IuysMIKG8v/DWmKUOy8VI2c0gKXUW0mBfEWq6y3w0Czl94/xh1x7X0YLsTNg==
   dependencies:
     metro-core "0.76.0"
@@ -6426,7 +6426,7 @@ metro-cache@0.76.0:
 
 metro-config@0.76.0:
   version "0.76.0"
-  resolved "http://localhost:4873/metro-config/-/metro-config-0.76.0.tgz#fe38e555faa1c6fa7eb2fbe9fa504844b1156154"
+  resolved "https://registry.yarnpkg.com/metro-config/-/metro-config-0.76.0.tgz#fe38e555faa1c6fa7eb2fbe9fa504844b1156154"
   integrity sha512-5bfOtovHM7qjSobGBGRWXGh9+wMJlXHgot1LhjL3YTaNLUY42umbzdNC7dPcrGNLHH3MXTlG4cyNeCWZxtm6Hg==
   dependencies:
     cosmiconfig "^5.0.5"
@@ -6438,7 +6438,7 @@ metro-config@0.76.0:
 
 metro-core@0.76.0:
   version "0.76.0"
-  resolved "http://localhost:4873/metro-core/-/metro-core-0.76.0.tgz#16f8a73d40173ffe659a2de8b727bb2c84a2846e"
+  resolved "https://registry.yarnpkg.com/metro-core/-/metro-core-0.76.0.tgz#16f8a73d40173ffe659a2de8b727bb2c84a2846e"
   integrity sha512-LRNWBpvHWcMeK+LZ74VZRo6QfU8izh6BmmqeW57HnZec69JQ1uODV6e7gQig6PWH89aMzhq8QKQr0dPDUGDYIg==
   dependencies:
     lodash.throttle "^4.1.1"
@@ -6446,7 +6446,7 @@ metro-core@0.76.0:
 
 metro-file-map@0.76.0:
   version "0.76.0"
-  resolved "http://localhost:4873/metro-file-map/-/metro-file-map-0.76.0.tgz#a27586bd4e22112864e76ba49bda6bb851bf5e49"
+  resolved "https://registry.yarnpkg.com/metro-file-map/-/metro-file-map-0.76.0.tgz#a27586bd4e22112864e76ba49bda6bb851bf5e49"
   integrity sha512-ifhMf75SlkSR8QcRBK1ecDwt9APZNEMWG7U8RIhtoDAtBYKuTbjjHNJiAwAU8UPE78m/Aryz6A+5cwpuAvSGrA==
   dependencies:
     abort-controller "^3.0.0"
@@ -6467,12 +6467,12 @@ metro-file-map@0.76.0:
 
 metro-hermes-compiler@0.76.0:
   version "0.76.0"
-  resolved "http://localhost:4873/metro-hermes-compiler/-/metro-hermes-compiler-0.76.0.tgz#2c4cca498011cab799434527544c0303eb12b806"
+  resolved "https://registry.yarnpkg.com/metro-hermes-compiler/-/metro-hermes-compiler-0.76.0.tgz#2c4cca498011cab799434527544c0303eb12b806"
   integrity sha512-ZW1jHtErMp327aPEkhHP69dLmtbzGj7ajsNFEwayoz/tZtyrTXT+f/8j6QVynIBMMpnAJkSIlinNo9fgIbE08w==
 
 metro-inspector-proxy@0.76.0:
   version "0.76.0"
-  resolved "http://localhost:4873/metro-inspector-proxy/-/metro-inspector-proxy-0.76.0.tgz#01af31de7cd09d9ec5a204b73fc786e3f4ddc793"
+  resolved "https://registry.yarnpkg.com/metro-inspector-proxy/-/metro-inspector-proxy-0.76.0.tgz#01af31de7cd09d9ec5a204b73fc786e3f4ddc793"
   integrity sha512-1RCMmXzcvDsFvJyfRqzUl2B3r0FTgxW37WlH2c2tMhqVtGxobDGHn5cFySeaCLvKSHps0NELeB+1SF7MB9scxA==
   dependencies:
     connect "^3.6.5"
@@ -6488,14 +6488,14 @@ metro-memory-fs@0.75.1:
 
 metro-minify-terser@0.76.0:
   version "0.76.0"
-  resolved "http://localhost:4873/metro-minify-terser/-/metro-minify-terser-0.76.0.tgz#49cef5fc0c2ae9b2ed76a8832132934c3a10de4c"
+  resolved "https://registry.yarnpkg.com/metro-minify-terser/-/metro-minify-terser-0.76.0.tgz#49cef5fc0c2ae9b2ed76a8832132934c3a10de4c"
   integrity sha512-dxaE/pvFDFEvXoNHuiXbA2Tw/jT1MD3B4a9AM+aYPWJBh3PdT9XM1HdzumyJldtZpCn5yka4maYSrtuebKgOyw==
   dependencies:
     terser "^5.15.0"
 
 metro-minify-uglify@0.76.0:
   version "0.76.0"
-  resolved "http://localhost:4873/metro-minify-uglify/-/metro-minify-uglify-0.76.0.tgz#a34a64614b5abd364674dc6c0ff567d43d2b525c"
+  resolved "https://registry.yarnpkg.com/metro-minify-uglify/-/metro-minify-uglify-0.76.0.tgz#a34a64614b5abd364674dc6c0ff567d43d2b525c"
   integrity sha512-Fuoxr5wLw/2/BUmhJqmIsfNZK+x8BK/DDXID5CZvHmZj5PdN4MN2WGWkM/F4EOw2t1YxbJ1hFSXM8skfSZ7jkw==
   dependencies:
     uglify-es "^3.1.9"
@@ -6547,7 +6547,7 @@ metro-react-native-babel-preset@0.75.1:
 
 metro-react-native-babel-preset@0.76.0:
   version "0.76.0"
-  resolved "http://localhost:4873/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.76.0.tgz#440a0e8965b2eb01afa391ef95575faeed67636b"
+  resolved "https://registry.yarnpkg.com/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.76.0.tgz#440a0e8965b2eb01afa391ef95575faeed67636b"
   integrity sha512-2sM6dy9uAbuQlg7l/VOdiudUUMFRkABJ1YLkZU6Fpqi/rJCXn4fbF0pO+TwCFbBYNIQBY50clv9RPvD2n64hXg==
   dependencies:
     "@babel/core" "^7.20.0"
@@ -6605,7 +6605,7 @@ metro-react-native-babel-transformer@0.75.1:
 
 metro-resolver@0.76.0:
   version "0.76.0"
-  resolved "http://localhost:4873/metro-resolver/-/metro-resolver-0.76.0.tgz#3fa778adbab30859023a89e7a1241f4eb68171f2"
+  resolved "https://registry.yarnpkg.com/metro-resolver/-/metro-resolver-0.76.0.tgz#3fa778adbab30859023a89e7a1241f4eb68171f2"
   integrity sha512-bU6HvKzPJOHGoe9na+tUa0g3pZqMUaSGE+noFx2qeSMtoIgOYkDzmuU9ZOAGcUOz0qJJtGs+QmgM+nBqfSS/pQ==
 
 metro-runtime@0.75.1:
@@ -6618,7 +6618,7 @@ metro-runtime@0.75.1:
 
 metro-runtime@0.76.0:
   version "0.76.0"
-  resolved "http://localhost:4873/metro-runtime/-/metro-runtime-0.76.0.tgz#ccc4721010a24d4919bf50e9146d06d28266efb3"
+  resolved "https://registry.yarnpkg.com/metro-runtime/-/metro-runtime-0.76.0.tgz#ccc4721010a24d4919bf50e9146d06d28266efb3"
   integrity sha512-mEt1uWCYVwyvHYhCfsRXp7mqIBgOAYkocgousH5jwi07MwSAAvaDCvyRBUgtFohDQpL4j4N/QxNYExDDqUuuQw==
   dependencies:
     "@babel/runtime" "^7.0.0"
@@ -6640,7 +6640,7 @@ metro-source-map@0.75.1:
 
 metro-source-map@0.76.0:
   version "0.76.0"
-  resolved "http://localhost:4873/metro-source-map/-/metro-source-map-0.76.0.tgz#0f05263dc4648f654feaab36dae799b7118b36c0"
+  resolved "https://registry.yarnpkg.com/metro-source-map/-/metro-source-map-0.76.0.tgz#0f05263dc4648f654feaab36dae799b7118b36c0"
   integrity sha512-tAXlHI6EOtRTkhXynZbe/as7pBDBxDaHftq/7pV3QCGyLeSaTNy6wzXI5ewr3kTuZxtBXktQH/Zl0rhKO8DGMA==
   dependencies:
     "@babel/traverse" "^7.20.0"
@@ -6666,7 +6666,7 @@ metro-symbolicate@0.75.1:
 
 metro-symbolicate@0.76.0:
   version "0.76.0"
-  resolved "http://localhost:4873/metro-symbolicate/-/metro-symbolicate-0.76.0.tgz#3745875473d4fab544d054b90522df6779b41d37"
+  resolved "https://registry.yarnpkg.com/metro-symbolicate/-/metro-symbolicate-0.76.0.tgz#3745875473d4fab544d054b90522df6779b41d37"
   integrity sha512-duq4RbeHDUzYQu4nzU2zWfBdG1YEXpaMqpLSvsXn5WJF3KK+v+BbtBvmo0zrEvzeA7kczNMxtZ97Yev9rqeYrw==
   dependencies:
     invariant "^2.2.4"
@@ -6678,7 +6678,7 @@ metro-symbolicate@0.76.0:
 
 metro-transform-plugins@0.76.0:
   version "0.76.0"
-  resolved "http://localhost:4873/metro-transform-plugins/-/metro-transform-plugins-0.76.0.tgz#dbab337561444cd9cd0882365a5b13b03bb92433"
+  resolved "https://registry.yarnpkg.com/metro-transform-plugins/-/metro-transform-plugins-0.76.0.tgz#dbab337561444cd9cd0882365a5b13b03bb92433"
   integrity sha512-Pl84l7LZAI+RXVP3+Hv+vLQwv4I3dHE91lM+Lw1EVFSep6jvraVVbER5+5/lnb5j1OTEW4EtHXmFus3nnTckeg==
   dependencies:
     "@babel/core" "^7.20.0"
@@ -6689,7 +6689,7 @@ metro-transform-plugins@0.76.0:
 
 metro-transform-worker@0.76.0:
   version "0.76.0"
-  resolved "http://localhost:4873/metro-transform-worker/-/metro-transform-worker-0.76.0.tgz#b53ae1d7033b9dae550384afcedeec46905cc6f9"
+  resolved "https://registry.yarnpkg.com/metro-transform-worker/-/metro-transform-worker-0.76.0.tgz#b53ae1d7033b9dae550384afcedeec46905cc6f9"
   integrity sha512-diV1gXL+/5R/LFPH3UwuU+dNlzT59c0qCHZm2iFqJYaVHuXUgAjyw48gVfOGDbytXLLcswQQD6C594Sc0QNnPA==
   dependencies:
     "@babel/core" "^7.20.0"
@@ -6708,7 +6708,7 @@ metro-transform-worker@0.76.0:
 
 metro@0.76.0:
   version "0.76.0"
-  resolved "http://localhost:4873/metro/-/metro-0.76.0.tgz#eedb7a48c79a222faa953de902f3d81e529eb4c2"
+  resolved "https://registry.yarnpkg.com/metro/-/metro-0.76.0.tgz#eedb7a48c79a222faa953de902f3d81e529eb4c2"
   integrity sha512-Pm9eMGyNQKnAaDOCmG+26YnodCh34gyl9ZD4UMKSBZA0ent2uUIZWGfZ5Bznljx1WH7JvPvn48VuZVJhctAhLQ==
   dependencies:
     "@babel/code-frame" "^7.0.0"
@@ -6776,7 +6776,7 @@ mime-db@1.51.0, "mime-db@>= 1.36.0 < 2":
 
 mime-db@1.52.0:
   version "1.52.0"
-  resolved "http://localhost:4873/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
 mime-types@^2.1.12, mime-types@^2.1.27, mime-types@~2.1.19, mime-types@~2.1.24:
@@ -6788,7 +6788,7 @@ mime-types@^2.1.12, mime-types@^2.1.27, mime-types@~2.1.19, mime-types@~2.1.24:
 
 mime-types@~2.1.34:
   version "2.1.35"
-  resolved "http://localhost:4873/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
   dependencies:
     mime-db "1.52.0"
@@ -6894,7 +6894,7 @@ negotiator@0.6.2:
 
 negotiator@0.6.3:
   version "0.6.3"
-  resolved "http://localhost:4873/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
+  resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
   integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
 
 neo-async@^2.5.0:
@@ -7021,7 +7021,7 @@ ob1@0.75.1:
 
 ob1@0.76.0:
   version "0.76.0"
-  resolved "http://localhost:4873/ob1/-/ob1-0.76.0.tgz#d36e1a2f2e7ff4534cf25aaf2ab27b48161a408f"
+  resolved "https://registry.yarnpkg.com/ob1/-/ob1-0.76.0.tgz#d36e1a2f2e7ff4534cf25aaf2ab27b48161a408f"
   integrity sha512-ZLPDN2wCuFRAno0S2BSitMse+l0ipfjQQCDlYZMjZn9YnOGsRneifMlvN+3mWgTA8TOHsoAMYQdciBylgsfAmA==
 
 object-assign@^4.1.0, object-assign@^4.1.1:


### PR DESCRIPTION
A continuation of https://github.com/facebook/react-native/pull/36654, but fixing the `localhost` references in the lockfile for compatibility externally.