### PR TITLE
Delete getViewManagers method from ReactHost

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactInstanceDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactInstanceDelegate.java
@@ -15,7 +15,6 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.fabric.ReactNativeConfig;
 import com.facebook.react.turbomodule.core.TurboModuleManager;
 import com.facebook.react.turbomodule.core.TurboModuleManagerDelegate;
-import com.facebook.react.uimanager.ViewManager;
 import java.util.List;
 
 @ThreadSafe
@@ -27,8 +26,6 @@ public interface ReactInstanceDelegate {
   BindingsInstaller getBindingsInstaller();
 
   TurboModuleManagerDelegate getTurboModuleManagerDelegate(ReactApplicationContext context);
-
-  List<ViewManager> getViewManagers(ReactApplicationContext context);
 
   JSEngineInstance getJSEngineInstance(ReactApplicationContext context);
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/annotations/UnstableReactNativeAPI.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/annotations/UnstableReactNativeAPI.kt
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.common.annotations
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+@RequiresOptIn(
+    level = RequiresOptIn.Level.ERROR,
+    message = "This API is experimental and is likely to change or to be removed in the future")
+annotation class UnstableReactNativeAPI

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/annotations/VisibleForTesting.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/annotations/VisibleForTesting.kt
@@ -5,10 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-package com.facebook.react.common.annotations;
+
+package com.facebook.react.common.annotations
 
 /**
  * Annotates a method that should have restricted visibility but it's required to be public for use
  * in test code only.
  */
-public @interface VisibleForTesting {}
+annotation class VisibleForTesting


### PR DESCRIPTION
Summary:
Deleting getViewManagers method from ReactHost since it is not used

chnagelog: [internal] internal

Reviewed By: philIip

Differential Revision: D45494325

