### PR TITLE
Disable TurboModule interop by default

### DIFF
--- a/packages/react-native/React/Base/RCTBridge.m
+++ b/packages/react-native/React/Base/RCTBridge.m
@@ -120,7 +120,7 @@ void RCTDisableTurboModuleManagerDelegateLocking(BOOL disabled)
   turboModuleManagerDelegateLockingDisabled = disabled;
 }
 
-static BOOL turboModuleInteropEnabled = YES;
+static BOOL turboModuleInteropEnabled = NO;
 BOOL RCTTurboModuleInteropEnabled(void)
 {
   return turboModuleInteropEnabled;


### PR DESCRIPTION
Summary:
This was accidentally set to true by default.

This resulted in the TurboModule interop layer being enabled on Standalone apps.

Changelog: [Internal]

Differential Revision: D45783832

