### PR TITLE
Refactor ReactInstance to reduce visibility

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/BridgelessReactStateTracker.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/BridgelessReactStateTracker.java
@@ -15,21 +15,18 @@ import java.util.List;
 
 @Nullsafe(Nullsafe.Mode.LOCAL)
 class BridgelessReactStateTracker {
-  final List<String> mStates = Collections.synchronizedList(new ArrayList<String>());
-  final boolean mShouldTrackStates;
+  private static final String TAG = "BridgelessReact";
+  private final List<String> mStates = Collections.synchronizedList(new ArrayList<>());
+  private final boolean mShouldTrackStates;
 
   BridgelessReactStateTracker(boolean shouldTrackStates) {
     mShouldTrackStates = shouldTrackStates;
   }
 
-  public void enterState(String state) {
-    FLog.w("BridgelessReact", state);
+  void enterState(String state) {
+    FLog.w(TAG, state);
     if (mShouldTrackStates) {
       mStates.add(state);
     }
-  }
-
-  public void assertStateOrder(String... expectedStates) {
-    // TODO: Implement
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHost.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHost.java
@@ -1398,7 +1398,7 @@ public class ReactHost {
 
         // Noop on redundant calls to destroyReactInstance()
         if (instance == null) {
-          log(method, "ReactInstance nil");
+          log(method, "ReactInstance is null");
           return;
         }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactInstance.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactInstance.java
@@ -68,7 +68,7 @@ import javax.annotation.Nullable;
  */
 @Nullsafe(Nullsafe.Mode.LOCAL)
 @ThreadSafe
-public final class ReactInstance {
+final class ReactInstance {
 
   private static final String TAG = ReactInstance.class.getSimpleName();
 


### PR DESCRIPTION
Summary:
ReactInstance is not meant to be used outside of bridgless package, this diff reduces its visibility.

changelog: [internal] internal

Differential Revision: D45197462

