### PR TITLE
Make `jni_YGNodeDeallocateJNI` call `YGNodeDeallocate`

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/YGJNIVanilla.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/YGJNIVanilla.cpp
@@ -210,7 +210,7 @@ static void jni_YGNodeDeallocateJNI(
     return;
   }
   const YGNodeRef node = _jlong2YGNodeRef(nativePointer);
-  YGNodeFree(node);
+  YGNodeDeallocate(node);
 }
 
 static void jni_YGNodeResetJNI(


### PR DESCRIPTION
Summary:
Fixes https://github.com/facebook/yoga/issues/1271

Updating this glue was missed in D45556206 when moving from one revision to the other...

Differential Revision: D45780647

