### PR TITLE
introduce RCTHostJSEngineProvider

### DIFF
--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.h
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.h
@@ -34,6 +34,8 @@ RCT_EXTERN NSString *const RCTHostWillReloadNotification;
  */
 RCT_EXTERN NSString *const RCTHostDidReloadNotification;
 
+typedef std::shared_ptr<facebook::react::JSEngineInstance> (^RCTHostJSEngineProvider)(void);
+
 @protocol RCTHostDelegate <NSObject>
 
 - (std::shared_ptr<facebook::react::JSEngineInstance>)getJSEngine;
@@ -53,7 +55,8 @@ RCT_EXTERN NSString *const RCTHostDidReloadNotification;
           turboModuleManagerDelegate:(id<RCTTurboModuleManagerDelegate>)turboModuleManagerDelegate
                  bindingsInstallFunc:(facebook::react::ReactInstance::BindingsInstallFunc)bindingsInstallFunc
                  jsErrorHandlingFunc:(facebook::react::JsErrorHandler::JsErrorHandlingFunc)jsErrorHandlingFunc
-    NS_DESIGNATED_INITIALIZER FB_OBJC_DIRECT;
+                    jsEngineProvider:(nullable RCTHostJSEngineProvider)jsEngineProvider NS_DESIGNATED_INITIALIZER
+    FB_OBJC_DIRECT;
 
 /**
  * This function initializes an RCTInstance if one does not yet exist.  This function is currently only called on the

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.mm
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.mm
@@ -34,6 +34,7 @@ NSString *const RCTHostDidReloadNotification = @"RCTHostDidReloadNotification";
   RCTBundleManager *_bundleManager;
   facebook::react::ReactInstance::BindingsInstallFunc _bindingsInstallFunc;
   JsErrorHandler::JsErrorHandlingFunc _jsErrorHandlingFunc;
+  RCTHostJSEngineProvider _jsEngineProvider;
 
   // All the surfaces that need to be started after main bundle execution
   NSMutableArray<RCTFabricSurface *> *_surfaceStartBuffer;
@@ -57,7 +58,8 @@ NSString *const RCTHostDidReloadNotification = @"RCTHostDidReloadNotification";
 - (instancetype)initWithHostDelegate:(id<RCTHostDelegate>)hostDelegate
           turboModuleManagerDelegate:(id<RCTTurboModuleManagerDelegate>)turboModuleManagerDelegate
                  bindingsInstallFunc:(facebook::react::ReactInstance::BindingsInstallFunc)bindingsInstallFunc
-                 jsErrorHandlingFunc:(JsErrorHandler::JsErrorHandlingFunc)jsErrorHandlingFunc;
+                 jsErrorHandlingFunc:(JsErrorHandler::JsErrorHandlingFunc)jsErrorHandlingFunc
+                    jsEngineProvider:(nullable RCTHostJSEngineProvider)jsEngineProvider
 {
   if (self = [super init]) {
     _hostDelegate = hostDelegate;
@@ -67,6 +69,7 @@ NSString *const RCTHostDidReloadNotification = @"RCTHostDidReloadNotification";
     _bindingsInstallFunc = bindingsInstallFunc;
     _moduleRegistry = [RCTModuleRegistry new];
     _jsErrorHandlingFunc = jsErrorHandlingFunc;
+    _jsEngineProvider = [jsEngineProvider copy];
 
     __weak RCTHost *weakHost = self;
 
@@ -148,14 +151,15 @@ NSString *const RCTHostDidReloadNotification = @"RCTHostDidReloadNotification";
   }
   [self _refreshBundleURL];
   RCTReloadCommandSetBundleURL(_bundleURL);
-  _instance = [[RCTInstance alloc] initWithDelegate:self
-                                   jsEngineInstance:[_hostDelegate getJSEngine]
-                                      bundleManager:_bundleManager
-                         turboModuleManagerDelegate:_turboModuleManagerDelegate
-                                onInitialBundleLoad:_onInitialBundleLoad
-                                bindingsInstallFunc:_bindingsInstallFunc
-                                     moduleRegistry:_moduleRegistry
-                                jsErrorHandlingFunc:_jsErrorHandlingFunc];
+  _instance =
+      [[RCTInstance alloc] initWithDelegate:self
+                           jsEngineInstance:_jsEngineProvider ? _jsEngineProvider() : [_hostDelegate getJSEngine]
+                              bundleManager:_bundleManager
+                 turboModuleManagerDelegate:_turboModuleManagerDelegate
+                        onInitialBundleLoad:_onInitialBundleLoad
+                        bindingsInstallFunc:_bindingsInstallFunc
+                             moduleRegistry:_moduleRegistry
+                        jsErrorHandlingFunc:_jsErrorHandlingFunc];
 }
 
 - (RCTFabricSurface *)createSurfaceWithModuleName:(NSString *)moduleName
@@ -212,14 +216,15 @@ NSString *const RCTHostDidReloadNotification = @"RCTHostDidReloadNotification";
     _surfaceStartBuffer = [NSMutableArray arrayWithArray:[self _getAttachedSurfaces]];
   }
 
-  _instance = [[RCTInstance alloc] initWithDelegate:self
-                                   jsEngineInstance:[_hostDelegate getJSEngine]
-                                      bundleManager:_bundleManager
-                         turboModuleManagerDelegate:_turboModuleManagerDelegate
-                                onInitialBundleLoad:_onInitialBundleLoad
-                                bindingsInstallFunc:_bindingsInstallFunc
-                                     moduleRegistry:_moduleRegistry
-                                jsErrorHandlingFunc:_jsErrorHandlingFunc];
+  _instance =
+      [[RCTInstance alloc] initWithDelegate:self
+                           jsEngineInstance:_jsEngineProvider ? _jsEngineProvider() : [_hostDelegate getJSEngine]
+                              bundleManager:_bundleManager
+                 turboModuleManagerDelegate:_turboModuleManagerDelegate
+                        onInitialBundleLoad:_onInitialBundleLoad
+                        bindingsInstallFunc:_bindingsInstallFunc
+                             moduleRegistry:_moduleRegistry
+                        jsErrorHandlingFunc:_jsErrorHandlingFunc];
   [[NSNotificationCenter defaultCenter]
       postNotification:[NSNotification notificationWithName:RCTHostDidReloadNotification object:nil]];
 


### PR DESCRIPTION
Summary:
Changelog: [Internal]

in this change, i introduced a block type that returns a `JSEngineInstance`. a block gives a bit more flexibility in terms of lazily loading the engine + its dependencies, but i might get rid of it later and just pass down the engine itself.

Differential Revision: D45678969

