### PR TITLE
Implement scaffolding for the Pointer Capture imperative host ref APIs

### DIFF
--- a/packages/react-native/Libraries/ReactNative/FabricUIManager.js
+++ b/packages/react-native/Libraries/ReactNative/FabricUIManager.js
@@ -86,6 +86,13 @@ export type Spec = {|
     /* offsetTop: */ number,
     /* offsetLeft: */ number,
   ],
+
+  /**
+   * Support methods for the Pointer Capture APIs.
+   */
+  +hasPointerCapture: (node: Node, pointerId: number) => boolean,
+  +setPointerCapture: (node: Node, pointerId: number) => void,
+  +releasePointerCapture: (node: Node, pointerId: number) => void,
 |};
 
 // This is exposed as a getter because apps using the legacy renderer AND

--- a/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricHostComponent.js
+++ b/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricHostComponent.js
@@ -31,6 +31,9 @@ const {
   measureInWindow: fabricMeasureInWindow,
   measureLayout: fabricMeasureLayout,
   getBoundingClientRect: fabricGetBoundingClientRect,
+  hasPointerCapture: fabricHasPointerCapture,
+  setPointerCapture: fabricSetPointerCapture,
+  releasePointerCapture: fabricReleasePointerCapture,
   setNativeProps,
 } = nullthrows(getFabricUIManager());
 
@@ -133,6 +136,34 @@ export default class ReactFabricHostComponent implements INativeMethods {
 
     // Empty rect if any of the above failed
     return new DOMRect(0, 0, 0, 0);
+  }
+
+  hasPointerCapture(pointerId: number): boolean {
+    const node = getNodeFromInternalInstanceHandle(
+      this.__internalInstanceHandle,
+    );
+    if (node != null) {
+      return fabricHasPointerCapture(node, pointerId);
+    }
+    return false;
+  }
+
+  setPointerCapture(pointerId: number): void {
+    const node = getNodeFromInternalInstanceHandle(
+      this.__internalInstanceHandle,
+    );
+    if (node != null) {
+      fabricSetPointerCapture(node, pointerId);
+    }
+  }
+
+  releasePointerCapture(pointerId: number): void {
+    const node = getNodeFromInternalInstanceHandle(
+      this.__internalInstanceHandle,
+    );
+    if (node != null) {
+      fabricReleasePointerCapture(node, pointerId);
+    }
   }
 
   setNativeProps(nativeProps: {...}): void {

--- a/packages/react-native/Libraries/ReactNative/__mocks__/FabricUIManager.js
+++ b/packages/react-native/Libraries/ReactNative/__mocks__/FabricUIManager.js
@@ -277,6 +277,9 @@ const FabricUIManagerMock: FabricUIManager = {
       return [x, y, width, height];
     },
   ),
+  hasPointerCapture: jest.fn((node: Node, pointerId: number): boolean => false),
+  setPointerCapture: jest.fn((node: Node, pointerId: number): void => {}),
+  releasePointerCapture: jest.fn((node: Node, pointerId: number): void => {}),
   setNativeProps: jest.fn((node: Node, newProps: NodeProps): void => {}),
   dispatchCommand: jest.fn(
     (node: Node, commandName: string, args: Array<mixed>): void => {},

--- a/packages/react-native/React/Fabric/Mounting/RCTMountingManager.h
+++ b/packages/react-native/React/Fabric/Mounting/RCTMountingManager.h
@@ -7,6 +7,7 @@
 
 #import <UIKit/UIKit.h>
 
+#import <React/RCTFabricSurface.h>
 #import <React/RCTMountingManagerDelegate.h>
 #import <React/RCTPrimitives.h>
 #import <react/renderer/core/ComponentDescriptor.h>
@@ -65,6 +66,18 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setIsJSResponder:(BOOL)isJSResponder
     blockNativeResponder:(BOOL)blockNativeResponder
            forShadowView:(facebook::react::ShadowView const &)shadowView;
+
+- (BOOL)requestPointerCaptureStatus:(int)pointerId
+                          onSurface:(RCTFabricSurface *)surface
+                      forShadowView:(const facebook::react::ShadowView &)shadowView;
+
+- (void)setPointerCapture:(int)pointerId
+                onSurface:(RCTFabricSurface *)surface
+            forShadowView:(const facebook::react::ShadowView &)shadowView;
+
+- (void)releasePointerCapture:(int)pointerId
+                    onSurface:(RCTFabricSurface *)surface
+                forShadowView:(const facebook::react::ShadowView &)shadowView;
 
 - (void)synchronouslyUpdateViewOnUIThread:(ReactTag)reactTag
                              changedProps:(NSDictionary *)props

--- a/packages/react-native/React/Fabric/Mounting/RCTMountingManager.mm
+++ b/packages/react-native/React/Fabric/Mounting/RCTMountingManager.mm
@@ -294,6 +294,42 @@ static void RCTPerformMountInstructions(
   });
 }
 
