### PR TITLE
Rollout unmountApplicationOnInstanceDetach feature flag

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -1308,11 +1308,7 @@ public class ReactInstanceManager {
 
     synchronized (mAttachedReactRoots) {
       for (ReactRoot reactRoot : mAttachedReactRoots) {
-        if (ReactFeatureFlags.unmountApplicationOnInstanceDetach) {
-          detachRootViewFromInstance(reactRoot, reactContext);
-        } else {
-          clearReactRoot(reactRoot);
-        }
+        detachRootViewFromInstance(reactRoot, reactContext);
       }
     }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
@@ -156,10 +156,4 @@ public class ReactFeatureFlags {
    * HostObject pattern
    */
   public static boolean useNativeState = false;
-
-  /**
-   * Unmount React application on ReactInstance detach. Controls rollout of change to align React
-   * application lifecycle with React Native instance.
-   */
-  public static boolean unmountApplicationOnInstanceDetach = false;
 }

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
@@ -166,10 +166,9 @@ Scheduler::~Scheduler() {
         surfaceIds.push_back(shadowTree.getSurfaceId());
       });
 
-  // TODO(T88046056): Fix Android memory leak before uncommenting changes
-  //  react_native_assert(
-  //      surfaceIds.empty() &&
-  //      "Scheduler was destroyed with outstanding Surfaces.");
+  react_native_assert(
+      surfaceIds.empty() &&
+      "Scheduler was destroyed with outstanding Surfaces.");
 
   if (surfaceIds.empty()) {
     return;

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceHandler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceHandler.cpp
@@ -325,11 +325,9 @@ void SurfaceHandler::setUIManager(UIManager const *uiManager) const noexcept {
 }
 
 SurfaceHandler::~SurfaceHandler() noexcept {
-  // TODO(T88046056): Fix Android memory leak before uncommenting changes
-  //  react_native_assert(
-  //      link_.status == Status::Unregistered &&
-  //      "`SurfaceHandler` must be unregistered (or moved-from) before
-  //      deallocation.");
+  react_native_assert(
+      link_.status == Status::Unregistered &&
+      "`SurfaceHandler` must be unregistered (or moved-from) before deallocation.");
 }
 
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
Rolling this out allows us to enable the asserts in Scheduler and SurfaceHandler again, which validate the correctness of our teardown routines.

Changelog: [Android][Fixed] When applications reload, the previous react root will be correctly closed

Differential Revision: D45905628

