### PR TITLE
fix: make sure initialScrollIndex is bigger than 0

### DIFF
--- a/packages/virtualized-lists/Lists/VirtualizedList.js
+++ b/packages/virtualized-lists/Lists/VirtualizedList.js
@@ -616,7 +616,7 @@ class VirtualizedList extends StateSafePureComponent<Props, State> {
         ),
       };
     } else {
-      // If we have a non-zero initialScrollIndex and run this before we've scrolled,
+      // If we have a positive non-zero initialScrollIndex and run this before we've scrolled,
       // we'll wipe out the initialNumToRender rendered elements starting at initialScrollIndex.
       // So let's wait until we've scrolled the view to the right place. And until then,
       // we will trust the initialScrollIndex suggestion.
@@ -627,7 +627,8 @@ class VirtualizedList extends StateSafePureComponent<Props, State> {
       // - initialScrollIndex > 0 AND the end of the list is visible (this handles the case
       //   where the list is shorter than the visible area)
       if (
-        props.initialScrollIndex &&
+        props.initialScrollIndex != null &&
+        props.initialScrollIndex > 0 &&
         !this._scrollMetrics.offset &&
         Math.abs(distanceFromEnd) >= Number.EPSILON
       ) {

--- a/packages/virtualized-lists/Lists/__tests__/__snapshots__/VirtualizedList-test.js.snap
+++ b/packages/virtualized-lists/Lists/__tests__/__snapshots__/VirtualizedList-test.js.snap
@@ -3122,12 +3122,53 @@ exports[`gracefully handles negative initialScrollIndex 1`] = `
       />
     </View>
     <View
-      style={
-        Object {
-          "height": 60,
-        }
-      }
-    />
+      onFocusCapture={[Function]}
+      style={null}
+    >
+      <MockCellItem
+        value={4}
+      />
+    </View>
+    <View
+      onFocusCapture={[Function]}
+      style={null}
+    >
+      <MockCellItem
+        value={5}
+      />
+    </View>
+    <View
+      onFocusCapture={[Function]}
+      style={null}
+    >
+      <MockCellItem
+        value={6}
+      />
+    </View>
+    <View
+      onFocusCapture={[Function]}
+      style={null}
+    >
+      <MockCellItem
+        value={7}
+      />
+    </View>
+    <View
+      onFocusCapture={[Function]}
+      style={null}
+    >
+      <MockCellItem
+        value={8}
+      />
+    </View>
+    <View
+      onFocusCapture={[Function]}
+      style={null}
+    >
+      <MockCellItem
+        value={9}
+      />
+    </View>
   </View>
 </RCTScrollView>
 `;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Hey, 

`adjustCellsAroundViewport` function was checking if `props.initialScrollIndex` is truthy and -1 was returning true. This caused bugs with rendering for tvOS: https://github.com/react-native-tvos/react-native-tvos/pull/485 There are warnings in the code about `initalScrollIndex` being smaller than 0 but this if statement would still allow that. 

## Changelog:

[General] [Fixed] - Make sure initialScrollToIndex is bigger than 0 when adjusting cells

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Pass -1 as initialScrollToIndex. Check that this code is executed. 
