### PR TITLE
Fix gating for AnimatedObject

### DIFF
--- a/packages/react-native/Libraries/Animated/nodes/AnimatedProps.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedProps.js
@@ -12,7 +12,6 @@
 
 import type {PlatformConfig} from '../AnimatedPlatformConfig';
 
-import ReactNativeFeatureFlags from '../../ReactNative/ReactNativeFeatureFlags';
 import {findNodeHandle} from '../../ReactNative/RendererProxy';
 import {AnimatedEvent} from '../AnimatedEvent';
 import NativeAnimatedHelper from '../NativeAnimatedHelper';
@@ -29,10 +28,7 @@ function createAnimatedProps(inputProps: Object): Object {
       props[key] = new AnimatedStyle(value);
     } else if (value instanceof AnimatedNode) {
       props[key] = value;
-    } else if (
-      ReactNativeFeatureFlags.isAnimatedObjectEnabled &&
-      hasAnimatedNode(value)
-    ) {
+    } else if (hasAnimatedNode(value)) {
       props[key] = new AnimatedObject(value);
     } else {
       props[key] = value;

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedStyle.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedStyle.js
@@ -12,7 +12,6 @@
 
 import type {PlatformConfig} from '../AnimatedPlatformConfig';
 
-import ReactNativeFeatureFlags from '../../ReactNative/ReactNativeFeatureFlags';
 import flattenStyle from '../../StyleSheet/flattenStyle';
 import Platform from '../../Utilities/Platform';
 import NativeAnimatedHelper from '../NativeAnimatedHelper';
@@ -34,10 +33,7 @@ function createAnimatedStyle(
       animatedStyles[key] = new AnimatedTransform(value);
     } else if (value instanceof AnimatedNode) {
       animatedStyles[key] = value;
-    } else if (
-      ReactNativeFeatureFlags.isAnimatedObjectEnabled &&
-      hasAnimatedNode(value)
-    ) {
+    } else if (hasAnimatedNode(value)) {
       animatedStyles[key] = new AnimatedObject(value);
     } else if (keepUnanimatedValues) {
       animatedStyles[key] = value;

--- a/packages/react-native/Libraries/ReactNative/ReactNativeFeatureFlags.js
+++ b/packages/react-native/Libraries/ReactNative/ReactNativeFeatureFlags.js
@@ -45,10 +45,6 @@ export type FeatureFlags = {|
    * Enables access to the host tree in Fabric using DOM-compatible APIs.
    */
   enableAccessToHostTreeInFabric: () => boolean,
-  /**
-   * Enables animating object and array prop values.
-   */
-  isAnimatedObjectEnabled: () => boolean,
 |};
 
 const ReactNativeFeatureFlags: FeatureFlags = {
@@ -59,7 +55,6 @@ const ReactNativeFeatureFlags: FeatureFlags = {
   animatedShouldUseSingleOp: () => false,
   isGlobalWebPerformanceLoggerEnabled: () => false,
   enableAccessToHostTreeInFabric: () => false,
-  isAnimatedObjectEnabled: () => false,
 };
 
 module.exports = ReactNativeFeatureFlags;


### PR DESCRIPTION
Summary:
ReactNativeFeatureFlags.isAnimatedObjectEnabled is a function, so need to call it to get the actual boolean value.

Changelog:
[Internal] - Fix gating for AnimatedObject

Differential Revision: D45055855

