### PR TITLE
Add `hasErrata()`, `addErrata()`, `removeErrata()`

### DIFF
--- a/packages/react-native/ReactCommon/yoga/yoga/YGConfig.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGConfig.cpp
@@ -59,8 +59,20 @@ void YGConfig::setErrata(YGErrata errata) {
   errata_ = errata;
 }
 
+void YGConfig::addErrata(YGErrata errata) {
+  errata_ |= errata;
+}
+
+void YGConfig::removeErrata(YGErrata errata) {
+  errata_ &= (~errata);
+}
+
 YGErrata YGConfig::getErrata() const {
   return errata_;
+}
+
+bool YGConfig::hasErrata(YGErrata errata) const {
+  return (errata_ & errata) != YGErrataNone;
 }
 
 void YGConfig::setPointScaleFactor(float pointScaleFactor) {

--- a/packages/react-native/ReactCommon/yoga/yoga/YGConfig.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGConfig.h
@@ -67,7 +67,10 @@ struct YOGA_EXPORT YGConfig {
   facebook::yoga::ExperimentalFeatureSet getEnabledExperiments() const;
 
   void setErrata(YGErrata errata);
+  void addErrata(YGErrata errata);
+  void removeErrata(YGErrata errata);
   YGErrata getErrata() const;
+  bool hasErrata(YGErrata errata) const;
 
   void setPointScaleFactor(float pointScaleFactor);
   float getPointScaleFactor() const;

--- a/packages/react-native/ReactCommon/yoga/yoga/YGNode.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGNode.h
@@ -118,6 +118,8 @@ public:
 
   float baseline(float width, float height, void* layoutContext);
 
+  bool hasErrata(YGErrata errata) const { return config_->hasErrata(errata); }
+
   YGDirtiedFunc getDirtied() const { return dirtied_; }
 
   // For Performance reasons passing as reference.

--- a/packages/react-native/ReactCommon/yoga/yoga/Yoga.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/Yoga.cpp
@@ -2984,7 +2984,7 @@ static void YGNodelayoutImpl(
         availableInnerMainDim = maxInnerMainDim;
       } else {
         bool useLegacyStretchBehaviour =
-            node->getConfig()->getErrata() & YGErrataStretchFlexBasis;
+            node->hasErrata(YGErrataStretchFlexBasis);
 
         if (!useLegacyStretchBehaviour &&
             ((!YGFloatIsUndefined(
@@ -4313,16 +4313,16 @@ YOGA_EXPORT void YGConfigSetUseWebDefaults(
 
 YOGA_EXPORT bool YGConfigGetUseLegacyStretchBehaviour(
     const YGConfigRef config) {
-  return config->getErrata() & YGErrataStretchFlexBasis;
+  return config->hasErrata(YGErrataStretchFlexBasis);
 }
 
 YOGA_EXPORT void YGConfigSetUseLegacyStretchBehaviour(
     const YGConfigRef config,
     const bool useLegacyStretchBehaviour) {
   if (useLegacyStretchBehaviour) {
-    config->setErrata(config->getErrata() | YGErrataStretchFlexBasis);
+    config->addErrata(YGErrataStretchFlexBasis);
   } else {
-    config->setErrata(config->getErrata() & ~YGErrataStretchFlexBasis);
+    config->removeErrata(YGErrataStretchFlexBasis);
   }
 }
 


### PR DESCRIPTION
Summary:
Adds internal helpers to YGConfig to make bit manipulation more readable. We also expose `hasErrata()` to YGNode beacuse checking that will be a common pattern. We intentionally don't add mutating functions to the node, since current model is to inval a node on commiting whole config.

This is not exposed via the C ABI.

Reviewed By: yungsters

Differential Revision: D45765971

