### PR TITLE
Fix for investigating high number of ReactViewManager exceptions

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManagerWrapper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManagerWrapper.kt
@@ -17,7 +17,7 @@ import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.ViewManager
 
 /** Temporary to help trace the cause of T151032868 */
-class ReactViewReturnTypeException(message: String) : Exception(message)
+class ReactViewReturnTypeException(message: String, e: Throwable) : Exception(message, e)
 
 interface ReactViewManagerWrapper {
   fun createView(
@@ -55,20 +55,15 @@ interface ReactViewManagerWrapper {
         stateWrapper: StateWrapper?,
         jsResponderHandler: JSResponderHandler
     ): View {
-      val manager =
-          viewManager.createView(
-              reactTag,
-              reactContext,
-              props as? ReactStylesDiffMap,
-              stateWrapper,
-              jsResponderHandler)
-      // Throwing to try capture information about the cause of T151032868, remove after.
-      @Suppress("SENSELESS_COMPARISON")
-      if (manager == null) {
+      try {
+        return viewManager.createView(
+            reactTag, reactContext, props as? ReactStylesDiffMap, stateWrapper, jsResponderHandler)
+      } catch (e: NullPointerException) {
+        // Throwing to try capture information about the cause of T151032868, remove after.
         throw ReactViewReturnTypeException(
-            "DefaultViewManagerWrapper::createView(${viewManager.getName()}, ${viewManager::class.java}) can't return null")
+            "DefaultViewManagerWrapper::createView(${viewManager.getName()}, ${viewManager::class.java}) can't return null",
+            e)
       }
-      return manager
     }
 
     override fun updateProperties(viewToUpdate: View, props: Any?) {


### PR DESCRIPTION
Summary:
## Why?
Internally one of our apps is using a custom view manager that isn't respecting the `NotNull` constraint,
causing a runtime error. We have no visibility over what this manager is. The custom exception will give
us more clues to track this down.

If you look at the below stack trace, it's pretty clear the earlier approach would fail:
{F979121677}

Like a bit of a noddy, I've been waiting for days for the new exception to be hit, when it's very clear from [3 May](https://fburl.com/scuba/errorreporting_facebook_android_crashes/a63t7ilm) that this wasn't going to happen:
{F979130611}
The lesson here is to monitor 3 things:
1. the [original NullPointerExceptions](https://fburl.com/scuba/errorreporting_facebook_android_crashes/m2o0t45h),
2. the new [ReactViewReturnTypeException](https://fburl.com/scuba/errorreporting_facebook_android_crashes/2j0vtuwb), and
3. the [number of users exposed](https://fburl.com/scuba/mobile_active_users/9mbevwed) to whatever release this change goes out on.

Changelog: [Internal]
The NullPointerExceptions are hit when call the the java createView method. Previous (D45185598)
didn't capture this exception and wasn't very useful.

Differential Revision: D45660487

