### PR TITLE
RN: Upgrade to `flow-enums-runtime@0.0.6`

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -109,7 +109,7 @@
     "base64-js": "^1.1.2",
     "deprecated-react-native-prop-types": "4.1.0",
     "event-target-shim": "^5.0.1",
-    "flow-enums-runtime": "^0.0.5",
+    "flow-enums-runtime": "^0.0.6",
     "invariant": "^2.2.4",
     "jest-environment-node": "^29.2.1",
     "jsc-android": "^250231.0.0",

--- a/packages/rn-tester/package.json
+++ b/packages/rn-tester/package.json
@@ -22,7 +22,7 @@
     "clean-ios": "rm -rf build/generated/ios Pods Podfile.lock"
   },
   "dependencies": {
-    "flow-enums-runtime": "^0.0.5",
+    "flow-enums-runtime": "^0.0.6",
     "invariant": "^2.2.4",
     "nullthrows": "^1.1.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5333,10 +5333,10 @@ flow-bin@^0.205.1:
   resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.205.1.tgz#5faf24e60df8d36f4deafef20e44863c5b295315"
   integrity sha512-pGQ/ZFr9hnbhRmc+K3K1Ui9BwDivlesNEd2mZbm5pCnxEUvbbj9nXHlTD4s4qO0k+LBKYLMZzQwBVYyRUE380g==
 
-flow-enums-runtime@^0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/flow-enums-runtime/-/flow-enums-runtime-0.0.5.tgz#95884bfcc82edaf27eef7e1dd09732331cfbafbc"
-  integrity sha512-PSZF9ZuaZD03sT9YaIs0FrGJ7lSUw7rHZIex+73UYVXg46eL/wxN5PaVcPJFudE2cJu5f0fezitV5aBkLHPUOQ==
+flow-enums-runtime@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/flow-enums-runtime/-/flow-enums-runtime-0.0.6.tgz#5bb0cd1b0a3e471330f4d109039b7eba5cb3e787"
+  integrity sha512-3PYnM29RFXwvAN6Pc/scUfkI7RwhQ/xqyLUyPNlXUp9S40zI8nup9tUSrTLSVnWGBN38FNiGWbwZOB6uR4OGdw==
 
 flow-parser@0.*, flow-parser@^0.185.0:
   version "0.185.0"


### PR DESCRIPTION
Summary:
Upgrades to `flow-enums-runtime@0.0.6`, which is just a `README.md` update.

Changelog:
[Internal]

Differential Revision: D45713984

