### PR TITLE
move callFunctionOnJSModule to public api

### DIFF
--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.h
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.h
@@ -76,6 +76,12 @@ typedef std::shared_ptr<facebook::react::JSEngineInstance> (^RCTHostJSEngineProv
 
 - (RCTSurfacePresenter *)getSurfacePresenter FB_OBJC_DIRECT;
 
+/**
+ * Calls a method on a JS module that has been registered with `registerCallableModule`. Used to invoke a JS function
+ * from platform code.
+ */
+- (void)callFunctionOnJSModule:(NSString *)moduleName method:(NSString *)method args:(NSArray *)args;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.mm
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.mm
@@ -140,7 +140,7 @@ NSString *const RCTHostDidReloadNotification = @"RCTHostDidReloadNotification";
   return self;
 }
 
-#pragma mark - Public API
+#pragma mark - Public
 
 - (void)preload
 {
@@ -199,6 +199,11 @@ NSString *const RCTHostDidReloadNotification = @"RCTHostDidReloadNotification";
   return [_instance surfacePresenter];
 }
 
+- (void)callFunctionOnJSModule:(NSString *)moduleName method:(NSString *)method args:(NSArray *)args
+{
+  [_instance callFunctionOnJSModule:moduleName method:method args:args];
+}
+
 #pragma mark - RCTReloadListener
 
 - (void)didReceiveReloadCommand
@@ -236,11 +241,6 @@ NSString *const RCTHostDidReloadNotification = @"RCTHostDidReloadNotification";
 // TODO (T74233481) - Should raw instance be accessed in this class like this? These functions shouldn't be called very
 // early in startup, but could add some intelligent guards here.
 #pragma mark - ReactInstanceForwarding
-
-- (void)callFunctionOnModule:(NSString *)moduleName method:(NSString *)method args:(NSArray *)args
-{
-  [_instance callFunctionOnModule:moduleName method:method args:args];
-}
 
 - (void)registerSegmentWithId:(NSNumber *)segmentId path:(NSString *)path
 {

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.h
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.h
@@ -46,12 +46,6 @@ FB_RUNTIME_PROTOCOL
 @protocol ReactInstanceForwarding
 
 /**
- * Calls a method on a JS module that has been registered with `registerCallableModule`. Used to invoke a JS function
- * from platform code.
- */
-- (void)callFunctionOnModule:(NSString *)moduleName method:(NSString *)method args:(NSArray *)args;
-
-/**
  * Registers a new JS segment.
  */
 - (void)registerSegmentWithId:(NSNumber *)segmentId path:(NSString *)path;
@@ -76,6 +70,8 @@ typedef void (^_Null_unspecified RCTInstanceInitialBundleLoadCompletionBlock)();
                   moduleRegistry:(RCTModuleRegistry *)moduleRegistry
              jsErrorHandlingFunc:(facebook::react::JsErrorHandler::JsErrorHandlingFunc)jsErrorHandlingFunc
     FB_OBJC_DIRECT;
+
+- (void)callFunctionOnJSModule:(NSString *)moduleName method:(NSString *)method args:(NSArray *)args;
 
 - (void)invalidate;
 

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.mm
@@ -115,7 +115,7 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
           setBridgelessJSModuleMethodInvoker:^(
               NSString *moduleName, NSString *methodName, NSArray *args, dispatch_block_t onComplete) {
             // TODO: Make RCTInstance call onComplete
-            [weakInstance callFunctionOnModule:moduleName method:methodName args:args];
+            [weakInstance callFunctionOnJSModule:moduleName method:methodName args:args];
           }];
     }
 
@@ -127,6 +127,14 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
     [self _start];
   }
   return self;
+}
+
+- (void)callFunctionOnJSModule:(NSString *)moduleName method:(NSString *)method args:(NSArray *)args
+{
+  if (_valid) {
+    _reactInstance->callFunctionOnModule(
+        [moduleName UTF8String], [method UTF8String], convertIdToFollyDynamic(args ?: @[]));
+  }
 }
 
 - (void)invalidate
@@ -190,14 +198,6 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
 }
 
 #pragma mark - ReactInstanceForwarding
-
-- (void)callFunctionOnModule:(NSString *)moduleName method:(NSString *)method args:(NSArray *)args
-{
-  if (_valid) {
-    _reactInstance->callFunctionOnModule(
-        [moduleName UTF8String], [method UTF8String], convertIdToFollyDynamic(args ?: @[]));
-  }
-}
 
 - (void)registerSegmentWithId:(NSNumber *)segmentId path:(NSString *)path
 {


### PR DESCRIPTION
Summary:
Changelog: [Internal]

in this stack, i remove the `ReactInstanceForwarding` protocol. it is super lean and is only used by two classes, and the polymorphic behavior never comes into play because we never have a pointer to `id<ReactInstanceForwarding>` in our codebase.

being able to call into JS from native is tablestakes behavior in userland, so i'm moving that to the public API. i also renamed it to be more clear that it's calling from native into JS, not the other way around.

Reviewed By: cipolleschi

Differential Revision: D45760090

