### PR TITLE
Fix a crash new app template when `createRootView` is invoked with null bundle

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactActivityDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactActivityDelegate.kt
@@ -45,6 +45,6 @@ open class DefaultReactActivityDelegate(
   override fun createRootView(): ReactRootView =
       ReactRootView(context).apply { setIsFabric(fabricEnabled) }
 
-  override fun createRootView(bundle: Bundle): ReactRootView =
+  override fun createRootView(bundle: Bundle?): ReactRootView =
       ReactRootView(context).apply { setIsFabric(fabricEnabled) }
 }


### PR DESCRIPTION
Summary:
As the title says, this fixes a instacrash on template when `createRootView` is invoked with
a bundle being null. The crash was happening as the parameter, despite being not used, is
specified as `Bundle` and is not nullable. When the Java caller passes `null`, the app crashes.

Changelog:
[Android] [Fixed] - Fix a crash new app template when `createRootView` is invoked with null bundle

Differential Revision: D44668305

