### PR TITLE
Remove use of JSI_EXPORT from codegen

### DIFF
--- a/packages/react-native-codegen/e2e/__tests__/components/__snapshots__/GenerateEventEmitterH-test.js.snap
+++ b/packages/react-native-codegen/e2e/__tests__/components/__snapshots__/GenerateEventEmitterH-test.js.snap
@@ -14,12 +14,11 @@ Object {
 #pragma once
 
 #include <react/renderer/components/view/ViewEventEmitter.h>
-#include <jsi/jsi.h>
 
 
 namespace facebook {
 namespace react {
-class JSI_EXPORT ArrayPropsNativeComponentViewEventEmitter : public ViewEventEmitter {
+class ArrayPropsNativeComponentViewEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 
@@ -46,12 +45,11 @@ Object {
 #pragma once
 
 #include <react/renderer/components/view/ViewEventEmitter.h>
-#include <jsi/jsi.h>
 
 
 namespace facebook {
 namespace react {
-class JSI_EXPORT BooleanPropNativeComponentViewEventEmitter : public ViewEventEmitter {
+class BooleanPropNativeComponentViewEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 
@@ -78,12 +76,11 @@ Object {
 #pragma once
 
 #include <react/renderer/components/view/ViewEventEmitter.h>
-#include <jsi/jsi.h>
 
 
 namespace facebook {
 namespace react {
-class JSI_EXPORT ColorPropNativeComponentViewEventEmitter : public ViewEventEmitter {
+class ColorPropNativeComponentViewEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 
@@ -110,12 +107,11 @@ Object {
 #pragma once
 
 #include <react/renderer/components/view/ViewEventEmitter.h>
-#include <jsi/jsi.h>
 
 
 namespace facebook {
 namespace react {
-class JSI_EXPORT DimensionPropNativeComponentViewEventEmitter : public ViewEventEmitter {
+class DimensionPropNativeComponentViewEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 
@@ -142,12 +138,11 @@ Object {
 #pragma once
 
 #include <react/renderer/components/view/ViewEventEmitter.h>
-#include <jsi/jsi.h>
 
 
 namespace facebook {
 namespace react {
-class JSI_EXPORT EdgeInsetsPropNativeComponentViewEventEmitter : public ViewEventEmitter {
+class EdgeInsetsPropNativeComponentViewEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 
@@ -174,12 +169,11 @@ Object {
 #pragma once
 
 #include <react/renderer/components/view/ViewEventEmitter.h>
-#include <jsi/jsi.h>
 
 
 namespace facebook {
 namespace react {
-class JSI_EXPORT EnumPropNativeComponentViewEventEmitter : public ViewEventEmitter {
+class EnumPropNativeComponentViewEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 
@@ -206,12 +200,11 @@ Object {
 #pragma once
 
 #include <react/renderer/components/view/ViewEventEmitter.h>
-#include <jsi/jsi.h>
 
 
 namespace facebook {
 namespace react {
-class JSI_EXPORT EventNestedObjectPropsNativeComponentViewEventEmitter : public ViewEventEmitter {
+class EventNestedObjectPropsNativeComponentViewEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 
@@ -250,12 +243,11 @@ Object {
 #pragma once
 
 #include <react/renderer/components/view/ViewEventEmitter.h>
-#include <jsi/jsi.h>
 
 
 namespace facebook {
 namespace react {
-class JSI_EXPORT EventPropsNativeComponentViewEventEmitter : public ViewEventEmitter {
+class EventPropsNativeComponentViewEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 
@@ -329,12 +321,11 @@ Object {
 #pragma once
 
 #include <react/renderer/components/view/ViewEventEmitter.h>
-#include <jsi/jsi.h>
 
 
 namespace facebook {
 namespace react {
-class JSI_EXPORT FloatPropsNativeComponentViewEventEmitter : public ViewEventEmitter {
+class FloatPropsNativeComponentViewEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 
@@ -361,12 +352,11 @@ Object {
 #pragma once
 
 #include <react/renderer/components/view/ViewEventEmitter.h>
-#include <jsi/jsi.h>
 
 
 namespace facebook {
 namespace react {
-class JSI_EXPORT ImagePropNativeComponentViewEventEmitter : public ViewEventEmitter {
+class ImagePropNativeComponentViewEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 
@@ -393,12 +383,11 @@ Object {
 #pragma once
 
 #include <react/renderer/components/view/ViewEventEmitter.h>
-#include <jsi/jsi.h>
 
 
 namespace facebook {
 namespace react {
-class JSI_EXPORT IntegerPropNativeComponentViewEventEmitter : public ViewEventEmitter {
+class IntegerPropNativeComponentViewEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 
@@ -425,12 +414,11 @@ Object {
 #pragma once
 
 #include <react/renderer/components/view/ViewEventEmitter.h>
-#include <jsi/jsi.h>
 
 
 namespace facebook {
 namespace react {
-class JSI_EXPORT InterfaceOnlyNativeComponentViewEventEmitter : public ViewEventEmitter {
+class InterfaceOnlyNativeComponentViewEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 
@@ -459,12 +447,11 @@ Object {
 #pragma once
 
 #include <react/renderer/components/view/ViewEventEmitter.h>
-#include <jsi/jsi.h>
 
 
 namespace facebook {
 namespace react {
-class JSI_EXPORT MixedPropNativeComponentViewEventEmitter : public ViewEventEmitter {
+class MixedPropNativeComponentViewEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 
@@ -491,12 +478,11 @@ Object {
 #pragma once
 
 #include <react/renderer/components/view/ViewEventEmitter.h>
-#include <jsi/jsi.h>
 
 
 namespace facebook {
 namespace react {
-class JSI_EXPORT MultiNativePropNativeComponentViewEventEmitter : public ViewEventEmitter {
+class MultiNativePropNativeComponentViewEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 
@@ -523,12 +509,11 @@ Object {
 #pragma once
 
 #include <react/renderer/components/view/ViewEventEmitter.h>
-#include <jsi/jsi.h>
 
 
 namespace facebook {
 namespace react {
-class JSI_EXPORT NoPropsNoEventsNativeComponentViewEventEmitter : public ViewEventEmitter {
+class NoPropsNoEventsNativeComponentViewEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 
@@ -555,12 +540,11 @@ Object {
 #pragma once
 
 #include <react/renderer/components/view/ViewEventEmitter.h>
-#include <jsi/jsi.h>
 
 
 namespace facebook {
 namespace react {
-class JSI_EXPORT ObjectPropsNativeComponentEventEmitter : public ViewEventEmitter {
+class ObjectPropsNativeComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 
@@ -587,12 +571,11 @@ Object {
 #pragma once
 
 #include <react/renderer/components/view/ViewEventEmitter.h>
-#include <jsi/jsi.h>
 
 
 namespace facebook {
 namespace react {
-class JSI_EXPORT PointPropNativeComponentViewEventEmitter : public ViewEventEmitter {
+class PointPropNativeComponentViewEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 
@@ -619,12 +602,11 @@ Object {
 #pragma once
 
 #include <react/renderer/components/view/ViewEventEmitter.h>
-#include <jsi/jsi.h>
 
 
 namespace facebook {
 namespace react {
-class JSI_EXPORT StringPropNativeComponentViewEventEmitter : public ViewEventEmitter {
+class StringPropNativeComponentViewEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 

--- a/packages/react-native-codegen/e2e/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/e2e/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
@@ -14,7 +14,6 @@ Object {
 #pragma once
 
 #include <cinttypes>
-#include <jsi/jsi.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/core/propsConversions.h>
@@ -141,7 +140,7 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
   }
 }
 
-class JSI_EXPORT ArrayPropsNativeComponentViewProps final : public ViewProps {
+class ArrayPropsNativeComponentViewProps final : public ViewProps {
  public:
   ArrayPropsNativeComponentViewProps() = default;
   ArrayPropsNativeComponentViewProps(const PropsParserContext& context, const ArrayPropsNativeComponentViewProps &sourceProps, const RawProps &rawProps);
@@ -181,14 +180,13 @@ Object {
  */
 #pragma once
 
-#include <jsi/jsi.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 
 namespace facebook {
 namespace react {
 
-class JSI_EXPORT BooleanPropNativeComponentViewProps final : public ViewProps {
+class BooleanPropNativeComponentViewProps final : public ViewProps {
  public:
   BooleanPropNativeComponentViewProps() = default;
   BooleanPropNativeComponentViewProps(const PropsParserContext& context, const BooleanPropNativeComponentViewProps &sourceProps, const RawProps &rawProps);
@@ -218,7 +216,6 @@ Object {
  */
 #pragma once
 
-#include <jsi/jsi.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/graphics/Color.h>
@@ -226,7 +223,7 @@ Object {
 namespace facebook {
 namespace react {
 
-class JSI_EXPORT ColorPropNativeComponentViewProps final : public ViewProps {
+class ColorPropNativeComponentViewProps final : public ViewProps {
  public:
   ColorPropNativeComponentViewProps() = default;
   ColorPropNativeComponentViewProps(const PropsParserContext& context, const ColorPropNativeComponentViewProps &sourceProps, const RawProps &rawProps);
@@ -255,7 +252,6 @@ Object {
  */
 #pragma once
 
-#include <jsi/jsi.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <yoga/Yoga.h>
@@ -263,7 +259,7 @@ Object {
 namespace facebook {
 namespace react {
 
-class JSI_EXPORT DimensionPropNativeComponentViewProps final : public ViewProps {
+class DimensionPropNativeComponentViewProps final : public ViewProps {
  public:
   DimensionPropNativeComponentViewProps() = default;
   DimensionPropNativeComponentViewProps(const PropsParserContext& context, const DimensionPropNativeComponentViewProps &sourceProps, const RawProps &rawProps);
@@ -292,14 +288,13 @@ Object {
  */
 #pragma once
 
-#include <jsi/jsi.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 
 namespace facebook {
 namespace react {
 
-class JSI_EXPORT EdgeInsetsPropNativeComponentViewProps final : public ViewProps {
+class EdgeInsetsPropNativeComponentViewProps final : public ViewProps {
  public:
   EdgeInsetsPropNativeComponentViewProps() = default;
   EdgeInsetsPropNativeComponentViewProps(const PropsParserContext& context, const EdgeInsetsPropNativeComponentViewProps &sourceProps, const RawProps &rawProps);
@@ -328,7 +323,6 @@ Object {
  */
 #pragma once
 
-#include <jsi/jsi.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 
@@ -383,7 +377,7 @@ static inline std::string toString(const EnumPropNativeComponentViewIntervals &v
   }
 }
 
-class JSI_EXPORT EnumPropNativeComponentViewProps final : public ViewProps {
+class EnumPropNativeComponentViewProps final : public ViewProps {
  public:
   EnumPropNativeComponentViewProps() = default;
   EnumPropNativeComponentViewProps(const PropsParserContext& context, const EnumPropNativeComponentViewProps &sourceProps, const RawProps &rawProps);
@@ -413,14 +407,13 @@ Object {
  */
 #pragma once
 
-#include <jsi/jsi.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 
 namespace facebook {
 namespace react {
 
-class JSI_EXPORT EventNestedObjectPropsNativeComponentViewProps final : public ViewProps {
+class EventNestedObjectPropsNativeComponentViewProps final : public ViewProps {
  public:
   EventNestedObjectPropsNativeComponentViewProps() = default;
   EventNestedObjectPropsNativeComponentViewProps(const PropsParserContext& context, const EventNestedObjectPropsNativeComponentViewProps &sourceProps, const RawProps &rawProps);
@@ -449,14 +442,13 @@ Object {
  */
 #pragma once
 
-#include <jsi/jsi.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 
 namespace facebook {
 namespace react {
 
-class JSI_EXPORT EventPropsNativeComponentViewProps final : public ViewProps {
+class EventPropsNativeComponentViewProps final : public ViewProps {
  public:
   EventPropsNativeComponentViewProps() = default;
   EventPropsNativeComponentViewProps(const PropsParserContext& context, const EventPropsNativeComponentViewProps &sourceProps, const RawProps &rawProps);
@@ -485,14 +477,13 @@ Object {
  */
 #pragma once
 
-#include <jsi/jsi.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 
 namespace facebook {
 namespace react {
 
-class JSI_EXPORT FloatPropsNativeComponentViewProps final : public ViewProps {
+class FloatPropsNativeComponentViewProps final : public ViewProps {
  public:
   FloatPropsNativeComponentViewProps() = default;
   FloatPropsNativeComponentViewProps(const PropsParserContext& context, const FloatPropsNativeComponentViewProps &sourceProps, const RawProps &rawProps);
@@ -527,7 +518,6 @@ Object {
  */
 #pragma once
 
-#include <jsi/jsi.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/imagemanager/primitives.h>
@@ -535,7 +525,7 @@ Object {
 namespace facebook {
 namespace react {
 
-class JSI_EXPORT ImagePropNativeComponentViewProps final : public ViewProps {
+class ImagePropNativeComponentViewProps final : public ViewProps {
  public:
   ImagePropNativeComponentViewProps() = default;
   ImagePropNativeComponentViewProps(const PropsParserContext& context, const ImagePropNativeComponentViewProps &sourceProps, const RawProps &rawProps);
@@ -564,14 +554,13 @@ Object {
  */
 #pragma once
 
-#include <jsi/jsi.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 
 namespace facebook {
 namespace react {
 
-class JSI_EXPORT IntegerPropNativeComponentViewProps final : public ViewProps {
+class IntegerPropNativeComponentViewProps final : public ViewProps {
  public:
   IntegerPropNativeComponentViewProps() = default;
   IntegerPropNativeComponentViewProps(const PropsParserContext& context, const IntegerPropNativeComponentViewProps &sourceProps, const RawProps &rawProps);
@@ -602,14 +591,13 @@ Object {
  */
 #pragma once
 
-#include <jsi/jsi.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 
 namespace facebook {
 namespace react {
 
-class JSI_EXPORT InterfaceOnlyNativeComponentViewProps final : public ViewProps {
+class InterfaceOnlyNativeComponentViewProps final : public ViewProps {
  public:
   InterfaceOnlyNativeComponentViewProps() = default;
   InterfaceOnlyNativeComponentViewProps(const PropsParserContext& context, const InterfaceOnlyNativeComponentViewProps &sourceProps, const RawProps &rawProps);
@@ -638,14 +626,13 @@ Object {
  */
 #pragma once
 
-#include <jsi/jsi.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 
 namespace facebook {
 namespace react {
 
-class JSI_EXPORT MixedPropNativeComponentViewProps final : public ViewProps {
+class MixedPropNativeComponentViewProps final : public ViewProps {
  public:
   MixedPropNativeComponentViewProps() = default;
   MixedPropNativeComponentViewProps(const PropsParserContext& context, const MixedPropNativeComponentViewProps &sourceProps, const RawProps &rawProps);
@@ -674,7 +661,6 @@ Object {
  */
 #pragma once
 
-#include <jsi/jsi.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/graphics/Color.h>
@@ -684,7 +670,7 @@ Object {
 namespace facebook {
 namespace react {
 
-class JSI_EXPORT MultiNativePropNativeComponentViewProps final : public ViewProps {
+class MultiNativePropNativeComponentViewProps final : public ViewProps {
  public:
   MultiNativePropNativeComponentViewProps() = default;
   MultiNativePropNativeComponentViewProps(const PropsParserContext& context, const MultiNativePropNativeComponentViewProps &sourceProps, const RawProps &rawProps);
@@ -716,14 +702,13 @@ Object {
  */
 #pragma once
 
-#include <jsi/jsi.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 
 namespace facebook {
 namespace react {
 
-class JSI_EXPORT NoPropsNoEventsNativeComponentViewProps final : public ViewProps {
+class NoPropsNoEventsNativeComponentViewProps final : public ViewProps {
  public:
   NoPropsNoEventsNativeComponentViewProps() = default;
   NoPropsNoEventsNativeComponentViewProps(const PropsParserContext& context, const NoPropsNoEventsNativeComponentViewProps &sourceProps, const RawProps &rawProps);
@@ -752,7 +737,6 @@ Object {
  */
 #pragma once
 
-#include <jsi/jsi.h>
 #include <react/renderer/components/image/conversions.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
@@ -887,7 +871,7 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
 static inline std::string toString(const ObjectPropsNativeComponentObjectPrimitiveRequiredPropStruct &value) {
   return \\"[Object ObjectPropsNativeComponentObjectPrimitiveRequiredPropStruct]\\";
 }
-class JSI_EXPORT ObjectPropsNativeComponentProps final : public ViewProps {
+class ObjectPropsNativeComponentProps final : public ViewProps {
  public:
   ObjectPropsNativeComponentProps() = default;
   ObjectPropsNativeComponentProps(const PropsParserContext& context, const ObjectPropsNativeComponentProps &sourceProps, const RawProps &rawProps);
@@ -918,7 +902,6 @@ Object {
  */
 #pragma once
 
-#include <jsi/jsi.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/graphics/Point.h>
@@ -926,7 +909,7 @@ Object {
 namespace facebook {
 namespace react {
 
-class JSI_EXPORT PointPropNativeComponentViewProps final : public ViewProps {
+class PointPropNativeComponentViewProps final : public ViewProps {
  public:
   PointPropNativeComponentViewProps() = default;
   PointPropNativeComponentViewProps(const PropsParserContext& context, const PointPropNativeComponentViewProps &sourceProps, const RawProps &rawProps);
@@ -955,14 +938,13 @@ Object {
  */
 #pragma once
 
-#include <jsi/jsi.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 
 namespace facebook {
 namespace react {
 
-class JSI_EXPORT StringPropNativeComponentViewProps final : public ViewProps {
+class StringPropNativeComponentViewProps final : public ViewProps {
  public:
   StringPropNativeComponentViewProps() = default;
   StringPropNativeComponentViewProps(const PropsParserContext& context, const StringPropNativeComponentViewProps &sourceProps, const RawProps &rawProps);

--- a/packages/react-native-codegen/src/generators/components/GenerateEventEmitterH.js
+++ b/packages/react-native-codegen/src/generators/components/GenerateEventEmitterH.js
@@ -54,7 +54,6 @@ const FileTemplate = ({
 #pragma once
 
 #include <react/renderer/components/view/ViewEventEmitter.h>
-#include <jsi/jsi.h>
 ${[...extraIncludes].join('\n')}
 
 namespace facebook {
@@ -74,7 +73,7 @@ const ComponentTemplate = ({
   events: string,
 }) =>
   `
-class JSI_EXPORT ${className}EventEmitter : public ViewEventEmitter {
+class ${className}EventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 

--- a/packages/react-native-codegen/src/generators/components/GeneratePropsH.js
+++ b/packages/react-native-codegen/src/generators/components/GeneratePropsH.js
@@ -80,7 +80,7 @@ const ClassTemplate = ({
   `
 ${enums}
 ${structs}
-class JSI_EXPORT ${className} final${extendClasses} {
+class ${className} final${extendClasses} {
  public:
   ${className}() = default;
   ${className}(const PropsParserContext& context, const ${className} &sourceProps, const RawProps &rawProps);
@@ -478,7 +478,6 @@ function getExtendsImports(
   const imports: Set<string> = new Set();
 
   imports.add('#include <react/renderer/core/PropsParserContext.h>');
-  imports.add('#include <jsi/jsi.h>');
 
   extendsProps.forEach(extendProps => {
     switch (extendProps.type) {

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GenerateEventEmitterH-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GenerateEventEmitterH-test.js.snap
@@ -14,12 +14,11 @@ Map {
 #pragma once
 
 #include <react/renderer/components/view/ViewEventEmitter.h>
-#include <jsi/jsi.h>
 
 
 namespace facebook {
 namespace react {
-class JSI_EXPORT ArrayPropsNativeComponentEventEmitter : public ViewEventEmitter {
+class ArrayPropsNativeComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 
@@ -46,12 +45,11 @@ Map {
 #pragma once
 
 #include <react/renderer/components/view/ViewEventEmitter.h>
-#include <jsi/jsi.h>
 
 
 namespace facebook {
 namespace react {
-class JSI_EXPORT ArrayPropsNativeComponentEventEmitter : public ViewEventEmitter {
+class ArrayPropsNativeComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 
@@ -78,12 +76,11 @@ Map {
 #pragma once
 
 #include <react/renderer/components/view/ViewEventEmitter.h>
-#include <jsi/jsi.h>
 
 
 namespace facebook {
 namespace react {
-class JSI_EXPORT BooleanPropNativeComponentEventEmitter : public ViewEventEmitter {
+class BooleanPropNativeComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 
@@ -110,12 +107,11 @@ Map {
 #pragma once
 
 #include <react/renderer/components/view/ViewEventEmitter.h>
-#include <jsi/jsi.h>
 
 
 namespace facebook {
 namespace react {
-class JSI_EXPORT ColorPropNativeComponentEventEmitter : public ViewEventEmitter {
+class ColorPropNativeComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 
@@ -142,12 +138,11 @@ Map {
 #pragma once
 
 #include <react/renderer/components/view/ViewEventEmitter.h>
-#include <jsi/jsi.h>
 
 
 namespace facebook {
 namespace react {
-class JSI_EXPORT CommandNativeComponentEventEmitter : public ViewEventEmitter {
+class CommandNativeComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 
@@ -174,12 +169,11 @@ Map {
 #pragma once
 
 #include <react/renderer/components/view/ViewEventEmitter.h>
-#include <jsi/jsi.h>
 
 
 namespace facebook {
 namespace react {
-class JSI_EXPORT CommandNativeComponentEventEmitter : public ViewEventEmitter {
+class CommandNativeComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 
@@ -206,12 +200,11 @@ Map {
 #pragma once
 
 #include <react/renderer/components/view/ViewEventEmitter.h>
-#include <jsi/jsi.h>
 
 
 namespace facebook {
 namespace react {
-class JSI_EXPORT DimensionPropNativeComponentEventEmitter : public ViewEventEmitter {
+class DimensionPropNativeComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 
@@ -238,12 +231,11 @@ Map {
 #pragma once
 
 #include <react/renderer/components/view/ViewEventEmitter.h>
-#include <jsi/jsi.h>
 
 
 namespace facebook {
 namespace react {
-class JSI_EXPORT DoublePropNativeComponentEventEmitter : public ViewEventEmitter {
+class DoublePropNativeComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 
@@ -270,12 +262,11 @@ Map {
 #pragma once
 
 #include <react/renderer/components/view/ViewEventEmitter.h>
-#include <jsi/jsi.h>
 
 
 namespace facebook {
 namespace react {
-class JSI_EXPORT EventsNestedObjectNativeComponentEventEmitter : public ViewEventEmitter {
+class EventsNestedObjectNativeComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 
@@ -314,12 +305,11 @@ Map {
 #pragma once
 
 #include <react/renderer/components/view/ViewEventEmitter.h>
-#include <jsi/jsi.h>
 #include <folly/dynamic.h>
 
 namespace facebook {
 namespace react {
-class JSI_EXPORT EventsNativeComponentEventEmitter : public ViewEventEmitter {
+class EventsNativeComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 
@@ -383,12 +373,11 @@ Map {
 #pragma once
 
 #include <react/renderer/components/view/ViewEventEmitter.h>
-#include <jsi/jsi.h>
 
 
 namespace facebook {
 namespace react {
-class JSI_EXPORT InterfaceOnlyComponentEventEmitter : public ViewEventEmitter {
+class InterfaceOnlyComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 
@@ -423,12 +412,11 @@ Map {
 #pragma once
 
 #include <react/renderer/components/view/ViewEventEmitter.h>
-#include <jsi/jsi.h>
 
 
 namespace facebook {
 namespace react {
-class JSI_EXPORT ExcludedAndroidComponentEventEmitter : public ViewEventEmitter {
+class ExcludedAndroidComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 
@@ -455,12 +443,11 @@ Map {
 #pragma once
 
 #include <react/renderer/components/view/ViewEventEmitter.h>
-#include <jsi/jsi.h>
 
 
 namespace facebook {
 namespace react {
-class JSI_EXPORT ExcludedAndroidIosComponentEventEmitter : public ViewEventEmitter {
+class ExcludedAndroidIosComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 
@@ -487,19 +474,18 @@ Map {
 #pragma once
 
 #include <react/renderer/components/view/ViewEventEmitter.h>
-#include <jsi/jsi.h>
 
 
 namespace facebook {
 namespace react {
-class JSI_EXPORT ExcludedIosComponentEventEmitter : public ViewEventEmitter {
+class ExcludedIosComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 
   
   
 };
-class JSI_EXPORT MultiFileIncludedNativeComponentEventEmitter : public ViewEventEmitter {
+class MultiFileIncludedNativeComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 
@@ -526,12 +512,11 @@ Map {
 #pragma once
 
 #include <react/renderer/components/view/ViewEventEmitter.h>
-#include <jsi/jsi.h>
 
 
 namespace facebook {
 namespace react {
-class JSI_EXPORT FloatPropNativeComponentEventEmitter : public ViewEventEmitter {
+class FloatPropNativeComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 
@@ -558,12 +543,11 @@ Map {
 #pragma once
 
 #include <react/renderer/components/view/ViewEventEmitter.h>
-#include <jsi/jsi.h>
 
 
 namespace facebook {
 namespace react {
-class JSI_EXPORT ImagePropNativeComponentEventEmitter : public ViewEventEmitter {
+class ImagePropNativeComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 
@@ -590,12 +574,11 @@ Map {
 #pragma once
 
 #include <react/renderer/components/view/ViewEventEmitter.h>
-#include <jsi/jsi.h>
 
 
 namespace facebook {
 namespace react {
-class JSI_EXPORT InsetsPropNativeComponentEventEmitter : public ViewEventEmitter {
+class InsetsPropNativeComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 
@@ -622,12 +605,11 @@ Map {
 #pragma once
 
 #include <react/renderer/components/view/ViewEventEmitter.h>
-#include <jsi/jsi.h>
 
 
 namespace facebook {
 namespace react {
-class JSI_EXPORT Int32EnumPropsNativeComponentEventEmitter : public ViewEventEmitter {
+class Int32EnumPropsNativeComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 
@@ -654,12 +636,11 @@ Map {
 #pragma once
 
 #include <react/renderer/components/view/ViewEventEmitter.h>
-#include <jsi/jsi.h>
 
 
 namespace facebook {
 namespace react {
-class JSI_EXPORT IntegerPropNativeComponentEventEmitter : public ViewEventEmitter {
+class IntegerPropNativeComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 
@@ -686,12 +667,11 @@ Map {
 #pragma once
 
 #include <react/renderer/components/view/ViewEventEmitter.h>
-#include <jsi/jsi.h>
 
 
 namespace facebook {
 namespace react {
-class JSI_EXPORT InterfaceOnlyComponentEventEmitter : public ViewEventEmitter {
+class InterfaceOnlyComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 
@@ -720,12 +700,11 @@ Map {
 #pragma once
 
 #include <react/renderer/components/view/ViewEventEmitter.h>
-#include <jsi/jsi.h>
 
 
 namespace facebook {
 namespace react {
-class JSI_EXPORT MixedPropNativeComponentEventEmitter : public ViewEventEmitter {
+class MixedPropNativeComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 
@@ -752,12 +731,11 @@ Map {
 #pragma once
 
 #include <react/renderer/components/view/ViewEventEmitter.h>
-#include <jsi/jsi.h>
 
 
 namespace facebook {
 namespace react {
-class JSI_EXPORT ImageColorPropNativeComponentEventEmitter : public ViewEventEmitter {
+class ImageColorPropNativeComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 
@@ -784,12 +762,11 @@ Map {
 #pragma once
 
 #include <react/renderer/components/view/ViewEventEmitter.h>
-#include <jsi/jsi.h>
 
 
 namespace facebook {
 namespace react {
-class JSI_EXPORT NoPropsNoEventsComponentEventEmitter : public ViewEventEmitter {
+class NoPropsNoEventsComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 
@@ -816,12 +793,11 @@ Map {
 #pragma once
 
 #include <react/renderer/components/view/ViewEventEmitter.h>
-#include <jsi/jsi.h>
 
 
 namespace facebook {
 namespace react {
-class JSI_EXPORT ObjectPropsEventEmitter : public ViewEventEmitter {
+class ObjectPropsEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 
@@ -848,12 +824,11 @@ Map {
 #pragma once
 
 #include <react/renderer/components/view/ViewEventEmitter.h>
-#include <jsi/jsi.h>
 
 
 namespace facebook {
 namespace react {
-class JSI_EXPORT PointPropNativeComponentEventEmitter : public ViewEventEmitter {
+class PointPropNativeComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 
@@ -880,12 +855,11 @@ Map {
 #pragma once
 
 #include <react/renderer/components/view/ViewEventEmitter.h>
-#include <jsi/jsi.h>
 
 
 namespace facebook {
 namespace react {
-class JSI_EXPORT StringEnumPropsNativeComponentEventEmitter : public ViewEventEmitter {
+class StringEnumPropsNativeComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 
@@ -912,12 +886,11 @@ Map {
 #pragma once
 
 #include <react/renderer/components/view/ViewEventEmitter.h>
-#include <jsi/jsi.h>
 
 
 namespace facebook {
 namespace react {
-class JSI_EXPORT StringPropComponentEventEmitter : public ViewEventEmitter {
+class StringPropComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 
@@ -944,19 +917,18 @@ Map {
 #pragma once
 
 #include <react/renderer/components/view/ViewEventEmitter.h>
-#include <jsi/jsi.h>
 
 
 namespace facebook {
 namespace react {
-class JSI_EXPORT MultiFile1NativeComponentEventEmitter : public ViewEventEmitter {
+class MultiFile1NativeComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 
   
   
 };
-class JSI_EXPORT MultiFile2NativeComponentEventEmitter : public ViewEventEmitter {
+class MultiFile2NativeComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 
@@ -983,19 +955,18 @@ Map {
 #pragma once
 
 #include <react/renderer/components/view/ViewEventEmitter.h>
-#include <jsi/jsi.h>
 
 
 namespace facebook {
 namespace react {
-class JSI_EXPORT MultiComponent1NativeComponentEventEmitter : public ViewEventEmitter {
+class MultiComponent1NativeComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 
   
   
 };
-class JSI_EXPORT MultiComponent2NativeComponentEventEmitter : public ViewEventEmitter {
+class MultiComponent2NativeComponentEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsH-test.js.snap
@@ -14,7 +14,6 @@ Map {
 #pragma once
 
 #include <cinttypes>
-#include <jsi/jsi.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/core/propsConversions.h>
@@ -193,7 +192,7 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
   }
 }
 
-class JSI_EXPORT ArrayPropsNativeComponentProps final : public ViewProps {
+class ArrayPropsNativeComponentProps final : public ViewProps {
  public:
   ArrayPropsNativeComponentProps() = default;
   ArrayPropsNativeComponentProps(const PropsParserContext& context, const ArrayPropsNativeComponentProps &sourceProps, const RawProps &rawProps);
@@ -233,7 +232,6 @@ Map {
  */
 #pragma once
 
-#include <jsi/jsi.h>
 #include <react/renderer/components/image/conversions.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
@@ -282,7 +280,7 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
   }
 }
 
-class JSI_EXPORT ArrayPropsNativeComponentProps final : public ViewProps {
+class ArrayPropsNativeComponentProps final : public ViewProps {
  public:
   ArrayPropsNativeComponentProps() = default;
   ArrayPropsNativeComponentProps(const PropsParserContext& context, const ArrayPropsNativeComponentProps &sourceProps, const RawProps &rawProps);
@@ -311,14 +309,13 @@ Map {
  */
 #pragma once
 
-#include <jsi/jsi.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 
 namespace facebook {
 namespace react {
 
-class JSI_EXPORT BooleanPropNativeComponentProps final : public ViewProps {
+class BooleanPropNativeComponentProps final : public ViewProps {
  public:
   BooleanPropNativeComponentProps() = default;
   BooleanPropNativeComponentProps(const PropsParserContext& context, const BooleanPropNativeComponentProps &sourceProps, const RawProps &rawProps);
@@ -347,7 +344,6 @@ Map {
  */
 #pragma once
 
-#include <jsi/jsi.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/graphics/Color.h>
@@ -355,7 +351,7 @@ Map {
 namespace facebook {
 namespace react {
 
-class JSI_EXPORT ColorPropNativeComponentProps final : public ViewProps {
+class ColorPropNativeComponentProps final : public ViewProps {
  public:
   ColorPropNativeComponentProps() = default;
   ColorPropNativeComponentProps(const PropsParserContext& context, const ColorPropNativeComponentProps &sourceProps, const RawProps &rawProps);
@@ -384,14 +380,13 @@ Map {
  */
 #pragma once
 
-#include <jsi/jsi.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 
 namespace facebook {
 namespace react {
 
-class JSI_EXPORT CommandNativeComponentProps final : public ViewProps {
+class CommandNativeComponentProps final : public ViewProps {
  public:
   CommandNativeComponentProps() = default;
   CommandNativeComponentProps(const PropsParserContext& context, const CommandNativeComponentProps &sourceProps, const RawProps &rawProps);
@@ -420,14 +415,13 @@ Map {
  */
 #pragma once
 
-#include <jsi/jsi.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 
 namespace facebook {
 namespace react {
 
-class JSI_EXPORT CommandNativeComponentProps final : public ViewProps {
+class CommandNativeComponentProps final : public ViewProps {
  public:
   CommandNativeComponentProps() = default;
   CommandNativeComponentProps(const PropsParserContext& context, const CommandNativeComponentProps &sourceProps, const RawProps &rawProps);
@@ -456,7 +450,6 @@ Map {
  */
 #pragma once
 
-#include <jsi/jsi.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <yoga/Yoga.h>
@@ -464,7 +457,7 @@ Map {
 namespace facebook {
 namespace react {
 
-class JSI_EXPORT DimensionPropNativeComponentProps final : public ViewProps {
+class DimensionPropNativeComponentProps final : public ViewProps {
  public:
   DimensionPropNativeComponentProps() = default;
   DimensionPropNativeComponentProps(const PropsParserContext& context, const DimensionPropNativeComponentProps &sourceProps, const RawProps &rawProps);
@@ -493,14 +486,13 @@ Map {
  */
 #pragma once
 
-#include <jsi/jsi.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 
 namespace facebook {
 namespace react {
 
-class JSI_EXPORT DoublePropNativeComponentProps final : public ViewProps {
+class DoublePropNativeComponentProps final : public ViewProps {
  public:
   DoublePropNativeComponentProps() = default;
   DoublePropNativeComponentProps(const PropsParserContext& context, const DoublePropNativeComponentProps &sourceProps, const RawProps &rawProps);
@@ -534,14 +526,13 @@ Map {
  */
 #pragma once
 
-#include <jsi/jsi.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 
 namespace facebook {
 namespace react {
 
-class JSI_EXPORT EventsNestedObjectNativeComponentProps final : public ViewProps {
+class EventsNestedObjectNativeComponentProps final : public ViewProps {
  public:
   EventsNestedObjectNativeComponentProps() = default;
   EventsNestedObjectNativeComponentProps(const PropsParserContext& context, const EventsNestedObjectNativeComponentProps &sourceProps, const RawProps &rawProps);
@@ -570,14 +561,13 @@ Map {
  */
 #pragma once
 
-#include <jsi/jsi.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 
 namespace facebook {
 namespace react {
 
-class JSI_EXPORT EventsNativeComponentProps final : public ViewProps {
+class EventsNativeComponentProps final : public ViewProps {
  public:
   EventsNativeComponentProps() = default;
   EventsNativeComponentProps(const PropsParserContext& context, const EventsNativeComponentProps &sourceProps, const RawProps &rawProps);
@@ -606,14 +596,13 @@ Map {
  */
 #pragma once
 
-#include <jsi/jsi.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 
 namespace facebook {
 namespace react {
 
-class JSI_EXPORT InterfaceOnlyComponentProps final : public ViewProps {
+class InterfaceOnlyComponentProps final : public ViewProps {
  public:
   InterfaceOnlyComponentProps() = default;
   InterfaceOnlyComponentProps(const PropsParserContext& context, const InterfaceOnlyComponentProps &sourceProps, const RawProps &rawProps);
@@ -642,14 +631,13 @@ Map {
  */
 #pragma once
 
-#include <jsi/jsi.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 
 namespace facebook {
 namespace react {
 
-class JSI_EXPORT ExcludedAndroidComponentProps final : public ViewProps {
+class ExcludedAndroidComponentProps final : public ViewProps {
  public:
   ExcludedAndroidComponentProps() = default;
   ExcludedAndroidComponentProps(const PropsParserContext& context, const ExcludedAndroidComponentProps &sourceProps, const RawProps &rawProps);
@@ -678,14 +666,13 @@ Map {
  */
 #pragma once
 
-#include <jsi/jsi.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 
 namespace facebook {
 namespace react {
 
-class JSI_EXPORT ExcludedAndroidIosComponentProps final : public ViewProps {
+class ExcludedAndroidIosComponentProps final : public ViewProps {
  public:
   ExcludedAndroidIosComponentProps() = default;
   ExcludedAndroidIosComponentProps(const PropsParserContext& context, const ExcludedAndroidIosComponentProps &sourceProps, const RawProps &rawProps);
@@ -714,14 +701,13 @@ Map {
  */
 #pragma once
 
-#include <jsi/jsi.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 
 namespace facebook {
 namespace react {
 
-class JSI_EXPORT ExcludedIosComponentProps final : public ViewProps {
+class ExcludedIosComponentProps final : public ViewProps {
  public:
   ExcludedIosComponentProps() = default;
   ExcludedIosComponentProps(const PropsParserContext& context, const ExcludedIosComponentProps &sourceProps, const RawProps &rawProps);
@@ -731,7 +717,7 @@ class JSI_EXPORT ExcludedIosComponentProps final : public ViewProps {
   
 };
 
-class JSI_EXPORT MultiFileIncludedNativeComponentProps final : public ViewProps {
+class MultiFileIncludedNativeComponentProps final : public ViewProps {
  public:
   MultiFileIncludedNativeComponentProps() = default;
   MultiFileIncludedNativeComponentProps(const PropsParserContext& context, const MultiFileIncludedNativeComponentProps &sourceProps, const RawProps &rawProps);
@@ -760,14 +746,13 @@ Map {
  */
 #pragma once
 
-#include <jsi/jsi.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 
 namespace facebook {
 namespace react {
 
-class JSI_EXPORT FloatPropNativeComponentProps final : public ViewProps {
+class FloatPropNativeComponentProps final : public ViewProps {
  public:
   FloatPropNativeComponentProps() = default;
   FloatPropNativeComponentProps(const PropsParserContext& context, const FloatPropNativeComponentProps &sourceProps, const RawProps &rawProps);
@@ -801,7 +786,6 @@ Map {
  */
 #pragma once
 
-#include <jsi/jsi.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/imagemanager/primitives.h>
@@ -809,7 +793,7 @@ Map {
 namespace facebook {
 namespace react {
 
-class JSI_EXPORT ImagePropNativeComponentProps final : public ViewProps {
+class ImagePropNativeComponentProps final : public ViewProps {
  public:
   ImagePropNativeComponentProps() = default;
   ImagePropNativeComponentProps(const PropsParserContext& context, const ImagePropNativeComponentProps &sourceProps, const RawProps &rawProps);
@@ -838,7 +822,6 @@ Map {
  */
 #pragma once
 
-#include <jsi/jsi.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/graphics/RectangleEdges.h>
@@ -846,7 +829,7 @@ Map {
 namespace facebook {
 namespace react {
 
-class JSI_EXPORT InsetsPropNativeComponentProps final : public ViewProps {
+class InsetsPropNativeComponentProps final : public ViewProps {
  public:
   InsetsPropNativeComponentProps() = default;
   InsetsPropNativeComponentProps(const PropsParserContext& context, const InsetsPropNativeComponentProps &sourceProps, const RawProps &rawProps);
@@ -875,7 +858,6 @@ Map {
  */
 #pragma once
 
-#include <jsi/jsi.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 
@@ -909,7 +891,7 @@ static inline std::string toString(const Int32EnumPropsNativeComponentMaxInterva
   }
 }
 
-class JSI_EXPORT Int32EnumPropsNativeComponentProps final : public ViewProps {
+class Int32EnumPropsNativeComponentProps final : public ViewProps {
  public:
   Int32EnumPropsNativeComponentProps() = default;
   Int32EnumPropsNativeComponentProps(const PropsParserContext& context, const Int32EnumPropsNativeComponentProps &sourceProps, const RawProps &rawProps);
@@ -938,14 +920,13 @@ Map {
  */
 #pragma once
 
-#include <jsi/jsi.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 
 namespace facebook {
 namespace react {
 
-class JSI_EXPORT IntegerPropNativeComponentProps final : public ViewProps {
+class IntegerPropNativeComponentProps final : public ViewProps {
  public:
   IntegerPropNativeComponentProps() = default;
   IntegerPropNativeComponentProps(const PropsParserContext& context, const IntegerPropNativeComponentProps &sourceProps, const RawProps &rawProps);
@@ -976,14 +957,13 @@ Map {
  */
 #pragma once
 
-#include <jsi/jsi.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 
 namespace facebook {
 namespace react {
 
-class JSI_EXPORT InterfaceOnlyComponentProps final : public ViewProps {
+class InterfaceOnlyComponentProps final : public ViewProps {
  public:
   InterfaceOnlyComponentProps() = default;
   InterfaceOnlyComponentProps(const PropsParserContext& context, const InterfaceOnlyComponentProps &sourceProps, const RawProps &rawProps);
@@ -1012,14 +992,13 @@ Map {
  */
 #pragma once
 
-#include <jsi/jsi.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 
 namespace facebook {
 namespace react {
 
-class JSI_EXPORT MixedPropNativeComponentProps final : public ViewProps {
+class MixedPropNativeComponentProps final : public ViewProps {
  public:
   MixedPropNativeComponentProps() = default;
   MixedPropNativeComponentProps(const PropsParserContext& context, const MixedPropNativeComponentProps &sourceProps, const RawProps &rawProps);
@@ -1048,7 +1027,6 @@ Map {
  */
 #pragma once
 
-#include <jsi/jsi.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/graphics/Color.h>
@@ -1058,7 +1036,7 @@ Map {
 namespace facebook {
 namespace react {
 
-class JSI_EXPORT ImageColorPropNativeComponentProps final : public ViewProps {
+class ImageColorPropNativeComponentProps final : public ViewProps {
  public:
   ImageColorPropNativeComponentProps() = default;
   ImageColorPropNativeComponentProps(const PropsParserContext& context, const ImageColorPropNativeComponentProps &sourceProps, const RawProps &rawProps);
@@ -1090,14 +1068,13 @@ Map {
  */
 #pragma once
 
-#include <jsi/jsi.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 
 namespace facebook {
 namespace react {
 
-class JSI_EXPORT NoPropsNoEventsComponentProps final : public ViewProps {
+class NoPropsNoEventsComponentProps final : public ViewProps {
  public:
   NoPropsNoEventsComponentProps() = default;
   NoPropsNoEventsComponentProps(const PropsParserContext& context, const NoPropsNoEventsComponentProps &sourceProps, const RawProps &rawProps);
@@ -1126,7 +1103,6 @@ Map {
  */
 #pragma once
 
-#include <jsi/jsi.h>
 #include <react/renderer/components/image/conversions.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
@@ -1353,7 +1329,7 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
 static inline std::string toString(const ObjectPropsObjectPropStruct &value) {
   return \\"[Object ObjectPropsObjectPropStruct]\\";
 }
-class JSI_EXPORT ObjectPropsProps final : public ViewProps {
+class ObjectPropsProps final : public ViewProps {
  public:
   ObjectPropsProps() = default;
   ObjectPropsProps(const PropsParserContext& context, const ObjectPropsProps &sourceProps, const RawProps &rawProps);
@@ -1382,7 +1358,6 @@ Map {
  */
 #pragma once
 
-#include <jsi/jsi.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/graphics/Point.h>
@@ -1390,7 +1365,7 @@ Map {
 namespace facebook {
 namespace react {
 
-class JSI_EXPORT PointPropNativeComponentProps final : public ViewProps {
+class PointPropNativeComponentProps final : public ViewProps {
  public:
   PointPropNativeComponentProps() = default;
   PointPropNativeComponentProps(const PropsParserContext& context, const PointPropNativeComponentProps &sourceProps, const RawProps &rawProps);
@@ -1419,7 +1394,6 @@ Map {
  */
 #pragma once
 
-#include <jsi/jsi.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 
@@ -1444,7 +1418,7 @@ static inline std::string toString(const StringEnumPropsNativeComponentAlignment
   }
 }
 
-class JSI_EXPORT StringEnumPropsNativeComponentProps final : public ViewProps {
+class StringEnumPropsNativeComponentProps final : public ViewProps {
  public:
   StringEnumPropsNativeComponentProps() = default;
   StringEnumPropsNativeComponentProps(const PropsParserContext& context, const StringEnumPropsNativeComponentProps &sourceProps, const RawProps &rawProps);
@@ -1473,14 +1447,13 @@ Map {
  */
 #pragma once
 
-#include <jsi/jsi.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 
 namespace facebook {
 namespace react {
 
-class JSI_EXPORT StringPropComponentProps final : public ViewProps {
+class StringPropComponentProps final : public ViewProps {
  public:
   StringPropComponentProps() = default;
   StringPropComponentProps(const PropsParserContext& context, const StringPropComponentProps &sourceProps, const RawProps &rawProps);
@@ -1510,14 +1483,13 @@ Map {
  */
 #pragma once
 
-#include <jsi/jsi.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 
 namespace facebook {
 namespace react {
 
-class JSI_EXPORT MultiFile1NativeComponentProps final : public ViewProps {
+class MultiFile1NativeComponentProps final : public ViewProps {
  public:
   MultiFile1NativeComponentProps() = default;
   MultiFile1NativeComponentProps(const PropsParserContext& context, const MultiFile1NativeComponentProps &sourceProps, const RawProps &rawProps);
@@ -1527,7 +1499,7 @@ class JSI_EXPORT MultiFile1NativeComponentProps final : public ViewProps {
   bool disabled{false};
 };
 
-class JSI_EXPORT MultiFile2NativeComponentProps final : public ViewProps {
+class MultiFile2NativeComponentProps final : public ViewProps {
  public:
   MultiFile2NativeComponentProps() = default;
   MultiFile2NativeComponentProps(const PropsParserContext& context, const MultiFile2NativeComponentProps &sourceProps, const RawProps &rawProps);
@@ -1556,14 +1528,13 @@ Map {
  */
 #pragma once
 
-#include <jsi/jsi.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 
 namespace facebook {
 namespace react {
 
-class JSI_EXPORT MultiComponent1NativeComponentProps final : public ViewProps {
+class MultiComponent1NativeComponentProps final : public ViewProps {
  public:
   MultiComponent1NativeComponentProps() = default;
   MultiComponent1NativeComponentProps(const PropsParserContext& context, const MultiComponent1NativeComponentProps &sourceProps, const RawProps &rawProps);
@@ -1573,7 +1544,7 @@ class JSI_EXPORT MultiComponent1NativeComponentProps final : public ViewProps {
   bool disabled{false};
 };
 
-class JSI_EXPORT MultiComponent2NativeComponentProps final : public ViewProps {
+class MultiComponent2NativeComponentProps final : public ViewProps {
  public:
   MultiComponent2NativeComponentProps() = default;
   MultiComponent2NativeComponentProps(const PropsParserContext& context, const MultiComponent2NativeComponentProps &sourceProps, const RawProps &rawProps);


### PR DESCRIPTION
Summary:
changelog: [internal]

Props and event emitter does not need to use JSI_EXPORT. Therefore we can remove include of jsi.h as well.

Reviewed By: rshest

Differential Revision: D45274824

