### PR TITLE
RN: Delete Misleading `jest.setMock(ErrorUtils)`

### DIFF
--- a/packages/react-native/jest/setup.js
+++ b/packages/react-native/jest/setup.js
@@ -56,12 +56,6 @@ Object.defineProperties(global, {
   },
 });
 
-// there's a __mock__ for it.
-jest.setMock(
-  '../Libraries/vendor/core/ErrorUtils',
-  require('../Libraries/vendor/core/ErrorUtils'),
-);
-
 jest
   .mock('../Libraries/Core/InitializeCore', () => {})
   .mock('../Libraries/Core/NativeExceptionsManager', () => ({


### PR DESCRIPTION
Summary:
Deletes this call to `jest.setMock` for `ErrorUtils`. There is no such manual mock in `__mocks__` adjacent to `ErrorUtils` and this call does nothing.

Changelog:
[Internal]

Reviewed By: fkgozali

Differential Revision: D45234899

