### PR TITLE
rn_codegen: renamed src_prefix to codegen_src_prefix

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -769,23 +769,23 @@ rn_codegen(
     name = "FBReactNativeSpec",
     android_package_name = "com.facebook.fbreact.specs",
     codegen_modules = True,
+    codegen_src_prefix = "packages/react-native/Libraries/",
     ios_assume_nonnull = False,
     library_labels = [
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
     ],
     native_module_spec_name = "FBReactNativeSpec",
-    src_prefix = "packages/react-native/Libraries/",
 )
 
 # TODO: Merge this into FBReactNativeSpec
 rn_codegen(
     name = "FBReactNativeComponentSpec",
     codegen_components = True,
+    codegen_src_prefix = "packages/react-native/Libraries/",
     ios_assume_nonnull = False,
     library_labels = [
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
     ],
-    src_prefix = "packages/react-native/Libraries/",
 )
 
 rn_apple_library(

--- a/tools/build_defs/oss/rn_codegen_defs.bzl
+++ b/tools/build_defs/oss/rn_codegen_defs.bzl
@@ -31,7 +31,7 @@ def rn_codegen(
         codegen_components = False,
         codegen_modules = False,
         library_labels = [],
-        src_prefix = "",
+        codegen_src_prefix = "",
         external_spec_target = None):
     if codegen_modules:
         error_header = "rn_codegen(name=\"{}\")".format(name)
@@ -43,11 +43,11 @@ def rn_codegen(
 
         spec_srcs = native.glob(
             [
-                src_prefix + "**/Native*.js",
-                src_prefix + "**/Native*.ts",
+                codegen_src_prefix + "**/Native*.js",
+                codegen_src_prefix + "**/Native*.ts",
             ],
             exclude = [
-                src_prefix + "**/nativeImageSource.js",
+                codegen_src_prefix + "**/nativeImageSource.js",
                 "**/__*__/**",
             ],
         )
@@ -82,8 +82,8 @@ def rn_codegen(
             name = "codegen_rn_components_schema_{}".format(component_spec_name),
             srcs = native.glob(
                 [
-                    src_prefix + "**/*NativeComponent.js",
-                    src_prefix + "**/*NativeComponent.ts",
+                    codegen_src_prefix + "**/*NativeComponent.js",
+                    codegen_src_prefix + "**/*NativeComponent.ts",
                 ],
                 exclude = [
                     "**/__*__/**",


### PR DESCRIPTION
Summary:
For consistency with internal build rules, rename this kwarg. This will make it easier to keep both internal and external usages consistent.

Changelog: [General][Changed] react-native-codegen: Buck-only: renamed src_prefix kwarg

Differential Revision: D44857745

