### PR TITLE
Remove config variant copy ctor from YGNode

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
@@ -488,7 +488,7 @@ void YogaLayoutableShadowNode::layoutTree(
    * the only value in the config of the root node is taken into account
    * (and this is by design).
    */
-  yogaConfig_.pointScaleFactor = layoutContext.pointScaleFactor;
+  YGConfigSetPointScaleFactor(&yogaConfig_, layoutContext.pointScaleFactor);
 
   auto minimumSize = layoutConstraints.minimumSize;
   auto maximumSize = layoutConstraints.maximumSize;
@@ -743,11 +743,11 @@ YogaLayoutableShadowNode &YogaLayoutableShadowNode::shadowNodeFromContext(
 }
 
 YGConfig &YogaLayoutableShadowNode::initializeYogaConfig(YGConfig &config) {
-  config.setCloneNodeCallback(
-      YogaLayoutableShadowNode::yogaNodeCloneCallbackConnector);
-  config.useLegacyStretchBehaviour = true;
+  YGConfigSetCloneNodeFunc(
+      &config, YogaLayoutableShadowNode::yogaNodeCloneCallbackConnector);
+  YGConfigSetUseLegacyStretchBehaviour(&config, true);
 #ifdef RN_DEBUG_YOGA_LOGGER
-  config.printTree = true;
+  YGConfigSetPrintTreeFlag(&config, true);
 #endif
   return config;
 }

--- a/packages/react-native/ReactCommon/yoga/yoga/YGNode.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGNode.cpp
@@ -23,17 +23,6 @@ YGNode::YGNode(const YGConfigRef config) : config_{config} {
   }
 };
 
-YGNode::YGNode(const YGNode& node, YGConfigRef config) : YGNode{node} {
-  YGAssert(
-      config != nullptr, "Attempting to construct YGNode with null config");
-
-  config_ = config;
-  flags_.hasNewLayout = true;
-  if (config->useWebDefaults) {
-    useWebDefaults();
-  }
-}
-
 YGNode::YGNode(YGNode&& node) {
   context_ = node.context_;
   flags_ = node.flags_;

--- a/packages/react-native/ReactCommon/yoga/yoga/YGNode.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGNode.h
@@ -93,10 +93,6 @@ public:
   // Should we remove this?
   YGNode(const YGNode& node) = default;
 
-  [[deprecated("Will be removed imminently")]] YGNode(
-      const YGNode& node,
-      YGConfigRef config);
-
   // assignment means potential leaks of existing children, or alternatively
   // freeing unowned memory, double free, or freeing stack memory.
   YGNode& operator=(const YGNode&) = delete;


### PR DESCRIPTION
Summary: This private constructor was added specifically for Fabric when config setting was deprecated, but that is undeprecated now. Fbsource fabric was moved off of it, and the RN desktop for was in the last diff in the stack, so we can remove it now.

Differential Revision: D45292729

