### PR TITLE
Reduce visibility of BridgelessDevSupportManager class

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/BridgelessAtomicRef.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/BridgelessAtomicRef.java
@@ -14,7 +14,7 @@ import androidx.annotation.Nullable;
 import com.facebook.infer.annotation.Nullsafe;
 
 @Nullsafe(Nullsafe.Mode.LOCAL)
-public class BridgelessAtomicRef<T> {
+class BridgelessAtomicRef<T> {
 
   interface Provider<T> {
     T get();

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/BridgelessDevSupportManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/BridgelessDevSupportManager.java
@@ -30,7 +30,7 @@ import javax.annotation.Nullable;
  * APIs for asynchronously loading the JS bundle.
  */
 @Nullsafe(Nullsafe.Mode.LOCAL)
-public class BridgelessDevSupportManager extends DevSupportManagerBase {
+class BridgelessDevSupportManager extends DevSupportManagerBase {
 
   private final ReactHost mReactHost;
 


### PR DESCRIPTION
Summary:
This diff I'm reducing visibility of BridgelessDevSupportManager to package only

changelog: [internal] internal

Differential Revision: D45192195

