### PR TITLE
Introduce kotlin annotation to OptIn into the new Architecture API

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/annotations/UnstableReactNativeAPI.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/annotations/UnstableReactNativeAPI.kt
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.common.annotations
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+@RequiresOptIn(
+    level = RequiresOptIn.Level.ERROR,
+    message = "This API is experimental and is likely to change or to be removed in the future")
+annotation class UnstableReactNativeAPI

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/annotations/VisibleForTesting.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/annotations/VisibleForTesting.kt
@@ -5,10 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-package com.facebook.react.common.annotations;
+
+package com.facebook.react.common.annotations
 
 /**
  * Annotates a method that should have restricted visibility but it's required to be public for use
  * in test code only.
  */
-public @interface VisibleForTesting {}
+annotation class VisibleForTesting


### PR DESCRIPTION
Summary:
In this diff I'm introducing a new kotlin annotation to OptIn into the new Architecture API. I named it "NewReactNativeArchitectureExperimentalAPI" but I'm open to name suggestions, maybe make it a bit more generic like:
ReactNativeExperimental?

Ideally it should be named similar to how we are going to publicitize the New Architecture in OSS.

The plan is to use this annotation to mark classes of experimental API, forcing external developers to explicitly optIn into new APIs:

```
NewReactNativeArchitectureExperimentalAPI
class ReactHost // A class requiring opt-in

// Client code
// this code will compile
OptIn(NewReactNativeArchitectureExperimentalAPI::class)
fun getReactHost(): ReactHost {
    // ...
    return ReactHost()
}

// This code wont compile
fun getReactHost(): ReactHost {
    // ...
    return ReactHost()
}

```

For more details about OptIn read:
https://kotlinlang.org/docs/opt-in-requirements.html#create-opt-in-requirement-annotations

changelog: [internal] internal

Differential Revision: D45417255

