### PR TITLE
replace host reload notifications with hostDidStart:

### DIFF
--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.h
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.h
@@ -25,16 +25,6 @@ NS_ASSUME_NONNULL_BEGIN
 FB_RUNTIME_PROTOCOL
 @protocol RCTTurboModuleManagerDelegate;
 
-/**
- * This notification fires just before RCTHost releases it's RCTInstance reference.
- */
-RCT_EXTERN NSString *const RCTHostWillReloadNotification;
-
-/**
- * This notification fires just after RCTHost releases it's RCTInstance reference.
- */
-RCT_EXTERN NSString *const RCTHostDidReloadNotification;
-
 typedef std::shared_ptr<facebook::react::JSEngineInstance> (^RCTHostJSEngineProvider)(void);
 
 @protocol RCTHostDelegate <NSObject>
@@ -47,6 +37,7 @@ typedef std::shared_ptr<facebook::react::JSEngineInstance> (^RCTHostJSEngineProv
                    message:(NSString *)message
                exceptionId:(NSUInteger)exceptionId
                    isFatal:(BOOL)isFatal;
+- (void)hostDidStart:(RCTHost *)host;
 
 @end
 

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.mm
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.mm
@@ -20,9 +20,6 @@
 
 using namespace facebook::react;
 
-NSString *const RCTHostWillReloadNotification = @"RCTHostWillReloadNotification";
-NSString *const RCTHostDidReloadNotification = @"RCTHostDidReloadNotification";
-
 @interface RCTHost () <RCTReloadListener, RCTInstanceDelegate>
 @end
 
@@ -156,6 +153,7 @@ NSString *const RCTHostDidReloadNotification = @"RCTHostDidReloadNotification";
                                 onInitialBundleLoad:_onInitialBundleLoad
                                 bindingsInstallFunc:_bindingsInstallFunc
                                      moduleRegistry:_moduleRegistry];
+  [_hostDelegate hostDidStart:self];
 }
 
 - (RCTFabricSurface *)createSurfaceWithModuleName:(NSString *)moduleName
@@ -204,8 +202,6 @@ NSString *const RCTHostDidReloadNotification = @"RCTHostDidReloadNotification";
 
 - (void)didReceiveReloadCommand
 {
-  [[NSNotificationCenter defaultCenter]
-      postNotification:[NSNotification notificationWithName:RCTHostWillReloadNotification object:nil]];
   [_instance invalidate];
   _instance = nil;
   [self _refreshBundleURL];
@@ -224,8 +220,7 @@ NSString *const RCTHostDidReloadNotification = @"RCTHostDidReloadNotification";
                                 onInitialBundleLoad:_onInitialBundleLoad
                                 bindingsInstallFunc:_bindingsInstallFunc
                                      moduleRegistry:_moduleRegistry];
-  [[NSNotificationCenter defaultCenter]
-      postNotification:[NSNotification notificationWithName:RCTHostDidReloadNotification object:nil]];
+  [_hostDelegate hostDidStart:self];
 
   for (RCTFabricSurface *surface in [self _getAttachedSurfaces]) {
     [surface resetWithSurfacePresenter:[self getSurfacePresenter]];


### PR DESCRIPTION
Summary:
Changelog: [Internal]

In this change, I'm removing these public notification strings that are used to listen to CMD + R reload by replacing them with a more general, lifecycle callback. Consumers can use this if there's anything in userland that they need to do once React is ready, such as doing some work with any native modules.

Reviewed By: sammy-SC

Differential Revision: D45760847

