### PR TITLE
Refactor: Rename TurboModuleHolder -> ModuleHolder

### DIFF
--- a/packages/react-native/Libraries/Animated/NativeAnimatedHelper.js
+++ b/packages/react-native/Libraries/Animated/NativeAnimatedHelper.js
@@ -28,9 +28,7 @@ import invariant from 'invariant';
 
 // TODO T69437152 @petetheheat - Delete this fork when Fabric ships to 100%.
 const NativeAnimatedModule =
-  Platform.OS === 'ios' && global.RN$Bridgeless === true
-    ? NativeAnimatedTurboModule
-    : NativeAnimatedNonTurboModule;
+  NativeAnimatedNonTurboModule ?? NativeAnimatedTurboModule;
 
 let __nativeAnimatedNodeTagCount = 1; /* used for animated nodes */
 let __nativeAnimationIdCount = 1; /* used for started animations */

--- a/packages/react-native/Libraries/Animated/NativeAnimatedModule.js
+++ b/packages/react-native/Libraries/Animated/NativeAnimatedModule.js
@@ -11,6 +11,7 @@
 import type {TurboModule} from '../TurboModule/RCTExport';
 
 import * as TurboModuleRegistry from '../TurboModule/TurboModuleRegistry';
+import shouldUseTurboAnimatedModule from './shouldUseTurboAnimatedModule';
 
 type EndResult = {finished: boolean, ...};
 type EndCallback = (result: EndResult) => void;
@@ -70,4 +71,7 @@ export interface Spec extends TurboModule {
   +queueAndExecuteBatchedOperations?: (operationsAndArgs: Array<any>) => void;
 }
 
-export default (TurboModuleRegistry.get<Spec>('NativeAnimatedModule'): ?Spec);
+const NativeModule: ?Spec = !shouldUseTurboAnimatedModule()
+  ? TurboModuleRegistry.get<Spec>('NativeAnimatedModule')
+  : null;
+export default NativeModule;

--- a/packages/react-native/Libraries/Animated/NativeAnimatedTurboModule.js
+++ b/packages/react-native/Libraries/Animated/NativeAnimatedTurboModule.js
@@ -11,6 +11,7 @@
 import type {TurboModule} from '../TurboModule/RCTExport';
 
 import * as TurboModuleRegistry from '../TurboModule/TurboModuleRegistry';
+import shouldUseTurboAnimatedModule from './shouldUseTurboAnimatedModule';
 
 type EndResult = {finished: boolean, ...};
 type EndCallback = (result: EndResult) => void;
@@ -70,6 +71,8 @@ export interface Spec extends TurboModule {
   +queueAndExecuteBatchedOperations?: (operationsAndArgs: Array<any>) => void;
 }
 
-export default (TurboModuleRegistry.get<Spec>(
-  'NativeAnimatedTurboModule',
-): ?Spec);
+const NativeModule: ?Spec = shouldUseTurboAnimatedModule()
+  ? TurboModuleRegistry.get<Spec>('NativeAnimatedTurboModule')
+  : null;
+
+export default NativeModule;

--- a/packages/react-native/Libraries/Animated/shouldUseTurboAnimatedModule.js
+++ b/packages/react-native/Libraries/Animated/shouldUseTurboAnimatedModule.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+import Platform from '../Utilities/Platform';
+
+function shouldUseTurboAnimatedModule(): boolean {
+  return Platform.OS === 'ios' && global.RN$Bridgeless === true;
+}
+
+export default shouldUseTurboAnimatedModule;

--- a/packages/react-native/React/Base/RCTBridge.h
+++ b/packages/react-native/React/Base/RCTBridge.h
@@ -60,6 +60,10 @@ RCT_EXTERN void RCTDisableTurboModuleManagerDelegateLocking(BOOL enabled);
 RCT_EXTERN BOOL RCTTurboModuleInteropEnabled(void);
 RCT_EXTERN void RCTEnableTurboModuleInterop(BOOL enabled);
 
