### PR TITLE
Remove deprecated POST_NOTIFICATION from `PermissionsAndroid`

### DIFF
--- a/packages/react-native/Libraries/PermissionsAndroid/PermissionsAndroid.js
+++ b/packages/react-native/Libraries/PermissionsAndroid/PermissionsAndroid.js
@@ -75,7 +75,6 @@ const PERMISSIONS = Object.freeze({
   ANSWER_PHONE_CALLS: 'android.permission.ANSWER_PHONE_CALLS',
   READ_PHONE_NUMBERS: 'android.permission.READ_PHONE_NUMBERS',
   UWB_RANGING: 'android.permission.UWB_RANGING',
-  POST_NOTIFICATION: 'android.permission.POST_NOTIFICATIONS', // Remove in 0.72
   POST_NOTIFICATIONS: 'android.permission.POST_NOTIFICATIONS',
   NEARBY_WIFI_DEVICES: 'android.permission.NEARBY_WIFI_DEVICES',
 });
@@ -107,7 +106,6 @@ class PermissionsAndroid {
     CAMERA: string,
     GET_ACCOUNTS: string,
     NEARBY_WIFI_DEVICES: string,
-    POST_NOTIFICATION: string, // Remove in 0.72
     POST_NOTIFICATIONS: string,
     PROCESS_OUTGOING_CALLS: string,
     READ_CALENDAR: string,


### PR DESCRIPTION
Summary:
I'm removing `POST_NOTIFICATION` as that's a typo as it should be `POST_NOTIFICATIONS`
We had both in version 0.71 so we can remove the wrong one as it's misleading for users.

Changelog:
[Android] [Removed] - Remove deprecated POST_NOTIFICATION from `PermissionsAndroid`

Reviewed By: sshic

Differential Revision: D45054310

