### PR TITLE
Unbreak RNTester build

### DIFF
--- a/packages/rn-tester/RNTester/AppDelegate.mm
+++ b/packages/rn-tester/RNTester/AppDelegate.mm
@@ -226,7 +226,8 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
 #else
   return std::make_unique<facebook::react::JSCExecutorFactory>(
 #endif
-      facebook::react::RCTJSIExecutorRuntimeInstaller([weakSelf, bridge](facebook::jsi::Runtime &runtime) {
+      facebook::react::RCTJSIExecutorRuntimeInstaller([weakSelf, bridge, turboModuleManager](
+                                                          facebook::jsi::Runtime &runtime) {
         if (!bridge) {
           return;
         }


### PR DESCRIPTION
Summary:
CircleCI signal was missed in D45310066

Changelog: [Internal]

Reviewed By: fabriziocucci

Differential Revision: D45355691

