### PR TITLE
Deprecate YGConfigSetUseLegacyStretchBehaviour (#1265)

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/YGJNIVanilla.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/YGJNIVanilla.cpp
@@ -102,7 +102,10 @@ static void jni_YGConfigSetUseLegacyStretchBehaviourJNI(
     jlong nativePointer,
     jboolean useLegacyStretchBehaviour) {
   const YGConfigRef config = _jlong2YGConfigRef(nativePointer);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
   YGConfigSetUseLegacyStretchBehaviour(config, useLegacyStretchBehaviour);
+#pragma clang diagnostic pop
 }
 
 static void jni_YGConfigSetErrataJNI(

--- a/packages/react-native/ReactCommon/yoga/yoga/YGMacros.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGMacros.h
@@ -19,6 +19,14 @@
 #define YG_EXTERN_C_END
 #endif
 
+#if defined(__cplusplus)
+#define YG_DEPRECATED(message) [[deprecated(message)]]
+#elif defined(_MSC_VER)
+#define YG_DEPRECATED(message) __declspec(depreacted(message))
+#else
+#define YG_DEPRECATED(message) __attribute__((deprecated(message)))
+#endif
+
 #ifdef _WINDLL
 #define WIN_EXPORT __declspec(dllexport)
 #else

--- a/packages/react-native/ReactCommon/yoga/yoga/Yoga.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/Yoga.h
@@ -323,8 +323,19 @@ WIN_EXPORT void YGConfigSetPointScaleFactor(
 // resulted in implicit behaviour similar to align-self: stretch; Because this
 // was such a long-standing bug we must allow legacy users to switch back to
 // this behaviour.
-WIN_EXPORT bool YGConfigGetUseLegacyStretchBehaviour(YGConfigRef config);
-WIN_EXPORT void YGConfigSetUseLegacyStretchBehaviour(
+WIN_EXPORT YG_DEPRECATED(
+    "Please use "
+    "\"YGConfigGetErrata()\"") bool YGConfigGetUseLegacyStretchBehaviour(YGConfigRef
+                                                                             config);
+WIN_EXPORT
+YG_DEPRECATED(
+    "\"YGConfigSetUseLegacyStretchBehaviour\" will be removed in the next "
+    "release. Usage should be replaced with \"YGConfigSetErrata(YGErrataAll)\" "
+    "to opt out of all future breaking conformance fixes, or "
+    "\"YGConfigSetErrata(YGErrataStretchFlexBasis)\" to opt out of the "
+    "specific conformance fix previously disabled by "
+    "\"UseLegacyStretchBehaviour\".")
+void YGConfigSetUseLegacyStretchBehaviour(
     YGConfigRef config,
     bool useLegacyStretchBehaviour);
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/yoga/pull/1265

This deprecates `YGConfigSetUseLegacyStretchBehaviour` and `YGConfigGetUseLegacyStretchBehaviour`and points users to errata APIs instead. Using the C API will fire deprecation warnings, which should create errors in builds with `-Werror`, though they can be ignored if truly needed (like we do with the language bindings which need to expose their own deprecated interface).

Differential Revision: D45337198

