### PR TITLE
Fix MobileConfig react_fabric:enable_text_measure_cache

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphLayoutManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphLayoutManager.cpp
@@ -7,7 +7,6 @@
 
 #include "ParagraphLayoutManager.h"
 #include <folly/Hash.h>
-#include <glog/logging.h>
 #include <react/renderer/core/CoreFeatures.h>
 
 namespace facebook::react {


### PR DESCRIPTION
Summary:
changelog: [internal]

This diff wires up MobileConfig `react_fabric:enable_text_measure_cache` and remove unnecessary header include.

Reviewed By: christophpurrer

Differential Revision: D45779990

