### PR TITLE
[Codegen 96-97] Extract throwIfConfigNotfound and throwIfMoreThanOneConfig from findComponentConfig function

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
@@ -11,7 +11,10 @@
 
 'use strict';
 
-import {throwIfConfigNotfound, throwIfMoreThanOneConfig} from '../error-utils';
+const {
+  throwIfConfigNotfound,
+  throwIfMoreThanOneConfig,
+} = require('../error-utils');
 
 const {
   throwIfModuleInterfaceNotFound,

--- a/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
@@ -11,6 +11,8 @@
 
 'use strict';
 
+import {throwIfConfigNotfound} from '../error-utils';
+
 const {
   throwIfModuleInterfaceNotFound,
   throwIfMoreThanOneModuleRegistryCalls,
@@ -846,6 +848,27 @@ describe('throwIfMoreThanOneCodegenNativecommands', () => {
     ];
     expect(() => {
       throwIfMoreThanOneCodegenNativecommands(commandsTypeNames);
+    }).not.toThrow();
+  });
+});
+
+describe('throwIfConfigNotfound', () => {
+  it('throws an error if config is not found', () => {
+    const configs: Array<{[string]: string}> = [];
+    expect(() => {
+      throwIfConfigNotfound(configs);
+    }).toThrowError('Could not find component config for native component');
+  });
+
+  it('does not throw an error if config contains some elements', () => {
+    const configs: Array<{[string]: string}> = [
+      {
+        propsTypeName: 'testPropsTypeName',
+        componentName: 'testComponentName',
+      },
+    ];
+    expect(() => {
+      throwIfConfigNotfound(configs);
     }).not.toThrow();
   });
 });

--- a/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-import {throwIfConfigNotfound} from '../error-utils';
+import {throwIfConfigNotfound, throwIfMoreThanOneConfig} from '../error-utils';
 
 const {
   throwIfModuleInterfaceNotFound,
@@ -869,6 +869,36 @@ describe('throwIfConfigNotfound', () => {
     ];
     expect(() => {
       throwIfConfigNotfound(configs);
+    }).not.toThrow();
+  });
+});
+
+describe('throwIfMoreThanOneConfig', () => {
+  it('throws an error if config is not found', () => {
+    const configs: Array<{[string]: string}> = [
+      {
+        propsTypeName: 'testPropsTypeName1',
+        componentName: 'testComponentName1',
+      },
+      {
+        propsTypeName: 'testPropsTypeName2',
+        componentName: 'testComponentName2',
+      },
+    ];
+    expect(() => {
+      throwIfMoreThanOneConfig(configs);
+    }).toThrowError('Only one component is supported per file');
+  });
+
+  it('does not throw an error if config contains some elements', () => {
+    const configs: Array<{[string]: string}> = [
+      {
+        propsTypeName: 'testPropsTypeName',
+        componentName: 'testComponentName',
+      },
+    ];
+    expect(() => {
+      throwIfMoreThanOneConfig(configs);
     }).not.toThrow();
   });
 });

--- a/packages/react-native-codegen/src/parsers/error-utils.js
+++ b/packages/react-native-codegen/src/parsers/error-utils.js
@@ -304,6 +304,12 @@ function throwIfConfigNotfound(foundConfigs: Array<{[string]: string}>) {
   }
 }
 
+function throwIfMoreThanOneConfig(foundConfigs: Array<{[string]: string}>) {
+  if (foundConfigs.length > 1) {
+    throw new Error('Only one component is supported per file');
+  }
+}
+
 module.exports = {
   throwIfModuleInterfaceIsMisnamed,
   throwIfUnsupportedFunctionReturnTypeAnnotationParserError,
@@ -323,4 +329,5 @@ module.exports = {
   throwIfPartialWithMoreParameter,
   throwIfMoreThanOneCodegenNativecommands,
   throwIfConfigNotfound,
+  throwIfMoreThanOneConfig,
 };

--- a/packages/react-native-codegen/src/parsers/error-utils.js
+++ b/packages/react-native-codegen/src/parsers/error-utils.js
@@ -298,6 +298,12 @@ function throwIfMoreThanOneCodegenNativecommands(
   }
 }
 
