### PR TITLE
Refactor hasComponent binding so it uses bridging API

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/RCTComponentViewFactory.mm
+++ b/packages/react-native/React/Fabric/Mounting/RCTComponentViewFactory.mm
@@ -49,7 +49,7 @@ void RCTInstallNativeComponentRegistryBinding(facebook::jsi::Runtime &runtime)
     return [[RCTComponentViewFactory currentComponentViewFactory]
         registerComponentIfPossible:componentNameByReactViewName(name)];
   };
-  NativeComponentRegistryBinding::install(runtime, std::move(hasComponentProvider));
+  bindHasComponentProvider(runtime, std::move(hasComponentProvider));
 }
 
 static Class<RCTComponentViewProtocol> RCTComponentViewClassWithName(const char *componentName)

--- a/packages/react-native/ReactAndroid/src/main/jni/react/uimanager/ComponentNameResolverManager.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/uimanager/ComponentNameResolverManager.cpp
@@ -67,8 +67,7 @@ void ComponentNameResolverManager::installJSIBindings() {
       return thizz->componentNames_.find(name) != thizz->componentNames_.end();
     };
 
-    react::NativeComponentRegistryBinding::install(
-        runtime, std::move(viewManagerProvider));
+    bindHasComponentProvider(runtime, std::move(viewManagerProvider));
   });
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/componentregistry/native/NativeComponentRegistryBinding.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/componentregistry/native/NativeComponentRegistryBinding.cpp
@@ -7,60 +7,22 @@
 
 #include "NativeComponentRegistryBinding.h"
 
+#include <react/bridging/Bridging.h>
 #include <stdexcept>
 #include <string>
-
-using namespace facebook;
 
 namespace facebook::react {
 
 /**
- * Public API to install the NativeComponentRegistryBinding.
+ * Public API to install the Native Component Registry bindings.
  */
-NativeComponentRegistryBinding::NativeComponentRegistryBinding(
-    const HasComponentProviderFunctionType &&hasComponentProvider)
-    : hasComponentProvider_(hasComponentProvider) {}
-
-void NativeComponentRegistryBinding::install(
+void bindHasComponentProvider(
     jsi::Runtime &runtime,
-    const HasComponentProviderFunctionType &&hasComponentProvider) {
+    HasComponentProviderFunctionType &&provider) {
   runtime.global().setProperty(
       runtime,
       "__nativeComponentRegistry__hasComponent",
-      jsi::Function::createFromHostFunction(
-          runtime,
-          jsi::PropNameID::forAscii(
-              runtime, "__nativeComponentRegistry__hasComponent"),
-          1,
-          [binding = std::make_shared<NativeComponentRegistryBinding>(
-               std::move(hasComponentProvider))](
-              jsi::Runtime &rt,
-              const jsi::Value &thisVal,
-              const jsi::Value *args,
-              size_t count) {
-            return binding->jsProxy(rt, thisVal, args, count);
-          }));
-}
-
-bool NativeComponentRegistryBinding::hasComponent(const std::string &name) {
-  return hasComponentProvider_(name);
-}
-
-jsi::Value NativeComponentRegistryBinding::jsProxy(
-    jsi::Runtime &runtime,
-    const jsi::Value & /*thisVal*/,
-    const jsi::Value *args,
-    size_t count) {
-  if (count != 1) {
-    throw std::invalid_argument(
-        "__nativeComponentRegistry__hasComponent must be called with 1 argument");
-  }
-  std::string moduleName = args[0].getString(runtime).utf8(runtime);
-  jsi::Value nullSchema = jsi::Value::undefined();
-
-  bool result = hasComponent(moduleName);
-
-  return {result};
+      bridging::toJs(runtime, provider, {}));
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/componentregistry/native/NativeComponentRegistryBinding.h
+++ b/packages/react-native/ReactCommon/react/renderer/componentregistry/native/NativeComponentRegistryBinding.h
@@ -20,40 +20,12 @@ namespace facebook::react {
 using HasComponentProviderFunctionType =
     std::function<bool(const std::string &name)>;
 
-/**
- * Represents the JavaScript binding for the HasComponent global function.
+/*
+ * Installs HasComponentProviderFunction into JavaScript runtime.
+ * Thread synchronization must be enforced externally.
  */
-class NativeComponentRegistryBinding {
- public:
-  /*
-   * Installs NativeComponentRegistryBinding into JavaScript runtime.
-   * Thread synchronization must be enforced externally.
-   */
-  static void install(
-      jsi::Runtime &runtime,
-      const HasComponentProviderFunctionType &&provider);
-
-  NativeComponentRegistryBinding(
-      const HasComponentProviderFunctionType &&provider);
-
-  /**
-   * Returns if there's a component registered with the name received as a
-   * parameter
-   */
-  bool hasComponent(const std::string &name);
-
- private:
-  /**
-   * A lookup function exposed to JS to determine if a component is registered
-   * in the native platform.
-   */
-  jsi::Value jsProxy(
-      jsi::Runtime &runtime,
-      const jsi::Value &thisVal,
-      const jsi::Value *args,
-      size_t count);
-
-  HasComponentProviderFunctionType hasComponentProvider_;
-};
+void bindHasComponentProvider(
+    jsi::Runtime &runtime,
+    HasComponentProviderFunctionType &&provider);
 
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
This diff should simplify binding of `__nativeComponentRegistry__hasComponent`.

Changelog: [Internal] - Simplify `hasComponent` binding by using bridging API.

Reviewed By: javache

Differential Revision: D45150027

