### PR TITLE
W3CPointerEvents: fix pointercancel test scrollview on Android

### DIFF
--- a/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventPointerCancelTouch.js
+++ b/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventPointerCancelTouch.js
@@ -157,10 +157,11 @@ function PointerEventPointerCancelTouchTestCase(
 }
 
 const styles = StyleSheet.create({
-  scrollContainer: {width: '100%', height: '100%'},
+  scrollContainer: {width: '100%', height: 100},
   target: {
     backgroundColor: 'black',
     padding: 32,
+    height: 200,
   },
 });
 


### PR DESCRIPTION
Summary:
Changelog: [Internal] - W3CPointerEvents: fix pointercancel test scrollview on Android

On Android the contents of the scrollview were not large enough to allow for scrolling (i.e. they didn't overflow the scroll container). This change sets the height of the content and container explicitly to ensure that the view can be scrolled.

Differential Revision: D45064333

