### PR TITLE
Add flag to do granular state updates in scroll views in iOS

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -437,7 +437,7 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrol
 
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView
 {
-  if (!_isUserTriggeredScrolling) {
+  if (!_isUserTriggeredScrolling || CoreFeatures::enableGranularScrollViewStateUpdatesIOS) {
     [self _updateStateWithContentOffset];
   }
 

--- a/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
+++ b/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
@@ -276,6 +276,10 @@ static BackgroundExecutor RCTGetBackgroundExecutor()
     CoreFeatures::disableTransactionCommit = true;
   }
 
+  if (reactNativeConfig && reactNativeConfig->getBool("react_fabric:enable_granular_scroll_view_state_updates_ios")) {
+    CoreFeatures::enableGranularScrollViewStateUpdatesIOS = true;
+  }
+
   auto componentRegistryFactory =
       [factory = wrapManagedObject(_mountingManager.componentViewRegistry.componentViewFactory)](
           EventDispatcher::Weak const &eventDispatcher, ContextContainer::Shared const &contextContainer) {

--- a/packages/react-native/ReactCommon/react/renderer/core/CoreFeatures.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/CoreFeatures.cpp
@@ -16,5 +16,6 @@ bool CoreFeatures::useNativeState = false;
 bool CoreFeatures::cacheLastTextMeasurement = false;
 bool CoreFeatures::cancelImageDownloadsOnRecycle = false;
 bool CoreFeatures::disableTransactionCommit = false;
+bool CoreFeatures::enableGranularScrollViewStateUpdatesIOS = false;
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/CoreFeatures.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/CoreFeatures.h
@@ -48,6 +48,10 @@ class CoreFeatures {
   // [CATransaction end] This feature flag disables it to measure its impact in
   // production.
   static bool disableTransactionCommit;
+
+  // When enabled, RCTScrollViewComponentView will trigger ShadowTree state
+  // updates for all changes in scroll position.
+  static bool enableGranularScrollViewStateUpdatesIOS;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/LayoutMetrics.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/LayoutMetrics.h
@@ -20,17 +20,23 @@ namespace facebook::react {
  * Describes results of layout process for particular shadow node.
  */
 struct LayoutMetrics {
-  // Origin: relative to its parent content frame (unless using a method that
-  // computes it relative to other parent or the viewport)
+  // Origin: relative to the outer border of its parent.
   // Size: includes border, padding and content.
   Rect frame;
-  // Width of the border + padding in all directions.
+  // Width of the border + padding in each direction.
   EdgeInsets contentInsets{0};
-  // Width of the border in all directions.
+  // Width of the border in each direction.
   EdgeInsets borderWidth{0};
+  // See `DisplayType` for all possible options.
   DisplayType displayType{DisplayType::Flex};
+  // See `LayoutDirection` for all possible options.
   LayoutDirection layoutDirection{LayoutDirection::Undefined};
+  // Pixel density. Number of device pixels per density-independent pixel.
   Float pointScaleFactor{1.0};
+  // How much the children of the node actually overflow in each direction.
+  // Positive values indicate that children are overflowing outside of the node.
+  // Negative values indicate that children are clipped inside the node
+  // (like when using `overflow: clip` on Web).
   EdgeInsets overflowInset{};
 
   // Origin: the outer border of the node.

--- a/packages/react-native/ReactCommon/react/renderer/core/LayoutableShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/LayoutableShadowNode.cpp
@@ -105,7 +105,12 @@ LayoutMetrics LayoutableShadowNode::computeRelativeLayoutMetrics(
   }
 
   auto ancestors = descendantNodeFamily.getAncestors(ancestorNode);
+  return computeRelativeLayoutMetrics(ancestors, policy);
+}
 
+LayoutMetrics LayoutableShadowNode::computeRelativeLayoutMetrics(
+    AncestorList const &ancestors,
+    LayoutInspectingPolicy policy) {
   if (ancestors.empty()) {
     // Specified nodes do not form an ancestor-descender relationship
     // in the same tree. Aborting.

--- a/packages/react-native/ReactCommon/react/renderer/core/LayoutableShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/LayoutableShadowNode.cpp
@@ -52,14 +52,14 @@ static LayoutableSmallVector<Rect> calculateTransformedFrames(
       if (i != size) {
         auto parentShadowNode =
             traitCast<LayoutableShadowNode const *>(shadowNodeList.at(i));
-        auto contentOritinOffset = parentShadowNode->getContentOriginOffset();
+        auto contentOriginOffset = parentShadowNode->getContentOriginOffset();
         if (Transform::isVerticalInversion(transformation)) {
-          contentOritinOffset.y = -contentOritinOffset.y;
+          contentOriginOffset.y = -contentOriginOffset.y;
         }
         if (Transform::isHorizontalInversion(transformation)) {
-          contentOritinOffset.x = -contentOritinOffset.x;
+          contentOriginOffset.x = -contentOriginOffset.x;
         }
-        currentFrame.origin += contentOritinOffset;
+        currentFrame.origin += contentOriginOffset;
       }
 
       transformation = transformation * currentShadowNode->getTransform();
@@ -208,12 +208,17 @@ LayoutMetrics LayoutableShadowNode::computeRelativeLayoutMetrics(
     auto shouldApplyTransformation = (policy.includeTransform && !isRootNode) ||
         (policy.includeViewportOffset && isRootNode);
 
+    // Move frame to the coordinate space of the current node.
+    resultFrame.origin += currentFrame.origin;
+
     if (shouldApplyTransformation) {
-      resultFrame.size = resultFrame.size * currentShadowNode->getTransform();
-      currentFrame = currentFrame * currentShadowNode->getTransform();
+      // If a node has a transform, we need to use the center of that node as
+      // the origin of the transform when transforming its children (which
+      // affects the result of transforms like `scale` and `rotate`).
+      resultFrame = currentShadowNode->getTransform().applyWithCenter(
+          resultFrame, currentFrame.getCenter());
     }
 
-    resultFrame.origin += currentFrame.origin;
     if (!shouldCalculateTransformedFrames && i != 0 &&
         policy.includeTransform) {
       resultFrame.origin += currentShadowNode->getContentOriginOffset();

--- a/packages/react-native/ReactCommon/react/renderer/core/LayoutableShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/LayoutableShadowNode.h
@@ -63,6 +63,13 @@ class LayoutableShadowNode : public ShadowNode {
       LayoutInspectingPolicy policy);
 
   /*
+   * Computes the layout metrics of a node relative to its specified ancestors.
+   */
+  static LayoutMetrics computeRelativeLayoutMetrics(
+      AncestorList const &ancestors,
+      LayoutInspectingPolicy policy);
+
+  /*
    * Performs layout of the tree starting from this node. Usually is being
    * called on the root node.
    * Default implementation does nothing.

--- a/packages/react-native/ReactCommon/react/renderer/core/LayoutableShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/LayoutableShadowNode.h
@@ -46,6 +46,7 @@ class LayoutableShadowNode : public ShadowNode {
   struct LayoutInspectingPolicy {
     bool includeTransform{true};
     bool includeViewportOffset{false};
+    bool enableOverflowClipping{false};
   };
 
   using UnsharedList = butter::

--- a/packages/react-native/ReactCommon/react/renderer/core/tests/LayoutableShadowNodeTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/tests/LayoutableShadowNodeTest.cpp
@@ -377,8 +377,8 @@ TEST(LayoutableShadowNodeTest, relativeLayoutMetricsOnTransformedParent) {
       LayoutableShadowNode::computeRelativeLayoutMetrics(
           childShadowNode->getFamily(), *parentShadowNode, {});
 
-  EXPECT_EQ(relativeLayoutMetrics.frame.origin.x, 45);
-  EXPECT_EQ(relativeLayoutMetrics.frame.origin.y, 45);
+  EXPECT_EQ(relativeLayoutMetrics.frame.origin.x, 40);
+  EXPECT_EQ(relativeLayoutMetrics.frame.origin.y, 40);
 
   EXPECT_EQ(relativeLayoutMetrics.frame.size.width, 25);
   EXPECT_EQ(relativeLayoutMetrics.frame.size.height, 25);

--- a/packages/react-native/ReactCommon/react/renderer/graphics/Rect.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Rect.h
@@ -69,6 +69,24 @@ struct Rect {
         point.y <= (origin.y + size.height);
   }
 
+  static Rect intersect(Rect const &rect1, Rect const &rect2) {
+    Float x1 = std::max(rect1.origin.x, rect2.origin.x);
+    Float y1 = std::max(rect1.origin.y, rect2.origin.y);
+    Float x2 = std::min(
+        rect1.origin.x + rect1.size.width, rect2.origin.x + rect2.size.width);
+    Float y2 = std::min(
+        rect1.origin.y + rect1.size.height, rect2.origin.y + rect2.size.height);
+
+    Float intersectionWidth = x2 - x1;
+    Float intersectionHeight = y2 - y1;
+
+    if (intersectionWidth < 0 || intersectionHeight < 0) {
+      return {};
+    }
+
+    return {{x1, y1}, {intersectionWidth, intersectionHeight}};
+  }
+
   static Rect boundingRect(
       Point const &a,
       Point const &b,

--- a/packages/react-native/ReactCommon/react/renderer/graphics/Transform.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Transform.cpp
@@ -366,22 +366,25 @@ Point operator*(Point const &point, Transform const &transform) {
 }
 
 Rect operator*(Rect const &rect, Transform const &transform) {
-  auto centre = rect.getCenter();
+  auto center = rect.getCenter();
+  return transform.applyWithCenter(rect, center);
+}
 
-  auto a = Point{rect.origin.x, rect.origin.y} - centre;
-  auto b = Point{rect.getMaxX(), rect.origin.y} - centre;
-  auto c = Point{rect.getMaxX(), rect.getMaxY()} - centre;
-  auto d = Point{rect.origin.x, rect.getMaxY()} - centre;
+Rect Transform::applyWithCenter(Rect const &rect, Point const &center) const {
+  auto a = Point{rect.origin.x, rect.origin.y} - center;
+  auto b = Point{rect.getMaxX(), rect.origin.y} - center;
+  auto c = Point{rect.getMaxX(), rect.getMaxY()} - center;
+  auto d = Point{rect.origin.x, rect.getMaxY()} - center;
 
-  auto vectorA = transform * Vector{a.x, a.y, 0, 1};
-  auto vectorB = transform * Vector{b.x, b.y, 0, 1};
-  auto vectorC = transform * Vector{c.x, c.y, 0, 1};
-  auto vectorD = transform * Vector{d.x, d.y, 0, 1};
+  auto vectorA = *this * Vector{a.x, a.y, 0, 1};
+  auto vectorB = *this * Vector{b.x, b.y, 0, 1};
+  auto vectorC = *this * Vector{c.x, c.y, 0, 1};
+  auto vectorD = *this * Vector{d.x, d.y, 0, 1};
 
-  Point transformedA{vectorA.x + centre.x, vectorA.y + centre.y};
-  Point transformedB{vectorB.x + centre.x, vectorB.y + centre.y};
-  Point transformedC{vectorC.x + centre.x, vectorC.y + centre.y};
-  Point transformedD{vectorD.x + centre.x, vectorD.y + centre.y};
+  Point transformedA{vectorA.x + center.x, vectorA.y + center.y};
+  Point transformedB{vectorB.x + center.x, vectorB.y + center.y};
+  Point transformedC{vectorC.x + center.x, vectorC.y + center.y};
+  Point transformedD{vectorD.x + center.x, vectorD.y + center.y};
 
   return Rect::boundingRect(
       transformedA, transformedB, transformedC, transformedD);

--- a/packages/react-native/ReactCommon/react/renderer/graphics/Transform.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Transform.h
@@ -155,6 +155,8 @@ struct Transform {
    */
   Transform operator*(Transform const &rhs) const;
 
+  Rect applyWithCenter(Rect const &rect, Point const &center) const;
+
   /**
    * Convert to folly::dynamic.
    */

--- a/packages/react-native/ReactCommon/react/renderer/graphics/tests/TransformTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/tests/TransformTest.cpp
@@ -41,6 +41,22 @@ TEST(TransformTest, scalingRect) {
   EXPECT_EQ(transformedRect.size.height, 200);
 }
 
+TEST(TransformTest, scalingRectWithDifferentCenter) {
+  auto point = facebook::react::Point{100, 200};
+  auto size = facebook::react::Size{300, 400};
+  auto rect = facebook::react::Rect{point, size};
+
+  auto center = facebook::react::Point{0, 0};
+
+  auto transformedRect =
+      Transform::Scale(0.5, 0.5, 1).applyWithCenter(rect, center);
+
+  EXPECT_EQ(transformedRect.origin.x, 50);
+  EXPECT_EQ(transformedRect.origin.y, 100);
+  EXPECT_EQ(transformedRect.size.width, 150);
+  EXPECT_EQ(transformedRect.size.height, 200);
+}
+
 TEST(TransformTest, invertingSize) {
   auto size = facebook::react::Size{300, 400};
   auto transformedSize = size * Transform::VerticalInversion();


### PR DESCRIPTION
Summary:
This adds a feature flag to dispatch state updates for scroll position in every scroll position update in iOS, as opposed to only at the beginning, end and other specific moments.

This is necessary to implement features like `IntersectionObserver`, but we want to test the performance impact of this change before rolling it out completely.

Changelog: [internal]

Differential Revision: D45916675

