### PR TITLE
Fix RCTDeviceEventEmitter export type

### DIFF
--- a/packages/react-native/Libraries/EventEmitter/RCTDeviceEventEmitter.d.ts
+++ b/packages/react-native/Libraries/EventEmitter/RCTDeviceEventEmitter.d.ts
@@ -16,7 +16,7 @@ import EventEmitter, {
  * Deprecated - subclass NativeEventEmitter to create granular event modules instead of
  * adding all event listeners directly to RCTDeviceEventEmitter.
  */
-export default interface DeviceEventEmitter extends EventEmitter {
+export default interface DeviceEventEmitterStatic extends EventEmitter {
   sharedSubscriber: EventSubscriptionVendor;
   new (): DeviceEventEmitterStatic;
   addListener(
@@ -25,3 +25,5 @@ export default interface DeviceEventEmitter extends EventEmitter {
     context?: any,
   ): EmitterSubscription;
 }
+
+export const DeviceEventEmitter: DeviceEventEmitterStatic;

--- a/packages/react-native/Libraries/EventEmitter/RCTDeviceEventEmitter.d.ts
+++ b/packages/react-native/Libraries/EventEmitter/RCTDeviceEventEmitter.d.ts
@@ -9,7 +9,6 @@
 
 import EventEmitter, {
   EmitterSubscription,
-  EventSubscriptionVendor,
 } from '../vendor/emitter/EventEmitter';
 
 /**
@@ -17,7 +16,6 @@ import EventEmitter, {
  * adding all event listeners directly to RCTDeviceEventEmitter.
  */
 export default interface DeviceEventEmitterStatic extends EventEmitter {
-  sharedSubscriber: EventSubscriptionVendor;
   new (): DeviceEventEmitterStatic;
   addListener(
     type: string,

--- a/packages/react-native/Libraries/EventEmitter/RCTDeviceEventEmitter.d.ts
+++ b/packages/react-native/Libraries/EventEmitter/RCTDeviceEventEmitter.d.ts
@@ -16,7 +16,7 @@ import EventEmitter, {
  * Deprecated - subclass NativeEventEmitter to create granular event modules instead of
  * adding all event listeners directly to RCTDeviceEventEmitter.
  */
-interface DeviceEventEmitterStatic extends EventEmitter {
+export default interface DeviceEventEmitter extends EventEmitter {
   sharedSubscriber: EventSubscriptionVendor;
   new (): DeviceEventEmitterStatic;
   addListener(
@@ -25,5 +25,3 @@ interface DeviceEventEmitterStatic extends EventEmitter {
     context?: any,
   ): EmitterSubscription;
 }
-
-export const DeviceEventEmitter: DeviceEventEmitterStatic;

--- a/packages/react-native/Libraries/EventEmitter/RCTNativeAppEventEmitter.d.ts
+++ b/packages/react-native/Libraries/EventEmitter/RCTNativeAppEventEmitter.d.ts
@@ -7,7 +7,7 @@
  * @format
  */
 
-import {DeviceEventEmitterStatic} from './RCTDeviceEventEmitter';
+import DeviceEventEmitterStatic from './RCTDeviceEventEmitter';
 
 export interface NativeEventSubscription {
   /**

--- a/packages/react-native/types/index.d.ts
+++ b/packages/react-native/types/index.d.ts
@@ -106,6 +106,7 @@ export * from '../Libraries/Components/Button';
 export * from '../Libraries/DevToolsSettings/DevToolsSettingsManager';
 export * from '../Libraries/EventEmitter/NativeEventEmitter';
 export * from '../Libraries/EventEmitter/RCTDeviceEventEmitter';
+export {default as DeviceEventEmitterStatic} from '../Libraries/EventEmitter/RCTDeviceEventEmitter';
 export * from '../Libraries/EventEmitter/RCTNativeAppEventEmitter';
 export * from '../Libraries/Image/Image';
 export * from '../Libraries/Image/ImageResizeMode';


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

In a recent update of React Native, we noticed that the export of RCTDeviceEventEmitter types is wrong.

After the update, the export in `.d.ts` has been changed to `export const`.

But in the `.js` file the export still with `export default`.

Fixes #37358

## Changelog:

[GENERAL][FIXED] - Fix RCTDeviceEventEmitter export type

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
