### PR TITLE
Cleanup the `IS_OSS_BUILD` logic from Buck files

### DIFF
--- a/packages/react-native-codegen/BUCK
+++ b/packages/react-native-codegen/BUCK
@@ -1,13 +1,9 @@
 load("//tools/build_defs:fb_native_wrapper.bzl", "fb_native")
-load("//tools/build_defs/oss:rn_defs.bzl", "ANDROID", "APPLE", "IOS", "IS_OSS_BUILD", "YOGA_TARGET", "react_native_root_target", "react_native_target", "rn_android_library", "rn_xplat_cxx_library")
+load("//tools/build_defs/oss:rn_defs.bzl", "ANDROID", "APPLE", "IOS", "YOGA_TARGET", "react_native_root_target", "react_native_target", "rn_android_library", "rn_xplat_cxx_library")
 load("//tools/build_defs/third_party:yarn_defs.bzl", "yarn_workspace")
 load(":DEFS.bzl", "rn_codegen_cli", "rn_codegen_components", "rn_codegen_modules")
 
 rn_codegen_cli()
-
-SETUP_ENV_DEPS = [] if IS_OSS_BUILD else [
-    "//xplat/js:setup_env",
-]
 
 fb_native.genrule(
     name = "codegen_tests_schema",

--- a/packages/react-native/ReactAndroid/src/androidTest/java/com/facebook/react/testing/rule/BUCK
+++ b/packages/react-native/ReactAndroid/src/androidTest/java/com/facebook/react/testing/rule/BUCK
@@ -1,6 +1,5 @@
 load(
     "//tools/build_defs/oss:rn_defs.bzl",
-    "IS_OSS_BUILD",
     "react_native_dep",
     "react_native_integration_tests_target",
     "react_native_target",
@@ -35,8 +34,7 @@ rn_android_library(
         react_native_target("java/com/facebook/react/modules/core:core"),
         react_native_target("java/com/facebook/react/shell:shell"),
         react_native_target("java/com/facebook/react/uimanager:uimanager"),
-    ] + [
         react_native_dep("java/com/facebook/testing/instrumentation:instrumentation"),
         react_native_dep("java/com/facebook/testing/instrumentation/base:base"),
-    ] if not IS_OSS_BUILD else [],
+    ],
 )

