### PR TITLE
Report loaded modules when first module load fails

### DIFF
--- a/packages/react-native/Libraries/TurboModule/TurboModuleRegistry.js
+++ b/packages/react-native/Libraries/TurboModule/TurboModuleRegistry.js
@@ -16,22 +16,50 @@ const NativeModules = require('../BatchedBridge/NativeModules');
 
 const turboModuleProxy = global.__turboModuleProxy;
 
+const moduleLoadHistory = {
+  NativeModules: ([]: Array<string>),
+  TurboModules: ([]: Array<string>),
+  NotFound: ([]: Array<string>),
+};
+
+function isBridgeless() {
+  return global.RN$Bridgeless === true;
+}
+
+function isTurboModuleInteropEnabled() {
+  return global.RN$TurboInterop === true;
+}
+
+function shouldReportLoadedModules() {
+  return isTurboModuleInteropEnabled();
+}
+
 // TODO(148943970): Consider reversing the lookup here:
 // Lookup on __turboModuleProxy, then lookup on nativeModuleProxy
 function requireModule<T: TurboModule>(name: string): ?T {
-  const isBridgeless = global.RN$Bridgeless === true;
-  const isTurboModuleInteropEnabled = global.RN$TurboInterop === true;
-  if (!isBridgeless || isTurboModuleInteropEnabled) {
+  if (!isBridgeless() || isTurboModuleInteropEnabled()) {
     // Backward compatibility layer during migration.
     const legacyModule = NativeModules[name];
     if (legacyModule != null) {
+      if (shouldReportLoadedModules()) {
+        moduleLoadHistory.NativeModules.push(name);
+      }
       return ((legacyModule: $FlowFixMe): T);
     }
   }
 
   if (turboModuleProxy != null) {
     const module: ?T = turboModuleProxy(name);
-    return module;
+    if (module != null) {
+      if (shouldReportLoadedModules()) {
+        moduleLoadHistory.TurboModules.push(name);
+      }
+      return module;
+    }
+  }
+
+  if (shouldReportLoadedModules()) {
+    moduleLoadHistory.NotFound.push(name);
   }
 
   return null;
@@ -43,10 +71,14 @@ export function get<T: TurboModule>(name: string): ?T {
 
 export function getEnforcing<T: TurboModule>(name: string): T {
   const module = requireModule<T>(name);
-  invariant(
-    module != null,
+  let message =
     `TurboModuleRegistry.getEnforcing(...): '${name}' could not be found. ` +
-      'Verify that a module by this name is registered in the native binary.',
-  );
+    'Verify that a module by this name is registered in the native binary.';
+
+  if (shouldReportLoadedModules()) {
+    message += 'Modules loaded: ' + JSON.stringify(moduleLoadHistory);
+  }
+
+  invariant(module != null, message);
   return module;
 }


### PR DESCRIPTION
Summary:
With the TurboModule interop layer, some modules aren't being loaded at all. This logging will help us root cause the problem: is the issue with the TurboModule system, or with instantiating a particular module.

Changelog: [Internal]

Reviewed By: cortinico

Differential Revision: D45102812

