### PR TITLE
Reduce visibility of BridgelessAtomicRef to package

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/BridgelessAtomicRef.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/BridgelessAtomicRef.java
@@ -14,7 +14,7 @@ import androidx.annotation.Nullable;
 import com.facebook.infer.annotation.Nullsafe;
 
 @Nullsafe(Nullsafe.Mode.LOCAL)
-public class BridgelessAtomicRef<T> {
+class BridgelessAtomicRef<T> {
 
   interface Provider<T> {
     T get();


### PR DESCRIPTION
Summary:
BridgelessAtomicRef is only used in com.facebook.react.bridgeless, we reduce visibility to package only

changelog: [internal] internal

Differential Revision: D45192193

