### PR TITLE
fix(textinput): backporting of fixes for next 0.69 patch release (V3)

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/CustomLetterSpacingSpan.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/CustomLetterSpacingSpan.java
@@ -37,6 +37,10 @@ public class CustomLetterSpacingSpan extends MetricAffectingSpan implements Reac
     apply(paint);
   }
 
+  public float getSpacing() {
+    return mLetterSpacing;
+  }
+
   private void apply(TextPaint paint) {
     if (!Float.isNaN(mLetterSpacing)) {
       paint.setLetterSpacing(mLetterSpacing);

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/CustomStyleSpan.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/CustomStyleSpan.java
@@ -71,6 +71,10 @@ public class CustomStyleSpan extends MetricAffectingSpan implements ReactSpan {
     return mFontFamily;
   }
 
+  public @Nullable String getFontFeatureSettings() {
+    return mFeatureSettings;
+  }
+
   private static void apply(
       Paint paint,
       int style,

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -550,9 +550,7 @@ public class ReactEditText extends AppCompatEditText
         new SpannableStringBuilder(reactTextUpdate.getText());
 
     manageSpans(spannableStringBuilder, reactTextUpdate.mContainsMultipleFragments);
-
-    // Mitigation for https://github.com/facebook/react-native/issues/35936 (S318090)
-    stripAtributeEquivalentSpans(spannableStringBuilder);
+    stripStyleEquivalentSpans(spannableStringBuilder);
 
     mContainsImages = reactTextUpdate.containsImages();
 
@@ -627,28 +625,44 @@ public class ReactEditText extends AppCompatEditText
     }
   }
 
-  private void stripAtributeEquivalentSpans(SpannableStringBuilder sb) {
-    // We have already set a font size on the EditText itself. We can safely remove sizing spans
-    // which are the same as the set font size, and not otherwise overlapped.
-    final int effectiveFontSize = mTextAttributes.getEffectiveFontSize();
-    ReactAbsoluteSizeSpan[] spans = sb.getSpans(0, sb.length(), ReactAbsoluteSizeSpan.class);
+  // TODO: Replace with Predicate<T> and lambdas once Java 8 builds in OSS
+  interface SpanPredicate<T> {
+    boolean test(T span);
+  }
 
-    outerLoop:
-    for (ReactAbsoluteSizeSpan span : spans) {
-      ReactAbsoluteSizeSpan[] overlappingSpans =
-          sb.getSpans(sb.getSpanStart(span), sb.getSpanEnd(span), ReactAbsoluteSizeSpan.class);
+  /**
+   * Remove spans from the SpannableStringBuilder which can be represented by TextAppearance
+   * attributes on the underlying EditText. This works around instability on Samsung devices with
+   * the presence of spans https://github.com/facebook/react-native/issues/35936 (S318090)
+   */
+  private void stripStyleEquivalentSpans(SpannableStringBuilder sb) {
+    stripSpansOfKind(
+        sb,
+        ReactAbsoluteSizeSpan.class,
+        new SpanPredicate<ReactAbsoluteSizeSpan>() {
+          @Override
+          public boolean test(ReactAbsoluteSizeSpan span) {
+            return span.getSize() == mTextAttributes.getEffectiveFontSize();
+          }
+        });
+  }
 
-      for (ReactAbsoluteSizeSpan overlappingSpan : overlappingSpans) {
-        if (span.getSize() != effectiveFontSize) {
-          continue outerLoop;
-        }
+  private <T> void stripSpansOfKind(
+      SpannableStringBuilder sb, Class<T> clazz, SpanPredicate<T> shouldStrip) {
+    T[] spans = sb.getSpans(0, sb.length(), clazz);
+
+    for (T span : spans) {
+      if (shouldStrip.test(span)) {
+        sb.removeSpan(span);
       }
-
-      sb.removeSpan(span);
     }
   }
 
-  private void unstripAttributeEquivalentSpans(SpannableStringBuilder workingText) {
+  /**
+   * Copy back styles represented as attributes to the underlying span, for later measurement
+   * outside the ReactEditText.
+   */
+  private void restoreStyleEquivalentSpans(SpannableStringBuilder workingText) {
     int spanFlags = Spannable.SPAN_INCLUSIVE_INCLUSIVE;
 
     // Set all bits for SPAN_PRIORITY so that this span has the highest possible priority
@@ -1081,7 +1095,7 @@ public class ReactEditText extends AppCompatEditText
       // - android.app.Activity.dispatchKeyEvent (Activity.java:3447)
       try {
         sb.append(currentText.subSequence(0, currentText.length()));
-        unstripAttributeEquivalentSpans(sb);
+        restoreStyleEquivalentSpans(sb);
       } catch (IndexOutOfBoundsException e) {
         ReactSoftExceptionLogger.logSoftException(TAG, e);
       }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -65,6 +65,7 @@ import com.facebook.react.views.text.TextLayoutManager;
 import com.facebook.react.views.view.ReactViewBackgroundManager;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * A wrapper around the EditText that lets us better control what happens when an EditText gets
@@ -483,6 +484,14 @@ public class ReactEditText extends AppCompatEditText
     }
   }
 
+  @Override
+  public void setFontFeatureSettings(String fontFeatureSettings) {
+    if (!Objects.equals(fontFeatureSettings, getFontFeatureSettings())) {
+      super.setFontFeatureSettings(fontFeatureSettings);
+      mTypefaceDirty = true;
+    }
+  }
+
   public void maybeUpdateTypeface() {
     if (!mTypefaceDirty) {
       return;
@@ -494,6 +503,17 @@ public class ReactEditText extends AppCompatEditText
         ReactTypefaceUtils.applyStyles(
             getTypeface(), mFontStyle, mFontWeight, mFontFamily, getContext().getAssets());
     setTypeface(newTypeface);
+
+    // Match behavior of CustomStyleSpan and enable SUBPIXEL_TEXT_FLAG when setting anything
+    // nonstandard
+    if (mFontStyle != UNSET
+        || mFontWeight != UNSET
+        || mFontFamily != null
+        || getFontFeatureSettings() != null) {
+      setPaintFlags(getPaintFlags() | Paint.SUBPIXEL_TEXT_FLAG);
+    } else {
+      setPaintFlags(getPaintFlags() & (~Paint.SUBPIXEL_TEXT_FLAG));
+    }
   }
 
   // VisibleForTesting from {@link TextInputEventsTestCase}.
@@ -703,6 +723,19 @@ public class ReactEditText extends AppCompatEditText
             }
           });
     }
+
+    stripSpansOfKind(
+        sb,
+        CustomStyleSpan.class,
+        new SpanPredicate<CustomStyleSpan>() {
+          @Override
+          public boolean test(CustomStyleSpan span) {
+            return span.getStyle() == mFontStyle
+                && Objects.equals(span.getFontFamily(), mFontFamily)
+                && span.getWeight() == mFontWeight
+                && Objects.equals(span.getFontFeatureSettings(), getFontFeatureSettings());
+          }
+        });
   }
 
   private <T> void stripSpansOfKind(
@@ -759,6 +792,22 @@ public class ReactEditText extends AppCompatEditText
             workingText.length(),
             spanFlags);
       }
