### PR TITLE
feat: [iOS] add caretHeight and caretYoffset to TextInput component

### DIFF
--- a/packages/react-native/Libraries/Components/TextInput/RCTTextInputViewConfig.js
+++ b/packages/react-native/Libraries/Components/TextInput/RCTTextInputViewConfig.js
@@ -124,6 +124,8 @@ const RCTTextInputViewConfig = {
     editable: true,
     inputAccessoryViewID: true,
     caretHidden: true,
+    caretHeight: true,
+    caretYOffset: true,
     enablesReturnKeyAutomatically: true,
     placeholderTextColor: {
       process: require('../../StyleSheet/processColor').default,

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
@@ -669,6 +669,18 @@ export interface TextInputProps
   caretHidden?: boolean | undefined;
 
   /**
+   * Allows to adjust caret height.
+   * The default value is 0, which means the height of the caret will be calculated automatically
+   */
+  caretHeight?: number | undefined;
+
+  /**
+   * Allows to adjust caret postiion relative to the Y axis
+   * The default value is 0.
+   */
+  caretYOffset?: number | undefined;
+
+  /**
    * If true, context menu is hidden. The default value is false.
    */
   contextMenuHidden?: boolean | undefined;

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
@@ -671,12 +671,14 @@ export interface TextInputProps
   /**
    * Allows to adjust caret height.
    * The default value is 0, which means the height of the caret will be calculated automatically
+   * @platform ios
    */
   caretHeight?: number | undefined;
 
   /**
-   * Allows to adjust caret postiion relative to the Y axis
+   * Allows to adjust caret position relative to the Y axis
    * The default value is 0.
+   * @platform ios
    */
   caretYOffset?: number | undefined;
 

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
@@ -591,6 +591,18 @@ export type Props = $ReadOnly<{|
    */
   caretHidden?: ?boolean,
 
+  /**
+   * Allows to adjust caret height.
+   * The default value is 0, which means the height of the caret will be calculated automatically
+   */
+
+  caretYOffset?: ?number,
+  /**
+   * Allows to adjust caret postiion relative to the Y axis
+   * The default value is 0.
+   */
+  caretYHeight?: ?number,
+
   /*
    * If `true`, contextMenuHidden is hidden. The default value is `false`.
    */

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
@@ -594,12 +594,14 @@ export type Props = $ReadOnly<{|
   /**
    * Allows to adjust caret height.
    * The default value is 0, which means the height of the caret will be calculated automatically
+   * @platform ios
    */
-
   caretYOffset?: ?number,
+
   /**
-   * Allows to adjust caret postiion relative to the Y axis
+   * Allows to adjust caret position relative to the Y axis
    * The default value is 0.
+   * @platform ios
    */
   caretYHeight?: ?number,
 

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -1517,8 +1517,6 @@ function InternalTextInput(props: Props): React.Node {
           style,
         )}
         text={text}
-        caretYOffset={props.caretYOffset}
-        caretHeight={props.caretHeight}
       />
     );
   } else if (Platform.OS === 'android') {

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -369,12 +369,14 @@ type IOSProps = $ReadOnly<{|
   /**
    * Allows to adjust caret height.
    * The default value is 0, which means the height of the caret will be calculated automatically
+   * @platform ios
    */
   caretYOffset?: ?number,
 
   /**
-   * Allows to adjust caret postiion relative to the Y axis
+   * Allows to adjust caret position relative to the Y axis
    * The default value is 0.
+   * @platform ios
    */
   caretHeight?: ?number,
 |}>;
@@ -1515,8 +1517,6 @@ function InternalTextInput(props: Props): React.Node {
           style,
         )}
         text={text}
-        caretYOffset={props.caretYOffset}
-        caretHeight={props.caretHeight}
       />
     );
   } else if (Platform.OS === 'android') {

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -365,6 +365,18 @@ type IOSProps = $ReadOnly<{|
    * @platform ios
    */
   smartInsertDelete?: ?boolean,
+
+  /**
+   * Allows to adjust caret height.
+   * The default value is 0, which means the height of the caret will be calculated automatically
+   */
+  caretYOffset?: ?number,
+
+  /**
+   * Allows to adjust caret postiion relative to the Y axis
+   * The default value is 0.
+   */
+  caretHeight?: ?number,
 |}>;
 
 type AndroidProps = $ReadOnly<{|
@@ -1503,6 +1515,8 @@ function InternalTextInput(props: Props): React.Node {
           style,
         )}
         text={text}
+        caretYOffset={props.caretYOffset}
+        caretHeight={props.caretHeight}
       />
     );
   } else if (Platform.OS === 'android') {

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -1517,6 +1517,8 @@ function InternalTextInput(props: Props): React.Node {
           style,
         )}
         text={text}
