### PR TITLE
'value' is unavailable: introduced in iOS 12.0

### DIFF
--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -364,11 +364,11 @@ def __apply_Xcode_12_5_M1_post_install_workaround(installer)
   # The most reliable known workaround is to bump iOS deployment target to match react-native (iOS 11 now).
   installer.pods_project.targets.each do |target|
     target.build_configurations.each do |config|
-      # ensure IPHONEOS_DEPLOYMENT_TARGET is at least 11.0
+      # ensure IPHONEOS_DEPLOYMENT_TARGET is at least 12.0
       deployment_target = config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'].to_f
-      should_upgrade = deployment_target < 11.0 && deployment_target != 0.0
+      should_upgrade = deployment_target < 12.0 && deployment_target != 0.0
       if should_upgrade
-        config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '11.0'
+        config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '12.0'
       end
     end
   end


### PR DESCRIPTION
After updating Xcode to 14.3. 
The app starts crashing and gives an error 
'value' is unavailable: introduced in iOS 12.0.
To Fix that I have updated the deployment target from 11.0 to 12.0

## Changelog:

[iOS] [Fixed] -  Fix the crash in iOS by updating the deployment target from 11.0 to 12.0.
