### PR TITLE
Mark BindingsInstaller as optional parameter in ReactHostDelegate

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHostDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHostDelegate.kt
@@ -23,7 +23,7 @@ import com.facebook.react.turbomodule.core.TurboModuleManagerDelegate
 interface ReactHostDelegate {
   val jSMainModulePath: String
 
-  val bindingsInstaller: BindingsInstaller
+  val bindingsInstaller: BindingsInstaller?
 
   val reactPackages: List<ReactPackage>
 
@@ -40,7 +40,7 @@ interface ReactHostDelegate {
   @UnstableReactNativeAPI
   class ReactHostDelegateBase(
       override val jSMainModulePath: String,
-      override val bindingsInstaller: BindingsInstaller,
+      override val bindingsInstaller: BindingsInstaller? = null,
       override val reactPackages: List<ReactPackage>,
       private val jsBundleLoader: JSBundleLoader,
       private val turboModuleManagerDelegate: TurboModuleManagerDelegate,


### PR DESCRIPTION
Summary:
BindingsInstaller is not required to initialize react native, marking this as optional parameter in ReactHostDelegate

changelog: [internal] internal

Reviewed By: RSNara

Differential Revision: D45578882

