### PR TITLE
Add support for basic union types in TurboModules

### DIFF
--- a/packages/react-native-codegen/src/CodegenSchema.d.ts
+++ b/packages/react-native-codegen/src/CodegenSchema.d.ts
@@ -306,11 +306,14 @@ export interface NativeModulePromiseTypeAnnotation {
 export type UnionTypeAnnotationMemberType =
   | 'NumberTypeAnnotation'
   | 'ObjectTypeAnnotation'
-  | 'StringTypeAnnotation';
+  | 'StringTypeAnnotation'
+  | 'GenericObjectTypeAnnotation';
 
 export interface NativeModuleUnionTypeAnnotation {
   readonly type: 'UnionTypeAnnotation';
-  readonly memberType: UnionTypeAnnotationMemberType;
+  readonly memberType:
+    | UnionTypeAnnotationMemberType
+    | UnionTypeAnnotationMemberType[];
 }
 
 export interface NativeModuleMixedTypeAnnotation {
@@ -352,4 +355,3 @@ export type NativeModuleReturnOnlyTypeAnnotation =
   | NativeModuleFunctionTypeAnnotation
   | NativeModulePromiseTypeAnnotation
   | VoidTypeAnnotation;
-

--- a/packages/react-native-codegen/src/CodegenSchema.js
+++ b/packages/react-native-codegen/src/CodegenSchema.js
@@ -338,11 +338,14 @@ export type NativeModulePromiseTypeAnnotation = $ReadOnly<{
 export type UnionTypeAnnotationMemberType =
   | 'NumberTypeAnnotation'
   | 'ObjectTypeAnnotation'
-  | 'StringTypeAnnotation';
+  | 'StringTypeAnnotation'
+  | 'GenericObjectTypeAnnotation';
 
 export type NativeModuleUnionTypeAnnotation = $ReadOnly<{
   type: 'UnionTypeAnnotation',
-  memberType: UnionTypeAnnotationMemberType,
+  memberType:
+    | UnionTypeAnnotationMemberType
+    | $ReadOnlyArray<UnionTypeAnnotationMemberType>,
 }>;
 
 export type NativeModuleMixedTypeAnnotation = $ReadOnly<{

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleCpp.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleCpp.js
@@ -186,10 +186,20 @@ function serializeArg(
     case 'GenericObjectTypeAnnotation':
       return wrap(val => `${val}.asObject(rt)`);
     case 'UnionTypeAnnotation':
+      if (Array.isArray(realTypeAnnotation.memberType)) {
+        // TODO: handle the union properly
+        throw new Error(
+          `Unsupported union member type for param  "${
+            arg.name
+          }, found: [${realTypeAnnotation.memberType.join(', ')}]"`,
+        );
+      }
+
       switch (typeAnnotation.memberType) {
         case 'NumberTypeAnnotation':
           return wrap(val => `${val}.asNumber()`);
         case 'ObjectTypeAnnotation':
+        case 'GenericObjectTypeAnnotation':
           return wrap(val => `${val}.asObject(rt)`);
         case 'StringTypeAnnotation':
           return wrap(val => `${val}.asString(rt)`);

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleJavaSpec.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleJavaSpec.js
@@ -157,10 +157,19 @@ function translateFunctionParamToJavaType(
           throw new Error(createErrorMessage(realTypeAnnotation.type));
       }
     case 'UnionTypeAnnotation':
+      if (Array.isArray(realTypeAnnotation.memberType)) {
+        // TODO: handle the union properly
+        throw new Error(
+          `Unsupported union member returning value, found: [${realTypeAnnotation.memberType.join(
+            ', ',
+          )}]"`,
+        );
+      }
       switch (typeAnnotation.memberType) {
         case 'NumberTypeAnnotation':
           return wrapNullable('double', 'Double');
         case 'ObjectTypeAnnotation':
+        case 'GenericObjectTypeAnnotation':
           imports.add('com.facebook.react.bridge.ReadableMap');
           return wrapNullable('ReadableMap');
         case 'StringTypeAnnotation':
@@ -249,6 +258,14 @@ function translateFunctionReturnTypeToJavaType(
           throw new Error(createErrorMessage(realTypeAnnotation.type));
       }
     case 'UnionTypeAnnotation':
+      if (Array.isArray(realTypeAnnotation.memberType)) {
+        // TODO: handle the union type properly
+        throw new Error(
+          `Unsupported union member returning value, found: [${realTypeAnnotation.memberType.join(
+            ', ',
+          )}]"`,
+        );
+      }
       switch (realTypeAnnotation.memberType) {
         case 'NumberTypeAnnotation':
           return wrapNullable('double', 'Double');
@@ -325,6 +342,14 @@ function getFalsyReturnStatementFromReturnType(
           throw new Error(createErrorMessage(realTypeAnnotation.type));
       }
     case 'UnionTypeAnnotation':
+      if (Array.isArray(realTypeAnnotation.memberType)) {
+        // TODO: handle the union type properly
+        throw new Error(
+          `Unsupported union member returning value, found: [${realTypeAnnotation.memberType.join(
+            ',',
+          )}]"`,
+        );
+      }
       switch (realTypeAnnotation.memberType) {
         case 'NumberTypeAnnotation':
           return nullable ? 'return null;' : 'return 0;';

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleJniCpp.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleJniCpp.js
@@ -164,10 +164,19 @@ function translateReturnTypeToKind(
           );
       }
     case 'UnionTypeAnnotation':
+      if (Array.isArray(realTypeAnnotation.memberType)) {
+        // TODO: handle the array union type properly
+        throw new Error(
+          `Unsupported union member returning value, found: [${realTypeAnnotation.memberType.join(
+            ', ',
+          )}]"`,
+        );
+      }
       switch (typeAnnotation.memberType) {
         case 'NumberTypeAnnotation':
           return 'NumberKind';
         case 'ObjectTypeAnnotation':
+        case 'GenericObjectTypeAnnotation':
           return 'ObjectKind';
         case 'StringTypeAnnotation':
           return 'StringKind';
@@ -243,6 +252,14 @@ function translateParamTypeToJniType(
           );
       }
     case 'UnionTypeAnnotation':
+      if (Array.isArray(realTypeAnnotation.memberType)) {
+        // TODO handle the array type properly
+        throw new Error(
+          `Unsupported union prop value, found: [${realTypeAnnotation.memberType.join(
+            ', ',
+          )}]"`,
+        );
+      }
       switch (typeAnnotation.memberType) {
         case 'NumberTypeAnnotation':
           return !isRequired ? 'Ljava/lang/Double;' : 'D';
@@ -319,6 +336,15 @@ function translateReturnTypeToJniType(
           );
       }
     case 'UnionTypeAnnotation':
+      if (Array.isArray(realTypeAnnotation.memberType)) {
+        // TODO: handle the union type properly
+        throw new Error(
+          `Unsupported union member type, found: [${realTypeAnnotation.memberType.join(
+            ', ',
+          )}]"`,
+        );
+      }
+
       switch (typeAnnotation.memberType) {
         case 'NumberTypeAnnotation':
           return nullable ? 'Ljava/lang/Double;' : 'D';

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/serializeMethod.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/serializeMethod.js
@@ -358,10 +358,20 @@ function getReturnObjCType(
           );
       }
     case 'UnionTypeAnnotation':
+      if (Array.isArray(typeAnnotation.memberType)) {
+        // TODO: handle the array properly
+        throw new Error(
+          `Unsupported union return type for ${methodName}, found: [${typeAnnotation.memberType.join(
+            ', ',
+          )}]"`,
+        );
+      }
+
       switch (typeAnnotation.memberType) {
         case 'NumberTypeAnnotation':
           return wrapIntoNullableIfNeeded('NSNumber *');
         case 'ObjectTypeAnnotation':
+        case 'GenericObjectTypeAnnotation':
           return wrapIntoNullableIfNeeded('NSDictionary *');
         case 'StringTypeAnnotation':
           // TODO: Can NSString * returns not be _Nullable?

--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-primitives-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-primitives-test.js
@@ -11,8 +11,6 @@
 
 'use-strict';
 
-import type {UnionTypeAnnotationMemberType} from '../../CodegenSchema';
-
 const {
   emitArrayType,
   emitBoolean,
@@ -36,7 +34,6 @@ const {
 } = require('../parsers-primitives.js');
 const {MockedParser} = require('../parserMock');
 const {emitUnion} = require('../parsers-primitives');
-const {UnsupportedUnionTypeAnnotationParserError} = require('../errors');
 const {FlowParser} = require('../flow/parser');
 const {TypeScriptParser} = require('../typescript/parser');
 
@@ -813,49 +810,6 @@ describe('emitUnion', () => {
         });
       });
     });
-
-    describe('when members type is mixed', () => {
-      const typeAnnotation = {
-        type: 'UnionTypeAnnotation',
-        types: [
-          {type: 'NumberLiteralTypeAnnotation'},
-          {type: 'StringLiteralTypeAnnotation'},
-          {type: 'ObjectTypeAnnotation'},
-        ],
-      };
-      const unionTypes: UnionTypeAnnotationMemberType[] = [
-        'NumberTypeAnnotation',
-        'StringTypeAnnotation',
-        'ObjectTypeAnnotation',
-      ];
-      describe('when nullable is true', () => {
-        it('throws an excpetion', () => {
-          const expected = new UnsupportedUnionTypeAnnotationParserError(
-            hasteModuleName,
-            typeAnnotation,
-            unionTypes,
-          );
-
-          expect(() => {
-            emitUnion(true, hasteModuleName, typeAnnotation, flowParser);
-          }).toThrow(expected);
-        });
-      });
-
-      describe('when nullable is false', () => {
-        it('throws an excpetion', () => {
-          const expected = new UnsupportedUnionTypeAnnotationParserError(
-            hasteModuleName,
-            typeAnnotation,
-            unionTypes,
-          );
-
-          expect(() => {
-            emitUnion(false, hasteModuleName, typeAnnotation, flowParser);
-          }).toThrow(expected);
-        });
-      });
-    });
   });
 
   describe('when language is typescript', () => {
@@ -1015,57 +969,6 @@ describe('emitUnion', () => {
           };
 
           expect(result).toEqual(expected);
-        });
-      });
-    });
-
-    describe('when members type is mixed', () => {
-      const typeAnnotation = {
-        type: 'TSUnionType',
-        types: [
-          {
-            type: 'TSLiteralType',
-            literal: {type: 'NumericLiteral'},
-          },
-          {
-            type: 'TSLiteralType',
-            literal: {type: 'StringLiteral'},
-          },
-          {
-            type: 'TSLiteralType',
-          },
-        ],
-      };
-      const unionTypes = [
-        'NumberTypeAnnotation',
-        'StringTypeAnnotation',
-        'ObjectTypeAnnotation',
-      ];
-      describe('when nullable is true', () => {
-        it('throws an excpetion', () => {
-          const expected = new UnsupportedUnionTypeAnnotationParserError(
-            hasteModuleName,
-            typeAnnotation,
-            unionTypes,
-          );
-
-          expect(() => {
-            emitUnion(true, hasteModuleName, typeAnnotation, typeScriptParser);
-          }).toThrow(expected);
-        });
-      });
-
-      describe('when nullable is false', () => {
-        it('throws an excpetion', () => {
-          const expected = new UnsupportedUnionTypeAnnotationParserError(
-            hasteModuleName,
-            typeAnnotation,
-            unionTypes,
-          );
-
-          expect(() => {
-            emitUnion(false, hasteModuleName, typeAnnotation, typeScriptParser);
-          }).toThrow(expected);
         });
       });
     });

--- a/packages/react-native-codegen/src/parsers/flow/modules/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__test_fixtures__/fixtures.js
@@ -774,10 +774,37 @@ export interface Spec extends TurboModule {
   returnObjectArray(): Promise<Array<Object>>;
   returnNullableNumber(): Promise<number | null>;
   returnEmpty(): Promise<empty>;
-  returnUnsupportedIndex(): Promise<{ [string]: 'authorized' | 'denied' | 'undetermined' | true | false }>;
-  returnSupportedIndex(): Promise<{ [string]: CustomObject }>;
+  returnHeterogeneousIndex(): Promise<{ [string]: 'authorized' | 'denied' | 'undetermined' | true | false }>;
+  returnHomogeneousIndex(): Promise<{ [string]: CustomObject }>;
   returnEnum() : Promise<Season>;
   returnObject() : Promise<CustomObject>;
+}
+
+export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+`;
+
+const UNION_WITH_DIFFERENT_TYPES = `
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+'use strict';
+
+import type {TurboModule} from '../RCTExport';
+import * as TurboModuleRegistry from '../TurboModuleRegistry';
+
+type MyObject = {
+  aNumber: number,
+};
+
+export interface Spec extends TurboModule {
+  returnUnion(param: string | number | { astring: string } | MyObject): string | number | { aString: string } | MyObject
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
@@ -809,4 +836,5 @@ module.exports = {
   IOS_ONLY_NATIVE_MODULE,
   CXX_ONLY_NATIVE_MODULE,
   PROMISE_WITH_COMMONLY_USED_TYPES,
+  UNION_WITH_DIFFERENT_TYPES,
 };

--- a/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap
@@ -2147,18 +2147,21 @@ exports[`RN Codegen Flow Parser can generate fixture PROMISE_WITH_COMMONLY_USED_
             }
           },
           {
-            'name': 'returnUnsupportedIndex',
+            'name': 'returnHeterogeneousIndex',
             'optional': false,
             'typeAnnotation': {
               'type': 'FunctionTypeAnnotation',
               'returnTypeAnnotation': {
-                'type': 'PromiseTypeAnnotation'
+                'type': 'PromiseTypeAnnotation',
+                'elementType': {
+                  'type': 'GenericObjectTypeAnnotation'
+                }
               },
               'params': []
             }
           },
           {
-            'name': 'returnSupportedIndex',
+            'name': 'returnHomogeneousIndex',
             'optional': false,
             'typeAnnotation': {
               'type': 'FunctionTypeAnnotation',
@@ -2199,6 +2202,54 @@ exports[`RN Codegen Flow Parser can generate fixture PROMISE_WITH_COMMONLY_USED_
                 }
               },
               'params': []
+            }
+          }
+        ]
+      },
+      'moduleName': 'SampleTurboModule'
+    }
+  }
+}"
+`;
+
+exports[`RN Codegen Flow Parser can generate fixture UNION_WITH_DIFFERENT_TYPES 1`] = `
+"{
+  'modules': {
+    'NativeSampleTurboModule': {
+      'type': 'NativeModule',
+      'aliasMap': {},
+      'enumMap': {},
+      'spec': {
+        'properties': [
+          {
+            'name': 'returnUnion',
+            'optional': false,
+            'typeAnnotation': {
+              'type': 'FunctionTypeAnnotation',
+              'returnTypeAnnotation': {
+                'type': 'UnionTypeAnnotation',
+                'memberType': [
+                  'StringTypeAnnotation',
+                  'NumberTypeAnnotation',
+                  'ObjectTypeAnnotation',
+                  'GenericObjectTypeAnnotation'
+                ]
+              },
+              'params': [
+                {
+                  'name': 'param',
+                  'optional': false,
+                  'typeAnnotation': {
+                    'type': 'UnionTypeAnnotation',
+                    'memberType': [
+                      'StringTypeAnnotation',
+                      'NumberTypeAnnotation',
+                      'ObjectTypeAnnotation',
+                      'GenericObjectTypeAnnotation'
+                    ]
+                  }
+                }
+              ]
             }
           }
         ]

--- a/packages/react-native-codegen/src/parsers/flow/parser.js
+++ b/packages/react-native-codegen/src/parsers/flow/parser.js
@@ -85,7 +85,8 @@ class FlowParser implements Parser {
     const remapLiteral = (item: $FlowFixMe) => {
       return item.type
         .replace('NumberLiteralTypeAnnotation', 'NumberTypeAnnotation')
-        .replace('StringLiteralTypeAnnotation', 'StringTypeAnnotation');
+        .replace('StringLiteralTypeAnnotation', 'StringTypeAnnotation')
+        .replace('GenericTypeAnnotation', 'GenericObjectTypeAnnotation');
     };
 
     return [...new Set(membersTypes.map(remapLiteral))];

--- a/packages/react-native-codegen/src/parsers/parsers-primitives.js
+++ b/packages/react-native-codegen/src/parsers/parsers-primitives.js
@@ -337,8 +337,10 @@ function emitUnion(
     typeAnnotation.types,
   );
 
-  // Only support unionTypes of the same kind
-  if (unionTypes.length > 1) {
+  if (
+    unionTypes.length > 1 &&
+    unionTypes.indexOf('NullLiteralTypeAnnotation') > -1 //discard nullables
+  ) {
     throw new UnsupportedUnionTypeAnnotationParserError(
       hasteModuleName,
       typeAnnotation,
@@ -348,7 +350,7 @@ function emitUnion(
 
   return wrapNullable(nullable, {
     type: 'UnionTypeAnnotation',
-    memberType: unionTypes[0],
+    memberType: unionTypes.length === 1 ? unionTypes[0] : unionTypes,
   });
 }
 

--- a/packages/react-native-codegen/src/parsers/typescript/modules/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/__test_fixtures__/fixtures.js
@@ -839,6 +839,30 @@ export default TurboModuleRegistry.getEnforcing<Spec>(
 );
 `;
 
+const UNION_WITH_DIFFERENT_TYPES = `
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+import type {TurboModule} from 'react-native/Libraries/TurboModule/RCTExport';
+import * as TurboModuleRegistry from 'react-native/Libraries/TurboModule/TurboModuleRegistry';
+
+type MyObject = {
+  aNumber: number,
+};
+
+export interface Spec extends TurboModule {
+  returnUnion(param: string | number | { astring: string } | MyObject): string | number | { aString: string } | MyObject
+}
+
+export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+`;
+
 module.exports = {
   NATIVE_MODULE_WITH_OBJECT_WITH_OBJECT_DEFINED_IN_FILE_AS_PROPERTY,
   NATIVE_MODULE_WITH_ARRAY_WITH_UNION_AND_TOUPLE,
@@ -870,4 +894,5 @@ module.exports = {
   ANDROID_ONLY_NATIVE_MODULE,
   IOS_ONLY_NATIVE_MODULE,
   CXX_ONLY_NATIVE_MODULE,
+  UNION_WITH_DIFFERENT_TYPES,
 };

--- a/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/__snapshots__/typescript-module-parser-snapshot-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/__snapshots__/typescript-module-parser-snapshot-test.js.snap
@@ -2515,3 +2515,51 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_UN
   }
 }"
 `;
+
+exports[`RN Codegen TypeScript Parser can generate fixture UNION_WITH_DIFFERENT_TYPES 1`] = `
+"{
+  'modules': {
+    'NativeSampleTurboModule': {
+      'type': 'NativeModule',
+      'aliasMap': {},
+      'enumMap': {},
+      'spec': {
+        'properties': [
+          {
+            'name': 'returnUnion',
+            'optional': false,
+            'typeAnnotation': {
+              'type': 'FunctionTypeAnnotation',
+              'returnTypeAnnotation': {
+                'type': 'UnionTypeAnnotation',
+                'memberType': [
+                  'StringTypeAnnotation',
+                  'NumberTypeAnnotation',
+                  'ObjectTypeAnnotation',
+                  'GenericObjectTypeAnnotation'
+                ]
+              },
+              'params': [
+                {
+                  'name': 'param',
+                  'optional': false,
+                  'typeAnnotation': {
+                    'type': 'UnionTypeAnnotation',
+                    'memberType': [
+                      'StringTypeAnnotation',
+                      'NumberTypeAnnotation',
+                      'ObjectTypeAnnotation',
+                      'GenericObjectTypeAnnotation'
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      'moduleName': 'SampleTurboModule'
+    }
+  }
+}"
+`;

--- a/packages/react-native-codegen/src/parsers/typescript/parser.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parser.js
@@ -83,11 +83,29 @@ class TypeScriptParser implements Parser {
     membersTypes: $FlowFixMe[],
   ): UnionTypeAnnotationMemberType[] {
     const remapLiteral = (item: $FlowFixMe) => {
-      return item.literal
-        ? item.literal.type
-            .replace('NumericLiteral', 'NumberTypeAnnotation')
-            .replace('StringLiteral', 'StringTypeAnnotation')
-        : 'ObjectTypeAnnotation';
+      if (item.literal) {
+        switch (item.literal.type) {
+          case 'NumericLiteral':
+            return 'NumberTypeAnnotation';
+          case 'StringLiteral':
+            return 'StringTypeAnnotation';
+          default:
+            return item.literal.type;
+        }
+      } else {
+        switch (item.type) {
+          case 'TSStringKeyword':
+            return 'StringTypeAnnotation';
+          case 'TSNumberKeyword':
+            return 'NumberTypeAnnotation';
+          case 'TSTypeLiteral':
+            return 'ObjectTypeAnnotation';
+          case 'TSTypeReference':
+            return 'GenericObjectTypeAnnotation';
+          default:
+            return 'ObjectTypeAnnotation';
+        }
+      }
     };
 
     return [...new Set(membersTypes.map(remapLiteral))];


### PR DESCRIPTION
Summary:
This diff is a first take at parsing union types in TurboModules.

## Changelog:
[General][Added] - Add parsing union types in TM

Differential Revision: D44575234

