### PR TITLE
Use FB-specific renderers when running tests in Meta infra

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -9,6 +9,8 @@
 
 'use strict';
 
+const {defaults} = require('jest-config');
+
 module.exports = {
   transform: {
     '^.+\\.(bmp|gif|jpg|jpeg|mp4|png|psd|svg|webp)$':
@@ -24,7 +26,8 @@ module.exports = {
     escapeString: true,
     printBasicPrototype: true,
   },
-  testRegex: '/__tests__/.*-test\\.js$',
+  // This allows running Meta-internal tests with the `-test.fb.js` suffix.
+  testRegex: '/__tests__/.*-test(\\.fb)?\\.js$',
   testPathIgnorePatterns: [
     '/node_modules/',
     '<rootDir>/packages/react-native/template',
@@ -36,6 +39,13 @@ module.exports = {
     defaultPlatform: 'ios',
     platforms: ['ios', 'android'],
   },
+  moduleNameMapper: {
+    // This module is internal to Meta and used by their custom React renderer.
+    // In tests, we can just use a mock.
+    '^ReactNativeInternalFeatureFlags$':
+      '<rootDir>/packages/react-native/jest/ReactNativeInternalFeatureFlagsMock.js',
+  },
+  moduleFileExtensions: ['fb.js'].concat(defaults.moduleFileExtensions),
   unmockedModulePathPatterns: [
     'node_modules/react/',
     'packages/react-native/Libraries/Renderer',

--- a/packages/react-native/jest/ReactNativeInternalFeatureFlagsMock.js
+++ b/packages/react-native/jest/ReactNativeInternalFeatureFlagsMock.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow strict
+ */
+
+'use strict';
+
+module.exports = {};

--- a/packages/react-native/jest/setup.js
+++ b/packages/react-native/jest/setup.js
@@ -374,4 +374,11 @@ jest
       __esModule: true,
       default: Component,
     };
+  })
+  // In tests, we can use the default version instead of the one using
+  // dependency injection.
+  .mock('../Libraries/ReactNative/RendererProxy', () => {
+    return jest.requireActual(
+      '../Libraries/ReactNative/RendererImplementation',
+    );
   });


### PR DESCRIPTION
Summary:
This diffs allows having Meta-specific tests and modules that are only used when running tests in Meta's infra. Meta-specific modules aren't synced to Github, so the OSS versions will be used when running tests on Github.

This is needed because we recently some files from React to React Native, including a test that now uses the `ReactFabric` module to test the behavior of public instances in React Native. This module is always using the OSS version of the renderer, but at Meta we have a custom version that's being ignored in tests.

Changelog: [internal]

Differential Revision: D44874631