+    }
+
+    if (mFontStyle != UNSET
+        || mFontWeight != UNSET
+        || mFontFamily != null
+        || getFontFeatureSettings() != null) {
+      workingText.setSpan(
+          new CustomStyleSpan(
+              mFontStyle,
+              mFontWeight,
+              getFontFeatureSettings(),
+              mFontFamily,
+              getContext().getAssets()),
+          0,
+          workingText.length(),
+          spanFlags);
     }
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -52,6 +52,7 @@ import com.facebook.react.views.text.CustomLineHeightSpan;
 import com.facebook.react.views.text.CustomStyleSpan;
 import com.facebook.react.views.text.ReactAbsoluteSizeSpan;
 import com.facebook.react.views.text.ReactBackgroundColorSpan;
+import com.facebook.react.views.text.ReactForegroundColorSpan;
 import com.facebook.react.views.text.ReactSpan;
 import com.facebook.react.views.text.ReactTextUpdate;
 import com.facebook.react.views.text.ReactTypefaceUtils;
@@ -657,6 +658,16 @@ public class ReactEditText extends AppCompatEditText
             return span.getBackgroundColor() == mReactBackgroundManager.getBackgroundColor();
           }
         });
+
+    stripSpansOfKind(
+        sb,
+        ReactForegroundColorSpan.class,
+        new SpanPredicate<ReactForegroundColorSpan>() {
+          @Override
+          public boolean test(ReactForegroundColorSpan span) {
+            return span.getForegroundColor() == getCurrentTextColor();
+          }
+        });
   }
 
   private <T> void stripSpansOfKind(
@@ -683,6 +694,7 @@ public class ReactEditText extends AppCompatEditText
 
     List<Object> spans = new ArrayList<>();
     spans.add(new ReactAbsoluteSizeSpan(mTextAttributes.getEffectiveFontSize()));
+    spans.add(new ReactForegroundColorSpan(getCurrentTextColor()));
 
     int backgroundColor = mReactBackgroundManager.getBackgroundColor();
     if (backgroundColor != Color.TRANSPARENT) {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -552,7 +552,7 @@ public class ReactEditText extends AppCompatEditText
     manageSpans(spannableStringBuilder, reactTextUpdate.mContainsMultipleFragments);
 
     // Mitigation for https://github.com/facebook/react-native/issues/35936 (S318090)
-    stripAbsoluteSizeSpans(spannableStringBuilder);
+    stripAtributeEquivalentSpans(spannableStringBuilder);
 
     mContainsImages = reactTextUpdate.containsImages();
 
@@ -627,7 +627,7 @@ public class ReactEditText extends AppCompatEditText
     }
   }
 
