### PR TITLE
TS definition: Change StyleSheet.flatten return type to reflect its nullability

### DIFF
--- a/packages/react-native/Libraries/StyleSheet/StyleSheet.d.ts
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheet.d.ts
@@ -78,8 +78,48 @@ export namespace StyleSheet {
    * the alternative use.
    */
   export function flatten<T>(
-    style?: StyleProp<T>,
-  ): (T extends (infer U)[] ? U : T) | undefined;
+    style: StyleProp<T>,
+  ): T extends (infer U)[] ? U : T;
+  /**
+   * Flattens an array of style objects, into one aggregated style object.
+   * Alternatively, this method can be used to lookup IDs, returned by
+   * StyleSheet.register.
+   *
+   * > **NOTE**: Exercise caution as abusing this can tax you in terms of
+   * > optimizations.
+   * >
+   * > IDs enable optimizations through the bridge and memory in general. Referring
+   * > to style objects directly will deprive you of these optimizations.
+   *
+   * Example:
+   * ```
+   * const styles = StyleSheet.create({
+   *   listItem: {
+   *     flex: 1,
+   *     fontSize: 16,
+   *     color: 'white'
+   *   },
+   *   selectedListItem: {
+   *     color: 'green'
+   *   }
+   * });
+   *
+   * StyleSheet.flatten([styles.listItem, styles.selectedListItem])
+   * // returns { flex: 1, fontSize: 16, color: 'green' }
+   * ```
+   * Alternative use:
+   * ```
+   * StyleSheet.flatten(styles.listItem);
+   * // return { flex: 1, fontSize: 16, color: 'white' }
+   * // Simply styles.listItem would return its ID (number)
+   * ```
+   * This method internally uses `StyleSheetRegistry.getStyleByID(style)`
+   * to resolve style objects represented by IDs. Thus, an array of style
+   * objects (instances of StyleSheet.create), are individually resolved to,
+   * their respective objects, merged as one and then returned. This also explains
+   * the alternative use.
+   */
+  export function flatten(style: undefined): undefined;
 
   /**
    * Combines two styles such that style2 will override any styles in style1.

--- a/packages/react-native/Libraries/StyleSheet/StyleSheet.d.ts
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheet.d.ts
@@ -79,7 +79,7 @@ export namespace StyleSheet {
    */
   export function flatten<T>(
     style?: StyleProp<T>,
-  ): T extends (infer U)[] ? U : T;
+  ): (T extends (infer U)[] ? U : T) | undefined;
 
   /**
    * Combines two styles such that style2 will override any styles in style1.

--- a/packages/react-native/types/__typetests__/index.tsx
+++ b/packages/react-native/types/__typetests__/index.tsx
@@ -119,6 +119,7 @@ import {
   ToastAndroid,
   Touchable,
   LayoutAnimation,
+  FontVariant,
 } from 'react-native';
 
 declare module 'react-native' {
@@ -215,7 +216,9 @@ StyleSheet.setStyleAttributePreprocessor(
   (family: string) => family,
 );
 
-const welcomeFontSize = StyleSheet.flatten(styles.welcome)?.fontSize;
+const welcomeFontSize: number | undefined = StyleSheet.flatten(
+  styles.welcome,
+).fontSize;
 
 const viewStyle: StyleProp<ViewStyle> = {
   backgroundColor: '#F5FCFF',
@@ -230,15 +233,20 @@ const fontVariantStyle: StyleProp<TextStyle> = {
   fontVariant: ['tabular-nums'],
 };
 
-const viewProperty = StyleSheet.flatten(viewStyle)?.backgroundColor;
-const textProperty = StyleSheet.flatten(textStyle)?.fontSize;
-const imageProperty = StyleSheet.flatten(imageStyle)?.resizeMode;
-const fontVariantProperty = StyleSheet.flatten(fontVariantStyle)?.fontVariant;
+const viewProperty: ColorValue | undefined =
+  StyleSheet.flatten(viewStyle).backgroundColor;
+const textProperty: number | undefined = StyleSheet.flatten(textStyle).fontSize;
+const imageProperty: ImageResizeMode | undefined =
+  StyleSheet.flatten(imageStyle).resizeMode;
+const fontVariantProperty: FontVariant[] | undefined =
+  StyleSheet.flatten(fontVariantStyle).fontVariant;
 
 // correct use of the StyleSheet.flatten
 const styleArray: StyleProp<ViewStyle>[] = [];
 const flattenStyle = StyleSheet.flatten(styleArray);
-const top = flattenStyle?.top;
+const {top} = flattenStyle;
+
+const undefinedStyle: undefined = StyleSheet.flatten(undefined);
 
 const s = StyleSheet.create({
   shouldWork: {

--- a/packages/react-native/types/__typetests__/index.tsx
+++ b/packages/react-native/types/__typetests__/index.tsx
@@ -215,7 +215,7 @@ StyleSheet.setStyleAttributePreprocessor(
   (family: string) => family,
 );
 
-const welcomeFontSize = StyleSheet.flatten(styles.welcome).fontSize;
+const welcomeFontSize = StyleSheet.flatten(styles.welcome)?.fontSize;
 
 const viewStyle: StyleProp<ViewStyle> = {
   backgroundColor: '#F5FCFF',
@@ -230,15 +230,15 @@ const fontVariantStyle: StyleProp<TextStyle> = {
   fontVariant: ['tabular-nums'],
 };
 
-const viewProperty = StyleSheet.flatten(viewStyle).backgroundColor;
-const textProperty = StyleSheet.flatten(textStyle).fontSize;
-const imageProperty = StyleSheet.flatten(imageStyle).resizeMode;
-const fontVariantProperty = StyleSheet.flatten(fontVariantStyle).fontVariant;
+const viewProperty = StyleSheet.flatten(viewStyle)?.backgroundColor;
+const textProperty = StyleSheet.flatten(textStyle)?.fontSize;
+const imageProperty = StyleSheet.flatten(imageStyle)?.resizeMode;
+const fontVariantProperty = StyleSheet.flatten(fontVariantStyle)?.fontVariant;
 
 // correct use of the StyleSheet.flatten
 const styleArray: StyleProp<ViewStyle>[] = [];
 const flattenStyle = StyleSheet.flatten(styleArray);
-const {top} = flattenStyle;
+const top = flattenStyle?.top;
 
 const s = StyleSheet.create({
   shouldWork: {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

I realize this would be a breaking change and there may be better ways of addressing it, but in our codebase, we've been bitten by runtime exceptions due to overlooking the undefined case before, and a more precise type definition would help avoid that. Please tell me if you think there's a better strategy 🙏 

- Implementation: https://github.com/facebook/react-native/blob/main/packages/react-native/Libraries/StyleSheet/flattenStyle.js#L20-L22

## Changelog:

[GENERAL] [BREAKING] - Change StyleSheet.flatten return type to reflect its nullability

## Test Plan

Use type tests
