### PR TITLE
Android fno-rtti

### DIFF
--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleJniH.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleJniH.js
@@ -108,7 +108,7 @@ target_compile_options(
   PRIVATE
   -DLOG_TAG=\\"ReactNative\\"
   -fexceptions
-  -frtti
+  -fno-rtti
   -std=c++17
   -Wall
 )

--- a/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleJniH-test.js.snap
+++ b/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleJniH-test.js.snap
@@ -78,7 +78,7 @@ target_compile_options(
   PRIVATE
   -DLOG_TAG=\\\\\\"ReactNative\\\\\\"
   -fexceptions
-  -frtti
+  -fno-rtti
   -std=c++17
   -Wall
 )
@@ -164,7 +164,7 @@ target_compile_options(
   PRIVATE
   -DLOG_TAG=\\\\\\"ReactNative\\\\\\"
   -fexceptions
-  -frtti
+  -fno-rtti
   -std=c++17
   -Wall
 )
@@ -243,7 +243,7 @@ target_compile_options(
   PRIVATE
   -DLOG_TAG=\\\\\\"ReactNative\\\\\\"
   -fexceptions
-  -frtti
+  -fno-rtti
   -std=c++17
   -Wall
 )
@@ -329,7 +329,7 @@ target_compile_options(
   PRIVATE
   -DLOG_TAG=\\\\\\"ReactNative\\\\\\"
   -fexceptions
-  -frtti
+  -fno-rtti
   -std=c++17
   -Wall
 )
@@ -415,7 +415,7 @@ target_compile_options(
   PRIVATE
   -DLOG_TAG=\\\\\\"ReactNative\\\\\\"
   -fexceptions
-  -frtti
+  -fno-rtti
   -std=c++17
   -Wall
 )
@@ -509,7 +509,7 @@ target_compile_options(
   PRIVATE
   -DLOG_TAG=\\\\\\"ReactNative\\\\\\"
   -fexceptions
-  -frtti
+  -fno-rtti
   -std=c++17
   -Wall
 )
@@ -595,7 +595,7 @@ target_compile_options(
   PRIVATE
   -DLOG_TAG=\\\\\\"ReactNative\\\\\\"
   -fexceptions
-  -frtti
+  -fno-rtti
   -std=c++17
   -Wall
 )
@@ -689,7 +689,7 @@ target_compile_options(
   PRIVATE
   -DLOG_TAG=\\\\\\"ReactNative\\\\\\"
   -fexceptions
-  -frtti
+  -fno-rtti
   -std=c++17
   -Wall
 )

--- a/packages/react-native/ReactAndroid/cmake-utils/ReactNative-application.cmake
+++ b/packages/react-native/ReactAndroid/cmake-utils/ReactNative-application.cmake
@@ -46,7 +46,7 @@ target_include_directories(${CMAKE_PROJECT_NAME}
                 ${CMAKE_CURRENT_SOURCE_DIR}
                 ${PROJECT_BUILD_DIR}/generated/rncli/src/main/jni)
 
