### PR TITLE
Codegen 123: add parser-primitive function for emitBoolProp

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-primitives-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-primitives-test.js
@@ -16,6 +16,7 @@ import type {UnionTypeAnnotationMemberType} from '../../CodegenSchema';
 const {
   emitArrayType,
   emitBoolean,
+  emitBoolProp,
   emitDouble,
   emitFloat,
   emitNumber,
@@ -829,7 +830,7 @@ describe('emitUnion', () => {
         'ObjectTypeAnnotation',
       ];
       describe('when nullable is true', () => {
-        it('throws an excpetion', () => {
+        it('throws an exception', () => {
           const expected = new UnsupportedUnionTypeAnnotationParserError(
             hasteModuleName,
             typeAnnotation,
@@ -843,7 +844,7 @@ describe('emitUnion', () => {
       });
 
       describe('when nullable is false', () => {
-        it('throws an excpetion', () => {
+        it('throws an exception', () => {
           const expected = new UnsupportedUnionTypeAnnotationParserError(
             hasteModuleName,
             typeAnnotation,
@@ -1042,7 +1043,7 @@ describe('emitUnion', () => {
         'ObjectTypeAnnotation',
       ];
       describe('when nullable is true', () => {
-        it('throws an excpetion', () => {
+        it('throws an exception', () => {
           const expected = new UnsupportedUnionTypeAnnotationParserError(
             hasteModuleName,
             typeAnnotation,
@@ -1056,7 +1057,7 @@ describe('emitUnion', () => {
       });
 
       describe('when nullable is false', () => {
-        it('throws an excpetion', () => {
+        it('throws an exception', () => {
           const expected = new UnsupportedUnionTypeAnnotationParserError(
             hasteModuleName,
             typeAnnotation,
@@ -1503,6 +1504,37 @@ describe('emitCommonTypes', () => {
     };
     it('returns null', () => {
       expect(emitCommonTypesForUnitTest(typeAnnotation, false)).toBeNull();
+    });
+  });
+});
+
+describe('emitBoolProp', () => {
+  describe('when optional is true', () => {
+    it('returns optional type annotation', () => {
+      const result = emitBoolProp('someProp', true);
+      const expected = {
+        name: 'someProp',
+        optional: true,
+        typeAnnotation: {
+          type: 'BooleanTypeAnnotation',
+        },
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+  describe('when optional is false', () => {
+    it('returns required type annotation', () => {
+      const result = emitBoolProp('someProp', false);
+      const expected = {
+        name: 'someProp',
+        optional: false,
+        typeAnnotation: {
+          type: 'BooleanTypeAnnotation',
+        },
+      };
+
+      expect(result).toEqual(expected);
     });
   });
 });

--- a/packages/react-native-codegen/src/parsers/flow/components/events.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/events.js
@@ -16,12 +16,14 @@ import type {
   EventTypeAnnotation,
 } from '../../../CodegenSchema.js';
 import type {Parser} from '../../parser';
+
 const {
   throwIfEventHasNoName,
   throwIfBubblingTypeIsNull,
   throwIfArgumentPropsAreNull,
 } = require('../../error-utils');
 const {getEventArgument} = require('../../parsers-commons');
+const {emitBoolProp} = require('../../parsers-primitives');
 
 function getPropertyType(
   /* $FlowFixMe[missing-local-annot] The type annotation(s) required by Flow's
@@ -35,13 +37,7 @@ function getPropertyType(
 
   switch (type) {
     case 'BooleanTypeAnnotation':
-      return {
-        name,
-        optional,
-        typeAnnotation: {
-          type: 'BooleanTypeAnnotation',
-        },
-      };
+      return emitBoolProp(name, optional);
     case 'StringTypeAnnotation':
       return {
         name,

--- a/packages/react-native-codegen/src/parsers/parsers-primitives.js
+++ b/packages/react-native-codegen/src/parsers/parsers-primitives.js
@@ -33,6 +33,8 @@ import type {
   VoidTypeAnnotation,
   NativeModuleObjectTypeAnnotation,
   NativeModuleEnumDeclaration,
+  NamedShape,
+  EventTypeAnnotation,
 } from '../CodegenSchema';
 import type {Parser} from './parser';
 import type {
@@ -577,9 +579,23 @@ function emitCommonTypes(
   );
 }
 
+function emitBoolProp(
+  name: string,
+  optional: boolean,
+): NamedShape<EventTypeAnnotation> {
+  return {
+    name,
+    optional,
+    typeAnnotation: {
+      type: 'BooleanTypeAnnotation',
+    },
+  };
+}
+
 module.exports = {
   emitArrayType,
   emitBoolean,
+  emitBoolProp,
   emitDouble,
   emitFloat,
   emitFunction,

--- a/packages/react-native-codegen/src/parsers/typescript/components/events.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/events.js
@@ -25,7 +25,7 @@ const {
   throwIfArgumentPropsAreNull,
 } = require('../../error-utils');
 const {getEventArgument} = require('../../parsers-commons');
-import {emitBoolProp} from '../../parsers-primitives';
+const {emitBoolProp} = require('../../parsers-primitives');
 
 function getPropertyType(
   /* $FlowFixMe[missing-local-annot] The type annotation(s) required by Flow's

--- a/packages/react-native-codegen/src/parsers/typescript/components/events.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/events.js
@@ -25,6 +25,8 @@ const {
   throwIfArgumentPropsAreNull,
 } = require('../../error-utils');
 const {getEventArgument} = require('../../parsers-commons');
+const {emitBoolProp} = require('../../../../lib/parsers/parsers-primitives');
+
 function getPropertyType(
   /* $FlowFixMe[missing-local-annot] The type annotation(s) required by Flow's
    * LTI update could not be added via codemod */
@@ -45,13 +47,7 @@ function getPropertyType(
 
   switch (type) {
     case 'TSBooleanKeyword':
-      return {
-        name,
-        optional,
-        typeAnnotation: {
-          type: 'BooleanTypeAnnotation',
-        },
-      };
+      return emitBoolProp(name, optional);
     case 'TSStringKeyword':
       return {
         name,

--- a/packages/react-native-codegen/src/parsers/typescript/components/events.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/events.js
@@ -25,7 +25,7 @@ const {
   throwIfArgumentPropsAreNull,
 } = require('../../error-utils');
 const {getEventArgument} = require('../../parsers-commons');
-const {emitBoolProp} = require('../../../../lib/parsers/parsers-primitives');
+import {emitBoolProp} from '../../parsers-primitives';
 
 function getPropertyType(
   /* $FlowFixMe[missing-local-annot] The type annotation(s) required by Flow's


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Part of https://github.com/facebook/react-native/issues/34872, Improving Codegen

Reduces code duplication by creating a helper function `emitBoolProp(name: string, optional: boolean)` in `parser-primitives.js`. Refactors the code from [Flow](https://github.com/facebook/react-native/blob/d8ced6f8953cd896471983714e722caf50783960/packages/react-native-codegen/src/parsers/flow/components/events.js#L37-L43) and [TypeScript](https://github.com/facebook/react-native/blob/d8ced6f8953cd896471983714e722caf50783960/packages/react-native-codegen/src/parsers/typescript/components/events.js#L47-L53) to utilize the new function.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[INTERNAL] [CHANGED] - Extract contents of the case `BooleanTypeAnnotation` and `TSBooleanKeyword` into a single `emitBoolProp` function

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

Run `yarn jest react-native-codegen`

<img width="392" alt="image" src="https://github.com/facebook/react-native/assets/374022/79dae56d-e12d-4be2-9426-50a72e893dfe">


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
