### PR TITLE
[Actions] Add greet action 🎉

### DIFF
--- a/.github/workflows/greet.yml
+++ b/.github/workflows/greet.yml
@@ -1,0 +1,50 @@
+name: 🎉 Greet First Time Contributors 🎉
+# This workflow is triggered on pull requests.
+
+on:
+  pull_request:
+    types: [opened]
+
+permissions:
+  contents: read
+
+jobs:
+  check_for_first_contribution:
+    name: '🎉 Greet First Time Contributors'
+    permissions:
+      contents: read
+      pull-requests: write # for actions/first-interaction to comment on PR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/first-interaction@v1.1.1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          pr-message: |
+            ### Hi there, :wave:
+
+            ### Congratulations :tada: on your **_'First Pull Request'_** to [React Native](https://github.com/facebook/react-native)! :partying_face:
+
+            Thank you, :pray: for taking the time to contribute to this project and share your ideas.
+
+            Someone from the team will review your PR and get back to you _as soon as possible_ with feedback if any. :blush: Post review, and if all tests are passing, your PR will be _imported_ to internal FB phabricator and should be merged if it also passes all internal tests. :partying_face:
+
+            <details>
+            <summary>P.S.: In the <i>meantime</i>, you should go through below checklist: <sup>(click to expand)</sup>
+            </summary>
+
+            1. Make sure you have _signed_ the [CLA](https://code.facebook.com/cla) :balance_scale:,
+            2. There are _no_ typos :sweat_smile:,
+            3. There are _no_ warnings reported by the **Danger** workflow :robot:,
+            4. You ran `yarn prettier` and `yarn lint` :nail_care:,
+            5. All tests :test_tube: are _passing_. i.e. The CI checks should be green :green_circle:, and
+            6. You have _added_ necessary tests for your code, if it's a refactor or a new functionality. :test_tube:
+
+            </details>
+
+            ---
+
+            <sup>
+
+            [Contributing Guidelines](https://reactnative.dev/contributing/overview) | [React Native Website](https://reactnative.dev/) | [Framework discussions, proposals and RFCs](https://github.com/react-native-community/discussions-and-proposals/discussions)
+
+            </sup>


### PR DESCRIPTION
## Summary:

Currently we do _not_ greet; **"First Time Contributors"**.
It is important to greet every first time contributor keep the OSS community thriving. 😊

This PR; Adds a greet action `greet.yml` :tada:, which comments under First Time Contributors PRs, greeting them as well suggesting some basic steps/guidelines.

## Changelog:

[GENERAL] [ADDED] - [Actions] Add greet action 🎉

## Test Plan:

- Should greet 1st time contributors
