### PR TITLE
Fix wording for unselected checkbox state

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -710,21 +710,40 @@ static NSString *RCTRecursiveAccessibilityLabel(UIView *view)
     }
   }
 
+  NSMutableArray *valueComponents = [NSMutableArray new];
+  NSString *roleString = [NSString stringWithUTF8String:props.accessibilityRole.c_str()];
+
+  // In iOS, checkbox and radio buttons aren't recognized as traits. However,
+  // because our apps use checkbox and radio buttons often, we should announce
+  // these to screenreader users.  (They should already be familiar with them
+  // from using web).
+  if ([roleString isEqualToString:@"checkbox"]) {
+    [valueComponents addObject:@"checkbox"];
+  }
+
+  if ([roleString isEqualToString:@"radio"]) {
+    [valueComponents addObject:@"radio button"];
+  }
+
   // Handle states which haven't already been handled.
   if (props.accessibilityState.checked == AccessibilityState::Checked) {
-    return @"checked";
+    [valueComponents addObject:@"checked"];
   }
   if (props.accessibilityState.checked == AccessibilityState::Unchecked) {
-    return @"unchecked";
+    [valueComponents addObject:@"unchecked"];
   }
   if (props.accessibilityState.checked == AccessibilityState::Mixed) {
-    return @"mixed";
+    [valueComponents addObject:@"mixed"];
   }
   if (props.accessibilityState.expanded) {
-    return @"expanded";
+    [valueComponents addObject:@"expanded"];
   }
   if (props.accessibilityState.busy) {
-    return @"busy";
+    [valueComponents addObject:@"busy"];
+  }
+
+  if (valueComponents.count > 0) {
+    return [valueComponents componentsJoinedByString:@", "];
   }
 
   return nil;

--- a/packages/react-native/React/Views/RCTView.m
+++ b/packages/react-native/React/Views/RCTView.m
@@ -310,7 +310,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
         @"timer" : @"timer",
         @"toolbar" : @"tool bar",
         @"checked" : @"checked",
-        @"unchecked" : @"not checked",
+        @"unchecked" : @"unchecked",
         @"busy" : @"busy",
         @"expanded" : @"expanded",
         @"collapsed" : @"collapsed",


### PR DESCRIPTION
Summary: Previously, when focusing on an unchecked checkbox in React Native Paper with VoiceOver, it was announcing as "not selected".  iOS voiceover uses "unselected" instead ("not selected" is used on Android Talkback).  Update code to use "unselected".

Reviewed By: cipolleschi

Differential Revision: D45799922

