### PR TITLE
Fix RNTester in main

### DIFF
--- a/packages/rn-tester/RNTester/AppDelegate.mm
+++ b/packages/rn-tester/RNTester/AppDelegate.mm
@@ -160,7 +160,7 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
 
 - (NSURL *)sourceURLForBridge:(__unused RCTBridge *)bridge
 {
-  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"packages/rn-tester/js/RNTesterApp.ios"];
+  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"js/RNTesterApp.ios"];
 }
 
 - (void)initializeFlipper:(UIApplication *)application

--- a/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.java
+++ b/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.java
@@ -40,7 +40,7 @@ public class RNTesterApplication extends Application implements ReactApplication
       new DefaultReactNativeHost(this) {
         @Override
         public String getJSMainModuleName() {
-          return "packages/rn-tester/js/RNTesterApp.android";
+          return "js/RNTesterApp.android";
         }
 
         @Override


### PR DESCRIPTION
Summary:
After the recent changes of Metro and Metro-Config, we need to update the path used to load the bundle in RNTester

## Changelog:
[General][Fixed] - Use the right path to load RNTester bundle

Differential Revision: D44465418

