### PR TITLE
Remove reference to non existing butter/mutex.h

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/timeline/Timeline.h
+++ b/packages/react-native/ReactCommon/react/renderer/timeline/Timeline.h
@@ -8,9 +8,8 @@
 #pragma once
 
 #include <memory>
+#include <mutex>
 #include <vector>
-
-#include <butter/mutex.h>
 
 #include <react/renderer/core/ReactPrimitives.h>
 #include <react/renderer/timeline/TimelineSnapshot.h>


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Removed in https://github.com/facebook/react-native/commit/e665a0f9952a7852c5506bf334452f8156991ad2

Differential Revision: D44901760

