### PR TITLE
Comment out unreferenced formal parameter

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModule.h
@@ -120,7 +120,7 @@ class JSI_EXPORT TurboModule : public facebook::jsi::HostObject {
           static_cast<unsigned int>(meta.argCount),
           [this, meta](
               jsi::Runtime &rt,
-              const jsi::Value &/*thisVal*/,
+              [[maybe_unused]] const jsi::Value &*thisVal,
               const jsi::Value *args,
               size_t count) { return meta.invoker(rt, *this, args, count); });
     }

--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModule.h
@@ -120,7 +120,7 @@ class JSI_EXPORT TurboModule : public facebook::jsi::HostObject {
           static_cast<unsigned int>(meta.argCount),
           [this, meta](
               jsi::Runtime &rt,
-              const jsi::Value &thisVal,
+              const jsi::Value &/*thisVal*/,
               const jsi::Value *args,
               size_t count) { return meta.invoker(rt, *this, args, count); });
     }

--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModule.h
@@ -120,7 +120,7 @@ class JSI_EXPORT TurboModule : public facebook::jsi::HostObject {
           static_cast<unsigned int>(meta.argCount),
           [this, meta](
               jsi::Runtime &rt,
-              [[maybe_unused]] const jsi::Value &*thisVal,
+              [[maybe_unused]] const jsi::Value &thisVal,
               const jsi::Value *args,
               size_t count) { return meta.invoker(rt, *this, args, count); });
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Recent windows integration brought in a change where a unreferenced formal parameter was introduced in TurboModule.h. Windows treats with warning as an error, this change comments out the formal parameter name to get rid of the error/warning.

## Changelog:

[GENERAL] [FIXED] - Comment out unreferenced formal parameter

## Test Plan:

Passed Windows testcases
