### PR TITLE
[iOS] [Breaking] Fix compilation errors caused by the "module" keyword becoming a rese…

### DIFF
--- a/packages/react-native/React/Base/RCTBridgeMethod.h
+++ b/packages/react-native/React/Base/RCTBridgeMethod.h
@@ -32,6 +32,6 @@ static inline const char *RCTFunctionDescriptorFromType(RCTFunctionType type)
 @property (nonatomic, readonly) const char *JSMethodName;
 @property (nonatomic, readonly) RCTFunctionType functionType;
 
-- (id)invokeWithBridge:(RCTBridge *)bridge module:(id)module arguments:(NSArray *)arguments;
+- (id)invokeWithBridge:(RCTBridge *)bridge bridgeModule:(id)bridgeModule arguments:(NSArray *)arguments;
 
 @end

--- a/packages/react-native/React/Base/RCTModuleMethod.mm
+++ b/packages/react-native/React/Base/RCTModuleMethod.mm
@@ -516,7 +516,7 @@ RCT_EXTERN_C_END
   }
 }
 
-- (id)invokeWithBridge:(RCTBridge *)bridge module:(id)module arguments:(NSArray *)arguments
+- (id)invokeWithBridge:(RCTBridge *)bridge bridgeModule:(id)bridgeModule arguments:(NSArray *)arguments
 {
   if (_argumentBlocks == nil) {
     [self processMethodSignature];
@@ -524,8 +524,8 @@ RCT_EXTERN_C_END
 
 #if RCT_DEBUG
   // Sanity check
-  RCTAssert([module class] == _moduleClass, @"Attempted to invoke method \
-            %@ on a module of class %@", [self methodName], [module class]);
+  RCTAssert([bridgeModule class] == _moduleClass, @"Attempted to invoke method \
+            %@ on a module of class %@", [self methodName], [bridgeModule class]);
 
   // Safety check
   if (arguments.count != _argumentBlocks.count) {
@@ -567,7 +567,7 @@ RCT_EXTERN_C_END
 #ifdef RCT_MAIN_THREAD_WATCH_DOG_THRESHOLD
   if (RCTIsMainQueue()) {
     CFTimeInterval start = CACurrentMediaTime();
-    [_invocation invokeWithTarget:module];
+    [_invocation invokeWithTarget:bridgeModule];
     CFTimeInterval duration = CACurrentMediaTime() - start;
     if (duration > RCT_MAIN_THREAD_WATCH_DOG_THRESHOLD) {
       RCTLogWarn(
@@ -578,10 +578,10 @@ RCT_EXTERN_C_END
           (int)(duration * 1000));
     }
   } else {
-    [_invocation invokeWithTarget:module];
+    [_invocation invokeWithTarget:bridgeModule];
   }
 #else
-  [_invocation invokeWithTarget:module];
+  [_invocation invokeWithTarget:bridgeModule];
 #endif
 
   [_retainedObjects removeAllObjects];

--- a/packages/react-native/React/CxxModule/RCTCxxMethod.mm
+++ b/packages/react-native/React/CxxModule/RCTCxxMethod.mm
@@ -49,9 +49,9 @@ using namespace facebook::react;
   }
 }
 
-- (id)invokeWithBridge:(RCTBridge *)bridge module:(id)module arguments:(NSArray *)arguments
+- (id)invokeWithBridge:(RCTBridge *)bridge bridgeModule:(id)bridgeModule arguments:(NSArray *)arguments
 {
-  // module is unused except for printing errors. The C++ object it represents
+  // bridgeModule is unused except for printing errors. The C++ object it represents
   // is also baked into _method.
 
   // the last N arguments are callbacks, according to the Method data.  The
@@ -64,7 +64,7 @@ using namespace facebook::react;
   if (arguments.count < _method->callbacks) {
     RCTLogError(
         @"Method %@.%s expects at least %zu arguments, but got %tu",
-        RCTBridgeModuleNameForClass([module class]),
+        RCTBridgeModuleNameForClass([bridgeModule class]),
         _method->name.c_str(),
         _method->callbacks,
         arguments.count);
@@ -77,7 +77,7 @@ using namespace facebook::react;
           @"Argument %tu (%@) of %@.%s should be a function",
           arguments.count - 1,
           arguments[arguments.count - 1],
-          RCTBridgeModuleNameForClass([module class]),
+          RCTBridgeModuleNameForClass([bridgeModule class]),
           _method->name.c_str());
       return nil;
     }
@@ -89,7 +89,7 @@ using namespace facebook::react;
             @"Argument %tu (%@) of %@.%s should be a function",
             arguments.count - 2,
             arguments[arguments.count - 2],
-            RCTBridgeModuleNameForClass([module class]),
+            RCTBridgeModuleNameForClass([bridgeModule class]),
             _method->name.c_str());
         return nil;
       }
