### PR TITLE
Add support for Arrays in generator

### DIFF
--- a/packages/react-native-codegen/src/CodegenSchema.d.ts
+++ b/packages/react-native-codegen/src/CodegenSchema.d.ts
@@ -113,7 +113,11 @@ export type EventTypeAnnotation =
   | FloatTypeAnnotation
   | Int32TypeAnnotation
   | StringEnumTypeAnnotation
-  | ObjectTypeAnnotation<EventTypeAnnotation>;
+  | ObjectTypeAnnotation<EventTypeAnnotation>
+  | {
+    readonly type: 'ArrayTypeAnnotation';
+    readonly elementType: EventTypeAnnotation
+  };
 
 export type PropTypeAnnotation =
   | {
@@ -352,4 +356,3 @@ export type NativeModuleReturnOnlyTypeAnnotation =
   | NativeModuleFunctionTypeAnnotation
   | NativeModulePromiseTypeAnnotation
   | VoidTypeAnnotation;
-

--- a/packages/react-native-codegen/src/CodegenSchema.js
+++ b/packages/react-native-codegen/src/CodegenSchema.js
@@ -128,7 +128,11 @@ export type EventTypeAnnotation =
   | Int32TypeAnnotation
   | MixedTypeAnnotation
   | StringEnumTypeAnnotation
-  | ObjectTypeAnnotation<EventTypeAnnotation>;
+  | ObjectTypeAnnotation<EventTypeAnnotation>
+  | $ReadOnly<{
+      type: 'ArrayTypeAnnotation',
+      elementType: EventTypeAnnotation,
+    }>;
 
 export type PropTypeAnnotation =
   | $ReadOnly<{

--- a/packages/react-native-codegen/src/generators/components/CppHelpers.js
+++ b/packages/react-native-codegen/src/generators/components/CppHelpers.js
@@ -49,6 +49,42 @@ function getCppTypeForAnnotation(
   }
 }
 
+function getCppArrayTypeForAnnotation(
+  typeElement: EventTypeAnnotation,
+  structParts?: string[],
+): string {
+  switch (typeElement.type) {
+    case 'BooleanTypeAnnotation':
+    case 'StringTypeAnnotation':
+    case 'DoubleTypeAnnotation':
+    case 'FloatTypeAnnotation':
+    case 'Int32TypeAnnotation':
+    case 'MixedTypeAnnotation':
+      return `std::vector<${getCppTypeForAnnotation(typeElement.type)}>`;
+    case 'StringEnumTypeAnnotation':
+    case 'ObjectTypeAnnotation':
+      if (!structParts) {
+        throw new Error(
+          `Trying to generate the event emitter for an Array of ${typeElement.type} without informations to generate the generic type`,
+        );
+      }
+      return `std::vector<${generateEventStructName(structParts)}>`;
+    case 'ArrayTypeAnnotation':
+      return `std::vector<${getCppArrayTypeForAnnotation(
+        typeElement.elementType,
+        structParts,
+      )}>`;
+    default:
+      throw new Error(
+        `Can't determine array type with typeElement: ${JSON.stringify(
+          typeElement,
+          null,
+          2,
+        )}`,
+      );
+  }
+}
+
 function getImports(
   properties:
     | $ReadOnlyArray<NamedShape<PropTypeAnnotation>>
@@ -222,6 +258,7 @@ function convertDefaultTypeToString(
 
 module.exports = {
   convertDefaultTypeToString,
+  getCppArrayTypeForAnnotation,
   getCppTypeForAnnotation,
   getEnumMaskName,
   getImports,

--- a/packages/react-native-codegen/src/generators/components/GenerateEventEmitterCpp.js
+++ b/packages/react-native-codegen/src/generators/components/GenerateEventEmitterCpp.js
@@ -102,9 +102,12 @@ function generateSetter(
   variableName: string,
   propertyName: string,
   propertyParts: $ReadOnlyArray<string>,
+  usingEvent: boolean,
   valueMapper: string => string = value => value,
 ) {
-  const eventChain = `$event.${[...propertyParts, propertyName].join('.')}`;
+  const eventChain = usingEvent
+    ? `$event.${[...propertyParts, propertyName].join('.')}`
+    : [propertyParts, propertyName].join('.');
   return `${variableName}.setProperty(runtime, "${propertyName}", ${valueMapper(
     eventChain,
   )});`;
@@ -116,6 +119,7 @@ function generateObjectSetter(
   propertyParts: $ReadOnlyArray<string>,
   typeAnnotation: ObjectTypeAnnotation<EventTypeAnnotation>,
   extraIncludes: Set<string>,
+  usingEvent: boolean,
 ) {
   return `
 {
@@ -126,6 +130,7 @@ function generateObjectSetter(
       typeAnnotation.properties,
       propertyParts.concat([propertyName]),
       extraIncludes,
+      usingEvent,
     ),
     2,
   )}
@@ -134,11 +139,165 @@ function generateObjectSetter(
 `.trim();
 }
 
+function setValueAtIndex(
+  propertyName: string,
+  indexVariable: string,
+  loopLocalVariable: string,
+  mappingFunction: string => string = value => value,
+) {
+  return `${propertyName}.setValueAtIndex(runtime, ${indexVariable}++, ${mappingFunction(
+    loopLocalVariable,
+  )});`;
+}
+
+function generateArraySetter(
+  variableName: string,
+  propertyName: string,
+  propertyParts: $ReadOnlyArray<string>,
+  elementType: EventTypeAnnotation,
+  extraIncludes: Set<string>,
+  usingEvent: boolean,
+): string {
+  const eventChain = usingEvent
+    ? `$event.${[...propertyParts, propertyName].join('.')}`
+    : [propertyParts, propertyName].join('.');
+  const indexVar = `${propertyName}Index`;
+  const innerLoopVar = `${propertyName}Value`;
+  return `
+    auto ${propertyName} = jsi::Array(runtime, ${eventChain}.size());
+    size_t ${indexVar} = 0;
+    for (auto ${innerLoopVar} : ${eventChain}) {
+      ${handleArrayElementType(
+        elementType,
+        propertyName,
+        indexVar,
+        innerLoopVar,
+        propertyParts,
+        extraIncludes,
+        usingEvent,
+      )}
+    }
+    ${variableName}.setProperty(runtime, "${propertyName}", ${propertyName});
+  `;
+}
+
+function handleArrayElementType(
+  elementType: EventTypeAnnotation,
+  propertyName: string,
+  indexVariable: string,
+  loopLocalVariable: string,
+  propertyParts: $ReadOnlyArray<string>,
+  extraIncludes: Set<string>,
+  usingEvent: boolean,
+): string {
+  switch (elementType.type) {
+    case 'BooleanTypeAnnotation':
+      return setValueAtIndex(
+        propertyName,
+        indexVariable,
+        loopLocalVariable,
+        val => `(bool)${val}`,
+      );
+    case 'StringTypeAnnotation':
+    case 'Int32TypeAnnotation':
+    case 'DoubleTypeAnnotation':
+    case 'FloatTypeAnnotation':
+      return setValueAtIndex(propertyName, indexVariable, loopLocalVariable);
+    case 'MixedTypeAnnotation':
+      return setValueAtIndex(
+        propertyName,
+        indexVariable,
+        loopLocalVariable,
+        val => `jsi::valueFromDynamic(runtime, ${val})`,
+      );
+    case 'StringEnumTypeAnnotation':
+      return setValueAtIndex(
+        propertyName,
+        indexVariable,
+        loopLocalVariable,
+        val => `toString(${val})`,
+      );
+    case 'ObjectTypeAnnotation':
+      return convertObjectTypeArray(
+        propertyName,
+        indexVariable,
+        loopLocalVariable,
+        propertyParts,
+        elementType,
+        extraIncludes,
+      );
+    case 'ArrayTypeAnnotation':
+      return convertArrayTypeArray(
+        propertyName,
+        indexVariable,
+        loopLocalVariable,
+        propertyParts,
+        elementType,
+        extraIncludes,
+        usingEvent,
+      );
+    default:
+      throw new Error(
+        `Received invalid elementType for array ${elementType.type}`,
+      );
+  }
+}
+
+function convertObjectTypeArray(
+  propertyName: string,
+  indexVariable: string,
+  loopLocalVariable: string,
+  propertyParts: $ReadOnlyArray<string>,
+  objectTypeAnnotation: ObjectTypeAnnotation<EventTypeAnnotation>,
+  extraIncludes: Set<string>,
+): string {
+  return `auto ${propertyName}Object = jsi::Object(runtime);
+      ${generateSetters(
+        `${propertyName}Object`,
+        objectTypeAnnotation.properties,
+        [].concat([loopLocalVariable]),
+        extraIncludes,
+        false,
+      )}
+      ${setValueAtIndex(propertyName, indexVariable, `${propertyName}Object`)}`;
+}
+
+function convertArrayTypeArray(
+  propertyName: string,
+  indexVariable: string,
+  loopLocalVariable: string,
+  propertyParts: $ReadOnlyArray<string>,
+  eventTypeAnnotation: EventTypeAnnotation,
+  extraIncludes: Set<string>,
+  usingEvent: boolean,
+): string {
+  if (eventTypeAnnotation.type !== 'ArrayTypeAnnotation') {
+    throw new Error(
+      `Inconsistent eventTypeAnnotation received. Expected type = 'ArrayTypeAnnotation'; received = ${eventTypeAnnotation.type}`,
+    );
+  }
+  return `auto ${propertyName}Array = jsi::Array(runtime, ${loopLocalVariable}.size());
+      size_t ${indexVariable}Internal = 0;
+      for (auto ${loopLocalVariable}Internal : ${loopLocalVariable}) {
+        ${handleArrayElementType(
+          eventTypeAnnotation.elementType,
+          `${propertyName}Array`,
+          `${indexVariable}Internal`,
+          `${loopLocalVariable}Internal`,
+          propertyParts,
+          extraIncludes,
+          usingEvent,
+        )}
+      }
+      ${setValueAtIndex(propertyName, indexVariable, `${propertyName}Array`)}`;
+}
+
 function generateSetters(
   parentPropertyName: string,
   properties: $ReadOnlyArray<NamedShape<EventTypeAnnotation>>,
   propertyParts: $ReadOnlyArray<string>,
   extraIncludes: Set<string>,
+  usingEvent: boolean = true,
 ): string {
   const propSetters = properties
     .map(eventProperty => {
@@ -153,6 +312,7 @@ function generateSetters(
             parentPropertyName,
             eventProperty.name,
             propertyParts,
+            usingEvent,
           );
         case 'MixedTypeAnnotation':
           extraIncludes.add('#include <jsi/JSIDynamic.h>');
@@ -160,6 +320,7 @@ function generateSetters(
             parentPropertyName,
             eventProperty.name,
             propertyParts,
+            usingEvent,
             prop => `jsi::valueFromDynamic(runtime, ${prop})`,
           );
         case 'StringEnumTypeAnnotation':
@@ -167,6 +328,7 @@ function generateSetters(
             parentPropertyName,
             eventProperty.name,
             propertyParts,
+            usingEvent,
             prop => `toString(${prop})`,
           );
         case 'ObjectTypeAnnotation':
@@ -176,10 +338,17 @@ function generateSetters(
             propertyParts,
             typeAnnotation,
             extraIncludes,
+            usingEvent,
           );
         case 'ArrayTypeAnnotation':
-          // TODO: implement this in the next diff
-          break;
+          return generateArraySetter(
+            parentPropertyName,
+            eventProperty.name,
+            propertyParts,
+            typeAnnotation.elementType,
+            extraIncludes,
+            usingEvent,
+          );
         default:
           (typeAnnotation.type: empty);
           throw new Error(

--- a/packages/react-native-codegen/src/generators/components/GenerateEventEmitterCpp.js
+++ b/packages/react-native-codegen/src/generators/components/GenerateEventEmitterCpp.js
@@ -177,6 +177,9 @@ function generateSetters(
             typeAnnotation,
             extraIncludes,
           );
+        case 'ArrayTypeAnnotation':
+          // TODO: implement this in the next diff
+          break;
         default:
           (typeAnnotation.type: empty);
           throw new Error(

--- a/packages/react-native-codegen/src/generators/components/GenerateEventEmitterH.js
+++ b/packages/react-native-codegen/src/generators/components/GenerateEventEmitterH.js
@@ -14,6 +14,7 @@ const nullthrows = require('nullthrows');
 
 const {
   getImports,
+  getCppArrayTypeForAnnotation,
   getCppTypeForAnnotation,
   generateEventStructName,
 } = require('./CppHelpers');
@@ -134,8 +135,16 @@ function getNativeTypeFromAnnotation(
     case 'ObjectTypeAnnotation':
       return generateEventStructName([...nameParts, eventProperty.name]);
     case 'ArrayTypeAnnotation':
-      // TODO: implement this in the next diff
-      return '';
+      const eventTypeAnnotation = eventProperty.typeAnnotation;
+      if (eventTypeAnnotation.type !== 'ArrayTypeAnnotation') {
+        throw new Error(
+          "Inconsistent Codegen state: type was ArrayTypeAnnotation at the beginning of the body and now it isn't",
+        );
+      }
+      return getCppArrayTypeForAnnotation(eventTypeAnnotation.elementType, [
+        ...nameParts,
+        eventProperty.name,
+      ]);
     default:
       (type: empty);
       throw new Error(`Received invalid event property type ${type}`);
@@ -168,6 +177,33 @@ function generateEnum(
   );
 }
 
+function handleGenerateStructForArray(
+  structs: StructsMap,
+  name: string,
+  componentName: string,
+  elementType: EventTypeAnnotation,
+  nameParts: $ReadOnlyArray<string>,
+): void {
+  if (elementType.type === 'ObjectTypeAnnotation') {
+    generateStruct(
+      structs,
+      componentName,
+      nameParts.concat([name]),
+      nullthrows(elementType.properties),
+    );
+  } else if (elementType.type === 'StringEnumTypeAnnotation') {
+    generateEnum(structs, elementType.options, nameParts.concat([name]));
+  } else if (elementType.type === 'ArrayTypeAnnotation') {
+    handleGenerateStructForArray(
+      structs,
+      name,
+      componentName,
+      elementType.elementType,
+      nameParts,
+    );
+  }
+}
+
 function generateStruct(
   structs: StructsMap,
   componentName: string,
@@ -197,6 +233,15 @@ function generateStruct(
       case 'FloatTypeAnnotation':
       case 'MixedTypeAnnotation':
         return;
+      case 'ArrayTypeAnnotation':
+        handleGenerateStructForArray(
+          structs,
+          name,
+          componentName,
+          typeAnnotation.elementType,
+          nameParts,
+        );
+        return;
       case 'ObjectTypeAnnotation':
         generateStruct(
           structs,
@@ -208,9 +253,6 @@ function generateStruct(
       case 'StringEnumTypeAnnotation':
         generateEnum(structs, typeAnnotation.options, nameParts.concat([name]));
         return;
-      case 'ArrayTypeAnnotation':
-        //TODO: implement this in the next diff
-        break;
       default:
         (typeAnnotation.type: empty);
         throw new Error(
@@ -277,7 +319,7 @@ module.exports = {
       .map(moduleName => {
         const module = schema.modules[moduleName];
         if (module.type !== 'Component') {
-          return;
+          return null;
         }
 
         const {components} = module;

--- a/packages/react-native-codegen/src/generators/components/GenerateEventEmitterH.js
+++ b/packages/react-native-codegen/src/generators/components/GenerateEventEmitterH.js
@@ -133,6 +133,9 @@ function getNativeTypeFromAnnotation(
     case 'StringEnumTypeAnnotation':
     case 'ObjectTypeAnnotation':
       return generateEventStructName([...nameParts, eventProperty.name]);
+    case 'ArrayTypeAnnotation':
+      // TODO: implement this in the next diff
+      return '';
     default:
       (type: empty);
       throw new Error(`Received invalid event property type ${type}`);
@@ -205,6 +208,9 @@ function generateStruct(
       case 'StringEnumTypeAnnotation':
         generateEnum(structs, typeAnnotation.options, nameParts.concat([name]));
         return;
+      case 'ArrayTypeAnnotation':
+        //TODO: implement this in the next diff
+        break;
       default:
         (typeAnnotation.type: empty);
         throw new Error(

--- a/packages/react-native-codegen/src/generators/components/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/generators/components/__test_fixtures__/fixtures.js
@@ -1207,6 +1207,99 @@ const EVENT_PROPS: SchemaType = {
               },
             },
             {
+              name: 'onArrayEventType',
+              optional: true,
+              bubblingType: 'bubble',
+              typeAnnotation: {
+                type: 'EventTypeAnnotation',
+                argument: {
+                  type: 'ObjectTypeAnnotation',
+                  properties: [
+                    {
+                      name: 'bool_array_event_prop',
+                      optional: false,
+                      typeAnnotation: {
+                        type: 'ArrayTypeAnnotation',
+                        elementType: {
+                          type: 'BooleanTypeAnnotation',
+                        },
+                      },
+                    },
+                    {
+                      name: 'string_enum_event_prop',
+                      optional: false,
+                      typeAnnotation: {
+                        type: 'ArrayTypeAnnotation',
+                        elementType: {
+                          type: 'StringEnumTypeAnnotation',
+                          options: ['YES', 'NO'],
+                        },
+                      },
+                    },
+                    {
+                      name: 'array_array_event_prop',
+                      optional: false,
+                      typeAnnotation: {
+                        type: 'ArrayTypeAnnotation',
+                        elementType: {
+                          type: 'ArrayTypeAnnotation',
+                          elementType: {
+                            type: 'StringTypeAnnotation',
+                          },
+                        },
+                      },
+                    },
+                    {
+                      name: 'array_object_event_prop',
+                      optional: false,
+                      typeAnnotation: {
+                        type: 'ArrayTypeAnnotation',
+                        elementType: {
+                          type: 'ObjectTypeAnnotation',
+                          properties: [
+                            {
+                              name: 'lat',
+                              optional: false,
+                              typeAnnotation: {
+                                type: 'DoubleTypeAnnotation',
+                              },
+                            },
+                            {
+                              name: 'lon',
+                              optional: false,
+                              typeAnnotation: {
+                                type: 'DoubleTypeAnnotation',
+                              },
+                            },
+                            {
+                              name: 'names',
+                              optional: false,
+                              typeAnnotation: {
+                                type: 'ArrayTypeAnnotation',
+                                elementType: {
+                                  type: 'StringTypeAnnotation',
+                                },
+                              },
+                            },
+                          ],
+                        },
+                      },
+                    },
+                    {
+                      name: 'array_mixed_event_prop',
+                      optional: false,
+                      typeAnnotation: {
+                        type: 'ArrayTypeAnnotation',
+                        elementType: {
+                          type: 'MixedTypeAnnotation',
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+            {
               name: 'onEventDirect',
               optional: true,
               bubblingType: 'direct',

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GenerateEventEmitterCpp-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GenerateEventEmitterCpp-test.js.snap
@@ -264,6 +264,70 @@ $payload.setProperty(runtime, \\"scale\\", $event.scale);
 }
 
 
+void EventsNativeComponentEventEmitter::onArrayEventType(OnArrayEventType $event) const {
+  dispatchEvent(\\"arrayEventType\\", [$event=std::move($event)](jsi::Runtime &runtime) {
+    auto $payload = jsi::Object(runtime);
+    
+    auto bool_array_event_prop = jsi::Array(runtime, $event.bool_array_event_prop.size());
+    size_t bool_array_event_propIndex = 0;
+    for (auto bool_array_event_propValue : $event.bool_array_event_prop) {
+      bool_array_event_prop.setValueAtIndex(runtime, bool_array_event_propIndex++, (bool)bool_array_event_propValue);
+    }
+    $payload.setProperty(runtime, \\"bool_array_event_prop\\", bool_array_event_prop);
+  
+
+    auto string_enum_event_prop = jsi::Array(runtime, $event.string_enum_event_prop.size());
+    size_t string_enum_event_propIndex = 0;
+    for (auto string_enum_event_propValue : $event.string_enum_event_prop) {
+      string_enum_event_prop.setValueAtIndex(runtime, string_enum_event_propIndex++, toString(string_enum_event_propValue));
+    }
+    $payload.setProperty(runtime, \\"string_enum_event_prop\\", string_enum_event_prop);
+  
+
+    auto array_array_event_prop = jsi::Array(runtime, $event.array_array_event_prop.size());
+    size_t array_array_event_propIndex = 0;
+    for (auto array_array_event_propValue : $event.array_array_event_prop) {
+      auto array_array_event_propArray = jsi::Array(runtime, array_array_event_propValue.size());
+      size_t array_array_event_propIndexInternal = 0;
+      for (auto array_array_event_propValueInternal : array_array_event_propValue) {
+        array_array_event_propArray.setValueAtIndex(runtime, array_array_event_propIndexInternal++, array_array_event_propValueInternal);
+      }
+      array_array_event_prop.setValueAtIndex(runtime, array_array_event_propIndex++, array_array_event_propArray);
+    }
+    $payload.setProperty(runtime, \\"array_array_event_prop\\", array_array_event_prop);
+  
+
+    auto array_object_event_prop = jsi::Array(runtime, $event.array_object_event_prop.size());
+    size_t array_object_event_propIndex = 0;
+    for (auto array_object_event_propValue : $event.array_object_event_prop) {
+      auto array_object_event_propObject = jsi::Object(runtime);
+      array_object_event_propObject.setProperty(runtime, \\"lat\\", array_object_event_propValue.lat);
+array_object_event_propObject.setProperty(runtime, \\"lon\\", array_object_event_propValue.lon);
+
+    auto names = jsi::Array(runtime, array_object_event_propValue.names.size());
+    size_t namesIndex = 0;
+    for (auto namesValue : array_object_event_propValue.names) {
+      names.setValueAtIndex(runtime, namesIndex++, namesValue);
+    }
+    array_object_event_propObject.setProperty(runtime, \\"names\\", names);
+  
+      array_object_event_prop.setValueAtIndex(runtime, array_object_event_propIndex++, array_object_event_propObject);
+    }
+    $payload.setProperty(runtime, \\"array_object_event_prop\\", array_object_event_prop);
+  
+
+    auto array_mixed_event_prop = jsi::Array(runtime, $event.array_mixed_event_prop.size());
+    size_t array_mixed_event_propIndex = 0;
+    for (auto array_mixed_event_propValue : $event.array_mixed_event_prop) {
+      array_mixed_event_prop.setValueAtIndex(runtime, array_mixed_event_propIndex++, jsi::valueFromDynamic(runtime, array_mixed_event_propValue));
+    }
+    $payload.setProperty(runtime, \\"array_mixed_event_prop\\", array_mixed_event_prop);
+  
+    return $payload;
+  });
+}
+
+
 void EventsNativeComponentEventEmitter::onEventDirect(OnEventDirect $event) const {
   dispatchEvent(\\"eventDirect\\", [$event=std::move($event)](jsi::Runtime &runtime) {
     auto $payload = jsi::Object(runtime);

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GenerateEventEmitterH-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GenerateEventEmitterH-test.js.snap
@@ -320,6 +320,32 @@ class EventsNativeComponentEventEmitter : public ViewEventEmitter {
     Float scale;
     };
 
+  enum class OnArrayEventTypeString_enum_event_prop {
+    YES,
+    NO
+  };
+
+  static char const *toString(const OnArrayEventTypeString_enum_event_prop value) {
+    switch (value) {
+      case OnArrayEventTypeString_enum_event_prop::YES: return \\"YES\\";
+      case OnArrayEventTypeString_enum_event_prop::NO: return \\"NO\\";
+    }
+  }
+
+  struct OnArrayEventTypeArray_object_event_prop {
+      double lat;
+    double lon;
+    std::vector<std::string> names;
+    };
+
+  struct OnArrayEventType {
+      std::vector<bool> bool_array_event_prop;
+    std::vector<OnArrayEventTypeString_enum_event_prop> string_enum_event_prop;
+    std::vector<std::vector<std::string>> array_array_event_prop;
+    std::vector<OnArrayEventTypeArray_object_event_prop> array_object_event_prop;
+    std::vector<folly::dynamic> array_mixed_event_prop;
+    };
+
   struct OnEventDirect {
       bool value;
     };
@@ -344,6 +370,8 @@ class EventsNativeComponentEventEmitter : public ViewEventEmitter {
       folly::dynamic value;
     };
   void onChange(OnChange value) const;
+
+  void onArrayEventType(OnArrayEventType value) const;
 
   void onEventDirect(OnEventDirect value) const;
 

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GenerateViewConfigJs-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GenerateViewConfigJs-test.js.snap
@@ -394,6 +394,13 @@ export const __INTERNAL_VIEW_CONFIG = {
       },
     },
 
+    topArrayEventType: {
+      phasedRegistrationNames: {
+        captured: 'onArrayEventTypeCapture',
+        bubbled: 'onArrayEventType',
+      },
+    },
+
     topEnd: {
       phasedRegistrationNames: {
         captured: 'onEndCapture',
@@ -421,6 +428,7 @@ export const __INTERNAL_VIEW_CONFIG = {
 
     ...ConditionallyIgnoredEventHandlers({
       onChange: true,
+      onArrayEventType: true,
       onEventDirect: true,
       onOrientationChange: true,
       onEnd: true,

--- a/packages/react-native-codegen/src/parsers/flow/components/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/__test_fixtures__/fixtures.js
@@ -84,6 +84,57 @@ const EVENT_DEFINITION = `
   object_readonly_optional_both?: ?$ReadOnly<{
     int32_optional_both?: ?Int32,
   }>,
+
+  boolean_array_required: $ReadOnlyArray<boolean>,
+  boolean_array_optional_key?: boolean[],
+  boolean_array_optional_value: ?$ReadOnlyArray<boolean>,
+  boolean_array_optional_both?: ?boolean[],
+
+  string_array_required: $ReadOnlyArray<string>,
+  string_array_optional_key?: string[],
+  string_array_optional_value: ?$ReadOnlyArray<string>,
+  string_array_optional_both?: ?string[],
+
+  double_array_required: $ReadOnlyArray<Double>,
+  double_array_optional_key?: Double[],
+  double_array_optional_value: ?$ReadOnlyArray<Double>,
+  double_array_optional_both?: ?Double[],
+
+  float_array_required: $ReadOnlyArray<Float>,
+  float_array_optional_key?: Float[],
+  float_array_optional_value: ?$ReadOnlyArray<Float>,
+  float_array_optional_both?: ?Float[],
+
+  int32_array_required: $ReadOnlyArray<Int32>,
+  int32_array_optional_key?: Int32[],
+  int32_array_optional_value: ?$ReadOnlyArray<Int32>,
+  int32_array_optional_both?: ?Int32[],
+
+  enum_array_required: $ReadOnlyArray<('small' | 'large')>,
+  enum_array_optional_key?: ('small' | 'large')[],
+  enum_array_optional_value: ?$ReadOnlyArray<('small' | 'large')>,
+  enum_array_optional_both?: ?('small' | 'large')[],
+
+  object_array_required: $ReadOnlyArray<{
+    boolean_required: boolean,
+  }>,
+
+  object_array_optional_key?: {
+    string_optional_key?: string,
+  }[],
+
+  object_array_optional_value: ?$ReadOnlyArray<{
+    float_optional_value: ?Float,
+  }>,
+
+  object_array_optional_both?: ?{
+    int32_optional_both?: ?Int32,
+  }[],
+
+  int32_array_array_required: $ReadOnlyArray<$ReadOnlyArray<Int32>>,
+  int32_array_array_optional_key?: Int32[][],
+  int32_array_array_optional_value: ?$ReadOnlyArray<$ReadOnlyArray<Int32>>,
+  int32_array_array_optional_both?: ?Int32[][],
 `;
 
 const ONE_OF_EACH_PROP_EVENT_DEFAULT_AND_OPTIONS = `

--- a/packages/react-native-codegen/src/parsers/flow/components/__tests__/__snapshots__/component-parser-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/flow/components/__tests__/__snapshots__/component-parser-test.js.snap
@@ -1843,6 +1843,390 @@ exports[`RN Codegen Flow Parser can generate fixture COMMANDS_EVENTS_TYPES_EXPOR
                           }
                         ]
                       }
+                    },
+                    {
+                      'name': 'boolean_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'boolean_required',
+                              'optional': false,
+                              'typeAnnotation': {
+                                'type': 'BooleanTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'string_optional_key',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'StringTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'float_optional_value',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'FloatTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'int32_optional_both',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'Int32TypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
                     }
                   ]
                 }
@@ -2222,6 +2606,390 @@ exports[`RN Codegen Flow Parser can generate fixture COMMANDS_EVENTS_TYPES_EXPOR
                           }
                         ]
                       }
+                    },
+                    {
+                      'name': 'boolean_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'boolean_required',
+                              'optional': false,
+                              'typeAnnotation': {
+                                'type': 'BooleanTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'string_optional_key',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'StringTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'float_optional_value',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'FloatTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'int32_optional_both',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'Int32TypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
                     }
                   ]
                 }
@@ -2599,6 +3367,390 @@ exports[`RN Codegen Flow Parser can generate fixture COMMANDS_EVENTS_TYPES_EXPOR
                             }
                           }
                         ]
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'boolean_required',
+                              'optional': false,
+                              'typeAnnotation': {
+                                'type': 'BooleanTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'string_optional_key',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'StringTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'float_optional_value',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'FloatTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'int32_optional_both',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'Int32TypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
                       }
                     }
                   ]
@@ -2978,6 +4130,390 @@ exports[`RN Codegen Flow Parser can generate fixture COMMANDS_EVENTS_TYPES_EXPOR
                             }
                           }
                         ]
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'boolean_required',
+                              'optional': false,
+                              'typeAnnotation': {
+                                'type': 'BooleanTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'string_optional_key',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'StringTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'float_optional_value',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'FloatTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'int32_optional_both',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'Int32TypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
                       }
                     }
                   ]
@@ -3604,6 +5140,390 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                           }
                         ]
                       }
+                    },
+                    {
+                      'name': 'boolean_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'boolean_required',
+                              'optional': false,
+                              'typeAnnotation': {
+                                'type': 'BooleanTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'string_optional_key',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'StringTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'float_optional_value',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'FloatTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'int32_optional_both',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'Int32TypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
                     }
                   ]
                 }
@@ -3981,6 +5901,390 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                             }
                           }
                         ]
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'boolean_required',
+                              'optional': false,
+                              'typeAnnotation': {
+                                'type': 'BooleanTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'string_optional_key',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'StringTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'float_optional_value',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'FloatTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'int32_optional_both',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'Int32TypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
                       }
                     }
                   ]
@@ -4360,6 +6664,390 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                           }
                         ]
                       }
+                    },
+                    {
+                      'name': 'boolean_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'boolean_required',
+                              'optional': false,
+                              'typeAnnotation': {
+                                'type': 'BooleanTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'string_optional_key',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'StringTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'float_optional_value',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'FloatTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'int32_optional_both',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'Int32TypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
                     }
                   ]
                 }
@@ -4737,6 +7425,390 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                             }
                           }
                         ]
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'boolean_required',
+                              'optional': false,
+                              'typeAnnotation': {
+                                'type': 'BooleanTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'string_optional_key',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'StringTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'float_optional_value',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'FloatTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'int32_optional_both',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'Int32TypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
                       }
                     }
                   ]
@@ -5117,6 +8189,390 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                           }
                         ]
                       }
+                    },
+                    {
+                      'name': 'boolean_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'boolean_required',
+                              'optional': false,
+                              'typeAnnotation': {
+                                'type': 'BooleanTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'string_optional_key',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'StringTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'float_optional_value',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'FloatTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'int32_optional_both',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'Int32TypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
                     }
                   ]
                 }
@@ -5494,6 +8950,390 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                             }
                           }
                         ]
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'boolean_required',
+                              'optional': false,
+                              'typeAnnotation': {
+                                'type': 'BooleanTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'string_optional_key',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'StringTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'float_optional_value',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'FloatTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'int32_optional_both',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'Int32TypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
                       }
                     }
                   ]
@@ -5873,6 +9713,390 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                           }
                         ]
                       }
+                    },
+                    {
+                      'name': 'boolean_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'boolean_required',
+                              'optional': false,
+                              'typeAnnotation': {
+                                'type': 'BooleanTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'string_optional_key',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'StringTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'float_optional_value',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'FloatTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'int32_optional_both',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'Int32TypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
                     }
                   ]
                 }
@@ -6250,6 +10474,390 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                             }
                           }
                         ]
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'boolean_required',
+                              'optional': false,
+                              'typeAnnotation': {
+                                'type': 'BooleanTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'string_optional_key',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'StringTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'float_optional_value',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'FloatTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'int32_optional_both',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'Int32TypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
                       }
                     }
                   ]
@@ -6629,6 +11237,390 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                           }
                         ]
                       }
+                    },
+                    {
+                      'name': 'boolean_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'boolean_required',
+                              'optional': false,
+                              'typeAnnotation': {
+                                'type': 'BooleanTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'string_optional_key',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'StringTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'float_optional_value',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'FloatTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'int32_optional_both',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'Int32TypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
                     }
                   ]
                 }
@@ -7007,6 +11999,390 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                             }
                           }
                         ]
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'boolean_required',
+                              'optional': false,
+                              'typeAnnotation': {
+                                'type': 'BooleanTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'string_optional_key',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'StringTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'float_optional_value',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'FloatTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'int32_optional_both',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'Int32TypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
                       }
                     }
                   ]
@@ -8402,6 +13778,390 @@ exports[`RN Codegen Flow Parser can generate fixture PROPS_AND_EVENTS_TYPES_EXPO
                           }
                         ]
                       }
+                    },
+                    {
+                      'name': 'boolean_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'boolean_required',
+                              'optional': false,
+                              'typeAnnotation': {
+                                'type': 'BooleanTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'string_optional_key',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'StringTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'float_optional_value',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'FloatTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'int32_optional_both',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'Int32TypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
                     }
                   ]
                 }
@@ -8781,6 +14541,390 @@ exports[`RN Codegen Flow Parser can generate fixture PROPS_AND_EVENTS_TYPES_EXPO
                           }
                         ]
                       }
+                    },
+                    {
+                      'name': 'boolean_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'boolean_required',
+                              'optional': false,
+                              'typeAnnotation': {
+                                'type': 'BooleanTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'string_optional_key',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'StringTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'float_optional_value',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'FloatTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'int32_optional_both',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'Int32TypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
                     }
                   ]
                 }
@@ -9158,6 +15302,390 @@ exports[`RN Codegen Flow Parser can generate fixture PROPS_AND_EVENTS_TYPES_EXPO
                             }
                           }
                         ]
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'boolean_required',
+                              'optional': false,
+                              'typeAnnotation': {
+                                'type': 'BooleanTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'string_optional_key',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'StringTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'float_optional_value',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'FloatTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'int32_optional_both',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'Int32TypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
                       }
                     }
                   ]
@@ -9537,6 +16065,390 @@ exports[`RN Codegen Flow Parser can generate fixture PROPS_AND_EVENTS_TYPES_EXPO
                             }
                           }
                         ]
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'boolean_required',
+                              'optional': false,
+                              'typeAnnotation': {
+                                'type': 'BooleanTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'string_optional_key',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'StringTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'float_optional_value',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'FloatTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'int32_optional_both',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'Int32TypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
                       }
                     }
                   ]

--- a/packages/react-native-codegen/src/parsers/flow/components/events.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/events.js
@@ -28,10 +28,7 @@ function getPropertyType(
   optional: boolean,
   typeAnnotation: $FlowFixMe,
 ): NamedShape<EventTypeAnnotation> {
-  const type =
-    typeAnnotation.type === 'GenericTypeAnnotation'
-      ? typeAnnotation.id.name
-      : typeAnnotation.type;
+  const type = extractTypeFromTypeAnnotation(typeAnnotation);
 
   switch (type) {
     case 'BooleanTypeAnnotation':
@@ -106,10 +103,85 @@ function getPropertyType(
           type: 'MixedTypeAnnotation',
         },
       };
+    case 'ArrayTypeAnnotation':
+    case '$ReadOnlyArray':
+      return {
+        name,
+        optional,
+        typeAnnotation: extractArrayElementType(typeAnnotation, name),
+      };
     default:
-      (type: empty);
       throw new Error(`Unable to determine event type for "${name}": ${type}`);
   }
+}
+
+function extractArrayElementType(
+  typeAnnotation: $FlowFixMe,
+  name: string,
+): EventTypeAnnotation {
+  const type = extractTypeFromTypeAnnotation(typeAnnotation);
+
+  switch (type) {
+    case 'BooleanTypeAnnotation':
+      return {type: 'BooleanTypeAnnotation'};
+    case 'StringTypeAnnotation':
+      return {type: 'StringTypeAnnotation'};
+    case 'Int32':
+      return {type: 'Int32TypeAnnotation'};
+    case 'Float':
+      return {type: 'FloatTypeAnnotation'};
+    case 'NumberTypeAnnotation':
+    case 'Double':
+      return {
+        type: 'DoubleTypeAnnotation',
+      };
+    case 'UnionTypeAnnotation':
+      return {
+        type: 'StringEnumTypeAnnotation',
+        options: typeAnnotation.types.map(option => option.value),
+      };
+    case 'UnsafeMixed':
+      return {type: 'MixedTypeAnnotation'};
+    case 'ObjectTypeAnnotation':
+      return {
+        type: 'ObjectTypeAnnotation',
+        properties: typeAnnotation.properties.map(buildPropertiesForEvent),
+      };
+    case 'ArrayTypeAnnotation':
+      return {
+        type: 'ArrayTypeAnnotation',
+        elementType: extractArrayElementType(typeAnnotation.elementType, name),
+      };
+    case '$ReadOnlyArray':
+      const genericParams = typeAnnotation.typeParameters.params;
+      if (genericParams.length !== 1) {
+        throw new Error(
+          `Events only supports arrays with 1 Generic type. Found ${
+            genericParams.length
+          } types:\n${prettify(genericParams)}`,
+        );
+      }
+      return {
+        type: 'ArrayTypeAnnotation',
+        elementType: extractArrayElementType(genericParams[0], name),
+      };
+    default:
+      throw new Error(
+        `Unrecognized ${type} for Array ${name} in events.\n${prettify(
+          typeAnnotation,
+        )}`,
+      );
+  }
+}
+
+function prettify(jsonObject: $FlowFixMe): string {
+  return JSON.stringify(jsonObject, null, 2);
+}
+
+function extractTypeFromTypeAnnotation(typeAnnotation: $FlowFixMe): string {
+  return typeAnnotation.type === 'GenericTypeAnnotation'
+    ? typeAnnotation.id.name
+    : typeAnnotation.type;
 }
 
 function findEventArgumentsAndType(
@@ -219,24 +291,20 @@ function buildEventSchema(
   const {argumentProps, bubblingType, paperTopLevelNameDeprecated} =
     findEventArgumentsAndType(parser, typeAnnotation, types);
 
-  if (bubblingType && argumentProps) {
-    if (paperTopLevelNameDeprecated != null) {
-      return {
-        name,
-        optional,
-        bubblingType,
-        paperTopLevelNameDeprecated,
-        typeAnnotation: {
-          type: 'EventTypeAnnotation',
-          argument: getEventArgument(argumentProps, name),
-        },
-      };
-    }
+  if (!argumentProps) {
+    throw new Error(`Unable to determine event arguments for "${name}"`);
+  }
 
+  if (!bubblingType) {
+    throw new Error(`Unable to determine event arguments for "${name}"`);
+  }
+
+  if (paperTopLevelNameDeprecated != null) {
     return {
       name,
       optional,
       bubblingType,
+      paperTopLevelNameDeprecated,
       typeAnnotation: {
         type: 'EventTypeAnnotation',
         argument: getEventArgument(argumentProps, name),
@@ -249,6 +317,16 @@ function buildEventSchema(
   }
 
   throwIfBubblingTypeIsNull(bubblingType, name);
+
+  return {
+    name,
+    optional,
+    bubblingType,
+    typeAnnotation: {
+      type: 'EventTypeAnnotation',
+      argument: getEventArgument(argumentProps, name),
+    },
+  };
 }
 
 // $FlowFixMe[unclear-type] there's no flowtype for ASTs

--- a/packages/react-native-codegen/src/parsers/typescript/components/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/__test_fixtures__/fixtures.js
@@ -84,6 +84,57 @@ const EVENT_DEFINITION = `
   object_readonly_optional_both?: Readonly<{
     int32_optional_both?: Int32 | null | undefined;
   }> | null | undefined;
+
+  boolean_array_required: boolean[];
+  boolean_array_optional_key?: boolean[];
+  boolean_array_optional_value: boolean[] | null | undefined;
+  boolean_array_optional_both?: boolean[] | null | undefined;
+
+  string_array_required: string[];
+  string_array_optional_key?: (string[]);
+  string_array_optional_value: (string[]) | null | undefined;
+  string_array_optional_both?: (string[] | null | undefined);
+
+  double_array_required: Double[];
+  double_array_optional_key?: Double[];
+  double_array_optional_value: Double[] | null | undefined;
+  double_array_optional_both?: Double[] | null | undefined;
+
+  float_array_required: Float[];
+  float_array_optional_key?: Float[];
+  float_array_optional_value: Float[] | null | undefined;
+  float_array_optional_both?: Float[] | null | undefined;
+
+  int32_array_required: Int32[];
+  int32_array_optional_key?: Int32[];
+  int32_array_optional_value: Int32[] | null | undefined;
+  int32_array_optional_both?: Int32[] | null | undefined;
+
+  enum_array_required: ('small' | 'large')[];
+  enum_array_optional_key?: ('small' | 'large')[];
+  enum_array_optional_value: ('small' | 'large')[] | null | undefined;
+  enum_array_optional_both?: ('small' | 'large')[] | null | undefined;
+
+  object_array_required: {
+    boolean_required: boolean;
+  }[];
+
+  object_array_optional_key?: {
+    string_optional_key?: string;
+  }[];
+
+  object_array_optional_value: {
+    float_optional_value: Float | null | undefined;
+  }[] | null | undefined;
+
+  object_array_optional_both?: {
+    int32_optional_both?: Int32 | null | undefined;
+  }[] | null | undefined;
+
+  int32_array_array_required: Int32[][];
+  int32_array_array_optional_key?: Int32[][];
+  int32_array_array_optional_value: Int32[][] | null | undefined;
+  int32_array_array_optional_both?: Int32[][] | null | undefined;
 `;
 
 const ONE_OF_EACH_PROP_EVENT_DEFAULT_AND_OPTIONS = `

--- a/packages/react-native-codegen/src/parsers/typescript/components/__tests__/__snapshots__/typescript-component-parser-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/typescript/components/__tests__/__snapshots__/typescript-component-parser-test.js.snap
@@ -2548,6 +2548,390 @@ exports[`RN Codegen TypeScript Parser can generate fixture COMMANDS_EVENTS_TYPES
                           }
                         ]
                       }
+                    },
+                    {
+                      'name': 'boolean_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'boolean_required',
+                              'optional': false,
+                              'typeAnnotation': {
+                                'type': 'BooleanTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'string_optional_key',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'StringTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'float_optional_value',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'FloatTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'int32_optional_both',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'Int32TypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
                     }
                   ]
                 }
@@ -2927,6 +3311,390 @@ exports[`RN Codegen TypeScript Parser can generate fixture COMMANDS_EVENTS_TYPES
                           }
                         ]
                       }
+                    },
+                    {
+                      'name': 'boolean_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'boolean_required',
+                              'optional': false,
+                              'typeAnnotation': {
+                                'type': 'BooleanTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'string_optional_key',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'StringTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'float_optional_value',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'FloatTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'int32_optional_both',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'Int32TypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
                     }
                   ]
                 }
@@ -3304,6 +4072,390 @@ exports[`RN Codegen TypeScript Parser can generate fixture COMMANDS_EVENTS_TYPES
                             }
                           }
                         ]
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'boolean_required',
+                              'optional': false,
+                              'typeAnnotation': {
+                                'type': 'BooleanTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'string_optional_key',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'StringTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'float_optional_value',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'FloatTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'int32_optional_both',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'Int32TypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
                       }
                     }
                   ]
@@ -3683,6 +4835,390 @@ exports[`RN Codegen TypeScript Parser can generate fixture COMMANDS_EVENTS_TYPES
                             }
                           }
                         ]
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'boolean_required',
+                              'optional': false,
+                              'typeAnnotation': {
+                                'type': 'BooleanTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'string_optional_key',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'StringTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'float_optional_value',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'FloatTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'int32_optional_both',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'Int32TypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
                       }
                     }
                   ]
@@ -4309,6 +5845,390 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                           }
                         ]
                       }
+                    },
+                    {
+                      'name': 'boolean_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'boolean_required',
+                              'optional': false,
+                              'typeAnnotation': {
+                                'type': 'BooleanTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'string_optional_key',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'StringTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'float_optional_value',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'FloatTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'int32_optional_both',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'Int32TypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
                     }
                   ]
                 }
@@ -4686,6 +6606,390 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                             }
                           }
                         ]
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'boolean_required',
+                              'optional': false,
+                              'typeAnnotation': {
+                                'type': 'BooleanTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'string_optional_key',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'StringTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'float_optional_value',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'FloatTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'int32_optional_both',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'Int32TypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
                       }
                     }
                   ]
