### PR TITLE
Remove duplicate function prototype

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
@@ -59,7 +59,6 @@ static jsi::String convertNSStringToJSIString(jsi::Runtime &runtime, NSString *v
   return jsi::String::createFromUtf8(runtime, [value UTF8String] ?: "");
 }
 
-jsi::Value convertObjCObjectToJSIValue(jsi::Runtime &runtime, id value);
 static jsi::Object convertNSDictionaryToJSIObject(jsi::Runtime &runtime, NSDictionary *value)
 {
   jsi::Object result = jsi::Object(runtime);


### PR DESCRIPTION
Summary:
`convertObjCObjectToJSIValue` function prototype is declared in `RCTTurboModule.h`. This diff removes its duplicate declaration from `RCTTurboModule.m`.
Changelog: [Interanal]

Differential Revision: D45483572

