### PR TITLE
Implement mount hooks in UIManager

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -437,7 +437,7 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrol
 
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView
 {
-  if (!_isUserTriggeredScrolling) {
+  if (!_isUserTriggeredScrolling || CoreFeatures::enableGranularScrollViewStateUpdatesIOS) {
     [self _updateStateWithContentOffset];
   }
 

--- a/packages/react-native/React/Fabric/RCTScheduler.h
+++ b/packages/react-native/React/Fabric/RCTScheduler.h
@@ -67,6 +67,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)animationTick;
 
+- (void)reportMount:(facebook::react::SurfaceId)surfaceId;
+
 - (void)addEventListener:(std::shared_ptr<facebook::react::EventListener> const &)listener;
 
 - (void)removeEventListener:(std::shared_ptr<facebook::react::EventListener> const &)listener;

--- a/packages/react-native/React/Fabric/RCTScheduler.mm
+++ b/packages/react-native/React/Fabric/RCTScheduler.mm
@@ -132,6 +132,11 @@ class LayoutAnimationDelegateProxy : public LayoutAnimationStatusDelegate, publi
   _scheduler->animationTick();
 }
 
+- (void)reportMount:(facebook::react::SurfaceId)surfaceId
+{
+  _scheduler->reportMount(surfaceId);
+}
+
 - (void)dealloc
 {
   if (_animationDriver) {

--- a/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
+++ b/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
@@ -280,6 +280,10 @@ static BackgroundExecutor RCTGetBackgroundExecutor()
     CoreFeatures::enableGranularScrollViewStateUpdatesIOS = true;
   }
 
+  if (reactNativeConfig && reactNativeConfig->getBool("react_fabric:enable_mount_hooks_ios")) {
+    CoreFeatures::enableMountHooks = true;
+  }
+
   auto componentRegistryFactory =
       [factory = wrapManagedObject(_mountingManager.componentViewRegistry.componentViewFactory)](
           EventDispatcher::Weak const &eventDispatcher, ContextContainer::Shared const &contextContainer) {
@@ -441,6 +445,15 @@ static BackgroundExecutor RCTGetBackgroundExecutor()
     if ([observer respondsToSelector:@selector(didMountComponentsWithRootTag:)]) {
       [observer didMountComponentsWithRootTag:rootTag];
     }
+  }
+
+  RCTScheduler *scheduler = [self scheduler];
+  if (scheduler) {
+    // Notify mount when the effects are visible and prevent mount hooks to
+    // delay paint.
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [scheduler reportMount:rootTag];
+    });
   }
 }
 

--- a/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
+++ b/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
@@ -276,6 +276,10 @@ static BackgroundExecutor RCTGetBackgroundExecutor()
     CoreFeatures::disableTransactionCommit = true;
   }
 
+  if (reactNativeConfig && reactNativeConfig->getBool("react_fabric:enable_granular_scroll_view_state_updates_ios")) {
+    CoreFeatures::enableGranularScrollViewStateUpdatesIOS = true;
+  }
+
   auto componentRegistryFactory =
       [factory = wrapManagedObject(_mountingManager.componentViewRegistry.componentViewFactory)](
           EventDispatcher::Weak const &eventDispatcher, ContextContainer::Shared const &contextContainer) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