+- (BOOL)requestPointerCaptureStatus:(int)pointerId
+                          onSurface:(RCTFabricSurface *)surface
+                      forShadowView:(const facebook::react::ShadowView &)shadowView
+{
+  __block NSNumber *result;
+  RCTUnsafeExecuteOnMainQueueSync(^{
+    UIView<RCTComponentViewProtocol> *componentView =
+        [self->_componentViewRegistry findComponentViewWithTag:shadowView.tag];
+    BOOL rawResult = [surface isPointerCaptured:pointerId forView:componentView];
+    result = @(rawResult);
+  });
+  return [result boolValue];
+}
+
+- (void)setPointerCapture:(int)pointerId
+                onSurface:(RCTFabricSurface *)surface
+            forShadowView:(const facebook::react::ShadowView &)shadowView
+{
+  RCTUnsafeExecuteOnMainQueueSync(^{
+    UIView<RCTComponentViewProtocol> *componentView =
+        [self->_componentViewRegistry findComponentViewWithTag:shadowView.tag];
+    [surface setPointerCapture:pointerId forView:componentView];
+  });
+}
+
+- (void)releasePointerCapture:(int)pointerId
+                    onSurface:(RCTFabricSurface *)surface
+                forShadowView:(const facebook::react::ShadowView &)shadowView
+{
+  RCTUnsafeExecuteOnMainQueueSync(^{
+    UIView<RCTComponentViewProtocol> *componentView =
+        [self->_componentViewRegistry findComponentViewWithTag:shadowView.tag];
+    [surface releasePointerCapture:pointerId forView:componentView];
+  });
+}
+
 - (void)synchronouslyUpdateViewOnUIThread:(ReactTag)reactTag
                              changedProps:(NSDictionary *)props
                       componentDescriptor:(const ComponentDescriptor &)componentDescriptor

--- a/packages/react-native/React/Fabric/RCTScheduler.h
+++ b/packages/react-native/React/Fabric/RCTScheduler.h
@@ -41,6 +41,13 @@ NS_ASSUME_NONNULL_BEGIN
                 blockNativeResponder:(BOOL)blockNativeResponder
                        forShadowView:(facebook::react::ShadowView const &)shadowView;
 
