### PR TITLE
Do not add Meta's license header to template

### DIFF
--- a/packages/react-native/template/android/app/build.gradle
+++ b/packages/react-native/template/android/app/build.gradle
@@ -1,10 +1,3 @@
-/*
- * Copyright (c) Meta Platforms, Inc. and affiliates.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 apply plugin: "com.android.application"
 apply plugin: "org.jetbrains.kotlin.android"
 apply plugin: "com.facebook.react"

--- a/packages/react-native/template/android/app/src/debug/java/com/helloworld/ReactNativeFlipper.kt
+++ b/packages/react-native/template/android/app/src/debug/java/com/helloworld/ReactNativeFlipper.kt
@@ -1,10 +1,3 @@
-/*
- * Copyright (c) Meta Platforms, Inc. and affiliates.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 package com.helloworld
 
 import android.content.Context

--- a/packages/react-native/template/android/app/src/main/java/com/helloworld/MainActivity.kt
+++ b/packages/react-native/template/android/app/src/main/java/com/helloworld/MainActivity.kt
@@ -1,10 +1,3 @@
-/*
- * Copyright (c) Meta Platforms, Inc. and affiliates.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 package com.helloworld
 
 import com.facebook.react.ReactActivity

--- a/packages/react-native/template/android/app/src/main/java/com/helloworld/MainApplication.kt
+++ b/packages/react-native/template/android/app/src/main/java/com/helloworld/MainApplication.kt
@@ -1,10 +1,3 @@
-/*
- * Copyright (c) Meta Platforms, Inc. and affiliates.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 package com.helloworld
 
 import android.app.Application

--- a/packages/react-native/template/android/app/src/release/java/com/helloworld/ReactNativeFlipper.kt
+++ b/packages/react-native/template/android/app/src/release/java/com/helloworld/ReactNativeFlipper.kt
@@ -1,10 +1,3 @@
-/*
- * Copyright (c) Meta Platforms, Inc. and affiliates.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 package com.helloworld
 
 import android.content.Context


### PR DESCRIPTION
Summary:
After the monorepo migration, we started to add license headers to the template file.
This needs to be reverted, I'm doing it here.

Changelog:
[Internal] [Changed] - Do not add Meta's license header to template

Differential Revision: D46070682

