### PR TITLE
Introduce CI tests to test dynamic frameworks in check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -588,9 +588,6 @@ jobs:
   test_ios:
     executor: reactnativeios
     parameters:
-      use_frameworks:
-        type: boolean
-        default: false
       run_unit_tests:
         description: Specifies whether unit tests should run.
         type: boolean
@@ -646,13 +643,6 @@ jobs:
       - run:
           name: Configure Watchman
           command: echo "{}" > .watchmanconfig
-
-      - when:
-          condition: << parameters.use_frameworks >>
-          steps:
-            - run:
-                name: Set USE_FRAMEWORKS=1
-                command: echo "export USE_FRAMEWORKS=1" >> $BASH_ENV
 
       - run:
           name: Setup the CocoaPods environment
@@ -931,6 +921,11 @@ jobs:
         description: Which React Native architecture to use. Must be one of "OldArch", "NewArch".
         type: enum
         enum: ["NewArch", "OldArch"]
+      use_frameworks:
+        default: "StaticLibraries"
+        description: The dependency building and linking strategy to use. Must be one of "StaticLibraries", "StaticFrameworks", "DynamicFrameworks"
+        type: enum
+        enum: ["StaticLibraries", "StaticFrameworks", "DynamicFrameworks"]
       ruby_version:
         default: "2.6.10"
         description: The version of ruby that must be used
@@ -963,6 +958,16 @@ jobs:
 
                   if [[ << parameters.jsengine >> == "JSC" ]]; then
                     export USE_HERMES=0
+                  fi
+
+                  if [[ << parameters.use_frameworks >> == "StaticFrameworks" ]]; then
+                    export NO_FLIPPER=1
+                    export USE_FRAMEWORKS=static
+                  fi
+
+                  if [[ << parameters.use_frameworks >> == "DynamicFrameworks" ]]; then
+                    export NO_FLIPPER=1
+                    export USE_FRAMEWORKS=dynamic
                   fi
 
                   cd packages/rn-tester
@@ -1648,11 +1653,6 @@ workflows:
                 use_frameworks: "DynamicFrameworks"
               - architecture: "NewArch"
                 flavor: "Release"
-                jsengine: "Hermes"
-                flipper: "WithoutFlipper"
-                use_frameworks: "DynamicFrameworks"
-              - architecture: "NewArch"
-                flavor: "Release"
                 jsengine: "JSC"
                 flipper: "WithFlipper"
                 use_frameworks: "StaticLibraries"
@@ -1665,11 +1665,6 @@ workflows:
                 flavor: "Release"
                 jsengine: "JSC"
                 flipper: "WithFlipper"
-                use_frameworks: "DynamicFrameworks"
-              - architecture: "NewArch"
-                flavor: "Release"
-                jsengine: "JSC"
-                flipper: "WithoutFlipper"
                 use_frameworks: "DynamicFrameworks"
               - architecture: "OldArch"
                 flavor: "Release"
@@ -1728,18 +1723,8 @@ workflows:
                 use_frameworks: "DynamicFrameworks"
               - architecture: "NewArch"
                 flavor: "Debug"
-                jsengine: "Hermes"
-                flipper: "WithoutFlipper"
-                use_frameworks: "DynamicFrameworks"
-              - architecture: "NewArch"
-                flavor: "Debug"
                 jsengine: "JSC"
                 flipper: "WithFlipper"
-                use_frameworks: "DynamicFrameworks"
-              - architecture: "NewArch"
-                flavor: "Debug"
-                jsengine: "JSC"
-                flipper: "WithoutFlipper"
                 use_frameworks: "DynamicFrameworks"
               - architecture: "OldArch"
                 flavor: "Debug"
@@ -1770,6 +1755,7 @@ workflows:
             parameters:
               architecture: ["NewArch", "OldArch"]
               jsengine: ["Hermes", "JSC"]
