### PR TITLE
Fix outdated viewport offset on Fabric surface

### DIFF
--- a/packages/react-native/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingView.mm
+++ b/packages/react-native/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingView.mm
@@ -74,9 +74,9 @@ RCT_NOT_IMPLEMENTED(-(nullable instancetype)initWithCoder : (NSCoder *)coder)
   [_surface stop];
 }
 
-- (void)setFrame:(CGRect)frame
+- (void)layoutSubviews
 {
-  [super setFrame:frame];
+  [super layoutSubviews];
 
   CGSize minimumSize;
   CGSize maximumSize;


### PR DESCRIPTION
Summary:
changelog: [internal]

if host view's position on screen changes, `RootShadowNode` has to be notified of this. Otherwise the state of UI is not correctly reflected in ShadowTree, leading to inconsistencies. For example, when trying to get views position in window, it won't be correct when hosting view isn't full screen.
Overriding `setFrame` only works for cases where it is hosting view's parent changing its position. But there are other cases where the position may change on the screen, like when hosting view's parent is moved by movable navigation bar. This does not affect frame of hosting view but it does change its position on the screen. To know about this event, we need to override `layoutSubviews`. `layoutSubviews` is called by UIKit whenever its internal flag `_needsLayout` is set to YES.

Differential Revision: D45122502

