### PR TITLE
Remove getNative* TurboModuleRegistry APIs

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java
@@ -457,7 +457,7 @@ public class CatalystInstanceImpl implements CatalystInstance {
   @Override
   public <T extends NativeModule> boolean hasNativeModule(Class<T> nativeModuleInterface) {
     String moduleName = getNameFromAnnotation(nativeModuleInterface);
-    return getTurboModuleRegistry() != null && getTurboModuleRegistry().hasNativeModule(moduleName)
+    return getTurboModuleRegistry() != null && getTurboModuleRegistry().hasModule(moduleName)
         ? true
         : mNativeModuleRegistry.hasModule(moduleName);
   }
@@ -482,7 +482,7 @@ public class CatalystInstanceImpl implements CatalystInstance {
   @Nullable
   public NativeModule getNativeModule(String moduleName) {
     if (getTurboModuleRegistry() != null) {
-      NativeModule module = getTurboModuleRegistry().getNativeModule(moduleName);
+      NativeModule module = getTurboModuleRegistry().getModule(moduleName);
       if (module != null) {
         return module;
       }
@@ -509,7 +509,7 @@ public class CatalystInstanceImpl implements CatalystInstance {
     nativeModules.addAll(mNativeModuleRegistry.getAllModules());
 
     if (getTurboModuleRegistry() != null) {
-      for (NativeModule module : getTurboModuleRegistry().getNativeModules()) {
+      for (NativeModule module : getTurboModuleRegistry().getModules()) {
         nativeModules.add(module);
       }
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactInstance.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactInstance.java
@@ -198,7 +198,7 @@ public final class ReactInstance {
 
     // Eagerly initialize TurboModules
     for (String moduleName : mTurboModuleManager.getEagerInitModuleNames()) {
-      mTurboModuleManager.getNativeModule(moduleName);
+      mTurboModuleManager.getModule(moduleName);
     }
 
     Systrace.endSection(Systrace.TRACE_TAG_REACT_JAVA_BRIDGE);
@@ -290,14 +290,14 @@ public final class ReactInstance {
   public <T extends NativeModule> boolean hasNativeModule(Class<T> nativeModuleInterface) {
     ReactModule annotation = nativeModuleInterface.getAnnotation(ReactModule.class);
     if (annotation != null) {
-      return mTurboModuleManager.hasNativeModule(annotation.name());
+      return mTurboModuleManager.hasModule(annotation.name());
     }
     return false;
   }
 
   public Collection<NativeModule> getNativeModules() {
     Collection<NativeModule> nativeModules = new ArrayList<>();
-    for (NativeModule module : mTurboModuleManager.getNativeModules()) {
+    for (NativeModule module : mTurboModuleManager.getModules()) {
       nativeModules.add(module);
     }
     return nativeModules;
@@ -313,7 +313,7 @@ public final class ReactInstance {
 
   public @Nullable NativeModule getNativeModule(String nativeModuleName) {
     synchronized (mTurboModuleManager) {
-      return mTurboModuleManager.getNativeModule(nativeModuleName);
+      return mTurboModuleManager.getModule(nativeModuleName);
     }
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/interfaces/TurboModuleRegistry.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/interfaces/TurboModuleRegistry.java
@@ -20,35 +20,18 @@ import java.util.List;
  */
 public interface TurboModuleRegistry {
   /**
-   * Return the TurboModule instance that has that name `moduleName`. If the `moduleName`
+   * Return the NativeModule instance that has that name `moduleName`. If the `moduleName`
    * TurboModule hasn't been instantiated, instantiate it. If no TurboModule is registered under
    * `moduleName`, return null.
    */
-  @Deprecated
   @Nullable
-  TurboModule getModule(String moduleName);
+  NativeModule getModule(String moduleName);
 
-  /** Get all instantiated TurboModules. */
-  @Deprecated
-  Collection<TurboModule> getModules();
-
-  /** Has the TurboModule with name `moduleName` been instantiated? */
-  @Deprecated
-  boolean hasModule(String moduleName);
-
-  /**
-   * Return the NativeModule instance that has that name `moduleName`. If the `moduleName`
-   * NativeModule hasn't been instantiated, instantiate it. If no NativeModule is registered under
-   * `moduleName`, return null.
-   */
-  @Nullable
-  NativeModule getNativeModule(String moduleName);
-
-  /** Get all instantiated NativeModule. */
-  Collection<NativeModule> getNativeModules();
+  /** Get all instantiated NativeModules. */
+  Collection<NativeModule> getModules();
 
   /** Has the NativeModule with name `moduleName` been instantiated? */
-  boolean hasNativeModule(String moduleName);
+  boolean hasModule(String moduleName);
 
   /**
    * Return the names of all the NativeModules that are supposed to be eagerly initialized. By


### PR DESCRIPTION
Summary:
These getNative* TurboModuleRegistry APIs make the TurboModuleManager harder to understand. They should have never been introduced.

Let's remove them for added clarity.

Changelog: [Android][Removed] - Remove TurboModuleManager.getNativeModule,getNativeModules,hasNativeModule

Reviewed By: mdvacca

Differential Revision: D45158032

