### PR TITLE
Remove "activityindicator" subspec from React-Fabric pod

### DIFF
--- a/packages/react-native/ReactCommon/React-Fabric.podspec
+++ b/packages/react-native/ReactCommon/React-Fabric.podspec
@@ -120,14 +120,6 @@ Pod::Spec.new do |s|
   end
 
   s.subspec "components" do |ss|
-    ss.subspec "activityindicator" do |sss|
-      sss.dependency             folly_dep_name, folly_version
-      sss.compiler_flags       = folly_compiler_flags
-      sss.source_files         = "react/renderer/components/activityindicator/**/*.{m,mm,cpp,h}"
-      sss.exclude_files        = "react/renderer/components/activityindicator/tests"
-      sss.header_dir           = "react/renderer/components/activityindicator"
-    end
-
     ss.subspec "image" do |sss|
       sss.dependency             folly_dep_name, folly_version
       sss.compiler_flags       = folly_compiler_flags


### PR DESCRIPTION
Summary:
This directory doesn't exist.

Changelog: [Internal]

Differential Revision: D45204159