+function throwIfConfigNotfound(foundConfigs: Array<{[string]: string}>) {
+  if (foundConfigs.length === 0) {
+    throw new Error('Could not find component config for native component');
+  }
+}
+
 module.exports = {
   throwIfModuleInterfaceIsMisnamed,
   throwIfUnsupportedFunctionReturnTypeAnnotationParserError,
@@ -316,4 +322,5 @@ module.exports = {
   throwIfPartialNotAnnotatingTypeParameter,
   throwIfPartialWithMoreParameter,
   throwIfMoreThanOneCodegenNativecommands,
+  throwIfConfigNotfound,
 };

--- a/packages/react-native-codegen/src/parsers/flow/components/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/index.js
@@ -12,6 +12,8 @@
 import type {Parser} from '../../parser';
 import type {ComponentSchemaBuilderConfig} from '../../schema.js';
 
+import {throwIfConfigNotfound} from '../../error-utils';
+
 const {getCommands} = require('./commands');
 const {getEvents} = require('./events');
 const {getExtendsProps, removeKnownExtends} = require('./extends');
@@ -39,9 +41,7 @@ function findComponentConfig(ast: $FlowFixMe, parser: Parser) {
     findNativeComponentType(statement, foundConfigs, parser);
   });
 
-  if (foundConfigs.length === 0) {
-    throw new Error('Could not find component config for native component');
-  }
+  throwIfConfigNotfound(foundConfigs);
   if (foundConfigs.length > 1) {
     throw new Error('Only one component is supported per file');
   }

--- a/packages/react-native-codegen/src/parsers/flow/components/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/index.js
@@ -12,11 +12,6 @@
 import type {Parser} from '../../parser';
 import type {ComponentSchemaBuilderConfig} from '../../schema.js';
 
-import {
-  throwIfConfigNotfound,
-  throwIfMoreThanOneConfig,
-} from '../../error-utils';
-
 const {getCommands} = require('./commands');
 const {getEvents} = require('./events');
 const {getExtendsProps, removeKnownExtends} = require('./extends');
@@ -31,6 +26,10 @@ const {
   getOptions,
   getCommandTypeNameAndOptionsExpression,
 } = require('../../parsers-commons');
+const {
+  throwIfConfigNotfound,
+  throwIfMoreThanOneConfig,
+} = require('../../error-utils');
 
 // $FlowFixMe[signature-verification-failure] there's no flowtype for AST
 function findComponentConfig(ast: $FlowFixMe, parser: Parser) {

--- a/packages/react-native-codegen/src/parsers/flow/components/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/index.js
@@ -12,7 +12,10 @@
 import type {Parser} from '../../parser';
 import type {ComponentSchemaBuilderConfig} from '../../schema.js';
 
-import {throwIfConfigNotfound} from '../../error-utils';
+import {
+  throwIfConfigNotfound,
+  throwIfMoreThanOneConfig,
+} from '../../error-utils';
 
 const {getCommands} = require('./commands');
 const {getEvents} = require('./events');
@@ -42,9 +45,7 @@ function findComponentConfig(ast: $FlowFixMe, parser: Parser) {
   });
 
   throwIfConfigNotfound(foundConfigs);
-  if (foundConfigs.length > 1) {
-    throw new Error('Only one component is supported per file');
-  }
+  throwIfMoreThanOneConfig(foundConfigs);
 
   const foundConfig = foundConfigs[0];
 

--- a/packages/react-native-codegen/src/parsers/typescript/components/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/index.js
@@ -13,7 +13,10 @@ import type {ExtendsPropsShape} from '../../../CodegenSchema.js';
 import type {Parser} from '../../parser';
 import type {ComponentSchemaBuilderConfig} from '../../schema.js';
 
