### PR TITLE
Add Meta header to xplat/js/react-native-github/tools/build_defs/oss/preload.bzl

### DIFF
--- a/tools/build_defs/oss/preload.bzl
+++ b/tools/build_defs/oss/preload.bzl
@@ -1,3 +1,8 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 # These are symbols that are available in newer versions of Buck, but not the open source one.
 
 def oncall(_team):


### PR DESCRIPTION
Summary:
Working through the backlog of failing open source requirements (T139285789). Most files that are violating Copyright rules are due to the exemptions being outdated, but this file actually needs a header.

Changelog: [Internal]

Reviewed By: cortinico, cipolleschi

Differential Revision: D44705585

