### PR TITLE
get rid of unnecessary weak reference in RCTInstance

### DIFF
--- a/packages/react-native/React/CoreModules/RCTDevSettings.mm
+++ b/packages/react-native/React/CoreModules/RCTDevSettings.mm
@@ -394,13 +394,9 @@ RCT_EXPORT_METHOD(setHotLoadingEnabled : (BOOL)enabled)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
       if (enabled) {
-        if (self.callableJSModules) {
-          [self.callableJSModules invokeModule:@"HMRClient" method:@"enable" withArgs:@[]];
-        }
+        [self.callableJSModules invokeModule:@"HMRClient" method:@"enable" withArgs:@[]];
       } else {
-        if (self.callableJSModules) {
-          [self.callableJSModules invokeModule:@"HMRClient" method:@"disable" withArgs:@[]];
-        }
+        [self.callableJSModules invokeModule:@"HMRClient" method:@"disable" withArgs:@[]];
       }
 #pragma clang diagnostic pop
     }
@@ -483,22 +479,18 @@ RCT_EXPORT_METHOD(addMenuItem : (NSString *)title)
     NSNumber *const port = urlComponents.port;
     NSString *const scheme = urlComponents.scheme;
     BOOL isHotLoadingEnabled = self.isHotLoadingEnabled;
-    if (self.callableJSModules) {
-      [self.callableJSModules invokeModule:@"HMRClient"
-                                    method:@"setup"
-                                  withArgs:@[ @"ios", path, host, RCTNullIfNil(port), @(isHotLoadingEnabled), scheme ]];
-    }
+    [self.callableJSModules invokeModule:@"HMRClient"
+                                  method:@"setup"
+                                withArgs:@[ @"ios", path, host, RCTNullIfNil(port), @(isHotLoadingEnabled), scheme ]];
   }
 }
 
 - (void)setupHMRClientWithAdditionalBundleURL:(NSURL *)bundleURL
 {
   if (bundleURL && !bundleURL.fileURL) { // isHotLoadingAvailable check
-    if (self.callableJSModules) {
-      [self.callableJSModules invokeModule:@"HMRClient"
-                                    method:@"registerBundle"
-                                  withArgs:@[ [bundleURL absoluteString] ]];
-    }
+    [self.callableJSModules invokeModule:@"HMRClient"
+                                  method:@"registerBundle"
+                                withArgs:@[ [bundleURL absoluteString] ]];
   }
 }
 

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.mm
@@ -326,7 +326,6 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
   }
 #endif
 
-  __weak RCTPerformanceLogger *weakPerformanceLogger = _performanceLogger;
   __weak __typeof(self) weakSelf = self;
   [RCTJavaScriptLoader loadBundleAtURL:sourceURL
       onProgress:^(RCTLoadingProgress *progressData) {
@@ -358,7 +357,7 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
             (RCTDevSettings *)[strongSelf->_turboModuleManager moduleForName:"DevSettings"];
         [strongSelf loadScriptFromSource:source];
         // Set up hot module reloading in Dev only.
-        [weakPerformanceLogger markStopForTag:RCTPLScriptDownload];
+        [strongSelf->_performanceLogger markStopForTag:RCTPLScriptDownload];
         [devSettings setupHMRClientWithBundleURL:sourceURL];
       }];
 }


### PR DESCRIPTION
Summary:
Changelog: [Internal]

we already had strongSelf captured, just use that instead

Reviewed By: christophpurrer

Differential Revision: D45510817

