### PR TITLE
Remove unused View foregroundColor

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.h
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.h
@@ -49,12 +49,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, nullable) NSString *nativeId;
 
 /**
- * Provides access to `foregroundColor` prop of the component.
- * Must be used by subclasses only.
- */
-@property (nonatomic, strong, nullable) UIColor *foregroundColor;
-
-/**
  * Returns the object - usually (sub)view - which represents this
  * component view in terms of accessibility.
  * All accessibility properties will be applied to this object.

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -205,11 +205,6 @@ using namespace facebook::react;
     needsInvalidateLayer = YES;
   }
 
-  // `foregroundColor`
-  if (oldViewProps.foregroundColor != newViewProps.foregroundColor) {
-    self.foregroundColor = RCTUIColorFromSharedColor(newViewProps.foregroundColor);
-  }
-
   // `shadowColor`
   if (oldViewProps.shadowColor != newViewProps.shadowColor) {
     CGColorRef shadowColor = RCTCreateCGColorRefFromSharedColor(newViewProps.shadowColor);

--- a/packages/react-native/ReactCommon/react/renderer/components/view/ViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ViewProps.cpp
@@ -33,15 +33,6 @@ ViewProps::ViewProps(
                                                        "opacity",
                                                        sourceProps.opacity,
                                                        (Float)1.0)),
-      foregroundColor(
-          CoreFeatures::enablePropIteratorSetter
-              ? sourceProps.foregroundColor
-              : convertRawProp(
-                    context,
-                    rawProps,
-                    "foregroundColor",
-                    sourceProps.foregroundColor,
-                    {})),
       backgroundColor(
           CoreFeatures::enablePropIteratorSetter
               ? sourceProps.backgroundColor
@@ -295,7 +286,6 @@ void ViewProps::setProp(
 
   switch (hash) {
     RAW_SET_PROP_SWITCH_CASE_BASIC(opacity);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(foregroundColor);
     RAW_SET_PROP_SWITCH_CASE_BASIC(backgroundColor);
     RAW_SET_PROP_SWITCH_CASE_BASIC(shadowColor);
     RAW_SET_PROP_SWITCH_CASE_BASIC(shadowOffset);
@@ -443,10 +433,6 @@ SharedDebugStringConvertibleList ViewProps::getDebugProps() const {
       SharedDebugStringConvertibleList{
           debugStringConvertibleItem(
               "opacity", opacity, defaultViewProps.opacity),
-          debugStringConvertibleItem(
-              "foregroundColor",
-              foregroundColor,
-              defaultViewProps.foregroundColor),
           debugStringConvertibleItem(
               "backgroundColor",
               backgroundColor,

--- a/packages/react-native/ReactCommon/react/renderer/components/view/ViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ViewProps.h
@@ -49,7 +49,6 @@ class ViewProps : public YogaStylableProps, public AccessibilityProps {
 
   // Color
   Float opacity{1.0};
-  SharedColor foregroundColor{};
   SharedColor backgroundColor{};
 
   // Borders

--- a/packages/react-native/ReactCommon/react/renderer/components/view/ViewPropsMapBuffer.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ViewPropsMapBuffer.cpp
@@ -56,10 +56,6 @@ void ViewProps::propsDiffMapBuffer(
     builder.putInt(VP_BG_COLOR, toAndroidRepr(newProps.backgroundColor));
   }
 
-  if (oldProps.foregroundColor != newProps.foregroundColor) {
-    builder.putInt(VP_FG_COLOR, toAndroidRepr(newProps.foregroundColor));
-  }
-
   if (oldProps.borderCurves != newProps.borderCurves) {
     builder.putMapBuffer(
         VP_BORDER_CURVES, convertCascadedCorners(newProps.borderCurves));

--- a/packages/react-native/ReactCommon/react/renderer/components/view/ViewPropsMapBuffer.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ViewPropsMapBuffer.h
@@ -45,7 +45,6 @@ constexpr MapBuffer::Key VP_POINTER_OVER_CAPTURE = 42;
 constexpr MapBuffer::Key VP_POINTER_OUT = 43;
 constexpr MapBuffer::Key VP_POINTER_OUT_CAPTURE = 44;
 constexpr MapBuffer::Key VP_BORDER_CURVES = 45;
-constexpr MapBuffer::Key VP_FG_COLOR = 46;
 
 // Yoga values
 constexpr MapBuffer::Key YG_BORDER_WIDTH = 100;

--- a/packages/react-native/ReactCommon/react/renderer/components/view/ViewShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ViewShadowNode.cpp
@@ -62,7 +62,6 @@ void ViewShadowNode::initialize() noexcept {
 
   bool formsView = formsStackingContext ||
       isColorMeaningful(viewProps.backgroundColor) ||
-      isColorMeaningful(viewProps.foregroundColor) ||
       !(viewProps.yogaStyle.border() == YGStyle::Edges{}) ||
       !viewProps.testId.empty();
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/tests/ViewTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/tests/ViewTest.cpp
@@ -114,7 +114,6 @@ TEST_F(YogaDirtyFlagTest, changingNonLayoutSubPropsMustNotDirtyYogaNode) {
         auto &props = *viewProps;
 
         props.nativeId = "some new native Id";
-        props.foregroundColor = whiteColor();
         props.backgroundColor = blackColor();
         props.opacity = props.opacity + 0.042;
         props.zIndex = props.zIndex.value_or(0) + 42;

--- a/packages/react-native/ReactCommon/react/renderer/mounting/tests/StackingContextTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/tests/StackingContextTest.cpp
@@ -402,7 +402,7 @@ TEST_F(StackingContextTest, somePropsForceViewsToMaterialize2) {
   //  │ ┃ ┃                            ┃ ┃ │    │ ┗━━━━━━━━━━━━━━━━━━━━━━━━━┛ │
   //  │ ┃ ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛ ┃ │    │ ┏━ BBA (tag: 7) ━━━━━━━━━━┓ │
   //  │ ┃ ┏━ BB (tag: 6) ━━━━━━━━━━━━━━┓ ┃ │    │ ┃ #FormsView              ┃ │
-  //  │ ┃ ┃ foregroundColor: black;    ┃ ┃ │    │ ┃ #FormsStackingContext   ┃ │
+  //  │ ┃ ┃ backgroundColor: black;    ┃ ┃ │    │ ┃ #FormsStackingContext   ┃ │
   //  │ ┃ ┃                            ┃ ┃ │━━━▶│ ┃                         ┃ │
   //  │ ┃ ┃                            ┃ ┃ │    │ ┗━━━━━━━━━━━━━━━━━━━━━━━━━┛ │
   //  │ ┃ ┃                            ┃ ┃ │    │ ┏━ BBB (tag: 8) ━━━━━━━━━━┓ │
@@ -448,7 +448,7 @@ TEST_F(StackingContextTest, somePropsForceViewsToMaterialize2) {
       nodeBA_, [](ViewProps &props) { props.nativeId = "42"; });
 
   mutateViewShadowNodeProps_(
-      nodeBB_, [](ViewProps &props) { props.foregroundColor = blackColor(); });
+      nodeBB_, [](ViewProps &props) { props.backgroundColor = blackColor(); });
 
   mutateViewShadowNodeProps_(nodeBBA_, [](ViewProps &props) {
     props.transform = Transform::Scale(2, 2, 2);

--- a/packages/react-native/ReactCommon/react/test_utils/shadowTreeGeneration.h
+++ b/packages/react-native/ReactCommon/react/test_utils/shadowTreeGeneration.h
@@ -142,11 +142,6 @@ static inline ShadowNode::Unshared messWithLayoutableOnlyFlag(
   }
 
   if (entropy.random<bool>(0.1)) {
-    viewProps.foregroundColor =
-        entropy.random<bool>() ? SharedColor() : blackColor();
-  }
-
-  if (entropy.random<bool>(0.1)) {
     viewProps.shadowColor =
         entropy.random<bool>() ? SharedColor() : blackColor();
   }
@@ -195,7 +190,6 @@ static inline ShadowNode::Unshared messWithNodeFlattenednessFlags(
     viewProps.nativeId = "";
     viewProps.collapsable = true;
     viewProps.backgroundColor = SharedColor();
-    viewProps.foregroundColor = SharedColor();
     viewProps.shadowColor = SharedColor();
     viewProps.accessible = false;
     viewProps.zIndex = {};
@@ -205,7 +199,6 @@ static inline ShadowNode::Unshared messWithNodeFlattenednessFlags(
   } else {
     viewProps.nativeId = "42";
     viewProps.backgroundColor = whiteColor();
-    viewProps.foregroundColor = blackColor();
     viewProps.shadowColor = blackColor();
     viewProps.accessible = true;
     viewProps.zIndex = {entropy.random<int>()};


### PR DESCRIPTION
Summary: This property was never used as TextAttributes has its own foreground color attribute.

Differential Revision: D44884978

Changelog: [Internal]
