### PR TITLE
Use NativeMethodCallInvoker for sync method calls

### DIFF
--- a/packages/react-native/React/CxxBridge/RCTCxxBridge.mm
+++ b/packages/react-native/React/CxxBridge/RCTCxxBridge.mm
@@ -1635,9 +1635,10 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithBundleURL
   return _reactInstance ? _reactInstance->getJSCallInvoker() : nullptr;
 }
 
-- (std::shared_ptr<CallInvoker>)decorateNativeCallInvoker:(std::shared_ptr<CallInvoker>)nativeInvoker
+- (std::shared_ptr<NativeMethodCallInvoker>)decorateNativeMethodCallInvoker:
+    (std::shared_ptr<NativeMethodCallInvoker>)nativeInvoker
 {
-  return _reactInstance ? _reactInstance->getDecoratedNativeCallInvoker(nativeInvoker) : nullptr;
+  return _reactInstance ? _reactInstance->getDecoratedNativeMethodCallInvoker(nativeInvoker) : nullptr;
 }
 
 @end

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -1379,7 +1379,7 @@ public class ReactInstanceManager {
               catalystInstance.getRuntimeExecutor(),
               tmmDelegate,
               catalystInstance.getJSCallInvokerHolder(),
-              catalystInstance.getNativeCallInvokerHolder());
+              catalystInstance.getNativeMethodCallInvokerHolder());
 
       catalystInstance.setTurboModuleManager(turboModuleManager);
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstance.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstance.java
@@ -12,6 +12,7 @@ import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.bridge.queue.ReactQueueConfiguration;
 import com.facebook.react.common.annotations.VisibleForTesting;
 import com.facebook.react.turbomodule.core.interfaces.CallInvokerHolder;
+import com.facebook.react.turbomodule.core.interfaces.NativeMethodCallInvokerHolder;
 import java.util.Collection;
 import java.util.List;
 
@@ -122,10 +123,10 @@ public interface CatalystInstance
   CallInvokerHolder getJSCallInvokerHolder();
 
   /**
-   * Returns a hybrid object that contains a pointer to a Native CallInvoker, which is used to
+   * Returns a hybrid object that contains a pointer to a NativeMethodCallInvoker, which is used to
    * schedule work on the NativeModules thread. Required for TurboModuleManager initialization.
    */
