### PR TITLE
react-native | Fix inconsistent-missing-destructor-override warnings

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
@@ -91,8 +91,6 @@ class ShadowNode : public Sealable,
   ShadowNode(ShadowNode const &shadowNode) noexcept = delete;
   ShadowNode &operator=(ShadowNode const &other) noexcept = delete;
 
-  virtual ~ShadowNode() = default;
-
   /*
    * Clones the shadow node using stored `cloneFunction`.
    */

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.h
@@ -40,7 +40,7 @@ class Scheduler final : public UIManagerDelegate {
       SchedulerToolbox const &schedulerToolbox,
       UIManagerAnimationDelegate *animationDelegate,
       SchedulerDelegate *delegate);
-  ~Scheduler();
+  ~Scheduler() override;
 
 #pragma mark - Surface Management
 

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.h
@@ -38,7 +38,7 @@ class UIManager final : public ShadowTreeDelegate {
       BackgroundExecutor backgroundExecutor,
       ContextContainer::Shared contextContainer);
 
-  ~UIManager();
+  ~UIManager() override;
 
   void setComponentDescriptorRegistry(
       const SharedComponentDescriptorRegistry &componentDescriptorRegistry);

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.h
@@ -37,7 +37,7 @@ class UIManagerBinding : public jsi::HostObject {
 
   UIManagerBinding(std::shared_ptr<UIManager> uiManager);
 
-  ~UIManagerBinding();
+  ~UIManagerBinding() override;
 
   jsi::Value getInspectorDataForInstance(
       jsi::Runtime &runtime,


### PR DESCRIPTION
Summary:
changelog: [internal]

Fixing inconsistent use of 'override' in destructors.

Differential Revision: D44942615