@@ -156,4 +156,7 @@ public class ReactFeatureFlags {
    * HostObject pattern
    */
   public static boolean useNativeState = false;
+
+  /** Report mount operations from the host platform to notify mount hooks. */
+  public static boolean enableMountHooks = false;
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/Binding.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/Binding.java
@@ -52,6 +52,8 @@ public interface Binding {
 
   public void driveCxxAnimations();
 
+  public void reportMount(int surfaceId);
+
   public ReadableNativeMap getInspectorDataForInstance(EventEmitterWrapper eventEmitterWrapper);
 
   public void register(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/BindingImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/BindingImpl.java
@@ -86,6 +86,8 @@ public class BindingImpl implements Binding {
 
   public native void driveCxxAnimations();
 
+  public native void reportMount(int surfaceId);
+
   public native ReadableNativeMap getInspectorDataForInstance(
       EventEmitterWrapper eventEmitterWrapper);
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountItemDispatcher.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountItemDispatcher.java
@@ -192,7 +192,7 @@ public class MountItemDispatcher {
       return false;
     }
 
-    mItemDispatchListener.willMountItems();
+    mItemDispatchListener.willMountItems(mountItemsToDispatch);
 
     // As an optimization, execute all ViewCommands first
     // This should be:
@@ -301,7 +301,7 @@ public class MountItemDispatcher {
       mBatchedExecutionTime += SystemClock.uptimeMillis() - batchedExecutionStartTime;
     }
 
-    mItemDispatchListener.didMountItems();
+    mItemDispatchListener.didMountItems(mountItemsToDispatch);
 
     Systrace.endSection(Systrace.TRACE_TAG_REACT_JAVA_BRIDGE);
 
@@ -419,9 +419,9 @@ public class MountItemDispatcher {
   }
 
   public interface ItemDispatchListener {
-    void willMountItems();
+    void willMountItems(List<MountItem> mountItems);
 
-    void didMountItems();
+    void didMountItems(List<MountItem> mountItems);
 
     void didDispatchMountItems();
   }

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.cpp
@@ -97,6 +97,15 @@ void Binding::driveCxxAnimations() {
   scheduler_->animationTick();
 }
 
+void Binding::reportMount(SurfaceId surfaceId) {
+  const auto &scheduler = getScheduler();
+  if (!scheduler) {
+    LOG(ERROR) << "Binding::reportMount: scheduler disappeared";
+    return;
+  }
+  scheduler->reportMount(surfaceId);
+}
+
 #pragma mark - Surface management
 
 void Binding::startSurface(
@@ -570,6 +579,7 @@ void Binding::registerNatives() {
       makeNativeMethod("setConstraints", Binding::setConstraints),
       makeNativeMethod("setPixelDensity", Binding::setPixelDensity),
       makeNativeMethod("driveCxxAnimations", Binding::driveCxxAnimations),
+      makeNativeMethod("reportMount", Binding::reportMount),
       makeNativeMethod(
           "uninstallFabricUIManager", Binding::uninstallFabricUIManager),
       makeNativeMethod("registerSurface", Binding::registerSurface),

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.h
@@ -119,6 +119,7 @@ class Binding : public jni::HybridClass<Binding>,
   void setPixelDensity(float pointScaleFactor);
 
   void driveCxxAnimations();
+  void reportMount(SurfaceId surfaceId);
 
   void uninstallFabricUIManager();
 

--- a/packages/react-native/ReactCommon/React-Fabric.podspec
+++ b/packages/react-native/ReactCommon/React-Fabric.podspec
@@ -54,6 +54,7 @@ Pod::Spec.new do |s|
   s.dependency "React-debug"
   s.dependency "React-utils"
   s.dependency "React-runtimescheduler"
+  s.dependency "React-cxxreact"
 
   if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
     s.dependency "hermes-engine"

--- a/packages/react-native/ReactCommon/react/renderer/core/CoreFeatures.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/CoreFeatures.cpp
@@ -16,5 +16,6 @@ bool CoreFeatures::useNativeState = false;
 bool CoreFeatures::cacheLastTextMeasurement = false;
 bool CoreFeatures::cancelImageDownloadsOnRecycle = false;
 bool CoreFeatures::disableTransactionCommit = false;
+bool CoreFeatures::enableGranularScrollViewStateUpdatesIOS = false;
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/CoreFeatures.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/CoreFeatures.cpp
@@ -17,5 +17,6 @@ bool CoreFeatures::cacheLastTextMeasurement = false;
 bool CoreFeatures::cancelImageDownloadsOnRecycle = false;
 bool CoreFeatures::disableTransactionCommit = false;
 bool CoreFeatures::enableGranularScrollViewStateUpdatesIOS = false;
+bool CoreFeatures::enableMountHooks = false;
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/CoreFeatures.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/CoreFeatures.h
@@ -48,6 +48,10 @@ class CoreFeatures {
   // [CATransaction end] This feature flag disables it to measure its impact in
   // production.
   static bool disableTransactionCommit;
+
+  // When enabled, RCTScrollViewComponentView will trigger ShadowTree state
+  // updates for all changes in scroll position.
+  static bool enableGranularScrollViewStateUpdatesIOS;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/CoreFeatures.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/CoreFeatures.h
@@ -52,6 +52,9 @@ class CoreFeatures {
   // When enabled, RCTScrollViewComponentView will trigger ShadowTree state
   // updates for all changes in scroll position.
   static bool enableGranularScrollViewStateUpdatesIOS;
+
+  // Report mount operations from the host platform to notify mount hooks.
+  static bool enableMountHooks;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/LayoutMetrics.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/LayoutMetrics.h
@@ -20,17 +20,23 @@ namespace facebook::react {
  * Describes results of layout process for particular shadow node.
  */
 struct LayoutMetrics {
-  // Origin: relative to its parent content frame (unless using a method that
-  // computes it relative to other parent or the viewport)
+  // Origin: relative to the outer border of its parent.
   // Size: includes border, padding and content.
   Rect frame;
-  // Width of the border + padding in all directions.
+  // Width of the border + padding in each direction.
   EdgeInsets contentInsets{0};
-  // Width of the border in all directions.
+  // Width of the border in each direction.
   EdgeInsets borderWidth{0};
+  // See `DisplayType` for all possible options.
   DisplayType displayType{DisplayType::Flex};
+  // See `LayoutDirection` for all possible options.
   LayoutDirection layoutDirection{LayoutDirection::Undefined};
+  // Pixel density. Number of device pixels per density-independent pixel.
   Float pointScaleFactor{1.0};
+  // How much the children of the node actually overflow in each direction.
+  // Positive values indicate that children are overflowing outside of the node.
+  // Negative values indicate that children are clipped inside the node
+  // (like when using `overflow: clip` on Web).
   EdgeInsets overflowInset{};
 
   // Origin: the outer border of the node.

--- a/packages/react-native/ReactCommon/react/renderer/core/LayoutableShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/LayoutableShadowNode.cpp
@@ -105,7 +105,12 @@ LayoutMetrics LayoutableShadowNode::computeRelativeLayoutMetrics(
   }
 
   auto ancestors = descendantNodeFamily.getAncestors(ancestorNode);
+  return computeRelativeLayoutMetrics(ancestors, policy);
+}
 
+LayoutMetrics LayoutableShadowNode::computeRelativeLayoutMetrics(
+    AncestorList const &ancestors,
+    LayoutInspectingPolicy policy) {
   if (ancestors.empty()) {
     // Specified nodes do not form an ancestor-descender relationship
     // in the same tree. Aborting.

--- a/packages/react-native/ReactCommon/react/renderer/core/LayoutableShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/LayoutableShadowNode.cpp
@@ -52,14 +52,14 @@ static LayoutableSmallVector<Rect> calculateTransformedFrames(
       if (i != size) {
         auto parentShadowNode =
             traitCast<LayoutableShadowNode const *>(shadowNodeList.at(i));
-        auto contentOritinOffset = parentShadowNode->getContentOriginOffset();
+        auto contentOriginOffset = parentShadowNode->getContentOriginOffset();
         if (Transform::isVerticalInversion(transformation)) {
-          contentOritinOffset.y = -contentOritinOffset.y;
+          contentOriginOffset.y = -contentOriginOffset.y;
         }
         if (Transform::isHorizontalInversion(transformation)) {
-          contentOritinOffset.x = -contentOritinOffset.x;
+          contentOriginOffset.x = -contentOriginOffset.x;
         }
-        currentFrame.origin += contentOritinOffset;
+        currentFrame.origin += contentOriginOffset;
       }
 
       transformation = transformation * currentShadowNode->getTransform();
@@ -208,12 +208,17 @@ LayoutMetrics LayoutableShadowNode::computeRelativeLayoutMetrics(
     auto shouldApplyTransformation = (policy.includeTransform && !isRootNode) ||
         (policy.includeViewportOffset && isRootNode);
 
+    // Move frame to the coordinate space of the current node.
+    resultFrame.origin += currentFrame.origin;
+
     if (shouldApplyTransformation) {
-      resultFrame.size = resultFrame.size * currentShadowNode->getTransform();
-      currentFrame = currentFrame * currentShadowNode->getTransform();
+      // If a node has a transform, we need to use the center of that node as
+      // the origin of the transform when transforming its children (which
+      // affects the result of transforms like `scale` and `rotate`).
+      resultFrame = currentShadowNode->getTransform().applyWithCenter(
+          resultFrame, currentFrame.getCenter());
     }
 
-    resultFrame.origin += currentFrame.origin;
     if (!shouldCalculateTransformedFrames && i != 0 &&
         policy.includeTransform) {
       resultFrame.origin += currentShadowNode->getContentOriginOffset();

--- a/packages/react-native/ReactCommon/react/renderer/core/LayoutableShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/LayoutableShadowNode.h
@@ -63,6 +63,13 @@ class LayoutableShadowNode : public ShadowNode {
       LayoutInspectingPolicy policy);
 
   /*
+   * Computes the layout metrics of a node relative to its specified ancestors.
+   */
+  static LayoutMetrics computeRelativeLayoutMetrics(
+      AncestorList const &ancestors,
+      LayoutInspectingPolicy policy);
+
+  /*
    * Performs layout of the tree starting from this node. Usually is being
    * called on the root node.
    * Default implementation does nothing.

--- a/packages/react-native/ReactCommon/react/renderer/core/LayoutableShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/LayoutableShadowNode.h
@@ -46,6 +46,7 @@ class LayoutableShadowNode : public ShadowNode {
   struct LayoutInspectingPolicy {
     bool includeTransform{true};
     bool includeViewportOffset{false};
+    bool enableOverflowClipping{false};
   };
 
   using UnsharedList = butter::

--- a/packages/react-native/ReactCommon/react/renderer/core/tests/LayoutableShadowNodeTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/tests/LayoutableShadowNodeTest.cpp
@@ -377,8 +377,8 @@ TEST(LayoutableShadowNodeTest, relativeLayoutMetricsOnTransformedParent) {
       LayoutableShadowNode::computeRelativeLayoutMetrics(
           childShadowNode->getFamily(), *parentShadowNode, {});
 
-  EXPECT_EQ(relativeLayoutMetrics.frame.origin.x, 45);
-  EXPECT_EQ(relativeLayoutMetrics.frame.origin.y, 45);
+  EXPECT_EQ(relativeLayoutMetrics.frame.origin.x, 40);
+  EXPECT_EQ(relativeLayoutMetrics.frame.origin.y, 40);
 
   EXPECT_EQ(relativeLayoutMetrics.frame.size.width, 25);
   EXPECT_EQ(relativeLayoutMetrics.frame.size.height, 25);

--- a/packages/react-native/ReactCommon/react/renderer/graphics/Rect.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Rect.h
@@ -69,6 +69,24 @@ struct Rect {
         point.y <= (origin.y + size.height);
   }
 
+  static Rect intersect(Rect const &rect1, Rect const &rect2) {
+    Float x1 = std::max(rect1.origin.x, rect2.origin.x);
+    Float y1 = std::max(rect1.origin.y, rect2.origin.y);
+    Float x2 = std::min(
+        rect1.origin.x + rect1.size.width, rect2.origin.x + rect2.size.width);
+    Float y2 = std::min(
+        rect1.origin.y + rect1.size.height, rect2.origin.y + rect2.size.height);
+
+    Float intersectionWidth = x2 - x1;
+    Float intersectionHeight = y2 - y1;
+
+    if (intersectionWidth < 0 || intersectionHeight < 0) {
+      return {};
+    }
+
+    return {{x1, y1}, {intersectionWidth, intersectionHeight}};
+  }
+
   static Rect boundingRect(
       Point const &a,
       Point const &b,

--- a/packages/react-native/ReactCommon/react/renderer/graphics/Transform.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Transform.cpp
@@ -366,22 +366,25 @@ Point operator*(Point const &point, Transform const &transform) {
 }
 
 Rect operator*(Rect const &rect, Transform const &transform) {
-  auto centre = rect.getCenter();
+  auto center = rect.getCenter();
+  return transform.applyWithCenter(rect, center);
+}
 
-  auto a = Point{rect.origin.x, rect.origin.y} - centre;
-  auto b = Point{rect.getMaxX(), rect.origin.y} - centre;
-  auto c = Point{rect.getMaxX(), rect.getMaxY()} - centre;
-  auto d = Point{rect.origin.x, rect.getMaxY()} - centre;
+Rect Transform::applyWithCenter(Rect const &rect, Point const &center) const {
+  auto a = Point{rect.origin.x, rect.origin.y} - center;
+  auto b = Point{rect.getMaxX(), rect.origin.y} - center;
+  auto c = Point{rect.getMaxX(), rect.getMaxY()} - center;
+  auto d = Point{rect.origin.x, rect.getMaxY()} - center;
 
-  auto vectorA = transform * Vector{a.x, a.y, 0, 1};
-  auto vectorB = transform * Vector{b.x, b.y, 0, 1};
-  auto vectorC = transform * Vector{c.x, c.y, 0, 1};
-  auto vectorD = transform * Vector{d.x, d.y, 0, 1};
+  auto vectorA = *this * Vector{a.x, a.y, 0, 1};
+  auto vectorB = *this * Vector{b.x, b.y, 0, 1};
+  auto vectorC = *this * Vector{c.x, c.y, 0, 1};
+  auto vectorD = *this * Vector{d.x, d.y, 0, 1};
 
-  Point transformedA{vectorA.x + centre.x, vectorA.y + centre.y};
-  Point transformedB{vectorB.x + centre.x, vectorB.y + centre.y};
-  Point transformedC{vectorC.x + centre.x, vectorC.y + centre.y};
-  Point transformedD{vectorD.x + centre.x, vectorD.y + centre.y};
+  Point transformedA{vectorA.x + center.x, vectorA.y + center.y};
+  Point transformedB{vectorB.x + center.x, vectorB.y + center.y};
+  Point transformedC{vectorC.x + center.x, vectorC.y + center.y};
+  Point transformedD{vectorD.x + center.x, vectorD.y + center.y};
 
   return Rect::boundingRect(
       transformedA, transformedB, transformedC, transformedD);

--- a/packages/react-native/ReactCommon/react/renderer/graphics/Transform.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Transform.h
@@ -155,6 +155,8 @@ struct Transform {
    */
   Transform operator*(Transform const &rhs) const;
 
+  Rect applyWithCenter(Rect const &rect, Point const &center) const;
+
   /**
    * Convert to folly::dynamic.
    */

--- a/packages/react-native/ReactCommon/react/renderer/graphics/tests/TransformTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/tests/TransformTest.cpp
@@ -41,6 +41,22 @@ TEST(TransformTest, scalingRect) {
   EXPECT_EQ(transformedRect.size.height, 200);
 }
 
+TEST(TransformTest, scalingRectWithDifferentCenter) {
+  auto point = facebook::react::Point{100, 200};
+  auto size = facebook::react::Size{300, 400};
+  auto rect = facebook::react::Rect{point, size};
+
+  auto center = facebook::react::Point{0, 0};
+
+  auto transformedRect =
+      Transform::Scale(0.5, 0.5, 1).applyWithCenter(rect, center);
+
+  EXPECT_EQ(transformedRect.origin.x, 50);
+  EXPECT_EQ(transformedRect.origin.y, 100);
+  EXPECT_EQ(transformedRect.size.width, 150);
+  EXPECT_EQ(transformedRect.size.height, 200);
+}
+
 TEST(TransformTest, invertingSize) {
   auto size = facebook::react::Size{300, 400};
   auto transformedSize = size * Transform::VerticalInversion();

--- a/packages/react-native/ReactCommon/react/renderer/mounting/MountingCoordinator.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/MountingCoordinator.cpp
@@ -179,6 +179,10 @@ TelemetryController const &MountingCoordinator::getTelemetryController() const {
   return telemetryController_;
 }
 
+ShadowTreeRevision const &MountingCoordinator::getBaseRevision() const {
+  return baseRevision_;
+}
+
 void MountingCoordinator::setMountingOverrideDelegate(
     std::weak_ptr<MountingOverrideDelegate const> delegate) const {
   std::lock_guard<std::mutex> lock(mutex_);

--- a/packages/react-native/ReactCommon/react/renderer/mounting/MountingCoordinator.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/MountingCoordinator.h
@@ -71,6 +71,8 @@ class MountingCoordinator final {
 
   TelemetryController const &getTelemetryController() const;
 
+  ShadowTreeRevision const &getBaseRevision() const;
+
   /*
    * Methods from this section are meant to be used by
    * `MountingOverrideDelegate` only.

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
@@ -377,6 +377,10 @@ void Scheduler::uiManagerDidSetIsJSResponder(
   }
 }
 
+void Scheduler::reportMount(SurfaceId surfaceId) const {
+  uiManager_->reportMount(surfaceId);
+}
+
 ContextContainer::Shared Scheduler::getContextContainer() const {
   return contextContainer_;
 }

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.h
@@ -108,6 +108,8 @@ class Scheduler final : public UIManagerDelegate {
 #pragma mark - UIManager
   std::shared_ptr<UIManager> getUIManager() const;
 
+  void reportMount(SurfaceId surfaceId) const;
+
 #pragma mark - Event listeners
   void addEventListener(const std::shared_ptr<EventListener const> &listener);
   void removeEventListener(

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/CMakeLists.txt
@@ -33,6 +33,7 @@ target_link_libraries(react_render_uimanager
         react_render_runtimescheduler
         react_render_mounting
         react_config
+        reactnative
         rrc_root
         rrc_view
         runtimeexecutor

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.h
@@ -30,6 +30,7 @@ namespace facebook::react {
 
 class UIManagerBinding;
 class UIManagerCommitHook;
+class UIManagerMountHook;
 
 class UIManager final : public ShadowTreeDelegate {
  public:
@@ -81,6 +82,12 @@ class UIManager final : public ShadowTreeDelegate {
    */
   void registerCommitHook(UIManagerCommitHook const &commitHook) const;
   void unregisterCommitHook(UIManagerCommitHook const &commitHook) const;
+
+  /*
+   * Registers and unregisters a mount hook.
+   */
+  void registerMountHook(UIManagerMountHook &mountHook);
+  void unregisterMountHook(UIManagerMountHook &mountHook);
 
   ShadowNode::Shared getNewestCloneOfShadowNode(
       ShadowNode const &shadowNode) const;
@@ -191,6 +198,8 @@ class UIManager final : public ShadowTreeDelegate {
 
   ShadowTreeRegistry const &getShadowTreeRegistry() const;
 
+  void reportMount(SurfaceId surfaceId) const;
+
  private:
   friend class UIManagerBinding;
   friend class Scheduler;
@@ -216,6 +225,9 @@ class UIManager final : public ShadowTreeDelegate {
 
   mutable std::shared_mutex commitHookMutex_;
   mutable std::vector<UIManagerCommitHook const *> commitHooks_;
+
+  mutable std::shared_mutex mountHookMutex_;
+  mutable std::vector<UIManagerMountHook *> mountHooks_;
 
   std::unique_ptr<LeakChecker> leakChecker_;
 };

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerMountHook.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerMountHook.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <react/renderer/components/root/RootShadowNode.h>
+#include "UIManager.h"
+
+namespace facebook::react {
+
+class ShadowTree;
+class UIManager;
+
+/*
+ * Implementing a mount hook allows to observe Shadow Trees being mounted in
+ * the host platform.
+ */
+class UIManagerMountHook {
+ public:
+  /*
+   * Called right after a `ShadowTree` is mounted in the host platform.
+   */
+  virtual void shadowTreeDidMount(
+      RootShadowNode::Shared const &rootShadowNode,
+      double mountTime) noexcept = 0;
+
+  virtual ~UIManagerMountHook() noexcept = default;
+};
+
+} // namespace facebook::react


### PR DESCRIPTION
Summary:
## Context

This implements the concept of mount hooks in UIManager which, similarly to commit hooks, receive a notification when a root shadow tree has been mounted in the host platform.

This is meant to be used internally in React Native, not by user-land libraries or products.

This will be used to implement `IntersectionObserver` in a following diff.

Changelog: [Internal]

Differential Revision: D45866244

