### PR TITLE
fold RCTInstanceDelegate into RCTHostDelegate

### DIFF
--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.h
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.h
@@ -38,6 +38,7 @@ RCT_EXTERN NSString *const RCTHostDidReloadNotification;
 
 - (std::shared_ptr<facebook::react::JSEngineInstance>)getJSEngine;
 - (NSURL *)getBundleURL;
+- (std::shared_ptr<facebook::react::ContextContainer>)createContextContainer;
 
 @end
 
@@ -49,7 +50,6 @@ RCT_EXTERN NSString *const RCTHostDidReloadNotification;
 @interface RCTHost : NSObject <ReactInstanceForwarding>
 
 - (instancetype)initWithHostDelegate:(id<RCTHostDelegate>)hostDelegate
-                    instanceDelegate:(id<RCTInstanceDelegate>)instanceDelegate
           turboModuleManagerDelegate:(id<RCTTurboModuleManagerDelegate>)turboModuleManagerDelegate
                  bindingsInstallFunc:(facebook::react::ReactInstance::BindingsInstallFunc)bindingsInstallFunc
                  jsErrorHandlingFunc:(facebook::react::JsErrorHandler::JsErrorHandlingFunc)jsErrorHandlingFunc

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.h
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.h
@@ -36,8 +36,6 @@ FB_RUNTIME_PROTOCOL
 // TODO (T74233481) - Delete this. Communication between Product Code <> RCTInstance should go through RCTHost.
 @protocol RCTInstanceDelegate <NSObject>
 
-@required
-
 - (std::shared_ptr<facebook::react::ContextContainer>)createContextContainer;
 
 @end


### PR DESCRIPTION
Summary: in general, userland has no reason to know about RCTInstance. this is the first step in starting to decouple consumers from the implementation details of bridgeless mode.

Differential Revision: D45542678

