### PR TITLE
Mark ReactInstanceDelegate as UnstableReactNativeAPI

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactInstanceDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactInstanceDelegate.kt
@@ -12,12 +12,14 @@ import com.facebook.infer.annotation.ThreadSafe
 import com.facebook.react.ReactPackage
 import com.facebook.react.bridge.JSBundleLoader
 import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.fabric.ReactNativeConfig
 import com.facebook.react.turbomodule.core.TurboModuleManager
 import com.facebook.react.turbomodule.core.TurboModuleManagerDelegate
 
 /** TODO: add javadoc for class and methods */
 @ThreadSafe
+@UnstableReactNativeAPI
 interface ReactInstanceDelegate {
   val jSMainModulePath: String
 
@@ -35,6 +37,7 @@ interface ReactInstanceDelegate {
 
   fun getReactNativeConfig(turboModuleManager: TurboModuleManager): ReactNativeConfig
 
+  @UnstableReactNativeAPI
   class ReactInstanceDelegateBase(
       override val jSMainModulePath: String,
       override val bindingsInstaller: BindingsInstaller,

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridgeless/ReactInstanceDelegateTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridgeless/ReactInstanceDelegateTest.kt
@@ -21,9 +21,11 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
-@UnstableReactNativeAPI
+@OptIn(UnstableReactNativeAPI::class)
 @Config(shadows = [ShadowSoLoader::class])
 class ReactInstanceDelegateTest {
+
+  /** Mock test for ReactInstanceDelegate, used to setup the process to create a stable API */
   @Test
   fun testReactInstanceDelegateCreation() {
     val jsBundleLoader: JSBundleLoader = Mockito.mock(JSBundleLoader::class.java)


### PR DESCRIPTION
Summary:
In this diff I'm marking ReactInstanceDelegate as UnstableReactNativeAPI

changelog: [internal] internal

Reviewed By: RSNara

Differential Revision: D45577887

