### PR TITLE
Do not strongly own State from Java

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/StateWrapperImpl.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/StateWrapperImpl.h
@@ -30,7 +30,7 @@ class StateWrapperImpl : public jni::HybridClass<StateWrapperImpl> {
   jni::local_ref<ReadableNativeMap::jhybridobject> getStateDataImpl();
   void updateStateImpl(NativeMap *map);
 
-  State::Shared state_;
+  std::weak_ptr<State const> state_;
 
  private:
   jni::alias_ref<StateWrapperImpl::jhybriddata> jhybridobject_;


### PR DESCRIPTION
Summary:
Changelog: [internal]

This fixes a crash introduced in D43692171 where `jsi::Pointer` outlives `jsi::Runtime` in which it was created. This leads to a crash.
The diff changed ownership model, retaining `TextLayoutManager` strongly from `ParagraphState`.

To resolve this, in this diff we change how `StateWrapperImpl` owns state, moving from shared_ptr to weak_ptr. We have tried to do it previously in D26815275 but it had to be reverted because it broke end to end tests. I made sure the tests are fine. However it is the right ownership model. Java objects should not strongly hold onto anything in ShadowTree. If ShadowTree is destroyed, Java calls should noop, not keep objects in memory and have them handle the case when runtime was destroyed.

jest_e2e[run_all_tests]

Reviewed By: cipolleschi

Differential Revision: D44472121

