### PR TITLE
Bump TypeScript in template from 4.8.4 to 5.0.4

### DIFF
--- a/packages/react-native/template/package.json
+++ b/packages/react-native/template/package.json
@@ -29,7 +29,7 @@
     "metro-react-native-babel-preset": "0.76.0",
     "prettier": "^2.4.1",
     "react-test-renderer": "18.2.0",
-    "typescript": "4.8.4"
+    "typescript": "5.0.4"
   },
   "engines": {
     "node": ">=16"


### PR DESCRIPTION
## Summary:

https://devblogs.microsoft.com/typescript/announcing-typescript-5-0

## Changelog:

[JavaScript] [Changed] - Bump TypeScript in template from 4.8.4 to 5.0.4

## Test Plan:

Everything builds and runs as expected
