### PR TITLE
[Codegen 116] move `getEventArgument` function into `parsers-commons.js`

### DIFF
--- a/packages/react-native-codegen/src/parsers/flow/components/events.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/events.js
@@ -20,6 +20,7 @@ const {
   throwIfEventHasNoName,
   throwIfBubblingTypeIsNull,
 } = require('../../error-utils');
+const {getEventArgument} = require('../../parsers-commons');
 
 function getPropertyType(
   /* $FlowFixMe[missing-local-annot] The type annotation(s) required by Flow's
@@ -257,15 +258,6 @@ function buildPropertiesForEvent(property): NamedShape<EventTypeAnnotation> {
   return getPropertyType(name, optional, typeAnnotation);
 }
 
-/* $FlowFixMe[missing-local-annot] The type annotation(s) required by Flow's
- * LTI update could not be added via codemod */
-function getEventArgument(argumentProps, name: $FlowFixMe) {
-  return {
-    type: 'ObjectTypeAnnotation',
-    properties: argumentProps.map(buildPropertiesForEvent),
-  };
-}
-
 function buildEventSchema(
   types: TypeMap,
   property: EventTypeAST,
@@ -307,7 +299,7 @@ function buildEventSchema(
       paperTopLevelNameDeprecated,
       typeAnnotation: {
         type: 'EventTypeAnnotation',
-        argument: getEventArgument(argumentProps, name),
+        argument: getEventArgument(argumentProps, buildPropertiesForEvent),
       },
     };
   }
@@ -324,7 +316,7 @@ function buildEventSchema(
     bubblingType,
     typeAnnotation: {
       type: 'EventTypeAnnotation',
-      argument: getEventArgument(argumentProps, name),
+      argument: getEventArgument(argumentProps, buildPropertiesForEvent),
     },
   };
 }

--- a/packages/react-native-codegen/src/parsers/parsers-commons.js
+++ b/packages/react-native-codegen/src/parsers/parsers-commons.js
@@ -23,6 +23,8 @@ import type {
   SchemaType,
   NativeModuleEnumMap,
   OptionsShape,
+  EventTypeAnnotation,
+  ObjectTypeAnnotation,
 } from '../CodegenSchema.js';
 
 import type {Parser} from './parser';
@@ -852,6 +854,20 @@ function extendsForProp(
   }
 }
 
+/* $FlowFixMe[missing-local-annot] The type annotation(s) required by Flow's
+ * LTI update could not be added via codemod */
+function getEventArgument(
+  argumentProps: PropAST,
+  buildPropertiesForEvent: (
+    property: PropAST,
+  ) => NamedShape<EventTypeAnnotation>,
+): ObjectTypeAnnotation<EventTypeAnnotation> {
+  return {
+    type: 'ObjectTypeAnnotation',
+    properties: argumentProps.map(buildPropertiesForEvent),
+  };
+}
+
 module.exports = {
   wrapModuleSchema,
   unwrapNullable,
@@ -872,4 +888,5 @@ module.exports = {
   getOptions,
   getCommandTypeNameAndOptionsExpression,
   extendsForProp,
+  getEventArgument,
 };

--- a/packages/react-native-codegen/src/parsers/typescript/components/events.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/events.js
@@ -23,7 +23,7 @@ const {
   throwIfEventHasNoName,
   throwIfBubblingTypeIsNull,
 } = require('../../error-utils');
-
+const {getEventArgument} = require('../../parsers-commons');
 function getPropertyType(
   /* $FlowFixMe[missing-local-annot] The type annotation(s) required by Flow's
    * LTI update could not be added via codemod */
@@ -270,15 +270,6 @@ function buildPropertiesForEvent(property): NamedShape<EventTypeAnnotation> {
   return getPropertyType(name, optional, typeAnnotation);
 }
 
-/* $FlowFixMe[missing-local-annot] The type annotation(s) required by Flow's
- * LTI update could not be added via codemod */
-function getEventArgument(argumentProps, name: $FlowFixMe) {
-  return {
-    type: 'ObjectTypeAnnotation',
-    properties: argumentProps.map(buildPropertiesForEvent),
-  };
-}
-
 // $FlowFixMe[unclear-type] TODO(T108222691): Use flow-types for @babel/parser
 type EventTypeAST = Object;
 
@@ -312,7 +303,7 @@ function buildEventSchema(
         paperTopLevelNameDeprecated,
         typeAnnotation: {
           type: 'EventTypeAnnotation',
-          argument: getEventArgument(argumentProps, name),
+          argument: getEventArgument(argumentProps, buildPropertiesForEvent),
         },
       };
     }
@@ -323,7 +314,7 @@ function buildEventSchema(
       bubblingType,
       typeAnnotation: {
         type: 'EventTypeAnnotation',
-        argument: getEventArgument(argumentProps, name),
+        argument: getEventArgument(argumentProps, buildPropertiesForEvent),
       },
     };
   }


### PR DESCRIPTION
## Summary:

[Codegen 116] This PR attempts to extract the logic of `getEventArgument` function from the following locations : 
- `parsers/flow/components/events.js`
- `parsers/typescript/components/events.js`
since they are the same and move the function to `parsers/parsers-commons.js` as requested on https://github.com/facebook/react-native/issues/34872

## Changelog:

[Internal] [Changed] - Move `getEventArgument` to parser-commons and update usages.

## Test Plan:

Run `yarn jest react-native-codegen` and ensure CI is green