### PR TITLE
Make standard colors constexpr

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/graphics/Color.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Color.cpp
@@ -18,37 +18,21 @@ bool isColorMeaningful(SharedColor const &color) noexcept {
 }
 
 SharedColor colorFromComponents(ColorComponents components) {
-  float ratio = 255;
-  return {
+  const float ratio = 255;
+  return SharedColor(
       ((int)round(components.alpha * ratio) & 0xff) << 24 |
       ((int)round(components.red * ratio) & 0xff) << 16 |
       ((int)round(components.green * ratio) & 0xff) << 8 |
-      ((int)round(components.blue * ratio) & 0xff)};
+      ((int)round(components.blue * ratio) & 0xff));
 }
 
-ColorComponents colorComponentsFromColor(SharedColor sharedColor) {
-  float ratio = 255;
-  Color color = *sharedColor;
+ColorComponents colorComponentsFromColor(SharedColor color) {
+  const float ratio = 255;
   return ColorComponents{
-      (float)((color >> 16) & 0xff) / ratio,
-      (float)((color >> 8) & 0xff) / ratio,
-      (float)((color >> 0) & 0xff) / ratio,
-      (float)((color >> 24) & 0xff) / ratio};
-}
-
-SharedColor clearColor() {
-  static SharedColor color = colorFromComponents(ColorComponents{0, 0, 0, 0});
-  return color;
-}
-
-SharedColor blackColor() {
-  static SharedColor color = colorFromComponents(ColorComponents{0, 0, 0, 1});
-  return color;
-}
-
-SharedColor whiteColor() {
-  static SharedColor color = colorFromComponents(ColorComponents{1, 1, 1, 1});
-  return color;
+      (float)((*color >> 16) & 0xff) / ratio,
+      (float)((*color >> 8) & 0xff) / ratio,
+      (float)((*color >> 0) & 0xff) / ratio,
+      (float)((*color >> 24) & 0xff) / ratio};
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/graphics/Color.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Color.h
@@ -15,23 +15,20 @@
 
 namespace facebook::react {
 
-using Color = int32_t;
-
 /*
- * On Android, a color can be represented as 32 bits integer, so there is no
- * need to instantiate complex color objects and then pass them as shared
- * pointers. Hense instead of using shared_ptr, we use a simple wrapper class
- * which provides a pointer-like interface.
+ * Represent colors as a 32-bit integer, which is wrapped here to provide
+ * a pointer-like interface, instead of passing it around as a shared pointer.
  */
 class SharedColor {
+  using ColorT = uint32_t;
+
  public:
-  static const Color UndefinedColor = std::numeric_limits<Color>::max();
+  static constexpr ColorT UndefinedColor = std::numeric_limits<ColorT>::max();
 
-  SharedColor() : color_(UndefinedColor) {}
+  constexpr SharedColor() : color_(UndefinedColor) {}
+  explicit constexpr SharedColor(ColorT color) : color_(color) {}
 
-  SharedColor(Color color) : color_(color) {}
-
-  Color operator*() const {
+  ColorT operator*() const {
     return color_;
   }
 
@@ -48,16 +45,23 @@ class SharedColor {
   }
 
  private:
-  Color color_;
+  ColorT color_;
 };
 
 bool isColorMeaningful(SharedColor const &color) noexcept;
+
 SharedColor colorFromComponents(ColorComponents components);
 ColorComponents colorComponentsFromColor(SharedColor color);
 
-SharedColor clearColor();
-SharedColor blackColor();
-SharedColor whiteColor();
+constexpr SharedColor clearColor() {
+  return SharedColor(0x00000000);
+}
+constexpr SharedColor blackColor() {
+  return SharedColor(0xFF000000);
+}
+constexpr SharedColor whiteColor() {
+  return SharedColor(0xFFFFFFFF);
+}
 
 } // namespace facebook::react
 


### PR DESCRIPTION
Summary:
We should make these constructors fully visible to the caller, so they can be inlined to simple ints instead of method calls. `static` fields have some overheads (eg locks) which we really shouldn't need to bother with here since we're representing things with just an int.

Changelog: [Internal]

Differential Revision: D44884979

