### PR TITLE
update pressability responder region for animations with useNativeDriver

### DIFF
--- a/packages/react-native/Libraries/Animated/AnimatedImplementation.js
+++ b/packages/react-native/Libraries/Animated/AnimatedImplementation.js
@@ -378,7 +378,7 @@ const parallel = function (
       }
 
       animations.forEach((animation, idx) => {
-        const cb = function (endResult: EndResult | {finished: boolean}) {
+        const cb = function (endResult: EndResult) {
           hasEnded[idx] = true;
           doneCount++;
           if (doneCount === animations.length) {

--- a/packages/react-native/Libraries/Animated/NativeAnimatedModule.js
+++ b/packages/react-native/Libraries/Animated/NativeAnimatedModule.js
@@ -12,7 +12,7 @@ import type {TurboModule} from '../TurboModule/RCTExport';
 
 import * as TurboModuleRegistry from '../TurboModule/TurboModuleRegistry';
 
-type EndResult = {finished: boolean, ...};
+type EndResult = {finished: boolean, value?: number, ...};
 type EndCallback = (result: EndResult) => void;
 type SaveValueCallback = (value: number) => void;
 

--- a/packages/react-native/Libraries/Animated/NativeAnimatedTurboModule.js
+++ b/packages/react-native/Libraries/Animated/NativeAnimatedTurboModule.js
@@ -12,7 +12,7 @@ import type {TurboModule} from '../TurboModule/RCTExport';
 
 import * as TurboModuleRegistry from '../TurboModule/TurboModuleRegistry';
 
-type EndResult = {finished: boolean, ...};
+type EndResult = {finished: boolean, value?: number, ...};
 type EndCallback = (result: EndResult) => void;
 type SaveValueCallback = (value: number) => void;
 

--- a/packages/react-native/Libraries/Animated/animations/Animation.js
+++ b/packages/react-native/Libraries/Animated/animations/Animation.js
@@ -15,7 +15,7 @@ import type AnimatedValue from '../nodes/AnimatedValue';
 
 import NativeAnimatedHelper from '../NativeAnimatedHelper';
 
-export type EndResult = {finished: boolean, ...};
+export type EndResult = {finished: boolean, value?: number, ...};
 export type EndCallback = (result: EndResult) => void;
 
 export type AnimationConfig = {

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedProps.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedProps.js
@@ -36,6 +36,10 @@ export default class AnimatedProps extends AnimatedNode {
     this._callback = callback;
   }
 
+  __getAnimatedView(): any {
+    return this._animatedView;
+  }
+
   __getValue(): Object {
     const props: {[string]: any | ((...args: any) => void)} = {};
     for (const key in this._props) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedNodesManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedNodesManager.java
@@ -640,17 +640,16 @@ public class NativeAnimatedNodesManager implements EventDispatcherListener {
       for (int i = mActiveAnimations.size() - 1; i >= 0; i--) {
         AnimationDriver animation = mActiveAnimations.valueAt(i);
         if (animation.mHasFinished) {
+          WritableMap params = Arguments.createMap();
+          params.putBoolean("finished", true);
+          params.putDouble("value", animation.mAnimatedValue.mValue);
           if (animation.mEndCallback != null) {
-            WritableMap endCallbackResponse = Arguments.createMap();
-            endCallbackResponse.putBoolean("finished", true);
-            animation.mEndCallback.invoke(endCallbackResponse);
+            animation.mEndCallback.invoke(params);
           } else if (mReactApplicationContext != null) {
             // If no callback is passed in, this /may/ be an animation set up by the single-op
             // instruction from JS, meaning that no jsi::functions are passed into native and
             // we communicate via RCTDeviceEventEmitter instead of callbacks.
-            WritableMap params = Arguments.createMap();
             params.putInt("animationId", animation.mId);
-            params.putBoolean("finished", true);
             mReactApplicationContext.emitDeviceEvent(
                 "onNativeAnimatedModuleAnimationFinished", params);
           }


### PR DESCRIPTION
Summary:
When using the native driver for animations that involve layout changes (ie. translateY and other transforms, but not styles such as opacity), because it bypasses Fabric, the new coordinates are not updated so the Pressability responder region/tap target is incorrect

Previous diff:
- Returning the final values from the native side, at the same place it sets the "finished" flag. This gets sent to JS in `animated/animations/Animation.js`. In this diff I'm passing the value when 'hasFinishedAnimations' is true, but in a follow up diff I will look into other cases such as cancelled animations

**This diff:**
2. Update the Animated.Value to reflect the new values
3. Call the onEnd function if there is one set
4. Use `setNativeProps` to pass the new values down for layout calculations and the correct Pressability responder region

Changelog:
[General][Fixed] - update Pressability responder regions correctly for animations using native driver

Differential Revision: D44116815

