### PR TITLE
Dirty nodes when dynamically setting config

### DIFF
--- a/packages/react-native/ReactCommon/yoga/yoga/YGConfig.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGConfig.cpp
@@ -7,7 +7,18 @@
 
 #include "YGConfig.h"
 
-using namespace facebook::yoga::detail;
+using namespace facebook::yoga;
+
+namespace facebook {
+namespace yoga {
+bool configUpdateInvalidatesLayout(YGConfigRef a, YGConfigRef b) {
+  return a->getErrata() != b->getErrata() ||
+      a->getEnabledExperiments() != b->getEnabledExperiments() ||
+      a->getPointScaleFactor() != b->getPointScaleFactor() ||
+      a->useWebDefaults() != b->useWebDefaults();
+}
+} // namespace yoga
+} // namespace facebook
 
 YGConfig::YGConfig(YGLogger logger) : cloneNodeCallback_{nullptr} {
   setLogger(logger);
@@ -38,6 +49,10 @@ void YGConfig::setExperimentalFeatureEnabled(
 bool YGConfig::isExperimentalFeatureEnabled(
     YGExperimentalFeature feature) const {
   return experimentalFeatures_.test(feature);
+}
+
+ExperimentalFeatureSet YGConfig::getEnabledExperiments() const {
+  return experimentalFeatures_;
 }
 
 void YGConfig::setErrata(YGErrata errata) {

--- a/packages/react-native/ReactCommon/yoga/yoga/YGNode.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGNode.cpp
@@ -269,6 +269,11 @@ void YGNode::setConfig(YGConfigRef config) {
       config,
       config->useWebDefaults() == config_->useWebDefaults(),
       "UseWebDefaults may not be changed after constructing a YGNode");
+
+  if (yoga::configUpdateInvalidatesLayout(config_, config)) {
+    markDirtyAndPropagate();
+  }
+
   config_ = config;
 }
 


### PR DESCRIPTION
Summary:
Yoga exposes public APIs for dirtying Nodes, but will itself perform dirty marking when changing bits which invalidate layout. E.g. changing the style of a Node will invalidate it along with every parent Node.

Because config setting is newly public to the C ABI, this makes a similar change so that replacing a Node's config will dirty the tree above the node if there is a layout impacting config change (I don't think children need to be invalidated since child output shouldn't change given the same owner dimensions).

One quirk of this is that configs may be changed independently of the node. So someone could attach a config to a Node, then change the live config after the fact. The config does not currently have a back pointer to the Node, so we do not invalidate in that case of live config edits. The future work to rectify this would be to make configs immutable once created.

There are also currently some experimental features here which should maybe be compared, but these should be moved to YGErrata anyway.

Differential Revision: D45505089

