### PR TITLE
refactor(codegen): extract throwIfArgumentPropsAreNull function in error-utils

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
@@ -35,6 +35,7 @@ const {
   throwIfMoreThanOneCodegenNativecommands,
   throwIfEventHasNoName,
   throwIfBubblingTypeIsNull,
+  throwIfArgumentPropsAreNull,
 } = require('../error-utils');
 const {
   UnsupportedModulePropertyParserError,
@@ -970,6 +971,26 @@ describe('throwIfBubblingTypeIsNull', () => {
 
     expect(() => {
       throwIfBubblingTypeIsNull(bubblingType, eventName);
+    }).not.toThrow();
+  });
+});
+
+describe('throwIfArgumentPropsAreNull', () => {
+  it('throws an error if unable to determine event arguments', () => {
+    const argumentProps = null;
+    const eventName = 'Event';
+
+    expect(() => {
+      throwIfArgumentPropsAreNull(argumentProps, eventName);
+    }).toThrowError(`Unable to determine event arguments for "${eventName}"`);
+  });
+
+  it('does not throw an error if able to determine event arguments', () => {
+    const argumentProps = {};
+    const eventName = 'Event';
+
+    expect(() => {
+      throwIfArgumentPropsAreNull(argumentProps, eventName);
     }).not.toThrow();
   });
 });