+// Route all TurboModules through TurboModule interop
+RCT_EXTERN BOOL RCTTurboModuleInteropForAllTurboModulesEnabled(void);
+RCT_EXTERN void RCTEnableTurboModuleInteropForAllTurboModules(BOOL enabled);
+
 typedef enum {
   kRCTGlobalScope,
   kRCTGlobalScopeUsingRetainJSCallback,

--- a/packages/react-native/React/Base/RCTBridge.h
+++ b/packages/react-native/React/Base/RCTBridge.h
@@ -56,6 +56,10 @@ RCT_EXTERN void RCTEnableTurboModuleEagerInit(BOOL enabled);
 RCT_EXTERN BOOL RCTTurboModuleManagerDelegateLockingDisabled(void);
 RCT_EXTERN void RCTDisableTurboModuleManagerDelegateLocking(BOOL enabled);
 
+// Turn on TurboModule interop
+RCT_EXTERN BOOL RCTTurboModuleInteropEnabled(void);
+RCT_EXTERN void RCTEnableTurboModuleInterop(BOOL enabled);
+
 typedef enum {
   kRCTGlobalScope,
   kRCTGlobalScopeUsingRetainJSCallback,

--- a/packages/react-native/React/Base/RCTBridge.m
+++ b/packages/react-native/React/Base/RCTBridge.m
@@ -120,6 +120,16 @@ void RCTDisableTurboModuleManagerDelegateLocking(BOOL disabled)
   turboModuleManagerDelegateLockingDisabled = disabled;
 }
 
+static BOOL turboModuleInteropEnabled = YES;
+BOOL RCTTurboModuleInteropEnabled(void)
+{
+  return turboModuleInteropEnabled;
+}
+void RCTEnableTurboModuleInterop(BOOL enabled)
+{
+  turboModuleInteropEnabled = enabled;
+}
+
 @interface RCTBridge () <RCTReloadListener>
 @end
 

--- a/packages/react-native/React/Base/RCTBridge.m
+++ b/packages/react-native/React/Base/RCTBridge.m
@@ -130,6 +130,16 @@ void RCTEnableTurboModuleInterop(BOOL enabled)
   turboModuleInteropEnabled = enabled;
 }
 
+static BOOL useTurboModuleInteropForAllTurboModules = NO;
+BOOL RCTTurboModuleInteropForAllTurboModulesEnabled(void)
+{
+  return useTurboModuleInteropForAllTurboModules;
+}
+void RCTEnableTurboModuleInteropForAllTurboModules(BOOL enabled)
+{
+  useTurboModuleInteropForAllTurboModules = enabled;
+}
+
 @interface RCTBridge () <RCTReloadListener>
 @end
 

