### PR TITLE
make getModuleClassFromName: required

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.h
@@ -19,12 +19,12 @@ RCT_EXTERN void RCTTurboModuleSetBindingMode(facebook::react::TurboModuleBinding
 
 @protocol RCTTurboModuleManagerDelegate <NSObject>
 
-@optional
-
 /**
- * Given a module name, return its actual class. If not provided, basic ObjC class lookup is performed.
+ * Given a module name, return its actual class. If nil is returned, basic ObjC class lookup is performed.
  */
 - (Class)getModuleClassFromName:(const char *)name;
+
+@optional
 
 /**
  * Given a module class, provide an instance for it. If not provided, default initializer is used.

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
@@ -388,14 +388,11 @@ static Class getFallbackClassFromName(const char *name)
     /**
      * Step 2a: Resolve platform-specific class.
      */
-
-    if ([_delegate respondsToSelector:@selector(getModuleClassFromName:)]) {
-      if (RCTTurboModuleManagerDelegateLockingDisabled()) {
-        moduleClass = [_delegate getModuleClassFromName:moduleName];
-      } else {
-        std::lock_guard<std::mutex> delegateGuard(_turboModuleManagerDelegateMutex);
-        moduleClass = [_delegate getModuleClassFromName:moduleName];
-      }
+    if (RCTTurboModuleManagerDelegateLockingDisabled()) {
+      moduleClass = [_delegate getModuleClassFromName:moduleName];
+    } else {
+      std::lock_guard<std::mutex> delegateGuard(_turboModuleManagerDelegateMutex);
+      moduleClass = [_delegate getModuleClassFromName:moduleName];
     }
 
     if (!moduleClass) {


### PR DESCRIPTION
Summary:
Changelog: [Internal]

we should be using `optional` never

#saynotoruntimechecks

Reviewed By: cipolleschi

Differential Revision: D45022003

