### PR TITLE
Delete unused method exposed in BaseJavaModule

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BaseJavaModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BaseJavaModule.java
@@ -56,16 +56,11 @@ public abstract class BaseJavaModule implements NativeModule {
 
   @Override
   public boolean canOverrideExistingModule() {
-    // TODO(t11394819): Make this final and use annotation
     return false;
   }
 
   @Override
   public void onCatalystInstanceDestroy() {}
-
-  public boolean hasConstants() {
-    return false;
-  }
 
   /**
    * The CatalystInstance is going away with Venice. Therefore, the TurboModule infra introduces the

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManager.java
@@ -37,7 +37,7 @@ import java.util.Stack;
 public abstract class ViewManager<T extends View, C extends ReactShadowNode>
     extends BaseJavaModule {
 
-  private static String NAME = ViewManager.class.getSimpleName();
+  private static final String NAME = ViewManager.class.getSimpleName();
 
   /**
    * For View recycling: we store a Stack of unused, dead Views. This is null by default, and when
@@ -46,19 +46,11 @@ public abstract class ViewManager<T extends View, C extends ReactShadowNode>
    */
   @Nullable private HashMap<Integer, Stack<T>> mRecyclableViews = null;
 
-  private int mRecyclableViewsBufferSize = 1024;
-
   /** Call in constructor of concrete ViewManager class to enable. */
   protected void setupViewRecycling() {
     if (ReactFeatureFlags.enableViewRecycling) {
       mRecyclableViews = new HashMap<>();
     }
-  }
-
-  /** Call in constructor of concrete ViewManager class to enable. */
-  protected void setupViewRecycling(int bufferSize) {
-    mRecyclableViewsBufferSize = bufferSize;
-    setupViewRecycling();
   }
 
   private @Nullable Stack<T> getRecyclableViewStack(int surfaceId) {
@@ -224,11 +216,7 @@ public abstract class ViewManager<T extends View, C extends ReactShadowNode>
     ThemedReactContext themedReactContext = (ThemedReactContext) viewContext;
     int surfaceId = themedReactContext.getSurfaceId();
     @Nullable Stack<T> recyclableViews = getRecyclableViewStack(surfaceId);
-
-    // Any max buffer size <0 results in an infinite buffer size
-    if (recyclableViews != null
-        && (mRecyclableViewsBufferSize < 0
-            || recyclableViews.size() < mRecyclableViewsBufferSize)) {
+    if (recyclableViews != null) {
       recyclableViews.push(prepareToRecycleView(themedReactContext, view));
     }
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManager.java
@@ -67,8 +67,9 @@ public abstract class ViewManager<T extends View, C extends ReactShadowNode>
    * For the vast majority of ViewManagers, you will not need to override this. Only override this
    * if you really know what you're doing and have a very unique use-case.
    *
-   * @param viewToUpdate
-   * @param props
+   * @param viewToUpdate {@link T} View instance that will be updated with the props received by
+   *     parameter.
+   * @param props {@link ReactStylesDiffMap} props to update the view with
    */
   public void updateProperties(@NonNull T viewToUpdate, ReactStylesDiffMap props) {
     final ViewManagerDelegate<T> delegate = getDelegate();


### PR DESCRIPTION
Summary:
Delete unused method exposed in BaseJavaModule

Changelog: [Android][Removed] Delete hasConstants() method from BaseJavaModule

Reviewed By: philIip

Differential Revision: D44678688

