### PR TITLE
rename handleException to handleTaskFault

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/README.md
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/README.md
@@ -1,0 +1,3 @@
+# Bridgeless Mode for Android
+
+This library is not ready for integration for production nor local experimentation. Expect breaking changes regularly if you use any of these APIs. Use at your own risk!

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHost.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHost.java
@@ -221,7 +221,7 @@ public class ReactHost {
                                 destroy(
                                     "old_preload() failure: " + task.getError().getMessage(),
                                     task.getError());
-                                mReactInstanceDelegate.handleException(task.getError());
+                                mReactInstanceDelegate.handleTaskFault(task.getError());
                               }
 
                               return task;
@@ -246,7 +246,7 @@ public class ReactHost {
                         .continueWithTask(
                             (task) -> {
                               if (task.isFaulted()) {
-                                mReactInstanceDelegate.handleException(task.getError());
+                                mReactInstanceDelegate.handleTaskFault(task.getError());
                                 // Wait for destroy to finish
                                 return new_getOrCreateDestroyTask(
                                         "new_preload() failure: " + task.getError().getMessage(),
@@ -571,7 +571,7 @@ public class ReactHost {
     log(method);
 
     destroy(method, e);
-    mReactInstanceDelegate.handleException(e);
+    mReactInstanceDelegate.handleTaskFault(e);
   }
 
   /**

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactInstanceDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactInstanceDelegate.java
@@ -32,7 +32,7 @@ public interface ReactInstanceDelegate {
 
   JSEngineInstance getJSEngineInstance(ReactApplicationContext context);
 
-  void handleException(Exception e);
+  void handleTaskFault(Exception e);
 
   ReactNativeConfig getReactNativeConfig(TurboModuleManager turboModuleManager);
 

--- a/packages/react-native/ReactCommon/react/bridgeless/README.md
+++ b/packages/react-native/ReactCommon/react/bridgeless/README.md
@@ -1,0 +1,3 @@
+# Bridgeless Mode for iOS
+
+This library is not ready for integration for production nor local experimentation. Expect breaking changes regularly if you use any of these APIs. Use at your own risk!


### PR DESCRIPTION
Summary:
Changelog: [Internal]

so when i was trying to help mdvacca with figuring out what this API does, it was really confusing to grep for since `handleException` is a very common pattern in general. when i looked more closely at the usage, it was specifically used to propagate faulted venice tasks. so i'm updating the name here to be more explicit and help us with refactoring later.

Reviewed By: mdvacca

Differential Revision: D45501548

