### PR TITLE
[Codegen 109] extract throwIfEventHasNoName into error-utils

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
@@ -33,6 +33,7 @@ const {
   throwIfPartialNotAnnotatingTypeParameter,
   throwIfPartialWithMoreParameter,
   throwIfMoreThanOneCodegenNativecommands,
+  throwIfEventHasNoName,
 } = require('../error-utils');
 const {
   UnsupportedModulePropertyParserError,
@@ -902,6 +903,50 @@ describe('throwIfMoreThanOneConfig', () => {
     ];
     expect(() => {
       throwIfMoreThanOneConfig(configs);
+    }).not.toThrow();
+  });
+});
+
+describe('throwIfEventHasNoName', () => {
+  const flowParser = new FlowParser();
+  const typescriptParser = new TypeScriptParser();
+
+  it('throws an error if typeAnnotation of event have no name in Flow', () => {
+    const typeAnnotation = {};
+    expect(() => {
+      throwIfEventHasNoName(typeAnnotation, flowParser);
+    }).toThrowError(`typeAnnotation of event doesn't have a name`);
+  });
+
+  it('does not throw an error if typeAnnotation of event have a name in Flow', () => {
+    const typeAnnotation = {
+      id: {
+        name: 'BubblingEventHandler',
+      },
+    };
+
+    expect(() => {
+      throwIfEventHasNoName(typeAnnotation, flowParser);
+    }).not.toThrow();
+  });
+
+  it('throws an error if typeAnnotation of event have no name in TypeScript', () => {
+    const typeAnnotation = {};
+
+    expect(() => {
+      throwIfEventHasNoName(typeAnnotation, typescriptParser);
+    }).toThrowError(`typeAnnotation of event doesn't have a name`);
+  });
+
+  it('does not throw an error if typeAnnotation of event have a name in TypeScript', () => {
+    const typeAnnotation = {
+      typeName: {
+        name: 'BubblingEventHandler',
+      },
+    };
+
+    expect(() => {
+      throwIfEventHasNoName(typeAnnotation, typescriptParser);
     }).not.toThrow();
   });
 });

--- a/packages/react-native-codegen/src/parsers/error-utils.js
+++ b/packages/react-native-codegen/src/parsers/error-utils.js
@@ -310,6 +310,15 @@ function throwIfMoreThanOneConfig(foundConfigs: Array<{[string]: string}>) {
   }
 }
 
+function throwIfEventHasNoName(typeAnnotation: $FlowFixMe, parser: Parser) {
+  const name =
+    parser.language() === 'Flow' ? typeAnnotation.id : typeAnnotation.typeName;
+
+  if (!name) {
+    throw new Error("typeAnnotation of event doesn't have a name");
+  }
+}
+
 module.exports = {
   throwIfModuleInterfaceIsMisnamed,
   throwIfUnsupportedFunctionReturnTypeAnnotationParserError,
@@ -330,4 +339,5 @@ module.exports = {
   throwIfMoreThanOneCodegenNativecommands,
   throwIfConfigNotfound,
   throwIfMoreThanOneConfig,
+  throwIfEventHasNoName,
 };

--- a/packages/react-native-codegen/src/parsers/flow/components/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/index.js
@@ -129,7 +129,7 @@ function buildComponentSchema(
   const {extendsProps, props} = getProps(propProperties, types);
 
   const options = getOptions(optionsExpression);
-  const events = getEvents(propProperties, types);
+  const events = getEvents(propProperties, types, parser);
   const commands = getCommands(commandProperties, types);
 
   return {

--- a/packages/react-native-codegen/src/parsers/typescript/components/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/index.js
@@ -136,7 +136,7 @@ function buildComponentSchema(
   const componentEventAsts: Array<PropsAST> = [];
   categorizeProps(propProperties, types, componentEventAsts);
   const {props, extendsProps} = getProps(propProperties, types);
-  const events = getEvents(componentEventAsts, types);
+  const events = getEvents(componentEventAsts, types, parser);
   const commands = getCommands(commandProperties, types);
 
   return {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Part of Codegen ☂️ Issue: #34872 

> Extract the typeAnnotation doesn't have a name error ([Flow](https://github.com/facebook/react-native/blob/e133100721939108b0f28dfa9f60ac627c804018/packages/react-native-codegen/src/parsers/flow/components/events.js#L120-L122); [TypeScript](https://github.com/facebook/react-native/blob/e133100721939108b0f28dfa9f60ac627c804018/packages/react-native-codegen/src/parsers/typescript/components/events.js#L138-L140)) in throwIfEventHasNoName function which takes a typeAnnotation and a parser as parameters. Use it in place of the if in the above call sites.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
[Internal] [Changed] - Extract throwIfEventHasNoName error from parsers components events in error-utils 

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

`yarn jest react-native-codegen`
<img width="810" alt="image" src="https://user-images.githubusercontent.com/34857453/234091461-67ec4187-1f38-43e0-a4ae-eb3716377665.png">
