### PR TITLE
codegen 107: add interfaceDeclaration prop in parsers

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-test.js
@@ -305,6 +305,12 @@ describe('FlowParser', () => {
       expect(parser.isOptionalProperty(property)).toEqual(true);
     });
   });
+
+  describe('interfaceDelcaration', () => {
+    it('returns interfaceDelcaration Property', () => {
+      expect(parser.interfaceDelcaration).toEqual('InterfaceDeclaration');
+    });
+  });
 });
 
 describe('TypeScriptParser', () => {
@@ -580,6 +586,12 @@ describe('TypeScriptParser', () => {
         optional: false,
       };
       expect(parser.isOptionalProperty(property)).toEqual(false);
+    });
+  });
+
+  describe('interfaceDelcaration', () => {
+    it('returns interfaceDelcaration Property', () => {
+      expect(parser.interfaceDelcaration).toEqual('TSInterfaceDeclaration');
     });
   });
 });

--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-test.js
@@ -306,9 +306,9 @@ describe('FlowParser', () => {
     });
   });
 
-  describe('interfaceDelcaration', () => {
-    it('returns interfaceDelcaration Property', () => {
-      expect(parser.interfaceDelcaration).toEqual('InterfaceDeclaration');
+  describe('interfaceDeclaration', () => {
+    it('returns interfaceDeclaration Property', () => {
+      expect(parser.interfaceDeclaration).toEqual('InterfaceDeclaration');
     });
   });
 });
@@ -589,9 +589,9 @@ describe('TypeScriptParser', () => {
     });
   });
 
