### PR TITLE
Codemod `$Shape` to `Partial` in xplat, suppressing errors [4]

### DIFF
--- a/packages/react-native/Libraries/Performance/QuickPerformanceLogger.js
+++ b/packages/react-native/Libraries/Performance/QuickPerformanceLogger.js
@@ -16,7 +16,7 @@ const DUMMY_INSTANCE_KEY = 0;
 // Defines map of annotations
 // Use as following:
 // {string: {key1: value1, key2: value2}}
-export type AnnotationsMap = $Shape<{
+export type AnnotationsMap = Partial<{
   string: ?{[string]: string, ...},
   int: ?{[string]: number, ...},
   double: ?{[string]: number, ...},

--- a/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.js
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.js
@@ -892,20 +892,22 @@ type GenericStyleProp<+T> =
   | $ReadOnlyArray<GenericStyleProp<T>>;
 
 export type ____DangerouslyImpreciseStyleProp_Internal = GenericStyleProp<
-  $Shape<____DangerouslyImpreciseStyle_Internal>,
+  Partial<____DangerouslyImpreciseStyle_Internal>,
 >;
 export type ____ViewStyleProp_Internal = GenericStyleProp<
-  $ReadOnly<$Shape<____ViewStyle_Internal>>,
+  $ReadOnly<Partial<____ViewStyle_Internal>>,
 >;
 export type ____TextStyleProp_Internal = GenericStyleProp<
-  $ReadOnly<$Shape<____TextStyle_Internal>>,
+  $ReadOnly<Partial<____TextStyle_Internal>>,
 >;
 export type ____ImageStyleProp_Internal = GenericStyleProp<
-  $ReadOnly<$Shape<____ImageStyle_Internal>>,
+  $ReadOnly<Partial<____ImageStyle_Internal>>,
 >;
 
 export type ____Styles_Internal = {
-  +[key: string]: $Shape<____DangerouslyImpreciseStyle_Internal>,
+  // $FlowFixMe[incompatible-exact]
+  // $FlowFixMe[incompatible-type]
+  +[key: string]: Partial<____DangerouslyImpreciseStyle_Internal>,
   ...
 };
 

--- a/packages/react-native/flow-typed/npm/yargs_v17.x.x.js
+++ b/packages/react-native/flow-typed/npm/yargs_v17.x.x.js
@@ -1,4 +1,3 @@
-// flow-typed signature: cab38813101e0a162deaae556391abc8
 // flow-typed version: f7c859e705/yargs_v17.x.x/flow_>=v0.104.x
 
 declare module "yargs" {
@@ -9,7 +8,7 @@ declare module "yargs" {
     ...
   };
 
-  declare type Options = $Shape<{
+  declare type Options = Partial<{
     alias: string | Array<string>,
     array: boolean,
     boolean: boolean,

--- a/packages/rn-tester/js/examples/FlatList/BaseFlatListExample.js
+++ b/packages/rn-tester/js/examples/FlatList/BaseFlatListExample.js
@@ -60,7 +60,7 @@ const Item = ({item, separators}: RenderItemProps<string>) => {
 };
 
 type Props = {
-  exampleProps: $Shape<React.ElementConfig<typeof FlatList>>,
+  exampleProps: Partial<React.ElementConfig<typeof FlatList>>,
   onTest?: ?() => void,
   testLabel?: ?string,
   testOutput?: ?string,
@@ -93,11 +93,14 @@ const BaseFlatListExample = React.forwardRef(
         {props.children}
         <FlatList
           {...props.exampleProps}
+          // $FlowFixMe[incompatible-type]
           ref={ref}
           testID="flat_list"
+          // $FlowFixMe[incompatible-type]
           data={DATA}
           keyExtractor={(item, index) => item + index}
           style={styles.list}
+          // $FlowFixMe[incompatible-type-arg]
           renderItem={Item}
         />
       </View>

--- a/packages/rn-tester/js/examples/SectionList/SectionListBaseExample.js
+++ b/packages/rn-tester/js/examples/SectionList/SectionListBaseExample.js
@@ -66,7 +66,7 @@ const Item = ({item, section, separators}) => {
 };
 
 type Props = {
-  exampleProps: $Shape<React.ElementConfig<typeof SectionList>>,
+  exampleProps: Partial<React.ElementConfig<typeof SectionList>>,
   onTest?: ?() => void,
   testLabel?: ?string,
   testOutput?: ?string,
@@ -98,6 +98,7 @@ const SectionListBaseExample: React.AbstractComponent<
         ref={ref}
         testID="section_list"
         accessibilityRole="list"
+        // $FlowFixMe[incompatible-type]
         sections={DATA}
         keyExtractor={(item, index) => item + index}
         style={styles.list}

--- a/packages/virtualized-lists/Lists/StateSafePureComponent.js
+++ b/packages/virtualized-lists/Lists/StateSafePureComponent.js
@@ -32,7 +32,7 @@ export default class StateSafePureComponent<
   }
 
   setState(
-    partialState: ?($Shape<State> | ((State, Props) => ?$Shape<State>)),
+    partialState: ?(Partial<State> | ((State, Props) => ?Partial<State>)),
     callback?: () => mixed,
   ): void {
     if (typeof partialState === 'function') {

--- a/packages/virtualized-lists/Lists/VirtualizedListCellRenderer.js
+++ b/packages/virtualized-lists/Lists/VirtualizedListCellRenderer.js
@@ -36,7 +36,7 @@ export type Props<ItemT> = {
   onUnmount: (cellKey: string) => void,
   onUpdateSeparators: (
     cellKeys: Array<?string>,
-    props: $Shape<SeparatorProps<ItemT>>,
+    props: Partial<SeparatorProps<ItemT>>,
   ) => void,
   prevCellKey: ?string,
   renderItem?: ?RenderItemType<ItemT>,

--- a/packages/virtualized-lists/Lists/VirtualizedSectionList.js
+++ b/packages/virtualized-lists/Lists/VirtualizedSectionList.js
@@ -561,7 +561,7 @@ function ItemWithSeparator(props: ItemWithSeparatorProps): React.Node {
     },
     updateProps: (
       select: 'leading' | 'trailing',
-      newProps: $Shape<ItemWithSeparatorCommonProps>,
+      newProps: Partial<ItemWithSeparatorCommonProps>,
     ) => {
       if (select === 'leading') {
         if (LeadingSeparatorComponent != null) {


### PR DESCRIPTION
Summary:
We're deprecating the unsafe `$Shape` and moving to the safe `Partial`: https://fb.workplace.com/groups/flowlang/posts/1251655088773485

I have previously codemodded all locations that do not cause errors. Now start on the remaining ones: codemod and suppress.

Changelog: [Internal]

Reviewed By: SamChou19815

Differential Revision: D45076273

