### PR TITLE
Fix broken android extraction/translation pipeline

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
   <string name="catalyst_reload" project="catalyst" translatable="false">Reload</string>
   <string name="catalyst_reload_error" project="catalyst" translatable="false">Failed to load bundle. Try restarting the bundler or reconnecting your device.</string>
   <string name="catalyst_change_bundle_location" project="catalyst" translatable="false">Change Bundle Location</string>
@@ -26,6 +26,6 @@
   <string name="catalyst_loading_from_url" project="catalyst" translatable="false">Loading from %1$s…</string>
   <string name="catalyst_sample_profiler_disable" project="catalyst" translatable="false">Disable Sampling Profiler</string>
   <string name="catalyst_sample_profiler_enable" project="catalyst" translatable="false">Enable Sampling Profiler</string>
-  <string name="catalyst_dev_menu_header">React Native Dev Menu (%1$s)</string>
-  <string name="catalyst_dev_menu_sub_header">Running %1$s</string>
+  <string name="catalyst_dev_menu_header">React Native Dev Menu <xliff:g id="menu_header_name">(%1$s)</xliff:g></string>
+  <string name="catalyst_dev_menu_sub_header">Running <xliff:g id="menu_sub_header_name">%1$s</xliff:g></string>
 </resources>


### PR DESCRIPTION
Summary:
<level:mustfix> <name:i18n.error> Failed extracting strings from file: <../xplat/js/react-native-github/packages/react-native/ReactAndroid/src/main/res/devsupport/values/strings.xml>
From IntlAndroidResourceExtractionException: Failed extracting resource catalyst_dev_menu_header
From InvariantViolationException: Format specifiers must be wrapped by an xliff:g tag
(FBLogger Parent Frame: /var/sandcastle/deployment/mount/54023/flib/intern/intl/extraction/StringExtractionLogger.php:43)

https://www.internalfb.com/skycastle/run/1932044240142241285/insights

Changelog:
[Internal] [Changed] - Fix broken pipelines

Differential Revision: D45615679

