### PR TITLE
DevServerHelper should not depend on internal ctor parameter

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
@@ -138,7 +138,10 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
     mBundleStatus = new InspectorPackagerConnection.BundleStatus();
     mDevServerHelper =
         new DevServerHelper(
-            mDevSettings, mApplicationContext.getPackageName(), () -> mBundleStatus);
+            mDevSettings,
+            mApplicationContext.getPackageName(),
+            () -> mBundleStatus,
+            mDevSettings.getPackagerConnectionSettings());
     mBundleDownloadListener = devBundleDownloadListener;
 
     // Prepare shake gesture detector (will be started/stopped from #reload)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/PerftestDevSupportManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/PerftestDevSupportManager.java
@@ -31,12 +31,8 @@ public final class PerftestDevSupportManager extends DisabledDevSupportManager {
         new DevServerHelper(
             mDevSettings,
             applicationContext.getPackageName(),
-            new InspectorPackagerConnection.BundleStatusProvider() {
-              @Override
-              public InspectorPackagerConnection.BundleStatus getBundleStatus() {
-                return mBundleStatus;
-              }
-            });
+            (InspectorPackagerConnection.BundleStatusProvider) () -> mBundleStatus,
+            mDevSettings.getPackagerConnectionSettings());
   }
 
   @Override


### PR DESCRIPTION
Summary:
DevServerHelper was having a constructor parameter as `DevInternalSettings` which is effectively internal. This should not be the case as that class is Internal as was bleeding out of the public API.

I've updated the primary constructor to take instead:

```
  public DevServerHelper(
          DeveloperSettings settings,
          String packageName,
          InspectorPackagerConnection.BundleStatusProvider bundleStatusProvider,
          PackagerConnectionSettings packagerConnectionSettings) {
```

This is breaking change for users that were depending on the Internal class.

Changelog:
[Android] [Removed] - DevServerHelper should not depend on internal ctor parameter

Differential Revision: D45600283

