### PR TITLE
Set dev menu title to "React Native Dev Menu", add JS executor description

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
@@ -24,6 +24,7 @@ import android.util.Pair;
 import android.view.Gravity;
 import android.view.View;
 import android.widget.EditText;
+import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 import androidx.annotation.Nullable;
@@ -526,17 +527,30 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
       return;
     }
 
-    final TextView textView = new TextView(getApplicationContext());
-    textView.setText("React Native DevMenu (" + getUniqueTag() + ")");
-    textView.setPadding(0, 50, 0, 0);
-    textView.setGravity(Gravity.CENTER);
-    textView.setTextColor(Color.BLACK);
-    textView.setTextSize(17);
-    textView.setTypeface(textView.getTypeface(), Typeface.BOLD);
+    final LinearLayout header = new LinearLayout(getApplicationContext());
+    header.setOrientation(LinearLayout.VERTICAL);
+
+    final TextView title = new TextView(getApplicationContext());
+    title.setText("React Native Dev Menu (" + getUniqueTag() + ")");
+    title.setPadding(0, 50, 0, 0);
+    title.setGravity(Gravity.CENTER);
+    title.setTextColor(Color.DKGRAY);
+    title.setTextSize(16);
+    title.setTypeface(title.getTypeface(), Typeface.BOLD);
+
+    final TextView jsExecutorLabel = new TextView(getApplicationContext());
+    jsExecutorLabel.setText(getJSExecutorDescription());
+    jsExecutorLabel.setPadding(0, 20, 0, 0);
+    jsExecutorLabel.setGravity(Gravity.CENTER);
+    jsExecutorLabel.setTextColor(Color.GRAY);
+    jsExecutorLabel.setTextSize(14);
+
+    header.addView(title);
+    header.addView(jsExecutorLabel);
 
     mDevOptionsDialog =
         new AlertDialog.Builder(context)
-            .setCustomTitle(textView)
+            .setCustomTitle(header)
             .setItems(
                 options.keySet().toArray(new String[0]),
                 (dialog, which) -> {
@@ -549,6 +563,10 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
     if (mCurrentContext != null) {
       mCurrentContext.getJSModule(RCTNativeAppEventEmitter.class).emit("RCTDevMenuShown", null);
     }
+  }
+
+  private String getJSExecutorDescription() {
+    return "Running " + getReactInstanceDevHelper().getJavaScriptExecutorFactory().toString();
   }
 
   /**


### PR DESCRIPTION
Summary:
Updates the Dev Menu header on Android.

- Small alignment related to #36981.
- Add subheading label showing current JS executor description (matching iOS) (note: on Android this is unformatted (but informative), e.g. `JSIExecutor+HermesRuntime`).

Changelog: [Internal]

| Before | After | (iOS) |
|--------|--------|--------|
| ![image](https://user-images.githubusercontent.com/2547783/235702289-375cd09d-7ff6-419f-8eed-818c9da49efe.png) | ![image](https://user-images.githubusercontent.com/2547783/235702371-80613eab-eb07-4ee7-91ff-ba0f3c3fe5b6.png) | ![image](https://user-images.githubusercontent.com/2547783/235702550-0415d431-2b09-430b-aadc-f6ddcf18da57.png) |

Differential Revision: D45142924

