### PR TITLE
Remove YGExperimentalFeatureFixAbsoluteTrailingColumnMargin

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaExperimentalFeature.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaExperimentalFeature.java
@@ -12,8 +12,7 @@ package com.facebook.yoga;
 public enum YogaExperimentalFeature {
   WEB_FLEX_BASIS(0),
   ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE(1),
-  FIX_ABSOLUTE_TRAILING_COLUMN_MARGIN(2),
-  FIX_JNILOCAL_REF_OVERFLOWS(3);
+  FIX_JNILOCAL_REF_OVERFLOWS(2);
 
   private final int mIntValue;
 
@@ -29,8 +28,7 @@ public enum YogaExperimentalFeature {
     switch (value) {
       case 0: return WEB_FLEX_BASIS;
       case 1: return ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE;
-      case 2: return FIX_ABSOLUTE_TRAILING_COLUMN_MARGIN;
-      case 3: return FIX_JNILOCAL_REF_OVERFLOWS;
+      case 2: return FIX_JNILOCAL_REF_OVERFLOWS;
       default: throw new IllegalArgumentException("Unknown enum value: " + value);
     }
   }

--- a/packages/react-native/ReactCommon/yoga/yoga/YGEnums.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGEnums.cpp
@@ -107,8 +107,6 @@ const char* YGExperimentalFeatureToString(const YGExperimentalFeature value) {
       return "web-flex-basis";
     case YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge:
       return "absolute-percentage-against-padding-edge";
-    case YGExperimentalFeatureFixAbsoluteTrailingColumnMargin:
-      return "fix-absolute-trailing-column-margin";
     case YGExperimentalFeatureFixJNILocalRefOverflows:
       return "fix-jnilocal-ref-overflows";
   }

--- a/packages/react-native/ReactCommon/yoga/yoga/YGEnums.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGEnums.h
@@ -66,7 +66,6 @@ YG_ENUM_SEQ_DECL(
     YGExperimentalFeature,
     YGExperimentalFeatureWebFlexBasis,
     YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge,
-    YGExperimentalFeatureFixAbsoluteTrailingColumnMargin,
     YGExperimentalFeatureFixJNILocalRefOverflows)
 
 YG_ENUM_SEQ_DECL(

--- a/packages/react-native/ReactCommon/yoga/yoga/Yoga.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/Yoga.cpp
@@ -1543,19 +1543,13 @@ static void YGNodeAbsoluteLayoutChild(
       depth,
       generationCount);
 
-  auto trailingMarginOuterSize =
-      node->getConfig()->isExperimentalFeatureEnabled(
-          YGExperimentalFeatureFixAbsoluteTrailingColumnMargin)
-      ? isMainAxisRow ? height : width
-      : width;
-
   if (child->isTrailingPosDefined(mainAxis) &&
       !child->isLeadingPositionDefined(mainAxis)) {
     child->setLayoutPosition(
         node->getLayout().measuredDimensions[dim[mainAxis]] -
             child->getLayout().measuredDimensions[dim[mainAxis]] -
             node->getTrailingBorder(mainAxis) -
-            child->getTrailingMargin(mainAxis, trailingMarginOuterSize)
+            child->getTrailingMargin(mainAxis, isMainAxisRow ? width : height)
                 .unwrap() -
             child->getTrailingPosition(mainAxis, isMainAxisRow ? width : height)
                 .unwrap(),
@@ -1598,7 +1592,7 @@ static void YGNodeAbsoluteLayoutChild(
         node->getLayout().measuredDimensions[dim[crossAxis]] -
             child->getLayout().measuredDimensions[dim[crossAxis]] -
             node->getTrailingBorder(crossAxis) -
-            child->getTrailingMargin(crossAxis, trailingMarginOuterSize)
+            child->getTrailingMargin(crossAxis, isMainAxisRow ? height : width)
                 .unwrap() -
             child
                 ->getTrailingPosition(crossAxis, isMainAxisRow ? height : width)


### PR DESCRIPTION
Summary: This is edge-casey enough, and I actually broke this in D42282358 without us noticing (I changed height to width of the bottom usage, instead, copy/pasting the value of the top one).

Differential Revision: D45766764

