### PR TITLE
fix: [gradle-plugin] 3rd party lib dependency substitution

### DIFF
--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/DependencyUtils.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/DependencyUtils.kt
@@ -69,6 +69,14 @@ internal object DependencyUtils {
               .using(it.module("${groupString}:hermes-android:${versionString}"))
               .because(
                   "The hermes-engine artifact was deprecated in favor of hermes-android due to https://github.com/facebook/react-native/issues/35210.")
+          if (groupString != DEFAULT_GROUP_STRING) {
+            it.substitute(it.module("com.facebook.react:react-android"))
+              .using(it.module("${groupString}:react-android:${versionString}"))
+              .because("The react-android dependency was modified to use the correct Maven group.")
+            it.substitute(it.module("com.facebook.react:hermes-android"))
+              .using(it.module("${groupString}:hermes-android:${versionString}"))
+              .because("The hermes-android dependency was modified to use the correct Maven group.")
+          }
         }
         configuration.resolutionStrategy.force(
             "${groupString}:react-android:${versionString}",


### PR DESCRIPTION
## Summary:

For 3rd party libraries to work with a React Native fork (such as the TV repo) that uses a different Maven group for `react-android` and `hermes-android` artifacts, an additional dependency substitution is required.

## Changelog:

[Android][fixed] RNGP dependency substitutions for fork with different Maven group

## Test Plan:

- Manual tested with an existing project
- Unit tests pass