### PR TITLE
refactor(codegen): add undefinedLiteralTypeAnnotation prop in parsers

### DIFF
--- a/packages/react-native-codegen/src/parsers/flow/parser.js
+++ b/packages/react-native-codegen/src/parsers/flow/parser.js
@@ -65,6 +65,7 @@ class FlowParser implements Parser {
   enumDeclaration: string = 'EnumDeclaration';
   interfaceDeclaration: string = 'InterfaceDeclaration';
   nullLiteralTypeAnnotation: string = 'NullLiteralTypeAnnotation';
+  undefinedLiteralTypeAnnotation: string = 'VoidLiteralTypeAnnotation';
 
   isProperty(property: $FlowFixMe): boolean {
     return property.type === 'ObjectTypeProperty';

--- a/packages/react-native-codegen/src/parsers/parser.js
+++ b/packages/react-native-codegen/src/parsers/parser.js
@@ -104,6 +104,11 @@ export interface Parser {
   nullLiteralTypeAnnotation: string;
 
   /**
+   * UndefinedLiteralTypeAnnotation property of the Parser
+   */
+  undefinedLiteralTypeAnnotation: string;
+
+  /**
    * Given a declaration, it returns true if it is a property
    */
   isProperty(property: $FlowFixMe): boolean;

--- a/packages/react-native-codegen/src/parsers/parserMock.js
+++ b/packages/react-native-codegen/src/parsers/parserMock.js
@@ -63,8 +63,8 @@ export class MockedParser implements Parser {
   typeAlias: string = 'TypeAlias';
   enumDeclaration: string = 'EnumDeclaration';
   interfaceDeclaration: string = 'InterfaceDeclaration';
-
   nullLiteralTypeAnnotation: string = 'NullLiteralTypeAnnotation';
+  undefinedLiteralTypeAnnotation: string = 'VoidLiteralTypeAnnotation';
 
   isProperty(property: $FlowFixMe): boolean {
     return property.type === 'ObjectTypeProperty';

--- a/packages/react-native-codegen/src/parsers/typescript/components/events.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/events.js
@@ -239,7 +239,7 @@ function findEventArgumentsAndType(
 
     switch (typeAnnotation.typeParameters.params[0].type) {
       case parser.nullLiteralTypeAnnotation:
-      case 'TSUndefinedKeyword':
+      case parser.undefinedLiteralTypeAnnotation:
         return {
           argumentProps: [],
           bubblingType: eventType,

--- a/packages/react-native-codegen/src/parsers/typescript/parser.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parser.js
@@ -62,8 +62,8 @@ class TypeScriptParser implements Parser {
   typeAlias: string = 'TSTypeAliasDeclaration';
   enumDeclaration: string = 'TSEnumDeclaration';
   interfaceDeclaration: string = 'TSInterfaceDeclaration';
-
   nullLiteralTypeAnnotation: string = 'TSNullKeyword';
+  undefinedLiteralTypeAnnotation: string = 'TSUndefinedKeyword';
 
   isProperty(property: $FlowFixMe): boolean {
     return property.type === 'TSPropertySignature';


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
part of codegen issue https://github.com/facebook/react-native/issues/34872

> Add an undefinedLiteralTypeAnnotation: string property into the Parser object and implement it in the FlowParser (returning VoidLiteralTypeAnnotation) and in the TypeScriptPArser(returning TSUndefinedKeyword). Replace them in and [parsers/typescript/components/events.js](https://github.com/facebook/react-native/blob/e133100721939108b0f28dfa9f60ac627c804018/packages/react-native-codegen/src/parsers/typescript/components/events.js#L158).

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
[Internal][Added]: Add undefinedLiteralTypeAnnotation property in parsers
## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
yarn test
