### PR TITLE
get rid of unused bridge selectors

### DIFF
--- a/packages/react-native/React/CoreModules/RCTSourceCode.mm
+++ b/packages/react-native/React/CoreModules/RCTSourceCode.mm
@@ -9,8 +9,6 @@
 
 #import <FBReactNativeSpec/FBReactNativeSpec.h>
 
-#import <React/RCTBridge.h>
-
 #import "CoreModulesPlugins.h"
 
 using namespace facebook::react;
@@ -22,7 +20,6 @@ using namespace facebook::react;
 
 RCT_EXPORT_MODULE()
 
-@synthesize bridge = _bridge;
 @synthesize bundleManager = _bundleManager;
 
 + (BOOL)requiresMainQueueSetup


### PR DESCRIPTION
Summary:
changelog: [internal]

these are not used, delete

Reviewed By: christophpurrer, RSNara

Differential Revision: D45072764

