### PR TITLE
Bump react-native-android docker container to 8.0

### DIFF
--- a/.circleci/Dockerfiles/Dockerfile.android
+++ b/.circleci/Dockerfiles/Dockerfile.android
@@ -14,10 +14,10 @@
 # and build a Android application that can be used to run the
 # tests specified in the scripts/ directory.
 #
-FROM reactnativecommunity/react-native-android:7.0
+FROM reactnativecommunity/react-native-android:8.0
 
 LABEL Description="React Native Android Test Image"
-LABEL maintainer="Héctor Ramos <hector@fb.com>"
+LABEL maintainer="Meta Open Source <opensource@meta.com>"
 
 # set default environment variables
 ENV GRADLE_OPTS="-Dorg.gradle.daemon=false -Dfile.encoding=utf-8 -Dorg.gradle.jvmargs=\"-Xmx512m -XX:+HeapDumpOnOutOfMemoryError\""

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,7 @@ executors:
   reactnativeandroid:
     <<: *defaults
     docker:
-      - image: reactnativecommunity/react-native-android:7.0
+      - image: reactnativecommunity/react-native-android:8.0
     resource_class: "xlarge"
     environment:
       - TERM: "dumb"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "prettier": "prettier --write \"./**/*.{js,md,yml,ts,tsx}\"",
     "format-check": "prettier --list-different \"./**/*.{js,md,yml,ts,tsx}\"",
     "update-lock": "npx yarn-deduplicate",
-    "docker-setup-android": "docker pull reactnativecommunity/react-native-android:7.0",
+    "docker-setup-android": "docker pull reactnativecommunity/react-native-android:8.0",
     "docker-build-android": "docker build -t reactnativeci/android -f .circleci/Dockerfiles/Dockerfile.android .",
     "test-android-run-instrumentation": "docker run --cap-add=SYS_ADMIN -it reactnativeci/android bash .circleci/Dockerfiles/scripts/run-android-docker-instrumentation-tests.sh",
     "test-android-run-unit": "docker run --cap-add=SYS_ADMIN -it reactnativeci/android bash .circleci/Dockerfiles/scripts/run-android-docker-unit-tests.sh",


### PR DESCRIPTION
Summary:
This bumps the docker container we use to the latest major.

Changelog:
[Internal] [Changed] - Bump react-native-android docker container to 8.0

Differential Revision: D45083111

