### PR TITLE
Codegen 113: add isOptionalProperty in parser

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-test.js
@@ -270,6 +270,41 @@ describe('FlowParser', () => {
       ).toEqual(expected);
     });
   });
+
+  describe('isOptionalProperty', () => {
+    it('when property is optional', () => {
+      const property = {
+        value: {
+          type: 'TypeAnnotation',
+        },
+        optional: true,
+      };
+
+      expect(parser.isOptionalProperty(property)).toEqual(true);
+    });
+
+    it('when property is not optional', () => {
+      const property = {
+        value: {
+          type: 'TypeAnnotation',
+        },
+        optional: false,
+      };
+
+      expect(parser.isOptionalProperty(property)).toEqual(false);
+    });
+
+    it('when property value type is NullableTypeAnnotation', () => {
+      const property = {
+        value: {
+          type: 'NullableTypeAnnotation',
+        },
+        optional: false,
+      };
+
+      expect(parser.isOptionalProperty(property)).toEqual(true);
+    });
+  });
 });
 
 describe('TypeScriptParser', () => {
@@ -529,6 +564,22 @@ describe('TypeScriptParser', () => {
       expect(
         parser.getNativeComponentType(typeArgumentParams, funcArgumentParams),
       ).toEqual(expected);
+    });
+  });
+
+  describe('isOptionalProperty', () => {
+    it('when property is optional', () => {
+      const property = {
+        optional: true,
+      };
+      expect(parser.isOptionalProperty(property)).toEqual(true);
+    });
+
+    it('when property is undefined or not optional', () => {
+      const property = {
+        optional: false,
+      };
+      expect(parser.isOptionalProperty(property)).toEqual(false);
     });
   });
 });

--- a/packages/react-native-codegen/src/parsers/flow/parser.js
+++ b/packages/react-native-codegen/src/parsers/flow/parser.js
@@ -337,6 +337,12 @@ class FlowParser implements Parser {
   nameForArgument(prop: PropAST): $FlowFixMe {
     return prop.argument.id.name;
   }
+
+  isOptionalProperty(property: $FlowFixMe): boolean {
+    return (
+      property.value.type === 'NullableTypeAnnotation' || property.optional
+    );
+  }
 }
 
 module.exports = {

--- a/packages/react-native-codegen/src/parsers/parser.js
+++ b/packages/react-native-codegen/src/parsers/parser.js
@@ -269,4 +269,11 @@ export interface Parser {
    * @returns: name property
    */
   nameForArgument(prop: PropAST): $FlowFixMe;
+
+  /**
+   * Given a property return if it is optional.
+   * @parameter property
+   * @returns: a boolean specifying if the Property is optional
+   */
+  isOptionalProperty(property: $FlowFixMe): boolean;
 }

--- a/packages/react-native-codegen/src/parsers/parserMock.js
+++ b/packages/react-native-codegen/src/parsers/parserMock.js
@@ -251,4 +251,8 @@ export class MockedParser implements Parser {
   nameForArgument(prop: PropAST): $FlowFixMe {
     return prop.expression.name;
   }
+
+  isOptionalProperty(property: $FlowFixMe): boolean {
+    return property.optional || false;
+  }
 }

--- a/packages/react-native-codegen/src/parsers/parsers-commons.js
+++ b/packages/react-native-codegen/src/parsers/parsers-commons.js
@@ -860,11 +860,15 @@ function getEventArgument(
   argumentProps: PropAST,
   buildPropertiesForEvent: (
     property: PropAST,
+    parser: Parser,
   ) => NamedShape<EventTypeAnnotation>,
+  parser: Parser,
 ): ObjectTypeAnnotation<EventTypeAnnotation> {
   return {
     type: 'ObjectTypeAnnotation',
-    properties: argumentProps.map(buildPropertiesForEvent),
+    properties: argumentProps.map(member =>
+      buildPropertiesForEvent(member, parser),
+    ),
   };
 }
 

--- a/packages/react-native-codegen/src/parsers/typescript/parser.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parser.js
@@ -336,6 +336,10 @@ class TypeScriptParser implements Parser {
   nameForArgument(prop: PropAST): $FlowFixMe {
     return prop.expression.name;
   }
+
+  isOptionalProperty(property: $FlowFixMe): boolean {
+    return property.optional || false;
+  }
 }
 
 module.exports = {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
part of codegen issue #34872 
Add a function isOptionalProperty(property) in the Parser object and implement it in FlowParser and TypeScriptParser, using the implementation you can find in the [parsers/flow/components/events.js](https://github.com/facebook/react-native/blob/e133100721939108b0f28dfa9f60ac627c804018/packages/react-native-codegen/src/parsers/flow/components/events.js#L172-L173) and [parsers/typescript/components/events.js](https://github.com/facebook/react-native/blob/e133100721939108b0f28dfa9f60ac627c804018/packages/react-native-codegen/src/parsers/typescript/components/events.js#L196). Use the parsers in the buildPropertiesForEvent.


## Changelog:
[Internal][Changed]: add isOptionalProperty in parser and use it in parser events.
<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
`yarn test react-native-codegen`
