### PR TITLE
[hermes-inspector] add Debugger.getPossibleBreakpoints support

### DIFF
--- a/packages/react-native/ReactCommon/hermes/inspector/Inspector.h
+++ b/packages/react-native/ReactCommon/hermes/inspector/Inspector.h
@@ -153,6 +153,11 @@ class Inspector : public facebook::hermes::debugger::EventObserver,
       folly::Function<void(const facebook::hermes::debugger::ProgramState &)>
           func);
 
+  folly::Future<std::vector<debugger::SourceLocation>> getPossibleBreakpoints(
+      facebook::hermes::debugger::SourceLocation start,
+      folly::Optional<facebook::hermes::debugger::SourceLocation> end,
+      folly::Optional<bool> restrictToFunction);
+
   /**
    * setBreakpoint can be called at any time after the debugger is enabled to
    * set a breakpoint in the VM. The future is fulfilled with the resolved
@@ -278,6 +283,13 @@ class Inspector : public facebook::hermes::debugger::EventObserver,
       folly::Function<void(const facebook::hermes::debugger::ProgramState &)>
           func,
       std::shared_ptr<folly::Promise<folly::Unit>> promise);
+
+  void getPossibleBreakpointsOnExecutor(
+      facebook::hermes::debugger::SourceLocation start,
+      folly::Optional<facebook::hermes::debugger::SourceLocation> end,
+      folly::Optional<bool> restrictToFunction,
+      std::shared_ptr<folly::Promise<
+          std::vector<facebook::hermes::debugger::SourceLocation>>> promise);
 
   void setBreakpointOnExecutor(
       debugger::SourceLocation loc,

--- a/packages/react-native/ReactCommon/hermes/inspector/chrome/MessageConverters.cpp
+++ b/packages/react-native/ReactCommon/hermes/inspector/chrome/MessageConverters.cpp
@@ -54,6 +54,16 @@ m::debugger::Location m::debugger::makeLocation(
   return result;
 }
 
+h::debugger::SourceLocation m::debugger::makeLocation(
+    const m::debugger::Location &loc) {
+  h::debugger::SourceLocation result;
+  result.fileId = folly::to<h::debugger::ScriptID>(loc.scriptId);
+  result.line = loc.lineNumber + 1;
+  result.column = loc.columnNumber ? loc.columnNumber.value() + 1
+                                   : h::debugger::kInvalidLocation;
+  return result;
+}
+
 m::debugger::CallFrame m::debugger::makeCallFrame(
     uint32_t callFrameIndex,
     const h::debugger::CallFrameInfo &callFrameInfo,

--- a/packages/react-native/ReactCommon/hermes/inspector/chrome/MessageConverters.h
+++ b/packages/react-native/ReactCommon/hermes/inspector/chrome/MessageConverters.h
@@ -93,6 +93,7 @@ OkResponse makeOkResponse(int id);
 namespace debugger {
 
 Location makeLocation(const facebook::hermes::debugger::SourceLocation &loc);
+facebook::hermes::debugger::SourceLocation makeLocation(const Location &loc);
 
 CallFrame makeCallFrame(
     uint32_t callFrameIndex,

--- a/packages/react-native/ReactCommon/hermes/inspector/chrome/MessageTypes.cpp
+++ b/packages/react-native/ReactCommon/hermes/inspector/chrome/MessageTypes.cpp
@@ -32,6 +32,8 @@ std::unique_ptr<Request> Request::fromJsonThrowOnError(const std::string &str) {
       {"Debugger.removeBreakpoint",
        makeUnique<debugger::RemoveBreakpointRequest>},
       {"Debugger.resume", makeUnique<debugger::ResumeRequest>},
+      {"Debugger.getPossibleBreakpoints",
+       makeUnique<debugger::GetPossibleBreakpointsRequest>},
       {"Debugger.setBreakpoint", makeUnique<debugger::SetBreakpointRequest>},
       {"Debugger.setBreakpointByUrl",
        makeUnique<debugger::SetBreakpointByUrlRequest>},
@@ -582,6 +584,39 @@ dynamic debugger::ResumeRequest::toDynamic() const {
 }
 
 void debugger::ResumeRequest::accept(RequestHandler &handler) const {
+  handler.handle(*this);
+}
+
+debugger::GetPossibleBreakpointsRequest::GetPossibleBreakpointsRequest()
+    : Request("Debugger.GetPossibleBreakpoints") {}
+
+debugger::GetPossibleBreakpointsRequest::GetPossibleBreakpointsRequest(
+    const dynamic &obj)
+    : Request("Debugger.GetPossibleBreakpoints") {
+  assign(id, obj, "id");
+  assign(method, obj, "method");
+
+  dynamic params = obj.at("params");
+  assign(start, params, "start");
+  assign(end, params, "end");
+  assign(restrictToFunction, params, "restrictToFunction");
+}
+
+dynamic debugger::GetPossibleBreakpointsRequest::toDynamic() const {
+  dynamic params = dynamic::object;
+  put(params, "start", start);
+  put(params, "end", end);
+  put(params, "restrictToFunction", restrictToFunction);
+
+  dynamic obj = dynamic::object;
+  put(obj, "id", id);
+  put(obj, "method", method);
+  put(obj, "params", std::move(params));
+  return obj;
+}
+
+void debugger::GetPossibleBreakpointsRequest::accept(
+    RequestHandler &handler) const {
   handler.handle(*this);
 }
 
@@ -1337,6 +1372,24 @@ dynamic debugger::EvaluateOnCallFrameResponse::toDynamic() const {
   dynamic res = dynamic::object;
   put(res, "result", result);
   put(res, "exceptionDetails", exceptionDetails);
+
+  dynamic obj = dynamic::object;
+  put(obj, "id", id);
+  put(obj, "result", std::move(res));
+  return obj;
+}
+
+debugger::GetPossibleBreakpointsResponse::GetPossibleBreakpointsResponse(
+    const dynamic &obj) {
+  assign(id, obj, "id");
+
+  dynamic res = obj.at("result");
+  assign(locations, res, "locations");
+}
+
+dynamic debugger::GetPossibleBreakpointsResponse::toDynamic() const {
+  dynamic res = dynamic::object;
+  put(res, "locations", locations);
 
   dynamic obj = dynamic::object;
   put(obj, "id", id);

--- a/packages/react-native/ReactCommon/hermes/inspector/chrome/MessageTypes.h
+++ b/packages/react-native/ReactCommon/hermes/inspector/chrome/MessageTypes.h
@@ -26,6 +26,8 @@ struct EnableRequest;
 struct EvaluateOnCallFrameRequest;
 struct EvaluateOnCallFrameResponse;
 struct Location;
+struct GetPossibleBreakpointsRequest;
+struct GetPossibleBreakpointsResponse;
 struct PauseRequest;
 struct PausedNotification;
 struct RemoveBreakpointRequest;
@@ -119,6 +121,7 @@ struct RequestHandler {
   virtual void handle(const debugger::PauseRequest &req) = 0;
   virtual void handle(const debugger::RemoveBreakpointRequest &req) = 0;
   virtual void handle(const debugger::ResumeRequest &req) = 0;
+  virtual void handle(const debugger::GetPossibleBreakpointsRequest &req) = 0;
   virtual void handle(const debugger::SetBreakpointRequest &req) = 0;
   virtual void handle(const debugger::SetBreakpointByUrlRequest &req) = 0;
   virtual void handle(const debugger::SetBreakpointsActiveRequest &req) = 0;
@@ -159,6 +162,7 @@ struct NoopRequestHandler : public RequestHandler {
   void handle(const debugger::PauseRequest &req) override {}
   void handle(const debugger::RemoveBreakpointRequest &req) override {}
   void handle(const debugger::ResumeRequest &req) override {}
+  void handle(const debugger::GetPossibleBreakpointsRequest &req) override {}
   void handle(const debugger::SetBreakpointRequest &req) override {}
   void handle(const debugger::SetBreakpointByUrlRequest &req) override {}
   void handle(const debugger::SetBreakpointsActiveRequest &req) override {}
@@ -462,6 +466,18 @@ struct debugger::ResumeRequest : public Request {
   std::optional<bool> terminateOnResume;
 };
 
+struct debugger::GetPossibleBreakpointsRequest : public Request {
+  GetPossibleBreakpointsRequest();
+  explicit GetPossibleBreakpointsRequest(const folly::dynamic &obj);
+
+  folly::dynamic toDynamic() const override;
+  void accept(RequestHandler &handler) const override;
+
+  debugger::Location start{};
+  folly::Optional<debugger::Location> end;
+  folly::Optional<bool> restrictToFunction;
+};
+
 struct debugger::SetBreakpointRequest : public Request {
   SetBreakpointRequest();
   explicit SetBreakpointRequest(const folly::dynamic &obj);
@@ -748,6 +764,14 @@ struct debugger::EvaluateOnCallFrameResponse : public Response {
 
   runtime::RemoteObject result{};
   std::optional<runtime::ExceptionDetails> exceptionDetails;
+};
+
+struct debugger::GetPossibleBreakpointsResponse : public Response {
+  GetPossibleBreakpointsResponse() = default;
+  explicit GetPossibleBreakpointsResponse(const folly::dynamic &obj);
+  folly::dynamic toDynamic() const override;
+
+  std::vector<debugger::Location> locations;
 };
 
 struct debugger::SetBreakpointResponse : public Response {


### PR DESCRIPTION
## Summary

The Hermes inspector does not support [`Debugger.getPossibleBreakpoints` CDP command](https://chromedevtools.github.io/devtools-protocol/v8/Debugger/#method-getPossibleBreakpoints), which is being widely used in Chrome DevTools and VSCode debugger. This PR tries to add this feature. The `Debugger.getPossibleBreakpoints` has an optional `restrictToFunction` parameter, since Hermes does not support this feature. I don't cover `restrictToFunction` support in this PR.

## Changelog

[GENERAL][ADDED] - Add `Debugger.getPossibleBreakpoints` CDP command support to Hermes inspector

## Test Plan

patch related code based on react-native 0.71.5 and try it on Flipper. I turned on DevTools' "Protocol Monitor" feature to check it responses correct payload.

![Screenshot 2023-03-29 at 11 42 26 PM](https://user-images.githubusercontent.com/46429/228595071-f4113546-46af-4746-b9d8-29c15899762d.png)