--- a/packages/react-native/ReactAndroid/src/androidTest/java/com/facebook/react/tests/core/BUCK
+++ b/packages/react-native/ReactAndroid/src/androidTest/java/com/facebook/react/tests/core/BUCK
@@ -1,6 +1,5 @@
 load(
     "//tools/build_defs/oss:rn_defs.bzl",
-    "IS_OSS_BUILD",
     "react_native_dep",
     "react_native_integration_tests_target",
     "react_native_target",
@@ -27,7 +26,6 @@ rn_android_library(
         react_native_target("java/com/facebook/react/module/model:model"),
         react_native_target("java/com/facebook/react/shell:shell"),
         react_native_target("java/com/facebook/react/uimanager:uimanager"),
-    ] + [
         react_native_dep("java/com/facebook/fbreact/testing:testing"),
-    ] if not IS_OSS_BUILD else [],
+    ],
 )

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BUCK
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BUCK
@@ -1,4 +1,4 @@
-load("//tools/build_defs/oss:rn_defs.bzl", "IS_OSS_BUILD", "YOGA_TARGET", "react_native_dep", "react_native_target", "react_native_tests_target", "rn_android_library")
+load("//tools/build_defs/oss:rn_defs.bzl", "YOGA_TARGET", "react_native_dep", "react_native_target", "react_native_tests_target", "rn_android_library")
 
 INTERFACES = [
     "Dynamic.java",
@@ -54,7 +54,8 @@ rn_android_library(
         react_native_target("java/com/facebook/react/turbomodule/core:callinvokerholder"),
         react_native_target("java/com/facebook/react/turbomodule/core/interfaces:interfaces"),
         react_native_target("java/com/facebook/react/uimanager/common:common"),
-    ] + ([react_native_target("jni/react/jni:jni")] if not IS_OSS_BUILD else []),
+        react_native_target("jni/react/jni:jni"),
+    ],
     exported_deps = [
         react_native_dep("libraries/fbjni:java"),
         react_native_dep("java/com/facebook/proguard/annotations:annotations"),

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/BUCK
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/BUCK
@@ -1,7 +1,4 @@
-load("//tools/build_defs/oss:rn_defs.bzl", "IS_OSS_BUILD", "YOGA_TARGET", "react_native_android_toplevel_dep", "react_native_dep", "react_native_target", "rn_android_library")
-
-# TODO(T115916830): Remove when Kotlin files are used in this module
-KOTLIN_STDLIB_DEPS = [react_native_android_toplevel_dep("third-party/kotlin:kotlin-stdlib")] if IS_OSS_BUILD else []
+load("//tools/build_defs/oss:rn_defs.bzl", "YOGA_TARGET", "react_native_dep", "react_native_target", "rn_android_library")
 
 rn_android_library(
     name = "fabric",
@@ -48,5 +45,5 @@ rn_android_library(
         react_native_target("java/com/facebook/react/views/text:text"),
         react_native_target("java/com/facebook/react/views/view:view"),
         react_native_target("jni/react/fabric:jni"),
-    ] + KOTLIN_STDLIB_DEPS,
+    ],
 )

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/BUCK
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/BUCK
@@ -1,7 +1,4 @@
-load("//tools/build_defs/oss:rn_defs.bzl", "IS_OSS_BUILD", "YOGA_TARGET", "react_native_android_toplevel_dep", "react_native_dep", "react_native_target", "rn_android_library")
-
-# TODO(T115916830): Remove when Kotlin files are used in this module
-KOTLIN_STDLIB_DEPS = [react_native_android_toplevel_dep("third-party/kotlin:kotlin-stdlib")] if IS_OSS_BUILD else []
+load("//tools/build_defs/oss:rn_defs.bzl", "YOGA_TARGET", "react_native_dep", "react_native_target", "rn_android_library")
 
 rn_android_library(
     name = "text",
@@ -35,5 +32,5 @@ rn_android_library(
         react_native_target("java/com/facebook/react/uimanager/annotations:annotations"),
         react_native_target("java/com/facebook/react/views/view:view"),
         react_native_target("res:uimanager"),
-    ] + KOTLIN_STDLIB_DEPS,
+    ],
 )

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/BUCK
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/BUCK
@@ -1,7 +1,4 @@
-load("//tools/build_defs/oss:rn_defs.bzl", "IS_OSS_BUILD", "YOGA_TARGET", "react_native_android_toplevel_dep", "react_native_dep", "react_native_target", "rn_android_library")
-
-# TODO(T115916830): Remove when Kotlin files are used in this module
-KOTLIN_STDLIB_DEPS = [react_native_android_toplevel_dep("third-party/kotlin:kotlin-stdlib")] if IS_OSS_BUILD else []
+load("//tools/build_defs/oss:rn_defs.bzl", "YOGA_TARGET", "react_native_dep", "react_native_target", "rn_android_library")
 
 rn_android_library(
     name = "textinput",
@@ -34,7 +31,7 @@ rn_android_library(
         react_native_target("java/com/facebook/react/common/mapbuffer:mapbuffer"),
         react_native_target("java/com/facebook/react/views/view:view"),
         react_native_target("java/com/facebook/react/config:config"),
-    ] + KOTLIN_STDLIB_DEPS,
+    ],
     exported_deps = [
         react_native_dep("third-party/android/androidx:appcompat"),
     ],

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/BUCK
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/BUCK
@@ -1,4 +1,4 @@
-load("//tools/build_defs/oss:rn_defs.bzl", "ANDROID", "FBGLOGINIT_TARGET", "FBJNI_TARGET", "IS_OSS_BUILD", "react_native_target", "react_native_xplat_dep", "react_native_xplat_target", "rn_xplat_cxx_library")
+load("//tools/build_defs/oss:rn_defs.bzl", "ANDROID", "FBJNI_TARGET", "react_native_target", "react_native_xplat_dep", "react_native_xplat_target", "rn_xplat_cxx_library")
 
 EXPORTED_HEADERS = [
     "CxxModuleWrapper.h",
@@ -48,18 +48,19 @@ rn_xplat_cxx_library(
         "-DLOG_TAG=\"ReactNativeJNI\"",
         "-DWITH_FBSYSTRACE=1",
         "-DWITH_INSPECTOR=1",
-    ] + ["-DWITH_GLOGINIT=0"] if not IS_OSS_BUILD else [],
+        "-DWITH_GLOGINIT=0",
+    ],
     soname = "libreactnativejni.$(ext)",
     visibility = [
         "PUBLIC",
     ],
     deps = [
-        "//xplat/third-party/linker_lib:android",
-        "//xplat/third-party/linker_lib:atomic",
         "//third-party/glog:glog",
+        "//xplat/fbsystrace:fbsystrace",
         "//xplat/folly:dynamic",
         "//xplat/folly:json",
-        "//xplat/fbsystrace:fbsystrace",
+        "//xplat/third-party/linker_lib:android",
+        "//xplat/third-party/linker_lib:atomic",
         react_native_target("jni/react/turbomodule:callinvokerholder"),
         react_native_xplat_target("cxxreact:bridge"),
         react_native_xplat_target("cxxreact:jsbigstring"),
@@ -70,7 +71,5 @@ rn_xplat_cxx_library(
         react_native_xplat_target("logger:logger"),
         react_native_xplat_dep("jsi:jsi"),
         FBJNI_TARGET,
-    ] + ([
-        FBGLOGINIT_TARGET,
-    ] if IS_OSS_BUILD else []),
+    ],
 )


### PR DESCRIPTION
Summary:
We don't need this logic anymore as `IS_OSS_BUILD` is always false.

Changelog:
[Internal] [Changed] - Cleanup the `IS_OSS_BUILD` logic from Buck files

Reviewed By: cipolleschi

Differential Revision: D44958368