@@ -5065,6 +7369,390 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                           }
                         ]
                       }
+                    },
+                    {
+                      'name': 'boolean_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'boolean_required',
+                              'optional': false,
+                              'typeAnnotation': {
+                                'type': 'BooleanTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'string_optional_key',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'StringTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'float_optional_value',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'FloatTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'int32_optional_both',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'Int32TypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
                     }
                   ]
                 }
@@ -5442,6 +8130,390 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                             }
                           }
                         ]
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'boolean_required',
+                              'optional': false,
+                              'typeAnnotation': {
+                                'type': 'BooleanTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'string_optional_key',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'StringTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'float_optional_value',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'FloatTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'int32_optional_both',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'Int32TypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
                       }
                     }
                   ]
@@ -5822,6 +8894,390 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                           }
                         ]
                       }
+                    },
+                    {
+                      'name': 'boolean_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'boolean_required',
+                              'optional': false,
+                              'typeAnnotation': {
+                                'type': 'BooleanTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'string_optional_key',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'StringTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'float_optional_value',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'FloatTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'int32_optional_both',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'Int32TypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
                     }
                   ]
                 }
@@ -6199,6 +9655,390 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                             }
                           }
                         ]
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'boolean_required',
+                              'optional': false,
+                              'typeAnnotation': {
+                                'type': 'BooleanTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'string_optional_key',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'StringTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'float_optional_value',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'FloatTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'int32_optional_both',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'Int32TypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
                       }
                     }
                   ]
