### PR TITLE
Bump activesupport to 6.1.7.3 to address CVE-2023-28120

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,4 @@ source 'https://rubygems.org'
 ruby ">= 2.6.10"
 
 gem 'cocoapods', '~> 1.12'
-gem 'activesupport', '>= 6.1.7.1'
+gem 'activesupport', '>= 6.1.7.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,11 +3,12 @@ GEM
   specs:
     CFPropertyList (3.0.6)
       rexml
-    activesupport (7.0.4.2)
+    activesupport (6.1.7.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
     algoliasearch (1.27.5)
@@ -84,12 +85,13 @@ GEM
       colored2 (~> 3.1)
       nanaimo (~> 0.3.0)
       rexml (~> 3.2.4)
+    zeitwerk (2.6.7)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport (>= 6.1.7.1)
+  activesupport (>= 6.1.7.3)
   cocoapods (~> 1.12)
 
 RUBY VERSION


### PR DESCRIPTION
Summary:
Changelog:
[Internal][Changed] - Bump activesupport to 6.1.7.3 to address CVE-2023-28120

Reviewed By: christophpurrer

Differential Revision: D44673150

