### PR TITLE
Set errata level in RN Paper, Litho, and Native Templates

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactYogaConfigProvider.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactYogaConfigProvider.java
@@ -9,6 +9,7 @@ package com.facebook.react.uimanager;
 
 import com.facebook.yoga.YogaConfig;
 import com.facebook.yoga.YogaConfigFactory;
+import com.facebook.yoga.YogaErrata;
 
 public class ReactYogaConfigProvider {
 
@@ -18,7 +19,7 @@ public class ReactYogaConfigProvider {
     if (YOGA_CONFIG == null) {
       YOGA_CONFIG = YogaConfigFactory.create();
       YOGA_CONFIG.setPointScaleFactor(0f);
-      YOGA_CONFIG.setUseLegacyStretchBehaviour(true);
+      YOGA_CONFIG.setErrata(YogaErrata.ALL);
     }
     return YOGA_CONFIG;
   }


### PR DESCRIPTION
Summary:
This searches fbsource for the following strings corresponding to node or config creation using Yoga Java bindings.
1. `YogaNodeFactory.create`
2. `YogaConfigFactory.create`

Apart from benchmarks/tests, thie leaves RN Paper, Litho and Native Templates. These are opted into compatibility with current Yoga behavior, using either `YogaErrata.CLASSIC`, or `YogaErrata.ALL` where `UseLegacyStretchBehaviour` is currently set.

Changelog:
[Internal]

Differential Revision: D45299721

