### PR TITLE
rn_codegen Buck: process TS spec files for native components as well

### DIFF
--- a/tools/build_defs/oss/rn_codegen_defs.bzl
+++ b/tools/build_defs/oss/rn_codegen_defs.bzl
@@ -31,7 +31,8 @@ def rn_codegen(
         codegen_components = False,
         codegen_modules = False,
         library_labels = [],
-        src_prefix = ""):
+        src_prefix = "",
+        external_spec_target = None):
     if codegen_modules:
         error_header = "rn_codegen(name=\"{}\")".format(name)
         if not native_module_spec_name:
@@ -43,6 +44,7 @@ def rn_codegen(
         spec_srcs = native.glob(
             [
                 src_prefix + "**/Native*.js",
+                src_prefix + "**/Native*.ts",
             ],
             exclude = [
                 src_prefix + "**/nativeImageSource.js",
@@ -81,6 +83,7 @@ def rn_codegen(
             srcs = native.glob(
                 [
                     src_prefix + "**/*NativeComponent.js",
+                    src_prefix + "**/*NativeComponent.ts",
                 ],
                 exclude = [
                     "**/__*__/**",


### PR DESCRIPTION
Summary:
It already consumes .ts files for native module specs, but not for native components, so let's enable it.

Changelog: [General][Fixed] react-native-codegen Buck support: also process .ts files for native component specs

Reviewed By: cortinico

Differential Revision: D44735387

