### PR TITLE
Fix incorrect usage of React.ElementConfig and React.ElementRef in xplat

### DIFF
--- a/packages/react-native/Libraries/Inspector/NetworkOverlay.js
+++ b/packages/react-native/Libraries/Inspector/NetworkOverlay.js
@@ -88,7 +88,7 @@ function keyExtractor(request: NetworkRequestInfo): string {
  * Show all the intercepted network requests over the InspectorPanel.
  */
 class NetworkOverlay extends React.Component<Props, State> {
-  _requestsListView: ?React.ElementRef<typeof FlatList>;
+  _requestsListView: ?React.ElementRef<Class<FlatList<NetworkRequestInfo>>>;
   _detailScrollView: ?React.ElementRef<typeof ScrollView>;
 
   // Metrics are used to decide when if the request list should be sticky, and

--- a/packages/rn-tester/js/examples/FlatList/FlatList-onEndReached.js
+++ b/packages/rn-tester/js/examples/FlatList/FlatList-onEndReached.js
@@ -45,7 +45,7 @@ export default ({
   name: 'onEndReached',
   description:
     'Scroll to end of list or tap Test button to see `onEndReached` triggered.',
-  render: function (): React.Element<typeof FlatList_onEndReached> {
+  render: function () {
     return <FlatList_onEndReached />;
   },
 }: RNTesterModuleExample);

--- a/packages/rn-tester/js/examples/FlatList/FlatList-onStartReached.js
+++ b/packages/rn-tester/js/examples/FlatList/FlatList-onStartReached.js
@@ -48,7 +48,7 @@ export default ({
   name: 'onStartReached',
   description:
     'Scroll to start of list or tap Test button to see `onStartReached` triggered.',
-  render: function (): React.Element<typeof FlatList_onStartReached> {
+  render: function () {
     return <FlatList_onStartReached />;
   },
 }: RNTesterModuleExample);

--- a/packages/rn-tester/js/examples/SectionList/SectionList-contentInset.js
+++ b/packages/rn-tester/js/examples/SectionList/SectionList-contentInset.js
@@ -78,7 +78,7 @@ export default {
   title: 'SectionList Content Inset',
   platform: 'ios',
   name: 'SectionList-contentInset',
-  render: function (): React.Element<typeof SectionList_contentInset> {
+  render: function (): React.MixedElement {
     return <SectionList_contentInset />;
   },
 };

--- a/packages/rn-tester/js/examples/SectionList/SectionList-inverted.js
+++ b/packages/rn-tester/js/examples/SectionList/SectionList-inverted.js
@@ -38,7 +38,7 @@ export function SectionList_inverted(): React.Node {
 export default {
   title: 'SectionList Inverted',
   name: 'SectionList-inverted',
-  render: function (): React.Element<typeof SectionList_inverted> {
+  render: function (): React.MixedElement {
     return <SectionList_inverted />;
   },
 };

--- a/packages/rn-tester/js/examples/SectionList/SectionList-onEndReached.js
+++ b/packages/rn-tester/js/examples/SectionList/SectionList-onEndReached.js
@@ -41,7 +41,7 @@ export default {
   title: 'SectionList onEndReached',
   name: 'SectionList-onEndReached',
   description: 'Test onEndReached behavior',
-  render: function (): React.Element<typeof SectionList_onEndReached> {
+  render: function (): React.MixedElement {
     return <SectionList_onEndReached />;
   },
 };

--- a/packages/rn-tester/js/examples/SectionList/SectionList-onViewableItemsChanged.js
+++ b/packages/rn-tester/js/examples/SectionList/SectionList-onViewableItemsChanged.js
@@ -73,9 +73,7 @@ const styles = StyleSheet.create({
 export default {
   title: 'SectionList On Viewable Items Changed',
   name: 'SectionList_onViewableItemsChanged',
-  render: function (): React.Element<
-    typeof SectionList_onViewableItemsChanged,
-  > {
+  render: function (): React.MixedElement {
     return (
       <SectionList_onViewableItemsChanged
         viewabilityConfig={VIEWABILITY_CONFIG}

--- a/packages/rn-tester/js/examples/SectionList/SectionList-scrollable.js
+++ b/packages/rn-tester/js/examples/SectionList/SectionList-scrollable.js
@@ -358,7 +358,7 @@ const styles = StyleSheet.create({
 export default {
   title: 'SectionList scrollable',
   name: 'SectionList-scrollable',
-  render: function (): React.Element<typeof SectionList_scrollable> {
+  render: function (): React.MixedElement {
     return <SectionList_scrollable />;
   },
 };

--- a/packages/rn-tester/js/examples/SectionList/SectionList-stickyHeadersEnabled.js
+++ b/packages/rn-tester/js/examples/SectionList/SectionList-stickyHeadersEnabled.js
@@ -45,9 +45,7 @@ export default {
   title: 'SectionList Sticky Headers Enabled',
   name: 'SectionList-stickyHeadersEnabled',
   description: 'Toggle sticky headers on/off',
-  render: function (): React.Element<
-    typeof SectionList_stickySectionHeadersEnabled,
-  > {
+  render: function (): React.MixedElement {
     return <SectionList_stickySectionHeadersEnabled />;
   },
 };

--- a/packages/rn-tester/js/examples/SectionList/SectionList-withSeparators.js
+++ b/packages/rn-tester/js/examples/SectionList/SectionList-withSeparators.js
@@ -54,7 +54,7 @@ const styles = StyleSheet.create({
 export default {
   title: 'SectionList With Separators',
   name: 'SectionList-withSeparators',
-  render: function (): React.Element<typeof SectionList_withSeparators> {
+  render: function (): React.MixedElement {
     return <SectionList_withSeparators />;
   },
 };


### PR DESCRIPTION
Summary:
`React.ElementConfig<a polymophic type>` will result in unpredictable behavior in Flow due to some types being unresolved. Since the type is already broken in most cases, I use $FlowFixMe as the type for those type arguments that are currently inferred as empty.

Changelog: [Internal]

Differential Revision: D44774275

