### PR TITLE
Update Node.js to v16 in all RN packages

### DIFF
--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -7,5 +7,8 @@
     "url": "git@github.com:facebook/react-native.git",
     "directory": "packages/assets"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "engines": {
+    "node": ">=16"
+  }
 }

--- a/packages/babel-plugin-codegen/package.json
+++ b/packages/babel-plugin-codegen/package.json
@@ -7,6 +7,9 @@
     "url": "git@github.com:facebook/react-native.git",
     "directory": "packages/babel-plugin-codegen"
   },
+  "engines": {
+    "node": ">=16"
+  },
   "files": [
     "index.js"
   ],

--- a/packages/eslint-config-react-native-community/package.json
+++ b/packages/eslint-config-react-native-community/package.json
@@ -10,6 +10,9 @@
     "directory": "packages/eslint-config-react-native-community"
   },
   "homepage": "https://github.com/facebook/react-native/tree/HEAD/packages/eslint-config-react-native-community#readme",
+  "engines": {
+    "node": ">=16"
+  },
   "dependencies": {
     "@babel/core": "^7.20.0",
     "@babel/eslint-parser": "^7.19.0",

--- a/packages/eslint-plugin-react-native-community/package.json
+++ b/packages/eslint-plugin-react-native-community/package.json
@@ -8,5 +8,8 @@
     "url": "git@github.com:facebook/react-native.git",
     "directory": "packages/eslint-plugin-react-native-community"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "engines": {
+    "node": ">=16"
+  }
 }

--- a/packages/eslint-plugin-specs/package.json
+++ b/packages/eslint-plugin-specs/package.json
@@ -8,6 +8,9 @@
     "url": "git@github.com:facebook/react-native.git",
     "directory": "packages/eslint-plugin-specs"
   },
+  "engines": {
+    "node": ">=16"
+  },
   "scripts": {
     "prepack": "node prepack.js",
     "postpack": "node postpack.js"

--- a/packages/hermes-inspector-msggen/package.json
+++ b/packages/hermes-inspector-msggen/package.json
@@ -6,6 +6,9 @@
   "bin": {
     "msggen": "./bin/index.js"
   },
+  "engines": {
+    "node": ">=16"
+  },
   "scripts": {
     "flow": "flow",
     "build": "babel src --out-dir bin --source-maps",

--- a/packages/metro-config/package.json
+++ b/packages/metro-config/package.json
@@ -8,6 +8,9 @@
     "directory": "packages/metro-config"
   },
   "license": "MIT",
+  "engines": {
+    "node": ">=16"
+  },
   "exports": "./index.js",
   "dependencies": {
     "@react-native/js-polyfills": "^0.73.0",

--- a/packages/normalize-color/package.json
+++ b/packages/normalize-color/package.json
@@ -7,5 +7,8 @@
     "url": "git@github.com:facebook/react-native.git",
     "directory": "packages/normalize-color"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "engines": {
+    "node": ">=16"
+  }
 }

--- a/packages/polyfills/package.json
+++ b/packages/polyfills/package.json
@@ -7,5 +7,8 @@
     "url": "git@github.com:facebook/react-native.git",
     "directory": "packages/polyfills"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "engines": {
+    "node": ">=16"
+  }
 }

--- a/packages/react-native-bots/package.json
+++ b/packages/react-native-bots/package.json
@@ -2,6 +2,9 @@
   "name": "@react-native/bots",
   "version": "0.0.0",
   "private": true,
+  "engines": {
+    "node": ">=16"
+  },
   "devDependencies": {
     "@rnx-kit/rn-changelog-generator": "^0.4.0",
     "@seadub/danger-plugin-eslint": "^3.0.2",

--- a/packages/react-native-codegen-typescript-test/package.json
+++ b/packages/react-native-codegen-typescript-test/package.json
@@ -8,6 +8,9 @@
     "url": "git@github.com:facebook/react-native.git",
     "directory": "packages/react-native-codegen-typescript-test"
   },
+  "engines": {
+    "node": ">=16"
+  },
   "scripts": {
     "build": "yarn clean && node scripts/build.js --verbose && tsc",
     "clean": "rimraf lib && rimraf __generated__/*.ts",

--- a/packages/react-native-codegen/package.json
+++ b/packages/react-native-codegen/package.json
@@ -8,6 +8,9 @@
     "url": "git@github.com:facebook/react-native.git",
     "directory": "packages/react-native-codegen"
   },
+  "engines": {
+    "node": ">=16"
+  },
   "scripts": {
     "build": "yarn clean && node scripts/build.js --verbose",
     "clean": "rimraf lib",

--- a/packages/react-native-gradle-plugin/package.json
+++ b/packages/react-native-gradle-plugin/package.json
@@ -8,6 +8,9 @@
     "url": "git@github.com:facebook/react-native.git",
     "directory": "packages/react-native-gradle-plugin"
   },
+  "engines": {
+    "node": ">=16"
+  },
   "scripts": {
     "build": "./gradlew build",
     "clean": "./gradlew clean",

--- a/packages/rn-tester/package.json
+++ b/packages/rn-tester/package.json
@@ -10,6 +10,9 @@
     "url": "git@github.com:facebook/react-native.git",
     "directory": "packages/rn-tester"
   },
+  "engines": {
+    "node": ">=16"
+  },
   "scripts": {
     "start": "react-native start",
     "install-android-jsc": "../../gradlew :packages:rn-tester:android:app:installJscDebug",

--- a/packages/virtualized-lists/package.json
+++ b/packages/virtualized-lists/package.json
@@ -8,6 +8,9 @@
     "directory": "packages/virtualized-lists"
   },
   "license": "MIT",
+  "engines": {
+    "node": ">=16"
+  },
   "dependencies": {
     "invariant": "^2.2.4",
     "nullthrows": "^1.1.1"


### PR DESCRIPTION
## Summary:

**NOTE**: This is a **BREAKING** change.
TLDR; Enforce minimum Node.js v16 in all RN packages.

This diff **Updates Node.js to v16** across all RN packages.

#### Context:

- For RN development and new project created; bump to node 16 was in https://github.com/facebook/react-native/pull/36217
- Recently `react-native-windows` also; updated node to v16, https://github.com/microsoft/react-native-windows/pull/11500

#### Changes:

- [BREAKING] Update Node.js to v16 across all RN packages under 'packages/' dir

## Changelog:

[GENERAL][BREAKING] - Update Node.js to v16 in all RN packages

## Test Plan:

- `yarn lint && yarn flow && yarn test-ci` --> _should be green_