--- a/packages/react-native/ReactCommon/react/bridgeless/ReactInstance.cpp
+++ b/packages/react-native/ReactCommon/react/bridgeless/ReactInstance.cpp
@@ -155,6 +155,12 @@ static void defineReadOnlyGlobal(
     jsi::Runtime &runtime,
     std::string propName,
     jsi::Value &&value) {
+  if (runtime.global().hasProperty(runtime, propName.c_str())) {
+    throw jsi::JSError(
+        runtime,
+        "Tried to redefine read-only global \"" + propName +
+            "\", but read-only globals can only be defined once.");
+  }
   jsi::Object jsObject =
       runtime.global().getProperty(runtime, "Object").asObject(runtime);
   jsi::Function defineProperty = jsObject.getProperty(runtime, "defineProperty")

--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.cpp
@@ -68,6 +68,12 @@ static void defineReadOnlyGlobal(
     jsi::Runtime &runtime,
     std::string propName,
     jsi::Value &&value) {
+  if (runtime.global().hasProperty(runtime, propName.c_str())) {
+    throw jsi::JSError(
+        runtime,
+        "Tried to redefine read-only global \"" + propName +
+            "\", but read-only globals can only be defined once.");
+  }
   jsi::Object jsObject =
       runtime.global().getProperty(runtime, "Object").asObject(runtime);
   jsi::Function defineProperty = jsObject.getProperty(runtime, "defineProperty")

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.h
@@ -75,7 +75,7 @@ class JSI_EXPORT ObjCTurboModule : public TurboModule {
   NSString *getArgumentTypeName(NSString *methodName, int argIndex);
   NSInvocation *getMethodInvocation(
       jsi::Runtime &runtime,
-      TurboModuleMethodValueKind returnType,
+      bool isSync,
       const char *methodName,
       SEL selector,
       const jsi::Value *args,

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.h
@@ -57,6 +57,11 @@ class JSI_EXPORT ObjCTurboModule : public TurboModule {
 
  protected:
   void setMethodArgConversionSelector(NSString *methodName, int argIndex, NSString *fnName);
+  virtual jsi::Value convertReturnIdToJSIValue(
+      jsi::Runtime &runtime,
+      const char *methodName,
+      TurboModuleMethodValueKind returnType,
+      id result);
 
  private:
   // Does the NativeModule dispatch async methods to the JS thread?
@@ -81,9 +86,9 @@ class JSI_EXPORT ObjCTurboModule : public TurboModule {
       const jsi::Value *args,
       size_t count,
       NSMutableArray *retainedObjectsForInvocation);
-  jsi::Value performMethodInvocation(
+  id performMethodInvocation(
       jsi::Runtime &runtime,
-      TurboModuleMethodValueKind returnType,
+      bool isSync,
       const char *methodName,
       NSInvocation *inv,
       NSMutableArray *retainedObjectsForInvocation);

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.h
@@ -46,7 +46,7 @@ class JSI_EXPORT ObjCTurboModule : public TurboModule {
 
   jsi::Value invokeObjCMethod(
       jsi::Runtime &runtime,
-      TurboModuleMethodValueKind valueKind,
+      TurboModuleMethodValueKind returnType,
       const std::string &methodName,
       SEL selector,
       const jsi::Value *args,

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.h
@@ -81,7 +81,7 @@ class JSI_EXPORT ObjCTurboModule : public TurboModule {
   bool isMethodSync(TurboModuleMethodValueKind returnType);
   BOOL hasMethodArgConversionSelector(NSString *methodName, int argIndex);
   SEL getMethodArgConversionSelector(NSString *methodName, int argIndex);
-  NSString *getArgumentTypeName(NSString *methodName, int argIndex);
+  NSString *getArgumentTypeName(jsi::Runtime &runtime, NSString *methodName, int argIndex);
   NSInvocation *createMethodInvocation(
       jsi::Runtime &runtime,
       bool isSync,

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.h
@@ -90,6 +90,14 @@ class JSI_EXPORT ObjCTurboModule : public TurboModule {
       const jsi::Value *args,
       size_t count,
       NSMutableArray *retainedObjectsForInvocation);
+  void setInvocationArg(
+      jsi::Runtime &runtime,
+      const char *methodName,
+      const std::string &objCArgType,
+      const jsi::Value &arg,
+      size_t i,
+      NSInvocation *inv,
+      NSMutableArray *retainedObjectsForInvocation);
   id performMethodInvocation(
       jsi::Runtime &runtime,
       bool isSync,

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.h
@@ -28,6 +28,10 @@ namespace facebook::react {
 class CallbackWrapper;
 class Instance;
 
+namespace TurboModuleConvertUtils {
+jsi::Value convertObjCObjectToJSIValue(jsi::Runtime &runtime, id value);
+}
+
 /**
  * ObjC++ specific TurboModule base class.
  */

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.h
@@ -82,7 +82,7 @@ class JSI_EXPORT ObjCTurboModule : public TurboModule {
   BOOL hasMethodArgConversionSelector(NSString *methodName, int argIndex);
   SEL getMethodArgConversionSelector(NSString *methodName, int argIndex);
   NSString *getArgumentTypeName(NSString *methodName, int argIndex);
-  NSInvocation *getMethodInvocation(
+  NSInvocation *createMethodInvocation(
       jsi::Runtime &runtime,
       bool isSync,
       const char *methodName,

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
@@ -531,7 +531,7 @@ NSString *ObjCTurboModule::getArgumentTypeName(NSString *methodName, int argInde
 
 NSInvocation *ObjCTurboModule::getMethodInvocation(
     jsi::Runtime &runtime,
-    TurboModuleMethodValueKind returnType,
+    bool isSync,
     const char *methodName,
     SEL selector,
     const jsi::Value *args,
@@ -541,7 +541,7 @@ NSInvocation *ObjCTurboModule::getMethodInvocation(
   const char *moduleName = name_.c_str();
   const id<RCTTurboModule> module = instance_;
 
-  if (isMethodSync(returnType)) {
+  if (isSync) {
     TurboModulePerfLogger::syncMethodCallArgConversionStart(moduleName, methodName);
   } else {
     TurboModulePerfLogger::asyncMethodCallArgConversionStart(moduleName, methodName);
@@ -648,7 +648,7 @@ NSInvocation *ObjCTurboModule::getMethodInvocation(
     }
   }
 
-  if (isMethodSync(returnType)) {
+  if (isSync) {
     TurboModulePerfLogger::syncMethodCallArgConversionEnd(moduleName, methodName);
   } else {
     TurboModulePerfLogger::asyncMethodCallArgConversionEnd(moduleName, methodName);
@@ -688,8 +688,8 @@ jsi::Value ObjCTurboModule::invokeObjCMethod(
   }
 
   NSMutableArray *retainedObjectsForInvocation = [NSMutableArray arrayWithCapacity:count + 2];
-  NSInvocation *inv =
-      getMethodInvocation(runtime, returnType, methodName, selector, args, count, retainedObjectsForInvocation);
+  NSInvocation *inv = getMethodInvocation(
+      runtime, isMethodSync(returnType), methodName, selector, args, count, retainedObjectsForInvocation);
 
   jsi::Value returnValue = returnType == PromiseKind
       ? createPromise(

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
@@ -29,6 +29,7 @@
 
 using namespace facebook;
 using namespace facebook::react;
+using namespace facebook::react::TurboModuleConvertUtils;
 
 static int32_t getUniqueId()
 {
@@ -36,6 +37,10 @@ static int32_t getUniqueId()
   return counter++;
 }
 
+namespace facebook {
+namespace react {
+
+namespace TurboModuleConvertUtils {
 /**
  * All static helper functions are ObjC++ specific.
  */
@@ -54,7 +59,7 @@ static jsi::String convertNSStringToJSIString(jsi::Runtime &runtime, NSString *v
   return jsi::String::createFromUtf8(runtime, [value UTF8String] ?: "");
 }
 
-static jsi::Value convertObjCObjectToJSIValue(jsi::Runtime &runtime, id value);
+jsi::Value convertObjCObjectToJSIValue(jsi::Runtime &runtime, id value);
 static jsi::Object convertNSDictionaryToJSIObject(jsi::Runtime &runtime, NSDictionary *value)
 {
   jsi::Object result = jsi::Object(runtime);
@@ -82,7 +87,7 @@ static std::vector<jsi::Value> convertNSArrayToStdVector(jsi::Runtime &runtime, 
   return result;
 }
 
-static jsi::Value convertObjCObjectToJSIValue(jsi::Runtime &runtime, id value)
+jsi::Value convertObjCObjectToJSIValue(jsi::Runtime &runtime, id value)
 {
   if ([value isKindOfClass:[NSString class]]) {
     return convertNSStringToJSIString(runtime, (NSString *)value);
@@ -211,8 +216,6 @@ convertJSIFunctionToCallback(jsi::Runtime &runtime, const jsi::Function &value, 
   return [callback copy];
 }
 
-namespace facebook::react {
-
 static jsi::Value createJSRuntimeError(jsi::Runtime &runtime, const std::string &message)
 {
   return runtime.global().getPropertyAsFunction(runtime, "Error").call(runtime, message);
@@ -235,6 +238,8 @@ static jsi::JSError convertNSExceptionToJSError(jsi::Runtime &runtime, NSExcepti
   jsi::Value error = createJSRuntimeError(runtime, "Exception in HostFunction: " + reason);
   error.asObject(runtime).setProperty(runtime, "cause", std::move(cause));
   return {runtime, std::move(error)};
+}
+
 }
 
 jsi::Value ObjCTurboModule::createPromise(jsi::Runtime &runtime, std::string methodName, PromiseInvocationBlock invoke)
@@ -771,4 +776,5 @@ void ObjCTurboModule::setMethodArgConversionSelector(NSString *methodName, int a
   methodArgConversionSelectors_[methodName][argIndex] = selectorValue;
 }
 
+}
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
@@ -494,7 +494,7 @@ jsi::Value ObjCTurboModule::convertReturnIdToJSIValue(
  * Note: This is only being introduced for backward compatibility. It will be removed
  *       in the future.
  */
-NSString *ObjCTurboModule::getArgumentTypeName(NSString *methodName, int argIndex)
+NSString *ObjCTurboModule::getArgumentTypeName(jsi::Runtime &runtime, NSString *methodName, int argIndex)
 {
   if (!methodArgumentTypeNames_) {
     NSMutableDictionary<NSString *, NSArray<NSString *> *> *methodArgumentTypeNames = [NSMutableDictionary new];
@@ -595,7 +595,7 @@ void ObjCTurboModule::setInvocationArg(
      * Convert objects using RCTConvert.
      */
     if (objCArgType == @encode(id)) {
-      NSString *argumentType = getArgumentTypeName(methodNameNSString, i);
+      NSString *argumentType = getArgumentTypeName(runtime, methodNameNSString, i);
       if (argumentType != nil) {
         NSString *rctConvertMethodName = [NSString stringWithFormat:@"%@:", argumentType];
         SEL rctConvertSelector = NSSelectorFromString(rctConvertMethodName);

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
@@ -541,7 +541,7 @@ NSString *ObjCTurboModule::getArgumentTypeName(NSString *methodName, int argInde
   return nil;
 }
 
-NSInvocation *ObjCTurboModule::getMethodInvocation(
+NSInvocation *ObjCTurboModule::createMethodInvocation(
     jsi::Runtime &runtime,
     bool isSync,
     const char *methodName,
@@ -700,7 +700,7 @@ jsi::Value ObjCTurboModule::invokeObjCMethod(
   }
 
   NSMutableArray *retainedObjectsForInvocation = [NSMutableArray arrayWithCapacity:count + 2];
-  NSInvocation *inv = getMethodInvocation(
+  NSInvocation *inv = createMethodInvocation(
       runtime, isMethodSync(returnType), methodName, selector, args, count, retainedObjectsForInvocation);
 
   jsi::Value returnValue = jsi::Value::undefined();


### PR DESCRIPTION
Summary:
In the future, this will hold TurboModules, as well as legacy/interop modules.

Changelog: [Internal]

Reviewed By: mdvacca

Differential Revision: D45404790

