### PR TITLE
Fix babel-runtime version

### DIFF
--- a/packages/react-native/template/package.json
+++ b/packages/react-native/template/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@babel/core": "^7.20.0",
     "@babel/preset-env": "^7.20.0",
-    "@babel/runtime": "^7.12.5",
+    "@babel/runtime": "^7.20.0",
     "@react-native/eslint-config": "^0.73.0",
     "@react-native/metro-config": "^0.73.0",
     "@react-native/typescript-config": "^0.73.0",


### PR DESCRIPTION
## Summary:

Inconsistent `@babel/runtime` version after 0.72.
On 0.71, it was aligned to [`^7.20.0`](https://github.com/facebook/react-native/blob/d2a873956520806e434084d2d48dc0a4ee913f07/template/package.json#L19)
From 0.72, it was downgraded to [`^7.12.5`](https://github.com/facebook/react-native/blob/d71ba2da345a324f85dcd9fd461a729cb5022b48/packages/react-native/template/package.json#L19)
this might be coming from monorepo movement.
 
## Changelog:

[GENERAL] [FIXED] - Aligned `@babel/runtime` version to `^7.20.0`

## Test Plan:

ci passed