### PR TITLE
Avoid retaining TurboModuleManager in AppDelegate

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.h
@@ -10,7 +10,6 @@
 #import <UIKit/UIKit.h>
 
 @class RCTSurfacePresenterBridgeAdapter;
-@class RCTTurboModuleManager;
 
 /**
  * The RCTAppDelegate is an utility class that implements some base configurations for all the React Native apps.
@@ -95,9 +94,6 @@
 - (UIViewController *)createRootViewController;
 
 #if RCT_NEW_ARCH_ENABLED
-
-/// The TurboModule manager
-@property (nonatomic, strong) RCTTurboModuleManager *turboModuleManager;
 @property (nonatomic, strong) RCTSurfacePresenterBridgeAdapter *bridgeAdapter;
 
 /// This method controls whether the `turboModules` feature of the New Architecture is turned on or off.

--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -130,10 +130,12 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
   _runtimeScheduler = std::make_shared<facebook::react::RuntimeScheduler>(RCTRuntimeExecutorFromBridge(bridge));
   std::shared_ptr<facebook::react::CallInvoker> callInvoker =
       std::make_shared<facebook::react::RuntimeSchedulerCallInvoker>(_runtimeScheduler);
-  self.turboModuleManager = [[RCTTurboModuleManager alloc] initWithBridge:bridge delegate:self jsInvoker:callInvoker];
+  RCTTurboModuleManager *turboModuleManager = [[RCTTurboModuleManager alloc] initWithBridge:bridge
+                                                                                   delegate:self
+                                                                                  jsInvoker:callInvoker];
   _contextContainer->erase("RuntimeScheduler");
   _contextContainer->insert("RuntimeScheduler", _runtimeScheduler);
-  return RCTAppSetupDefaultJsExecutorFactory(bridge, _turboModuleManager, _runtimeScheduler);
+  return RCTAppSetupDefaultJsExecutorFactory(bridge, turboModuleManager, _runtimeScheduler);
 }
 
 #pragma mark - RCTTurboModuleManagerDelegate

--- a/packages/rn-tester/RNTester/AppDelegate.mm
+++ b/packages/rn-tester/RNTester/AppDelegate.mm
@@ -82,8 +82,6 @@
   facebook::react::ContextContainer::Shared _contextContainer;
   std::shared_ptr<facebook::react::RuntimeScheduler> _runtimeScheduler;
 #endif
-
-  RCTTurboModuleManager *_turboModuleManager;
 }
 @end
 
@@ -207,15 +205,18 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
   _contextContainer->insert("RuntimeScheduler", _runtimeScheduler);
   callInvoker = std::make_shared<facebook::react::RuntimeSchedulerCallInvoker>(_runtimeScheduler);
 #endif
-  _turboModuleManager = [[RCTTurboModuleManager alloc] initWithBridge:bridge delegate:self jsInvoker:callInvoker];
-  [bridge setRCTTurboModuleRegistry:_turboModuleManager];
+
+  RCTTurboModuleManager *turboModuleManager = [[RCTTurboModuleManager alloc] initWithBridge:bridge
+                                                                                   delegate:self
+                                                                                  jsInvoker:callInvoker];
+  [bridge setRCTTurboModuleRegistry:turboModuleManager];
 
 #if RCT_DEV
   /**
    * Eagerly initialize RCTDevMenu so CMD + d, CMD + i, and CMD + r work.
    * This is a stop gap until we have a system to eagerly init Turbo Modules.
    */
-  [_turboModuleManager moduleForName:"RCTDevMenu"];
+  [turboModuleManager moduleForName:"RCTDevMenu"];
 #endif
 
   __weak __typeof(self) weakSelf = self;
@@ -229,17 +230,17 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
         if (!bridge) {
           return;
         }
-        __typeof(self) strongSelf = weakSelf;
+
 #if RN_FABRIC_ENABLED
+        __typeof(self) strongSelf = weakSelf;
         if (strongSelf && strongSelf->_runtimeScheduler) {
           facebook::react::RuntimeSchedulerBinding::createAndInstallIfNeeded(runtime, strongSelf->_runtimeScheduler);
         }
 #endif
-        if (strongSelf) {
-          facebook::react::RuntimeExecutor syncRuntimeExecutor =
-              [&](std::function<void(facebook::jsi::Runtime & runtime_)> &&callback) { callback(runtime); };
-          [strongSelf->_turboModuleManager installJSBindingWithRuntimeExecutor:syncRuntimeExecutor];
-        }
+
+        facebook::react::RuntimeExecutor syncRuntimeExecutor =
+            [&](std::function<void(facebook::jsi::Runtime & runtime_)> &&callback) { callback(runtime); };
+        [turboModuleManager installJSBindingWithRuntimeExecutor:syncRuntimeExecutor];
       }));
 }
 


### PR DESCRIPTION
Summary:
The AppDelegate (and other similar classes) only need to construct the TurboModuleManager for intialization purposes, and should not retain it beyond that. TurboModuleManager retains each of the TurboModule instances and through the new binding mechanism, also JSI pointers, which are invalid beyond the lifetime of the JS context.

Changelog: [iOS] Changed AppDelegate template to avoid retaining TurboModuleManager.

Differential Revision: D45310066

