### PR TITLE
decouple turbomodules from eager init

### DIFF
--- a/packages/react-native/React/Base/RCTBridge+Private.h
+++ b/packages/react-native/React/Base/RCTBridge+Private.h
@@ -70,6 +70,9 @@ RCT_EXTERN void RCTRegisterModule(Class);
  */
 @property (nonatomic, strong, readonly) RCTModuleRegistry *moduleRegistry;
 
+@property (nonatomic, copy, readwrite) NSArray<NSString *> *eagerInitModuleNames_DO_NOT_USE;
+@property (nonatomic, copy, readwrite) NSArray<NSString *> *eagerInitMainQueueModuleNames_DO_NOT_USE;
+
 @end
 
 @interface RCTBridge (RCTCxxBridge)

--- a/packages/react-native/React/Base/RCTTurboModuleRegistry.h
+++ b/packages/react-native/React/Base/RCTTurboModuleRegistry.h
@@ -23,7 +23,4 @@
  */
 - (id)moduleForName:(const char *)moduleName warnOnLookupFailure:(BOOL)warnOnLookupFailure;
 - (BOOL)moduleIsInitialized:(const char *)moduleName;
-
-- (NSArray<NSString *> *)eagerInitModuleNames;
-- (NSArray<NSString *> *)eagerInitMainQueueModuleNames;
 @end

--- a/packages/react-native/React/CxxBridge/RCTCxxBridge.mm
+++ b/packages/react-native/React/CxxBridge/RCTCxxBridge.mm
@@ -448,11 +448,11 @@ struct RCTInstanceCallback : public InstanceCallback {
    * RCTCxxBridge If id<RCTTurboModuleRegistry> is assigned by this time, eagerly initialize all TurboModules
    */
   if (_turboModuleRegistry && RCTTurboModuleEagerInitEnabled()) {
-    for (NSString *moduleName in [_turboModuleRegistry eagerInitModuleNames]) {
+    for (NSString *moduleName in [_parentBridge eagerInitModuleNames_DO_NOT_USE]) {
       [_turboModuleRegistry moduleForName:[moduleName UTF8String]];
     }
 
-    for (NSString *moduleName in [_turboModuleRegistry eagerInitMainQueueModuleNames]) {
+    for (NSString *moduleName in [_parentBridge eagerInitMainQueueModuleNames_DO_NOT_USE]) {
       if (RCTIsMainQueue()) {
         [_turboModuleRegistry moduleForName:[moduleName UTF8String]];
       } else {

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.h
@@ -20,8 +20,6 @@ RCT_EXTERN void RCTTurboModuleSetBindingMode(facebook::react::TurboModuleBinding
 @protocol RCTTurboModuleManagerDelegate <NSObject>
 
 @optional
-- (NSArray<NSString *> *)getEagerInitModuleNames;
-- (NSArray<NSString *> *)getEagerInitMainQueueModuleNames;
 
 /**
  * Given a module name, return its actual class. If not provided, basic ObjC class lookup is performed.

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
@@ -775,24 +775,6 @@ static Class getFallbackClassFromName(const char *name)
   return _turboModuleHolders.find(moduleName) != _turboModuleHolders.end();
 }
 
-- (NSArray<NSString *> *)eagerInitModuleNames
-{
-  if ([_delegate respondsToSelector:@selector(getEagerInitModuleNames)]) {
-    return [_delegate getEagerInitModuleNames];
-  }
-
-  return @[];
-}
-
-- (NSArray<NSString *> *)eagerInitMainQueueModuleNames
-{
-  if ([_delegate respondsToSelector:@selector(getEagerInitMainQueueModuleNames)]) {
-    return [_delegate getEagerInitMainQueueModuleNames];
-  }
-
-  return @[];
-}
-
 #pragma mark Invalidation logic
 
 - (void)bridgeWillInvalidateModules:(NSNotification *)notification


### PR DESCRIPTION
Differential Revision: D45021783

Changelog: [iOS][Removed]

the bridge only behavior of eager initialization of native modules was coupled with the turbomodule infra, even though it didn't need to be. this eager initialized modules is a static list, and the bridge owner, which is usually app scoped, can pass this list directly to the bridge instead.

