### PR TITLE
Fix old-arch component not updating background in interop layer example

### DIFF
--- a/packages/rn-tester/NativeComponentExample/js/MyLegacyViewNativeComponent.js
+++ b/packages/rn-tester/NativeComponentExample/js/MyLegacyViewNativeComponent.js
@@ -44,8 +44,9 @@ export function callNativeMethodToChangeBackgroundColor(
   }
   UIManager.dispatchViewManagerCommand(
     ReactNative.findNodeHandle(viewRef),
-    UIManager.getViewManagerConfig('RNTMyLegacyNativeView').Commands
-      .changeBackgroundColor.toString(),
+    UIManager.getViewManagerConfig(
+      'RNTMyLegacyNativeView'
+    ).Commands.changeBackgroundColor.toString(),
     [color],
   );
 }

--- a/packages/rn-tester/NativeComponentExample/js/MyLegacyViewNativeComponent.js
+++ b/packages/rn-tester/NativeComponentExample/js/MyLegacyViewNativeComponent.js
@@ -45,7 +45,7 @@ export function callNativeMethodToChangeBackgroundColor(
   UIManager.dispatchViewManagerCommand(
     ReactNative.findNodeHandle(viewRef),
     UIManager.getViewManagerConfig(
-      'RNTMyLegacyNativeView'
+      'RNTMyLegacyNativeView',
     ).Commands.changeBackgroundColor.toString(),
     [color],
   );

--- a/packages/rn-tester/NativeComponentExample/js/MyLegacyViewNativeComponent.js
+++ b/packages/rn-tester/NativeComponentExample/js/MyLegacyViewNativeComponent.js
@@ -45,7 +45,7 @@ export function callNativeMethodToChangeBackgroundColor(
   UIManager.dispatchViewManagerCommand(
     ReactNative.findNodeHandle(viewRef),
     UIManager.getViewManagerConfig('RNTMyLegacyNativeView').Commands
-      .changeBackgroundColor,
+      .changeBackgroundColor.toString(),
     [color],
   );
 }


### PR DESCRIPTION
## Summary:

I've noticed that in the Fabric Interop Layer sample on RN-Tester, when running with Old Arch, the legacy view is not receiving the commands correctly.
This is due to us not sending the command as string, which is making the command fail to deliver.

## Changelog:

[INTERNAL] - Fix old-arch component not updating background in interop layer example

## Test Plan:

Tested locally:

| Before | After |
|--------|--------|
| ![screen-1681728104](https://user-images.githubusercontent.com/3001957/232461662-68b23545-f38c-40fe-9a5d-44bb0cae29e9.png) | ![screen-1681728077](https://user-images.githubusercontent.com/3001957/232461651-eec93a51-b0f0-4650-af3a-c5dd991f2f96.png) |