+              use_frameworks: ["StaticLibraries", "StaticFrameworks", "DynamicFrameworks"]
       - test_ios:
           name: "Test iOS with Ruby 2.7.7"
           run_unit_tests: true
@@ -1789,13 +1775,6 @@ workflows:
           matrix:
             parameters:
               jsengine: ["Hermes", "JSC"]
-      # DISABLED: USE_FRAMEWORKS=1 not supported by Flipper
-      # - test_ios:
-      #     name: test_ios_frameworks
-      #     use_frameworks: true
-      #     run_unit_tests: true
-      #     requires:
-      #       - build_ios_frameworks
       - test_js:
           name: test_js_prev_lts
           executor: nodeprevlts

--- a/packages/react-native-codegen/src/generators/components/GenerateThirdPartyFabricComponentsProviderH.js
+++ b/packages/react-native-codegen/src/generators/components/GenerateThirdPartyFabricComponentsProviderH.js
@@ -36,7 +36,11 @@ extern "C" {
 
 Class<RCTComponentViewProtocol> RCTThirdPartyFabricComponentsProvider(const char *name);
 
+#ifndef RCT_DYNAMIC_FRAMEWORKS
+
 ${lookupFuncs}
+
+#endif
 
 #ifdef __cplusplus
 }

--- a/packages/react-native-codegen/src/generators/components/GenerateThirdPartyFabricComponentsProviderObjCpp.js
+++ b/packages/react-native-codegen/src/generators/components/GenerateThirdPartyFabricComponentsProviderObjCpp.js
@@ -34,7 +34,9 @@ const FileTemplate = ({lookupMap}: {lookupMap: string}) => `
 
 Class<RCTComponentViewProtocol> RCTThirdPartyFabricComponentsProvider(const char *name) {
   static std::unordered_map<std::string, Class (*)(void)> sFabricComponentsClassMap = {
+    #ifndef RCT_DYNAMIC_FRAMEWORKS
 ${lookupMap}
+    #endif
   };
 
   auto p = sFabricComponentsClassMap.find(name);

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GenerateThirdPartyFabricComponentsProviderH-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GenerateThirdPartyFabricComponentsProviderH-test.js.snap
@@ -23,6 +23,8 @@ extern \\"C\\" {
 
 Class<RCTComponentViewProtocol> RCTThirdPartyFabricComponentsProvider(const char *name);
 
+#ifndef RCT_DYNAMIC_FRAMEWORKS
+
 Class<RCTComponentViewProtocol> NoPropsNoEventsComponentCls(void) __attribute__((used)); // NO_PROPS_NO_EVENTS
 Class<RCTComponentViewProtocol> InterfaceOnlyComponentCls(void) __attribute__((used)); // INTERFACE_ONLY
 Class<RCTComponentViewProtocol> BooleanPropNativeComponentCls(void) __attribute__((used)); // BOOLEAN_PROP
@@ -54,6 +56,8 @@ Class<RCTComponentViewProtocol> CommandNativeComponentCls(void) __attribute__((u
 Class<RCTComponentViewProtocol> ExcludedAndroidComponentCls(void) __attribute__((used)); // EXCLUDE_ANDROID
 
 Class<RCTComponentViewProtocol> MultiFileIncludedNativeComponentCls(void) __attribute__((used)); // EXCLUDE_IOS_TWO_COMPONENTS_DIFFERENT_FILES
+
+#endif
 
 #ifdef __cplusplus
 }

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GenerateThirdPartyFabricComponentsProviderObjCpp-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GenerateThirdPartyFabricComponentsProviderObjCpp-test.js.snap
@@ -21,6 +21,7 @@ Map {
 
 Class<RCTComponentViewProtocol> RCTThirdPartyFabricComponentsProvider(const char *name) {
   static std::unordered_map<std::string, Class (*)(void)> sFabricComponentsClassMap = {
+    #ifndef RCT_DYNAMIC_FRAMEWORKS
 
     {\\"NoPropsNoEventsComponent\\", NoPropsNoEventsComponentCls}, // NO_PROPS_NO_EVENTS
 
@@ -80,6 +81,7 @@ Class<RCTComponentViewProtocol> RCTThirdPartyFabricComponentsProvider(const char
 
 
     {\\"MultiFileIncludedNativeComponent\\", MultiFileIncludedNativeComponentCls}, // EXCLUDE_IOS_TWO_COMPONENTS_DIFFERENT_FILES
+    #endif
   };
 
   auto p = sFabricComponentsClassMap.find(name);

--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.h
@@ -9,6 +9,7 @@
 #import <React/RCTBridgeDelegate.h>
 #import <UIKit/UIKit.h>
 
+@protocol RCTComponentViewProtocol;
 @class RCTSurfacePresenterBridgeAdapter;
 
 /**
@@ -95,6 +96,14 @@
 
 #if RCT_NEW_ARCH_ENABLED
 @property (nonatomic, strong) RCTSurfacePresenterBridgeAdapter *bridgeAdapter;
+
+/// This method returns a map of Component Descriptors and Components classes that needs to be registered in the
+/// new renderer. The Component Descriptor is a string which represent the name used in JS to refer to the native
+/// component. The default implementation returns an empty dictionary. Subclasses can override this method to register
+/// the required components.
+///
+/// @return a dictionary that associate a component for the new renderer with his descriptor.
+- (NSDictionary<NSString *, Class<RCTComponentViewProtocol>> *)thirdPartyFabricComponents;
 
 /// This method controls whether the `turboModules` feature of the New Architecture is turned on or off.
 ///

--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -11,6 +11,8 @@
 
 #if RCT_NEW_ARCH_ENABLED
 #import <React/CoreModulesPlugins.h>
+#import <React/RCTComponentViewFactory.h>
+#import <React/RCTComponentViewProtocol.h>
 #import <React/RCTCxxBridgeDelegate.h>
 #import <React/RCTFabricSurfaceHostingProxyRootView.h>
 #import <React/RCTLegacyViewManagerInteropComponentView.h>
@@ -24,7 +26,10 @@
 
 static NSString *const kRNConcurrentRoot = @"concurrentRoot";
 
-@interface RCTAppDelegate () <RCTTurboModuleManagerDelegate, RCTCxxBridgeDelegate> {
+@interface RCTAppDelegate () <
+    RCTTurboModuleManagerDelegate,
+    RCTCxxBridgeDelegate,
+    RCTComponentViewFactoryComponentProvider> {
   std::shared_ptr<const facebook::react::ReactNativeConfig> _reactNativeConfig;
   facebook::react::ContextContainer::Shared _contextContainer;
   std::shared_ptr<facebook::react::RuntimeScheduler> _runtimeScheduler;
@@ -64,6 +69,7 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
   self.bridge.surfacePresenter = self.bridgeAdapter.surfacePresenter;
 
   [self unstable_registerLegacyComponents];
+  [RCTComponentViewFactory currentComponentViewFactory].thirdPartyFabricComponentsProvider = self;
 #endif
 
   NSDictionary *initProps = [self prepareInitialProps];
@@ -161,6 +167,13 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
 - (id<RCTTurboModule>)getModuleInstanceFromClass:(Class)moduleClass
 {
   return RCTAppSetupDefaultModuleFromClass(moduleClass);
+}
+
+#pragma mark - RCTComponentViewFactoryComponentProvider
+
+- (NSDictionary<NSString *, Class<RCTComponentViewProtocol>> *)thirdPartyFabricComponents
+{
+  return @{};
 }
 
 #pragma mark - New Arch Enabled settings

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -18,6 +18,10 @@
 #import <react/renderer/components/view/ViewEventEmitter.h>
 #import <react/renderer/components/view/ViewProps.h>
 
+#ifdef RCT_DYNAMIC_FRAMEWORKS
+#import <React/RCTComponentViewFactory.h>
+#endif
+
 using namespace facebook::react;
 
 @implementation RCTViewComponentView {
@@ -29,6 +33,13 @@ using namespace facebook::react;
   NSMutableArray<UIView *> *_reactSubviews;
   NSSet<NSString *> *_Nullable _propKeysManagedByAnimated_DO_NOT_USE_THIS_IS_BROKEN;
 }
+
+#ifdef RCT_DYNAMIC_FRAMEWORKS
++ (void)load
+{
+  [RCTComponentViewFactory.currentComponentViewFactory registerComponentViewClass:self];
+}
+#endif
 
 - (instancetype)initWithFrame:(CGRect)frame
 {

--- a/packages/react-native/React/Fabric/Mounting/RCTComponentViewFactory.h
+++ b/packages/react-native/React/Fabric/Mounting/RCTComponentViewFactory.h
@@ -17,10 +17,26 @@ NS_ASSUME_NONNULL_BEGIN
 void RCTInstallNativeComponentRegistryBinding(facebook::jsi::Runtime &runtime);
 
 /**
+ * Protocol that can be implemented to provide some 3rd party components to Fabric.
+ * Fabric will check in this map whether there are some components that need to be registered.
+ */
+@protocol RCTComponentViewFactoryComponentProvider <NSObject>
+
+/**
+ * Return a dictionary of third party components where the `key` is the Component Handler and the `value` is a Class
+ * that conforms to `RCTComponentViewProtocol`.
+ */
+- (NSDictionary<NSString *, Class<RCTComponentViewProtocol>> *)thirdPartyFabricComponents;
+
+@end
+
+/**
  * Registry of supported component view classes that can instantiate
  * view component instances by given component handle.
  */
 @interface RCTComponentViewFactory : NSObject
+
+@property (nonatomic, weak) id<RCTComponentViewFactoryComponentProvider> thirdPartyFabricComponentsProvider;
 
 /**
  * Constructs and returns an instance of the class with a bunch of already registered standard components.

--- a/packages/react-native/scripts/cocoapods/new_architecture.rb
+++ b/packages/react-native/scripts/cocoapods/new_architecture.rb
@@ -67,6 +67,17 @@ class NewArchitectureHelper
                 end
             end
 
+            # Set "RCT_DYNAMIC_FRAMEWORKS=1" if pod are installed with USE_FRAMEWORKS=dynamic
+            # This helps with backward compatibility.
+            if pod_name == 'React-RCTFabric' && ENV['USE_FRAMEWORKS'] == 'dynamic'
+                Pod::UI.puts "Adding RCT_DYNAMIC_FRAMEWORKS=1 to React-RCTFabric".yellow
+                rct_dynamic_framework_flag = " -DRCT_DYNAMIC_FRAMEWORKS=1"
+                target_installation_result.native_target.build_configurations.each do |config|
+                    prev_build_settings = config.build_settings['OTHER_CPLUSPLUSFLAGS'] != nil ? config.build_settings['OTHER_CPLUSPLUSFLAGS'] : "$(inherithed)"
+                    config.build_settings['OTHER_CPLUSPLUSFLAGS'] = prev_build_settings + rct_dynamic_framework_flag
+                end
+            end
+
             target_installation_result.native_target.build_configurations.each do |config|
                 if config.name == "Release"
                     current_flags = config.build_settings['OTHER_CPLUSPLUSFLAGS'] != nil ? config.build_settings['OTHER_CPLUSPLUSFLAGS'] : "$(inherited)"

--- a/packages/react-native/scripts/cocoapods/new_architecture.rb
+++ b/packages/react-native/scripts/cocoapods/new_architecture.rb
@@ -70,7 +70,6 @@ class NewArchitectureHelper
             # Set "RCT_DYNAMIC_FRAMEWORKS=1" if pod are installed with USE_FRAMEWORKS=dynamic
             # This helps with backward compatibility.
             if pod_name == 'React-RCTFabric' && ENV['USE_FRAMEWORKS'] == 'dynamic'
-                Pod::UI.puts "Adding RCT_DYNAMIC_FRAMEWORKS=1 to React-RCTFabric".yellow
                 rct_dynamic_framework_flag = " -DRCT_DYNAMIC_FRAMEWORKS=1"
                 target_installation_result.native_target.build_configurations.each do |config|
                     prev_build_settings = config.build_settings['OTHER_CPLUSPLUSFLAGS'] != nil ? config.build_settings['OTHER_CPLUSPLUSFLAGS'] : "$(inherithed)"

--- a/packages/rn-tester/NativeComponentExample/ios/RNTMyNativeViewComponentView.mm
+++ b/packages/rn-tester/NativeComponentExample/ios/RNTMyNativeViewComponentView.mm
@@ -28,6 +28,14 @@ using namespace facebook::react;
   return concreteComponentDescriptorProvider<RNTMyNativeViewComponentDescriptor>();
 }
 
+// Load is not invoked if it is not defined, therefore, we must ask to update this.
+// See the Apple documentation: https://developer.apple.com/documentation/objectivec/nsobject/1418815-load?language=objc
+// "[...] but only if the newly loaded class or category implements a method that can respond."
++ (void)load
+{
+  [super load];
+}
+
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if (self = [super initWithFrame:frame]) {

--- a/packages/rn-tester/RNTester/AppDelegate.mm
+++ b/packages/rn-tester/RNTester/AppDelegate.mm
@@ -49,6 +49,7 @@
 #endif
 
 #ifdef RN_FABRIC_ENABLED
+#import <React/RCTComponentViewFactory.h>
 #import <React/RCTFabricSurfaceHostingProxyRootView.h>
 #import <React/RCTSurfacePresenter.h>
 #import <React/RCTSurfacePresenterBridgeAdapter.h>
@@ -58,6 +59,10 @@
 #import <react/renderer/runtimescheduler/RuntimeScheduler.h>
 #import <react/renderer/runtimescheduler/RuntimeSchedulerBinding.h>
 #import <react/renderer/runtimescheduler/RuntimeSchedulerCallInvoker.h>
+#endif
+
+#if RCT_NEW_ARCH_ENABLED
+#import <RNTMyNativeViewComponentView.h>
 #endif
 
 #if DEBUG
@@ -85,6 +90,12 @@
 }
 @end
 
+#if RCT_NEW_ARCH_ENABLED
+/// Declare conformance to `RCTComponentViewFactoryComponentProvider`
+@interface AppDelegate () <RCTComponentViewFactoryComponentProvider>
+@end
+#endif
+
 static NSString *const kRNConcurrentRoot = @"concurrentRoot";
 
 @implementation AppDelegate
@@ -109,6 +120,10 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
 
   // Appetizer.io params check
   NSDictionary *initProps = [self prepareInitialProps];
+
+#if RCT_NEW_ARCH_ENABLED
+  [RCTComponentViewFactory currentComponentViewFactory].thirdPartyFabricComponentsProvider = self;
+#endif
 
 #ifdef RN_FABRIC_ENABLED
   _bridgeAdapter = [[RCTSurfacePresenterBridgeAdapter alloc] initWithBridge:_bridge contextContainer:_contextContainer];
@@ -331,6 +346,15 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
   [RCTPushNotificationManager didReceiveLocalNotification:notification];
 }
 
+#endif
+
+#pragma mark - RCTComponentViewFactoryComponentProvider
+
+#if RCT_NEW_ARCH_ENABLED
+- (nonnull NSDictionary<NSString *, Class<RCTComponentViewProtocol>> *)thirdPartyFabricComponents
+{
+  return @{@"RNTMyNativeView" : RNTMyNativeViewComponentView.class};
+}
 #endif
 
 @end


### PR DESCRIPTION
Summary:
This change enables some tests on RNTester and on the Template to verify that we won't be breaking `use_frameworks!` again in the future.

## Changelog:
[iOS][Added] - Add tests to check use frameworks with dynamic linking.

Differential Revision: D45605977

