### PR TITLE
deprecate ReactModuleWithSpec

### DIFF
--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleJavaSpec.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleJavaSpec.js
@@ -52,7 +52,7 @@ package ${packageName};
 
 ${imports}
 
-public abstract class ${className} extends ReactContextBaseJavaModule implements ReactModuleWithSpec, TurboModule {
+public abstract class ${className} extends ReactContextBaseJavaModule implements TurboModule {
   public static final String NAME = "${jsName}";
 
   public ${className}(ReactApplicationContext reactContext) {
@@ -463,7 +463,6 @@ module.exports = {
         'com.facebook.react.bridge.ReactApplicationContext',
         'com.facebook.react.bridge.ReactContextBaseJavaModule',
         'com.facebook.react.bridge.ReactMethod',
-        'com.facebook.react.bridge.ReactModuleWithSpec',
         'com.facebook.react.turbomodule.core.interfaces.TurboModule',
         'com.facebook.proguard.annotations.DoNotStrip',
         'javax.annotation.Nonnull',

--- a/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleJavaSpec-test.js.snap
+++ b/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleJavaSpec-test.js.snap
@@ -20,11 +20,10 @@ import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
-import com.facebook.react.bridge.ReactModuleWithSpec;
 import com.facebook.react.turbomodule.core.interfaces.TurboModule;
 import javax.annotation.Nonnull;
 
-public abstract class NativeSampleTurboModuleSpec extends ReactContextBaseJavaModule implements ReactModuleWithSpec, TurboModule {
+public abstract class NativeSampleTurboModuleSpec extends ReactContextBaseJavaModule implements TurboModule {
   public static final String NAME = \\"SampleTurboModule\\";
 
   public NativeSampleTurboModuleSpec(ReactApplicationContext reactContext) {
@@ -63,7 +62,6 @@ import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
-import com.facebook.react.bridge.ReactModuleWithSpec;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableArray;
@@ -72,7 +70,7 @@ import com.facebook.react.turbomodule.core.interfaces.TurboModule;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-public abstract class NativeSampleTurboModuleSpec extends ReactContextBaseJavaModule implements ReactModuleWithSpec, TurboModule {
+public abstract class NativeSampleTurboModuleSpec extends ReactContextBaseJavaModule implements TurboModule {
   public static final String NAME = \\"SampleTurboModule\\";
 
   public NativeSampleTurboModuleSpec(ReactApplicationContext reactContext) {
@@ -138,11 +136,10 @@ import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
-import com.facebook.react.bridge.ReactModuleWithSpec;
 import com.facebook.react.turbomodule.core.interfaces.TurboModule;
 import javax.annotation.Nonnull;
 
-public abstract class NativeSampleTurboModuleSpec extends ReactContextBaseJavaModule implements ReactModuleWithSpec, TurboModule {
+public abstract class NativeSampleTurboModuleSpec extends ReactContextBaseJavaModule implements TurboModule {
   public static final String NAME = \\"SampleTurboModule\\";
 
   public NativeSampleTurboModuleSpec(ReactApplicationContext reactContext) {
@@ -180,12 +177,11 @@ import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
-import com.facebook.react.bridge.ReactModuleWithSpec;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.turbomodule.core.interfaces.TurboModule;
 import javax.annotation.Nonnull;
 
-public abstract class AliasTurboModuleSpec extends ReactContextBaseJavaModule implements ReactModuleWithSpec, TurboModule {
+public abstract class AliasTurboModuleSpec extends ReactContextBaseJavaModule implements TurboModule {
   public static final String NAME = \\"AliasTurboModule\\";
 
   public AliasTurboModuleSpec(ReactApplicationContext reactContext) {
@@ -226,13 +222,12 @@ import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
-import com.facebook.react.bridge.ReactModuleWithSpec;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.turbomodule.core.interfaces.TurboModule;
 import javax.annotation.Nonnull;
 
-public abstract class NativeCameraRollManagerSpec extends ReactContextBaseJavaModule implements ReactModuleWithSpec, TurboModule {
+public abstract class NativeCameraRollManagerSpec extends ReactContextBaseJavaModule implements TurboModule {
   public static final String NAME = \\"CameraRollManager\\";
 
   public NativeCameraRollManagerSpec(ReactApplicationContext reactContext) {
@@ -275,13 +270,12 @@ import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
-import com.facebook.react.bridge.ReactModuleWithSpec;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.turbomodule.core.interfaces.TurboModule;
 import javax.annotation.Nonnull;
 
-public abstract class NativeExceptionsManagerSpec extends ReactContextBaseJavaModule implements ReactModuleWithSpec, TurboModule {
+public abstract class NativeExceptionsManagerSpec extends ReactContextBaseJavaModule implements TurboModule {
   public static final String NAME = \\"ExceptionsManager\\";
 
   public NativeExceptionsManagerSpec(ReactApplicationContext reactContext) {
@@ -339,7 +333,6 @@ import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
-import com.facebook.react.bridge.ReactModuleWithSpec;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableArray;
@@ -353,7 +346,7 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-public abstract class NativeSampleTurboModuleSpec extends ReactContextBaseJavaModule implements ReactModuleWithSpec, TurboModule {
+public abstract class NativeSampleTurboModuleSpec extends ReactContextBaseJavaModule implements TurboModule {
   public static final String NAME = \\"SampleTurboModule\\";
 
   public NativeSampleTurboModuleSpec(ReactApplicationContext reactContext) {
@@ -469,11 +462,10 @@ import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
-import com.facebook.react.bridge.ReactModuleWithSpec;
 import com.facebook.react.turbomodule.core.interfaces.TurboModule;
 import javax.annotation.Nonnull;
 
-public abstract class NativeSampleTurboModuleSpec extends ReactContextBaseJavaModule implements ReactModuleWithSpec, TurboModule {
+public abstract class NativeSampleTurboModuleSpec extends ReactContextBaseJavaModule implements TurboModule {
   public static final String NAME = \\"SampleTurboModule\\";
 
   public NativeSampleTurboModuleSpec(ReactApplicationContext reactContext) {
@@ -508,11 +500,10 @@ import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
-import com.facebook.react.bridge.ReactModuleWithSpec;
 import com.facebook.react.turbomodule.core.interfaces.TurboModule;
 import javax.annotation.Nonnull;
 
-public abstract class NativeSampleTurboModule2Spec extends ReactContextBaseJavaModule implements ReactModuleWithSpec, TurboModule {
+public abstract class NativeSampleTurboModule2Spec extends ReactContextBaseJavaModule implements TurboModule {
   public static final String NAME = \\"SampleTurboModule2\\";
 
   public NativeSampleTurboModule2Spec(ReactApplicationContext reactContext) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaModuleWrapper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaModuleWrapper.java
@@ -16,6 +16,7 @@ import static com.facebook.systrace.Systrace.TRACE_TAG_REACT_JAVA_BRIDGE;
 import androidx.annotation.Nullable;
 import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.config.ReactFeatureFlags;
+import com.facebook.react.turbomodule.core.interfaces.TurboModule;
 import com.facebook.systrace.Systrace;
 import com.facebook.systrace.SystraceMessage;
 import java.lang.reflect.Method;
@@ -71,7 +72,7 @@ public class JavaModuleWrapper {
     Class<? extends NativeModule> classForMethods = mModuleHolder.getModule().getClass();
     Class<? extends NativeModule> superClass =
         (Class<? extends NativeModule>) classForMethods.getSuperclass();
-    if (ReactModuleWithSpec.class.isAssignableFrom(superClass)) {
+    if (TurboModule.class.isAssignableFrom(superClass)) {
       // For java module that is based on generated flow-type spec, inspect the
       // spec abstract class instead, which is the super class of the given java
       // module.

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactModuleWithSpec.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactModuleWithSpec.java
@@ -9,9 +9,7 @@ package com.facebook.react.bridge;
 
 import com.facebook.proguard.annotations.DoNotStrip;
 
-/**
- * An interface to be implemented by react modules that extends from the generated spec class. This
- * is experimental.
- */
+/** @deprecated Use {@link TurboModule} to identify generated specs */
 @DoNotStrip
+@Deprecated
 public interface ReactModuleWithSpec {}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/TurboModuleInteropUtils.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/TurboModuleInteropUtils.java
@@ -14,11 +14,11 @@ import com.facebook.react.bridge.Dynamic;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactMethod;
-import com.facebook.react.bridge.ReactModuleWithSpec;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.turbomodule.core.interfaces.TurboModule;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -112,7 +112,7 @@ public class TurboModuleInteropUtils {
     Class<? extends NativeModule> classForMethods = module.getClass();
     Class<? extends NativeModule> superClass =
         (Class<? extends NativeModule>) classForMethods.getSuperclass();
-    if (ReactModuleWithSpec.class.isAssignableFrom(superClass)) {
+    if (TurboModule.class.isAssignableFrom(superClass)) {
       // For java module that is based on generated flow-type spec, inspect the
       // spec abstract class instead, which is the super class of the given java
       // module.

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridge/BUCK
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridge/BUCK
@@ -40,6 +40,7 @@ rn_robolectric_test(
         react_native_dep("third-party/java/junit:junit"),
         react_native_target("java/com/facebook/react/bridge:bridge"),
         react_native_target("java/com/facebook/react/common:common"),
+        react_native_target("java/com/facebook/react/turbomodule/core/interfaces:interfaces"),
         react_native_target("java/com/facebook/react/uimanager:uimanager"),
         react_native_tests_target("java/com/facebook/common/logging:logging"),
     ],

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridge/BaseJavaModuleTest.java
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridge/BaseJavaModuleTest.java
@@ -10,6 +10,7 @@ package com.facebook.react.bridge;
 import static org.mockito.Mockito.when;
 
 import android.content.Context;
+import com.facebook.react.turbomodule.core.interfaces.TurboModule;
 import com.facebook.soloader.SoLoader;
 import java.util.List;
 import org.junit.Before;
@@ -127,7 +128,7 @@ public class BaseJavaModuleTest {
   }
 
   private abstract class NativeTestGeneratedModuleSpec extends BaseJavaModule
-      implements ReactModuleWithSpec {
+      implements TurboModule {
     @ReactMethod
     public abstract void generatedMethod(String a, int b);
   }

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/NativeSampleTurboModuleSpec.java
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/NativeSampleTurboModuleSpec.java
@@ -14,7 +14,6 @@ import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
-import com.facebook.react.bridge.ReactModuleWithSpec;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableArray;
@@ -28,7 +27,7 @@ import java.util.Set;
 import javax.annotation.Nullable;
 
 public abstract class NativeSampleTurboModuleSpec extends ReactContextBaseJavaModule
-    implements ReactModuleWithSpec, TurboModule {
+    implements TurboModule {
   public NativeSampleTurboModuleSpec(ReactApplicationContext reactContext) {
     super(reactContext);
   }


### PR DESCRIPTION
Summary:
Changelog: [Android][Removed]

in this change, we can safely get rid of ReactModuleWithSpec because it is no longer used.

this change should not be breaking, since this class did nothing for product developers in the first place.

Differential Revision: D44450959

