### PR TITLE
add README for bridgeless mode

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/README.md
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/README.md
@@ -1,0 +1,3 @@
+# Bridgeless Mode for Android
+
+This library is not ready for integration for production nor local experimentation. Expect breaking changes regularly if you use any of these APIs. Use at your own risk!

--- a/packages/react-native/ReactCommon/react/bridgeless/README.md
+++ b/packages/react-native/ReactCommon/react/bridgeless/README.md
@@ -1,0 +1,3 @@
+# Bridgeless Mode for iOS
+
+This library is not ready for integration for production nor local experimentation. Expect breaking changes regularly if you use any of these APIs. Use at your own risk!


### PR DESCRIPTION
Summary:
Changelog: [Internal]

i would like to communicate to OSS that these libraries are not to be used and are undergoing active changes. it seems tricky to enforce this at compile time atm so i think this will be a good first step

we can add stuff later like "what is bridgeless mode" but primary goal is to communicate not to use this

Differential Revision: D45493984