-  private void stripAbsoluteSizeSpans(SpannableStringBuilder sb) {
+  private void stripAtributeEquivalentSpans(SpannableStringBuilder sb) {
     // We have already set a font size on the EditText itself. We can safely remove sizing spans
     // which are the same as the set font size, and not otherwise overlapped.
     final int effectiveFontSize = mTextAttributes.getEffectiveFontSize();
@@ -645,6 +645,31 @@ public class ReactEditText extends AppCompatEditText
       }
 
       sb.removeSpan(span);
+    }
+  }
+
+  private void unstripAttributeEquivalentSpans(
+      SpannableStringBuilder workingText, Spannable originalText) {
+    // We must add spans back for Fabric to be able to measure, at lower precedence than any
+    // existing spans. Remove all spans, add the attributes, then re-add the spans over
+    workingText.append(originalText);
+
+    for (Object span : workingText.getSpans(0, workingText.length(), Object.class)) {
+      workingText.removeSpan(span);
+    }
+
+    workingText.setSpan(
+        new ReactAbsoluteSizeSpan(mTextAttributes.getEffectiveFontSize()),
+        0,
+        workingText.length(),
+        Spanned.SPAN_INCLUSIVE_INCLUSIVE);
+
+    for (Object span : originalText.getSpans(0, originalText.length(), Object.class)) {
+      workingText.setSpan(
+          span,
+          originalText.getSpanStart(span),
+          originalText.getSpanEnd(span),
+          originalText.getSpanFlags(span));
     }
   }
 
