### PR TITLE
fix(xcode): backport Xcode 14.3 fix to 71

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ references:
   #        Dependency Anchors
   # -------------------------
   dependency_versions:
-    xcode_version: &xcode_version "14.3.0"
+    xcode_version: &xcode_version "14.0.1"
     nodelts_image: &nodelts_image "cimg/node:18.12.1"
     nodeprevlts_image: &nodeprevlts_image "cimg/node:16.18.1"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ references:
   #        Dependency Anchors
   # -------------------------
   dependency_versions:
-    xcode_version: &xcode_version "14.0.1"
+    xcode_version: &xcode_version "14.3.0"
     nodelts_image: &nodelts_image "cimg/node:18.12.1"
     nodeprevlts_image: &nodeprevlts_image "cimg/node:16.18.1"
 

--- a/scripts/cocoapods/__tests__/codegen_utils-test.rb
+++ b/scripts/cocoapods/__tests__/codegen_utils-test.rb
@@ -486,6 +486,14 @@ class CodegenUtilsTests < Test::Unit::TestCase
 
     private
 
+    # mocking the min_ios_version_supported function
+    # as it is not possible to require the original react_native_pod
+    # without incurring in circular deps
+    # TODO: move `min_ios_version_supported` to utils.rb
+    def min_ios_version_supported
+        return '12.4'
+    end
+
     def get_podspec_no_fabric_no_script
         spec = {
           'name' => "React-Codegen",
@@ -498,7 +506,7 @@ class CodegenUtilsTests < Test::Unit::TestCase
           'source' => { :git => '' },
           'header_mappings_dir' => './',
           'platforms' => {
-            'ios' => '11.0',
+            'ios' => min_ios_version_supported,
           },
           'source_files' => "**/*.{h,mm,cpp}",
           'pod_target_xcconfig' => { "HEADER_SEARCH_PATHS" =>

--- a/scripts/cocoapods/codegen_utils.rb
+++ b/scripts/cocoapods/codegen_utils.rb
@@ -85,7 +85,7 @@ class CodegenUtils
           'source' => { :git => '' },
           'header_mappings_dir' => './',
           'platforms' => {
-            'ios' => '11.0',
+            'ios' => min_ios_version_supported,
           },
           'source_files' => "**/*.{h,mm,cpp}",
           'pod_target_xcconfig' => { "HEADER_SEARCH_PATHS" =>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

A quick attempt at a minimal fix for 0.71 for https://github.com/facebook/react-native/issues/36739, based on https://github.com/facebook/react-native/pull/36759


## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[IOS] [FIXED] - Fix React Codegen podspec to build on Xcode 14.3


## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
