### PR TITLE
Remove unused fields from AndroidTextInputState

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputComponentDescriptor.h
@@ -76,8 +76,6 @@ class AndroidTextInputComponentDescriptor final
             {},
             {},
             {},
-            {},
-            {},
             ((YGValue)theme[YGEdgeStart]).value,
             ((YGValue)theme[YGEdgeEnd]).value,
             ((YGValue)theme[YGEdgeTop]).value,

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputShadowNode.cpp
@@ -132,14 +132,6 @@ void AndroidTextInputShadowNode::updateStateIfNeeded() {
     return;
   }
 
-  // Store default TextAttributes in state.
-  // In the case where the TextInput is completely empty (no value, no
-  // defaultValue, no placeholder, no children) there are therefore no fragments
-  // in the AttributedString, and when State is updated, it needs some way to
-  // reconstruct a Fragment with default TextAttributes.
-  auto defaultTextAttributes = TextAttributes::defaultTextAttributes();
-  defaultTextAttributes.apply(getConcreteProps().textAttributes);
-
   // Even if we're here and updating state, it may be only to update the layout
   // manager If that is the case, make sure we don't update text: pass in the
   // current attributedString unchanged, and pass in zero for the "event count"
@@ -156,8 +148,6 @@ void AndroidTextInputShadowNode::updateStateIfNeeded() {
       newAttributedString,
       reactTreeAttributedString,
       getConcreteProps().paragraphAttributes,
-      defaultTextAttributes,
-      ShadowView(*this),
       state.defaultThemePaddingStart,
       state.defaultThemePaddingEnd,
       state.defaultThemePaddingTop,

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputState.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputState.cpp
@@ -24,8 +24,6 @@ AndroidTextInputState::AndroidTextInputState(
     AttributedString attributedString,
     AttributedString reactTreeAttributedString,
     ParagraphAttributes paragraphAttributes,
-    TextAttributes defaultTextAttributes,
-    ShadowView defaultParentShadowView,
     float defaultThemePaddingStart,
     float defaultThemePaddingEnd,
     float defaultThemePaddingTop,
@@ -34,8 +32,6 @@ AndroidTextInputState::AndroidTextInputState(
       attributedString(std::move(attributedString)),
       reactTreeAttributedString(std::move(reactTreeAttributedString)),
       paragraphAttributes(std::move(paragraphAttributes)),
-      defaultTextAttributes(std::move(defaultTextAttributes)),
-      defaultParentShadowView(std::move(defaultParentShadowView)),
       defaultThemePaddingStart(defaultThemePaddingStart),
       defaultThemePaddingEnd(defaultThemePaddingEnd),
       defaultThemePaddingTop(defaultThemePaddingTop),
@@ -55,8 +51,6 @@ AndroidTextInputState::AndroidTextInputState(
       attributedString(previousState.attributedString),
       reactTreeAttributedString(previousState.reactTreeAttributedString),
       paragraphAttributes(previousState.paragraphAttributes),
-      defaultTextAttributes(previousState.defaultTextAttributes),
-      defaultParentShadowView(previousState.defaultParentShadowView),
       defaultThemePaddingStart(data.getDefault(
                                        "themePaddingStart",
                                        previousState.defaultThemePaddingStart)

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputState.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputState.h
@@ -55,20 +55,6 @@ class AndroidTextInputState final {
   ParagraphAttributes paragraphAttributes{};
 
   /**
-   * Default TextAttributes used if we need to construct a new Fragment.
-   * Only used if text is inserted into an AttributedString with no existing
-   * Fragments.
-   */
-  TextAttributes defaultTextAttributes;
-
-  /**
-   * Default parent ShadowView used if we need to construct a new Fragment.
-   * Only used if text is inserted into an AttributedString with no existing
-   * Fragments.
-   */
-  ShadowView defaultParentShadowView;
-
-  /**
    * Communicates Android theme padding back to the ShadowNode / Component
    * Descriptor for layout.
    */
@@ -82,8 +68,6 @@ class AndroidTextInputState final {
       AttributedString attributedString,
       AttributedString reactTreeAttributedString,
       ParagraphAttributes paragraphAttributes,
-      TextAttributes defaultTextAttributes,
-      ShadowView defaultParentShadowView,
       float defaultThemePaddingStart,
       float defaultThemePaddingEnd,
       float defaultThemePaddingTop,


### PR DESCRIPTION
Summary:
defaultParentShadowView and defaultTextAttributes are never used

Changelog: [Internal]

Differential Revision: D44665067

