### PR TITLE
Allow to disable the New Architecture inside RN Tester

### DIFF
--- a/packages/rn-tester/android/app/build.gradle
+++ b/packages/rn-tester/android/app/build.gradle
@@ -189,7 +189,9 @@ android {
         cmake {
             // RN Tester is doing custom linking of C++ libraries therefore needs
             // a dedicated CMakeLists.txt file.
-            path "src/main/jni/CMakeLists.txt"
+            if (project.property("newArchEnabled") == "true") {
+                path("src/main/jni/CMakeLists.txt")
+            }
         }
     }
 }
@@ -202,8 +204,10 @@ afterEvaluate {
     // As we're building 4 native flavors in parallel, there is clash on the `.cxx/Debug` and
     // `.cxx/Release` folder where the CMake intermediates are stored.
     // We fixing this by instructing Gradle to always mergeLibs after they've been built.
-    mergeHermesDebugNativeLibs.mustRunAfter(externalNativeBuildJscDebug)
-    mergeHermesReleaseNativeLibs.mustRunAfter(externalNativeBuildJscRelease)
-    mergeJscDebugNativeLibs.mustRunAfter(externalNativeBuildHermesDebug)
-    mergeJscReleaseNativeLibs.mustRunAfter(externalNativeBuildHermesRelease)
+    if (project.property("newArchEnabled") == "true") {
+        mergeHermesDebugNativeLibs.mustRunAfter(externalNativeBuildJscDebug)
+        mergeHermesReleaseNativeLibs.mustRunAfter(externalNativeBuildJscRelease)
+        mergeJscDebugNativeLibs.mustRunAfter(externalNativeBuildHermesDebug)
+        mergeJscReleaseNativeLibs.mustRunAfter(externalNativeBuildHermesRelease)
+    }
 }

--- a/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.java
+++ b/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.java
@@ -118,7 +118,7 @@ public class RNTesterApplication extends Application implements ReactApplication
 
         @Override
         protected boolean isNewArchEnabled() {
-          return true;
+          return BuildConfig.IS_NEW_ARCHITECTURE_ENABLED;
         }
 
         @Override
@@ -132,7 +132,9 @@ public class RNTesterApplication extends Application implements ReactApplication
     ReactFontManager.getInstance().addCustomFont(this, "Rubik", R.font.rubik);
     super.onCreate();
     SoLoader.init(this, /* native exopackage */ false);
-    DefaultNewArchitectureEntryPoint.load();
+    if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
+      DefaultNewArchitectureEntryPoint.load();
+    }
     ReactNativeFlipper.initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
   }
 


### PR DESCRIPTION
Summary:
Currently RN-Tester build with the New Architecture hardcoded to true.
For testing is convenient to disable it at times so we can test how the app behaves in the old arch.

Changelog:
[Internal] [Changed] - Allow to disable the New Architecture inside RN Tester

Reviewed By: cipolleschi

Differential Revision: D44917566

