### PR TITLE
Recognize dictionary type in codegen

### DIFF
--- a/packages/react-native-codegen/src/CodegenSchema.d.ts
+++ b/packages/react-native-codegen/src/CodegenSchema.d.ts
@@ -291,7 +291,7 @@ export interface NativeModuleEnumDeclarationWithMembers {
 
 export interface NativeModuleGenericObjectTypeAnnotation {
   readonly type: 'GenericObjectTypeAnnotation';
-  readonly dictionaryValueType?: Nullable<NativeModuleTypeAnnotation>;
+  readonly dictionaryValueType?: Nullable<NativeModuleTypeAnnotation> | undefined;
 }
 
 export interface NativeModuleTypeAliasTypeAnnotation {

--- a/packages/react-native-codegen/src/CodegenSchema.d.ts
+++ b/packages/react-native-codegen/src/CodegenSchema.d.ts
@@ -291,6 +291,7 @@ export interface NativeModuleEnumDeclarationWithMembers {
 
 export interface NativeModuleGenericObjectTypeAnnotation {
   readonly type: 'GenericObjectTypeAnnotation';
+  readonly dictionaryValueType?: Nullable<NativeModuleTypeAnnotation>;
 }
 
 export interface NativeModuleTypeAliasTypeAnnotation {

--- a/packages/react-native-codegen/src/CodegenSchema.js
+++ b/packages/react-native-codegen/src/CodegenSchema.js
@@ -324,6 +324,11 @@ export type NativeModuleEnumDeclarationWithMembers = {
 
 export type NativeModuleGenericObjectTypeAnnotation = $ReadOnly<{
   type: 'GenericObjectTypeAnnotation',
+
+  // a dictionary type is codegen as "Object"
+  // but we know all its members are in the same type
+  // when it happens, the following field is non-null
+  dictionaryValueType?: Nullable<NativeModuleTypeAnnotation>,
 }>;
 
 export type NativeModuleTypeAliasTypeAnnotation = $ReadOnly<{

--- a/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap
@@ -201,14 +201,26 @@ exports[`RN Codegen Flow Parser can generate fixture CXX_ONLY_NATIVE_MODULE 1`] 
             'typeAnnotation': {
               'type': 'FunctionTypeAnnotation',
               'returnTypeAnnotation': {
-                'type': 'GenericObjectTypeAnnotation'
+                'type': 'GenericObjectTypeAnnotation',
+                'dictionaryValueType': {
+                  'type': 'NullableTypeAnnotation',
+                  'typeAnnotation': {
+                    'type': 'NumberTypeAnnotation'
+                  }
+                }
               },
               'params': [
                 {
                   'name': 'arg',
                   'optional': false,
                   'typeAnnotation': {
-                    'type': 'GenericObjectTypeAnnotation'
+                    'type': 'GenericObjectTypeAnnotation',
+                    'dictionaryValueType': {
+                      'type': 'NullableTypeAnnotation',
+                      'typeAnnotation': {
+                        'type': 'NumberTypeAnnotation'
+                      }
+                    }
                   }
                 }
               ]
@@ -220,14 +232,20 @@ exports[`RN Codegen Flow Parser can generate fixture CXX_ONLY_NATIVE_MODULE 1`] 
             'typeAnnotation': {
               'type': 'FunctionTypeAnnotation',
               'returnTypeAnnotation': {
-                'type': 'GenericObjectTypeAnnotation'
+                'type': 'GenericObjectTypeAnnotation',
+                'dictionaryValueType': {
+                  'type': 'StringTypeAnnotation'
+                }
               },
               'params': [
                 {
                   'name': 'arg',
                   'optional': false,
                   'typeAnnotation': {
-                    'type': 'GenericObjectTypeAnnotation'
+                    'type': 'GenericObjectTypeAnnotation',
+                    'dictionaryValueType': {
+                      'type': 'StringTypeAnnotation'
+                    }
                   }
                 }
               ]
@@ -2165,7 +2183,11 @@ exports[`RN Codegen Flow Parser can generate fixture PROMISE_WITH_COMMONLY_USED_
               'returnTypeAnnotation': {
                 'type': 'PromiseTypeAnnotation',
                 'elementType': {
-                  'type': 'GenericObjectTypeAnnotation'
+                  'type': 'GenericObjectTypeAnnotation',
+                  'dictionaryValueType': {
+                    'type': 'TypeAliasTypeAnnotation',
+                    'name': 'CustomObject'
+                  }
                 }
               },
               'params': []

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -32,7 +32,6 @@ const {
 const {
   emitArrayType,
   emitFunction,
-  emitGenericObject,
   emitDictionary,
   emitPromise,
   emitRootTag,

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -33,6 +33,7 @@ const {
   emitArrayType,
   emitFunction,
   emitGenericObject,
+  emitDictionary,
   emitPromise,
   emitRootTag,
   emitUnion,
@@ -152,7 +153,7 @@ function translateTypeAnnotation(
           // check the property type to prevent developers from using unsupported types
           // the return value from `translateTypeAnnotation` is unused
           const propertyType = indexers[0].value;
-          translateTypeAnnotation(
+          const valueType = translateTypeAnnotation(
             hasteModuleName,
             propertyType,
             types,
@@ -163,7 +164,7 @@ function translateTypeAnnotation(
             parser,
           );
           // no need to do further checking
-          return emitGenericObject(nullable);
+          return emitDictionary(nullable, valueType);
         }
       }
 

--- a/packages/react-native-codegen/src/parsers/parsers-primitives.js
+++ b/packages/react-native-codegen/src/parsers/parsers-primitives.js
@@ -311,7 +311,7 @@ function emitGenericObject(
 
 function emitDictionary(
   nullable: boolean,
-  valueType: NativeModuleBaseTypeAnnotation,
+  valueType: Nullable<NativeModuleTypeAnnotation>,
 ): Nullable<NativeModuleGenericObjectTypeAnnotation> {
   return wrapNullable(nullable, {
     type: 'GenericObjectTypeAnnotation',

--- a/packages/react-native-codegen/src/parsers/parsers-primitives.js
+++ b/packages/react-native-codegen/src/parsers/parsers-primitives.js
@@ -311,7 +311,7 @@ function emitGenericObject(
 
 function emitDictionary(
   nullable: boolean,
-  valueType: NativeModuleBaseTypeAnnotation
+  valueType: NativeModuleBaseTypeAnnotation,
 ): Nullable<NativeModuleGenericObjectTypeAnnotation> {
   return wrapNullable(nullable, {
     type: 'GenericObjectTypeAnnotation',

--- a/packages/react-native-codegen/src/parsers/parsers-primitives.js
+++ b/packages/react-native-codegen/src/parsers/parsers-primitives.js
@@ -309,6 +309,16 @@ function emitGenericObject(
   });
 }
 
+function emitDictionary(
+  nullable: boolean,
+  valueType: NativeModuleBaseTypeAnnotation
+): Nullable<NativeModuleGenericObjectTypeAnnotation> {
+  return wrapNullable(nullable, {
+    type: 'GenericObjectTypeAnnotation',
+    dictionaryValueType: valueType,
+  });
+}
+
 function emitObject(
   nullable: boolean,
   properties: Array<$FlowFixMe>,
@@ -576,6 +586,7 @@ module.exports = {
   emitInt32,
   emitNumber,
   emitGenericObject,
+  emitDictionary,
   emitObject,
   emitPromise,
   emitRootTag,

--- a/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/__snapshots__/typescript-module-parser-snapshot-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/__snapshots__/typescript-module-parser-snapshot-test.js.snap
@@ -199,14 +199,26 @@ exports[`RN Codegen TypeScript Parser can generate fixture CXX_ONLY_NATIVE_MODUL
             'typeAnnotation': {
               'type': 'FunctionTypeAnnotation',
               'returnTypeAnnotation': {
-                'type': 'GenericObjectTypeAnnotation'
+                'type': 'GenericObjectTypeAnnotation',
+                'dictionaryValueType': {
+                  'type': 'NullableTypeAnnotation',
+                  'typeAnnotation': {
+                    'type': 'NumberTypeAnnotation'
+                  }
+                }
               },
               'params': [
                 {
                   'name': 'arg',
                   'optional': false,
                   'typeAnnotation': {
-                    'type': 'GenericObjectTypeAnnotation'
+                    'type': 'GenericObjectTypeAnnotation',
+                    'dictionaryValueType': {
+                      'type': 'NullableTypeAnnotation',
+                      'typeAnnotation': {
+                        'type': 'NumberTypeAnnotation'
+                      }
+                    }
                   }
                 }
               ]
@@ -218,14 +230,20 @@ exports[`RN Codegen TypeScript Parser can generate fixture CXX_ONLY_NATIVE_MODUL
             'typeAnnotation': {
               'type': 'FunctionTypeAnnotation',
               'returnTypeAnnotation': {
-                'type': 'GenericObjectTypeAnnotation'
+                'type': 'GenericObjectTypeAnnotation',
+                'dictionaryValueType': {
+                  'type': 'StringTypeAnnotation'
+                }
               },
               'params': [
                 {
                   'name': 'arg',
                   'optional': false,
                   'typeAnnotation': {
-                    'type': 'GenericObjectTypeAnnotation'
+                    'type': 'GenericObjectTypeAnnotation',
+                    'dictionaryValueType': {
+                      'type': 'StringTypeAnnotation'
+                    }
                   }
                 }
               ]

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -36,6 +36,7 @@ const {
   emitArrayType,
   emitFunction,
   emitGenericObject,
+  emitDictionary,
   emitPromise,
   emitRootTag,
   emitUnion,
@@ -309,7 +310,7 @@ function translateTypeAnnotation(
           // check the property type to prevent developers from using unsupported types
           // the return value from `translateTypeAnnotation` is unused
           const propertyType = indexSignatures[0].typeAnnotation;
-          translateTypeAnnotation(
+          const valueType = translateTypeAnnotation(
             hasteModuleName,
             propertyType,
             types,
@@ -320,7 +321,7 @@ function translateTypeAnnotation(
             parser,
           );
           // no need to do further checking
-          return emitGenericObject(nullable);
+          return emitDictionary(nullable, valueType);
         }
       }
 

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -35,7 +35,6 @@ const {parseObjectProperty} = require('../../parsers-commons');
 const {
   emitArrayType,
   emitFunction,
-  emitGenericObject,
   emitDictionary,
   emitPromise,
   emitRootTag,


### PR DESCRIPTION
## Summary

Previously we allow `{[key:string]:Something}` in codegen, `Something` is type-checked but thrown away, generating a `GenericObjectTypeAnnotation`.
In this change, `Something` is added to `GenericObjectTypeAnnotation` as an optional field.
For downstream code such as C++ codegen, this change is **backward compatible**. It allows C++ codegen to produce a more precious type optionally.

## Changelog:

[General] [Added] - Recognize dictionary type in codegen

## Test Plan

```
yarn jest react-native-codegen
yarn jest react-native-codegen-typescript-test
```