+- (BOOL)schedulerDidRequestPointerCaptureStatus:(int)pointerId
+                                  forShadowView:(facebook::react::ShadowView const &)shadowView;
+
+- (void)schedulerDidSetPointerCapture:(int)pointerId forShadowView:(facebook::react::ShadowView const &)shadowView;
+
+- (void)schedulerDidReleasePointerCapture:(int)pointerId forShadowView:(facebook::react::ShadowView const &)shadowView;
+
 @end
 
 /**

--- a/packages/react-native/React/Fabric/RCTScheduler.mm
+++ b/packages/react-native/React/Fabric/RCTScheduler.mm
@@ -60,6 +60,24 @@ class SchedulerDelegateProxy : public SchedulerDelegate {
     [scheduler.delegate schedulerDidSendAccessibilityEvent:shadowView eventType:eventType];
   }
 
+  bool schedulerDidRequestPointerCaptureStatus(const ShadowView &shadowView, int pointerId) override
+  {
+    RCTScheduler *scheduler = (__bridge RCTScheduler *)scheduler_;
+    return [scheduler.delegate schedulerDidRequestPointerCaptureStatus:pointerId forShadowView:shadowView];
+  }
+
+  void schedulerDidSetPointerCapture(const ShadowView &shadowView, int pointerId) override
+  {
+    RCTScheduler *scheduler = (__bridge RCTScheduler *)scheduler_;
+    [scheduler.delegate schedulerDidSetPointerCapture:pointerId forShadowView:shadowView];
+  }
+
+  void schedulerDidReleasePointerCapture(const ShadowView &shadowView, int pointerId) override
+  {
+    RCTScheduler *scheduler = (__bridge RCTScheduler *)scheduler_;
+    [scheduler.delegate schedulerDidReleasePointerCapture:pointerId forShadowView:shadowView];
+  }
+
  private:
   void *scheduler_;
 };

--- a/packages/react-native/React/Fabric/RCTSurfacePointerHandler.h
+++ b/packages/react-native/React/Fabric/RCTSurfacePointerHandler.h
@@ -23,6 +23,13 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, assign) CGPoint viewOriginOffset;
 
+/*
+ * Pointer Capture APIs
+ */
+- (BOOL)isPointerCaptured:(int)pointerId forView:(UIView *)componentView;
+- (void)setPointerCapture:(int)pointerId forView:(UIView *)componentView;
+- (void)releasePointerCapture:(int)pointerId forView:(UIView *)componentView;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/react-native/React/Fabric/RCTSurfacePointerHandler.mm
+++ b/packages/react-native/React/Fabric/RCTSurfacePointerHandler.mm
@@ -913,4 +913,22 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithTarget : (id)target action : (SEL)act
   return eventPathViews;
 }
 
+#pragma mark - Pointer Capture APIs
+
+- (BOOL)isPointerCaptured:(int)pointerId forView:(UIView *)componentView
+{
+  // TODO: Implement
+  return NO;
+}
+
+- (void)setPointerCapture:(int)pointerId forView:(UIView *)componentView
+{
+  // TODO: Implement
+}
+
+- (void)releasePointerCapture:(int)pointerId forView:(UIView *)componentView
+{
+  // TODO: Implement
+}
+
 @end

--- a/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
+++ b/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
@@ -397,6 +397,25 @@ static BackgroundExecutor RCTGetBackgroundExecutor()
   [_mountingManager setIsJSResponder:isJSResponder blockNativeResponder:blockNativeResponder forShadowView:shadowView];
 }
 
+- (BOOL)schedulerDidRequestPointerCaptureStatus:(int)pointerId
+                                  forShadowView:(facebook::react::ShadowView const &)shadowView
+{
+  RCTFabricSurface *surface = [self surfaceForRootTag:shadowView.surfaceId];
+  return [_mountingManager requestPointerCaptureStatus:pointerId onSurface:surface forShadowView:shadowView];
+}
+
+- (void)schedulerDidSetPointerCapture:(int)pointerId forShadowView:(const facebook::react::ShadowView &)shadowView
+{
+  RCTFabricSurface *surface = [self surfaceForRootTag:shadowView.surfaceId];
+  [_mountingManager setPointerCapture:pointerId onSurface:surface forShadowView:shadowView];
+}
+
+- (void)schedulerDidReleasePointerCapture:(int)pointerId forShadowView:(const facebook::react::ShadowView &)shadowView
+{
+  RCTFabricSurface *surface = [self surfaceForRootTag:shadowView.surfaceId];
+  [_mountingManager releasePointerCapture:pointerId onSurface:surface forShadowView:shadowView];
+}
+
 - (void)addObserver:(id<RCTSurfacePresenterObserver>)observer
 {
   std::unique_lock lock(_observerListMutex);

--- a/packages/react-native/React/Fabric/RCTSurfaceTouchHandler.h
+++ b/packages/react-native/React/Fabric/RCTSurfaceTouchHandler.h
@@ -23,6 +23,13 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, assign) CGPoint viewOriginOffset;
 
+/*
+ * Pointer Capture APIs
+ */
+- (BOOL)isPointerCaptured:(int)pointerId forView:(UIView *)componentView;
+- (void)setPointerCapture:(int)pointerId forView:(UIView *)componentView;
+- (void)releasePointerCapture:(int)pointerId forView:(UIView *)componentView;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/react-native/React/Fabric/RCTSurfaceTouchHandler.mm
+++ b/packages/react-native/React/Fabric/RCTSurfaceTouchHandler.mm
@@ -405,6 +405,30 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithTarget : (id)target action : (SEL)act
   return NO;
 }
 
