### PR TITLE
fix: apply font size to ReactTextView to fix ellipsis cut

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextAnchorViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextAnchorViewManager.java
@@ -75,6 +75,11 @@ public abstract class ReactTextAnchorViewManager<T extends View, C extends React
     view.setAdjustFontSizeToFit(adjustsFontSizeToFit);
   }
 
+  @ReactProp(name = ViewProps.FONT_SIZE)
+  public void setFontSize(ReactTextView view, float fontSize) {
+    view.setFontSize(fontSize);
+  }
+
   @ReactProp(name = ViewProps.TEXT_ALIGN_VERTICAL)
   public void setTextAlignVertical(ReactTextView view, @Nullable String textAlignVertical) {
     if (textAlignVertical == null || "auto".equals(textAlignVertical)) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextAnchorViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextAnchorViewManager.java
@@ -80,6 +80,11 @@ public abstract class ReactTextAnchorViewManager<T extends View, C extends React
     view.setFontSize(fontSize);
   }
 
+  @ReactProp(name = ViewProps.LETTER_SPACING, defaultFloat = Float.NaN)
+  public void setLetterSpacing(ReactTextView view, float letterSpacing) {
+    view.setLetterSpacing(letterSpacing);
+  }
+
   @ReactProp(name = ViewProps.TEXT_ALIGN_VERTICAL)
   public void setTextAlignVertical(ReactTextView view, @Nullable String textAlignVertical) {
     if (textAlignVertical == null || "auto".equals(textAlignVertical)) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
@@ -18,6 +18,7 @@ import android.text.Spanned;
 import android.text.TextUtils;
 import android.text.method.LinkMovementMethod;
 import android.text.util.Linkify;
+import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.MotionEvent;
 import android.view.View;
@@ -57,6 +58,7 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
   private int mNumberOfLines;
   private TextUtils.TruncateAt mEllipsizeLocation;
   private boolean mAdjustsFontSizeToFit;
+  private float mFontSize = Float.NaN;
   private int mLinkifyMaskType;
   private boolean mNotifyOnInlineViewLayout;
   private boolean mTextIsSelectable;
@@ -389,6 +391,12 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
           (int) Math.floor(paddingBottom));
     }
 
+    // This is required to workaround the problem in Android here it
+    // can cut the ellipsis on cut text in certain font sizes and paddings
+    if (!Float.isNaN(mFontSize)) {
+      setTextSize(TypedValue.COMPLEX_UNIT_PX, mFontSize);
+    }
+
     int nextTextAlign = update.getTextAlign();
     if (nextTextAlign != getGravityHorizontal()) {
       setGravityHorizontal(nextTextAlign);
@@ -580,6 +588,13 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
 
   public void setAdjustFontSizeToFit(boolean adjustsFontSizeToFit) {
     mAdjustsFontSizeToFit = adjustsFontSizeToFit;
+  }
+
+  public void setFontSize(float fontSize) {
+    mFontSize =
+      mAdjustsFontSizeToFit
+        ? (float) Math.ceil(PixelUtil.toPixelFromSP(fontSize))
+        : (float) Math.ceil(PixelUtil.toPixelFromDIP(fontSize));
   }
 
   public void setEllipsizeLocation(TextUtils.TruncateAt ellipsizeLocation) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
@@ -391,7 +391,7 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
           (int) Math.floor(paddingBottom));
     }
 
-    // This is required to workaround the problem in Android here it
+    // This is required to workaround the problem in Android where it
     // can cut the ellipsis on cut text in certain font sizes and paddings
     if (!Float.isNaN(mFontSize)) {
       setTextSize(TypedValue.COMPLEX_UNIT_PX, mFontSize);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
@@ -391,8 +391,9 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
           (int) Math.floor(paddingBottom));
     }
 
-    // This is required to workaround the problem in Android where it
-    // can cut the ellipsis on cut text in certain font sizes and paddings
+    // Workaround for an issue where text can be cut off with an ellipsis when
+    // using certain font sizes and padding. Sets the provided text size
+    // (mFontSize) to ensure consistent rendering and prevent cut-off.
     if (!Float.isNaN(mFontSize)) {
       setTextSize(TypedValue.COMPLEX_UNIT_PX, mFontSize);
     }

--- a/packages/rn-tester/js/examples/Text/TextExample.android.js
+++ b/packages/rn-tester/js/examples/Text/TextExample.android.js
@@ -676,6 +676,10 @@ class TextExample extends React.Component<{...}> {
             Maximum of one line no matter now much I write here. If I keep
             writing it{"'"}ll just truncate after one line
           </Text>
+          <Text style={{fontSize: 31}} numberOfLines={1}>
+            Maximum of one line no matter now much I write here. If I keep
+            writing it{"'"}ll just truncate after one line
+          </Text>
           <Text numberOfLines={2} style={{marginTop: 20}}>
             Maximum of two lines no matter now much I write here. If I keep
             writing it{"'"}ll just truncate after two lines


### PR DESCRIPTION
## Summary:

This PR aims to fix https://github.com/facebook/react-native/issues/36350. In certain cases, when the text is cut due to  `numberOfLines`, the ellipsis appear cut. This is actually an Android bug, which was reported on their side [here](https://issuetracker.google.com/issues/278044456).

This PR contains a workaround for it by applying the text size to the TextView directly instead of just the Spannable inside it. This solves all problems and it seems like it does not cause any regressions.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[ANDROID] [FIXED] - Fix ellipsis being cut on certain font sizes

## Test Plan:

One piece of code where the problem could be replicated would be the one below, running on an Pixel 3A emulator.

```jsx
<Text style={{padding: 27, fontSize: 30}} numberOfLines={1}>
   This text will be cut-off strangely in Android
</Text>
```

RN-tester of the problem:

| Before | With the fix  |
| --------------- | --------------- |
|  <img width="460" alt="Screenshot 2023-05-04 at 12 05 11" src="https://user-images.githubusercontent.com/25725586/236187961-d7841594-2d39-4cdc-aff9-a36f60fe6d15.png">| <img width="460" alt="Screenshot 2023-05-04 at 12 08 07" src="https://user-images.githubusercontent.com/25725586/236187999-e823beb5-0473-4940-894e-b3d2ff02c6cc.png"> |


RN-Tester comparison:
| Before | With the fix  |
| --------------- | --------------- |
| <video src="https://user-images.githubusercontent.com/25725586/234273910-c6a9f55c-9a19-415d-b0cd-477c9087dac2.mp4">  | <video src="https://user-images.githubusercontent.com/25725586/234273973-ba6d5bd5-eba8-4eda-aefb-c926ea28c4e5.mp4"> |
