### PR TITLE
Add scripts to `yarn start` and `yarn android` from root

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "outputName": "js-test-results.xml"
   },
   "scripts": {
-    "start": "react-native start",
+    "start": "cd packages/rn-tester && npm run start",
+    "android": "cd packages/rn-tester && npm run android",
     "test": "jest",
     "test-ci": "jest --maxWorkers=2 --ci --reporters=\"default\" --reporters=\"jest-junit\"",
     "flow": "flow",

--- a/packages/rn-tester/package.json
+++ b/packages/rn-tester/package.json
@@ -14,6 +14,7 @@
   },
   "scripts": {
     "start": "react-native start",
+    "android": "react-native run-android --mode HermesDebug --appId 'com.facebook.react.uiapp' --main-activity 'com.facebook.react.uiapp.RNTesterActivity'",
     "install-android-jsc": "../../gradlew :packages:rn-tester:android:app:installJscDebug",
     "install-android-hermes": "../../gradlew :packages:rn-tester:android:app:installHermesDebug",
     "clean-android": "rm -rf android/app/build",

--- a/packages/rn-tester/react-native.config.js
+++ b/packages/rn-tester/react-native.config.js
@@ -29,5 +29,8 @@ module.exports = {
     ios: {
       sourceDir: '.',
     },
+    android: {
+      sourceDir: '../../',
+    },
   },
 };


### PR DESCRIPTION
Summary:
This adds script to better work with RN Tester from the root of the repo.
- `yarn start` is broken as of today
- `yarn android` is not working fine and I've adapter it here.

This should make easier to work with RN Tester from within the Repo.

Changelog:
[Internal] [Changed] - Add scripts to `yarn start` and `yarn android` from root

Reviewed By: mdvacca, cipolleschi

Differential Revision: D45735926

