### PR TITLE
Avoid usage of JSI Specializations which may use RTTI

### DIFF
--- a/packages/react-native/ReactCommon/jsi/jsi/jsi-inl.h
+++ b/packages/react-native/ReactCommon/jsi/jsi/jsi-inl.h
@@ -7,6 +7,16 @@
 
 #pragma once
 
+#ifndef JSI_HAS_RTTI
+#if defined(__clang__)
+#define JSI_HAS_RTTI __has_feature(cxx_rtti)
+#elif defined(_MSC_VER)
+#define JSI_HAS_RTTI _CPPRTTI
+#elif defined(__GNUG__)
+#define JSI_HAS_RTTI __GXX_RTTI
+#endif
+#endif
+
 namespace facebook {
 namespace jsi {
 namespace detail {
@@ -173,6 +183,9 @@ inline Function Object::getFunction(Runtime& runtime) && {
 
 template <typename T>
 inline bool Object::isHostObject(Runtime& runtime) const {
+  static_assert(
+      JSI_HAS_RTTI || std::is_same<T, HostObject>::value,
+      "Object::isHostObject<T> requires RTTI when T is not HostObject");
   return runtime.isHostObject(*this) &&
       std::dynamic_pointer_cast<T>(runtime.getHostObject(*this));
 }
@@ -184,6 +197,9 @@ inline bool Object::isHostObject<HostObject>(Runtime& runtime) const {
 
 template <typename T>
 inline std::shared_ptr<T> Object::getHostObject(Runtime& runtime) const {
+  static_assert(
+      JSI_HAS_RTTI || std::is_same<T, HostObject>::value,
+      "Object::getHostObject<T> requires RTTI when T is not HostObject");
   assert(isHostObject<T>(runtime));
   return std::static_pointer_cast<T>(runtime.getHostObject(*this));
 }
@@ -206,6 +222,9 @@ inline std::shared_ptr<HostObject> Object::getHostObject<HostObject>(
 
 template <typename T>
 inline bool Object::hasNativeState(Runtime& runtime) const {
+  static_assert(
+      JSI_HAS_RTTI || std::is_same<T, HostObject>::value,
+      "Object::hasNativeState<T> requires RTTI when T is not NativeState");
   return runtime.hasNativeState(*this) &&
       std::dynamic_pointer_cast<T>(runtime.getNativeState(*this));
 }
@@ -217,6 +236,9 @@ inline bool Object::hasNativeState<NativeState>(Runtime& runtime) const {
 
 template <typename T>
 inline std::shared_ptr<T> Object::getNativeState(Runtime& runtime) const {
+  static_assert(
+      JSI_HAS_RTTI || std::is_same<T, NativeState>::value,
+      "Object::getNativeState<T> requires RTTI when T is not NativeState");
   assert(hasNativeState<T>(runtime));
   return std::static_pointer_cast<T>(runtime.getNativeState(*this));
 }

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerBinding.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerBinding.cpp
@@ -39,7 +39,8 @@ RuntimeSchedulerBinding::createAndInstallIfNeeded(
   // The global namespace already has an instance of the binding;
   // we need to return that.
   auto runtimeSchedulerObject = runtimeSchedulerValue.asObject(runtime);
-  return runtimeSchedulerObject.getHostObject<RuntimeSchedulerBinding>(runtime);
+  return std::static_pointer_cast<RuntimeSchedulerBinding>(
+      runtimeSchedulerObject.getHostObject(runtime));
 }
 
 std::shared_ptr<RuntimeSchedulerBinding> RuntimeSchedulerBinding::getBinding(
@@ -53,7 +54,8 @@ std::shared_ptr<RuntimeSchedulerBinding> RuntimeSchedulerBinding::getBinding(
   }
 
   auto runtimeSchedulerObject = runtimeSchedulerValue.asObject(runtime);
-  return runtimeSchedulerObject.getHostObject<RuntimeSchedulerBinding>(runtime);
+  return std::static_pointer_cast<RuntimeSchedulerBinding>(
+      runtimeSchedulerObject.getHostObject(runtime));
 }
 
 RuntimeSchedulerBinding::RuntimeSchedulerBinding(

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/primitives.h
@@ -41,9 +41,12 @@ inline static std::shared_ptr<Task> taskFromValue(
   }
 
   if (CoreFeatures::useNativeState) {
-    return value.getObject(runtime).getNativeState<Task>(runtime);
+    return std::static_pointer_cast<Task>(
+        value.getObject(runtime).getNativeState(runtime));
   } else {
-    return value.getObject(runtime).getHostObject<TaskWrapper>(runtime)->task;
+    return std::static_pointer_cast<TaskWrapper>(
+               value.getObject(runtime).getHostObject(runtime))
+        ->task;
   }
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/tests/StubErrorUtils.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/tests/StubErrorUtils.h
@@ -32,7 +32,8 @@ class StubErrorUtils : public jsi::HostObject {
     }
 
     auto stubErrorUtilsObject = errorUtilsValue.asObject(runtime);
-    return stubErrorUtilsObject.getHostObject<StubErrorUtils>(runtime);
+    return std::static_pointer_cast<StubErrorUtils>(
+        stubErrorUtilsObject.getHostObject(runtime));
   }
 
   /*

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
@@ -50,7 +50,8 @@ std::shared_ptr<UIManagerBinding> UIManagerBinding::getBinding(
   }
 
   auto uiManagerObject = uiManagerValue.asObject(runtime);
-  return uiManagerObject.getHostObject<UIManagerBinding>(runtime);
+  return std::static_pointer_cast<UIManagerBinding>(
+      uiManagerObject.getHostObject(runtime));
 }
 
 UIManagerBinding::UIManagerBinding(std::shared_ptr<UIManager> uiManager)

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/primitives.h
@@ -61,10 +61,11 @@ inline static ShadowNode::Shared shadowNodeFromValue(
   }
 
   if (CoreFeatures::useNativeState) {
-    return value.getObject(runtime).getNativeState<ShadowNode>(runtime);
+    return std::static_pointer_cast<ShadowNode>(
+        value.getObject(runtime).getNativeState(runtime));
   } else {
-    return value.getObject(runtime)
-        .getHostObject<ShadowNodeWrapper>(runtime)
+    return std::static_pointer_cast<ShadowNodeWrapper>(
+               value.getObject(runtime).getHostObject(runtime))
         ->shadowNode;
   }
 }
@@ -88,12 +89,12 @@ inline static ShadowNode::UnsharedListOfShared shadowNodeListFromValue(
     jsi::Runtime &runtime,
     const jsi::Value &value) {
   if (CoreFeatures::useNativeState) {
-    return value.getObject(runtime)
-        .getNativeState<ShadowNodeListWrapper>(runtime)
+    return std::static_pointer_cast<ShadowNodeListWrapper>(
+               value.getObject(runtime).getNativeState(runtime))
         ->shadowNodeList;
   } else {
-    return value.getObject(runtime)
-        .getHostObject<ShadowNodeListWrapper>(runtime)
+    return std::static_pointer_cast<ShadowNodeListWrapper>(
+               value.getObject(runtime).getHostObject(runtime))
         ->shadowNodeList;
   }
 }


### PR DESCRIPTION
Summary:
`getNativeState()` and the version of `getHostObject()` not specialized to `HostObject` do a dynamic_cast inside of an assert() to do a type check.

Most of RN for Android is built without RTTI enabled, but hadn't run into issues with these because fbandroid sets NDEBUG even in debug builds, causing any raw assert() to be compiled out.

All these functions really do is a checked cast, where the check is only in debug, and already compiled out on Android. This changes them to do a static_cast themselves instead.

This solution is probably preferable to conditioning the existing asserts on RTTI availability within JSI, since some libraries do build with RTTI, and changing behavior dependent on it in a shared header seems like a recipe for ODR. Though I'm not sure why casting is the API responsibility of JSI in general.

Static asserts are added so that new usages of functions meant to use RTTI are not added to units compiled internally with `-frtti`.

Changelog: [Internal]

Differential Revision: D45814500