+        caretYOffset={props.caretYOffset}
+        caretHeight={props.caretHeight}
       />
     );
   } else if (Platform.OS === 'android') {

--- a/packages/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.h
+++ b/packages/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.h
@@ -35,6 +35,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) UITextFieldViewMode clearButtonMode;
 
 @property (nonatomic, assign) BOOL caretHidden;
+@property (nonatomic, assign) CGFloat caretYOffset;
+@property (nonatomic, assign) CGFloat caretHeight;
 
 @property (nonatomic, strong, nullable) NSString *inputAccessoryViewID;
 

--- a/packages/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
+++ b/packages/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
@@ -16,35 +16,27 @@
 //the UITextSelectionRect subclass needs to be created because the original version is not writable
 @interface CustomTextSelectionRect : UITextSelectionRect
 
-@property (nonatomic) CGRect _rect;
-@property (nonatomic) NSWritingDirection _writingDirection;
-@property (nonatomic) BOOL _containsStart; // Returns YES if the rect contains the start of the selection.
-@property (nonatomic) BOOL _containsEnd; // Returns YES if the rect contains the end of the selection.
-@property (nonatomic) BOOL _isVertical; // Returns YES if the rect is for vertically oriented text.
+@property (nonatomic, assign) CGRect rect;
+@property (nonatomic, assign) NSWritingDirection writingDirection;
+@property (nonatomic, assign) BOOL containsStart; // Returns YES if the rect contains the start of the selection.
+@property (nonatomic, assign) BOOL containsEnd; // Returns YES if the rect contains the end of the selection.
+@property (nonatomic, assign) BOOL isVertical; // Returns YES if the rect is for vertically oriented text.
 
 @end
 
-@implementation CustomTextSelectionRect
-
-- (CGRect)rect {
-    return __rect;
+@implementation CustomTextSelectionRect {
+    CGRect _customRect;
+    NSWritingDirection _customWritingDirection;
+    BOOL _customContainsStart;
+    BOOL _customContainsEnd;
+    BOOL _customIsVertical;
 }
 
-- (NSWritingDirection)writingDirection {
-    return __writingDirection;
-}
-
-- (BOOL)containsStart {
-    return __containsStart;
-}
-
-- (BOOL)containsEnd {
-    return __containsEnd;
-}
-
-- (BOOL)isVertical {
-    return __isVertical;
-}
+@synthesize rect = _customRect;
+@synthesize writingDirection = _customWritingDirection;
+@synthesize containsStart = _customContainsStart;
+@synthesize containsEnd = _customContainsEnd;
+@synthesize isVertical = _customIsVertical;
 
 @end
 
@@ -360,25 +352,25 @@ static UIColor *defaultPlaceholderColor(void)
 }
 
 - (NSArray *)selectionRectsForRange:(UITextRange *)range {
-  NSArray *superRects = [super selectionRectsForRange:range];
-  if(_caretYOffset != 0 && _caretHeight != 0) {
-    NSMutableArray *customTextSelectionRects = [NSMutableArray array];
+    NSArray *superRects = [super selectionRectsForRange:range];
+    if(_caretYOffset != 0 && _caretHeight != 0) {
+        NSMutableArray *customTextSelectionRects = [NSMutableArray array];
 
-    for (UITextSelectionRect *rect in superRects) {
-        CustomTextSelectionRect *customTextRect = [[CustomTextSelectionRect alloc] init];
+        for (UITextSelectionRect *rect in superRects) {
+            CustomTextSelectionRect *customTextRect = [[CustomTextSelectionRect alloc] init];
 
-        customTextRect._rect = CGRectMake(rect.rect.origin.x, rect.rect.origin.y + _caretYOffset, rect.rect.size.width, _caretHeight);
-        customTextRect._writingDirection = rect.writingDirection;
-        customTextRect._containsStart = rect.containsStart;
-        customTextRect._containsEnd = rect.containsEnd;
-        customTextRect._isVertical = rect.isVertical;
-        [customTextSelectionRects addObject:customTextRect];
+            customTextRect.rect = CGRectMake(rect.rect.origin.x, rect.rect.origin.y + _caretYOffset, rect.rect.size.width, _caretHeight);
+            customTextRect.writingDirection = rect.writingDirection;
+            customTextRect.containsStart = rect.containsStart;
+            customTextRect.containsEnd = rect.containsEnd;
+            customTextRect.isVertical = rect.isVertical;
+            [customTextSelectionRects addObject:customTextRect];
+        }
+
+        return customTextSelectionRects;
+
     }
-
-    return customTextSelectionRects;
-
-  }
-  return superRects;
+    return superRects;
 
 }
 

--- a/packages/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
+++ b/packages/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
@@ -352,10 +352,11 @@ static UIColor *defaultPlaceholderColor(void)
     originalRect.origin.y += _caretYOffset;
   }
 