@@ -124,7 +124,7 @@ using namespace facebook::react;
   } catch (const facebook::xplat::JsArgumentException &ex) {
     RCTLogError(
         @"Method %@.%s argument error: %s",
-        RCTBridgeModuleNameForClass([module class]),
+        RCTBridgeModuleNameForClass([bridgeModule class]),
         _method->name.c_str(),
         ex.what());
     return nil;

--- a/packages/react-native/React/CxxModule/RCTNativeModule.mm
+++ b/packages/react-native/React/CxxModule/RCTNativeModule.mm
@@ -194,7 +194,7 @@ static MethodCallResult invokeInner(
       BridgeNativeModulePerfLogger::asyncMethodCallExecutionArgConversionEnd(moduleName, methodName, (int32_t)callId);
     }
 
-    id result = [method invokeWithBridge:bridge module:moduleData.instance arguments:objcParams];
+    id result = [method invokeWithBridge:bridge bridgeModule:moduleData.instance arguments:objcParams];
 
     if (context == Sync) {
       BridgeNativeModulePerfLogger::syncMethodCallExecutionEnd(moduleName, methodName);

--- a/packages/react-native/React/Modules/RCTUIManager.m
+++ b/packages/react-native/React/Modules/RCTUIManager.m
@@ -1140,7 +1140,7 @@ RCT_EXPORT_METHOD(dispatchViewManagerCommand
   }
 
   NSArray *args = [@[ reactTag ] arrayByAddingObjectsFromArray:commandArgs];
-  [method invokeWithBridge:_bridge module:componentData.manager arguments:args];
+  [method invokeWithBridge:_bridge bridgeModule:componentData.manager arguments:args];
 }
 
 - (void)batchDidComplete

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/RCTLegacyViewManagerInteropCoordinator.mm
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/RCTLegacyViewManagerInteropCoordinator.mm
@@ -123,13 +123,13 @@ using namespace facebook::react;
   if (_bridge) {
     [_bridge.batchedBridge
         dispatchBlock:^{
-          [method invokeWithBridge:self->_bridge module:self->_componentData.manager arguments:newArgs];
+          [method invokeWithBridge:self->_bridge bridgeModule:self->_componentData.manager arguments:newArgs];
           [self->_bridge.uiManager setNeedsLayout];
         }
                 queue:RCTGetUIManagerQueue()];
   } else {
     // TODO T86826778 - Figure out which queue this should be dispatched to.
-    [method invokeWithBridge:nil module:self->_componentData.manager arguments:newArgs];
+    [method invokeWithBridge:nil bridgeModule:self->_componentData.manager arguments:newArgs];
   }
 }
 

--- a/packages/rn-tester/RNTesterUnitTests/RCTModuleMethodTests.mm
+++ b/packages/rn-tester/RNTesterUnitTests/RCTModuleMethodTests.mm
@@ -87,11 +87,11 @@ static RCTModuleMethod *buildSyncMethodWithMethodSignature(const char *methodSig
   const char *methodSignature = "doFooWithBar:(nonnull NSString *)bar";
   RCTModuleMethod *method = buildDefaultMethodWithMethodSignature(methodSignature);
   XCTAssertFalse(RCTLogsError(^{
-    [method invokeWithBridge:nil module:self arguments:@[ @"Hello World" ]];
+    [method invokeWithBridge:nil bridgeModule:self arguments:@[ @"Hello World" ]];
   }));
 
   XCTAssertTrue(RCTLogsError(^{
-    [method invokeWithBridge:nil module:self arguments:@[ [NSNull null] ]];
+    [method invokeWithBridge:nil bridgeModule:self arguments:@[ [NSNull null] ]];
   }));
 }
 
@@ -121,7 +121,7 @@ static RCTModuleMethod *buildSyncMethodWithMethodSignature(const char *methodSig
       const char *methodSignature = "doFooWithNumber:(NSNumber *)n";
       RCTModuleMethod *method = buildDefaultMethodWithMethodSignature(methodSignature);
       // Invoke method to trigger parsing
-      [method invokeWithBridge:nil module:self arguments:@[ @1 ]];
+      [method invokeWithBridge:nil bridgeModule:self arguments:@[ @1 ]];
     }));
   }
 
