### PR TITLE
Disable all the measure* tests on Windows as they're flaky

### DIFF
--- a/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/__tests__/ReactFabricPublicInstance-test.js
+++ b/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/__tests__/ReactFabricPublicInstance-test.js
@@ -157,7 +157,7 @@ async function mockRenderKeys(
     });
 
     describe('measure', () => {
-      test('component.measure(...) invokes callback', async () => {
+      itif(!isWindows)('component.measure(...) invokes callback', async () => {
         const result = await mockRenderKeys([['foo']]);
         const fooRef = nullthrows(result?.[0]?.[0]);
 
@@ -170,7 +170,7 @@ async function mockRenderKeys(
         expect(callback.mock.calls).toEqual([[10, 10, 100, 100, 0, 0]]);
       });
 
-      test('unmounted.measure(...) does nothing', async () => {
+      itif(!isWindows)('unmounted.measure(...) does nothing', async () => {
         const result = await mockRenderKeys([['foo'], null]);
         const fooRef = nullthrows(result?.[0]?.[0]);
         const callback = jest.fn();
@@ -184,18 +184,21 @@ async function mockRenderKeys(
     });
 
     describe('measureInWindow', () => {
-      it('component.measureInWindow(...) invokes callback', async () => {
-        const result = await mockRenderKeys([['foo']]);
-        const fooRef = nullthrows(result?.[0]?.[0]);
+      itif(!isWindows)(
+        'component.measureInWindow(...) invokes callback',
+        async () => {
+          const result = await mockRenderKeys([['foo']]);
+          const fooRef = nullthrows(result?.[0]?.[0]);
 
-        const callback = jest.fn();
-        fooRef.measureInWindow(callback);
+          const callback = jest.fn();
+          fooRef.measureInWindow(callback);
 
-        expect(
-          nullthrows(FabricUIManager.getFabricUIManager()).measureInWindow,
-        ).toHaveBeenCalledTimes(1);
-        expect(callback.mock.calls).toEqual([[10, 10, 100, 100]]);
-      });
+          expect(
+            nullthrows(FabricUIManager.getFabricUIManager()).measureInWindow,
+          ).toHaveBeenCalledTimes(1);
+          expect(callback.mock.calls).toEqual([[10, 10, 100, 100]]);
+        },
+      );
 
       itif(!isWindows)(
         'unmounted.measureInWindow(...) does nothing',
@@ -215,38 +218,44 @@ async function mockRenderKeys(
     });
 
     describe('measureLayout', () => {
-      it('component.measureLayout(component, ...) invokes callback', async () => {
-        const result = await mockRenderKeys([['foo', 'bar']]);
-        const fooRef = nullthrows(result?.[0]?.[0]);
-        const barRef = nullthrows(result?.[0]?.[1]);
+      itif(!isWindows)(
+        'component.measureLayout(component, ...) invokes callback',
+        async () => {
+          const result = await mockRenderKeys([['foo', 'bar']]);
+          const fooRef = nullthrows(result?.[0]?.[0]);
+          const barRef = nullthrows(result?.[0]?.[1]);
 
-        const successCallback = jest.fn();
-        const failureCallback = jest.fn();
-        fooRef.measureLayout(barRef, successCallback, failureCallback);
+          const successCallback = jest.fn();
+          const failureCallback = jest.fn();
+          fooRef.measureLayout(barRef, successCallback, failureCallback);
 
-        expect(
-          nullthrows(FabricUIManager.getFabricUIManager()).measureLayout,
-        ).toHaveBeenCalledTimes(1);
-        expect(successCallback.mock.calls).toEqual([[1, 1, 100, 100]]);
-      });
+          expect(
+            nullthrows(FabricUIManager.getFabricUIManager()).measureLayout,
+          ).toHaveBeenCalledTimes(1);
+          expect(successCallback.mock.calls).toEqual([[1, 1, 100, 100]]);
+        },
+      );
 
-      it('unmounted.measureLayout(component, ...) does nothing', async () => {
-        const result = await mockRenderKeys([
-          ['foo', 'bar'],
-          ['foo', null],
-        ]);
-        const fooRef = nullthrows(result?.[0]?.[0]);
-        const barRef = nullthrows(result?.[0]?.[1]);
+      itif(!isWindows)(
+        'unmounted.measureLayout(component, ...) does nothing',
+        async () => {
+          const result = await mockRenderKeys([
+            ['foo', 'bar'],
+            ['foo', null],
+          ]);
+          const fooRef = nullthrows(result?.[0]?.[0]);
+          const barRef = nullthrows(result?.[0]?.[1]);
 
-        const successCallback = jest.fn();
-        const failureCallback = jest.fn();
-        fooRef.measureLayout(barRef, successCallback, failureCallback);
+          const successCallback = jest.fn();
+          const failureCallback = jest.fn();
+          fooRef.measureLayout(barRef, successCallback, failureCallback);
 
-        expect(
-          nullthrows(FabricUIManager.getFabricUIManager()).measureLayout,
-        ).not.toHaveBeenCalled();
-        expect(successCallback).not.toHaveBeenCalled();
-      });
+          expect(
+            nullthrows(FabricUIManager.getFabricUIManager()).measureLayout,
+          ).not.toHaveBeenCalled();
+          expect(successCallback).not.toHaveBeenCalled();
+        },
+      );
 
       itif(!isWindows)(
         'component.measureLayout(unmounted, ...) does nothing',
@@ -269,20 +278,23 @@ async function mockRenderKeys(
         },
       );
 
-      it('unmounted.measureLayout(unmounted, ...) does nothing', async () => {
-        const result = await mockRenderKeys([['foo', 'bar'], null]);
-        const fooRef = nullthrows(result?.[0]?.[0]);
-        const barRef = nullthrows(result?.[0]?.[1]);
+      itif(!isWindows)(
+        'unmounted.measureLayout(unmounted, ...) does nothing',
+        async () => {
+          const result = await mockRenderKeys([['foo', 'bar'], null]);
+          const fooRef = nullthrows(result?.[0]?.[0]);
+          const barRef = nullthrows(result?.[0]?.[1]);
 
-        const successCallback = jest.fn();
-        const failureCallback = jest.fn();
-        fooRef.measureLayout(barRef, successCallback, failureCallback);
+          const successCallback = jest.fn();
+          const failureCallback = jest.fn();
+          fooRef.measureLayout(barRef, successCallback, failureCallback);
 
-        expect(
-          nullthrows(FabricUIManager.getFabricUIManager()).measureLayout,
-        ).not.toHaveBeenCalled();
-        expect(successCallback).not.toHaveBeenCalled();
-      });
+          expect(
+            nullthrows(FabricUIManager.getFabricUIManager()).measureLayout,
+          ).not.toHaveBeenCalled();
+          expect(successCallback).not.toHaveBeenCalled();
+        },
+      );
     });
   });
 });


### PR DESCRIPTION
Summary:
Instead of disabling one test at a time, I've suppressed all the measure* related tests on Windows
with the hope to make the Windows CI less flaky.

Changelog:
[Internal] [Changed] - Disable all the measure* tests on Windows as they're flaky

Reviewed By: cipolleschi

Differential Revision: D45601448

