### PR TITLE
AGP to 8.0.2

### DIFF
--- a/.circleci/Dockerfiles/Dockerfile.android
+++ b/.circleci/Dockerfiles/Dockerfile.android
@@ -14,7 +14,7 @@
 # and build a Android application that can be used to run the
 # tests specified in the scripts/ directory.
 #
-FROM reactnativecommunity/react-native-android:8.0
+FROM reactnativecommunity/react-native-android:9.0
 
 LABEL Description="React Native Android Test Image"
 LABEL maintainer="Meta Open Source <opensource@meta.com>"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ executors:
   reactnativeandroid:
     <<: *defaults
     docker:
-      - image: reactnativecommunity/react-native-android:8.0
+      - image: reactnativecommunity/react-native-android:9.0
     resource_class: "xlarge"
     environment:
       - TERM: "dumb"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,8 +7,8 @@
 
 plugins {
   id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
-  id("com.android.library") version "7.4.2" apply false
-  id("com.android.application") version "7.4.2" apply false
+  id("com.android.library") version "8.0.2" apply false
+  id("com.android.application") version "8.0.2" apply false
   id("de.undercouch.download") version "5.0.1" apply false
   kotlin("android") version "1.8.0" apply false
 }
@@ -30,7 +30,7 @@ version =
 group = "com.facebook.react"
 
 val ndkPath by extra(System.getenv("ANDROID_NDK"))
-val ndkVersion by extra(System.getenv("ANDROID_NDK_VERSION"))
+val ndkVersion by extra(System.getenv("ANDROID_NDK_VERSION") ?: "23.1.7779620")
 val sonatypeUsername = findProperty("SONATYPE_USERNAME")?.toString()
 val sonatypePassword = findProperty("SONATYPE_PASSWORD")?.toString()
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "prettier": "prettier --write \"./**/*.{js,md,yml,ts,tsx}\"",
     "format-check": "prettier --list-different \"./**/*.{js,md,yml,ts,tsx}\"",
     "update-lock": "npx yarn-deduplicate",
-    "docker-setup-android": "docker pull reactnativecommunity/react-native-android:8.0",
+    "docker-setup-android": "docker pull reactnativecommunity/react-native-android:9.0",
     "docker-build-android": "docker build -t reactnativeci/android -f .circleci/Dockerfiles/Dockerfile.android .",
     "test-android-run-instrumentation": "docker run --cap-add=SYS_ADMIN -it reactnativeci/android bash .circleci/Dockerfiles/scripts/run-android-docker-instrumentation-tests.sh",
     "test-android-run-unit": "docker run --cap-add=SYS_ADMIN -it reactnativeci/android bash .circleci/Dockerfiles/scripts/run-android-docker-unit-tests.sh",

--- a/packages/react-native-gradle-plugin/build.gradle.kts
+++ b/packages/react-native-gradle-plugin/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
   // The KGP/AGP version is defined by React Native Gradle plugin.
   // Therefore we specify an implementation dep rather than a compileOnly.
   implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.0")
-  implementation("com.android.tools.build:gradle:7.4.2")
+  implementation("com.android.tools.build:gradle:8.0.2")
 
   implementation("com.google.code.gson:gson:2.8.9")
   implementation("com.google.guava:guava:31.0.1-jre")
@@ -55,11 +55,14 @@ dependencies {
 }
 
 java {
+  // We intentionally don't build for Java 17 as users will see a cryptic bytecode version
+  // error first. Instead we produce a Java 11-compatible Gradle Plugin, so that AGP can print their
+  // nice message showing that JDK 11 (or 17) is required first
   sourceCompatibility = JavaVersion.VERSION_11
   targetCompatibility = JavaVersion.VERSION_11
 }
 
