### PR TITLE
fix(android): update text natively only if needed (fixes selection menu missing) 

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -581,7 +581,7 @@ public class ReactEditText extends AppCompatEditText
 
   // VisibleForTesting from {@link TextInputEventsTestCase}.
   public void maybeSetText(ReactTextUpdate reactTextUpdate) {
-    if (isSecureText() && TextUtils.equals(getText(), reactTextUpdate.getText())) {
+    if (TextUtils.equals(getText(), reactTextUpdate.getText())) {
       return;
     }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

### Problem

There exists a bug where on android when having a controlled `TextInput` using the `selection` prop the selection menu would not show up (the first TextInput is uncontrolled and there you can see its working):


https://user-images.githubusercontent.com/16821682/228009826-72679424-a3d5-4745-9f67-1cb1394d2dd1.mov


There has also been an issue, which was closed as stale:

- https://github.com/facebook/react-native/issues/33697

The reason for this behaviour is the following:

- The user moves the selection cursor in the native EditText view
- The native onSelectionChange listeners fires, which will call the JS onSelectionChange callback
- The JS onSelectionChange callback will update the react state `lastNativeSelectionState`
- When the TextInput is uncontrolled the selection that is passed to the native view will stay `null`
- When the TextInput is controlled however a new object gets set as state  for `lastNativeSelectionState`, **causing the component to re-render**.
- The re-render causes the props to get applied, which then leads to a `maybeSetText` call (e.g. updating the text of the native view)
- `maybeSetText` doesn't check if the text is the same, and updates the texts natively
- This update causes the selection menu to disappear. There is no way to prevent this.

### Solution

We don't want to update the text natively if it hasn't changed. There is already a check present in `maybeSetText`, but it only checks for text changes when the TextInput is a secure one (e.g. a password input).

I propose that we always check if the text has changed, and only update the text natively if it really did.
These changes can be seen in this PR.

With these changes you can see that in the tester app the text selection also works for controlled inputs:


https://user-images.githubusercontent.com/16821682/228017007-905caf38-9e1e-40f7-ae96-dd5796421e1a.mov



## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[ANDROID] [FIXED] - Selection menu missing when TextInput uses controlled `selection` prop

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

- I see that there are some references to a test file called `TextInputEventsTestCase`, however I can't find it anywhere in the code. I would like to run those tests and confirm everything is still working as expected
- Manual testing for the `TextInput` in the rn tester app 
