### PR TITLE
Use reference Yoga CMake build for libyogacore

### DIFF
--- a/packages/react-native/ReactCommon/yoga/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/yoga/CMakeLists.txt
@@ -6,17 +6,9 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -O3
-        -Wall
-        -Wpedantic
-        -Wno-gnu-zero-variadic-macro-arguments)
+# Yoga by default does not enable optimizations in debug builds. Enable -O2
+# for all builds in RN for faster debug app performance (at the cost of not
+# being able to debug inside Yoga)
+set(CMAKE_BUILD_TYPE Release)
 
-file(GLOB_RECURSE yogacore_SRC CONFIGURE_DEPENDS yoga/*.cpp)
-add_library(yogacore STATIC ${yogacore_SRC})
-
-target_include_directories(yogacore PUBLIC .)
-
-target_link_libraries(yogacore android log)
+add_subdirectory(yoga)


### PR DESCRIPTION
Summary: This makes React Native use `libyogacore` as provided by Yoga's reference CMake build. This in turn matches Yoga in the OSS RN build to the same compilation settings we use internally.

Differential Revision: D45764537

