### PR TITLE
Reset internal state of RCTScrollViewComponentView in scrollViewDidEndDragging

### DIFF
--- a/packages/react-native/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingView.mm
+++ b/packages/react-native/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingView.mm
@@ -74,9 +74,9 @@ RCT_NOT_IMPLEMENTED(-(nullable instancetype)initWithCoder : (NSCoder *)coder)
   [_surface stop];
 }
 
-- (void)setFrame:(CGRect)frame
+- (void)layoutSubviews
 {
-  [super setFrame:frame];
+  [super layoutSubviews];
 
   CGSize minimumSize;
   CGSize maximumSize;

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -492,7 +492,14 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrol
   }
 
   std::static_pointer_cast<ScrollViewEventEmitter const>(_eventEmitter)->onScrollEndDrag([self _scrollViewMetrics]);
+
   [self _updateStateWithContentOffset];
+
+  if (!decelerate) {
+    // ScrollView will not decelerate and `scrollViewDidEndDecelerating` will not be called.
+    // `_isUserTriggeredScrolling` must be set to NO here.
+    _isUserTriggeredScrolling = NO;
+  }
 }
 
 - (void)scrollViewWillBeginDecelerating:(UIScrollView *)scrollView


### PR DESCRIPTION
Summary:
changelog: [internal]

`_isUserTriggeredScrolling` must be NO when user interaction stops. This was not the case when user scrolled -> lifted finger but the scroll did not decelerate into position. The case with deceleration is handled in method `scrollViewDidEndDecelerating`.

Reviewed By: javache

Differential Revision: D45147325

