### PR TITLE
Remove path for "react_fabric:treat_auto_as_undefined"

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
@@ -11,7 +11,6 @@
 #include <folly/Conv.h>
 #include <folly/dynamic.h>
 #include <glog/logging.h>
-#include <react/config/ReactNativeConfig.h>
 #include <react/debug/react_native_expect.h>
 #include <react/renderer/components/view/primitives.h>
 #include <react/renderer/core/LayoutMetrics.h>
@@ -408,19 +407,13 @@ inline void fromRawValue(
     const PropsParserContext &context,
     const RawValue &value,
     YGStyle::ValueRepr &result) {
-  // For bug compatibility, pass "auto" as YGValueUndefined
-  static bool treatAutoAsUndefined =
-      context.contextContainer
-          .at<std::shared_ptr<ReactNativeConfig const>>("ReactNativeConfig")
-          ->getBool("react_fabric:treat_auto_as_undefined");
-
   if (value.hasType<Float>()) {
     result = yogaStyleValueFromFloat((Float)value);
     return;
   } else if (value.hasType<std::string>()) {
     const auto stringValue = (std::string)value;
     if (stringValue == "auto") {
-      result = treatAutoAsUndefined ? YGValueUndefined : YGValueAuto;
+      result = YGValueAuto;
       return;
     } else {
       if (stringValue.back() == '%') {
@@ -455,18 +448,8 @@ inline void fromRawValue(
     const PropsParserContext &context,
     const RawValue &value,
     YGFloatOptional &result) {
-  if (value.hasType<float>()) {
-    result = YGFloatOptional((float)value);
-    return;
-  } else if (value.hasType<std::string>()) {
-    const auto stringValue = (std::string)value;
-    if (stringValue == "auto") {
-      result = YGFloatOptional();
-      return;
-    }
-  }
-  LOG(ERROR) << "Could not parse YGFloatOptional";
-  react_native_expect(false);
+  result = value.hasType<float>() ? YGFloatOptional((float)value)
+                                  : YGFloatOptional{};
 }
 
 inline Float toRadians(


### PR DESCRIPTION
Summary:
This flag was added so that we could fix parsing the "auto" style value token without waiting on an experiment in the FB app to know if any code was indirectly relying on `margin: "auto"` and similar doing nothing.

This removes the special-case.

Differential Revision: D45417428

