### PR TITLE
remove extra semis from arfx/atlas/modules and deps attempt 2

### DIFF
--- a/packages/react-native/ReactCommon/yoga/yoga/YGNode.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGNode.cpp
@@ -21,7 +21,7 @@ YGNode::YGNode(const YGConfigRef config) : config_{config} {
   if (config->useWebDefaults()) {
     useWebDefaults();
   }
-};
+}
 
 YGNode::YGNode(YGNode&& node) {
   context_ = node.context_;

--- a/packages/react-native/ReactCommon/yoga/yoga/Yoga.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/Yoga.cpp
@@ -845,7 +845,7 @@ YOGA_EXPORT void YGNodeStyleSetMinWidthPercent(
 }
 YOGA_EXPORT YGValue YGNodeStyleGetMinWidth(const YGNodeConstRef node) {
   return node->getStyle().minDimensions()[YGDimensionWidth];
-};
+}
 
 YOGA_EXPORT void YGNodeStyleSetMinHeight(
     const YGNodeRef node,
@@ -863,7 +863,7 @@ YOGA_EXPORT void YGNodeStyleSetMinHeightPercent(
 }
 YOGA_EXPORT YGValue YGNodeStyleGetMinHeight(const YGNodeConstRef node) {
   return node->getStyle().minDimensions()[YGDimensionHeight];
-};
+}
 
 YOGA_EXPORT void YGNodeStyleSetMaxWidth(
     const YGNodeRef node,
@@ -881,7 +881,7 @@ YOGA_EXPORT void YGNodeStyleSetMaxWidthPercent(
 }
 YOGA_EXPORT YGValue YGNodeStyleGetMaxWidth(const YGNodeConstRef node) {
   return node->getStyle().maxDimensions()[YGDimensionWidth];
-};
+}
 
 YOGA_EXPORT void YGNodeStyleSetMaxHeight(
     const YGNodeRef node,
@@ -899,7 +899,7 @@ YOGA_EXPORT void YGNodeStyleSetMaxHeightPercent(
 }
 YOGA_EXPORT YGValue YGNodeStyleGetMaxHeight(const YGNodeConstRef node) {
   return node->getStyle().maxDimensions()[YGDimensionHeight];
-};
+}
 
 #define YG_NODE_LAYOUT_PROPERTY_IMPL(type, name, instanceName)   \
   YOGA_EXPORT type YGNodeLayoutGet##name(const YGNodeRef node) { \
@@ -933,18 +933,18 @@ YOGA_EXPORT YGValue YGNodeStyleGetMaxHeight(const YGNodeConstRef node) {
     return node->getLayout().instanceName[edge];                        \
   }
 
-YG_NODE_LAYOUT_PROPERTY_IMPL(float, Left, position[YGEdgeLeft]);
-YG_NODE_LAYOUT_PROPERTY_IMPL(float, Top, position[YGEdgeTop]);
-YG_NODE_LAYOUT_PROPERTY_IMPL(float, Right, position[YGEdgeRight]);
-YG_NODE_LAYOUT_PROPERTY_IMPL(float, Bottom, position[YGEdgeBottom]);
-YG_NODE_LAYOUT_PROPERTY_IMPL(float, Width, dimensions[YGDimensionWidth]);
-YG_NODE_LAYOUT_PROPERTY_IMPL(float, Height, dimensions[YGDimensionHeight]);
-YG_NODE_LAYOUT_PROPERTY_IMPL(YGDirection, Direction, direction());
-YG_NODE_LAYOUT_PROPERTY_IMPL(bool, HadOverflow, hadOverflow());
+YG_NODE_LAYOUT_PROPERTY_IMPL(float, Left, position[YGEdgeLeft])
+YG_NODE_LAYOUT_PROPERTY_IMPL(float, Top, position[YGEdgeTop])
+YG_NODE_LAYOUT_PROPERTY_IMPL(float, Right, position[YGEdgeRight])
+YG_NODE_LAYOUT_PROPERTY_IMPL(float, Bottom, position[YGEdgeBottom])
+YG_NODE_LAYOUT_PROPERTY_IMPL(float, Width, dimensions[YGDimensionWidth])
+YG_NODE_LAYOUT_PROPERTY_IMPL(float, Height, dimensions[YGDimensionHeight])
+YG_NODE_LAYOUT_PROPERTY_IMPL(YGDirection, Direction, direction())
+YG_NODE_LAYOUT_PROPERTY_IMPL(bool, HadOverflow, hadOverflow())
 
-YG_NODE_LAYOUT_RESOLVED_PROPERTY_IMPL(float, Margin, margin);
-YG_NODE_LAYOUT_RESOLVED_PROPERTY_IMPL(float, Border, border);
-YG_NODE_LAYOUT_RESOLVED_PROPERTY_IMPL(float, Padding, padding);
+YG_NODE_LAYOUT_RESOLVED_PROPERTY_IMPL(float, Margin, margin)
+YG_NODE_LAYOUT_RESOLVED_PROPERTY_IMPL(float, Border, border)
+YG_NODE_LAYOUT_RESOLVED_PROPERTY_IMPL(float, Padding, padding)
 
 std::atomic<uint32_t> gCurrentGenerationCount(0);
 


### PR DESCRIPTION
Summary:
deletes semicolons and adds whitespace sometimes

moved the runtime ipc chages int a seperate diff

Reviewed By: KSRandom

Differential Revision: D45835378

