### PR TITLE
Avoid install target in Apple build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ references:
     hermes_windows_cache_key: &hermes_windows_cache_key v2-hermes-{{ .Environment.CIRCLE_JOB }}-windows-{{ checksum "/Users/circleci/project/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}
     hermes_tarball_debug_cache_key: &hermes_tarball_debug_cache_key v4-hermes-tarball-debug-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}
     hermes_tarball_release_cache_key: &hermes_tarball_release_cache_key v3-hermes-tarball-release-{{ checksum "/tmp/hermes/hermesversion" }}-{{ checksum "/tmp/react-native-version" }}
-    pods_cache_key: &pods_cache_key v8-pods-{{ .Environment.CIRCLE_JOB }}-{{ checksum "packages/rn-tester/Podfile.lock.bak" }}-{{ checksum "packages/rn-tester/Podfile" }}
+    pods_cache_key: &pods_cache_key v10-pods-{{ .Environment.CIRCLE_JOB }}-{{ checksum "packages/rn-tester/Podfile.lock.bak" }}-{{ checksum "packages/rn-tester/Podfile" }}
     windows_yarn_cache_key: &windows_yarn_cache_key v1-win-yarn-cache-{{ arch }}-{{ checksum "yarn.lock" }}
     windows_choco_cache_key: &windows_choco_cache_key v1-win-choco-cache-{{ .Environment.CIRCLE_JOB }}
     yarn_cache_key: &yarn_cache_key v5-yarn-cache-{{ .Environment.CIRCLE_JOB }}

--- a/packages/react-native/sdks/hermes-engine/utils/build-hermes-xcode.sh
+++ b/packages/react-native/sdks/hermes-engine/utils/build-hermes-xcode.sh
@@ -9,11 +9,6 @@ set -x
 release_version="$1"; shift
 hermesc_path="$1"; shift
 
-build_cli_tools="false"
-if [[ "$PLATFORM_NAME" == macosx ]]; then
-  build_cli_tools="true"
-fi
-
 enable_debugger="false"
 if [[ "$CONFIGURATION" == "Debug" ]]; then
   enable_debugger="true"
@@ -51,22 +46,19 @@ echo "Configure Apple framework"
   -DHERMES_ENABLE_BITCODE:BOOLEAN=false \
   -DHERMES_BUILD_APPLE_FRAMEWORK:BOOLEAN=true \
   -DHERMES_BUILD_APPLE_DSYM:BOOLEAN=true \
-  -DHERMES_ENABLE_TOOLS:BOOLEAN="$build_cli_tools" \
   -DIMPORT_HERMESC:PATH="${hermesc_path}" \
   -DHERMES_RELEASE_VERSION="for RN $release_version" \
-  -DCMAKE_INSTALL_PREFIX:PATH="${PODS_ROOT}/hermes-engine/destroot" \
   -DCMAKE_BUILD_TYPE="$cmake_build_type"
 
 echo "Build Apple framework"
 
 "$CMAKE_BINARY" \
   --build "${PODS_ROOT}/hermes-engine/build/${PLATFORM_NAME}" \
-  --target "install/strip" \
+  --target libhermes \
   -j "$(sysctl -n hw.ncpu)"
 
 echo "Copy Apple framework to destroot/Library/Frameworks"
 
 cp -pfR \
-  "${PODS_ROOT}/hermes-engine/destroot/Library/Frameworks/${PLATFORM_NAME}/hermes.framework" \
+  "${PODS_ROOT}/hermes-engine/build/API/hermes/hermes.framework" \
   "${PODS_ROOT}/hermes-engine/destroot/Library/Frameworks/ios"
-rm -rf "${PODS_ROOT}/hermes-engine/destroot/Library/Frameworks/${PLATFORM_NAME}"


### PR DESCRIPTION
## Summary

Avoid using the install target in Hermes when building frameworks for Apple platforms. Instead, explicitly build the targets we need for each platform, and copy over the files we need. This has a few advantages:

1. It gives RN fine control over the organisation of files in the destroot directory.
2. The current install target seems to copy JSI headers from Hermes instead of the supplied `JSI_DIR`. In practice, this should never be a problem but it is good to be consistent.
3. Building the install target needlessly builds unrelated targets. This slows down the build, and in some cases, we may not technically support those targets for the platform we are building for.

## Test Plan

CI is able to build and use Hermes

## Changelog:
[Internal]