### PR TITLE
parse js error response in RCTHost and pass it to delegate

### DIFF
--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.h
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.h
@@ -18,6 +18,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @class RCTFabricSurface;
+@class RCTHost;
 @class RCTJSThreadManager;
 @class RCTModuleRegistry;
 @protocol RCTInstanceDelegate;
@@ -41,6 +42,12 @@ typedef std::shared_ptr<facebook::react::JSEngineInstance> (^RCTHostJSEngineProv
 - (std::shared_ptr<facebook::react::JSEngineInstance>)getJSEngine;
 - (NSURL *)getBundleURL;
 - (std::shared_ptr<facebook::react::ContextContainer>)createContextContainer;
+
+- (void)host:(RCTHost *)host
+    didReceiveJSErrorStack:(NSArray<NSDictionary<NSString *, id> *> *)stack
+                   message:(NSString *)message
+               exceptionId:(NSUInteger)exceptionId
+                   isFatal:(BOOL)isFatal;
 
 @end
 

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.mm
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.mm
@@ -260,7 +260,28 @@ NSString *const RCTHostDidReloadNotification = @"RCTHostDidReloadNotification";
 }
 
 - (void)instance:(RCTInstance *)instance didReceiveErrorMap:(facebook::react::MapBuffer)errorMap
-{}
+{
+  NSString *message = [NSString stringWithCString:errorMap.getString(JSErrorHandlerKey::kErrorMessage).c_str()
+                                         encoding:[NSString defaultCStringEncoding]];
+  std::vector<facebook::react::MapBuffer> frames = errorMap.getMapBufferList(JSErrorHandlerKey::kAllStackFrames);
+  NSMutableArray *stack = [NSMutableArray new];
+  for (facebook::react::MapBuffer const &mapBuffer : frames) {
+    NSDictionary *frame = @{
+      @"file" : [NSString stringWithCString:mapBuffer.getString(JSErrorHandlerKey::kFrameFileName).c_str()
+                                   encoding:[NSString defaultCStringEncoding]],
+      @"methodName" : [NSString stringWithCString:mapBuffer.getString(JSErrorHandlerKey::kFrameMethodName).c_str()
+                                         encoding:[NSString defaultCStringEncoding]],
+      @"lineNumber" : [NSNumber numberWithInt:mapBuffer.getInt(JSErrorHandlerKey::kFrameLineNumber)],
+      @"column" : [NSNumber numberWithInt:mapBuffer.getInt(JSErrorHandlerKey::kFrameColumnNumber)],
+    };
+    [stack addObject:frame];
+  }
+  [_hostDelegate host:self
+      didReceiveJSErrorStack:stack
+                     message:message
+                 exceptionId:errorMap.getInt(JSErrorHandlerKey::kExceptionId)
+                     isFatal:errorMap.getBool(JSErrorHandlerKey::kIsFatal)];
+}
 
 #pragma mark - Private
 - (void)_refreshBundleURL FB_OBJC_DIRECT

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.mm
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.mm
@@ -259,6 +259,9 @@ NSString *const RCTHostDidReloadNotification = @"RCTHostDidReloadNotification";
   return [_hostDelegate createContextContainer];
 }
 
+- (void)instance:(RCTInstance *)instance didReceiveErrorMap:(facebook::react::MapBuffer)errorMap
+{}
+
 #pragma mark - Private
 - (void)_refreshBundleURL FB_OBJC_DIRECT
 {

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.h
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.h
@@ -11,6 +11,7 @@
 #import <React/RCTDefines.h>
 #import <react/bridgeless/JSEngineInstance.h>
 #import <react/bridgeless/ReactInstance.h>
+#import <react/renderer/mapbuffer/MapBuffer.h>
 #import <react/utils/ContextContainer.h>
 
 /**
@@ -24,6 +25,7 @@ RCT_EXTERN void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags);
 NS_ASSUME_NONNULL_BEGIN
 
 @class RCTBundleManager;
+@class RCTInstance;
 @class RCTJSThreadManager;
 @class RCTModuleRegistry;
 @class RCTPerformanceLogger;
@@ -33,10 +35,11 @@ NS_ASSUME_NONNULL_BEGIN
 FB_RUNTIME_PROTOCOL
 @protocol RCTTurboModuleManagerDelegate;
 
-// TODO (T74233481) - Delete this. Communication between Product Code <> RCTInstance should go through RCTHost.
 @protocol RCTInstanceDelegate <NSObject>
 
 - (std::shared_ptr<facebook::react::ContextContainer>)createContextContainer;
+
+- (void)instance:(RCTInstance *)instance didReceiveErrorMap:(facebook::react::MapBuffer)errorMap;
 
 @end
 

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.mm
@@ -414,4 +414,9 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
   }
 }
 
+- (void)_handleJSErrorMap:(facebook::react::MapBuffer)errorMap
+{
+  [_delegate instance:self didReceiveErrorMap:std::move(errorMap)];
+}
+
 @end

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.mm
@@ -218,9 +218,12 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
   auto timerManager = std::make_shared<TimerManager>(std::move(objCTimerRegistry));
   objCTimerRegistryRawPtr->setTimerManager(timerManager);
 
+  __weak __typeof(self) weakSelf = self;
+  auto jsErrorHandlingFunc = [=](MapBuffer errorMap) { [weakSelf _handleJSErrorMap:std::move(errorMap)]; };
+
   // Create the React Instance
   _reactInstance = std::make_unique<ReactInstance>(
-      _jsEngineInstance->createJSRuntime(), _jsThreadManager.jsMessageThread, timerManager, _jsErrorHandlingFunc);
+      _jsEngineInstance->createJSRuntime(), _jsThreadManager.jsMessageThread, timerManager, jsErrorHandlingFunc);
   _valid = true;
 
   RuntimeExecutor bufferedRuntimeExecutor = _reactInstance->getBufferedRuntimeExecutor();
@@ -265,8 +268,6 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
 
   // DisplayLink is used to call timer callbacks.
   _displayLink = [RCTDisplayLink new];
-
-  __weak __typeof(self) weakSelf = self;
 
   ReactInstance::JSRuntimeFlags options = {
       .isProfiling = false, .runtimeDiagnosticFlags = [RCTInstanceRuntimeDiagnosticFlags() UTF8String]};


### PR DESCRIPTION
Summary:
Changelog: [Internal]

in this diff we do the following:
- pass an error handler that's responsible for bubbling up the error metadata from the react instance obj-c wrapper (RCTInstance) to the actual react instance (ReactInstance)
- parse the error metadata in RCTHost and pass it up to its delegate

Differential Revision: D45720132