-  describe('interfaceDelcaration', () => {
-    it('returns interfaceDelcaration Property', () => {
-      expect(parser.interfaceDelcaration).toEqual('TSInterfaceDeclaration');
+  describe('interfaceDeclaration', () => {
+    it('returns interfaceDeclaration Property', () => {
+      expect(parser.interfaceDeclaration).toEqual('TSInterfaceDeclaration');
     });
   });
 });

--- a/packages/react-native-codegen/src/parsers/flow/parser.js
+++ b/packages/react-native-codegen/src/parsers/flow/parser.js
@@ -50,6 +50,7 @@ const {
 
 class FlowParser implements Parser {
   typeParameterInstantiation: string = 'TypeParameterInstantiation';
+  interfaceDelcaration: string = 'InterfaceDeclaration';
 
   isProperty(property: $FlowFixMe): boolean {
     return property.type === 'ObjectTypeProperty';

--- a/packages/react-native-codegen/src/parsers/flow/parser.js
+++ b/packages/react-native-codegen/src/parsers/flow/parser.js
@@ -50,7 +50,7 @@ const {
 
 class FlowParser implements Parser {
   typeParameterInstantiation: string = 'TypeParameterInstantiation';
-  interfaceDelcaration: string = 'InterfaceDeclaration';
+  interfaceDeclaration: string = 'InterfaceDeclaration';
 
   isProperty(property: $FlowFixMe): boolean {
     return property.type === 'ObjectTypeProperty';

--- a/packages/react-native-codegen/src/parsers/parser.js
+++ b/packages/react-native-codegen/src/parsers/parser.js
@@ -73,6 +73,11 @@ export interface Parser {
   typeParameterInstantiation: string;
 
   /**
+   * InterfaceDelcaration property of the Parser
+   */
+  interfaceDelcaration: string;
+
+  /**
    * Given a declaration, it returns true if it is a property
    */
   isProperty(property: $FlowFixMe): boolean;

--- a/packages/react-native-codegen/src/parsers/parser.js
+++ b/packages/react-native-codegen/src/parsers/parser.js
@@ -73,9 +73,9 @@ export interface Parser {
   typeParameterInstantiation: string;
 
   /**
-   * InterfaceDelcaration property of the Parser
+   * InterfaceDeclaration property of the Parser
    */
-  interfaceDelcaration: string;
+  interfaceDeclaration: string;
 
   /**
    * Given a declaration, it returns true if it is a property

--- a/packages/react-native-codegen/src/parsers/parserMock.js
+++ b/packages/react-native-codegen/src/parsers/parserMock.js
@@ -49,7 +49,7 @@ const schemaMock = {
 
 export class MockedParser implements Parser {
   typeParameterInstantiation: string = 'TypeParameterInstantiation';
-  interfaceDelcaration: string = 'InterfaceDelcaration';
+  interfaceDeclaration: string = 'InterfaceDeclaration';
 
   isProperty(property: $FlowFixMe): boolean {
     return property.type === 'ObjectTypeProperty';

--- a/packages/react-native-codegen/src/parsers/parserMock.js
+++ b/packages/react-native-codegen/src/parsers/parserMock.js
@@ -49,6 +49,7 @@ const schemaMock = {
 
 export class MockedParser implements Parser {
   typeParameterInstantiation: string = 'TypeParameterInstantiation';
+  interfaceDelcaration: string = 'InterfaceDelcaration';
 
   isProperty(property: $FlowFixMe): boolean {
     return property.type === 'ObjectTypeProperty';

--- a/packages/react-native-codegen/src/parsers/parsers-commons.js
+++ b/packages/react-native-codegen/src/parsers/parsers-commons.js
@@ -337,7 +337,11 @@ function buildPropertySchema(
         : property.typeAnnotation;
   }
 
-  ({nullable, typeAnnotation: value} = resolveTypeAnnotation(value, types));
+  ({nullable, typeAnnotation: value} = resolveTypeAnnotation(
+    value,
+    types,
+    parser,
+  ));
 
   throwIfModuleTypeIsUnsupported(
     hasteModuleName,

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -190,7 +190,7 @@ function translateTypeAnnotation(
   parser: Parser,
 ): Nullable<NativeModuleTypeAnnotation> {
   const {nullable, typeAnnotation, typeResolutionStatus} =
-    resolveTypeAnnotation(typeScriptTypeAnnotation, types);
+    resolveTypeAnnotation(typeScriptTypeAnnotation, types, parser);
 
   switch (typeAnnotation.type) {
     case 'TSArrayType': {

--- a/packages/react-native-codegen/src/parsers/typescript/parser.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parser.js
@@ -49,6 +49,7 @@ const {
 
 class TypeScriptParser implements Parser {
   typeParameterInstantiation: string = 'TSTypeParameterInstantiation';
+  interfaceDelcaration: string = 'TSInterfaceDeclaration';
 
   isProperty(property: $FlowFixMe): boolean {
     return property.type === 'TSPropertySignature';

--- a/packages/react-native-codegen/src/parsers/typescript/parser.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parser.js
@@ -49,7 +49,7 @@ const {
 
 class TypeScriptParser implements Parser {
   typeParameterInstantiation: string = 'TSTypeParameterInstantiation';
-  interfaceDelcaration: string = 'TSInterfaceDeclaration';
+  interfaceDeclaration: string = 'TSInterfaceDeclaration';
 
   isProperty(property: $FlowFixMe): boolean {
     return property.type === 'TSPropertySignature';

--- a/packages/react-native-codegen/src/parsers/typescript/utils.js
+++ b/packages/react-native-codegen/src/parsers/typescript/utils.js
@@ -11,6 +11,7 @@
 'use strict';
 
 import type {TypeResolutionStatus, TypeDeclarationMap} from '../utils';
+import type {Parser} from '../../parsers/parser';
 
 const {parseTopLevelType} = require('./parseTopLevelType');
 
@@ -20,6 +21,7 @@ function resolveTypeAnnotation(
   // TODO(T108222691): Use flow-types for @babel/parser
   typeAnnotation: $FlowFixMe,
   types: TypeDeclarationMap,
+  parser: Parser,
 ): {
   nullable: boolean,
   typeAnnotation: $FlowFixMe,
@@ -63,7 +65,7 @@ function resolveTypeAnnotation(
         node = resolvedTypeAnnotation.typeAnnotation;
         break;
       }
-      case 'TSInterfaceDeclaration': {
+      case parser.interfaceDelcaration: {
         typeResolutionStatus = {
           successful: true,
           type: 'alias',
@@ -83,7 +85,7 @@ function resolveTypeAnnotation(
       }
       default: {
         throw new TypeError(
-          `A non GenericTypeAnnotation must be a type declaration ('TSTypeAliasDeclaration'), an interface ('TSInterfaceDeclaration'), or enum ('TSEnumDeclaration'). Instead, got the unsupported ${resolvedTypeAnnotation.type}.`,
+          `A non GenericTypeAnnotation must be a type declaration ('TSTypeAliasDeclaration'), an interface ('${parser.interfaceDelcaration}'), or enum ('TSEnumDeclaration'). Instead, got the unsupported ${resolvedTypeAnnotation.type}.`,
         );
       }
     }

--- a/packages/react-native-codegen/src/parsers/typescript/utils.js
+++ b/packages/react-native-codegen/src/parsers/typescript/utils.js
@@ -65,7 +65,7 @@ function resolveTypeAnnotation(
         node = resolvedTypeAnnotation.typeAnnotation;
         break;
       }
-      case parser.interfaceDelcaration: {
+      case parser.interfaceDeclaration: {
         typeResolutionStatus = {
           successful: true,
           type: 'alias',
@@ -85,7 +85,7 @@ function resolveTypeAnnotation(
       }
       default: {
         throw new TypeError(
-          `A non GenericTypeAnnotation must be a type declaration ('TSTypeAliasDeclaration'), an interface ('${parser.interfaceDelcaration}'), or enum ('TSEnumDeclaration'). Instead, got the unsupported ${resolvedTypeAnnotation.type}.`,
+          `A non GenericTypeAnnotation must be a type declaration ('TSTypeAliasDeclaration'), an interface ('${parser.interfaceDeclaration}'), or enum ('TSEnumDeclaration'). Instead, got the unsupported ${resolvedTypeAnnotation.type}.`,
         );
       }
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

part of codegen issue https://github.com/facebook/react-native/issues/34872

> Add a interfaceDeclaration: string property to the Parser class. Implement it in the Flow parser so that it returns InterfaceDeclaration and in the TypeScriptParser so that it returns TSInterfaceDeclaration. Replace the case in the switch  in the [parsers/typescript/utils.js](https://github.com/facebook/react-native/blob/e133100721939108b0f28dfa9f60ac627c804018/packages/react-native-codegen/src/parsers/typescript/utils.js#L69) with this prop.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[Internal][Added]: Add interfaceDeclaration property in parsers

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

yarn test
