### PR TITLE
chore: bump `actions/checkout` to `v3`

### DIFF
--- a/.github/workflows/autorebase.yml
+++ b/.github/workflows/autorebase.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the latest code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo


### PR DESCRIPTION
## Summary:

A recent [Rebase run](https://github.com/facebook/react-native/actions/runs/4724279197/jobs/8381306851) gave following warning:
>Node.js 12 actions are *deprecated*. Please update the following actions to use Node.js 16: actions/checkout@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

So, it makes sense to upgrade to `actions/checkout@v3`.

## Changelog:

[GENERAL] [SECURITY] - Bump `actions/checkout` to `v3`

## Test Plan:

- ci should be green + the `/rebase` command works as usual.
