### PR TITLE
Correct offset when drawing text to TextStorage coordinate system.

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
@@ -64,10 +64,14 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(EllipsizeMode ellipsi
                          layoutConstraints:(LayoutConstraints)layoutConstraints
                                textStorage:(NSTextStorage *_Nullable)textStorage
 {
-  return [self measureNSAttributedString:[self _nsAttributedStringFromAttributedString:attributedString]
-                     paragraphAttributes:paragraphAttributes
-                       layoutConstraints:layoutConstraints
-                             textStorage:textStorage];
+  if (textStorage) {
+    return [self _measureTextStorage:textStorage];
+  } else {
+    return [self measureNSAttributedString:[self _nsAttributedStringFromAttributedString:attributedString]
+                       paragraphAttributes:paragraphAttributes
+                         layoutConstraints:layoutConstraints
+                               textStorage:nil];
+  }
 }
 
 - (void)drawAttributedString:(AttributedString)attributedString


### PR DESCRIPTION
Summary:
changelog: [internal]

Previously, when `NSTextStorage` was cached, we were not accounting for case where text which was aligned to centre or left, was used to size its container.
The result was that it was painted outside of its container, therefore invisible. To fix this, we adjust the offset to make sure text is painted correctly.

This bug only happens if:
- Text is not aligned to left in right to left writing system.
- The canvas where text is drawn is not stretched to full width of its parent.
- The offset needs to be large enough for this to matter, otherwise the text is just slightly off.
- Because of the caching mechanism, it had to be a piece of text that was rendered before. Otherwise it would work.

This complexity is worth the trouble to avoid invalidation of layout inside NSTextContainer, which is expensive.

Differential Revision: D44624085

