### PR TITLE
Change how we set cmake policy (#1288)

### DIFF
--- a/packages/react-native/ReactCommon/yoga/yoga/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/yoga/yoga/CMakeLists.txt
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.13...3.26)
 project(yogacore)
 set(CMAKE_VERBOSE_MAKEFILE on)
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/yoga/pull/1288

Fixes https://github.com/facebook/yoga/issues/1283

New versions of CMake add "policies" which control how the build system acts wrt breaking changes. By default, CMake will emulate the behavior of the version specified in `cmake_minimum_required`.

Setting a policy to true (to opt into new behavior where `cmake_minimum_required` is lower than the current version) seems actually just error out on the old versions.

Googling around, apparently the way I should be doing this is to specify `<policy_max>` as part of `cmake_minimum_required `. https://gitlab.kitware.com/cmake/cmake/-/issues/20392

This should I think use new policies introduced up to 3.26 (what we test on right now), while letting 3.13 be the minimum.

Differential Revision: D45724864

