### PR TITLE
introduce shadows helper library for robolectric

### DIFF
--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridge/BUCK
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridge/BUCK
@@ -1,5 +1,7 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "react_native_android_toplevel_dep", "react_native_dep", "react_native_target", "react_native_tests_target", "rn_android_library", "rn_robolectric_test")
 
+oncall("react_native")
+
 STANDARD_TEST_SRCS = [
     "*Test.java",
 ]
@@ -43,5 +45,6 @@ rn_robolectric_test(
         react_native_target("java/com/facebook/react/turbomodule/core/interfaces:interfaces"),
         react_native_target("java/com/facebook/react/uimanager:uimanager"),
         react_native_tests_target("java/com/facebook/common/logging:logging"),
+        react_native_tests_target("java/com/facebook/testutils/shadows:shadows"),
     ],
 )

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridge/BaseJavaModuleTest.java
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridge/BaseJavaModuleTest.java
@@ -9,9 +9,8 @@ package com.facebook.react.bridge;
 
 import static org.mockito.Mockito.when;
 
-import android.content.Context;
 import com.facebook.react.turbomodule.core.interfaces.TurboModule;
-import com.facebook.soloader.SoLoader;
+import com.facebook.testutils.shadows.ShadowSoLoader;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
@@ -19,19 +18,6 @@ import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
-import org.robolectric.annotation.Implementation;
-import org.robolectric.annotation.Implements;
-
-@Implements(SoLoader.class)
-class ShadowSoLoader {
-  @Implementation
-  public static void init(Context context, int flags) {}
-
-  @Implementation
-  public static boolean loadLibrary(String shortName) {
-    return true;
-  }
-}
 
 /** Tests for {@link BaseJavaModule} and {@link JavaModuleWrapper} */
 @Config(

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/testutils/shadows/BUCK
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/testutils/shadows/BUCK
@@ -1,0 +1,18 @@
+load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "react_native_target", "rn_android_library")
+
+oncall("react_native")
+
+rn_android_library(
+    name = "shadows",
+    srcs = glob(["**/*.java"]),
+    autoglob = False,
+    language = "JAVA",
+    visibility = [
+        "PUBLIC",
+    ],
+    deps = [
+        react_native_target("java/com/facebook/react/bridge:bridge"),
+        react_native_dep("third-party/java/robolectric:robolectric"),
+        react_native_dep("libraries/soloader/java/com/facebook/soloader:soloader"),
+    ],
+)

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/testutils/shadows/ShadowSoLoader.java
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/testutils/shadows/ShadowSoLoader.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.testutils.shadows;
+
+import android.content.Context;
+import com.facebook.soloader.SoLoader;
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+
+@Implements(SoLoader.class)
+public class ShadowSoLoader {
+  @Implementation
+  public static void init(Context context, int flags) {}
+
+  @Implementation
+  public static boolean loadLibrary(String shortName) {
+    return true;
+  }
+}


### PR DESCRIPTION
Summary:
Changelog:
[Android][Added]

in this change, i'm creating a centralized place for test writers to add their shadows in robolectric. as we start deprecating powermock, we can expect that common infra classes will be needed to be stubbed out, so we can leverage this library in order to do so.

Differential Revision: D44565806