-kotlin { jvmToolchain(11) }
+kotlin { jvmToolchain(17) }
 
 tasks.withType<KotlinCompile> {
   kotlinOptions {

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
@@ -86,13 +86,13 @@ class ReactPlugin : Plugin<Project> {
 
   private fun checkJvmVersion(project: Project) {
     val jvmVersion = Jvm.current()?.javaVersion?.majorVersion
-    if ((jvmVersion?.toIntOrNull() ?: 0) <= 8) {
+    if ((jvmVersion?.toIntOrNull() ?: 0) <= 16) {
       project.logger.error(
           """
 
       ********************************************************************************
 
-      ERROR: requires JDK11 or higher.
+      ERROR: requires JDK17 or higher.
       Incompatible major version detected: '$jvmVersion'
 
       ********************************************************************************

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/AgpConfiguratorUtils.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/AgpConfiguratorUtils.kt
@@ -21,6 +21,7 @@ internal object AgpConfiguratorUtils {
     val action =
         Action<AppliedPlugin> {
           project.extensions.getByType(AndroidComponentsExtension::class.java).finalizeDsl { ext ->
+            ext.buildFeatures.buildConfig = true
             ext.defaultConfig.buildConfigField(
                 "boolean", "IS_NEW_ARCHITECTURE_ENABLED", project.isNewArchEnabled.toString())
             ext.defaultConfig.buildConfigField(

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/JdkConfiguratorUtils.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/JdkConfiguratorUtils.kt
@@ -19,28 +19,33 @@ internal object JdkConfiguratorUtils {
   /**
    * Function that takes care of configuring the JDK toolchain for all the projects projects. As we
    * do decide the JDK version based on the AGP version that RNGP brings over, here we can safely
-   * configure the toolchain to 11.
+   * configure the toolchain to 17.
    */
   fun configureJavaToolChains(input: Project) {
+    // Check at the app level if react.internal.disableJavaVersionAlignment is set.
     if (input.hasProperty(INTERNAL_DISABLE_JAVA_VERSION_ALIGNMENT)) {
       return
     }
     input.rootProject.allprojects { project ->
+      // Allows every single module to set react.internal.disableJavaVersionAlignment also.
+      if (project.hasProperty(INTERNAL_DISABLE_JAVA_VERSION_ALIGNMENT)) {
+        return@allprojects
+      }
       val action =
           Action<AppliedPlugin> {
             project.extensions.getByType(AndroidComponentsExtension::class.java).finalizeDsl { ext
               ->
-              ext.compileOptions.sourceCompatibility = JavaVersion.VERSION_11
-              ext.compileOptions.targetCompatibility = JavaVersion.VERSION_11
+              ext.compileOptions.sourceCompatibility = JavaVersion.VERSION_17
+              ext.compileOptions.targetCompatibility = JavaVersion.VERSION_17
             }
           }
       project.pluginManager.withPlugin("com.android.application", action)
       project.pluginManager.withPlugin("com.android.library", action)
       project.pluginManager.withPlugin("org.jetbrains.kotlin.android") {
-        project.extensions.getByType(KotlinTopLevelExtension::class.java).jvmToolchain(11)
+        project.extensions.getByType(KotlinTopLevelExtension::class.java).jvmToolchain(17)
       }
       project.pluginManager.withPlugin("org.jetbrains.kotlin.jvm") {
-        project.extensions.getByType(KotlinTopLevelExtension::class.java).jvmToolchain(11)
+        project.extensions.getByType(KotlinTopLevelExtension::class.java).jvmToolchain(17)
       }
     }
   }

--- a/packages/react-native/ReactAndroid/build.gradle
+++ b/packages/react-native/ReactAndroid/build.gradle
@@ -594,6 +594,7 @@ android {
     buildFeatures {
         prefab true
         prefabPublishing !skipPrefabPublishing
+        buildConfig true
     }
 
     prefab {
@@ -751,6 +752,8 @@ react {
 }
 
 kotlin {
+    // We intentionally don't build on JDK 17 as our tests are broken due to Mockito/PowerMock
+    // not running well on JDK 17.
     jvmToolchain(11)
 }
 

--- a/packages/react-native/ReactAndroid/gradle.properties
+++ b/packages/react-native/ReactAndroid/gradle.properties
@@ -33,3 +33,7 @@ GTEST_VERSION=1.12.1
 
 android.useAndroidX=true
 android.enableJetifier=true
+
+# We want to have more fine grained control on the Java version for
+# ReactAndroid, therefore we disable RGNP Java version alignment mechanism
+react.internal.disableJavaVersionAlignment=true

--- a/packages/react-native/ReactAndroid/hermes-engine/build.gradle
+++ b/packages/react-native/ReactAndroid/hermes-engine/build.gradle
@@ -202,6 +202,8 @@ android {
     }
 
     kotlin {
+        // We intentionally don't build on JDK 17 to keep this version aligned with
+        // the JVM toolchain of :ReactAndroid
         jvmToolchain(11)
     }
 

--- a/packages/react-native/build.gradle.kts
+++ b/packages/react-native/build.gradle.kts
@@ -11,8 +11,8 @@
 // their settings.gradle.kts file.
 // More on this here: https://reactnative.dev/contributing/how-to-build-from-source
 plugins {
-  id("com.android.library") version "7.4.2" apply false
-  id("com.android.application") version "7.4.2" apply false
+  id("com.android.library") version "8.0.2" apply false
+  id("com.android.application") version "8.0.2" apply false
   id("de.undercouch.download") version "5.0.1" apply false
   kotlin("android") version "1.8.0" apply false
 }


### PR DESCRIPTION
Summary:
This bumps the version of AGP to the latest stable.
There was a breaking change in how buildConfig are built which I had to handle.
This also requires a bump of RNGP to work correctly.

Changelog:
[Android] [Changed] - AGP to 8.0.0

Differential Revision: D45178748

