### PR TITLE
Store test artifacts for Android

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -724,10 +724,6 @@ jobs:
   # -------------------------
   test_android:
     executor: reactnativeandroid
-    parameters:
-      run_disabled_tests:
-        type: boolean
-        default: false
     steps:
       - checkout
       - setup_artifacts
@@ -745,13 +741,11 @@ jobs:
           path: ~/react-native/packages/rn-tester/android/app/build/outputs/apk/
           destination: rntester-apk
 
-      # Optionally, run disabled tests
-      - when:
-          condition: << parameters.run_disabled_tests >>
-          steps:
-            - run: echo "Failing tests may be moved here temporarily."
-            - run_e2e:
-                platform: android
+      - store_test_results:
+          path: ~/react-native/packages/react-native-gradle-plugin/build/test-results/test
+
+      - store_test_results:
+          path: ~/react-native/packages/react-native/ReactAndroid/build/test-results/testDebugUnitTest
 
   # -------------------------
   #    JOBS: Test Android Docker Image
@@ -1602,8 +1596,7 @@ workflows:
             - build_hermesc_windows
       - test_js:
           run_disabled_tests: false
-      - test_android:
-          run_disabled_tests: false
+      - test_android
       - test_android_docker_image
       - test_android_template:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -737,15 +737,15 @@ jobs:
       - report_bundle_size:
           platform: android
 
+      - store_test_results:
+          path: ~/react-native/packages/react-native-gradle-plugin/build/test-results
+      
+      - store_test_results:
+          path: ~/react-native/packages/react-native/ReactAndroid/build/test-results
+
       - store_artifacts:
           path: ~/react-native/packages/rn-tester/android/app/build/outputs/apk/
           destination: rntester-apk
-
-      - store_test_results:
-          path: ~/react-native/packages/react-native-gradle-plugin/build/test-results/test
-
-      - store_test_results:
-          path: ~/react-native/packages/react-native/ReactAndroid/build/test-results/testDebugUnitTest
 
   # -------------------------
   #    JOBS: Test Android Docker Image


### PR DESCRIPTION
## Summary:

We should store XML datas from the test we execute so when they fail it's easier to immediately see which test caused the failure.

## Changelog:

[INTERNAL] - Store test artifacts for Android

## Test Plan:

Wait for CI results