### PR TITLE
Remove YGNode "reserved_" field

### DIFF
--- a/packages/react-native/ReactCommon/yoga/yoga/YGNode.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGNode.h
@@ -42,7 +42,6 @@ struct YOGA_EXPORT YGNode {
 private:
   void* context_ = nullptr;
   YGNodeFlags flags_ = {};
-  uint8_t reserved_ = 0;
   union {
     YGMeasureFunc noContext;
     MeasureWithContextFn withContext;
@@ -113,9 +112,6 @@ public:
 
   // Getters
   void* getContext() const { return context_; }
-
-  uint8_t& reserved() { return reserved_; }
-  uint8_t reserved() const { return reserved_; }
 
   void print(void*);
 


### PR DESCRIPTION
Summary:
D15296732 added a byte to each YGNode exposed via private API, to stash random junk in. At the time, not adding to node size because of how fields ended up aligning.

There is a per-node "context" already that can store arbitrary data, and this reserved space isn't public, so this API is already a bit suspect.

The only place it is used is in instrumentation in fbandroid, enabled only in benchmarks, to store an enum to forward to QPL for what framework it thinks created the Yoga Node.

This is already broken for React Native (worked for Paper only), and afaict isn't used anywhere. But it also has little reason to be caching more information on the node (beyond maybe saving a couple memory accesses) since it derives this information from the node config already.

This removes the field.

Changelog:
[Internal]

Differential Revision: D45137133

