### PR TITLE
Don't cache UIManager type inside the Event data structure

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedNodesManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedNodesManager.java
@@ -25,6 +25,7 @@ import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.uimanager.UIManagerHelper;
 import com.facebook.react.uimanager.common.UIManagerType;
+import com.facebook.react.uimanager.common.ViewUtil;
 import com.facebook.react.uimanager.events.Event;
 import com.facebook.react.uimanager.events.EventDispatcher;
 import com.facebook.react.uimanager.events.EventDispatcherListener;
@@ -570,7 +571,9 @@ public class NativeAnimatedNodesManager implements EventDispatcherListener {
         return;
       }
       UIManager uiManager =
-          UIManagerHelper.getUIManager(mReactApplicationContext, event.getUIManagerType());
+          UIManagerHelper.getUIManager(
+              mReactApplicationContext,
+              ViewUtil.getUIManagerType(event.getViewTag(), event.getSurfaceId()));
       if (uiManager == null) {
         return;
       }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/Event.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/Event.java
@@ -11,8 +11,6 @@ import androidx.annotation.Nullable;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.common.SystemClock;
 import com.facebook.react.uimanager.IllegalViewOperationException;
-import com.facebook.react.uimanager.common.UIManagerType;
-import com.facebook.react.uimanager.common.ViewUtil;
 
 /**
  * A UI event that can be dispatched to JS.
@@ -35,7 +33,6 @@ public abstract class Event<T extends Event> {
   private static int sUniqueID = 0;
 
   private boolean mInitialized;
-  private @UIManagerType int mUIManagerType;
   private int mSurfaceId;
   private int mViewTag;
   private long mTimestampMs;
@@ -70,7 +67,6 @@ public abstract class Event<T extends Event> {
   protected void init(int surfaceId, int viewTag, long timestampMs) {
     mSurfaceId = surfaceId;
     mViewTag = viewTag;
-    mUIManagerType = ViewUtil.getUIManagerType(viewTag, surfaceId);
     mTimestampMs = timestampMs;
     mInitialized = true;
   }
@@ -137,10 +133,6 @@ public abstract class Event<T extends Event> {
   /*package*/ final void dispose() {
     mInitialized = false;
     onDispose();
-  }
-
-  public final @UIManagerType int getUIManagerType() {
-    return mUIManagerType;
   }
 
   /** @return the name of this event as registered in JS */

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/PointerEvent.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/PointerEvent.java
@@ -112,7 +112,7 @@ public class PointerEvent extends Event<PointerEvent> {
     boolean shouldCopy = mPointersEventData.size() > 1;
     for (WritableMap pointerEventData : mPointersEventData) {
       WritableMap eventData = shouldCopy ? pointerEventData.copy() : pointerEventData;
-      rctEventEmitter.receiveEvent(this.getViewTag(), mEventName, eventData);
+      rctEventEmitter.receiveEvent(getViewTag(), mEventName, eventData);
     }
     return;
   }
@@ -173,7 +173,7 @@ public class PointerEvent extends Event<PointerEvent> {
 
     ArrayList<WritableMap> w3cPointerEvents = new ArrayList<>();
     for (int index = 0; index < mMotionEvent.getPointerCount(); index++) {
-      w3cPointerEvents.add(this.createW3CPointerEvent(index));
+      w3cPointerEvents.add(createW3CPointerEvent(index));
     }
 
     return w3cPointerEvents;
@@ -215,8 +215,8 @@ public class PointerEvent extends Event<PointerEvent> {
     pointerEvent.putDouble("offsetX", PixelUtil.toDIPFromPixel(offsetCoords[0]));
     pointerEvent.putDouble("offsetY", PixelUtil.toDIPFromPixel(offsetCoords[1]));
 
-    pointerEvent.putInt("target", this.getViewTag());
-    pointerEvent.putDouble("timestamp", this.getTimestampMs());
+    pointerEvent.putInt("target", getViewTag());
+    pointerEvent.putDouble("timestamp", getTimestampMs());
 
     pointerEvent.putInt("detail", 0);
     pointerEvent.putDouble("tiltX", 0);
@@ -252,7 +252,7 @@ public class PointerEvent extends Event<PointerEvent> {
         // Cases where all pointer info is relevant
       case PointerEventHelper.POINTER_MOVE:
       case PointerEventHelper.POINTER_CANCEL:
-        pointersEventData = this.createW3CPointerEvents();
+        pointersEventData = createW3CPointerEvents();
         break;
         // Cases where only the "active" pointer info is relevant
       case PointerEventHelper.POINTER_ENTER:
@@ -296,8 +296,8 @@ public class PointerEvent extends Event<PointerEvent> {
     for (WritableMap pointerEventData : mPointersEventData) {
       WritableMap eventData = shouldCopy ? pointerEventData.copy() : pointerEventData;
       rctEventEmitter.receiveEvent(
-          this.getSurfaceId(),
-          this.getViewTag(),
+          getSurfaceId(),
+          getViewTag(),
           mEventName,
           mCoalescingKey != UNSET_COALESCING_KEY,
           mCoalescingKey,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/ReactEventEmitter.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/ReactEventEmitter.java
@@ -86,7 +86,8 @@ public class ReactEventEmitter implements RCTModernEventEmitter {
   @Override
   public void receiveTouches(TouchEvent event) {
     int reactTag = event.getViewTag();
-    @UIManagerType int uiManagerType = event.getUIManagerType();
+    @UIManagerType
+    int uiManagerType = ViewUtil.getUIManagerType(event.getViewTag(), event.getSurfaceId());
     if (uiManagerType == UIManagerType.FABRIC && mFabricEventEmitter != null) {
       mFabricEventEmitter.receiveTouches(event);
     } else if (uiManagerType == UIManagerType.DEFAULT && getEventEmitter(reactTag) != null) {


### PR DESCRIPTION
Summary:
## Changelog:

[Internal] - Don't cache UIManager type inside the Event data structure

A follow up to https://github.com/facebook/react-native/pull/36659

It's redundant, and it's good to have fewer "sources of truth" and keep the notion of UIManagerType separate from Event data structures.

Differential Revision: D44453812

