### PR TITLE
Bump CLI to `v11.3.0` in `0.72-stable`

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -79,9 +79,9 @@
   },
   "dependencies": {
     "@jest/create-cache-key-function": "^29.2.1",
-    "@react-native-community/cli": "11.2.3",
-    "@react-native-community/cli-platform-android": "11.2.3",
-    "@react-native-community/cli-platform-ios": "11.2.3",
+    "@react-native-community/cli": "11.3.0",
+    "@react-native-community/cli-platform-android": "11.3.0",
+    "@react-native-community/cli-platform-ios": "11.3.0",
     "@react-native/assets-registry": "^0.72.0",
     "@react-native/codegen": "^0.72.4",
     "@react-native/gradle-plugin": "^0.72.7",


### PR DESCRIPTION
## Summary:

Bump CLI to `v11.3.0` in `0.72-stable` which fixes several issues and adds new features.
For complete changelog, see:
- CLI `v11.3.0` Changelog : https://github.com/react-native-community/cli/releases/tag/v11.3.0
- Request: https://github.com/reactwg/react-native-releases/discussions/54#discussioncomment-5927718

## Changelog:

[GENERAL] [CHANGED] - Bump CLI to `v11.3.0`

## Test Plan:

- CI should be green
