### PR TITLE
Use C++17 namespace format

### DIFF
--- a/packages/react-native/ReactCommon/react/bridgeless/BufferedRuntimeExecutor.cpp
+++ b/packages/react-native/ReactCommon/react/bridgeless/BufferedRuntimeExecutor.cpp
@@ -9,8 +9,7 @@
 #include <cxxreact/MessageQueueThread.h>
 #include <algorithm>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 BufferedRuntimeExecutor::BufferedRuntimeExecutor(
     RuntimeExecutor runtimeExecutor)
@@ -58,5 +57,4 @@ void BufferedRuntimeExecutor::unsafeFlush() {
   }
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/bridgeless/BufferedRuntimeExecutor.h
+++ b/packages/react-native/ReactCommon/react/bridgeless/BufferedRuntimeExecutor.h
@@ -11,8 +11,7 @@
 #include <atomic>
 #include <queue>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class BufferedRuntimeExecutor {
  public:
@@ -47,5 +46,4 @@ class BufferedRuntimeExecutor {
   std::priority_queue<BufferedWork> queue_;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/bridgeless/JSEngineInstance.h
+++ b/packages/react-native/ReactCommon/react/bridgeless/JSEngineInstance.h
@@ -10,8 +10,7 @@
 #include <ReactCommon/RuntimeExecutor.h>
 #include <jsi/jsi.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /**
  * Interface for a class that creates and owns an instance of a JS VM
@@ -23,5 +22,4 @@ class JSEngineInstance {
   virtual ~JSEngineInstance() = default;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/bridgeless/PlatformTimerRegistry.h
+++ b/packages/react-native/ReactCommon/react/bridgeless/PlatformTimerRegistry.h
@@ -9,8 +9,7 @@
 
 #include <cstdint>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /**
  * This interface is implemented by each platform.
@@ -30,5 +29,4 @@ class PlatformTimerRegistry {
 
 using TimerManagerDelegate = PlatformTimerRegistry;
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/bridgeless/ReactInstance.cpp
+++ b/packages/react-native/ReactCommon/react/bridgeless/ReactInstance.cpp
@@ -22,8 +22,7 @@
 #include <tuple>
 #include <utility>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 // Looping on \c drainMicrotasks until it completes or hits the retries bound.
 static void performMicrotaskCheckpoint(jsi::Runtime &runtime) {
@@ -454,5 +453,4 @@ void ReactInstance::handleMemoryPressureJs(int pressureLevel) {
   }
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/bridgeless/ReactInstance.h
+++ b/packages/react-native/ReactCommon/react/bridgeless/ReactInstance.h
@@ -16,8 +16,7 @@
 #include <react/bridgeless/TimerManager.h>
 #include <react/renderer/runtimescheduler/RuntimeScheduler.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 struct CallableModule {
   explicit CallableModule(jsi::Function factory)
@@ -76,5 +75,4 @@ class ReactInstance final {
   std::shared_ptr<bool> hasFatalJsError_;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/bridgeless/TimerManager.cpp
+++ b/packages/react-native/ReactCommon/react/bridgeless/TimerManager.cpp
@@ -10,8 +10,7 @@
 #include <cxxreact/SystraceSection.h>
 #include <utility>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 TimerManager::TimerManager(
     std::unique_ptr<PlatformTimerRegistry> platformTimerRegistry) noexcept
@@ -412,5 +411,4 @@ void TimerManager::attachGlobals(jsi::Runtime &runtime) {
           }));
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/bridgeless/TimerManager.h
+++ b/packages/react-native/ReactCommon/react/bridgeless/TimerManager.h
@@ -14,8 +14,7 @@
 
 #include "PlatformTimerRegistry.h"
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * A HostObject subclass representing the result of a setTimeout call.
@@ -113,5 +112,4 @@ class TimerManager {
   std::vector<uint32_t> reactNativeMicrotasksQueue_;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/bridgeless/hermes/HermesInstance.cpp
+++ b/packages/react-native/ReactCommon/react/bridgeless/hermes/HermesInstance.cpp
@@ -18,8 +18,7 @@
 using namespace facebook::hermes;
 using namespace facebook::jsi;
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 #ifdef HERMES_ENABLE_DEBUGGER
 
@@ -119,5 +118,4 @@ std::unique_ptr<jsi::Runtime> HermesInstance::createJSRuntime(
   return hermesRuntime;
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/bridgeless/hermes/HermesInstance.h
+++ b/packages/react-native/ReactCommon/react/bridgeless/hermes/HermesInstance.h
@@ -11,8 +11,7 @@
 #include <jsi/jsi.h>
 #include <react/config/ReactNativeConfig.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class HermesInstance {
  public:
@@ -24,5 +23,4 @@ class HermesInstance {
       std::shared_ptr<::hermes::vm::CrashManager> cm) noexcept;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/bridgeless/tests/hermes/ReactInstanceTest.cpp
+++ b/packages/react-native/ReactCommon/react/bridgeless/tests/hermes/ReactInstanceTest.cpp
@@ -20,8 +20,7 @@
 using ::testing::_;
 using ::testing::SaveArg;
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class MockTimerRegistry : public PlatformTimerRegistry {
  public:
@@ -866,5 +865,4 @@ function getResult() {
   EXPECT_EQ(result.getNumber(), 1);
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/bridging/CallbackWrapper.h
+++ b/packages/react-native/ReactCommon/react/bridging/CallbackWrapper.h
@@ -12,8 +12,7 @@
 
 #include <memory>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 // Helper for passing jsi::Function arg to other methods.
 class CallbackWrapper : public LongLivedObject {
@@ -63,5 +62,4 @@ class CallbackWrapper : public LongLivedObject {
   }
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/bridging/LongLivedObject.cpp
+++ b/packages/react-native/ReactCommon/react/bridging/LongLivedObject.cpp
@@ -7,8 +7,7 @@
 
 #include "LongLivedObject.h"
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 // LongLivedObjectCollection
 LongLivedObjectCollection &LongLivedObjectCollection::get() {
@@ -47,5 +46,4 @@ void LongLivedObject::allowRelease() {
   LongLivedObjectCollection::get().remove(this);
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/bridging/LongLivedObject.h
+++ b/packages/react-native/ReactCommon/react/bridging/LongLivedObject.h
@@ -11,8 +11,7 @@
 #include <mutex>
 #include <unordered_set>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /**
  * A simple wrapper class that can be registered to a collection that keep it
@@ -55,5 +54,4 @@ class LongLivedObjectCollection {
   mutable std::mutex collectionMutex_;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/config/ReactNativeConfig.cpp
+++ b/packages/react-native/ReactCommon/react/config/ReactNativeConfig.cpp
@@ -7,8 +7,7 @@
 
 #include "ReactNativeConfig.h"
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /**
  * ReactNative configuration as provided by the hosting app.
@@ -42,5 +41,4 @@ double EmptyReactNativeConfig::getDouble(const std::string &param) const {
   return 0.0;
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/config/ReactNativeConfig.h
+++ b/packages/react-native/ReactCommon/react/config/ReactNativeConfig.h
@@ -9,8 +9,7 @@
 
 #include <string>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /**
  * ReactNative configuration as provided by the hosting app.
@@ -40,5 +39,4 @@ class EmptyReactNativeConfig : public ReactNativeConfig {
   double getDouble(const std::string &param) const override;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboCxxModule.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboCxxModule.cpp
@@ -15,8 +15,7 @@
 using namespace facebook;
 using namespace facebook::xplat::module;
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 namespace {
 CxxModule::Callback makeTurboCxxModuleCallback(
@@ -225,5 +224,4 @@ jsi::Value TurboCxxModule::invokeMethod(
   return jsi::Value::undefined();
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboCxxModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboCxxModule.h
@@ -14,8 +14,7 @@
 
 #include "TurboModule.h"
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /**
  * A helper class to convert the legacy CxxModule instance to a TurboModule
@@ -47,5 +46,4 @@ class JSI_EXPORT TurboCxxModule : public TurboModule {
   std::unique_ptr<facebook::xplat::module::CxxModule> cxxModule_;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModule.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModule.cpp
@@ -7,8 +7,7 @@
 
 #include "TurboModule.h"
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 TurboModule::TurboModule(
     std::string name,
@@ -39,5 +38,4 @@ void TurboModule::emitDeviceEvent(
   });
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModule.h
@@ -14,8 +14,7 @@
 
 #include <ReactCommon/CallInvoker.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /**
  * For now, support the same set of return types as existing impl.
@@ -139,5 +138,4 @@ class JSI_EXPORT TurboModule : public facebook::jsi::HostObject {
 using TurboModuleProviderFunctionType =
     std::function<std::shared_ptr<TurboModule>(const std::string &name)>;
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.cpp
@@ -15,8 +15,7 @@
 
 using namespace facebook;
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class BridgelessNativeModuleProxy : public jsi::HostObject {
   std::unique_ptr<TurboModuleBinding> binding_;
@@ -207,5 +206,4 @@ jsi::Value TurboModuleBinding::getModule(
   }
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.h
@@ -12,8 +12,7 @@
 #include <ReactCommon/TurboModule.h>
 #include <jsi/jsi.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 enum class TurboModuleBindingMode : uint8_t {
   HostObject = 0,
@@ -57,5 +56,4 @@ class TurboModuleBinding {
   TurboModuleProviderFunctionType moduleProvider_;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModulePerfLogger.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModulePerfLogger.cpp
@@ -7,8 +7,7 @@
 
 #include "TurboModulePerfLogger.h"
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 namespace TurboModulePerfLogger {
 
 std::unique_ptr<NativeModulePerfLogger> g_perfLogger = nullptr;
@@ -327,5 +326,4 @@ void asyncMethodCallExecutionFail(
 }
 
 } // namespace TurboModulePerfLogger
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModulePerfLogger.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModulePerfLogger.h
@@ -10,8 +10,7 @@
 #include <reactperflogger/NativeModulePerfLogger.h>
 #include <memory>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 namespace TurboModulePerfLogger {
 void enableLogging(std::unique_ptr<NativeModulePerfLogger> &&logger);
 void disableLogging();
@@ -108,5 +107,4 @@ void asyncMethodCallExecutionFail(
     int32_t id);
 
 } // namespace TurboModulePerfLogger
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleUtils.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleUtils.cpp
@@ -7,8 +7,7 @@
 
 #include "TurboModuleUtils.h"
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 static jsi::Value deepCopyJSIValue(jsi::Runtime &rt, const jsi::Value &value) {
   if (value.isNull()) {
@@ -101,5 +100,4 @@ jsi::Value createPromiseAsJSIValue(
   return JSPromise.callAsConstructor(rt, fn);
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleUtils.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleUtils.h
@@ -15,8 +15,7 @@
 #include <ReactCommon/CallInvoker.h>
 #include <ReactCommon/CallbackWrapper.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 jsi::Object deepCopyJSIObject(jsi::Runtime &rt, const jsi::Object &obj);
 jsi::Array deepCopyJSIArray(jsi::Runtime &rt, const jsi::Array &arr);
@@ -56,5 +55,4 @@ class RAIICallbackWrapperDestroyer {
   std::weak_ptr<CallbackWrapper> callbackWrapper_;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaInteropTurboModule.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaInteropTurboModule.cpp
@@ -7,8 +7,7 @@
 
 #include "JavaInteropTurboModule.h"
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 namespace {
 
@@ -188,5 +187,4 @@ std::vector<facebook::jsi::PropNameID> JavaInteropTurboModule::getPropertyNames(
   return propNames;
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaInteropTurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaInteropTurboModule.h
@@ -16,8 +16,7 @@
 
 #include "JavaTurboModule.h"
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class JSI_EXPORT JavaInteropTurboModule : public JavaTurboModule {
  public:
@@ -48,5 +47,4 @@ class JSI_EXPORT JavaInteropTurboModule : public JavaTurboModule {
   bool exportsConstants();
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaTurboModule.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaTurboModule.cpp
@@ -24,8 +24,7 @@
 
 #include "JavaTurboModule.h"
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 namespace TMPL = TurboModulePerfLogger;
 
@@ -850,5 +849,4 @@ jsi::Value JavaTurboModule::invokeJavaMethod(
   }
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaTurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaTurboModule.h
@@ -17,8 +17,7 @@
 #include <react/bridging/CallbackWrapper.h>
 #include <react/jni/JCallback.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 struct JTurboModule : jni::JavaClass<JTurboModule> {
   static auto constexpr kJavaDescriptor =
@@ -53,5 +52,4 @@ class JSI_EXPORT JavaTurboModule : public TurboModule {
   std::shared_ptr<CallInvoker> nativeInvoker_;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.h
@@ -23,8 +23,7 @@
   ((RCTTurboModuleEnabled() && [(klass) conformsToProtocol:@protocol(RCTTurboModule)]))
 #define RCT_IS_TURBO_MODULE_INSTANCE(module) RCT_IS_TURBO_MODULE_CLASS([(module) class])
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class CallbackWrapper;
 class Instance;
@@ -93,8 +92,7 @@ class JSI_EXPORT ObjCTurboModule : public TurboModule {
   jsi::Value createPromise(jsi::Runtime &runtime, std::string methodName, PromiseInvocationBlock invoke);
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react
 
 @protocol RCTTurboModule <NSObject>
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
@@ -211,8 +211,7 @@ convertJSIFunctionToCallback(jsi::Runtime &runtime, const jsi::Function &value, 
   return [callback copy];
 }
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 jsi::Value ObjCTurboModule::createPromise(jsi::Runtime &runtime, std::string methodName, PromiseInvocationBlock invoke)
 {
@@ -724,5 +723,4 @@ void ObjCTurboModule::setMethodArgConversionSelector(NSString *methodName, int a
   methodArgConversionSelectors_[methodName][argIndex] = selectorValue;
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/ReactCommon/NativeSampleTurboCxxModuleSpecJSI.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/ReactCommon/NativeSampleTurboCxxModuleSpecJSI.cpp
@@ -9,8 +9,7 @@
 
 // NOTE: This entire file should be codegen'ed.
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 static jsi::Value __hostFunction_NativeSampleTurboCxxModuleSpecJSI_voidFunc(
     jsi::Runtime &rt,
@@ -149,5 +148,4 @@ NativeSampleTurboCxxModuleSpecJSI::NativeSampleTurboCxxModuleSpecJSI(
       0, __hostFunction_NativeSampleTurboCxxModuleSpecJSI_getConstants};
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/ReactCommon/NativeSampleTurboCxxModuleSpecJSI.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/ReactCommon/NativeSampleTurboCxxModuleSpecJSI.h
@@ -12,8 +12,7 @@
 
 #include <ReactCommon/TurboModule.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 // TODO: This definition should be codegen'ed for type-safety purpose.
 class JSI_EXPORT NativeSampleTurboCxxModuleSpecJSI : public TurboModule {
@@ -40,5 +39,4 @@ class JSI_EXPORT NativeSampleTurboCxxModuleSpecJSI : public TurboModule {
   virtual jsi::Object getConstants(jsi::Runtime &rt) = 0;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/ReactCommon/SampleTurboCxxModule.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/ReactCommon/SampleTurboCxxModule.cpp
@@ -11,8 +11,7 @@
 
 using namespace facebook;
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 SampleTurboCxxModule::SampleTurboCxxModule(
     std::shared_ptr<CallInvoker> jsInvoker)
@@ -94,5 +93,4 @@ jsi::Object SampleTurboCxxModule::getConstants(jsi::Runtime &rt) {
   return result;
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/ReactCommon/SampleTurboCxxModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/ReactCommon/SampleTurboCxxModule.h
@@ -11,8 +11,7 @@
 
 #include "NativeSampleTurboCxxModuleSpecJSI.h"
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /**
  * A sample implementation of the C++ spec. In practice, this class can just
@@ -41,5 +40,4 @@ class SampleTurboCxxModule : public NativeSampleTurboCxxModuleSpecJSI {
   jsi::Object getConstants(jsi::Runtime &rt) override;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/ReactCommon/SampleTurboModuleSpec.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/ReactCommon/SampleTurboModuleSpec.cpp
@@ -9,8 +9,7 @@
 
 #include <ReactCommon/SampleTurboModuleSpec.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 static facebook::jsi::Value
 __hostFunction_NativeSampleTurboModuleSpecJSI_voidFunc(
@@ -361,5 +360,4 @@ std::shared_ptr<TurboModule> SampleTurboModuleSpec_ModuleProvider(
   return nullptr;
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/ReactCommon/SampleTurboModuleSpec.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/ReactCommon/SampleTurboModuleSpec.h
@@ -13,8 +13,7 @@
 #include <ReactCommon/TurboModule.h>
 #include <fbjni/fbjni.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /**
  * C++ class for module 'SampleTurboModule'
@@ -28,5 +27,4 @@ std::shared_ptr<TurboModule> SampleTurboModuleSpec_ModuleProvider(
     const std::string &moduleName,
     const JavaTurboModule::InitParams &params);
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTNativeSampleTurboModuleSpec.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTNativeSampleTurboModuleSpec.h
@@ -43,8 +43,7 @@
 
 @end
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /**
  * The iOS TurboModule impl specific to SampleTurboModule.
@@ -54,5 +53,4 @@ class JSI_EXPORT NativeSampleTurboModuleSpecJSI : public ObjCTurboModule {
   NativeSampleTurboModuleSpecJSI(const ObjCTurboModule::InitParams &params);
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTNativeSampleTurboModuleSpec.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTNativeSampleTurboModuleSpec.mm
@@ -7,8 +7,7 @@
 
 #import "RCTNativeSampleTurboModuleSpec.h"
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 static facebook::jsi::Value __hostFunction_NativeSampleTurboModuleSpecJSI_voidFunc(
     facebook::jsi::Runtime &rt,
@@ -227,5 +226,4 @@ NativeSampleTurboModuleSpecJSI::NativeSampleTurboModuleSpecJSI(const ObjCTurboMo
   methodMap_["getConstants"] = MethodMetadata{0, __hostFunction_NativeSampleTurboModuleSpecJSI_getConstants};
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/SampleTurboCxxModuleLegacyImpl.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/SampleTurboCxxModuleLegacyImpl.cpp
@@ -11,8 +11,7 @@
 
 using namespace facebook::xplat::module;
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 SampleTurboCxxModuleLegacyImpl::SampleTurboCxxModuleLegacyImpl() {}
 
@@ -175,5 +174,4 @@ void SampleTurboCxxModuleLegacyImpl::getValueWithPromise(
   }
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/SampleTurboCxxModuleLegacyImpl.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/SampleTurboCxxModuleLegacyImpl.h
@@ -9,8 +9,7 @@
 
 #import <cxxreact/CxxModule.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /**
  * A sample CxxModule (legacy system) implementation.
@@ -44,5 +43,4 @@ class SampleTurboCxxModuleLegacyImpl
       const facebook::xplat::module::CxxModule::Callback &reject);
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/animations/LayoutAnimationCallbackWrapper.h
+++ b/packages/react-native/ReactCommon/react/renderer/animations/LayoutAnimationCallbackWrapper.h
@@ -10,8 +10,7 @@
 #include <jsi/jsi.h>
 #include <memory>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class LayoutAnimationCallbackWrapper {
  public:
@@ -30,5 +29,4 @@ class LayoutAnimationCallbackWrapper {
   mutable std::shared_ptr<jsi::Function> callback_;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/animations/LayoutAnimationDriver.h
+++ b/packages/react-native/ReactCommon/react/renderer/animations/LayoutAnimationDriver.h
@@ -11,8 +11,7 @@
 #include <react/renderer/core/ReactPrimitives.h>
 #include <react/renderer/mounting/ShadowViewMutation.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class LayoutAnimationDriver : public LayoutAnimationKeyFrameManager {
  public:
@@ -32,5 +31,4 @@ class LayoutAnimationDriver : public LayoutAnimationKeyFrameManager {
       uint64_t now) const override;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/animations/LayoutAnimationKeyFrameManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/animations/LayoutAnimationKeyFrameManager.h
@@ -21,8 +21,7 @@
 
 #include <optional>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 #ifdef LAYOUT_ANIMATION_VERBOSE_LOGGING
 void PrintMutationInstruction(
@@ -176,5 +175,4 @@ class LayoutAnimationKeyFrameManager : public UIManagerAnimationDelegate,
       ShadowViewMutationList const &mutations) const;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/animations/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/animations/conversions.h
@@ -10,8 +10,7 @@
 
 #include <optional>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 static inline std::optional<AnimationType> parseAnimationType(
     std::string param) {
@@ -208,5 +207,4 @@ static inline std::optional<LayoutAnimationConfig> parseLayoutAnimationConfig(
       duration, *createConfig, *updateConfig, *deleteConfig};
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/animations/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/animations/primitives.h
@@ -14,8 +14,7 @@
 #include <react/renderer/mounting/ShadowViewMutation.h>
 #include <vector>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 // This corresponds exactly with JS.
 enum class AnimationType {
@@ -101,5 +100,4 @@ struct LayoutAnimation {
   std::vector<AnimationKeyFrame> keyFrames;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/animations/utils.h
+++ b/packages/react-native/ReactCommon/react/renderer/animations/utils.h
@@ -11,8 +11,7 @@
 #include <react/renderer/graphics/Float.h>
 #include <react/renderer/mounting/ShadowViewMutation.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 static inline bool shouldFirstComeBeforeSecondRemovesOnly(
     ShadowViewMutation const &lhs,
@@ -77,5 +76,4 @@ std::pair<Float, Float> calculateAnimationProgress(
     LayoutAnimation const &animation,
     AnimationConfig const &mutationConfig);
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/AttributedString.h
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/AttributedString.h
@@ -17,8 +17,7 @@
 #include <react/renderer/debug/DebugStringConvertible.h>
 #include <react/renderer/mounting/ShadowView.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class AttributedString;
 
@@ -117,8 +116,7 @@ class AttributedString : public Sealable, public DebugStringConvertible {
   Fragments fragments_;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react
 
 namespace std {
 template <>

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/AttributedStringBox.h
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/AttributedStringBox.h
@@ -11,8 +11,7 @@
 
 #include <react/renderer/attributedstring/AttributedString.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Represents an object storing a shared `AttributedString` or a shared pointer
@@ -61,8 +60,7 @@ class AttributedStringBox final {
 bool operator==(AttributedStringBox const &lhs, AttributedStringBox const &rhs);
 bool operator!=(AttributedStringBox const &lhs, AttributedStringBox const &rhs);
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react
 
 template <>
 struct std::hash<facebook::react::AttributedStringBox> {

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/ParagraphAttributes.h
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/ParagraphAttributes.h
@@ -14,8 +14,7 @@
 #include <react/renderer/debug/DebugStringConvertible.h>
 #include <react/renderer/graphics/Float.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class ParagraphAttributes;
 
@@ -81,8 +80,7 @@ class ParagraphAttributes : public DebugStringConvertible {
 #endif
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react
 
 namespace std {
 

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/TextAttributes.h
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/TextAttributes.h
@@ -20,8 +20,7 @@
 #include <react/renderer/graphics/Float.h>
 #include <react/renderer/graphics/Size.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class TextAttributes;
 
@@ -98,8 +97,7 @@ class TextAttributes : public DebugStringConvertible {
 #endif
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react
 
 namespace std {
 

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/conversions.h
@@ -30,8 +30,7 @@
 
 #include <glog/logging.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 inline std::string toString(const DynamicTypeRamp &dynamicTypeRamp) {
   switch (dynamicTypeRamp) {
@@ -1306,5 +1305,4 @@ inline MapBuffer toMapBuffer(const AttributedString &attributedString) {
 
 #endif
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/primitives.h
@@ -10,8 +10,7 @@
 #include <functional>
 #include <limits>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 enum class FontStyle { Normal, Italic, Oblique };
 
@@ -151,8 +150,7 @@ enum class HyphenationFrequency {
   Full // Standard amount of hyphenation.
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react
 
 namespace std {
 template <>

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/tests/AttributedStringTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/tests/AttributedStringTest.cpp
@@ -11,8 +11,7 @@
 #include <react/renderer/attributedstring/primitives.h>
 #include <react/renderer/core/graphicsConversions.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 #ifdef ANDROID
 
@@ -43,5 +42,4 @@ TEST(AttributedStringTest, testToDynamic) {
 
 #endif
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/tests/TextAttributesTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/tests/TextAttributesTest.cpp
@@ -11,8 +11,7 @@
 #include <react/renderer/attributedstring/primitives.h>
 #include <react/renderer/core/graphicsConversions.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 #ifdef ANDROID
 
@@ -35,5 +34,4 @@ TEST(TextAttributesTest, testToDynamic) {
 
 #endif
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/componentregistry/ComponentDescriptorFactory.h
+++ b/packages/react-native/ReactCommon/react/renderer/componentregistry/ComponentDescriptorFactory.h
@@ -15,8 +15,7 @@
 
 #include "ComponentDescriptorRegistry.h"
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /**
  * A factory to provide hosting app specific set of ComponentDescriptor's.
@@ -30,5 +29,4 @@ using ComponentRegistryFactory =
 
 ComponentRegistryFactory getDefaultComponentRegistryFactory();
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/componentregistry/ComponentDescriptorProvider.h
+++ b/packages/react-native/ReactCommon/react/renderer/componentregistry/ComponentDescriptorProvider.h
@@ -11,8 +11,7 @@
 #include <react/renderer/core/EventDispatcher.h>
 #include <react/utils/ContextContainer.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Callable signature that represents the signature of `ComponentDescriptor`
@@ -70,5 +69,4 @@ ComponentDescriptorProvider concreteComponentDescriptorProvider() {
       &concreteComponentDescriptorConstructor<ComponentDescriptorT>};
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/componentregistry/ComponentDescriptorProviderRegistry.h
+++ b/packages/react-native/ReactCommon/react/renderer/componentregistry/ComponentDescriptorProviderRegistry.h
@@ -13,8 +13,7 @@
 #include <react/renderer/componentregistry/ComponentDescriptorRegistry.h>
 #include <react/renderer/core/ComponentDescriptor.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 using ComponentDescriptorProviderRequest =
     std::function<void(ComponentName componentName)>;
@@ -67,5 +66,4 @@ class ComponentDescriptorProviderRegistry final {
       componentDescriptorProviderRequest_{};
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/componentregistry/ComponentDescriptorRegistry.h
+++ b/packages/react-native/ReactCommon/react/renderer/componentregistry/ComponentDescriptorRegistry.h
@@ -16,8 +16,7 @@
 #include <react/renderer/core/ComponentDescriptor.h>
 #include <react/utils/ContextContainer.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class ComponentDescriptorProviderRegistry;
 class ComponentDescriptorRegistry;
@@ -91,5 +90,4 @@ class ComponentDescriptorRegistry {
   ContextContainer::Shared contextContainer_;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/componentregistry/componentNameByReactViewName.h
+++ b/packages/react-native/ReactCommon/react/renderer/componentregistry/componentNameByReactViewName.h
@@ -9,13 +9,11 @@
 
 #include <string>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /**
  * Provides mapping from old view name format to the new format.
  */
 std::string componentNameByReactViewName(std::string viewName);
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/componentregistry/native/NativeComponentRegistryBinding.h
+++ b/packages/react-native/ReactCommon/react/renderer/componentregistry/native/NativeComponentRegistryBinding.h
@@ -11,8 +11,7 @@
 
 #include <jsi/jsi.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /**
  * An app/platform-specific provider function to determine if a component
@@ -57,5 +56,4 @@ class NativeComponentRegistryBinding {
   HasComponentProviderFunctionType hasComponentProvider_;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageComponentDescriptor.h
@@ -12,8 +12,7 @@
 #include <react/renderer/imagemanager/ImageManager.h>
 #include <react/utils/ContextContainer.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Descriptor for <Image> component.
@@ -40,5 +39,4 @@ class ImageComponentDescriptor final
   const SharedImageManager imageManager_;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageEventEmitter.h
@@ -9,8 +9,7 @@
 
 #include <react/renderer/components/view/ViewEventEmitter.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class ImageEventEmitter : public ViewEventEmitter {
  public:
@@ -24,5 +23,4 @@ class ImageEventEmitter : public ViewEventEmitter {
   void onPartialLoad() const;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.h
@@ -10,8 +10,7 @@
 #include <react/renderer/graphics/Color.h>
 #include <react/renderer/imagemanager/primitives.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 // TODO (T28334063): Consider for codegen.
 class ImageProps final : public ViewProps {
@@ -39,5 +38,4 @@ class ImageProps final : public ViewProps {
   std::string internal_analyticTag{};
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageShadowNode.h
@@ -14,8 +14,7 @@
 #include <react/renderer/imagemanager/ImageManager.h>
 #include <react/renderer/imagemanager/primitives.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 extern const char ImageComponentName[];
 
@@ -61,5 +60,4 @@ class ImageShadowNode final : public ConcreteViewShadowNode<
   void updateStateIfNeeded();
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageState.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageState.h
@@ -15,8 +15,7 @@
 #include <react/renderer/mapbuffer/MapBufferBuilder.h>
 #endif
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * State for <Image> component.
@@ -66,5 +65,4 @@ class ImageState final {
   Float const blurRadius_;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/image/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/conversions.h
@@ -15,8 +15,7 @@
 #include <react/renderer/core/graphicsConversions.h>
 #include <react/renderer/imagemanager/primitives.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 inline void fromRawValue(
     const PropsParserContext &context,
@@ -139,5 +138,4 @@ inline std::string toString(const ImageResizeMode &value) {
   }
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/inputaccessory/InputAccessoryComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/inputaccessory/InputAccessoryComponentDescriptor.h
@@ -11,8 +11,7 @@
 #include <react/renderer/components/inputaccessory/InputAccessoryShadowNode.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Descriptor for <InputAccessoryView> component.
@@ -42,5 +41,4 @@ class InputAccessoryComponentDescriptor final
   }
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/inputaccessory/InputAccessoryShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/inputaccessory/InputAccessoryShadowNode.cpp
@@ -7,10 +7,8 @@
 
 #include "InputAccessoryShadowNode.h"
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 extern const char InputAccessoryComponentName[] = "InputAccessoryView";
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/inputaccessory/InputAccessoryShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/inputaccessory/InputAccessoryShadowNode.h
@@ -12,8 +12,7 @@
 #include <react/renderer/components/rncore/Props.h>
 #include <react/renderer/components/view/ConcreteViewShadowNode.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 extern const char InputAccessoryComponentName[];
 
@@ -35,5 +34,4 @@ class InputAccessoryShadowNode final : public ConcreteViewShadowNode<
   }
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/inputaccessory/InputAccessoryState.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/inputaccessory/InputAccessoryState.h
@@ -10,8 +10,7 @@
 #include <react/renderer/core/graphicsConversions.h>
 #include <react/renderer/graphics/Float.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * State for <InputAccessoryView> component.
@@ -24,5 +23,4 @@ class InputAccessoryState final {
   const Size viewportSize{};
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropComponentDescriptor.h
@@ -10,8 +10,7 @@
 #include <react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropShadowNode.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class LegacyViewManagerInteropComponentDescriptor final
     : public ConcreteComponentDescriptor<LegacyViewManagerInteropShadowNode> {
@@ -34,5 +33,4 @@ class LegacyViewManagerInteropComponentDescriptor final
   std::shared_ptr<void> const _coordinator;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropComponentDescriptor.mm
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropComponentDescriptor.mm
@@ -16,8 +16,7 @@
 #include "LegacyViewManagerInteropState.h"
 #include "RCTLegacyViewManagerInteropCoordinator.h"
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 static std::string moduleNameFromComponentName(const std::string &componentName)
 {
@@ -117,5 +116,4 @@ void LegacyViewManagerInteropComponentDescriptor::adopt(ShadowNode::Unshared con
 
   legacyViewManagerInteropShadowNode->setStateData(std::move(state));
 }
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropShadowNode.cpp
@@ -5,11 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 extern const char LegacyViewManagerInteropComponentName[] =
     "LegacyViewManagerInterop";
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropShadowNode.h
@@ -12,8 +12,7 @@
 #include <react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropViewProps.h>
 #include <react/renderer/components/view/ConcreteViewShadowNode.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 extern const char LegacyViewManagerInteropComponentName[];
 
@@ -23,5 +22,4 @@ using LegacyViewManagerInteropShadowNode = ConcreteViewShadowNode<
     LegacyViewManagerInteropViewEventEmitter,
     LegacyViewManagerInteropState>;
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropState.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropState.h
@@ -9,8 +9,7 @@
 
 #import <memory>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * State for <LegacyViewManagerInterop> component.
@@ -20,5 +19,4 @@ class LegacyViewManagerInteropState final {
   std::shared_ptr<void> coordinator;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropState.mm
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropState.mm
@@ -7,7 +7,5 @@
 
 #include "LegacyViewManagerInteropState.h"
 
-namespace facebook {
-namespace react {
-} // namespace react
-} // namespace facebook
+namespace facebook::react {
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropViewEventEmitter.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropViewEventEmitter.cpp
@@ -8,13 +8,11 @@
 #include "LegacyViewManagerInteropViewEventEmitter.h"
 #include <iostream>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 void LegacyViewManagerInteropViewEventEmitter::dispatchEvent(
     std::string const &type,
     folly::dynamic const &payload) const {
   EventEmitter::dispatchEvent(type, payload);
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropViewEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropViewEventEmitter.h
@@ -13,8 +13,7 @@
 #include <react/renderer/components/view/ViewEventEmitter.h>
 #include <react/renderer/core/EventEmitter.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class LegacyViewManagerInteropViewEventEmitter;
 
@@ -29,5 +28,4 @@ class LegacyViewManagerInteropViewEventEmitter : public ViewEventEmitter {
       const;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropViewProps.cpp
@@ -8,8 +8,7 @@
 #include "LegacyViewManagerInteropViewProps.h"
 #include <react/renderer/core/DynamicPropsUtilities.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 LegacyViewManagerInteropViewProps::LegacyViewManagerInteropViewProps(
     const PropsParserContext &context,
@@ -20,5 +19,4 @@ LegacyViewManagerInteropViewProps::LegacyViewManagerInteropViewProps(
           mergeDynamicProps(sourceProps.otherProps, (folly::dynamic)rawProps)) {
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropViewProps.h
@@ -10,8 +10,7 @@
 #include <react/renderer/core/PropsParserContext.h>
 #include <unordered_map>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class LegacyViewManagerInteropViewProps final : public ViewProps {
  public:
@@ -26,5 +25,4 @@ class LegacyViewManagerInteropViewProps final : public ViewProps {
   folly::dynamic const otherProps;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/UnstableLegacyViewManagerInteropComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/UnstableLegacyViewManagerInteropComponentDescriptor.h
@@ -11,8 +11,7 @@
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Descriptor for <UnstableReactLegacyComponent> component.
@@ -34,5 +33,4 @@ class UnstableLegacyViewManagerInteropComponentDescriptor
  private:
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewComponentDescriptor.h
@@ -11,8 +11,7 @@
 #include <react/renderer/components/modal/ModalHostViewShadowNode.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Descriptor for <ModalHostView> component.
@@ -43,5 +42,4 @@ class ModalHostViewComponentDescriptor final
   }
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewShadowNode.h
@@ -12,8 +12,7 @@
 #include <react/renderer/components/rncore/Props.h>
 #include <react/renderer/components/view/ConcreteViewShadowNode.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 extern const char ModalHostViewComponentName[];
 
@@ -35,5 +34,4 @@ class ModalHostViewShadowNode final : public ConcreteViewShadowNode<
   }
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewState.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewState.h
@@ -16,8 +16,7 @@
 #include <react/renderer/mapbuffer/MapBufferBuilder.h>
 #endif
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * State for <ModalHostView> component.
@@ -51,5 +50,4 @@ class ModalHostViewState final {
 #pragma mark - Getters
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/AndroidProgressBarComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/AndroidProgressBarComponentDescriptor.h
@@ -11,8 +11,7 @@
 #include "AndroidProgressBarMeasurementsManager.h"
 #include "AndroidProgressBarShadowNode.h"
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Descriptor for <AndroidProgressBar> component.
@@ -48,5 +47,4 @@ class AndroidProgressBarComponentDescriptor final
       measurementsManager_;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/AndroidProgressBarMeasurementsManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/AndroidProgressBarMeasurementsManager.h
@@ -13,8 +13,7 @@
 #include <react/renderer/core/LayoutConstraints.h>
 #include <react/utils/ContextContainer.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class AndroidProgressBarMeasurementsManager {
  public:
@@ -34,5 +33,4 @@ class AndroidProgressBarMeasurementsManager {
   mutable Size cachedMeasurement_{};
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/AndroidProgressBarShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/AndroidProgressBarShadowNode.h
@@ -12,8 +12,7 @@
 #include <react/renderer/components/rncore/Props.h>
 #include <react/renderer/components/view/ConcreteViewShadowNode.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 extern const char AndroidProgressBarComponentName[];
 
@@ -42,5 +41,4 @@ class AndroidProgressBarShadowNode final : public ConcreteViewShadowNode<
   std::shared_ptr<AndroidProgressBarMeasurementsManager> measurementsManager_;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/conversions.h
@@ -9,8 +9,7 @@
 #include <react/renderer/components/rncore/Props.h>
 #include <react/renderer/core/propsConversions.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 #ifdef ANDROID
 inline folly::dynamic toDynamic(AndroidProgressBarProps const &props) {
@@ -26,5 +25,4 @@ inline folly::dynamic toDynamic(AndroidProgressBarProps const &props) {
 }
 #endif
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/root/RootComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/root/RootComponentDescriptor.h
@@ -10,10 +10,8 @@
 #include <react/renderer/components/root/RootShadowNode.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 using RootComponentDescriptor = ConcreteComponentDescriptor<RootShadowNode>;
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/root/RootProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/root/RootProps.h
@@ -14,8 +14,7 @@
 #include <react/renderer/core/LayoutContext.h>
 #include <react/renderer/core/PropsParserContext.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class RootProps final : public ViewProps {
  public:
@@ -36,5 +35,4 @@ class RootProps final : public ViewProps {
   LayoutContext layoutContext{};
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/root/RootShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/root/RootShadowNode.h
@@ -14,8 +14,7 @@
 #include <react/renderer/core/LayoutContext.h>
 #include <react/renderer/core/PropsParserContext.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class RootShadowNode;
 
@@ -59,5 +58,4 @@ class RootShadowNode final
   Transform getTransform() const override;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/safeareaview/SafeAreaViewComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/safeareaview/SafeAreaViewComponentDescriptor.h
@@ -11,8 +11,7 @@
 #include <react/renderer/components/safeareaview/SafeAreaViewShadowNode.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Descriptor for <SafeAreaView> component.
@@ -43,5 +42,4 @@ class SafeAreaViewComponentDescriptor final
   }
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/safeareaview/SafeAreaViewShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/safeareaview/SafeAreaViewShadowNode.cpp
@@ -7,10 +7,8 @@
 
 #include "SafeAreaViewShadowNode.h"
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 extern const char SafeAreaViewComponentName[] = "SafeAreaView";
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/safeareaview/SafeAreaViewShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/safeareaview/SafeAreaViewShadowNode.h
@@ -12,8 +12,7 @@
 #include <react/renderer/components/safeareaview/SafeAreaViewState.h>
 #include <react/renderer/components/view/ConcreteViewShadowNode.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 extern const char SafeAreaViewComponentName[];
 
@@ -35,5 +34,4 @@ class SafeAreaViewShadowNode final : public ConcreteViewShadowNode<
   }
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/safeareaview/SafeAreaViewState.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/safeareaview/SafeAreaViewState.cpp
@@ -7,6 +7,4 @@
 
 #include "SafeAreaViewState.h"
 
-namespace facebook {
-namespace react {} // namespace react
-} // namespace facebook
+namespace facebook::react {} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/safeareaview/SafeAreaViewState.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/safeareaview/SafeAreaViewState.h
@@ -9,8 +9,7 @@
 
 #include <react/renderer/graphics/RectangleEdges.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * State for <SafeAreaView> component.
@@ -20,5 +19,4 @@ class SafeAreaViewState final {
   EdgeInsets padding{};
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewComponentDescriptor.h
@@ -10,11 +10,9 @@
 #include <react/renderer/components/scrollview/ScrollViewShadowNode.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 using ScrollViewComponentDescriptor =
     ConcreteComponentDescriptor<ScrollViewShadowNode>;
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewEventEmitter.h
@@ -13,8 +13,7 @@
 #include <react/renderer/components/view/ViewEventEmitter.h>
 #include <react/renderer/core/EventEmitter.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class ScrollViewMetrics {
  public:
@@ -42,5 +41,4 @@ class ScrollViewEventEmitter : public ViewEventEmitter {
       EventPriority priority = EventPriority::AsynchronousBatched) const;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewProps.h
@@ -13,8 +13,7 @@
 
 #include <optional>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 // TODO (T28334063): Consider for codegen.
 class ScrollViewProps final : public ViewProps {
@@ -77,5 +76,4 @@ class ScrollViewProps final : public ViewProps {
 #endif
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewShadowNode.h
@@ -13,8 +13,7 @@
 #include <react/renderer/components/view/ConcreteViewShadowNode.h>
 #include <react/renderer/core/LayoutContext.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 extern const char ScrollViewComponentName[];
 
@@ -39,5 +38,4 @@ class ScrollViewShadowNode final : public ConcreteViewShadowNode<
   void updateScrollContentOffsetIfNeeded();
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewState.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewState.h
@@ -18,8 +18,7 @@
 #include <react/renderer/mapbuffer/MapBufferBuilder.h>
 #endif
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * State for <ScrollView> component.
@@ -55,5 +54,4 @@ class ScrollViewState final {
 #endif
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/conversions.h
@@ -12,8 +12,7 @@
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/core/propsConversions.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 inline void fromRawValue(
     const PropsParserContext &context,
@@ -179,5 +178,4 @@ inline std::string toString(
 
 #endif
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/primitives.h
@@ -9,8 +9,7 @@
 
 #include <optional>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 enum class ScrollViewSnapToAlignment { Start, Center, End };
 
@@ -40,5 +39,4 @@ class ScrollViewMaintainVisibleContentPosition final {
   }
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/switch/androidswitch/react/renderer/components/androidswitch/AndroidSwitchComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/switch/androidswitch/react/renderer/components/androidswitch/AndroidSwitchComponentDescriptor.h
@@ -12,8 +12,7 @@
 
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Descriptor for <AndroidSwitch> component.
@@ -47,5 +46,4 @@ class AndroidSwitchComponentDescriptor final
   const std::shared_ptr<AndroidSwitchMeasurementsManager> measurementsManager_;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/switch/androidswitch/react/renderer/components/androidswitch/AndroidSwitchMeasurementsManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/switch/androidswitch/react/renderer/components/androidswitch/AndroidSwitchMeasurementsManager.h
@@ -11,8 +11,7 @@
 #include <react/renderer/core/LayoutConstraints.h>
 #include <react/utils/ContextContainer.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class AndroidSwitchMeasurementsManager {
  public:
@@ -29,5 +28,4 @@ class AndroidSwitchMeasurementsManager {
   mutable Size cachedMeasurement_{};
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/switch/androidswitch/react/renderer/components/androidswitch/AndroidSwitchShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/switch/androidswitch/react/renderer/components/androidswitch/AndroidSwitchShadowNode.h
@@ -13,8 +13,7 @@
 #include <react/renderer/components/rncore/Props.h>
 #include <react/renderer/components/view/ConcreteViewShadowNode.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 extern const char AndroidSwitchComponentName[];
 
@@ -43,5 +42,4 @@ class AndroidSwitchShadowNode final : public ConcreteViewShadowNode<
   std::shared_ptr<AndroidSwitchMeasurementsManager> measurementsManager_;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/text/BaseTextProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/BaseTextProps.h
@@ -12,8 +12,7 @@
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/graphics/Color.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * `Props`-like class which is used as a base class for all Props classes
@@ -44,5 +43,4 @@ class BaseTextProps {
 #endif
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/text/BaseTextShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/BaseTextShadowNode.h
@@ -10,8 +10,7 @@
 #include <react/renderer/attributedstring/AttributedString.h>
 #include <react/renderer/attributedstring/TextAttributes.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Base class (one of) for shadow nodes that represents attributed text,
@@ -66,5 +65,4 @@ class BaseTextShadowNode {
   }
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphComponentDescriptor.h
@@ -12,8 +12,7 @@
 #include <react/renderer/textlayoutmanager/TextLayoutManager.h>
 #include <react/utils/ContextContainer.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Descriptor for <Paragraph> component.
@@ -44,5 +43,4 @@ class ParagraphComponentDescriptor final
   std::shared_ptr<TextLayoutManager const> textLayoutManager_;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphEventEmitter.h
@@ -10,8 +10,7 @@
 #include <react/renderer/components/view/ViewEventEmitter.h>
 #include <react/renderer/textlayoutmanager/TextMeasureCache.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class ParagraphEventEmitter : public ViewEventEmitter {
  public:
@@ -24,5 +23,4 @@ class ParagraphEventEmitter : public ViewEventEmitter {
   mutable LinesMeasurements linesMeasurementsMetrics_;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphProps.h
@@ -16,8 +16,7 @@
 #include <react/renderer/core/Props.h>
 #include <react/renderer/core/PropsParserContext.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Props of <Paragraph> component.
@@ -60,5 +59,4 @@ class ParagraphProps : public ViewProps, public BaseTextProps {
 #endif
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphShadowNode.h
@@ -16,8 +16,7 @@
 #include <react/renderer/core/LayoutContext.h>
 #include <react/renderer/core/ShadowNode.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 extern char const ParagraphComponentName[];
 
@@ -101,5 +100,4 @@ class ParagraphShadowNode final : public ConcreteViewShadowNode<
   mutable std::optional<Content> content_{};
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/text/RawTextComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/RawTextComponentDescriptor.h
@@ -10,11 +10,9 @@
 #include <react/renderer/components/text/RawTextShadowNode.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 using RawTextComponentDescriptor =
     ConcreteComponentDescriptor<RawTextShadowNode>;
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/text/RawTextProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/RawTextProps.h
@@ -13,8 +13,7 @@
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/debug/DebugStringConvertible.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class RawTextProps;
 
@@ -39,5 +38,4 @@ class RawTextProps : public Props {
 #endif
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/text/RawTextShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/RawTextShadowNode.h
@@ -10,8 +10,7 @@
 #include <react/renderer/components/text/RawTextProps.h>
 #include <react/renderer/core/ConcreteShadowNode.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 extern const char RawTextComponentName[];
 
@@ -37,5 +36,4 @@ class RawTextShadowNode : public ConcreteShadowNode<
   }
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/text/TextComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/TextComponentDescriptor.h
@@ -10,10 +10,8 @@
 #include <react/renderer/components/text/TextShadowNode.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 using TextComponentDescriptor = ConcreteComponentDescriptor<TextShadowNode>;
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/text/TextProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/TextProps.h
@@ -13,8 +13,7 @@
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/graphics/Color.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class TextProps : public Props, public BaseTextProps {
  public:
@@ -37,5 +36,4 @@ class TextProps : public Props, public BaseTextProps {
 #endif
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/text/TextShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/TextShadowNode.h
@@ -14,8 +14,7 @@
 #include <react/renderer/components/view/ViewEventEmitter.h>
 #include <react/renderer/core/ConcreteShadowNode.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 extern const char TextComponentName[];
 
@@ -62,5 +61,4 @@ class TextShadowNode : public ConcreteShadowNode<
 #endif
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/text/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/conversions.h
@@ -13,8 +13,7 @@
 #include <react/renderer/mapbuffer/MapBufferBuilder.h>
 #endif
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 #ifdef ANDROID
 inline folly::dynamic toDynamic(ParagraphState const &paragraphState) {
@@ -37,5 +36,4 @@ inline MapBuffer toMapBuffer(ParagraphState const &paragraphState) {
 }
 #endif
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/text/tests/ParagraphLocalDataTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/tests/ParagraphLocalDataTest.cpp
@@ -15,8 +15,7 @@
 #include <react/renderer/components/text/ParagraphState.h>
 #include <react/renderer/components/text/conversions.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 #ifdef ANDROID
 
@@ -50,5 +49,4 @@ TEST(ParagraphLocalDataTest, testSomething) {
 
 #endif
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputComponentDescriptor.h
@@ -17,8 +17,7 @@
 
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Descriptor for <AndroidTextInput> component.
@@ -181,5 +180,4 @@ class AndroidTextInputComponentDescriptor final
   mutable butter::map<int, YGStyle::Edges> surfaceIdToThemePaddingMap_;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputEventEmitter.h
@@ -9,8 +9,7 @@
 
 #include <react/renderer/components/view/ViewEventEmitter.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 // This emitter exists only as a placeholder and is not used for communication
 // with JS.
@@ -23,5 +22,4 @@ class AndroidTextInputEventEmitter : public ViewEventEmitter {
   using ViewEventEmitter::ViewEventEmitter;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputProps.h
@@ -24,8 +24,7 @@
 #include <cinttypes>
 #include <vector>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 struct AndroidTextInputSelectionStruct {
   int start;
@@ -190,5 +189,4 @@ class AndroidTextInputProps final : public ViewProps, public BaseTextProps {
 #endif
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputShadowNode.h
@@ -16,8 +16,7 @@
 
 #include <react/renderer/attributedstring/AttributedString.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 extern const char AndroidTextInputComponentName[];
 
@@ -84,5 +83,4 @@ class AndroidTextInputShadowNode final : public ConcreteViewShadowNode<
   mutable std::optional<AttributedString> cachedAttributedString_{};
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputState.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputState.h
@@ -17,8 +17,7 @@
 #include <react/renderer/mapbuffer/MapBufferBuilder.h>
 #endif
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * State for <TextInput> component.
@@ -81,5 +80,4 @@ class AndroidTextInputState final {
   MapBuffer getMapBuffer() const;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/TextInputComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/TextInputComponentDescriptor.h
@@ -10,8 +10,7 @@
 #include <react/renderer/components/iostextinput/TextInputShadowNode.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Descriptor for <TextInput> component.
@@ -39,5 +38,4 @@ class TextInputComponentDescriptor final
   std::shared_ptr<TextLayoutManager const> textLayoutManager_;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/TextInputEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/TextInputEventEmitter.h
@@ -10,8 +10,7 @@
 #include <react/renderer/attributedstring/AttributedString.h>
 #include <react/renderer/components/view/ViewEventEmitter.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class TextInputMetrics {
  public:
@@ -61,5 +60,4 @@ class TextInputEventEmitter : public ViewEventEmitter {
       EventPriority priority = EventPriority::AsynchronousBatched) const;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/TextInputProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/TextInputProps.h
@@ -20,8 +20,7 @@
 #include <react/renderer/imagemanager/primitives.h>
 #include <vector>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class TextInputProps final : public ViewProps, public BaseTextProps {
  public:
@@ -78,5 +77,4 @@ class TextInputProps final : public ViewProps, public BaseTextProps {
   ParagraphAttributes getEffectiveParagraphAttributes() const;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/TextInputShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/TextInputShadowNode.h
@@ -16,8 +16,7 @@
 #include <react/renderer/textlayoutmanager/TextLayoutManager.h>
 #include <react/utils/ContextContainer.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 extern const char TextInputComponentName[];
 
@@ -79,5 +78,4 @@ class TextInputShadowNode final : public ConcreteViewShadowNode<
   std::shared_ptr<TextLayoutManager const> textLayoutManager_;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/TextInputState.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/TextInputState.h
@@ -17,8 +17,7 @@
 #include <react/renderer/mapbuffer/MapBufferBuilder.h>
 #endif
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * State for <TextInput> component.
@@ -67,5 +66,4 @@ class TextInputState final {
 #endif
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/conversions.h
@@ -11,8 +11,7 @@
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/core/propsConversions.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 inline void fromRawValue(
     const PropsParserContext &context,
@@ -238,5 +237,4 @@ inline void fromRawValue(
   abort();
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/primitives.h
@@ -10,8 +10,7 @@
 #include <optional>
 #include <string>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 // iOS & Android.
 enum class AutocapitalizationType {
@@ -225,5 +224,4 @@ class TextInputTraits final {
   std::string passwordRules{};
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/propsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/propsConversions.h
@@ -12,8 +12,7 @@
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/core/propsConversions.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 static TextInputTraits convertRawProp(
     const PropsParserContext &context,
@@ -179,5 +178,4 @@ inline void fromRawValue(
     LOG(ERROR) << "Unsupported Selection type";
   }
 }
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/unimplementedview/UnimplementedViewComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/unimplementedview/UnimplementedViewComponentDescriptor.h
@@ -11,8 +11,7 @@
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 #include <react/renderer/core/PropsParserContext.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Descriptor for <UnimplementedView> component.
@@ -39,5 +38,4 @@ class UnimplementedViewComponentDescriptor final
       RawProps const &rawProps) const override;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/unimplementedview/UnimplementedViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/unimplementedview/UnimplementedViewProps.h
@@ -10,8 +10,7 @@
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * It's a normal `ViewProps` with additional information about the component
@@ -32,5 +31,4 @@ class UnimplementedViewProps final : public ViewProps {
   mutable ComponentName componentName_{};
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/unimplementedview/UnimplementedViewShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/unimplementedview/UnimplementedViewShadowNode.h
@@ -10,8 +10,7 @@
 #include <react/renderer/components/unimplementedview/UnimplementedViewProps.h>
 #include <react/renderer/components/view/ConcreteViewShadowNode.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 extern const char UnimplementedViewComponentName[];
 
@@ -19,5 +18,4 @@ using UnimplementedViewShadowNode = ConcreteViewShadowNode<
     UnimplementedViewComponentName,
     UnimplementedViewProps>;
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityPrimitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityPrimitives.h
@@ -12,8 +12,7 @@
 #include <string>
 #include <vector>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 enum class AccessibilityTraits : uint32_t {
   None = 0,
@@ -137,5 +136,4 @@ enum class AccessibilityLiveRegion : uint8_t {
   Assertive,
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityProps.h
@@ -13,8 +13,7 @@
 #include <react/renderer/core/ReactPrimitives.h>
 #include <react/renderer/debug/DebugStringConvertible.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class AccessibilityProps {
  public:
@@ -67,5 +66,4 @@ class AccessibilityProps {
 #endif
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityPropsMapBuffer.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityPropsMapBuffer.cpp
@@ -8,8 +8,7 @@
 #include "AccessibilityPropsMapBuffer.h"
 #include "AccessibilityProps.h"
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 #ifdef ANDROID
 
@@ -162,5 +161,4 @@ void AccessibilityProps::propsDiffMapBuffer(
 }
 #endif
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityPropsMapBuffer.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityPropsMapBuffer.h
@@ -12,8 +12,7 @@
 #include <react/renderer/mapbuffer/MapBuffer.h>
 #include <react/renderer/mapbuffer/MapBufferBuilder.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 constexpr MapBuffer::Key AP_ACCESSIBILITY_ACTIONS = 0;
 constexpr MapBuffer::Key AP_ACCESSIBILITY_HINT = 1;
@@ -30,6 +29,5 @@ constexpr MapBuffer::Key AP_IMPORTANT_FOR_ACCESSIBILITY = 19;
 constexpr MapBuffer::Key ACCESSIBILITY_ACTION_NAME = 0;
 constexpr MapBuffer::Key ACCESSIBILITY_ACTION_LABEL = 1;
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react
 #endif

--- a/packages/react-native/ReactCommon/react/renderer/components/view/ConcreteViewShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ConcreteViewShadowNode.h
@@ -16,8 +16,7 @@
 #include <react/renderer/core/ShadowNodeFragment.h>
 #include <react/renderer/debug/DebugStringConvertibleItem.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Template for all <View>-like classes (classes which have all same props
@@ -120,5 +119,4 @@ class ConcreteViewShadowNode : public ConcreteShadowNode<
   }
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/PointerEvent.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/PointerEvent.h
@@ -11,8 +11,7 @@
 #include <react/renderer/debug/DebugStringConvertible.h>
 #include <react/renderer/graphics/Point.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 struct PointerEvent {
   /*
@@ -121,5 +120,4 @@ std::vector<DebugStringConvertibleObject> getDebugProps(
 
 #endif
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/Touch.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/Touch.h
@@ -11,8 +11,7 @@
 #include <react/renderer/debug/DebugStringConvertible.h>
 #include <react/renderer/graphics/Point.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Describes an individual touch point for a touch event.
@@ -85,5 +84,4 @@ std::vector<DebugStringConvertibleObject> getDebugProps(
 
 #endif
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/TouchEvent.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/TouchEvent.h
@@ -13,8 +13,7 @@
 
 #include <react/renderer/components/view/Touch.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Defines the `touchstart`, `touchend`, `touchmove`, and `touchcancel` event
@@ -49,5 +48,4 @@ std::vector<DebugStringConvertibleObject> getDebugProps(
 
 #endif
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/TouchEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/TouchEventEmitter.h
@@ -14,8 +14,7 @@
 #include <react/renderer/core/ReactPrimitives.h>
 #include <react/renderer/debug/DebugStringConvertible.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class TouchEventEmitter;
 
@@ -53,5 +52,4 @@ class TouchEventEmitter : public EventEmitter {
       RawEvent::Category category) const;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/ViewComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ViewComponentDescriptor.h
@@ -10,8 +10,7 @@
 #include <react/renderer/components/view/ViewShadowNode.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class ViewComponentDescriptor
     : public ConcreteComponentDescriptor<ViewShadowNode> {
@@ -20,5 +19,4 @@ class ViewComponentDescriptor
       : ConcreteComponentDescriptor<ViewShadowNode>(parameters) {}
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/ViewEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ViewEventEmitter.h
@@ -15,8 +15,7 @@
 
 #include "TouchEventEmitter.h"
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class ViewEventEmitter;
 
@@ -69,5 +68,4 @@ class ViewEventEmitter : public TouchEventEmitter {
       std::make_shared<LayoutEventState>()};
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/ViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ViewProps.h
@@ -18,8 +18,7 @@
 
 #include <optional>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class ViewProps;
 
@@ -110,5 +109,4 @@ class ViewProps : public YogaStylableProps, public AccessibilityProps {
 #endif
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/ViewPropsInterpolation.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ViewPropsInterpolation.h
@@ -10,8 +10,7 @@
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/graphics/Transform.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /**
  * Given animation progress, old props, new props, and an "interpolated" shared
@@ -53,5 +52,4 @@ static inline void interpolateViewProps(
 #endif
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/ViewPropsMapBuffer.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ViewPropsMapBuffer.cpp
@@ -15,8 +15,7 @@
 #include <react/renderer/core/graphicsConversions.h>
 #include <react/renderer/mapbuffer/MapBufferBuilder.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 // TODO: Currently unsupported: nextFocusForward/Left/Up/Right/Down
 void ViewProps::propsDiffMapBuffer(
@@ -192,7 +191,6 @@ void ViewProps::propsDiffMapBuffer(
   }
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react
 
 #endif

--- a/packages/react-native/ReactCommon/react/renderer/components/view/ViewPropsMapBuffer.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ViewPropsMapBuffer.h
@@ -9,8 +9,7 @@
 
 #include <react/renderer/mapbuffer/MapBuffer.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 #ifdef ANDROID
 constexpr MapBuffer::Key VP_BACKFACE_VISIBILITY = 9;
@@ -51,5 +50,4 @@ constexpr MapBuffer::Key YG_BORDER_WIDTH = 100;
 constexpr MapBuffer::Key YG_OVERFLOW = 101;
 #endif
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/ViewShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ViewShadowNode.h
@@ -10,8 +10,7 @@
 #include <react/renderer/components/view/ConcreteViewShadowNode.h>
 #include <react/renderer/components/view/ViewProps.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 extern const char ViewComponentName[];
 
@@ -54,5 +53,4 @@ class ViewShadowNode final : public ConcreteViewShadowNode<
   void initialize() noexcept;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.h
@@ -19,8 +19,7 @@
 #include <react/renderer/core/ShadowNode.h>
 #include <react/renderer/debug/DebugStringConvertible.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class YogaLayoutableShadowNode : public LayoutableShadowNode {
   using CompactValue = facebook::yoga::detail::CompactValue;
@@ -202,5 +201,4 @@ class YogaLayoutableShadowNode : public LayoutableShadowNode {
   ListOfShared yogaLayoutableChildren_;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaStylableProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaStylableProps.h
@@ -13,8 +13,7 @@
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/debug/DebugStringConvertible.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class YogaStylableProps : public Props {
   using CompactValue = facebook::yoga::detail::CompactValue;
@@ -86,5 +85,4 @@ class YogaStylableProps : public Props {
       RawProps const &rawProps);
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaStylablePropsMapBuffer.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaStylablePropsMapBuffer.cpp
@@ -14,8 +14,7 @@
 
 #include <react/renderer/mapbuffer/MapBufferBuilder.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 MapBuffer convertBorderWidths(YGStyle::Edges const &border) {
   MapBufferBuilder builder(7);
@@ -81,7 +80,6 @@ void YogaStylableProps::propsDiffMapBuffer(
   }
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react
 
 #endif

--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaStylablePropsMapBuffer.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaStylablePropsMapBuffer.h
@@ -11,14 +11,12 @@
 
 #include <react/renderer/mapbuffer/MapBuffer.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 // Yoga values
 constexpr MapBuffer::Key YG_BORDER_WIDTH = 100;
 constexpr MapBuffer::Key YG_OVERFLOW = 101;
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react
 
 #endif

--- a/packages/react-native/ReactCommon/react/renderer/components/view/accessibilityPropsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/accessibilityPropsConversions.h
@@ -15,8 +15,7 @@
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/core/propsConversions.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 inline void fromString(const std::string &string, AccessibilityTraits &result) {
   if (string == "none") {
@@ -299,5 +298,4 @@ inline void fromRawValue(
   }
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
@@ -24,8 +24,7 @@
 #include <cmath>
 #include <optional>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Yoga's `float` <-> React Native's `Float` (can be `double` or `float`)
@@ -855,5 +854,4 @@ inline std::string toString(const YGStyle::Edges &value) {
   return "{" + result + "}";
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/primitives.h
@@ -16,8 +16,7 @@
 #include <cmath>
 #include <optional>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 enum class PointerEventsMode : uint8_t { Auto, None, BoxNone, BoxOnly };
 
@@ -320,5 +319,4 @@ struct NativeDrawable {
 
 #endif
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/propsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/propsConversions.h
@@ -13,8 +13,7 @@
 
 #include <optional>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 // Nearly this entire file can be deleted when iterator-style Prop parsing
 // ships fully for View
@@ -779,5 +778,4 @@ static inline void fromRawValue(
 
 #endif
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/viewPropConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/viewPropConversions.h
@@ -16,8 +16,7 @@
 
 #include <optional>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 namespace {
 
@@ -212,5 +211,4 @@ inline MapBuffer convertTransform(Transform const &transform) {
 }
 } // namespace
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/BatchedEventQueue.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/BatchedEventQueue.h
@@ -10,8 +10,7 @@
 #include <react/renderer/core/EventQueue.h>
 #include <react/renderer/core/EventQueueProcessor.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Event Queue that dispatches event in batches synchronizing them with
@@ -26,5 +25,4 @@ class BatchedEventQueue final : public EventQueue {
   void onEnqueue() const override;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/ComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ComponentDescriptor.h
@@ -17,8 +17,7 @@
 #include <react/renderer/graphics/Float.h>
 #include <react/utils/ContextContainer.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class ComponentDescriptorParameters;
 class ComponentDescriptor;
@@ -158,5 +157,4 @@ class ComponentDescriptorParameters {
   ComponentDescriptor::Flavor flavor;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/ConcreteComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ConcreteComponentDescriptor.h
@@ -22,8 +22,7 @@
 #include <react/renderer/core/State.h>
 #include <react/renderer/graphics/Float.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Default template-based implementation of ComponentDescriptor.
@@ -213,5 +212,4 @@ class ConcreteComponentDescriptor : public ComponentDescriptor {
   }
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/ConcreteShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ConcreteShadowNode.h
@@ -15,8 +15,7 @@
 #include <react/renderer/core/ShadowNode.h>
 #include <react/renderer/core/StateData.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Base templace class for all `ShadowNode`s which connects exact `ShadowNode`
@@ -132,5 +131,4 @@ class ConcreteShadowNode : public BaseShadowNodeT {
   }
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/ConcreteState.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ConcreteState.h
@@ -13,8 +13,7 @@
 #include <react/debug/react_native_assert.h>
 #include <react/renderer/core/State.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Concrete and only template implementation of State interface.
@@ -111,5 +110,4 @@ class ConcreteState : public State {
 #endif
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/CoreFeatures.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/CoreFeatures.cpp
@@ -7,8 +7,7 @@
 
 #include "CoreFeatures.h"
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 bool CoreFeatures::enablePropIteratorSetter = false;
 bool CoreFeatures::enableMapBuffer = false;
@@ -17,5 +16,4 @@ bool CoreFeatures::useNativeState = false;
 bool CoreFeatures::cacheNSTextStorage = false;
 bool CoreFeatures::cacheLastTextMeasurement = false;
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/CoreFeatures.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/CoreFeatures.h
@@ -7,8 +7,7 @@
 
 #pragma once
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Contains the set of feature flags for the renderer core.
@@ -46,5 +45,4 @@ class CoreFeatures {
   static bool cacheLastTextMeasurement;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/EventBeat.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventBeat.h
@@ -12,8 +12,7 @@
 #include <functional>
 #include <memory>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Event Beat serves two interleaving purposes: synchronization of event queues
@@ -87,5 +86,4 @@ class EventBeat {
   mutable std::atomic<bool> isRequested_{false};
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/EventDispatcher.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventDispatcher.h
@@ -15,8 +15,7 @@
 #include <react/renderer/core/StateUpdate.h>
 #include <react/renderer/core/UnbatchedEventQueue.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 struct RawEvent;
 
@@ -76,5 +75,4 @@ class EventDispatcher {
   mutable EventListenerContainer eventListeners_;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/EventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventEmitter.h
@@ -16,8 +16,7 @@
 #include <react/renderer/core/EventTarget.h>
 #include <react/renderer/core/ReactPrimitives.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class EventEmitter;
 
@@ -102,5 +101,4 @@ class EventEmitter {
   mutable bool isEnabled_{false};
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/EventHandler.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventHandler.h
@@ -9,8 +9,7 @@
 
 #include <memory>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * We need this types only to ensure type-safety when we deal with them.
@@ -26,5 +25,4 @@ struct EventHandler {
 };
 using UniqueEventHandler = std::unique_ptr<const EventHandler>;
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/EventListener.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventListener.h
@@ -12,8 +12,7 @@
 
 #include <react/renderer/core/RawEvent.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /**
  * Listener for events dispatched to JS runtime.
@@ -39,5 +38,4 @@ class EventListenerContainer {
   std::vector<std::shared_ptr<EventListener const>> eventListeners_;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/EventPipe.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventPipe.h
@@ -15,8 +15,7 @@
 #include <react/renderer/core/ReactEventPriority.h>
 #include <react/renderer/core/ValueFactory.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 using EventPipe = std::function<void(
     jsi::Runtime &runtime,
@@ -25,5 +24,4 @@ using EventPipe = std::function<void(
     ReactEventPriority priority,
     const ValueFactory &payloadFactory)>;
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/EventPriority.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventPriority.h
@@ -7,8 +7,7 @@
 
 #pragma once
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 enum class EventPriority {
   SynchronousUnbatched,
@@ -22,5 +21,4 @@ enum class EventPriority {
   Deferred = AsynchronousBatched
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/EventQueue.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventQueue.h
@@ -17,8 +17,7 @@
 #include <react/renderer/core/RawEvent.h>
 #include <react/renderer/core/StateUpdate.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Event Queue synchronized with given Event Beat and dispatching event
@@ -72,5 +71,4 @@ class EventQueue {
   mutable bool hasContinuousEventStarted_{false};
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/EventQueueProcessor.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventQueueProcessor.h
@@ -15,8 +15,7 @@
 #include <react/renderer/core/StatePipe.h>
 #include <react/renderer/core/StateUpdate.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class EventQueueProcessor {
  public:
@@ -32,5 +31,4 @@ class EventQueueProcessor {
   mutable bool hasContinuousEventStarted_{false};
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/EventTarget.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventTarget.h
@@ -11,8 +11,7 @@
 
 #include <jsi/jsi.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * `EventTarget` represents storage of a weak instance handle object with some
@@ -74,5 +73,4 @@ class EventTarget {
 
 using SharedEventTarget = std::shared_ptr<const EventTarget>;
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/LayoutConstraints.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/LayoutConstraints.h
@@ -13,8 +13,7 @@
 #include <react/renderer/core/LayoutPrimitives.h>
 #include <react/renderer/graphics/Size.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Unified layout constraints for measuring.
@@ -46,8 +45,7 @@ inline bool operator!=(
   return !(lhs == rhs);
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react
 
 namespace std {
 template <>

--- a/packages/react-native/ReactCommon/react/renderer/core/LayoutContext.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/LayoutContext.h
@@ -11,8 +11,7 @@
 
 #include <react/renderer/core/LayoutableShadowNode.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * LayoutContext: Additional contextual information useful for particular
@@ -81,5 +80,4 @@ inline bool operator!=(LayoutContext const &lhs, LayoutContext const &rhs) {
   return !(lhs == rhs);
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/LayoutMetrics.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/LayoutMetrics.h
@@ -14,8 +14,7 @@
 #include <react/renderer/graphics/Rect.h>
 #include <react/renderer/graphics/RectangleEdges.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Describes results of layout process for particular shadow node.
@@ -85,8 +84,7 @@ std::vector<DebugStringConvertibleObject> getDebugProps(
 
 #endif
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react
 
 namespace std {
 

--- a/packages/react-native/ReactCommon/react/renderer/core/LayoutPrimitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/LayoutPrimitives.h
@@ -10,8 +10,7 @@
 #include <functional>
 #include <limits>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Defines visibility of the shadow node and particular layout
@@ -32,8 +31,7 @@ enum class LayoutDirection {
   RightToLeft = 2,
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react
 
 namespace std {
 template <>

--- a/packages/react-native/ReactCommon/react/renderer/core/LayoutableShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/LayoutableShadowNode.h
@@ -20,8 +20,7 @@
 #include <react/renderer/debug/DebugStringConvertible.h>
 #include <react/renderer/graphics/Transform.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 struct LayoutConstraints;
 struct LayoutContext;
@@ -165,5 +164,4 @@ class LayoutableShadowNode : public ShadowNode {
   LayoutMetrics layoutMetrics_;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/Props.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/Props.h
@@ -20,8 +20,7 @@
 #include <react/renderer/mapbuffer/MapBufferBuilder.h>
 #endif
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Represents the most generic props object.
@@ -65,5 +64,4 @@ class Props : public virtual Sealable, public virtual DebugStringConvertible {
 #endif
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/PropsMapBuffer.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/PropsMapBuffer.cpp
@@ -10,8 +10,7 @@
 
 #ifdef ANDROID
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 void Props::propsDiffMapBuffer(
     Props const *oldPropsPtr,
@@ -31,6 +30,5 @@ void Props::propsDiffMapBuffer(
   }
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react
 #endif

--- a/packages/react-native/ReactCommon/react/renderer/core/PropsMapBuffer.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/PropsMapBuffer.h
@@ -12,13 +12,11 @@
 #include <react/renderer/mapbuffer/MapBuffer.h>
 #include <react/renderer/mapbuffer/MapBufferBuilder.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 constexpr MapBuffer::Key PROPS_MAX = 1;
 constexpr MapBuffer::Key PROPS_NATIVE_ID = 1;
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react
 
 #endif

--- a/packages/react-native/ReactCommon/react/renderer/core/PropsParserContext.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/PropsParserContext.h
@@ -10,8 +10,7 @@
 #include <react/renderer/core/ReactPrimitives.h>
 #include <react/utils/ContextContainer.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 // For props requiring some context to parse, this toolbox can be used.
 // It should be used as infrequently as possible - most props can and should
@@ -25,5 +24,4 @@ struct PropsParserContext {
   ContextContainer const &contextContainer;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/RawEvent.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawEvent.h
@@ -14,8 +14,7 @@
 #include <react/renderer/core/EventTarget.h>
 #include <react/renderer/core/ValueFactory.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Represents ready-to-dispatch event object.
@@ -72,5 +71,4 @@ struct RawEvent {
   EventTag loggingTag{0};
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/RawProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawProps.h
@@ -21,8 +21,7 @@
 #include <react/renderer/core/RawValue.h>
 #include <vector>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class RawPropsParser;
 
@@ -142,5 +141,4 @@ class RawProps final {
           values_;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/RawPropsKey.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawPropsKey.h
@@ -11,8 +11,7 @@
 
 #include <react/renderer/core/RawPropsPrimitives.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Represent a prop name stored as three `char const *` fragments.
@@ -38,5 +37,4 @@ class RawPropsKey final {
 bool operator==(RawPropsKey const &lhs, RawPropsKey const &rhs) noexcept;
 bool operator!=(RawPropsKey const &lhs, RawPropsKey const &rhs) noexcept;
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/RawPropsKeyMap.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawPropsKeyMap.h
@@ -12,8 +12,7 @@
 #include <react/renderer/core/RawPropsKey.h>
 #include <react/renderer/core/RawPropsPrimitives.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * A map especially optimized to hold `{name: index}` relations.
@@ -60,5 +59,4 @@ class RawPropsKeyMap final {
       buckets_{};
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/RawPropsParser.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawPropsParser.h
@@ -17,8 +17,7 @@
 #include <react/renderer/core/RawPropsPrimitives.h>
 #include <react/renderer/core/RawValue.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Specialized (to a particular type of Props) parser that provides the most
@@ -91,5 +90,4 @@ class RawPropsParser final {
   mutable bool ready_{false};
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/RawPropsPrimitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawPropsPrimitives.h
@@ -10,8 +10,7 @@
 #include <folly/Hash.h>
 #include <limits>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Type used to represent an index of some stored values in small arrays.
@@ -51,5 +50,4 @@ constexpr static auto kNumberOfPropsPerComponentSoftCap = 150;
  */
 constexpr static auto kPropNameLengthHardCap = 64;
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/RawValue.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawValue.h
@@ -16,8 +16,7 @@
 
 #include <react/debug/react_native_assert.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class RawPropsParser;
 
@@ -278,5 +277,4 @@ class RawValue {
   }
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/ReactEventPriority.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ReactEventPriority.h
@@ -7,8 +7,7 @@
 
 #pragma once
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * An enum that represents React's event priority.
@@ -39,5 +38,4 @@ static constexpr std::underlying_type<ReactEventPriority>::type serialize(
       reactEventPriority);
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/ReactPrimitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ReactPrimitives.h
@@ -11,8 +11,7 @@
 #include <memory>
 #include <string>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * `Tag` and `InstanceHandle` are used to address React Native components.
@@ -74,5 +73,4 @@ enum class DisplayMode {
   Hidden = 2,
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/Sealable.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/Sealable.h
@@ -11,8 +11,7 @@
 
 #include <react/debug/flags.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Represents an object which can be *sealed* (imperatively marked as
@@ -91,5 +90,4 @@ class Sealable {
 
 #endif
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
@@ -21,8 +21,7 @@
 #include <react/renderer/core/State.h>
 #include <react/renderer/debug/DebugStringConvertible.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 static constexpr const int kShadowNodeChildrenSmallVectorSize = 8;
 
@@ -226,5 +225,4 @@ class ShadowNode : public Sealable,
   ShadowNodeTraits traits_;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeFamily.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeFamily.h
@@ -16,8 +16,7 @@
 #include <react/renderer/core/ReactPrimitives.h>
 #include <react/renderer/core/ShadowNodeFamilyFragment.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class ComponentDescriptor;
 class ShadowNode;
@@ -151,5 +150,4 @@ class ShadowNodeFamily final {
   mutable bool hasParent_{false};
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeFamilyFragment.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeFamilyFragment.h
@@ -10,8 +10,7 @@
 #include <react/renderer/core/EventEmitter.h>
 #include <react/renderer/core/ReactPrimitives.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class ShadowNodeFamily;
 
@@ -51,5 +50,4 @@ class ShadowNodeFamilyFragment final {
   };
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeFragment.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeFragment.h
@@ -13,8 +13,7 @@
 #include <react/renderer/core/ShadowNode.h>
 #include <react/renderer/core/State.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * An object which supposed to be used as a parameter specifying a shape
@@ -62,5 +61,4 @@ struct ShadowNodeFragment {
   };
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeTraits.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeTraits.h
@@ -9,8 +9,7 @@
 
 #include <cstdint>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * A set of predefined traits associated with a particular `ShadowNode` class
@@ -119,5 +118,4 @@ class ShadowNodeTraits {
   Trait traits_{Trait::None};
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/State.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/State.h
@@ -15,8 +15,7 @@
 
 #include <react/renderer/core/ShadowNodeFamily.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * An abstract interface of State.
@@ -110,5 +109,4 @@ class State {
   size_t revision_;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/StateData.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/StateData.h
@@ -15,8 +15,7 @@
 #include <react/renderer/mapbuffer/MapBufferBuilder.h>
 #endif
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Dummy type that is used as a placeholder for state data for nodes that
@@ -33,5 +32,4 @@ struct StateData final {
 #endif
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/StatePipe.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/StatePipe.h
@@ -11,10 +11,8 @@
 
 #include <react/renderer/core/StateUpdate.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 using StatePipe = std::function<void(StateUpdate const &stateUpdate)>;
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/StateUpdate.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/StateUpdate.h
@@ -11,8 +11,7 @@
 
 #include <react/renderer/core/StateData.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class ShadowNodeFamily;
 using SharedShadowNodeFamily = std::shared_ptr<ShadowNodeFamily const>;
@@ -27,5 +26,4 @@ class StateUpdate {
   Callback callback;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/UnbatchedEventQueue.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/UnbatchedEventQueue.h
@@ -9,8 +9,7 @@
 
 #include <react/renderer/core/EventQueue.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Event Queue that dispatches events as granular as possible without waiting
@@ -23,5 +22,4 @@ class UnbatchedEventQueue final : public EventQueue {
   void onEnqueue() const override;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/ValueFactory.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ValueFactory.h
@@ -11,10 +11,8 @@
 
 #include <jsi/jsi.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 using ValueFactory = std::function<jsi::Value(jsi::Runtime &runtime)>;
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/conversions.h
@@ -9,8 +9,7 @@
 
 #include <react/renderer/core/LayoutPrimitives.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 inline std::string toString(const LayoutDirection &layoutDirection) {
   switch (layoutDirection) {
@@ -70,5 +69,4 @@ inline Size yogaMeassureToSize(int64_t value) {
   return {*measuredWidth, *measuredHeight};
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/graphicsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/graphicsConversions.h
@@ -20,8 +20,7 @@
 #include <react/renderer/graphics/RectangleEdges.h>
 #include <react/renderer/graphics/Size.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 #pragma mark - Color
 
@@ -256,5 +255,4 @@ inline std::string toString(const CornerInsets &cornerInsets) {
       folly::to<std::string>(cornerInsets.bottomRight) + "}";
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/propsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/propsConversions.h
@@ -16,8 +16,7 @@
 #include <react/renderer/core/graphicsConversions.h>
 #include <react/renderer/graphics/Color.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /**
  * Use this only when a prop update has definitely been sent from JS;
@@ -142,5 +141,4 @@ T convertRawProp(
   }
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/debug/DebugStringConvertible.h
+++ b/packages/react-native/ReactCommon/react/renderer/debug/DebugStringConvertible.h
@@ -16,8 +16,7 @@
 
 #include "flags.h"
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 #if RN_DEBUG_STRING_CONVERTIBLE
 
@@ -384,5 +383,4 @@ inline std::string getDebugValue(DebugStringConvertibleObject const &object) {
 
 #endif
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/debug/DebugStringConvertibleItem.h
+++ b/packages/react-native/ReactCommon/react/renderer/debug/DebugStringConvertibleItem.h
@@ -11,8 +11,7 @@
 
 #include <react/renderer/debug/DebugStringConvertible.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 #if RN_DEBUG_STRING_CONVERTIBLE
 
@@ -43,5 +42,4 @@ class DebugStringConvertibleItem : public DebugStringConvertible {
 
 #endif
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/debug/SystraceSection.h
+++ b/packages/react-native/ReactCommon/react/renderer/debug/SystraceSection.h
@@ -11,8 +11,7 @@
 #include <fbsystrace.h>
 #endif
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /**
  * Allow providing an fbsystrace implementation that can short-circuit out
@@ -57,5 +56,4 @@ struct DummySystraceSection {
 using SystraceSection = DummySystraceSection;
 #endif
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/debug/debugStringConvertibleUtils.h
+++ b/packages/react-native/ReactCommon/react/renderer/debug/debugStringConvertibleUtils.h
@@ -16,8 +16,7 @@
 #include <react/renderer/debug/DebugStringConvertible.h>
 #include <react/renderer/debug/DebugStringConvertibleItem.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 #if RN_DEBUG_STRING_CONVERTIBLE
 
@@ -63,5 +62,4 @@ inline SharedDebugStringConvertible debugStringConvertibleItem(
 
 #endif
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/element/ComponentBuilder.h
+++ b/packages/react-native/ReactCommon/react/renderer/element/ComponentBuilder.h
@@ -18,8 +18,7 @@
 #include <react/renderer/element/Element.h>
 #include <react/renderer/element/ElementFragment.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Build `ShadowNode` trees with a given given `Element` trees.
@@ -55,5 +54,4 @@ class ComponentBuilder final {
   ComponentDescriptorRegistry::Shared componentDescriptorRegistry_;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/element/Element.h
+++ b/packages/react-native/ReactCommon/react/renderer/element/Element.h
@@ -14,8 +14,7 @@
 
 #include <react/renderer/element/ElementFragment.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * `Element<>` is an abstraction layer that allows describing component
@@ -154,5 +153,4 @@ class Element final {
   ElementFragment fragment_;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/element/ElementFragment.h
+++ b/packages/react-native/ReactCommon/react/renderer/element/ElementFragment.h
@@ -13,8 +13,7 @@
 
 #include <react/renderer/core/ShadowNode.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * This is an implementation detail, do not use it directly.
@@ -58,5 +57,4 @@ class ElementFragment final {
   StateCallback stateCallback;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/element/testUtils.h
+++ b/packages/react-native/ReactCommon/react/renderer/element/testUtils.h
@@ -17,8 +17,7 @@
 #include <react/renderer/components/view/ViewComponentDescriptor.h>
 #include <react/renderer/element/ComponentBuilder.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 inline ComponentBuilder simpleComponentBuilder() {
   ComponentDescriptorProviderRegistry componentDescriptorProviderRegistry{};
@@ -45,5 +44,4 @@ inline ComponentBuilder simpleComponentBuilder() {
   return ComponentBuilder{componentDescriptorRegistry};
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/graphics/ColorComponents.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/ColorComponents.h
@@ -7,8 +7,7 @@
 
 #pragma once
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 struct ColorComponents {
   float red{0};
@@ -17,5 +16,4 @@ struct ColorComponents {
   float alpha{0};
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/graphics/Point.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Point.h
@@ -12,8 +12,7 @@
 #include <folly/Hash.h>
 #include <react/renderer/graphics/Float.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Contains a point in a two-dimensional coordinate system.
@@ -57,8 +56,7 @@ inline bool operator!=(Point const &rhs, Point const &lhs) noexcept {
   return !(lhs == rhs);
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react
 
 namespace std {
 

--- a/packages/react-native/ReactCommon/react/renderer/graphics/Rect.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Rect.h
@@ -15,8 +15,7 @@
 #include <react/renderer/graphics/Point.h>
 #include <react/renderer/graphics/Size.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Contains the location and dimensions of a rectangle.
@@ -101,8 +100,7 @@ struct Rect {
   }
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react
 
 namespace std {
 

--- a/packages/react-native/ReactCommon/react/renderer/graphics/RectangleCorners.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/RectangleCorners.h
@@ -12,8 +12,7 @@
 #include <folly/Hash.h>
 #include <react/renderer/graphics/Float.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Generic data structure describes some values associated with *corners*
@@ -50,8 +49,7 @@ struct RectangleCorners {
  */
 using CornerInsets = RectangleCorners<Float>;
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react
 
 namespace std {
 

--- a/packages/react-native/ReactCommon/react/renderer/graphics/RectangleEdges.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/RectangleEdges.h
@@ -13,8 +13,7 @@
 #include <react/renderer/graphics/Float.h>
 #include <react/renderer/graphics/Rect.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Generic data structure describes some values associated with *edges*
@@ -93,8 +92,7 @@ inline Rect outsetBy(Rect const &rect, EdgeInsets const &outsets) noexcept {
        rect.size.height + outsets.top + outsets.bottom}};
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react
 
 namespace std {
 

--- a/packages/react-native/ReactCommon/react/renderer/graphics/Size.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Size.h
@@ -13,8 +13,7 @@
 #include <react/renderer/graphics/Float.h>
 #include <react/renderer/graphics/Point.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Contains width and height values.
@@ -44,8 +43,7 @@ inline bool operator!=(Size const &rhs, Size const &lhs) noexcept {
   return !(lhs == rhs);
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react
 
 namespace std {
 

--- a/packages/react-native/ReactCommon/react/renderer/graphics/Transform.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Transform.h
@@ -21,8 +21,7 @@
 #include <folly/dynamic.h>
 #endif
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 inline bool isZero(Float n) {
   // We use this ternary expression instead of abs, fabsf, etc, because
@@ -206,8 +205,7 @@ EdgeInsets operator*(EdgeInsets const &edgeInsets, Transform const &transform);
 
 Vector operator*(Transform const &transform, Vector const &vector);
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react
 
 namespace std {
 

--- a/packages/react-native/ReactCommon/react/renderer/graphics/Vector.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Vector.h
@@ -9,8 +9,7 @@
 
 #include <react/renderer/graphics/Float.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 struct Vector {
   Float x{0};
@@ -19,5 +18,4 @@ struct Vector {
   Float w{0};
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/android/react/renderer/graphics/Float.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/android/react/renderer/graphics/Float.h
@@ -9,8 +9,7 @@
 
 #include <limits>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Exact type of float numbers which ideally should match a type behing
@@ -18,5 +17,4 @@ namespace react {
  */
 using Float = float;
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/android/react/renderer/graphics/PlatformColorParser.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/android/react/renderer/graphics/PlatformColorParser.h
@@ -12,8 +12,7 @@
 #include <react/renderer/core/RawProps.h>
 #include <react/renderer/graphics/ColorComponents.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 inline ColorComponents parsePlatformColor(
     const PropsParserContext &context,
@@ -50,5 +49,4 @@ inline ColorComponents parsePlatformColor(
   return colorComponents;
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/cxx/react/renderer/graphics/Float.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/cxx/react/renderer/graphics/Float.h
@@ -9,8 +9,7 @@
 
 #include <limits>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Exact type of float numbers which ideally should match a type behing
@@ -18,5 +17,4 @@ namespace react {
  */
 using Float = float;
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/cxx/react/renderer/graphics/PlatformColorParser.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/cxx/react/renderer/graphics/PlatformColorParser.h
@@ -11,8 +11,7 @@
 #include <react/renderer/core/RawProps.h>
 #include <react/renderer/graphics/ColorComponents.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 inline ColorComponents parsePlatformColor(
     const PropsParserContext &context,
@@ -25,5 +24,4 @@ inline ColorComponents parsePlatformColor(
   return {red, green, blue, alpha};
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/ios/react/renderer/graphics/Float.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/ios/react/renderer/graphics/Float.h
@@ -10,8 +10,7 @@
 #include <CoreGraphics/CoreGraphics.h>
 #include <limits>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Exact type of float numbers which ideally should match a type behing
@@ -19,5 +18,4 @@ namespace react {
  */
 using Float = CGFloat;
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/ios/react/renderer/graphics/PlatformColorParser.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/ios/react/renderer/graphics/PlatformColorParser.h
@@ -12,8 +12,7 @@
 #include <react/renderer/graphics/ColorComponents.h>
 #include <react/renderer/graphics/RCTPlatformColorUtils.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 inline ColorComponents parsePlatformColor(
     const PropsParserContext &context,
@@ -30,5 +29,4 @@ inline ColorComponents parsePlatformColor(
   return {0, 0, 0, 0};
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/graphics/rounding.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/rounding.h
@@ -9,8 +9,7 @@
 
 #include <react/renderer/graphics/Float.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Convenience functions for rounding float values to be aligned with a device
@@ -81,5 +80,4 @@ inline long double floor(long double value) noexcept {
   return ::floorl(value);
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageManager.h
@@ -14,8 +14,7 @@
 #include <react/renderer/imagemanager/primitives.h>
 #include <react/utils/ContextContainer.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class ImageManager;
 
@@ -36,5 +35,4 @@ class ImageManager {
   void *self_{};
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageRequest.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageRequest.h
@@ -13,8 +13,7 @@
 #include <react/renderer/imagemanager/ImageTelemetry.h>
 #include <react/renderer/imagemanager/primitives.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Represents ongoing request for an image resource.
@@ -96,5 +95,4 @@ class ImageRequest final {
   std::function<void(void)> cancelRequest_;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageResponse.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageResponse.h
@@ -9,8 +9,7 @@
 
 #include <memory>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Represents retrieved image bitmap and any associated platform-specific info.
@@ -35,5 +34,4 @@ class ImageResponse final {
   std::shared_ptr<void> metadata_{};
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageResponseObserver.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageResponseObserver.h
@@ -9,8 +9,7 @@
 
 #include <react/renderer/imagemanager/ImageResponse.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Represents any observer of ImageResponse progression, completion, or failure.
@@ -25,5 +24,4 @@ class ImageResponseObserver {
   virtual void didReceiveFailure() const = 0;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageResponseObserverCoordinator.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageResponseObserverCoordinator.h
@@ -14,8 +14,7 @@
 #include <mutex>
 #include <vector>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * The ImageResponseObserverCoordinator receives events and completed image
@@ -85,5 +84,4 @@ class ImageResponseObserverCoordinator {
   mutable std::mutex mutex_;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageTelemetry.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageTelemetry.h
@@ -10,8 +10,7 @@
 #include <react/renderer/core/ReactPrimitives.h>
 #include <react/utils/Telemetry.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Represents telemetry data associated with a image request
@@ -33,5 +32,4 @@ class ImageTelemetry final {
   const SurfaceId surfaceId_;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/ImageManager.mm
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/ImageManager.mm
@@ -14,8 +14,7 @@
 #import "RCTImageManager.h"
 #import "RCTSyncImageManager.h"
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 ImageManager::ImageManager(ContextContainer::Shared const &contextContainer)
 {
@@ -41,5 +40,4 @@ ImageRequest ImageManager::requestImage(const ImageSource &imageSource, SurfaceI
   return [imageManager requestImage:imageSource surfaceId:surfaceId];
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/ImageRequest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/ImageRequest.cpp
@@ -7,8 +7,7 @@
 
 #include <react/renderer/imagemanager/ImageRequest.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 ImageRequest::ImageRequest(
     ImageSource imageSource,
@@ -57,5 +56,4 @@ const std::shared_ptr<const ImageResponseObserverCoordinator>
   return coordinator_;
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/primitives.h
@@ -13,8 +13,7 @@
 #include <react/renderer/graphics/Float.h>
 #include <react/renderer/graphics/Size.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class ImageSource {
  public:
@@ -45,5 +44,4 @@ enum class ImageResizeMode {
   Repeat,
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/leakchecker/LeakChecker.h
+++ b/packages/react-native/ReactCommon/react/renderer/leakchecker/LeakChecker.h
@@ -13,8 +13,7 @@
 #include <react/renderer/leakchecker/WeakFamilyRegistry.h>
 #include <vector>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 using GarbageCollectionTrigger = std::function<void()>;
 
@@ -35,5 +34,4 @@ class LeakChecker final {
   SurfaceId previouslyStoppedSurface_{};
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/leakchecker/WeakFamilyRegistry.h
+++ b/packages/react-native/ReactCommon/react/renderer/leakchecker/WeakFamilyRegistry.h
@@ -12,8 +12,7 @@
 #include <unordered_map>
 #include <vector>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class WeakFamilyRegistry final {
  public:
@@ -35,5 +34,4 @@ class WeakFamilyRegistry final {
   mutable std::unordered_map<SurfaceId, WeakFamilies> families_{};
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBuffer.h
+++ b/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBuffer.h
@@ -17,8 +17,7 @@
 #include <string>
 #include <vector>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class JReadableMapBuffer;
 
@@ -151,5 +150,4 @@ class MapBuffer {
   friend JReadableMapBuffer;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBufferBuilder.h
+++ b/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBufferBuilder.h
@@ -11,8 +11,7 @@
 #include <react/renderer/mapbuffer/MapBuffer.h>
 #include <vector>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 // Default reserved size for buckets_ vector
 constexpr uint32_t INITIAL_BUCKETS_SIZE = 10;
@@ -60,5 +59,4 @@ class MapBufferBuilder {
       uint32_t valueSize);
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/mounting/Differentiator.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/Differentiator.h
@@ -12,8 +12,7 @@
 #include <react/renderer/mounting/ShadowViewMutation.h>
 #include <deque>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 enum class ReparentMode { Flatten, Unflatten };
 
@@ -67,5 +66,4 @@ ShadowViewNodePair::NonOwningList sliceChildShadowNodeViewPairsV2(
 ShadowViewNodePair::OwningList sliceChildShadowNodeViewPairsLegacy(
     ShadowNode const &shadowNode);
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/mounting/MountingCoordinator.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/MountingCoordinator.h
@@ -22,8 +22,7 @@
 #include <react/renderer/mounting/stubs.h>
 #endif
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Stores inside all non-mounted yet revisions of a shadow tree and coordinates
@@ -117,5 +116,4 @@ class MountingCoordinator final {
 #endif
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/mounting/MountingOverrideDelegate.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/MountingOverrideDelegate.h
@@ -9,8 +9,7 @@
 
 #pragma once
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class MountingCoordinator;
 
@@ -43,5 +42,4 @@ class MountingOverrideDelegate {
       ShadowViewMutationList mutations) const = 0;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/mounting/MountingTransaction.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/MountingTransaction.h
@@ -11,8 +11,7 @@
 #include <react/renderer/telemetry/SurfaceTelemetry.h>
 #include <react/renderer/telemetry/TransactionTelemetry.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Encapsulates all artifacts of `ShadowTree` commit (or a series of them),
@@ -84,5 +83,4 @@ class MountingTransaction final {
   mutable TransactionTelemetry telemetry_;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.h
@@ -20,8 +20,7 @@
 #include <react/utils/ContextContainer.h>
 #include "MountingOverrideDelegate.h"
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 using ShadowTreeCommitTransaction = std::function<RootShadowNode::Unshared(
     RootShadowNode const &oldRootShadowNode)>;
@@ -148,5 +147,4 @@ class ShadowTree final {
   MountingCoordinator::Shared mountingCoordinator_;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTreeDelegate.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTreeDelegate.h
@@ -9,8 +9,7 @@
 
 #include <react/renderer/mounting/MountingCoordinator.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class ShadowTree;
 
@@ -40,5 +39,4 @@ class ShadowTreeDelegate {
   virtual ~ShadowTreeDelegate() noexcept = default;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTreeRegistry.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTreeRegistry.h
@@ -14,8 +14,7 @@
 #include <react/renderer/core/ReactPrimitives.h>
 #include <react/renderer/mounting/ShadowTree.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Owning registry of `ShadowTree`s.
@@ -68,5 +67,4 @@ class ShadowTreeRegistry final {
       registry_; // Protected by `mutex_`.
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTreeRevision.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTreeRevision.h
@@ -13,8 +13,7 @@
 #include <react/renderer/mounting/ShadowViewMutation.h>
 #include <react/renderer/telemetry/TransactionTelemetry.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Represent a particular committed state of a shadow tree. The object contains
@@ -36,5 +35,4 @@ class ShadowTreeRevision final {
   TransactionTelemetry telemetry;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowView.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowView.h
@@ -16,8 +16,7 @@
 #include <react/renderer/core/ShadowNode.h>
 #include <react/renderer/debug/flags.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Describes a view that can be mounted.
@@ -123,8 +122,7 @@ struct ShadowViewNodePairLegacy final {
   bool operator!=(const ShadowViewNodePairLegacy &rhs) const;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react
 
 namespace std {
 

--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowViewMutation.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowViewMutation.h
@@ -11,8 +11,7 @@
 
 #include <react/renderer/mounting/ShadowView.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Describes a single native view tree mutation which may contain
@@ -132,5 +131,4 @@ std::vector<DebugStringConvertibleObject> getDebugProps(
 
 #endif
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/mounting/StubView.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/StubView.h
@@ -15,8 +15,7 @@
 #include <react/renderer/debug/debugStringConvertibleUtils.h>
 #include <react/renderer/mounting/ShadowView.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 static const int NO_VIEW_TAG = -1;
 
@@ -59,5 +58,4 @@ std::vector<StubView> getDebugChildren(
 
 #endif
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/mounting/StubViewTree.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/StubViewTree.h
@@ -13,8 +13,7 @@
 #include <react/renderer/mounting/ShadowViewMutation.h>
 #include <react/renderer/mounting/StubView.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class StubViewTree {
  public:
@@ -46,5 +45,4 @@ class StubViewTree {
 bool operator==(StubViewTree const &lhs, StubViewTree const &rhs);
 bool operator!=(StubViewTree const &lhs, StubViewTree const &rhs);
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/mounting/TelemetryController.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/TelemetryController.h
@@ -13,8 +13,7 @@
 #include <react/renderer/mounting/MountingTransaction.h>
 #include <react/renderer/telemetry/TransactionTelemetry.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class MountingCoordinator;
 
@@ -56,5 +55,4 @@ class TelemetryController final {
   mutable std::mutex mutex_;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/mounting/stubs.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/stubs.h
@@ -11,8 +11,7 @@
 #include "StubView.h"
 #include "StubViewTree.h"
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Builds a ShadowView tree from given root ShadowNode using custom built-in
@@ -28,5 +27,4 @@ StubViewTree buildStubViewTreeWithoutUsingDifferentiator(
 StubViewTree buildStubViewTreeUsingDifferentiator(
     ShadowNode const &rootShadowNode);
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/ErrorUtils.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/ErrorUtils.h
@@ -7,8 +7,7 @@
 
 #include <jsi/jsi.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 inline static void handleFatalError(
     jsi::Runtime &runtime,
@@ -32,5 +31,4 @@ inline static void handleFatalError(
   func.call(runtime, error.value());
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.h
@@ -14,8 +14,7 @@
 #include <memory>
 #include <queue>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class RuntimeScheduler final {
  public:
@@ -152,5 +151,4 @@ class RuntimeScheduler final {
   mutable std::atomic_bool isPerformingWork_{false};
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerBinding.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerBinding.h
@@ -10,8 +10,7 @@
 #include <jsi/jsi.h>
 #include <react/renderer/runtimescheduler/RuntimeScheduler.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Exposes RuntimeScheduler to JavaScript realm.
@@ -48,5 +47,4 @@ class RuntimeSchedulerBinding : public jsi::HostObject {
   std::shared_ptr<RuntimeScheduler> runtimeScheduler_;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerCallInvoker.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerCallInvoker.h
@@ -10,8 +10,7 @@
 #include <ReactCommon/CallInvoker.h>
 #include <react/renderer/runtimescheduler/RuntimeScheduler.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Exposes RuntimeScheduler to native modules. All calls invoked on JavaScript
@@ -33,5 +32,4 @@ class RuntimeSchedulerCallInvoker : public CallInvoker {
   std::weak_ptr<RuntimeScheduler> runtimeScheduler_;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerClock.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerClock.h
@@ -9,8 +9,7 @@
 
 #include <chrono>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Represents a monotonic clock suitable for measuring intervals.
@@ -20,5 +19,4 @@ using RuntimeSchedulerClock = std::chrono::steady_clock;
 using RuntimeSchedulerTimePoint = RuntimeSchedulerClock::time_point;
 using RuntimeSchedulerDuration = RuntimeSchedulerClock::duration;
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/primitives.h
@@ -12,8 +12,7 @@
 #include <react/renderer/core/CoreFeatures.h>
 #include <react/renderer/runtimescheduler/Task.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 struct TaskWrapper : public jsi::HostObject {
   TaskWrapper(std::shared_ptr<Task> const &task) : task(task) {}
@@ -48,5 +47,4 @@ inline static std::shared_ptr<Task> taskFromValue(
   }
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/tests/StubErrorUtils.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/tests/StubErrorUtils.h
@@ -10,8 +10,7 @@
 #include <glog/logging.h>
 #include <jsi/jsi.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Exposes StubErrorUtils to JavaScript realm.
@@ -68,5 +67,4 @@ class StubErrorUtils : public jsi::HostObject {
   int reportFatalCallCount_;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/InspectorData.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/InspectorData.h
@@ -7,8 +7,7 @@
 
 #include <vector>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 struct InspectorData {
   std::vector<std::string> hierarchy;
@@ -20,5 +19,4 @@ struct InspectorData {
   folly::dynamic props;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.h
@@ -28,8 +28,7 @@
 #include <react/renderer/uimanager/UIManagerDelegate.h>
 #include <react/utils/ContextContainer.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Scheduler coordinates Shadow Tree updates and event flows.
@@ -147,5 +146,4 @@ class Scheduler final : public UIManagerDelegate {
   bool reduceDeleteCreateMutationLayoutAnimation_{false};
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SchedulerToolbox.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SchedulerToolbox.h
@@ -19,8 +19,7 @@
 #include <react/utils/ContextContainer.h>
 #include <react/utils/RunLoopObserver.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Contains all external dependencies of Scheduler.
@@ -79,5 +78,4 @@ struct SchedulerToolbox final {
   std::vector<std::shared_ptr<UIManagerCommitHook const>> commitHooks;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceHandler.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceHandler.h
@@ -15,8 +15,7 @@
 #include <react/renderer/core/ReactPrimitives.h>
 #include <react/utils/ContextContainer.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class Scheduler;
 class ShadowTree;
@@ -206,5 +205,4 @@ class SurfaceHandler {
   mutable Parameters parameters_;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceManager.h
@@ -15,8 +15,7 @@
 #include <react/renderer/mounting/MountingCoordinator.h>
 #include <react/renderer/scheduler/SurfaceHandler.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * `SurfaceManager` allows controlling React Native Surfaces via
@@ -64,5 +63,4 @@ class SurfaceManager final {
   mutable butter::map<SurfaceId, SurfaceHandler> registry_{};
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SynchronousEventBeat.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SynchronousEventBeat.h
@@ -12,8 +12,7 @@
 #include <react/renderer/runtimescheduler/RuntimeScheduler.h>
 #include <react/utils/RunLoopObserver.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Event beat associated with main run loop.
@@ -43,5 +42,4 @@ class SynchronousEventBeat final : public EventBeat,
   std::shared_ptr<RuntimeScheduler> runtimeScheduler_;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/telemetry/SurfaceTelemetry.h
+++ b/packages/react-native/ReactCommon/react/renderer/telemetry/SurfaceTelemetry.h
@@ -13,8 +13,7 @@
 #include <react/renderer/telemetry/TransactionTelemetry.h>
 #include <react/utils/Telemetry.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Represents telemetry data associated with a particular running Surface.
@@ -65,5 +64,4 @@ class SurfaceTelemetry final {
           recentTransactionTelemetries_{};
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/telemetry/TransactionTelemetry.h
+++ b/packages/react-native/ReactCommon/react/renderer/telemetry/TransactionTelemetry.h
@@ -13,8 +13,7 @@
 
 #include <react/utils/Telemetry.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Represents telemetry data associated with a particular revision of
@@ -83,5 +82,4 @@ class TransactionTelemetry final {
   std::function<TelemetryTimePoint()> now_;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/templateprocessor/UITemplateProcessor.h
+++ b/packages/react-native/ReactCommon/react/renderer/templateprocessor/UITemplateProcessor.h
@@ -16,8 +16,7 @@
 #include <react/renderer/core/ShadowNode.h>
 #include <react/renderer/uimanager/UIManagerDelegate.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 // Temporary NativeModuleRegistry definition
 using NativeModuleCallFn =
@@ -62,5 +61,4 @@ class UITemplateProcessor {
       const NativeModuleRegistry &nativeModuleRegistry,
       std::shared_ptr<const ReactNativeConfig> const &reactNativeConfig);
 };
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/TextMeasureCache.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/TextMeasureCache.h
@@ -14,8 +14,7 @@
 #include <react/utils/FloatComparison.h>
 #include <react/utils/SimpleThreadSafeCache.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 struct LineMeasurement {
   std::string text;
@@ -203,8 +202,7 @@ inline bool operator!=(
   return !(lhs == rhs);
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react
 
 namespace std {
 

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/android/react/renderer/textlayoutmanager/TextLayoutManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/android/react/renderer/textlayoutmanager/TextLayoutManager.h
@@ -14,8 +14,7 @@
 #include <react/renderer/textlayoutmanager/TextMeasureCache.h>
 #include <react/utils/ContextContainer.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class TextLayoutManager;
 
@@ -99,5 +98,4 @@ class TextLayoutManager {
   TextMeasureCache measureCache_;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/cxx/TextLayoutManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/cxx/TextLayoutManager.cpp
@@ -7,8 +7,7 @@
 
 #include "TextLayoutManager.h"
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 void *TextLayoutManager::getNativeTextLayoutManager() const {
   return (void *)this;
@@ -43,5 +42,4 @@ std::shared_ptr<void> TextLayoutManager::getHostTextStorage(
   return nullptr;
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/cxx/TextLayoutManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/cxx/TextLayoutManager.h
@@ -16,8 +16,7 @@
 #include <react/renderer/textlayoutmanager/TextMeasureCache.h>
 #include <react/utils/ContextContainer.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class TextLayoutManager;
 
@@ -60,5 +59,4 @@ class TextLayoutManager {
       LayoutConstraints layoutConstraints) const;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/TextLayoutManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/TextLayoutManager.h
@@ -15,8 +15,7 @@
 #include <react/renderer/textlayoutmanager/TextMeasureCache.h>
 #include <react/utils/ContextContainer.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class TextLayoutManager;
 
@@ -61,5 +60,4 @@ class TextLayoutManager {
   TextMeasureCache measureCache_{};
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/TextLayoutManager.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/TextLayoutManager.mm
@@ -11,8 +11,7 @@
 
 #import "RCTTextLayoutManager.h"
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 TextLayoutManager::TextLayoutManager(ContextContainer::Shared const &contextContainer)
 {
@@ -116,5 +115,4 @@ LinesMeasurements TextLayoutManager::measureLines(
                                                    size:{size.width, size.height}];
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/timeline/Timeline.h
+++ b/packages/react-native/ReactCommon/react/renderer/timeline/Timeline.h
@@ -15,8 +15,7 @@
 #include <react/renderer/timeline/TimelineSnapshot.h>
 #include <react/renderer/uimanager/UIManagerCommitHook.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class UIManager;
 
@@ -58,5 +57,4 @@ class Timeline final {
   mutable bool rewinding_{false};
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/timeline/TimelineController.h
+++ b/packages/react-native/ReactCommon/react/renderer/timeline/TimelineController.h
@@ -16,8 +16,7 @@
 #include <react/renderer/timeline/TimelineHandler.h>
 #include <react/renderer/uimanager/UIManagerCommitHook.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Provides tools for introspecting the series of commits and associated
@@ -76,5 +75,4 @@ class TimelineController final : public UIManagerCommitHook {
   mutable SurfaceId lastUpdatedSurface_;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/timeline/TimelineFrame.h
+++ b/packages/react-native/ReactCommon/react/renderer/timeline/TimelineFrame.h
@@ -11,8 +11,7 @@
 #include <react/renderer/uimanager/UIManagerCommitHook.h>
 #include <react/utils/Telemetry.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Represents a reference to a commit from the past.
@@ -42,5 +41,4 @@ class TimelineFrame final {
   TelemetryTimePoint timePoint_;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/timeline/TimelineHandler.h
+++ b/packages/react-native/ReactCommon/react/renderer/timeline/TimelineHandler.h
@@ -11,8 +11,7 @@
 #include <react/renderer/timeline/TimelineFrame.h>
 #include <react/renderer/uimanager/UIManagerCommitHook.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class Timeline;
 
@@ -76,5 +75,4 @@ class TimelineHandler final {
   Timeline const *timeline_{};
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/timeline/TimelineSnapshot.h
+++ b/packages/react-native/ReactCommon/react/renderer/timeline/TimelineSnapshot.h
@@ -10,8 +10,7 @@
 #include <react/renderer/components/root/RootShadowNode.h>
 #include <react/renderer/timeline/TimelineFrame.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Represents a reference to a commit from the past used by `Timeline`.
@@ -30,5 +29,4 @@ class TimelineSnapshot final {
   TimelineFrame frame_;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/test_utils/Entropy.h
+++ b/packages/react-native/ReactCommon/react/test_utils/Entropy.h
@@ -10,8 +10,7 @@
 #include <algorithm>
 #include <random>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * The source of pseudo-random numbers and some problem-oriented tools built on
@@ -131,5 +130,4 @@ class Entropy final {
   uint_fast32_t seed_;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/test_utils/MockSurfaceHandler.h
+++ b/packages/react-native/ReactCommon/react/test_utils/MockSurfaceHandler.h
@@ -11,8 +11,7 @@
 
 #include <react/renderer/scheduler/SurfaceHandler.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 class MockSurfaceHandler : public SurfaceHandler {
  public:
@@ -22,5 +21,4 @@ class MockSurfaceHandler : public SurfaceHandler {
   MOCK_METHOD(SurfaceId, getSurfaceId, (), (const, noexcept));
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/test_utils/shadowTreeGeneration.h
+++ b/packages/react-native/ReactCommon/react/test_utils/shadowTreeGeneration.h
@@ -23,8 +23,7 @@
 
 #include "Entropy.h"
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 static Tag generateReactTag() {
   static Tag tag = 1000;
@@ -311,5 +310,4 @@ static inline ShadowNode::Shared generateShadowNodeTree(
       family);
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/utils/CalledOnceMovableOnlyFunction.h
+++ b/packages/react-native/ReactCommon/react/utils/CalledOnceMovableOnlyFunction.h
@@ -9,8 +9,7 @@
 
 #include <react/debug/react_native_assert.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Implements a moveable-only function that asserts if called more than once
@@ -85,5 +84,4 @@ class CalledOnceMovableOnlyFunction {
   }
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/utils/ContextContainer.h
+++ b/packages/react-native/ReactCommon/react/utils/ContextContainer.h
@@ -18,8 +18,7 @@
 #include <react/debug/flags.h>
 #include <react/debug/react_native_assert.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * General purpose dependency injection container.
@@ -109,5 +108,4 @@ class ContextContainer final {
   mutable butter::map<std::string, std::shared_ptr<void>> instances_;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/utils/FloatComparison.h
+++ b/packages/react-native/ReactCommon/react/utils/FloatComparison.h
@@ -7,13 +7,11 @@
 
 #pragma once
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 inline bool floatEquality(float a, float b, float epsilon = 0.005f) {
   return (std::isnan(a) && std::isnan(b)) ||
       (!std::isnan(a) && !std::isnan(b) && fabs(a - b) < epsilon);
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/utils/ManagedObjectWrapper.h
+++ b/packages/react-native/ReactCommon/react/utils/ManagedObjectWrapper.h
@@ -24,8 +24,7 @@
 @property (nonatomic, weak) id object;
 @end
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 namespace detail {
 
@@ -75,8 +74,7 @@ inline id unwrapManagedObjectWeakly(std::shared_ptr<void> const &object) noexcep
   return weakWrapper.object;
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react
 
 #endif
 #endif

--- a/packages/react-native/ReactCommon/react/utils/ManagedObjectWrapper.mm
+++ b/packages/react-native/ReactCommon/react/utils/ManagedObjectWrapper.mm
@@ -9,8 +9,7 @@
 
 #if TARGET_OS_MAC
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 namespace detail {
 
 void wrappedManagedObjectDeleter(void *cfPointer) noexcept
@@ -27,8 +26,7 @@ void wrappedManagedObjectDeleter(void *cfPointer) noexcept
 }
 
 } // namespace detail
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react
 
 @implementation RCTInternalGenericWeakWrapper
 @end

--- a/packages/react-native/ReactCommon/react/utils/RunLoopObserver.cpp
+++ b/packages/react-native/ReactCommon/react/utils/RunLoopObserver.cpp
@@ -9,8 +9,7 @@
 
 #include <react/debug/react_native_assert.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 RunLoopObserver::RunLoopObserver(
     Activity activities,
@@ -59,5 +58,4 @@ RunLoopObserver::WeakOwner RunLoopObserver::getOwner() const noexcept {
   return owner_;
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/utils/RunLoopObserver.h
+++ b/packages/react-native/ReactCommon/react/utils/RunLoopObserver.h
@@ -11,8 +11,7 @@
 #include <functional>
 #include <memory>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * A cross-platform abstraction for observing a run loop life cycle.
@@ -125,5 +124,4 @@ class RunLoopObserver {
   mutable std::atomic<bool> enabled_{false};
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/utils/SharedFunction.h
+++ b/packages/react-native/ReactCommon/react/utils/SharedFunction.h
@@ -9,8 +9,7 @@
 #include <memory>
 #include <shared_mutex>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * `SharedFunction` implements a pattern of a shared callable object that
@@ -56,5 +55,4 @@ class SharedFunction {
   std::shared_ptr<Pair> pair_;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/utils/SimpleThreadSafeCache.h
+++ b/packages/react-native/ReactCommon/react/utils/SimpleThreadSafeCache.h
@@ -12,8 +12,7 @@
 
 #include <folly/container/EvictingCacheMap.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Simple thread-safe LRU cache.
@@ -72,5 +71,4 @@ class SimpleThreadSafeCache {
   mutable std::mutex mutex_;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/utils/Telemetry.h
+++ b/packages/react-native/ReactCommon/react/utils/Telemetry.h
@@ -10,8 +10,7 @@
 #include <chrono>
 #include <type_traits>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
 
 /*
  * Represents a monotonic clock suitable for measuring intervals.
@@ -111,5 +110,4 @@ static inline int64_t telemetryDurationToMilliseconds(
       .count();
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react


### PR DESCRIPTION
Summary:
Changelog: [Internal]

This updates ReactCommon/react code to use C++17 namespace format which was already used partially in other files

Differential Revision: D45121589

