### PR TITLE
[IOS] [FIXED] Fix RCTImageBlurUtils.m Greyscale Crash

### DIFF
--- a/packages/react-native/Libraries/Image/RCTImageBlurUtils.m
+++ b/packages/react-native/Libraries/Image/RCTImageBlurUtils.m
@@ -19,7 +19,7 @@ UIImage *RCTBlurredImageWithRadius(UIImage *inputImage, CGFloat radius)
   }
 
   // convert to ARGB if it isn't
-  if (CGImageGetBitsPerPixel(imageRef) != 32 || CGImageGetBitsPerComponent(imageRef) != 8 ||
+  if (CGImageGetBitsPerPixel(imageRef) != 32 ||
       !((CGImageGetBitmapInfo(imageRef) & kCGBitmapAlphaInfoMask))) {
     UIGraphicsImageRendererFormat *const rendererFormat = [UIGraphicsImageRendererFormat defaultFormat];
     rendererFormat.scale = inputImage.scale;


### PR DESCRIPTION
## Summary: 

This PR fixes a kernel crash caused by trying to blur greyscale images, as described in this issue:
https://github.com/facebook/react-native/issues/35706#issuecomment-1513359724

## Context:

The CGImageGetBitsPerPixel(imageRef) == 8 expression checks if each pixel of the image is represented by 8 bits.

In an image, each pixel is typically represented by a certain amount of information to store its color. In a grayscale image, for instance, we often use 8 bits per pixel, which allows for 256 different shades of gray (2^8 = 256).

The function vImageBoxConvolve_ARGB8888 works with ARGB images (which stands for Alpha, Red, Green, Blue). If the image is only black & white, it means it's a grayscale image, and hence, it is not compatible with this function, causing the kernel crash.

To prevent the issue, we should also convert grayscale images to ARGB before processing them.


## Changelog:
[IOS] [FIXED] - Fix RCTImageBlurUtils.m Greyscale Crash

## Test Plan:

```
<ImageBackground
        blurRadius={18}
        source={{uri: 'https://i.scdn.co/image/ab67616d0000b2737663b2f75fe4d8fb2cac8c27'}}
/>

<ImageBackground
        blurRadius={5}
        source={{uri: 'https://i.scdn.co/image/ab67616d0000b273d5a219b270d74a266131df18'}}
/>
``