### PR TITLE
[LOCAL] Remove license header from android/app/build.gradle

### DIFF
--- a/packages/react-native/template/android/app/build.gradle
+++ b/packages/react-native/template/android/app/build.gradle
@@ -1,10 +1,3 @@
-/*
- * Copyright (c) Meta Platforms, Inc. and affiliates.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 apply plugin: "com.android.application"
 apply plugin: "com.facebook.react"
 


### PR DESCRIPTION
## Summary:

I've looked through the upgrade helper for 0.72 and noticed that we added a license header to `android/app/build.gradle` which should be reverted. This is a byproduct of the monorepo work as those files were excluded from the license header linter.

The equivalent change on main is:
- https://github.com/facebook/react-native/pull/37513

## Changelog:

[INTERNAL] - Remove license header from android/app/build.gradle

## Test Plan:

Nothing to test