### PR TITLE
Stop using bolts for memory pressure handling

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
@@ -56,6 +56,9 @@ public class ReactFeatureFlags {
    */
   public static boolean enableBridgelessArchitecture = false;
 
+  /** Server-side gating for a hacky fix to an ANR in the bridgeless core, related to Bolts task. */
+  public static boolean unstable_bridgelessArchitectureMemoryPressureHackyBoltsFix = false;
+
   /**
    * Does the bridgeless architecture log soft exceptions. Could be useful for tracking down issues.
    */


### PR DESCRIPTION
Summary:
An ANR recently surface in Fb4a: T152128771. The stack points into the Bolts task library. (It's on the memory pressure handling code-path).

This diff mitigates that ANR: it migrates the memory pressure handling path off Bolts tasks.

There is server-side gating, in case we want to disable this fix server-side.

Changelog: [Internal]

Reviewed By: fkgozali

Differential Revision: D45461419

