### PR TITLE
fix(gradle-plugin): fix nightly build regression

### DIFF
--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/DependencyUtils.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/DependencyUtils.kt
@@ -84,7 +84,7 @@ internal object DependencyUtils {
     val versionStringFromFile = reactAndroidProperties["VERSION_NAME"] as? String ?: ""
     // If on a nightly, we need to fetch the -SNAPSHOT artifact from Sonatype.
     val versionString =
-        if (versionStringFromFile.startsWith("0.0.0")) {
+        if (versionStringFromFile.startsWith("0.0.0") || "-nightly-" in versionStringFromFile) {
           "$versionStringFromFile-SNAPSHOT"
         } else {
           versionStringFromFile


### PR DESCRIPTION
## Summary:

Nightly builds of Android no longer build due to a recent version format change.

## Changelog:

[ANDROID] [FIXED] - Fixed nightly builds of Android no longer building due to a recent version format change

## Test Plan:

```
git clone https://github.com/microsoft/react-native-test-app.git
cd react-native-test-app
npm run set-react-version nightly
cd example
yarn android
```