### PR TITLE
Only create NSAttributedString if NSTextStorage is nil

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
@@ -64,10 +64,14 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(EllipsizeMode ellipsi
                          layoutConstraints:(LayoutConstraints)layoutConstraints
                                textStorage:(NSTextStorage *_Nullable)textStorage
 {
-  return [self measureNSAttributedString:[self _nsAttributedStringFromAttributedString:attributedString]
-                     paragraphAttributes:paragraphAttributes
-                       layoutConstraints:layoutConstraints
-                             textStorage:textStorage];
+  if (textStorage) {
+    return [self _measureTextStorage:textStorage];
+  } else {
+    return [self measureNSAttributedString:[self _nsAttributedStringFromAttributedString:attributedString]
+                       paragraphAttributes:paragraphAttributes
+                         layoutConstraints:layoutConstraints
+                               textStorage:nil];
+  }
 }
 
 - (void)drawAttributedString:(AttributedString)attributedString


### PR DESCRIPTION
Summary:
changelog: [internal]

Do not construct `NSAttributedString` if NSTextStorage exists. Creating `NSAttributedString` is expensive and it isn't needed to measure text if `NSTextStorage` `exists`

Differential Revision: D44620292

