### PR TITLE
fix(RNTester): fix RNTester Android working on newer tooling (WIP)

### DIFF
--- a/packages/rn-tester/android/app/build.gradle
+++ b/packages/rn-tester/android/app/build.gradle
@@ -154,6 +154,11 @@ android {
     if (rootProject.hasProperty("ndkVersion")) {
         ndkVersion rootProject.ext.ndkVersion
     }
+    // For M1 Users we need to use the NDK 24, otherwise we default to the
+    // side-by-side NDK version from AGP.
+    if (System.properties['os.arch'] == "aarch64") {
+        ndkVersion = "24.0.8215888"
+    }
 
     flavorDimensions "vm"
     productFlavors {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

While trying to test the backports https://github.com/facebook/react-native/pull/37000 I hit some issues with RNTester on Android which I think are mostly due to that config not playing well with new settings (such as M1, newer Android studio versions etc etc).

So this PR is an attempt to address all the problems. (the current commit is inspired by https://github.com/facebook/react-native/commit/4befd2a29cb94b026d9c048a041aa9f1817295b5)
Currently, I've fixed a build error but it still instacrashes. More work will be required 😭

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[INTERNAL] [FIXED] - fix RNTester Android working on newer tooling


## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Use `./scripts/test-manual-e2e.sh` to run RNTester on Android.