### PR TITLE
Replace 'React' with 'react' in rntester examples

### DIFF
--- a/packages/rn-tester/js/examples/ActivityIndicator/ActivityIndicatorExample.js
+++ b/packages/rn-tester/js/examples/ActivityIndicator/ActivityIndicatorExample.js
@@ -8,7 +8,7 @@
  * @flow strict-local
  */
 
-import type {Node} from 'React';
+import type {Node} from 'react';
 
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {ActivityIndicator, StyleSheet, View} from 'react-native';

--- a/packages/rn-tester/js/examples/Crash/CrashExample.js
+++ b/packages/rn-tester/js/examples/Crash/CrashExample.js
@@ -8,7 +8,7 @@
  * @flow strict-local
  */
 
-import type {Node} from 'React';
+import type {Node} from 'react';
 import {Button} from 'react-native';
 import React from 'react';
 


### PR DESCRIPTION
Summary:
Updates a few imports in RNTester to 'react' as we had previously done in:
https://github.com/facebook/react-native/commit/0ee5f689

Differential Revision: D45445211

