### PR TITLE
Mark dtor as virtual

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
@@ -91,6 +91,8 @@ class ShadowNode : public Sealable,
   ShadowNode(ShadowNode const &shadowNode) noexcept = delete;
   ShadowNode &operator=(ShadowNode const &other) noexcept = delete;
 
+  virtual ~ShadowNode() override = default;
+
   /*
    * Clones the shadow node using stored `cloneFunction`.
    */


### PR DESCRIPTION
Summary:
changelog: [internal]

ShadowNode must have its destructor as virtual because it is a base class and is used polymorphically. It is deleted through a pointer.

Reviewed By: nlutsenko

Differential Revision: D45045682

