### PR TITLE
Re-enable newArch on RN-Tester

### DIFF
--- a/packages/rn-tester/android/app/gradle.properties
+++ b/packages/rn-tester/android/app/gradle.properties
@@ -13,6 +13,6 @@ android.enableJetifier=true
 FLIPPER_VERSION=0.182.0
 
 # RN-Tester is building with NewArch always enabled
-newArchEnabled=false
+newArchEnabled=true
 # RN-Tester is running with Hermes enabled and filtering variants with enableHermesOnlyInVariants
 hermesEnabled=true


### PR DESCRIPTION
Summary:
I accidentally turned off New Architecture on RN-Tester while shipping the Fabric Interop. This reverts it.

Changelog:
[Internal] [Changed] - Re-enable newArch on RN-Tester

Reviewed By: cipolleschi

Differential Revision: D45398914

