### PR TITLE
create fallback contextContainer

### DIFF
--- a/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
+++ b/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
@@ -131,19 +131,6 @@ static BackgroundExecutor RCTGetBackgroundExecutor()
   return _contextContainer;
 }
 
-- (void)setContextContainer:(ContextContainer::Shared)contextContainer
-{
-  std::lock_guard<std::mutex> lock(_schedulerLifeCycleMutex);
-  _contextContainer = contextContainer;
-  _mountingManager.contextContainer = contextContainer;
-}
-
-- (RuntimeExecutor)runtimeExecutor
-{
-  std::lock_guard<std::mutex> lock(_schedulerLifeCycleMutex);
-  return _runtimeExecutor;
-}
-
 - (void)setRuntimeExecutor:(RuntimeExecutor)runtimeExecutor
 {
   std::lock_guard<std::mutex> lock(_schedulerLifeCycleMutex);

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.mm
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.mm
@@ -69,34 +69,34 @@ NSString *const RCTHostDidReloadNotification = @"RCTHostDidReloadNotification";
     _moduleRegistry = [RCTModuleRegistry new];
     _jsEngineProvider = [jsEngineProvider copy];
 
-    __weak RCTHost *weakHost = self;
+    __weak RCTHost *weakSelf = self;
 
     auto bundleURLGetter = ^NSURL *()
     {
-      RCTHost *strongHost = weakHost;
-      if (!strongHost) {
+      RCTHost *strongSelf = weakSelf;
+      if (!strongSelf) {
         return nil;
       }
 
-      return strongHost->_bundleURL;
+      return strongSelf->_bundleURL;
     };
 
     auto bundleURLSetter = ^(NSURL *bundleURL) {
-      RCTHost *strongHost = weakHost;
-      if (!strongHost) {
+      RCTHost *strongSelf = weakSelf;
+      if (!strongSelf) {
         return;
       }
-      strongHost->_bundleURL = bundleURL;
+      strongSelf->_bundleURL = bundleURL;
     };
 
     auto defaultBundleURLGetter = ^NSURL *()
     {
-      RCTHost *strongHost = weakHost;
-      if (!strongHost) {
+      RCTHost *strongSelf = weakSelf;
+      if (!strongSelf) {
         return nil;
       }
 
-      return [strongHost->_hostDelegate getBundleURL];
+      return [strongSelf->_hostDelegate getBundleURL];
     };
 
     [_bundleManager setBridgelessBundleURLGetter:bundleURLGetter
@@ -112,17 +112,17 @@ NSString *const RCTHostDidReloadNotification = @"RCTHostDidReloadNotification";
      * JS calls before the main JSBundle finishes execution, and execute them after.
      */
     _onInitialBundleLoad = ^{
-      RCTHost *strongHost = weakHost;
-      if (!strongHost) {
+      RCTHost *strongSelf = weakSelf;
+      if (!strongSelf) {
         return;
       }
 
       NSArray<RCTFabricSurface *> *unstartedSurfaces = @[];
 
       {
-        std::lock_guard<std::mutex> guard{strongHost->_surfaceStartBufferMutex};
-        unstartedSurfaces = [NSArray arrayWithArray:strongHost->_surfaceStartBuffer];
-        strongHost->_surfaceStartBuffer = nil;
+        std::lock_guard<std::mutex> guard{strongSelf->_surfaceStartBufferMutex};
+        unstartedSurfaces = [NSArray arrayWithArray:strongSelf->_surfaceStartBuffer];
+        strongSelf->_surfaceStartBuffer = nil;
       }
 
       for (RCTFabricSurface *surface in unstartedSurfaces) {

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.mm
@@ -107,12 +107,12 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
                                                                       bundleManager:bundleManager
                                                                   callableJSModules:[RCTCallableJSModules new]];
     {
-      __weak __typeof(self) weakInstance = self;
+      __weak __typeof(self) weakSelf = self;
       [_bridgeModuleDecorator.callableJSModules
           setBridgelessJSModuleMethodInvoker:^(
               NSString *moduleName, NSString *methodName, NSArray *args, dispatch_block_t onComplete) {
             // TODO: Make RCTInstance call onComplete
-            [weakInstance callFunctionOnJSModule:moduleName method:methodName args:args];
+            [weakSelf callFunctionOnJSModule:moduleName method:methodName args:args];
           }];
     }
 
@@ -304,10 +304,10 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
 
 - (void)_attachBridgelessAPIsToModule:(id<RCTTurboModule>)module FB_OBJC_DIRECT
 {
-  __weak RCTInstance *weakInstance = self;
+  __weak RCTInstance *weakSelf = self;
   if ([module respondsToSelector:@selector(setDispatchToJSThread:)]) {
     ((id<RCTJSDispatcherModule>)module).dispatchToJSThread = ^(dispatch_block_t block) {
-      __strong __typeof(self) strongSelf = weakInstance;
+      __strong __typeof(self) strongSelf = weakSelf;
 
       if (strongSelf && strongSelf->_valid) {
         strongSelf->_reactInstance->getBufferedRuntimeExecutor()([=](jsi::Runtime &runtime) { block(); });

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.mm
@@ -237,6 +237,9 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
   RCTLogSetBridgelessCallableJSModules(_bridgeModuleDecorator.callableJSModules);
 
   auto contextContainer = [_delegate createContextContainer];
+  if (!contextContainer) {
+    contextContainer = std::make_shared<ContextContainer>();
+  }
   contextContainer->insert(
       "RCTImageLoader", facebook::react::wrapManagedObject([_turboModuleManager moduleForName:"RCTImageLoader"]));
   contextContainer->insert(


### PR DESCRIPTION
Summary:
Changelog: [Internal]

i just noticed that `[_delegate createContextContainer]` can be null because it returns `shared_ptr`, we should protect against that!

Reviewed By: javache

Differential Revision: D45805196

