### PR TITLE
Replace usages of YGConfigSetUseLegacyStretchBehaviour

### DIFF
--- a/packages/react-native/React/Views/RCTShadowView.m
+++ b/packages/react-native/React/Views/RCTShadowView.m
@@ -50,7 +50,7 @@ typedef NS_ENUM(unsigned int, meta_prop_t) {
   dispatch_once(&onceToken, ^{
     yogaConfig = YGConfigNew();
     YGConfigSetPointScaleFactor(yogaConfig, RCTScreenScale());
-    YGConfigSetUseLegacyStretchBehaviour(yogaConfig, true);
+    YGConfigSetErrata(yogaConfig, YGErrataAll);
   });
   return yogaConfig;
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactYogaConfigProvider.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactYogaConfigProvider.java
@@ -9,6 +9,7 @@ package com.facebook.react.uimanager;
 
 import com.facebook.yoga.YogaConfig;
 import com.facebook.yoga.YogaConfigFactory;
+import com.facebook.yoga.YogaErrata;
 
 public class ReactYogaConfigProvider {
 
@@ -18,7 +19,7 @@ public class ReactYogaConfigProvider {
     if (YOGA_CONFIG == null) {
       YOGA_CONFIG = YogaConfigFactory.create();
       YOGA_CONFIG.setPointScaleFactor(0f);
-      YOGA_CONFIG.setUseLegacyStretchBehaviour(true);
+      YOGA_CONFIG.setErrata(YogaErrata.ALL);
     }
     return YOGA_CONFIG;
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaConfig.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaConfig.java
@@ -22,7 +22,13 @@ public abstract class YogaConfig {
    * Yoga previously had an error where containers would take the maximum space possible instead of the minimum
    * like they are supposed to. In practice this resulted in implicit behaviour similar to align-self: stretch;
    * Because this was such a long-standing bug we must allow legacy users to switch back to this behaviour.
+   *
+   * @deprecated "setUseLegacyStretchBehaviour" will be removed in the next release. Usage should be replaced with
+   * "setErrata(YogaErrata.ALL)" to opt out of all future breaking conformance fixes, or
+   * "setErrata(YogaErrata.STRETCH_FLEX_BASIS)" to opt out of the specific conformance fix previously disabled by
+   * "UseLegacyStretchBehaviour".
    */
+  @Deprecated
   public abstract void setUseLegacyStretchBehaviour(boolean useLegacyStretchBehaviour);
 
   public abstract void setErrata(YogaErrata errata);

--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
@@ -745,7 +745,7 @@ YogaLayoutableShadowNode &YogaLayoutableShadowNode::shadowNodeFromContext(
 YGConfig &YogaLayoutableShadowNode::initializeYogaConfig(YGConfig &config) {
   YGConfigSetCloneNodeFunc(
       &config, YogaLayoutableShadowNode::yogaNodeCloneCallbackConnector);
-  YGConfigSetUseLegacyStretchBehaviour(&config, true);
+  YGConfigSetErrata(&config, YGErrataAll);
 #ifdef RN_DEBUG_YOGA_LOGGER
   YGConfigSetPrintTreeFlag(&config, true);
 #endif


### PR DESCRIPTION
Summary:
This replaces product usages of `YGConfigSetUseLegacyStretchBehaviour` with instead setting `YGErrataAll`, to opt out of future conformance fixes which may impact compatibility.

We need to still audit C/C++ usage for where we should be applying `YGErrataClassic`, port this change to the RN desktop fork, then mark the function as deprecated (taking care to allow deprecated functions in the Yoga bindings to call deprecated C ABI functions without warning).

Changelog: [Internal]

Differential Revision: D45300631

