### PR TITLE
Restore 'import' in default Package Exports conditions

### DIFF
--- a/packages/metro-config/index.js
+++ b/packages/metro-config/index.js
@@ -42,7 +42,7 @@ function getDefaultConfig(
     resolver: {
       resolverMainFields: ['react-native', 'browser', 'main'],
       platforms: ['android', 'ios'],
-      unstable_conditionNames: ['require', 'react-native'],
+      unstable_conditionNames: ['require', 'import', 'react-native'],
     },
     serializer: {
       getPolyfills: () => require('@react-native/js-polyfills')(),


### PR DESCRIPTION
Summary:
Reverts https://github.com/facebook/react-native/pull/36584.

Since we've come across example packages (typically targeting Node.js) which only distribute ESM, we believe it's more helpful to return to asserting the `"import"` condition by default, for maximum compatibility. The above issue and comments outline the pros/cons.

Changelog:
[General][Changed] - Default condition set for experimental Package Exports is now ['require', 'import', 'react-native']

Metro changelog: [Experimental] Package Exports unstable_conditionNames now defaults to ['require', 'import']

Differential Revision: D44962143