+#pragma mark - Pointer Capture APIs
+
+- (BOOL)isPointerCaptured:(int)pointerId forView:(UIView *)componentView
+{
+  if (_pointerHandler) {
+    return [_pointerHandler isPointerCaptured:pointerId forView:componentView];
+  }
+  return NO;
+}
+
+- (void)setPointerCapture:(int)pointerId forView:(UIView *)componentView
+{
+  if (_pointerHandler) {
+    [_pointerHandler setPointerCapture:pointerId forView:componentView];
+  }
+}
+
+- (void)releasePointerCapture:(int)pointerId forView:(UIView *)componentView
+{
+  if (_pointerHandler) {
+    [_pointerHandler releasePointerCapture:pointerId forView:componentView];
+  }
+}
+
 #pragma mark -
 
 - (void)_cancelTouches

--- a/packages/react-native/React/Fabric/Surface/RCTFabricSurface.h
+++ b/packages/react-native/React/Fabric/Surface/RCTFabricSurface.h
@@ -110,6 +110,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (BOOL)synchronouslyWaitFor:(NSTimeInterval)timeout;
 
+#pragma mark - Touch handler Methods
+
+- (BOOL)isPointerCaptured:(int)pointerId forView:(UIView *)componentView;
+- (void)setPointerCapture:(int)pointerId forView:(UIView *)componentView;
+- (void)releasePointerCapture:(int)pointerId forView:(UIView *)componentView;
+
 @end
 
 @interface RCTFabricSurface (Internal)

--- a/packages/react-native/React/Fabric/Surface/RCTFabricSurface.mm
+++ b/packages/react-native/React/Fabric/Surface/RCTFabricSurface.mm
@@ -272,6 +272,23 @@ using namespace facebook::react;
   [self _updateLayoutContext];
 }
 
+#pragma mark - Touch handler methods
+
+- (BOOL)isPointerCaptured:(int)pointerId forView:(UIView *)componentView
+{
+  return [_touchHandler isPointerCaptured:pointerId forView:componentView];
+}
+
+- (void)setPointerCapture:(int)pointerId forView:(UIView *)componentView
+{
+  return [_touchHandler setPointerCapture:pointerId forView:componentView];
+}
+
+- (void)releasePointerCapture:(int)pointerId forView:(UIView *)componentView
+{
+  return [_touchHandler releasePointerCapture:pointerId forView:componentView];
+}
+
 #pragma mark - Private
 
 - (SurfaceHandler const &)surfaceHandler;

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.cpp
@@ -547,6 +547,25 @@ void Binding::schedulerDidSetIsJSResponder(
       shadowView, isJSResponder, blockNativeResponder);
 }
 
+bool Binding::schedulerDidRequestPointerCaptureStatus(
+    ShadowView const &shadowView,
+    int pointerId) {
+  // TODO(T150517979): Implement
+  return false;
+}
+
+void Binding::schedulerDidSetPointerCapture(
+    ShadowView const &shadowView,
+    int pointerId) {
+  // TODO(T150517979): Implement
+}
+
+void Binding::schedulerDidReleasePointerCapture(
+    ShadowView const &shadowView,
+    int pointerId) {
+  // TODO(T150517979): Implement
+}
+
 void Binding::onAnimationStarted() {
   auto &mountingManager = verifyMountingManager("Binding::onAnimationStarted");
   if (!mountingManager) {

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.h
@@ -117,6 +117,18 @@ class Binding : public jni::HybridClass<Binding>,
       bool isJSResponder,
       bool blockNativeResponder) override;
 
+  bool schedulerDidRequestPointerCaptureStatus(
+      ShadowView const &shadowView,
+      int pointerId) override;
+
+  void schedulerDidSetPointerCapture(
+      ShadowView const &shadowView,
+      int pointerId) override;
+
+  void schedulerDidReleasePointerCapture(
+      ShadowView const &shadowView,
+      int pointerId) override;
+
   void preallocateView(SurfaceId surfaceId, ShadowNode const &shadowNode);
 
   void setPixelDensity(float pointScaleFactor);

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
@@ -375,6 +375,34 @@ void Scheduler::uiManagerDidSetIsJSResponder(
   }
 }
 
