### PR TITLE
Re-add "aria-live" usage to UTs

### DIFF
--- a/packages/react-native/Libraries/Components/TextInput/__tests__/TextInput-test.js
+++ b/packages/react-native/Libraries/Components/TextInput/__tests__/TextInput-test.js
@@ -322,7 +322,7 @@ describe('TextInput compat with web', () => {
       'aria-label': 'label',
       'aria-labelledby': 'labelledby',
       'aria-level': 3,
-      // aria-live': 'polite', [TODO: https://github.com/facebook/react-native-deprecated-modules/pull/20]
+      'aria-live': 'polite',
       'aria-modal': true,
       'aria-multiline': true,
       'aria-multiselectable': true,
@@ -381,6 +381,7 @@ describe('TextInput compat with web', () => {
         aria-label="label"
         aria-labelledby="labelledby"
         aria-level={3}
+        aria-live="polite"
         aria-modal={true}
         aria-multiline={true}
         aria-multiselectable={true}


### PR DESCRIPTION
Summary:
This should no longer log to `console.error()` after the latest prop-types update.

Changelog: [Internal]

Differential Revision: D45654389

