### PR TITLE
Remove YGTraversePreOrder

### DIFF
--- a/packages/react-native/ReactCommon/yoga/yoga/Yoga.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/Yoga.cpp
@@ -4347,22 +4347,3 @@ YOGA_EXPORT void YGConfigSetCloneNodeFunc(
     const YGCloneNodeFunc callback) {
   config->setCloneNodeCallback(callback);
 }
-
-static void YGTraverseChildrenPreOrder(
-    const YGVector& children,
-    const std::function<void(YGNodeRef node)>& f) {
-  for (YGNodeRef node : children) {
-    f(node);
-    YGTraverseChildrenPreOrder(node->getChildren(), f);
-  }
-}
-
-void YGTraversePreOrder(
-    YGNodeRef const node,
-    std::function<void(YGNodeRef node)>&& f) {
-  if (!node) {
-    return;
-  }
-  f(node);
-  YGTraverseChildrenPreOrder(node->getChildren(), f);
-}

--- a/packages/react-native/ReactCommon/yoga/yoga/Yoga.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/Yoga.h
@@ -367,13 +367,7 @@ YG_EXTERN_C_END
 
 #ifdef __cplusplus
 
-#include <functional>
 #include <vector>
-
-// Calls f on each node in the tree including the given node argument.
-void YGTraversePreOrder(
-    YGNodeRef node,
-    std::function<void(YGNodeRef node)>&& f);
 
 void YGNodeSetChildren(YGNodeRef owner, const std::vector<YGNodeRef>& children);
 


### PR DESCRIPTION
Summary: This is unused, and kinda missed the intent of Yoga.h and YG* functions being a C ABI.

Reviewed By: rshest

Differential Revision: D45138646