@@ -6578,6 +10418,390 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                           }
                         ]
                       }
+                    },
+                    {
+                      'name': 'boolean_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'boolean_required',
+                              'optional': false,
+                              'typeAnnotation': {
+                                'type': 'BooleanTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'string_optional_key',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'StringTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'float_optional_value',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'FloatTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'int32_optional_both',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'Int32TypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
                     }
                   ]
                 }
@@ -6955,6 +11179,390 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                             }
                           }
                         ]
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'boolean_required',
+                              'optional': false,
+                              'typeAnnotation': {
+                                'type': 'BooleanTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'string_optional_key',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'StringTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'float_optional_value',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'FloatTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'int32_optional_both',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'Int32TypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
                       }
                     }
                   ]
@@ -7334,6 +11942,390 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                           }
                         ]
                       }
+                    },
+                    {
+                      'name': 'boolean_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'boolean_required',
+                              'optional': false,
+                              'typeAnnotation': {
+                                'type': 'BooleanTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'string_optional_key',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'StringTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'float_optional_value',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'FloatTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'int32_optional_both',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'Int32TypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
                     }
                   ]
                 }
@@ -7712,6 +12704,390 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                             }
                           }
                         ]
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'boolean_required',
+                              'optional': false,
+                              'typeAnnotation': {
+                                'type': 'BooleanTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'string_optional_key',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'StringTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'float_optional_value',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'FloatTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'int32_optional_both',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'Int32TypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
                       }
                     }
                   ]
