### PR TITLE
Add missing #pragma once to JsErrorHandler.h

### DIFF
--- a/packages/react-native/ReactCommon/jserrorhandler/JsErrorHandler.h
+++ b/packages/react-native/ReactCommon/jserrorhandler/JsErrorHandler.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#pragma once
+
 #include <jsi/jsi.h>
 #include <react/renderer/mapbuffer/MapBuffer.h>
 


### PR DESCRIPTION
Summary:
Changelog: [Internal]

W/o #pragma once, .cpp files would include the same header file content multiple times leading to compile errors as

```
react-native-github/packages/react-native/ReactCommon/jserrorhandler/JsErrorHandler.h:14:6: note: unguarded header; consider using #ifdef guards or #pragma once
enum JSErrorHandlerKey : uint16_t {
     ^
```

Differential Revision: D45100413

