### PR TITLE
Changing tab bar controller orientation to portrait

### DIFF
--- a/packages/react-native/React/Base/RCTConvert.h
+++ b/packages/react-native/React/Base/RCTConvert.h
@@ -72,6 +72,8 @@ typedef NSURL RCTFileURL;
 + (UIKeyboardAppearance)UIKeyboardAppearance:(id)json;
 + (UIReturnKeyType)UIReturnKeyType:(id)json;
 + (UIUserInterfaceStyle)UIUserInterfaceStyle:(id)json API_AVAILABLE(ios(12));
++ (UIInterfaceOrientationMask)UIInterfaceOrientationMask:(NSString *)orientation;
+
 #if !TARGET_OS_TV
 + (UIDataDetectorTypes)UIDataDetectorTypes:(id)json;
 #endif

--- a/packages/react-native/React/Base/RCTConvert.m
+++ b/packages/react-native/React/Base/RCTConvert.m
@@ -512,6 +512,18 @@ RCT_ENUM_CONVERTER(
     integerValue)
 
 RCT_ENUM_CONVERTER(
+    UIInterfaceOrientationMask,
+    (@{
+      @"ALL" : @(UIInterfaceOrientationMaskAll),
+      @"PORTRAIT" : @(UIInterfaceOrientationMaskPortrait),
+      @"LANDSCAPE" : @(UIInterfaceOrientationMaskLandscape),
+      @"LANDSCAPE_LEFT" : @(UIInterfaceOrientationMaskLandscapeLeft),
+      @"LANDSCAPE_RIGHT" : @(UIInterfaceOrientationMaskLandscapeRight),
+    }),
+    NSNotFound,
+    unsignedIntegerValue)
+
+RCT_ENUM_CONVERTER(
     UIViewContentMode,
     (@{
       @"scale-to-fill" : @(UIViewContentModeScaleToFill),


### PR DESCRIPTION
Summary:
Applying orientation from navigationOptions to the TabBarController

## Changelog
[iOS][Added] - Added conversion helper for UIInterfaceOrientationMask to RCTConvert

Reviewed By: philIip

Differential Revision: D44553533

