### PR TITLE
Allow overriding hermes-engine binary location

### DIFF
--- a/packages/react-native/sdks/hermes-engine/hermes-utils.rb
+++ b/packages/react-native/sdks/hermes-engine/hermes-utils.rb
@@ -35,6 +35,8 @@ def compute_hermes_source(build_from_source, hermestag_file, git, version, build
 
     if ENV.has_key?('HERMES_ENGINE_TARBALL_PATH')
         use_tarball(source)
+    elsif ENV.has_key('HERMES_ENGINE_TARBALL_URL')
+        use_exrternal_tarball(source)
     elsif ENV.has_key?('HERMES_COMMIT')
         build_hermes_from_commit(source, git, ENV['HERMES_COMMIT'])
     elsif build_from_source
@@ -58,6 +60,11 @@ def use_tarball(source)
     tarball_path = ENV['HERMES_ENGINE_TARBALL_PATH']
     putsIfPodPresent("[Hermes] Using pre-built Hermes binaries from local path: #{tarball_path}")
     source[:http] = "file://#{tarball_path}"
+end
+
+def use_external_tarball(source)
+    tarball_url = ENV['HERMES_ENGINE_TARBALL_URL']
+    source[:http] = tarball_url
 end
 
 def build_from_tagfile(source, git, hermestag_file)

--- a/packages/react-native/sdks/hermes-engine/hermes-utils.rb
+++ b/packages/react-native/sdks/hermes-engine/hermes-utils.rb
@@ -36,7 +36,7 @@ def compute_hermes_source(build_from_source, hermestag_file, git, version, build
     if ENV.has_key?('HERMES_ENGINE_TARBALL_PATH')
         use_tarball(source)
     elsif ENV.has_key('HERMES_ENGINE_TARBALL_URL')
-        use_exrternal_tarball(source)
+        use_external_tarball(source)
     elsif ENV.has_key?('HERMES_COMMIT')
         build_hermes_from_commit(source, git, ENV['HERMES_COMMIT'])
     elsif build_from_source


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

My organization blocks/proxies MavenCentral to an internal nexus registry. Currently there is no way to use another url to get the Hermes binary from. This change would allow setting that url as an environment variable.

## Changelog:

Adds an environment variable to override default Hermes binary location

## Test Plan
Set environment variable for override, block mavencentral via `/etc/hosts`, successful pod install

tags: [IOS] [ADDED]
