### PR TITLE
Rename cleanAll to clean and refine it

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,12 +43,15 @@ nexusPublishing {
   }
 }
 
-tasks.register("cleanAll", Delete::class.java) {
+tasks.register("clean", Delete::class.java) {
   description = "Remove all the build files and intermediate build outputs"
   dependsOn(gradle.includedBuild("react-native-gradle-plugin").task(":clean"))
-  dependsOn(":packages:react-native:ReactAndroid:clean")
-  dependsOn(":packages:react-native:ReactAndroid:hermes-engine:clean")
-  dependsOn(":packages:rn-tester:android:app:clean")
+  subprojects.forEach {
+    if (it.project.plugins.hasPlugin("com.android.library") ||
+        it.project.plugins.hasPlugin("com.android.application")) {
+      dependsOn(it.tasks.named("clean"))
+    }
+  }
   delete(allprojects.map { it.buildDir })
   delete(rootProject.file("./packages/react-native/ReactAndroid/.cxx"))
   delete(rootProject.file("./packages/react-native/ReactAndroid/hermes-engine/.cxx"))
@@ -62,6 +65,7 @@ tasks.register("cleanAll", Delete::class.java) {
   delete(rootProject.file("./packages/react-native/ReactAndroid/src/main/jni/prebuilt/lib/x86/"))
   delete(rootProject.file("./packages/react-native/ReactAndroid/src/main/jni/prebuilt/lib/x86_64/"))
   delete(rootProject.file("./packages/react-native-codegen/lib"))
+  delete(rootProject.file("./node_modules/@react-native/codegen/lib"))
   delete(rootProject.file("./packages/rn-tester/android/app/.cxx"))
 }
 

--- a/scripts/test-e2e-local-clean.js
+++ b/scripts/test-e2e-local-clean.js
@@ -19,7 +19,7 @@
  *
  * It will:
  *  - clean up node modules
- *  - clean up the build folder (derived data, gradlew cleanAll)
+ *  - clean up the build folder (derived data, gradlew clean)
  *  - clean up the pods folder for RNTester (pod install) (and Podfile.lock too)
  *  - kill all packagers
  *  - remove RNTestProject folder
@@ -42,7 +42,7 @@ if (isPackagerRunning() === 'running') {
 
 // Android
 console.info('\n** Cleaning Gradle build artifacts **\n');
-exec('./gradlew cleanAll');
+exec('./gradlew clean');
 exec('rm -rf /tmp/maven-local');
 
 // iOS


### PR DESCRIPTION
Summary:
We used to use `cleanAll` instead of `clean` to do cleaning of everything due to a bug on AGP on how clean was performed.
The bug is resolved, so we can now use `clean` properly.
Moreover, we have sporadic failures when the codegen/lib/ folder is not cleaned up. This fixes it.

Changelog:
[Internal] [Changed] - Rename cleanAll to clean and refine it

Reviewed By: cipolleschi

Differential Revision: D44745849