+bool Scheduler::uiManagerDidRequestPointerCaptureStatus(
+    ShadowNode::Shared const &shadowNode,
+    int pointerId) {
+  if (delegate_ != nullptr) {
+    return delegate_->schedulerDidRequestPointerCaptureStatus(
+        ShadowView(*shadowNode), pointerId);
+  }
+  return false;
+}
+
+void Scheduler::uiManagerDidSetPointerCapture(
+    ShadowNode::Shared const &shadowNode,
+    int pointerId) {
+  if (delegate_ != nullptr) {
+    delegate_->schedulerDidSetPointerCapture(
+        ShadowView(*shadowNode), pointerId);
+  }
+}
+
+void Scheduler::uiManagerDidReleasePointerCapture(
+    ShadowNode::Shared const &shadowNode,
+    int pointerId) {
+  if (delegate_ != nullptr) {
+    delegate_->schedulerDidReleasePointerCapture(
+        ShadowView(*shadowNode), pointerId);
+  }
+}
+
 ContextContainer::Shared Scheduler::getContextContainer() const {
   return contextContainer_;
 }

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.h
@@ -102,6 +102,15 @@ class Scheduler final : public UIManagerDelegate {
       ShadowNode::Shared const &shadowNode,
       bool isJSResponder,
       bool blockNativeResponder) override;
+  bool uiManagerDidRequestPointerCaptureStatus(
+      ShadowNode::Shared const &shadowNode,
+      int pointerId) override;
+  void uiManagerDidSetPointerCapture(
+      ShadowNode::Shared const &shadowNode,
+      int pointerId) override;
+  void uiManagerDidReleasePointerCapture(
+      ShadowNode::Shared const &shadowNode,
+      int pointerId) override;
 
 #pragma mark - ContextContainer
   ContextContainer::Shared getContextContainer() const;

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SchedulerDelegate.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SchedulerDelegate.h
@@ -52,6 +52,18 @@ class SchedulerDelegate {
       bool isJSResponder,
       bool blockNativeResponder) = 0;
 
+  virtual bool schedulerDidRequestPointerCaptureStatus(
+      ShadowView const &shadowView,
+      int pointerId) = 0;
+
+  virtual void schedulerDidSetPointerCapture(
+      ShadowView const &shadowView,
+      int pointerId) = 0;
+
+  virtual void schedulerDidReleasePointerCapture(
+      ShadowView const &shadowView,
+      int pointerId) = 0;
+
   virtual ~SchedulerDelegate() noexcept = default;
 };
 

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
@@ -501,6 +501,32 @@ void UIManager::sendAccessibilityEvent(
   }
 }
 
