### PR TITLE
Remove AllocInYoung/RevertToYGAtTTI from OSS Hermes config

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/hermes/reactexecutor/OnLoad.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/hermes/reactexecutor/OnLoad.cpp
@@ -31,15 +31,7 @@ static std::once_flag flag;
 
 static ::hermes::vm::RuntimeConfig makeRuntimeConfig(jlong heapSizeMB) {
   namespace vm = ::hermes::vm;
-  auto gcConfigBuilder =
-      vm::GCConfig::Builder()
-          .withName("RN")
-          // For the next two arguments: avoid GC before TTI by initializing the
-          // runtime to allocate directly in the old generation, but revert to
-          // normal operation when we reach the (first) TTI point.
-          .withAllocInYoung(false)
-          .withRevertToYGAtTTI(true);
-
+  auto gcConfigBuilder = vm::GCConfig::Builder().withName("RN");
   if (heapSizeMB > 0) {
     gcConfigBuilder.withMaxHeapSize(heapSizeMB << 20);
   }


### PR DESCRIPTION
Summary:
We expose a variant of `HermesExecutor.java` which allows you to set a custom max heap size. This variant also sets the `AllocInYoung/RevertToYGAtTTI`, which should never really be used without a matching call to `HermesInternal.ttiReached()`, which is not documented.

Changelog: [Internal]

Differential Revision: D44457318

