### PR TITLE
Make createConstantsForViewManager work correctly with read-only maps

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModuleConstantsHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModuleConstantsHelper.java
@@ -15,6 +15,7 @@ import com.facebook.react.common.MapBuilder;
 import com.facebook.react.config.ReactFeatureFlags;
 import com.facebook.systrace.SystraceMessage;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -187,6 +188,11 @@ import java.util.Set;
       Object sourceValue = source.get(key);
       Object destValue = dest.get(key);
       if (destValue != null && (sourceValue instanceof Map) && (destValue instanceof Map)) {
+        // Since event maps are client based Map interface, it could be immutable
+        if (!(destValue instanceof HashMap)) {
+          destValue = new HashMap((Map) destValue);
+          dest.replace(key, (Map) destValue);
+        }
         recursiveMerge((Map) destValue, (Map) sourceValue);
       } else {
         dest.put(key, sourceValue);


### PR DESCRIPTION
Summary:
Changelog: [Internal]

The root cause was that one of the custom view managers was returning a read-only map for getExportedCustomDirectEventTypeConstants. React Native merges these maps between view managers, so if the view managers were initialized in a particular order, it will try to merge events into the read-only map and silently crashes.

Reviewed By: rshest

Differential Revision: D45370622

