### PR TITLE
make getModuleInstanceFromClass: required

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.h
@@ -24,12 +24,12 @@ RCT_EXTERN void RCTTurboModuleSetBindingMode(facebook::react::TurboModuleBinding
  */
 - (Class)getModuleClassFromName:(const char *)name;
 
-@optional
-
 /**
- * Given a module class, provide an instance for it. If not provided, default initializer is used.
+ * Given a module class, provide an instance for it. If nil is returned, default initializer is used.
  */
 - (id<RCTTurboModule>)getModuleInstanceFromClass:(Class)moduleClass;
+
+@optional
 
 /**
  * Create an instance of a TurboModule without relying on any ObjC++ module instance.

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.h
@@ -19,12 +19,12 @@ RCT_EXTERN void RCTTurboModuleSetBindingMode(facebook::react::TurboModuleBinding
 
 @protocol RCTTurboModuleManagerDelegate <NSObject>
 
-@optional
-
 /**
- * Given a module name, return its actual class. If not provided, basic ObjC class lookup is performed.
+ * Given a module name, return its actual class. If nil is returned, basic ObjC class lookup is performed.
  */
 - (Class)getModuleClassFromName:(const char *)name;
+
+@optional
 
 /**
  * Given a module class, provide an instance for it. If not provided, default initializer is used.

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
@@ -388,14 +388,11 @@ static Class getFallbackClassFromName(const char *name)
     /**
      * Step 2a: Resolve platform-specific class.
      */
-
-    if ([_delegate respondsToSelector:@selector(getModuleClassFromName:)]) {
-      if (RCTTurboModuleManagerDelegateLockingDisabled()) {
-        moduleClass = [_delegate getModuleClassFromName:moduleName];
-      } else {
-        std::lock_guard<std::mutex> delegateGuard(_turboModuleManagerDelegateMutex);
-        moduleClass = [_delegate getModuleClassFromName:moduleName];
-      }
+    if (RCTTurboModuleManagerDelegateLockingDisabled()) {
+      moduleClass = [_delegate getModuleClassFromName:moduleName];
+    } else {
+      std::lock_guard<std::mutex> delegateGuard(_turboModuleManagerDelegateMutex);
+      moduleClass = [_delegate getModuleClassFromName:moduleName];
     }
 
     if (!moduleClass) {


### PR DESCRIPTION
Summary:
Changelog: [iOS][Breaking]

continuing getting rid of optional methods, but this does have a behavioral change. if the delegate does not provide the module instance, then we lazily create it. before we were returning nil, idk why. this will be a breaking change if you have any classes that conform to `RCTTurboModuleManagerDelegate`

#saynotoruntimechecks

Reviewed By: cipolleschi

Differential Revision: D45022139

