### PR TITLE
Add missing <algorithm> import in

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/componentregistry/componentNameByReactViewName.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/componentregistry/componentNameByReactViewName.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "componentNameByReactViewName.h"
+#include <algorithm>
 
 namespace facebook::react {
 


### PR DESCRIPTION
Summary:
Fix compile errors on Windows as
```
stderr:react-native-github\packages\react-native\ReactCommon\react\renderer\componentregistry\componentNameByReactViewName.cpp(18,12): error: no member named 'mismatch' in namespace 'std'
  if (std::mismatch(rctPrefix.begin(), rctPrefix.end(), viewName.begin())
      ~~~~~^
```

Changelog: [Internal]

Differential Revision: D45597108

