### PR TITLE
Add clearAllInteractionHandles method to fix InteractionManager's hanging issues 

### DIFF
--- a/packages/react-native/Libraries/Interaction/InteractionManager.d.ts
+++ b/packages/react-native/Libraries/Interaction/InteractionManager.d.ts
@@ -64,6 +64,11 @@ export interface InteractionManagerStatic {
   clearInteractionHandle(handle: Handle): void;
 
   /**
+   * Notify manager that all ongoing interactions have been completed.
+   */
+  clearAllInteractionHandles(): void;
+
+  /**
    * A positive number will use setTimeout to schedule any tasks after
    * the eventLoopRunningTime hits the deadline value, otherwise all
    * tasks will be executed in one setImmediate batch (default).

--- a/packages/react-native/Libraries/Interaction/InteractionManager.js
+++ b/packages/react-native/Libraries/Interaction/InteractionManager.js
@@ -137,6 +137,16 @@ const InteractionManager = {
     _deleteInteractionSet.add(handle);
   },
 
+  /**
+   * Notify manager that all ongoing interactions have been completed.
+   */
+  clearAllInteractionHandles() {
+    DEBUG && infoLog('InteractionManager: clear all interaction handles');
+    _scheduleUpdate();
+    _addInteractionSet.clear();
+    _interactionSet.forEach(handle => _deleteInteractionSet.add(handle));
+  },
+
   // $FlowFixMe[method-unbinding] added when improving typing for this parameters
   addListener: (_emitter.addListener.bind(_emitter): $FlowFixMe),
 

--- a/packages/react-native/Libraries/Interaction/__tests__/InteractionManager-test.js
+++ b/packages/react-native/Libraries/Interaction/__tests__/InteractionManager-test.js
@@ -154,6 +154,42 @@ describe('InteractionManager', () => {
     expect(task1).not.toBeCalled();
     expect(task2).toBeCalled();
   });
+
+  it('notifies when clearing all interactions', () => {
+    InteractionManager.createInteractionHandle();
+    InteractionManager.createInteractionHandle();
+    jest.runAllTimers();
+
+    interactionStart.mockClear();
+    interactionComplete.mockClear();
+
+    InteractionManager.clearAllInteractionHandles();
+    jest.runAllTimers();
+    expect(interactionComplete).toBeCalled();
+  });
+
+  it('does not notify when all interactions are started & stopped in the same event loop', () => {
+    InteractionManager.createInteractionHandle();
+    InteractionManager.createInteractionHandle();
+    InteractionManager.clearAllInteractionHandles();
+
+    jest.runAllTimers();
+    expect(interactionStart).not.toBeCalled();
+    expect(interactionComplete).not.toBeCalled();
+  });
+
+  it('does not notify after clearing a handle that is already cleared', () => {
+    const handle = InteractionManager.createInteractionHandle();
+    jest.runAllTimers();
+
+    InteractionManager.clearAllInteractionHandles();
+    jest.runAllTimers();
+    expect(interactionComplete).toBeCalled();
+
+    InteractionManager.clearInteractionHandle(handle);
+    jest.runAllTimers();
+    expectToBeCalledOnce(interactionComplete);
+  });
 });
 
 describe('promise tasks', () => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

### Why
InteractionManager allows tasks to be scheduled after interactions/animations have been completed. The events creating interaction must call `clearInteractionHandle(handle)` after they have been completed. If the clearing method is not called, the `InteractionManager` will hang forever. The only way to clear the handles is to restart the app.

The hanging means that `runAfterInteractions` will never resolve. The hanging creates also issues with components such as `FlatList` since they are using InteractionManager underhood.

In theory, all the methods creating the interaction handle should always clean it. However, in practice, it's not the case, unfortunately. For instance, the hanging issues appear when `panResponder` is re-created accidentally during a touch interaction, and thus the original clearing method is never called. The issues also appear when the animation never finishes.

Large RN projects often use dozens of amazing React Native libraries, and sometimes one of the libraries might not do the clearing properly. There might be rare corner cases when the clearing is skipped. Unfortunately, these cases are often difficult to spot, since when InteractionManager hangs, it doesn't often lead to immediately noticeable bugs. It's one of the reasons why the hanging bugs might exist unnoticed for a long time. 

To combat the hanging issues, it seems like some people have stopped using InteractionManager and started to use only `requestAnimationFrame` or `setTimeout` as a workaround. The more people avoid using the InteractionManager as a workaround, the less likely the actual underlying bugs are found and fixed.

### What

Adds `clearAllInteractionHandles` that clears all existing interaction handles. So developers can create proper workarounds for possible InteractionManager hanging issues. 

The method clears all the handles, so it's rarely a perfect solution, which should encourage the developers to find and fix the actual underlying issue. However, the method still allows for fixing the hanging issues in an easy and reasonable manner. 

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[GENERAL] [ADDED] - Added clearAllInteractionHandles method to InteractionManager

## Test Plan:

Added tests, and ran `yarn test` with no errors.
