### PR TITLE
Delete ImageRequest::~ImageRequest

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageRequest.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageRequest.h
@@ -41,8 +41,6 @@ class ImageRequest final {
    */
   ImageRequest(const ImageRequest &other) = delete;
 
-  ~ImageRequest();
-
   /**
    * Set cancelation function.
    */

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageRequest.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageRequest.h
@@ -34,7 +34,7 @@ class ImageRequest final {
   /*
    * The move constructor.
    */
-  ImageRequest(ImageRequest &&other) noexcept;
+  ImageRequest(ImageRequest &&other) noexcept = default;
 
   /*
    * `ImageRequest` does not support copying by design.

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/cxx/react/renderer/imagemanager/ImageRequest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/cxx/react/renderer/imagemanager/ImageRequest.cpp
@@ -18,13 +18,6 @@ ImageRequest::ImageRequest(
   // Not implemented.
 }
 
-ImageRequest::ImageRequest(ImageRequest &&other) noexcept
-    : imageSource_(std::move(other.imageSource_)),
-      telemetry_(std::move(other.telemetry_)),
-      coordinator_(std::move(other.coordinator_)) {
-  // Not implemented.
-}
-
 ImageRequest::~ImageRequest() {
   // Not implemented.
 }

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/cxx/react/renderer/imagemanager/ImageRequest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/cxx/react/renderer/imagemanager/ImageRequest.cpp
@@ -18,10 +18,6 @@ ImageRequest::ImageRequest(
   // Not implemented.
 }
 
-ImageRequest::~ImageRequest() {
-  // Not implemented.
-}
-
 const ImageResponseObserverCoordinator &ImageRequest::getObserverCoordinator()
     const {
   // Not implemented

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/ImageRequest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/ImageRequest.cpp
@@ -16,12 +16,6 @@ ImageRequest::ImageRequest(
   coordinator_ = std::make_shared<ImageResponseObserverCoordinator>();
 }
 
-ImageRequest::~ImageRequest() {
-  if (cancelRequest_) {
-    cancelRequest_();
-  }
-}
-
 void ImageRequest::setCancelationFunction(
     std::function<void(void)> cancelationFunction) {
   cancelRequest_ = cancelationFunction;

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/ImageRequest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/ImageRequest.cpp
@@ -16,16 +16,6 @@ ImageRequest::ImageRequest(
   coordinator_ = std::make_shared<ImageResponseObserverCoordinator>();
 }
 
-ImageRequest::ImageRequest(ImageRequest &&other) noexcept
-    : imageSource_(std::move(other.imageSource_)),
-      telemetry_(std::move(other.telemetry_)),
-      coordinator_(std::move(other.coordinator_)) {
-  other.coordinator_ = nullptr;
-  other.cancelRequest_ = nullptr;
-  other.telemetry_ = nullptr;
-  other.imageSource_ = {};
-}
-
 ImageRequest::~ImageRequest() {
   if (cancelRequest_) {
     cancelRequest_();


### PR DESCRIPTION
Summary:
changelog: [internal]

User defined destructor does not make sense here. ImageRequest is owned by ImageState, which is owned by ImageShadowNode. ImageShadowNode requires garbage collection from the runtime to be destroyed. Calling cancel in dtor is not deterministic and that is undesired.

Differential Revision: D45524705

