### PR TITLE
Refactor MobileConfig Access for "react_fabric: treat_auto_as_undefined"

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
@@ -11,7 +11,6 @@
 #include <folly/Conv.h>
 #include <folly/dynamic.h>
 #include <glog/logging.h>
-#include <react/config/ReactNativeConfig.h>
 #include <react/debug/react_native_expect.h>
 #include <react/renderer/components/view/primitives.h>
 #include <react/renderer/core/LayoutMetrics.h>
@@ -408,19 +407,14 @@ inline void fromRawValue(
     const PropsParserContext &context,
     const RawValue &value,
     YGStyle::ValueRepr &result) {
-  // For bug compatibility, pass "auto" as YGValueUndefined
-  static bool treatAutoAsUndefined =
-      context.contextContainer
-          .at<std::shared_ptr<ReactNativeConfig const>>("ReactNativeConfig")
-          ->getBool("react_fabric:treat_auto_as_undefined");
-
   if (value.hasType<Float>()) {
     result = yogaStyleValueFromFloat((Float)value);
     return;
   } else if (value.hasType<std::string>()) {
     const auto stringValue = (std::string)value;
     if (stringValue == "auto") {
-      result = treatAutoAsUndefined ? YGValueUndefined : YGValueAuto;
+      result = context.treatAutoAsYGValueUndefined() ? YGValueUndefined
+                                                     : YGValueAuto;
       return;
     } else {
       if (stringValue.back() == '%') {

--- a/packages/react-native/ReactCommon/react/renderer/core/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/core/CMakeLists.txt
@@ -23,6 +23,7 @@ target_link_libraries(react_render_core
         folly_runtime
         glog
         jsi
+        react_config
         react_debug
         react_render_debug
         react_render_graphics

--- a/packages/react-native/ReactCommon/react/renderer/core/PropsParserContext.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/PropsParserContext.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "PropsParserContext.h"
+
+#include <react/config/ReactNativeConfig.h>
+
+namespace facebook::react {
+
+bool PropsParserContext::treatAutoAsYGValueUndefined() const {
+  if (treatAutoAsYGValueUndefined_ == std::nullopt) {
+    auto config = contextContainer.at<std::shared_ptr<const ReactNativeConfig>>(
+        "ReactNativeConfig");
+    treatAutoAsYGValueUndefined_ = config
+        ? config->getBool("react_fabric:treat_auto_as_undefined")
+        : false;
+  }
+
+  return *treatAutoAsYGValueUndefined_;
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/PropsParserContext.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/PropsParserContext.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <optional>
+
 #include <react/renderer/core/ReactPrimitives.h>
 #include <react/utils/ContextContainer.h>
 
@@ -16,12 +18,23 @@ namespace facebook::react {
 // It should be used as infrequently as possible - most props can and should
 // be parsed without any context.
 struct PropsParserContext {
+  PropsParserContext(
+      SurfaceId const surfaceId,
+      ContextContainer const &contextContainer)
+      : surfaceId(surfaceId), contextContainer(contextContainer) {}
+
   // Non-copyable
   PropsParserContext(const PropsParserContext &) = delete;
   PropsParserContext &operator=(const PropsParserContext &) = delete;
 
   SurfaceId const surfaceId;
   ContextContainer const &contextContainer;
+
+  // Temporary feature flags
+  bool treatAutoAsYGValueUndefined() const;
+
+ private:
+  mutable std::optional<bool> treatAutoAsYGValueUndefined_;
 };
 
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
The right parameters for this seems to sent down when the client requests the `react_fabric` config, but there are no exposures being logged to indicate the `treat_auto_as_undefined` parameter is being accessed. This would seem to imply the code where the parameter is  accessed isn't run, but that doesn't make sense to me. The assignment is happening when initializing a static scoped to a function which should be called any time a style value is parsed, in both the old and new style props parser. As a sanity check, a breakpoint in the function is hit near immediately in Catalyst.

It doesn't seem like it's a layer lower either, or else any other new C++ experiments using the API wouldn't be getting exposures (unless maybe we haven't done one of those recently).

MC values may change throughout the lifetime of the app (e.g. user change, caching values, etc). I think it is unlikely to be the issue, but before going further, I wanted to clean the scoping of this code to ensure timing of access is not a factor. After this change MC is checked a single time before parsing all the props on a node, which lets it respond to values changing (e.g. user switch), while having some level of consistency. The MC access is also scoped further, to only trigger exposure if "auto" is encountered.

Changelog: [Internal]

Differential Revision: D45434603