@@ -129,7 +129,7 @@ static RCTModuleMethod *buildSyncMethodWithMethodSignature(const char *methodSig
     const char *methodSignature = "doFooWithNumber:(nonnull NSNumber *)n";
     RCTModuleMethod *method = buildDefaultMethodWithMethodSignature(methodSignature);
     XCTAssertTrue(RCTLogsError(^{
-      [method invokeWithBridge:nil module:self arguments:@[ [NSNull null] ]];
+      [method invokeWithBridge:nil bridgeModule:self arguments:@[ [NSNull null] ]];
     }));
   }
 
@@ -137,7 +137,7 @@ static RCTModuleMethod *buildSyncMethodWithMethodSignature(const char *methodSig
     const char *methodSignature = "doFooWithDouble:(double)n";
     RCTModuleMethod *method = buildDefaultMethodWithMethodSignature(methodSignature);
     XCTAssertTrue(RCTLogsError(^{
-      [method invokeWithBridge:nil module:self arguments:@[ [NSNull null] ]];
+      [method invokeWithBridge:nil bridgeModule:self arguments:@[ [NSNull null] ]];
     }));
   }
 
@@ -145,7 +145,7 @@ static RCTModuleMethod *buildSyncMethodWithMethodSignature(const char *methodSig
     const char *methodSignature = "doFooWithInteger:(NSInteger)n";
     RCTModuleMethod *method = buildDefaultMethodWithMethodSignature(methodSignature);
     XCTAssertTrue(RCTLogsError(^{
-      [method invokeWithBridge:nil module:self arguments:@[ [NSNull null] ]];
+      [method invokeWithBridge:nil bridgeModule:self arguments:@[ [NSNull null] ]];
     }));
   }
 }
@@ -156,7 +156,7 @@ static RCTModuleMethod *buildSyncMethodWithMethodSignature(const char *methodSig
   RCTModuleMethod *method = buildDefaultMethodWithMethodSignature(methodSignature);
 
   CGRect r = CGRectMake(10, 20, 30, 40);
-  [method invokeWithBridge:nil module:self arguments:@[ @[ @10, @20, @30, @40 ] ]];
+  [method invokeWithBridge:nil bridgeModule:self arguments:@[ @[ @10, @20, @30, @40 ] ]];
   XCTAssertTrue(CGRectEqualToRect(r, _s));
 }
 
@@ -172,7 +172,7 @@ static RCTModuleMethod *buildSyncMethodWithMethodSignature(const char *methodSig
   XCTAssertEqualObjects(@(method.JSMethodName), @"doFoo");
 
   XCTAssertFalse(RCTLogsError(^{
-    [method invokeWithBridge:nil module:self arguments:@[ @"bar" ]];
+    [method invokeWithBridge:nil bridgeModule:self arguments:@[ @"bar" ]];
   }));
 }
 
@@ -246,14 +246,14 @@ static RCTModuleMethod *buildSyncMethodWithMethodSignature(const char *methodSig
   {
     const char *methodSignature = "echoString:(NSString *)input";
     RCTModuleMethod *method = buildSyncMethodWithMethodSignature(methodSignature);
-    id result = [method invokeWithBridge:nil module:self arguments:@[ @"Test String Value" ]];
+    id result = [method invokeWithBridge:nil bridgeModule:self arguments:@[ @"Test String Value" ]];
     XCTAssertEqualObjects(result, @"Test String Value");
   }
 
   {
     const char *methodSignature = "methodThatReturnsNil";
     RCTModuleMethod *method = buildSyncMethodWithMethodSignature(methodSignature);
-    id result = [method invokeWithBridge:nil module:self arguments:@[]];
+    id result = [method invokeWithBridge:nil bridgeModule:self arguments:@[]];
     XCTAssertNil(result);
   }
 }
@@ -262,7 +262,7 @@ static RCTModuleMethod *buildSyncMethodWithMethodSignature(const char *methodSig
 {
   const char *methodSignature = "doFoo";
   RCTModuleMethod *method = buildDefaultMethodWithMethodSignature(methodSignature);
-  id result = [method invokeWithBridge:nil module:self arguments:@[]];
+  id result = [method invokeWithBridge:nil bridgeModule:self arguments:@[]];
   XCTAssertNil(result);
 }
 


### PR DESCRIPTION
Fix issue https://github.com/facebook/react-native/issues/36700

## Summary
Fix compilation errors caused by the \"module\" keyword becoming a reserved keyword.

This is a breaking change commit.
RCTBridgeMethod 's public api:
- (id)invokeWithBridge:(RCTBridge *)bridge module:(id)module arguments:(NSArray *)arguments;
renamed to :
- (id)invokeWithBridge:(RCTBridge *)bridge bridgeModule:(id)bridgeModule arguments:(NSArray *)arguments;