### PR TITLE
do not expose RCTPerformanceLogger from RCTInstance

### DIFF
--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.h
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.h
@@ -71,8 +71,6 @@ RCT_EXTERN NSString *const RCTHostDidReloadNotification;
 
 - (RCTModuleRegistry *)getModuleRegistry FB_OBJC_DIRECT;
 
-- (NSArray *)getLoggingData FB_OBJC_DIRECT;
-
 - (RCTSurfacePresenter *)getSurfacePresenter FB_OBJC_DIRECT;
 
 @end

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.mm
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.mm
@@ -190,11 +190,6 @@ NSString *const RCTHostDidReloadNotification = @"RCTHostDidReloadNotification";
   return _moduleRegistry;
 }
 
-- (NSArray *)getLoggingData
-{
-  return [[_instance performanceLogger] valuesForTags];
-}
-
 - (RCTSurfacePresenter *)getSurfacePresenter
 {
   return [_instance surfacePresenter];

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.h
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.h
@@ -79,8 +79,6 @@ typedef void (^_Null_unspecified RCTInstanceInitialBundleLoadCompletionBlock)();
 
 - (void)invalidate;
 
-@property (nonatomic, readonly, strong) RCTPerformanceLogger *performanceLogger;
-
 @property (nonatomic, readonly, strong) RCTSurfacePresenter *surfacePresenter;
 
 @end

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.mm
@@ -68,6 +68,7 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
   __weak id<RCTTurboModuleManagerDelegate> _appTMMDelegate;
   __weak id<RCTInstanceDelegate> _delegate;
   RCTSurfacePresenter *_surfacePresenter;
+  RCTPerformanceLogger *_performanceLogger;
   RCTDisplayLink *_displayLink;
   RCTInstanceInitialBundleLoadCompletionBlock _onInitialBundleLoad;
   ReactInstance::BindingsInstallFunc _bindingsInstallFunc;


### PR DESCRIPTION
Summary:
Changelog: [Internal]

since no one is using this outside of RCTInstance, let's clean this up!

Differential Revision: D45553212

