### PR TITLE
Refer to the correct community package in the Clipboard deprecation notice

### DIFF
--- a/packages/react-native/Libraries/Components/Clipboard/Clipboard.d.ts
+++ b/packages/react-native/Libraries/Components/Clipboard/Clipboard.d.ts
@@ -14,15 +14,15 @@ export interface ClipboardStatic {
 
 /**
  * Clipboard has been extracted from react-native core and will be removed in a future release.
- * It can now be installed and imported from `@react-native-community/clipboard` instead of 'react-native'.
- * @see https://github.com/react-native-community/clipboard
+ * It can now be installed and imported from `@react-native-clipboard/clipboard` instead of 'react-native'.
+ * @see https://github.com/react-native-clipboard/clipboard
  * @deprecated
  */
 export const Clipboard: ClipboardStatic;
 /**
  * Clipboard has been extracted from react-native core and will be removed in a future release.
- * It can now be installed and imported from `@react-native-community/clipboard` instead of 'react-native'.
- * @see https://github.com/react-native-community/clipboard
+ * It can now be installed and imported from `@react-native-clipboard/clipboard` instead of 'react-native'.
+ * @see https://github.com/react-native-clipboard/clipboard
  * @deprecated
  */
 export type Clipboard = ClipboardStatic;


### PR DESCRIPTION
The URLs in this file were pointing to something but that package ended up not working for me. I checked the docs and sure enough those suggest a URL which ultimately redirects to a different URL that the one in these docs:

https://reactnative.dev/docs/clipboard -> https://reactnative.directory/?search=clipboard -> https://github.com/react-native-clipboard/clipboard

I believe this is the right URL.