### PR TITLE
Add YGErrata integration within C ABI

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
@@ -488,7 +488,7 @@ void YogaLayoutableShadowNode::layoutTree(
    * the only value in the config of the root node is taken into account
    * (and this is by design).
    */
-  yogaConfig_.pointScaleFactor = layoutContext.pointScaleFactor;
+  YGConfigSetPointScaleFactor(&yogaConfig_, layoutContext.pointScaleFactor);
 
   auto minimumSize = layoutConstraints.minimumSize;
   auto maximumSize = layoutConstraints.maximumSize;
@@ -743,11 +743,11 @@ YogaLayoutableShadowNode &YogaLayoutableShadowNode::shadowNodeFromContext(
 }
 
 YGConfig &YogaLayoutableShadowNode::initializeYogaConfig(YGConfig &config) {
-  config.setCloneNodeCallback(
-      YogaLayoutableShadowNode::yogaNodeCloneCallbackConnector);
-  config.useLegacyStretchBehaviour = true;
+  YGConfigSetCloneNodeFunc(
+      &config, YogaLayoutableShadowNode::yogaNodeCloneCallbackConnector);
+  YGConfigSetUseLegacyStretchBehaviour(&config, true);
 #ifdef RN_DEBUG_YOGA_LOGGER
-  config.printTree = true;
+  YGConfigSetPrintTreeFlag(&config, true);
 #endif
   return config;
 }

--- a/packages/react-native/ReactCommon/yoga/yoga/BitUtils.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/BitUtils.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <bitset>
 #include <cstdio>
 #include <cstdint>
 #include "YGEnums.h"
@@ -15,6 +16,10 @@ namespace facebook {
 namespace yoga {
 
 namespace detail {
+
+// std::bitset with one bit for each option defined in YG_ENUM_SEQ_DECL
+template <typename Enum>
+using EnumBitset = std::bitset<facebook::yoga::enums::count<Enum>()>;
 
 constexpr size_t log2ceilFn(size_t n) {
   return n < 1 ? 0 : (1 + log2ceilFn(n / 2));

--- a/packages/react-native/ReactCommon/yoga/yoga/YGConfig.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGConfig.cpp
@@ -7,9 +7,75 @@
 
 #include "YGConfig.h"
 
+using namespace facebook::yoga::detail;
+
 YGConfig::YGConfig(YGLogger logger) : cloneNodeCallback_{nullptr} {
+  setLogger(logger);
+}
+
+void YGConfig::setUseWebDefaults(bool useWebDefaults) {
+  flags_.useWebDefaults = useWebDefaults;
+}
+
+bool YGConfig::useWebDefaults() const {
+  return flags_.useWebDefaults;
+}
+
+void YGConfig::setShouldPrintTree(bool printTree) {
+  flags_.printTree = printTree;
+}
+
+bool YGConfig::shouldPrintTree() const {
+  return flags_.printTree;
+}
+
+void YGConfig::setExperimentalFeatureEnabled(
+    YGExperimentalFeature feature,
+    bool enabled) {
+  experimentalFeatures_.set(feature, enabled);
+}
+
+bool YGConfig::isExperimentalFeatureEnabled(
+    YGExperimentalFeature feature) const {
+  return experimentalFeatures_.test(feature);
+}
+
+void YGConfig::setErrata(YGErrata errata) {
+  errata_ = errata;
+}
+
+YGErrata YGConfig::getErrata() const {
+  return errata_;
+}
+
+void YGConfig::setPointScaleFactor(float pointScaleFactor) {
+  pointScaleFactor_ = pointScaleFactor;
+}
+
+float YGConfig::getPointScaleFactor() const {
+  return pointScaleFactor_;
+}
+
+void YGConfig::setContext(void* context) {
+  context_ = context;
+}
+
+void* YGConfig::getContext() const {
+  return context_;
+}
+
+void YGConfig::setLogger(YGLogger logger) {
   logger_.noContext = logger;
-  loggerUsesContext_ = false;
+  flags_.loggerUsesContext = false;
+}
+
+void YGConfig::setLogger(LogWithContextFn logger) {
+  logger_.withContext = logger;
+  flags_.loggerUsesContext = true;
+}
+
+void YGConfig::setLogger(std::nullptr_t) {
+  setLogger(YGLogger{nullptr});
 }
 
 void YGConfig::log(
@@ -18,22 +84,36 @@ void YGConfig::log(
     YGLogLevel logLevel,
     void* logContext,
     const char* format,
-    va_list args) {
-  if (loggerUsesContext_) {
+    va_list args) const {
+  if (flags_.loggerUsesContext) {
     logger_.withContext(config, node, logLevel, logContext, format, args);
   } else {
     logger_.noContext(config, node, logLevel, format, args);
   }
 }
 
+void YGConfig::setCloneNodeCallback(YGCloneNodeFunc cloneNode) {
+  cloneNodeCallback_.noContext = cloneNode;
+  flags_.cloneNodeUsesContext = false;
+}
+
+void YGConfig::setCloneNodeCallback(CloneWithContextFn cloneNode) {
+  cloneNodeCallback_.withContext = cloneNode;
+  flags_.cloneNodeUsesContext = true;
+}
+
+void YGConfig::setCloneNodeCallback(std::nullptr_t) {
+  setCloneNodeCallback(YGCloneNodeFunc{nullptr});
+}
+
 YGNodeRef YGConfig::cloneNode(
     YGNodeRef node,
     YGNodeRef owner,
     int childIndex,
-    void* cloneContext) {
+    void* cloneContext) const {
   YGNodeRef clone = nullptr;
   if (cloneNodeCallback_.noContext != nullptr) {
-    clone = cloneNodeUsesContext_
+    clone = flags_.cloneNodeUsesContext
         ? cloneNodeCallback_.withContext(node, owner, childIndex, cloneContext)
         : cloneNodeCallback_.noContext(node, owner, childIndex);
   }

--- a/packages/react-native/ReactCommon/yoga/yoga/YGNode.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGNode.cpp
@@ -18,7 +18,7 @@ YGNode::YGNode(const YGConfigRef config) : config_{config} {
       config != nullptr, "Attempting to construct YGNode with null config");
 
   flags_.hasNewLayout = true;
-  if (config->useWebDefaults) {
+  if (config->useWebDefaults()) {
     useWebDefaults();
   }
 };
@@ -267,7 +267,7 @@ void YGNode::setConfig(YGConfigRef config) {
   YGAssert(config != nullptr, "Attempting to set a null config on a YGNode");
   YGAssertWithConfig(
       config,
-      config->useWebDefaults == config_->useWebDefaults,
+      config->useWebDefaults() == config_->useWebDefaults(),
       "UseWebDefaults may not be changed after constructing a YGNode");
   config_ = config;
 }
@@ -419,7 +419,7 @@ YGValue YGNode::resolveFlexBasisPtr() const {
     return flexBasis;
   }
   if (!style_.flex().isUndefined() && style_.flex().unwrap() > 0.0f) {
-    return config_->useWebDefaults ? YGValueAuto : YGValueZero;
+    return config_->useWebDefaults() ? YGValueAuto : YGValueZero;
   }
   return YGValueAuto;
 }
@@ -495,11 +495,11 @@ float YGNode::resolveFlexShrink() const {
   if (!style_.flexShrink().isUndefined()) {
     return style_.flexShrink().unwrap();
   }
-  if (!config_->useWebDefaults && !style_.flex().isUndefined() &&
+  if (!config_->useWebDefaults() && !style_.flex().isUndefined() &&
       style_.flex().unwrap() < 0.0f) {
     return -style_.flex().unwrap();
   }
-  return config_->useWebDefaults ? kWebDefaultFlexShrink : kDefaultFlexShrink;
+  return config_->useWebDefaults() ? kWebDefaultFlexShrink : kDefaultFlexShrink;
 }
 
 bool YGNode::isNodeFlexible() {

--- a/packages/react-native/ReactCommon/yoga/yoga/YGNode.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGNode.cpp
@@ -23,17 +23,6 @@ YGNode::YGNode(const YGConfigRef config) : config_{config} {
   }
 };
 
-YGNode::YGNode(const YGNode& node, YGConfigRef config) : YGNode{node} {
-  YGAssert(
-      config != nullptr, "Attempting to construct YGNode with null config");
-
-  config_ = config;
-  flags_.hasNewLayout = true;
-  if (config->useWebDefaults) {
-    useWebDefaults();
-  }
-}
-
 YGNode::YGNode(YGNode&& node) {
   context_ = node.context_;
   flags_ = node.flags_;

--- a/packages/react-native/ReactCommon/yoga/yoga/YGNode.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGNode.h
@@ -93,10 +93,6 @@ public:
   // Should we remove this?
   YGNode(const YGNode& node) = default;
 
-  [[deprecated("Will be removed imminently")]] YGNode(
-      const YGNode& node,
-      YGConfigRef config);
-
   // assignment means potential leaks of existing children, or alternatively
   // freeing unowned memory, double free, or freeing stack memory.
   YGNode& operator=(const YGNode&) = delete;

--- a/packages/react-native/ReactCommon/yoga/yoga/Yoga.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/Yoga.h
@@ -357,6 +357,9 @@ WIN_EXPORT YGConfigRef YGConfigGetDefault(void);
 WIN_EXPORT void YGConfigSetContext(YGConfigRef config, void* context);
 WIN_EXPORT void* YGConfigGetContext(YGConfigRef config);
 
+WIN_EXPORT void YGConfigSetErrata(YGConfigRef config, YGErrata errata);
+WIN_EXPORT YGErrata YGConfigGetErrata(YGConfigRef config);
+
 WIN_EXPORT float YGRoundValueToPixelGrid(
     double value,
     double pointScaleFactor,


### PR DESCRIPTION
Summary:
This diff wires up YGErrata to a public API, along with existing functions to set UseLegacyStretchBehaviour.

The `UseLegacyStretchBehaviour` functions will be removed after the world internally is transitioned to `YGConfigSetErrata`. This is intentionally breaking, since most users previously enabling `UseLegacyStretchBehaviour` will want to pick a new appropriate errata setting. Internally, users of the API will be moved to`YGErrataAll`.

The overall change looks like:
1. Clean up YGConfig to use accessors/setters
2. Change up YGconfig internal storage
    1. Fabric has a config per ShadowNode, so it makes sense to do some size optimization before adding more (free-form bools to bitfield, `std::array<bool,>` to `std::bitset` since not specialized)
3. Wire accessor/setter of UseLegacyStretchBehaviour to errata while both APIs exist
4. Add errata APIs to C ABI

After this we will need to expose the ABI to more language projections, and (more involved), add usages of the API to internal consumption of Yoga before adding more errata and removing `UseLegacyStretchBehaviour`.

Note that this API representation is similar, but distinct to `YGExperimentalFeature`. I think that API may also have made sense as an enum bitset, like we explicitly want for the new API, but it's not really worth changing the existing API to make that happen.

Differential Revision: D45254097