-import {throwIfConfigNotfound} from '../../error-utils';
+import {
+  throwIfConfigNotfound,
+  throwIfMoreThanOneConfig,
+} from '../../error-utils';
 
 const {getCommands} = require('./commands');
 const {getEvents} = require('./events');
@@ -43,9 +46,7 @@ function findComponentConfig(ast: $FlowFixMe, parser: Parser) {
   );
 
   throwIfConfigNotfound(foundConfigs);
-  if (foundConfigs.length > 1) {
-    throw new Error('Only one component is supported per file');
-  }
+  throwIfMoreThanOneConfig(foundConfigs);
 
   const foundConfig = foundConfigs[0];
 

--- a/packages/react-native-codegen/src/parsers/typescript/components/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/index.js
@@ -13,11 +13,6 @@ import type {ExtendsPropsShape} from '../../../CodegenSchema.js';
 import type {Parser} from '../../parser';
 import type {ComponentSchemaBuilderConfig} from '../../schema.js';
 
-import {
-  throwIfConfigNotfound,
-  throwIfMoreThanOneConfig,
-} from '../../error-utils';
-
 const {getCommands} = require('./commands');
 const {getEvents} = require('./events');
 const {categorizeProps} = require('./extends');
@@ -32,6 +27,10 @@ const {
   getOptions,
   getCommandTypeNameAndOptionsExpression,
 } = require('../../parsers-commons');
+const {
+  throwIfConfigNotfound,
+  throwIfMoreThanOneConfig,
+} = require('../../error-utils');
 
 // $FlowFixMe[signature-verification-failure] TODO(T108222691): Use flow-types for @babel/parser
 function findComponentConfig(ast: $FlowFixMe, parser: Parser) {

--- a/packages/react-native-codegen/src/parsers/typescript/components/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/index.js
@@ -13,6 +13,8 @@ import type {ExtendsPropsShape} from '../../../CodegenSchema.js';
 import type {Parser} from '../../parser';
 import type {ComponentSchemaBuilderConfig} from '../../schema.js';
 
+import {throwIfConfigNotfound} from '../../error-utils';
+
 const {getCommands} = require('./commands');
 const {getEvents} = require('./events');
 const {categorizeProps} = require('./extends');
@@ -40,9 +42,7 @@ function findComponentConfig(ast: $FlowFixMe, parser: Parser) {
     findNativeComponentType(statement, foundConfigs, parser),
   );
 
-  if (foundConfigs.length === 0) {
-    throw new Error('Could not find component config for native component');
-  }
+  throwIfConfigNotfound(foundConfigs);
   if (foundConfigs.length > 1) {
     throw new Error('Only one component is supported per file');
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This PR contains tasks 96 and 97 from https://github.com/facebook/react-native/issues/34872:

>[Codegen 96 - assigned to @AntoineDoubovetzky] Create a throwIfConfigNotfound in the error-utils.js file and extract the error code from [Flow](https://github.com/facebook/react-native/blob/main/packages/react-native-codegen/src/parsers/flow/components/index.js#L61-L63) and [TS](https://github.com/facebook/react-native/blob/main/packages/react-native-codegen/src/parsers/typescript/components/index.js#L62-L64)
 [Codegen 97 - assigned to @AntoineDoubovetzky] Create a throwIfMoreThanOneConfig in the error-utils.js file and extract the error code from [Flow](https://github.com/facebook/react-native/blob/main/packages/react-native-codegen/src/parsers/flow/components/index.js#L64-L66) and [TS](https://github.com/facebook/react-native/blob/main/packages/react-native-codegen/src/parsers/typescript/components/index.js#L65-L67)

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[Internal] [Changed] - Extract throwIfConfigNotfound and throwIfMoreThanOneConfig from findComponentConfig function

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

I tested using Jest and Flow commands.