### PR TITLE
Remove instructions from `Dockerfile.android` that are BUCK related.

### DIFF
--- a/.circleci/Dockerfiles/Dockerfile.android
+++ b/.circleci/Dockerfiles/Dockerfile.android
@@ -23,9 +23,6 @@ LABEL maintainer="Meta Open Source <opensource@meta.com>"
 ENV GRADLE_OPTS="-Dorg.gradle.daemon=false -Dfile.encoding=utf-8 -Dorg.gradle.jvmargs=\"-Xmx512m -XX:+HeapDumpOnOutOfMemoryError\""
 ENV KOTLIN_HOME="packages/react-native/third-party/kotlin"
 
-ADD .buckconfig /app/.buckconfig
-ADD .buckjavaargs /app/.buckjavaargs
-ADD BUCK /app/BUCK
 ADD packages/react-native/Libraries /app/packages/react-native/Libraries
 ADD packages/react-native/ReactAndroid /app/packages/react-native/ReactAndroid
 ADD packages/react-native/ReactCommon /app/packages/react-native/ReactCommon


### PR DESCRIPTION
Summary:
As we don't invoke `buck` anymore inside `Dockerfile.android` anymore,
those instructions can be removed.

Changelog:
[Internal] [Changed] - Remove instructions from `Dockerfile.android` that are BUCK related

Differential Revision: D45086054

