### PR TITLE
Remove "auto" from YGFloatOptional conversion

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
@@ -455,18 +455,8 @@ inline void fromRawValue(
     const PropsParserContext &context,
     const RawValue &value,
     YGFloatOptional &result) {
-  if (value.hasType<float>()) {
-    result = YGFloatOptional((float)value);
-    return;
-  } else if (value.hasType<std::string>()) {
-    const auto stringValue = (std::string)value;
-    if (stringValue == "auto") {
-      result = YGFloatOptional();
-      return;
-    }
-  }
-  LOG(ERROR) << "Could not parse YGFloatOptional";
-  react_native_expect(false);
+  result = value.hasType<float>() ? YGFloatOptional((float)value)
+                                  : YGFloatOptional();
 }
 
 inline Float toRadians(


### PR DESCRIPTION
Summary:
"auto" is not a valid value to go into anything accepting `YGFloatOptional`. Remove the code here which special cases it (though we will produce the same result). Also remove error logging which is not localized/useful, in the theme of having user style inputs be handled gracefully.

Changelog: [Internal]

Reviewed By: yungsters

Differential Revision: D45434650

