### PR TITLE
rn_codegen: define a method to convert package.json codegenConfig into Buck format

### DIFF
--- a/tools/build_defs/oss/rn_codegen_defs.bzl
+++ b/tools/build_defs/oss/rn_codegen_defs.bzl
@@ -99,3 +99,32 @@ def rn_codegen(
             schema_target = ":codegen_rn_components_schema_{}".format(component_spec_name),
             library_labels = library_labels,
         )
+
+# Given the codegenConfig defined inside package.json, convert it to the Buck specific configs.
+# Specification: https://reactnative.dev/docs/next/new-architecture-library-intro#configure-codegen
+def buck_codegen_config_from_package_codegen_config(package_codegen_config):
+    configs = {}
+
+    name = package_codegen_config["name"]
+    android_package_name = "com.facebook.fbreact.specs"
+    if "android" in package_codegen_config:
+        android_config = package_codegen_config["android"]
+        if "javaPackageName" in android_config:
+            # Note: assume Kotlin will use the same package name
+            android_package_name = android_config["javaPackageName"]
+
+    codegen_type = package_codegen_config["type"]
+    if codegen_type == "modules" or codegen_type == "all":
+        configs["codegen_modules"] = True
+        configs["native_module_spec_name"] = name
+        configs["android_package_name"] = android_package_name
+
+    if codegen_type == "components" or codegen_type == "all":
+        configs["codegen_components"] = True
+        configs["native_component_spec_name"] = name
+        configs["android_package_name"] = android_package_name
+
+    js_srcs_dir = package_codegen_config["jsSrcsDir"]
+    configs["codegen_src_prefix"] = (js_srcs_dir + "/") if js_srcs_dir else ""
+
+    return configs


### PR DESCRIPTION
Summary:
Given a codegenConfig definition in a library's package.json, convert it into Buck specific codegen format, as defined by the kwargs of rn_codegen().

Reference:
https://reactnative.dev/docs/next/new-architecture-library-intro#configure-codegen

Changelog: [Internal]

Differential Revision: D44857743

