### PR TITLE
Suppress warning on null check due to crash investigation

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManagerWrapper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManagerWrapper.kt
@@ -63,6 +63,7 @@ interface ReactViewManagerWrapper {
               stateWrapper,
               jsResponderHandler)
       // Throwing to try capture information about the cause of T151032868, remove after.
+      @Suppress("SENSELESS_COMPARISON")
       if (manager == null) {
         throw ReactViewReturnTypeException(
             "DefaultViewManagerWrapper::createView(${viewManager.getName()}, ${viewManager::class.java}) can't return null")


### PR DESCRIPTION
Summary:
We suspect this null check is actually necessary as we're investigating a crash.
This will silent the warning on this statement

Changelog:
[Internal] [Changed] - Suppress warning on null check due to crash investigation

Reviewed By: blakef

Differential Revision: D45525270

