### PR TITLE
Migrate VisibleForTesting to kotlin

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/annotations/VisibleForTesting.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/annotations/VisibleForTesting.kt
@@ -5,10 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-package com.facebook.react.common.annotations;
+
+package com.facebook.react.common.annotations
 
 /**
  * Annotates a method that should have restricted visibility but it's required to be public for use
  * in test code only.
  */
-public @interface VisibleForTesting {}
+annotation class VisibleForTesting


### PR DESCRIPTION
Summary:
EZ diff that migrates VisibleForTesting interface to kotlin

There are just 2 files into the annotations package, now both will be written in kotlin

changelog: [internal] internal

Reviewed By: cortinico, yungsters

Differential Revision: D45454643

