### PR TITLE
fix(textinput): backporting of fixes for next 0.69 patch release (V2)

### DIFF
--- a/ReactAndroid/src/androidTest/java/com/facebook/react/testing/BUCK
+++ b/ReactAndroid/src/androidTest/java/com/facebook/react/testing/BUCK
@@ -11,6 +11,7 @@ rn_android_library(
     ),
     autoglob = False,
     is_androidx = True,
+    language = "JAVA",
     visibility = [
         "PUBLIC",
     ],

--- a/ReactAndroid/src/androidTest/java/com/facebook/react/testing/idledetection/BUCK
+++ b/ReactAndroid/src/androidTest/java/com/facebook/react/testing/idledetection/BUCK
@@ -5,6 +5,7 @@ rn_android_library(
     srcs = glob(["**/*.java"]),
     autoglob = False,
     is_androidx = True,
+    language = "JAVA",
     visibility = [
         "PUBLIC",
     ],

--- a/ReactAndroid/src/androidTest/java/com/facebook/react/testing/network/BUCK
+++ b/ReactAndroid/src/androidTest/java/com/facebook/react/testing/network/BUCK
@@ -8,6 +8,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     visibility = [
         "PUBLIC",
     ],

--- a/ReactAndroid/src/androidTest/java/com/facebook/react/testing/rule/BUCK
+++ b/ReactAndroid/src/androidTest/java/com/facebook/react/testing/rule/BUCK
@@ -12,6 +12,7 @@ rn_android_library(
     srcs = glob(["*.java"]),
     autoglob = False,
     is_androidx = True,
+    language = "JAVA",
     visibility = [
         "PUBLIC",
     ],

--- a/ReactAndroid/src/androidTest/java/com/facebook/react/tests/BUCK
+++ b/ReactAndroid/src/androidTest/java/com/facebook/react/tests/BUCK
@@ -5,6 +5,7 @@ rn_android_library(
     srcs = glob(["*.java"]),
     autoglob = False,
     is_androidx = True,
+    language = "JAVA",
     visibility = [
         "PUBLIC",
     ],

--- a/ReactAndroid/src/androidTest/java/com/facebook/react/tests/core/BUCK
+++ b/ReactAndroid/src/androidTest/java/com/facebook/react/tests/core/BUCK
@@ -12,6 +12,7 @@ rn_android_library(
     srcs = glob(["*.java"]),
     autoglob = False,
     is_androidx = True,
+    language = "JAVA",
     deps = [
         react_native_dep("third-party/android/androidx:test-espresso-core"),
         react_native_dep("third-party/java/assertj:assertj-core"),

--- a/ReactAndroid/src/main/java/com/facebook/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/BUCK
@@ -4,6 +4,7 @@ rn_android_library(
     name = "yoga",
     srcs = glob(["yoga/*.java"]),
     autoglob = False,
+    language = "JAVA",
     visibility = ["PUBLIC"],
     deps = [
         react_native_dep("libraries/fbjni:java"),

--- a/ReactAndroid/src/main/java/com/facebook/debug/debugoverlay/model/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/debug/debugoverlay/model/BUCK
@@ -4,6 +4,7 @@ rn_android_library(
     name = "model",
     srcs = glob(["*.java"]),
     autoglob = False,
+    language = "JAVA",
     visibility = [
         "PUBLIC",
     ],

--- a/ReactAndroid/src/main/java/com/facebook/debug/holder/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/debug/holder/BUCK
@@ -8,6 +8,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     visibility = [
         "PUBLIC",
     ],

--- a/ReactAndroid/src/main/java/com/facebook/debug/tags/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/debug/tags/BUCK
@@ -8,6 +8,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     visibility = [
         "PUBLIC",
     ],

--- a/ReactAndroid/src/main/java/com/facebook/hermes/instrumentation/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/hermes/instrumentation/BUCK
@@ -4,6 +4,7 @@ rn_android_library(
     name = "instrumentation",
     srcs = ["HermesMemoryDumper.java"],
     autoglob = False,
+    language = "JAVA",
     visibility = [
         "PUBLIC",
     ],
@@ -17,6 +18,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     visibility = ["PUBLIC"],
     deps = [
         react_native_dep("java/com/facebook/proguard/annotations:annotations"),

--- a/ReactAndroid/src/main/java/com/facebook/hermes/reactexecutor/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/hermes/reactexecutor/BUCK
@@ -7,6 +7,7 @@ rn_android_library(
         "HermesExecutorFactory.java",
     ],
     autoglob = False,
+    language = "JAVA",
     visibility = [
         "PUBLIC",
     ],
@@ -27,6 +28,7 @@ rn_android_library(
         "RuntimeConfig.java",
     ],
     autoglob = False,
+    language = "JAVA",
     visibility = [
         "PUBLIC",
     ],

--- a/ReactAndroid/src/main/java/com/facebook/hermes/unicode/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/hermes/unicode/BUCK
@@ -4,6 +4,7 @@ rn_android_library(
     name = "unicode",
     srcs = glob(["**/*.java"]),
     autoglob = False,
+    language = "JAVA",
     visibility = [
         "PUBLIC",
     ],

--- a/ReactAndroid/src/main/java/com/facebook/perftest/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/perftest/BUCK
@@ -4,6 +4,7 @@ rn_android_library(
     name = "perftest",
     srcs = glob(["*.java"]),
     autoglob = False,
+    language = "JAVA",
     visibility = [
         "PUBLIC",
     ],

--- a/ReactAndroid/src/main/java/com/facebook/proguard/annotations/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/proguard/annotations/BUCK
@@ -17,6 +17,7 @@ rn_android_library(
     name = "annotations",
     srcs = glob(["*.java"]),
     autoglob = False,
+    language = "JAVA",
     proguard_config = "proguard_annotations.pro",
     visibility = [
         "PUBLIC",

--- a/ReactAndroid/src/main/java/com/facebook/react/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/BUCK
@@ -9,6 +9,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     provided_deps = [
         react_native_dep("third-party/android/androidx:annotation"),
         react_native_dep("third-party/android/androidx:appcompat"),

--- a/ReactAndroid/src/main/java/com/facebook/react/animated/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/animated/BUCK
@@ -11,6 +11,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     provided_deps = [
         react_native_dep("third-party/android/androidx:annotation"),
         react_native_dep("third-party/android/androidx:core"),

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/BUCK
@@ -26,6 +26,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     proguard_config = "reactnative.pro",
     provided_deps = [
         react_native_dep("third-party/android/androidx:annotation"),
@@ -75,6 +76,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     proguard_config = "reactnative.pro",
     provided_deps = [
         react_native_dep("third-party/android/androidx:annotation"),

--- a/ReactAndroid/src/main/java/com/facebook/react/common/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/common/BUCK
@@ -17,6 +17,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     provided_deps = [
         react_native_dep("third-party/android/androidx:annotation"),
         react_native_dep("third-party/android/androidx:core"),

--- a/ReactAndroid/src/main/java/com/facebook/react/common/network/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/common/network/BUCK
@@ -8,6 +8,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     visibility = [
         "PUBLIC",
     ],

--- a/ReactAndroid/src/main/java/com/facebook/react/config/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/config/BUCK
@@ -8,6 +8,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     visibility = [
         "PUBLIC",
     ],

--- a/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
@@ -74,7 +74,7 @@ public class ReactFeatureFlags {
   /** Feature flag to configure synchronized queue access for Animated module */
   public static boolean enableSynchronizationForAnimated = false;
 
-  private static boolean mapBufferSerializationEnabled = false;
+  public static boolean mapBufferSerializationEnabled = false;
 
   /** Enables or disables MapBuffer Serialization */
   public static void setMapBufferSerializationEnabled(boolean enabled) {

--- a/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
@@ -117,4 +117,20 @@ public class ReactFeatureFlags {
 
   /** Feature Flag to control RN Android scrollEventThrottle prop. */
   public static boolean enableScrollEventThrottle = false;
+
+  /**
+   * Feature flag that controls how turbo modules are exposed to JS
+   *
+   * <ul>
+   *   <li>0 = as a HostObject
+   *   <li>1 = as a plain object, backed with a HostObject as prototype
+   *   <li>2 = as a plain object, with all methods eagerly configured
+   * </ul>
+   */
+  public static int turboModuleBindingMode = 0;
+
+  /**
+   * Feature Flag to enable View Recycling. When enabled, individual ViewManagers must still opt-in.
+   */
+  public static boolean enableViewRecycling = false;
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/BUCK
@@ -9,6 +9,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     manifest = "AndroidManifest.xml",
     provided_deps = [
         react_native_dep("third-party/android/androidx:core"),
@@ -56,6 +57,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     visibility = [
         "PUBLIC",
     ],

--- a/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -116,6 +116,7 @@ public class FabricUIManager implements UIManager, LifecycleEventListener {
   @NonNull private final MountingManager mMountingManager;
   @NonNull private final EventDispatcher mEventDispatcher;
   @NonNull private final MountItemDispatcher mMountItemDispatcher;
+  @NonNull private final ViewManagerRegistry mViewManagerRegistry;
 
   @NonNull private final EventBeatManager mEventBeatManager;
 
@@ -176,6 +177,9 @@ public class FabricUIManager implements UIManager, LifecycleEventListener {
     mShouldDeallocateEventDispatcher = false;
     mEventBeatManager = eventBeatManager;
     mReactApplicationContext.addLifecycleEventListener(this);
+
+    mViewManagerRegistry = viewManagerRegistry;
+    mReactApplicationContext.registerComponentCallbacks(viewManagerRegistry);
   }
 
   public FabricUIManager(
@@ -194,6 +198,9 @@ public class FabricUIManager implements UIManager, LifecycleEventListener {
     mShouldDeallocateEventDispatcher = true;
     mEventBeatManager = eventBeatManager;
     mReactApplicationContext.addLifecycleEventListener(this);
+
+    mViewManagerRegistry = viewManagerRegistry;
+    mReactApplicationContext.registerComponentCallbacks(viewManagerRegistry);
   }
 
   // TODO (T47819352): Rename this to startSurface for consistency with xplat/iOS
@@ -421,6 +428,8 @@ public class FabricUIManager implements UIManager, LifecycleEventListener {
 
     mEventDispatcher.removeBatchEventDispatchedListener(mEventBeatManager);
     mEventDispatcher.unregisterEventEmitter(FABRIC);
+
+    mReactApplicationContext.unregisterComponentCallbacks(mViewManagerRegistry);
 
     // Remove lifecycle listeners (onHostResume, onHostPause) since the FabricUIManager is going
     // away. Then stop the mDispatchUIFrameCallback false will cause the choreographer

--- a/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/SurfaceMountingManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/SurfaceMountingManager.java
@@ -300,6 +300,10 @@ public class SurfaceMountingManager {
             mRootViewManager = null;
             mMountItemExecutor = null;
             mOnViewAttachItems.clear();
+
+            if (ReactFeatureFlags.enableViewRecycling) {
+              mViewManagerRegistry.onSurfaceStopped(mSurfaceId);
+            }
           }
         };
 

--- a/ReactAndroid/src/main/java/com/facebook/react/jscexecutor/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/jscexecutor/BUCK
@@ -8,6 +8,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     visibility = [
         "PUBLIC",
     ],

--- a/ReactAndroid/src/main/java/com/facebook/react/jstasks/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/jstasks/BUCK
@@ -8,6 +8,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     visibility = [
         "PUBLIC",
     ],

--- a/ReactAndroid/src/main/java/com/facebook/react/module/annotations/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/module/annotations/BUCK
@@ -8,6 +8,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     required_for_source_only_abi = True,
     visibility = [
         "PUBLIC",

--- a/ReactAndroid/src/main/java/com/facebook/react/module/model/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/module/model/BUCK
@@ -8,6 +8,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     visibility = [
         "PUBLIC",
     ],

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/accessibilityinfo/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/accessibilityinfo/BUCK
@@ -9,6 +9,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     visibility = [
         "PUBLIC",
     ],

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/appearance/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/appearance/BUCK
@@ -9,6 +9,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     visibility = [
         "PUBLIC",
     ],

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/appregistry/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/appregistry/BUCK
@@ -8,6 +8,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     visibility = [
         "PUBLIC",
     ],

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/appstate/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/appstate/BUCK
@@ -8,6 +8,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     visibility = [
         "PUBLIC",
     ],

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/blob/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/blob/BUCK
@@ -9,6 +9,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     provided_deps = [
         react_native_dep("third-party/android/androidx:annotation"),
         react_native_dep("third-party/android/androidx:core"),

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/bundleloader/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/bundleloader/BUCK
@@ -9,6 +9,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     provided_deps = [
         react_native_dep("third-party/android/androidx:annotation"),
     ],

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/camera/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/camera/BUCK
@@ -9,6 +9,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     visibility = [
         "PUBLIC",
     ],

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/clipboard/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/clipboard/BUCK
@@ -8,6 +8,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     visibility = [
         "PUBLIC",
     ],

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/common/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/common/BUCK
@@ -8,6 +8,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     visibility = [
         "PUBLIC",
     ],

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/core/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/core/BUCK
@@ -9,6 +9,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     visibility = [
         "PUBLIC",
     ],

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/debug/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/debug/BUCK
@@ -9,6 +9,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     visibility = [
         "PUBLIC",
     ],
@@ -39,6 +40,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     visibility = [
         "PUBLIC",
     ],

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/deviceinfo/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/deviceinfo/BUCK
@@ -9,6 +9,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     visibility = [
         "PUBLIC",
     ],

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/BUCK
@@ -9,6 +9,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     provided_deps = [
         react_native_dep("third-party/android/androidx:annotation"),
         react_native_dep("third-party/android/androidx:core"),

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/fabric/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/fabric/BUCK
@@ -8,6 +8,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     provided_deps = [
     ],
     visibility = [

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/fresco/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/fresco/BUCK
@@ -9,6 +9,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     provided_deps = [
         react_native_dep("third-party/android/androidx:annotation"),
         react_native_dep("third-party/android/androidx:core"),

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/i18nmanager/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/i18nmanager/BUCK
@@ -9,6 +9,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     provided_deps = [
         react_native_dep("third-party/android/androidx:annotation"),
         react_native_dep("third-party/android/androidx:core"),

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/image/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/image/BUCK
@@ -9,6 +9,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     visibility = [
         "PUBLIC",
     ],

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/intent/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/intent/BUCK
@@ -9,6 +9,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     visibility = [
         "PUBLIC",
     ],

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/network/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/network/BUCK
@@ -9,6 +9,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     provided_deps = [
         react_native_dep("third-party/android/androidx:annotation"),
         react_native_dep("third-party/android/androidx:core"),

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/permissions/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/permissions/BUCK
@@ -8,6 +8,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     visibility = [
         "PUBLIC",
     ],

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/share/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/share/BUCK
@@ -8,6 +8,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     visibility = [
         "PUBLIC",
     ],

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/sound/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/sound/BUCK
@@ -9,6 +9,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     provided_deps = [
     ],
     visibility = [

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/statusbar/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/statusbar/BUCK
@@ -9,6 +9,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     provided_deps = [
         react_native_dep("third-party/android/androidx:annotation"),
         react_native_dep("third-party/android/androidx:core"),

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/storage/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/storage/BUCK
@@ -9,6 +9,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     visibility = [
         "PUBLIC",
     ],

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/BUCK
@@ -12,6 +12,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     visibility = [
         "PUBLIC",
     ],
@@ -41,6 +42,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     visibility = [
         "PUBLIC",
     ],

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/toast/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/toast/BUCK
@@ -8,6 +8,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     visibility = [
         "PUBLIC",
     ],

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/vibration/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/vibration/BUCK
@@ -8,6 +8,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     visibility = [
         "PUBLIC",
     ],

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/BUCK
@@ -9,6 +9,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     visibility = [
         "PUBLIC",
     ],

--- a/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/BUCK
@@ -11,6 +11,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     visibility = [
         "PUBLIC",
     ],

--- a/ReactAndroid/src/main/java/com/facebook/react/reactperflogger/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/reactperflogger/BUCK
@@ -12,6 +12,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     required_for_source_only_abi = True,
     visibility = [
         "PUBLIC",

--- a/ReactAndroid/src/main/java/com/facebook/react/shell/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/shell/BUCK
@@ -9,6 +9,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     provided_deps = [
         react_native_dep("third-party/android/androidx:annotation"),
         react_native_dep("third-party/android/androidx:core"),

--- a/ReactAndroid/src/main/java/com/facebook/react/surface/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/surface/BUCK
@@ -9,6 +9,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     visibility = [
         "PUBLIC",
     ],

--- a/ReactAndroid/src/main/java/com/facebook/react/touch/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/touch/BUCK
@@ -9,6 +9,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     visibility = [
         "PUBLIC",
     ],

--- a/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/BUCK
@@ -13,6 +13,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     required_for_source_only_abi = True,
     visibility = [
         "PUBLIC",
@@ -48,6 +49,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     required_for_source_only_abi = True,
     visibility = [
         "PUBLIC",

--- a/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/interfaces/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/interfaces/BUCK
@@ -11,6 +11,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     required_for_source_only_abi = True,
     visibility = [
         "PUBLIC",

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/BUCK
@@ -18,6 +18,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     provided_deps = [
         react_native_dep("third-party/android/androidx:annotation"),
     ],
@@ -54,6 +55,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     provided_deps = [
         react_native_dep("third-party/android/androidx:core"),
         react_native_dep("third-party/android/androidx:fragment"),
@@ -105,6 +107,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     provided_deps = [
         react_native_dep("third-party/android/androidx:annotation"),
     ],

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
@@ -105,6 +105,36 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
     view.setOutlineAmbientShadowColor(Color.BLACK);
     view.setOutlineSpotShadowColor(Color.BLACK);
 
+    // Focus IDs
+    // Also see in AOSP source:
+    // https://android.googlesource.com/platform/frameworks/base/+/a175a5b/core/java/android/view/View.java#4493
+    view.setNextFocusDownId(View.NO_ID);
+    view.setNextFocusForwardId(View.NO_ID);
+    view.setNextFocusRightId(View.NO_ID);
+    view.setNextFocusUpId(View.NO_ID);
+
+    // This is possibly subject to change and overrideable per-platform, but these
+    // are the default view flags in View.java:
+    // https://android.googlesource.com/platform/frameworks/base/+/a175a5b/core/java/android/view/View.java#2712
+    // `mViewFlags = SOUND_EFFECTS_ENABLED | HAPTIC_FEEDBACK_ENABLED | LAYOUT_DIRECTION_INHERIT`
+    // Therefore we set the following options as such:
+    view.setFocusable(false);
+    view.setFocusableInTouchMode(false);
+
+    // https://android.googlesource.com/platform/frameworks/base/+/refs/tags/android-mainline-12.0.0_r96/core/java/android/view/View.java#5491
+    view.setElevation(0);
+
+    // Predictably, alpha defaults to 1:
+    // https://android.googlesource.com/platform/frameworks/base/+/a175a5b/core/java/android/view/View.java#2186
+    // This accounts for resetting mBackfaceOpacity and mBackfaceVisibility
+    view.setAlpha(1);
+
+    // setPadding is a noop for most View types, but it is not for Text
+    setPadding(view, 0, 0, 0, 0);
+
+    // Other stuff
+    view.setForeground(null);
+
     return view;
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
@@ -100,6 +100,8 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
     view.setRight(0);
     view.setElevation(0);
     view.setAnimationMatrix(null);
+
+    // setShadowColor
     view.setOutlineAmbientShadowColor(Color.BLACK);
     view.setOutlineSpotShadowColor(Color.BLACK);
 

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
@@ -65,6 +65,48 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
   private static final String STATE_MIXED = "mixed";
 
   @Override
+  protected T prepareToRecycleView(@NonNull ThemedReactContext reactContext, T view) {
+    // Reset tags
+    view.setTag(R.id.pointer_enter, null);
+    view.setTag(R.id.pointer_leave, null);
+    view.setTag(R.id.pointer_move, null);
+    view.setTag(R.id.react_test_id, null);
+    view.setTag(R.id.view_tag_native_id, null);
+    view.setTag(R.id.labelled_by, null);
+    view.setTag(R.id.accessibility_label, null);
+    view.setTag(R.id.accessibility_hint, null);
+    view.setTag(R.id.accessibility_role, null);
+    view.setTag(R.id.accessibility_state, null);
+    view.setTag(R.id.accessibility_actions, null);
+    view.setTag(R.id.accessibility_value, null);
+
+    // This indirectly calls (and resets):
+    // setTranslationX
+    // setTranslationY
+    // setRotation
+    // setRotationX
+    // setRotationY
+    // setScaleX
+    // setScaleY
+    // setCameraDistance
+    setTransform(view, null);
+
+    // RenderNode params not covered by setTransform above
+    view.setPivotX(0);
+    view.setPivotY(0);
+    view.setTop(0);
+    view.setBottom(0);
+    view.setLeft(0);
+    view.setRight(0);
+    view.setElevation(0);
+    view.setAnimationMatrix(null);
+    view.setOutlineAmbientShadowColor(Color.BLACK);
+    view.setOutlineSpotShadowColor(Color.BLACK);
+
+    return view;
+  }
+
+  @Override
   @ReactProp(
       name = ViewProps.BACKGROUND_COLOR,
       defaultInt = Color.TRANSPARENT,

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
@@ -207,6 +207,7 @@ public class UIManagerModule extends ReactContextBaseJavaModule
   @Override
   public void initialize() {
     getReactApplicationContext().registerComponentCallbacks(mMemoryTrimCallback);
+    getReactApplicationContext().registerComponentCallbacks(mViewManagerRegistry);
     mEventDispatcher.registerEventEmitter(
         DEFAULT, getReactApplicationContext().getJSModule(RCTEventEmitter.class));
   }
@@ -234,6 +235,7 @@ public class UIManagerModule extends ReactContextBaseJavaModule
 
     ReactApplicationContext reactApplicationContext = getReactApplicationContext();
     reactApplicationContext.unregisterComponentCallbacks(mMemoryTrimCallback);
+    reactApplicationContext.unregisterComponentCallbacks(mViewManagerRegistry);
     YogaNodePool.get().clear();
     ViewManagerPropertyUpdater.clear();
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManager.java
@@ -41,13 +41,21 @@ public abstract class ViewManager<T extends View, C extends ReactShadowNode>
    * null signals that View Recycling is disabled. `enableViewRecycling` must be explicitly called
    * in a concrete constructor to enable View Recycling per ViewManager.
    */
-  private HashMap<Integer, Stack<T>> mRecyclableViews = null;
+  @Nullable private HashMap<Integer, Stack<T>> mRecyclableViews = null;
+
+  private int mRecyclableViewsBufferSize = 1024;
 
   /** Call in constructor of concrete ViewManager class to enable. */
-  protected void enableViewRecycling() {
+  protected void setupViewRecycling() {
     if (ReactFeatureFlags.enableViewRecycling) {
       mRecyclableViews = new HashMap<>();
     }
+  }
+
+  /** Call in constructor of concrete ViewManager class to enable. */
+  protected void setupViewRecycling(int bufferSize) {
+    mRecyclableViewsBufferSize = bufferSize;
+    setupViewRecycling();
   }
 
   private @Nullable Stack<T> getRecyclableViewStack(int surfaceId) {
@@ -191,12 +199,16 @@ public abstract class ViewManager<T extends View, C extends ReactShadowNode>
    * {@link ViewManager} subclass.
    */
   public void onDropViewInstance(@NonNull T view) {
-    @Nullable
-    Stack<T> recyclableViews =
-        getRecyclableViewStack(((ThemedReactContext) view.getContext()).getSurfaceId());
-    // By default we treat views as recyclable
-    if (recyclableViews != null) {
-      recyclableViews.push(prepareToRecycleView((ThemedReactContext) view.getContext(), view));
+    // View recycling
+    ThemedReactContext themedReactContext = (ThemedReactContext) view.getContext();
+    int surfaceId = themedReactContext.getSurfaceId();
+    @Nullable Stack<T> recyclableViews = getRecyclableViewStack(surfaceId);
+
+    // Any max buffer size <0 results in an infinite buffer size
+    if (recyclableViews != null
+        && (mRecyclableViewsBufferSize < 0
+            || recyclableViews.size() < mRecyclableViewsBufferSize)) {
+      recyclableViews.push(prepareToRecycleView(themedReactContext, view));
     }
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManager.java
@@ -285,7 +285,7 @@ public abstract class ViewManager<T extends View, C extends ReactShadowNode>
    * this component type.
    */
   public @Nullable Object updateState(
-      @NonNull T view, ReactStylesDiffMap props, @Nullable StateWrapper stateWrapper) {
+      @NonNull T view, ReactStylesDiffMap props, StateWrapper stateWrapper) {
     return null;
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManager.java
@@ -16,13 +16,16 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.common.mapbuffer.MapBuffer;
+import com.facebook.react.config.ReactFeatureFlags;
 import com.facebook.react.touch.JSResponderHandler;
 import com.facebook.react.touch.ReactInterceptingViewGroup;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.annotations.ReactPropGroup;
 import com.facebook.react.uimanager.annotations.ReactPropertyHolder;
 import com.facebook.yoga.YogaMeasureMode;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Stack;
 
 /**
  * Class responsible for knowing how to create and update catalyst Views of a given type. It is also
@@ -32,6 +35,30 @@ import java.util.Map;
 @ReactPropertyHolder
 public abstract class ViewManager<T extends View, C extends ReactShadowNode>
     extends BaseJavaModule {
+
+  /**
+   * For View recycling: we store a Stack of unused, dead Views. This is null by default, and when
+   * null signals that View Recycling is disabled. `enableViewRecycling` must be explicitly called
+   * in a concrete constructor to enable View Recycling per ViewManager.
+   */
+  private HashMap<Integer, Stack<T>> mRecyclableViews = null;
+
+  /** Call in constructor of concrete ViewManager class to enable. */
+  protected void enableViewRecycling() {
+    if (ReactFeatureFlags.enableViewRecycling) {
+      mRecyclableViews = new HashMap<>();
+    }
+  }
+
+  private @Nullable Stack<T> getRecyclableViewStack(int surfaceId) {
+    if (mRecyclableViews == null) {
+      return null;
+    }
+    if (!mRecyclableViews.containsKey(surfaceId)) {
+      mRecyclableViews.put(surfaceId, new Stack<>());
+    }
+    return mRecyclableViews.get(surfaceId);
+  }
 
   /**
    * For the vast majority of ViewManagers, you will not need to override this. Only override this
@@ -137,7 +164,13 @@ public abstract class ViewManager<T extends View, C extends ReactShadowNode>
       @NonNull ThemedReactContext reactContext,
       @Nullable ReactStylesDiffMap initialProps,
       @Nullable StateWrapper stateWrapper) {
-    T view = createViewInstance(reactContext);
+    T view = null;
+    @Nullable Stack<T> recyclableViews = getRecyclableViewStack(reactContext.getSurfaceId());
+    if (recyclableViews != null && !recyclableViews.empty()) {
+      view = recycleView(reactContext, recyclableViews.pop());
+    } else {
+      view = createViewInstance(reactContext);
+    }
     view.setId(reactTag);
     addEventEmitters(reactContext, view);
     if (initialProps != null) {
@@ -157,7 +190,27 @@ public abstract class ViewManager<T extends View, C extends ReactShadowNode>
    * Called when view is detached from view hierarchy and allows for some additional cleanup by the
    * {@link ViewManager} subclass.
    */
-  public void onDropViewInstance(@NonNull T view) {}
+  public void onDropViewInstance(@NonNull T view) {
+    @Nullable
+    Stack<T> recyclableViews =
+        getRecyclableViewStack(((ThemedReactContext) view.getContext()).getSurfaceId());
+    // By default we treat views as recyclable
+    if (recyclableViews != null) {
+      recyclableViews.push(prepareToRecycleView((ThemedReactContext) view.getContext(), view));
+    }
+  }
+
+  /**
+   * Called when a View is removed from the hierachy. This should be used to reset any properties.
+   */
+  protected T prepareToRecycleView(@NonNull ThemedReactContext reactContext, @NonNull T view) {
+    return view;
+  }
+
+  /** Called when a View is going to be reused. */
+  protected T recycleView(@NonNull ThemedReactContext reactContext, @NonNull T view) {
+    return view;
+  }
 
   /**
    * Subclasses can override this method to install custom event emitters on the given View. You
@@ -370,4 +423,24 @@ public abstract class ViewManager<T extends View, C extends ReactShadowNode>
    * components support setting padding, the default implementation of this method does nothing.
    */
   public void setPadding(T view, int left, int top, int right, int bottom) {}
+
+  /**
+   * Lifecycle method: called when a surface is stopped. Currently only used for View Recycling
+   * cleanup. There is no corresponding startSurface lifecycle event for ViewManagers because we
+   * currently only need this for recycling cleanup. Only called in Fabric.
+   */
+  public void onSurfaceStopped(int surfaceId) {
+    if (mRecyclableViews != null) {
+      mRecyclableViews.remove(surfaceId);
+    }
+  }
+
+  /** With even slight memory pressure, we immediately evict all recyclable Views. */
+  /* package */ void trimMemory() {
+    // Wipe out all existing recyclable Views, but do not disable View Recycling entirely.
+    // We only take any action if View Recycling is already enabled.
+    if (mRecyclableViews != null) {
+      mRecyclableViews = new HashMap<>();
+    }
+  }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagerRegistry.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagerRegistry.java
@@ -19,11 +19,10 @@ import java.util.Map;
  * Class that stores the mapping between native view name used in JS and the corresponding instance
  * of {@link ViewManager}.
  */
-public final class ViewManagerRegistry {
+public final class ViewManagerRegistry implements ComponentCallbacks2 {
 
   private final Map<String, ViewManager> mViewManagers;
   private final @Nullable ViewManagerResolver mViewManagerResolver;
-  private final MemoryTrimCallback mMemoryTrimCallback = new MemoryTrimCallback();
 
   public ViewManagerRegistry(ViewManagerResolver viewManagerResolver) {
     mViewManagers = MapBuilder.newHashMap();
@@ -44,40 +43,6 @@ public final class ViewManagerRegistry {
     mViewManagers =
         viewManagerMap != null ? viewManagerMap : MapBuilder.<String, ViewManager>newHashMap();
     mViewManagerResolver = null;
-  }
-
-  /**
-   * Trim View Recycling memory aggressively. Whenever the system is running even slightly low on
-   * memory or is backgrounded, we immediately flush all recyclable Views. GC and memory swaps cause
-   * intense CPU pressure, so we always favor low memory usage over View recycling, even if there is
-   * only "moderate" pressure.
-   */
-  private class MemoryTrimCallback implements ComponentCallbacks2 {
-    @Override
-    public void onTrimMemory(int level) {
-      Runnable runnable =
-          new Runnable() {
-            @Override
-            public void run() {
-              for (Map.Entry<String, ViewManager> entry : mViewManagers.entrySet()) {
-                entry.getValue().trimMemory();
-              }
-            }
-          };
-      if (UiThreadUtil.isOnUiThread()) {
-        runnable.run();
-      } else {
-        UiThreadUtil.runOnUiThread(runnable);
-      }
-    }
-
-    @Override
-    public void onConfigurationChanged(Configuration newConfig) {}
-
-    @Override
-    public void onLowMemory() {
-      this.onTrimMemory(0);
-    }
   }
 
   /**
@@ -146,5 +111,34 @@ public final class ViewManagerRegistry {
     } else {
       UiThreadUtil.runOnUiThread(runnable);
     }
+  }
+
+  /** ComponentCallbacks2 method. */
+  @Override
+  public void onTrimMemory(int level) {
+    Runnable runnable =
+        new Runnable() {
+          @Override
+          public void run() {
+            for (Map.Entry<String, ViewManager> entry : mViewManagers.entrySet()) {
+              entry.getValue().trimMemory();
+            }
+          }
+        };
+    if (UiThreadUtil.isOnUiThread()) {
+      runnable.run();
+    } else {
+      UiThreadUtil.runOnUiThread(runnable);
+    }
+  }
+
+  /** ComponentCallbacks2 method. */
+  @Override
+  public void onConfigurationChanged(Configuration newConfig) {}
+
+  /** ComponentCallbacks2 method. */
+  @Override
+  public void onLowMemory() {
+    this.onTrimMemory(0);
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/annotations/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/annotations/BUCK
@@ -9,6 +9,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     required_for_source_only_abi = True,
     visibility = [
         "PUBLIC",

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/common/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/common/BUCK
@@ -9,6 +9,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     provided_deps = [
         react_native_dep("third-party/android/androidx:annotation"),
         react_native_dep("third-party/android/androidx:core"),

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/util/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/util/BUCK
@@ -9,6 +9,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     visibility = [
         "PUBLIC",
     ],

--- a/ReactAndroid/src/main/java/com/facebook/react/util/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/util/BUCK
@@ -8,6 +8,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     visibility = [
         "PUBLIC",
     ],

--- a/ReactAndroid/src/main/java/com/facebook/react/views/common/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/common/BUCK
@@ -9,6 +9,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     provided_deps = [
         react_native_dep("third-party/java/jsr-305:jsr-305"),
         react_native_dep("third-party/android/androidx:annotation"),

--- a/ReactAndroid/src/main/java/com/facebook/react/views/drawer/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/drawer/BUCK
@@ -9,6 +9,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     provided_deps = [
         react_native_dep("third-party/android/androidx:annotation"),
         react_native_dep("third-party/android/androidx:core"),

--- a/ReactAndroid/src/main/java/com/facebook/react/views/image/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/image/BUCK
@@ -13,6 +13,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     provided_deps = [
         react_native_dep("third-party/android/androidx:annotation"),
         react_native_dep("third-party/android/androidx:core"),
@@ -41,6 +42,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     provided_deps = [
         react_native_dep("third-party/android/androidx:annotation"),
         react_native_dep("third-party/android/androidx:core"),

--- a/ReactAndroid/src/main/java/com/facebook/react/views/imagehelper/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/imagehelper/BUCK
@@ -12,6 +12,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     visibility = [
         "PUBLIC",
     ],
@@ -31,6 +32,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     visibility = [
         "PUBLIC",
     ],

--- a/ReactAndroid/src/main/java/com/facebook/react/views/modal/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/modal/BUCK
@@ -9,6 +9,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     provided_deps = [
         react_native_dep("third-party/android/androidx:annotation"),
     ],

--- a/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostManager.java
@@ -166,7 +166,7 @@ public class ReactModalHostManager extends ViewGroupManager<ReactModalHostView>
 
   @Override
   public Object updateState(
-      ReactModalHostView view, ReactStylesDiffMap props, @Nullable StateWrapper stateWrapper) {
+      ReactModalHostView view, ReactStylesDiffMap props, StateWrapper stateWrapper) {
     view.getFabricViewStateManager().setStateWrapper(stateWrapper);
     Point modalSize = ModalHostHelper.getModalHostSize(view.getContext());
     view.updateState(modalSize.x, modalSize.y);

--- a/ReactAndroid/src/main/java/com/facebook/react/views/progressbar/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/progressbar/BUCK
@@ -9,6 +9,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     visibility = [
         "PUBLIC",
     ],

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/BUCK
@@ -9,6 +9,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     provided_deps = [
         react_native_dep("third-party/android/androidx:annotation"),
         react_native_dep("third-party/android/androidx:core"),

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
@@ -66,9 +66,7 @@ public class ReactHorizontalScrollViewManager extends ViewGroupManager<ReactHori
 
   @Override
   public Object updateState(
-      ReactHorizontalScrollView view,
-      ReactStylesDiffMap props,
-      @Nullable StateWrapper stateWrapper) {
+      ReactHorizontalScrollView view, ReactStylesDiffMap props, StateWrapper stateWrapper) {
     view.getFabricViewStateManager().setStateWrapper(stateWrapper);
     return null;
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.java
@@ -328,7 +328,7 @@ public class ReactScrollViewManager extends ViewGroupManager<ReactScrollView>
 
   @Override
   public Object updateState(
-      ReactScrollView view, ReactStylesDiffMap props, @Nullable StateWrapper stateWrapper) {
+      ReactScrollView view, ReactStylesDiffMap props, StateWrapper stateWrapper) {
     view.getFabricViewStateManager().setStateWrapper(stateWrapper);
     return null;
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/slider/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/slider/BUCK
@@ -9,6 +9,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     visibility = [
         "PUBLIC",
     ],

--- a/ReactAndroid/src/main/java/com/facebook/react/views/swiperefresh/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/swiperefresh/BUCK
@@ -9,6 +9,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     provided_deps = [
         react_native_dep("third-party/android/androidx:annotation"),
         react_native_dep("third-party/android/androidx:core"),

--- a/ReactAndroid/src/main/java/com/facebook/react/views/switchview/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/switchview/BUCK
@@ -9,6 +9,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     provided_deps = [
         react_native_dep("third-party/android/androidx:appcompat"),
         react_native_dep("third-party/android/androidx:core"),

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/CustomLetterSpacingSpan.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/CustomLetterSpacingSpan.java
@@ -37,6 +37,10 @@ public class CustomLetterSpacingSpan extends MetricAffectingSpan implements Reac
     apply(paint);
   }
 
+  public float getSpacing() {
+    return mLetterSpacing;
+  }
+
   private void apply(TextPaint paint) {
     if (!Float.isNaN(mLetterSpacing)) {
       paint.setLetterSpacing(mLetterSpacing);

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/CustomStyleSpan.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/CustomStyleSpan.java
@@ -71,6 +71,10 @@ public class CustomStyleSpan extends MetricAffectingSpan implements ReactSpan {
     return mFontFamily;
   }
 
+  public @Nullable String getFontFeatureSettings() {
+    return mFeatureSettings;
+  }
+
   private static void apply(
       Paint paint,
       int style,

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextAnchorViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextAnchorViewManager.java
@@ -193,24 +193,25 @@ public abstract class ReactTextAnchorViewManager<T extends View, C extends React
 
   @ReactProp(name = "dataDetectorType")
   public void setDataDetectorType(ReactTextView view, @Nullable String type) {
-    switch (type) {
-      case "phoneNumber":
-        view.setLinkifyMask(Linkify.PHONE_NUMBERS);
-        break;
-      case "link":
-        view.setLinkifyMask(Linkify.WEB_URLS);
-        break;
-      case "email":
-        view.setLinkifyMask(Linkify.EMAIL_ADDRESSES);
-        break;
-      case "all":
-        view.setLinkifyMask(Linkify.ALL);
-        break;
-      case "none":
-      default:
-        view.setLinkifyMask(0);
-        break;
+    if (type != null) {
+      switch (type) {
+        case "phoneNumber":
+          view.setLinkifyMask(Linkify.PHONE_NUMBERS);
+          return;
+        case "link":
+          view.setLinkifyMask(Linkify.WEB_URLS);
+          return;
+        case "email":
+          view.setLinkifyMask(Linkify.EMAIL_ADDRESSES);
+          return;
+        case "all":
+          view.setLinkifyMask(Linkify.ALL);
+          return;
+      }
     }
+
+    // "none" case, default, and null type are equivalent.
+    view.setLinkifyMask(0);
   }
 
   @ReactProp(name = "onInlineViewLayout")

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextUpdate.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextUpdate.java
@@ -31,8 +31,6 @@ public class ReactTextUpdate {
   private final int mSelectionEnd;
   private final int mJustificationMode;
 
-  public boolean mContainsMultipleFragments;
-
   /**
    * @deprecated Use a non-deprecated constructor for ReactTextUpdate instead. This one remains
    *     because it's being used by a unit test that isn't currently open source.
@@ -142,13 +140,11 @@ public class ReactTextUpdate {
       int jsEventCounter,
       int textAlign,
       int textBreakStrategy,
-      int justificationMode,
-      boolean containsMultipleFragments) {
+      int justificationMode) {
 
     ReactTextUpdate reactTextUpdate =
         new ReactTextUpdate(
             text, jsEventCounter, false, textAlign, textBreakStrategy, justificationMode);
-    reactTextUpdate.mContainsMultipleFragments = containsMultipleFragments;
     return reactTextUpdate;
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
@@ -54,7 +54,6 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
   private boolean mContainsImages;
   private final int mDefaultGravityHorizontal;
   private final int mDefaultGravityVertical;
-  private int mTextAlign;
   private int mNumberOfLines;
   private TextUtils.TruncateAt mEllipsizeLocation;
   private boolean mAdjustsFontSizeToFit;
@@ -69,8 +68,7 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
     super(context);
 
     // Get these defaults only during the constructor - these should never be set otherwise
-    mDefaultGravityHorizontal =
-        getGravity() & (Gravity.HORIZONTAL_GRAVITY_MASK | Gravity.RELATIVE_HORIZONTAL_GRAVITY_MASK);
+    mDefaultGravityHorizontal = getGravityHorizontal();
     mDefaultGravityVertical = getGravity() & Gravity.VERTICAL_GRAVITY_MASK;
 
     initView();
@@ -89,10 +87,10 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
 
     mReactBackgroundManager = new ReactViewBackgroundManager(this);
 
-    mTextAlign = Gravity.NO_GRAVITY;
     mNumberOfLines = ViewDefaults.NUMBER_OF_LINES;
     mAdjustsFontSizeToFit = false;
     mLinkifyMaskType = 0;
+    mNotifyOnInlineViewLayout = false;
     mTextIsSelectable = false;
     mEllipsizeLocation = TextUtils.TruncateAt.END;
 
@@ -392,10 +390,9 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
     }
 
     int nextTextAlign = update.getTextAlign();
-    if (mTextAlign != nextTextAlign) {
-      mTextAlign = nextTextAlign;
+    if (nextTextAlign != getGravityHorizontal()) {
+      setGravityHorizontal(nextTextAlign);
     }
-    setGravityHorizontal(mTextAlign);
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
       if (getBreakStrategy() != update.getTextBreakStrategy()) {
         setBreakStrategy(update.getTextBreakStrategy());
@@ -550,6 +547,11 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
   @Override
   public boolean hasOverlappingRendering() {
     return false;
+  }
+
+  /* package */ int getGravityHorizontal() {
+    return getGravity()
+        & (Gravity.HORIZONTAL_GRAVITY_MASK | Gravity.RELATIVE_HORIZONTAL_GRAVITY_MASK);
   }
 
   /* package */ void setGravityHorizontal(int gravityHorizontal) {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
@@ -105,9 +105,13 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
 
     // Defaults for these fields:
     // https://github.com/aosp-mirror/platform_frameworks_base/blob/master/core/java/android/widget/TextView.java#L1061
-    setBreakStrategy(Layout.BREAK_STRATEGY_SIMPLE);
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      setBreakStrategy(Layout.BREAK_STRATEGY_SIMPLE);
+    }
     setMovementMethod(getDefaultMovementMethod());
-    setJustificationMode(Layout.JUSTIFICATION_MODE_NONE);
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      setJustificationMode(Layout.JUSTIFICATION_MODE_NONE);
+    }
 
     // reset text
     setLayoutParams(EMPTY_LAYOUT_PARAMS);

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
@@ -52,8 +52,8 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
       new ViewGroup.LayoutParams(0, 0);
 
   private boolean mContainsImages;
-  private int mDefaultGravityHorizontal;
-  private int mDefaultGravityVertical;
+  private final int mDefaultGravityHorizontal;
+  private final int mDefaultGravityVertical;
   private int mTextAlign;
   private int mNumberOfLines;
   private TextUtils.TruncateAt mEllipsizeLocation;
@@ -67,6 +67,12 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
 
   public ReactTextView(Context context) {
     super(context);
+
+    // Get these defaults only during the constructor - these should never be set otherwise
+    mDefaultGravityHorizontal =
+        getGravity() & (Gravity.HORIZONTAL_GRAVITY_MASK | Gravity.RELATIVE_HORIZONTAL_GRAVITY_MASK);
+    mDefaultGravityVertical = getGravity() & Gravity.VERTICAL_GRAVITY_MASK;
+
     initView();
   }
 
@@ -82,9 +88,6 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
     }
 
     mReactBackgroundManager = new ReactViewBackgroundManager(this);
-    mDefaultGravityHorizontal =
-        getGravity() & (Gravity.HORIZONTAL_GRAVITY_MASK | Gravity.RELATIVE_HORIZONTAL_GRAVITY_MASK);
-    mDefaultGravityVertical = getGravity() & Gravity.VERTICAL_GRAVITY_MASK;
 
     mTextAlign = Gravity.NO_GRAVITY;
     mNumberOfLines = ViewDefaults.NUMBER_OF_LINES;

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
@@ -140,9 +140,13 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
     //         mViewFlags = SOUND_EFFECTS_ENABLED | HAPTIC_FEEDBACK_ENABLED |
     // LAYOUT_DIRECTION_INHERIT;
     setEnabled(true);
-    setFocusable(View.FOCUSABLE_AUTO);
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      setFocusable(View.FOCUSABLE_AUTO);
+    }
 
-    setHyphenationFrequency(Layout.HYPHENATION_FREQUENCY_NONE);
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      setHyphenationFrequency(Layout.HYPHENATION_FREQUENCY_NONE);
+    }
 
     updateView(); // call after changing ellipsizeLocation in particular
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
@@ -96,16 +96,18 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
     mSpanned = null;
   }
 
-  /* package */ void recycleView(ReactTextView defaultView) {
+  /* package */ void recycleView() {
     // Set default field values
     initView();
 
-    setForeground(null);
+    // Defaults for these fields:
+    // https://github.com/aosp-mirror/platform_frameworks_base/blob/master/core/java/android/widget/TextView.java#L1061
+    setBreakStrategy(Layout.BREAK_STRATEGY_SIMPLE);
+    setMovementMethod(getDefaultMovementMethod());
+    setJustificationMode(Layout.JUSTIFICATION_MODE_NONE);
 
     // reset text
     setLayoutParams(EMPTY_LAYOUT_PARAMS);
-    setMovementMethod(defaultView.getMovementMethod());
-    setBreakStrategy(defaultView.getBreakStrategy());
     super.setText(null);
 
     // Call setters to ensure that any super setters are called
@@ -124,20 +126,7 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
     // reset data detectors
     setLinkifyMask(0);
 
-    setJustificationMode(defaultView.getJustificationMode());
-
     setEllipsizeLocation(mEllipsizeLocation);
-
-    // Focus IDs
-    // Also see in AOSP source:
-    // https://android.googlesource.com/platform/frameworks/base/+/a175a5b/core/java/android/view/View.java#4493
-    setNextFocusDownId(View.NO_ID);
-    setNextFocusForwardId(View.NO_ID);
-    setNextFocusRightId(View.NO_ID);
-    setNextFocusUpId(View.NO_ID);
-
-    // https://android.googlesource.com/platform/frameworks/base/+/refs/tags/android-mainline-12.0.0_r96/core/java/android/view/View.java#5491
-    setElevation(0);
 
     // View flags - defaults are here:
     // https://android.googlesource.com/platform/frameworks/base/+/98e54bb941cb6feb07127b75da37833281951d52/core/java/android/view/View.java#5311
@@ -146,8 +135,7 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
     setEnabled(true);
     setFocusable(View.FOCUSABLE_AUTO);
 
-    // Things that could be set as a result of updateText/setText
-    setPadding(0, 0, 0, 0);
+    setHyphenationFrequency(Layout.HYPHENATION_FREQUENCY_NONE);
 
     updateView(); // call after changing ellipsizeLocation in particular
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.java
@@ -9,6 +9,7 @@ package com.facebook.react.views.text;
 
 import android.content.Context;
 import android.text.Spannable;
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.facebook.react.R;
 import com.facebook.react.bridge.ReadableMap;
@@ -44,7 +45,36 @@ public class ReactTextViewManager
 
   @VisibleForTesting public static final String REACT_CLASS = "RCTText";
 
+  private ReactTextView mDefaultViewForRecycling = null;
+
   protected @Nullable ReactTextViewManagerCallback mReactTextViewManagerCallback;
+
+  public ReactTextViewManager() {
+    super();
+
+    enableViewRecycling();
+  }
+
+  @Override
+  protected ReactTextView prepareToRecycleView(
+      @NonNull ThemedReactContext reactContext, ReactTextView view) {
+    // TODO: use context as key
+    if (mDefaultViewForRecycling == null) {
+      mDefaultViewForRecycling = createViewInstance(reactContext);
+    }
+
+    // BaseViewManager
+    super.prepareToRecycleView(reactContext, view);
+
+    // Resets background and borders
+    view.recycleView(mDefaultViewForRecycling);
+
+    // Defaults from ReactTextAnchorViewManager
+    setSelectionColor(view, null);
+    setAndroidHyphenationFrequency(view, null);
+
+    return view;
+  }
 
   @Override
   public String getName() {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.java
@@ -106,11 +106,7 @@ public class ReactTextViewManager
 
   @Override
   public Object updateState(
-      ReactTextView view, ReactStylesDiffMap props, @Nullable StateWrapper stateWrapper) {
-    if (stateWrapper == null) {
-      return null;
-    }
-
+      ReactTextView view, ReactStylesDiffMap props, StateWrapper stateWrapper) {
     if (ReactFeatureFlags.isMapBufferSerializationEnabled()) {
       MapBuffer stateMapBuffer = stateWrapper.getStateDataMapBuffer();
       if (stateMapBuffer != null) {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.java
@@ -45,33 +45,25 @@ public class ReactTextViewManager
 
   @VisibleForTesting public static final String REACT_CLASS = "RCTText";
 
-  private ReactTextView mDefaultViewForRecycling = null;
-
   protected @Nullable ReactTextViewManagerCallback mReactTextViewManagerCallback;
 
   public ReactTextViewManager() {
     super();
 
-    enableViewRecycling();
+    setupViewRecycling();
   }
 
   @Override
   protected ReactTextView prepareToRecycleView(
       @NonNull ThemedReactContext reactContext, ReactTextView view) {
-    // TODO: use context as key
-    if (mDefaultViewForRecycling == null) {
-      mDefaultViewForRecycling = createViewInstance(reactContext);
-    }
-
     // BaseViewManager
     super.prepareToRecycleView(reactContext, view);
 
     // Resets background and borders
-    view.recycleView(mDefaultViewForRecycling);
+    view.recycleView();
 
     // Defaults from ReactTextAnchorViewManager
     setSelectionColor(view, null);
-    setAndroidHyphenationFrequency(view, null);
 
     return view;
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.java
@@ -8,6 +8,7 @@
 package com.facebook.react.views.text;
 
 import android.content.Context;
+import android.os.Build;
 import android.text.Spannable;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -24,6 +25,7 @@ import com.facebook.react.uimanager.ReactAccessibilityDelegate;
 import com.facebook.react.uimanager.ReactStylesDiffMap;
 import com.facebook.react.uimanager.StateWrapper;
 import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.ViewProps;
 import com.facebook.yoga.YogaMeasureMode;
 import java.util.HashMap;
 import java.util.Map;
@@ -149,15 +151,19 @@ public class ReactTextViewManager
     view.setSpanned(spanned);
 
     int textBreakStrategy =
-        TextAttributeProps.getTextBreakStrategy(paragraphAttributes.getString("textBreakStrategy"));
+        TextAttributeProps.getTextBreakStrategy(
+            paragraphAttributes.getString(ViewProps.TEXT_BREAK_STRATEGY));
+    int currentJustificationMode =
+        Build.VERSION.SDK_INT < Build.VERSION_CODES.O ? 0 : view.getJustificationMode();
 
     return new ReactTextUpdate(
         spanned,
         state.hasKey("mostRecentEventCount") ? state.getInt("mostRecentEventCount") : -1,
         false, // TODO add this into local Data
-        TextAttributeProps.getTextAlignment(props, TextLayoutManager.isRTL(attributedString)),
+        TextAttributeProps.getTextAlignment(
+            props, TextLayoutManager.isRTL(attributedString), view.getGravityHorizontal()),
         textBreakStrategy,
-        TextAttributeProps.getJustificationMode(props));
+        TextAttributeProps.getJustificationMode(props, currentJustificationMode));
   }
 
   private Object getReactTextUpdate(ReactTextView view, ReactStylesDiffMap props, MapBuffer state) {
@@ -172,15 +178,17 @@ public class ReactTextViewManager
     int textBreakStrategy =
         TextAttributeProps.getTextBreakStrategy(
             paragraphAttributes.getString(TextLayoutManagerMapBuffer.PA_KEY_TEXT_BREAK_STRATEGY));
+    int currentJustificationMode =
+        Build.VERSION.SDK_INT < Build.VERSION_CODES.O ? 0 : view.getJustificationMode();
 
     return new ReactTextUpdate(
         spanned,
         -1, // UNUSED FOR TEXT
         false, // TODO add this into local Data
         TextAttributeProps.getTextAlignment(
-            props, TextLayoutManagerMapBuffer.isRTL(attributedString)),
+            props, TextLayoutManagerMapBuffer.isRTL(attributedString), view.getGravityHorizontal()),
         textBreakStrategy,
-        TextAttributeProps.getJustificationMode(props));
+        TextAttributeProps.getJustificationMode(props, currentJustificationMode));
   }
 
   @Override

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/TextAttributeProps.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/TextAttributeProps.java
@@ -249,35 +249,35 @@ public class TextAttributeProps {
     return result;
   }
 
-  public static int getTextAlignment(ReactStylesDiffMap props, boolean isRTL) {
-    @Nullable
-    String textAlignPropValue =
-        props.hasKey(ViewProps.TEXT_ALIGN) ? props.getString(ViewProps.TEXT_ALIGN) : null;
-    int textAlignment;
+  public static int getTextAlignment(ReactStylesDiffMap props, boolean isRTL, int defaultValue) {
+    if (!props.hasKey(ViewProps.TEXT_ALIGN)) {
+      return defaultValue;
+    }
 
+    String textAlignPropValue = props.getString(ViewProps.TEXT_ALIGN);
     if ("justify".equals(textAlignPropValue)) {
-      textAlignment = Gravity.LEFT;
+      return Gravity.LEFT;
     } else {
       if (textAlignPropValue == null || "auto".equals(textAlignPropValue)) {
-        textAlignment = Gravity.NO_GRAVITY;
+        return Gravity.NO_GRAVITY;
       } else if ("left".equals(textAlignPropValue)) {
-        textAlignment = isRTL ? Gravity.RIGHT : Gravity.LEFT;
+        return isRTL ? Gravity.RIGHT : Gravity.LEFT;
       } else if ("right".equals(textAlignPropValue)) {
-        textAlignment = isRTL ? Gravity.LEFT : Gravity.RIGHT;
+        return isRTL ? Gravity.LEFT : Gravity.RIGHT;
       } else if ("center".equals(textAlignPropValue)) {
-        textAlignment = Gravity.CENTER_HORIZONTAL;
+        return Gravity.CENTER_HORIZONTAL;
       } else {
         throw new JSApplicationIllegalArgumentException("Invalid textAlign: " + textAlignPropValue);
       }
     }
-    return textAlignment;
   }
 
-  public static int getJustificationMode(ReactStylesDiffMap props) {
-    @Nullable
-    String textAlignPropValue =
-        props.hasKey(ViewProps.TEXT_ALIGN) ? props.getString(ViewProps.TEXT_ALIGN) : null;
+  public static int getJustificationMode(ReactStylesDiffMap props, int defaultValue) {
+    if (!props.hasKey(ViewProps.TEXT_ALIGN)) {
+      return defaultValue;
+    }
 
+    String textAlignPropValue = props.getString(ViewProps.TEXT_ALIGN);
     if ("justify".equals(textAlignPropValue) && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
       return Layout.JUSTIFICATION_MODE_INTER_WORD;
     }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManagerMapBuffer.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManagerMapBuffer.java
@@ -105,6 +105,11 @@ public class TextLayoutManagerMapBuffer {
 
     MapBuffer fragment = fragments.getMapBuffer((short) 0);
     MapBuffer textAttributes = fragment.getMapBuffer(FR_KEY_TEXT_ATTRIBUTES);
+
+    if (!textAttributes.contains(TextAttributeProps.TA_KEY_LAYOUT_DIRECTION)) {
+      return false;
+    }
+
     return TextAttributeProps.getLayoutDirection(
             textAttributes.getString(TextAttributeProps.TA_KEY_LAYOUT_DIRECTION))
         == LayoutDirection.RTL;

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/frescosupport/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/frescosupport/BUCK
@@ -9,6 +9,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     visibility = [
         "PUBLIC",
     ],

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/BUCK
@@ -9,6 +9,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     required_for_source_only_abi = True,
     visibility = [
         "PUBLIC",

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/BUCK
@@ -9,7 +9,8 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
-    language = "JAVA",
+    language = "KOTLIN",
+    pure_kotlin = False,
     required_for_source_only_abi = True,
     visibility = [
         "PUBLIC",
@@ -29,7 +30,9 @@ rn_android_library(
         react_native_target("java/com/facebook/react/views/imagehelper:imagehelper"),
         react_native_target("java/com/facebook/react/views/scroll:scroll"),
         react_native_target("java/com/facebook/react/views/text:text"),
+        react_native_target("java/com/facebook/react/common/mapbuffer:mapbuffer"),
         react_native_target("java/com/facebook/react/views/view:view"),
+        react_native_target("java/com/facebook/react/config:config"),
     ],
     exported_deps = [
         react_native_dep("third-party/android/androidx:appcompat"),

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -550,9 +550,7 @@ public class ReactEditText extends AppCompatEditText
         new SpannableStringBuilder(reactTextUpdate.getText());
 
     manageSpans(spannableStringBuilder, reactTextUpdate.mContainsMultipleFragments);
-
-    // Mitigation for https://github.com/facebook/react-native/issues/35936 (S318090)
-    stripAtributeEquivalentSpans(spannableStringBuilder);
+    stripStyleEquivalentSpans(spannableStringBuilder);
 
     mContainsImages = reactTextUpdate.containsImages();
 
@@ -627,28 +625,44 @@ public class ReactEditText extends AppCompatEditText
     }
   }
 
-  private void stripAtributeEquivalentSpans(SpannableStringBuilder sb) {
-    // We have already set a font size on the EditText itself. We can safely remove sizing spans
-    // which are the same as the set font size, and not otherwise overlapped.
-    final int effectiveFontSize = mTextAttributes.getEffectiveFontSize();
-    ReactAbsoluteSizeSpan[] spans = sb.getSpans(0, sb.length(), ReactAbsoluteSizeSpan.class);
+  // TODO: Replace with Predicate<T> and lambdas once Java 8 builds in OSS
+  interface SpanPredicate<T> {
+    boolean test(T span);
+  }
 
-    outerLoop:
-    for (ReactAbsoluteSizeSpan span : spans) {
-      ReactAbsoluteSizeSpan[] overlappingSpans =
-          sb.getSpans(sb.getSpanStart(span), sb.getSpanEnd(span), ReactAbsoluteSizeSpan.class);
+  /**
+   * Remove spans from the SpannableStringBuilder which can be represented by TextAppearance
+   * attributes on the underlying EditText. This works around instability on Samsung devices with
+   * the presence of spans https://github.com/facebook/react-native/issues/35936 (S318090)
+   */
+  private void stripStyleEquivalentSpans(SpannableStringBuilder sb) {
+    stripSpansOfKind(
+        sb,
+        ReactAbsoluteSizeSpan.class,
+        new SpanPredicate<ReactAbsoluteSizeSpan>() {
+          @Override
+          public boolean test(ReactAbsoluteSizeSpan span) {
+            return span.getSize() == mTextAttributes.getEffectiveFontSize();
+          }
+        });
+  }
 
-      for (ReactAbsoluteSizeSpan overlappingSpan : overlappingSpans) {
-        if (span.getSize() != effectiveFontSize) {
-          continue outerLoop;
-        }
+  private <T> void stripSpansOfKind(
+      SpannableStringBuilder sb, Class<T> clazz, SpanPredicate<T> shouldStrip) {
+    T[] spans = sb.getSpans(0, sb.length(), clazz);
+
+    for (T span : spans) {
+      if (shouldStrip.test(span)) {
+        sb.removeSpan(span);
       }
-
-      sb.removeSpan(span);
     }
   }
 
-  private void unstripAttributeEquivalentSpans(SpannableStringBuilder workingText) {
+  /**
+   * Copy back styles represented as attributes to the underlying span, for later measurement
+   * outside the ReactEditText.
+   */
+  private void restoreStyleEquivalentSpans(SpannableStringBuilder workingText) {
     int spanFlags = Spannable.SPAN_INCLUSIVE_INCLUSIVE;
 
     // Set all bits for SPAN_PRIORITY so that this span has the highest possible priority
@@ -1081,7 +1095,7 @@ public class ReactEditText extends AppCompatEditText
       // - android.app.Activity.dispatchKeyEvent (Activity.java:3447)
       try {
         sb.append(currentText.subSequence(0, currentText.length()));
-        unstripAttributeEquivalentSpans(sb);
+        restoreStyleEquivalentSpans(sb);
       } catch (IndexOutOfBoundsException e) {
         ReactSoftExceptionLogger.logSoftException(TAG, e);
       }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -65,6 +65,7 @@ import com.facebook.react.views.text.TextLayoutManager;
 import com.facebook.react.views.view.ReactViewBackgroundManager;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * A wrapper around the EditText that lets us better control what happens when an EditText gets
@@ -483,6 +484,14 @@ public class ReactEditText extends AppCompatEditText
     }
   }
 
+  @Override
+  public void setFontFeatureSettings(String fontFeatureSettings) {
+    if (!Objects.equals(fontFeatureSettings, getFontFeatureSettings())) {
+      super.setFontFeatureSettings(fontFeatureSettings);
+      mTypefaceDirty = true;
+    }
+  }
+
   public void maybeUpdateTypeface() {
     if (!mTypefaceDirty) {
       return;
@@ -494,6 +503,17 @@ public class ReactEditText extends AppCompatEditText
         ReactTypefaceUtils.applyStyles(
             getTypeface(), mFontStyle, mFontWeight, mFontFamily, getContext().getAssets());
     setTypeface(newTypeface);
+
+    // Match behavior of CustomStyleSpan and enable SUBPIXEL_TEXT_FLAG when setting anything
+    // nonstandard
+    if (mFontStyle != UNSET
+        || mFontWeight != UNSET
+        || mFontFamily != null
+        || getFontFeatureSettings() != null) {
+      setPaintFlags(getPaintFlags() | Paint.SUBPIXEL_TEXT_FLAG);
+    } else {
+      setPaintFlags(getPaintFlags() & (~Paint.SUBPIXEL_TEXT_FLAG));
+    }
   }
 
   // VisibleForTesting from {@link TextInputEventsTestCase}.
@@ -703,6 +723,19 @@ public class ReactEditText extends AppCompatEditText
             }
           });
     }
+
+    stripSpansOfKind(
+        sb,
+        CustomStyleSpan.class,
+        new SpanPredicate<CustomStyleSpan>() {
+          @Override
+          public boolean test(CustomStyleSpan span) {
+            return span.getStyle() == mFontStyle
+                && Objects.equals(span.getFontFamily(), mFontFamily)
+                && span.getWeight() == mFontWeight
+                && Objects.equals(span.getFontFeatureSettings(), getFontFeatureSettings());
+          }
+        });
   }
 
   private <T> void stripSpansOfKind(
@@ -759,6 +792,22 @@ public class ReactEditText extends AppCompatEditText
             workingText.length(),
             spanFlags);
       }
+    }
+
+    if (mFontStyle != UNSET
+        || mFontWeight != UNSET
+        || mFontFamily != null
+        || getFontFeatureSettings() != null) {
+      workingText.setSpan(
+          new CustomStyleSpan(
+              mFontStyle,
+              mFontWeight,
+              getFontFeatureSettings(),
+              mFontFamily,
+              getContext().getAssets()),
+          0,
+          workingText.length(),
+          spanFlags);
     }
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -52,6 +52,7 @@ import com.facebook.react.views.text.CustomLineHeightSpan;
 import com.facebook.react.views.text.CustomStyleSpan;
 import com.facebook.react.views.text.ReactAbsoluteSizeSpan;
 import com.facebook.react.views.text.ReactBackgroundColorSpan;
+import com.facebook.react.views.text.ReactForegroundColorSpan;
 import com.facebook.react.views.text.ReactSpan;
 import com.facebook.react.views.text.ReactTextUpdate;
 import com.facebook.react.views.text.ReactTypefaceUtils;
@@ -657,6 +658,16 @@ public class ReactEditText extends AppCompatEditText
             return span.getBackgroundColor() == mReactBackgroundManager.getBackgroundColor();
           }
         });
+
+    stripSpansOfKind(
+        sb,
+        ReactForegroundColorSpan.class,
+        new SpanPredicate<ReactForegroundColorSpan>() {
+          @Override
+          public boolean test(ReactForegroundColorSpan span) {
+            return span.getForegroundColor() == getCurrentTextColor();
+          }
+        });
   }
 
   private <T> void stripSpansOfKind(
@@ -683,6 +694,7 @@ public class ReactEditText extends AppCompatEditText
 
     List<Object> spans = new ArrayList<>();
     spans.add(new ReactAbsoluteSizeSpan(mTextAttributes.getEffectiveFontSize()));
+    spans.add(new ReactForegroundColorSpan(getCurrentTextColor()));
 
     int backgroundColor = mReactBackgroundManager.getBackgroundColor();
     if (backgroundColor != Color.TRANSPARENT) {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -552,7 +552,7 @@ public class ReactEditText extends AppCompatEditText
     manageSpans(spannableStringBuilder, reactTextUpdate.mContainsMultipleFragments);
 
     // Mitigation for https://github.com/facebook/react-native/issues/35936 (S318090)
-    stripAbsoluteSizeSpans(spannableStringBuilder);
+    stripAtributeEquivalentSpans(spannableStringBuilder);
 
     mContainsImages = reactTextUpdate.containsImages();
 
@@ -627,7 +627,7 @@ public class ReactEditText extends AppCompatEditText
     }
   }
 
-  private void stripAbsoluteSizeSpans(SpannableStringBuilder sb) {
+  private void stripAtributeEquivalentSpans(SpannableStringBuilder sb) {
     // We have already set a font size on the EditText itself. We can safely remove sizing spans
     // which are the same as the set font size, and not otherwise overlapped.
     final int effectiveFontSize = mTextAttributes.getEffectiveFontSize();
@@ -645,6 +645,31 @@ public class ReactEditText extends AppCompatEditText
       }
 
       sb.removeSpan(span);
+    }
+  }
+
+  private void unstripAttributeEquivalentSpans(
+      SpannableStringBuilder workingText, Spannable originalText) {
+    // We must add spans back for Fabric to be able to measure, at lower precedence than any
+    // existing spans. Remove all spans, add the attributes, then re-add the spans over
+    workingText.append(originalText);
+
+    for (Object span : workingText.getSpans(0, workingText.length(), Object.class)) {
+      workingText.removeSpan(span);
+    }
+
+    workingText.setSpan(
+        new ReactAbsoluteSizeSpan(mTextAttributes.getEffectiveFontSize()),
+        0,
+        workingText.length(),
+        Spanned.SPAN_INCLUSIVE_INCLUSIVE);
+
+    for (Object span : originalText.getSpans(0, originalText.length(), Object.class)) {
+      workingText.setSpan(
+          span,
+          originalText.getSpanStart(span),
+          originalText.getSpanEnd(span),
+          originalText.getSpanFlags(span));
     }
   }
 
@@ -1066,7 +1091,8 @@ public class ReactEditText extends AppCompatEditText
       // ...
       // - android.app.Activity.dispatchKeyEvent (Activity.java:3447)
       try {
-        sb.append(currentText.subSequence(0, currentText.length()));
+        Spannable text = (Spannable) currentText.subSequence(0, currentText.length());
+        unstripAttributeEquivalentSpans(sb, text);
       } catch (IndexOutOfBoundsException e) {
         ReactSoftExceptionLogger.logSoftException(TAG, e);
       }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -727,32 +727,38 @@ public class ReactEditText extends AppCompatEditText
     // (least precedence). This ensures the span is behind any overlapping spans.
     spanFlags |= Spannable.SPAN_PRIORITY;
 
-    List<Object> spans = new ArrayList<>();
-    spans.add(new ReactAbsoluteSizeSpan(mTextAttributes.getEffectiveFontSize()));
-    spans.add(new ReactForegroundColorSpan(getCurrentTextColor()));
+    workingText.setSpan(
+        new ReactAbsoluteSizeSpan(mTextAttributes.getEffectiveFontSize()),
+        0,
+        workingText.length(),
+        spanFlags);
+
+    workingText.setSpan(
+        new ReactForegroundColorSpan(getCurrentTextColor()), 0, workingText.length(), spanFlags);
 
     int backgroundColor = mReactBackgroundManager.getBackgroundColor();
     if (backgroundColor != Color.TRANSPARENT) {
-      spans.add(new ReactBackgroundColorSpan(backgroundColor));
+      workingText.setSpan(
+          new ReactBackgroundColorSpan(backgroundColor), 0, workingText.length(), spanFlags);
     }
 
     if ((getPaintFlags() & Paint.STRIKE_THRU_TEXT_FLAG) != 0) {
-      spans.add(new ReactStrikethroughSpan());
+      workingText.setSpan(new ReactStrikethroughSpan(), 0, workingText.length(), spanFlags);
     }
 
     if ((getPaintFlags() & Paint.UNDERLINE_TEXT_FLAG) != 0) {
-      spans.add(new ReactUnderlineSpan());
+      workingText.setSpan(new ReactUnderlineSpan(), 0, workingText.length(), spanFlags);
     }
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
       float effectiveLetterSpacing = mTextAttributes.getEffectiveLetterSpacing();
       if (!Float.isNaN(effectiveLetterSpacing)) {
-        spans.add(new CustomLetterSpacingSpan(effectiveLetterSpacing));
+        workingText.setSpan(
+            new CustomLetterSpacingSpan(effectiveLetterSpacing),
+            0,
+            workingText.length(),
+            spanFlags);
       }
-    }
-
-    for (Object span : spans) {
-      workingText.setSpan(span, 0, workingText.length(), spanFlags);
     }
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -11,6 +11,7 @@ import static com.facebook.react.uimanager.UIManagerHelper.getReactContext;
 import static com.facebook.react.views.text.TextAttributeProps.UNSET;
 
 import android.content.Context;
+import android.graphics.Color;
 import android.graphics.Rect;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
@@ -50,6 +51,7 @@ import com.facebook.react.views.text.CustomLetterSpacingSpan;
 import com.facebook.react.views.text.CustomLineHeightSpan;
 import com.facebook.react.views.text.CustomStyleSpan;
 import com.facebook.react.views.text.ReactAbsoluteSizeSpan;
+import com.facebook.react.views.text.ReactBackgroundColorSpan;
 import com.facebook.react.views.text.ReactSpan;
 import com.facebook.react.views.text.ReactTextUpdate;
 import com.facebook.react.views.text.ReactTypefaceUtils;
@@ -645,6 +647,16 @@ public class ReactEditText extends AppCompatEditText
             return span.getSize() == mTextAttributes.getEffectiveFontSize();
           }
         });
+
+    stripSpansOfKind(
+        sb,
+        ReactBackgroundColorSpan.class,
+        new SpanPredicate<ReactBackgroundColorSpan>() {
+          @Override
+          public boolean test(ReactBackgroundColorSpan span) {
+            return span.getBackgroundColor() == mReactBackgroundManager.getBackgroundColor();
+          }
+        });
   }
 
   private <T> void stripSpansOfKind(
@@ -669,11 +681,17 @@ public class ReactEditText extends AppCompatEditText
     // (least precedence). This ensures the span is behind any overlapping spans.
     spanFlags |= Spannable.SPAN_PRIORITY;
 
-    workingText.setSpan(
-        new ReactAbsoluteSizeSpan(mTextAttributes.getEffectiveFontSize()),
-        0,
-        workingText.length(),
-        spanFlags);
+    List<Object> spans = new ArrayList<>();
+    spans.add(new ReactAbsoluteSizeSpan(mTextAttributes.getEffectiveFontSize()));
+
+    int backgroundColor = mReactBackgroundManager.getBackgroundColor();
+    if (backgroundColor != Color.TRANSPARENT) {
+      spans.add(new ReactBackgroundColorSpan(backgroundColor));
+    }
+
+    for (Object span : spans) {
+      workingText.setSpan(span, 0, workingText.length(), spanFlags);
+    }
   }
 
   private static boolean sameTextForSpan(

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -64,7 +64,6 @@ import com.facebook.react.views.text.TextInlineImageSpan;
 import com.facebook.react.views.text.TextLayoutManager;
 import com.facebook.react.views.view.ReactViewBackgroundManager;
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 
 /**
@@ -89,7 +88,6 @@ public class ReactEditText extends AppCompatEditText
   // *TextChanged events should be triggered. This is less expensive than removing the text
   // listeners and adding them back again after the text change is completed.
   protected boolean mIsSettingTextFromJS;
-  protected boolean mIsSettingTextFromCacheUpdate = false;
   private int mDefaultGravityHorizontal;
   private int mDefaultGravityVertical;
 
@@ -369,7 +367,7 @@ public class ReactEditText extends AppCompatEditText
     }
 
     super.onSelectionChanged(selStart, selEnd);
-    if (!mIsSettingTextFromCacheUpdate && mSelectionWatcher != null && hasFocus()) {
+    if (mSelectionWatcher != null && hasFocus()) {
       mSelectionWatcher.onSelectionChanged(selStart, selEnd);
     }
   }
@@ -575,7 +573,7 @@ public class ReactEditText extends AppCompatEditText
     SpannableStringBuilder spannableStringBuilder =
         new SpannableStringBuilder(reactTextUpdate.getText());
 
-    manageSpans(spannableStringBuilder, reactTextUpdate.mContainsMultipleFragments);
+    manageSpans(spannableStringBuilder);
     stripStyleEquivalentSpans(spannableStringBuilder);
 
     mContainsImages = reactTextUpdate.containsImages();
@@ -604,7 +602,7 @@ public class ReactEditText extends AppCompatEditText
     }
 
     // Update cached spans (in Fabric only).
-    updateCachedSpannable(false);
+    updateCachedSpannable();
   }
 
   /**
@@ -613,8 +611,7 @@ public class ReactEditText extends AppCompatEditText
    * will adapt to the new text, hence why {@link SpannableStringBuilder#replace} never removes
    * them.
    */
-  private void manageSpans(
-      SpannableStringBuilder spannableStringBuilder, boolean skipAddSpansForMeasurements) {
+  private void manageSpans(SpannableStringBuilder spannableStringBuilder) {
     Object[] spans = getText().getSpans(0, length(), Object.class);
     for (int spanIdx = 0; spanIdx < spans.length; spanIdx++) {
       Object span = spans[spanIdx];
@@ -641,13 +638,6 @@ public class ReactEditText extends AppCompatEditText
       if (sameTextForSpan(getText(), spannableStringBuilder, spanStart, spanEnd)) {
         spannableStringBuilder.setSpan(span, spanStart, spanEnd, spanFlags);
       }
-    }
-
-    // In Fabric only, apply necessary styles to entire span
-    // If the Spannable was constructed from multiple fragments, we don't apply any spans that could
-    // impact the whole Spannable, because that would override "local" styles per-fragment
-    if (!skipAddSpansForMeasurements) {
-      addSpansForMeasurement(getText());
     }
   }
 
@@ -750,10 +740,10 @@ public class ReactEditText extends AppCompatEditText
   }
 
   /**
-   * Copy back styles represented as attributes to the underlying span, for later measurement
-   * outside the ReactEditText.
+   * Copy styles represented as attributes to the underlying span, for later measurement or other
+   * usage outside the ReactEditText.
    */
-  private void restoreStyleEquivalentSpans(SpannableStringBuilder workingText) {
+  private void addSpansFromStyleAttributes(SpannableStringBuilder workingText) {
     int spanFlags = Spannable.SPAN_INCLUSIVE_INCLUSIVE;
 
     // Set all bits for SPAN_PRIORITY so that this span has the highest possible priority
@@ -809,6 +799,11 @@ public class ReactEditText extends AppCompatEditText
           workingText.length(),
           spanFlags);
     }
+
+    float lineHeight = mTextAttributes.getEffectiveLineHeight();
+    if (!Float.isNaN(lineHeight)) {
+      workingText.setSpan(new CustomLineHeightSpan(lineHeight), 0, workingText.length(), spanFlags);
+    }
   }
 
   private static boolean sameTextForSpan(
@@ -825,73 +820,6 @@ public class ReactEditText extends AppCompatEditText
       }
     }
     return true;
-  }
-
-  // This is hacked in for Fabric. When we delete non-Fabric code, we might be able to simplify or
-  // clean this up a bit.
-  private void addSpansForMeasurement(Spannable spannable) {
-    if (!mFabricViewStateManager.hasStateWrapper()) {
-      return;
-    }
-
-    boolean originalDisableTextDiffing = mDisableTextDiffing;
-    mDisableTextDiffing = true;
-
-    int start = 0;
-    int end = spannable.length();
-
-    // Remove duplicate spans we might add here
-    Object[] spans = spannable.getSpans(0, length(), Object.class);
-    for (Object span : spans) {
-      int spanFlags = spannable.getSpanFlags(span);
-      boolean isInclusive =
-          (spanFlags & Spanned.SPAN_INCLUSIVE_INCLUSIVE) == Spanned.SPAN_INCLUSIVE_INCLUSIVE
-              || (spanFlags & Spanned.SPAN_INCLUSIVE_EXCLUSIVE) == Spanned.SPAN_INCLUSIVE_EXCLUSIVE;
-      if (isInclusive
-          && span instanceof ReactSpan
-          && spannable.getSpanStart(span) == start
-          && spannable.getSpanEnd(span) == end) {
-        spannable.removeSpan(span);
-      }
-    }
-
-    List<TextLayoutManager.SetSpanOperation> ops = new ArrayList<>();
-
-    if (!Float.isNaN(mTextAttributes.getLetterSpacing())) {
-      ops.add(
-          new TextLayoutManager.SetSpanOperation(
-              start, end, new CustomLetterSpacingSpan(mTextAttributes.getLetterSpacing())));
-    }
-    ops.add(
-        new TextLayoutManager.SetSpanOperation(
-            start, end, new ReactAbsoluteSizeSpan((int) mTextAttributes.getEffectiveFontSize())));
-    if (mFontStyle != UNSET || mFontWeight != UNSET || mFontFamily != null) {
-      ops.add(
-          new TextLayoutManager.SetSpanOperation(
-              start,
-              end,
-              new CustomStyleSpan(
-                  mFontStyle,
-                  mFontWeight,
-                  null, // TODO: do we need to support FontFeatureSettings / fontVariant?
-                  mFontFamily,
-                  getReactContext(ReactEditText.this).getAssets())));
-    }
-    if (!Float.isNaN(mTextAttributes.getEffectiveLineHeight())) {
-      ops.add(
-          new TextLayoutManager.SetSpanOperation(
-              start, end, new CustomLineHeightSpan(mTextAttributes.getEffectiveLineHeight())));
-    }
-
-    int priority = 0;
-    for (TextLayoutManager.SetSpanOperation op : ops) {
-      // Actual order of calling {@code execute} does NOT matter,
-      // but the {@code priority} DOES matter.
-      op.execute(spannable, priority);
-      priority++;
-    }
-
-    mDisableTextDiffing = originalDisableTextDiffing;
   }
 
   protected boolean showSoftKeyboard() {
@@ -1174,7 +1102,7 @@ public class ReactEditText extends AppCompatEditText
    * TextLayoutManager.java with some very minor modifications. There's some duplication between
    * here and TextLayoutManager, so there might be an opportunity for refactor.
    */
-  private void updateCachedSpannable(boolean resetStyles) {
+  private void updateCachedSpannable() {
     // Noops in non-Fabric
     if (mFabricViewStateManager != null && !mFabricViewStateManager.hasStateWrapper()) {
       return;
@@ -1182,12 +1110,6 @@ public class ReactEditText extends AppCompatEditText
     // If this view doesn't have an ID yet, we don't have a cache key, so bail here
     if (getId() == -1) {
       return;
-    }
-
-    if (resetStyles) {
-      mIsSettingTextFromCacheUpdate = true;
-      addSpansForMeasurement(getText());
-      mIsSettingTextFromCacheUpdate = false;
     }
 
     Editable currentText = getText();
@@ -1232,7 +1154,6 @@ public class ReactEditText extends AppCompatEditText
       // - android.app.Activity.dispatchKeyEvent (Activity.java:3447)
       try {
         sb.append(currentText.subSequence(0, currentText.length()));
-        restoreStyleEquivalentSpans(sb);
       } catch (IndexOutOfBoundsException e) {
         ReactSoftExceptionLogger.logSoftException(TAG, e);
       }
@@ -1248,11 +1169,9 @@ public class ReactEditText extends AppCompatEditText
         // Measure something so we have correct height, even if there's no string.
         sb.append("I");
       }
-
-      // Make sure that all text styles are applied when we're measurable the hint or "blank" text
-      addSpansForMeasurement(sb);
     }
 
+    addSpansFromStyleAttributes(sb);
     TextLayoutManager.setCachedSpannabledForTag(getId(), sb);
   }
 
@@ -1267,7 +1186,7 @@ public class ReactEditText extends AppCompatEditText
   private class TextWatcherDelegator implements TextWatcher {
     @Override
     public void beforeTextChanged(CharSequence s, int start, int count, int after) {
-      if (!mIsSettingTextFromCacheUpdate && !mIsSettingTextFromJS && mListeners != null) {
+      if (!mIsSettingTextFromJS && mListeners != null) {
         for (TextWatcher listener : mListeners) {
           listener.beforeTextChanged(s, start, count, after);
         }
@@ -1281,23 +1200,20 @@ public class ReactEditText extends AppCompatEditText
             TAG, "onTextChanged[" + getId() + "]: " + s + " " + start + " " + before + " " + count);
       }
 
-      if (!mIsSettingTextFromCacheUpdate) {
-        if (!mIsSettingTextFromJS && mListeners != null) {
-          for (TextWatcher listener : mListeners) {
-            listener.onTextChanged(s, start, before, count);
-          }
+      if (!mIsSettingTextFromJS && mListeners != null) {
+        for (TextWatcher listener : mListeners) {
+          listener.onTextChanged(s, start, before, count);
         }
-
-        updateCachedSpannable(
-            !mIsSettingTextFromJS && !mIsSettingTextFromState && start == 0 && before == 0);
       }
+
+      updateCachedSpannable();
 
       onContentSizeChange();
     }
 
     @Override
     public void afterTextChanged(Editable s) {
-      if (!mIsSettingTextFromCacheUpdate && !mIsSettingTextFromJS && mListeners != null) {
+      if (!mIsSettingTextFromJS && mListeners != null) {
         for (TextWatcher listener : mListeners) {
           listener.afterTextChanged(s);
         }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -648,29 +648,18 @@ public class ReactEditText extends AppCompatEditText
     }
   }
 
-  private void unstripAttributeEquivalentSpans(
-      SpannableStringBuilder workingText, Spannable originalText) {
-    // We must add spans back for Fabric to be able to measure, at lower precedence than any
-    // existing spans. Remove all spans, add the attributes, then re-add the spans over
-    workingText.append(originalText);
+  private void unstripAttributeEquivalentSpans(SpannableStringBuilder workingText) {
+    int spanFlags = Spannable.SPAN_INCLUSIVE_INCLUSIVE;
 
-    for (Object span : workingText.getSpans(0, workingText.length(), Object.class)) {
-      workingText.removeSpan(span);
-    }
+    // Set all bits for SPAN_PRIORITY so that this span has the highest possible priority
+    // (least precedence). This ensures the span is behind any overlapping spans.
+    spanFlags |= Spannable.SPAN_PRIORITY;
 
     workingText.setSpan(
         new ReactAbsoluteSizeSpan(mTextAttributes.getEffectiveFontSize()),
         0,
         workingText.length(),
-        Spanned.SPAN_INCLUSIVE_INCLUSIVE);
-
-    for (Object span : originalText.getSpans(0, originalText.length(), Object.class)) {
-      workingText.setSpan(
-          span,
-          originalText.getSpanStart(span),
-          originalText.getSpanEnd(span),
-          originalText.getSpanFlags(span));
-    }
+        spanFlags);
   }
 
   private static boolean sameTextForSpan(
@@ -1091,8 +1080,8 @@ public class ReactEditText extends AppCompatEditText
       // ...
       // - android.app.Activity.dispatchKeyEvent (Activity.java:3447)
       try {
-        Spannable text = (Spannable) currentText.subSequence(0, currentText.length());
-        unstripAttributeEquivalentSpans(sb, text);
+        sb.append(currentText.subSequence(0, currentText.length()));
+        unstripAttributeEquivalentSpans(sb);
       } catch (IndexOutOfBoundsException e) {
         ReactSoftExceptionLogger.logSoftException(TAG, e);
       }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -691,6 +691,18 @@ public class ReactEditText extends AppCompatEditText
             return (getPaintFlags() & Paint.UNDERLINE_TEXT_FLAG) != 0;
           }
         });
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+      stripSpansOfKind(
+          sb,
+          CustomLetterSpacingSpan.class,
+          new SpanPredicate<CustomLetterSpacingSpan>() {
+            @Override
+            public boolean test(CustomLetterSpacingSpan span) {
+              return span.getSpacing() == mTextAttributes.getEffectiveLetterSpacing();
+            }
+          });
+    }
   }
 
   private <T> void stripSpansOfKind(
@@ -730,6 +742,13 @@ public class ReactEditText extends AppCompatEditText
 
     if ((getPaintFlags() & Paint.UNDERLINE_TEXT_FLAG) != 0) {
       spans.add(new ReactUnderlineSpan());
+    }
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+      float effectiveLetterSpacing = mTextAttributes.getEffectiveLetterSpacing();
+      if (!Float.isNaN(effectiveLetterSpacing)) {
+        spans.add(new CustomLetterSpacingSpan(effectiveLetterSpacing));
+      }
     }
 
     for (Object span : spans) {
@@ -1083,7 +1102,9 @@ public class ReactEditText extends AppCompatEditText
 
     float effectiveLetterSpacing = mTextAttributes.getEffectiveLetterSpacing();
     if (!Float.isNaN(effectiveLetterSpacing)) {
-      setLetterSpacing(effectiveLetterSpacing);
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+        setLetterSpacing(effectiveLetterSpacing);
+      }
     }
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -875,6 +875,11 @@ public class ReactEditText extends AppCompatEditText
     }
   }
 
+  /* package */ int getGravityHorizontal() {
+    return getGravity()
+        & (Gravity.HORIZONTAL_GRAVITY_MASK | Gravity.RELATIVE_HORIZONTAL_GRAVITY_MASK);
+  }
+
   /* package */ void setGravityHorizontal(int gravityHorizontal) {
     if (gravityHorizontal == 0) {
       gravityHorizontal = mDefaultGravityHorizontal;

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -12,6 +12,7 @@ import static com.facebook.react.views.text.TextAttributeProps.UNSET;
 
 import android.content.Context;
 import android.graphics.Color;
+import android.graphics.Paint;
 import android.graphics.Rect;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
@@ -54,8 +55,10 @@ import com.facebook.react.views.text.ReactAbsoluteSizeSpan;
 import com.facebook.react.views.text.ReactBackgroundColorSpan;
 import com.facebook.react.views.text.ReactForegroundColorSpan;
 import com.facebook.react.views.text.ReactSpan;
+import com.facebook.react.views.text.ReactStrikethroughSpan;
 import com.facebook.react.views.text.ReactTextUpdate;
 import com.facebook.react.views.text.ReactTypefaceUtils;
+import com.facebook.react.views.text.ReactUnderlineSpan;
 import com.facebook.react.views.text.TextAttributes;
 import com.facebook.react.views.text.TextInlineImageSpan;
 import com.facebook.react.views.text.TextLayoutManager;
@@ -668,6 +671,26 @@ public class ReactEditText extends AppCompatEditText
             return span.getForegroundColor() == getCurrentTextColor();
           }
         });
+
+    stripSpansOfKind(
+        sb,
+        ReactStrikethroughSpan.class,
+        new SpanPredicate<ReactStrikethroughSpan>() {
+          @Override
+          public boolean test(ReactStrikethroughSpan span) {
+            return (getPaintFlags() & Paint.STRIKE_THRU_TEXT_FLAG) != 0;
+          }
+        });
+
+    stripSpansOfKind(
+        sb,
+        ReactUnderlineSpan.class,
+        new SpanPredicate<ReactUnderlineSpan>() {
+          @Override
+          public boolean test(ReactUnderlineSpan span) {
+            return (getPaintFlags() & Paint.UNDERLINE_TEXT_FLAG) != 0;
+          }
+        });
   }
 
   private <T> void stripSpansOfKind(
@@ -699,6 +722,14 @@ public class ReactEditText extends AppCompatEditText
     int backgroundColor = mReactBackgroundManager.getBackgroundColor();
     if (backgroundColor != Color.TRANSPARENT) {
       spans.add(new ReactBackgroundColorSpan(backgroundColor));
+    }
+
+    if ((getPaintFlags() & Paint.STRIKE_THRU_TEXT_FLAG) != 0) {
+      spans.add(new ReactStrikethroughSpan());
+    }
+
+    if ((getPaintFlags() & Paint.UNDERLINE_TEXT_FLAG) != 0) {
+      spans.add(new ReactUnderlineSpan());
     }
 
     for (Object span : spans) {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -68,6 +68,7 @@ import com.facebook.react.views.text.DefaultStyleValuesUtil;
 import com.facebook.react.views.text.ReactBaseTextShadowNode;
 import com.facebook.react.views.text.ReactTextUpdate;
 import com.facebook.react.views.text.ReactTextViewManagerCallback;
+import com.facebook.react.views.text.ReactTypefaceUtils;
 import com.facebook.react.views.text.TextAttributeProps;
 import com.facebook.react.views.text.TextInlineImageSpan;
 import com.facebook.react.views.text.TextLayoutManager;
@@ -396,6 +397,11 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
   @ReactProp(name = ViewProps.FONT_STYLE)
   public void setFontStyle(ReactEditText view, @Nullable String fontStyle) {
     view.setFontStyle(fontStyle);
+  }
+
+  @ReactProp(name = ViewProps.FONT_VARIANT)
+  public void setFontVariant(ReactEditText view, @Nullable ReadableArray fontVariant) {
+    view.setFontFeatureSettings(ReactTypefaceUtils.parseFontVariant(fontVariant));
   }
 
   @ReactProp(name = ViewProps.INCLUDE_FONT_PADDING, defaultBoolean = true)

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -1355,9 +1355,6 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
         TextLayoutManager.getOrCreateSpannableForText(
             view.getContext(), attributedString, mReactTextViewManagerCallback);
 
-    boolean containsMultipleFragments =
-        attributedString.getArray("fragments").toArrayList().size() > 1;
-
     int textBreakStrategy =
         TextAttributeProps.getTextBreakStrategy(paragraphAttributes.getString("textBreakStrategy"));
 
@@ -1366,8 +1363,7 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
         state.getInt("mostRecentEventCount"),
         TextAttributeProps.getTextAlignment(props, TextLayoutManager.isRTL(attributedString)),
         textBreakStrategy,
-        TextAttributeProps.getJustificationMode(props),
-        containsMultipleFragments);
+        TextAttributeProps.getJustificationMode(props, currentJustificationMode));
   }
 
   public Object getReactTextUpdate(ReactEditText view, ReactStylesDiffMap props, MapBuffer state) {
@@ -1388,9 +1384,6 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
         TextLayoutManagerMapBuffer.getOrCreateSpannableForText(
             view.getContext(), attributedString, mReactTextViewManagerCallback);
 
-    boolean containsMultipleFragments =
-        attributedString.getMapBuffer(TextLayoutManagerMapBuffer.AS_KEY_FRAGMENTS).getCount() > 1;
-
     int textBreakStrategy =
         TextAttributeProps.getTextBreakStrategy(
             paragraphAttributes.getString(TextLayoutManagerMapBuffer.PA_KEY_TEXT_BREAK_STRATEGY));
@@ -1401,7 +1394,6 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
         TextAttributeProps.getTextAlignment(
             props, TextLayoutManagerMapBuffer.isRTL(attributedString)),
         textBreakStrategy,
-        TextAttributeProps.getJustificationMode(props),
-        containsMultipleFragments);
+        TextAttributeProps.getJustificationMode(props, currentJustificationMode));
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -46,6 +46,8 @@ import com.facebook.react.bridge.ReadableType;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableNativeMap;
 import com.facebook.react.common.MapBuilder;
+import com.facebook.react.common.mapbuffer.MapBuffer;
+import com.facebook.react.config.ReactFeatureFlags;
 import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.FabricViewStateManager;
@@ -72,6 +74,7 @@ import com.facebook.react.views.text.ReactTypefaceUtils;
 import com.facebook.react.views.text.TextAttributeProps;
 import com.facebook.react.views.text.TextInlineImageSpan;
 import com.facebook.react.views.text.TextLayoutManager;
+import com.facebook.react.views.text.TextLayoutManagerMapBuffer;
 import com.facebook.react.views.text.TextTransform;
 import com.facebook.yoga.YogaConstants;
 import java.lang.reflect.Field;
@@ -85,6 +88,12 @@ import java.util.Map;
 public class ReactTextInputManager extends BaseViewManager<ReactEditText, LayoutShadowNode> {
   public static final String TAG = ReactTextInputManager.class.getSimpleName();
   public static final String REACT_CLASS = "AndroidTextInput";
+
+  // See also ReactTextViewManager
+  private static final short TX_STATE_KEY_ATTRIBUTED_STRING = 0;
+  private static final short TX_STATE_KEY_PARAGRAPH_ATTRIBUTES = 1;
+  private static final short TX_STATE_KEY_HASH = 2;
+  private static final short TX_STATE_KEY_MOST_RECENT_EVENT_COUNT = 3;
 
   private static final int[] SPACING_TYPES = {
     Spacing.ALL, Spacing.LEFT, Spacing.RIGHT, Spacing.TOP, Spacing.BOTTOM,
@@ -1319,6 +1328,13 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
 
     stateManager.setStateWrapper(stateWrapper);
 
+    if (ReactFeatureFlags.mapBufferSerializationEnabled) {
+      MapBuffer stateMapBuffer = stateWrapper.getStateDataMapBuffer();
+      if (stateMapBuffer != null) {
+        return getReactTextUpdate(view, props, stateMapBuffer);
+      }
+    }
+
     ReadableNativeMap state = stateWrapper.getStateData();
 
     if (state == null) {
@@ -1349,6 +1365,41 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
         spanned,
         state.getInt("mostRecentEventCount"),
         TextAttributeProps.getTextAlignment(props, TextLayoutManager.isRTL(attributedString)),
+        textBreakStrategy,
+        TextAttributeProps.getJustificationMode(props),
+        containsMultipleFragments);
+  }
+
+  public Object getReactTextUpdate(ReactEditText view, ReactStylesDiffMap props, MapBuffer state) {
+    // If native wants to update the state wrapper but the state data hasn't actually
+    // changed, the MapBuffer may be empty
+    if (state.getCount() == 0) {
+      return null;
+    }
+
+    MapBuffer attributedString = state.getMapBuffer(TX_STATE_KEY_ATTRIBUTED_STRING);
+    MapBuffer paragraphAttributes = state.getMapBuffer(TX_STATE_KEY_PARAGRAPH_ATTRIBUTES);
+    if (attributedString == null || paragraphAttributes == null) {
+      throw new IllegalArgumentException(
+          "Invalid TextInput State (MapBuffer) was received as a parameters");
+    }
+
+    Spannable spanned =
+        TextLayoutManagerMapBuffer.getOrCreateSpannableForText(
+            view.getContext(), attributedString, mReactTextViewManagerCallback);
+
+    boolean containsMultipleFragments =
+        attributedString.getMapBuffer(TextLayoutManagerMapBuffer.AS_KEY_FRAGMENTS).getCount() > 1;
+
+    int textBreakStrategy =
+        TextAttributeProps.getTextBreakStrategy(
+            paragraphAttributes.getString(TextLayoutManagerMapBuffer.PA_KEY_TEXT_BREAK_STRATEGY));
+
+    return ReactTextUpdate.buildReactTextUpdateFromState(
+        spanned,
+        state.getInt(TX_STATE_KEY_MOST_RECENT_EVENT_COUNT),
+        TextAttributeProps.getTextAlignment(
+            props, TextLayoutManagerMapBuffer.isRTL(attributedString)),
         textBreakStrategy,
         TextAttributeProps.getJustificationMode(props),
         containsMultipleFragments);

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -1303,8 +1303,7 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
 
   @Override
   public Object updateState(
-      ReactEditText view, ReactStylesDiffMap props, @Nullable StateWrapper stateWrapper) {
-
+      ReactEditText view, ReactStylesDiffMap props, StateWrapper stateWrapper) {
     if (ReactEditText.DEBUG_MODE) {
       FLog.e(TAG, "updateState: [" + view.getId() + "]");
     }
@@ -1319,10 +1318,6 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
     }
 
     stateManager.setStateWrapper(stateWrapper);
-
-    if (stateWrapper == null) {
-      return null;
-    }
 
     ReadableNativeMap state = stateWrapper.getStateData();
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -13,6 +13,7 @@ import android.content.Context;
 import android.content.res.ColorStateList;
 import android.graphics.BlendMode;
 import android.graphics.BlendModeColorFilter;
+import android.graphics.Paint;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
@@ -911,6 +912,20 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
   @ReactProp(name = "autoFocus", defaultBoolean = false)
   public void setAutoFocus(ReactEditText view, boolean autoFocus) {
     view.setAutoFocus(autoFocus);
+  }
+
+  @ReactProp(name = ViewProps.TEXT_DECORATION_LINE)
+  public void setTextDecorationLine(ReactEditText view, @Nullable String textDecorationLineString) {
+    view.setPaintFlags(
+        view.getPaintFlags() & ~(Paint.STRIKE_THRU_TEXT_FLAG | Paint.UNDERLINE_TEXT_FLAG));
+
+    for (String token : textDecorationLineString.split(" ")) {
+      if (token.equals("underline")) {
+        view.setPaintFlags(view.getPaintFlags() | Paint.UNDERLINE_TEXT_FLAG);
+      } else if (token.equals("line-through")) {
+        view.setPaintFlags(view.getPaintFlags() | Paint.STRIKE_THRU_TEXT_FLAG);
+      }
+    }
   }
 
   @ReactPropGroup(

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -1336,12 +1336,7 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
     }
 
     ReadableNativeMap state = stateWrapper.getStateData();
-
-    if (state == null) {
-      return null;
-    }
-
-    if (!state.hasKey("attributedString")) {
+    if (state == null || !state.hasKey("attributedString")) {
       return null;
     }
     ReadableMap attributedString = state.getMap("attributedString");
@@ -1356,12 +1351,16 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
             view.getContext(), attributedString, mReactTextViewManagerCallback);
 
     int textBreakStrategy =
-        TextAttributeProps.getTextBreakStrategy(paragraphAttributes.getString("textBreakStrategy"));
+        TextAttributeProps.getTextBreakStrategy(
+            paragraphAttributes.getString(ViewProps.TEXT_BREAK_STRATEGY));
+    int currentJustificationMode =
+        Build.VERSION.SDK_INT < Build.VERSION_CODES.O ? 0 : view.getJustificationMode();
 
     return ReactTextUpdate.buildReactTextUpdateFromState(
         spanned,
         state.getInt("mostRecentEventCount"),
-        TextAttributeProps.getTextAlignment(props, TextLayoutManager.isRTL(attributedString)),
+        TextAttributeProps.getTextAlignment(
+            props, TextLayoutManager.isRTL(attributedString), view.getGravityHorizontal()),
         textBreakStrategy,
         TextAttributeProps.getJustificationMode(props, currentJustificationMode));
   }
@@ -1387,12 +1386,14 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
     int textBreakStrategy =
         TextAttributeProps.getTextBreakStrategy(
             paragraphAttributes.getString(TextLayoutManagerMapBuffer.PA_KEY_TEXT_BREAK_STRATEGY));
+    int currentJustificationMode =
+        Build.VERSION.SDK_INT < Build.VERSION_CODES.O ? 0 : view.getJustificationMode();
 
     return ReactTextUpdate.buildReactTextUpdateFromState(
         spanned,
         state.getInt(TX_STATE_KEY_MOST_RECENT_EVENT_COUNT),
         TextAttributeProps.getTextAlignment(
-            props, TextLayoutManagerMapBuffer.isRTL(attributedString)),
+            props, TextLayoutManagerMapBuffer.isRTL(attributedString), view.getGravityHorizontal()),
         textBreakStrategy,
         TextAttributeProps.getJustificationMode(props, currentJustificationMode));
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -1309,7 +1309,16 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
       FLog.e(TAG, "updateState: [" + view.getId() + "]");
     }
 
-    view.getFabricViewStateManager().setStateWrapper(stateWrapper);
+    FabricViewStateManager stateManager = view.getFabricViewStateManager();
+    if (!stateManager.hasStateWrapper()) {
+      // HACK: In Fabric, we assume all components start off with zero padding, which is
+      // not true for TextInput components. We expose the theme's default padding via
+      // AndroidTextInputComponentDescriptor, which will be applied later though setPadding.
+      // TODO T58784068: move this constructor once Fabric is shipped
+      view.setPadding(0, 0, 0, 0);
+    }
+
+    stateManager.setStateWrapper(stateWrapper);
 
     if (stateWrapper == null) {
       return null;

--- a/ReactAndroid/src/main/java/com/facebook/react/views/unimplementedview/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/unimplementedview/BUCK
@@ -9,6 +9,7 @@ rn_android_library(
         "pfh:ReactNative_CommonInfrastructurePlaceholder",
         "supermodule:xplat/default/public.react_native.infra",
     ],
+    language = "JAVA",
     provided_deps = [
         react_native_dep("third-party/android/androidx:annotation"),
         react_native_dep("third-party/android/androidx:core"),

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/BUCK
@@ -39,5 +39,6 @@ rn_android_library(
         react_native_target("java/com/facebook/react/uimanager:uimanager"),
         react_native_target("java/com/facebook/react/modules/i18nmanager:i18nmanager"),
         react_native_target("java/com/facebook/react/uimanager/annotations:annotations"),
+        react_native_target("res:uimanager"),
     ],
 )

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewBackgroundManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewBackgroundManager.java
@@ -19,6 +19,7 @@ public class ReactViewBackgroundManager {
 
   private @Nullable ReactViewBackgroundDrawable mReactBackgroundDrawable;
   private View mView;
+  private int mColor = Color.TRANSPARENT;
 
   public ReactViewBackgroundManager(View view) {
     this.mView = view;
@@ -48,6 +49,10 @@ public class ReactViewBackgroundManager {
     } else {
       getOrCreateReactViewBackground().setColor(color);
     }
+  }
+
+  public int getBackgroundColor() {
+    return mColor;
   }
 
   public void setBorderWidth(int position, float width) {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewBackgroundManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewBackgroundManager.java
@@ -25,6 +25,12 @@ public class ReactViewBackgroundManager {
     this.mView = view;
   }
 
+  public void cleanup() {
+    ViewCompat.setBackground(mView, null);
+    this.mView = null;
+    this.mReactBackgroundDrawable = null;
+  }
+
   private ReactViewBackgroundDrawable getOrCreateReactViewBackground() {
     if (mReactBackgroundDrawable == null) {
       mReactBackgroundDrawable = new ReactViewBackgroundDrawable(mView.getContext());

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -176,32 +176,6 @@ public class ReactViewGroup extends ViewGroup
     // Reset background, borders
     updateBackgroundDrawable(null);
 
-    setForeground(null);
-
-    // This is possibly subject to change and overrideable per-platform, but these
-    // are the default view flags in View.java:
-    // https://android.googlesource.com/platform/frameworks/base/+/a175a5b/core/java/android/view/View.java#2712
-    // `mViewFlags = SOUND_EFFECTS_ENABLED | HAPTIC_FEEDBACK_ENABLED | LAYOUT_DIRECTION_INHERIT`
-    // Therefore we set the following options as such:
-    setFocusable(false);
-    setFocusableInTouchMode(false);
-
-    // Focus IDs
-    // Also see in AOSP source:
-    // https://android.googlesource.com/platform/frameworks/base/+/a175a5b/core/java/android/view/View.java#4493
-    setNextFocusDownId(View.NO_ID);
-    setNextFocusForwardId(View.NO_ID);
-    setNextFocusRightId(View.NO_ID);
-    setNextFocusUpId(View.NO_ID);
-
-    // Predictable, alpha defaults to 1:
-    // https://android.googlesource.com/platform/frameworks/base/+/a175a5b/core/java/android/view/View.java#2186
-    // This accounts for resetting mBackfaceOpacity and mBackfaceVisibility
-    setAlpha(1);
-
-    // https://android.googlesource.com/platform/frameworks/base/+/refs/tags/android-mainline-12.0.0_r96/core/java/android/view/View.java#5491
-    setElevation(0);
-
     resetPointerEvents();
   }
 
@@ -801,11 +775,6 @@ public class ReactViewGroup extends ViewGroup
   @Override
   public void setOverflowInset(int left, int top, int right, int bottom) {
     mOverflowInset.set(left, top, right, bottom);
-  }
-
-  public void setOverflowInset(Rect overflowInset) {
-    mOverflowInset.set(
-        overflowInset.left, overflowInset.top, overflowInset.right, overflowInset.bottom);
   }
 
   @Override

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -116,26 +116,93 @@ public class ReactViewGroup extends ViewGroup
   // whenever the option is set. We also override {@link ViewGroup#getChildAt} and
   // {@link ViewGroup#getChildCount} so those methods may return views that are not attached.
   // This is risky but allows us to perform a correct cleanup in {@link NativeViewHierarchyManager}.
-  private boolean mRemoveClippedSubviews = false;
-  private @Nullable View[] mAllChildren = null;
+  private boolean mRemoveClippedSubviews;
+  private @Nullable View[] mAllChildren;
   private int mAllChildrenCount;
   private @Nullable Rect mClippingRect;
   private @Nullable Rect mHitSlopRect;
   private @Nullable String mOverflow;
-  private PointerEvents mPointerEvents = PointerEvents.AUTO;
+  private PointerEvents mPointerEvents;
   private @Nullable ChildrenLayoutChangeListener mChildrenLayoutChangeListener;
   private @Nullable ReactViewBackgroundDrawable mReactBackgroundDrawable;
   private @Nullable OnInterceptTouchEventListener mOnInterceptTouchEventListener;
-  private boolean mNeedsOffscreenAlphaCompositing = false;
-  private @Nullable ViewGroupDrawingOrderHelper mDrawingOrderHelper = null;
+  private boolean mNeedsOffscreenAlphaCompositing;
+  private @Nullable ViewGroupDrawingOrderHelper mDrawingOrderHelper;
   private @Nullable Path mPath;
   private int mLayoutDirection;
-  private float mBackfaceOpacity = 1.f;
-  private String mBackfaceVisibility = "visible";
+  private float mBackfaceOpacity;
+  private String mBackfaceVisibility;
 
   public ReactViewGroup(Context context) {
     super(context);
+    initView();
+  }
+
+  /**
+   * Set all default values here as opposed to in the constructor or field defaults. It is important
+   * that these properties are set during the constructor, but also on-demand whenever an existing
+   * ReactTextView is recycled.
+   */
+  private void initView() {
     setClipChildren(false);
+
+    mRemoveClippedSubviews = false;
+    mAllChildren = null;
+    mAllChildrenCount = 0;
+    mClippingRect = null;
+    mHitSlopRect = null;
+    mOverflow = null;
+    mPointerEvents = PointerEvents.AUTO;
+    mChildrenLayoutChangeListener = null;
+    mReactBackgroundDrawable = null;
+    mOnInterceptTouchEventListener = null;
+    mNeedsOffscreenAlphaCompositing = false;
+    mDrawingOrderHelper = null;
+    mPath = null;
+    mLayoutDirection = 0; // set when background is created
+    mBackfaceOpacity = 1.f;
+    mBackfaceVisibility = "visible";
+  }
+
+  /* package */ void recycleView() {
+    // Set default field values
+    initView();
+    mOverflowInset.setEmpty();
+    sHelperRect.setEmpty();
+
+    // Remove any children
+    removeAllViews();
+
+    // Reset background, borders
+    updateBackgroundDrawable(null);
+
+    setForeground(null);
+
+    // This is possibly subject to change and overrideable per-platform, but these
+    // are the default view flags in View.java:
+    // https://android.googlesource.com/platform/frameworks/base/+/a175a5b/core/java/android/view/View.java#2712
+    // `mViewFlags = SOUND_EFFECTS_ENABLED | HAPTIC_FEEDBACK_ENABLED | LAYOUT_DIRECTION_INHERIT`
+    // Therefore we set the following options as such:
+    setFocusable(false);
+    setFocusableInTouchMode(false);
+
+    // Focus IDs
+    // Also see in AOSP source:
+    // https://android.googlesource.com/platform/frameworks/base/+/a175a5b/core/java/android/view/View.java#4493
+    setNextFocusDownId(View.NO_ID);
+    setNextFocusForwardId(View.NO_ID);
+    setNextFocusRightId(View.NO_ID);
+    setNextFocusUpId(View.NO_ID);
+
+    // Predictable, alpha defaults to 1:
+    // https://android.googlesource.com/platform/frameworks/base/+/a175a5b/core/java/android/view/View.java#2186
+    // This accounts for resetting mBackfaceOpacity and mBackfaceVisibility
+    setAlpha(1);
+
+    // https://android.googlesource.com/platform/frameworks/base/+/refs/tags/android-mainline-12.0.0_r96/core/java/android/view/View.java#5491
+    setElevation(0);
+
+    resetPointerEvents();
   }
 
   private ViewGroupDrawingOrderHelper getDrawingOrderHelper() {
@@ -543,6 +610,10 @@ public class ReactViewGroup extends ViewGroup
     mPointerEvents = pointerEvents;
   }
 
+  /*package*/ void resetPointerEvents() {
+    mPointerEvents = PointerEvents.AUTO;
+  }
+
   /*package*/ int getAllChildrenCount() {
     return mAllChildrenCount;
   }
@@ -686,7 +757,7 @@ public class ReactViewGroup extends ViewGroup
     return DEFAULT_BACKGROUND_COLOR;
   }
 
-  private ReactViewBackgroundDrawable getOrCreateReactViewBackground() {
+  /* package */ ReactViewBackgroundDrawable getOrCreateReactViewBackground() {
     if (mReactBackgroundDrawable == null) {
       mReactBackgroundDrawable = new ReactViewBackgroundDrawable(getContext());
       Drawable backgroundDrawable = getBackground();
@@ -732,6 +803,11 @@ public class ReactViewGroup extends ViewGroup
     mOverflowInset.set(left, top, right, bottom);
   }
 
+  public void setOverflowInset(Rect overflowInset) {
+    mOverflowInset.set(
+        overflowInset.left, overflowInset.top, overflowInset.right, overflowInset.bottom);
+  }
+
   @Override
   public Rect getOverflowInset() {
     return mOverflowInset;
@@ -744,7 +820,7 @@ public class ReactViewGroup extends ViewGroup
    * @param drawable {@link Drawable} The Drawable to use as the background, or null to remove the
    *     background
    */
-  private void updateBackgroundDrawable(Drawable drawable) {
+  /* package */ void updateBackgroundDrawable(Drawable drawable) {
     super.setBackground(drawable);
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
@@ -52,12 +52,10 @@ public class ReactViewManager extends ReactClippingViewManager<ReactViewGroup> {
   private static final int CMD_SET_PRESSED = 2;
   private static final String HOTSPOT_UPDATE_KEY = "hotspotUpdate";
 
-  private ReactViewGroup mDefaultViewForRecycling = null;
-
   public ReactViewManager() {
     super();
 
-    enableViewRecycling();
+    setupViewRecycling();
   }
 
   @Override

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
@@ -52,6 +52,25 @@ public class ReactViewManager extends ReactClippingViewManager<ReactViewGroup> {
   private static final int CMD_SET_PRESSED = 2;
   private static final String HOTSPOT_UPDATE_KEY = "hotspotUpdate";
 
+  private ReactViewGroup mDefaultViewForRecycling = null;
+
+  public ReactViewManager() {
+    super();
+
+    enableViewRecycling();
+  }
+
+  @Override
+  protected ReactViewGroup prepareToRecycleView(
+      @NonNull ThemedReactContext reactContext, ReactViewGroup view) {
+    // BaseViewManager
+    super.prepareToRecycleView(reactContext, view);
+
+    view.recycleView();
+
+    return view;
+  }
+
   @ReactProp(name = "accessible")
   public void setAccessible(ReactViewGroup view, boolean accessible) {
     view.setFocusable(accessible);

--- a/ReactAndroid/src/main/java/com/facebook/systrace/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/systrace/BUCK
@@ -4,6 +4,7 @@ rn_android_library(
     name = "systrace",
     srcs = glob(["*.java"]),
     autoglob = False,
+    language = "JAVA",
     visibility = [
         "PUBLIC",
     ],

--- a/ReactAndroid/src/main/libraries/fbcore/src/main/java/com/facebook/common/logging/BUCK
+++ b/ReactAndroid/src/main/libraries/fbcore/src/main/java/com/facebook/common/logging/BUCK
@@ -3,6 +3,7 @@ load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "rn_android_libra
 rn_android_library(
     name = "logging",
     autoglob = False,
+    language = "JAVA",
     visibility = ["//ReactAndroid/..."],
     exported_deps = [
         react_native_dep("libraries/fresco/fresco-react-native:fbcore"),

--- a/ReactAndroid/src/main/libraries/fresco/fresco-react-native/BUCK
+++ b/ReactAndroid/src/main/libraries/fresco/fresco-react-native/BUCK
@@ -28,6 +28,7 @@ fb_native.remote_file(
 rn_android_library(
     name = "imagepipeline",
     autoglob = False,
+    language = "JAVA",
     visibility = ["//ReactAndroid/..."],
     exported_deps = [
         ":bolts",

--- a/ReactAndroid/src/main/third-party/java/asm/BUCK
+++ b/ReactAndroid/src/main/third-party/java/asm/BUCK
@@ -4,6 +4,7 @@ load("//tools/build_defs/oss:rn_defs.bzl", "rn_android_library", "rn_prebuilt_ja
 rn_android_library(
     name = "asm",
     autoglob = False,
+    language = "JAVA",
     visibility = ["//ReactAndroid/..."],
     exported_deps = [
         ":asm-analysis",

--- a/ReactAndroid/src/main/third-party/java/junit/BUCK
+++ b/ReactAndroid/src/main/third-party/java/junit/BUCK
@@ -4,6 +4,7 @@ load("//tools/build_defs/oss:rn_defs.bzl", "rn_android_library", "rn_prebuilt_ja
 rn_android_library(
     name = "junit",
     autoglob = False,
+    language = "JAVA",
     visibility = ["//ReactAndroid/..."],
     exported_deps = [
         ":hamcrest",

--- a/ReactAndroid/src/main/third-party/java/mockito/BUCK
+++ b/ReactAndroid/src/main/third-party/java/mockito/BUCK
@@ -4,6 +4,7 @@ load("//tools/build_defs/oss:rn_defs.bzl", "rn_android_library", "rn_prebuilt_ja
 rn_android_library(
     name = "mockito",
     autoglob = False,
+    language = "JAVA",
     visibility = ["//ReactAndroid/..."],
     exported_deps = [
         ":mockito-core",

--- a/ReactAndroid/src/main/third-party/java/mockito2/BUCK
+++ b/ReactAndroid/src/main/third-party/java/mockito2/BUCK
@@ -4,6 +4,7 @@ load("//tools/build_defs/oss:rn_defs.bzl", "rn_android_library", "rn_prebuilt_ja
 rn_android_library(
     name = "mockito2",
     autoglob = False,
+    language = "JAVA",
     visibility = ["PUBLIC"],
     exported_deps = [
         ":byte-buddy",

--- a/ReactAndroid/src/main/third-party/java/okhttp/BUCK
+++ b/ReactAndroid/src/main/third-party/java/okhttp/BUCK
@@ -4,6 +4,7 @@ load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "react_native_tar
 rn_android_library(
     name = "okhttp3",
     autoglob = False,
+    language = "JAVA",
     visibility = ["//ReactAndroid/..."],
     exported_deps = [
         ":okhttp3-binary",
@@ -16,6 +17,7 @@ rn_android_library(
 rn_android_library(
     name = "okhttp3-urlconnection",
     autoglob = False,
+    language = "JAVA",
     visibility = ["//ReactAndroid/..."],
     exported_deps = [
         ":okhttp3",

--- a/ReactAndroid/src/main/third-party/java/okio/BUCK
+++ b/ReactAndroid/src/main/third-party/java/okio/BUCK
@@ -4,6 +4,7 @@ load("//tools/build_defs/oss:rn_defs.bzl", "react_native_target", "rn_android_li
 rn_android_library(
     name = "okio",
     autoglob = False,
+    language = "JAVA",
     visibility = ["//ReactAndroid/..."],
     exported_deps = [
         ":okio-binary",

--- a/ReactAndroid/src/main/third-party/java/robolectric/BUCK
+++ b/ReactAndroid/src/main/third-party/java/robolectric/BUCK
@@ -4,6 +4,7 @@ load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "rn_android_libra
 rn_android_library(
     name = "robolectric",
     autoglob = False,
+    language = "JAVA",
     visibility = ["PUBLIC"],
     exported_deps = [
         ":android-all-5.0.2_r3-robolectric-r0",

--- a/ReactAndroid/src/main/third-party/java/sqlite/BUCK
+++ b/ReactAndroid/src/main/third-party/java/sqlite/BUCK
@@ -4,6 +4,7 @@ load("//tools/build_defs/oss:rn_defs.bzl", "rn_android_library", "rn_prebuilt_ja
 rn_android_library(
     name = "sqlite",
     autoglob = False,
+    language = "JAVA",
     visibility = ["//ReactAndroid/..."],
     exported_deps = [
         ":sqlite4java",

--- a/ReactAndroid/src/main/third-party/kotlin/BUCK
+++ b/ReactAndroid/src/main/third-party/kotlin/BUCK
@@ -3,6 +3,7 @@ load("//tools/build_defs/oss:rn_defs.bzl", "rn_android_library", "rn_prebuilt_ja
 
 rn_android_library(
     name = "kotlin-stdlib",
+    language = "JAVA",
     visibility = ["PUBLIC"],
     exported_deps = [
         ":jetbrains-annotations",
@@ -13,6 +14,7 @@ rn_android_library(
 
 rn_android_library(
     name = "kotlin-stdlib-jdk7",
+    language = "JAVA",
     visibility = ["PUBLIC"],
     exported_deps = [
         ":kotlin-stdlib",
@@ -22,6 +24,7 @@ rn_android_library(
 
 rn_android_library(
     name = "kotlin-stdlib-jdk8",
+    language = "JAVA",
     visibility = ["PUBLIC"],
     exported_deps = [
         ":kotlin-stdlib",

--- a/ReactAndroid/src/test/java/com/facebook/common/logging/BUCK
+++ b/ReactAndroid/src/test/java/com/facebook/common/logging/BUCK
@@ -4,6 +4,7 @@ rn_android_library(
     name = "logging",
     srcs = glob(["**/*.java"]),
     autoglob = False,
+    language = "JAVA",
     visibility = [
         "PUBLIC",
     ],

--- a/ReactAndroid/src/test/java/com/facebook/react/bridge/BUCK
+++ b/ReactAndroid/src/test/java/com/facebook/react/bridge/BUCK
@@ -11,6 +11,7 @@ rn_android_library(
         exclude = STANDARD_TEST_SRCS,
     ),
     autoglob = False,
+    language = "JAVA",
     visibility = [
         "PUBLIC",
     ],

--- a/ReactAndroid/src/test/java/org/mockito/configuration/BUCK
+++ b/ReactAndroid/src/test/java/org/mockito/configuration/BUCK
@@ -4,6 +4,7 @@ rn_android_library(
     name = "configuration",
     srcs = glob(["**/*.java"]),
     autoglob = False,
+    language = "JAVA",
     visibility = [
         "PUBLIC",
     ],

--- a/ReactCommon/libraries/fbcore/src/test/java/com/facebook/powermock/BUCK
+++ b/ReactCommon/libraries/fbcore/src/test/java/com/facebook/powermock/BUCK
@@ -4,6 +4,7 @@ load("//tools/build_defs/oss:rn_defs.bzl", "rn_android_library", "rn_prebuilt_ja
 rn_android_library(
     name = "powermock2",
     autoglob = False,
+    language = "JAVA",
     visibility = ["PUBLIC"],
     exported_deps = [
         ":javassist-prebuilt",
@@ -22,6 +23,7 @@ rn_android_library(
 rn_android_library(
     name = "powermock-reflect",
     autoglob = False,
+    language = "JAVA",
     visibility = ["PUBLIC"],
     exported_deps = [
         ":byte-buddy",

--- a/ReactCommon/react/nativemodule/samples/BUCK
+++ b/ReactCommon/react/nativemodule/samples/BUCK
@@ -81,6 +81,7 @@ rn_android_library(
     name = "impl",
     srcs = glob(["platform/android/*.java"]),
     autoglob = False,
+    language = "JAVA",
     required_for_source_only_abi = True,
     visibility = [
         "PUBLIC",

--- a/ReactCommon/react/renderer/components/text/ParagraphState.h
+++ b/ReactCommon/react/renderer/components/text/ParagraphState.h
@@ -20,6 +20,15 @@
 namespace facebook {
 namespace react {
 
+#ifdef ANDROID
+// constants for Text State serialization
+constexpr static MapBuffer::Key TX_STATE_KEY_ATTRIBUTED_STRING = 0;
+constexpr static MapBuffer::Key TX_STATE_KEY_PARAGRAPH_ATTRIBUTES = 1;
+// Used for TextInput only
+constexpr static MapBuffer::Key TX_STATE_KEY_HASH = 2;
+constexpr static MapBuffer::Key TX_STATE_KEY_MOST_RECENT_EVENT_COUNT = 3;
+#endif
+
 /*
  * State for <Paragraph> component.
  * Represents what to render and how to render.

--- a/ReactCommon/react/renderer/components/text/conversions.h
+++ b/ReactCommon/react/renderer/components/text/conversions.h
@@ -26,21 +26,13 @@ inline folly::dynamic toDynamic(ParagraphState const &paragraphState) {
   return newState;
 }
 
-// constants for Text State serialization
-constexpr static MapBuffer::Key TX_STATE_KEY_ATTRIBUTED_STRING = 0;
-constexpr static MapBuffer::Key TX_STATE_KEY_PARAGRAPH_ATTRIBUTES = 1;
-// Used for TextInput
-constexpr static MapBuffer::Key TX_STATE_KEY_HASH = 2;
-constexpr static MapBuffer::Key TX_STATE_KEY_MOST_RECENT_EVENT_COUNT = 3;
-
 inline MapBuffer toMapBuffer(ParagraphState const &paragraphState) {
   auto builder = MapBufferBuilder();
   auto attStringMapBuffer = toMapBuffer(paragraphState.attributedString);
   builder.putMapBuffer(TX_STATE_KEY_ATTRIBUTED_STRING, attStringMapBuffer);
   auto paMapBuffer = toMapBuffer(paragraphState.paragraphAttributes);
   builder.putMapBuffer(TX_STATE_KEY_PARAGRAPH_ATTRIBUTES, paMapBuffer);
-  // TODO: Used for TextInput
-  builder.putInt(TX_STATE_KEY_HASH, 1234);
+  builder.putInt(TX_STATE_KEY_HASH, attStringMapBuffer.getInt(AS_KEY_HASH));
   return builder.build();
 }
 #endif

--- a/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputState.cpp
+++ b/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputState.cpp
@@ -10,6 +10,11 @@
 #include <react/renderer/components/text/conversions.h>
 #include <react/renderer/debug/debugStringConvertibleUtils.h>
 
+#ifdef ANDROID
+#include <react/renderer/mapbuffer/MapBuffer.h>
+#include <react/renderer/mapbuffer/MapBufferBuilder.h>
+#endif
+
 #include <utility>
 
 namespace facebook {
@@ -89,6 +94,23 @@ folly::dynamic AndroidTextInputState::getDynamic() const {
   }
   return newState;
 }
+
+MapBuffer AndroidTextInputState::getMapBuffer() const {
+  auto builder = MapBufferBuilder();
+  // See comment in getDynamic block.
+  if (cachedAttributedStringId == 0) {
+    builder.putInt(TX_STATE_KEY_MOST_RECENT_EVENT_COUNT, mostRecentEventCount);
+
+    auto attStringMapBuffer = toMapBuffer(attributedString);
+    builder.putMapBuffer(TX_STATE_KEY_ATTRIBUTED_STRING, attStringMapBuffer);
+    auto paMapBuffer = toMapBuffer(paragraphAttributes);
+    builder.putMapBuffer(TX_STATE_KEY_PARAGRAPH_ATTRIBUTES, paMapBuffer);
+
+    builder.putInt(TX_STATE_KEY_HASH, attStringMapBuffer.getInt(AS_KEY_HASH));
+  }
+  return builder.build();
+}
+
 #endif
 
 } // namespace react

--- a/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputState.h
+++ b/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputState.h
@@ -94,9 +94,7 @@ class AndroidTextInputState final {
       AndroidTextInputState const &previousState,
       folly::dynamic const &data);
   folly::dynamic getDynamic() const;
-  MapBuffer getMapBuffer() const {
-    return MapBufferBuilder::EMPTY();
-  };
+  MapBuffer getMapBuffer() const;
 };
 
 } // namespace react

--- a/packages/react-native-codegen/BUCK
+++ b/packages/react-native-codegen/BUCK
@@ -39,6 +39,7 @@ rn_android_library(
         ["buck_tests/*.java"],
     ),
     autoglob = False,
+    language = "JAVA",
     visibility = [
         "PUBLIC",
     ],


### PR DESCRIPTION
## Summary:

This PR takes care of backporting the [needed commits](https://github.com/reactwg/react-native-releases/discussions/62#discussioncomment-5519482) for the textinput samsung issue to 0.69 stable.

I had a couple of merge conflicts to address:
* for commit https://github.com/facebook/react-native/commit/b9e2627d1ce64e8e293e90f743bf13a515db3b4d, it was fairly straightforward
* for commit https://github.com/facebook/react-native/commit/92b898149956a301a44f99019f5c7500335c5553, I had to cherry pick a few extra commits: 
  * 44804a698ad24a2c93bfe4083166e36a964d32d2
  * e087a4470f4da43ad24316c529ff3f6be1ab0482
  * fd733d5a11d938967973f116a85e74fa5e7a03e3
  * https://github.com/facebook/react-native/commit/04c75ba988bf600f21f637120fca1a16835d80c9

In the first PR (https://github.com/facebook/react-native/pull/36876).

Things seemed around ok, but then when CI went red on 0.71 on this commit https://github.com/facebook/react-native/commit/9be29593c8bac64178d441e46c6f7b31e591360e I realized one more commit was needed, this one: https://github.com/facebook/react-native/commit/843d57ecc15632e2a6452d58d8ba032e1306105e and when trying to pick that in this 0.69-stable branch, all hell breaks loose. You can see it in the commit history of this PR: to cleaning pick that one I had to pick a bunch of other commits, but even with that, there's still some issues going on Android side.

So I'm putting this in draft mode while we try to figure out how to backport the samsung fixes to 0.69 more properly.

Let's make sure to **NOT** squash and merge this when merging, so that we can keep all the separate commit references.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[ANDROID] [FIXED] - backporting of fixes for next 0.69 patch release

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Test in RNTester that the textinput component page all works ok.