### PR TITLE
fix(metro-config): fix and realign the situation for metro config for 0.72

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@definitelytyped/dtslint": "^0.0.127",
     "@jest/create-cache-key-function": "^29.2.1",
     "@reactions/component": "^2.0.2",
-    "@react-native/metro-config": "^0.72.0",
+    "@react-native/metro-config": "^0.72.1",
     "@types/react": "^18.0.18",
     "@typescript-eslint/parser": "^5.30.5",
     "async": "^3.2.2",

--- a/packages/metro-config/index.js
+++ b/packages/metro-config/index.js
@@ -83,4 +83,4 @@ function getDefaultConfig(
   );
 }
 
-module.exports = {getDefaultConfig};
+module.exports = {getDefaultConfig, mergeConfig};

--- a/packages/metro-config/package.json
+++ b/packages/metro-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native/metro-config",
-  "version": "0.72.0",
+  "version": "0.72.1",
   "description": "Metro configuration for React Native.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

As noted by @hoxyq [here](https://github.com/reactwg/react-native-releases/discussions/54#discussioncomment-5490653) there's some inconsistencies with what happened with metro config and its releases.

Basically, it looks like 0.72.1 of metro-config was released from main branch instead of 0.72-stable, which means that currently 0.72 is in an inconsistent state for [its package](https://github.com/facebook/react-native/blob/0.72-stable/packages/metro-config/package.json#L3).

Relevant commits:
* for 0.72-stable https://github.com/facebook/react-native/commit/9ffe82edd3f0a891b2421b34327d2859d3f5abdf
* for main https://github.com/facebook/react-native/commit/c5a47abaf894235f71eea03e57d2f5287d80f3d4#diff-cbcd5b7d5c2dff9dbd901bc385916ed457d12cfcdf9c2ed16bb44d18bb49232f

It shouldn't be too big of a deal, and this PR should realign the situation so that the metro-config folder in 0.72-stable is exactly the same as main (and future 0.72.x releases of metro-config will need to happen from this branch, while main is on 0.73.x now).

Because I'm doing it this way, CI won't trigger and won't attempt to re-release 0.72.1 of metro-config.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[INTERNAL] [FIXED] - fix and realign the situation for metro config for 0.72


## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

N/A