### PR TITLE
 [Codegen 110] Add a nullLiteralTypeAnnotation: string property into the Parser object

### DIFF
--- a/packages/react-native-codegen/src/parsers/flow/components/events.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/events.js
@@ -223,7 +223,7 @@ function findEventArgumentsAndType(
         : null;
     if (
       typeAnnotation.typeParameters.params[0].type ===
-      'NullLiteralTypeAnnotation'
+      parser.nullLiteralTypeAnnotation
     ) {
       return {
         argumentProps: [],

--- a/packages/react-native-codegen/src/parsers/flow/parser.js
+++ b/packages/react-native-codegen/src/parsers/flow/parser.js
@@ -51,6 +51,8 @@ const {
 class FlowParser implements Parser {
   typeParameterInstantiation: string = 'TypeParameterInstantiation';
 
+  nullLiteralTypeAnnotation: string = 'NullLiteralTypeAnnotation';
+
   isProperty(property: $FlowFixMe): boolean {
     return property.type === 'ObjectTypeProperty';
   }

--- a/packages/react-native-codegen/src/parsers/parser.js
+++ b/packages/react-native-codegen/src/parsers/parser.js
@@ -73,6 +73,11 @@ export interface Parser {
   typeParameterInstantiation: string;
 
   /**
+   * This is the NullLiteralTypeAnnotation value
+   */
+  nullLiteralTypeAnnotation: string;
+
+  /**
    * Given a declaration, it returns true if it is a property
    */
   isProperty(property: $FlowFixMe): boolean;

--- a/packages/react-native-codegen/src/parsers/parserMock.js
+++ b/packages/react-native-codegen/src/parsers/parserMock.js
@@ -50,6 +50,8 @@ const schemaMock = {
 export class MockedParser implements Parser {
   typeParameterInstantiation: string = 'TypeParameterInstantiation';
 
+  nullLiteralTypeAnnotation: string = 'NullLiteralTypeAnnotation';
+
   isProperty(property: $FlowFixMe): boolean {
     return property.type === 'ObjectTypeProperty';
   }

--- a/packages/react-native-codegen/src/parsers/typescript/components/events.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/events.js
@@ -237,7 +237,7 @@ function findEventArgumentsAndType(
         : null;
 
     switch (typeAnnotation.typeParameters.params[0].type) {
-      case 'TSNullKeyword':
+      case parser.nullLiteralTypeAnnotation:
       case 'TSUndefinedKeyword':
         return {
           argumentProps: [],

--- a/packages/react-native-codegen/src/parsers/typescript/parser.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parser.js
@@ -50,6 +50,8 @@ const {
 class TypeScriptParser implements Parser {
   typeParameterInstantiation: string = 'TSTypeParameterInstantiation';
 
+  nullLiteralTypeAnnotation: string = 'TSNullKeyword';
+
   isProperty(property: $FlowFixMe): boolean {
     return property.type === 'TSPropertySignature';
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Part of #34872 
> [Codegen 110] Add a nullLiteralTypeAnnotation: string property into the Parser object and implement it in the FlowParser (returning
NullLiteralTypeAnnotation) and in the TypeScriptParser(returning TSNullKeyword). Replace them in the [parsers/flow/components/events.js](https://github.com/facebook/react-native/blob/e133100721939108b0f28dfa9f60ac627c804018/packages/react-native-codegen/src/parsers/flow/components/events.js#L137-L138) and [parsers/typescript/components/events.js](https://github.com/facebook/react-native/blob/e133100721939108b0f28dfa9f60ac627c804018/packages/react-native-codegen/src/parsers/typescript/components/events.js#L157).

## Changelog:

[Internal][Added]: Add nullLiteralTypeAnnotation property in Parser object

## Test Plan:

`yarn test react-native-codegen`