@@ -1066,7 +1091,8 @@ public class ReactEditText extends AppCompatEditText
       // ...
       // - android.app.Activity.dispatchKeyEvent (Activity.java:3447)
       try {
-        sb.append(currentText.subSequence(0, currentText.length()));
+        Spannable text = (Spannable) currentText.subSequence(0, currentText.length());
+        unstripAttributeEquivalentSpans(sb, text);
       } catch (IndexOutOfBoundsException e) {
         ReactSoftExceptionLogger.logSoftException(TAG, e);
       }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -727,32 +727,38 @@ public class ReactEditText extends AppCompatEditText
     // (least precedence). This ensures the span is behind any overlapping spans.
     spanFlags |= Spannable.SPAN_PRIORITY;
 
-    List<Object> spans = new ArrayList<>();
-    spans.add(new ReactAbsoluteSizeSpan(mTextAttributes.getEffectiveFontSize()));
-    spans.add(new ReactForegroundColorSpan(getCurrentTextColor()));
+    workingText.setSpan(
+        new ReactAbsoluteSizeSpan(mTextAttributes.getEffectiveFontSize()),
+        0,
+        workingText.length(),
+        spanFlags);
+
+    workingText.setSpan(
+        new ReactForegroundColorSpan(getCurrentTextColor()), 0, workingText.length(), spanFlags);
 
     int backgroundColor = mReactBackgroundManager.getBackgroundColor();
     if (backgroundColor != Color.TRANSPARENT) {
-      spans.add(new ReactBackgroundColorSpan(backgroundColor));
+      workingText.setSpan(
+          new ReactBackgroundColorSpan(backgroundColor), 0, workingText.length(), spanFlags);
     }
 
     if ((getPaintFlags() & Paint.STRIKE_THRU_TEXT_FLAG) != 0) {
-      spans.add(new ReactStrikethroughSpan());
+      workingText.setSpan(new ReactStrikethroughSpan(), 0, workingText.length(), spanFlags);
     }
 
     if ((getPaintFlags() & Paint.UNDERLINE_TEXT_FLAG) != 0) {
-      spans.add(new ReactUnderlineSpan());
+      workingText.setSpan(new ReactUnderlineSpan(), 0, workingText.length(), spanFlags);
     }
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
       float effectiveLetterSpacing = mTextAttributes.getEffectiveLetterSpacing();
       if (!Float.isNaN(effectiveLetterSpacing)) {
-        spans.add(new CustomLetterSpacingSpan(effectiveLetterSpacing));
+        workingText.setSpan(
+            new CustomLetterSpacingSpan(effectiveLetterSpacing),
+            0,
+            workingText.length(),
+            spanFlags);
       }
-    }
-
-    for (Object span : spans) {
-      workingText.setSpan(span, 0, workingText.length(), spanFlags);
     }
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -11,6 +11,7 @@ import static com.facebook.react.uimanager.UIManagerHelper.getReactContext;
 import static com.facebook.react.views.text.TextAttributeProps.UNSET;
 
 import android.content.Context;
+import android.graphics.Color;
 import android.graphics.Rect;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
@@ -50,6 +51,7 @@ import com.facebook.react.views.text.CustomLetterSpacingSpan;
 import com.facebook.react.views.text.CustomLineHeightSpan;
 import com.facebook.react.views.text.CustomStyleSpan;
 import com.facebook.react.views.text.ReactAbsoluteSizeSpan;
+import com.facebook.react.views.text.ReactBackgroundColorSpan;
 import com.facebook.react.views.text.ReactSpan;
 import com.facebook.react.views.text.ReactTextUpdate;
 import com.facebook.react.views.text.ReactTypefaceUtils;
@@ -645,6 +647,16 @@ public class ReactEditText extends AppCompatEditText
             return span.getSize() == mTextAttributes.getEffectiveFontSize();
           }
         });
