### PR TITLE
Deprecate APIs that are deprecate only on JavaDoc

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -555,6 +555,7 @@ public class ReactInstanceManager {
    * @deprecated Use {@link #onHostPause(Activity)} instead.
    */
   @ThreadConfined(UI)
+  @Deprecated
   public void onHostPause() {
     UiThreadUtil.assertOnUiThread();
 
@@ -669,6 +670,7 @@ public class ReactInstanceManager {
    * @deprecated use {@link #onHostDestroy(Activity)} instead
    */
   @ThreadConfined(UI)
+  @Deprecated
   public void onHostDestroy() {
     UiThreadUtil.assertOnUiThread();
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeModule.java
@@ -52,6 +52,7 @@ public interface NativeModule {
    *
    * @deprecated use {@link #invalidate()} instead.
    */
+  @Deprecated
   void onCatalystInstanceDestroy();
 
   /** Allow NativeModule to clean up. Called before {CatalystInstance#onHostDestroy} */

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
@@ -516,6 +516,7 @@ public class ReactContext extends ContextWrapper {
   }
 
   /** @deprecated DO NOT USE, this method will be removed in the near future. */
+  @Deprecated
   public boolean isBridgeless() {
     return false;
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/common/ModuleDataCleaner.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/common/ModuleDataCleaner.java
@@ -43,6 +43,7 @@ public class ModuleDataCleaner {
    *
    * @deprecated
    */
+  @Deprecated
   public static void cleanDataFromModules(CatalystInstance catalystInstance) {
     for (NativeModule nativeModule : catalystInstance.getNativeModules()) {
       if (nativeModule instanceof Cleanable) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/RootView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/RootView.java
@@ -20,6 +20,7 @@ public interface RootView {
   void onChildStartedNativeGesture(View childView, MotionEvent ev);
 
   /** @deprecated */
+  @Deprecated
   void onChildStartedNativeGesture(MotionEvent ev);
 
   /**


### PR DESCRIPTION
Summary:
Those methods all have replacements and they have been annotated as `deprecated` but only on the Javadoc level.
The Java compiler from 11 starts to emit warnigns for those functions so I'm actually annotating them with Deprecated correctly.

Changelog:
[Android] [Changed] - Deprecate APIs that are deprecate only on JavaDoc

Differential Revision: D45525406

