### PR TITLE
Separate turbo and legacy module caches

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/TurboModuleManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/TurboModuleManager.java
@@ -36,8 +36,8 @@ import java.util.Map;
 public class TurboModuleManager implements JSIModule, TurboModuleRegistry {
   private static volatile boolean sIsSoLibraryLoaded;
   private final List<String> mEagerInitModuleNames;
-  private final ModuleProvider<TurboModule> mModuleProvider;
-  private final ModuleProvider<NativeModule> mLegacyModuleProvider;
+  private final ModuleProvider mTurboModuleProvider;
+  private final ModuleProvider mLegacyModuleProvider;
 
   // Prevents the creation of new TurboModules once cleanup as been initiated.
   private final Object mModuleCleanupLock = new Object();
@@ -68,47 +68,43 @@ public class TurboModuleManager implements JSIModule, TurboModuleRegistry {
     installJSIBindings(shouldCreateLegacyModules());
 
     mEagerInitModuleNames =
-        delegate == null ? new ArrayList<String>() : delegate.getEagerInitModuleNames();
+        delegate == null ? new ArrayList<>() : delegate.getEagerInitModuleNames();
 
-    mModuleProvider =
-        moduleName -> {
-          if (delegate == null || shouldRouteTurboModulesThroughInteropLayer()) {
-            return null;
-          }
+    ModuleProvider nullProvider = moduleName -> null;
 
-          TurboModule module = delegate.getModule(moduleName);
-          if (module == null) {
-            CxxModuleWrapper legacyCxxModule = delegate.getLegacyCxxModule(moduleName);
+    mTurboModuleProvider =
+        delegate == null
+            ? nullProvider
+            : moduleName -> {
+              NativeModule module = (NativeModule) delegate.getModule(moduleName);
+              if (module == null) {
+                CxxModuleWrapper legacyCxxModule = delegate.getLegacyCxxModule(moduleName);
 
-            if (legacyCxxModule != null) {
-              // TurboModuleManagerDelegate.getLegacyCxxModule() must always return TurboModules
-              Assertions.assertCondition(
-                  legacyCxxModule instanceof TurboModule,
-                  "CxxModuleWrapper \"" + moduleName + "\" is not a TurboModule");
-              module = (TurboModule) legacyCxxModule;
-            }
-          }
-          return module;
-        };
+                if (legacyCxxModule != null) {
+                  // TurboModuleManagerDelegate.getLegacyCxxModule() must always return TurboModules
+                  Assertions.assertCondition(
+                      legacyCxxModule instanceof TurboModule,
+                      "CxxModuleWrapper \"" + moduleName + "\" is not a TurboModule");
+                  return legacyCxxModule;
+                }
+              }
+              return module;
+            };
 
     mLegacyModuleProvider =
-        moduleName -> {
-          if (delegate == null || !shouldCreateLegacyModules()) {
-            return null;
-          }
-
-          NativeModule nativeModule = delegate.getLegacyModule(moduleName);
-          if (nativeModule != null) {
-            if (!shouldRouteTurboModulesThroughInteropLayer()) {
-              // TurboModuleManagerDelegate.getLegacyModule must never return a TurboModule
-              Assertions.assertCondition(
-                  !(nativeModule instanceof TurboModule),
-                  "NativeModule \"" + moduleName + "\" is a TurboModule");
-            }
-            return nativeModule;
-          }
-          return nativeModule;
-        };
+        delegate == null || !shouldCreateLegacyModules()
+            ? nullProvider
+            : moduleName -> {
+              NativeModule nativeModule = delegate.getLegacyModule(moduleName);
+              if (nativeModule != null) {
+                // TurboModuleManagerDelegate.getLegacyModule must never return a TurboModule
+                Assertions.assertCondition(
+                    !(nativeModule instanceof TurboModule),
+                    "NativeModule \"" + moduleName + "\" is a TurboModule");
+                return nativeModule;
+              }
+              return null;
+            };
   }
 
   private static boolean shouldCreateLegacyModules() {
@@ -136,8 +132,12 @@ public class TurboModuleManager implements JSIModule, TurboModuleRegistry {
   @Nullable
   private NativeModule getLegacyJavaModule(String moduleName) {
     final NativeModule module = getNativeModule(moduleName);
-    return !(module instanceof CxxModuleWrapper)
-            && (shouldRouteTurboModulesThroughInteropLayer() || !(module instanceof TurboModule))
+
+    if (shouldRouteTurboModulesThroughInteropLayer()) {
+      return !(module instanceof CxxModuleWrapper) ? module : null;
+    }
+
+    return !(module instanceof CxxModuleWrapper) && !(module instanceof TurboModule)
         ? module
         : null;
   }
@@ -147,8 +147,12 @@ public class TurboModuleManager implements JSIModule, TurboModuleRegistry {
   @Nullable
   private CxxModuleWrapper getLegacyCxxModule(String moduleName) {
     final NativeModule module = getNativeModule(moduleName);
-    return module instanceof CxxModuleWrapper
-            && (shouldRouteTurboModulesThroughInteropLayer() || !(module instanceof TurboModule))
+
+    if (shouldRouteTurboModulesThroughInteropLayer()) {
+      return module instanceof CxxModuleWrapper ? (CxxModuleWrapper) module : null;
+    }
+
+    return module instanceof CxxModuleWrapper && !(module instanceof TurboModule)
         ? (CxxModuleWrapper) module
         : null;
   }
@@ -160,6 +164,7 @@ public class TurboModuleManager implements JSIModule, TurboModuleRegistry {
     if (shouldRouteTurboModulesThroughInteropLayer()) {
       return null;
     }
+
     final NativeModule module = getNativeModule(moduleName);
     return module instanceof CxxModuleWrapper && module instanceof TurboModule
         ? (CxxModuleWrapper) module
@@ -172,6 +177,7 @@ public class TurboModuleManager implements JSIModule, TurboModuleRegistry {
     if (shouldRouteTurboModulesThroughInteropLayer()) {
       return null;
     }
+
     final NativeModule module = getNativeModule(moduleName);
     return !(module instanceof CxxModuleWrapper) && module instanceof TurboModule
         ? (TurboModule) module
@@ -254,7 +260,7 @@ public class TurboModuleManager implements JSIModule, TurboModuleRegistry {
 
     if (shouldCreateModule) {
       TurboModulePerfLogger.moduleCreateConstructStart(moduleName, moduleHolder.getModuleId());
-      NativeModule nativeModule = (NativeModule) mModuleProvider.getModule(moduleName);
+      NativeModule nativeModule = mTurboModuleProvider.getModule(moduleName);
 
       if (nativeModule == null) {
         nativeModule = mLegacyModuleProvider.getModule(moduleName);
@@ -476,8 +482,8 @@ public class TurboModuleManager implements JSIModule, TurboModuleRegistry {
     }
   }
 
-  private interface ModuleProvider<T> {
+  private interface ModuleProvider {
     @Nullable
-    T getModule(String name);
+    NativeModule getModule(String name);
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManager.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManager.cpp
@@ -114,7 +114,8 @@ TurboModuleManager::TurboModuleManager(
       jsCallInvoker_(jsCallInvoker),
       nativeCallInvoker_(nativeCallInvoker),
       delegate_(jni::make_global(delegate)),
-      turboModuleCache_(std::make_shared<TurboModuleCache>()) {}
+      turboModuleCache_(std::make_shared<ModuleCache>()),
+      legacyModuleCache_(std::make_shared<ModuleCache>()) {}
 
 jni::local_ref<TurboModuleManager::jhybriddata> TurboModuleManager::initHybrid(
     jni::alias_ref<jhybridobject> jThis,
@@ -140,88 +141,7 @@ void TurboModuleManager::registerNatives() {
 
 TurboModuleProviderFunctionType
 TurboModuleManager::createTurboModuleProvider() {
-  return
-      [turboModuleCache_ = std::weak_ptr<TurboModuleCache>(turboModuleCache_),
-       jsCallInvoker_ = std::weak_ptr<CallInvoker>(jsCallInvoker_),
-       nativeCallInvoker_ = std::weak_ptr<CallInvoker>(nativeCallInvoker_),
-       delegate_ = jni::make_weak(delegate_),
-       javaPart_ = jni::make_weak(javaPart_)](
-          const std::string &name) -> std::shared_ptr<TurboModule> {
-        auto turboModuleCache = turboModuleCache_.lock();
-        auto jsCallInvoker = jsCallInvoker_.lock();
-        auto nativeCallInvoker = nativeCallInvoker_.lock();
-        auto delegate = delegate_.lockLocal();
-        auto javaPart = javaPart_.lockLocal();
-
-        if (!turboModuleCache || !jsCallInvoker || !nativeCallInvoker ||
-            !delegate || !javaPart) {
-          return nullptr;
-        }
-
-        const char *moduleName = name.c_str();
-
-        TurboModulePerfLogger::moduleJSRequireBeginningStart(moduleName);
-
-        auto turboModuleLookup = turboModuleCache->find(name);
-        if (turboModuleLookup != turboModuleCache->end()) {
-          TurboModulePerfLogger::moduleJSRequireBeginningCacheHit(moduleName);
-          TurboModulePerfLogger::moduleJSRequireBeginningEnd(moduleName);
-          return turboModuleLookup->second;
-        }
-
-        TurboModulePerfLogger::moduleJSRequireBeginningEnd(moduleName);
-
-        auto cxxModule = delegate->cthis()->getTurboModule(name, jsCallInvoker);
-        if (cxxModule) {
-          turboModuleCache->insert({name, cxxModule});
-          return cxxModule;
-        }
-
-        static auto getTurboLegacyCxxModule =
-            javaPart->getClass()
-                ->getMethod<jni::alias_ref<CxxModuleWrapper::javaobject>(
-                    const std::string &)>("getTurboLegacyCxxModule");
-        auto legacyCxxModule = getTurboLegacyCxxModule(javaPart.get(), name);
-
-        if (legacyCxxModule) {
-          TurboModulePerfLogger::moduleJSRequireEndingStart(moduleName);
-
-          auto turboModule = std::make_shared<react::TurboCxxModule>(
-              legacyCxxModule->cthis()->getModule(), jsCallInvoker);
-          turboModuleCache->insert({name, turboModule});
-
-          TurboModulePerfLogger::moduleJSRequireEndingEnd(moduleName);
-          return turboModule;
-        }
-
-        static auto getTurboJavaModule =
-            javaPart->getClass()
-                ->getMethod<jni::alias_ref<JTurboModule>(const std::string &)>(
-                    "getTurboJavaModule");
-        auto moduleInstance = getTurboJavaModule(javaPart.get(), name);
-
-        if (moduleInstance) {
-          TurboModulePerfLogger::moduleJSRequireEndingStart(moduleName);
-          JavaTurboModule::InitParams params = {
-              .moduleName = name,
-              .instance = moduleInstance,
-              .jsInvoker = jsCallInvoker,
-              .nativeInvoker = nativeCallInvoker};
-
-          auto turboModule = delegate->cthis()->getTurboModule(name, params);
-          turboModuleCache->insert({name, turboModule});
-          TurboModulePerfLogger::moduleJSRequireEndingEnd(moduleName);
-          return turboModule;
-        }
-
-        return nullptr;
-      };
-}
-
-TurboModuleProviderFunctionType
-TurboModuleManager::createLegacyModuleProvider() {
-  return [turboModuleCache_ =
-              std::weak_ptr<TurboModuleCache>(turboModuleCache_),
+  return [turboModuleCache_ = std::weak_ptr<ModuleCache>(turboModuleCache_),
           jsCallInvoker_ = std::weak_ptr<CallInvoker>(jsCallInvoker_),
           nativeCallInvoker_ = std::weak_ptr<CallInvoker>(nativeCallInvoker_),
           delegate_ = jni::make_weak(delegate_),
@@ -251,6 +171,85 @@ TurboModuleManager::createLegacyModuleProvider() {
 
     TurboModulePerfLogger::moduleJSRequireBeginningEnd(moduleName);
 
+    auto cxxModule = delegate->cthis()->getTurboModule(name, jsCallInvoker);
+    if (cxxModule) {
+      turboModuleCache->insert({name, cxxModule});
+      return cxxModule;
+    }
+
+    static auto getTurboLegacyCxxModule =
+        javaPart->getClass()
+            ->getMethod<jni::alias_ref<CxxModuleWrapper::javaobject>(
+                const std::string &)>("getTurboLegacyCxxModule");
+    auto legacyCxxModule = getTurboLegacyCxxModule(javaPart.get(), name);
+
+    if (legacyCxxModule) {
+      TurboModulePerfLogger::moduleJSRequireEndingStart(moduleName);
+
+      auto turboModule = std::make_shared<react::TurboCxxModule>(
+          legacyCxxModule->cthis()->getModule(), jsCallInvoker);
+      turboModuleCache->insert({name, turboModule});
+
+      TurboModulePerfLogger::moduleJSRequireEndingEnd(moduleName);
+      return turboModule;
+    }
+
+    static auto getTurboJavaModule =
+        javaPart->getClass()
+            ->getMethod<jni::alias_ref<JTurboModule>(const std::string &)>(
+                "getTurboJavaModule");
+    auto moduleInstance = getTurboJavaModule(javaPart.get(), name);
+
+    if (moduleInstance) {
+      TurboModulePerfLogger::moduleJSRequireEndingStart(moduleName);
+      JavaTurboModule::InitParams params = {
+          .moduleName = name,
+          .instance = moduleInstance,
+          .jsInvoker = jsCallInvoker,
+          .nativeInvoker = nativeCallInvoker};
+
+      auto turboModule = delegate->cthis()->getTurboModule(name, params);
+      turboModuleCache->insert({name, turboModule});
+      TurboModulePerfLogger::moduleJSRequireEndingEnd(moduleName);
+      return turboModule;
+    }
+
+    return nullptr;
+  };
+}
+
+TurboModuleProviderFunctionType
+TurboModuleManager::createLegacyModuleProvider() {
+  return [legacyModuleCache_ = std::weak_ptr<ModuleCache>(legacyModuleCache_),
+          jsCallInvoker_ = std::weak_ptr<CallInvoker>(jsCallInvoker_),
+          nativeCallInvoker_ = std::weak_ptr<CallInvoker>(nativeCallInvoker_),
+          delegate_ = jni::make_weak(delegate_),
+          javaPart_ = jni::make_weak(javaPart_)](
+             const std::string &name) -> std::shared_ptr<TurboModule> {
+    auto legacyModuleCache = legacyModuleCache_.lock();
+    auto jsCallInvoker = jsCallInvoker_.lock();
+    auto nativeCallInvoker = nativeCallInvoker_.lock();
+    auto delegate = delegate_.lockLocal();
+    auto javaPart = javaPart_.lockLocal();
+
+    if (!legacyModuleCache || !jsCallInvoker || !nativeCallInvoker ||
+        !delegate || !javaPart) {
+      return nullptr;
+    }
+
+    const char *moduleName = name.c_str();
+
+    TurboModulePerfLogger::moduleJSRequireBeginningStart(moduleName);
+
+    auto legacyModuleLookup = legacyModuleCache->find(name);
+    if (legacyModuleLookup != legacyModuleCache->end()) {
+      TurboModulePerfLogger::moduleJSRequireBeginningCacheHit(moduleName);
+      TurboModulePerfLogger::moduleJSRequireBeginningEnd(moduleName);
+      return legacyModuleLookup->second;
+    }
+
+    TurboModulePerfLogger::moduleJSRequireBeginningEnd(moduleName);
+
     static auto getLegacyCxxModule =
         javaPart->getClass()
             ->getMethod<jni::alias_ref<CxxModuleWrapper::javaobject>(
@@ -262,7 +261,7 @@ TurboModuleManager::createLegacyModuleProvider() {
 
       auto turboModule = std::make_shared<react::TurboCxxModule>(
           legacyCxxModule->cthis()->getModule(), jsCallInvoker);
-      turboModuleCache->insert({name, turboModule});
+      legacyModuleCache->insert({name, turboModule});
 
       TurboModulePerfLogger::moduleJSRequireEndingEnd(moduleName);
       return turboModule;
@@ -301,7 +300,7 @@ TurboModuleManager::createLegacyModuleProvider() {
       auto turboModule =
           std::make_shared<JavaInteropTurboModule>(params, methodDescriptors);
 
-      turboModuleCache->insert({name, turboModule});
+      legacyModuleCache->insert({name, turboModule});
       TurboModulePerfLogger::moduleJSRequireEndingEnd(moduleName);
       return turboModule;
     }

--- a/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManager.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManager.h
@@ -43,7 +43,7 @@ class TurboModuleManager : public jni::HybridClass<TurboModuleManager> {
   std::shared_ptr<CallInvoker> nativeCallInvoker_;
   jni::global_ref<TurboModuleManagerDelegate::javaobject> delegate_;
 
-  using TurboModuleCache =
+  using ModuleCache =
       std::unordered_map<std::string, std::shared_ptr<react::TurboModule>>;
 
   /**
@@ -52,7 +52,8 @@ class TurboModuleManager : public jni::HybridClass<TurboModuleManager> {
    * We need to come up with a mechanism to allow modules to specify whether
    * they want to be long-lived or short-lived.
    */
-  std::shared_ptr<TurboModuleCache> turboModuleCache_;
+  std::shared_ptr<ModuleCache> turboModuleCache_;
+  std::shared_ptr<ModuleCache> legacyModuleCache_;
 
   void installJSIBindings(bool shouldCreateLegacyModules);
   explicit TurboModuleManager(


### PR DESCRIPTION
Summary:
global.nativeModuleProxy and global.__turboModuleProxy should not share the same cache.

Otherwise, global.nativeModuleProxy could return TurboModules, and global.__turboModuleProxy could return legacy native modules.

Changelog: [Internal]

Differential Revision: D45131296

