### PR TITLE
Introduce ReactInstanceDelegate.Builder

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactInstanceDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactInstanceDelegate.kt
@@ -16,6 +16,7 @@ import com.facebook.react.fabric.ReactNativeConfig
 import com.facebook.react.turbomodule.core.TurboModuleManager
 import com.facebook.react.turbomodule.core.TurboModuleManagerDelegate
 
+/** TODO: add javadoc for class and methods */
 @ThreadSafe
 interface ReactInstanceDelegate {
   val jSMainModulePath: String
@@ -33,4 +34,26 @@ interface ReactInstanceDelegate {
   fun handleInstanceException(e: Exception)
 
   fun getReactNativeConfig(turboModuleManager: TurboModuleManager): ReactNativeConfig
+
+  class ReactInstanceDelegateBase(
+      override val jSMainModulePath: String,
+      override val bindingsInstaller: BindingsInstaller,
+      override val reactPackages: List<ReactPackage>,
+      private val jsBundleLoader: JSBundleLoader,
+      private val turboModuleManagerDelegate: TurboModuleManagerDelegate,
+      private val jsEngineInstance: JSEngineInstance,
+      private val reactNativeConfig: ReactNativeConfig,
+      private val exceptionHandler: (Exception) -> Unit = {}
+  ) : ReactInstanceDelegate {
+    override fun getJSBundleLoader(context: Context) = jsBundleLoader
+
+    override fun getTurboModuleManagerDelegate(context: ReactApplicationContext) =
+        turboModuleManagerDelegate
+
+    override fun getJSEngineInstance(context: ReactApplicationContext) = jsEngineInstance
+
+    override fun getReactNativeConfig(turboModuleManager: TurboModuleManager) = reactNativeConfig
+
+    override fun handleInstanceException(e: Exception) = exceptionHandler(e)
+  }
 }


### PR DESCRIPTION
Summary:
In this diff I'm introducing the ReactInstanceDelegate.Builder class that will be used to initialize ReactHost in Android

This class is still under development, it is missing:
- Tests
- Documentantion for class and methods
- Default objects for optional fields on ReactInstanceDelegate.Builder

The goal of this diff is to introduce the class, test UnstableReactNativeAPI annotation and create a diff stack that shows the process to create a stable API in Android.

bypass-github-export-checks

changelog: [internal] internal

Reviewed By: cortinico

Differential Revision: D45509432