+bool UIManager::requestPointerCaptureStatus(
+    const ShadowNode::Shared &shadowNode,
+    int pointerId) {
+  if (delegate_ != nullptr) {
+    return delegate_->uiManagerDidRequestPointerCaptureStatus(
+        shadowNode, pointerId);
+  }
+  return false;
+}
+
+void UIManager::setPointerCapture(
+    const ShadowNode::Shared &shadowNode,
+    int pointerId) {
+  if (delegate_ != nullptr) {
+    delegate_->uiManagerDidSetPointerCapture(shadowNode, pointerId);
+  }
+}
+
+void UIManager::releasePointerCapture(
+    const ShadowNode::Shared &shadowNode,
+    int pointerId) {
+  if (delegate_ != nullptr) {
+    delegate_->uiManagerDidReleasePointerCapture(shadowNode, pointerId);
+  }
+}
+
 void UIManager::configureNextLayoutAnimation(
     jsi::Runtime &runtime,
     RawValue const &config,

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.h
@@ -181,6 +181,16 @@ class UIManager final : public ShadowTreeDelegate {
       const ShadowNode::Shared &shadowNode,
       std::string const &eventType);
 
+  bool requestPointerCaptureStatus(
+      ShadowNode::Shared const &shadowNode,
+      int pointerId);
+
+  void setPointerCapture(ShadowNode::Shared const &shadowNode, int pointerId);
+
+  void releasePointerCapture(
+      ShadowNode::Shared const &shadowNode,
+      int pointerId);
+
   /*
    * Iterates over all shadow nodes which are parts of all registered surfaces
    * and find the one that has given `tag`. Returns `nullptr` if the node wasn't

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
@@ -1013,6 +1013,61 @@ jsi::Value UIManagerBinding::get(
         });
   }
 
+  /**
+   * Pointer Capture APIs
+   */
+
+  if (methodName == "hasPointerCapture") {
+    return jsi::Function::createFromHostFunction(
+        runtime,
+        name,
+        2,
+        [uiManager](
+            jsi::Runtime &runtime,
+            jsi::Value const &,
+            jsi::Value const *arguments,
+            size_t) -> jsi::Value {
+          bool isCapturing = uiManager->requestPointerCaptureStatus(
+              shadowNodeFromValue(runtime, arguments[0]),
+              (int)arguments[1].asNumber());
+          return jsi::Value(isCapturing);
+        });
+  }
+
+  if (methodName == "setPointerCapture") {
+    return jsi::Function::createFromHostFunction(
+        runtime,
+        name,
+        2,
+        [uiManager](
+            jsi::Runtime &runtime,
+            jsi::Value const &,
+            jsi::Value const *arguments,
+            size_t) -> jsi::Value {
+          uiManager->setPointerCapture(
+              shadowNodeFromValue(runtime, arguments[0]),
+              (int)arguments[1].asNumber());
+          return jsi::Value::undefined();
+        });
+  }
+
+  if (methodName == "releasePointerCapture") {
+    return jsi::Function::createFromHostFunction(
+        runtime,
+        name,
+        2,
+        [uiManager](
+            jsi::Runtime &runtime,
+            jsi::Value const &,
+            jsi::Value const *arguments,
+            size_t) -> jsi::Value {
+          uiManager->releasePointerCapture(
+              shadowNodeFromValue(runtime, arguments[0]),
+              (int)arguments[1].asNumber());
+          return jsi::Value::undefined();
+        });
+  }
+
   return jsi::Value::undefined();
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerDelegate.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerDelegate.h
@@ -58,6 +58,27 @@ class UIManagerDelegate {
       bool isJSResponder,
       bool blockNativeResponder) = 0;
 
+  /*
+   * Asks to determine if a fiven view is capturing the given pointer id.
+   */
+  virtual bool uiManagerDidRequestPointerCaptureStatus(
+      ShadowNode::Shared const &shadowNode,
+      int pointerId) = 0;
+
+  /*
+   * Sets the pointer capture override to a given view.
+   */
+  virtual void uiManagerDidSetPointerCapture(
+      ShadowNode::Shared const &shadowNode,
+      int pointerId) = 0;
+
+  /*
+   * Releases the pointer capture override to a given view.
+   */
+  virtual void uiManagerDidReleasePointerCapture(
+      ShadowNode::Shared const &shadowNode,
+      int pointerId) = 0;
+
   virtual ~UIManagerDelegate() noexcept = default;
 };
 


### PR DESCRIPTION
Summary:
Changelog: [Internal] - Implement scaffodling for the Pointer Capture imperative host ref APIs on iOS

This diff is fundamentally about adding 3 new methods to `RCTSurfacePointerHandler` (`hasPointerCapture`, `setPointerCapture`, and `releasePointerCapture`), and make it possible to call those methods synchronously from `ReactFabricHostComponent.js`. This diff doesn't actually start the logic implementation of these methods as I specifically would like to get focused feedback on how I accomplished hooking this up.

The delegate tree I had to traverse is fairly long and involves a lot of files so to make this easier to review here's a little diagram I made to make heads and tails of this:

{F946626014}

For the most part the code is just traversing this class tree except for when we reach the `RCTSurfacePresenter` where we retrieve the `RCTFabricSurface` related to the given `ShadowView` by leveraging it's `surfaceId`. That surface contains touch/pointer handler we need to call but we cannot do so yet because we haven't resolved the `UIView` that corresponds to that `ShadowView` yet so we call into `RCTMountingManager` is able to resolve the view, and pass it the surface so that it can call the necessary methods.

Additionally — because I'm adding new methods on `SchedulerDelegate` the Android renderer has to update it's interface to have those methods in the `Binding` class but because I'm focused on iOS I've left them as no-ops to be implemented later.

Differential Revision: D44891230

