### PR TITLE
Use stable sort for performance entries

### DIFF
--- a/packages/react-native/Libraries/WebPerformance/NativePerformance.cpp
+++ b/packages/react-native/Libraries/WebPerformance/NativePerformance.cpp
@@ -28,9 +28,8 @@ NativePerformance::NativePerformance(std::shared_ptr<CallInvoker> jsInvoker)
 void NativePerformance::mark(
     jsi::Runtime &rt,
     std::string name,
-    double startTime,
-    double duration) {
-  PerformanceEntryReporter::getInstance().mark(name, startTime, duration);
+    double startTime) {
+  PerformanceEntryReporter::getInstance().mark(name, startTime);
 }
 
 void NativePerformance::measure(

--- a/packages/react-native/Libraries/WebPerformance/NativePerformance.h
+++ b/packages/react-native/Libraries/WebPerformance/NativePerformance.h
@@ -41,8 +41,7 @@ class NativePerformance : public NativePerformanceCxxSpec<NativePerformance>,
  public:
   NativePerformance(std::shared_ptr<CallInvoker> jsInvoker);
 
-  void
-  mark(jsi::Runtime &rt, std::string name, double startTime, double duration);
+  void mark(jsi::Runtime &rt, std::string name, double startTime);
 
   void measure(
       jsi::Runtime &rt,

--- a/packages/react-native/Libraries/WebPerformance/NativePerformance.js
+++ b/packages/react-native/Libraries/WebPerformance/NativePerformance.js
@@ -22,7 +22,7 @@ export type ReactNativeStartupTiming = {|
 |};
 
 export interface Spec extends TurboModule {
-  +mark: (name: string, startTime: number, duration: number) => void;
+  +mark: (name: string, startTime: number) => void;
   +measure: (
     name: string,
     startTime: number,

--- a/packages/react-native/Libraries/WebPerformance/Performance.js
+++ b/packages/react-native/Libraries/WebPerformance/Performance.js
@@ -157,7 +157,7 @@ export default class Performance {
     const mark = new PerformanceMark(markName, markOptions);
 
     if (NativePerformance?.mark) {
-      NativePerformance.mark(markName, mark.startTime, mark.duration);
+      NativePerformance.mark(markName, mark.startTime);
     } else {
       warnNoNativePerformance();
     }

--- a/packages/react-native/Libraries/WebPerformance/PerformanceEntryReporter.cpp
+++ b/packages/react-native/Libraries/WebPerformance/PerformanceEntryReporter.cpp
@@ -72,7 +72,7 @@ GetPendingEntriesResult PerformanceEntryReporter::popPendingEntries() {
   }
 
   // Sort by starting time (or ending time, if starting times are equal)
-  std::sort(
+  std::stable_sort(
       res.entries.begin(),
       res.entries.end(),
       [](const RawPerformanceEntry &lhs, const RawPerformanceEntry &rhs) {

--- a/packages/react-native/Libraries/WebPerformance/PerformanceEntryReporter.h
+++ b/packages/react-native/Libraries/WebPerformance/PerformanceEntryReporter.h
@@ -111,7 +111,9 @@ class PerformanceEntryReporter : public EventLogger {
     return droppedEntryCount_;
   }
 
-  void mark(const std::string &name, double startTime, double duration);
+  void mark(
+      const std::string &name,
+      const std::optional<double> &startTime = std::nullopt);
 
   void measure(
       const std::string &name,

--- a/packages/react-native/Libraries/WebPerformance/__mocks__/NativePerformance.js
+++ b/packages/react-native/Libraries/WebPerformance/__mocks__/NativePerformance.js
@@ -20,12 +20,12 @@ import {RawPerformanceEntryTypeValues} from '../RawPerformanceEntry';
 const marks: Map<string, number> = new Map();
 
 const NativePerformanceMock: NativePerformance = {
-  mark: (name: string, startTime: number, duration: number): void => {
+  mark: (name: string, startTime: number): void => {
     NativePerformanceObserver?.logRawEntry({
       name,
       entryType: RawPerformanceEntryTypeValues.MARK,
       startTime,
-      duration,
+      duration: 0,
     });
     marks.set(name, startTime);
   },

--- a/packages/react-native/Libraries/WebPerformance/__tests__/PerformanceEntryReporterTest.cpp
+++ b/packages/react-native/Libraries/WebPerformance/__tests__/PerformanceEntryReporterTest.cpp
@@ -146,6 +146,10 @@ TEST(PerformanceEntryReporter, PerformanceEntryReporterTestReportMeasures) {
   reporter.measure("measure3", 0.0, 0.0, 5.0, "mark1");
   reporter.measure("measure4", 1.5, 0.0, std::nullopt, std::nullopt, "mark2");
 
+  reporter.mark("mark3", 2.0);
+  reporter.measure("measure5", 2.0, 2.0);
+  reporter.mark("mark4", 2.0);
+
   auto res = reporter.popPendingEntries();
   const auto &entries = res.entries;
 
@@ -207,7 +211,29 @@ TEST(PerformanceEntryReporter, PerformanceEntryReporterTestReportMeasures) {
        0.0,
        std::nullopt,
        std::nullopt,
-       std::nullopt}};
+       std::nullopt},
+      {"mark3",
+       static_cast<int>(PerformanceEntryType::MARK),
+       2.0,
+       0.0,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt},
+      {"mark4",
+       static_cast<int>(PerformanceEntryType::MARK),
+       2.0,
+       0.0,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt},
+      {"measure5",
+       static_cast<int>(PerformanceEntryType::MEASURE),
+       2.0,
+       0.0,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt},
+  };
 
   ASSERT_EQ(expected, entries);
 }

--- a/packages/react-native/Libraries/WebPerformance/__tests__/PerformanceEntryReporterTest.cpp
+++ b/packages/react-native/Libraries/WebPerformance/__tests__/PerformanceEntryReporterTest.cpp
@@ -54,9 +54,9 @@ TEST(PerformanceEntryReporter, PerformanceEntryReporterTestStopReporting) {
 
   reporter.startReporting(PerformanceEntryType::MARK);
 
-  reporter.mark("mark0", 0.0, 0.0);
-  reporter.mark("mark1", 0.0, 0.0);
-  reporter.mark("mark2", 0.0, 0.0);
+  reporter.mark("mark0", 0.0);
+  reporter.mark("mark1", 0.0);
+  reporter.mark("mark2", 0.0);
   reporter.measure("measure0", 0.0, 0.0);
 
   auto res = reporter.popPendingEntries();
@@ -73,7 +73,7 @@ TEST(PerformanceEntryReporter, PerformanceEntryReporterTestStopReporting) {
   reporter.stopReporting(PerformanceEntryType::MARK);
   reporter.startReporting(PerformanceEntryType::MEASURE);
 
-  reporter.mark("mark3", 0.0, 0.0);
+  reporter.mark("mark3");
   reporter.measure("measure1", 0.0, 0.0);
 
   res = reporter.popPendingEntries();
@@ -91,9 +91,9 @@ TEST(PerformanceEntryReporter, PerformanceEntryReporterTestReportMarks) {
 
   reporter.startReporting(PerformanceEntryType::MARK);
 
-  reporter.mark("mark0", 0.0, 1.0);
-  reporter.mark("mark1", 1.0, 3.0);
-  reporter.mark("mark2", 2.0, 4.0);
+  reporter.mark("mark0", 0.0);
+  reporter.mark("mark1", 1.0);
+  reporter.mark("mark2", 2.0);
 
   auto res = reporter.popPendingEntries();
   const auto &entries = res.entries;
@@ -105,21 +105,21 @@ TEST(PerformanceEntryReporter, PerformanceEntryReporterTestReportMarks) {
       {"mark0",
        static_cast<int>(PerformanceEntryType::MARK),
        0.0,
-       1.0,
+       0.0,
        std::nullopt,
        std::nullopt,
        std::nullopt},
       {"mark1",
        static_cast<int>(PerformanceEntryType::MARK),
        1.0,
-       3.0,
+       0.0,
        std::nullopt,
        std::nullopt,
        std::nullopt},
       {"mark2",
        static_cast<int>(PerformanceEntryType::MARK),
        2.0,
-       4.0,
+       0.0,
        std::nullopt,
        std::nullopt,
        std::nullopt}};
@@ -136,9 +136,9 @@ TEST(PerformanceEntryReporter, PerformanceEntryReporterTestReportMeasures) {
   reporter.startReporting(PerformanceEntryType::MARK);
   reporter.startReporting(PerformanceEntryType::MEASURE);
 
-  reporter.mark("mark0", 0.0, 1.0);
-  reporter.mark("mark1", 1.0, 3.0);
-  reporter.mark("mark2", 2.0, 4.0);
+  reporter.mark("mark0", 0.0);
+  reporter.mark("mark1", 1.0);
+  reporter.mark("mark2", 2.0);
 
   reporter.measure("measure0", 0.0, 2.0);
   reporter.measure("measure1", 0.0, 2.0, 4.0);
@@ -155,7 +155,7 @@ TEST(PerformanceEntryReporter, PerformanceEntryReporterTestReportMeasures) {
       {"mark0",
        static_cast<int>(PerformanceEntryType::MARK),
        0.0,
-       1.0,
+       0.0,
        std::nullopt,
        std::nullopt,
        std::nullopt},
@@ -173,17 +173,17 @@ TEST(PerformanceEntryReporter, PerformanceEntryReporterTestReportMeasures) {
        std::nullopt,
        std::nullopt,
        std::nullopt},
+      {"mark1",
+       static_cast<int>(PerformanceEntryType::MARK),
+       1.0,
+       0.0,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt},
       {"measure2",
        static_cast<int>(PerformanceEntryType::MEASURE),
        1.0,
        1.0,
-       std::nullopt,
-       std::nullopt,
-       std::nullopt},
-      {"mark1",
-       static_cast<int>(PerformanceEntryType::MARK),
-       1.0,
-       3.0,
        std::nullopt,
        std::nullopt,
        std::nullopt},
@@ -204,7 +204,7 @@ TEST(PerformanceEntryReporter, PerformanceEntryReporterTestReportMeasures) {
       {"mark2",
        static_cast<int>(PerformanceEntryType::MARK),
        2.0,
-       4.0,
+       0.0,
        std::nullopt,
        std::nullopt,
        std::nullopt}};
@@ -249,9 +249,9 @@ TEST(PerformanceEntryReporter, PerformanceEntryReporterTestGetEntries) {
   reporter.startReporting(PerformanceEntryType::MARK);
   reporter.startReporting(PerformanceEntryType::MEASURE);
 
-  reporter.mark("common_name", 0.0, 1.0);
-  reporter.mark("mark1", 1.0, 3.0);
-  reporter.mark("mark2", 2.0, 4.0);
+  reporter.mark("common_name", 0.0);
+  reporter.mark("mark1", 1.0);
+  reporter.mark("mark2", 2.0);
 
   reporter.measure("common_name", 0.0, 2.0);
   reporter.measure("measure1", 0.0, 2.0, 4.0);
@@ -296,9 +296,9 @@ TEST(PerformanceEntryReporter, PerformanceEntryReporterTestClearEntries) {
   reporter.startReporting(PerformanceEntryType::MARK);
   reporter.startReporting(PerformanceEntryType::MEASURE);
 
-  reporter.mark("common_name", 0.0, 1.0);
-  reporter.mark("mark1", 1.0, 3.0);
-  reporter.mark("mark2", 2.0, 4.0);
+  reporter.mark("common_name", 0.0);
+  reporter.mark("mark1", 1.0);
+  reporter.mark("mark2", 2.0);
 
   reporter.measure("common_name", 0.0, 2.0);
   reporter.measure("measure1", 0.0, 2.0, 4.0);


### PR DESCRIPTION
Summary:
For performance entries that have the same start/end time it makes more sense to report them back to `PerformanceObserver` in the same order they were logged.

This kind of determinism is arguably better both in terms of API, and from the point of view of testing.

Chagelog: [Internal]

Reviewed By: javache

Differential Revision: D45142500

