### PR TITLE
Filter LogBox using a function

### DIFF
--- a/packages/react-native/Libraries/LogBox/Data/LogBoxData.js
+++ b/packages/react-native/Libraries/LogBox/Data/LogBoxData.js
@@ -40,7 +40,7 @@ export type Observer = (
   |}>,
 ) => void;
 
-export type IgnorePattern = string | RegExp;
+export type IgnorePattern = string | RegExp | ((message: string) => boolean);
 
 export type Subscription = $ReadOnly<{|
   unsubscribe: () => void,
@@ -116,6 +116,7 @@ export function isMessageIgnored(message: string): boolean {
   for (const pattern of ignorePatterns) {
     if (
       (pattern instanceof RegExp && pattern.test(message)) ||
+      (typeof pattern === 'function' && pattern(message) === false) ||
       (typeof pattern === 'string' && message.includes(pattern))
     ) {
       return true;
@@ -340,7 +341,6 @@ export function addIgnorePatterns(
           return;
         }
       }
-      ignorePatterns.add(pattern);
     }
     ignorePatterns.add(pattern);
   });

--- a/packages/react-native/Libraries/LogBox/Data/__tests__/LogBoxData-test.js
+++ b/packages/react-native/Libraries/LogBox/Data/__tests__/LogBoxData-test.js
@@ -435,14 +435,17 @@ describe('LogBoxData', () => {
   });
 
   it('ignores logs matching patterns (logs)', () => {
-    addLogs(['A!', 'B?', 'C!']);
+    addLogs(['A!', 'B?', 'C!', 'D#']);
 
-    expect(filteredRegistry().length).toBe(3);
+    expect(filteredRegistry().length).toBe(4);
 
     LogBoxData.addIgnorePatterns(['!']);
-    expect(filteredRegistry().length).toBe(1);
+    expect(filteredRegistry().length).toBe(2);
 
     LogBoxData.addIgnorePatterns(['?']);
+    expect(filteredRegistry().length).toBe(1);
+
+    LogBoxData.addIgnorePatterns([() => false]);
     expect(filteredRegistry().length).toBe(0);
   });
 

--- a/packages/react-native/Libraries/LogBox/LogBox.d.ts
+++ b/packages/react-native/Libraries/LogBox/LogBox.d.ts
@@ -11,7 +11,9 @@ export interface LogBoxStatic {
   /**
    * Silence any logs that match the given strings or regexes.
    */
-  ignoreLogs(patterns: (string | RegExp)[]): void;
+  ignoreLogs(
+    patterns: (string | RegExp | ((message: string) => boolean))[],
+  ): void;
 
   /**
    * Toggle error and warning notifications


### PR DESCRIPTION
## Summary:

`LogBox.ignoreLogs((message) => loggingisOn);`

Matching on strings and regex is handy, but I have a use-case where we want to turn logging on and off for certain features, so that members of one team can listen to logs only on features they are working on. So I thought I would take a stab at this, and since @cipolleschi is giving a talk at #ChainReact2023 *about contributing to React Native*, there's not better time to propose this upstream! 😏 

## Changelog:

[GENERAL] [ADDED] - LogBox.ignoreLogs now supports a filter function, `(message: string) => true` will include the message, and `(message: string) => false` excludes the message (matching the behavior of `[].filter`).

## Test Plan:

I've run the tests, I haven't tested manually yet. Need to set up a demo app pointing to my fork.

```
yarn test packages/react-native/Libraries/LogBox/Data/__tests__/
…

Test Suites: 4 passed, 4 total
Tests:       82 passed, 82 total
Snapshots:   0 total
Time:        1.173 s
```

All tests:
```
yarn test react-native
…
Test Suites: 1 skipped, 208 passed, 208 of 209 total
Tests:       2 skipped, 3905 passed, 3907 total
Snapshots:   1141 passed, 1141 total
Time:        12.253 s
```
