### PR TITLE
Kotlin to 1.8.0 and JDK Toolchain to 11

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
   id("com.android.library") version "7.4.2" apply false
   id("com.android.application") version "7.4.2" apply false
   id("de.undercouch.download") version "5.0.1" apply false
-  kotlin("android") version "1.7.22" apply false
+  kotlin("android") version "1.8.0" apply false
 }
 
 val reactAndroidProperties = java.util.Properties()

--- a/packages/react-native-gradle-plugin/build.gradle.kts
+++ b/packages/react-native-gradle-plugin/build.gradle.kts
@@ -11,7 +11,7 @@ import org.gradle.configurationcache.extensions.serviceOf
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-  kotlin("jvm") version "1.7.22"
+  kotlin("jvm") version "1.8.0"
   id("java-gradle-plugin")
 }
 
@@ -33,7 +33,12 @@ group = "com.facebook.react"
 
 dependencies {
   implementation(gradleApi())
+
+  // The KGP/AGP version is defined by React Native Gradle plugin.
+  // Therefore we specify an implementation dep rather than a compileOnly.
+  implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.0")
   implementation("com.android.tools.build:gradle:7.4.2")
+
   implementation("com.google.code.gson:gson:2.8.9")
   implementation("com.google.guava:guava:31.0.1-jre")
   implementation("com.squareup:javapoet:1.13.0")
@@ -53,6 +58,8 @@ java {
   sourceCompatibility = JavaVersion.VERSION_11
   targetCompatibility = JavaVersion.VERSION_11
 }
+
+kotlin { jvmToolchain(11) }
 
 tasks.withType<KotlinCompile> {
   kotlinOptions {

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
@@ -19,6 +19,7 @@ import com.facebook.react.utils.BackwardCompatUtils.configureBackwardCompatibili
 import com.facebook.react.utils.DependencyUtils.configureDependencies
 import com.facebook.react.utils.DependencyUtils.configureRepositories
 import com.facebook.react.utils.DependencyUtils.readVersionString
+import com.facebook.react.utils.JdkConfiguratorUtils.configureJavaToolChains
 import com.facebook.react.utils.JsonUtils
 import com.facebook.react.utils.NdkConfiguratorUtils.configureReactNativeNdk
 import com.facebook.react.utils.ProjectUtils.needsCodegenFromPackageJson
@@ -63,6 +64,7 @@ class ReactPlugin : Plugin<Project> {
       configureBuildConfigFields(project)
       configureDevPorts(project)
       configureBackwardCompatibilityReactMap(project)
+      configureJavaToolChains(project)
 
       project.extensions.getByType(AndroidComponentsExtension::class.java).apply {
         onVariants(selector().all()) { variant ->

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/JdkConfiguratorUtils.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/JdkConfiguratorUtils.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.utils
+
+import com.android.build.api.variant.AndroidComponentsExtension
+import org.gradle.api.JavaVersion
+import org.gradle.api.Project
+import org.jetbrains.kotlin.gradle.dsl.KotlinTopLevelExtension
+
+internal object JdkConfiguratorUtils {
+  /**
+   * Function that takes care of configuring the JDK toolchain for Application projects. As we do
+   * decide the JDK version based on the AGP version that RNGP brings over, here we can safely
+   * configure the toolchain to 11.
+   */
+  fun configureJavaToolChains(project: Project) {
+    project.extensions.getByType(AndroidComponentsExtension::class.java).finalizeDsl { ext ->
+      ext.compileOptions.sourceCompatibility = JavaVersion.VERSION_11
+      ext.compileOptions.targetCompatibility = JavaVersion.VERSION_11
+    }
+    project.pluginManager.withPlugin("org.jetbrains.kotlin.android") {
+      project.extensions.getByType(KotlinTopLevelExtension::class.java).jvmToolchain(11)
+    }
+    project.pluginManager.withPlugin("org.jetbrains.kotlin.jvm") {
+      project.extensions.getByType(KotlinTopLevelExtension::class.java).jvmToolchain(11)
+    }
+  }
+}

--- a/packages/react-native/ReactAndroid/build.gradle
+++ b/packages/react-native/ReactAndroid/build.gradle
@@ -444,6 +444,11 @@ android {
         ndkVersion rootProject.ext.ndkVersion
     }
 
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
     defaultConfig {
         minSdk = 21
         targetSdk = 33
@@ -718,11 +723,14 @@ react {
     jsRootDir = file("../Libraries")
 }
 
+kotlin {
+    jvmToolchain(11)
+}
+
 tasks.withType(Test).all {
     // We add --add-opens flags to make sure we can run PowerMock tests on JDK >= 17
     if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
         jvmArgs += [
-            "-XX:+AllowRedefinitionToAddDeleteMethods",
             "--illegal-access=permit",
             "--add-opens=java.base/java.lang=ALL-UNNAMED",
             "--add-opens=java.base/java.xml.internal=ALL-UNNAMED",

--- a/packages/react-native/ReactAndroid/hermes-engine/build.gradle
+++ b/packages/react-native/ReactAndroid/hermes-engine/build.gradle
@@ -190,6 +190,15 @@ android {
         }
     }
 
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
+    kotlin {
+        jvmToolchain(11)
+    }
+
     sourceSets {
         main {
             manifest.srcFile "$hermesDir/android/hermes/src/main/AndroidManifest.xml"

--- a/packages/react-native/build.gradle.kts
+++ b/packages/react-native/build.gradle.kts
@@ -14,5 +14,5 @@ plugins {
   id("com.android.library") version "7.4.2" apply false
   id("com.android.application") version "7.4.2" apply false
   id("de.undercouch.download") version "5.0.1" apply false
-  kotlin("android") version "1.7.22" apply false
+  kotlin("android") version "1.8.0" apply false
 }

--- a/packages/react-native/template/android/build.gradle
+++ b/packages/react-native/template/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 
         // We use NDK 23 which has both M1 support and is the side-by-side NDK version from AGP.
         ndkVersion = "23.1.7779620"
-        kotlinVersion = "1.7.22"
+        kotlinVersion = "1.8.0"
     }
     repositories {
         google()
@@ -18,6 +18,6 @@ buildscript {
     dependencies {
         classpath("com.android.tools.build:gradle")
         classpath("com.facebook.react:react-native-gradle-plugin")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin")
     }
 }


### PR DESCRIPTION
Summary:
I'm bumping Kotlin to 1.8.0 to align to the version used internally.

On top of this, I had to configure the JDK toolchain to 11 as Kotlin 1.8
was changing the default version of the stdlib it ships with by default.

This also shields us against problems once we'll bump to AGP 8 which requires
JDK 17 but still allows to produce libraries that are JDK 11 compatible.

Changelog:
[Android] [Changed] - Kotlin to 1.8.0 and JDK Toolchain to 11

Differential Revision: D45524689

