### PR TITLE
Trigger pointer leave when active controller switched

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/JSPointerDispatcher.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/JSPointerDispatcher.java
@@ -158,6 +158,10 @@ public class JSPointerDispatcher {
           motionEvent,
           enterViewTargets,
           eventDispatcher);
+    } else {
+      // There are cases when the pointer may have moved in the same frame as the down event.
+      // Dispatch the move event before the down event.
+      onMove(activeTargetTag, eventState, motionEvent, eventDispatcher);
     }
 
     boolean listeningForDown =


### PR DESCRIPTION
Summary:
For VR, JSPointerDispatcher skips calculating the delta of hit targets (which happens in onMove) on the frame in which the active controller is switched because the motion event is a DOWN event, not a MOVE event in that specific frame.

This diff fixes the issue by just calling onMove in addition to onDown for DOWN motion events. Unfortunately we do not have separate pointer IDs for each controller.

This won't change the behavior for non-hoverable pointers. For hoverable pointers, it will dispatch an extra pointer_enter if the hit path has changed between the last move event and the down event.

Changelog:
[Internal][Fixed] - Trigger pointer leave when active controller switched

Reviewed By: lunaleaps, javache

Differential Revision: D44377324

