### PR TITLE
Re-land "[react-native][PR] [Upstream][Security] Use `execFileSync` over `exec` for cases with uncontrolled absolute paths"

### DIFF
--- a/packages/react-native/scripts/codegen/__tests__/generate-artifacts-executor-test.js
+++ b/packages/react-native/scripts/codegen/__tests__/generate-artifacts-executor-test.js
@@ -34,32 +34,39 @@ describe('generateCode', () => {
     const node = 'usr/bin/node';
     const pathToSchema = 'app/build/schema.json';
     const rnRoot = path.join(__dirname, '../..');
-    const libraryType = 'all';
+    const libraryTypeArg = 'all';
 
-    const tmpOutDir = path.join(tmpDir, 'out');
+    const tmpOutputDir = path.join(tmpDir, 'out');
 
     // mock used functions
     jest.spyOn(fs, 'mkdirSync').mockImplementation();
     jest.spyOn(child_process, 'execSync').mockImplementation();
+    jest.spyOn(child_process, 'execFileSync').mockImplementation();
 
     underTest._generateCode(iosOutputDir, library, tmpDir, node, pathToSchema);
 
-    const expectedCommand = `${node} ${path.join(
-      rnRoot,
-      'generate-specs-cli.js',
-    )}         --platform ios         --schemaPath ${pathToSchema}         --outputDir ${tmpOutDir}         --libraryName ${
-      library.config.name
-    }         --libraryType ${libraryType}`;
-
-    expect(child_process.execSync).toHaveBeenCalledTimes(2);
-    expect(child_process.execSync).toHaveBeenNthCalledWith(1, expectedCommand);
+    expect(child_process.execFileSync).toHaveBeenCalledTimes(1);
+    expect(child_process.execFileSync).toHaveBeenNthCalledWith(1, node, [
+      `${path.join(rnRoot, 'generate-specs-cli.js')}`,
+      '--platform',
+      'ios',
+      '--schemaPath',
+      pathToSchema,
+      '--outputDir',
+      tmpOutputDir,
+      '--libraryName',
+      library.config.name,
+      '--libraryType',
+      libraryTypeArg,
+    ]);
+    expect(child_process.execSync).toHaveBeenCalledTimes(1);
     expect(child_process.execSync).toHaveBeenNthCalledWith(
-      2,
-      `cp -R ${tmpOutDir}/* ${iosOutputDir}`,
+      1,
+      `cp -R ${tmpOutputDir}/* ${iosOutputDir}`,
     );
 
     expect(fs.mkdirSync).toHaveBeenCalledTimes(2);
-    expect(fs.mkdirSync).toHaveBeenNthCalledWith(1, tmpOutDir, {
+    expect(fs.mkdirSync).toHaveBeenNthCalledWith(1, tmpOutputDir, {
       recursive: true,
     });
     expect(fs.mkdirSync).toHaveBeenNthCalledWith(2, iosOutputDir, {

--- a/packages/react-native/scripts/codegen/generate-artifacts-executor.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor.js
@@ -16,7 +16,7 @@
  * in a codegenConfigFilename file.
  */
 
-const {execSync} = require('child_process');
+const {execSync, execFileSync} = require('child_process');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
@@ -45,8 +45,8 @@ function isReactNativeCoreLibrary(libraryName) {
   return libraryName in CORE_LIBRARIES_WITH_OUTPUT_FOLDER;
 }
 
-function executeNodeScript(node, script) {
-  execSync(`${node} ${script}`);
+function executeNodeScript(node, scriptArgs) {
+  execFileSync(node, scriptArgs);
 }
 
 function isAppRootValid(appRootDir) {
@@ -326,42 +326,47 @@ function generateSchema(tmpDir, library, node, codegenCliPath) {
 
   console.log(`\n\n[Codegen] >>>>> Processing ${library.config.name}`);
   // Generate one schema for the entire library...
-  executeNodeScript(
-    node,
+  executeNodeScript(node, [
     `${path.join(
       codegenCliPath,
       'lib',
       'cli',
       'combine',
       'combine-js-to-schema-cli.js',
-    )} --platform ios ${pathToSchema} ${pathToJavaScriptSources}`,
-  );
+    )}`,
+    '--platform',
+    'ios',
+    pathToSchema,
+    pathToJavaScriptSources,
+  ]);
   console.log(`[Codegen] Generated schema: ${pathToSchema}`);
   return pathToSchema;
 }
 
 function generateCode(iosOutputDir, library, tmpDir, node, pathToSchema) {
   // ...then generate native code artifacts.
-  const libraryTypeArg = library.config.type
-    ? `--libraryType ${library.config.type}`
-    : '';
+  const libraryTypeArg = library.config.type ? `${library.config.type}` : '';
 
   const tmpOutputDir = path.join(tmpDir, 'out');
   fs.mkdirSync(tmpOutputDir, {recursive: true});
 
-  executeNodeScript(
-    node,
+  executeNodeScript(node, [
     `${path.join(
       REACT_NATIVE_PACKAGE_ROOT_FOLDER,
       'scripts',
       'generate-specs-cli.js',
-    )} \
-        --platform ios \
-        --schemaPath ${pathToSchema} \
-        --outputDir ${tmpOutputDir} \
-        --libraryName ${library.config.name} \
-        ${libraryTypeArg}`,
-  );
+    )}`,
+    '--platform',
+    'ios',
+    '--schemaPath',
+    pathToSchema,
+    '--outputDir',
+    tmpOutputDir,
+    '--libraryName',
+    library.config.name,
+    '--libraryType',
+    libraryTypeArg,
+  ]);
 
   // Finally, copy artifacts to the final output directory.
   const outputDir =
@@ -426,14 +431,19 @@ function createComponentProvider(
 
     // Generate FabricComponentProvider.
     // Only for iOS at this moment.
-    executeNodeScript(
-      node,
+    executeNodeScript(node, [
       `${path.join(
         REACT_NATIVE_PACKAGE_ROOT_FOLDER,
         'scripts',
         'generate-provider-cli.js',
-      )} --platform ios --schemaListPath "${schemaListTmpPath}" --outputDir ${outputDir}`,
-    );
+      )}`,
+      '--platform',
+      'ios',
+      '--schemaListPath',
+      schemaListTmpPath,
+      '--outputDir',
+      outputDir,
+    ]);
     console.log(`Generated provider in: ${outputDir}`);
   }
 }

--- a/scripts/run-ci-e2e-tests.js
+++ b/scripts/run-ci-e2e-tests.js
@@ -20,7 +20,7 @@
  */
 
 const {cd, cp, echo, exec, exit, mv} = require('shelljs');
-const spawn = require('child_process').spawn;
+const {execFileSync, spawn} = require('child_process');
 const argv = require('yargs').argv;
 const path = require('path');
 
@@ -99,9 +99,11 @@ try {
   );
 
   describe('Scaffold a basic React Native app from template');
-  exec(
-    `rsync -a ${ROOT}/packages/react-native/template ${REACT_NATIVE_TEMP_DIR}`,
-  );
+  execFileSync('rsync', [
+    '-a',
+    `${ROOT}/packages/react-native/template`,
+    REACT_NATIVE_TEMP_DIR,
+  ]);
   cd(REACT_NATIVE_APP_DIR);
 
   mv('_bundle', '.bundle');


### PR DESCRIPTION
Summary:
This is a re-land of D44635949. It was reverted as it was a suspected cause of CircleCI fails. It turned out the diff was unrelated, and the cause was something else.

## Changelog

[Internal][Security] - Use execFileSync over exec for cases with uncontrolled absolute paths

Reviewed By: cortinico

Differential Revision: D44663132

