### PR TITLE
RN: Cleanup `NativeExceptionsManager` Mock

### DIFF
--- a/packages/react-native/Libraries/Core/__mocks__/NativeExceptionsManager.js
+++ b/packages/react-native/Libraries/Core/__mocks__/NativeExceptionsManager.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ * @format
+ * @oncall react_native
+ */
+
+import typeof NativeExceptionsManager from '../NativeExceptionsManager';
+
+export default ({
+  reportFatalException: jest.fn(),
+  reportSoftException: jest.fn(),
+  updateExceptionMessage: jest.fn(),
+  dismissRedbox: jest.fn(),
+  reportException: jest.fn(),
+}: NativeExceptionsManager);

--- a/packages/react-native/jest/__tests__/setup-test.js
+++ b/packages/react-native/jest/__tests__/setup-test.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ * @format
+ * @oncall react_native
+ */
+
+import NativeExceptionsManager from '../../Libraries/Core/NativeExceptionsManager';
+
+test('NativeExceptionsManager is a mock', () => {
+  expect(jest.isMockFunction(NativeExceptionsManager.reportException)).toBe(
+    true,
+  );
+});

--- a/packages/react-native/jest/setup.js
+++ b/packages/react-native/jest/setup.js
@@ -58,12 +58,7 @@ Object.defineProperties(global, {
 
 jest
   .mock('../Libraries/Core/InitializeCore', () => {})
-  .mock('../Libraries/Core/NativeExceptionsManager', () => ({
-    __esModule: true,
-    default: {
-      reportException: jest.fn(),
-    },
-  }))
+  .mock('../Libraries/Core/NativeExceptionsManager')
   .mock('../Libraries/ReactNative/UIManager', () => ({
     AndroidViewPager: {
       Commands: {

--- a/packages/react-native/jest/setup.js
+++ b/packages/react-native/jest/setup.js
@@ -56,12 +56,6 @@ Object.defineProperties(global, {
   },
 });
 
-// there's a __mock__ for it.
-jest.setMock(
-  '../Libraries/vendor/core/ErrorUtils',
-  require('../Libraries/vendor/core/ErrorUtils'),
-);
-
 jest
   .mock('../Libraries/Core/InitializeCore', () => {})
   .mock('../Libraries/Core/NativeExceptionsManager', () => ({


### PR DESCRIPTION
Summary:
I am exploring ways of cleaning up the React Native Jest `setup.js` logic so that we can enable Flow and make it easier to maintain.

This does a few things:

- Create a new Jest test to verify that mocking works as expected (i.e. `jest.mock(X)` and `import ... from 'X'` does the right thing).
- Move the mock implementation for `NativeExceptionsManager` into a `__mocks__` directory that Jest can find automatically.
- Add `flow strict` and fill out the missing implementation details of the `NativeExceptionsManager` mock.

Differential Revision: D45244175

