### PR TITLE
Combine iOS and Android optimisations

### DIFF
--- a/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
+++ b/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
@@ -281,10 +281,6 @@ static BackgroundExecutor RCTGetBackgroundExecutor()
     CoreFeatures::useNativeState = true;
   }
 
-  if (reactNativeConfig && reactNativeConfig->getBool("react_fabric:enable_nstextstorage_caching")) {
-    CoreFeatures::cacheNSTextStorage = true;
-  }
-
   if (reactNativeConfig && reactNativeConfig->getBool("react_fabric:cancel_image_downloads_on_recycle")) {
     CoreFeatures::cancelImageDownloadsOnRecycle = true;
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
@@ -97,9 +97,6 @@ public class ReactFeatureFlags {
   /** Feature Flag to enable the pending event queue in fabric before mounting views */
   public static boolean enableFabricPendingEventQueue = false;
 
-  /** Feature Flag to enable caching mechanism of text measurement at shadow node level */
-  public static boolean enableTextMeasureCachePerShadowNode = false;
-
   /**
    * Feature flag that controls how turbo modules are exposed to JS
    *

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.cpp
@@ -421,8 +421,6 @@ void Binding::installFabricUIManager(
       "CalculateTransformedFramesEnabled",
       getFeatureFlagValue("calculateTransformedFramesEnabled"));
 
-  CoreFeatures::cacheLastTextMeasurement =
-      getFeatureFlagValue("enableTextMeasureCachePerShadowNode");
   CoreFeatures::enablePropIteratorSetter =
       getFeatureFlagValue("enableCppPropsIteratorSetter");
   CoreFeatures::useNativeState = getFeatureFlagValue("useNativeState");

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphLayoutManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphLayoutManager.h
@@ -52,20 +52,41 @@ class ParagraphLayoutManager {
 
  private:
   std::shared_ptr<TextLayoutManager const> mutable textLayoutManager_{};
+
+  /*
+   * Stores opaque pointer to `NSTextStorage` on iOS. nullptr on Android.
+   * TODO: In the future, we may want to cache Android's text storage.
+   */
   std::shared_ptr<void> mutable hostTextStorage_{};
 
+  /*
+   * Hash of AttributedString and ParagraphAttributes last used to
+   * measure. Result of that measure is stored in cachedTextMeasurement_.
+   * The available width defined for the measurement is stored in
+   * lastAvailableWidth_.
+   */
+  size_t mutable paragraphInputHash_{};
+
   /* The width Yoga set as maximum width.
-   * Yoga sometimes calls measure twice with two
-   * different maximum width. One if available space.
+   * Yoga calls measure twice with two
+   * different maximum width. One of available space.
    * The other one is exact space needed for the string.
    * This happens when node is dirtied but its size is not affected.
    * To deal with this inefficiency, we cache `TextMeasurement` for each
    * `ParagraphShadowNode`. If Yoga tries to re-measure with available width
    * or exact width, we provide it with the cached value.
    */
-  Float mutable availableWidth_{};
+  Float mutable lastAvailableWidth_{};
   TextMeasurement mutable cachedTextMeasurement_{};
 
-  size_t mutable hash_{};
+  /*
+   * Checks whether the inputs into text measurement meaningfully affect
+   * text measurement result. Returns true if inputs have changed and measure is
+   * needed.
+   */
+  bool shoudMeasureString(
+      AttributedString const &attributedString,
+      ParagraphAttributes const &paragraphAttributes,
+      LayoutConstraints layoutConstraints) const;
 };
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/CoreFeatures.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/CoreFeatures.cpp
@@ -13,7 +13,6 @@ bool CoreFeatures::enablePropIteratorSetter = false;
 bool CoreFeatures::enableMapBuffer = false;
 bool CoreFeatures::blockPaintForUseLayoutEffect = false;
 bool CoreFeatures::useNativeState = false;
-bool CoreFeatures::cacheNSTextStorage = false;
 bool CoreFeatures::cacheLastTextMeasurement = false;
 bool CoreFeatures::cancelImageDownloadsOnRecycle = false;
 

--- a/packages/react-native/ReactCommon/react/renderer/core/CoreFeatures.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/CoreFeatures.h
@@ -34,14 +34,10 @@ class CoreFeatures {
   // in simple data passing scenarios with JS
   static bool useNativeState;
 
-  // Creating NSTextStorage is relatively expensive operation and we were
-  // creating it twice. Once when measuring text and once when rendering it.
-  // This flag caches it inside ParagraphState.
-  static bool cacheNSTextStorage;
-
   // Yoga might measure multiple times the same Text with the same constraints
   // This flag enables a caching mechanism to avoid subsequents measurements
   // of the same Text with the same constrainst.
+  // On iOS, we also cache NSTextStorage.
   static bool cacheLastTextMeasurement;
 
   // Fabric was not cancelling image downloads when <ImageView /> was removed

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
@@ -131,6 +131,9 @@ Scheduler::Scheduler(
   CoreFeatures::blockPaintForUseLayoutEffect = reactNativeConfig_->getBool(
       "react_fabric:block_paint_for_use_layout_effect");
 
+  CoreFeatures::cacheLastTextMeasurement =
+      reactNativeConfig_->getBool("react_fabric:enable_text_measure_cache");
+
   if (animationDelegate != nullptr) {
     animationDelegate->setComponentDescriptorRegistry(
         componentDescriptorRegistry_);


### PR DESCRIPTION
Summary:
changelog: [internal]

This diff does three things:
1. Combines Android's mobile config `react_fabric:enable_text_measure_cache` with iOS mobile config `react_fabric:enable_nstextstorage_caching`. We will get into why later.
2. Fixes cache `ParagraphLayoutManager::cachedTextMeasurement_` invalidation logic for iOS and Android.
3. Fixes cache invalidation logic for `ParagraphLayoutManager::hostTextStorage_`.

Initially, Android's text measure cache (D44221170) and iOS's NSTextStorage (D43692171) were design as two separate optimisations. But they overlap and NSTextStorage actually needs some parts of text measure cache to work correctly. That's why I decided to merge them together.

Previously, `ParagraphLayoutManager::cachedTextMeasurement_` was only invalidated if maximum width for the node changed. But node can change in different ways, for example input string changes or attributes change. This diff accounts for that by computing a hash for AttributedString+ParagraphAttributes to check if anything has changed.

Previously, `ParagraphLayoutManager::hostTextStorage_` was not correctly invalidated if maximum width changed. To my surprise, this happens less frequently than one expects.

Differential Revision: D45637797

