### PR TITLE
Fix race condition in SurfaceHandler

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceHandler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceHandler.cpp
@@ -112,6 +112,7 @@ void SurfaceHandler::stop() const noexcept {
 }
 
 void SurfaceHandler::setDisplayMode(DisplayMode displayMode) const noexcept {
+  auto parameters = Parameters{};
   {
     std::unique_lock lock(parametersMutex_);
     if (parameters_.displayMode == displayMode) {
@@ -119,6 +120,7 @@ void SurfaceHandler::setDisplayMode(DisplayMode displayMode) const noexcept {
     }
 
     parameters_.displayMode = displayMode;
+    parameters = parameters_;
   }
 
   {
@@ -129,10 +131,10 @@ void SurfaceHandler::setDisplayMode(DisplayMode displayMode) const noexcept {
     }
 
     link_.uiManager->setSurfaceProps(
-        parameters_.surfaceId,
-        parameters_.moduleName,
-        parameters_.props,
-        parameters_.displayMode);
+        parameters.surfaceId,
+        parameters.moduleName,
+        parameters.props,
+        parameters.displayMode);
 
     applyDisplayMode(displayMode);
   }


### PR DESCRIPTION
Summary:
changelog: [internal]

This is a race condition. parameters need to be copied out, otherwise they might be changed during read.

Reviewed By: luluwu2032

Differential Revision: D45272086

