### PR TITLE
Do not use deprecated [minSdk|targetSdk]version functions

### DIFF
--- a/packages/react-native/ReactAndroid/build.gradle
+++ b/packages/react-native/ReactAndroid/build.gradle
@@ -445,8 +445,8 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion(21)
-        targetSdkVersion(33)
+        minSdk = 21
+        targetSdk = 33
         versionCode(1)
         versionName("1.0")
 

--- a/packages/react-native/ReactAndroid/hermes-engine/build.gradle
+++ b/packages/react-native/ReactAndroid/hermes-engine/build.gradle
@@ -139,7 +139,7 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 21
+        minSdk = 21
 
         externalNativeBuild {
             cmake {

--- a/packages/rn-tester/android/app/build.gradle
+++ b/packages/rn-tester/android/app/build.gradle
@@ -116,8 +116,8 @@ android {
 
     defaultConfig {
         applicationId "com.facebook.react.uiapp"
-        minSdkVersion 21
-        targetSdkVersion 33
+        minSdk = 21
+        targetSdk = 33
         versionCode 1
         versionName "1.0"
         testBuildType System.getProperty('testBuildType', 'debug')  // This will later be used to control the test apk build type


### PR DESCRIPTION
Summary:
Those functions are deprecated and should be replaced with the properties minSdk and targetSdk.
I'm replacing all of those (apart from the template).

Changelog:
[Internal] [Changed] - Do not use deprecated [minSdk|targetSdk]version functions

Differential Revision: D45525922

