### PR TITLE
Add @react-native/typescript-config

### DIFF
--- a/packages/react-native/template/package.json
+++ b/packages/react-native/template/package.json
@@ -19,7 +19,7 @@
     "@babel/runtime": "^7.12.5",
     "@react-native/eslint-config": "^0.73.0",
     "@react-native/metro-config": "^0.73.0",
-    "@tsconfig/react-native": "^3.0.0",
+    "@react-native/typescript-config": "^0.73.0",
     "@types/react": "^18.0.24",
     "@types/react-test-renderer": "^18.0.0",
     "babel-jest": "^29.2.1",

--- a/packages/react-native/template/tsconfig.json
+++ b/packages/react-native/template/tsconfig.json
@@ -1,3 +1,3 @@
 {
-  "extends": "@tsconfig/react-native/tsconfig.json"
+  "extends": "@react-native/typescript-config/tsconfig.json"
 }

--- a/packages/typescript-config/README.md
+++ b/packages/typescript-config/README.md
@@ -1,0 +1,5 @@
+# @react-native/typescript-config
+
+This package provides the default `tsconfig.json` used by newly built React Native apps.
+
+This template is customized for specific versions of React Native, and should be updated in sync with the rest of your app.

--- a/packages/typescript-config/package.json
+++ b/packages/typescript-config/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@react-native/typescript-config",
+  "version": "0.73.0",
+  "description": "Default TypeScript configuration for React Native apps",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/facebook/react-native.git",
+    "directory": "packages/typescript-config"
+  },
+  "homepage": "https://github.com/facebook/react-native/tree/HEAD/packages/typescript-config#readme",
+  "keywords": ["typescript", "tsconfig", "react-native"],
+  "bugs": "https://github.com/facebook/react-native/issues",
+  "main": "tsconfig.json"
+}

--- a/packages/typescript-config/tsconfig.json
+++ b/packages/typescript-config/tsconfig.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "https://json.schemastore.org/tsconfig",
+    "display": "React Native",
+    "compilerOptions": {
+      "target": "esnext",
+      "module": "commonjs",
+      "types": ["react-native", "jest"],
+      "lib": [
+        "es2019",
+        "es2020.bigint",
+        "es2020.date",
+        "es2020.number",
+        "es2020.promise",
+        "es2020.string",
+        "es2020.symbol.wellknown",
+        "es2021.promise",
+        "es2021.string",
+        "es2021.weakref",
+        "es2022.array",
+        "es2022.object",
+        "es2022.string"
+      ],
+      "allowJs": true,
+      "jsx": "react-native",
+      "noEmit": true,
+      "isolatedModules": true,
+      "strict": true,
+      "moduleResolution": "nodenext",
+      "resolveJsonModule": true,
+      "allowSyntheticDefaultImports": true,
+      "esModuleInterop": true,
+      "skipLibCheck": true,
+      // Causes issues with package.json "exports"
+      "forceConsistentCasingInFileNames": false
+    },
+    "exclude": [
+      "node_modules",
+      "babel.config.js",
+      "metro.config.js",
+      "jest.config.js"
+    ]
+  }


### PR DESCRIPTION
Summary:
This moves from `tsconfig/react-native`, a centralized repository of tsconfigs, to `react-native/typescript-config`, a package maintained as part of the RN monorepo.

We end up wanting to make changes where the versions are coupled, so this publishes them as part of the same repo, etc. It also means Meta engineers can more freely make changes to it with normal approval processes.

I also used this opportunity to fix the file-structure of `eslint-config-react-native-communtiy`, and `eslint-plugin-react-native-communtiy` to match the name they were renamed to as part of 0.72.

Differential Revision: D45721088

