### PR TITLE
Use `ContextContainer::find()` for MC access instead of `ContextContainer::at()`

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/PropsParserContext.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/PropsParserContext.cpp
@@ -13,10 +13,11 @@ namespace facebook::react {
 
 bool PropsParserContext::treatAutoAsYGValueUndefined() const {
   if (treatAutoAsYGValueUndefined_ == std::nullopt) {
-    auto config = contextContainer.at<std::shared_ptr<const ReactNativeConfig>>(
-        "ReactNativeConfig");
-    treatAutoAsYGValueUndefined_ = config
-        ? config->getBool("react_fabric:treat_auto_as_undefined")
+    auto config =
+        contextContainer.find<std::shared_ptr<const ReactNativeConfig>>(
+            "ReactNativeConfig");
+    treatAutoAsYGValueUndefined_ = config && *config != nullptr
+        ? (*config)->getBool("react_fabric:treat_auto_as_undefined")
         : false;
   }
 


### PR DESCRIPTION
Summary:
Intent of a change to the last diff was to make `PropsParserContext` act gracefully if it tried to parse "auto" without a `ReactNativeConfig` being set (e.g. if our tests wanted to do that).

We would actually assert if we tried to do that with what I added, since `ContextContainer::at()` acts like `at()` does in the STL containers and will expect the parameter to be in bounds/present. (`RawProps::at()` is the odd one out that will return `nullptr` instead).

This changes the usage to ContextContainer::find() which will return ` std::optional<std::shared_ptr>>`.

Changelog: [Internal]

Differential Revision: D45651032

