### PR TITLE
Deprecate EventBeatManager constructor

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BaseJavaModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BaseJavaModule.java
@@ -56,16 +56,11 @@ public abstract class BaseJavaModule implements NativeModule {
 
   @Override
   public boolean canOverrideExistingModule() {
-    // TODO(t11394819): Make this final and use annotation
     return false;
   }
 
   @Override
   public void onCatalystInstanceDestroy() {}
-
-  public boolean hasConstants() {
-    return false;
-  }
 
   /**
    * The CatalystInstance is going away with Venice. Therefore, the TurboModule infra introduces the

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricJSIModuleProvider.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricJSIModuleProvider.java
@@ -36,7 +36,7 @@ public class FabricJSIModuleProvider implements JSIModuleProvider<UIManager> {
   @Override
   public UIManager get() {
     Systrace.beginSection(Systrace.TRACE_TAG_REACT_JAVA_BRIDGE, "FabricJSIModuleProvider.get");
-    final EventBeatManager eventBeatManager = new EventBeatManager(mReactApplicationContext);
+    final EventBeatManager eventBeatManager = new EventBeatManager();
     final FabricUIManager uiManager = createUIManager(eventBeatManager);
 
     Systrace.beginSection(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/events/EventBeatManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/events/EventBeatManager.java
@@ -19,22 +19,25 @@ import com.facebook.react.uimanager.events.BatchEventDispatchedListener;
  * Class that acts as a proxy between the list of EventBeats registered in C++ and the Android side.
  */
 @SuppressLint("MissingNativeLoadLibrary")
-public class EventBeatManager implements BatchEventDispatchedListener {
+public final class EventBeatManager implements BatchEventDispatchedListener {
 
   static {
     FabricSoLoader.staticInit();
   }
 
   @DoNotStrip private final HybridData mHybridData;
-  private final ReactApplicationContext mReactApplicationContext;
 
   private static native HybridData initHybrid();
 
   private native void tick();
 
+  @Deprecated(forRemoval = true)
   public EventBeatManager(@NonNull ReactApplicationContext reactApplicationContext) {
+    this();
+  }
+
+  public EventBeatManager() {
     mHybridData = initHybrid();
-    mReactApplicationContext = reactApplicationContext;
   }
 
   @Override

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
@@ -44,21 +44,9 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
   private static final int PERSPECTIVE_ARRAY_INVERTED_CAMERA_DISTANCE_INDEX = 2;
   private static final float CAMERA_DISTANCE_NORMALIZATION_MULTIPLIER = (float) Math.sqrt(5);
 
-  private static MatrixMathHelper.MatrixDecompositionContext sMatrixDecompositionContext =
+  private static final MatrixMathHelper.MatrixDecompositionContext sMatrixDecompositionContext =
       new MatrixMathHelper.MatrixDecompositionContext();
-  private static double[] sTransformDecompositionArray = new double[16];
-
-  public static final Map<String, Integer> sStateDescription = new HashMap<>();
-
-  static {
-    sStateDescription.put("busy", R.string.state_busy_description);
-    sStateDescription.put("expanded", R.string.state_expanded_description);
-    sStateDescription.put("collapsed", R.string.state_collapsed_description);
-  }
-
-  // State definition constants -- must match the definition in
-  // ViewAccessibility.js. These only include states for which there
-  // is no native support in android.
+  private static final double[] sTransformDecompositionArray = new double[16];
 
   private static final String STATE_CHECKED = "checked"; // Special case for mixed state checkboxes
   private static final String STATE_BUSY = "busy";

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManager.java
@@ -37,7 +37,7 @@ import java.util.Stack;
 public abstract class ViewManager<T extends View, C extends ReactShadowNode>
     extends BaseJavaModule {
 
-  private static String NAME = ViewManager.class.getSimpleName();
+  private static final String NAME = ViewManager.class.getSimpleName();
 
   /**
    * For View recycling: we store a Stack of unused, dead Views. This is null by default, and when
@@ -46,19 +46,11 @@ public abstract class ViewManager<T extends View, C extends ReactShadowNode>
    */
   @Nullable private HashMap<Integer, Stack<T>> mRecyclableViews = null;
 
-  private int mRecyclableViewsBufferSize = 1024;
-
   /** Call in constructor of concrete ViewManager class to enable. */
   protected void setupViewRecycling() {
     if (ReactFeatureFlags.enableViewRecycling) {
       mRecyclableViews = new HashMap<>();
     }
-  }
-
-  /** Call in constructor of concrete ViewManager class to enable. */
-  protected void setupViewRecycling(int bufferSize) {
-    mRecyclableViewsBufferSize = bufferSize;
-    setupViewRecycling();
   }
 
   private @Nullable Stack<T> getRecyclableViewStack(int surfaceId) {
@@ -224,11 +216,7 @@ public abstract class ViewManager<T extends View, C extends ReactShadowNode>
     ThemedReactContext themedReactContext = (ThemedReactContext) viewContext;
     int surfaceId = themedReactContext.getSurfaceId();
     @Nullable Stack<T> recyclableViews = getRecyclableViewStack(surfaceId);
-
-    // Any max buffer size <0 results in an infinite buffer size
-    if (recyclableViews != null
-        && (mRecyclableViewsBufferSize < 0
-            || recyclableViews.size() < mRecyclableViewsBufferSize)) {
+    if (recyclableViews != null) {
       recyclableViews.push(prepareToRecycleView(themedReactContext, view));
     }
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManager.java
@@ -66,9 +66,6 @@ public abstract class ViewManager<T extends View, C extends ReactShadowNode>
   /**
    * For the vast majority of ViewManagers, you will not need to override this. Only override this
    * if you really know what you're doing and have a very unique use-case.
-   *
-   * @param viewToUpdate
-   * @param props
    */
   public void updateProperties(@NonNull T viewToUpdate, ReactStylesDiffMap props) {
     final ViewManagerDelegate<T> delegate = getDelegate();


### PR DESCRIPTION
Summary:
In this diff I'm deprecating EventBeatManager constructor that receives a Context as a parameter.

changelog: [Android][Deprecated] deprecating EventBeatManager constructor that receives a Context as a parameter.

Reviewed By: fkgozali

Differential Revision: D44759827

