### PR TITLE
Fix Flipper by moving FB_SONARKIT_ENABLED to RCTAppDelegate 

### DIFF
--- a/packages/react-native/scripts/cocoapods/__tests__/flipper-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/flipper-test.rb
@@ -82,7 +82,7 @@ class FlipperTests < Test::Unit::TestCase
             assert_equal(config.build_settings['SWIFT_VERSION'], '4.1')
         end
 
-        reactCore_target = installer.target_with_name("React-Core")
+        reactCore_target = installer.target_with_name("React-RCTAppDelegate")
         reactCore_target.build_configurations.each do |config|
             if config.name == 'Debug' || config.name == 'CustomConfig' then
                 assert_equal(config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'], ['$(inherited)', 'FB_SONARKIT_ENABLED=1'])
@@ -139,6 +139,14 @@ class FlipperTests < Test::Unit::TestCase
                     ),
                     TargetMock.new(
                         "React-Core",
+                        [
+                            BuildConfigurationMock.new("Debug", is_debug: true),
+                            BuildConfigurationMock.new("Release", is_debug: false),
+                            BuildConfigurationMock.new("CustomConfig", is_debug: true),
+                        ]
+                    ),
+                    TargetMock.new(
+                        "React-RCTAppDelegate",
                         [
                             BuildConfigurationMock.new("Debug", is_debug: true),
                             BuildConfigurationMock.new("Release", is_debug: false),

--- a/packages/react-native/scripts/cocoapods/flipper.rb
+++ b/packages/react-native/scripts/cocoapods/flipper.rb
@@ -78,7 +78,7 @@ def flipper_post_install(installer)
         end
 
         # Enable flipper for React-Core Debug configuration
-        if target.name == 'React-Core'
+        if target.name == 'React-RCTAppDelegate'
             target.build_configurations.each do |config|
                 if config.debug?
                     config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] = ['$(inherited)', 'FB_SONARKIT_ENABLED=1']

--- a/packages/react-native/scripts/cocoapods/flipper.rb
+++ b/packages/react-native/scripts/cocoapods/flipper.rb
@@ -77,7 +77,7 @@ def flipper_post_install(installer)
             end
         end
 
-        # Enable flipper for React-Core Debug configuration
+        # Enable flipper for React-RCTAppDelegate Debug configuration
         if target.name == 'React-RCTAppDelegate'
             target.build_configurations.each do |config|
                 if config.debug?


### PR DESCRIPTION
## Summary:

An out-of-the-box react-native init project no longer enables Flipper properly as of 0.72.0-rc1.

## Changelog:

[IOS] [FIXED] Fix Flipper by moving podfile modification of preprocessor def `FB_SONARKIT_ENABLED` from React-Core to React-RCTAppDelegate where it is now used.

## Test Plan:

Generated an app and verified Flipper cannot see the app. Made the modification and generated another app and verified Flipper now sees it and can enable plugins. Verified that runtime (non-test) use of FB_SONARKIT_ENABLED is limited to Libraries/AppDelegate in this project.