### PR TITLE
Bump @tsconfig/react-native to 3.0.0

### DIFF
--- a/packages/react-native/template/package.json
+++ b/packages/react-native/template/package.json
@@ -19,7 +19,7 @@
     "@babel/runtime": "^7.12.5",
     "@react-native/eslint-config": "^0.73.0",
     "@react-native/metro-config": "^0.73.0",
-    "@tsconfig/react-native": "^2.0.2",
+    "@tsconfig/react-native": "^3.0.0",
     "@types/metro-config": "^0.76.1",
     "@types/react": "^18.0.24",
     "@types/react-test-renderer": "^18.0.0",


### PR DESCRIPTION
Summary:
Fixes https://github.com/facebook/react-native/issues/36830

This bumps the version of tsconfig/react-native to inform TypeScript of more libraries provided by Hermes/React Native. See https://github.com/tsconfig/bases/commit/eee5f19ce8c6a9a8d8baed5ce42588b95262b1a8.

I did the search off of current Hermes/RN main branch, but I think the new config should be valid as far back as 0.71. It doesn't make sense to change the new app template for an old version though, so instead I think we should include this new version in 0.72.

Changelog:
[General][Changed] - Bump tsconfig/react-native to 3.0.0

Differential Revision: D45085932

