### PR TITLE
Fix: Adapt template to new rules

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,10 @@
 <!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->
 
-## Summary
+## Summary:
 
 <!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
 
-## Changelog
+## Changelog:
 
 <!-- Help reviewers and the release process by writing your own changelog entry.
 
@@ -16,6 +16,6 @@ For more details, see:
 https://reactnative.dev/contributing/changelogs-in-pull-requests
 -->
 
-## Test Plan
+## Test Plan:
 
 <!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->


### PR DESCRIPTION
## Summary:

Recently, we changed the logic to verify the body of a PR so that it is more compatible internally and externally, in both ways. But we forgot to update the template, so right 
now, all the created PR are incompatible with the internal PR checker.
The required change is to have `:` after the Changelog title.
For consistency, I added the `:` after ALL the titles.

## Changelog:

[Internal] - Changed the PR template to align it to the new rules

## Test Plan

No danger errors nor internal linter errors
