### PR TITLE
Add Fabric Interop event example

### DIFF
--- a/packages/rn-tester/NativeComponentExample/js/MyNativeView.js
+++ b/packages/rn-tester/NativeComponentExample/js/MyNativeView.js
@@ -10,13 +10,12 @@
 
 import * as React from 'react';
 import {useRef, useState} from 'react';
-import {View, Button, Text} from 'react-native';
+import {View, Button, Text, UIManager} from 'react-native';
 import RNTMyNativeView, {
   Commands as RNTMyNativeViewCommands,
 } from './MyNativeViewNativeComponent';
 import RNTMyLegacyNativeView from './MyLegacyViewNativeComponent';
 import type {MyNativeViewType} from './MyNativeViewNativeComponent';
-import {UIManager} from 'react-native';
 
 const colors = [
   '#0000FF',
@@ -76,8 +75,8 @@ export default function MyNativeView(props: {}): React.Node {
           )
         }
       />
-      <Text>HSBA: {hsba.toString()}</Text>
-      <Text>
+      <Text style={{color: 'green'}}>HSBA: {hsba.toString()}</Text>
+      <Text style={{color: 'green'}}>
         Constants From Interop Layer:{' '}
         {UIManager.RNTMyLegacyNativeView.Constants.PI}
       </Text>

--- a/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/component/MyLegacyViewManager.java
+++ b/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/component/MyLegacyViewManager.java
@@ -11,12 +11,14 @@ import android.graphics.Color;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.common.MapBuilder;
 import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewProps;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 /** Legacy View manager (non Fabric compatible) for {@link MyNativeView} components. */
@@ -58,5 +60,20 @@ public class MyLegacyViewManager extends SimpleViewManager<MyNativeView> {
   @Override
   public final Map<String, Object> getExportedViewConstants() {
     return Collections.singletonMap("PI", 3.14);
+  }
+
+  @Override
+  public final Map<String, Object> getExportedCustomBubblingEventTypeConstants() {
+    Map<String, Object> eventTypeConstants = new HashMap<String, Object>();
+    eventTypeConstants.putAll(
+        MapBuilder.<String, Object>builder()
+            .put(
+                "onColorChanged",
+                MapBuilder.of(
+                    "phasedRegistrationNames",
+                    MapBuilder.of(
+                        "bubbled", "onColorChanged", "captured", "onColorChangedCapture")))
+            .build());
+    return eventTypeConstants;
   }
 }

--- a/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/component/MyLegacyViewManager.java
+++ b/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/component/MyLegacyViewManager.java
@@ -16,6 +16,8 @@ import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewProps;
 import com.facebook.react.uimanager.annotations.ReactProp;
+import java.util.Collections;
+import java.util.Map;
 
 /** Legacy View manager (non Fabric compatible) for {@link MyNativeView} components. */
 @ReactModule(name = MyLegacyViewManager.REACT_CLASS)
@@ -51,5 +53,10 @@ public class MyLegacyViewManager extends SimpleViewManager<MyNativeView> {
   @ReactProp(name = ViewProps.COLOR)
   public void setColor(@NonNull MyNativeView view, @Nullable String color) {
     view.setBackgroundColor(Color.parseColor(color));
+  }
+
+  @Override
+  public final Map<String, Object> getExportedViewConstants() {
+    return Collections.singletonMap("PI", 3.14);
   }
 }

--- a/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/component/MyNativeView.java
+++ b/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/component/MyNativeView.java
@@ -8,11 +8,41 @@
 package com.facebook.react.uiapp.component;
 
 import android.content.Context;
+import android.graphics.Color;
 import android.view.View;
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.uimanager.events.RCTEventEmitter;
 
 class MyNativeView extends View {
 
+  private int currentColor = 0;
+
   public MyNativeView(Context context) {
     super(context);
+  }
+
+  @Override
+  public void setBackgroundColor(int color) {
+    super.setBackgroundColor(color);
+    if (color != currentColor) {
+      currentColor = color;
+      emitNativeEvent(color);
+    }
+  }
+
+  private void emitNativeEvent(int color) {
+    WritableMap event = Arguments.createMap();
+    WritableMap backgroundColor = Arguments.createMap();
+    float[] hsv = new float[3];
+    Color.colorToHSV(color, hsv);
+    backgroundColor.putDouble("hue", hsv[0]);
+    backgroundColor.putDouble("saturation", hsv[1]);
+    backgroundColor.putDouble("brightness", hsv[2]);
+    backgroundColor.putDouble("alpha", Color.alpha(color));
+    event.putMap("backgroundColor", backgroundColor);
+    ReactContext reactContext = (ReactContext) getContext();
+    reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "onColorChanged", event);
   }
 }


### PR DESCRIPTION
Summary:
Similar to the iOS counterpart,
this changes adds an example to RNTester to verify that the Interop Layer can process bubbling events in Fabric as it used to do in Paper.

Changelog:
[Internal] [Changed] - Add Fabric Interop event example

Differential Revision: D44467555

