### PR TITLE
Integrate TurboModuleManager with legacy module registration

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.h
@@ -38,6 +38,18 @@ RCT_EXTERN void RCTTurboModuleSetBindingMode(facebook::react::TurboModuleBinding
                                                       jsInvoker:
                                                           (std::shared_ptr<facebook::react::CallInvoker>)jsInvoker;
 
+/**
+ * Return a pre-initialized list of leagcy native modules.
+ * These modules shouldn't be TurboModule-compatible (i.e: they should not conform to RCTTurboModule).
+ *
+ * This method is only used by the TurboModule interop layer.
+ *
+ * It must match the signature of RCTBridgeDelegate extraModulesForBridge:
+ * - (NSArray<id<RCTBridgeModule>> *)extraModulesForBridge:(RCTBridge *)bridge;
+ */
+- (NSArray<id<RCTBridgeModule>> *)extraModulesForBridge:(RCTBridge *)bridge
+    __attribute((deprecated("Please make all native modules returned from this method TurboModule-compatible.")));
+
 @end
 
 @interface RCTTurboModuleManager : NSObject <RCTTurboModuleRegistry>


### PR DESCRIPTION
Summary:
## Rationale
In Bridgeless mode, the TurboModule system needs to integrate with the legacy native module registration mechanisms.

That way, it knows what legacy native modules it's responsible for creating.

## Context
There are three ways to register native modules with the Bridge.

### A) Class loads (i.e: +load)
1. Write an [RCT_EXPORT_MODULE()](https://www.internalfb.com/code/fbsource/[ee3eaa48f826202c6c0e2ee663916ef62fb135d0]/xplat/js/react-native-github/packages/rn-tester/NativeComponentExample/ios/RNTMyLegacyNativeViewManager.mm?lines=25) macro in the module's implementation.
2. This macro [generates a +load](https://www.internalfb.com/code/fbsource/[ee3eaa48f826202c6c0e2ee663916ef62fb135d0]/xplat/js/react-native-github/packages/react-native/React/Base/RCTBridgeModule.h?lines=70%2C76-79) method on the native module class. When the ObjC runtime loads the native module class (during app start), it executes the class's +load method, which [inserts the native module class into a global array (i.e: RCTModuleClasses)](https://www.internalfb.com/code/fbsource/[daf070f990c6a701677f4db3de8bf6fd3d00c6a4]/xplat/js/react-native-github/packages/react-native/React/Base/RCTBridge.m?lines=43-44%2C58-61)
4. Then, when the application starts the bridge, the bridge [registers all these native module classes (in RCTModuleClasses) with itself](https://www.internalfb.com/code/fbsource/xplat/js/react-native-github/packages/react-native/React/CxxBridge/RCTCxxBridge.mm?lines=412).

### B) App provides modules eagerly (i.e: extraModulesForBridge)

1. The application provides an RCTBridgeDelegate to the Bridge. This delegate implements [extraModulesForBridge:](https://www.internalfb.com/code/fbsource/[ee3eaa48f826202c6c0e2ee663916ef62fb135d0]/xplat/js/react-native-github/packages/react-native/React/Base/RCTBridgeDelegate.h?lines=13%2C23%2C25-39)
2. The Bridge [registers these extra modules with itself](https://www.internalfb.com/code/fbsource/[574e410dcffbc900152cea60a50e750d833a2534]/xplat/js/react-native-github/packages/react-native/React/CxxBridge/RCTCxxBridge.mm?lines=389%2C410%2C412%2C799%2C804-805), when it starts up.

### C) App provides modules lazily (i.e: bridge:didNotLoadModule)
1. The application provides an RCTBridgeDelegate to the Bridge. This delegate implements [bridge:didNotFindModule:](https://www.internalfb.com/code/fbsource/[ee3eaa48f826202c6c0e2ee663916ef62fb135d0]/xplat/js/react-native-github/packages/react-native/React/Base/RCTBridgeDelegate.h?lines=13%2C23%2C57)
2. When module lookup fails on the bridge, the bridge [calls the delegate's bridge:didNotFindModule](https://www.internalfb.com/code/fbsource/[ee3eaa48f826202c6c0e2ee663916ef62fb135d0]/xplat/js/react-native-github/packages/react-native/React/CxxBridge/RCTCxxBridge.mm?lines=585%2C618-619)
3. In this method, the delegate [loads the native module class from *somewhere*](https://www.internalfb.com/code/fbsource/[0f0f48a4723c830310c6e2c194822b6a5ba3000e]/fbobjc/Apps/Wilde/FBReactModule2/FBReactModuleAPI/FBReactModuleAPI/Exported/FBReactModule.mm?lines=1072%2C1074-1075), and [registers it with the bridge](https://www.internalfb.com/code/fbsource/[0f0f48a4723c830310c6e2c194822b6a5ba3000e]/fbobjc/Apps/Wilde/FBReactModule2/FBReactModuleAPI/FBReactModuleAPI/Exported/FBReactModule.mm?lines=1072%2C1083-1085)

## Changes
This diff integrates the TurboModule system with +loads and extraModulesForBridge.

It does not integrate with the lazy module registration mechanism, because I believe that mechanism isn't used in open source.

Changelog: [Internal]

Reviewed By: philIip

Differential Revision: D44647858