-target_compile_options(${CMAKE_PROJECT_NAME} PRIVATE -Wall -Werror -fexceptions -frtti -std=c++17 -DWITH_INSPECTOR=1 -DLOG_TAG=\"ReactNative\")
+target_compile_options(${CMAKE_PROJECT_NAME} PRIVATE -Wall -Werror -fexceptions -fno-rtti -std=c++17 -DWITH_INSPECTOR=1 -DLOG_TAG=\"ReactNative\")
 
 # Prefab packages from React Native
 find_package(ReactAndroid REQUIRED CONFIG)

--- a/packages/react-native/ReactAndroid/src/main/jni/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/CMakeLists.txt
@@ -166,17 +166,17 @@ add_executable(reactnative_unittest
   ${REACT_COMMON_DIR}/react/renderer/templateprocessor/tests/UITemplateProcessorTest.cpp
   ${REACT_COMMON_DIR}/react/renderer/textlayoutmanager/tests/TextLayoutManagerTest.cpp
   ${REACT_COMMON_DIR}/react/renderer/uimanager/tests/FabricUIManagerTest.cpp
-  
+
   ########## (COMPILE BUT FAIL ON ASSERTS) ###########
   # ${REACT_COMMON_DIR}/react/renderer/animations/tests/LayoutAnimationTest.cpp
   # ${REACT_COMMON_DIR}/react/renderer/mounting/tests/MountingTest.cpp
   # ${REACT_COMMON_DIR}/react/renderer/mounting/tests/ShadowTreeLifeCycleTest.cpp
-  
+
   ########## (COMPILE BUT FAIL WITH RUNTIME EXCEPTIONS) ###########
   # ${REACT_COMMON_DIR}/hermes/inspector/chrome/tests/ConnectionDemuxTests.cpp
   # ${REACT_COMMON_DIR}/hermes/inspector/detail/tests/SerialExecutorTests.cpp
   # ${REACT_COMMON_DIR}/hermes/inspector/tests/InspectorTests.cpp
-  
+
   ########## (DO NOT COMPILE) ###########
   # ${REACT_COMMON_DIR}/react/renderer/core/tests/ShadowNodeTest.cpp
   # ${REACT_COMMON_DIR}/react/renderer/core/tests/ConcreteShadowNodeTest.cpp
@@ -196,7 +196,7 @@ add_executable(reactnative_unittest
   target_link_libraries(reactnative_unittest
   folly_runtime
   folly_futures
-  glog  
+  glog
   glog_init
   gtest
   hermes-engine::libhermes

--- a/packages/react-native/ReactAndroid/src/main/jni/first-party/fb/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/first-party/fb/CMakeLists.txt
@@ -16,7 +16,7 @@ add_compile_options(
         -DDISABLE_CPUCAP
         -DDISABLE_XPLAT
         -fexceptions
-        -frtti
+        -fno-rtti
         -Wno-unused-parameter
         -Wno-error=unused-but-set-variable
         -DHAVE_POSIX_CLOCKS

--- a/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/CMakeLists.txt
@@ -9,7 +9,7 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 add_compile_options(
         -fvisibility=hidden
         -fexceptions
-        -frtti
+        -fno-rtti
         -O3)
 
 file(GLOB yoga_SRC CONFIGURE_DEPENDS jni/*.cpp)

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/CMakeLists.txt
@@ -63,7 +63,7 @@ target_compile_options(
         PRIVATE
         -DLOG_TAG=\"Fabric\"
         -fexceptions
-        -frtti
+        -fno-rtti
         -std=c++17
         -Wall
 )

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/CMakeLists.txt
@@ -10,7 +10,7 @@ file(GLOB reactnativejni_SRC CONFIGURE_DEPENDS *.cpp)
 
 add_compile_options(
         -fexceptions
-        -frtti
+        -fno-rtti
         -Wno-unused-lambda-capture
         -std=c++17
         -DWITH_INSPECTOR=1)

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jscexecutor/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jscexecutor/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-fvisibility=hidden -fexceptions -frtti)
+add_compile_options(-fvisibility=hidden -fexceptions -fno-rtti)
 
 file(GLOB jscexecutor_SRC CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
 add_library(jscexecutor SHARED ${jscexecutor_SRC})

--- a/packages/react-native/ReactAndroid/src/main/jni/react/mapbuffer/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/mapbuffer/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-fexceptions -frtti -std=c++17 -Wall -DLOG_TAG=\"Fabric\")
+add_compile_options(-fexceptions -fno-rtti -std=c++17 -Wall -DLOG_TAG=\"Fabric\")
 
 file(GLOB mapbuffer_SRC CONFIGURE_DEPENDS
         ${CMAKE_CURRENT_SOURCE_DIR}/react/common/mapbuffer/*.cpp)

--- a/packages/react-native/ReactAndroid/src/main/jni/react/newarchdefaults/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/newarchdefaults/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-fexceptions -frtti -std=c++17 -Wall -DLOG_TAG=\"ReactNative\")
+add_compile_options(-fexceptions -fno-rtti -std=c++17 -Wall -DLOG_TAG=\"ReactNative\")
 
 file(GLOB react_newarchdefaults_SRC CONFIGURE_DEPENDS *.cpp)
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/reactnativeblob/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/reactnativeblob/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-fvisibility=hidden -fexceptions -frtti)
+add_compile_options(-fvisibility=hidden -fexceptions -fno-rtti)
 
 file(GLOB reactnativeblob_SRC CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
 add_library(reactnativeblob SHARED ${reactnativeblob_SRC})

--- a/packages/react-native/ReactAndroid/src/main/jni/react/reactperflogger/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/reactperflogger/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-fexceptions -frtti -std=c++17 -Wall)
+add_compile_options(-fexceptions -fno-rtti -std=c++17 -Wall)
 
 add_library(reactperfloggerjni SHARED reactperflogger/OnLoad.cpp)
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 add_compile_options(
         -fexceptions
-        -frtti
+        -fno-rtti
         -Wno-unused-lambda-capture
         -std=c++17)
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/uimanager/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/uimanager/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-fexceptions -frtti -std=c++17 -Wall -DLOG_TAG=\"ReactNative\")
+add_compile_options(-fexceptions -fno-rtti -std=c++17 -Wall -DLOG_TAG=\"ReactNative\")
 
 file(GLOB uimanagerjni_SRC CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
 add_library(uimanagerjni SHARED ${uimanagerjni_SRC})

--- a/packages/react-native/ReactCommon/butter/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/butter/CMakeLists.txt
@@ -9,7 +9,7 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 add_compile_options(
         -DLOG_TAG=\"Butter\"
         -fexceptions
-        -frtti
+        -fno-rtti
         -std=c++17
         -Wall
         -Wpedantic

--- a/packages/react-native/ReactCommon/callinvoker/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/callinvoker/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 add_compile_options(
         -fexceptions
-        -frtti
+        -fno-rtti
         -std=c++17
         -Wall
         -Wpedantic

--- a/packages/react-native/ReactCommon/cxxreact/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/cxxreact/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 add_compile_options(
         -fexceptions
-        -frtti
+        -fno-rtti
         -std=c++17
         -Wno-unused-lambda-capture
         -DLOG_TAG=\"ReactNative\")

--- a/packages/react-native/ReactCommon/react/bridging/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/bridging/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 add_compile_options(
         -fexceptions
-        -frtti
+        -fno-rtti
         -std=c++17
         -Wall
         -Wpedantic

--- a/packages/react-native/ReactCommon/react/config/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/config/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 add_compile_options(
         -fexceptions
-        -frtti
+        -fno-rtti
         -std=c++17
         -Wall
         -Wpedantic

--- a/packages/react-native/ReactCommon/react/debug/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/debug/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 add_compile_options(
         -fexceptions
-        -frtti
+        -fno-rtti
         -std=c++17
         -Wall
         -Wpedantic

--- a/packages/react-native/ReactCommon/react/nativemodule/core/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 add_compile_options(
         -fexceptions
-        -frtti
+        -fno-rtti
         -std=c++17
         -Wall
         -Wpedantic

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 add_compile_options(
         -fexceptions
-        -frtti
+        -fno-rtti
         -std=c++17
         -Wall
         -Wpedantic

--- a/packages/react-native/ReactCommon/react/renderer/animations/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/animations/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 add_compile_options(
         -fexceptions
-        -frtti
+        -fno-rtti
         -std=c++17
         -Wall
         -Wpedantic

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 add_compile_options(
         -fexceptions
-        -frtti
+        -fno-rtti
         -std=c++17
         -Wall
         -Wpedantic

--- a/packages/react-native/ReactCommon/react/renderer/componentregistry/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/componentregistry/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 add_compile_options(
         -fexceptions
-        -frtti
+        -fno-rtti
         -std=c++17
         -Wall
         -Wpedantic

--- a/packages/react-native/ReactCommon/react/renderer/componentregistry/native/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/componentregistry/native/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 add_compile_options(
         -fexceptions
-        -frtti
+        -fno-rtti
         -std=c++17
         -Wall
         -Wpedantic

--- a/packages/react-native/ReactCommon/react/renderer/components/image/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 add_compile_options(
         -fexceptions
-        -frtti
+        -fno-rtti
         -std=c++17
         -Wall
         -Wpedantic

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 add_compile_options(
         -fexceptions
-        -frtti
+        -fno-rtti
         -std=c++17
         -Wall
         -Wpedantic

--- a/packages/react-native/ReactCommon/react/renderer/components/modal/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/modal/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 add_compile_options(
         -fexceptions
-        -frtti
+        -fno-rtti
         -std=c++17
         -Wall
         -Wpedantic

--- a/packages/react-native/ReactCommon/react/renderer/components/progressbar/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/progressbar/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 add_compile_options(
         -fexceptions
-        -frtti
+        -fno-rtti
         -std=c++17
         -Wall
         -Wpedantic

--- a/packages/react-native/ReactCommon/react/renderer/components/root/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/root/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 add_compile_options(
         -fexceptions
-        -frtti
+        -fno-rtti
         -std=c++17
         -Wall
         -Wpedantic

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 add_compile_options(
         -fexceptions
-        -frtti
+        -fno-rtti
         -std=c++17
         -Wall
         -Wpedantic

--- a/packages/react-native/ReactCommon/react/renderer/components/switch/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/switch/CMakeLists.txt
@@ -38,7 +38,7 @@ target_compile_options(
         PRIVATE
         -DLOG_TAG=\"Fabric\"
         -fexceptions
-        -frtti
+        -fno-rtti
         -std=c++17
         -Wall
         -Wpedantic

--- a/packages/react-native/ReactCommon/react/renderer/components/text/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 add_compile_options(
         -fexceptions
-        -frtti
+        -fno-rtti
         -std=c++17
         -Wall
         -Wpedantic

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 add_compile_options(
         -fexceptions
-        -frtti
+        -fno-rtti
         -std=c++17
         -Wall
         -Wpedantic

--- a/packages/react-native/ReactCommon/react/renderer/components/unimplementedview/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/unimplementedview/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 add_compile_options(
         -fexceptions
-        -frtti
+        -fno-rtti
         -std=c++17
         -Wall
         -Wpedantic

--- a/packages/react-native/ReactCommon/react/renderer/components/view/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 add_compile_options(
         -fexceptions
-        -frtti
+        -fno-rtti
         -std=c++17
         -Wall
         -Wpedantic

--- a/packages/react-native/ReactCommon/react/renderer/core/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/core/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 add_compile_options(
         -fexceptions
-        -frtti
+        -fno-rtti
         -std=c++17
         -Wall
         -Wpedantic

--- a/packages/react-native/ReactCommon/react/renderer/debug/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/debug/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 add_compile_options(
         -fexceptions
-        -frtti
+        -fno-rtti
         -std=c++17
         -Wall
         -Wpedantic

--- a/packages/react-native/ReactCommon/react/renderer/element/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/element/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 add_compile_options(
         -fexceptions
-        -frtti
+        -fno-rtti
         -std=c++17
         -Wall
         -Wpedantic
@@ -26,4 +26,3 @@ target_link_libraries(react_render_element
         react_render_core
         react_render_componentregistry
 )
-

--- a/packages/react-native/ReactCommon/react/renderer/graphics/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 add_compile_options(
         -fexceptions
-        -frtti
+        -fno-rtti
         -std=c++17
         -Wall
         -Wpedantic
@@ -25,4 +25,3 @@ target_include_directories(react_render_graphics
         )
 
 target_link_libraries(react_render_graphics glog fb fbjni folly_runtime react_debug)
-

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 add_compile_options(
         -fexceptions
-        -frtti
+        -fno-rtti
         -std=c++17
         -Wall
         -Wpedantic

--- a/packages/react-native/ReactCommon/react/renderer/leakchecker/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/leakchecker/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 add_compile_options(
         -fexceptions
-        -frtti
+        -fno-rtti
         -std=c++17
         -Wall
         -Wpedantic

--- a/packages/react-native/ReactCommon/react/renderer/mapbuffer/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/mapbuffer/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 add_compile_options(
         -fexceptions
-        -frtti
+        -fno-rtti
         -std=c++17
         -Wall
         -Wpedantic

--- a/packages/react-native/ReactCommon/react/renderer/mounting/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 add_compile_options(
         -fexceptions
-        -frtti
+        -fno-rtti
         -std=c++17
         -Wall
         -Wpedantic

--- a/packages/react-native/ReactCommon/react/renderer/telemetry/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/telemetry/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 add_compile_options(
         -fexceptions
-        -frtti
+        -fno-rtti
         -std=c++17
         -Wall
         -Wpedantic

--- a/packages/react-native/ReactCommon/react/renderer/templateprocessor/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/templateprocessor/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 add_compile_options(
         -fexceptions
-        -frtti
+        -fno-rtti
         -std=c++17
         -Wall
         -Wpedantic

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 add_compile_options(
         -fexceptions
-        -frtti
+        -fno-rtti
         -std=c++17
         -Wall
         -Wpedantic

--- a/packages/react-native/ReactCommon/react/utils/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/utils/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 add_compile_options(
         -fexceptions
-        -frtti
+        -fno-rtti
         -std=c++17
         -Wall
         -Wpedantic

--- a/packages/react-native/ReactCommon/reactperflogger/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/reactperflogger/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 add_compile_options(
         -fexceptions
-        -frtti
+        -fno-rtti
         -std=c++17
         -Wall
         -Wpedantic

--- a/packages/react-native/ReactCommon/runtimeexecutor/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/runtimeexecutor/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 add_compile_options(
         -fexceptions
-        -frtti
+        -fno-rtti
         -std=c++17
         -Wall
         -Wpedantic

--- a/packages/rn-tester/NativeCxxModuleExample/CMakeLists.txt
+++ b/packages/rn-tester/NativeCxxModuleExample/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 add_compile_options(
         -fexceptions
-        -frtti
+        -fno-rtti
         -std=c++17
         -Wall
         -Wpedantic


### PR DESCRIPTION
Summary:
We did the work to support this internally, let's see the savings we get with this or if we run into issues.

This is technically breaking for users of the new architecture who are relying on dynamic_cast, but that should be relatively rare. We could also maybe scope this so that the framework builds with RTTI, but user modules do not (so user's could dynamic_cast their own types).

Changelog:
[Android][Breaking] - Disable RTTI

Differential Revision: D45771601

