### PR TITLE
Revert D44563649: Multisect successfully blamed D44153451 for test or build failures

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/BUCK
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/BUCK
@@ -44,7 +44,6 @@ rn_android_library(
         react_native_target("java/com/facebook/react/modules/i18nmanager:i18nmanager"),
         react_native_target("java/com/facebook/react/touch:touch"),
         react_native_target("java/com/facebook/react/uimanager:uimanager"),
-        react_native_target("java/com/facebook/react/uimanager/common:common"),
         react_native_target("java/com/facebook/react/views/text:text"),
         react_native_target("java/com/facebook/react/views/view:view"),
         react_native_target("jni/react/fabric:jni"),

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/events/FabricEventEmitter.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/events/FabricEventEmitter.java
@@ -12,7 +12,6 @@ import androidx.annotation.Nullable;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.fabric.FabricUIManager;
-import com.facebook.react.uimanager.common.ViewUtil;
 import com.facebook.react.uimanager.events.EventCategoryDef;
 import com.facebook.react.uimanager.events.RCTModernEventEmitter;
 import com.facebook.react.uimanager.events.TouchEvent;
@@ -20,6 +19,8 @@ import com.facebook.react.uimanager.events.TouchesHelper;
 import com.facebook.systrace.Systrace;
 
 public class FabricEventEmitter implements RCTModernEventEmitter {
+
+  private static final String TAG = "FabricEventEmitter";
 
   @NonNull private final FabricUIManager mUIManager;
 
@@ -29,7 +30,7 @@ public class FabricEventEmitter implements RCTModernEventEmitter {
 
   @Override
   public void receiveEvent(int reactTag, @NonNull String eventName, @Nullable WritableMap params) {
-    receiveEvent(ViewUtil.NO_SURFACE_ID, reactTag, eventName, params);
+    receiveEvent(-1, reactTag, eventName, params);
   }
 
   @Override
@@ -50,12 +51,9 @@ public class FabricEventEmitter implements RCTModernEventEmitter {
     Systrace.beginSection(
         Systrace.TRACE_TAG_REACT_JAVA_BRIDGE,
         "FabricEventEmitter.receiveEvent('" + eventName + "')");
-    try {
-      mUIManager.receiveEvent(
-          surfaceId, reactTag, eventName, canCoalesceEvent, customCoalesceKey, params, category);
-    } finally {
-      Systrace.endSection(Systrace.TRACE_TAG_REACT_JAVA_BRIDGE);
-    }
+    mUIManager.receiveEvent(
+        surfaceId, reactTag, eventName, canCoalesceEvent, customCoalesceKey, params, category);
+    Systrace.endSection(Systrace.TRACE_TAG_REACT_JAVA_BRIDGE);
   }
 
   /** Touches are dispatched by {@link #receiveTouches(TouchEvent)} */

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountingManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountingManager.java
@@ -32,7 +32,6 @@ import com.facebook.react.touch.JSResponderHandler;
 import com.facebook.react.uimanager.RootViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewManagerRegistry;
-import com.facebook.react.uimanager.common.ViewUtil;
 import com.facebook.yoga.YogaMeasureMode;
 import java.util.Map;
 import java.util.Queue;
@@ -281,12 +280,12 @@ public class MountingManager {
    * Send an accessibility eventType to a Native View. eventType is any valid `AccessibilityEvent.X`
    * value.
    *
-   * <p>Why accept {@ViewUtils.NO_SURFACE_ID}(-1) SurfaceId? Currently there are calls to
-   * UIManager.sendAccessibilityEvent which is a legacy API and accepts only reactTag. We will have
-   * to investigate and migrate away from those calls over time.
+   * <p>Why accept `-1` SurfaceId? Currently there are calls to UIManager.sendAccessibilityEvent
+   * which is a legacy API and accepts only reactTag. We will have to investigate and migrate away
+   * from those calls over time.
    *
-   * @param surfaceId {@link int} that identifies the surface or {@ViewUtils.NO_SURFACE_ID}(-1) to
-   *     temporarily support backward compatibility.
+   * @param surfaceId {@link int} that identifies the surface or -1 to temporarily support backward
+   *     compatibility.
    * @param reactTag {@link int} that identifies the react Tag of the view.
    * @param eventType {@link int} that identifies Android eventType. see {@link
    *     View#sendAccessibilityEvent}
@@ -327,9 +326,7 @@ public class MountingManager {
   @ThreadConfined(ANY)
   public @Nullable EventEmitterWrapper getEventEmitter(int surfaceId, int reactTag) {
     SurfaceMountingManager surfaceMountingManager =
-        (surfaceId == ViewUtil.NO_SURFACE_ID
-            ? getSurfaceManagerForView(reactTag)
-            : getSurfaceManager(surfaceId));
+        (surfaceId == -1 ? getSurfaceManagerForView(reactTag) : getSurfaceManager(surfaceId));
     if (surfaceMountingManager == null) {
       return null;
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/common/ViewUtil.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/common/ViewUtil.java
@@ -12,8 +12,6 @@ import static com.facebook.react.uimanager.common.UIManagerType.FABRIC;
 
 public class ViewUtil {
 
-  public static final int NO_SURFACE_ID = -1;
-
   /**
    * Counter for uniquely identifying views. - % 2 === 0 means it is a Fabric tag. See
    * https://github.com/facebook/react/pull/12587

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/drawer/events/DrawerClosedEvent.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/drawer/events/DrawerClosedEvent.java
@@ -9,7 +9,6 @@ package com.facebook.react.views.drawer.events;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;
-import com.facebook.react.uimanager.common.ViewUtil;
 import com.facebook.react.uimanager.events.Event;
 
 public class DrawerClosedEvent extends Event<DrawerClosedEvent> {
@@ -18,7 +17,7 @@ public class DrawerClosedEvent extends Event<DrawerClosedEvent> {
 
   @Deprecated
   public DrawerClosedEvent(int viewId) {
-    this(ViewUtil.NO_SURFACE_ID, viewId);
+    this(-1, viewId);
   }
 
   public DrawerClosedEvent(int surfaceId, int viewId) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/drawer/events/DrawerOpenedEvent.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/drawer/events/DrawerOpenedEvent.java
@@ -9,7 +9,6 @@ package com.facebook.react.views.drawer.events;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;
-import com.facebook.react.uimanager.common.ViewUtil;
 import com.facebook.react.uimanager.events.Event;
 
 public class DrawerOpenedEvent extends Event<DrawerOpenedEvent> {
@@ -18,7 +17,7 @@ public class DrawerOpenedEvent extends Event<DrawerOpenedEvent> {
 
   @Deprecated
   public DrawerOpenedEvent(int viewId) {
-    this(ViewUtil.NO_SURFACE_ID, viewId);
+    this(-1, viewId);
   }
 
   public DrawerOpenedEvent(int surfaceId, int viewId) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/drawer/events/DrawerSlideEvent.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/drawer/events/DrawerSlideEvent.java
@@ -9,7 +9,6 @@ package com.facebook.react.views.drawer.events;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;
-import com.facebook.react.uimanager.common.ViewUtil;
 import com.facebook.react.uimanager.events.Event;
 
 /** Event emitted by a DrawerLayout as it is being moved open/closed. */
@@ -21,7 +20,7 @@ public class DrawerSlideEvent extends Event<DrawerSlideEvent> {
 
   @Deprecated
   public DrawerSlideEvent(int viewId, float offset) {
-    this(ViewUtil.NO_SURFACE_ID, viewId, offset);
+    this(-1, viewId, offset);
   }
 
   public DrawerSlideEvent(int surfaceId, int viewId, float offset) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/drawer/events/DrawerStateChangedEvent.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/drawer/events/DrawerStateChangedEvent.java
@@ -9,7 +9,6 @@ package com.facebook.react.views.drawer.events;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;
-import com.facebook.react.uimanager.common.ViewUtil;
 import com.facebook.react.uimanager.events.Event;
 
 public class DrawerStateChangedEvent extends Event<DrawerStateChangedEvent> {
@@ -20,7 +19,7 @@ public class DrawerStateChangedEvent extends Event<DrawerStateChangedEvent> {
 
   @Deprecated
   public DrawerStateChangedEvent(int viewId, int drawerState) {
-    this(ViewUtil.NO_SURFACE_ID, viewId, drawerState);
+    this(-1, viewId, drawerState);
   }
 
   public DrawerStateChangedEvent(int surfaceId, int viewId, int drawerState) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ImageLoadEvent.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ImageLoadEvent.java
@@ -11,7 +11,6 @@ import androidx.annotation.IntDef;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;
-import com.facebook.react.uimanager.common.ViewUtil;
 import com.facebook.react.uimanager.events.Event;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -37,29 +36,29 @@ public class ImageLoadEvent extends Event<ImageLoadEvent> {
 
   @Deprecated
   public static final ImageLoadEvent createLoadStartEvent(int viewId) {
-    return createLoadStartEvent(ViewUtil.NO_SURFACE_ID, viewId);
+    return createLoadStartEvent(-1, viewId);
   }
 
   @Deprecated
   public static final ImageLoadEvent createProgressEvent(
       int viewId, @Nullable String imageUri, int loaded, int total) {
-    return createProgressEvent(ViewUtil.NO_SURFACE_ID, viewId, imageUri, loaded, total);
+    return createProgressEvent(-1, viewId, imageUri, loaded, total);
   }
 
   @Deprecated
   public static final ImageLoadEvent createLoadEvent(
       int viewId, @Nullable String imageUri, int width, int height) {
-    return createLoadEvent(ViewUtil.NO_SURFACE_ID, viewId, imageUri, width, height);
+    return createLoadEvent(-1, viewId, imageUri, width, height);
   }
 
   @Deprecated
   public static final ImageLoadEvent createErrorEvent(int viewId, Throwable throwable) {
-    return createErrorEvent(ViewUtil.NO_SURFACE_ID, viewId, throwable);
+    return createErrorEvent(-1, viewId, throwable);
   }
 
   @Deprecated
   public static final ImageLoadEvent createLoadEndEvent(int viewId) {
-    return createLoadEndEvent(ViewUtil.NO_SURFACE_ID, viewId);
+    return createLoadEndEvent(-1, viewId);
   }
 
   public static final ImageLoadEvent createLoadStartEvent(int surfaceId, int viewId) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/RequestCloseEvent.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/RequestCloseEvent.java
@@ -10,7 +10,6 @@ package com.facebook.react.views.modal;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;
-import com.facebook.react.uimanager.common.ViewUtil;
 import com.facebook.react.uimanager.events.Event;
 
 /** {@link Event} for dismissing a Dialog. */
@@ -20,7 +19,7 @@ import com.facebook.react.uimanager.events.Event;
 
   @Deprecated
   protected RequestCloseEvent(int viewTag) {
-    this(ViewUtil.NO_SURFACE_ID, viewTag);
+    this(-1, viewTag);
   }
 
   protected RequestCloseEvent(int surfaceId, int viewTag) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ShowEvent.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ShowEvent.java
@@ -10,7 +10,6 @@ package com.facebook.react.views.modal;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;
-import com.facebook.react.uimanager.common.ViewUtil;
 import com.facebook.react.uimanager.events.Event;
 
 /** {@link Event} for showing a Dialog. */
@@ -20,7 +19,7 @@ import com.facebook.react.uimanager.events.Event;
 
   @Deprecated
   protected ShowEvent(int viewTag) {
-    this(ViewUtil.NO_SURFACE_ID, viewTag);
+    this(-1, viewTag);
   }
 
   protected ShowEvent(int surfaceId, int viewTag) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ScrollEvent.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ScrollEvent.java
@@ -14,7 +14,6 @@ import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactSoftExceptionLogger;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.uimanager.PixelUtil;
-import com.facebook.react.uimanager.common.ViewUtil;
 import com.facebook.react.uimanager.events.Event;
 
 /** A event dispatched from a ScrollView scrolling. */
@@ -47,7 +46,7 @@ public class ScrollEvent extends Event<ScrollEvent> {
       int scrollViewWidth,
       int scrollViewHeight) {
     return obtain(
-        ViewUtil.NO_SURFACE_ID,
+        -1,
         viewTag,
         scrollEventType,
         scrollX,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/swiperefresh/RefreshEvent.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/swiperefresh/RefreshEvent.java
@@ -10,14 +10,13 @@ package com.facebook.react.views.swiperefresh;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;
-import com.facebook.react.uimanager.common.ViewUtil;
 import com.facebook.react.uimanager.events.Event;
 
 public class RefreshEvent extends Event<RefreshEvent> {
 
   @Deprecated
   protected RefreshEvent(int viewTag) {
-    this(ViewUtil.NO_SURFACE_ID, viewTag);
+    this(-1, viewTag);
   }
 
   protected RefreshEvent(int surfaceId, int viewTag) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/switchview/ReactSwitchEvent.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/switchview/ReactSwitchEvent.java
@@ -10,7 +10,6 @@ package com.facebook.react.views.switchview;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;
-import com.facebook.react.uimanager.common.ViewUtil;
 import com.facebook.react.uimanager.events.Event;
 
 /** Event emitted by a ReactSwitchManager once a switch is fully switched on/off */
@@ -22,7 +21,7 @@ import com.facebook.react.uimanager.events.Event;
 
   @Deprecated
   public ReactSwitchEvent(int viewId, boolean isChecked) {
-    this(ViewUtil.NO_SURFACE_ID, viewId, isChecked);
+    this(-1, viewId, isChecked);
   }
 
   public ReactSwitchEvent(int surfaceId, int viewId, boolean isChecked) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactContentSizeChangedEvent.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactContentSizeChangedEvent.java
@@ -10,7 +10,6 @@ package com.facebook.react.views.textinput;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;
-import com.facebook.react.uimanager.common.ViewUtil;
 import com.facebook.react.uimanager.events.Event;
 
 /** Event emitted by EditText native view when content size changes. */
@@ -23,7 +22,7 @@ public class ReactContentSizeChangedEvent extends Event<ReactTextChangedEvent> {
 
   @Deprecated
   public ReactContentSizeChangedEvent(int viewId, float contentSizeWidth, float contentSizeHeight) {
-    this(ViewUtil.NO_SURFACE_ID, viewId, contentSizeWidth, contentSizeHeight);
+    this(-1, viewId, contentSizeWidth, contentSizeHeight);
   }
 
   public ReactContentSizeChangedEvent(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextChangedEvent.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextChangedEvent.java
@@ -10,7 +10,6 @@ package com.facebook.react.views.textinput;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;
-import com.facebook.react.uimanager.common.ViewUtil;
 import com.facebook.react.uimanager.events.Event;
 
 /**
@@ -26,7 +25,7 @@ public class ReactTextChangedEvent extends Event<ReactTextChangedEvent> {
 
   @Deprecated
   public ReactTextChangedEvent(int viewId, String text, int eventCount) {
-    this(ViewUtil.NO_SURFACE_ID, viewId, text, eventCount);
+    this(-1, viewId, text, eventCount);
   }
 
   public ReactTextChangedEvent(int surfaceId, int viewId, String text, int eventCount) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputBlurEvent.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputBlurEvent.java
@@ -10,7 +10,6 @@ package com.facebook.react.views.textinput;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;
-import com.facebook.react.uimanager.common.ViewUtil;
 import com.facebook.react.uimanager.events.Event;
 
 /** Event emitted by EditText native view when it loses focus. */
@@ -20,7 +19,7 @@ import com.facebook.react.uimanager.events.Event;
 
   @Deprecated
   public ReactTextInputBlurEvent(int viewId) {
-    this(ViewUtil.NO_SURFACE_ID, viewId);
+    this(-1, viewId);
   }
 
   public ReactTextInputBlurEvent(int surfaceId, int viewId) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputEndEditingEvent.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputEndEditingEvent.java
@@ -10,7 +10,6 @@ package com.facebook.react.views.textinput;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;
-import com.facebook.react.uimanager.common.ViewUtil;
 import com.facebook.react.uimanager.events.Event;
 
 /**
@@ -25,7 +24,7 @@ class ReactTextInputEndEditingEvent extends Event<ReactTextInputEndEditingEvent>
 
   @Deprecated
   public ReactTextInputEndEditingEvent(int viewId, String text) {
-    this(ViewUtil.NO_SURFACE_ID, viewId, text);
+    this(-1, viewId, text);
   }
 
   public ReactTextInputEndEditingEvent(int surfaceId, int viewId, String text) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputEvent.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputEvent.java
@@ -10,7 +10,6 @@ package com.facebook.react.views.textinput;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;
-import com.facebook.react.uimanager.common.ViewUtil;
 import com.facebook.react.uimanager.events.Event;
 
 /**
@@ -29,7 +28,7 @@ public class ReactTextInputEvent extends Event<ReactTextInputEvent> {
   @Deprecated
   public ReactTextInputEvent(
       int viewId, String text, String previousText, int rangeStart, int rangeEnd) {
-    this(ViewUtil.NO_SURFACE_ID, viewId, text, previousText, rangeStart, rangeEnd);
+    this(-1, viewId, text, previousText, rangeStart, rangeEnd);
   }
 
   public ReactTextInputEvent(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputFocusEvent.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputFocusEvent.java
@@ -10,7 +10,6 @@ package com.facebook.react.views.textinput;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;
-import com.facebook.react.uimanager.common.ViewUtil;
 import com.facebook.react.uimanager.events.Event;
 
 /** Event emitted by EditText native view when it receives focus. */
@@ -20,7 +19,7 @@ import com.facebook.react.uimanager.events.Event;
 
   @Deprecated
   public ReactTextInputFocusEvent(int viewId) {
-    this(ViewUtil.NO_SURFACE_ID, viewId);
+    this(-1, viewId);
   }
 
   public ReactTextInputFocusEvent(int surfaceId, int viewId) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputKeyPressEvent.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputKeyPressEvent.java
@@ -10,7 +10,6 @@ package com.facebook.react.views.textinput;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;
-import com.facebook.react.uimanager.common.ViewUtil;
 import com.facebook.react.uimanager.events.Event;
 
 /** Event emitted by EditText native view when key pressed */
@@ -22,7 +21,7 @@ public class ReactTextInputKeyPressEvent extends Event<ReactTextInputEvent> {
 
   @Deprecated
   ReactTextInputKeyPressEvent(int viewId, final String key) {
-    this(ViewUtil.NO_SURFACE_ID, viewId, key);
+    this(-1, viewId, key);
   }
 
   ReactTextInputKeyPressEvent(int surfaceId, int viewId, final String key) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputSelectionEvent.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputSelectionEvent.java
@@ -10,7 +10,6 @@ package com.facebook.react.views.textinput;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;
-import com.facebook.react.uimanager.common.ViewUtil;
 import com.facebook.react.uimanager.events.Event;
 
 /** Event emitted by EditText native view when the text selection changes. */
@@ -23,7 +22,7 @@ import com.facebook.react.uimanager.events.Event;
 
   @Deprecated
   public ReactTextInputSelectionEvent(int viewId, int selectionStart, int selectionEnd) {
-    this(ViewUtil.NO_SURFACE_ID, viewId, selectionStart, selectionEnd);
+    this(-1, viewId, selectionStart, selectionEnd);
   }
 
   public ReactTextInputSelectionEvent(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputSubmitEditingEvent.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputSubmitEditingEvent.java
@@ -10,7 +10,6 @@ package com.facebook.react.views.textinput;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;
-import com.facebook.react.uimanager.common.ViewUtil;
 import com.facebook.react.uimanager.events.Event;
 
 /** Event emitted by EditText native view when the user submits the text. */
@@ -23,7 +22,7 @@ import com.facebook.react.uimanager.events.Event;
 
   @Deprecated
   public ReactTextInputSubmitEditingEvent(int viewId, String text) {
-    this(ViewUtil.NO_SURFACE_ID, viewId, text);
+    this(-1, viewId, text);
   }
 
   public ReactTextInputSubmitEditingEvent(int surfaceId, int viewId, String text) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ViewGroupClickEvent.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ViewGroupClickEvent.java
@@ -10,7 +10,6 @@ package com.facebook.react.views.view;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;
-import com.facebook.react.uimanager.common.ViewUtil;
 import com.facebook.react.uimanager.events.Event;
 
 /** Represents a Click on the ReactViewGroup */
@@ -19,7 +18,7 @@ public class ViewGroupClickEvent extends Event<ViewGroupClickEvent> {
 
   @Deprecated
   public ViewGroupClickEvent(int viewId) {
-    this(ViewUtil.NO_SURFACE_ID, viewId);
+    this(-1, viewId);
   }
 
   public ViewGroupClickEvent(int surfaceId, int viewId) {


### PR DESCRIPTION
Summary:
This diff is reverting D44563649
D44153451: [Fabric][Android] Reduce visibility of FabricSoLoader by mdvacca has been identified to be causing the following test or build failures:

Tests affected:
- [xplat/endtoend/jest-e2e/apps/fb4a/__tests__/consumerwifi/venice/fb4aVeniceAddressSearch-e2e.js](https://www.internalfb.com/intern/test/281475007251570/)

Here's the Multisect link:
https://www.internalfb.com/multisect/1799601
Here are the tasks that are relevant to this breakage:

We're generating a revert to back out the changes in this diff, please note the backout may land if someone accepts it.

changelog: [internal] internal

Reviewed By: linmx0130

Differential Revision: D44602272

