### PR TITLE
Check nullability for current context

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -1068,8 +1068,11 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
     }
 
     private void emitUpdateDimensionsEvent() {
-      DeviceInfoModule deviceInfo =
-          getCurrentReactContext().getNativeModule(DeviceInfoModule.class);
+      ReactContext reactContext = getCurrentReactContext();
+      if (reactContext == null) {
+        return;
+      }
+      DeviceInfoModule deviceInfo = reactContext.getNativeModule(DeviceInfoModule.class);
 
       if (deviceInfo != null) {
         deviceInfo.emitUpdateDimensionsEvent();


### PR DESCRIPTION
Summary:
We check RN instance immediately when onGlobalLayout is called in ReactRootView
https://www.internalfb.com/code/fbsource/[1f189dbb7238aa69319925bdc6a9e5389e160ad8]/xplat/js/react-native-github/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java?lines=903-907

but the RN instance could be destroyed due to exception, so when emitUpdateDimensionsEvent is called down the line there could be NPE which results in this [Logview](https://www.internalfb.com/logview/details/facebook_android_crashes/0f56580ff7b95827c8d4f932f2358841), we need to double check nullability in emitUpdateDimensionsEvent to avoid this

Changelog:
[Fixed][Android] - Check nullability for current context

Differential Revision: D44539899

