### PR TITLE
Fixing Typo in Codegen's Interface Declaration

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-test.js
@@ -318,9 +318,9 @@ describe('FlowParser', () => {
     });
   });
 
-  describe('interfaceDelcaration', () => {
-    it('returns interfaceDelcaration Property', () => {
-      expect(parser.interfaceDelcaration).toEqual('InterfaceDeclaration');
+  describe('interfaceDeclaration', () => {
+    it('returns interfaceDeclaration Property', () => {
+      expect(parser.interfaceDeclaration).toEqual('InterfaceDeclaration');
     });
   });
 });
@@ -613,9 +613,9 @@ describe('TypeScriptParser', () => {
     });
   });
 
-  describe('interfaceDelcaration', () => {
-    it('returns interfaceDelcaration Property', () => {
-      expect(parser.interfaceDelcaration).toEqual('TSInterfaceDeclaration');
+  describe('interfaceDeclaration', () => {
+    it('returns interfaceDeclaration Property', () => {
+      expect(parser.interfaceDeclaration).toEqual('TSInterfaceDeclaration');
     });
   });
 });

--- a/packages/react-native-codegen/src/parsers/flow/parser.js
+++ b/packages/react-native-codegen/src/parsers/flow/parser.js
@@ -64,7 +64,7 @@ class FlowParser implements Parser {
   typeParameterInstantiation: string = 'TypeParameterInstantiation';
   typeAlias: string = 'TypeAlias';
   enumDeclaration: string = 'EnumDeclaration';
-  interfaceDelcaration: string = 'InterfaceDeclaration';
+  interfaceDeclaration: string = 'InterfaceDeclaration';
 
   nullLiteralTypeAnnotation: string = 'NullLiteralTypeAnnotation';
 

--- a/packages/react-native-codegen/src/parsers/parser.js
+++ b/packages/react-native-codegen/src/parsers/parser.js
@@ -94,9 +94,9 @@ export interface Parser {
   enumDeclaration: string;
 
   /**
-   * InterfaceDelcaration property of the Parser
+   * InterfaceDeclaration property of the Parser
    */
-  interfaceDelcaration: string;
+  interfaceDeclaration: string;
 
   /**
    * This is the NullLiteralTypeAnnotation value

--- a/packages/react-native-codegen/src/parsers/parserMock.js
+++ b/packages/react-native-codegen/src/parsers/parserMock.js
@@ -62,7 +62,7 @@ export class MockedParser implements Parser {
   typeParameterInstantiation: string = 'TypeParameterInstantiation';
   typeAlias: string = 'TypeAlias';
   enumDeclaration: string = 'EnumDeclaration';
-  interfaceDelcaration: string = 'InterfaceDelcaration';
+  interfaceDeclaration: string = 'InterfaceDeclaration';
 
   nullLiteralTypeAnnotation: string = 'NullLiteralTypeAnnotation';
 

--- a/packages/react-native-codegen/src/parsers/typescript/parser.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parser.js
@@ -62,7 +62,7 @@ class TypeScriptParser implements Parser {
   typeParameterInstantiation: string = 'TSTypeParameterInstantiation';
   typeAlias: string = 'TSTypeAliasDeclaration';
   enumDeclaration: string = 'TSEnumDeclaration';
-  interfaceDelcaration: string = 'TSInterfaceDeclaration';
+  interfaceDeclaration: string = 'TSInterfaceDeclaration';
 
   nullLiteralTypeAnnotation: string = 'TSNullKeyword';
 

--- a/packages/react-native-codegen/src/parsers/typescript/utils.js
+++ b/packages/react-native-codegen/src/parsers/typescript/utils.js
@@ -67,7 +67,7 @@ function resolveTypeAnnotation(
         node = resolvedTypeAnnotation.typeAnnotation;
         break;
       }
-      case parser.interfaceDelcaration: {
+      case parser.interfaceDeclaration: {
         typeResolutionStatus = {
           successful: true,
           type: 'alias',
@@ -87,7 +87,7 @@ function resolveTypeAnnotation(
       }
       default: {
         throw new TypeError(
-          `A non GenericTypeAnnotation must be a type declaration ('${parser.typeAlias}'), an interface ('${parser.interfaceDelcaration}'), or enum ('${parser.enumDeclaration}'). Instead, got the unsupported ${resolvedTypeAnnotation.type}.`,
+          `A non GenericTypeAnnotation must be a type declaration ('${parser.typeAlias}'), an interface ('${parser.interfaceDeclaration}'), or enum ('${parser.enumDeclaration}'). Instead, got the unsupported ${resolvedTypeAnnotation.type}.`,
         );
       }
     }


### PR DESCRIPTION
Summary:
We recently landed a change with a typo in the interface declaration. We just fixed the typo

## CHANGELOG
[General][Fixed] - Fixed a typo in the interface declaration

Differential Revision: D45978419

