### PR TITLE
Fix getDebugProps implementation for LayoutableShadowNode

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/ConcreteViewShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ConcreteViewShadowNode.h
@@ -83,23 +83,6 @@ class ConcreteViewShadowNode : public ConcreteShadowNode<
     return BaseShadowNode::getConcreteProps().transform;
   }
 
-#pragma mark - DebugStringConvertible
-
-#if RN_DEBUG_STRING_CONVERTIBLE
-  SharedDebugStringConvertibleList getDebugProps() const override {
-    auto list = SharedDebugStringConvertibleList{};
-
-    auto basePropsList = ShadowNode::getDebugProps();
-    std::move(
-        basePropsList.begin(), basePropsList.end(), std::back_inserter(list));
-
-    list.push_back(std::make_shared<DebugStringConvertibleItem>(
-        "layout", "", LayoutableShadowNode::getDebugProps()));
-
-    return list;
-  }
-#endif
-
  private:
   void initialize() noexcept {
     auto &props = BaseShadowNode::getConcreteProps();

--- a/packages/react-native/ReactCommon/react/renderer/core/LayoutableShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/LayoutableShadowNode.cpp
@@ -335,35 +335,41 @@ ShadowNode::Shared LayoutableShadowNode::findNodeAtPoint(
 
 #if RN_DEBUG_STRING_CONVERTIBLE
 SharedDebugStringConvertibleList LayoutableShadowNode::getDebugProps() const {
-  auto list = SharedDebugStringConvertibleList{};
+  auto list = ShadowNode::getDebugProps();
+
+  auto layoutInfo = SharedDebugStringConvertibleList{};
 
   if (!getIsLayoutClean()) {
-    list.push_back(std::make_shared<DebugStringConvertibleItem>("dirty"));
+    layoutInfo.push_back(std::make_shared<DebugStringConvertibleItem>("dirty"));
   }
 
   auto layoutMetrics = getLayoutMetrics();
   auto defaultLayoutMetrics = LayoutMetrics();
 
-  list.push_back(std::make_shared<DebugStringConvertibleItem>(
+  layoutInfo.push_back(std::make_shared<DebugStringConvertibleItem>(
       "frame", toString(layoutMetrics.frame)));
 
   if (layoutMetrics.borderWidth != defaultLayoutMetrics.borderWidth) {
-    list.push_back(std::make_shared<DebugStringConvertibleItem>(
+    layoutInfo.push_back(std::make_shared<DebugStringConvertibleItem>(
         "borderWidth", toString(layoutMetrics.borderWidth)));
   }
 
   if (layoutMetrics.contentInsets != defaultLayoutMetrics.contentInsets) {
-    list.push_back(std::make_shared<DebugStringConvertibleItem>(
+    layoutInfo.push_back(std::make_shared<DebugStringConvertibleItem>(
         "contentInsets", toString(layoutMetrics.contentInsets)));
   }
 
   if (layoutMetrics.displayType == DisplayType::None) {
-    list.push_back(std::make_shared<DebugStringConvertibleItem>("hidden"));
+    layoutInfo.push_back(
+        std::make_shared<DebugStringConvertibleItem>("hidden"));
   }
 
   if (layoutMetrics.layoutDirection == LayoutDirection::RightToLeft) {
-    list.push_back(std::make_shared<DebugStringConvertibleItem>("rtl"));
+    layoutInfo.push_back(std::make_shared<DebugStringConvertibleItem>("rtl"));
   }
+
+  list.push_back(
+      std::make_shared<DebugStringConvertibleItem>("layout", "", layoutInfo));
 
   return list;
 }


### PR DESCRIPTION
Summary:
The core implementation for ShadowNode's `getDebugProps` lives in ConcreteViewShadowNode, but is not actually specific to that class. Additionally, `LayoutableShadowNode` overrides `getDebugProps` in a way that doesn't concat props from its base class. Instead, override the method properly so we only need the implementation in `LayoutableShadowNode`.

Changelog: [Internal]

Reviewed By: sammy-SC

Differential Revision: D45729105

