### PR TITLE
Fix YGNodeSetConfig causing excessive dirtying

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
@@ -120,9 +120,13 @@ YogaLayoutableShadowNode::YogaLayoutableShadowNode(
     }
   }
 
+  YGConfigRef previousConfig = YGNodeGetConfig(
+      &static_cast<YogaLayoutableShadowNode const &>(sourceShadowNode)
+           .yogaNode_);
+
   yogaNode_.setContext(this);
   yogaNode_.setOwner(nullptr);
-  yogaNode_.setConfig(&initializeYogaConfig(yogaConfig_));
+  yogaNode_.setConfig(&initializeYogaConfig(yogaConfig_, previousConfig));
   updateYogaChildrenOwnersIfNeeded();
 
   // This is the only legit place where we can dirty cloned Yoga node.
@@ -742,10 +746,17 @@ YogaLayoutableShadowNode &YogaLayoutableShadowNode::shadowNodeFromContext(
       *static_cast<ShadowNode *>(yogaNode->getContext()));
 }
 
-YGConfig &YogaLayoutableShadowNode::initializeYogaConfig(YGConfig &config) {
+YGConfig &YogaLayoutableShadowNode::initializeYogaConfig(
+    YGConfig &config,
+    const YGConfigRef previousConfig) {
   YGConfigSetCloneNodeFunc(
       &config, YogaLayoutableShadowNode::yogaNodeCloneCallbackConnector);
   YGConfigSetErrata(&config, YGErrataAll);
+  if (previousConfig != nullptr) {
+    YGConfigSetPointScaleFactor(
+        &config, YGConfigGetPointScaleFactor(previousConfig));
+  }
+
 #ifdef RN_DEBUG_YOGA_LOGGER
   YGConfigSetPrintTreeFlag(&config, true);
 #endif

--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.h
@@ -132,7 +132,9 @@ class YogaLayoutableShadowNode : public LayoutableShadowNode {
    */
   void adoptYogaChild(size_t index);
 
-  static YGConfig &initializeYogaConfig(YGConfig &config);
+  static YGConfig &initializeYogaConfig(
+      YGConfig &config,
+      YGConfigRef previousConfig = nullptr);
   static YGNode *yogaNodeCloneCallbackConnector(
       YGNode *oldYogaNode,
       YGNode *parentYogaNode,

--- a/packages/react-native/ReactCommon/yoga/yoga/Yoga.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/Yoga.cpp
@@ -4075,6 +4075,10 @@ YOGA_EXPORT void YGConfigSetPointScaleFactor(
   }
 }
 
+YOGA_EXPORT float YGConfigGetPointScaleFactor(const YGConfigRef config) {
+  return config->getPointScaleFactor();
+}
+
 static void YGRoundToPixelGrid(
     const YGNodeRef node,
     const double pointScaleFactor,

--- a/packages/react-native/ReactCommon/yoga/yoga/Yoga.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/Yoga.h
@@ -317,6 +317,7 @@ WIN_EXPORT void YGAssertWithConfig(
 WIN_EXPORT void YGConfigSetPointScaleFactor(
     YGConfigRef config,
     float pixelsInPoint);
+WIN_EXPORT float YGConfigGetPointScaleFactor(YGConfigRef config);
 
 // Yoga previously had an error where containers would take the maximum space
 // possible instead of the minimum like they are supposed to. In practice this


### PR DESCRIPTION
Summary:
In Fabric, a ShadowNode may re-initialize YGConfig several times throughout the lifetime of a perpetually cloned Yoga Node.

RN sets `pointScaleFactor` lazily, when laying out the rootview. So right now it initializes a config to `pointScaleFactor` of 1.0, sets it, sets a new `pointScaleFactor` on the config, then repeats. This cycles the config between two `pointScaleFactor` values and will excessively dirty the node.

This change makes it so that we retain previously used `pointScaleFactor` when cloning the Yoga nodes.

Changelog: [Internal]

Differential Revision: D45669878