--- a/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
@@ -986,7 +986,7 @@ describe('throwIfArgumentPropsAreNull', () => {
   });
 
   it('does not throw an error if able to determine event arguments', () => {
-    const argumentProps = {};
+    const argumentProps = [{}];
     const eventName = 'Event';
 
     expect(() => {

--- a/packages/react-native-codegen/src/parsers/error-utils.js
+++ b/packages/react-native-codegen/src/parsers/error-utils.js
@@ -322,21 +322,25 @@ function throwIfEventHasNoName(typeAnnotation: $FlowFixMe, parser: Parser) {
 function throwIfBubblingTypeIsNull(
   bubblingType: ?('direct' | 'bubble'),
   eventName: string,
-) {
+): 'direct' | 'bubble' {
   if (!bubblingType) {
     throw new Error(
       `Unable to determine event bubbling type for "${eventName}"`,
     );
   }
+
+  return bubblingType;
 }
 
 function throwIfArgumentPropsAreNull(
-  argumentProps: $FlowFixMe,
+  argumentProps: ?$ReadOnlyArray<$FlowFixMe>,
   eventName: string,
-) {
+): $ReadOnlyArray<$FlowFixMe> {
   if (!argumentProps) {
     throw new Error(`Unable to determine event arguments for "${eventName}"`);
   }
+
+  return argumentProps;
 }
 
 module.exports = {

--- a/packages/react-native-codegen/src/parsers/error-utils.js
+++ b/packages/react-native-codegen/src/parsers/error-utils.js
@@ -330,6 +330,15 @@ function throwIfBubblingTypeIsNull(
   }
 }
 
+function throwIfArgumentPropsAreNull(
+  argumentProps: $FlowFixMe,
+  eventName: string,
+) {
+  if (!argumentProps) {
+    throw new Error(`Unable to determine event arguments for "${eventName}"`);
+  }
+}
+
 module.exports = {
   throwIfModuleInterfaceIsMisnamed,
   throwIfUnsupportedFunctionReturnTypeAnnotationParserError,
@@ -352,4 +361,5 @@ module.exports = {
   throwIfMoreThanOneConfig,
   throwIfEventHasNoName,
   throwIfBubblingTypeIsNull,
+  throwIfArgumentPropsAreNull,
 };

--- a/packages/react-native-codegen/src/parsers/flow/components/events.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/events.js
@@ -297,24 +297,22 @@ function buildEventSchema(
   const {argumentProps, bubblingType, paperTopLevelNameDeprecated} =
     findEventArgumentsAndType(parser, typeAnnotation, types);
 
-  if (!argumentProps) {
-    throwIfArgumentPropsAreNull(argumentProps, name);
-  }
-
-  if (!bubblingType) {
-    throwIfBubblingTypeIsNull(bubblingType, name);
-  }
+  const nonNullableArgumentProps = throwIfArgumentPropsAreNull(
+    argumentProps,
+    name,
+  );
+  const nonNullableBubblingType = throwIfBubblingTypeIsNull(bubblingType, name);
 
   if (paperTopLevelNameDeprecated != null) {
     return {
       name,
       optional,
-      bubblingType,
+      bubblingType: nonNullableBubblingType,
       paperTopLevelNameDeprecated,
       typeAnnotation: {
         type: 'EventTypeAnnotation',
         argument: getEventArgument(
-          argumentProps,
+          nonNullableArgumentProps,
           buildPropertiesForEvent,
           parser,
         ),
@@ -325,11 +323,11 @@ function buildEventSchema(
   return {
     name,
     optional,
-    bubblingType,
+    bubblingType: nonNullableBubblingType,
     typeAnnotation: {
       type: 'EventTypeAnnotation',
       argument: getEventArgument(
-        argumentProps,
+        nonNullableArgumentProps,
         buildPropertiesForEvent,
         parser,
       ),

--- a/packages/react-native-codegen/src/parsers/flow/components/events.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/events.js
@@ -19,6 +19,7 @@ import type {Parser} from '../../parser';
 const {
   throwIfEventHasNoName,
   throwIfBubblingTypeIsNull,
+  throwIfArgumentPropsAreNull,
 } = require('../../error-utils');
 const {getEventArgument} = require('../../parsers-commons');
 
@@ -297,11 +298,11 @@ function buildEventSchema(
     findEventArgumentsAndType(parser, typeAnnotation, types);
 
   if (!argumentProps) {
-    throw new Error(`Unable to determine event arguments for "${name}"`);
+    throwIfArgumentPropsAreNull(argumentProps, name);
   }
 
   if (!bubblingType) {
-    throw new Error(`Unable to determine event arguments for "${name}"`);
+    throwIfBubblingTypeIsNull(bubblingType, name);
   }
 
   if (paperTopLevelNameDeprecated != null) {
@@ -320,12 +321,6 @@ function buildEventSchema(
       },
     };
   }
-
-  if (argumentProps === null) {
-    throw new Error(`Unable to determine event arguments for "${name}"`);
-  }
-
-  throwIfBubblingTypeIsNull(bubblingType, name);
 
   return {
     name,

--- a/packages/react-native-codegen/src/parsers/typescript/components/events.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/events.js
@@ -308,42 +308,42 @@ function buildEventSchema(
   const {argumentProps, bubblingType, paperTopLevelNameDeprecated} =
     findEventArgumentsAndType(parser, typeAnnotation, types);
 
-  if (!argumentProps) {
-    throwIfArgumentPropsAreNull(argumentProps, name);
-  } else if (!bubblingType) {
-    throwIfBubblingTypeIsNull(bubblingType, name);
-  } else {
-    if (paperTopLevelNameDeprecated != null) {
-      return {
-        name,
-        optional,
-        bubblingType,
-        paperTopLevelNameDeprecated,
-        typeAnnotation: {
-          type: 'EventTypeAnnotation',
-          argument: getEventArgument(
-            argumentProps,
-            buildPropertiesForEvent,
-            parser,
-          ),
-        },
-      };
-    }
+  const nonNullableArgumentProps = throwIfArgumentPropsAreNull(
+    argumentProps,
+    name,
+  );
+  const nonNullableBubblingType = throwIfBubblingTypeIsNull(bubblingType, name);
 
+  if (paperTopLevelNameDeprecated != null) {
     return {
       name,
       optional,
-      bubblingType,
+      bubblingType: nonNullableBubblingType,
+      paperTopLevelNameDeprecated,
       typeAnnotation: {
         type: 'EventTypeAnnotation',
         argument: getEventArgument(
-          argumentProps,
+          nonNullableArgumentProps,
           buildPropertiesForEvent,
           parser,
         ),
       },
     };
   }
+
+  return {
+    name,
+    optional,
+    bubblingType: nonNullableBubblingType,
+    typeAnnotation: {
+      type: 'EventTypeAnnotation',
+      argument: getEventArgument(
+        nonNullableArgumentProps,
+        buildPropertiesForEvent,
+        parser,
+      ),
+    },
+  };
 }
 
 function getEvents(

--- a/packages/react-native-codegen/src/parsers/typescript/components/events.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/events.js
@@ -22,6 +22,7 @@ const {parseTopLevelType} = require('../parseTopLevelType');
 const {
   throwIfEventHasNoName,
   throwIfBubblingTypeIsNull,
+  throwIfArgumentPropsAreNull,
 } = require('../../error-utils');
 const {getEventArgument} = require('../../parsers-commons');
 function getPropertyType(
@@ -308,7 +309,7 @@ function buildEventSchema(
     findEventArgumentsAndType(parser, typeAnnotation, types);
 
   if (!argumentProps) {
-    throw new Error(`Unable to determine event arguments for "${name}"`);
+    throwIfArgumentPropsAreNull(argumentProps, name);
   } else if (!bubblingType) {
     throwIfBubblingTypeIsNull(bubblingType, name);
   } else {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This PR contains task 117 from https://github.com/facebook/react-native/issues/34872:
> [Codegen 117] Extract the code that throws if argumentProps are null in a throwIfArgumentPropsAreNull function in the error-utils.js file. Use it in the [flow/components/events.js](https://github.com/facebook/react-native/blob/e133100721939108b0f28dfa9f60ac627c804018/packages/react-native-codegen/src/parsers/flow/components/events.js#L240-L242) and in the [typescript/components/event.js](https://github.com/facebook/react-native/blob/e133100721939108b0f28dfa9f60ac627c804018/packages/react-native-codegen/src/parsers/typescript/components/events.js#L230-L231) files

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[Internal] [Changed] - Extract throwIfArgumentPropsAreNull function in error-utils

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

I tested using Jest and Flow commands.