### PR TITLE
Add a compile-time safeguard against ShadowNode lacking a virtual destructor

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
@@ -9,6 +9,7 @@
 
 #include <memory>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 #include <butter/small_vector.h>
@@ -224,5 +225,9 @@ class ShadowNode : public Sealable,
    */
   ShadowNodeTraits traits_;
 };
+
+static_assert(
+    std::has_virtual_destructor<ShadowNode>::value,
+    "ShadowNode must have a virtual destructor");
 
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
## Changelog:
[Internal] -

Add a safeguard against accidentally removing a virtual destructor from `ShadowNode`.

Since this is something that happened before, and `ShadowNode` has a non-trivial class inheritance tree, this could be a good idea to prevent potential memory leaks.

Differential Revision: D45691614

