### PR TITLE
(jest/setup): Add missing methods to Image mock

### DIFF
--- a/packages/react-native/jest/setup.js
+++ b/packages/react-native/jest/setup.js
@@ -95,9 +95,17 @@ jest
       Constants: {},
     },
   }))
-  .mock('../Libraries/Image/Image', () =>
-    mockComponent('../Libraries/Image/Image'),
-  )
+  .mock('../Libraries/Image/Image', () => {
+    const Image = mockComponent('../Libraries/Image/Image');
+    Image.getSize = jest.fn();
+    Image.getSizeWithHeaders = jest.fn();
+    Image.prefetch = jest.fn();
+    Image.prefetchWithMetadata = jest.fn();
+    Image.queryCache = jest.fn();
+    Image.resolveAssetSource = jest.fn();
+
+    return Image;
+  })
   .mock('../Libraries/Text/Text', () =>
     mockComponent('../Libraries/Text/Text', MockNativeMethods),
   )


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Fixes #35518

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[INTERNAL] [FIXED] - Add missing methods to Image mock

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

I used the example provided in the issue:

```javascript
import { useEffect } from "react"
import { Image } from "react-native"
import { render } from '@testing-library/react-native';

const MyComponent = () => {
    useEffect(() => {
        Image.getSize('uri', (width, height) => {
            console.log({width, height})
        })
    }, [])

    return null
}

describe('Foo', () => {
    it('something', () => {
        render(<MyComponent/>)
    })
})
```

Before the fix:
<img width="779" alt="Capture d’écran 2023-04-20 à 09 31 48" src="https://user-images.githubusercontent.com/17070498/233293066-e8673755-217f-48b4-a856-b9356ec3624e.png">

And after the fix:
<img width="346" alt="Capture d’écran 2023-04-20 à 09 32 40" src="https://user-images.githubusercontent.com/17070498/233293261-b6d02307-e67a-444f-a2de-e31eae32c0f1.png">
