### PR TITLE
Bump Robolectric SDK target to 33

### DIFF
--- a/packages/react-native/ReactAndroid/build.gradle
+++ b/packages/react-native/ReactAndroid/build.gradle
@@ -657,6 +657,12 @@ android {
             includeBuildTypeValues('debug', 'release')
         }
     }
+
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
 }
 
 dependencies {

--- a/packages/react-native/ReactAndroid/build.gradle
+++ b/packages/react-native/ReactAndroid/build.gradle
@@ -657,17 +657,6 @@ android {
             includeBuildTypeValues('debug', 'release')
         }
     }
-
-    testOptions {
-        unitTests.all {
-            // Robolectric tests are downloading JARs at runtime. This allows to specify
-            // a local file mirror with REACT_NATIVE_ROBOLECTRIC_MIRROR to go in offline more.
-            if (System.getenv("REACT_NATIVE_ROBOLECTRIC_MIRROR") != null) {
-                systemProperty 'robolectric.offline', 'true'
-                systemProperty 'robolectric.dependency.dir', System.getenv("REACT_NATIVE_ROBOLECTRIC_MIRROR")
-            }
-        }
-    }
 }
 
 dependencies {

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/RootViewTest.java
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/RootViewTest.java
@@ -17,8 +17,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import android.app.Activity;
+import android.graphics.Insets;
 import android.graphics.Rect;
 import android.view.MotionEvent;
+import android.view.WindowInsets;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.CatalystInstance;
 import com.facebook.react.bridge.JavaOnlyArray;
@@ -47,6 +50,7 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.rule.PowerMockRule;
+import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 
@@ -217,10 +221,12 @@ public class RootViewTest {
   @Test
   public void testCheckForKeyboardEvents() {
     ReactInstanceManager instanceManager = mock(ReactInstanceManager.class);
+    Activity mActivity = Robolectric.buildActivity(Activity.class).create().get();
 
     when(instanceManager.getCurrentReactContext()).thenReturn(mReactContext);
+
     ReactRootView rootView =
-        new ReactRootView(mReactContext) {
+        new ReactRootView(mActivity) {
           @Override
           public void getWindowVisibleDisplayFrame(Rect outRect) {
             if (outRect.bottom == 0) {
@@ -229,6 +235,14 @@ public class RootViewTest {
             } else {
               outRect.bottom += 370;
             }
+          }
+
+          @Override
+          public WindowInsets getRootWindowInsets() {
+            return new WindowInsets.Builder()
+                .setInsets(WindowInsets.Type.ime(), Insets.of(0, 0, 0, 370))
+                .setVisible(WindowInsets.Type.ime(), true)
+                .build();
           }
         };
 

--- a/packages/react-native/ReactAndroid/src/test/resources/robolectric.properties
+++ b/packages/react-native/ReactAndroid/src/test/resources/robolectric.properties
@@ -1,2 +1,2 @@
 # Set this to minimum supported API level for React Native.
-sdk=21
+sdk=33


### PR DESCRIPTION
Summary:
Currently Robolectric runs with target SDK 21 on OSS and 33 on Buck internal.
Having those two versions misaligned makes tests harder to maintain, so we should probably re-aling them. Here I bump SDK to 33 + I'm fixing `RootViewTest` which is broken on SDK 33 (both on Gradle and Internal).

Changelog:
[Internal] [Changed] - Bump Robolectric SDK target to 33

Differential Revision: D45497430