-  CallInvokerHolder getNativeCallInvokerHolder();
+  NativeMethodCallInvokerHolder getNativeMethodCallInvokerHolder();
 
   /**
    * For the time being, we want code relying on the old infra to also work with TurboModules.

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java
@@ -28,6 +28,7 @@ import com.facebook.react.common.annotations.VisibleForTesting;
 import com.facebook.react.config.ReactFeatureFlags;
 import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.turbomodule.core.CallInvokerHolderImpl;
+import com.facebook.react.turbomodule.core.NativeMethodCallInvokerHolderImpl;
 import com.facebook.react.turbomodule.core.interfaces.TurboModuleRegistry;
 import com.facebook.systrace.Systrace;
 import com.facebook.systrace.TraceListener;
@@ -111,7 +112,7 @@ public class CatalystInstanceImpl implements CatalystInstance {
 
   public native CallInvokerHolderImpl getJSCallInvokerHolder();
 
-  public native CallInvokerHolderImpl getNativeCallInvokerHolder();
+  public native NativeMethodCallInvokerHolderImpl getNativeMethodCallInvokerHolder();
 
   private CatalystInstanceImpl(
       final ReactQueueConfigurationSpec reactQueueConfigurationSpec,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactInstance.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactInstance.java
@@ -44,6 +44,7 @@ import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.modules.core.JavaTimerManager;
 import com.facebook.react.modules.core.ReactChoreographer;
 import com.facebook.react.turbomodule.core.CallInvokerHolderImpl;
+import com.facebook.react.turbomodule.core.NativeMethodCallInvokerHolderImpl;
 import com.facebook.react.turbomodule.core.TurboModuleManager;
 import com.facebook.react.turbomodule.core.TurboModuleManagerDelegate;
 import com.facebook.react.uimanager.ComponentNameResolver;
@@ -193,7 +194,7 @@ final class ReactInstance {
             unbufferedRuntimeExecutor,
             turboModuleManagerDelegate,
             getJSCallInvokerHolder(),
-            getNativeCallInvokerHolder());
+            getNativeMethodCallInvokerHolder());
 
     // Eagerly initialize TurboModules
     for (String moduleName : mTurboModuleManager.getEagerInitModuleNames()) {
@@ -397,7 +398,7 @@ final class ReactInstance {
 
   private native CallInvokerHolderImpl getJSCallInvokerHolder();
 
-  private native CallInvokerHolderImpl getNativeCallInvokerHolder();
+  private native NativeMethodCallInvokerHolderImpl getNativeMethodCallInvokerHolder();
 
   private native RuntimeExecutor getUnbufferedRuntimeExecutor();
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/NativeMethodCallInvokerHolderImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/NativeMethodCallInvokerHolderImpl.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.turbomodule.core;
+
+import com.facebook.jni.HybridData;
+import com.facebook.react.turbomodule.core.interfaces.NativeMethodCallInvokerHolder;
+import com.facebook.soloader.SoLoader;
+
+/**
+ * NativeMethodCallInvokerHolder is created at a different time/place (i.e: in CatalystInstance)
+ * than TurboModuleManager. Therefore, we need to wrap NativeMethodCallInvokerHolder within a hybrid
+ * class so that we may pass it from CatalystInstance, through Java, to
+ * TurboModuleManager::initHybrid.
+ */
+public class NativeMethodCallInvokerHolderImpl implements NativeMethodCallInvokerHolder {
+  private static volatile boolean sIsSoLibraryLoaded;
+
+  private final HybridData mHybridData;
+
+  private NativeMethodCallInvokerHolderImpl(HybridData hd) {
+    maybeLoadSoLibrary();
+    mHybridData = hd;
+  }
+
+  // Prevents issues with initializer interruptions. See T38996825 and D13793825 for more context.
+  private static synchronized void maybeLoadSoLibrary() {
+    if (!sIsSoLibraryLoaded) {
+      SoLoader.loadLibrary("turbomodulejsijni");
+      sIsSoLibraryLoaded = true;
+    }
+  }
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/TurboModuleManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/TurboModuleManager.java
@@ -22,6 +22,7 @@ import com.facebook.react.bridge.ReactSoftExceptionLogger;
 import com.facebook.react.bridge.RuntimeExecutor;
 import com.facebook.react.config.ReactFeatureFlags;
 import com.facebook.react.turbomodule.core.interfaces.CallInvokerHolder;
+import com.facebook.react.turbomodule.core.interfaces.NativeMethodCallInvokerHolder;
 import com.facebook.react.turbomodule.core.interfaces.TurboModule;
 import com.facebook.react.turbomodule.core.interfaces.TurboModuleRegistry;
 import com.facebook.soloader.SoLoader;
@@ -61,14 +62,14 @@ public class TurboModuleManager implements JSIModule, TurboModuleRegistry {
       RuntimeExecutor runtimeExecutor,
       @Nullable final TurboModuleManagerDelegate delegate,
       CallInvokerHolder jsCallInvokerHolder,
-      CallInvokerHolder nativeCallInvokerHolder) {
+      NativeMethodCallInvokerHolder nativeMethodCallInvokerHolder) {
     maybeLoadSoLibrary();
     mDelegate = delegate;
     mHybridData =
         initHybrid(
             runtimeExecutor,
             (CallInvokerHolderImpl) jsCallInvokerHolder,
-            (CallInvokerHolderImpl) nativeCallInvokerHolder,
+            (NativeMethodCallInvokerHolderImpl) nativeMethodCallInvokerHolder,
             delegate);
     installJSIBindings(shouldCreateLegacyModules());
 
@@ -405,7 +406,7 @@ public class TurboModuleManager implements JSIModule, TurboModuleRegistry {
   private native HybridData initHybrid(
       RuntimeExecutor runtimeExecutor,
       CallInvokerHolderImpl jsCallInvokerHolder,
-      CallInvokerHolderImpl nativeCallInvokerHolder,
+      NativeMethodCallInvokerHolderImpl nativeMethodCallInvoker,
       TurboModuleManagerDelegate tmmDelegate);
 
   private native void installJSIBindings(boolean shouldCreateLegacyModules);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/interfaces/NativeMethodCallInvokerHolder.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/interfaces/NativeMethodCallInvokerHolder.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.turbomodule.core.interfaces;
+
+/**
+ * This interface represents the opaque Java object that contains a pointer to and instance of
+ * NativeMethodCallInvoker.
+ */
+public interface NativeMethodCallInvokerHolder {}

--- a/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/jni/JReactInstance.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/jni/JReactInstance.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <ReactCommon/CallInvokerHolder.h>
+#include <ReactCommon/NativeMethodCallInvokerHolder.h>
 #include <ReactCommon/RuntimeExecutor.h>
 #include <fb/fbjni.h>
 #include <jni.h>
@@ -92,14 +93,16 @@ class JReactInstance : public jni::HybridClass<JReactInstance> {
       bool isProfiling) noexcept;
 
   jni::alias_ref<CallInvokerHolder::javaobject> getJSCallInvokerHolder();
-  jni::alias_ref<CallInvokerHolder::javaobject> getNativeCallInvokerHolder();
+  jni::alias_ref<NativeMethodCallInvokerHolder::javaobject>
+  getNativeMethodCallInvokerHolder();
 
   std::unique_ptr<ReactInstance> instance_;
   jni::global_ref<JRuntimeExecutor::javaobject> unbufferedRuntimeExecutor_;
   jni::global_ref<JRuntimeExecutor::javaobject> bufferedRuntimeExecutor_;
   jni::global_ref<JRuntimeScheduler::javaobject> runtimeScheduler_;
   jni::global_ref<CallInvokerHolder::javaobject> jsCallInvokerHolder_;
-  jni::global_ref<CallInvokerHolder::javaobject> nativeCallInvokerHolder_;
+  jni::global_ref<NativeMethodCallInvokerHolder::javaobject>
+      nativeMethodCallInvokerHolder_;
   jni::global_ref<JReactExceptionManager::javaobject> jReactExceptionManager_;
   jni::global_ref<JBindingsInstaller::javaobject> jBindingsInstaller_;
 };

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/CatalystInstanceImpl.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/CatalystInstanceImpl.cpp
@@ -131,8 +131,8 @@ void CatalystInstanceImpl::registerNatives() {
           "getJSCallInvokerHolder",
           CatalystInstanceImpl::getJSCallInvokerHolder),
       makeNativeMethod(
-          "getNativeCallInvokerHolder",
-          CatalystInstanceImpl::getNativeCallInvokerHolder),
+          "getNativeMethodCallInvokerHolder",
+          CatalystInstanceImpl::getNativeMethodCallInvokerHolder),
       makeNativeMethod(
           "jniHandleMemoryPressure",
           CatalystInstanceImpl::handleMemoryPressure),
@@ -358,36 +358,41 @@ CatalystInstanceImpl::getJSCallInvokerHolder() {
   return jsCallInvokerHolder_;
 }
 
-jni::alias_ref<CallInvokerHolder::javaobject>
-CatalystInstanceImpl::getNativeCallInvokerHolder() {
-  if (!nativeCallInvokerHolder_) {
-    class NativeThreadCallInvoker : public CallInvoker {
+jni::alias_ref<NativeMethodCallInvokerHolder::javaobject>
+CatalystInstanceImpl::getNativeMethodCallInvokerHolder() {
+  if (!nativeMethodCallInvokerHolder_) {
+    class NativeMethodCallInvokerImpl : public NativeMethodCallInvoker {
      private:
       std::shared_ptr<JMessageQueueThread> messageQueueThread_;
 
      public:
-      NativeThreadCallInvoker(
+      NativeMethodCallInvokerImpl(
           std::shared_ptr<JMessageQueueThread> messageQueueThread)
           : messageQueueThread_(messageQueueThread) {}
-      void invokeAsync(std::function<void()> &&work) override {
+      void invokeAsync(
+          const std::string &methodName,
+          std::function<void()> &&work) override {
         messageQueueThread_->runOnQueue(std::move(work));
       }
-      void invokeSync(std::function<void()> &&work) override {
+      void invokeSync(
+          const std::string &methodName,
+          std::function<void()> &&work) override {
         messageQueueThread_->runOnQueueSync(std::move(work));
       }
     };
 
-    std::shared_ptr<CallInvoker> nativeInvoker =
-        std::make_shared<NativeThreadCallInvoker>(moduleMessageQueue_);
+    std::shared_ptr<NativeMethodCallInvoker> nativeMethodCallInvoker =
+        std::make_shared<NativeMethodCallInvokerImpl>(moduleMessageQueue_);
 
-    std::shared_ptr<CallInvoker> decoratedNativeInvoker =
-        instance_->getDecoratedNativeCallInvoker(nativeInvoker);
+    std::shared_ptr<NativeMethodCallInvoker> decoratedNativeMethodCallInvoker =
+        instance_->getDecoratedNativeMethodCallInvoker(nativeMethodCallInvoker);
 
-    nativeCallInvokerHolder_ = jni::make_global(
-        CallInvokerHolder::newObjectCxxArgs(decoratedNativeInvoker));
+    nativeMethodCallInvokerHolder_ =
+        jni::make_global(NativeMethodCallInvokerHolder::newObjectCxxArgs(
+            decoratedNativeMethodCallInvoker));
   }
 
-  return nativeCallInvokerHolder_;
+  return nativeMethodCallInvokerHolder_;
 }
 
 jni::alias_ref<JRuntimeExecutor::javaobject>

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/CatalystInstanceImpl.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/CatalystInstanceImpl.h
@@ -9,6 +9,7 @@
 #include <string>
 
 #include <ReactCommon/CallInvokerHolder.h>
+#include <ReactCommon/NativeMethodCallInvokerHolder.h>
 #include <ReactCommon/RuntimeExecutor.h>
 #include <fbjni/fbjni.h>
 
@@ -96,7 +97,8 @@ class CatalystInstanceImpl : public jni::HybridClass<CatalystInstanceImpl> {
       NativeArray *arguments);
   void jniCallJSCallback(jint callbackId, NativeArray *arguments);
   jni::alias_ref<CallInvokerHolder::javaobject> getJSCallInvokerHolder();
-  jni::alias_ref<CallInvokerHolder::javaobject> getNativeCallInvokerHolder();
+  jni::alias_ref<NativeMethodCallInvokerHolder::javaobject>
+  getNativeMethodCallInvokerHolder();
   jni::alias_ref<JRuntimeExecutor::javaobject> getRuntimeExecutor();
   jni::alias_ref<JRuntimeScheduler::javaobject> getRuntimeScheduler();
   void setGlobalVariable(std::string propName, std::string &&jsonValue);
@@ -111,7 +113,8 @@ class CatalystInstanceImpl : public jni::HybridClass<CatalystInstanceImpl> {
   std::shared_ptr<ModuleRegistry> moduleRegistry_;
   std::shared_ptr<JMessageQueueThread> moduleMessageQueue_;
   jni::global_ref<CallInvokerHolder::javaobject> jsCallInvokerHolder_;
-  jni::global_ref<CallInvokerHolder::javaobject> nativeCallInvokerHolder_;
+  jni::global_ref<NativeMethodCallInvokerHolder::javaobject>
+      nativeMethodCallInvokerHolder_;
   jni::global_ref<JRuntimeExecutor::javaobject> runtimeExecutor_;
   jni::global_ref<JRuntimeScheduler::javaobject> runtimeScheduler_;
 };

--- a/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(
         callinvokerholder
         STATIC
         ReactCommon/CallInvokerHolder.cpp
+        ReactCommon/NativeMethodCallInvokerHolder.cpp
 )
 
 target_include_directories(callinvokerholder

--- a/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/NativeMethodCallInvokerHolder.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/NativeMethodCallInvokerHolder.cpp
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "NativeMethodCallInvokerHolder.h"
+
+namespace facebook::react {
+
+NativeMethodCallInvokerHolder::NativeMethodCallInvokerHolder(
+    std::shared_ptr<NativeMethodCallInvoker> nativeMethodCallInvoker)
+    : _nativeMethodCallInvoker(nativeMethodCallInvoker) {}
+
+std::shared_ptr<NativeMethodCallInvoker>
+NativeMethodCallInvokerHolder::getNativeMethodCallInvoker() {
+  return _nativeMethodCallInvoker;
+}
+
+void NativeMethodCallInvokerHolder::registerNatives() {}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/NativeMethodCallInvokerHolder.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/NativeMethodCallInvokerHolder.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <ReactCommon/CallInvoker.h>
+#include <fbjni/fbjni.h>
+#include <memory>
+
+namespace facebook::react {
+
+class NativeMethodCallInvokerHolder
+    : public jni::HybridClass<NativeMethodCallInvokerHolder> {
+ public:
+  static auto constexpr kJavaDescriptor =
+      "Lcom/facebook/react/turbomodule/core/NativeMethodCallInvokerHolderImpl;";
+
+  static void registerNatives();
+  std::shared_ptr<NativeMethodCallInvoker> getNativeMethodCallInvoker();
+
+ private:
+  friend HybridBase;
+  NativeMethodCallInvokerHolder(
+      std::shared_ptr<NativeMethodCallInvoker> nativeMethodCallInvoker);
+  std::shared_ptr<NativeMethodCallInvoker> _nativeMethodCallInvoker;
+};
+
+} // namespace facebook::react

--- a/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManager.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManager.h
@@ -10,6 +10,7 @@
 #include <ReactCommon/CallInvokerHolder.h>
 #include <ReactCommon/JavaTurboModule.h>
 #include <ReactCommon/LongLivedObject.h>
+#include <ReactCommon/NativeMethodCallInvokerHolder.h>
 #include <ReactCommon/RuntimeExecutor.h>
 #include <ReactCommon/TurboModule.h>
 #include <ReactCommon/TurboModuleManagerDelegate.h>
@@ -30,7 +31,8 @@ class TurboModuleManager : public jni::HybridClass<TurboModuleManager> {
       jni::alias_ref<jhybridobject> jThis,
       jni::alias_ref<JRuntimeExecutor::javaobject> runtimeExecutor,
       jni::alias_ref<CallInvokerHolder::javaobject> jsCallInvokerHolder,
-      jni::alias_ref<CallInvokerHolder::javaobject> nativeCallInvokerHolder,
+      jni::alias_ref<NativeMethodCallInvokerHolder::javaobject>
+          nativeMethodCallInvokerHolder,
       jni::alias_ref<TurboModuleManagerDelegate::javaobject> delegate);
   static void registerNatives();
 
@@ -39,7 +41,7 @@ class TurboModuleManager : public jni::HybridClass<TurboModuleManager> {
   jni::global_ref<TurboModuleManager::javaobject> javaPart_;
   RuntimeExecutor runtimeExecutor_;
   std::shared_ptr<CallInvoker> jsCallInvoker_;
-  std::shared_ptr<CallInvoker> nativeCallInvoker_;
+  std::shared_ptr<NativeMethodCallInvoker> nativeMethodCallInvoker_;
   jni::global_ref<TurboModuleManagerDelegate::javaobject> delegate_;
 
   using ModuleCache =
@@ -59,7 +61,7 @@ class TurboModuleManager : public jni::HybridClass<TurboModuleManager> {
       jni::alias_ref<TurboModuleManager::jhybridobject> jThis,
       RuntimeExecutor runtimeExecutor,
       std::shared_ptr<CallInvoker> jsCallInvoker,
-      std::shared_ptr<CallInvoker> nativeCallInvoker,
+      std::shared_ptr<NativeMethodCallInvoker> nativeMethodCallInvoker,
       jni::alias_ref<TurboModuleManagerDelegate::javaobject> delegate);
 
   TurboModuleProviderFunctionType createTurboModuleProvider();

--- a/packages/react-native/ReactCommon/callinvoker/ReactCommon/CallInvoker.h
+++ b/packages/react-native/ReactCommon/callinvoker/ReactCommon/CallInvoker.h
@@ -32,4 +32,11 @@ class CallInvoker {
   virtual ~CallInvoker() {}
 };
 
+class NativeMethodCallInvoker {
+ public:
+  virtual void invokeAsync(const std::string &methodName, CallFunc &&func) = 0;
+  virtual void invokeSync(const std::string &methodName, CallFunc &&func) = 0;
+  virtual ~NativeMethodCallInvoker() {}
+};
+
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/cxxreact/Instance.cpp
+++ b/packages/react-native/ReactCommon/cxxreact/Instance.cpp
@@ -233,9 +233,11 @@ RuntimeExecutor Instance::getRuntimeExecutor() {
   return runtimeExecutor;
 }
 
-std::shared_ptr<CallInvoker> Instance::getDecoratedNativeCallInvoker(
-    std::shared_ptr<CallInvoker> nativeInvoker) {
-  return nativeToJsBridge_->getDecoratedNativeCallInvoker(nativeInvoker);
+std::shared_ptr<NativeMethodCallInvoker>
+Instance::getDecoratedNativeMethodCallInvoker(
+    std::shared_ptr<NativeMethodCallInvoker> nativeMethodCallInvoker) {
+  return nativeToJsBridge_->getDecoratedNativeMethodCallInvoker(
+      nativeMethodCallInvoker);
 }
 
 void Instance::JSCallInvoker::setNativeToJsBridgeAndFlushCalls(

--- a/packages/react-native/ReactCommon/cxxreact/Instance.h
+++ b/packages/react-native/ReactCommon/cxxreact/Instance.h
@@ -101,10 +101,10 @@ class RN_EXPORT Instance {
   std::shared_ptr<CallInvoker> getJSCallInvoker();
 
   /**
-   * Native CallInvoker is used by TurboModules to schedule work on the
+   * NativeMethodCallInvoker is used by TurboModules to schedule work on the
    * NativeModule thread(s).
    *
-   * Why is the bridge decorating native CallInvoker?
+   * Why is the bridge decorating NativeMethodCallInvoker?
    *
    * - The bridge must be informed of all TurboModule async method calls. Why?
    *   When all queued NativeModule method calls are flushed by a call from
@@ -116,16 +116,16 @@ class RN_EXPORT Instance {
    *   since the last time the bridge was flushed. If this number is non-zero,
    *   we fire onBatchComplete.
    *
-   * Why can't we just create and return a new native CallInvoker?
+   * Why can't we just create and return a new NativeMethodCallInvoker?
    *
    * - On Android, we have one NativeModule thread. That thread is created and
    *   managed outside of NativeToJsBridge. On iOS, we have one MethodQueue per
    *   module. Those MethodQueues are also created and managed outside of
-   *   NativeToJsBridge. Therefore, we need to pass in a CallInvoker that
-   *   schedules work on the respective thread.
+   *   NativeToJsBridge. Therefore, we need to pass in a
+   * NativeMethodCallInvoker that schedules work on the respective thread.
    */
-  std::shared_ptr<CallInvoker> getDecoratedNativeCallInvoker(
-      std::shared_ptr<CallInvoker> nativeInvoker);
+  std::shared_ptr<NativeMethodCallInvoker> getDecoratedNativeMethodCallInvoker(
+      std::shared_ptr<NativeMethodCallInvoker> nativeInvoker);
 
   /**
    * RuntimeExecutor is used by Fabric to access the jsi::Runtime.

--- a/packages/react-native/ReactCommon/cxxreact/NativeToJsBridge.cpp
+++ b/packages/react-native/ReactCommon/cxxreact/NativeToJsBridge.cpp
@@ -310,33 +310,38 @@ void NativeToJsBridge::runOnExecutorQueue(
       });
 }
 
-std::shared_ptr<CallInvoker> NativeToJsBridge::getDecoratedNativeCallInvoker(
-    std::shared_ptr<CallInvoker> nativeInvoker) {
-  class NativeCallInvoker : public CallInvoker {
+std::shared_ptr<NativeMethodCallInvoker>
+NativeToJsBridge::getDecoratedNativeMethodCallInvoker(
+    std::shared_ptr<NativeMethodCallInvoker> nativeMethodCallInvoker) const {
+  class NativeMethodCallInvokerImpl : public NativeMethodCallInvoker {
    private:
     std::weak_ptr<JsToNativeBridge> m_jsToNativeBridge;
-    std::shared_ptr<CallInvoker> m_nativeInvoker;
+    std::shared_ptr<NativeMethodCallInvoker> m_nativeInvoker;
 
    public:
-    NativeCallInvoker(
+    NativeMethodCallInvokerImpl(
         std::weak_ptr<JsToNativeBridge> jsToNativeBridge,
-        std::shared_ptr<CallInvoker> nativeInvoker)
-        : m_jsToNativeBridge(jsToNativeBridge),
-          m_nativeInvoker(nativeInvoker) {}
+        std::shared_ptr<NativeMethodCallInvoker> nativeInvoker)
+        : m_jsToNativeBridge(std::move(jsToNativeBridge)),
+          m_nativeInvoker(std::move(nativeInvoker)) {}
 
-    void invokeAsync(std::function<void()> &&func) override {
+    void invokeAsync(
+        const std::string &methodName,
+        std::function<void()> &&func) override {
       if (auto strongJsToNativeBridge = m_jsToNativeBridge.lock()) {
         strongJsToNativeBridge->recordTurboModuleAsyncMethodCall();
       }
-      m_nativeInvoker->invokeAsync(std::move(func));
+      m_nativeInvoker->invokeAsync(methodName, std::move(func));
     }
 
-    void invokeSync(std::function<void()> &&func) override {
-      m_nativeInvoker->invokeSync(std::move(func));
+    void invokeSync(const std::string &methodName, std::function<void()> &&func)
+        override {
+      m_nativeInvoker->invokeSync(methodName, std::move(func));
     }
   };
 
-  return std::make_shared<NativeCallInvoker>(m_delegate, nativeInvoker);
+  return std::make_shared<NativeMethodCallInvokerImpl>(
+      m_delegate, std::move(nativeMethodCallInvoker));
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/cxxreact/NativeToJsBridge.h
+++ b/packages/react-native/ReactCommon/cxxreact/NativeToJsBridge.h
@@ -100,11 +100,11 @@ class NativeToJsBridge {
   void runOnExecutorQueue(std::function<void(JSExecutor *)> task);
 
   /**
-   * Native CallInvoker is used by TurboModules to schedule work on the
+   * NativeMethodCallInvoker is used by TurboModules to schedule work on the
    * NativeModule thread(s).
    */
-  std::shared_ptr<CallInvoker> getDecoratedNativeCallInvoker(
-      std::shared_ptr<CallInvoker> nativeInvoker);
+  std::shared_ptr<NativeMethodCallInvoker> getDecoratedNativeMethodCallInvoker(
+      std::shared_ptr<NativeMethodCallInvoker> nativeInvoker) const;
 
  private:
   // This is used to avoid a race condition where a proxyCallback gets queued

--- a/packages/react-native/ReactCommon/react/bridgeless/BridgelessNativeMethodCallInvoker.cpp
+++ b/packages/react-native/ReactCommon/react/bridgeless/BridgelessNativeMethodCallInvoker.cpp
@@ -5,19 +5,23 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "BridgelessNativeCallInvoker.h"
+#include "BridgelessNativeMethodCallInvoker.h"
 
 namespace facebook::react {
 
-BridgelessNativeCallInvoker::BridgelessNativeCallInvoker(
+BridgelessNativeMethodCallInvoker::BridgelessNativeMethodCallInvoker(
     std::shared_ptr<MessageQueueThread> messageQueueThread)
     : messageQueueThread_(std::move(messageQueueThread)) {}
 
-void BridgelessNativeCallInvoker::invokeAsync(std::function<void()> &&func) {
+void BridgelessNativeMethodCallInvoker::invokeAsync(
+    const std::string &methodName,
+    std::function<void()> &&func) {
   messageQueueThread_->runOnQueue(std::move(func));
 }
 
-void BridgelessNativeCallInvoker::invokeSync(std::function<void()> &&func) {
+void BridgelessNativeMethodCallInvoker::invokeSync(
+    const std::string &methodName,
+    std::function<void()> &&func) {
   messageQueueThread_->runOnQueueSync(std::move(func));
 }
 

--- a/packages/react-native/ReactCommon/react/bridgeless/BridgelessNativeMethodCallInvoker.h
+++ b/packages/react-native/ReactCommon/react/bridgeless/BridgelessNativeMethodCallInvoker.h
@@ -12,12 +12,14 @@
 
 namespace facebook::react {
 
-class BridgelessNativeCallInvoker : public CallInvoker {
+class BridgelessNativeMethodCallInvoker : public NativeMethodCallInvoker {
  public:
-  explicit BridgelessNativeCallInvoker(
+  explicit BridgelessNativeMethodCallInvoker(
       std::shared_ptr<MessageQueueThread> messageQueueThread);
-  void invokeAsync(std::function<void()> &&func) override;
-  void invokeSync(std::function<void()> &&func) override;
+  void invokeAsync(const std::string &methodName, std::function<void()> &&func)
+      override;
+  void invokeSync(const std::string &methodName, std::function<void()> &&func)
+      override;
 
  private:
   std::shared_ptr<MessageQueueThread> messageQueueThread_;

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaTurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaTurboModule.h
@@ -31,7 +31,7 @@ class JSI_EXPORT JavaTurboModule : public TurboModule {
     std::string moduleName;
     jni::alias_ref<jobject> instance;
     std::shared_ptr<CallInvoker> jsInvoker;
-    std::shared_ptr<CallInvoker> nativeInvoker;
+    std::shared_ptr<NativeMethodCallInvoker> nativeMethodCallInvoker;
   };
 
   JavaTurboModule(const InitParams &params);
@@ -49,7 +49,7 @@ class JSI_EXPORT JavaTurboModule : public TurboModule {
  private:
   // instance_ can be of type JTurboModule, or JNativeModule
   jni::global_ref<jobject> instance_;
-  std::shared_ptr<CallInvoker> nativeInvoker_;
+  std::shared_ptr<NativeMethodCallInvoker> nativeMethodCallInvoker_;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.h
@@ -43,7 +43,7 @@ class JSI_EXPORT ObjCTurboModule : public TurboModule {
     std::string moduleName;
     id<RCTBridgeModule> instance;
     std::shared_ptr<CallInvoker> jsInvoker;
-    std::shared_ptr<CallInvoker> nativeInvoker;
+    std::shared_ptr<NativeMethodCallInvoker> nativeMethodCallInvoker;
     bool isSyncModule;
   };
 
@@ -58,7 +58,7 @@ class JSI_EXPORT ObjCTurboModule : public TurboModule {
       size_t count);
 
   id<RCTBridgeModule> instance_;
-  std::shared_ptr<CallInvoker> nativeInvoker_;
+  std::shared_ptr<NativeMethodCallInvoker> nativeMethodCallInvoker_;
 
  protected:
   void setMethodArgConversionSelector(NSString *methodName, int argIndex, NSString *fnName);
@@ -159,6 +159,6 @@ class JSI_EXPORT ObjCTurboModule : public TurboModule {
  */
 @interface RCTBridge (RCTTurboModule)
 - (std::shared_ptr<facebook::react::CallInvoker>)jsCallInvoker;
-- (std::shared_ptr<facebook::react::CallInvoker>)decorateNativeCallInvoker:
-    (std::shared_ptr<facebook::react::CallInvoker>)nativeInvoker;
+- (std::shared_ptr<facebook::react::NativeMethodCallInvoker>)decorateNativeMethodCallInvoker:
+    (std::shared_ptr<facebook::react::NativeMethodCallInvoker>)nativeMethodCallInvoker;
 @end

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
@@ -419,7 +419,7 @@ id ObjCTurboModule::performMethodInvocation(
   };
 
   if (isSync) {
-    block();
+    nativeMethodCallInvoker_->invokeSync(methodNameStr, [&]() -> void { block(); });
     return result;
   } else {
     asyncCallCounter = getUniqueId();

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
@@ -424,7 +424,7 @@ id ObjCTurboModule::performMethodInvocation(
   } else {
     asyncCallCounter = getUniqueId();
     TurboModulePerfLogger::asyncMethodCallDispatch(moduleName, methodName);
-    nativeInvoker_->invokeAsync([block]() -> void { block(); });
+    nativeMethodCallInvoker_->invokeAsync(methodNameStr, [block]() -> void { block(); });
     return nil;
   }
 }
@@ -685,7 +685,7 @@ bool ObjCTurboModule::isMethodSync(TurboModuleMethodValueKind returnType)
 ObjCTurboModule::ObjCTurboModule(const InitParams &params)
     : TurboModule(params.moduleName, params.jsInvoker),
       instance_(params.instance),
-      nativeInvoker_(params.nativeInvoker),
+      nativeMethodCallInvoker_(params.nativeMethodCallInvoker),
       isSyncModule_(params.isSyncModule)
 {
 }


### PR DESCRIPTION
Summary:
## Changes
Make the TurboModule system use NativeMethodCallInvoker::invokeSync to schedule synchronous native module method calls. Functionally, this changes nothing.

## What this unlocks
In the future (i.e: D45924977), the TurboModule interop layer will implement NativeMethodCallInvoker::invokeSync to dispatch the constantsToExport method call on to the main queue, when the legacy module requires main queue setup.

Changelog: [Internal]

Differential Revision: D45924976

