### PR TITLE
move registerSegmentWithId: to internal APIs

### DIFF
--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost+Internal.h
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost+Internal.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RCTHost.h"
+
+@interface RCTHost (Internal)
+
+- (void)registerSegmentWithId:(NSNumber *)segmentId path:(NSString *)path;
+
+@end

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.h
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.h
@@ -49,7 +49,7 @@ typedef std::shared_ptr<facebook::react::JSEngineInstance> (^RCTHostJSEngineProv
  * RCTHost is long lived, while an instance may be deallocated and re-initialized. Some examples of when this happens:
  * CMD+R reload in DEV or a JS crash. The host should be the single owner of an RCTInstance.
  */
-@interface RCTHost : NSObject <ReactInstanceForwarding>
+@interface RCTHost : NSObject
 
 - (instancetype)initWithHostDelegate:(id<RCTHostDelegate>)hostDelegate
           turboModuleManagerDelegate:(id<RCTTurboModuleManagerDelegate>)turboModuleManagerDelegate

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.h
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.h
@@ -76,6 +76,12 @@ typedef std::shared_ptr<facebook::react::JSEngineInstance> (^RCTHostJSEngineProv
 
 - (RCTSurfacePresenter *)getSurfacePresenter FB_OBJC_DIRECT;
 
+/**
+ * Calls a method on a JS module that has been registered with `registerCallableModule`. Used to invoke a JS function
+ * from platform code.
+ */
+- (void)callFunctionOnJSModule:(NSString *)moduleName method:(NSString *)method args:(NSArray *)args;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.mm
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.mm
@@ -140,7 +140,7 @@ NSString *const RCTHostDidReloadNotification = @"RCTHostDidReloadNotification";
   return self;
 }
 
-#pragma mark - Public API
+#pragma mark - Public
 
 - (void)preload
 {
@@ -199,6 +199,11 @@ NSString *const RCTHostDidReloadNotification = @"RCTHostDidReloadNotification";
   return [_instance surfacePresenter];
 }
 
+- (void)callFunctionOnJSModule:(NSString *)moduleName method:(NSString *)method args:(NSArray *)args
+{
+  [_instance callFunctionOnJSModule:moduleName method:method args:args];
+}
+
 #pragma mark - RCTReloadListener
 
 - (void)didReceiveReloadCommand
@@ -236,11 +241,6 @@ NSString *const RCTHostDidReloadNotification = @"RCTHostDidReloadNotification";
 // TODO (T74233481) - Should raw instance be accessed in this class like this? These functions shouldn't be called very
 // early in startup, but could add some intelligent guards here.
 #pragma mark - ReactInstanceForwarding
-
-- (void)callFunctionOnModule:(NSString *)moduleName method:(NSString *)method args:(NSArray *)args
-{
-  [_instance callFunctionOnModule:moduleName method:method args:args];
-}
 
 - (void)registerSegmentWithId:(NSNumber *)segmentId path:(NSString *)path
 {

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.mm
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.mm
@@ -6,6 +6,7 @@
  */
 
 #import "RCTHost.h"
+#import "RCTHost+Internal.h"
 
 #import <PikaOptimizationsMacros/PikaOptimizationsMacros.h>
 #import <React/RCTAssert.h>
@@ -238,15 +239,6 @@ NSString *const RCTHostDidReloadNotification = @"RCTHostDidReloadNotification";
   }
 }
 