+
+    stripSpansOfKind(
+        sb,
+        ReactBackgroundColorSpan.class,
+        new SpanPredicate<ReactBackgroundColorSpan>() {
+          @Override
+          public boolean test(ReactBackgroundColorSpan span) {
+            return span.getBackgroundColor() == mReactBackgroundManager.getBackgroundColor();
+          }
+        });
   }
 
   private <T> void stripSpansOfKind(
@@ -669,11 +681,17 @@ public class ReactEditText extends AppCompatEditText
     // (least precedence). This ensures the span is behind any overlapping spans.
     spanFlags |= Spannable.SPAN_PRIORITY;
 
-    workingText.setSpan(
-        new ReactAbsoluteSizeSpan(mTextAttributes.getEffectiveFontSize()),
-        0,
-        workingText.length(),
-        spanFlags);
+    List<Object> spans = new ArrayList<>();
+    spans.add(new ReactAbsoluteSizeSpan(mTextAttributes.getEffectiveFontSize()));
+
+    int backgroundColor = mReactBackgroundManager.getBackgroundColor();
+    if (backgroundColor != Color.TRANSPARENT) {
+      spans.add(new ReactBackgroundColorSpan(backgroundColor));
+    }
+
+    for (Object span : spans) {
+      workingText.setSpan(span, 0, workingText.length(), spanFlags);
+    }
   }
 
   private static boolean sameTextForSpan(

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -648,29 +648,18 @@ public class ReactEditText extends AppCompatEditText
     }
   }
 
-  private void unstripAttributeEquivalentSpans(
-      SpannableStringBuilder workingText, Spannable originalText) {
-    // We must add spans back for Fabric to be able to measure, at lower precedence than any
-    // existing spans. Remove all spans, add the attributes, then re-add the spans over
-    workingText.append(originalText);
+  private void unstripAttributeEquivalentSpans(SpannableStringBuilder workingText) {
+    int spanFlags = Spannable.SPAN_INCLUSIVE_INCLUSIVE;
 
-    for (Object span : workingText.getSpans(0, workingText.length(), Object.class)) {
-      workingText.removeSpan(span);
-    }
+    // Set all bits for SPAN_PRIORITY so that this span has the highest possible priority
+    // (least precedence). This ensures the span is behind any overlapping spans.
+    spanFlags |= Spannable.SPAN_PRIORITY;
 
     workingText.setSpan(
         new ReactAbsoluteSizeSpan(mTextAttributes.getEffectiveFontSize()),
         0,
         workingText.length(),
-        Spanned.SPAN_INCLUSIVE_INCLUSIVE);
-
-    for (Object span : originalText.getSpans(0, originalText.length(), Object.class)) {
-      workingText.setSpan(
-          span,
-          originalText.getSpanStart(span),
-          originalText.getSpanEnd(span),
-          originalText.getSpanFlags(span));
-    }
+        spanFlags);
   }
 
   private static boolean sameTextForSpan(
@@ -1091,8 +1080,8 @@ public class ReactEditText extends AppCompatEditText
       // ...
       // - android.app.Activity.dispatchKeyEvent (Activity.java:3447)
       try {
-        Spannable text = (Spannable) currentText.subSequence(0, currentText.length());
-        unstripAttributeEquivalentSpans(sb, text);
+        sb.append(currentText.subSequence(0, currentText.length()));
+        unstripAttributeEquivalentSpans(sb);
       } catch (IndexOutOfBoundsException e) {
         ReactSoftExceptionLogger.logSoftException(TAG, e);
       }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -691,6 +691,18 @@ public class ReactEditText extends AppCompatEditText
             return (getPaintFlags() & Paint.UNDERLINE_TEXT_FLAG) != 0;
           }
         });
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+      stripSpansOfKind(
+          sb,
+          CustomLetterSpacingSpan.class,
+          new SpanPredicate<CustomLetterSpacingSpan>() {
+            @Override
+            public boolean test(CustomLetterSpacingSpan span) {
+              return span.getSpacing() == mTextAttributes.getEffectiveLetterSpacing();
+            }
+          });
+    }
   }
 
   private <T> void stripSpansOfKind(
@@ -730,6 +742,13 @@ public class ReactEditText extends AppCompatEditText
 
     if ((getPaintFlags() & Paint.UNDERLINE_TEXT_FLAG) != 0) {
       spans.add(new ReactUnderlineSpan());
+    }
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+      float effectiveLetterSpacing = mTextAttributes.getEffectiveLetterSpacing();
+      if (!Float.isNaN(effectiveLetterSpacing)) {
+        spans.add(new CustomLetterSpacingSpan(effectiveLetterSpacing));
+      }
     }
 
     for (Object span : spans) {
@@ -1083,7 +1102,9 @@ public class ReactEditText extends AppCompatEditText
 
     float effectiveLetterSpacing = mTextAttributes.getEffectiveLetterSpacing();
     if (!Float.isNaN(effectiveLetterSpacing)) {
-      setLetterSpacing(effectiveLetterSpacing);
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+        setLetterSpacing(effectiveLetterSpacing);
+      }
     }
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -12,6 +12,7 @@ import static com.facebook.react.views.text.TextAttributeProps.UNSET;
 
 import android.content.Context;
 import android.graphics.Color;
