### PR TITLE
Fix for potential breakage due to incompatibility between binary and JS code in NativePerformanceObserver

### DIFF
--- a/packages/react-native/Libraries/WebPerformance/Performance.js
+++ b/packages/react-native/Libraries/WebPerformance/Performance.js
@@ -47,10 +47,12 @@ const getCurrentTimeStamp: () => HighResTimeStamp = global.nativePerformanceNow
 // even if they are not currently observed - this is either to be able to
 // retrieve them at any time via Performance.getEntries* or to refer by other entries
 // (such as when measures may refer to marks, even if the latter are not observed)
-NativePerformanceObserver?.setIsBuffered(
-  ALWAYS_LOGGED_ENTRY_TYPES.map(performanceEntryTypeToRaw),
-  true,
-);
+if (NativePerformanceObserver?.setIsBuffered) {
+  NativePerformanceObserver?.setIsBuffered(
+    ALWAYS_LOGGED_ENTRY_TYPES.map(performanceEntryTypeToRaw),
+    true,
+  );
+}
 
 export class PerformanceMark extends PerformanceEntry {
   detail: DetailType;


### PR DESCRIPTION
Summary:
## Changelog:
[Internal] -

A follow-up to D44712550, which did not take into account that there may be incompatibility between app's binary and JS code.

Note that this is for VR apps only, as other platforms don't (yet) use the module in question (WebPerformance).

Reviewed By: javache

Differential Revision: D44751928