-// TODO (T74233481) - Should raw instance be accessed in this class like this? These functions shouldn't be called very
-// early in startup, but could add some intelligent guards here.
-#pragma mark - ReactInstanceForwarding
-
-- (void)registerSegmentWithId:(NSNumber *)segmentId path:(NSString *)path
-{
-  [_instance registerSegmentWithId:segmentId path:path];
-}
-
 - (void)dealloc
 {
   [_instance invalidate];
@@ -257,6 +249,13 @@ NSString *const RCTHostDidReloadNotification = @"RCTHostDidReloadNotification";
 - (std::shared_ptr<facebook::react::ContextContainer>)createContextContainer
 {
   return [_hostDelegate createContextContainer];
+}
+
+#pragma mark - Internal
+
+- (void)registerSegmentWithId:(NSNumber *)segmentId path:(NSString *)path
+{
+  [_instance registerSegmentWithId:segmentId path:path];
 }
 
 #pragma mark - Private

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.h
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.h
@@ -46,12 +46,6 @@ FB_RUNTIME_PROTOCOL
 @protocol ReactInstanceForwarding
 
 /**
- * Calls a method on a JS module that has been registered with `registerCallableModule`. Used to invoke a JS function
- * from platform code.
- */
-- (void)callFunctionOnModule:(NSString *)moduleName method:(NSString *)method args:(NSArray *)args;
-
-/**
  * Registers a new JS segment.
  */
 - (void)registerSegmentWithId:(NSNumber *)segmentId path:(NSString *)path;
@@ -76,6 +70,8 @@ typedef void (^_Null_unspecified RCTInstanceInitialBundleLoadCompletionBlock)();
                   moduleRegistry:(RCTModuleRegistry *)moduleRegistry
              jsErrorHandlingFunc:(facebook::react::JsErrorHandler::JsErrorHandlingFunc)jsErrorHandlingFunc
     FB_OBJC_DIRECT;
+
+- (void)callFunctionOnJSModule:(NSString *)moduleName method:(NSString *)method args:(NSArray *)args;
 
 - (void)invalidate;
 

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.h
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.h
@@ -40,18 +40,6 @@ FB_RUNTIME_PROTOCOL
 
 @end
 
-/**
- * A set of functions which are forwarded through RCTHost, RCTInstance to ReactInstance.
- */
-@protocol ReactInstanceForwarding
-
-/**
- * Registers a new JS segment.
- */
-- (void)registerSegmentWithId:(NSNumber *)segmentId path:(NSString *)path;
-
-@end
-
 typedef void (^_Null_unspecified RCTInstanceInitialBundleLoadCompletionBlock)();
 
 /**
@@ -59,7 +47,7 @@ typedef void (^_Null_unspecified RCTInstanceInitialBundleLoadCompletionBlock)();
  * Native. RCTInstance should never be instantiated in product code, but rather accessed through RCTHost. The host
  * ensures that any access to the instance is safe, and manages instance lifecycle.
  */
-@interface RCTInstance : NSObject <ReactInstanceForwarding>
+@interface RCTInstance : NSObject
 
 - (instancetype)initWithDelegate:(id<RCTInstanceDelegate>)delegate
                 jsEngineInstance:(std::shared_ptr<facebook::react::JSEngineInstance>)jsEngineInstance
@@ -72,6 +60,8 @@ typedef void (^_Null_unspecified RCTInstanceInitialBundleLoadCompletionBlock)();
     FB_OBJC_DIRECT;
 
 - (void)callFunctionOnJSModule:(NSString *)moduleName method:(NSString *)method args:(NSArray *)args;
+
+- (void)registerSegmentWithId:(NSNumber *)segmentId path:(NSString *)path;
 
 - (void)invalidate;
 

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.mm
@@ -115,7 +115,7 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
           setBridgelessJSModuleMethodInvoker:^(
               NSString *moduleName, NSString *methodName, NSArray *args, dispatch_block_t onComplete) {
             // TODO: Make RCTInstance call onComplete
-            [weakInstance callFunctionOnModule:moduleName method:methodName args:args];
+            [weakInstance callFunctionOnJSModule:moduleName method:methodName args:args];
           }];
     }
 
@@ -127,6 +127,14 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
     [self _start];
   }
   return self;
+}
+
+- (void)callFunctionOnJSModule:(NSString *)moduleName method:(NSString *)method args:(NSArray *)args
+{
+  if (_valid) {
+    _reactInstance->callFunctionOnModule(
+        [moduleName UTF8String], [method UTF8String], convertIdToFollyDynamic(args ?: @[]));
+  }
 }
 
 - (void)invalidate
@@ -190,14 +198,6 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
 }
 
 #pragma mark - ReactInstanceForwarding
-
-- (void)callFunctionOnModule:(NSString *)moduleName method:(NSString *)method args:(NSArray *)args
-{
-  if (_valid) {
-    _reactInstance->callFunctionOnModule(
-        [moduleName UTF8String], [method UTF8String], convertIdToFollyDynamic(args ?: @[]));
-  }
-}
 
 - (void)registerSegmentWithId:(NSNumber *)segmentId path:(NSString *)path
 {

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.mm
@@ -165,6 +165,13 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
   }];
 }
 
+- (void)registerSegmentWithId:(NSNumber *)segmentId path:(NSString *)path
+{
+  if (_valid) {
+    _reactInstance->registerSegment(static_cast<uint32_t>([segmentId unsignedIntValue]), path.UTF8String);
+  }
+}
+
 #pragma mark - RCTTurboModuleManagerDelegate
 
 - (Class)getModuleClassFromName:(const char *)name
@@ -195,15 +202,6 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
   }
 
   return nullptr;
-}
-
-#pragma mark - ReactInstanceForwarding
-
-- (void)registerSegmentWithId:(NSNumber *)segmentId path:(NSString *)path
-{
-  if (_valid) {
-    _reactInstance->registerSegment(static_cast<uint32_t>([segmentId unsignedIntValue]), path.UTF8String);
-  }
 }
 
 #pragma mark - Private


### PR DESCRIPTION
Summary:
Changelog: [Internal]

in this diff, i introduce an internal category and header for RCTHost for functionality that needs to be accessible for our purposes, but not an official part of our stable API.

after this change, we can remove `ReactInstanceForwarding`.

Reviewed By: cipolleschi

Differential Revision: D45760091

