### PR TITLE
fix: fix FlatList viewabilityConfig prop type

### DIFF
--- a/packages/react-native/Libraries/Lists/FlatList.d.ts
+++ b/packages/react-native/Libraries/Lists/FlatList.d.ts
@@ -12,6 +12,7 @@ import type {
   ListRenderItem,
   ViewToken,
   VirtualizedListProps,
+  ViewabilityConfig,
 } from '@react-native/virtualized-lists';
 import type {ScrollViewComponent} from '../Components/ScrollView/ScrollView';
 import type {StyleProp} from '../StyleSheet/StyleSheet';
@@ -144,7 +145,7 @@ export interface FlatListProps<ItemT> extends VirtualizedListProps<ItemT> {
   /**
    * See `ViewabilityHelper` for flow type and further documentation.
    */
-  viewabilityConfig?: any | undefined;
+  viewabilityConfig?: ViewabilityConfig | undefined;
 
   /**
    * Note: may have bugs (missing content) in some circumstances - use at your own risk.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

FlatList `viewabilityConfig` prop seems  no need to be any type. So I replaced it with `ViewabilityConfig` from `VirtualizedList.d.ts`

## Changelog:

[GENERAL] [FIXED] - change FlatList `viewabilityConfig` prop type `any` to `ViewabilityConfig`

## Test Plan:

Ran yarn test-typescript and yarn test-typescript-offline with no errors.
