### PR TITLE
introduce callback path for js errors

### DIFF
--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.h
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.h
@@ -18,6 +18,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @class RCTFabricSurface;
+@class RCTHost;
 @class RCTJSThreadManager;
 @class RCTModuleRegistry;
 @protocol RCTInstanceDelegate;
@@ -41,6 +42,12 @@ typedef std::shared_ptr<facebook::react::JSEngineInstance> (^RCTHostJSEngineProv
 - (std::shared_ptr<facebook::react::JSEngineInstance>)getJSEngine;
 - (NSURL *)getBundleURL;
 - (std::shared_ptr<facebook::react::ContextContainer>)createContextContainer;
+
+- (void)host:(RCTHost *)host
+    didReceiveJSErrorStack:(NSArray<NSDictionary<NSString *, id> *> *)stack
+                   message:(NSString *)message
+               exceptionId:(NSUInteger)exceptionId
+                   isFatal:(BOOL)isFatal;
 
 @end
 

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.mm
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.mm
@@ -259,6 +259,9 @@ NSString *const RCTHostDidReloadNotification = @"RCTHostDidReloadNotification";
   return [_hostDelegate createContextContainer];
 }
 
+- (void)instance:(RCTInstance *)instance didReceiveErrorMap:(facebook::react::MapBuffer)errorMap
+{}
+
 #pragma mark - Private
 - (void)_refreshBundleURL FB_OBJC_DIRECT
 {

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.h
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.h
@@ -11,6 +11,7 @@
 #import <React/RCTDefines.h>
 #import <react/bridgeless/JSEngineInstance.h>
 #import <react/bridgeless/ReactInstance.h>
+#import <react/renderer/mapbuffer/MapBuffer.h>
 #import <react/utils/ContextContainer.h>
 
 /**
@@ -24,6 +25,7 @@ RCT_EXTERN void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags);
 NS_ASSUME_NONNULL_BEGIN
 
 @class RCTBundleManager;
+@class RCTInstance;
 @class RCTJSThreadManager;
 @class RCTModuleRegistry;
 @class RCTPerformanceLogger;
@@ -33,10 +35,11 @@ NS_ASSUME_NONNULL_BEGIN
 FB_RUNTIME_PROTOCOL
 @protocol RCTTurboModuleManagerDelegate;
 
-// TODO (T74233481) - Delete this. Communication between Product Code <> RCTInstance should go through RCTHost.
 @protocol RCTInstanceDelegate <NSObject>
 
 - (std::shared_ptr<facebook::react::ContextContainer>)createContextContainer;
+
+- (void)instance:(RCTInstance *)instance didReceiveErrorMap:(facebook::react::MapBuffer)errorMap;
 
 @end
 

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.mm
@@ -414,4 +414,9 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
   }
 }
 
+- (void)_handleJSErrorMap:(facebook::react::MapBuffer)errorMap
+{
+  [_delegate instance:self didReceiveErrorMap:std::move(errorMap)];
+}
+
 @end


### PR DESCRIPTION
Summary:
Changelog: [Internal]

in this stack i address the `jsErrorHandlingFunc` argument in the constructor of `RCTHost`.

currently in userland, the delegate of `RCTHost` is responsible for the following if they want to handle the errors fired in C++ land:
- importing the C++ class MapBuffer
- creating a C++ lambda method
- parsing the MapBuffer

in this diff stack i simplify this so we only need to implement a delegate method where userland only receives Foundation types. yay!

Differential Revision: D45720131

