### PR TITLE
Do not run OSS changelog validator on diffs exported from Phabricator

### DIFF
--- a/packages/react-native-bots/dangerfile.js
+++ b/packages/react-native-bots/dangerfile.js
@@ -60,19 +60,21 @@ if (!includesTestPlan && !isFromPhabricator) {
 }
 
 // Check if there is a changelog and validate it
-const status = validateChangelog(danger.github.pr.body);
-const changelogInstructions =
-  'See <a target="_blank" href="https://reactnative.dev/contributing/changelogs-in-pull-requests">Changelog format</a>';
-if (status === 'missing') {
-  // Provides advice if a changelog is missing
-  const title = ':clipboard: Missing Changelog';
-  const idea =
-    'Please add a Changelog to your PR description. ' + changelogInstructions;
-  fail(`${title} - <i>${idea}</i>`);
-} else if (status === 'invalid') {
-  const title = ':clipboard: Verify Changelog Format';
-  const idea = changelogInstructions;
-  fail(`${title} - <i>${idea}</i>`);
+if (!isFromPhabricator) {
+  const status = validateChangelog(danger.github.pr.body);
+  const changelogInstructions =
+    'See <a target="_blank" href="https://reactnative.dev/contributing/changelogs-in-pull-requests">Changelog format</a>';
+  if (status === 'missing') {
+    // Provides advice if a changelog is missing
+    const title = ':clipboard: Missing Changelog';
+    const idea =
+      'Please add a Changelog to your PR description. ' + changelogInstructions;
+    fail(`${title} - <i>${idea}</i>`);
+  } else if (status === 'invalid') {
+    const title = ':clipboard: Verify Changelog Format';
+    const idea = changelogInstructions;
+    fail(`${title} - <i>${idea}</i>`);
+  }
 }
 
 // Warns if the PR is opened against stable, as commits need to be cherry picked and tagged by a release maintainer.


### PR DESCRIPTION
Summary:
We already run changelog validation internally which has specific exemptions for codemods and dirsynced directories. Do not run twice, now that we need to export diffs.

An alternative solution would be to port the logic to the OSS changelog generator and stop running the internal one, but that would increase latency, and we have made fixes to the internal once as recent as two weeks ago in D44746795.

Changelog: [Internal]

Differential Revision: D45135111

