### PR TITLE
trigger codegenned reflection if module is a turbomodule

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaModuleWrapper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaModuleWrapper.java
@@ -16,6 +16,7 @@ import static com.facebook.systrace.Systrace.TRACE_TAG_REACT_JAVA_BRIDGE;
 import androidx.annotation.Nullable;
 import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.config.ReactFeatureFlags;
+import com.facebook.react.turbomodule.core.interfaces.TurboModule;
 import com.facebook.systrace.Systrace;
 import com.facebook.systrace.SystraceMessage;
 import java.lang.reflect.Method;
@@ -71,7 +72,7 @@ public class JavaModuleWrapper {
     Class<? extends NativeModule> classForMethods = mModuleHolder.getModule().getClass();
     Class<? extends NativeModule> superClass =
         (Class<? extends NativeModule>) classForMethods.getSuperclass();
-    if (ReactModuleWithSpec.class.isAssignableFrom(superClass)) {
+    if (TurboModule.class.isAssignableFrom(superClass)) {
       // For java module that is based on generated flow-type spec, inspect the
       // spec abstract class instead, which is the super class of the given java
       // module.

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridge/BUCK
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridge/BUCK
@@ -40,6 +40,7 @@ rn_robolectric_test(
         react_native_dep("third-party/java/junit:junit"),
         react_native_target("java/com/facebook/react/bridge:bridge"),
         react_native_target("java/com/facebook/react/common:common"),
+        react_native_target("java/com/facebook/react/turbomodule/core/interfaces:interfaces"),
         react_native_target("java/com/facebook/react/uimanager:uimanager"),
         react_native_tests_target("java/com/facebook/common/logging:logging"),
     ],

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridge/BaseJavaModuleTest.java
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridge/BaseJavaModuleTest.java
@@ -9,28 +9,36 @@ package com.facebook.react.bridge;
 
 import static org.mockito.Mockito.when;
 
+import android.content.Context;
 import com.facebook.soloader.SoLoader;
 import java.util.List;
 import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.rule.PowerMockRule;
+import org.mockito.Mockito;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+
+@Implements(SoLoader.class)
+class ShadowSoLoader {
+  @Implementation
+  public static void init(Context context, int flags) {}
+
+  @Implementation
+  public static boolean loadLibrary(String shortName) {
+    return true;
+  }
+}
 
 /** Tests for {@link BaseJavaModule} and {@link JavaModuleWrapper} */
-@PrepareForTest({ReadableNativeArray.class, SoLoader.class})
-@PowerMockIgnore({"org.mockito.*", "org.robolectric.*", "androidx.*", "android.*"})
+@Config(
+    shadows = {
+      ShadowSoLoader.class,
+    })
 @RunWith(RobolectricTestRunner.class)
-@Ignore("Ignored due to unsupported mocking mechanism with JDK 18")
 public class BaseJavaModuleTest {
-
-  @Rule public PowerMockRule rule = new PowerMockRule();
-
   private List<JavaModuleWrapper.MethodDescriptor> mMethods;
   private JavaModuleWrapper mWrapper;
   private ReadableNativeArray mArguments;
@@ -40,8 +48,7 @@ public class BaseJavaModuleTest {
     ModuleHolder moduleHolder = new ModuleHolder(new MethodsModule());
     mWrapper = new JavaModuleWrapper(null, moduleHolder);
     mMethods = mWrapper.getMethodDescriptors();
-    PowerMockito.mockStatic(SoLoader.class);
-    mArguments = PowerMockito.mock(ReadableNativeArray.class);
+    mArguments = Mockito.mock(ReadableNativeArray.class);
   }
 
   private int findMethod(String mname, List<JavaModuleWrapper.MethodDescriptor> methods) {

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridge/BaseJavaModuleTest.java
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridge/BaseJavaModuleTest.java
@@ -10,6 +10,7 @@ package com.facebook.react.bridge;
 import static org.mockito.Mockito.when;
 
 import android.content.Context;
+import com.facebook.react.turbomodule.core.interfaces.TurboModule;
 import com.facebook.soloader.SoLoader;
 import java.util.List;
 import org.junit.Before;
@@ -127,7 +128,7 @@ public class BaseJavaModuleTest {
   }
 
   private abstract class NativeTestGeneratedModuleSpec extends BaseJavaModule
-      implements ReactModuleWithSpec {
+      implements TurboModule {
     @ReactMethod
     public abstract void generatedMethod(String a, int b);
   }


### PR DESCRIPTION
Summary:
Changelog: [Internal]

if we look at usages of ReactModuleWithSpec, we see that it's existence was to simply identify generated native modules since the inheritance graph of native modules was different if they were generated.

this was introduced before we created the TurboModule interface, which all codegenned native modules also conform to. since that exists now, there's no need for both of these. this is the only callsite in our code where ReactModuleWithSpec triggers any logic, so i'm updating it.

Differential Revision: D44450687

