### PR TITLE
Update ReactActivityDelegateTest to compile and run with Buck

### DIFF
--- a/packages/react-native/ReactAndroid/build.gradle
+++ b/packages/react-native/ReactAndroid/build.gradle
@@ -657,6 +657,12 @@ android {
             includeBuildTypeValues('debug', 'release')
         }
     }
+
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
 }
 
 dependencies {

--- a/packages/react-native/ReactAndroid/build.gradle
+++ b/packages/react-native/ReactAndroid/build.gradle
@@ -657,17 +657,6 @@ android {
             includeBuildTypeValues('debug', 'release')
         }
     }
-
-    testOptions {
-        unitTests.all {
-            // Robolectric tests are downloading JARs at runtime. This allows to specify
-            // a local file mirror with REACT_NATIVE_ROBOLECTRIC_MIRROR to go in offline more.
-            if (System.getenv("REACT_NATIVE_ROBOLECTRIC_MIRROR") != null) {
-                systemProperty 'robolectric.offline', 'true'
-                systemProperty 'robolectric.dependency.dir', System.getenv("REACT_NATIVE_ROBOLECTRIC_MIRROR")
-            }
-        }
-    }
 }
 
 dependencies {

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/ReactActivityDelegateTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/ReactActivityDelegateTest.kt
@@ -7,6 +7,7 @@
 
 package com.facebook.react
 
+import android.app.Activity
 import android.os.Bundle
 import org.junit.Assert.*
 import org.junit.Test
@@ -16,10 +17,12 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class ReactActivityDelegateTest {
 
+  val nullDelegate: Activity? = null
+
   @Test
   fun delegateWithFabricEnabled_populatesInitialPropsCorrectly() {
     val delegate =
-        object : ReactActivityDelegate(null, "test-delegate") {
+        object : ReactActivityDelegate(nullDelegate, "test-delegate") {
           override fun isFabricEnabled() = true
           public val inspectLaunchOptions: Bundle?
             get() = composeLaunchOptions()
@@ -33,7 +36,7 @@ class ReactActivityDelegateTest {
   @Test
   fun delegateWithoutFabricEnabled_hasNullInitialProperties() {
     val delegate =
-        object : ReactActivityDelegate(null, "test-delegate") {
+        object : ReactActivityDelegate(nullDelegate, "test-delegate") {
           override fun isFabricEnabled() = false
           public val inspectLaunchOptions: Bundle?
             get() = composeLaunchOptions()
@@ -45,7 +48,7 @@ class ReactActivityDelegateTest {
   @Test
   fun delegateWithFabricEnabled_composesInitialPropertiesCorrectly() {
     val delegate =
-        object : ReactActivityDelegate(null, "test-delegate") {
+        object : ReactActivityDelegate(nullDelegate, "test-delegate") {
           override fun isFabricEnabled() = true
           override fun getLaunchOptions(): Bundle =
               Bundle().apply { putString("test-property", "test-value") }

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/RootViewTest.java
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/RootViewTest.java
@@ -17,8 +17,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import android.app.Activity;
+import android.graphics.Insets;
 import android.graphics.Rect;
 import android.view.MotionEvent;
+import android.view.WindowInsets;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.CatalystInstance;
 import com.facebook.react.bridge.JavaOnlyArray;
@@ -47,6 +50,7 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.rule.PowerMockRule;
+import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 
@@ -217,10 +221,12 @@ public class RootViewTest {
   @Test
   public void testCheckForKeyboardEvents() {
     ReactInstanceManager instanceManager = mock(ReactInstanceManager.class);
+    Activity mActivity = Robolectric.buildActivity(Activity.class).create().get();
 
     when(instanceManager.getCurrentReactContext()).thenReturn(mReactContext);
+
     ReactRootView rootView =
-        new ReactRootView(mReactContext) {
+        new ReactRootView(mActivity) {
           @Override
           public void getWindowVisibleDisplayFrame(Rect outRect) {
             if (outRect.bottom == 0) {
@@ -229,6 +235,14 @@ public class RootViewTest {
             } else {
               outRect.bottom += 370;
             }
+          }
+
+          @Override
+          public WindowInsets getRootWindowInsets() {
+            return new WindowInsets.Builder()
+                .setInsets(WindowInsets.Type.ime(), Insets.of(0, 0, 0, 370))
+                .setVisible(WindowInsets.Type.ime(), true)
+                .build();
           }
         };
 

--- a/packages/react-native/ReactAndroid/src/test/resources/robolectric.properties
+++ b/packages/react-native/ReactAndroid/src/test/resources/robolectric.properties
@@ -1,2 +1,2 @@
 # Set this to minimum supported API level for React Native.
-sdk=21
+sdk=33


### PR DESCRIPTION
Summary:
This test `ReactActivityDelegateTest` is written in Kotlin and is not currently
picked up by BUCK. As we look into having more and more tests written in Kotlin,
I'm updating one Kotlin test to be executed correctly within Buck.

Changelog:
[Internal] [Changed] - Update ReactActivityDelegateTest to compile and run with Buck

Differential Revision: D45497636

