### PR TITLE
Add example for dispatchViewManagerCommand on Fabric Interop

### DIFF
--- a/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/component/MyLegacyViewManager.java
+++ b/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/component/MyLegacyViewManager.java
@@ -11,6 +11,7 @@ import android.graphics.Color;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.uimanager.SimpleViewManager;
@@ -26,6 +27,7 @@ import java.util.Map;
 public class MyLegacyViewManager extends SimpleViewManager<MyNativeView> {
 
   public static final String REACT_CLASS = "RNTMyLegacyNativeView";
+  private static final Integer COMMAND_CHANGE_BACKGROUND_COLOR = 42;
   private final ReactApplicationContext mCallerContext;
 
   public MyLegacyViewManager(ReactApplicationContext reactContext) {
@@ -75,5 +77,20 @@ public class MyLegacyViewManager extends SimpleViewManager<MyNativeView> {
                         "bubbled", "onColorChanged", "captured", "onColorChangedCapture")))
             .build());
     return eventTypeConstants;
+  }
+
+  @Override
+  public void receiveCommand(
+      @NonNull MyNativeView view, String commandId, @Nullable ReadableArray args) {
+    if (commandId.contentEquals(COMMAND_CHANGE_BACKGROUND_COLOR.toString())) {
+      int sentColor = Color.parseColor(args.getString(0));
+      view.setBackgroundColor(sentColor);
+    }
+  }
+
+  @Nullable
+  @Override
+  public Map<String, Integer> getCommandsMap() {
+    return MapBuilder.of("changeBackgroundColor", COMMAND_CHANGE_BACKGROUND_COLOR);
   }
 }


### PR DESCRIPTION
Summary:
This diff adds an example of using `dispatchViewManagerCommand` for the Fabric Intreop on Android.

Changelog:
[Android] [Added] - Add example for dispatchViewManagerCommand on Fabric Interop

Reviewed By: cipolleschi

Differential Revision: D44540951

