### PR TITLE
Emit logs in "module not found" scenarios

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackageTurboModuleManagerDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackageTurboModuleManagerDelegate.java
@@ -168,6 +168,26 @@ public abstract class ReactPackageTurboModuleManagerDelegate extends TurboModule
     return (TurboModule) resolvedModule;
   }
 
+  public boolean unstable_isModuleRegistered(String moduleName) {
+    for (final ModuleProvider moduleProvider : mModuleProviders) {
+      final ReactModuleInfo moduleInfo = mPackageModuleInfos.get(moduleProvider).get(moduleName);
+      if (moduleInfo != null && moduleInfo.isTurboModule()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  public boolean unstable_isLegacyModuleRegistered(String moduleName) {
+    for (final ModuleProvider moduleProvider : mModuleProviders) {
+      final ReactModuleInfo moduleInfo = mPackageModuleInfos.get(moduleProvider).get(moduleName);
+      if (moduleInfo != null && !moduleInfo.isTurboModule()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   @Nullable
   @Override
   public NativeModule getLegacyModule(String moduleName) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackageTurboModuleManagerDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackageTurboModuleManagerDelegate.java
@@ -219,13 +219,6 @@ public abstract class ReactPackageTurboModuleManagerDelegate extends TurboModule
     return resolvedModule;
   }
 
-  @Deprecated
-  @Nullable
-  @Override
-  public CxxModuleWrapper getLegacyCxxModule(String moduleName) {
-    return null;
-  }
-
   @Override
   public List<String> getEagerInitModuleNames() {
     List<String> moduleNames = new ArrayList<>();

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackageTurboModuleManagerDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackageTurboModuleManagerDelegate.java
@@ -52,11 +52,7 @@ public abstract class ReactPackageTurboModuleManagerDelegate extends TurboModule
       if (reactPackage instanceof TurboReactPackage) {
         final TurboReactPackage turboPkg = (TurboReactPackage) reactPackage;
         final ModuleProvider moduleProvider =
-            new ModuleProvider() {
-              public NativeModule getModule(String moduleName) {
-                return turboPkg.getModule(moduleName, applicationContext);
-              }
-            };
+            moduleName -> turboPkg.getModule(moduleName, applicationContext);
         mModuleProviders.add(moduleProvider);
         mPackageModuleInfos.put(
             moduleProvider, turboPkg.getReactModuleInfoProvider().getReactModuleInfos());
@@ -73,11 +69,9 @@ public abstract class ReactPackageTurboModuleManagerDelegate extends TurboModule
         }
 
         final ModuleProvider moduleProvider =
-            new ModuleProvider() {
-              public NativeModule getModule(String moduleName) {
-                Provider<? extends NativeModule> provider = moduleSpecProviderMap.get(moduleName);
-                return provider != null ? provider.get() : null;
-              }
+            moduleName -> {
+              Provider<? extends NativeModule> provider = moduleSpecProviderMap.get(moduleName);
+              return provider != null ? provider.get() : null;
             };
 
         mModuleProviders.add(moduleProvider);
@@ -130,12 +124,7 @@ public abstract class ReactPackageTurboModuleManagerDelegate extends TurboModule
           moduleMap.put(moduleName, module);
         }
 
-        final ModuleProvider moduleProvider =
-            new ModuleProvider() {
-              public NativeModule getModule(String moduleName) {
-                return moduleMap.get(moduleName);
-              }
-            };
+        final ModuleProvider moduleProvider = moduleMap::get;
 
         mModuleProviders.add(moduleProvider);
         mPackageModuleInfos.put(moduleProvider, reactModuleInfoMap);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java
@@ -457,7 +457,7 @@ public class CatalystInstanceImpl implements CatalystInstance {
   @Override
   public <T extends NativeModule> boolean hasNativeModule(Class<T> nativeModuleInterface) {
     String moduleName = getNameFromAnnotation(nativeModuleInterface);
-    return getTurboModuleRegistry() != null && getTurboModuleRegistry().hasNativeModule(moduleName)
+    return getTurboModuleRegistry() != null && getTurboModuleRegistry().hasModule(moduleName)
         ? true
         : mNativeModuleRegistry.hasModule(moduleName);
   }
@@ -482,7 +482,7 @@ public class CatalystInstanceImpl implements CatalystInstance {
   @Nullable
   public NativeModule getNativeModule(String moduleName) {
     if (getTurboModuleRegistry() != null) {
-      NativeModule module = getTurboModuleRegistry().getNativeModule(moduleName);
+      NativeModule module = getTurboModuleRegistry().getModule(moduleName);
       if (module != null) {
         return module;
       }
@@ -509,7 +509,7 @@ public class CatalystInstanceImpl implements CatalystInstance {
     nativeModules.addAll(mNativeModuleRegistry.getAllModules());
 
     if (getTurboModuleRegistry() != null) {
-      for (NativeModule module : getTurboModuleRegistry().getNativeModules()) {
+      for (NativeModule module : getTurboModuleRegistry().getModules()) {
         nativeModules.add(module);
       }
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactInstance.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactInstance.java
@@ -198,7 +198,7 @@ public final class ReactInstance {
 
     // Eagerly initialize TurboModules
     for (String moduleName : mTurboModuleManager.getEagerInitModuleNames()) {
-      mTurboModuleManager.getNativeModule(moduleName);
+      mTurboModuleManager.getModule(moduleName);
     }
 
     Systrace.endSection(Systrace.TRACE_TAG_REACT_JAVA_BRIDGE);
@@ -290,14 +290,14 @@ public final class ReactInstance {
   public <T extends NativeModule> boolean hasNativeModule(Class<T> nativeModuleInterface) {
     ReactModule annotation = nativeModuleInterface.getAnnotation(ReactModule.class);
     if (annotation != null) {
-      return mTurboModuleManager.hasNativeModule(annotation.name());
+      return mTurboModuleManager.hasModule(annotation.name());
     }
     return false;
   }
 
   public Collection<NativeModule> getNativeModules() {
     Collection<NativeModule> nativeModules = new ArrayList<>();
-    for (NativeModule module : mTurboModuleManager.getNativeModules()) {
+    for (NativeModule module : mTurboModuleManager.getModules()) {
       nativeModules.add(module);
     }
     return nativeModules;
@@ -313,7 +313,7 @@ public final class ReactInstance {
 
   public @Nullable NativeModule getNativeModule(String nativeModuleName) {
     synchronized (mTurboModuleManager) {
-      return mTurboModuleManager.getNativeModule(nativeModuleName);
+      return mTurboModuleManager.getModule(nativeModuleName);
     }
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/TurboModuleManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/TurboModuleManager.java
@@ -75,21 +75,7 @@ public class TurboModuleManager implements JSIModule, TurboModuleRegistry {
     mTurboModuleProvider =
         delegate == null
             ? nullProvider
-            : moduleName -> {
-              NativeModule module = (NativeModule) delegate.getModule(moduleName);
-              if (module == null) {
-                CxxModuleWrapper legacyCxxModule = delegate.getLegacyCxxModule(moduleName);
-
-                if (legacyCxxModule != null) {
-                  // TurboModuleManagerDelegate.getLegacyCxxModule() must always return TurboModules
-                  Assertions.assertCondition(
-                      legacyCxxModule instanceof TurboModule,
-                      "CxxModuleWrapper \"" + moduleName + "\" is not a TurboModule");
-                  return legacyCxxModule;
-                }
-              }
-              return module;
-            };
+            : moduleName -> (NativeModule) delegate.getModule(moduleName);
 
     mLegacyModuleProvider =
         delegate == null || !shouldCreateLegacyModules()

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/TurboModuleManagerDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/TurboModuleManagerDelegate.java
@@ -10,7 +10,6 @@ package com.facebook.react.turbomodule.core;
 import androidx.annotation.Nullable;
 import com.facebook.jni.HybridData;
 import com.facebook.proguard.annotations.DoNotStrip;
-import com.facebook.react.bridge.CxxModuleWrapper;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.turbomodule.core.interfaces.TurboModule;
 import com.facebook.soloader.SoLoader;
@@ -38,16 +37,6 @@ public abstract class TurboModuleManagerDelegate {
    */
   @Nullable
   public abstract TurboModule getModule(String moduleName);
-
-  /**
-   * Create and return a CxxModuleWrapper NativeModule with name `moduleName`. If `moduleName` isn't
-   * a CxxModule, return null. CxxModuleWrapper must implement TurboModule.
-   *
-   * <p>Deprecated. Please just return your CxxModuleWrappers from getModule.
-   */
-  @Deprecated
-  @Nullable
-  public abstract CxxModuleWrapper getLegacyCxxModule(String moduleName);
 
   /**
    * Create an return a legacy NativeModule with name `moduleName`. If `moduleName` is a

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/TurboModuleManagerDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/TurboModuleManagerDelegate.java
@@ -38,6 +38,8 @@ public abstract class TurboModuleManagerDelegate {
   @Nullable
   public abstract TurboModule getModule(String moduleName);
 
+  public abstract boolean unstable_isModuleRegistered(String moduleName);
+
   /**
    * Create an return a legacy NativeModule with name `moduleName`. If `moduleName` is a
    * TurboModule, return null.
@@ -46,6 +48,10 @@ public abstract class TurboModuleManagerDelegate {
   public NativeModule getLegacyModule(String moduleName) {
     return null;
   }
+
+  public boolean unstable_isLegacyModuleRegistered(String moduleName) {
+    return false;
+  };
 
   public List<String> getEagerInitModuleNames() {
     return new ArrayList<>();

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/interfaces/TurboModuleRegistry.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/interfaces/TurboModuleRegistry.java
@@ -20,35 +20,18 @@ import java.util.List;
  */
 public interface TurboModuleRegistry {
   /**
-   * Return the TurboModule instance that has that name `moduleName`. If the `moduleName`
+   * Return the NativeModule instance that has that name `moduleName`. If the `moduleName`
    * TurboModule hasn't been instantiated, instantiate it. If no TurboModule is registered under
    * `moduleName`, return null.
    */
-  @Deprecated
   @Nullable
-  TurboModule getModule(String moduleName);
+  NativeModule getModule(String moduleName);
 
-  /** Get all instantiated TurboModules. */
-  @Deprecated
-  Collection<TurboModule> getModules();
-
-  /** Has the TurboModule with name `moduleName` been instantiated? */
-  @Deprecated
-  boolean hasModule(String moduleName);
-
-  /**
-   * Return the NativeModule instance that has that name `moduleName`. If the `moduleName`
-   * NativeModule hasn't been instantiated, instantiate it. If no NativeModule is registered under
-   * `moduleName`, return null.
-   */
-  @Nullable
-  NativeModule getNativeModule(String moduleName);
-
-  /** Get all instantiated NativeModule. */
-  Collection<NativeModule> getNativeModules();
+  /** Get all instantiated NativeModules. */
+  Collection<NativeModule> getModules();
 
   /** Has the NativeModule with name `moduleName` been instantiated? */
-  boolean hasNativeModule(String moduleName);
+  boolean hasModule(String moduleName);
 
   /**
    * Return the names of all the NativeModules that are supposed to be eagerly initialized. By


### PR DESCRIPTION
Summary:
In the TurboModule interop layer, several modules are appearing as null. It's unclear why. We landed a few module resolution simplification diffs, to *attempt* to mitigate the problem: D45131297. But we're not sure if those diffs will be 100% successful.

So, this diff inserts two logs into the TurboModule system, for scenarios we know could lead to TurboModules being null. The hope: this helps us understand the actual problem, in case our earlier fix attempt (i.e: D45131297) fails.

Notes:
- These logs are temporary.
- These logs will only run in the TurboModule interop's test group.

Changelog: [Internal]

Reviewed By: mdvacca

Differential Revision: D45197703

