### PR TITLE
Publish NPM packages with `--access public`

### DIFF
--- a/scripts/monorepo/find-and-publish-all-bumped-packages.js
+++ b/scripts/monorepo/find-and-publish-all-bumped-packages.js
@@ -103,12 +103,16 @@ const findAndPublishAllBumpedPackages = () => {
 
       const npmOTPFlag = NPM_CONFIG_OTP ? `--otp ${NPM_CONFIG_OTP}` : '';
 
-      const {status, stderr} = spawnSync('npm', ['publish', `${npmOTPFlag}`], {
-        cwd: packageAbsolutePath,
-        shell: true,
-        stdio: 'pipe',
-        encoding: 'utf-8',
-      });
+      const {status, stderr} = spawnSync(
+        'npm',
+        ['publish', '--access', 'public', `${npmOTPFlag}`],
+        {
+          cwd: packageAbsolutePath,
+          shell: true,
+          stdio: 'pipe',
+          encoding: 'utf-8',
+        },
+      );
       if (status !== 0) {
         console.log(
           `\u274c Failed to publish version ${nextVersion} of ${packageManifest.name}. npm publish exited with code ${status}:`,


### PR DESCRIPTION
Summary:
From cortinico I heard that scoped packages will be auto-published as private, requiring a manual step right now of `npm publish --acess public`.

Everything in the OSS RN monorepo should be public, so I think we can just pass that when we publish nightly?

Changelog: [Internal]

Differential Revision: D45726397

