### PR TITLE
Polish DevServerHelper

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
@@ -138,7 +138,10 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
     mBundleStatus = new InspectorPackagerConnection.BundleStatus();
     mDevServerHelper =
         new DevServerHelper(
-            mDevSettings, mApplicationContext.getPackageName(), () -> mBundleStatus);
+            mDevSettings,
+            mApplicationContext.getPackageName(),
+            () -> mBundleStatus,
+            mDevSettings.getPackagerConnectionSettings());
     mBundleDownloadListener = devBundleDownloadListener;
 
     // Prepare shake gesture detector (will be started/stopped from #reload)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/PerftestDevSupportManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/PerftestDevSupportManager.java
@@ -31,12 +31,8 @@ public final class PerftestDevSupportManager extends DisabledDevSupportManager {
         new DevServerHelper(
             mDevSettings,
             applicationContext.getPackageName(),
-            new InspectorPackagerConnection.BundleStatusProvider() {
-              @Override
-              public InspectorPackagerConnection.BundleStatus getBundleStatus() {
-                return mBundleStatus;
-              }
-            });
+            (InspectorPackagerConnection.BundleStatusProvider) () -> mBundleStatus,
+            mDevSettings.getPackagerConnectionSettings());
   }
 
   @Override


### PR DESCRIPTION
Summary:
This class is full of warnings and other issues which I'm doing a pass on it since I touched it:
- Missing `NonNull` annotations
- Try with resources missing
- Unused inner Interfaces that can be removed

Technically a breaking change for users as we do have some public interfaces that have been removed, though not sure why people would depend on those.

Changelog:
[Android] [Removed] - Polish DevServerHelper (remove unused Interfaces)

Reviewed By: motiz88

Differential Revision: D45600284

