### PR TITLE
chore: specify `eol` config in `.prettierrc` as `lf`

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -4,5 +4,6 @@
   "bracketSpacing": false,
   "requirePragma": true,
   "singleQuote": true,
-  "trailingComma": "all"
+  "trailingComma": "all",
+  "endOfLine": "lf"
 }


### PR DESCRIPTION
## Summary:
- Although we have `.editorconfig`, on Windows machines most of the times the IDEs default to `CRLF` as default EOL config
- we've already specified the `eol` config as `lf` in `.editorconfig` at root level
- this diff syncs same config for prettier as well

>NOTE: Using `[skip ci]` as it's non code change and is tested for formatting.

## Changelog:

[GENERAL] [CHANGED] - Specify `eol` config in `.prettierrc` as `lf` at the root level

## Test Plan:

- `yarn run format`  --> _nothing should change_
