### PR TITLE
Modify ViewManager.receiveCommand to call into delegate

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java
@@ -860,12 +860,7 @@ public class NativeViewHierarchyManager {
               + commandId);
     }
     ViewManager viewManager = resolveViewManager(reactTag);
-    ViewManagerDelegate delegate = viewManager.getDelegate();
-    if (delegate != null) {
-      delegate.receiveCommand(view, commandId, args);
-    } else {
-      viewManager.receiveCommand(view, commandId, args);
-    }
+    viewManager.receiveCommand(view, commandId, args);
   }
 
   /**

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManager.java
@@ -285,7 +285,12 @@ public abstract class ViewManager<T extends View, C extends ReactShadowNode>
    * @param commandId code of the command
    * @param args optional arguments for the command
    */
-  public void receiveCommand(@NonNull T root, String commandId, @Nullable ReadableArray args) {}
+  public void receiveCommand(@NonNull T root, String commandId, @Nullable ReadableArray args) {
+    final ViewManagerDelegate<T> delegate = getDelegate();
+    if (delegate != null) {
+      delegate.receiveCommand(root, commandId, args);
+    }
+  }
 
   /**
    * Subclasses of {@link ViewManager} that expect to receive commands through {@link


### PR DESCRIPTION
Summary:
This diff fixes an issue where codegened native commands are not able to be triggered, as codegen adds command handling to the delegate. This also brings how receiveCommand is handled into parity with how setProperties is called on the delegate.

Changelog:
[Fixed][Android] - Modify ViewManager.receiveCommand to call into delegate

Differential Revision: D45236213

