### PR TITLE
Fix hashing function in event name mapping in PerformanceEntryReporter

### DIFF
--- a/packages/react-native/Libraries/WebPerformance/PerformanceEntryReporter.cpp
+++ b/packages/react-native/Libraries/WebPerformance/PerformanceEntryReporter.cpp
@@ -273,10 +273,9 @@ void PerformanceEntryReporter::scheduleFlushBuffer() {
 
 struct StrKey {
   uint32_t key;
-  constexpr StrKey(const char *s)
-      : key(folly::hash::fnv32_buf(s, sizeof(s) - 1)) {}
+  StrKey(const char *s) : key(folly::hash::fnv32_buf(s, std::strlen(s))) {}
 
-  constexpr bool operator==(const StrKey &rhs) const {
+  bool operator==(const StrKey &rhs) const {
     return key == rhs.key;
   }
 };


### PR DESCRIPTION
Summary:
## Changelog:

[Internal][Fix] - Fix hashing function in event name mapping in PerformanceEntryReporter

A textbook mistake, when mapping event names via the constant lookup table, only the first 8 characters were effectively taken into account, thus mixing names of some events.

Reviewed By: rubennorte

Differential Revision: D44462195

