### PR TITLE
Incorporate refresh control height into ScrollView content inset

### DIFF
--- a/packages/react-native/React/Views/RCTView.m
+++ b/packages/react-native/React/Views/RCTView.m
@@ -475,6 +475,11 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
     baseInset.left += autoInset.left;
     baseInset.right += autoInset.right;
   }
+  
+  if (scrollView.refreshControl.refreshing) {
+    baseInset.top += scrollView.refreshControl.frame.size.height;
+  }
+
   scrollView.contentInset = baseInset;
   scrollView.scrollIndicatorInsets = baseInset;
 


### PR DESCRIPTION
## Summary

The refresh control height needs to be added to the top content inset while refreshing, otherwise the inset calculation will be wrong when the refreshing is done, and the top of the view content will be cut off.

Fixes #36641

## Changelog

[iOS] [Fixed] - Fix content inset calculation on scroll view with refresh control

## Test Plan

|Before|After|
|---|---|
|https://user-images.githubusercontent.com/24447831/227746584-b3f0fe61-7465-433e-ad37-38988302c720.mp4|https://user-images.githubusercontent.com/24447831/228463351-04b1455f-4879-4cf0-9c20-f0be5522389c.mp4|