### PR TITLE
rename host preload -> start

### DIFF
--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.h
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.h
@@ -39,7 +39,6 @@ typedef std::shared_ptr<facebook::react::JSEngineInstance> (^RCTHostJSEngineProv
 
 @protocol RCTHostDelegate <NSObject>
 
-- (std::shared_ptr<facebook::react::JSEngineInstance>)getJSEngine;
 - (NSURL *)getBundleURL;
 - (std::shared_ptr<facebook::react::ContextContainer>)createContextContainer;
 
@@ -61,8 +60,7 @@ typedef std::shared_ptr<facebook::react::JSEngineInstance> (^RCTHostJSEngineProv
 - (instancetype)initWithHostDelegate:(id<RCTHostDelegate>)hostDelegate
           turboModuleManagerDelegate:(id<RCTTurboModuleManagerDelegate>)turboModuleManagerDelegate
                  bindingsInstallFunc:(facebook::react::ReactInstance::BindingsInstallFunc)bindingsInstallFunc
-                    jsEngineProvider:(nullable RCTHostJSEngineProvider)jsEngineProvider NS_DESIGNATED_INITIALIZER
-    FB_OBJC_DIRECT;
+                    jsEngineProvider:(RCTHostJSEngineProvider)jsEngineProvider NS_DESIGNATED_INITIALIZER FB_OBJC_DIRECT;
 
 /**
  * This function initializes an RCTInstance if one does not yet exist.  This function is currently only called on the

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.h
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.h
@@ -67,7 +67,7 @@ typedef std::shared_ptr<facebook::react::JSEngineInstance> (^RCTHostJSEngineProv
  * main thread, but it should be threadsafe.
  * TODO T74233481 - Verify if this function is threadsafe.
  */
-- (void)preload;
+- (void)start;
 
 - (RCTFabricSurface *)createSurfaceWithModuleName:(NSString *)moduleName
                                              mode:(facebook::react::DisplayMode)displayMode

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.mm
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.mm
@@ -140,7 +140,7 @@ NSString *const RCTHostDidReloadNotification = @"RCTHostDidReloadNotification";
 
 #pragma mark - Public
 
-- (void)preload
+- (void)start
 {
   if (_instance) {
     RCTLogWarn(


### PR DESCRIPTION
Summary:
Changelog: [Internal]

in this simple change, i renamed the `preload` API, which triggers all the rct instance / javascript runtime creation to `start`. `preload` is a confusing API on the host because the host should be agnostic of when the timing to create its dependencies are, and the consumer should determine when initialization is lazy, early, etc.

Reviewed By: cipolleschi

Differential Revision: D45760583

