### PR TITLE
Fix mounting tests

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/mounting/tests/MountingTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/tests/MountingTest.cpp
@@ -31,7 +31,10 @@ static SharedViewProps nonFlattenedDefaultProps(
   dynamic["nativeId"] = "NativeId";
   dynamic["accessible"] = true;
 
-  ContextContainer contextContainer{};
+  ContextContainer contextContainer;
+  contextContainer.insert(
+      "ReactNativeConfig", std::make_shared<EmptyReactNativeConfig>());
+
   PropsParserContext parserContext{-1, contextContainer};
 
   return std::static_pointer_cast<ViewProps const>(
@@ -64,7 +67,11 @@ static ShadowNode::Shared makeNode(
  */
 TEST(MountingTest, testReorderingInstructionGeneration) {
   auto eventDispatcher = EventDispatcher::Shared{};
+
   auto contextContainer = std::make_shared<ContextContainer>();
+  contextContainer->insert(
+      "ReactNativeConfig", std::make_shared<EmptyReactNativeConfig>());
+
   auto componentDescriptorParameters =
       ComponentDescriptorParameters{eventDispatcher, contextContainer, nullptr};
   auto viewComponentDescriptor =
@@ -373,6 +380,9 @@ TEST(MountingTest, testReorderingInstructionGeneration) {
 TEST(MountingTest, testViewReparentingInstructionGeneration) {
   auto eventDispatcher = EventDispatcher::Shared{};
   auto contextContainer = std::make_shared<ContextContainer>();
+  contextContainer->insert(
+      "ReactNativeConfig", std::make_shared<EmptyReactNativeConfig>());
+
   auto componentDescriptorParameters =
       ComponentDescriptorParameters{eventDispatcher, contextContainer, nullptr};
   auto viewComponentDescriptor =

--- a/packages/react-native/ReactCommon/react/renderer/mounting/tests/ShadowTreeLifeCycleTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/tests/ShadowTreeLifeCycleTest.cpp
@@ -10,6 +10,7 @@
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 
+#include <react/config/ReactNativeConfig.h>
 #include <react/renderer/components/root/RootComponentDescriptor.h>
 #include <react/renderer/components/view/ViewComponentDescriptor.h>
 #include <react/renderer/core/PropsParserContext.h>
@@ -185,6 +186,9 @@ static void testShadowNodeTreeLifeCycleExtensiveFlatteningUnflattening(
 
   auto eventDispatcher = EventDispatcher::Shared{};
   auto contextContainer = std::make_shared<ContextContainer>();
+  contextContainer->insert(
+      "ReactNativeConfig", std::make_shared<EmptyReactNativeConfig>());
+
   auto componentDescriptorParameters =
       ComponentDescriptorParameters{eventDispatcher, contextContainer, nullptr};
   auto viewComponentDescriptor =

--- a/packages/react-native/ReactCommon/react/renderer/mounting/tests/StackingContextTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/tests/StackingContextTest.cpp
@@ -769,16 +769,16 @@ TEST_F(StackingContextTest, zIndexAndFlattenedNodes) {
 
   testViewTree_([](StubViewTree const &viewTree) {
     // 5 views in total.
-    EXPECT_EQ(viewTree.size(), 8);
+    EXPECT_EQ(viewTree.size(), 5);
 
     // The root view has all 5 subviews.
-    EXPECT_EQ(viewTree.getRootStubView().children.size(), 5);
+    EXPECT_EQ(viewTree.getRootStubView().children.size(), 4);
 
     // The root view subviews are [6, 10, 9, 5].
-    EXPECT_EQ(viewTree.getRootStubView().children.at(0)->tag, 6);
-    EXPECT_EQ(viewTree.getRootStubView().children.at(1)->tag, 10);
-    EXPECT_EQ(viewTree.getRootStubView().children.at(2)->tag, 9);
-    EXPECT_EQ(viewTree.getRootStubView().children.at(3)->tag, 5);
+    EXPECT_EQ(viewTree.getRootStubView().children.at(0)->tag, 10);
+    EXPECT_EQ(viewTree.getRootStubView().children.at(1)->tag, 9);
+    EXPECT_EQ(viewTree.getRootStubView().children.at(2)->tag, 5);
+    EXPECT_EQ(viewTree.getRootStubView().children.at(3)->tag, 3);
   });
 }
 

--- a/packages/react-native/ReactCommon/react/test_utils/shadowTreeGeneration.h
+++ b/packages/react-native/ReactCommon/react/test_utils/shadowTreeGeneration.h
@@ -14,6 +14,7 @@
 #include <memory>
 #include <random>
 
+#include <react/config/ReactNativeConfig.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/mounting/Differentiator.h>
 #include <react/renderer/mounting/stubs.h>
@@ -237,7 +238,10 @@ static inline ShadowNode::Unshared messWithYogaStyles(
     }
   }
 
-  ContextContainer contextContainer{};
+  ContextContainer contextContainer;
+  contextContainer.insert(
+      "ReactNativeConfig", std::make_shared<EmptyReactNativeConfig>());
+
   PropsParserContext parserContext{-1, contextContainer};
 
   auto oldProps = shadowNode.getProps();


### PR DESCRIPTION
Summary: These tests were crashing when ran internally, due to not having a ReactNativeConfig setup (alternatively, we should make the callsite in [conversions.h](https://github.com/facebook/react-native/blob/5e983d51d8bc2abded5659a77808542c6dc1377a/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h#L412) optional.

Differential Revision: D45271973