@@ -9107,6 +14483,390 @@ exports[`RN Codegen TypeScript Parser can generate fixture PROPS_AND_EVENTS_TYPE
                           }
                         ]
                       }
+                    },
+                    {
+                      'name': 'boolean_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'boolean_required',
+                              'optional': false,
+                              'typeAnnotation': {
+                                'type': 'BooleanTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'string_optional_key',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'StringTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'float_optional_value',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'FloatTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'int32_optional_both',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'Int32TypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
                     }
                   ]
                 }
@@ -9486,6 +15246,390 @@ exports[`RN Codegen TypeScript Parser can generate fixture PROPS_AND_EVENTS_TYPE
                           }
                         ]
                       }
+                    },
+                    {
+                      'name': 'boolean_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'boolean_required',
+                              'optional': false,
+                              'typeAnnotation': {
+                                'type': 'BooleanTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'string_optional_key',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'StringTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'float_optional_value',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'FloatTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'int32_optional_both',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'Int32TypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
                     }
                   ]
                 }
@@ -9863,6 +16007,390 @@ exports[`RN Codegen TypeScript Parser can generate fixture PROPS_AND_EVENTS_TYPE
                             }
                           }
                         ]
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'boolean_required',
+                              'optional': false,
+                              'typeAnnotation': {
+                                'type': 'BooleanTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'string_optional_key',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'StringTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'float_optional_value',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'FloatTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'int32_optional_both',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'Int32TypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
                       }
                     }
                   ]
@@ -10242,6 +16770,390 @@ exports[`RN Codegen TypeScript Parser can generate fixture PROPS_AND_EVENTS_TYPE
                             }
                           }
                         ]
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'boolean_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'BooleanTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'string_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'double_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'DoubleTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'float_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'FloatTypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'Int32TypeAnnotation'
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'enum_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'StringEnumTypeAnnotation',
+                          'options': [
+                            'small',
+                            'large'
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'boolean_required',
+                              'optional': false,
+                              'typeAnnotation': {
+                                'type': 'BooleanTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'string_optional_key',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'StringTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'float_optional_value',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'FloatTypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'object_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ObjectTypeAnnotation',
+                          'properties': [
+                            {
+                              'name': 'int32_optional_both',
+                              'optional': true,
+                              'typeAnnotation': {
+                                'type': 'Int32TypeAnnotation'
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_required',
+                      'optional': false,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_key',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_value',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'name': 'int32_array_array_optional_both',
+                      'optional': true,
+                      'typeAnnotation': {
+                        'type': 'ArrayTypeAnnotation',
+                        'elementType': {
+                          'type': 'ArrayTypeAnnotation',
+                          'elementType': {
+                            'type': 'Int32TypeAnnotation'
+                          }
+                        }
                       }
                     }
                   ]


### PR DESCRIPTION
Summary:
This diff adds the generation of Array types in events.

It supports the generation of Array of:
- Boolean
- Int32
- Float
- Double
- String
- Objects
- Array

**Note:** This is a first iteration. We could improve the generation further by leveraging the `Bridging` module within React Native.
I'll take a stab at it in a next diff.

## Changelog:
[General][Added] - Generate events with arrays

Differential Revision: D45321685

