### PR TITLE
Create version of LayoutableShadowNode::computeRelativeLayoutMetrics that works with an ancestor list

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/LayoutableShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/LayoutableShadowNode.cpp
@@ -105,7 +105,12 @@ LayoutMetrics LayoutableShadowNode::computeRelativeLayoutMetrics(
   }
 
   auto ancestors = descendantNodeFamily.getAncestors(ancestorNode);
+  return computeRelativeLayoutMetrics(ancestors, policy);
+}
 
+LayoutMetrics LayoutableShadowNode::computeRelativeLayoutMetrics(
+    AncestorList const &ancestors,
+    LayoutInspectingPolicy policy) {
   if (ancestors.empty()) {
     // Specified nodes do not form an ancestor-descender relationship
     // in the same tree. Aborting.

--- a/packages/react-native/ReactCommon/react/renderer/core/LayoutableShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/LayoutableShadowNode.h
@@ -63,6 +63,13 @@ class LayoutableShadowNode : public ShadowNode {
       LayoutInspectingPolicy policy);
 
   /*
+   * Computes the layout metrics of a node relative to its specified ancestors.
+   */
+  static LayoutMetrics computeRelativeLayoutMetrics(
+      AncestorList const &ancestors,
+      LayoutInspectingPolicy policy);
+
+  /*
    * Performs layout of the tree starting from this node. Usually is being
    * called on the root node.
    * Default implementation does nothing.


### PR DESCRIPTION
Summary:
We'll be using this method in IntersectionObserver to avoid having to get the list of ancestor multiple times when calling computeRelativeLayoutMetrics for the target bounding rect and for the intersection rect.

Changelog: [Internal]

Differential Revision: D45866232

