### PR TITLE
[Codegen 127] Create a function emitFloatProp

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-primitives-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-primitives-test.js
@@ -18,6 +18,7 @@ const {
   emitBoolean,
   emitDouble,
   emitFloat,
+  emitFloatProp,
   emitNumber,
   emitInt32,
   emitGenericObject,
@@ -636,6 +637,38 @@ describe('emitFloat', () => {
       const result = emitFloat(false);
       const expected = {
         type: 'FloatTypeAnnotation',
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+});
+
+describe('emitFloatProp', () => {
+  describe('when optional is true', () => {
+    it('returns optional FloatTypeAnnotation', () => {
+      const result = emitFloatProp('myProp', true);
+      const expected = {
+        name: 'myProp',
+        optional: true,
+        typeAnnotation: {
+          type: 'FloatTypeAnnotation',
+        },
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when optional is false', () => {
+    it('returns required FloatTypeAnnotation', () => {
+      const result = emitFloatProp('myProp', false);
+      const expected = {
+        name: 'myProp',
+        optional: false,
+        typeAnnotation: {
+          type: 'FloatTypeAnnotation',
+        },
       };
 
       expect(result).toEqual(expected);

--- a/packages/react-native-codegen/src/parsers/flow/components/events.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/events.js
@@ -22,6 +22,7 @@ const {
   throwIfArgumentPropsAreNull,
 } = require('../../error-utils');
 const {getEventArgument} = require('../../parsers-commons');
+const {emitFloatProp} = require('../../parsers-primitives');
 
 function getPropertyType(
   /* $FlowFixMe[missing-local-annot] The type annotation(s) required by Flow's
@@ -67,13 +68,7 @@ function getPropertyType(
         },
       };
     case 'Float':
-      return {
-        name,
-        optional,
-        typeAnnotation: {
-          type: 'FloatTypeAnnotation',
-        },
-      };
+      return emitFloatProp(name, optional);
     case '$ReadOnly':
       return getPropertyType(
         name,

--- a/packages/react-native-codegen/src/parsers/parsers-primitives.js
+++ b/packages/react-native-codegen/src/parsers/parsers-primitives.js
@@ -14,7 +14,9 @@ import type {
   Nullable,
   BooleanTypeAnnotation,
   DoubleTypeAnnotation,
+  EventTypeAnnotation,
   Int32TypeAnnotation,
+  NamedShape,
   NativeModuleAliasMap,
   NativeModuleEnumMap,
   NativeModuleBaseTypeAnnotation,
@@ -337,6 +339,19 @@ function emitFloat(
   });
 }
 
+function emitFloatProp(
+  name: string,
+  optional: boolean,
+): NamedShape<EventTypeAnnotation> {
+  return {
+    name,
+    optional,
+    typeAnnotation: {
+      type: 'FloatTypeAnnotation',
+    },
+  };
+}
+
 function emitUnion(
   nullable: boolean,
   hasteModuleName: string,
@@ -582,6 +597,7 @@ module.exports = {
   emitBoolean,
   emitDouble,
   emitFloat,
+  emitFloatProp,
   emitFunction,
   emitInt32,
   emitNumber,

--- a/packages/react-native-codegen/src/parsers/typescript/components/events.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/events.js
@@ -25,6 +25,8 @@ const {
   throwIfArgumentPropsAreNull,
 } = require('../../error-utils');
 const {getEventArgument} = require('../../parsers-commons');
+const {emitFloatProp} = require('../../parsers-primitives');
+
 function getPropertyType(
   /* $FlowFixMe[missing-local-annot] The type annotation(s) required by Flow's
    * LTI update could not be added via codemod */
@@ -77,13 +79,7 @@ function getPropertyType(
         },
       };
     case 'Float':
-      return {
-        name,
-        optional,
-        typeAnnotation: {
-          type: 'FloatTypeAnnotation',
-        },
-      };
+      return emitFloatProp(name, optional);
     case 'TSTypeLiteral':
       return {
         name,


### PR DESCRIPTION
## Summary:

part of #34872 

> Create a function emitFloatProp(name: string, optional: boolean) in parser-primitives.js. Factor out the code from [Flow](https://github.com/facebook/react-native/blob/d8ced6f8953cd896471983714e722caf50783960/packages/react-native-codegen/src/parsers/flow/components/events.js#L69-L75) and [TypeScript](https://github.com/facebook/react-native/blob/d8ced6f8953cd896471983714e722caf50783960/packages/react-native-codegen/src/parsers/typescript/components/events.js#L79-L85) into that function. Use that function in the original call site.


## Changelog:


[INTERNAL] [ADDED] - emitFloatProp in parser primitves

## Test Plan:

`yarn jest packages/react-native-codegen`
