### PR TITLE
decouple ShareModuleTest from PowerMock

### DIFF
--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/BUCK
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/BUCK
@@ -1,5 +1,7 @@
 load("//tools/build_defs/oss:rn_defs.bzl", "YOGA_TARGET", "react_native_dep", "react_native_target", "react_native_tests_target", "rn_robolectric_test")
 
+oncall("react_native")
+
 rn_robolectric_test(
     name = "modules",
     srcs = glob(["**/*.java"]),
@@ -41,5 +43,6 @@ rn_robolectric_test(
         react_native_target("java/com/facebook/react/touch:touch"),
         react_native_target("java/com/facebook/react/uimanager:uimanager"),
         react_native_tests_target("java/com/facebook/react/bridge:testhelpers"),
+        react_native_tests_target("java/com/facebook/testutils/shadows:shadows"),
     ],
 )

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/share/ShareModuleTest.java
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/share/ShareModuleTest.java
@@ -15,62 +15,30 @@ import android.app.Activity;
 import android.content.Intent;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.JavaOnlyMap;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactTestHelper;
 import com.facebook.react.bridge.WritableMap;
+import com.facebook.testutils.shadows.ShadowArguments;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.rule.PowerMockRule;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
 
-@PrepareForTest({Arguments.class})
+@Config(shadows = {ShadowArguments.class})
 @RunWith(RobolectricTestRunner.class)
-@PowerMockIgnore({
-  "org.mockito.*",
-  "org.robolectric.*",
-  "androidx.*",
-  "android.*",
-  "javax.xml.*",
-  "org.xml.sax.*",
-  "org.w3c.dom.*",
-  "org.springframework.context.*",
-  "org.apache.log4j.*"
-})
-@Ignore("Ignored due to unsupported mocking mechanism with JDK 18")
 public class ShareModuleTest {
 
   private Activity mActivity;
   private ShareModule mShareModule;
 
-  @Rule public PowerMockRule rule = new PowerMockRule();
-
   @Before
   public void prepareModules() throws Exception {
-    PowerMockito.mockStatic(Arguments.class);
-    Mockito.when(Arguments.createMap())
-        .thenAnswer(
-            new Answer<Object>() {
-              @Override
-              public Object answer(InvocationOnMock invocation) throws Throwable {
-                return new JavaOnlyMap();
-              }
-            });
-
     mActivity = Robolectric.setupActivity(Activity.class);
 
     ReactApplicationContext applicationContext = ReactTestHelper.createCatalystContextForTest();

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/testutils/shadows/ShadowArguments.java
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/testutils/shadows/ShadowArguments.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.testutils.shadows;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.JavaOnlyMap;
+import com.facebook.react.bridge.WritableMap;
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+
+@Implements(Arguments.class)
+public class ShadowArguments {
+  @Implementation
+  public static WritableMap createMap() {
+    return new JavaOnlyMap();
+  }
+}


### PR DESCRIPTION
Summary:
Changelog: [Internal]

as title! i'm not actually familiar enough with junit as to why the test infra cannot find `Arguments.java` since it is part of our framework, not something externally linked or an under the hood library, so if someone wants to explain that to me that'd be great

Reviewed By: cortinico, mdvacca

Differential Revision: D44527486

