### PR TITLE
Fix version check in Core

### DIFF
--- a/packages/react-native/Libraries/Core/ReactNativeVersionCheck.js
+++ b/packages/react-native/Libraries/Core/ReactNativeVersionCheck.js
@@ -39,8 +39,12 @@ exports.checkVersions = function checkVersions(): void {
   }
 };
 
+// Note: in OSS, the prerelease version is usually 0.Y.0-rc.W, so it is a string and not a number
+// Then we need to keep supporting that object shape.
 function _formatVersion(
-  version: (typeof Platform)['constants']['reactNativeVersion'],
+  version:
+    | (typeof Platform)['constants']['reactNativeVersion']
+    | {major: number, minor: number, patch: number, prerelease: ?string},
 ): string {
   return (
     `${version.major}.${version.minor}.${version.patch}` +


### PR DESCRIPTION
Summary:
When we do a release in OSS, the prerelease is not a number but something like `rc.K`, where `K` is the only number.

This change restore the check so that it can support also the OSS

## Changelog:
[Internal][Fixed] - Restore support for `prerelease` as `?string`

Differential Revision: D44426011

