### PR TITLE
Enable lazy bundling in dev on iOS/Android

### DIFF
--- a/packages/react-native/React/Base/RCTBundleURLProvider.mm
+++ b/packages/react-native/React/Base/RCTBundleURLProvider.mm
@@ -265,10 +265,11 @@ static NSURL *serverRootWithHostPort(NSString *hostPort, NSString *scheme)
                           runModule:(BOOL)runModule
 {
   NSString *path = [NSString stringWithFormat:@"/%@.bundle", bundleRoot];
-
+  BOOL lazy = enableDev;
   // When we support only iOS 8 and above, use queryItems for a better API.
-  NSString *query = [NSString stringWithFormat:@"platform=ios&dev=%@&minify=%@&modulesOnly=%@&runModule=%@",
+  NSString *query = [NSString stringWithFormat:@"platform=ios&dev=%@&lazy=%@&minify=%@&modulesOnly=%@&runModule=%@",
                                                enableDev ? @"true" : @"false",
+                                               lazy ? @"true" : @"false",
                                                enableMinification ? @"true" : @"false",
                                                modulesOnly ? @"true" : @"false",
                                                runModule ? @"true" : @"false"];

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.java
@@ -345,13 +345,16 @@ public class DevServerHelper {
 
   private String createBundleURL(
       String mainModuleID, BundleType type, String host, boolean modulesOnly, boolean runModule) {
+    boolean dev = getDevMode();
+    boolean lazy = dev;
     return String.format(
         Locale.US,
-        "http://%s/%s.%s?platform=android&dev=%s&minify=%s&app=%s&modulesOnly=%s&runModule=%s",
+        "http://%s/%s.%s?platform=android&dev=%s&lazy=%s&minify=%s&app=%s&modulesOnly=%s&runModule=%s",
         host,
         mainModuleID,
         type.typeID(),
-        getDevMode(),
+        dev,
+        lazy,
         getJSMinifyMode(),
         mPackageName,
         modulesOnly ? "true" : "false",

--- a/packages/rn-tester/RNTesterUnitTests/RCTBundleURLProviderTests.m
+++ b/packages/rn-tester/RNTesterUnitTests/RCTBundleURLProviderTests.m
@@ -26,7 +26,7 @@ static NSURL *localhostBundleURL()
       URLWithString:
           [NSString
               stringWithFormat:
-                  @"http://localhost:8081/%@.bundle?platform=ios&dev=true&minify=false&modulesOnly=false&runModule=true&app=com.apple.dt.xctest.tool",
+                  @"http://localhost:8081/%@.bundle?platform=ios&dev=true&lazy=true&minify=false&modulesOnly=false&runModule=true&app=com.apple.dt.xctest.tool",
                   testFile]];
 }
 
@@ -36,7 +36,7 @@ static NSURL *ipBundleURL()
       URLWithString:
           [NSString
               stringWithFormat:
-                  @"http://192.168.1.1:8081/%@.bundle?platform=ios&dev=true&minify=false&modulesOnly=false&runModule=true&app=com.apple.dt.xctest.tool",
+                  @"http://192.168.1.1:8081/%@.bundle?platform=ios&dev=true&lazy=true&minify=false&modulesOnly=false&runModule=true&app=com.apple.dt.xctest.tool",
                   testFile]];
 }
 


### PR DESCRIPTION
Summary:
Changelog: [General][Added] [3/n] Support lazy bundling in development

Enables [lazy bundling](https://github.com/react-native-community/discussions-and-proposals/blob/main/proposals/0605-lazy-bundling.md) when requesting a development bundle from Metro.

NOTE: This depends on a Metro diff (https://github.com/facebook/metro/pull/971) that hasn't landed yet, but is a no-op until then.

Reviewed By: jacdebug

Differential Revision: D43600054

