### PR TITLE
Fix occasional failures of triage-issue job

### DIFF
--- a/.github/workflows/addDescriptiveLabels.js
+++ b/.github/workflows/addDescriptiveLabels.js
@@ -37,8 +37,9 @@ module.exports = async (github, context) => {
       labelsToAdd.push(topics[topic]);
     }
   }
-
-  await addLabels(labelsToAdd);
+  if (labelsToAdd.length > 0){
+    await addLabels(labelsToAdd);
+  }
 };
 
 const labelAndroid = 'Platform: Android';

--- a/.github/workflows/addDescriptiveLabels.js
+++ b/.github/workflows/addDescriptiveLabels.js
@@ -37,7 +37,7 @@ module.exports = async (github, context) => {
       labelsToAdd.push(topics[topic]);
     }
   }
-  if (labelsToAdd.length > 0){
+  if (labelsToAdd.length > 0) {
     await addLabels(labelsToAdd);
   }
 };


### PR DESCRIPTION
## Summary:

I added a new step to the triage-issue job last week, to add descriptive labels to issues based on their title. This job has occasionally be failing, [like this](https://github.com/facebook/react-native/actions/runs/4630279135/jobs/8191646900). This happens when no applicable labels are found, and we send up an empty array to the add labels endpoint. Adding an array length check to protect against this case.

## Changelog:
[INTERNAL] [FIXED] - Fixed occasional failures in the issue triage pipeline related to issue labeling


## Test Plan:

Repro run in my repository before the fix: https://github.com/SlyCaptainFlint/react-native/actions/runs/4631843716 (note that the error is the same as in the example failure listed in the description)
And here is a success on the same issue after the fix: https://github.com/SlyCaptainFlint/react-native/actions/runs/4631920441

