### PR TITLE
Remove references to REACT_NATIVE_ROBOLECTRIC_MIRROR

### DIFF
--- a/packages/react-native/ReactAndroid/build.gradle
+++ b/packages/react-native/ReactAndroid/build.gradle
@@ -657,17 +657,6 @@ android {
             includeBuildTypeValues('debug', 'release')
         }
     }
-
-    testOptions {
-        unitTests.all {
-            // Robolectric tests are downloading JARs at runtime. This allows to specify
-            // a local file mirror with REACT_NATIVE_ROBOLECTRIC_MIRROR to go in offline more.
-            if (System.getenv("REACT_NATIVE_ROBOLECTRIC_MIRROR") != null) {
-                systemProperty 'robolectric.offline', 'true'
-                systemProperty 'robolectric.dependency.dir', System.getenv("REACT_NATIVE_ROBOLECTRIC_MIRROR")
-            }
-        }
-    }
 }
 
 dependencies {


### PR DESCRIPTION
Summary:
As we don't need to have a Robolectric Offline Mirror anymore due to how we execute Robolectric tests only on Gradle/CircleCI or Buck/Internal, we can remove this configuration.

Changelog:
[Internal] [Changed] - Remove references to REACT_NATIVE_ROBOLECTRIC_MIRROR

Differential Revision: D45497431

