### PR TITLE
Better TypeScript support for package.json exports field

### DIFF
--- a/packages/typescript-config/tsconfig.json
+++ b/packages/typescript-config/tsconfig.json
@@ -3,7 +3,7 @@
     "display": "React Native",
     "compilerOptions": {
       "target": "esnext",
-      "module": "commonjs",
+      "module": "es2015",
       "types": ["react-native", "jest"],
       "lib": [
         "es2019",
@@ -25,8 +25,12 @@
       "noEmit": true,
       "isolatedModules": true,
       "strict": true,
-      "moduleResolution": "nodenext",
+      "moduleResolution": "bundler",
+      "customConditions": ["react-native"],
+      "allowImportingTsExtensions": true,
+      "allowArbitraryExtensions": true,
       "resolveJsonModule": true,
+      "resolvePackageJsonImports": false,
       "allowSyntheticDefaultImports": true,
       "esModuleInterop": true,
       "skipLibCheck": true,


### PR DESCRIPTION
Summary:
For 0.72 I enabled `moduleResolution: "nodenext"` which allows some package exports support, but this is imperfect. E.g. RN will typecheck against the `node` condition and there are some more restrictions than we need.

D45720238 bumped TypeScript to 5.0 for RN 0.73, along with D45721088 which brought the tsconfig inline. This lets us switch to the new [`moduleResolution: "bundler"`](https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/#moduleresolution-bundler) and instructs `tsc` to follow the `react-native` export condition.

See even more context at: https://github.com/microsoft/TypeScript/pull/51669

Changelog:
[General][Added] - Better TypeScript support for package.json exports field

Differential Revision: D45769740