-    if(_caretHeight != 0) {
+  if(_caretHeight != 0) {
     originalRect.size.height = _caretHeight;
   }
-    return originalRect;
+
+  return originalRect;
 }
 
 - (NSArray *)selectionRectsForRange:(UITextRange *)range {

--- a/packages/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
+++ b/packages/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
@@ -13,8 +13,8 @@
 #import <React/RCTBackedTextInputDelegateAdapter.h>
 #import <React/RCTTextAttributes.h>
 
-//the UITextSelectionRect subclass needs to be created because the original version is not writable
-@interface CustomTextSelectionRect : UITextSelectionRect
+// subclass needs to be created as UITextSelectionRect is an abstract base class
+@interface RCTTextSelectionRect : UITextSelectionRect
 
 @property (nonatomic, assign) CGRect rect;
 @property (nonatomic, assign) NSWritingDirection writingDirection;
@@ -24,7 +24,7 @@
 
 @end
 
-@implementation CustomTextSelectionRect {
+@implementation RCTTextSelectionRect {
     CGRect _customRect;
     NSWritingDirection _customWritingDirection;
     BOOL _customContainsStart;
@@ -351,13 +351,13 @@ static UIColor *defaultPlaceholderColor(void)
   return originalRect;
 }
 
-- (NSArray *)selectionRectsForRange:(UITextRange *)range {
+- (NSArray<UITextSelectionRect *> *)selectionRectsForRange:(UITextRange *)range {
     NSArray *superRects = [super selectionRectsForRange:range];
     if(_caretYOffset != 0 && _caretHeight != 0) {
         NSMutableArray *customTextSelectionRects = [NSMutableArray array];
 
         for (UITextSelectionRect *rect in superRects) {
-            CustomTextSelectionRect *customTextRect = [[CustomTextSelectionRect alloc] init];
+            RCTTextSelectionRect *customTextRect = [[RCTTextSelectionRect alloc] init];
 
             customTextRect.rect = CGRectMake(rect.rect.origin.x, rect.rect.origin.y + _caretYOffset, rect.rect.size.width, _caretHeight);
             customTextRect.writingDirection = rect.writingDirection;

--- a/packages/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
+++ b/packages/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
@@ -13,6 +13,41 @@
 #import <React/RCTBackedTextInputDelegateAdapter.h>
 #import <React/RCTTextAttributes.h>
 
+//the UITextSelectionRect subclass needs to be created because the original version is not writable
+@interface CustomTextSelectionRect : UITextSelectionRect
+
+@property (nonatomic) CGRect _rect;
+@property (nonatomic) NSWritingDirection _writingDirection;
+@property (nonatomic) BOOL _containsStart; // Returns YES if the rect contains the start of the selection.
+@property (nonatomic) BOOL _containsEnd; // Returns YES if the rect contains the end of the selection.
+@property (nonatomic) BOOL _isVertical; // Returns YES if the rect is for vertically oriented text.
+
+@end
+
+@implementation CustomTextSelectionRect
+
+- (CGRect)rect {
+    return __rect;
+}
+
+- (NSWritingDirection)writingDirection {
+    return __writingDirection;
+}
+
+- (BOOL)containsStart {
+    return __containsStart;
+}
+
+- (BOOL)containsEnd {
+    return __containsEnd;
+}
+
+- (BOOL)isVertical {
+    return __isVertical;
+}
+
+@end
+
 @implementation RCTUITextView {
   UILabel *_placeholderView;
   UITextView *_detachedTextView;
@@ -307,11 +342,43 @@ static UIColor *defaultPlaceholderColor(void)
 
 - (CGRect)caretRectForPosition:(UITextPosition *)position
 {
+  CGRect originalRect = [super caretRectForPosition:position];
+
   if (_caretHidden) {
     return CGRectZero;
   }
 
-  return [super caretRectForPosition:position];
+  if(_caretYOffset != 0) {
+    originalRect.origin.y += _caretYOffset;
+  }
+
+    if(_caretHeight != 0) {
+    originalRect.size.height = _caretHeight;
+  }
+    return originalRect;
+}
+
+- (NSArray *)selectionRectsForRange:(UITextRange *)range {
+  NSArray *superRects = [super selectionRectsForRange:range];
+  if(_caretYOffset != 0 && _caretHeight != 0) {
+    NSMutableArray *customTextSelectionRects = [NSMutableArray array];
+
+    for (UITextSelectionRect *rect in superRects) {
+        CustomTextSelectionRect *customTextRect = [[CustomTextSelectionRect alloc] init];
+
+        customTextRect._rect = CGRectMake(rect.rect.origin.x, rect.rect.origin.y + _caretYOffset, rect.rect.size.width, _caretHeight);
+        customTextRect._writingDirection = rect.writingDirection;
+        customTextRect._containsStart = rect.containsStart;
+        customTextRect._containsEnd = rect.containsEnd;
+        customTextRect._isVertical = rect.isVertical;
+        [customTextSelectionRects addObject:customTextRect];
+    }
+
+    return customTextSelectionRects;
+
+  }
+  return superRects;
+
 }
 
 #pragma mark - Utility Methods

--- a/packages/react-native/Libraries/Text/TextInput/RCTBackedTextInputViewProtocol.h
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBackedTextInputViewProtocol.h
@@ -28,6 +28,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) BOOL contextMenuHidden;
 @property (nonatomic, assign, getter=isEditable) BOOL editable;
 @property (nonatomic, assign) BOOL caretHidden;
+@property (nonatomic, assign) CGFloat caretYOffset;
+@property (nonatomic, assign) CGFloat caretHeight;
 @property (nonatomic, assign) BOOL enablesReturnKeyAutomatically;
 @property (nonatomic, assign) UITextFieldViewMode clearButtonMode;
 @property (nonatomic, getter=isScrollEnabled) BOOL scrollEnabled;

--- a/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputViewManager.mm
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputViewManager.mm
@@ -44,6 +44,8 @@ RCT_REMAP_VIEW_PROPERTY(returnKeyType, backedTextInputView.returnKeyType, UIRetu
 RCT_REMAP_VIEW_PROPERTY(selectionColor, backedTextInputView.tintColor, UIColor)
 RCT_REMAP_VIEW_PROPERTY(spellCheck, backedTextInputView.spellCheckingType, UITextSpellCheckingType)
 RCT_REMAP_VIEW_PROPERTY(caretHidden, backedTextInputView.caretHidden, BOOL)
+RCT_REMAP_VIEW_PROPERTY(caretYOffset, backedTextInputView.caretYOffset, CGFloat)
+RCT_REMAP_VIEW_PROPERTY(caretHeight, backedTextInputView.caretHeight, CGFloat)
 RCT_REMAP_VIEW_PROPERTY(clearButtonMode, backedTextInputView.clearButtonMode, UITextFieldViewMode)
 RCT_REMAP_VIEW_PROPERTY(scrollEnabled, backedTextInputView.scrollEnabled, BOOL)
 RCT_REMAP_VIEW_PROPERTY(secureTextEntry, backedTextInputView.secureTextEntry, BOOL)

--- a/packages/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.h
+++ b/packages/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.h
@@ -22,6 +22,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, weak) id<RCTBackedTextInputDelegate> textInputDelegate;
 
 @property (nonatomic, assign) BOOL caretHidden;
+@property (nonatomic, assign) BOOL caretYOffset;
+@property (nonatomic, assign) BOOL caretHeight;
 @property (nonatomic, assign) BOOL contextMenuHidden;
 @property (nonatomic, assign, readonly) BOOL textWasPasted;
 @property (nonatomic, assign, readonly) BOOL dictationRecognizing;

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -2405,18 +2405,6 @@ declare export default HostComponent<NativeProps>;
 "
 `;
 
-exports[`public API should not change unintentionally Libraries/Components/TextInput/InputAccessoryView.js 1`] = `
-"type Props = $ReadOnly<{|
-  +children: React.Node,
-  nativeID?: ?string,
-  style?: ?ViewStyleProp,
-  backgroundColor?: ?ColorValue,
-|}>;
-declare const InputAccessoryView: React.AbstractComponent<Props>;
-declare export default typeof InputAccessoryView;
-"
-`;
-
 exports[`public API should not change unintentionally Libraries/Components/TextInput/RCTInputAccessoryViewNativeComponent.js 1`] = `
 "export * from \\"../../../src/private/specs/components/RCTInputAccessoryViewNativeComponent\\";
 declare export default typeof RCTInputAccessoryViewNativeComponent;

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -151,6 +151,14 @@ using namespace facebook::react;
     _backedTextInputView.caretHidden = newTextInputProps.traits.caretHidden;
   }
 
+  if(newTextInputProps.traits.caretYOffset != oldTextInputProps.traits.caretYOffset) {
+    _backedTextInputView.caretYOffset = newTextInputProps.traits.caretYOffset;
+  }
+
+  if(newTextInputProps.traits.caretHeight != oldTextInputProps.traits.caretHeight) {
+    _backedTextInputView.caretHeight = newTextInputProps.traits.caretHeight;
+  }
+
   if (newTextInputProps.traits.clearButtonMode != oldTextInputProps.traits.clearButtonMode) {
     _backedTextInputView.clearButtonMode =
         RCTUITextFieldViewModeFromTextInputAccessoryVisibilityMode(newTextInputProps.traits.clearButtonMode);

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.mm
@@ -39,7 +39,7 @@ void RCTCopyBackedTextInput(
   toTextInput.spellCheckingType = fromTextInput.spellCheckingType;
   toTextInput.caretHidden = fromTextInput.caretHidden;
   toTextInput.caretYOffset = fromTextInput.caretYOffset;
-  toTextInput.caretHeight = toTextInput.caretHeight;
+  toTextInput.caretHeight = fromTextInput.caretHeight;
   toTextInput.clearButtonMode = fromTextInput.clearButtonMode;
   toTextInput.scrollEnabled = fromTextInput.scrollEnabled;
   toTextInput.secureTextEntry = fromTextInput.secureTextEntry;

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.mm
@@ -38,6 +38,8 @@ void RCTCopyBackedTextInput(
   toTextInput.keyboardAppearance = fromTextInput.keyboardAppearance;
   toTextInput.spellCheckingType = fromTextInput.spellCheckingType;
   toTextInput.caretHidden = fromTextInput.caretHidden;
+  toTextInput.caretYOffset = fromTextInput.caretYOffset;
+  toTextInput.caretHeight = toTextInput.caretHeight;
   toTextInput.clearButtonMode = fromTextInput.clearButtonMode;
   toTextInput.scrollEnabled = fromTextInput.scrollEnabled;
   toTextInput.secureTextEntry = fromTextInput.secureTextEntry;

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/primitives.h
@@ -156,6 +156,19 @@ class TextInputTraits final {
   bool caretHidden{false};
 
   /*
+   * iOS-only (inherently iOS-specific)
+   * Default value: 0 with a default font.
+   */
+
+  int caretHeight{0};
+
+  /*
+   * iOS-only (inherently iOS-specific)
+   * Default value: 0 means that the caret offset will have the default value
+   */
+  int caretYOffset{0};
+
+  /*
    * Controls the visibility of a `Clean` button.
    * iOS-only (implemented only on iOS for now)
    * Default value: `Never`.

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/primitives.h
@@ -159,7 +159,6 @@ class TextInputTraits final {
    * iOS-only (inherently iOS-specific)
    * Default value: 0 with a default font.
    */
-
   int caretHeight{0};
 
   /*

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/propsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/propsConversions.h
@@ -75,6 +75,18 @@ static TextInputTraits convertRawProp(
       "caretHidden",
       sourceTraits.caretHidden,
       defaultTraits.caretHidden);
+  traits.caretYOffset = convertRawProp(
+    context,
+    rawProps,
+    "caretYOffset",
+    sourceTraits.caretYOffset,
+    defaultTraits.caretYOffset);
+  traits.caretHeight= convertRawProp(
+    context,
+    rawProps,
+    "caretHeight",
+    sourceTraits.caretHeight,
+    defaultTraits.caretHeight);
   traits.clearButtonMode = convertRawProp(
       context,
       rawProps,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:
This PR adds support for the caret height and caret position properties in iOS multi-line TextInput
PR for the docs update: https://github.com/facebook/react-native-website/pull/3709

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

[IOS] [ADDED] - Add `caretHeight` and `caretYOffset` props to TextInput component

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:
Default caret:

https://user-images.githubusercontent.com/19835085/236169989-54ddf4f7-6606-4b1c-b615-dab64fb2d948.mov

Caret with `caretHeight` and `caretYOffset`adjustment:

https://user-images.githubusercontent.com/19835085/236170124-82b915ae-304e-426a-ba91-851c20954c7a.mov



<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
