### PR TITLE
Pass the hermestag file to the `read` function

### DIFF
--- a/packages/react-native/scripts/cocoapods/jsengine.rb
+++ b/packages/react-native/scripts/cocoapods/jsengine.rb
@@ -33,7 +33,7 @@ def setup_hermes!(react_native_path: "../node_modules/react-native", fabric_enab
     # This `:tag => hermestag` below is only to tell CocoaPods to update hermes-engine when React Native version changes.
     # We have custom logic to compute the source for hermes-engine. See sdks/hermes-engine/*
     hermestag_file = File.join(react_native_path, "sdks", ".hermesversion")
-    hermestag = File.exist?(hermestag_file) ? File.read().strip : ''
+    hermestag = File.exist?(hermestag_file) ? File.read(hermestag_file).strip : ''
     pod 'hermes-engine', :podspec => "#{react_native_path}/sdks/hermes-engine/hermes-engine.podspec", :tag => hermestag
     pod 'React-hermes', :path => "#{react_native_path}/ReactCommon/hermes"
     pod 'libevent', '~> 2.1.12'


### PR DESCRIPTION
Summary:
In a previous diff, we tried to disambiguate between versions of hermes engine by reading the hermestag file.

However, we forgot to pass the file to the `read` function.

It used to work both on main and on CI because that file doesn't exists in those environments. But it failed as soon as we tried to test a release.

## Changelog:
[iOS][Fixed] - Pass the hermestag file to the `read` function.

Differential Revision: D45530010

