### PR TITLE
Move Hermes code coverage to non-OSS

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/.clang-format
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/.clang-format
@@ -1,0 +1,91 @@
+---
+AccessModifierOffset: -1
+AlignAfterOpenBracket: AlwaysBreak
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlinesLeft: true
+AlignOperands:   false
+AlignTrailingComments: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: false
+BinPackParameters: false
+BraceWrapping:
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: false
+ColumnLimit:       80
+CommentPragmas:  '^ IWYU pragma:'
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ForEachMacros:   [ FOR_EACH_RANGE, FOR_EACH, ]
+IncludeCategories:
+  - Regex:           '^<.*\.h(pp)?>'
+    Priority:        1
+  - Regex:           '^<.*'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        3
+IndentCaseLabels: true
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Right
+ReflowComments:  true
+SortIncludes:    true
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+TabWidth:        8
+UseTab:          Never
+---
+Language: ObjC
+ColumnLimit:     120
+BreakBeforeBraces: WebKit
+...

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/.clang-tidy
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/.clang-tidy
@@ -1,0 +1,20 @@
+---
+Checks: '
+*,
+-cert-err60-cpp,
+-cppcoreguidelines-pro-bounds-pointer-arithmetic,
+-cppcoreguidelines-special-member-functions,
+-cppcoreguidelines-pro-type-const-cast,
+-fuchsia-default-arguments-calls,
+-fuchsia-multiple-inheritance,
+-google-readability-casting,
+-google-runtime-int,
+-google-runtime-references,
+-hicpp-special-member-functions,
+-llvm-header-guard,
+-misc-non-private-member-variables-in-classes,
+-misc-unused-parameters,
+-modernize-use-trailing-return-type,
+-performance-unnecessary-value-param
+'
+...

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/BridgelessAtomicRef.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/BridgelessAtomicRef.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+
+package com.facebook.react.bridgeless;
+
+import static com.facebook.infer.annotation.Assertions.assertNotNull;
+
+import android.annotation.SuppressLint;
+import androidx.annotation.Nullable;
+import com.facebook.infer.annotation.Nullsafe;
+
+@Nullsafe(Nullsafe.Mode.LOCAL)
+public class BridgelessAtomicRef<T> {
+
+  interface Provider<T> {
+    T get();
+  }
+
+  @Nullable volatile T mValue;
+  @Nullable T mInitialValue;
+
+  enum State {
+    Init,
+    Creating,
+    Success,
+    Failure
+  }
+
+  volatile State state;
+  volatile String failureMessage;
+
+  public BridgelessAtomicRef(@Nullable T initialValue) {
+    mValue = initialValue;
+    mInitialValue = initialValue;
+    state = State.Init;
+    failureMessage = "";
+  }
+
+  public BridgelessAtomicRef() {
+    this(null);
+  }
+
+  @SuppressLint("CatchGeneralException")
+  public T getOrCreate(BridgelessAtomicRef.Provider<T> provider) {
+    boolean shouldCreate = false;
+    synchronized (this) {
+      if (state == State.Success) {
+        return get();
+      }
+
+      if (state == State.Failure) {
+        throw new RuntimeException(
+            "BridgelessAtomicRef: Failed to create object. Reason: " + failureMessage);
+      }
+
+      if (state != State.Creating) {
+        state = State.Creating;
+        shouldCreate = true;
+      }
+    }
+
+    if (shouldCreate) {
+      try {
+        // Call provider with lock on `this` released to mitigate deadlock hazard
+        mValue = provider.get();
+
+        synchronized (this) {
+          state = State.Success;
+          notifyAll();
+          return get();
+        }
+      } catch (RuntimeException ex) {
+        synchronized (this) {
+          state = State.Failure;
+          String message = ex.getMessage();
+          failureMessage = message != null ? message : "null";
+          notifyAll();
+        }
+
+        throw new RuntimeException("BridgelessAtomicRef: Failed to create object.", ex);
+      }
+    }
+
+    synchronized (this) {
+      boolean wasInterrupted = false;
+      while (state == State.Creating) {
+        try {
+          wait();
+        } catch (InterruptedException ex) {
+          wasInterrupted = true;
+        }
+      }
+
+      if (wasInterrupted) {
+        Thread.currentThread().interrupt();
+      }
+
+      if (state == State.Failure) {
+        throw new RuntimeException(
+            "BridgelessAtomicRef: Failed to create object. Reason: " + failureMessage);
+      }
+
+      return get();
+    }
+  }
+
+  public synchronized T getAndReset() {
+    T value = get();
+    reset();
+    return value;
+  }
+
+  public synchronized void reset() {
+    mValue = mInitialValue;
+    state = State.Init;
+    failureMessage = "";
+  }
+
+  public synchronized T get() {
+    return assertNotNull(mValue);
+  }
+
+  public synchronized @Nullable T getNullable() {
+    return mValue;
+  }
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/BridgelessDevSupportManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/BridgelessDevSupportManager.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+
+package com.facebook.react.bridgeless;
+
+import android.app.Activity;
+import android.content.Context;
+import android.view.View;
+import bolts.Continuation;
+import bolts.Task;
+import com.facebook.infer.annotation.Nullsafe;
+import com.facebook.react.bridge.JSBundleLoader;
+import com.facebook.react.bridge.JavaJSExecutor;
+import com.facebook.react.bridge.JavaScriptExecutorFactory;
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.devsupport.DevSupportManagerBase;
+import com.facebook.react.devsupport.HMRClient;
+import com.facebook.react.devsupport.ReactInstanceDevHelper;
+import com.facebook.react.devsupport.interfaces.DevSplitBundleCallback;
+import com.facebook.react.modules.core.DeviceEventManagerModule;
+import javax.annotation.Nullable;
+
+/**
+ * An implementation of {@link com.facebook.react.devsupport.interfaces.DevSupportManager} that
+ * extends the functionality in {@link DevSupportManagerBase} with some additional, more flexible
+ * APIs for asynchronously loading the JS bundle.
+ */
+@Nullsafe(Nullsafe.Mode.LOCAL)
+public class BridgelessDevSupportManager extends DevSupportManagerBase {
+
+  private final ReactHost mReactHost;
+
+  public BridgelessDevSupportManager(
+      ReactHost host, Context context, @Nullable String packagerPathForJSBundleName) {
+    super(
+        context.getApplicationContext(),
+        createInstanceDevHelper(host),
+        packagerPathForJSBundleName,
+        true /* enableOnCreate */,
+        null /* redBoxHandler */,
+        null /* devBundleDownloadListener */,
+        2 /* minNumShakes */,
+        null /* customPackagerCommandHandlers */,
+        null /* surfaceDelegateFactory */,
+        null /* devLoadingViewManager */);
+    mReactHost = host;
+  }
+
+  @Override
+  protected String getUniqueTag() {
+    return "Bridgeless";
+  }
+
+  @Override
+  public void loadSplitBundleFromServer(
+      final String bundlePath, final DevSplitBundleCallback callback) {
+    fetchSplitBundleAndCreateBundleLoader(
+        bundlePath,
+        new CallbackWithBundleLoader() {
+          @Override
+          public void onSuccess(final JSBundleLoader bundleLoader) {
+            mReactHost
+                .loadBundle(bundleLoader)
+                .onSuccess(
+                    new Continuation<Boolean, Void>() {
+                      @Override
+                      public Void then(Task<Boolean> task) {
+                        if (task.getResult().equals(Boolean.TRUE)) {
+                          String bundleURL =
+                              getDevServerHelper().getDevServerSplitBundleURL(bundlePath);
+                          ReactContext reactContext = mReactHost.getCurrentReactContext();
+                          if (reactContext != null) {
+                            reactContext.getJSModule(HMRClient.class).registerBundle(bundleURL);
+                          }
+                          callback.onSuccess();
+                        }
+                        return null;
+                      }
+                    });
+          }
+
+          @Override
+          public void onError(String url, Throwable cause) {
+            callback.onError(url, cause);
+          }
+        });
+  }
+
+  @Override
+  public void handleReloadJS() {
+    hideRedboxDialog();
+    mReactHost.reload("BridgelessDevSupportManager.handleReloadJS()");
+  }
+
+  private static ReactInstanceDevHelper createInstanceDevHelper(final ReactHost reactHost) {
+    return new ReactInstanceDevHelper() {
+      @Override
+      public void onReloadWithJSDebugger(JavaJSExecutor.Factory proxyExecutorFactory) {
+        // Not implemented
+      }
+
+      @Override
+      public void onJSBundleLoadedFromServer() {
+        throw new IllegalStateException("Not implemented for bridgeless mode");
+      }
+
+      @Override
+      public void toggleElementInspector() {
+        ReactContext reactContext = reactHost.getCurrentReactContext();
+        if (reactContext != null) {
+          reactContext
+              .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+              .emit("toggleElementInspector", null);
+        }
+      }
+
+      @androidx.annotation.Nullable
+      @Override
+      public Activity getCurrentActivity() {
+        return reactHost.getCurrentActivity();
+      }
+
+      @Override
+      public JavaScriptExecutorFactory getJavaScriptExecutorFactory() {
+        throw new IllegalStateException("Not implemented for bridgeless mode");
+      }
+
+      @androidx.annotation.Nullable
+      @Override
+      public View createRootView(String appKey) {
+        Activity currentActivity = getCurrentActivity();
+        if (currentActivity != null && !reactHost.isSurfaceWithModuleNameAttached(appKey)) {
+          ReactSurface reactSurface = ReactSurface.createWithView(currentActivity, appKey, null);
+          reactSurface.attach(reactHost);
+          reactSurface.start();
+
+          return reactSurface.getView();
+        }
+        return null;
+      }
+
+      @Override
+      public void destroyRootView(View rootView) {
+        // Not implemented
+      }
+    };
+  }
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/BridgelessReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/BridgelessReactContext.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+
+package com.facebook.react.bridgeless;
+
+import android.content.Context;
+import com.facebook.infer.annotation.Nullsafe;
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.Callback;
+import com.facebook.react.bridge.CatalystInstance;
+import com.facebook.react.bridge.JSIModule;
+import com.facebook.react.bridge.JSIModuleType;
+import com.facebook.react.bridge.JavaScriptModule;
+import com.facebook.react.bridge.JavaScriptModuleRegistry;
+import com.facebook.react.bridge.NativeArray;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactNoCrashBridgeNotAllowedSoftException;
+import com.facebook.react.bridge.ReactSoftExceptionLogger;
+import com.facebook.react.bridge.WritableNativeArray;
+import com.facebook.react.devsupport.interfaces.DevSupportManager;
+import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
+import com.facebook.react.uimanager.events.EventDispatcher;
+import com.facebook.react.uimanager.events.EventDispatcherProvider;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.Collection;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nullable;
+
+/**
+ * This class is used instead of {@link ReactApplicationContext} when React Native is operating in
+ * bridgeless mode. The purpose of this class is to override some methods on {@link
+ * com.facebook.react.bridge.ReactContext} that use the {@link
+ * com.facebook.react.bridge.CatalystInstance}, which doesn't exist in bridgeless mode.
+ */
+@Nullsafe(Nullsafe.Mode.LOCAL)
+public class BridgelessReactContext extends ReactApplicationContext
+    implements EventDispatcherProvider {
+
+  private final ReactHost mReactHost;
+  private final AtomicReference<String> mSourceURL = new AtomicReference<>();
+  private final String TAG = this.getClass().getSimpleName();
+
+  BridgelessReactContext(Context context, ReactHost host) {
+    super(context);
+    mReactHost = host;
+  }
+
+  @Override
+  public boolean isBridgeless() {
+    return true;
+  }
+
+  @Override
+  public EventDispatcher getEventDispatcher() {
+    return mReactHost.getEventDispatcher();
+  }
+
+  public void setSourceURL(String sourceURL) {
+    mSourceURL.set(sourceURL);
+  }
+
+  @Override
+  public @Nullable String getSourceURL() {
+    return mSourceURL.get();
+  }
+
+  @Override
+  public @Nullable JSIModule getJSIModule(JSIModuleType moduleType) {
+    if (moduleType == JSIModuleType.UIManager) {
+      return mReactHost.getUIManager();
+    }
+    throw new UnsupportedOperationException(
+        "getJSIModule is not implemented for bridgeless mode. Trying to get module: "
+            + moduleType.name());
+  }
+
+  @Override
+  public CatalystInstance getCatalystInstance() {
+    ReactSoftExceptionLogger.logSoftExceptionVerbose(
+        TAG,
+        new ReactNoCrashBridgeNotAllowedSoftException(
+            "getCatalystInstance() cannot be called when the bridge is disabled"));
+    throw new UnsupportedOperationException("There is no Catalyst instance in bridgeless mode.");
+  }
+
+  @Override
+  public boolean hasActiveReactInstance() {
+    return mReactHost.isInstanceInitialized();
+  }
+
+  public DevSupportManager getDevSupportManager() {
+    return mReactHost.getDevSupportManager();
+  }
+
+  @Override
+  public void registerSegment(int segmentId, String path, Callback callback) {
+    mReactHost.registerSegment(segmentId, path, callback);
+  }
+
+  private static class BridgelessJSModuleInvocationHandler implements InvocationHandler {
+    private final ReactHost mReactHost;
+    private final Class<? extends JavaScriptModule> mJSModuleInterface;
+
+    public BridgelessJSModuleInvocationHandler(
+        ReactHost reactHost, Class<? extends JavaScriptModule> jsModuleInterface) {
+      mReactHost = reactHost;
+      mJSModuleInterface = jsModuleInterface;
+    }
+
+    @Override
+    public @Nullable Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+      NativeArray jsArgs = args != null ? Arguments.fromJavaArgs(args) : new WritableNativeArray();
+      mReactHost.callFunctionOnModule(
+          JavaScriptModuleRegistry.getJSModuleName(mJSModuleInterface), method.getName(), jsArgs);
+      return null;
+    }
+  }
+
+  @Override
+  public <T extends JavaScriptModule> T getJSModule(Class<T> jsInterface) {
+    JavaScriptModule interfaceProxy =
+        (JavaScriptModule)
+            Proxy.newProxyInstance(
+                jsInterface.getClassLoader(),
+                new Class[] {jsInterface},
+                new BridgelessJSModuleInvocationHandler(mReactHost, jsInterface));
+    return (T) interfaceProxy;
+  }
+
+  @Override
+  public <T extends NativeModule> boolean hasNativeModule(Class<T> nativeModuleInterface) {
+    return mReactHost.hasNativeModule(nativeModuleInterface);
+  }
+
+  @Override
+  public Collection<NativeModule> getNativeModules() {
+    return mReactHost.getNativeModules();
+  }
+
+  @Override
+  public @Nullable <T extends NativeModule> T getNativeModule(Class<T> nativeModuleInterface) {
+    return mReactHost.getNativeModule(nativeModuleInterface);
+  }
+
+  @Override
+  public void handleException(Exception e) {
+    mReactHost.handleException(e);
+  }
+
+  public DefaultHardwareBackBtnHandler getDefaultHardwareBackBtnHandler() {
+    return mReactHost.getDefaultBackButtonHandler();
+  }
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/BridgelessReactStateTracker.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/BridgelessReactStateTracker.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+
+package com.facebook.react.bridgeless;
+
+import com.facebook.common.logging.FLog;
+import com.facebook.infer.annotation.Nullsafe;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@Nullsafe(Nullsafe.Mode.LOCAL)
+public class BridgelessReactStateTracker {
+  final List<String> mStates = Collections.synchronizedList(new ArrayList<String>());
+  final boolean mShouldTrackStates;
+
+  BridgelessReactStateTracker(boolean shouldTrackStates) {
+    mShouldTrackStates = shouldTrackStates;
+  }
+
+  public void enterState(String state) {
+    FLog.w("BridgelessReact", state);
+    if (mShouldTrackStates) {
+      mStates.add(state);
+    }
+  }
+
+  public void assertStateOrder(String... expectedStates) {
+    // TODO: Implement
+  }
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/JSEngineInstance.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/JSEngineInstance.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+
+package com.facebook.react.bridgeless;
+
+import com.facebook.infer.annotation.Nullsafe;
+import com.facebook.jni.HybridData;
+import com.facebook.proguard.annotations.DoNotStrip;
+import com.facebook.soloader.SoLoader;
+
+@Nullsafe(Nullsafe.Mode.LOCAL)
+public abstract class JSEngineInstance {
+  static {
+    SoLoader.loadLibrary("rninstance");
+  }
+
+  @DoNotStrip private HybridData mHybridData;
+
+  protected JSEngineInstance(HybridData hybridData) {
+    mHybridData = hybridData;
+  }
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/JSTimerExecutor.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/JSTimerExecutor.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+
+package com.facebook.react.bridgeless;
+
+import com.facebook.infer.annotation.Nullsafe;
+import com.facebook.jni.HybridData;
+import com.facebook.jni.annotations.DoNotStrip;
+import com.facebook.react.bridge.WritableArray;
+import com.facebook.react.bridge.WritableNativeArray;
+import com.facebook.react.modules.core.JavaScriptTimerExecutor;
+import com.facebook.soloader.SoLoader;
+import com.facebook.soloader.annotation.SoLoaderLibrary;
+
+@Nullsafe(Nullsafe.Mode.LOCAL)
+@SoLoaderLibrary("rninstance")
+public class JSTimerExecutor implements JavaScriptTimerExecutor {
+
+  static {
+    SoLoader.loadLibrary("rninstance");
+  }
+
+  @DoNotStrip private HybridData mHybridData;
+
+  public JSTimerExecutor(HybridData hybridData) {
+    mHybridData = hybridData;
+  }
+
+  @Override
+  public void callTimers(WritableArray timerIDs) {
+    callTimers((WritableNativeArray) timerIDs);
+  }
+
+  private native void callTimers(WritableNativeArray timerIDs);
+
+  @Override
+  public void callIdleCallbacks(double frameTime) {
+    // TODO T52558331
+  }
+
+  @Override
+  public void emitTimeDriftWarning(String warningMessage) {
+    // TODO T52558331
+  }
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHost.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHost.java
@@ -1,0 +1,1437 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+
+package com.facebook.react.bridgeless;
+
+import static com.facebook.infer.annotation.Assertions.assertNotNull;
+import static com.facebook.infer.annotation.Assertions.nullsafeFIXME;
+import static com.facebook.infer.annotation.ThreadConfined.UI;
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
+
+import android.app.Activity;
+import android.content.Context;
+import androidx.annotation.Nullable;
+import bolts.Continuation;
+import bolts.Task;
+import bolts.TaskCompletionSource;
+import com.facebook.common.logging.FLog;
+import com.facebook.infer.annotation.Assertions;
+import com.facebook.infer.annotation.Nullsafe;
+import com.facebook.infer.annotation.ThreadConfined;
+import com.facebook.infer.annotation.ThreadSafe;
+import com.facebook.react.MemoryPressureRouter;
+import com.facebook.react.ReactInstanceEventListener;
+import com.facebook.react.bridge.Callback;
+import com.facebook.react.bridge.JSBundleLoader;
+import com.facebook.react.bridge.MemoryPressureListener;
+import com.facebook.react.bridge.NativeArray;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.ReactMarker;
+import com.facebook.react.bridge.ReactMarkerConstants;
+import com.facebook.react.bridge.ReactNoCrashBridgeNotAllowedSoftException;
+import com.facebook.react.bridge.ReactNoCrashSoftException;
+import com.facebook.react.bridge.ReactSoftExceptionLogger;
+import com.facebook.react.bridge.UiThreadUtil;
+import com.facebook.react.bridge.queue.QueueThreadExceptionHandler;
+import com.facebook.react.bridge.queue.ReactQueueConfiguration;
+import com.facebook.react.bridgeless.exceptionmanager.ReactJsExceptionHandler;
+import com.facebook.react.common.LifecycleState;
+import com.facebook.react.common.build.ReactBuildConfig;
+import com.facebook.react.config.ReactFeatureFlags;
+import com.facebook.react.devsupport.DisabledDevSupportManager;
+import com.facebook.react.devsupport.interfaces.DevSupportManager;
+import com.facebook.react.fabric.FabricUIManager;
+import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
+import com.facebook.react.modules.core.DeviceEventManagerModule;
+import com.facebook.react.uimanager.UIManagerModule;
+import com.facebook.react.uimanager.events.BlackHoleEventDispatcher;
+import com.facebook.react.uimanager.events.EventDispatcher;
+import com.facebook.react.views.imagehelper.ResourceDrawableIdHelper;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * A ReactHost is an object that manages a single {@link ReactInstance}. A ReactHost can be
+ * constructed without initializing the ReactInstance, and it will continue to exist after the
+ * instance is destroyed. This class ensures safe access to the ReactInstance and the JS runtime;
+ * methods that operate on the instance use Bolts Tasks to defer the operation until the instance
+ * has been initialized. They also return a Task so the caller can be notified of completion.
+ *
+ * @see <a href="https://github.com/BoltsFramework/Bolts-Android#tasks">Bolts Android</a>
+ */
+@ThreadSafe
+@Nullsafe(Nullsafe.Mode.LOCAL)
+public class ReactHost {
+
+  // TODO T61403233 Make this configurable by product code
+  private static final boolean DEV = ReactBuildConfig.DEBUG;
+
+  private static final int BRIDGELESS_MARKER_INSTANCE_KEY = 1;
+
+  public static final String TAG = "ReactHost";
+
+  private final Context mContext;
+  private final ReactInstanceDelegate mReactInstanceDelegate;
+  private final ReactJsExceptionHandler mReactJsExceptionHandler;
+  private final DevSupportManager mDevSupportManager;
+  private final Executor mBGExecutor;
+  private final Executor mUIExecutor;
+  private final QueueThreadExceptionHandler mQueueThreadExceptionHandler;
+  private final Set<ReactSurface> mAttachedSurfaces =
+      Collections.synchronizedSet(new HashSet<ReactSurface>());
+  private final MemoryPressureRouter mMemoryPressureRouter;
+  private final MemoryPressureListener mMemoryPressureListener;
+  private final boolean mAllowPackagerServerAccess;
+  private final boolean mUseDevSupport;
+  private final Collection<ReactInstanceEventListener> mReactInstanceEventListeners =
+      Collections.synchronizedList(new ArrayList<ReactInstanceEventListener>());
+
+  private final BridgelessAtomicRef<Task<ReactInstance>> mReactInstanceTaskRef =
+      new BridgelessAtomicRef<>(
+          Task.forResult(
+              nullsafeFIXME(
+                  (ReactInstance) null,
+                  "forResult parameter supports null, but is not annotated as @Nullable")));
+
+  private final BridgelessAtomicRef<BridgelessReactContext> mBridgelessReactContextRef =
+      new BridgelessAtomicRef<>(null);
+
+  private final AtomicReference<Activity> mActivity = new AtomicReference<>();
+  private @Nullable DefaultHardwareBackBtnHandler mDefaultHardwareBackBtnHandler;
+  private final BridgelessReactStateTracker mBridgelessReactStateTracker =
+      new BridgelessReactStateTracker(DEV);
+  private final ReactLifecycleStateManager mReactLifecycleStateManager =
+      new ReactLifecycleStateManager(mBridgelessReactStateTracker);
+
+  private static AtomicInteger mCounter = new AtomicInteger(0);
+  private final int mId = mCounter.getAndIncrement();
+
+  public ReactHost(
+      Context context,
+      ReactInstanceDelegate delegate,
+      boolean allowPackagerServerAccess,
+      ReactJsExceptionHandler reactJsExceptionHandler,
+      boolean useDevSupport) {
+    this(
+        context,
+        delegate,
+        Executors.newSingleThreadExecutor(),
+        Task.UI_THREAD_EXECUTOR,
+        reactJsExceptionHandler,
+        allowPackagerServerAccess,
+        useDevSupport);
+  }
+
+  public ReactHost(
+      Context context,
+      ReactInstanceDelegate delegate,
+      Executor bgExecutor,
+      Executor uiExecutor,
+      ReactJsExceptionHandler reactJsExceptionHandler,
+      boolean allowPackagerServerAccess,
+      boolean useDevSupport) {
+    mContext = context;
+    mReactInstanceDelegate = delegate;
+    mBGExecutor = bgExecutor;
+    mUIExecutor = uiExecutor;
+    mReactJsExceptionHandler = reactJsExceptionHandler;
+    mQueueThreadExceptionHandler = ReactHost.this::handleException;
+    mMemoryPressureRouter = new MemoryPressureRouter(context);
+    mMemoryPressureListener =
+        level ->
+            callWithExistingReactInstance(
+                "handleMemoryPressure(" + level + ")",
+                reactInstance -> reactInstance.handleMemoryPressure(level));
+    mAllowPackagerServerAccess = allowPackagerServerAccess;
+    if (DEV) {
+      mDevSupportManager =
+          new BridgelessDevSupportManager(
+              ReactHost.this, mContext, mReactInstanceDelegate.getJSMainModulePath());
+    } else {
+      mDevSupportManager = new DisabledDevSupportManager();
+    }
+    mUseDevSupport = useDevSupport;
+  }
+
+  public LifecycleState getLifecycleState() {
+    return mReactLifecycleStateManager.getLifecycleState();
+  }
+
+  /**
+   * This function can be used to initialize the ReactInstance in a background thread before a
+   * surface needs to be rendered. It is not necessary to call this function; startSurface() will
+   * initialize the ReactInstance if it hasn't been preloaded.
+   *
+   * @return A Task that completes when the instance is initialized. The task will be faulted if any
+   *     errors occur during initialization, and will be cancelled if ReactHost.destroy() is called
+   *     before it completes.
+   */
+  public Task<Void> preload() {
+    if (ReactFeatureFlags.enableBridgelessArchitectureNewCreateReloadDestroy) {
+      return new_preload();
+    }
+
+    return old_preload();
+  }
+
+  @Nullable Task<Void> mPreloadTask = null;
+
+  public Task<Void> old_preload() {
+    final String method = "old_preload()";
+    return Task.call(
+            () -> {
+              if (mPreloadTask == null) {
+                log(method, "Schedule");
+                mPreloadTask =
+                    getOrCreateReactInstanceTask()
+                        .continueWithTask(
+                            task -> {
+                              if (task.isFaulted()) {
+                                destroy(
+                                    "old_preload() failure: " + task.getError().getMessage(),
+                                    task.getError());
+                                mReactInstanceDelegate.handleException(task.getError());
+                              }
+
+                              return task;
+                            },
+                            mBGExecutor)
+                        .makeVoid();
+              }
+              return mPreloadTask;
+            },
+            mBGExecutor)
+        .continueWithTask(Task::getResult);
+  }
+
+  public Task<Void> new_preload() {
+    final String method = "new_preload()";
+    return Task.call(
+            () -> {
+              if (mPreloadTask == null) {
+                log(method, "Schedule");
+                mPreloadTask =
+                    getOrCreateReactInstanceTask()
+                        .continueWithTask(
+                            (task) -> {
+                              if (task.isFaulted()) {
+                                mReactInstanceDelegate.handleException(task.getError());
+                                // Wait for destroy to finish
+                                return new_getOrCreateDestroyTask(
+                                        "new_preload() failure: " + task.getError().getMessage(),
+                                        task.getError())
+                                    .continueWithTask(destroyTask -> Task.forError(task.getError()))
+                                    .makeVoid();
+                              }
+                              return task.makeVoid();
+                            },
+                            mBGExecutor);
+              }
+              return mPreloadTask;
+            },
+            mBGExecutor)
+        .continueWithTask(Task::getResult);
+  }
+
+  /** Initialize and run a React Native surface in a background without mounting real views. */
+  public Task<Void> prerenderSurface(final ReactSurface surface) {
+    final String method = "prerenderSurface(surfaceId = " + surface.getSurfaceID() + ")";
+    log(method, "Schedule");
+
+    attachSurface(surface);
+    return callAfterGetOrCreateReactInstance(
+        method,
+        reactInstance -> {
+          log(method, "Execute");
+          reactInstance.prerenderSurface(surface);
+        });
+  }
+
+  /**
+   * Start rendering a React Native surface on screen.
+   *
+   * @param surface The ReactSurface to render
+   * @return A Task that will complete when startSurface has been called.
+   */
+  public Task<Void> startSurface(final ReactSurface surface) {
+    final String method = "startSurface(surfaceId = " + surface.getSurfaceID() + ")";
+    log(method, "Schedule");
+
+    attachSurface(surface);
+    return callAfterGetOrCreateReactInstance(
+        method,
+        reactInstance -> {
+          log(method, "Execute");
+          reactInstance.startSurface(surface);
+        });
+  }
+
+  /**
+   * Stop rendering a React Native surface.
+   *
+   * @param surface The surface to stop
+   * @return A Task that will complete when stopSurface has been called.
+   */
+  public Task<Boolean> stopSurface(final ReactSurface surface) {
+    final String method = "stopSurface(surfaceId = " + surface.getSurfaceID() + ")";
+    log(method, "Schedule");
+
+    detachSurface(surface);
+    return callWithExistingReactInstance(
+        method,
+        reactInstance -> {
+          log(method, "Execute");
+          reactInstance.stopSurface(surface);
+        });
+  }
+
+  /**
+   * To be called when the host activity is resumed.
+   *
+   * @param activity The host activity
+   */
+  @ThreadConfined(UI)
+  public void onHostResume(
+      final @Nullable Activity activity, DefaultHardwareBackBtnHandler defaultBackButtonImpl) {
+    mDefaultHardwareBackBtnHandler = defaultBackButtonImpl;
+    onHostResume(activity);
+  }
+
+  @ThreadConfined(UI)
+  public void onHostResume(final @Nullable Activity activity) {
+    final String method = "onHostResume(activity)";
+    log(method);
+
+    mActivity.set(activity);
+    ReactContext currentContext = getCurrentReactContext();
+
+    // TODO(T137233065): Enable DevSupportManager here
+    mReactLifecycleStateManager.moveToOnHostResume(currentContext, mActivity.get());
+  }
+
+  @ThreadConfined(UI)
+  public void onHostPause(final @Nullable Activity activity) {
+    final String method = "onHostPause(activity)";
+    log(method);
+
+    ReactContext currentContext = getCurrentReactContext();
+
+    Activity currentActivity = mActivity.get();
+    if (currentActivity != null) {
+      String currentActivityClass = currentActivity.getClass().getSimpleName();
+      String activityClass = activity == null ? "null" : activity.getClass().getSimpleName();
+      Assertions.assertCondition(
+          activity == currentActivity,
+          "Pausing an activity that is not the current activity, this is incorrect! "
+              + "Current activity: "
+              + currentActivityClass
+              + " "
+              + "Paused activity: "
+              + activityClass);
+    }
+
+    // TODO(T137233065): Disable DevSupportManager here
+    mDefaultHardwareBackBtnHandler = null;
+    mReactLifecycleStateManager.moveToOnHostPause(currentContext, currentActivity);
+  }
+
+  /** To be called when the host activity is paused. */
+  @ThreadConfined(UI)
+  public void onHostPause() {
+    final String method = "onHostPause()";
+    log(method);
+
+    ReactContext currentContext = getCurrentReactContext();
+
+    // TODO(T137233065): Disable DevSupportManager here
+    mDefaultHardwareBackBtnHandler = null;
+    mReactLifecycleStateManager.moveToOnHostPause(currentContext, mActivity.get());
+  }
+
+  /** To be called when the host activity is destroyed. */
+  @ThreadConfined(UI)
+  public void onHostDestroy() {
+    final String method = "onHostDestroy()";
+    log(method);
+
+    // TODO(T137233065): Disable DevSupportManager here
+    moveToHostDestroy(getCurrentReactContext());
+  }
+
+  @ThreadConfined(UI)
+  public void onHostDestroy(@Nullable Activity activity) {
+    final String method = "onHostDestroy(activity)";
+    log(method);
+
+    Activity currentActivity = mActivity.get();
+
+    // TODO(T137233065): Disable DevSupportManager here
+    if (currentActivity == activity) {
+      moveToHostDestroy(getCurrentReactContext());
+    }
+  }
+
+  @ThreadConfined(UI)
+  private void moveToHostDestroy(@Nullable ReactContext currentContext) {
+    mReactLifecycleStateManager.moveToOnHostDestroy(currentContext);
+    mActivity.set(null);
+  }
+
+  /**
+   * Returns current ReactContext which could be nullable if ReactInstance hasn't been created.
+   *
+   * @return The {@link BridgelessReactContext} associated with ReactInstance.
+   */
+  public @Nullable BridgelessReactContext getCurrentReactContext() {
+    return mBridgelessReactContextRef.getNullable();
+  }
+
+  public DevSupportManager getDevSupportManager() {
+    return assertNotNull(mDevSupportManager);
+  }
+
+  public @Nullable Activity getCurrentActivity() {
+    return mActivity.get();
+  }
+
+  /**
+   * Get the {@link EventDispatcher} from the {@link FabricUIManager}. This always returns an
+   * EventDispatcher, even if the instance isn't alive; in that case, it returns a {@link
+   * BlackHoleEventDispatcher} which no-ops.
+   *
+   * @return The real {@link EventDispatcher} if the instance is alive; otherwise, a {@link
+   *     BlackHoleEventDispatcher}.
+   */
+  public EventDispatcher getEventDispatcher() {
+    final ReactInstance reactInstance = mReactInstanceTaskRef.get().getResult();
+    if (reactInstance == null) {
+      return BlackHoleEventDispatcher.get();
+    }
+
+    return reactInstance.getEventDispatcher();
+  }
+
+  public @Nullable FabricUIManager getUIManager() {
+    final ReactInstance reactInstance = mReactInstanceTaskRef.get().getResult();
+    if (reactInstance == null) {
+      return null;
+    }
+    return reactInstance.getUIManager();
+  }
+
+  public <T extends NativeModule> boolean hasNativeModule(Class<T> nativeModuleInterface) {
+    final ReactInstance reactInstance = mReactInstanceTaskRef.get().getResult();
+    if (reactInstance != null) {
+      return reactInstance.hasNativeModule(nativeModuleInterface);
+    }
+    return false;
+  }
+
+  public Collection<NativeModule> getNativeModules() {
+    final ReactInstance reactInstance = mReactInstanceTaskRef.get().getResult();
+    if (reactInstance != null) {
+      return reactInstance.getNativeModules();
+    }
+    return new ArrayList<>();
+  }
+
+  public @Nullable <T extends NativeModule> T getNativeModule(Class<T> nativeModuleInterface) {
+    if (nativeModuleInterface == UIManagerModule.class) {
+      ReactSoftExceptionLogger.logSoftExceptionVerbose(
+          TAG,
+          new ReactNoCrashBridgeNotAllowedSoftException(
+              "getNativeModule(UIManagerModule.class) cannot be called when the bridge is disabled"));
+    }
+
+    final ReactInstance reactInstance = mReactInstanceTaskRef.get().getResult();
+    if (reactInstance != null) {
+      return reactInstance.getNativeModule(nativeModuleInterface);
+    }
+    return null;
+  }
+
+  public DefaultHardwareBackBtnHandler getDefaultBackButtonHandler() {
+    return () -> {
+      UiThreadUtil.assertOnUiThread();
+      if (mDefaultHardwareBackBtnHandler != null) {
+        mDefaultHardwareBackBtnHandler.invokeDefaultOnBackPressed();
+      }
+    };
+  }
+
+  public MemoryPressureRouter getMemoryPressureRouter() {
+    return mMemoryPressureRouter;
+  }
+
+  public boolean isInstanceInitialized() {
+    final ReactInstance reactInstance = mReactInstanceTaskRef.get().getResult();
+    return reactInstance != null;
+  }
+
+  @ThreadConfined(UI)
+  public boolean onBackPressed() {
+    UiThreadUtil.assertOnUiThread();
+    final ReactInstance reactInstance = mReactInstanceTaskRef.get().getResult();
+    if (reactInstance == null) {
+      return false;
+    }
+
+    DeviceEventManagerModule deviceEventManagerModule =
+        reactInstance.getNativeModule(DeviceEventManagerModule.class);
+    if (deviceEventManagerModule == null) {
+      return false;
+    }
+
+    deviceEventManagerModule.emitHardwareBackPressed();
+    return true;
+  }
+
+  public @Nullable ReactQueueConfiguration getReactQueueConfiguration() {
+    synchronized (mReactInstanceTaskRef) {
+      Task<ReactInstance> task = mReactInstanceTaskRef.get();
+      if (!task.isFaulted() && !task.isCancelled() && task.getResult() != null) {
+        return task.getResult().getReactQueueConfiguration();
+      }
+    }
+    return null;
+  }
+
+  /** Add a listener to be notified of ReactInstance events. */
+  public void addReactInstanceEventListener(ReactInstanceEventListener listener) {
+    mReactInstanceEventListeners.add(listener);
+  }
+
+  /** Remove a listener previously added with {@link #addReactInstanceEventListener}. */
+  public void removeReactInstanceEventListener(ReactInstanceEventListener listener) {
+    mReactInstanceEventListeners.remove(listener);
+  }
+
+  /* package */ Task<Boolean> loadBundle(final JSBundleLoader bundleLoader) {
+    final String method = "loadBundle()";
+    log(method, "Schedule");
+
+    return callWithExistingReactInstance(
+        method,
+        reactInstance -> {
+          log(method, "Execute");
+          reactInstance.loadJSBundle(bundleLoader);
+        });
+  }
+
+  /* package */ Task<Boolean> registerSegment(
+      final int segmentId, final String path, final Callback callback) {
+    final String method =
+        "registerSegment(segmentId = \"" + segmentId + "\", path = \"" + path + "\")";
+    log(method, "Schedule");
+
+    return callWithExistingReactInstance(
+        method,
+        reactInstance -> {
+          log(method, "Execute");
+          reactInstance.registerSegment(segmentId, path);
+          assertNotNull(callback).invoke();
+        });
+  }
+
+  /*package */ void handleException(Exception e) {
+    final String method = "handleException(message = \"" + e.getMessage() + "\")";
+    log(method);
+
+    destroy(method, e);
+    mReactInstanceDelegate.handleException(e);
+  }
+
+  /**
+   * Call a function on a JS module that has been registered as callable.
+   *
+   * @param moduleName The name of the JS module
+   * @param methodName The function to call
+   * @param args Arguments to be passed to the function
+   * @return A Task that will complete when the function call has been enqueued on the JS thread.
+   */
+  /* package */ Task<Boolean> callFunctionOnModule(
+      final String moduleName, final String methodName, final NativeArray args) {
+    final String method = "callFunctionOnModule(\"" + moduleName + "\", \"" + methodName + "\")";
+    return callWithExistingReactInstance(
+        method,
+        reactInstance -> {
+          reactInstance.callFunctionOnModule(moduleName, methodName, args);
+        });
+  }
+
+  /* package */ void attachSurface(ReactSurface surface) {
+    final String method = "attachSurface(surfaceId = " + surface.getSurfaceID() + ")";
+    log(method);
+
+    synchronized (mAttachedSurfaces) {
+      mAttachedSurfaces.add(surface);
+    }
+  }
+
+  /* package */ void detachSurface(ReactSurface surface) {
+    final String method = "detachSurface(surfaceId = " + surface.getSurfaceID() + ")";
+    log(method);
+
+    synchronized (mAttachedSurfaces) {
+      mAttachedSurfaces.remove(surface);
+    }
+  }
+
+  boolean isSurfaceAttached(ReactSurface surface) {
+    synchronized (mAttachedSurfaces) {
+      return mAttachedSurfaces.contains(surface);
+    }
+  }
+
+  boolean isSurfaceWithModuleNameAttached(String moduleName) {
+    synchronized (mAttachedSurfaces) {
+      for (ReactSurface surface : mAttachedSurfaces) {
+        if (surface.getModuleName().equals(moduleName)) {
+          return true;
+        }
+      }
+      return false;
+    }
+  }
+
+  interface VeniceThenable<T> {
+    void then(T t);
+  }
+
+  private void raiseSoftException(String method, String message) {
+    raiseSoftException(method, message, null);
+  }
+
+  private void raiseSoftException(String method, String message, @Nullable Throwable throwable) {
+    log(method, message);
+    if (ReactFeatureFlags.enableBridgelessArchitectureSoftExceptions) {
+      if (throwable != null) {
+        ReactSoftExceptionLogger.logSoftException(
+            TAG, new ReactNoCrashSoftException(method + ": " + message, throwable));
+        return;
+      }
+
+      ReactSoftExceptionLogger.logSoftException(
+          TAG, new ReactNoCrashSoftException(method + ": " + message));
+    }
+  }
+
+  private Task<Boolean> callWithExistingReactInstance(
+      final String callingMethod, final VeniceThenable<ReactInstance> continuation) {
+    final String method = "callWithExistingReactInstance(" + callingMethod + ")";
+
+    return mReactInstanceTaskRef
+        .get()
+        .onSuccess(
+            task -> {
+              final ReactInstance reactInstance = task.getResult();
+              if (reactInstance == null) {
+                raiseSoftException(method, "Execute: ReactInstance null. Dropping work.");
+                return FALSE;
+              }
+
+              continuation.then(reactInstance);
+              return TRUE;
+            },
+            mBGExecutor);
+  }
+
+  private Task<Void> callAfterGetOrCreateReactInstance(
+      final String callingMethod, final VeniceThenable<ReactInstance> runnable) {
+    final String method = "callAfterGetOrCreateReactInstance(" + callingMethod + ")";
+
+    return getOrCreateReactInstanceTask()
+        .onSuccess(
+            (Continuation<ReactInstance, Void>)
+                task -> {
+                  final ReactInstance reactInstance = task.getResult();
+                  if (reactInstance == null) {
+                    raiseSoftException(method, "Execute: ReactInstance is null");
+                    return null;
+                  }
+
+                  runnable.then(reactInstance);
+                  return null;
+                },
+            mBGExecutor)
+        .continueWith(
+            task -> {
+              if (task.isFaulted()) {
+                handleException(task.getError());
+              }
+              return null;
+            },
+            mBGExecutor);
+  }
+
+  private BridgelessReactContext getOrCreateReactContext() {
+    final String method = "getOrCreateReactContext()";
+    return mBridgelessReactContextRef.getOrCreate(
+        () -> {
+          log(method, "Creating BridgelessReactContext");
+          return new BridgelessReactContext(mContext, ReactHost.this);
+        });
+  }
+
+  /**
+   * Entrypoint to create the ReactInstance.
+   *
+   * <p>If the ReactInstance is reloading, will return the reload task. If the ReactInstance is
+   * destroying, will wait until destroy is finished, before creating.
+   *
+   * @return
+   */
+  private Task<ReactInstance> getOrCreateReactInstanceTask() {
+    final String method = "getOrCreateReactInstanceTask()";
+    if (ReactFeatureFlags.enableBridgelessArchitectureNewCreateReloadDestroy) {
+      return waitThen_new_getOrCreateReactInstanceTaskWithRetries(0);
+    }
+
+    return old_getOrCreateReactInstanceTask();
+  }
+
+  private Task<ReactInstance> waitThen_new_getOrCreateReactInstanceTaskWithRetries(int tryNum) {
+    final String method = "waitThen_new_getOrCreateReactInstanceTaskWithRetries";
+    synchronized (mReloadTaskRef) {
+      Task<ReactInstance> reloadTask = mReloadTaskRef.getNullable();
+      if (reloadTask != null) {
+        log(method, "React Native is reloading. Return reload task.");
+        return reloadTask;
+      }
+
+      synchronized (mDestroyTaskRef) {
+        Task<Void> destroyTask = mDestroyTaskRef.getNullable();
+        if (destroyTask != null) {
+          boolean shouldTryAgain = tryNum < 4;
+          if (shouldTryAgain) {
+            log(
+                method,
+                "React Native is tearing down."
+                    + "Wait for teardown to finish, before trying again (try count = "
+                    + tryNum
+                    + ").");
+            return destroyTask.onSuccessTask(
+                (task) -> waitThen_new_getOrCreateReactInstanceTaskWithRetries(tryNum + 1),
+                mBGExecutor);
+          }
+
+          raiseSoftException(
+              method,
+              "React Native is tearing down. Not wait for teardown to finish: reached max retries.");
+        }
+
+        return new_getOrCreateReactInstanceTask();
+      }
+    }
+  }
+
+  private Task<ReactInstance> new_getOrCreateReactInstanceTask() {
+    final String method = "new_getOrCreateReactInstanceTask()";
+    log(method);
+
+    return mReactInstanceTaskRef.getOrCreate(
+        () -> {
+          log(method, "Start");
+          ReactMarker.logMarker(
+              ReactMarkerConstants.REACT_BRIDGELESS_LOADING_START, BRIDGELESS_MARKER_INSTANCE_KEY);
+
+          // TODO: Why can't we create the ReactContext on the ReactHost background thread?
+          getOrCreateReactContext();
+
+          return getJSBundleLoader()
+              .onSuccess(
+                  task -> {
+                    final JSBundleLoader bundleLoader = task.getResult();
+                    final BridgelessReactContext reactContext = getOrCreateReactContext();
+                    final DevSupportManager devSupportManager = getDevSupportManager();
+
+                    log(method, "Creating ReactInstance");
+                    final ReactInstance instance =
+                        new ReactInstance(
+                            reactContext,
+                            mReactInstanceDelegate,
+                            devSupportManager,
+                            mQueueThreadExceptionHandler,
+                            mReactJsExceptionHandler,
+                            mUseDevSupport);
+
+                    mMemoryPressureRouter.addMemoryPressureListener(mMemoryPressureListener);
+
+                    log(method, "Loading JS Bundle");
+                    instance.loadJSBundle(bundleLoader);
+
+                    log(
+                        method,
+                        "Calling DevSupportManagerBase.onNewReactContextCreated(reactContext)");
+                    devSupportManager.onNewReactContextCreated(reactContext);
+
+                    reactContext.runOnJSQueueThread(
+                        () -> {
+                          // Executing on the JS thread to ensurethat we're done
+                          // loading the JS bundle.
+                          // TODO T76081936 Move this if we switch to a sync RTE
+                          ReactMarker.logMarker(
+                              ReactMarkerConstants.REACT_BRIDGELESS_LOADING_END,
+                              BRIDGELESS_MARKER_INSTANCE_KEY);
+                        });
+
+                    class Result {
+                      final ReactInstance mInstance;
+                      final ReactContext mContext;
+
+                      Result(ReactInstance instance, ReactContext context) {
+                        mInstance = instance;
+                        mContext = context;
+                      }
+                    }
+
+                    return new Result(instance, reactContext);
+                  },
+                  mBGExecutor)
+              .onSuccess(
+                  task -> {
+                    ReactInstance reactInstance = task.getResult().mInstance;
+                    ReactContext reactContext = task.getResult().mContext;
+
+                    /**
+                     * Call ReactContext.onHostResume() only when already in the resumed state which
+                     * aligns with the bridge https://fburl.com/diffusion/2qhxmudv.
+                     */
+                    mReactLifecycleStateManager.resumeReactContextIfHostResumed(
+                        reactContext, mActivity.get());
+
+                    ReactInstanceEventListener[] listeners =
+                        new ReactInstanceEventListener[mReactInstanceEventListeners.size()];
+                    final ReactInstanceEventListener[] finalListeners =
+                        mReactInstanceEventListeners.toArray(listeners);
+
+                    log(method, "Executing ReactInstanceEventListeners");
+                    for (ReactInstanceEventListener listener : finalListeners) {
+                      if (listener != null) {
+                        listener.onReactContextInitialized(reactContext);
+                      }
+                    }
+                    return reactInstance;
+                  },
+                  mUIExecutor);
+        });
+  }
+
+  private Task<ReactInstance> old_getOrCreateReactInstanceTask() {
+    final String method = "old_getOrCreateReactInstanceTask()";
+    log(method);
+
+    return mReactInstanceTaskRef.getOrCreate(
+        () -> {
+          log(method, "Start");
+          ReactMarker.logMarker(
+              ReactMarkerConstants.REACT_BRIDGELESS_LOADING_START, BRIDGELESS_MARKER_INSTANCE_KEY);
+
+          final BridgelessReactContext reactContext = getOrCreateReactContext();
+          final DevSupportManager devSupportManager = getDevSupportManager();
+
+          return getJSBundleLoader()
+              .onSuccess(
+                  task -> {
+                    final JSBundleLoader bundleLoader = task.getResult();
+                    log(method, "Creating ReactInstance");
+                    final ReactInstance instance =
+                        new ReactInstance(
+                            reactContext,
+                            mReactInstanceDelegate,
+                            devSupportManager,
+                            mQueueThreadExceptionHandler,
+                            mReactJsExceptionHandler,
+                            mUseDevSupport);
+
+                    mMemoryPressureRouter.addMemoryPressureListener(mMemoryPressureListener);
+
+                    log(method, "Loading JS Bundle");
+                    instance.loadJSBundle(bundleLoader);
+
+                    log(
+                        method,
+                        "Calling DevSupportManagerBase.onNewReactContextCreated(reactContext)");
+                    devSupportManager.onNewReactContextCreated(reactContext);
+                    reactContext.runOnJSQueueThread(
+                        () -> {
+                          // Executing on the JS thread to ensurethat we're done
+                          // loading the JS bundle.
+                          // TODO T76081936 Move this if we switchto a sync RTE
+                          ReactMarker.logMarker(
+                              ReactMarkerConstants.REACT_BRIDGELESS_LOADING_END,
+                              BRIDGELESS_MARKER_INSTANCE_KEY);
+                        });
+                    return instance;
+                  },
+                  mBGExecutor)
+              .onSuccess(
+                  task -> {
+                    /**
+                     * Call ReactContext.onHostResume() only when already in the resumed state which
+                     * aligns with the bridge https://fburl.com/diffusion/2qhxmudv.
+                     */
+                    mReactLifecycleStateManager.resumeReactContextIfHostResumed(
+                        reactContext, mActivity.get());
+
+                    ReactInstanceEventListener[] listeners =
+                        new ReactInstanceEventListener[mReactInstanceEventListeners.size()];
+                    final ReactInstanceEventListener[] finalListeners =
+                        mReactInstanceEventListeners.toArray(listeners);
+
+                    log(method, "Executing ReactInstanceEventListeners");
+                    for (ReactInstanceEventListener listener : finalListeners) {
+                      if (listener != null) {
+                        listener.onReactContextInitialized(reactContext);
+                      }
+                    }
+
+                    return task.getResult();
+                  },
+                  mUIExecutor);
+        });
+  }
+
+  private Task<JSBundleLoader> getJSBundleLoader() {
+    final String method = "getJSBundleLoader()";
+    log(method);
+
+    if (DEV && mAllowPackagerServerAccess) {
+      return isMetroRunning()
+          .onSuccessTask(
+              task -> {
+                boolean isMetroRunning = task.getResult();
+                if (isMetroRunning) {
+                  // Since metro is running, fetch the JS bundle from the server
+                  return loadJSBundleFromMetro();
+                }
+                return Task.forResult(mReactInstanceDelegate.getJSBundleLoader(mContext));
+              },
+              mBGExecutor);
+    } else {
+      if (DEV) {
+        FLog.d(TAG, "Packager server access is disabled in this environment");
+      }
+
+      /**
+       * In prod mode: fall back to the JS bundle loader from the delegate.
+       *
+       * <p>Note: Create the prod JSBundleLoader inside a Task.call. Why: If JSBundleLoader creation
+       * throws an exception, the task will fault, and we'll go through the ReactHost error
+       * reporting pipeline.
+       */
+      return Task.call(() -> mReactInstanceDelegate.getJSBundleLoader(mContext));
+    }
+  }
+
+  private Task<Boolean> isMetroRunning() {
+    final String method = "isMetroRunning()";
+    log(method);
+
+    final TaskCompletionSource<Boolean> taskCompletionSource = new TaskCompletionSource<>();
+    final DevSupportManager asyncDevSupportManager = getDevSupportManager();
+
+    asyncDevSupportManager.isPackagerRunning(
+        packagerIsRunning -> {
+          log(method, "Async result = " + packagerIsRunning);
+          taskCompletionSource.setResult(packagerIsRunning);
+        });
+
+    return taskCompletionSource.getTask();
+  }
+
+  /**
+   * TODO(T104078367): Ensure that if creating this JSBundleLoader fails, we route the errors
+   * through ReactHost's error reporting pipeline
+   */
+  private Task<JSBundleLoader> loadJSBundleFromMetro() {
+    final String method = "loadJSBundleFromMetro()";
+    log(method);
+
+    final TaskCompletionSource<JSBundleLoader> taskCompletionSource = new TaskCompletionSource<>();
+    final DevSupportManager asyncDevSupportManager = getDevSupportManager();
+    final String sourceUrl = asyncDevSupportManager.getSourceUrl();
+
+    asyncDevSupportManager.reloadJSFromServer(
+        sourceUrl,
+        () -> {
+          log(method, "Creating BundleLoader");
+          JSBundleLoader bundleLoader =
+              JSBundleLoader.createCachedBundleFromNetworkLoader(
+                  sourceUrl, asyncDevSupportManager.getDownloadedJSBundleFile());
+          taskCompletionSource.setResult(bundleLoader);
+        });
+
+    return taskCompletionSource.getTask();
+  }
+
+  private void log(String method, String message) {
+    mBridgelessReactStateTracker.enterState("ReactHost{" + mId + "}." + method + ": " + message);
+  }
+
+  private void log(String method) {
+    mBridgelessReactStateTracker.enterState("ReactHost{" + mId + "}." + method);
+  }
+
+  /**
+   * Entrypoint to reload the ReactInstance. If the ReactInstance is destroying, will wait until
+   * destroy is finished, before reloading.
+   *
+   * @return A task that completes when React Native reloads
+   */
+  public Task<Void> reload(String reason) {
+    final String method = "reload()";
+    if (ReactFeatureFlags.enableBridgelessArchitectureNewCreateReloadDestroy) {
+      synchronized (mDestroyTaskRef) {
+        Task<Void> destroyTask = mDestroyTaskRef.getNullable();
+        if (destroyTask != null) {
+          log(
+              method,
+              "Destroying React Native. Waiting for destroy to finish, before reloading React Native.");
+          return destroyTask.continueWithTask(task -> new_getOrCreateReloadTask(reason)).makeVoid();
+        }
+      }
+
+      return new_getOrCreateReloadTask(reason).makeVoid();
+    }
+
+    return old_reload(reason);
+  }
+
+  private final BridgelessAtomicRef<Task<ReactInstance>> mReloadTaskRef =
+      new BridgelessAtomicRef<>();
+
+  /**
+   * The ReactInstance is loaded. Tear it down, and re-create it.
+   *
+   * <p>If the ReactInstance is in an "invalid state", make a "best effort" attempt to clean up
+   * React. "invalid state" means: ReactInstance task is faulted; ReactInstance is null; React
+   * instance task is cancelled; BridgelessReactContext is null. This can typically happen if the
+   * ReactInstance task work throws an exception.
+   */
+  private Task<ReactInstance> new_getOrCreateReloadTask(String reason) {
+    final String method = "new_getOrCreateReloadTask()";
+    log(method);
+
+    // Log how React Native is destroyed
+    // TODO(T136397487): Remove after Venice is shipped to 100%
+    raiseSoftException(method, reason);
+
+    return mReloadTaskRef.getOrCreate(
+        () ->
+            mReactInstanceTaskRef
+                .get()
+                .continueWithTask(
+                    (task) -> {
+                      log(method, "Starting on UI thread");
+
+                      if (task.isFaulted()) {
+                        raiseSoftException(
+                            method,
+                            "ReactInstance task faulted. Reload reason: " + reason,
+                            task.getError());
+                      }
+
+                      if (task.isCancelled()) {
+                        raiseSoftException(
+                            method, "ReactInstance task cancelled. Reload reason: " + reason);
+                      }
+
+                      final ReactInstance reactInstance = task.getResult();
+                      if (reactInstance == null) {
+                        raiseSoftException(
+                            method, "ReactInstance is null. Reload reason: " + reason);
+                      }
+
+                      final ReactContext reactContext = mBridgelessReactContextRef.getNullable();
+                      if (reactContext == null) {
+                        raiseSoftException(
+                            method, "ReactContext is null. Reload reason: " + reason);
+                      }
+
+                      if (reactContext != null
+                          && mReactLifecycleStateManager.getLifecycleState()
+                              == LifecycleState.RESUMED) {
+                        log(method, "Calling ReactContext.onHostPause()");
+                        reactContext.onHostPause();
+                      }
+
+                      return task;
+                    },
+                    mUIExecutor)
+                .continueWithTask(
+                    task -> {
+                      final ReactInstance reactInstance = task.getResult();
+
+                      log(method, "Stopping all React Native surfaces");
+                      synchronized (mAttachedSurfaces) {
+                        for (ReactSurface surface : mAttachedSurfaces) {
+                          if (reactInstance != null) {
+                            reactInstance.stopSurface(surface);
+                          }
+
+                          surface.clear();
+                        }
+                      }
+
+                      return task;
+                    },
+                    mBGExecutor)
+                .continueWithTask(
+                    task -> {
+                      log(method, "Removing memory pressure listener");
+                      mMemoryPressureRouter.removeMemoryPressureListener(mMemoryPressureListener);
+
+                      final ReactContext reactContext = mBridgelessReactContextRef.getNullable();
+                      if (reactContext != null) {
+                        log(method, "Destroying ReactContext");
+                        reactContext.destroy();
+                      }
+
+                      if (mUseDevSupport && reactContext != null) {
+                        log(
+                            method,
+                            "Calling DevSupportManager.onReactInstanceDestroyed(reactContext)");
+                        mDevSupportManager.onReactInstanceDestroyed(reactContext);
+                      }
+
+                      return task;
+                    },
+                    mUIExecutor)
+                .continueWithTask(
+                    task -> {
+                      final ReactInstance reactInstance = task.getResult();
+
+                      log(method, "Destroying ReactInstance");
+                      if (reactInstance != null) {
+                        reactInstance.destroy();
+                      }
+
+                      log(method, "Resetting ReactContext ref");
+                      mBridgelessReactContextRef.reset();
+
+                      log(method, "Resetting ReactInstance task ref");
+                      mReactInstanceTaskRef.reset();
+
+                      log(method, "Resetting preload task ref");
+                      mPreloadTask = null;
+
+                      // Kickstart a new ReactInstance create
+                      return new_getOrCreateReactInstanceTask();
+                    },
+                    mBGExecutor)
+                .onSuccess(
+                    task -> {
+                      final ReactInstance reactInstance = task.getResult();
+                      if (reactInstance != null) {
+                        log(method, "Restarting previously running React Native Surfaces");
+
+                        synchronized (mAttachedSurfaces) {
+                          for (ReactSurface surface : mAttachedSurfaces) {
+                            reactInstance.startSurface(surface);
+                          }
+                        }
+                      }
+                      return reactInstance;
+                    },
+                    mBGExecutor)
+                .continueWithTask(
+                    task -> {
+                      if (task.isFaulted()) {
+                        raiseSoftException(
+                            method,
+                            "Failed to re-created ReactInstance. Task faulted. Reload reason: "
+                                + reason,
+                            task.getError());
+                      }
+
+                      if (task.isCancelled()) {
+                        raiseSoftException(
+                            method,
+                            "Failed to re-created ReactInstance. Task cancelled. Reload reason: "
+                                + reason);
+                      }
+
+                      log(method, "Resetting reload task ref");
+                      mReloadTaskRef.reset();
+                      return task;
+                    },
+                    mBGExecutor));
+  }
+
+  /**
+   * Entrypoint to destroy the ReactInstance. If the ReactInstance is reloading, will wait until
+   * reload is finished, before destroying.
+   *
+   * @return A task that completes when React Native gets destroyed.
+   */
+  public Task<Void> destroy(String reason) {
+    return destroy(reason, null);
+  }
+
+  public Task<Void> destroy(String reason, @Nullable Exception ex) {
+    final String method = "destroy()";
+    if (ReactFeatureFlags.enableBridgelessArchitectureNewCreateReloadDestroy) {
+      synchronized (mReloadTaskRef) {
+        Task<ReactInstance> reloadTask = mReloadTaskRef.getNullable();
+        if (reloadTask != null) {
+          log(
+              method,
+              "Reloading React Native. Waiting for reload to finish before destroying React Native.");
+          return reloadTask.continueWithTask(task -> new_getOrCreateDestroyTask(reason, ex));
+        }
+        return new_getOrCreateDestroyTask(reason, ex);
+      }
+    }
+
+    old_destroy(reason, ex);
+    return Task.forResult(nullsafeFIXME(null, "Empty Destroy Task"));
+  }
+
+  private final BridgelessAtomicRef<Task<Void>> mDestroyTaskRef = new BridgelessAtomicRef<>();
+
+  /**
+   * The ReactInstance is loaded. Tear it down.
+   *
+   * <p>If the ReactInstance is in an "invalid state", make a "best effort" attempt to clean up
+   * React. "invalid state" means: ReactInstance task is faulted; ReactInstance is null; React
+   * instance task is cancelled; BridgelessReactContext is null. This can typically happen if the *
+   * ReactInstance task work throws an exception.
+   */
+  private Task<Void> new_getOrCreateDestroyTask(final String reason, @Nullable Exception ex) {
+    final String method = "new_getOrCreateDestroyTask()";
+    log(method);
+
+    // Log how React Native is destroyed
+    // TODO(T136397487): Remove after Venice is shipped to 100%
+    raiseSoftException(method, reason, ex);
+
+    return mDestroyTaskRef.getOrCreate(
+        () ->
+            mReactInstanceTaskRef
+                .get()
+                .continueWithTask(
+                    task -> {
+                      log(method, "Destroying ReactInstance on UI Thread");
+
+                      if (task.isFaulted()) {
+                        raiseSoftException(
+                            method,
+                            "ReactInstance task faulted. Destroy reason: " + reason,
+                            task.getError());
+                      }
+
+                      if (task.isCancelled()) {
+                        raiseSoftException(
+                            method, "ReactInstance task cancelled. Destroy reason: " + reason);
+                      }
+
+                      final ReactInstance reactInstance = task.getResult();
+                      if (reactInstance == null) {
+                        raiseSoftException(
+                            method, "ReactInstance is null. Destroy reason: " + reason);
+                      }
+
+                      // Step 1: Destroy DevSupportManager
+                      if (mUseDevSupport) {
+                        log(method, "DevSupportManager cleanup");
+                        // TODO(T137233065): Disable DevSupportManager here
+                        mDevSupportManager.stopInspector();
+                      }
+
+                      final ReactContext reactContext = mBridgelessReactContextRef.getNullable();
+
+                      if (reactContext == null) {
+                        raiseSoftException(
+                            method, "ReactContext is null. Destroy reason: " + reason);
+                      }
+
+                      // Step 2: Move React Native to onHostDestroy()
+                      log(method, "Move ReactHost to onHostDestroy()");
+                      mReactLifecycleStateManager.moveToOnHostDestroy(reactContext);
+
+                      // Step 3: De-register the memory pressure listener
+                      log(method, "Destroying MemoryPressureRouter");
+                      mMemoryPressureRouter.destroy(mContext);
+
+                      if (reactContext != null) {
+                        log(method, "Destroying ReactContext");
+                        reactContext.destroy();
+                      }
+
+                      // Reset current activity
+                      mActivity.set(null);
+
+                      // Clear ResourceIdleDrawableIdMap
+                      ResourceDrawableIdHelper.getInstance().clear();
+
+                      return task;
+                    },
+                    mUIExecutor)
+                .continueWith(
+                    task -> {
+                      final ReactInstance reactInstance = task.getResult();
+                      if (reactInstance != null) {
+                        log(method, "Destroying ReactInstance");
+                        reactInstance.destroy();
+                      }
+
+                      log(method, "Resetting ReactContext ref ");
+                      mBridgelessReactContextRef.reset();
+
+                      log(method, "Resetting ReactInstance task ref");
+                      mReactInstanceTaskRef.reset();
+
+                      log(method, "Resetting Preload task ref");
+                      mPreloadTask = null;
+
+                      log(method, "Resetting destroy task ref");
+                      mDestroyTaskRef.reset();
+                      return null;
+                    },
+                    mBGExecutor));
+  }
+
+  /** Destroy and recreate the ReactInstance and context. */
+  private Task<Void> old_reload(String reason) {
+    final String method = "old_reload()";
+    log(method);
+
+    // Log how React Native is destroyed
+    // TODO(T136397487): Remove after Venice is shipped to 100%
+    raiseSoftException(method, reason);
+
+    synchronized (mReactInstanceTaskRef) {
+      mMemoryPressureRouter.removeMemoryPressureListener(mMemoryPressureListener);
+      old_destroyReactInstanceAndContext(method, reason);
+
+      return callAfterGetOrCreateReactInstance(
+          method,
+          reactInstance -> {
+            // Restart any attached surfaces
+            log(method, "Restarting Surfaces");
+            synchronized (mAttachedSurfaces) {
+              for (ReactSurface surface : mAttachedSurfaces) {
+                reactInstance.startSurface(surface);
+              }
+            }
+          });
+    }
+  }
+
+  /** Destroy the specified instance and context. */
+  private void old_destroy(String reason, @Nullable Exception ex) {
+    final String method = "old_destroy()";
+    log(method);
+
+    // Log how React Native is destroyed
+    // TODO(T136397487): Remove after Venice is shipped to 100%
+    raiseSoftException(method, reason, ex);
+
+    synchronized (mReactInstanceTaskRef) {
+      // Retain a reference to current ReactContext before de-referenced by mReactContextRef
+      final ReactContext reactContext = getCurrentReactContext();
+
+      if (reactContext != null) {
+        mMemoryPressureRouter.destroy(reactContext);
+      }
+
+      old_destroyReactInstanceAndContext(method, reason);
+
+      // Remove all attached surfaces
+      log(method, "Clearing attached surfaces");
+      synchronized (mAttachedSurfaces) {
+        mAttachedSurfaces.clear();
+      }
+
+      Task.call(
+          (Callable<Void>)
+              () -> {
+                moveToHostDestroy(reactContext);
+                return null;
+              },
+          mUIExecutor);
+    }
+  }
+
+  private void old_destroyReactInstanceAndContext(final String callingMethod, final String reason) {
+    final String method = "old_destroyReactInstanceAndContext(" + callingMethod + ")";
+    log(method);
+
+    synchronized (mReactInstanceTaskRef) {
+      Task<ReactInstance> task = mReactInstanceTaskRef.getAndReset();
+      if (!task.isFaulted() && !task.isCancelled()) {
+        final ReactInstance instance = task.getResult();
+
+        // Noop on redundant calls to destroyReactInstance()
+        if (instance == null) {
+          log(method, "ReactInstance nil");
+          return;
+        }
+
+        /*
+         * The surfaces should be stopped before the instance destroy.
+         * Calling stop directly on instance ensures we keep the list of attached surfaces for restart.
+         */
+        log(method, "Stopping surfaces");
+        synchronized (mAttachedSurfaces) {
+          for (ReactSurface surface : mAttachedSurfaces) {
+            instance.stopSurface(surface);
+            surface.clear();
+          }
+        }
+
+        ReactContext reactContext = getCurrentReactContext();
+
+        // Reset the ReactContext inside the DevSupportManager
+        if (reactContext != null) {
+          log(method, "DevSupportManager.onReactInstanceDestroyed()");
+          getDevSupportManager().onReactInstanceDestroyed(reactContext);
+          log(method, "Destroy ReactContext");
+          mBridgelessReactContextRef.reset();
+        }
+
+        mBGExecutor.execute(
+            () -> {
+              // instance.destroy() is time consuming and is confined to ReactHost thread.
+              log(method, "Destroy ReactInstance");
+              instance.destroy();
+
+              // Re-enable preloads
+              log(method, "Resetting Preload task ref");
+              mPreloadTask = null;
+            });
+      } else {
+        raiseSoftException(
+            method,
+            ("Not cleaning up ReactInstance: task.isFaulted() = "
+                    + task.isFaulted()
+                    + ", task.isCancelled() = "
+                    + task.isCancelled())
+                + ". Reason: "
+                + reason);
+
+        mBGExecutor.execute(
+            () -> {
+              log(method, "Resetting Preload task ref");
+              mPreloadTask = null;
+            });
+      }
+    }
+  }
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactInstance.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactInstance.java
@@ -1,0 +1,494 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+
+package com.facebook.react.bridgeless;
+
+import android.content.res.AssetManager;
+import android.view.View;
+import com.facebook.common.logging.FLog;
+import com.facebook.fbreact.fabric.components.CatalystRegistry;
+import com.facebook.infer.annotation.Nullsafe;
+import com.facebook.infer.annotation.ThreadConfined;
+import com.facebook.infer.annotation.ThreadSafe;
+import com.facebook.jni.HybridData;
+import com.facebook.proguard.annotations.DoNotStrip;
+import com.facebook.react.ReactPackage;
+import com.facebook.react.ViewManagerOnDemandReactPackage;
+import com.facebook.react.bridge.JSBundleLoader;
+import com.facebook.react.bridge.JSBundleLoaderDelegate;
+import com.facebook.react.bridge.LifecycleEventListener;
+import com.facebook.react.bridge.NativeArray;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactSoftExceptionLogger;
+import com.facebook.react.bridge.RuntimeExecutor;
+import com.facebook.react.bridge.RuntimeScheduler;
+import com.facebook.react.bridge.queue.MessageQueueThread;
+import com.facebook.react.bridge.queue.MessageQueueThreadSpec;
+import com.facebook.react.bridge.queue.QueueThreadExceptionHandler;
+import com.facebook.react.bridge.queue.ReactQueueConfiguration;
+import com.facebook.react.bridge.queue.ReactQueueConfigurationImpl;
+import com.facebook.react.bridge.queue.ReactQueueConfigurationSpec;
+import com.facebook.react.bridgeless.exceptionmanager.ReactJsExceptionHandler;
+import com.facebook.react.devsupport.interfaces.DevSupportManager;
+import com.facebook.react.fabric.Binding;
+import com.facebook.react.fabric.BindingImpl;
+import com.facebook.react.fabric.ComponentFactory;
+import com.facebook.react.fabric.FabricUIManager;
+import com.facebook.react.fabric.ReactNativeConfig;
+import com.facebook.react.fabric.events.EventBeatManager;
+import com.facebook.react.module.annotations.ReactModule;
+import com.facebook.react.modules.core.JavaTimerManager;
+import com.facebook.react.modules.core.ReactChoreographer;
+import com.facebook.react.turbomodule.core.CallInvokerHolderImpl;
+import com.facebook.react.turbomodule.core.TurboModuleManager;
+import com.facebook.react.turbomodule.core.TurboModuleManagerDelegate;
+import com.facebook.react.uimanager.ComponentNameResolver;
+import com.facebook.react.uimanager.ComponentNameResolverManager;
+import com.facebook.react.uimanager.DisplayMetricsHolder;
+import com.facebook.react.uimanager.IllegalViewOperationException;
+import com.facebook.react.uimanager.ViewManager;
+import com.facebook.react.uimanager.ViewManagerRegistry;
+import com.facebook.react.uimanager.ViewManagerResolver;
+import com.facebook.react.uimanager.events.EventDispatcher;
+import com.facebook.soloader.SoLoader;
+import com.facebook.soloader.annotation.SoLoaderLibrary;
+import com.facebook.systrace.Systrace;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+/**
+ * An experimental replacement for {@link com.facebook.react.ReactInstanceManager} responsible for
+ * creating and managing a React Native instance
+ */
+@Nullsafe(Nullsafe.Mode.LOCAL)
+@ThreadSafe
+@SoLoaderLibrary({"rninstance"})
+public final class ReactInstance {
+
+  private static final String TAG = ReactInstance.class.getSimpleName();
+
+  @DoNotStrip private HybridData mHybridData;
+
+  private final ReactInstanceDelegate mDelegate;
+  private final BridgelessReactContext mBridgelessReactContext;
+
+  private final ReactQueueConfiguration mQueueConfiguration;
+  private final TurboModuleManager mTurboModuleManager;
+  private final FabricUIManager mFabricUIManager;
+  private final JavaTimerManager mJavaTimerManager;
+
+  @DoNotStrip @Nullable private ComponentNameResolverManager mComponentNameResolverManager;
+
+  private static volatile boolean sIsLibraryLoaded;
+
+  /* package */ ReactInstance(
+      BridgelessReactContext bridgelessReactContext,
+      ReactInstanceDelegate delegate,
+      DevSupportManager devSupportManager,
+      QueueThreadExceptionHandler exceptionHandler,
+      ReactJsExceptionHandler reactExceptionManager,
+      boolean useDevSupport) {
+    mBridgelessReactContext = bridgelessReactContext;
+    mDelegate = delegate;
+    loadLibraryIfNeeded();
+
+    Systrace.beginSection(Systrace.TRACE_TAG_REACT_JAVA_BRIDGE, "ReactInstance.initialize");
+
+    /**
+     * Prepare the ReactInstance by installing JSI bindings, initializing Fabric + TurboModules, and
+     * loading the JS bundle.
+     */
+    MessageQueueThreadSpec nativeModulesSpec =
+        MessageQueueThreadSpec.newBackgroundThreadSpec("v_native");
+    ReactQueueConfigurationSpec spec =
+        ReactQueueConfigurationSpec.builder()
+            .setJSQueueThreadSpec(MessageQueueThreadSpec.newBackgroundThreadSpec("v_js"))
+            .setNativeModulesQueueThreadSpec(nativeModulesSpec)
+            .build();
+    mQueueConfiguration = ReactQueueConfigurationImpl.create(spec, exceptionHandler);
+    FLog.d(TAG, "Calling initializeMessageQueueThreads()");
+    mBridgelessReactContext.initializeMessageQueueThreads(mQueueConfiguration);
+    MessageQueueThread jsMessageQueueThread = mQueueConfiguration.getJSQueueThread();
+    MessageQueueThread nativeModulesMessageQueueThread =
+        mQueueConfiguration.getNativeModulesQueueThread();
+
+    ReactChoreographer.initialize();
+    if (useDevSupport) {
+      devSupportManager.startInspector();
+    }
+    JSTimerExecutor jsTimerExecutor = createJSTimerExecutor();
+    mJavaTimerManager =
+        new JavaTimerManager(
+            mBridgelessReactContext,
+            jsTimerExecutor,
+            ReactChoreographer.getInstance(),
+            devSupportManager);
+
+    mBridgelessReactContext.addLifecycleEventListener(
+        new LifecycleEventListener() {
+          @Override
+          public void onHostResume() {
+            mJavaTimerManager.onHostResume();
+          }
+
+          @Override
+          public void onHostPause() {
+            mJavaTimerManager.onHostPause();
+          }
+
+          @Override
+          public void onHostDestroy() {
+            mJavaTimerManager.onHostDestroy();
+          }
+        });
+
+    JSEngineInstance jsEngineInstance = mDelegate.getJSEngineInstance(mBridgelessReactContext);
+    // Notify JS if profiling is enabled
+    boolean isProfiling =
+        Systrace.isTracing(Systrace.TRACE_TAG_REACT_APPS | Systrace.TRACE_TAG_REACT_JS_VM_CALLS);
+    mHybridData =
+        initHybrid(
+            jsEngineInstance,
+            jsMessageQueueThread,
+            nativeModulesMessageQueueThread,
+            mJavaTimerManager,
+            jsTimerExecutor,
+            reactExceptionManager,
+            isProfiling);
+
+    RuntimeExecutor unbufferedRuntimeExecutor = getUnbufferedRuntimeExecutor();
+
+    // Initialize function for JS's UIManager.hasViewManagerConfig()
+    mComponentNameResolverManager =
+        new ComponentNameResolverManager(
+            // Use unbuffered RuntimeExecutor to install binding
+            unbufferedRuntimeExecutor,
+            new ComponentNameResolver() {
+              @Override
+              public String[] getComponentNames() {
+                Collection<String> viewManagerNames = getViewManagerNames();
+                if (viewManagerNames == null) {
+                  FLog.e(TAG, "No ViewManager names found");
+                  return new String[0];
+                }
+                return viewManagerNames.toArray(new String[0]);
+              }
+            });
+
+    // Set up TurboModules
+    Systrace.beginSection(
+        Systrace.TRACE_TAG_REACT_JAVA_BRIDGE, "ReactInstance.initialize#initTurboModules");
+    TurboModuleManagerDelegate turboModuleManagerDelegate =
+        mDelegate.getTurboModuleManagerDelegate(mBridgelessReactContext);
+    mTurboModuleManager =
+        new TurboModuleManager(
+            // Use unbuffered RuntimeExecutor to install binding
+            unbufferedRuntimeExecutor,
+            turboModuleManagerDelegate,
+            getJSCallInvokerHolder(),
+            getNativeCallInvokerHolder());
+
+    // Eagerly initialize TurboModules
+    for (String moduleName : mTurboModuleManager.getEagerInitModuleNames()) {
+      mTurboModuleManager.getNativeModule(moduleName);
+    }
+
+    Systrace.endSection(Systrace.TRACE_TAG_REACT_JAVA_BRIDGE);
+
+    // Set up Fabric
+    Systrace.beginSection(
+        Systrace.TRACE_TAG_REACT_JAVA_BRIDGE, "ReactInstance.initialize#initFabric");
+
+    ViewManagerRegistry viewManagerRegistry =
+        new ViewManagerRegistry(
+            new ViewManagerResolver() {
+              @Override
+              public @Nullable ViewManager getViewManager(String viewManagerName) {
+                return createViewManager(viewManagerName);
+              }
+
+              @Override
+              public Collection<String> getViewManagerNames() {
+                return ReactInstance.this.getViewManagerNames();
+              }
+            });
+
+    EventBeatManager eventBeatManager = new EventBeatManager(mBridgelessReactContext);
+    mFabricUIManager =
+        new FabricUIManager(mBridgelessReactContext, viewManagerRegistry, eventBeatManager);
+
+    ReactNativeConfig config = mDelegate.getReactNativeConfig(mTurboModuleManager);
+    ComponentFactory componentFactory = new ComponentFactory();
+    // Using Catalyst for the defaults for now. This should be passed in from the Application.
+    CatalystRegistry.register(componentFactory);
+
+    // Misc initialization that needs to be done before Fabric init
+    DisplayMetricsHolder.initDisplayMetricsIfNotInitialized(mBridgelessReactContext);
+
+    Binding binding = new BindingImpl();
+    binding.register(
+        getBufferedRuntimeExecutor(),
+        getRuntimeScheduler(),
+        mFabricUIManager,
+        eventBeatManager,
+        componentFactory,
+        config);
+    Systrace.endSection(Systrace.TRACE_TAG_REACT_JAVA_BRIDGE);
+
+    // Initialize the FabricUIManager
+    mFabricUIManager.initialize();
+  }
+
+  private static synchronized void loadLibraryIfNeeded() {
+    if (!sIsLibraryLoaded) {
+      SoLoader.loadLibrary("rninstance");
+      sIsLibraryLoaded = true;
+    }
+  }
+
+  public ReactQueueConfiguration getReactQueueConfiguration() {
+    return mQueueConfiguration;
+  }
+
+  public void loadJSBundle(JSBundleLoader bundleLoader) {
+    // Load the JS bundle
+    Systrace.beginSection(Systrace.TRACE_TAG_REACT_JAVA_BRIDGE, "ReactInstance.loadJSBundle");
+    bundleLoader.loadScript(
+        new JSBundleLoaderDelegate() {
+          @Override
+          public void loadScriptFromFile(
+              String fileName, String sourceURL, boolean loadSynchronously) {
+            mBridgelessReactContext.setSourceURL(sourceURL);
+            loadJSBundleFromFile(fileName, sourceURL);
+          }
+
+          @Override
+          public void loadSplitBundleFromFile(String fileName, String sourceURL) {
+            loadJSBundleFromFile(fileName, sourceURL);
+          }
+
+          @Override
+          public void loadScriptFromAssets(
+              AssetManager assetManager, String assetURL, boolean loadSynchronously) {
+            mBridgelessReactContext.setSourceURL(assetURL);
+            loadJSBundleFromAssets(assetManager, assetURL);
+          }
+
+          @Override
+          public void setSourceURLs(String deviceURL, String remoteURL) {
+            mBridgelessReactContext.setSourceURL(deviceURL);
+          }
+        });
+    Systrace.endSection(Systrace.TRACE_TAG_REACT_JAVA_BRIDGE);
+  }
+
+  public <T extends NativeModule> boolean hasNativeModule(Class<T> nativeModuleInterface) {
+    ReactModule annotation = nativeModuleInterface.getAnnotation(ReactModule.class);
+    if (annotation != null) {
+      return mTurboModuleManager.hasNativeModule(annotation.name());
+    }
+    return false;
+  }
+
+  public Collection<NativeModule> getNativeModules() {
+    Collection<NativeModule> nativeModules = new ArrayList<>();
+    for (NativeModule module : mTurboModuleManager.getNativeModules()) {
+      nativeModules.add(module);
+    }
+    return nativeModules;
+  }
+
+  public @Nullable <T extends NativeModule> T getNativeModule(Class<T> nativeModuleInterface) {
+    ReactModule annotation = nativeModuleInterface.getAnnotation(ReactModule.class);
+    if (annotation != null) {
+      return (T) getNativeModule(annotation.name());
+    }
+    return null;
+  }
+
+  public @Nullable NativeModule getNativeModule(String nativeModuleName) {
+    synchronized (mTurboModuleManager) {
+      return mTurboModuleManager.getNativeModule(nativeModuleName);
+    }
+  }
+
+  /* package */ void prerenderSurface(ReactSurface surface) {
+    Systrace.beginSection(Systrace.TRACE_TAG_REACT_JAVA_BRIDGE, "ReactInstance.prerenderSurface");
+    FLog.d(TAG, "call prerenderSurface with surface: " + surface.getModuleName());
+    mFabricUIManager.startSurface(surface.getSurfaceHandler(), surface.getContext(), null);
+    Systrace.endSection(Systrace.TRACE_TAG_REACT_JAVA_BRIDGE);
+  }
+
+  /**
+   * Renders a React Native surface.
+   *
+   * @param surface The {@link ReactSurface} to render.
+   */
+  @ThreadConfined("ReactHost")
+  /* package */ void startSurface(ReactSurface surface) {
+    FLog.d(TAG, "startSurface() is called with surface: " + surface.getSurfaceID());
+    Systrace.beginSection(Systrace.TRACE_TAG_REACT_JAVA_BRIDGE, "ReactInstance.startSurface");
+
+    View view = surface.getView();
+    if (view == null) {
+      throw new IllegalStateException(
+          "Starting surface without a view is not supported, use prerenderSurface instead.");
+    }
+
+    /**
+     * This is a temporary mitigation for 646912b2590a6d5e760316cc064d1e27,
+     *
+     * <p>TODO T83828172 investigate why surface.getView() has id NOT equal to View.NO_ID
+     */
+    if (view.getId() != View.NO_ID) {
+      ReactSoftExceptionLogger.logSoftException(
+          TAG,
+          new IllegalViewOperationException(
+              "surfaceView's is NOT equal to View.NO_ID before calling startSurface."));
+      view.setId(View.NO_ID);
+    }
+    if (surface.isRunning()) {
+      // surface was initialized beforehand, only attaching view
+      mFabricUIManager.attachRootView(surface.getSurfaceHandler(), view);
+    } else {
+      mFabricUIManager.startSurface(surface.getSurfaceHandler(), surface.getContext(), view);
+    }
+    Systrace.endSection(Systrace.TRACE_TAG_REACT_JAVA_BRIDGE);
+  }
+
+  @ThreadConfined("ReactHost")
+  /* package */ void stopSurface(ReactSurface surface) {
+    FLog.d(TAG, "stopSurface() is called with surface: " + surface.getSurfaceID());
+    mFabricUIManager.stopSurface(surface.getSurfaceHandler());
+  }
+
+  /* --- Lifecycle methods --- */
+  @ThreadConfined("ReactHost")
+  /* package */ void destroy() {
+    FLog.d(TAG, "ReactInstance.destroy() is called.");
+    mQueueConfiguration.destroy();
+    mTurboModuleManager.onCatalystInstanceDestroy();
+    mFabricUIManager.onCatalystInstanceDestroy();
+    mHybridData.resetNative();
+    mComponentNameResolverManager = null;
+  }
+
+  /* --- Native methods --- */
+
+  @DoNotStrip
+  private native HybridData initHybrid(
+      JSEngineInstance jsEngineInstance,
+      MessageQueueThread jsMessageQueueThread,
+      MessageQueueThread nativeModulesMessageQueueThread,
+      JavaTimerManager timerManager,
+      JSTimerExecutor jsTimerExecutor,
+      ReactJsExceptionHandler jReactExceptionsManager,
+      boolean isProfiling);
+
+  @DoNotStrip
+  private static native JSTimerExecutor createJSTimerExecutor();
+
+  @DoNotStrip
+  private native void installGlobals(boolean isProfiling);
+
+  private native void loadJSBundleFromFile(String fileName, String sourceURL);
+
+  private native void loadJSBundleFromAssets(AssetManager assetManager, String assetURL);
+
+  private native CallInvokerHolderImpl getJSCallInvokerHolder();
+
+  private native CallInvokerHolderImpl getNativeCallInvokerHolder();
+
+  private native RuntimeExecutor getUnbufferedRuntimeExecutor();
+
+  private native RuntimeExecutor getBufferedRuntimeExecutor();
+
+  private native RuntimeScheduler getRuntimeScheduler();
+
+  /* package */ native void callFunctionOnModule(
+      String moduleName, String methodName, NativeArray args);
+
+  private native void registerSegmentNative(int segmentId, String segmentPath);
+
+  private native void handleMemoryPressureJs(int pressureLevel);
+
+  public void handleMemoryPressure(int level) {
+    try {
+      handleMemoryPressureJs(level);
+    } catch (NullPointerException e) {
+      ReactSoftExceptionLogger.logSoftException(
+          TAG,
+          new IllegalViewOperationException(
+              "Native method handleMemoryPressureJs is called earlier than librninstance.so got ready."));
+    }
+  }
+
+  /**
+   * @return The {@link EventDispatcher} used by {@link FabricUIManager} to emit UI events to JS.
+   */
+  /* protected */ EventDispatcher getEventDispatcher() {
+    return mFabricUIManager.getEventDispatcher();
+  }
+
+  /** @return The {@link FabricUIManager} if it's been initialized. */
+  /* protected */ FabricUIManager getUIManager() {
+    return mFabricUIManager;
+  }
+
+  public void registerSegment(int segmentId, String path) {
+    registerSegmentNative(segmentId, path);
+  }
+
+  private @Nullable ViewManager createViewManager(String viewManagerName) {
+    if (mDelegate != null) {
+      List<ReactPackage> packages = mDelegate.getReactPackages();
+      if (packages != null) {
+        synchronized (packages) {
+          for (ReactPackage reactPackage : packages) {
+            if (reactPackage instanceof ViewManagerOnDemandReactPackage) {
+              ViewManager viewManager =
+                  ((ViewManagerOnDemandReactPackage) reactPackage)
+                      .createViewManager(mBridgelessReactContext, viewManagerName);
+              if (viewManager != null) {
+                return viewManager;
+              }
+            }
+          }
+        }
+      }
+    }
+
+    return null;
+  }
+
+  private Collection<String> getViewManagerNames() {
+    Set<String> uniqueNames = new HashSet<>();
+    if (mDelegate != null) {
+      List<ReactPackage> packages = mDelegate.getReactPackages();
+      if (packages != null) {
+        synchronized (packages) {
+          for (ReactPackage reactPackage : packages) {
+            if (reactPackage instanceof ViewManagerOnDemandReactPackage) {
+              Collection<String> names =
+                  ((ViewManagerOnDemandReactPackage) reactPackage)
+                      .getViewManagerNames(mBridgelessReactContext);
+              if (names != null) {
+                uniqueNames.addAll(names);
+              }
+            }
+          }
+        }
+      }
+    }
+    return uniqueNames;
+  }
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactInstanceDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactInstanceDelegate.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+
+package com.facebook.react.bridgeless;
+
+import android.content.Context;
+import com.facebook.infer.annotation.ThreadSafe;
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.JSBundleLoader;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.fabric.ReactNativeConfig;
+import com.facebook.react.turbomodule.core.TurboModuleManager;
+import com.facebook.react.turbomodule.core.TurboModuleManagerDelegate;
+import com.facebook.react.uimanager.ViewManager;
+import java.util.List;
+
+@ThreadSafe
+public interface ReactInstanceDelegate {
+  String getJSMainModulePath();
+
+  JSBundleLoader getJSBundleLoader(Context context);
+
+  TurboModuleManagerDelegate getTurboModuleManagerDelegate(ReactApplicationContext context);
+
+  List<ViewManager> getViewManagers(ReactApplicationContext context);
+
+  JSEngineInstance getJSEngineInstance(ReactApplicationContext context);
+
+  void handleException(Exception e);
+
+  ReactNativeConfig getReactNativeConfig(TurboModuleManager turboModuleManager);
+
+  List<ReactPackage> getReactPackages();
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactLifecycleStateManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactLifecycleStateManager.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+
+package com.facebook.react.bridgeless;
+
+import static com.facebook.infer.annotation.ThreadConfined.UI;
+
+import android.app.Activity;
+import androidx.annotation.Nullable;
+import com.facebook.infer.annotation.Nullsafe;
+import com.facebook.infer.annotation.ThreadConfined;
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.common.LifecycleState;
+
+@Nullsafe(Nullsafe.Mode.LOCAL)
+class ReactLifecycleStateManager {
+  LifecycleState mState = LifecycleState.BEFORE_CREATE;
+  private final BridgelessReactStateTracker mBridgelessReactStateTracker;
+
+  ReactLifecycleStateManager(BridgelessReactStateTracker bridgelessReactStateTracker) {
+    mBridgelessReactStateTracker = bridgelessReactStateTracker;
+  }
+
+  public LifecycleState getLifecycleState() {
+    return mState;
+  }
+
+  @ThreadConfined(UI)
+  public void resumeReactContextIfHostResumed(
+      final ReactContext currentContext, final @Nullable Activity activity) {
+    if (mState == LifecycleState.RESUMED) {
+      mBridgelessReactStateTracker.enterState("ReactContext.onHostResume()");
+      currentContext.onHostResume(activity);
+    }
+  }
+
+  @ThreadConfined(UI)
+  public void moveToOnHostResume(
+      final @Nullable ReactContext currentContext, final @Nullable Activity activity) {
+    if (mState == LifecycleState.RESUMED) {
+      return;
+    }
+
+    if (currentContext != null) {
+      mBridgelessReactStateTracker.enterState("ReactContext.onHostResume()");
+      currentContext.onHostResume(activity);
+    }
+    mState = LifecycleState.RESUMED;
+  }
+
+  @ThreadConfined(UI)
+  public void moveToOnHostPause(
+      final @Nullable ReactContext currentContext, final @Nullable Activity activity) {
+    if (currentContext != null) {
+      if (mState == LifecycleState.BEFORE_CREATE) {
+        // TODO: Investigate if we can remove this transition.
+        mBridgelessReactStateTracker.enterState("ReactContext.onHostResume()");
+        currentContext.onHostResume(activity);
+        mBridgelessReactStateTracker.enterState("ReactContext.onHostPause()");
+        currentContext.onHostPause();
+      } else if (mState == LifecycleState.RESUMED) {
+        mBridgelessReactStateTracker.enterState("ReactContext.onHostPause()");
+        currentContext.onHostPause();
+      }
+    }
+
+    mState = LifecycleState.BEFORE_RESUME;
+  }
+
+  @ThreadConfined(UI)
+  public void moveToOnHostDestroy(final @Nullable ReactContext currentContext) {
+    if (currentContext != null) {
+      if (mState == LifecycleState.BEFORE_RESUME) {
+        mBridgelessReactStateTracker.enterState("ReactContext.onHostDestroy()");
+        currentContext.onHostDestroy();
+      } else if (mState == LifecycleState.RESUMED) {
+        mBridgelessReactStateTracker.enterState("ReactContext.onHostPause()");
+        currentContext.onHostPause();
+        mBridgelessReactStateTracker.enterState("ReactContext.onHostDestroy()");
+        currentContext.onHostDestroy();
+      }
+    }
+
+    mState = LifecycleState.BEFORE_CREATE;
+  }
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactSurface.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactSurface.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+
+package com.facebook.react.bridgeless;
+
+import android.content.Context;
+import android.os.Bundle;
+import android.util.DisplayMetrics;
+import android.view.View;
+import android.view.View.MeasureSpec;
+import androidx.annotation.UiThread;
+import bolts.Task;
+import com.facebook.infer.annotation.Nullsafe;
+import com.facebook.infer.annotation.ThreadSafe;
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.NativeMap;
+import com.facebook.react.bridge.UiThreadUtil;
+import com.facebook.react.bridge.WritableNativeMap;
+import com.facebook.react.common.annotations.VisibleForTesting;
+import com.facebook.react.fabric.SurfaceHandler;
+import com.facebook.react.fabric.SurfaceHandlerBinding;
+import com.facebook.react.modules.i18nmanager.I18nUtil;
+import com.facebook.react.uimanager.events.EventDispatcher;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nullable;
+
+/** A class responsible for creating and rendering a full-screen React surface. */
+@Nullsafe(Nullsafe.Mode.LOCAL)
+@ThreadSafe
+public class ReactSurface {
+  private static final String TAG = "ReactSurface";
+
+  private final AtomicReference<ReactSurfaceView> mSurfaceView = new AtomicReference<>(null);
+
+  private final AtomicReference<ReactHost> mReactHost = new AtomicReference<>(null);
+
+  private final SurfaceHandler mSurfaceHandler;
+
+  /**
+   * Surface can hold two types of context: one used to init the surface without view (e.g. during
+   * prerendering), and themed view context later, whenever it is available. The assumption is that
+   * custom theming is applied to both the same way, so changing them SHOULD NOT change the visual
+   * output.
+   */
+  private Context mContext;
+
+  public static ReactSurface createWithView(
+      Context context, String moduleName, @Nullable Bundle initialProps) {
+    ReactSurface surface = new ReactSurface(context, moduleName, initialProps);
+    surface.attachView(new ReactSurfaceView(context, surface));
+    return surface;
+  }
+
+  /**
+   * @param context The Android Context to use to render the ReactSurfaceView
+   * @param moduleName The string key used to register this surface in JS with SurfaceRegistry
+   * @param initialProps A Bundle of properties to be passed to the root React component
+   */
+  public ReactSurface(Context context, String moduleName, @Nullable Bundle initialProps) {
+    this(new SurfaceHandlerBinding(moduleName), context);
+
+    NativeMap nativeProps =
+        initialProps == null
+            ? new WritableNativeMap()
+            : (NativeMap) Arguments.fromBundle(initialProps);
+    mSurfaceHandler.setProps(nativeProps);
+
+    DisplayMetrics displayMetrics = context.getResources().getDisplayMetrics();
+    mSurfaceHandler.setLayoutConstraints(
+        MeasureSpec.makeMeasureSpec(displayMetrics.widthPixels, MeasureSpec.AT_MOST),
+        MeasureSpec.makeMeasureSpec(displayMetrics.heightPixels, MeasureSpec.AT_MOST),
+        0,
+        0,
+        doRTLSwap(context),
+        isRTL(context),
+        getPixelDensity(context));
+  }
+
+  @VisibleForTesting
+  ReactSurface(SurfaceHandler surfaceHandler, Context context) {
+    mSurfaceHandler = surfaceHandler;
+    mContext = context;
+  }
+
+  /**
+   * Attach a ReactHost to the ReactSurface.
+   *
+   * @param host The ReactHost to attach.
+   */
+  public void attach(ReactHost host) {
+    if (!mReactHost.compareAndSet(null, host)) {
+      throw new IllegalStateException("This surface is already attached to a host!");
+    }
+  }
+
+  /**
+   * Attaches a view to the surface. View can be attached only once and should not be detached
+   * after.
+   */
+  public void attachView(ReactSurfaceView view) {
+    if (!mSurfaceView.compareAndSet(null, view)) {
+      throw new IllegalStateException(
+          "Trying to call ReactSurface.attachView(), but the view is already attached.");
+    }
+    // re: thread safety. Context can be changed only once, during view init, so view atomic above
+    // already guards the context update.
+    mContext = view.getContext();
+  }
+
+  public void updateInitProps(Bundle newProps) {
+    mSurfaceHandler.setProps((NativeMap) Arguments.fromBundle(newProps));
+  }
+
+  @VisibleForTesting
+  ReactHost getReactHost() {
+    // NULLSAFE_FIXME[Return Not Nullable]
+    return mReactHost.get();
+  }
+
+  /** Detach the ReactSurface from its ReactHost. */
+  public void detach() {
+    mReactHost.set(null);
+  }
+
+  public SurfaceHandler getSurfaceHandler() {
+    return mSurfaceHandler;
+  }
+
+  public @Nullable ReactSurfaceView getView() {
+    return mSurfaceView.get();
+  }
+
+  public Task<Void> prerender() {
+    ReactHost host = mReactHost.get();
+    if (host == null) {
+      return Task.forError(
+          new IllegalStateException(
+              "Trying to call ReactSurface.prerender(), but no ReactHost is attached."));
+    }
+    return host.prerenderSurface(this);
+  }
+
+  public Task<Void> start() {
+    if (mSurfaceView.get() == null) {
+      return Task.forError(
+          new IllegalStateException(
+              "Trying to call ReactSurface.start(), but view is not created."));
+    }
+
+    ReactHost host = mReactHost.get();
+    if (host == null) {
+      return Task.forError(
+          new IllegalStateException(
+              "Trying to call ReactSurface.start(), but no ReactHost is attached."));
+    }
+    return host.startSurface(this);
+  }
+
+  public Task<Void> stop() {
+    ReactHost host = mReactHost.get();
+    if (host == null) {
+      return Task.forError(
+          new IllegalStateException(
+              "Trying to call ReactSurface.stop(), but no ReactHost is attached."));
+    }
+    return host.stopSurface(this).makeVoid();
+  }
+
+  public int getSurfaceID() {
+    return mSurfaceHandler.getSurfaceId();
+  }
+
+  public String getModuleName() {
+    return mSurfaceHandler.getModuleName();
+  }
+
+  public void clear() {
+    UiThreadUtil.runOnUiThread(
+        new Runnable() {
+          @Override
+          public void run() {
+            ReactSurfaceView view = getView();
+            if (view != null) {
+              view.removeAllViews();
+              view.setId(View.NO_ID);
+            }
+          }
+        });
+  }
+
+  @UiThread
+  /* package */ synchronized void updateLayoutSpecs(
+      int widthMeasureSpec, int heightMeasureSpec, int offsetX, int offsetY) {
+    mSurfaceHandler.setLayoutConstraints(
+        widthMeasureSpec,
+        heightMeasureSpec,
+        offsetX,
+        offsetY,
+        doRTLSwap(mContext),
+        isRTL(mContext),
+        getPixelDensity(mContext));
+  }
+
+  /* package */ @Nullable
+  EventDispatcher getEventDispatcher() {
+    ReactHost host = mReactHost.get();
+    if (host == null) {
+      return null;
+    }
+    return host.getEventDispatcher();
+  }
+
+  @VisibleForTesting
+  boolean isAttached() {
+    return mReactHost.get() != null;
+  }
+
+  public boolean isRunning() {
+    return mSurfaceHandler.isRunning();
+  }
+
+  public Context getContext() {
+    return mContext;
+  }
+
+  private static float getPixelDensity(Context context) {
+    return context.getResources().getDisplayMetrics().density;
+  }
+
+  private static boolean isRTL(Context context) {
+    return I18nUtil.getInstance().isRTL(context);
+  }
+
+  private static boolean doRTLSwap(Context context) {
+    return I18nUtil.getInstance().doLeftAndRightSwapInRTL(context);
+  }
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactSurfaceView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactSurfaceView.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+
+package com.facebook.react.bridgeless;
+
+import android.content.Context;
+import android.graphics.Point;
+import android.graphics.Rect;
+import android.view.MotionEvent;
+import android.view.View;
+import android.view.ViewParent;
+import androidx.annotation.Nullable;
+import com.facebook.common.logging.FLog;
+import com.facebook.infer.annotation.Nullsafe;
+import com.facebook.react.ReactRootView;
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.config.ReactFeatureFlags;
+import com.facebook.react.uimanager.IllegalViewOperationException;
+import com.facebook.react.uimanager.JSPointerDispatcher;
+import com.facebook.react.uimanager.JSTouchDispatcher;
+import com.facebook.react.uimanager.common.UIManagerType;
+import com.facebook.react.uimanager.events.EventDispatcher;
+import com.facebook.systrace.Systrace;
+
+/** A view created by {@link ReactSurface} that's responsible for rendering a React component. */
+@Nullsafe(Nullsafe.Mode.LOCAL)
+public class ReactSurfaceView extends ReactRootView {
+
+  private static final String TAG = "ReactSurfaceView";
+
+  private ReactSurface mSurface;
+
+  private final JSTouchDispatcher mJSTouchDispatcher;
+  private @Nullable JSPointerDispatcher mJSPointerDispatcher;
+
+  private boolean mWasMeasured = false;
+  private int mWidthMeasureSpec = 0;
+  private int mHeightMeasureSpec = 0;
+
+  public ReactSurfaceView(Context context, ReactSurface surface) {
+    super(context);
+    mSurface = surface;
+    mJSTouchDispatcher = new JSTouchDispatcher(this);
+    if (ReactFeatureFlags.dispatchPointerEvents) {
+      mJSPointerDispatcher = new JSPointerDispatcher(this);
+    }
+  }
+
+  @Override
+  protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+    Systrace.beginSection(Systrace.TRACE_TAG_REACT_JAVA_BRIDGE, "ReactSurfaceView.onMeasure");
+
+    int width = 0;
+    int height = 0;
+    int widthMode = MeasureSpec.getMode(widthMeasureSpec);
+    if (widthMode == MeasureSpec.AT_MOST || widthMode == MeasureSpec.UNSPECIFIED) {
+      for (int i = 0; i < getChildCount(); i++) {
+        View child = getChildAt(i);
+        int childSize =
+            child.getLeft()
+                + child.getMeasuredWidth()
+                + child.getPaddingLeft()
+                + child.getPaddingRight();
+        width = Math.max(width, childSize);
+      }
+    } else {
+      width = MeasureSpec.getSize(widthMeasureSpec);
+    }
+    int heightMode = MeasureSpec.getMode(heightMeasureSpec);
+    if (heightMode == MeasureSpec.AT_MOST || heightMode == MeasureSpec.UNSPECIFIED) {
+      for (int i = 0; i < getChildCount(); i++) {
+        View child = getChildAt(i);
+        int childSize =
+            child.getTop()
+                + child.getMeasuredHeight()
+                + child.getPaddingTop()
+                + child.getPaddingBottom();
+        height = Math.max(height, childSize);
+      }
+    } else {
+      height = MeasureSpec.getSize(heightMeasureSpec);
+    }
+    setMeasuredDimension(width, height);
+
+    mWasMeasured = true;
+    mWidthMeasureSpec = widthMeasureSpec;
+    mHeightMeasureSpec = heightMeasureSpec;
+
+    Point viewportOffset = getViewportOffset();
+
+    mSurface.updateLayoutSpecs(
+        mWidthMeasureSpec, mHeightMeasureSpec, viewportOffset.x, viewportOffset.y);
+
+    Systrace.endSection(Systrace.TRACE_TAG_REACT_JAVA_BRIDGE);
+  }
+
+  @Override
+  protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
+    // Call updateLayoutSpecs to update locationOnScreen offsets, in case they've changed
+    if (mWasMeasured && changed) {
+      Point viewportOffset = getViewportOffset();
+      mSurface.updateLayoutSpecs(
+          mWidthMeasureSpec, mHeightMeasureSpec, viewportOffset.x, viewportOffset.y);
+    }
+  }
+
+  private Point getViewportOffset() {
+    int[] locationOnScreen = new int[2];
+    getLocationOnScreen(locationOnScreen);
+
+    // we need to subtract visibleWindowCoords - to subtract possible window insets, split
+    // screen or multi window
+    Rect visibleWindowFrame = new Rect();
+    getWindowVisibleDisplayFrame(visibleWindowFrame);
+    locationOnScreen[0] -= visibleWindowFrame.left;
+    locationOnScreen[1] -= visibleWindowFrame.top;
+
+    return new Point(locationOnScreen[0], locationOnScreen[1]);
+  }
+
+  @Override
+  public void requestDisallowInterceptTouchEvent(boolean disallowIntercept) {
+    // Override in order to still receive events to onInterceptTouchEvent even when some other
+    // views disallow that, but propagate it up the tree if possible.
+    ViewParent parent = getParent();
+    if (parent != null) {
+      parent.requestDisallowInterceptTouchEvent(disallowIntercept);
+    }
+  }
+
+  /**
+   * Called when a child starts a native gesture (e.g. a scroll in a ScrollView). Should be called
+   * from the child's onTouchIntercepted implementation.
+   */
+  @Override
+  public void onChildStartedNativeGesture(MotionEvent ev) {
+    if (mJSTouchDispatcher != null && mSurface.getEventDispatcher() != null) {
+      mJSTouchDispatcher.onChildStartedNativeGesture(ev, mSurface.getEventDispatcher());
+    }
+  }
+
+  /**
+   * Called when a child starts a native gesture (e.g. a scroll in a ScrollView). Should be called
+   * from the child's onTouchIntercepted implementation.
+   */
+  @Override
+  public void onChildStartedNativeGesture(View childView, MotionEvent ev) {
+    onChildStartedNativeGesture(ev);
+  }
+
+  @Override
+  public void onChildEndedNativeGesture(View childView, MotionEvent ev) {
+    if (mJSTouchDispatcher != null && mSurface.getEventDispatcher() != null) {
+      mJSTouchDispatcher.onChildEndedNativeGesture(ev, mSurface.getEventDispatcher());
+    }
+  }
+
+  @Override
+  public void handleException(Throwable t) {
+    if (mSurface.getReactHost() != null) {
+      String errorMessage = t.getMessage() == null ? "" : t.getMessage();
+      Exception e = new IllegalViewOperationException(errorMessage, this, t);
+      mSurface.getReactHost().handleException(e);
+    }
+  }
+
+  @Override
+  public void setIsFabric(boolean isFabric) {
+    // This surface view is always on Fabric regardless.
+    super.setIsFabric(true);
+  }
+
+  @Override
+  public @UIManagerType int getUIManagerType() {
+    // This surface view is always on Fabric.
+    return UIManagerType.FABRIC;
+  }
+
+  @Override
+  protected void dispatchJSTouchEvent(MotionEvent event) {
+    if (mJSTouchDispatcher == null) {
+      FLog.w(TAG, "Unable to dispatch touch events to JS before the dispatcher is available");
+      return;
+    }
+    EventDispatcher eventDispatcher = mSurface.getEventDispatcher();
+    if (eventDispatcher != null) {
+      mJSTouchDispatcher.handleTouchEvent(event, eventDispatcher);
+    } else {
+      FLog.w(
+          TAG, "Unable to dispatch touch events to JS as the React instance has not been attached");
+    }
+  }
+
+  @Override
+  protected void dispatchJSPointerEvent(MotionEvent event, boolean isCapture) {
+    if (mJSPointerDispatcher == null) {
+      if (!ReactFeatureFlags.dispatchPointerEvents) {
+        return;
+      }
+      FLog.w(TAG, "Unable to dispatch pointer events to JS before the dispatcher is available");
+      return;
+    }
+    EventDispatcher eventDispatcher = mSurface.getEventDispatcher();
+    if (eventDispatcher != null) {
+      mJSPointerDispatcher.handleMotionEvent(event, eventDispatcher, isCapture);
+    } else {
+      FLog.w(
+          TAG,
+          "Unable to dispatch pointer events to JS as the React instance has not been attached");
+    }
+  }
+
+  @Override
+  public boolean hasActiveReactContext() {
+    return mSurface.isAttached() && mSurface.getReactHost().getCurrentReactContext() != null;
+  }
+
+  @Override
+  public boolean hasActiveReactInstance() {
+    return mSurface.isAttached() && mSurface.getReactHost().isInstanceInitialized();
+  }
+
+  @Override
+  public @Nullable ReactContext getCurrentReactContext() {
+    if (mSurface.isAttached()) {
+      return mSurface.getReactHost().getCurrentReactContext();
+    }
+    return null;
+  }
+
+  @Override
+  public boolean isViewAttachedToReactInstance() {
+    return mSurface.isAttached();
+  }
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/exceptionmanager/ReactJsExceptionHandler.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/exceptionmanager/ReactJsExceptionHandler.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+
+package com.facebook.react.bridgeless.exceptionmanager;
+
+import com.facebook.proguard.annotations.DoNotStripAny;
+import com.facebook.react.common.mapbuffer.ReadableMapBuffer;
+
+@DoNotStripAny
+public interface ReactJsExceptionHandler {
+
+  public void reportJsException(ReadableMapBuffer errorMap);
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/hermes/HermesInstance.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/hermes/HermesInstance.kt
@@ -8,16 +8,13 @@
 
 package com.facebook.react.bridgeless.hermes
 
-import com.facebook.common.process.ProcessName
 import com.facebook.jni.HybridData
 import com.facebook.jni.annotations.DoNotStrip
-import com.facebook.jsi.mdcd.HermesCodeCoverage
-import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridgeless.JSEngineInstance
 import com.facebook.soloader.SoLoader
 import kotlin.jvm.JvmStatic
 
-class HermesInstance(context: ReactApplicationContext) : JSEngineInstance(initHybrid()!!) {
+class HermesInstance() : JSEngineInstance(initHybrid()!!) {
 
   companion object {
     @JvmStatic @DoNotStrip protected external fun initHybrid(): HybridData?
@@ -25,11 +22,5 @@ class HermesInstance(context: ReactApplicationContext) : JSEngineInstance(initHy
     init {
       SoLoader.loadLibrary("hermesinstancejni")
     }
-  }
-
-  init {
-    // Initialize Code Coverage tracing for select usecases, like E2E coverage and Hermes MDCD
-    val processName = ProcessName.current().fullName
-    HermesCodeCoverage.initialize(context, processName.orEmpty())
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/hermes/HermesInstance.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/hermes/HermesInstance.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+
+package com.facebook.react.bridgeless.hermes
+
+import com.facebook.common.process.ProcessName
+import com.facebook.jni.HybridData
+import com.facebook.jni.annotations.DoNotStrip
+import com.facebook.jsi.mdcd.HermesCodeCoverage
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridgeless.JSEngineInstance
+import com.facebook.soloader.SoLoader
+import kotlin.jvm.JvmStatic
+
+class HermesInstance(context: ReactApplicationContext) : JSEngineInstance(initHybrid()!!) {
+
+  companion object {
+    @JvmStatic @DoNotStrip protected external fun initHybrid(): HybridData?
+
+    init {
+      SoLoader.loadLibrary("hermesinstancejni")
+    }
+  }
+
+  init {
+    // Initialize Code Coverage tracing for select usecases, like E2E coverage and Hermes MDCD
+    val processName = ProcessName.current().fullName
+    HermesCodeCoverage.initialize(context, processName.orEmpty())
+  }
+}

--- a/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/bindings/BindingsInstaller.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/bindings/BindingsInstaller.h
@@ -1,0 +1,26 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <ReactCommon/RuntimeExecutor.h>
+#include <react/bridgeless/ReactInstance.h>
+
+#include <qpljsibindings/QuickPerformanceLoggerJSIBindings.h>
+#include <qpljsibindings/UserFlowJSIBindings.h>
+
+namespace facebook {
+namespace react {
+
+class BindingsInstaller {
+ public:
+  ReactInstance::BindingsInstallFunc getBindingsInstallFunc() {
+    auto installBindings = [](jsi::Runtime &runtime) {
+      jsi::installQPLBindings(runtime);
+      jsi::installUserFlowBindings(runtime);
+    };
+    return installBindings;
+  }
+};
+
+} // namespace react
+} // namespace facebook

--- a/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/hermes/jni/.clang-tidy
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/hermes/jni/.clang-tidy
@@ -1,0 +1,20 @@
+---
+Checks: '
+*,
+-cert-err60-cpp,
+-cppcoreguidelines-pro-bounds-pointer-arithmetic,
+-cppcoreguidelines-special-member-functions,
+-cppcoreguidelines-pro-type-const-cast,
+-fuchsia-default-arguments-calls,
+-fuchsia-multiple-inheritance,
+-google-readability-casting,
+-google-runtime-int,
+-google-runtime-references,
+-hicpp-special-member-functions,
+-llvm-header-guard,
+-misc-non-private-member-variables-in-classes,
+-misc-unused-parameters,
+-modernize-use-trailing-return-type,
+-performance-unnecessary-value-param
+'
+...

--- a/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/hermes/jni/JHermesInstance.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/hermes/jni/JHermesInstance.cpp
@@ -1,0 +1,27 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "JHermesInstance.h"
+
+#include <fb/fbjni.h>
+
+namespace facebook {
+namespace react {
+
+jni::local_ref<JHermesInstance::jhybriddata> JHermesInstance::initHybrid(
+    jni::alias_ref<jhybridobject>) {
+  return makeCxxInstance();
+}
+
+void JHermesInstance::registerNatives() {
+  registerHybrid({
+      makeNativeMethod("initHybrid", JHermesInstance::initHybrid),
+  });
+}
+
+std::unique_ptr<jsi::Runtime> JHermesInstance::createJSRuntime() noexcept {
+  // TODO T105438175 Pass ReactNativeConfig to init Hermes with MobileConfig
+  return HermesInstance::createJSRuntime();
+}
+
+} // namespace react
+} // namespace facebook

--- a/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/hermes/jni/JHermesInstance.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/hermes/jni/JHermesInstance.h
@@ -1,0 +1,37 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include <fb/fbjni.h>
+#include <jni.h>
+#include <jsi/jsi.h>
+#include <react/bridgeless/JSEngineInstance.h>
+#include <react/bridgeless/hermes/HermesInstance.h>
+#include "../../jni/JJSEngineInstance.h"
+
+namespace facebook {
+namespace react {
+
+class JHermesInstance
+    : public jni::HybridClass<JHermesInstance, JJSEngineInstance> {
+ public:
+  static constexpr auto kJavaDescriptor =
+      "Lcom/facebook/venice/hermes/HermesInstance;";
+
+  static jni::local_ref<jhybriddata> initHybrid(jni::alias_ref<jhybridobject>);
+
+  static void registerNatives();
+
+  std::unique_ptr<jsi::Runtime> createJSRuntime() noexcept;
+
+  ~JHermesInstance() {}
+
+ private:
+  friend HybridBase;
+};
+
+} // namespace react
+} // namespace facebook

--- a/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/hermes/jni/JHermesInstance.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/hermes/jni/JHermesInstance.h
@@ -1,4 +1,10 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 
 #pragma once
 
@@ -19,7 +25,7 @@ class JHermesInstance
     : public jni::HybridClass<JHermesInstance, JJSEngineInstance> {
  public:
   static constexpr auto kJavaDescriptor =
-      "Lcom/facebook/venice/hermes/HermesInstance;";
+      "Lcom/facebook/react/bridgeless/hermes/HermesInstance;";
 
   static jni::local_ref<jhybriddata> initHybrid(jni::alias_ref<jhybridobject>);
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/hermes/jni/OnLoad.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/hermes/jni/OnLoad.cpp
@@ -1,0 +1,11 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <fb/fbjni.h>
+#include <fb/xplat_init.h>
+
+#include "JHermesInstance.h"
+
+JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *) {
+  return facebook::xplat::initialize(
+      vm, [] { facebook::react::JHermesInstance::registerNatives(); });
+}

--- a/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/jni/.clang-tidy
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/jni/.clang-tidy
@@ -1,0 +1,20 @@
+---
+Checks: '
+*,
+-cert-err60-cpp,
+-cppcoreguidelines-pro-bounds-pointer-arithmetic,
+-cppcoreguidelines-special-member-functions,
+-cppcoreguidelines-pro-type-const-cast,
+-fuchsia-default-arguments-calls,
+-fuchsia-multiple-inheritance,
+-google-readability-casting,
+-google-runtime-int,
+-google-runtime-references,
+-hicpp-special-member-functions,
+-llvm-header-guard,
+-misc-non-private-member-variables-in-classes,
+-misc-unused-parameters,
+-modernize-use-trailing-return-type,
+-performance-unnecessary-value-param
+'
+...

--- a/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/jni/BridgelessJSCallInvoker.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/jni/BridgelessJSCallInvoker.cpp
@@ -1,0 +1,26 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "BridgelessJSCallInvoker.h"
+
+#include <exception>
+#include <utility>
+
+namespace facebook {
+namespace react {
+
+BridgelessJSCallInvoker::BridgelessJSCallInvoker(
+    RuntimeExecutor runtimeExecutor)
+    : runtimeExecutor_(std::move(runtimeExecutor)) {}
+
+void BridgelessJSCallInvoker::invokeAsync(std::function<void()> &&func) {
+  runtimeExecutor_([func = std::move(func)](jsi::Runtime &runtime) { func(); });
+}
+
+void BridgelessJSCallInvoker::invokeSync(std::function<void()> &&func) {
+  // TODO: Replace JS Callinvoker with RuntimeExecutor.
+  throw std::runtime_error(
+      "Synchronous native -> JS calls are currently not supported.");
+}
+
+} // namespace react
+} // namespace facebook

--- a/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/jni/BridgelessJSCallInvoker.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/jni/BridgelessJSCallInvoker.h
@@ -1,0 +1,25 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <functional>
+#include <memory>
+
+#include <ReactCommon/CallInvoker.h>
+#include <ReactCommon/RuntimeExecutor.h>
+#include <fb/fbjni.h>
+#include <jsi/jsi.h>
+
+namespace facebook {
+namespace react {
+
+class BridgelessJSCallInvoker : public CallInvoker {
+ public:
+  explicit BridgelessJSCallInvoker(RuntimeExecutor runtimeExecutor);
+  void invokeAsync(std::function<void()> &&func) override;
+  void invokeSync(std::function<void()> &&func) override;
+
+ private:
+  RuntimeExecutor runtimeExecutor_;
+};
+
+} // namespace react
+} // namespace facebook

--- a/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/jni/BridgelessNativeCallInvoker.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/jni/BridgelessNativeCallInvoker.cpp
@@ -1,0 +1,24 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "BridgelessNativeCallInvoker.h"
+
+#include <exception>
+#include <utility>
+
+namespace facebook {
+namespace react {
+
+BridgelessNativeCallInvoker::BridgelessNativeCallInvoker(
+    std::shared_ptr<JMessageQueueThread> messageQueueThread)
+    : messageQueueThread_(std::move(messageQueueThread)) {}
+
+void BridgelessNativeCallInvoker::invokeAsync(std::function<void()> &&func) {
+  messageQueueThread_->runOnQueue(std::move(func));
+}
+
+void BridgelessNativeCallInvoker::invokeSync(std::function<void()> &&func) {
+  messageQueueThread_->runOnQueueSync(std::move(func));
+}
+
+} // namespace react
+} // namespace facebook

--- a/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/jni/BridgelessNativeCallInvoker.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/jni/BridgelessNativeCallInvoker.h
@@ -1,0 +1,27 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <functional>
+#include <memory>
+
+#include <ReactCommon/CallInvoker.h>
+#include <ReactCommon/RuntimeExecutor.h>
+#include <fb/fbjni.h>
+#include <jsi/jsi.h>
+#include <react/jni/JMessageQueueThread.h>
+
+namespace facebook {
+namespace react {
+
+class BridgelessNativeCallInvoker : public CallInvoker {
+ public:
+  explicit BridgelessNativeCallInvoker(
+      std::shared_ptr<JMessageQueueThread> messageQueueThread);
+  void invokeAsync(std::function<void()> &&func) override;
+  void invokeSync(std::function<void()> &&func) override;
+
+ private:
+  std::shared_ptr<JMessageQueueThread> messageQueueThread_;
+};
+
+} // namespace react
+} // namespace facebook

--- a/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/jni/JJSEngineInstance.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/jni/JJSEngineInstance.h
@@ -1,0 +1,24 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <fb/fbjni.h>
+#include <jni.h>
+#include <react/bridgeless/JSEngineInstance.h>
+
+namespace facebook {
+
+namespace react {
+
+class JJSEngineInstance : public jni::HybridClass<JJSEngineInstance>,
+                          public JSEngineInstance {
+ public:
+  static auto constexpr kJavaDescriptor =
+      "Lcom/facebook/venice/JSEngineInstance;";
+
+ private:
+  friend HybridBase;
+};
+
+} // namespace react
+} // namespace facebook

--- a/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/jni/JJSEngineInstance.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/jni/JJSEngineInstance.h
@@ -1,4 +1,10 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 
 #pragma once
 
@@ -14,7 +20,7 @@ class JJSEngineInstance : public jni::HybridClass<JJSEngineInstance>,
                           public JSEngineInstance {
  public:
   static auto constexpr kJavaDescriptor =
-      "Lcom/facebook/venice/JSEngineInstance;";
+      "Lcom/facebook/react/bridgeless/JSEngineInstance;";
 
  private:
   friend HybridBase;

--- a/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/jni/JJSTimerExecutor.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/jni/JJSTimerExecutor.cpp
@@ -1,0 +1,32 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "JJSTimerExecutor.h"
+
+#include <fb/fbjni.h>
+#include <jni.h>
+
+namespace facebook {
+namespace react {
+
+void JJSTimerExecutor::setTimerManager(
+    std::weak_ptr<TimerManager> timerManager) {
+  assert(timerManager && "`timerManager` must not be `nullptr`.");
+  timerManager_ = timerManager;
+}
+
+void JJSTimerExecutor::callTimers(WritableNativeArray *timerIDs) {
+  if (auto timerManager = timerManager_.lock()) {
+    for (const auto &timerID : timerIDs->consume()) {
+      timerManager->callTimer((uint32_t)timerID.asInt());
+    }
+  }
+}
+
+void JJSTimerExecutor::registerNatives() {
+  registerHybrid({
+      makeNativeMethod("callTimers", JJSTimerExecutor::callTimers),
+  });
+}
+
+} // namespace react
+} // namespace facebook

--- a/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/jni/JJSTimerExecutor.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/jni/JJSTimerExecutor.h
@@ -1,0 +1,34 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <ReactCommon/RuntimeExecutor.h>
+#include <fb/fbjni.h>
+#include <jni.h>
+#include <react/bridgeless/TimerManager.h>
+#include <react/jni/WritableNativeArray.h>
+
+namespace facebook {
+namespace react {
+
+class JJSTimerExecutor : public jni::HybridClass<JJSTimerExecutor> {
+ public:
+  JJSTimerExecutor() = default;
+
+  constexpr static auto kJavaDescriptor =
+      "Lcom/facebook/venice/JSTimerExecutor;";
+
+  static void registerNatives();
+
+  void setTimerManager(std::weak_ptr<TimerManager> timerManager);
+
+  void callTimers(WritableNativeArray *timerIDs);
+
+ private:
+  friend HybridBase;
+
+  std::weak_ptr<TimerManager> timerManager_;
+};
+
+} // namespace react
+} // namespace facebook

--- a/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/jni/JJSTimerExecutor.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/jni/JJSTimerExecutor.h
@@ -1,4 +1,10 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 
 #pragma once
 
@@ -16,7 +22,7 @@ class JJSTimerExecutor : public jni::HybridClass<JJSTimerExecutor> {
   JJSTimerExecutor() = default;
 
   constexpr static auto kJavaDescriptor =
-      "Lcom/facebook/venice/JSTimerExecutor;";
+      "Lcom/facebook/react/bridgeless/JSTimerExecutor;";
 
   static void registerNatives();
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/jni/JJavaTimerManager.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/jni/JJavaTimerManager.cpp
@@ -1,0 +1,27 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "JJavaTimerManager.h"
+
+#include <fb/fbjni.h>
+#include <jni.h>
+
+namespace facebook {
+namespace react {
+
+void JJavaTimerManager::createTimer(
+    uint32_t timerID,
+    double duration,
+    bool repeat) {
+  static const auto method =
+      javaClassStatic()->getMethod<void(jint, jlong, jboolean)>("createTimer");
+  method(self(), timerID, (long)duration, static_cast<unsigned char>(repeat));
+}
+
+void JJavaTimerManager::deleteTimer(uint32_t timerID) {
+  static const auto method =
+      javaClassStatic()->getMethod<void(jint)>("deleteTimer");
+  method(self(), timerID);
+}
+
+} // namespace react
+} // namespace facebook

--- a/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/jni/JJavaTimerManager.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/jni/JJavaTimerManager.h
@@ -1,0 +1,23 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstdint>
+
+#include <fb/fbjni.h>
+#include <jni.h>
+
+namespace facebook {
+namespace react {
+
+struct JJavaTimerManager : jni::JavaClass<JJavaTimerManager> {
+  static auto constexpr kJavaDescriptor =
+      "Lcom/facebook/react/modules/core/JavaTimerManager;";
+
+  void createTimer(uint32_t timerID, double duration, bool repeat);
+
+  void deleteTimer(uint32_t timerID);
+};
+
+} // namespace react
+} // namespace facebook

--- a/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/jni/JReactExceptionManager.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/jni/JReactExceptionManager.cpp
@@ -1,0 +1,23 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "JReactExceptionManager.h"
+#include <fb/fbjni.h>
+#include <glog/logging.h>
+#include <jni.h>
+#include <iostream>
+
+namespace facebook {
+namespace react {
+
+void JReactExceptionManager::reportJsException(
+    const JReadableMapBuffer::javaobject errorMapBuffer) {
+  static const auto method =
+      javaClassStatic()->getMethod<void(JReadableMapBuffer::javaobject)>(
+          "reportJsException");
+  if (self() != nullptr) {
+    method(self(), errorMapBuffer);
+  }
+}
+
+} // namespace react
+} // namespace facebook

--- a/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/jni/JReactExceptionManager.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/jni/JReactExceptionManager.h
@@ -1,0 +1,22 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <fb/fbjni.h>
+#include <jni.h>
+#include <react/common/mapbuffer/JReadableMapBuffer.h>
+
+namespace facebook {
+namespace react {
+
+class JReactExceptionManager
+    : public facebook::jni::JavaClass<JReactExceptionManager> {
+ public:
+  static auto constexpr kJavaDescriptor =
+      "Lcom/facebook/venice/exceptionmanager/ReactJsExceptionHandler;";
+
+  void reportJsException(const JReadableMapBuffer::javaobject errorMapBuffer);
+};
+
+} // namespace react
+} // namespace facebook

--- a/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/jni/JReactExceptionManager.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/jni/JReactExceptionManager.h
@@ -1,4 +1,10 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 
 #pragma once
 
@@ -13,7 +19,7 @@ class JReactExceptionManager
     : public facebook::jni::JavaClass<JReactExceptionManager> {
  public:
   static auto constexpr kJavaDescriptor =
-      "Lcom/facebook/venice/exceptionmanager/ReactJsExceptionHandler;";
+      "Lcom/facebook/react/bridgeless/exceptionmanager/ReactJsExceptionHandler;";
 
   void reportJsException(const JReadableMapBuffer::javaobject errorMapBuffer);
 };

--- a/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/jni/JReactInstance.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/jni/JReactInstance.cpp
@@ -1,0 +1,228 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "JReactInstance.h"
+
+#ifdef WITH_FBSYSTRACE
+#include <fbsystrace.h>
+#endif
+
+#include <BindingsInstaller.h>
+#include <cxxreact/JSBigString.h>
+#include <cxxreact/RecoverableError.h>
+#include <fb/fbjni.h>
+#include <glog/logging.h>
+#include <jni.h>
+#include <jsi/jsi.h>
+#include <jsireact/JSIExecutor.h>
+#include <react/common/mapbuffer/JReadableMapBuffer.h>
+#include <react/jni/JRuntimeExecutor.h>
+#include <react/jni/JSLogging.h>
+#include <react/renderer/mapbuffer/MapBuffer.h>
+#include "BridgelessJSCallInvoker.h"
+#include "BridgelessNativeCallInvoker.h"
+#include "JavaTimerRegistry.h"
+
+namespace facebook {
+namespace react {
+
+JReactInstance::JReactInstance(
+    jni::alias_ref<JJSEngineInstance::javaobject> jsEngineInstance,
+    jni::alias_ref<JavaMessageQueueThread::javaobject> jsMessageQueueThread,
+    jni::alias_ref<JavaMessageQueueThread::javaobject> nativeMessageQueueThread,
+    jni::alias_ref<JJavaTimerManager::javaobject> javaTimerManager,
+    jni::alias_ref<JJSTimerExecutor::javaobject> jsTimerExecutor,
+    jni::alias_ref<JReactExceptionManager::javaobject> jReactExceptionManager,
+    bool isProfiling) noexcept {
+  // TODO(janzer): Lazily create runtime
+  auto sharedJSMessageQueueThread =
+      std::make_shared<JMessageQueueThread>(jsMessageQueueThread);
+  auto sharedNativeMessageQueueThread =
+      std::make_shared<JMessageQueueThread>(nativeMessageQueueThread);
+
+  // Create the timer manager (for JS timers)
+  auto timerRegistry =
+      std::make_unique<JavaTimerRegistry>(jni::make_global(javaTimerManager));
+  auto timerManager = std::make_shared<TimerManager>(std::move(timerRegistry));
+  jsTimerExecutor->cthis()->setTimerManager(timerManager);
+
+  // Create the instance
+  std::unique_ptr<BindingsInstaller> bindingsInstaller =
+      std::make_unique<BindingsInstaller>();
+
+  jReactExceptionManager_ = jni::make_global(jReactExceptionManager);
+  auto jsErrorHandlingFunc = [this](MapBuffer errorMap) noexcept {
+    if (jReactExceptionManager_ != nullptr) {
+      auto jErrorMap =
+          JReadableMapBuffer::createWithContents(std::move(errorMap));
+      jReactExceptionManager_->reportJsException(jErrorMap.get());
+    }
+  };
+
+  instance_ = std::make_unique<ReactInstance>(
+      jsEngineInstance->cthis()->createJSRuntime(),
+      sharedJSMessageQueueThread,
+      timerManager,
+      std::move(jsErrorHandlingFunc));
+  auto appBindingInstaller = bindingsInstaller->getBindingsInstallFunc();
+
+  auto bufferedRuntimeExecutor = instance_->getBufferedRuntimeExecutor();
+  timerManager->setRuntimeExecutor(bufferedRuntimeExecutor);
+
+  ReactInstance::JSRuntimeFlags options = {.isProfiling = isProfiling};
+  instance_->initializeRuntime(
+      options,
+      [appBindingInstaller, instance = instance_.get()](jsi::Runtime &runtime) {
+        react::Logger androidLogger =
+            static_cast<void (*)(const std::string &, unsigned int)>(
+                &reactAndroidLoggingHook);
+        react::bindNativeLogger(runtime, androidLogger);
+        appBindingInstaller(runtime);
+      });
+
+  auto unbufferedRuntimeExecutor = instance_->getUnbufferedRuntimeExecutor();
+  // Set up the JS and native modules call invokers (for TurboModules)
+  auto jsInvoker =
+      std::make_unique<BridgelessJSCallInvoker>(unbufferedRuntimeExecutor);
+  jsCallInvokerHolder_ = jni::make_global(
+      CallInvokerHolder::newObjectCxxArgs(std::move(jsInvoker)));
+  auto nativeInvoker = std::make_unique<BridgelessNativeCallInvoker>(
+      sharedNativeMessageQueueThread);
+  nativeCallInvokerHolder_ = jni::make_global(
+      CallInvokerHolder::newObjectCxxArgs(std::move(nativeInvoker)));
+
+  // Storing this here to make sure the Java reference doesn't get destroyed
+  unbufferedRuntimeExecutor_ = jni::make_global(
+      JRuntimeExecutor::newObjectCxxArgs(unbufferedRuntimeExecutor));
+  bufferedRuntimeExecutor_ = jni::make_global(
+      JRuntimeExecutor::newObjectCxxArgs(bufferedRuntimeExecutor));
+  runtimeScheduler_ = jni::make_global(
+      JRuntimeScheduler::newObjectCxxArgs(instance_->getRuntimeScheduler()));
+}
+
+jni::local_ref<JReactInstance::jhybriddata> JReactInstance::initHybrid(
+    jni::alias_ref<jhybridobject> /* unused */,
+    jni::alias_ref<JJSEngineInstance::javaobject> jsEngineInstance,
+    jni::alias_ref<JavaMessageQueueThread::javaobject> jsMessageQueueThread,
+    jni::alias_ref<JavaMessageQueueThread::javaobject> nativeMessageQueueThread,
+    jni::alias_ref<JJavaTimerManager::javaobject> javaTimerManager,
+    jni::alias_ref<JJSTimerExecutor::javaobject> jsTimerExecutor,
+    jni::alias_ref<JReactExceptionManager::javaobject> jReactExceptionManager,
+    bool isProfiling) {
+  return makeCxxInstance(
+      jsEngineInstance,
+      jsMessageQueueThread,
+      nativeMessageQueueThread,
+      javaTimerManager,
+      jsTimerExecutor,
+      jReactExceptionManager,
+      isProfiling);
+}
+
+void JReactInstance::loadJSBundleFromAssets(
+    jni::alias_ref<JAssetManager::javaobject> assetManager,
+    const std::string &assetURL) {
+  const int kAssetsLength = 9; // strlen("assets://");
+  auto sourceURL = assetURL.substr(kAssetsLength);
+
+  auto manager = extractAssetManager(assetManager);
+  auto script = loadScriptFromAssets(manager, sourceURL);
+  instance_->loadScript(std::move(script), sourceURL);
+}
+
+void JReactInstance::loadJSBundleFromFile(
+    const std::string &fileName,
+    const std::string &sourceURL) {
+  std::unique_ptr<const JSBigFileString> script;
+  RecoverableError::runRethrowingAsRecoverable<std::system_error>(
+      [&fileName, &script]() { script = JSBigFileString::fromPath(fileName); });
+  instance_->loadScript(std::move(script), sourceURL);
+}
+
+/**
+ * This is needed to initialize TurboModules; in the future this will be
+ * replaced with something similar to runtimeExecutor, which we'll use for
+ * Fabric as well.
+ * TODO T44251068 Replace with runtimeExecutor
+ */
+jni::alias_ref<CallInvokerHolder::javaobject>
+JReactInstance::getJSCallInvokerHolder() {
+  return jsCallInvokerHolder_;
+}
+
+jni::alias_ref<CallInvokerHolder::javaobject>
+JReactInstance::getNativeCallInvokerHolder() {
+  return nativeCallInvokerHolder_;
+}
+
+jni::global_ref<JJSTimerExecutor::javaobject>
+JReactInstance::createJSTimerExecutor(
+    jni::alias_ref<jhybridobject> /* unused */) {
+  return jni::make_global(JJSTimerExecutor::newObjectCxxArgs());
+}
+
+void JReactInstance::callFunctionOnModule(
+    const std::string &moduleName,
+    const std::string &methodName,
+    NativeArray *args) {
+  instance_->callFunctionOnModule(moduleName, methodName, args->consume());
+}
+
+jni::alias_ref<JRuntimeExecutor::javaobject>
+JReactInstance::getUnbufferedRuntimeExecutor() noexcept {
+  return unbufferedRuntimeExecutor_;
+}
+
+jni::alias_ref<JRuntimeExecutor::javaobject>
+JReactInstance::getBufferedRuntimeExecutor() noexcept {
+  return bufferedRuntimeExecutor_;
+}
+
+jni::alias_ref<JRuntimeScheduler::javaobject>
+JReactInstance::getRuntimeScheduler() noexcept {
+  return runtimeScheduler_;
+}
+
+void JReactInstance::registerSegment(
+    int segmentId,
+    const std::string &segmentPath) noexcept {
+  instance_->registerSegment((uint32_t)segmentId, segmentPath);
+}
+
+void JReactInstance::handleMemoryPressureJs(jint level) {
+  instance_->handleMemoryPressureJs(level);
+}
+
+void JReactInstance::registerNatives() {
+  registerHybrid({
+      makeNativeMethod("initHybrid", JReactInstance::initHybrid),
+      makeNativeMethod(
+          "createJSTimerExecutor", JReactInstance::createJSTimerExecutor),
+      makeNativeMethod(
+          "loadJSBundleFromAssets", JReactInstance::loadJSBundleFromAssets),
+      makeNativeMethod(
+          "loadJSBundleFromFile", JReactInstance::loadJSBundleFromFile),
+      makeNativeMethod(
+          "getJSCallInvokerHolder", JReactInstance::getJSCallInvokerHolder),
+      makeNativeMethod(
+          "getNativeCallInvokerHolder",
+          JReactInstance::getNativeCallInvokerHolder),
+      makeNativeMethod(
+          "callFunctionOnModule", JReactInstance::callFunctionOnModule),
+      makeNativeMethod(
+          "getUnbufferedRuntimeExecutor",
+          JReactInstance::getUnbufferedRuntimeExecutor),
+      makeNativeMethod(
+          "getBufferedRuntimeExecutor",
+          JReactInstance::getBufferedRuntimeExecutor),
+      makeNativeMethod(
+          "getRuntimeScheduler", JReactInstance::getRuntimeScheduler),
+
+      makeNativeMethod(
+          "registerSegmentNative", JReactInstance::registerSegment),
+      makeNativeMethod(
+          "handleMemoryPressureJs", JReactInstance::handleMemoryPressureJs),
+  });
+}
+
+} // namespace react
+} // namespace facebook

--- a/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/jni/JReactInstance.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/jni/JReactInstance.h
@@ -1,0 +1,99 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <ReactCommon/CallInvokerHolder.h>
+#include <ReactCommon/RuntimeExecutor.h>
+#include <fb/fbjni.h>
+#include <jni.h>
+#include <jsi/jsi.h>
+#include <react/bridgeless/JSEngineInstance.h>
+#include <react/bridgeless/PlatformTimerRegistry.h>
+#include <react/bridgeless/ReactInstance.h>
+#include <react/jni/JMessageQueueThread.h>
+#include <react/jni/JRuntimeExecutor.h>
+#include <react/jni/JRuntimeScheduler.h>
+#include <react/jni/JSLoader.h>
+#include <react/jni/ReadableNativeMap.h>
+
+#include "JJSEngineInstance.h"
+#include "JJSTimerExecutor.h"
+#include "JJavaTimerManager.h"
+#include "JReactExceptionManager.h"
+
+namespace facebook {
+namespace react {
+
+class JReactInstance : public jni::HybridClass<JReactInstance> {
+ public:
+  constexpr static auto kJavaDescriptor = "Lcom/facebook/venice/ReactInstance;";
+
+  static jni::local_ref<jhybriddata> initHybrid(
+      jni::alias_ref<jhybridobject>,
+      jni::alias_ref<JJSEngineInstance::javaobject> jsEngineInstance,
+      jni::alias_ref<JavaMessageQueueThread::javaobject> jsMessageQueueThread,
+      jni::alias_ref<JavaMessageQueueThread::javaobject>
+          nativeMessageQueueThread,
+      jni::alias_ref<JJavaTimerManager::javaobject> javaTimerManager,
+      jni::alias_ref<JJSTimerExecutor::javaobject> jsTimerExecutor,
+      jni::alias_ref<JReactExceptionManager::javaobject> jReactExceptionManager,
+      bool isProfiling);
+
+  /*
+   * Instantiates and returns an instance of `JSTimerExecutor`.
+   */
+  static jni::global_ref<JJSTimerExecutor::javaobject> createJSTimerExecutor(
+      jni::alias_ref<jhybridobject> /* unused */);
+
+  static void registerNatives();
+
+  void loadJSBundleFromAssets(
+      jni::alias_ref<JAssetManager::javaobject> assetManager,
+      const std::string &assetURL);
+
+  void loadJSBundleFromFile(
+      const std::string &fileName,
+      const std::string &sourceURL);
+
+  void callFunctionOnModule(
+      const std::string &moduleName,
+      const std::string &methodName,
+      NativeArray *args);
+
+  jni::alias_ref<JRuntimeExecutor::javaobject>
+  getUnbufferedRuntimeExecutor() noexcept;
+  jni::alias_ref<JRuntimeExecutor::javaobject>
+  getBufferedRuntimeExecutor() noexcept;
+  jni::alias_ref<JRuntimeScheduler::javaobject> getRuntimeScheduler() noexcept;
+
+  void registerSegment(int segmentId, const std::string &segmentPath) noexcept;
+
+  void handleMemoryPressureJs(jint level);
+
+ private:
+  friend HybridBase;
+
+  explicit JReactInstance(
+      jni::alias_ref<JJSEngineInstance::javaobject> jsEngineInstance,
+      jni::alias_ref<JavaMessageQueueThread::javaobject> jsMessageQueueThread,
+      jni::alias_ref<JavaMessageQueueThread::javaobject>
+          nativeMessageQueueThread,
+      jni::alias_ref<JJavaTimerManager::javaobject> javaTimerManager,
+      jni::alias_ref<JJSTimerExecutor::javaobject> jsTimerExecutor,
+      jni::alias_ref<JReactExceptionManager::javaobject> jReactExceptionManager,
+      bool isProfiling) noexcept;
+
+  jni::alias_ref<CallInvokerHolder::javaobject> getJSCallInvokerHolder();
+  jni::alias_ref<CallInvokerHolder::javaobject> getNativeCallInvokerHolder();
+
+  std::unique_ptr<ReactInstance> instance_;
+  jni::global_ref<JRuntimeExecutor::javaobject> unbufferedRuntimeExecutor_;
+  jni::global_ref<JRuntimeExecutor::javaobject> bufferedRuntimeExecutor_;
+  jni::global_ref<JRuntimeScheduler::javaobject> runtimeScheduler_;
+  jni::global_ref<CallInvokerHolder::javaobject> jsCallInvokerHolder_;
+  jni::global_ref<CallInvokerHolder::javaobject> nativeCallInvokerHolder_;
+  jni::global_ref<JReactExceptionManager::javaobject> jReactExceptionManager_;
+};
+
+} // namespace react
+} // namespace facebook

--- a/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/jni/JReactInstance.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/jni/JReactInstance.h
@@ -1,4 +1,10 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 
 #pragma once
 
@@ -26,7 +32,9 @@ namespace react {
 
 class JReactInstance : public jni::HybridClass<JReactInstance> {
  public:
-  constexpr static auto kJavaDescriptor = "Lcom/facebook/venice/ReactInstance;";
+  constexpr static auto kJavaDescriptor =
+      "Lcom/facebook/react/bridgeless/ReactInstance;";
+
 
   static jni::local_ref<jhybriddata> initHybrid(
       jni::alias_ref<jhybridobject>,

--- a/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/jni/JavaTimerRegistry.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/jni/JavaTimerRegistry.cpp
@@ -1,0 +1,25 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "JavaTimerRegistry.h"
+
+namespace facebook {
+namespace react {
+
+JavaTimerRegistry::JavaTimerRegistry(
+    jni::global_ref<JJavaTimerManager::javaobject> javaTimerManager)
+    : javaTimerManager_(javaTimerManager) {}
+
+void JavaTimerRegistry::createTimer(uint32_t timerID, double delayMS) {
+  javaTimerManager_->createTimer(timerID, delayMS, /* repeat */ false);
+}
+
+void JavaTimerRegistry::createRecurringTimer(uint32_t timerID, double delayMS) {
+  javaTimerManager_->createTimer(timerID, delayMS, /* repeat */ true);
+}
+
+void JavaTimerRegistry::deleteTimer(uint32_t timerID) {
+  javaTimerManager_->deleteTimer(timerID);
+}
+
+} // namespace react
+} // namespace facebook

--- a/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/jni/JavaTimerRegistry.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/jni/JavaTimerRegistry.h
@@ -1,0 +1,35 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <memory>
+
+#include <fb/fbjni.h>
+#include <react/bridgeless/PlatformTimerRegistry.h>
+
+#include "JJavaTimerManager.h"
+
+namespace facebook {
+namespace react {
+
+/**
+ * Call into JavaTimerManager.java to schedule and delete timers
+ * with the Platform.
+ */
+class JavaTimerRegistry : public PlatformTimerRegistry {
+ public:
+  JavaTimerRegistry(
+      jni::global_ref<JJavaTimerManager::javaobject> javaTimerManager);
+
+#pragma mark - PlatformTimerRegistry
+
+  void createTimer(uint32_t timerID, double delayMS) override;
+  void createRecurringTimer(uint32_t timerID, double delayMS) override;
+  void deleteTimer(uint32_t timerID) override;
+
+ private:
+  jni::global_ref<JJavaTimerManager::javaobject> javaTimerManager_;
+};
+
+} // namespace react
+} // namespace facebook

--- a/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/jni/OnLoad.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/jni/OnLoad.cpp
@@ -1,0 +1,16 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <fb/fbjni.h>
+#include <fb/xplat_init.h>
+#include <react/jni/JReactMarker.h>
+
+#include "JJSTimerExecutor.h"
+#include "JReactInstance.h"
+
+JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void * /*unused*/) {
+  return facebook::xplat::initialize(vm, [] {
+    facebook::react::JReactMarker::setLogPerfMarkerIfNeeded();
+    facebook::react::JReactInstance::registerNatives();
+    facebook::react::JJSTimerExecutor::registerNatives();
+  });
+}

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridgeless/BridgelessReactContextTest.java
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridgeless/BridgelessReactContextTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+
+package com.facebook.react.bridgeless;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+
+import android.app.Activity;
+import android.content.Context;
+import com.facebook.react.bridge.JSIModuleType;
+import com.facebook.react.fabric.FabricUIManager;
+import com.facebook.react.uimanager.UIManagerModule;
+import com.facebook.testing.robolectric.v4.WithTestDefaultsRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+import org.robolectric.Robolectric;
+
+/** Tests {@link BridgelessReactContext} */
+@RunWith(WithTestDefaultsRunner.class)
+public class BridgelessReactContextTest {
+
+  private Context mContext;
+  private ReactHost mReactHost;
+  private BridgelessReactContext mBridgelessReactContext;
+
+  @Before
+  public void setUp() {
+    mContext = Robolectric.buildActivity(Activity.class).create().get();
+    mReactHost = Mockito.mock(ReactHost.class);
+    mBridgelessReactContext = new BridgelessReactContext(mContext, mReactHost);
+  }
+
+  @Test
+  public void getNativeModuleTest() {
+    UIManagerModule mUiManagerModule = Mockito.mock(UIManagerModule.class);
+    doReturn(mUiManagerModule)
+        .when(mReactHost)
+        .getNativeModule(ArgumentMatchers.<Class<UIManagerModule>>any());
+
+    UIManagerModule uiManagerModule =
+        mBridgelessReactContext.getNativeModule(UIManagerModule.class);
+
+    assertThat(uiManagerModule).isEqualTo(mUiManagerModule);
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void getJSIModule_throwsException() {
+    mBridgelessReactContext.getJSIModule(JSIModuleType.TurboModuleManager);
+  }
+
+  @Test
+  public void getJSIModuleTest() {
+    FabricUIManager fabricUiManager = Mockito.mock(FabricUIManager.class);
+    doReturn(fabricUiManager).when(mReactHost).getUIManager();
+    assertThat(mBridgelessReactContext.getJSIModule(JSIModuleType.UIManager))
+        .isEqualTo(fabricUiManager);
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void getCatalystInstance_throwsException() {
+    mBridgelessReactContext.getCatalystInstance();
+  }
+}

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridgeless/ReactHostTest.java
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridgeless/ReactHostTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+
+package com.facebook.react.bridgeless;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.MockitoAnnotations.initMocks;
+import static org.powermock.api.mockito.PowerMockito.whenNew;
+
+import android.app.Activity;
+import bolts.TaskCompletionSource;
+import com.facebook.base.applicationholder.ApplicationHolder;
+import com.facebook.react.MemoryPressureRouter;
+import com.facebook.react.bridge.JSBundleLoader;
+import com.facebook.react.bridge.MemoryPressureListener;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.UIManager;
+import com.facebook.react.devsupport.interfaces.PackagerStatusCallback;
+import com.facebook.react.uimanager.events.BlackHoleEventDispatcher;
+import com.facebook.react.uimanager.events.EventDispatcher;
+import com.facebook.testing.robolectric.RobolectricTestUtil;
+import com.facebook.testing.robolectric.v4.WithTestDefaultsRunner;
+import com.facebook.ultralight.testing.MockitoWithUltralightAutoMockSupport;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.rule.PowerMockRule;
+import org.robolectric.Robolectric;
+import org.robolectric.android.controller.ActivityController;
+
+/** Tests {@linkcom.facebook.react.bridgeless.ReactHost} */
+@RunWith(WithTestDefaultsRunner.class)
+@PowerMockIgnore({
+  "org.mockito.*",
+  "org.robolectric.*",
+  "android.*",
+  "androidx.*",
+  "javax.net.ssl.*"
+})
+@PrepareForTest({ReactHost.class})
+public class ReactHostTest extends MockitoWithUltralightAutoMockSupport {
+
+  private ReactInstanceDelegate mReactInstanceDelegate;
+  private ReactInstance mReactInstance;
+  private MemoryPressureRouter mMemoryPressureRouter;
+  private BridgelessDevSupportManager mDevSupportManager;
+  private JSBundleLoader mJSBundleLoader;
+  private ReactHost mReactHost;
+  private ActivityController<Activity> mActivityController;
+
+  @Rule public PowerMockRule rule = new PowerMockRule();
+
+  @Before
+  public void setUp() throws Exception {
+    initMocks(this);
+
+    try {
+      ApplicationHolder.set(RobolectricTestUtil.getInstance().getApplication());
+    } catch (IllegalStateException e) {
+      // Do nothing, we're already initialized.
+    }
+
+    mActivityController = Robolectric.buildActivity(Activity.class).create().start().resume();
+    initializeNiceMockInjector(mActivityController.get());
+
+    mReactInstanceDelegate = mock(ReactInstanceDelegate.class);
+    mReactInstance = mock(ReactInstance.class);
+    mMemoryPressureRouter = mock(MemoryPressureRouter.class);
+    mDevSupportManager = mock(BridgelessDevSupportManager.class);
+    mJSBundleLoader = mock(JSBundleLoader.class);
+
+    whenNew(ReactInstance.class).withAnyArguments().thenReturn(mReactInstance);
+    whenNew(MemoryPressureRouter.class).withAnyArguments().thenReturn(mMemoryPressureRouter);
+    whenNew(BridgelessDevSupportManager.class).withAnyArguments().thenReturn(mDevSupportManager);
+
+    doReturn(mJSBundleLoader)
+        .when(mReactInstanceDelegate)
+        .getJSBundleLoader(ArgumentMatchers.<ReactApplicationContext>any());
+
+    mReactHost =
+        new ReactHost(
+            mActivityController.get().getApplication(), mReactInstanceDelegate, false, null, false);
+  }
+
+  @Test
+  public void getEventDispatcher_returnsBlackHoleEventDispatcher() {
+    EventDispatcher eventDispatcher = mReactHost.getEventDispatcher();
+    assertThat(eventDispatcher).isInstanceOf(BlackHoleEventDispatcher.class);
+  }
+
+  @Test
+  public void getUIManager_returnsNullIfNoInstance() {
+    UIManager uiManager = mReactHost.getUIManager();
+    assertThat(uiManager).isNull();
+  }
+
+  @Ignore("FIXME")
+  public void testGetDevSupportManager() {
+    assertThat(mReactHost.getDevSupportManager()).isEqualTo(mDevSupportManager);
+  }
+
+  @Ignore("waitForCompletion is locking the test thread making the entire venice tests to timeout")
+  public void testPreload() throws Exception {
+    TaskCompletionSource<Boolean> taskCompletionSource = new TaskCompletionSource<>();
+    taskCompletionSource.setResult(true);
+    whenNew(TaskCompletionSource.class).withAnyArguments().thenReturn(taskCompletionSource);
+    doNothing().when(mDevSupportManager).isPackagerRunning(any(PackagerStatusCallback.class));
+
+    assertThat(mReactHost.isInstanceInitialized()).isFalse();
+
+    mReactHost.preload().waitForCompletion();
+
+    assertThat(mReactHost.isInstanceInitialized()).isTrue();
+    assertThat(mReactHost.getCurrentReactContext()).isNotNull();
+    verify(mMemoryPressureRouter).addMemoryPressureListener((MemoryPressureListener) any());
+  }
+}

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridgeless/ReactSurfaceTest.java
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridgeless/ReactSurfaceTest.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+
+package com.facebook.react.bridgeless;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.robolectric.shadows.ShadowInstrumentation.getInstrumentation;
+
+import android.app.Activity;
+import android.content.Context;
+import android.view.View;
+import bolts.Task;
+import com.facebook.react.bridge.NativeMap;
+import com.facebook.react.fabric.SurfaceHandler;
+import com.facebook.react.uimanager.events.EventDispatcher;
+import com.facebook.testing.robolectric.v4.WithTestDefaultsRunner;
+import java.util.concurrent.Callable;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.robolectric.Robolectric;
+
+@RunWith(WithTestDefaultsRunner.class)
+public class ReactSurfaceTest {
+  @Mock ReactInstanceDelegate mReactInstanceDelegate;
+  @Mock EventDispatcher mEventDispatcher;
+
+  private ReactHost mReactHost;
+  private Context mContext;
+  private ReactSurface mReactSurface;
+  private TestSurfaceHandler mSurfaceHandler;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+
+    mContext = Robolectric.buildActivity(Activity.class).create().get();
+
+    mReactHost = spy(new ReactHost(mContext, mReactInstanceDelegate, false, null, false));
+    doAnswer(mockedStartSurface()).when(mReactHost).startSurface(any(ReactSurface.class));
+    doAnswer(mockedStartSurface()).when(mReactHost).prerenderSurface(any(ReactSurface.class));
+    doAnswer(mockedStopSurface()).when(mReactHost).stopSurface(any(ReactSurface.class));
+    doReturn(mEventDispatcher).when(mReactHost).getEventDispatcher();
+
+    mSurfaceHandler = new TestSurfaceHandler();
+    mReactSurface = new ReactSurface(mSurfaceHandler, mContext);
+    mReactSurface.attachView(new ReactSurfaceView(mContext, mReactSurface));
+  }
+
+  @Test
+  public void testAttach() {
+    assertThat(mReactSurface.getReactHost()).isNull();
+    mReactSurface.attach(mReactHost);
+    assertThat(mReactSurface.getReactHost()).isEqualTo(mReactHost);
+    assertThat(mReactSurface.isAttached()).isTrue();
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testAttachThrowExeption() {
+    mReactSurface.attach(mReactHost);
+    mReactSurface.attach(mReactHost);
+  }
+
+  @Test
+  public void testPrerender() throws InterruptedException {
+    mReactSurface.attach(mReactHost);
+    Task<Void> task = mReactSurface.prerender();
+    task.waitForCompletion();
+
+    verify(mReactHost).prerenderSurface(mReactSurface);
+    assertThat(mSurfaceHandler.isRunning).isTrue();
+  }
+
+  @Test
+  public void testStart() throws InterruptedException {
+    mReactSurface.attach(mReactHost);
+    assertThat(mReactHost.isSurfaceAttached(mReactSurface)).isFalse();
+    Task<Void> task = mReactSurface.start();
+    task.waitForCompletion();
+
+    verify(mReactHost).startSurface(mReactSurface);
+    assertThat(mSurfaceHandler.isRunning).isTrue();
+  }
+
+  @Test
+  public void testStop() throws InterruptedException {
+    mReactSurface.attach(mReactHost);
+
+    Task<Void> task = mReactSurface.start();
+    task.waitForCompletion();
+
+    task = mReactSurface.stop();
+    task.waitForCompletion();
+
+    verify(mReactHost).stopSurface(mReactSurface);
+  }
+
+  @Test
+  public void testClear() {
+    mReactSurface.getView().addView(new View(mContext));
+
+    mReactSurface.clear();
+
+    getInstrumentation().waitForIdleSync();
+
+    assertThat(mReactSurface.getView().getId()).isEqualTo(View.NO_ID);
+    assertThat(mReactSurface.getView().getChildCount()).isEqualTo(0);
+  }
+
+  @Test
+  public void testGetLayoutSpecs() {
+    int measureSpecWidth = Integer.MAX_VALUE;
+    int measureSpecHeight = Integer.MIN_VALUE;
+
+    assertThat(mSurfaceHandler.mWidthMeasureSpec).isNotEqualTo(measureSpecWidth);
+    assertThat(mSurfaceHandler.mHeightMeasureSpec).isNotEqualTo(measureSpecHeight);
+
+    mReactSurface.attach(mReactHost);
+    mReactSurface.updateLayoutSpecs(measureSpecWidth, measureSpecHeight, 2, 3);
+
+    assertThat(mSurfaceHandler.mWidthMeasureSpec).isEqualTo(measureSpecWidth);
+    assertThat(mSurfaceHandler.mHeightMeasureSpec).isEqualTo(measureSpecHeight);
+  }
+
+  @Test
+  public void testGetEventDispatcher() {
+    mReactSurface.attach(mReactHost);
+    assertThat(mReactSurface.getEventDispatcher()).isEqualTo(mEventDispatcher);
+  }
+
+  @Test
+  public void testStartStopHandlerCalls() throws InterruptedException {
+    mReactSurface.attach(mReactHost);
+
+    assertThat(mReactSurface.isRunning()).isFalse();
+
+    mReactSurface.start().waitForCompletion();
+
+    assertThat(mReactSurface.isRunning()).isTrue();
+
+    mReactSurface.stop().waitForCompletion();
+
+    assertThat(mReactSurface.isRunning()).isFalse();
+  }
+
+  private Answer<Task<Void>> mockedStartSurface() {
+    return new Answer<Task<Void>>() {
+      @Override
+      public Task<Void> answer(InvocationOnMock invocation) {
+        return Task.call(
+            new Callable<Void>() {
+              @Override
+              public Void call() {
+                mSurfaceHandler.start();
+                return null;
+              }
+            });
+      }
+    };
+  }
+
+  private Answer<Task<Boolean>> mockedStopSurface() {
+    return new Answer<Task<Boolean>>() {
+      @Override
+      public Task<Boolean> answer(InvocationOnMock invocation) {
+        return Task.call(
+            new Callable<Boolean>() {
+              @Override
+              public Boolean call() {
+                mSurfaceHandler.stop();
+                return true;
+              }
+            });
+      }
+    };
+  }
+
+  static class TestSurfaceHandler implements SurfaceHandler {
+    private boolean isRunning = false;
+    private int mSurfaceId = 0;
+
+    private int mHeightMeasureSpec = 0;
+    private int mWidthMeasureSpec = 0;
+
+    @Override
+    public void start() {
+      isRunning = true;
+    }
+
+    @Override
+    public void stop() {
+      isRunning = false;
+    }
+
+    @Override
+    public int getSurfaceId() {
+      return mSurfaceId;
+    }
+
+    @Override
+    public void setSurfaceId(int surfaceId) {
+      mSurfaceId = surfaceId;
+    }
+
+    @Override
+    public boolean isRunning() {
+      return isRunning;
+    }
+
+    @Override
+    public String getModuleName() {
+      return null;
+    }
+
+    @Override
+    public void setMountable(boolean mountable) {
+      // no-op
+    }
+
+    @Override
+    public void setLayoutConstraints(
+        int widthMeasureSpec,
+        int heightMeasureSpec,
+        int offsetX,
+        int offsetY,
+        boolean doLeftAndRightSwapInRTL,
+        boolean isRTL,
+        float pixelDensity) {
+      mWidthMeasureSpec = widthMeasureSpec;
+      mHeightMeasureSpec = heightMeasureSpec;
+    }
+
+    @Override
+    public void setProps(NativeMap props) {
+      // no-op
+    }
+  }
+}

--- a/packages/react-native/ReactCommon/react/bridgeless/.clang-tidy
+++ b/packages/react-native/ReactCommon/react/bridgeless/.clang-tidy
@@ -1,0 +1,17 @@
+---
+InheritParentConfig: true
+Checks: '
+-cert-err60-cpp,
+-cppcoreguidelines-pro-bounds-pointer-arithmetic,
+-cppcoreguidelines-special-member-functions,
+-fuchsia-default-arguments-calls,
+-google-readability-casting,
+-google-runtime-references,
+-hicpp-special-member-functions,
+-llvm-header-guard,
+-misc-non-private-member-variables-in-classes,
+-misc-unused-parameters,
+-modernize-use-trailing-return-type,
+-performance-unnecessary-value-param
+'
+...

--- a/packages/react-native/ReactCommon/react/bridgeless/BufferedRuntimeExecutor.cpp
+++ b/packages/react-native/ReactCommon/react/bridgeless/BufferedRuntimeExecutor.cpp
@@ -1,0 +1,57 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "BufferedRuntimeExecutor.h"
+#include <cxxreact/MessageQueueThread.h>
+#include <algorithm>
+
+namespace facebook {
+namespace react {
+
+BufferedRuntimeExecutor::BufferedRuntimeExecutor(
+    RuntimeExecutor runtimeExecutor)
+    : runtimeExecutor_(runtimeExecutor),
+      isBufferingEnabled_(true),
+      lastIndex_(0) {}
+
+void BufferedRuntimeExecutor::execute(Work &&callback) {
+  if (!isBufferingEnabled_) {
+    // Fast path: Schedule directly to RuntimeExecutor, without locking
+    runtimeExecutor_(std::move(callback));
+    return;
+  }
+
+  /**
+   * Note: std::mutex doesn't have a FIFO ordering.
+   * To preserve the order of the buffered work, use a priority queue and
+   * track the last known work index.
+   */
+  uint64_t newIndex = lastIndex_++;
+  std::lock_guard<std::mutex> guard(lock_);
+  if (isBufferingEnabled_) {
+    queue_.push({.index_ = newIndex, .work_ = std::move(callback)});
+    return;
+  }
+
+  // Force flush the queue to maintain the execution order.
+  unsafeFlush();
+
+  runtimeExecutor_(std::move(callback));
+}
+
+void BufferedRuntimeExecutor::flush() {
+  std::lock_guard<std::mutex> guard(lock_);
+  unsafeFlush();
+  isBufferingEnabled_ = false;
+}
+
+void BufferedRuntimeExecutor::unsafeFlush() {
+  while (queue_.size() > 0) {
+    BufferedWork const &bufferedWork = queue_.top();
+    Work work = std::move(bufferedWork.work_);
+    runtimeExecutor_(std::move(work));
+    queue_.pop();
+  }
+}
+
+} // namespace react
+} // namespace facebook

--- a/packages/react-native/ReactCommon/react/bridgeless/BufferedRuntimeExecutor.h
+++ b/packages/react-native/ReactCommon/react/bridgeless/BufferedRuntimeExecutor.h
@@ -1,0 +1,46 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <ReactCommon/RuntimeExecutor.h>
+#include <jsi/jsi.h>
+#include <react/bridgeless/TimerManager.h>
+#include <atomic>
+#include <queue>
+
+namespace facebook {
+namespace react {
+
+class BufferedRuntimeExecutor {
+ public:
+  using Work = std::function<void(jsi::Runtime &runtime)>;
+
+  // A utility structure to track pending work in the order of when they arrive.
+  struct BufferedWork {
+    uint64_t index_;
+    Work work_;
+    bool operator<(const BufferedWork &rhs) const {
+      // Higher index has lower priority, so this inverted comparison puts
+      // the smaller index on top of the queue.
+      return index_ > rhs.index_;
+    }
+  };
+
+  BufferedRuntimeExecutor(RuntimeExecutor runtimeExecutor);
+
+  void execute(Work &&callback);
+
+  // Flush buffered JS calls and then diable JS buffering
+  void flush();
+
+ private:
+  // Perform flushing without locking mechanism
+  void unsafeFlush();
+
+  RuntimeExecutor runtimeExecutor_;
+  bool isBufferingEnabled_;
+  std::mutex lock_;
+  std::atomic<uint64_t> lastIndex_;
+  std::priority_queue<BufferedWork> queue_;
+};
+
+} // namespace react
+} // namespace facebook

--- a/packages/react-native/ReactCommon/react/bridgeless/JSEngineInstance.h
+++ b/packages/react-native/ReactCommon/react/bridgeless/JSEngineInstance.h
@@ -1,0 +1,22 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <ReactCommon/RuntimeExecutor.h>
+#include <jsi/jsi.h>
+
+namespace facebook {
+namespace react {
+
+/**
+ * Interface for a class that creates and owns an instance of a JS VM
+ */
+class JSEngineInstance {
+ public:
+  virtual std::unique_ptr<jsi::Runtime> createJSRuntime() noexcept = 0;
+
+  virtual ~JSEngineInstance() = default;
+};
+
+} // namespace react
+} // namespace facebook

--- a/packages/react-native/ReactCommon/react/bridgeless/PlatformTimerRegistry.h
+++ b/packages/react-native/ReactCommon/react/bridgeless/PlatformTimerRegistry.h
@@ -1,0 +1,29 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstdint>
+
+namespace facebook {
+namespace react {
+
+/**
+ * This interface is implemented by each platform.
+ * Responsibility: Call into some platform API to register/schedule, or delete
+ * registered/scheduled timers.
+ */
+class PlatformTimerRegistry {
+ public:
+  virtual void createTimer(uint32_t timerID, double delayMS) = 0;
+
+  virtual void deleteTimer(uint32_t timerID) = 0;
+
+  virtual void createRecurringTimer(uint32_t timerID, double delayMS) = 0;
+
+  virtual ~PlatformTimerRegistry() noexcept = default;
+};
+
+using TimerManagerDelegate = PlatformTimerRegistry;
+
+} // namespace react
+} // namespace facebook

--- a/packages/react-native/ReactCommon/react/bridgeless/ReactInstance.cpp
+++ b/packages/react-native/ReactCommon/react/bridgeless/ReactInstance.cpp
@@ -1,0 +1,453 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "ReactInstance.h"
+
+#include <cxxreact/ErrorUtils.h>
+#include <cxxreact/JSBigString.h>
+#include <cxxreact/SystraceSection.h>
+#include <glog/logging.h>
+#include <jsi/instrumentation.h>
+#include <jsi/jsi/JSIDynamic.h>
+#include <jsireact/JSIExecutor.h>
+#include <jsireact/JSITracing.h>
+#include <react/renderer/runtimescheduler/RuntimeSchedulerBinding.h>
+
+#include <cxxreact/ReactMarker.h>
+#include <iostream>
+#include <tuple>
+#include <utility>
+
+namespace facebook {
+namespace react {
+
+// Looping on \c drainMicrotasks until it completes or hits the retries bound.
+static void performMicrotaskCheckpoint(jsi::Runtime &runtime) {
+  uint8_t retries = 0;
+  // A heuristic number to guard inifinite or absurd numbers of retries.
+  constexpr unsigned int kRetriesBound = 255;
+
+  while (retries < kRetriesBound) {
+    try {
+      // The default behavior of \c drainMicrotasks is unbounded execution.
+      // We may want to make it bounded in the future.
+      if (runtime.drainMicrotasks()) {
+        break;
+      }
+    } catch (jsi::JSError &error) {
+      handleJSError(runtime, error, true);
+    }
+    retries++;
+  }
+
+  if (retries == kRetriesBound) {
+    throw std::runtime_error("Hits microtasks retries bound.");
+  }
+}
+
+ReactInstance::ReactInstance(
+    std::unique_ptr<jsi::Runtime> runtime,
+    std::shared_ptr<MessageQueueThread> jsMessageQueueThread,
+    std::shared_ptr<TimerManager> timerManager,
+    JsErrorHandler::JsErrorHandlingFunc jsErrorHandlingFunc)
+    : runtime_(std::move(runtime)),
+      jsMessageQueueThread_(jsMessageQueueThread),
+      timerManager_(std::move(timerManager)),
+      jsErrorHandler_(jsErrorHandlingFunc),
+      hasFatalJsError_(std::make_shared<bool>(false)) {
+  auto runtimeExecutor = [weakRuntime = std::weak_ptr<jsi::Runtime>(runtime_),
+                          weakTimerManager =
+                              std::weak_ptr<TimerManager>(timerManager_),
+                          weakJsMessageQueueThread =
+                              std::weak_ptr<MessageQueueThread>(
+                                  jsMessageQueueThread_),
+                          weakHasFatalJsError =
+                              std::weak_ptr<bool>(hasFatalJsError_)](
+                             std::function<void(jsi::Runtime & runtime)>
+                                 &&callback) {
+    if (std::shared_ptr<bool> sharedHasFatalJsError =
+            weakHasFatalJsError.lock()) {
+      if (*sharedHasFatalJsError) {
+        LOG(INFO)
+            << "Calling into JS using runtimeExecutor but hasFatalJsError_ is true";
+        return;
+      }
+    }
+    if (weakRuntime.expired()) {
+      return;
+    }
+
+    if (std::shared_ptr<MessageQueueThread> sharedJsMessageQueueThread =
+            weakJsMessageQueueThread.lock()) {
+      sharedJsMessageQueueThread->runOnQueue(
+          [weakRuntime, weakTimerManager, callback = std::move(callback)]() {
+            if (auto strongRuntime = weakRuntime.lock()) {
+              SystraceSection s("ReactInstance::_runtimeExecutor[Callback]");
+              try {
+                callback(*strongRuntime);
+                if (auto strongTimerManager = weakTimerManager.lock()) {
+                  strongTimerManager->callReactNativeMicrotasks(*strongRuntime);
+                }
+                performMicrotaskCheckpoint(*strongRuntime);
+              } catch (jsi::JSError &originalError) {
+                handleJSError(*strongRuntime, originalError, true);
+              }
+            }
+          });
+    }
+  };
+
+  runtimeScheduler_ =
+      std::make_shared<RuntimeScheduler>(std::move(runtimeExecutor));
+
+  auto pipedRuntimeExecutor =
+      [runtimeScheduler = runtimeScheduler_.get()](
+          std::function<void(jsi::Runtime & runtime)> &&callback) {
+        runtimeScheduler->scheduleWork(std::move(callback));
+      };
+
+  bufferedRuntimeExecutor_ =
+      std::make_shared<BufferedRuntimeExecutor>(pipedRuntimeExecutor);
+}
+
+RuntimeExecutor ReactInstance::getUnbufferedRuntimeExecutor() noexcept {
+  return [runtimeScheduler = runtimeScheduler_.get()](
+             std::function<void(jsi::Runtime & runtime)> &&callback) {
+    runtimeScheduler->scheduleWork(std::move(callback));
+  };
+}
+
+// This BufferedRuntimeExecutor ensures that the main JS bundle finished
+// execution before any JS queued into it from C++ are executed. Use
+// getBufferedRuntimeExecutor() instead if you do not need the main JS bundle to
+// have finished. e.g. setting global variables into JS runtime.
+RuntimeExecutor ReactInstance::getBufferedRuntimeExecutor() noexcept {
+  return [weakBufferedRuntimeExecutor_ =
+              std::weak_ptr<BufferedRuntimeExecutor>(bufferedRuntimeExecutor_)](
+             std::function<void(jsi::Runtime & runtime)> &&callback) {
+    if (auto strongBufferedRuntimeExecutor_ =
+            weakBufferedRuntimeExecutor_.lock()) {
+      strongBufferedRuntimeExecutor_->execute(std::move(callback));
+    }
+  };
+}
+
+std::shared_ptr<RuntimeScheduler>
+ReactInstance::getRuntimeScheduler() noexcept {
+  return runtimeScheduler_;
+}
+
+/**
+ * Defines a property on the global object that is neither enumerable, nor
+ * configurable, nor writable. This ensures that the private globals exposed by
+ * ReactInstance cannot overwritten by third-party JavaScript code. It also
+ * ensures that third-party JavaScript code unaware of these globals isn't able
+ * to accidentally access them. In JavaScript, equivalent to:
+ *
+ * Object.defineProperty(global, propName, {
+ *   value: value
+ * })
+ */
+static void defineReadOnlyGlobal(
+    jsi::Runtime &runtime,
+    std::string propName,
+    jsi::Value &&value) {
+  jsi::Object jsObject =
+      runtime.global().getProperty(runtime, "Object").asObject(runtime);
+  jsi::Function defineProperty = jsObject.getProperty(runtime, "defineProperty")
+                                     .asObject(runtime)
+                                     .asFunction(runtime);
+
+  jsi::Object descriptor = jsi::Object(runtime);
+  descriptor.setProperty(runtime, "value", std::move(value));
+  defineProperty.callWithThis(
+      runtime,
+      jsObject,
+      runtime.global(),
+      jsi::String::createFromUtf8(runtime, propName),
+      descriptor);
+}
+
+namespace {
+
+// Copied from JSIExecutor.cpp
+// basename_r isn't in all iOS SDKs, so use this simple version instead.
+std::string simpleBasename(const std::string &path) {
+  size_t pos = path.rfind("/");
+  return (pos != std::string::npos) ? path.substr(pos) : path;
+}
+
+} // namespace
+
+/**
+ * Load the JS bundle and flush buffered JS calls, future JS calls won't be
+ * buffered after calling this.
+ * Note that this method is asynchronous. However, a completion callback
+ * isn't needed because all calls into JS should be dispatched to the JSThread,
+ * preferably via the runtimeExecutor_.
+ */
+void ReactInstance::loadScript(
+    std::unique_ptr<const JSBigString> script,
+    const std::string &sourceURL) {
+  auto buffer = std::make_shared<BigStringBuffer>(std::move(script));
+  std::string scriptName = simpleBasename(sourceURL);
+
+  runtimeScheduler_->scheduleWork(
+      [this,
+       scriptName,
+       sourceURL,
+       buffer = std::move(buffer),
+       weakBufferedRuntimeExecuter = std::weak_ptr<BufferedRuntimeExecutor>(
+           bufferedRuntimeExecutor_)](jsi::Runtime &runtime) {
+        try {
+          SystraceSection s("ReactInstance::loadScript");
+          bool hasLogger(ReactMarker::logTaggedMarkerBridgelessImpl);
+          if (hasLogger) {
+            ReactMarker::logTaggedMarkerBridgeless(
+                ReactMarker::RUN_JS_BUNDLE_START, scriptName.c_str());
+          }
+
+          runtime.evaluateJavaScript(buffer, sourceURL);
+          if (hasLogger) {
+            ReactMarker::logTaggedMarkerBridgeless(
+                ReactMarker::RUN_JS_BUNDLE_STOP, scriptName.c_str());
+          }
+          if (auto strongBufferedRuntimeExecuter =
+                  weakBufferedRuntimeExecuter.lock()) {
+            strongBufferedRuntimeExecuter->flush();
+          }
+        } catch (jsi::JSError &error) {
+          // Handle uncaught JS errors during loading JS bundle
+          *hasFatalJsError_ = true;
+          this->jsErrorHandler_.handleJsError(error, true);
+        }
+      });
+}
+
+/*
+ * Calls a method on a JS module that has been registered with
+ * `registerCallableModule`. Used to invoke a JS function from platform code.
+ */
+void ReactInstance::callFunctionOnModule(
+    const std::string &moduleName,
+    const std::string &methodName,
+    const folly::dynamic &args) {
+  bufferedRuntimeExecutor_->execute([=](jsi::Runtime &runtime) {
+    SystraceSection s(
+        "ReactInstance::callFunctionOnModule",
+        "moduleName",
+        moduleName,
+        "methodName",
+        methodName);
+    if (modules_.find(moduleName) == modules_.end()) {
+      std::ostringstream knownModules;
+      int i = 0;
+      for (auto it = modules_.begin(); it != modules_.end(); it++, i++) {
+        const char *space = (i > 0 ? ", " : " ");
+        knownModules << space << it->first;
+      }
+      throw jsi::JSError(
+          runtime,
+          "Failed to call into JavaScript module method " + moduleName + "." +
+              methodName +
+              "(). Module has not been registered as callable. Registered callable JavaScript modules (n = " +
+              std::to_string(modules_.size()) + "):" + knownModules.str() +
+              ". Did you forget to call `RN$registerCallableModule`?");
+    }
+
+    auto module = modules_[moduleName]->factory.call(runtime).asObject(runtime);
+    auto method = module.getProperty(runtime, methodName.c_str());
+    if (method.isUndefined()) {
+      throw jsi::JSError(
+          runtime,
+          "Failed to call into JavaScript module method " + moduleName + "." +
+              methodName + ". Module exists, but the method is undefined.");
+    }
+
+    std::vector<jsi::Value> jsArgs;
+    for (auto &arg : args) {
+      jsArgs.push_back(jsi::valueFromDynamic(runtime, arg));
+    }
+    method.asObject(runtime).asFunction(runtime).callWithThis(
+        runtime, module, (const jsi::Value *)jsArgs.data(), jsArgs.size());
+  });
+}
+
+void ReactInstance::registerSegment(
+    uint32_t segmentId,
+    const std::string &segmentPath) {
+  LOG(WARNING) << "Starting to run ReactInstance::registerSegment with segment "
+               << segmentId;
+  runtimeScheduler_->scheduleWork([=](jsi::Runtime &runtime) {
+    SystraceSection s("ReactInstance::registerSegment");
+    const auto tag = folly::to<std::string>(segmentId);
+    auto script = JSBigFileString::fromPath(segmentPath);
+    if (script->size() == 0) {
+      throw std::invalid_argument(
+          "Empty segment registered with ID " + tag + " from " + segmentPath);
+    }
+    auto buffer = std::make_shared<BigStringBuffer>(std::move(script));
+
+    bool hasLogger(ReactMarker::logTaggedMarkerBridgelessImpl);
+    if (hasLogger) {
+      ReactMarker::logTaggedMarkerBridgeless(
+          ReactMarker::REGISTER_JS_SEGMENT_START, tag.c_str());
+    }
+    LOG(WARNING) << "Starting to evaluate segment " << segmentId
+                 << " in ReactInstance::registerSegment";
+    runtime.evaluateJavaScript(
+        buffer, JSExecutor::getSyntheticBundlePath(segmentId, segmentPath));
+    LOG(WARNING) << "Finished evaluating segment " << segmentId
+                 << " in ReactInstance::registerSegment";
+    if (hasLogger) {
+      ReactMarker::logTaggedMarkerBridgeless(
+          ReactMarker::REGISTER_JS_SEGMENT_STOP, tag.c_str());
+    }
+  });
+}
+
+namespace {
+void defineReactInstanceFlags(
+    jsi::Runtime &runtime,
+    ReactInstance::JSRuntimeFlags options) noexcept {
+  defineReadOnlyGlobal(runtime, "RN$Bridgeless", jsi::Value(true));
+
+  jsi::addNativeTracingHooks(runtime);
+
+  if (options.isProfiling) {
+    defineReadOnlyGlobal(runtime, "__RCTProfileIsProfiling", jsi::Value(true));
+  }
+
+  if (options.runtimeDiagnosticFlags.length() > 0) {
+    defineReadOnlyGlobal(
+        runtime,
+        "RN$DiagnosticFlags",
+        jsi::String::createFromUtf8(runtime, options.runtimeDiagnosticFlags));
+  }
+}
+
+} // namespace
+
+void ReactInstance::initializeRuntime(
+    JSRuntimeFlags options,
+    BindingsInstallFunc bindingsInstallFunc) noexcept {
+  runtimeScheduler_->scheduleWork([this, options, bindingsInstallFunc](
+                                      jsi::Runtime &runtime) {
+    SystraceSection s("ReactInstance::initializeRuntime");
+    RuntimeSchedulerBinding::createAndInstallIfNeeded(
+        runtime, runtimeScheduler_);
+
+    defineReactInstanceFlags(runtime, options);
+
+    defineReadOnlyGlobal(
+        runtime,
+        "RN$registerCallableModule",
+        jsi::Function::createFromHostFunction(
+            runtime,
+            jsi::PropNameID::forAscii(runtime, "registerCallableModule"),
+            2,
+            [this](
+                jsi::Runtime &runtime,
+                const jsi::Value & /*unused*/,
+                const jsi::Value *args,
+                size_t count) {
+              if (count != 2) {
+                throw jsi::JSError(
+                    runtime,
+                    "registerCallableModule requires exactly 2 arguments");
+              }
+              if (!args[0].isString()) {
+                throw jsi::JSError(
+                    runtime,
+                    "The first argument to registerCallableModule must be a string (the name of the JS module).");
+              }
+              auto name = args[0].asString(runtime).utf8(runtime);
+              if (!args[1].isObject() ||
+                  !args[1].asObject(runtime).isFunction(runtime)) {
+                throw jsi::JSError(
+                    runtime,
+                    "The second argument to registerCallableModule must be a function that returns the JS module.");
+              }
+              modules_[name] = std::make_shared<CallableModule>(
+                  args[1].getObject(runtime).asFunction(runtime));
+              return jsi::Value::undefined();
+            }));
+
+    timerManager_->attachGlobals(runtime);
+
+    bindingsInstallFunc(runtime);
+  });
+}
+
+void ReactInstance::handleMemoryPressureJs(int pressureLevel) {
+  // The level is an enum value passed by the Android OS to an onTrimMemory
+  // event callback. Defined in ComponentCallbacks2.
+  enum AndroidMemoryPressure {
+    TRIM_MEMORY_BACKGROUND = 40,
+    TRIM_MEMORY_COMPLETE = 80,
+    TRIM_MEMORY_MODERATE = 60,
+    TRIM_MEMORY_RUNNING_CRITICAL = 15,
+    TRIM_MEMORY_RUNNING_LOW = 10,
+    TRIM_MEMORY_RUNNING_MODERATE = 5,
+    TRIM_MEMORY_UI_HIDDEN = 20,
+  };
+  const char *levelName;
+  switch (pressureLevel) {
+    case TRIM_MEMORY_BACKGROUND:
+      levelName = "TRIM_MEMORY_BACKGROUND";
+      break;
+    case TRIM_MEMORY_COMPLETE:
+      levelName = "TRIM_MEMORY_COMPLETE";
+      break;
+    case TRIM_MEMORY_MODERATE:
+      levelName = "TRIM_MEMORY_MODERATE";
+      break;
+    case TRIM_MEMORY_RUNNING_CRITICAL:
+      levelName = "TRIM_MEMORY_RUNNING_CRITICAL";
+      break;
+    case TRIM_MEMORY_RUNNING_LOW:
+      levelName = "TRIM_MEMORY_RUNNING_LOW";
+      break;
+    case TRIM_MEMORY_RUNNING_MODERATE:
+      levelName = "TRIM_MEMORY_RUNNING_MODERATE";
+      break;
+    case TRIM_MEMORY_UI_HIDDEN:
+      levelName = "TRIM_MEMORY_UI_HIDDEN";
+      break;
+    default:
+      levelName = "UNKNOWN";
+      break;
+  }
+
+  switch (pressureLevel) {
+    case TRIM_MEMORY_RUNNING_LOW:
+    case TRIM_MEMORY_RUNNING_MODERATE:
+    case TRIM_MEMORY_UI_HIDDEN:
+      // For non-severe memory trims, do nothing.
+      LOG(INFO) << "Memory warning (pressure level: " << levelName
+                << ") received by JS VM, ignoring because it's non-severe";
+      break;
+    case TRIM_MEMORY_BACKGROUND:
+    case TRIM_MEMORY_COMPLETE:
+    case TRIM_MEMORY_MODERATE:
+    case TRIM_MEMORY_RUNNING_CRITICAL:
+      // For now, pressureLevel is unused by collectGarbage.
+      // This may change in the future if the JS GC has different styles of
+      // collections.
+      LOG(INFO) << "Memory warning (pressure level: " << levelName
+                << ") received by JS VM, running a GC";
+      runtimeScheduler_->scheduleWork([=](jsi::Runtime &runtime) {
+        SystraceSection s("ReactInstance::handleMemoryPressure");
+        runtime.instrumentation().collectGarbage(levelName);
+      });
+      break;
+    default:
+      // Use the raw number instead of the name here since the name is
+      // meaningless.
+      LOG(WARNING) << "Memory warning (pressure level: " << pressureLevel
+                   << ") received by JS VM, unrecognized pressure level";
+      break;
+  }
+}
+
+} // namespace react
+} // namespace facebook

--- a/packages/react-native/ReactCommon/react/bridgeless/ReactInstance.h
+++ b/packages/react-native/ReactCommon/react/bridgeless/ReactInstance.h
@@ -1,0 +1,75 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <JsErrorHandler/JsErrorHandler.h>
+#include <ReactCommon/RuntimeExecutor.h>
+#include <cxxreact/MessageQueueThread.h>
+#include <jsi/jsi.h>
+#include <jsireact/JSIExecutor.h>
+#include <react/bridgeless/BufferedRuntimeExecutor.h>
+#include <react/bridgeless/TimerManager.h>
+#include <react/renderer/runtimescheduler/RuntimeScheduler.h>
+
+namespace facebook {
+namespace react {
+
+struct CallableModule {
+  explicit CallableModule(jsi::Function factory)
+      : factory(std::move(factory)) {}
+  jsi::Function factory;
+};
+
+class ReactInstance final {
+ public:
+  using BindingsInstallFunc = std::function<void(jsi::Runtime &runtime)>;
+
+  ReactInstance(
+      std::unique_ptr<jsi::Runtime> runtime,
+      std::shared_ptr<MessageQueueThread> jsMessageQueueThread,
+      std::shared_ptr<TimerManager> timerManager,
+      JsErrorHandler::JsErrorHandlingFunc JsErrorHandlingFunc);
+
+  RuntimeExecutor getUnbufferedRuntimeExecutor() noexcept;
+
+  RuntimeExecutor getBufferedRuntimeExecutor() noexcept;
+
+  std::shared_ptr<RuntimeScheduler> getRuntimeScheduler() noexcept;
+
+  struct JSRuntimeFlags {
+    bool isProfiling = false;
+    const std::string runtimeDiagnosticFlags = "";
+  };
+
+  void initializeRuntime(
+      JSRuntimeFlags options,
+      BindingsInstallFunc bindingsInstallFunc) noexcept;
+
+  void loadScript(
+      std::unique_ptr<const JSBigString> script,
+      const std::string &sourceURL);
+
+  void registerSegment(uint32_t segmentId, const std::string &segmentPath);
+
+  void callFunctionOnModule(
+      const std::string &moduleName,
+      const std::string &methodName,
+      const folly::dynamic &args);
+
+  void handleMemoryPressureJs(int pressureLevel);
+
+ private:
+  std::shared_ptr<jsi::Runtime> runtime_;
+  std::shared_ptr<MessageQueueThread> jsMessageQueueThread_;
+  std::shared_ptr<BufferedRuntimeExecutor> bufferedRuntimeExecutor_;
+  std::shared_ptr<TimerManager> timerManager_;
+  std::unordered_map<std::string, std::shared_ptr<CallableModule>> modules_;
+  std::shared_ptr<RuntimeScheduler> runtimeScheduler_;
+  JsErrorHandler jsErrorHandler_;
+
+  // Whether there are errors caught during bundle loading
+  std::shared_ptr<bool> hasFatalJsError_;
+};
+
+} // namespace react
+} // namespace facebook

--- a/packages/react-native/ReactCommon/react/bridgeless/TimerManager.cpp
+++ b/packages/react-native/ReactCommon/react/bridgeless/TimerManager.cpp
@@ -1,0 +1,411 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "TimerManager.h"
+
+#include <cxxreact/SystraceSection.h>
+#include <utility>
+
+namespace facebook {
+namespace react {
+
+TimerManager::TimerManager(
+    std::unique_ptr<PlatformTimerRegistry> platformTimerRegistry) noexcept
+    : platformTimerRegistry_(std::move(platformTimerRegistry)) {}
+
+void TimerManager::setRuntimeExecutor(
+    RuntimeExecutor runtimeExecutor) noexcept {
+  runtimeExecutor_ = runtimeExecutor;
+}
+
+std::shared_ptr<TimerHandle> TimerManager::createReactNativeMicrotask(
+    jsi::Function &&callback,
+    std::vector<jsi::Value> &&args) {
+  auto sharedCallback = std::make_shared<TimerCallback>(
+      std::move(callback), std::move(args), /* repeat */ false);
+
+  // Get the id for the callback.
+  uint32_t timerID = timerIndex_++;
+  timers_[timerID] = std::move(sharedCallback);
+
+  reactNativeMicrotasksQueue_.push_back(timerID);
+  return std::make_shared<TimerHandle>(timerID);
+}
+
+void TimerManager::callReactNativeMicrotasks(jsi::Runtime &runtime) {
+  std::vector<uint32_t> reactNativeMicrotasksQueue;
+  while (!reactNativeMicrotasksQueue_.empty()) {
+    reactNativeMicrotasksQueue.clear();
+    reactNativeMicrotasksQueue.swap(reactNativeMicrotasksQueue_);
+
+    for (auto reactNativeMicrotaskID : reactNativeMicrotasksQueue) {
+      // ReactNativeMicrotasks can clear other scheduled reactNativeMicrotasks.
+      if (timers_.count(reactNativeMicrotaskID) > 0) {
+        timers_[reactNativeMicrotaskID]->invoke(runtime);
+        timers_.erase(reactNativeMicrotaskID);
+      }
+    }
+  }
+}
+
+std::shared_ptr<TimerHandle> TimerManager::createTimer(
+    jsi::Function &&callback,
+    std::vector<jsi::Value> &&args,
+    double delay) {
+  auto sharedCallback = std::make_shared<TimerCallback>(
+      std::move(callback), std::move(args), false);
+
+  // Get the id for the callback.
+  uint32_t timerID = timerIndex_++;
+  timers_[timerID] = std::move(sharedCallback);
+
+  platformTimerRegistry_->createTimer(timerID, delay);
+
+  return std::make_shared<TimerHandle>(timerID);
+}
+
+std::shared_ptr<TimerHandle> TimerManager::createRecurringTimer(
+    jsi::Function &&callback,
+    std::vector<jsi::Value> &&args,
+    double delay) {
+  auto sharedCallback = std::make_shared<TimerCallback>(
+      std::move(callback), std::move(args), true);
+
+  // Get the id for the callback.
+  uint32_t timerID = timerIndex_++;
+  timers_[timerID] = std::move(sharedCallback);
+
+  platformTimerRegistry_->createRecurringTimer(timerID, delay);
+
+  return std::make_shared<TimerHandle>(timerID);
+}
+
+void TimerManager::deleteReactNativeMicrotask(
+    jsi::Runtime &runtime,
+    std::shared_ptr<TimerHandle> timerHandle) {
+  if (timerHandle == nullptr) {
+    throw jsi::JSError(
+        runtime, "clearReactNativeMicrotask was called with an invalid handle");
+  }
+
+  for (auto it = reactNativeMicrotasksQueue_.begin();
+       it != reactNativeMicrotasksQueue_.end();
+       it++) {
+    if ((*it) == timerHandle->index()) {
+      reactNativeMicrotasksQueue_.erase(it);
+      break;
+    }
+  }
+
+  if (timers_.find(timerHandle->index()) != timers_.end()) {
+    timers_.erase(timerHandle->index());
+  }
+}
+
+void TimerManager::deleteTimer(
+    jsi::Runtime &runtime,
+    std::shared_ptr<TimerHandle> timerHandle) {
+  if (timerHandle == nullptr) {
+    throw jsi::JSError(runtime, "clearTimeout called with an invalid handle");
+  }
+
+  platformTimerRegistry_->deleteTimer(timerHandle->index());
+  if (timers_.find(timerHandle->index()) != timers_.end()) {
+    timers_.erase(timerHandle->index());
+  }
+}
+
+void TimerManager::deleteRecurringTimer(
+    jsi::Runtime &runtime,
+    std::shared_ptr<TimerHandle> timerHandle) {
+  if (timerHandle == nullptr) {
+    throw jsi::JSError(runtime, "clearInterval called with an invalid handle");
+  }
+
+  platformTimerRegistry_->deleteTimer(timerHandle->index());
+  if (timers_.find(timerHandle->index()) != timers_.end()) {
+    timers_.erase(timerHandle->index());
+  }
+}
+
+void TimerManager::callTimer(uint32_t timerID) {
+  runtimeExecutor_([this, timerID](jsi::Runtime &runtime) {
+    SystraceSection s("TimerManager::callTimer");
+    if (timers_.count(timerID) > 0) {
+      timers_[timerID]->invoke(runtime);
+      // Invoking a timer has the potential to delete it. Double check the timer
+      // still exists before accessing it again.
+      if (timers_.count(timerID) > 0 && !timers_[timerID]->repeat) {
+        timers_.erase(timerID);
+      }
+    }
+  });
+}
+
+void TimerManager::attachGlobals(jsi::Runtime &runtime) {
+  // Install host functions for timers.
+  // TODO (T45786383): Add missing timer functions from JSTimers
+  // TODL (T96212789): Skip immediate APIs when JSVM microtask queue is used.
+  runtime.global().setProperty(
+      runtime,
+      "setImmediate",
+      jsi::Function::createFromHostFunction(
+          runtime,
+          jsi::PropNameID::forAscii(runtime, "setImmediate"),
+          2, // Function, ...args
+          [this](
+              jsi::Runtime &rt,
+              const jsi::Value &thisVal,
+              const jsi::Value *args,
+              size_t count) {
+            if (count == 0) {
+              throw jsi::JSError(
+                  rt,
+                  "setImmediate must be called with at least one argument (a function to call)");
+            }
+
+            if (!args[0].isObject() || !args[0].asObject(rt).isFunction(rt)) {
+              throw jsi::JSError(
+                  rt, "The first argument to setImmediate must be a function.");
+            }
+            auto callback = args[0].getObject(rt).getFunction(rt);
+
+            // Package up the remaining argument values into one place.
+            std::vector<jsi::Value> moreArgs;
+            for (size_t extraArgNum = 1; extraArgNum < count; extraArgNum++) {
+              moreArgs.emplace_back(rt, args[extraArgNum]);
+            }
+
+            auto handle = createReactNativeMicrotask(
+                std::move(callback), std::move(moreArgs));
+            return jsi::Object::createFromHostObject(rt, handle);
+          }));
+
+  runtime.global().setProperty(
+      runtime,
+      "clearImmediate",
+      jsi::Function::createFromHostFunction(
+          runtime,
+          jsi::PropNameID::forAscii(runtime, "clearImmediate"),
+          1, // handle
+          [this](
+              jsi::Runtime &rt,
+              const jsi::Value &thisVal,
+              const jsi::Value *args,
+              size_t count) {
+            if (count == 0 || !args[0].isObject() ||
+                !args[0].asObject(rt).isHostObject<TimerHandle>(rt)) {
+              return jsi::Value::undefined();
+            }
+            std::shared_ptr<TimerHandle> handle =
+                args[0].asObject(rt).asHostObject<TimerHandle>(rt);
+            deleteReactNativeMicrotask(rt, handle);
+            return jsi::Value::undefined();
+          }));
+
+  runtime.global().setProperty(
+      runtime,
+      "setTimeout",
+      jsi::Function::createFromHostFunction(
+          runtime,
+          jsi::PropNameID::forAscii(runtime, "setTimeout"),
+          3, // Function, delay, ...args
+          [this](
+              jsi::Runtime &rt,
+              const jsi::Value &thisVal,
+              const jsi::Value *args,
+              size_t count) {
+            if (count == 0) {
+              throw jsi::JSError(
+                  rt,
+                  "setTimeout must be called with at least one argument (the function to call).");
+            }
+
+            if (!args[0].isObject() || !args[0].asObject(rt).isFunction(rt)) {
+              throw jsi::JSError(
+                  rt, "The first argument to setTimeout must be a function.");
+            }
+            auto callback = args[0].getObject(rt).getFunction(rt);
+
+            if (count > 1 && !args[1].isNumber() && !args[1].isUndefined()) {
+              throw jsi::JSError(
+                  rt,
+                  "The second argument to setTimeout must be a number or undefined.");
+            }
+            auto delay =
+                count > 1 && args[1].isNumber() ? args[1].getNumber() : 0;
+
+            // Package up the remaining argument values into one place.
+            std::vector<jsi::Value> moreArgs;
+            for (size_t extraArgNum = 2; extraArgNum < count; extraArgNum++) {
+              moreArgs.emplace_back(rt, args[extraArgNum]);
+            }
+
+            auto handle =
+                createTimer(std::move(callback), std::move(moreArgs), delay);
+            return jsi::Object::createFromHostObject(rt, handle);
+          }));
+
+  runtime.global().setProperty(
+      runtime,
+      "clearTimeout",
+      jsi::Function::createFromHostFunction(
+          runtime,
+          jsi::PropNameID::forAscii(runtime, "clearTimeout"),
+          1, // timerID
+          [this](
+              jsi::Runtime &rt,
+              const jsi::Value &thisVal,
+              const jsi::Value *args,
+              size_t count) {
+            if (count == 0 || !args[0].isObject() ||
+                !args[0].asObject(rt).isHostObject<TimerHandle>(rt)) {
+              return jsi::Value::undefined();
+            }
+            std::shared_ptr<TimerHandle> host =
+                args[0].asObject(rt).asHostObject<TimerHandle>(rt);
+            deleteTimer(rt, host);
+            return jsi::Value::undefined();
+          }));
+
+  runtime.global().setProperty(
+      runtime,
+      "setInterval",
+      jsi::Function::createFromHostFunction(
+          runtime,
+          jsi::PropNameID::forAscii(runtime, "setInterval"),
+          3, // Function, delay, ...args
+          [this](
+              jsi::Runtime &rt,
+              const jsi::Value &thisVal,
+              const jsi::Value *args,
+              size_t count) {
+            if (count < 2) {
+              throw jsi::JSError(
+                  rt,
+                  "setInterval must be called with at least two arguments (the function to call and the delay).");
+            }
+
+            if (!args[0].isObject() || !args[0].asObject(rt).isFunction(rt)) {
+              throw jsi::JSError(
+                  rt, "The first argument to setInterval must be a function.");
+            }
+            auto callback = args[0].getObject(rt).getFunction(rt);
+
+            if (!args[1].isNumber()) {
+              throw jsi::JSError(
+                  rt, "The second argument to setInterval must be a number.");
+            }
+            auto delay = args[1].getNumber();
+
+            // Package up the remaining argument values into one place.
+            std::vector<jsi::Value> moreArgs;
+            for (size_t extraArgNum = 2; extraArgNum < count; extraArgNum++) {
+              moreArgs.emplace_back(rt, args[extraArgNum]);
+            }
+
+            auto handle = createRecurringTimer(
+                std::move(callback), std::move(moreArgs), delay);
+            return jsi::Object::createFromHostObject(rt, handle);
+          }));
+
+  runtime.global().setProperty(
+      runtime,
+      "clearInterval",
+      jsi::Function::createFromHostFunction(
+          runtime,
+          jsi::PropNameID::forAscii(runtime, "clearInterval"),
+          1, // timerID
+          [this](
+              jsi::Runtime &rt,
+              const jsi::Value &thisVal,
+              const jsi::Value *args,
+              size_t count) {
+            if (count == 0 || !args[0].isObject() ||
+                !args[0].asObject(rt).isHostObject<TimerHandle>(rt)) {
+              return jsi::Value::undefined();
+            }
+            std::shared_ptr<TimerHandle> host =
+                args[0].asObject(rt).asHostObject<TimerHandle>(rt);
+            deleteRecurringTimer(rt, host);
+            return jsi::Value::undefined();
+          }));
+
+  runtime.global().setProperty(
+      runtime,
+      "requestAnimationFrame",
+      jsi::Function::createFromHostFunction(
+          runtime,
+          jsi::PropNameID::forAscii(runtime, "requestAnimationFrame"),
+          1, // callback
+          [this](
+              jsi::Runtime &rt,
+              const jsi::Value &thisVal,
+              const jsi::Value *args,
+              size_t count) {
+            if (count == 0) {
+              throw jsi::JSError(
+                  rt,
+                  "requestAnimationFrame must be called with at least one argument (i.e: a callback)");
+            }
+
+            if (!args[0].isObject() || !args[0].asObject(rt).isFunction(rt)) {
+              throw jsi::JSError(
+                  rt,
+                  "The first argument to requestAnimationFrame must be a function.");
+            }
+
+            using CallbackContainer = std::tuple<jsi::Function>;
+            auto callback = jsi::Function::createFromHostFunction(
+                rt,
+                jsi::PropNameID::forAscii(rt, "RN$rafFn"),
+                0,
+                [callbackContainer = std::make_shared<CallbackContainer>(
+                     args[0].getObject(rt).getFunction(rt))](
+                    jsi::Runtime &rt,
+                    const jsi::Value &thisVal,
+                    const jsi::Value *args,
+                    size_t count) {
+                  auto performance =
+                      rt.global().getPropertyAsObject(rt, "performance");
+                  auto nowFn = performance.getPropertyAsFunction(rt, "now");
+                  auto now = nowFn.callWithThis(rt, performance, {});
+
+                  return std::get<0>(*callbackContainer)
+                      .call(rt, {std::move(now)});
+                });
+
+            // The current implementation of requestAnimationFrame is the same
+            // as setTimeout(0). This isn't exactly how requestAnimationFrame
+            // is supposed to work on web, and may change in the future.
+            auto handle = createTimer(
+                std::move(callback),
+                std::vector<jsi::Value>(),
+                /* delay */ 0);
+            return jsi::Object::createFromHostObject(rt, handle);
+          }));
+
+  runtime.global().setProperty(
+      runtime,
+      "cancelAnimationFrame",
+      jsi::Function::createFromHostFunction(
+          runtime,
+          jsi::PropNameID::forAscii(runtime, "cancelAnimationFrame"),
+          1, // timerID
+          [this](
+              jsi::Runtime &rt,
+              const jsi::Value &thisVal,
+              const jsi::Value *args,
+              size_t count) {
+            if (count == 0 || !args[0].isObject() ||
+                !args[0].asObject(rt).isHostObject<TimerHandle>(rt)) {
+              return jsi::Value::undefined();
+            }
+            std::shared_ptr<TimerHandle> host =
+                args[0].asObject(rt).asHostObject<TimerHandle>(rt);
+            deleteTimer(rt, host);
+            return jsi::Value::undefined();
+          }));
+}
+
+} // namespace react
+} // namespace facebook

--- a/packages/react-native/ReactCommon/react/bridgeless/TimerManager.h
+++ b/packages/react-native/ReactCommon/react/bridgeless/TimerManager.h
@@ -1,0 +1,112 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <ReactCommon/RuntimeExecutor.h>
+#include <cstdint>
+#include <unordered_map>
+#include <vector>
+
+#include "PlatformTimerRegistry.h"
+
+namespace facebook {
+namespace react {
+
+/*
+ * A HostObject subclass representing the result of a setTimeout call.
+ * Can be used as an argument to clearTimeout.
+ */
+class TimerHandle : public jsi::HostObject {
+ public:
+  explicit TimerHandle(uint32_t index) : index_(index) {}
+
+  uint32_t index() const {
+    return index_;
+  }
+
+  ~TimerHandle() override = default;
+
+ private:
+  // Index in the timeouts_ map of the owning SetTimeoutQueue.
+  uint32_t index_;
+};
+
+/*
+ * Wraps a jsi::Function to make it copyable so we can pass it into a lambda.
+ */
+struct TimerCallback {
+  TimerCallback(TimerCallback &&) = default;
+
+  TimerCallback(
+      jsi::Function callback,
+      std::vector<jsi::Value> args,
+      bool repeat)
+      : callback_(std::move(callback)),
+        args_(std::move(args)),
+        repeat(repeat) {}
+
+  void invoke(jsi::Runtime &runtime) {
+    callback_.call(runtime, args_.data(), args_.size());
+  }
+
+  jsi::Function callback_;
+  const std::vector<jsi::Value> args_;
+  bool repeat;
+};
+
+class TimerManager {
+ public:
+  explicit TimerManager(
+      std::unique_ptr<PlatformTimerRegistry> platformTimerRegistry) noexcept;
+
+  void setRuntimeExecutor(RuntimeExecutor runtimeExecutor) noexcept;
+
+  void callReactNativeMicrotasks(jsi::Runtime &runtime);
+
+  void callTimer(uint32_t);
+
+  void attachGlobals(jsi::Runtime &runtime);
+
+ private:
+  std::shared_ptr<TimerHandle> createReactNativeMicrotask(
+      jsi::Function &&callback,
+      std::vector<jsi::Value> &&args);
+
+  void deleteReactNativeMicrotask(
+      jsi::Runtime &runtime,
+      std::shared_ptr<TimerHandle> handle);
+
+  std::shared_ptr<TimerHandle> createTimer(
+      jsi::Function &&callback,
+      std::vector<jsi::Value> &&args,
+      double delay);
+
+  void deleteTimer(jsi::Runtime &runtime, std::shared_ptr<TimerHandle> handle);
+
+  std::shared_ptr<TimerHandle> createRecurringTimer(
+      jsi::Function &&callback,
+      std::vector<jsi::Value> &&args,
+      double delay);
+
+  void deleteRecurringTimer(
+      jsi::Runtime &runtime,
+      std::shared_ptr<TimerHandle> handle);
+
+  RuntimeExecutor runtimeExecutor_;
+  std::unique_ptr<PlatformTimerRegistry> platformTimerRegistry_;
+
+  // A map (id => callback func) of the currently active JS timers
+  std::unordered_map<uint32_t, std::shared_ptr<TimerCallback>> timers_;
+
+  // Each timeout that is registered on this queue gets a sequential id.  This
+  // is the global count from which those are assigned.
+  uint64_t timerIndex_{0};
+
+  // The React Native microtask queue is used to back public APIs including
+  // `queueMicrotask`, `clearImmediate`, and `setImmediate` (which is used by
+  // the Promise polyfill) when the JSVM microtask mechanism is not used.
+  std::vector<uint32_t> reactNativeMicrotasksQueue_;
+};
+
+} // namespace react
+} // namespace facebook

--- a/packages/react-native/ReactCommon/react/bridgeless/hermes/HermesInstance.cpp
+++ b/packages/react-native/ReactCommon/react/bridgeless/hermes/HermesInstance.cpp
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+
+#include "HermesInstance.h"
+
+#include <jsi/jsilib.h>
+
+#ifdef HERMES_ENABLE_DEBUGGER
+#include <hermes/inspector/RuntimeAdapter.h>
+#include <hermes/inspector/chrome/Registration.h>
+#include <jsi/decorator.h>
+#endif
+
+using namespace facebook::hermes;
+using namespace facebook::jsi;
+
+namespace facebook {
+namespace react {
+
+#ifdef HERMES_ENABLE_DEBUGGER
+
+// Wrapper that strongly retains the HermesRuntime for on device debugging.
+//
+// HermesInstanceRuntimeAdapter needs to strongly retain the HermesRuntime. Why:
+//   - facebook::hermes::inspector::chrome::Connection::Impl owns the Adapter
+//   - facebook::hermes::inspector::chrome::Connection::Impl also owns jsi::
+//   objects
+//   - jsi:: objects need to be deleted before the Runtime.
+//
+// If Adapter doesn't share ownership over jsi::Runtime, the runtime can be
+// deleted before Connection::Impl cleans up all its jsi:: Objects. This will
+// lead to a runtime crash.
+class HermesInstanceRuntimeAdapter : public inspector::RuntimeAdapter {
+ public:
+  HermesInstanceRuntimeAdapter(std::shared_ptr<HermesRuntime> hermesRuntime)
+      : hermesRuntime_(hermesRuntime) {}
+  virtual ~HermesInstanceRuntimeAdapter() = default;
+
+  HermesRuntime &getRuntime() override {
+    return *hermesRuntime_;
+  }
+
+ private:
+  std::shared_ptr<HermesRuntime> hermesRuntime_;
+};
+
+class DecoratedRuntime : public jsi::RuntimeDecorator<jsi::Runtime> {
+ public:
+  DecoratedRuntime(std::unique_ptr<HermesRuntime> runtime)
+      : RuntimeDecorator<jsi::Runtime>(*runtime), runtime_(std::move(runtime)) {
+    auto adapter = std::make_unique<HermesInstanceRuntimeAdapter>(runtime_);
+
+    debugToken_ = inspector::chrome::enableDebugging(
+        std::move(adapter), "Hermes Bridgeless React Native");
+  }
+
+  ~DecoratedRuntime() {
+    inspector::chrome::disableDebugging(debugToken_);
+  }
+
+ private:
+  std::shared_ptr<HermesRuntime> runtime_;
+  inspector::chrome::DebugSessionToken debugToken_;
+};
+
+#endif
+
+std::unique_ptr<jsi::Runtime> HermesInstance::createJSRuntime() noexcept {
+  return createJSRuntime(nullptr, nullptr);
+}
+
+std::unique_ptr<jsi::Runtime> HermesInstance::createJSRuntime(
+    std::shared_ptr<const ReactNativeConfig> reactNativeConfig,
+    std::shared_ptr<::hermes::vm::CrashManager> cm) noexcept {
+  int64_t vmExperimentFlags = reactNativeConfig
+      ? reactNativeConfig->getInt64("ios_hermes:vm_experiment_flags")
+      : 0;
+
+  int64_t heapSizeConfig = reactNativeConfig
+      ? reactNativeConfig->getInt64("ios_hermes:rn_heap_size_mb")
+      : 0;
+  // Default to 3GB if MobileConfigs is not available
+  auto heapSizeMB = heapSizeConfig > 0
+      ? static_cast<::hermes::vm::gcheapsize_t>(heapSizeConfig)
+      : 3072;
+  ::hermes::vm::RuntimeConfig::Builder runtimeConfigBuilder =
+      ::hermes::vm::RuntimeConfig::Builder()
+          .withGCConfig(::hermes::vm::GCConfig::Builder()
+                            .withMaxHeapSize(heapSizeMB << 20)
+                            .withName("RNBridgeless")
+                            // For the next two arguments: avoid GC before TTI
+                            // by initializing the runtime to allocate directly
+                            // in the old generation, but revert to normal
+                            // operation when we reach the (first) TTI point.
+                            .withAllocInYoung(false)
+                            .withRevertToYGAtTTI(true)
+                            .build())
+          .withES6Proxy(false)
+          .withEnableSampleProfiling(true)
+          .withVMExperimentFlags(vmExperimentFlags);
+
+  if (cm) {
+    runtimeConfigBuilder.withCrashMgr(cm);
+  }
+
+  std::unique_ptr<HermesRuntime> hermesRuntime =
+      hermes::makeHermesRuntime(runtimeConfigBuilder.build());
+
+#ifdef HERMES_ENABLE_DEBUGGER
+  std::unique_ptr<DecoratedRuntime> decoratedRuntime =
+      std::make_unique<DecoratedRuntime>(std::move(hermesRuntime));
+  return decoratedRuntime;
+#endif
+
+  return hermesRuntime;
+}
+
+} // namespace react
+} // namespace facebook

--- a/packages/react-native/ReactCommon/react/bridgeless/hermes/HermesInstance.h
+++ b/packages/react-native/ReactCommon/react/bridgeless/hermes/HermesInstance.h
@@ -1,0 +1,23 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <hermes/API/hermes/hermes.h>
+#include <jsi/jsi.h>
+#import <react/config/ReactNativeConfig.h>
+
+namespace facebook {
+namespace react {
+
+class HermesInstance {
+ public:
+  // This is only needed for Android. Consider removing.
+  static std::unique_ptr<jsi::Runtime> createJSRuntime() noexcept;
+
+  static std::unique_ptr<jsi::Runtime> createJSRuntime(
+      std::shared_ptr<const ReactNativeConfig> reactNativeConfig,
+      std::shared_ptr<::hermes::vm::CrashManager> cm) noexcept;
+};
+
+} // namespace react
+} // namespace facebook

--- a/packages/react-native/ReactCommon/react/bridgeless/tests/hermes/ReactInstanceTest.cpp
+++ b/packages/react-native/ReactCommon/react/bridgeless/tests/hermes/ReactInstanceTest.cpp
@@ -1,0 +1,865 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <memory>
+#include <queue>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <ReactCommon/RuntimeExecutor.h>
+#include <ReactNative/venice/ReactInstance.h>
+#include <hermes/API/hermes/hermes.h>
+#include <jsi/jsi.h>
+#include <react/renderer/mapbuffer/MapBuffer.h>
+
+using ::testing::_;
+using ::testing::SaveArg;
+
+namespace facebook {
+namespace react {
+
+class MockTimerRegistry : public PlatformTimerRegistry {
+ public:
+  MOCK_METHOD2(createTimer, void(uint32_t, double));
+  MOCK_METHOD2(createRecurringTimer, void(uint32_t, double));
+  MOCK_METHOD1(deleteTimer, void(uint32_t));
+};
+
+class MockMessageQueueThread : public MessageQueueThread {
+ public:
+  void runOnQueue(std::function<void()> &&func) {
+    callbackQueue_.push(func);
+  }
+
+  // Unused
+  void runOnQueueSync(std::function<void()> &&) {}
+
+  // Unused
+  void quitSynchronous() {}
+
+  void tick() {
+    if (!callbackQueue_.empty()) {
+      auto callback = callbackQueue_.front();
+      callback();
+      callbackQueue_.pop();
+    }
+  }
+
+  void guardedTick() {
+    try {
+      tick();
+    } catch (const std::exception &e) {
+      // For easier debugging
+      FAIL() << e.what();
+    }
+  }
+
+  size_t size() {
+    return callbackQueue_.size();
+  }
+
+ private:
+  std::queue<std::function<void()>> callbackQueue_;
+};
+
+class ErrorUtils : public jsi::HostObject {
+ public:
+  jsi::Value get(jsi::Runtime &rt, const jsi::PropNameID &name) override {
+    auto methodName = name.utf8(rt);
+
+    if (methodName == "reportFatalError") {
+      return jsi::Function::createFromHostFunction(
+          rt,
+          name,
+          1,
+          [this](
+              jsi::Runtime &runtime,
+              const jsi::Value &thisValue,
+              const jsi::Value *arguments,
+              size_t count) {
+            if (count >= 1) {
+              auto value = jsi::Value(runtime, std::move(arguments[0]));
+              auto error = jsi::JSError(runtime, std::move(value));
+              reportFatalError(std::move(error));
+            }
+            return jsi::Value::undefined();
+          });
+    } else {
+      throw std::runtime_error("Unknown method: " + methodName);
+    }
+  }
+
+  void reportFatalError(jsi::JSError &&error) {
+    errors_.push_back(std::move(error));
+  }
+
+  size_t size() {
+    return errors_.size();
+  }
+
+  jsi::JSError getLastError() {
+    auto error = errors_.back();
+    errors_.pop_back();
+    return error;
+  }
+
+ private:
+  std::vector<jsi::JSError> errors_;
+};
+
+class ReactInstanceTest : public ::testing::Test {
+ protected:
+  ReactInstanceTest() {}
+
+  void SetUp() override {
+    auto runtime = hermes::makeHermesRuntime();
+    runtime_ = runtime.get();
+    messageQueueThread_ = std::make_shared<MockMessageQueueThread>();
+    auto mockRegistry = std::make_unique<MockTimerRegistry>();
+    mockRegistry_ = mockRegistry.get();
+    timerManager_ = std::make_shared<TimerManager>(std::move(mockRegistry));
+    auto jsErrorHandlingFunc = [](MapBuffer errorMap) noexcept {
+      // Do nothing
+    };
+    instance_ = std::make_unique<ReactInstance>(
+        std::move(runtime),
+        messageQueueThread_,
+        timerManager_,
+        std::move(jsErrorHandlingFunc));
+    timerManager_->setRuntimeExecutor(instance_->getBufferedRuntimeExecutor());
+
+    // Install a C++ error handler
+    errorHandler_ = std::make_shared<ErrorUtils>();
+    runtime_->global().setProperty(
+        *runtime_,
+        "ErrorUtils",
+        jsi::Object::createFromHostObject(*runtime_, errorHandler_));
+  }
+
+  void initializeRuntimeWithScript(
+      ReactInstance::JSRuntimeFlags jsRuntimeFlags,
+      std::string script) {
+    instance_->initializeRuntime(jsRuntimeFlags, [](jsi::Runtime &runtime) {});
+    step();
+
+    // Run the main bundle, so that native -> JS calls no longer get buffered.
+    loadScript(script);
+  }
+
+  void initializeRuntimeWithScript(std::string script) {
+    instance_->initializeRuntime(
+        {.isProfiling = false}, [](jsi::Runtime &runtime) {});
+    step();
+
+    // Run the main bundle, so that native -> JS calls no longer get buffered.
+    loadScript(script);
+  }
+
+  jsi::Value eval(std::string js) {
+    RuntimeExecutor runtimeExecutor = instance_->getUnbufferedRuntimeExecutor();
+    jsi::Value ret = jsi::Value::undefined();
+    runtimeExecutor([js, &ret](jsi::Runtime &runtime) {
+      ret = runtime.evaluateJavaScript(
+          std::make_unique<jsi::StringBuffer>(js), "");
+    });
+    step();
+    return ret;
+  }
+
+  // Call instance_->loadScript() to evaluate JS script and flush buffered JS
+  // calls
+  jsi::Value loadScript(std::string js) {
+    jsi::Value ret = jsi::Value::undefined();
+    instance_->loadScript(std::make_unique<JSBigStdString>(std::move(js)), "");
+    step();
+    return ret;
+  }
+
+  void expectError() {
+    EXPECT_NE(errorHandler_->size(), 0)
+        << "Expected an error to have been thrown, but it wasn't.";
+  }
+
+  void expectNoError() {
+    EXPECT_EQ(errorHandler_->size(), 0)
+        << "Expected no error to have been thrown, but one was.";
+  }
+
+  std::string getLastErrorMessage() {
+    auto error = errorHandler_->getLastError();
+    return error.getMessage();
+  }
+
+  std::string getErrorMessage(std::string js) {
+    eval(js);
+    return getLastErrorMessage();
+  }
+
+  void step() {
+    messageQueueThread_->guardedTick();
+  }
+
+  jsi::Runtime *runtime_;
+  std::shared_ptr<MockMessageQueueThread> messageQueueThread_;
+  std::unique_ptr<ReactInstance> instance_;
+  std::shared_ptr<TimerManager> timerManager_;
+  MockTimerRegistry *mockRegistry_;
+  std::shared_ptr<ErrorUtils> errorHandler_;
+};
+
+TEST_F(ReactInstanceTest, testBridgelessFlagIsSet) {
+  eval("RN$Bridgeless === true");
+  expectError();
+  initializeRuntimeWithScript("");
+  auto val = eval("RN$Bridgeless === true");
+  EXPECT_EQ(val.getBool(), true);
+}
+
+TEST_F(ReactInstanceTest, testProfilingFlag) {
+  eval("__RCTProfileIsProfiling === true");
+  expectError();
+  initializeRuntimeWithScript({.isProfiling = true}, "");
+  auto val = eval("__RCTProfileIsProfiling === true");
+  EXPECT_EQ(val.getBool(), true);
+}
+
+TEST_F(ReactInstanceTest, testPromiseIntegration) {
+  initializeRuntimeWithScript("");
+
+  eval(R"xyz123(
+let called = 0;
+function getResult() {
+  return called;
+}
+Promise.resolve().then(() => {
+  called++;
+}).then(() => {
+  called++;
+})
+)xyz123");
+  auto result = runtime_->global()
+                    .getPropertyAsFunction(*runtime_, "getResult")
+                    .call(*runtime_);
+  EXPECT_EQ(result.getNumber(), 2);
+}
+
+TEST_F(ReactInstanceTest, testSetImmediate) {
+  initializeRuntimeWithScript("");
+
+  eval(R"xyz123(
+let called = false;
+function getResult() {
+  return called;
+}
+setImmediate(() => {
+  called = true;
+});
+)xyz123");
+  auto result = runtime_->global()
+                    .getPropertyAsFunction(*runtime_, "getResult")
+                    .call(*runtime_);
+  EXPECT_EQ(result.getBool(), true);
+}
+
+TEST_F(ReactInstanceTest, testNestedSetImmediate) {
+  initializeRuntimeWithScript("");
+
+  eval(R"xyz123(
+let called = false;
+function getResult() {
+  return called;
+}
+setImmediate(() => {
+  setImmediate(() => {
+    called = true;
+  })
+});
+)xyz123");
+  auto result = runtime_->global()
+                    .getPropertyAsFunction(*runtime_, "getResult")
+                    .call(*runtime_);
+  EXPECT_EQ(result.getBool(), true);
+}
+
+TEST_F(ReactInstanceTest, testSetImmediateWithInvalidArgs) {
+  initializeRuntimeWithScript("");
+
+  EXPECT_EQ(
+      getErrorMessage("setImmediate();"),
+      "setImmediate must be called with at least one argument (a function to call)");
+  EXPECT_EQ(
+      getErrorMessage("setImmediate('invalid');"),
+      "The first argument to setImmediate must be a function.");
+  EXPECT_EQ(
+      getErrorMessage("setImmediate({});"),
+      "The first argument to setImmediate must be a function.");
+}
+
+TEST_F(ReactInstanceTest, testClearImmediate) {
+  initializeRuntimeWithScript("");
+
+  eval(R"xyz123(
+let called = false;
+function getResult() {
+  return called;
+}
+const handle = setImmediate(() => {
+  called = true;
+});
+clearImmediate(handle);
+)xyz123");
+
+  auto func = runtime_->global().getPropertyAsFunction(*runtime_, "getResult");
+  auto val = func.call(*runtime_);
+  EXPECT_EQ(val.getBool(), false);
+}
+
+TEST_F(ReactInstanceTest, testClearImmediateWithInvalidHandle) {
+  initializeRuntimeWithScript("");
+
+  auto js = R"xyz123(
+let called = false;
+const handle = setImmediate(() => {
+  called = true;
+});
+function getResult() {
+  return called;
+}
+function clearInvalidHandle() {
+  clearImmediate(handle);
+}
+)xyz123";
+  eval(js);
+
+  auto clear =
+      runtime_->global().getPropertyAsFunction(*runtime_, "clearInvalidHandle");
+  // Clearing an invalid handle should fail silently.
+  EXPECT_NO_THROW(clear.call((*runtime_)));
+}
+
+TEST_F(ReactInstanceTest, testClearImmediateWithInvalidArgs) {
+  initializeRuntimeWithScript("");
+
+  eval("clearImmediate();");
+  expectNoError();
+
+  eval("clearImmediate('invalid');");
+  expectNoError();
+
+  eval("clearImmediate({});");
+  expectNoError();
+
+  eval("clearImmediate(undefined);");
+  expectNoError();
+}
+
+TEST_F(ReactInstanceTest, testSetTimeout) {
+  initializeRuntimeWithScript("");
+
+  uint32_t timerID{0};
+  EXPECT_CALL(*mockRegistry_, createTimer(_, 100))
+      .WillOnce(SaveArg<0>(&timerID));
+  eval(R"xyz123(
+let called = false;
+setTimeout(() => {
+  called = true;
+}, 100);
+function getResult() {
+  return called;
+}
+  )xyz123");
+  timerManager_->callTimer(timerID);
+  step();
+  auto called = runtime_->global()
+                    .getPropertyAsFunction(*runtime_, "getResult")
+                    .call(*runtime_);
+  EXPECT_EQ(called.getBool(), true);
+}
+
+TEST_F(ReactInstanceTest, testSetTimeoutWithoutDelay) {
+  initializeRuntimeWithScript("");
+
+  EXPECT_CALL(
+      *mockRegistry_,
+      createTimer(_, 0)); // If delay is not provided, it should use 0
+  eval("setTimeout(() => {});");
+}
+
+TEST_F(ReactInstanceTest, testSetTimeoutWithPassThroughArgs) {
+  initializeRuntimeWithScript("");
+
+  uint32_t timerID{0};
+  EXPECT_CALL(*mockRegistry_, createTimer(_, 0)).WillOnce(SaveArg<0>(&timerID));
+  eval(R"xyz123(
+let result;
+setTimeout(arg => {
+  result = arg;
+}, undefined, 'foo');
+function getResult() {
+  return result;
+}
+  )xyz123");
+  timerManager_->callTimer(timerID);
+  step();
+  auto result = runtime_->global()
+                    .getPropertyAsFunction(*runtime_, "getResult")
+                    .call(*runtime_);
+  EXPECT_EQ(result.asString(*runtime_).utf8(*runtime_), "foo");
+}
+
+TEST_F(ReactInstanceTest, testSetTimeoutWithInvalidArgs) {
+  initializeRuntimeWithScript("");
+
+  EXPECT_EQ(
+      getErrorMessage("setTimeout();"),
+      "setTimeout must be called with at least one argument (the function to call).");
+  EXPECT_EQ(
+      getErrorMessage("setTimeout('invalid');"),
+      "The first argument to setTimeout must be a function.");
+  EXPECT_EQ(
+      getErrorMessage("setTimeout(() => {}, 'invalid');"),
+      "The second argument to setTimeout must be a number or undefined.");
+}
+
+TEST_F(ReactInstanceTest, testClearTimeout) {
+  initializeRuntimeWithScript("");
+
+  uint32_t timerID{0};
+  EXPECT_CALL(*mockRegistry_, createTimer(_, 100))
+      .WillOnce(SaveArg<0>(&timerID));
+  eval(R"xyz123(
+const handle = setTimeout(() => {}, 100);
+function clear() {
+  clearTimeout(handle);
+}
+  )xyz123");
+  EXPECT_CALL(*mockRegistry_, deleteTimer(timerID));
+  runtime_->global().getPropertyAsFunction(*runtime_, "clear").call(*runtime_);
+}
+
+TEST_F(ReactInstanceTest, testClearTimeoutWithInvalidArgs) {
+  initializeRuntimeWithScript("");
+
+  eval("clearTimeout();");
+  expectNoError();
+
+  eval("clearTimeout('invalid');");
+  expectNoError();
+
+  eval("clearTimeout({});");
+  expectNoError();
+
+  eval("clearTimeout(undefined);");
+  expectNoError();
+}
+
+TEST_F(ReactInstanceTest, testClearTimeoutForExpiredTimer) {
+  initializeRuntimeWithScript("");
+
+  uint32_t timerID{0};
+  EXPECT_CALL(*mockRegistry_, createTimer(_, 100))
+      .WillOnce(SaveArg<0>(&timerID));
+  eval(R"xyz123(
+const handle = setTimeout(() => {}, 100);
+function clear() {
+  clearTimeout(handle);
+}
+  )xyz123");
+  // Call the timer
+  timerManager_->callTimer(timerID);
+  step();
+
+  // Now clear the called timer
+  EXPECT_CALL(*mockRegistry_, deleteTimer(timerID));
+  auto clear = runtime_->global().getPropertyAsFunction(*runtime_, "clear");
+  EXPECT_NO_THROW(clear.call(*runtime_));
+}
+
+TEST_F(ReactInstanceTest, testSetInterval) {
+  initializeRuntimeWithScript("");
+
+  uint32_t timerID{0};
+  EXPECT_CALL(*mockRegistry_, createRecurringTimer(_, 100))
+      .WillOnce(SaveArg<0>(&timerID));
+  eval(R"xyz123(
+let result = 0;
+setInterval(() => {
+  result++;
+}, 100);
+function getResult() {
+  return result;
+}
+  )xyz123");
+  timerManager_->callTimer(timerID);
+  step();
+  auto getResult =
+      runtime_->global().getPropertyAsFunction(*runtime_, "getResult");
+  EXPECT_EQ(getResult.call(*runtime_).asNumber(), 1.0);
+
+  // Should be able to call the same callback again.
+  timerManager_->callTimer(timerID);
+  step();
+  EXPECT_EQ(getResult.call(*runtime_).asNumber(), 2.0);
+}
+
+TEST_F(ReactInstanceTest, testSetIntervalWithPassThroughArgs) {
+  initializeRuntimeWithScript("");
+
+  uint32_t timerID{0};
+  EXPECT_CALL(*mockRegistry_, createRecurringTimer(_, 100))
+      .WillOnce(SaveArg<0>(&timerID));
+  eval(R"xyz123(
+let result;
+setInterval(arg => {
+  result = arg;
+}, 100, 'foo');
+function getResult() {
+  return result;
+}
+  )xyz123");
+  timerManager_->callTimer(timerID);
+  step();
+
+  auto getResult =
+      runtime_->global().getPropertyAsFunction(*runtime_, "getResult");
+  EXPECT_EQ(
+      getResult.call(*runtime_).asString(*runtime_).utf8(*runtime_), "foo");
+}
+
+TEST_F(ReactInstanceTest, testSetIntervalWithInvalidArgs) {
+  initializeRuntimeWithScript("");
+
+  EXPECT_EQ(
+      getErrorMessage("setInterval();"),
+      "setInterval must be called with at least two arguments (the function to call and the delay).");
+  EXPECT_EQ(
+      getErrorMessage("setInterval(() => {});"),
+      "setInterval must be called with at least two arguments (the function to call and the delay).");
+  EXPECT_EQ(
+      getErrorMessage("setInterval('invalid', 100);"),
+      "The first argument to setInterval must be a function.");
+  EXPECT_EQ(
+      getErrorMessage("setInterval(() => {}, 'invalid');"),
+      "The second argument to setInterval must be a number.");
+}
+
+TEST_F(ReactInstanceTest, testClearInterval) {
+  initializeRuntimeWithScript("");
+
+  uint32_t timerID{0};
+  EXPECT_CALL(*mockRegistry_, createRecurringTimer(_, 100))
+      .WillOnce(SaveArg<0>(&timerID));
+  eval(R"xyz123(
+let result = 0;
+const handle = setInterval(() => {
+  result++;
+}, 100);
+function clear() {
+  clearInterval(handle);
+}
+function getResult() {
+  return result;
+}
+  )xyz123");
+  timerManager_->callTimer(timerID);
+  step();
+  auto getResult =
+      runtime_->global().getPropertyAsFunction(*runtime_, "getResult");
+  EXPECT_EQ(getResult.call(*runtime_).asNumber(), 1.0);
+
+  EXPECT_CALL(*mockRegistry_, deleteTimer(timerID));
+  runtime_->global().getPropertyAsFunction(*runtime_, "clear").call(*runtime_);
+  step();
+
+  timerManager_->callTimer(timerID);
+  step();
+  // Callback should not have been invoked again.
+  EXPECT_EQ(getResult.call(*runtime_).asNumber(), 1.0);
+}
+
+TEST_F(ReactInstanceTest, testClearIntervalWithInvalidArgs) {
+  initializeRuntimeWithScript("");
+
+  eval("clearInterval();");
+  expectNoError();
+
+  eval("clearInterval(false);");
+  expectNoError();
+
+  eval("clearInterval({});");
+  expectNoError();
+
+  eval("clearInterval(undefined);");
+  expectNoError();
+}
+
+TEST_F(ReactInstanceTest, testRequestAnimationFrame) {
+  initializeRuntimeWithScript("");
+
+  uint32_t timerID{0};
+  EXPECT_CALL(*mockRegistry_, createTimer(_, 0)).WillOnce(SaveArg<0>(&timerID));
+  eval(R"xyz123(
+let called = false;
+performance = {
+  now: () => 0
+}
+requestAnimationFrame(() => {
+  called = true;
+});
+function getResult() {
+  return called;
+}
+  )xyz123");
+  auto getResult =
+      runtime_->global().getPropertyAsFunction(*runtime_, "getResult");
+  EXPECT_EQ(getResult.call(*runtime_).getBool(), false);
+
+  timerManager_->callTimer(timerID);
+  step();
+  EXPECT_EQ(getResult.call(*runtime_).getBool(), true);
+}
+
+TEST_F(
+    ReactInstanceTest,
+    testRequestAnimationFrameCallbackArgIsPerformanceNow) {
+  initializeRuntimeWithScript("");
+
+  uint32_t timerID{0};
+  EXPECT_CALL(*mockRegistry_, createTimer(_, 0)).WillOnce(SaveArg<0>(&timerID));
+  eval(R"xyz123(
+let now = 0;
+performance = {
+  now: () => 123456
+}
+requestAnimationFrame(($now) => {
+  now = $now;
+});
+function getResult() {
+  return now;
+}
+  )xyz123");
+  auto getResult =
+      runtime_->global().getPropertyAsFunction(*runtime_, "getResult");
+  EXPECT_EQ(getResult.call(*runtime_).getNumber(), 0);
+
+  timerManager_->callTimer(timerID);
+  step();
+  EXPECT_EQ(getResult.call(*runtime_).getNumber(), 123456);
+}
+
+TEST_F(ReactInstanceTest, testRequestAnimationFrameWithInvalidArgs) {
+  initializeRuntimeWithScript("");
+
+  eval(R"xyz123(
+performance = {
+  now: () => 0
+}
+  )xyz123");
+
+  EXPECT_EQ(
+      getErrorMessage("requestAnimationFrame();"),
+      "requestAnimationFrame must be called with at least one argument (i.e: a callback)");
+  EXPECT_EQ(
+      getErrorMessage("requestAnimationFrame('invalid');"),
+      "The first argument to requestAnimationFrame must be a function.");
+  EXPECT_EQ(
+      getErrorMessage("requestAnimationFrame({});"),
+      "The first argument to requestAnimationFrame must be a function.");
+}
+
+TEST_F(ReactInstanceTest, testCancelAnimationFrame) {
+  initializeRuntimeWithScript("");
+
+  uint32_t timerID{0};
+  EXPECT_CALL(*mockRegistry_, createTimer(_, 0)).WillOnce(SaveArg<0>(&timerID));
+  eval(R"xyz123(
+let called = false;
+performance = {
+  now: () => 0
+}
+const handle = requestAnimationFrame(() => {
+  called = true;
+});
+function clear() {
+  cancelAnimationFrame(handle);
+}
+function getResult() {
+  return called;
+}
+  )xyz123");
+
+  EXPECT_CALL(*mockRegistry_, deleteTimer(timerID));
+  runtime_->global().getPropertyAsFunction(*runtime_, "clear").call(*runtime_);
+
+  // Attempt to call timer; should fail silently.
+  timerManager_->callTimer(timerID);
+  step();
+
+  // Verify the callback was not called.
+  auto called = runtime_->global()
+                    .getPropertyAsFunction(*runtime_, "getResult")
+                    .call(*runtime_);
+  EXPECT_EQ(called.getBool(), false);
+}
+
+TEST_F(ReactInstanceTest, testCancelAnimationFrameWithInvalidArgs) {
+  initializeRuntimeWithScript("");
+
+  eval("cancelAnimationFrame();");
+  expectNoError();
+
+  eval("cancelAnimationFrame(false);");
+  expectNoError();
+
+  eval("cancelAnimationFrame({});");
+  expectNoError();
+
+  eval("cancelAnimationFrame(undefined);");
+  expectNoError();
+}
+
+TEST_F(ReactInstanceTest, testCancelAnimationFrameWithExpiredTimer) {
+  initializeRuntimeWithScript("");
+
+  uint32_t timerID{0};
+  EXPECT_CALL(*mockRegistry_, createTimer(_, 0)).WillOnce(SaveArg<0>(&timerID));
+  eval(R"xyz123(
+let called = false;
+performance = {
+  now: () => 0
+}
+const handle = requestAnimationFrame(() => {
+  called = true;
+});
+function clear() {
+  cancelAnimationFrame(handle);
+}
+function getResult() {
+  return called;
+}
+  )xyz123");
+
+  timerManager_->callTimer(timerID);
+  step();
+
+  auto called = runtime_->global()
+                    .getPropertyAsFunction(*runtime_, "getResult")
+                    .call(*runtime_);
+  EXPECT_EQ(called.getBool(), true);
+
+  EXPECT_CALL(*mockRegistry_, deleteTimer(timerID));
+  auto clear = runtime_->global().getPropertyAsFunction(*runtime_, "clear");
+  // Canceling an expired timer should fail silently.
+  EXPECT_NO_THROW(clear.call(*runtime_));
+}
+
+TEST_F(ReactInstanceTest, testRegisterCallableModule) {
+  initializeRuntimeWithScript(R"xyz123(
+let called = false;
+const module = {
+  bar: () => {
+    called = true;
+  },
+};
+function getResult() {
+  return called;
+}
+RN$registerCallableModule('foo', () => module);
+  )xyz123");
+
+  auto args = folly::dynamic::array(0);
+  instance_->callFunctionOnModule("foo", "bar", std::move(args));
+  step();
+
+  auto called = runtime_->global()
+                    .getPropertyAsFunction(*runtime_, "getResult")
+                    .call(*runtime_);
+  EXPECT_EQ(called.getBool(), true);
+}
+
+TEST_F(ReactInstanceTest, testRegisterCallableModule_invalidArgs) {
+  initializeRuntimeWithScript("");
+
+  EXPECT_EQ(
+      getErrorMessage("RN$registerCallableModule();"),
+      "registerCallableModule requires exactly 2 arguments");
+  EXPECT_EQ(
+      getErrorMessage("RN$registerCallableModule('foo');"),
+      "registerCallableModule requires exactly 2 arguments");
+  EXPECT_EQ(
+      getErrorMessage("RN$registerCallableModule(1, () => ({}));"),
+      "The first argument to registerCallableModule must be a string (the name of the JS module).");
+  EXPECT_EQ(
+      getErrorMessage("RN$registerCallableModule('foo', false);"),
+      "The second argument to registerCallableModule must be a function that returns the JS module.");
+}
+
+TEST_F(ReactInstanceTest, testCallFunctionOnModule_invalidModule) {
+  initializeRuntimeWithScript("");
+
+  auto args = folly::dynamic::array(0);
+  instance_->callFunctionOnModule("invalidModule", "method", std::move(args));
+  step();
+  expectError();
+  EXPECT_EQ(
+      getLastErrorMessage(),
+      "Failed to call into JavaScript module method invalidModule.method(). Module has not been registered as callable. Registered callable JavaScript modules (n = 0):. Did you forget to call `RN$registerCallableModule`?");
+}
+
+TEST_F(ReactInstanceTest, testCallFunctionOnModule_undefinedMethod) {
+  initializeRuntimeWithScript(R"xyz123(
+const module = {
+  bar: () => {},
+};
+RN$registerCallableModule('foo', () => module);
+  )xyz123");
+
+  auto args = folly::dynamic::array(0);
+  instance_->callFunctionOnModule("foo", "invalidMethod", std::move(args));
+  step();
+  expectError();
+  EXPECT_EQ(
+      getLastErrorMessage(),
+      "Failed to call into JavaScript module method foo.invalidMethod. Module exists, but the method is undefined.");
+}
+
+TEST_F(ReactInstanceTest, testCallFunctionOnModule_invalidMethod) {
+  initializeRuntimeWithScript(R"xyz123(
+const module = {
+  bar: false,
+};
+RN$registerCallableModule('foo', () => module);
+  )xyz123");
+
+  auto args = folly::dynamic::array(0);
+  instance_->callFunctionOnModule("foo", "bar", std::move(args));
+  step();
+  expectError();
+}
+
+TEST_F(ReactInstanceTest, testRegisterCallableModule_withArgs) {
+  initializeRuntimeWithScript(R"xyz123(
+let result;
+const module = {
+  bar: thing => {
+    result = thing;
+  },
+};
+RN$registerCallableModule('foo', () => module);
+function getResult() {
+  return result;
+}
+  )xyz123");
+
+  auto args = folly::dynamic::array(1);
+  instance_->callFunctionOnModule("foo", "bar", std::move(args));
+  step();
+
+  auto result = runtime_->global()
+                    .getPropertyAsFunction(*runtime_, "getResult")
+                    .call(*runtime_);
+  EXPECT_EQ(result.getNumber(), 1);
+}
+
+} // namespace react
+} // namespace facebook


### PR DESCRIPTION
Summary:
Hermes code coverage was added in D43458602, move the logic to internal to avoid internal dependencies in Bridgeless.

Changelog:
[Android][Changed] - Move Hermes code coverage to non-OSS

Reviewed By: cortinico

Differential Revision: D44626679

