### PR TITLE
Re-enable Fabric in the default app template/RN-Tester

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactActivityDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactActivityDelegate.kt
@@ -7,6 +7,7 @@
 
 package com.facebook.react.defaults
 
+import android.os.Bundle
 import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate
 import com.facebook.react.ReactRootView
@@ -42,5 +43,8 @@ open class DefaultReactActivityDelegate(
   override fun isFabricEnabled(): Boolean = fabricEnabled
 
   override fun createRootView(): ReactRootView =
+      ReactRootView(context).apply { setIsFabric(fabricEnabled) }
+
+  override fun createRootView(bundle: Bundle): ReactRootView =
       ReactRootView(context).apply { setIsFabric(fabricEnabled) }
 }


### PR DESCRIPTION
Summary:
After D43711737 landed, it turns out that Fabric is always disabled for both
RN-Tester and new app from template (so for 0.72 also RC0).
The reason is that a new method `createRootView(Bundle)` was introduced inside
`ReactActivityDelegate`. Both RN Tester and the template were using the
old `createRootView()` method which is not called anymore at this stage
(should potentially be deprecated?).

This diff fixes it by overriding both method inside `DefaultReactActivityDelegate`
so that both methods are setting the Fabric renderer.

Changelog:
[Android] [Fixed] - Re-enable Fabric in the default app template/RN-Tester

Differential Revision: D44536222

