### PR TITLE
Codegen 105: add typeAlias prop in parsers

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-test.js
@@ -305,6 +305,12 @@ describe('FlowParser', () => {
       expect(parser.isOptionalProperty(property)).toEqual(true);
     });
   });
+
+  describe('typeAlias', () => {
+    it('returns typeAlias Property', () => {
+      expect(parser.typeAlias).toEqual('TypeAlias');
+    });
+  });
 });
 
 describe('TypeScriptParser', () => {
@@ -580,6 +586,12 @@ describe('TypeScriptParser', () => {
         optional: false,
       };
       expect(parser.isOptionalProperty(property)).toEqual(false);
+    });
+  });
+
+  describe('typeAlias', () => {
+    it('returns typeAlias Property', () => {
+      expect(parser.typeAlias).toEqual('TSTypeAliasDeclaration');
     });
   });
 });

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -60,7 +60,7 @@ function translateTypeAnnotation(
   parser: Parser,
 ): Nullable<NativeModuleTypeAnnotation> {
   const {nullable, typeAnnotation, typeResolutionStatus} =
-    resolveTypeAnnotation(flowTypeAnnotation, types);
+    resolveTypeAnnotation(flowTypeAnnotation, types, parser);
 
   switch (typeAnnotation.type) {
     case 'GenericTypeAnnotation': {

--- a/packages/react-native-codegen/src/parsers/flow/parser.js
+++ b/packages/react-native-codegen/src/parsers/flow/parser.js
@@ -50,6 +50,7 @@ const {
 
 class FlowParser implements Parser {
   typeParameterInstantiation: string = 'TypeParameterInstantiation';
+  typeAlias: string = 'TypeAlias';
 
   isProperty(property: $FlowFixMe): boolean {
     return property.type === 'ObjectTypeProperty';

--- a/packages/react-native-codegen/src/parsers/flow/utils.js
+++ b/packages/react-native-codegen/src/parsers/flow/utils.js
@@ -11,6 +11,7 @@
 'use strict';
 
 import type {TypeResolutionStatus, TypeDeclarationMap, ASTNode} from '../utils';
+import type {Parser} from '../../parsers/parser';
 
 const invariant = require('invariant');
 
@@ -18,6 +19,7 @@ function resolveTypeAnnotation(
   // TODO(T71778680): This is an Flow TypeAnnotation. Flow-type this
   typeAnnotation: $FlowFixMe,
   types: TypeDeclarationMap,
+  parser: Parser,
 ): {
   nullable: boolean,
   typeAnnotation: $FlowFixMe,
@@ -51,7 +53,7 @@ function resolveTypeAnnotation(
     }
 
     switch (resolvedTypeAnnotation.type) {
-      case 'TypeAlias': {
+      case parser.typeAlias: {
         typeResolutionStatus = {
           successful: true,
           type: 'alias',
@@ -71,7 +73,7 @@ function resolveTypeAnnotation(
       }
       default: {
         throw new TypeError(
-          `A non GenericTypeAnnotation must be a type declaration ('TypeAlias') or enum ('EnumDeclaration'). Instead, got the unsupported ${resolvedTypeAnnotation.type}.`,
+          `A non GenericTypeAnnotation must be a type declaration ('${parser.typeAlias}') or enum ('EnumDeclaration'). Instead, got the unsupported ${resolvedTypeAnnotation.type}.`,
         );
       }
     }

--- a/packages/react-native-codegen/src/parsers/parser.js
+++ b/packages/react-native-codegen/src/parsers/parser.js
@@ -73,6 +73,11 @@ export interface Parser {
   typeParameterInstantiation: string;
 
   /**
+   * TypeAlias property of the Parser
+   */
+  typeAlias: string;
+
+  /**
    * Given a declaration, it returns true if it is a property
    */
   isProperty(property: $FlowFixMe): boolean;

--- a/packages/react-native-codegen/src/parsers/parserMock.js
+++ b/packages/react-native-codegen/src/parsers/parserMock.js
@@ -49,6 +49,7 @@ const schemaMock = {
 
 export class MockedParser implements Parser {
   typeParameterInstantiation: string = 'TypeParameterInstantiation';
+  typeAlias: string = 'TypeAlias';
 
   isProperty(property: $FlowFixMe): boolean {
     return property.type === 'ObjectTypeProperty';

--- a/packages/react-native-codegen/src/parsers/parsers-commons.js
+++ b/packages/react-native-codegen/src/parsers/parsers-commons.js
@@ -337,7 +337,11 @@ function buildPropertySchema(
         : property.typeAnnotation;
   }
 
-  ({nullable, typeAnnotation: value} = resolveTypeAnnotation(value, types));
+  ({nullable, typeAnnotation: value} = resolveTypeAnnotation(
+    value,
+    types,
+    parser,
+  ));
 
   throwIfModuleTypeIsUnsupported(
     hasteModuleName,

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -190,7 +190,7 @@ function translateTypeAnnotation(
   parser: Parser,
 ): Nullable<NativeModuleTypeAnnotation> {
   const {nullable, typeAnnotation, typeResolutionStatus} =
-    resolveTypeAnnotation(typeScriptTypeAnnotation, types);
+    resolveTypeAnnotation(typeScriptTypeAnnotation, types, parser);
 
   switch (typeAnnotation.type) {
     case 'TSArrayType': {

--- a/packages/react-native-codegen/src/parsers/typescript/parser.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parser.js
@@ -49,6 +49,7 @@ const {
 
 class TypeScriptParser implements Parser {
   typeParameterInstantiation: string = 'TSTypeParameterInstantiation';
+  typeAlias: string = 'TSTypeAliasDeclaration';
 
   isProperty(property: $FlowFixMe): boolean {
     return property.type === 'TSPropertySignature';

--- a/packages/react-native-codegen/src/parsers/typescript/utils.js
+++ b/packages/react-native-codegen/src/parsers/typescript/utils.js
@@ -11,6 +11,7 @@
 'use strict';
 
 import type {TypeResolutionStatus, TypeDeclarationMap} from '../utils';
+import type {Parser} from '../../parsers/parser';
 
 const {parseTopLevelType} = require('./parseTopLevelType');
 
@@ -20,6 +21,7 @@ function resolveTypeAnnotation(
   // TODO(T108222691): Use flow-types for @babel/parser
   typeAnnotation: $FlowFixMe,
   types: TypeDeclarationMap,
+  parser: Parser,
 ): {
   nullable: boolean,
   typeAnnotation: $FlowFixMe,
@@ -54,7 +56,7 @@ function resolveTypeAnnotation(
     }
 
     switch (resolvedTypeAnnotation.type) {
-      case 'TSTypeAliasDeclaration': {
+      case parser.typeAlias: {
         typeResolutionStatus = {
           successful: true,
           type: 'alias',
@@ -83,7 +85,7 @@ function resolveTypeAnnotation(
       }
       default: {
         throw new TypeError(
-          `A non GenericTypeAnnotation must be a type declaration ('TSTypeAliasDeclaration'), an interface ('TSInterfaceDeclaration'), or enum ('TSEnumDeclaration'). Instead, got the unsupported ${resolvedTypeAnnotation.type}.`,
+          `A non GenericTypeAnnotation must be a type declaration ('${parser.typeAlias}'), an interface ('TSInterfaceDeclaration'), or enum ('TSEnumDeclaration'). Instead, got the unsupported ${resolvedTypeAnnotation.type}.`,
         );
       }
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Part of Codegen Issue: #34872 
> Add a typeAlias: string property to the Parser class. Implement it in the Flow parser so that it returns TypeAlias and in
> the TypeScriptParser so that it returns TSTypeAliasDeclaration. Replace the case in the switch  in the [parsers/flow/utils.js](https://github.com/facebook/react-native/blob/e133100721939108b0f28dfa9f60ac627c804018/packages/react-native-codegen/src/parsers/flow/utils.js#L57) and [parsers/typescript/utils.js](https://github.com/facebook/react-native/blob/e133100721939108b0f28dfa9f60ac627c804018/packages/react-native-codegen/src/parsers/typescript/utils.js#L60) with this prop.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
[Internal][Added]: Add typeAlias property in parsers

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

```yarn test```
