### PR TITLE
Cache Spannables during rendering of Text

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
@@ -80,6 +80,9 @@ public class ReactFeatureFlags {
 
   public static boolean dispatchPointerEvents = false;
 
+  /** Feature Flag to enable a cache of Spannable objects used by TextLayoutManagerMapBuffer */
+  public static boolean enableTextSpannableCache = false;
+
   /** Feature Flag to enable the pending event queue in fabric before mounting views */
   public static boolean enableFabricPendingEventQueue = false;
 


### PR DESCRIPTION
Summary:
Create cache to hold Spannables during measurment and rendering of Text

We used to have a similar cache in the past, it was removed because it seemed not have an implact.
We are incorporating this again to measure while rendering 1000s of text components

changelog: [internal] internal

Differential Revision: D44918981