+import android.graphics.Paint;
 import android.graphics.Rect;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
@@ -54,8 +55,10 @@ import com.facebook.react.views.text.ReactAbsoluteSizeSpan;
 import com.facebook.react.views.text.ReactBackgroundColorSpan;
 import com.facebook.react.views.text.ReactForegroundColorSpan;
 import com.facebook.react.views.text.ReactSpan;
+import com.facebook.react.views.text.ReactStrikethroughSpan;
 import com.facebook.react.views.text.ReactTextUpdate;
 import com.facebook.react.views.text.ReactTypefaceUtils;
+import com.facebook.react.views.text.ReactUnderlineSpan;
 import com.facebook.react.views.text.TextAttributes;
 import com.facebook.react.views.text.TextInlineImageSpan;
 import com.facebook.react.views.text.TextLayoutManager;
@@ -668,6 +671,26 @@ public class ReactEditText extends AppCompatEditText
             return span.getForegroundColor() == getCurrentTextColor();
           }
         });
+
+    stripSpansOfKind(
+        sb,
+        ReactStrikethroughSpan.class,
+        new SpanPredicate<ReactStrikethroughSpan>() {
+          @Override
+          public boolean test(ReactStrikethroughSpan span) {
+            return (getPaintFlags() & Paint.STRIKE_THRU_TEXT_FLAG) != 0;
+          }
+        });
+
+    stripSpansOfKind(
+        sb,
+        ReactUnderlineSpan.class,
+        new SpanPredicate<ReactUnderlineSpan>() {
+          @Override
+          public boolean test(ReactUnderlineSpan span) {
+            return (getPaintFlags() & Paint.UNDERLINE_TEXT_FLAG) != 0;
+          }
+        });
   }
 
   private <T> void stripSpansOfKind(
@@ -699,6 +722,14 @@ public class ReactEditText extends AppCompatEditText
     int backgroundColor = mReactBackgroundManager.getBackgroundColor();
     if (backgroundColor != Color.TRANSPARENT) {
       spans.add(new ReactBackgroundColorSpan(backgroundColor));
+    }
+
+    if ((getPaintFlags() & Paint.STRIKE_THRU_TEXT_FLAG) != 0) {
+      spans.add(new ReactStrikethroughSpan());
+    }
+
+    if ((getPaintFlags() & Paint.UNDERLINE_TEXT_FLAG) != 0) {
+      spans.add(new ReactUnderlineSpan());
     }
 
     for (Object span : spans) {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -68,6 +68,7 @@ import com.facebook.react.views.text.DefaultStyleValuesUtil;
 import com.facebook.react.views.text.ReactBaseTextShadowNode;
 import com.facebook.react.views.text.ReactTextUpdate;
 import com.facebook.react.views.text.ReactTextViewManagerCallback;
+import com.facebook.react.views.text.ReactTypefaceUtils;
 import com.facebook.react.views.text.TextAttributeProps;
 import com.facebook.react.views.text.TextInlineImageSpan;
 import com.facebook.react.views.text.TextLayoutManager;
@@ -396,6 +397,11 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
   @ReactProp(name = ViewProps.FONT_STYLE)
   public void setFontStyle(ReactEditText view, @Nullable String fontStyle) {
     view.setFontStyle(fontStyle);
+  }
+
+  @ReactProp(name = ViewProps.FONT_VARIANT)
+  public void setFontVariant(ReactEditText view, @Nullable ReadableArray fontVariant) {
+    view.setFontFeatureSettings(ReactTypefaceUtils.parseFontVariant(fontVariant));
   }
 
   @ReactProp(name = ViewProps.INCLUDE_FONT_PADDING, defaultBoolean = true)

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -13,6 +13,7 @@ import android.content.Context;
 import android.content.res.ColorStateList;
 import android.graphics.BlendMode;
 import android.graphics.BlendModeColorFilter;
+import android.graphics.Paint;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
@@ -911,6 +912,20 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
   @ReactProp(name = "autoFocus", defaultBoolean = false)
   public void setAutoFocus(ReactEditText view, boolean autoFocus) {
     view.setAutoFocus(autoFocus);
+  }
+
+  @ReactProp(name = ViewProps.TEXT_DECORATION_LINE)
+  public void setTextDecorationLine(ReactEditText view, @Nullable String textDecorationLineString) {
+    view.setPaintFlags(
+        view.getPaintFlags() & ~(Paint.STRIKE_THRU_TEXT_FLAG | Paint.UNDERLINE_TEXT_FLAG));
+
+    for (String token : textDecorationLineString.split(" ")) {
+      if (token.equals("underline")) {
+        view.setPaintFlags(view.getPaintFlags() | Paint.UNDERLINE_TEXT_FLAG);
+      } else if (token.equals("line-through")) {
+        view.setPaintFlags(view.getPaintFlags() | Paint.STRIKE_THRU_TEXT_FLAG);
+      }
+    }
   }
 
   @ReactPropGroup(

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewBackgroundManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewBackgroundManager.java
@@ -19,6 +19,7 @@ public class ReactViewBackgroundManager {
 
   private @Nullable ReactViewBackgroundDrawable mReactBackgroundDrawable;
   private View mView;
+  private int mColor = Color.TRANSPARENT;
 
   public ReactViewBackgroundManager(View view) {
     this.mView = view;
@@ -48,6 +49,10 @@ public class ReactViewBackgroundManager {
     } else {
       getOrCreateReactViewBackground().setColor(color);
     }
+  }
+
+  public int getBackgroundColor() {
+    return mColor;
   }
 
   public void setBorderWidth(int position, float width) {


### PR DESCRIPTION
## Summary:

Hopefully, third time's the charm (attempt 1: https://github.com/facebook/react-native/pull/36876, attempt 2: https://github.com/facebook/react-native/pull/36929).

This PR takes care of backporting the [needed commits](https://github.com/reactwg/react-native-releases/discussions/62#discussioncomment-5519482) for the textinput samsung issue to 0.69 stable.

I've only hit one minor merge conflict on for commit https://github.com/facebook/react-native/commit/b9e2627d1ce64e8e293e90f743bf13a515db3b4d, it was fairly straightforward.

As you might have noticed, this one misses the 9/9 commit and that's because it's not strictly necessary for the main fix - this was discussed with @NickGerleman.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[ANDROID] [FIXED] - backporting of fixes for next 0.69 patch release

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Can't test RNTester Android currently (that's being that with in this separate PR https://github.com/facebook/react-native/pull/37001), but RNTestProject seems to work fine:
<img width="1714" alt="Screenshot 2023-04-20 at 15 40 24" src="https://user-images.githubusercontent.com/16104054/233407464-6653c051-00b1-487b-9904-49c3b1312456.png">
