### PR TITLE
Codegen 118: add throwIfBubblingTypeisNull in error-utils and use it in events

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
@@ -34,6 +34,7 @@ const {
   throwIfPartialWithMoreParameter,
   throwIfMoreThanOneCodegenNativecommands,
   throwIfEventHasNoName,
+  throwIfBubblingTypeIsNull,
 } = require('../error-utils');
 const {
   UnsupportedModulePropertyParserError,
@@ -947,6 +948,28 @@ describe('throwIfEventHasNoName', () => {
 
     expect(() => {
       throwIfEventHasNoName(typeAnnotation, typescriptParser);
+    }).not.toThrow();
+  });
+});
+
+describe('throwIfBubblingTypeIsNull', () => {
+  it('throw an error if unable to determine event bubbling type', () => {
+    const bubblingType = null;
+    const eventName = 'Event';
+
+    expect(() => {
+      throwIfBubblingTypeIsNull(bubblingType, eventName);
+    }).toThrowError(
+      `Unable to determine event bubbling type for "${eventName}"`,
+    );
+  });
+
+  it('does not throw an error if able to determine event bubbling type', () => {
+    const bubblingType = 'direct';
+    const eventName = 'Event';
+
+    expect(() => {
+      throwIfBubblingTypeIsNull(bubblingType, eventName);
     }).not.toThrow();
   });
 });

--- a/packages/react-native-codegen/src/parsers/error-utils.js
+++ b/packages/react-native-codegen/src/parsers/error-utils.js
@@ -319,6 +319,17 @@ function throwIfEventHasNoName(typeAnnotation: $FlowFixMe, parser: Parser) {
   }
 }
 
+function throwIfBubblingTypeIsNull(
+  bubblingType: ?('direct' | 'bubble'),
+  eventName: string,
+) {
+  if (!bubblingType) {
+    throw new Error(
+      `Unable to determine event bubbling type for "${eventName}"`,
+    );
+  }
+}
+
 module.exports = {
   throwIfModuleInterfaceIsMisnamed,
   throwIfUnsupportedFunctionReturnTypeAnnotationParserError,
@@ -340,4 +351,5 @@ module.exports = {
   throwIfConfigNotfound,
   throwIfMoreThanOneConfig,
   throwIfEventHasNoName,
+  throwIfBubblingTypeIsNull,
 };

--- a/packages/react-native-codegen/src/parsers/flow/components/events.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/events.js
@@ -16,7 +16,10 @@ import type {
   EventTypeAnnotation,
 } from '../../../CodegenSchema.js';
 import type {Parser} from '../../parser';
-const {throwIfEventHasNoName} = require('../../error-utils');
+const {
+  throwIfEventHasNoName,
+  throwIfBubblingTypeIsNull,
+} = require('../../error-utils');
 
 function getPropertyType(
   /* $FlowFixMe[missing-local-annot] The type annotation(s) required by Flow's
@@ -245,9 +248,7 @@ function buildEventSchema(
     throw new Error(`Unable to determine event arguments for "${name}"`);
   }
 
-  if (bubblingType === null) {
-    throw new Error(`Unable to determine event arguments for "${name}"`);
-  }
+  throwIfBubblingTypeIsNull(bubblingType, name);
 }
 
 // $FlowFixMe[unclear-type] there's no flowtype for ASTs


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
part of codegen Issue #34872 

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
[Internal][Changed]: Add throwIfBubblingTypeisNull in error-utils and use it in events

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

`yarn jest react-native-codegen`
