### PR TITLE
[Codegen 126] Create a function emitDoubleProp

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-primitives-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-primitives-test.js
@@ -11,12 +11,17 @@
 
 'use-strict';
 
-import type {UnionTypeAnnotationMemberType} from '../../CodegenSchema';
+import type {
+  DoubleTypeAnnotation,
+  NamedShape,
+  UnionTypeAnnotationMemberType,
+} from '../../CodegenSchema';
 
 const {
   emitArrayType,
   emitBoolean,
   emitDouble,
+  emitDoubleProp,
   emitFloat,
   emitNumber,
   emitInt32,
@@ -223,6 +228,35 @@ describe('emitDouble', () => {
         type: 'DoubleTypeAnnotation',
       };
 
+      expect(result).toEqual(expected);
+    });
+  });
+});
+
+describe('emitDoubleProp', () => {
+  describe('when optional is true', () => {
+    it('returns optional type annotation', () => {
+      const result = emitDoubleProp('Foo', true);
+      const expected: NamedShape<DoubleTypeAnnotation> = {
+        name: 'Foo',
+        optional: true,
+        typeAnnotation: {
+          type: 'DoubleTypeAnnotation',
+        },
+      };
+      expect(result).toEqual(expected);
+    });
+  });
+  describe('when optional is false', () => {
+    it('returns required type annotation', () => {
+      const result = emitDoubleProp('Foo', false);
+      const expected: NamedShape<DoubleTypeAnnotation> = {
+        name: 'Foo',
+        optional: false,
+        typeAnnotation: {
+          type: 'DoubleTypeAnnotation',
+        },
+      };
       expect(result).toEqual(expected);
     });
   });

--- a/packages/react-native-codegen/src/parsers/flow/components/events.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/events.js
@@ -17,13 +17,13 @@ import type {
 } from '../../../CodegenSchema.js';
 import type {Parser} from '../../parser';
 
-import {emitDoubleProp} from '../../parsers-primitives';
 const {
   throwIfEventHasNoName,
   throwIfBubblingTypeIsNull,
   throwIfArgumentPropsAreNull,
 } = require('../../error-utils');
 const {getEventArgument} = require('../../parsers-commons');
+const {emitDoubleProp} = require('../../parsers-primitives');
 
 function getPropertyType(
   /* $FlowFixMe[missing-local-annot] The type annotation(s) required by Flow's

--- a/packages/react-native-codegen/src/parsers/flow/components/events.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/events.js
@@ -16,6 +16,8 @@ import type {
   EventTypeAnnotation,
 } from '../../../CodegenSchema.js';
 import type {Parser} from '../../parser';
+
+import {emitDoubleProp} from '../../parsers-primitives';
 const {
   throwIfEventHasNoName,
   throwIfBubblingTypeIsNull,
@@ -59,13 +61,7 @@ function getPropertyType(
         },
       };
     case 'Double':
-      return {
-        name,
-        optional,
-        typeAnnotation: {
-          type: 'DoubleTypeAnnotation',
-        },
-      };
+      return emitDoubleProp(name, optional);
     case 'Float':
       return {
         name,

--- a/packages/react-native-codegen/src/parsers/parsers-primitives.js
+++ b/packages/react-native-codegen/src/parsers/parsers-primitives.js
@@ -33,6 +33,7 @@ import type {
   VoidTypeAnnotation,
   NativeModuleObjectTypeAnnotation,
   NativeModuleEnumDeclaration,
+  NamedShape,
 } from '../CodegenSchema';
 import type {Parser} from './parser';
 import type {
@@ -93,6 +94,19 @@ function emitDouble(nullable: boolean): Nullable<DoubleTypeAnnotation> {
   return wrapNullable(nullable, {
     type: 'DoubleTypeAnnotation',
   });
+}
+
+function emitDoubleProp(
+  name: string,
+  optional: boolean,
+): NamedShape<DoubleTypeAnnotation> {
+  return {
+    name,
+    optional,
+    typeAnnotation: {
+      type: 'DoubleTypeAnnotation',
+    },
+  };
 }
 
 function emitVoid(nullable: boolean): Nullable<VoidTypeAnnotation> {
@@ -581,6 +595,7 @@ module.exports = {
   emitArrayType,
   emitBoolean,
   emitDouble,
+  emitDoubleProp,
   emitFloat,
   emitFunction,
   emitInt32,

--- a/packages/react-native-codegen/src/parsers/typescript/components/events.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/events.js
@@ -25,7 +25,7 @@ const {
   throwIfArgumentPropsAreNull,
 } = require('../../error-utils');
 const {getEventArgument} = require('../../parsers-commons');
-import {emitDoubleProp} from '../../parsers-primitives';
+const {emitDoubleProp} = require('../../parsers-primitives');
 function getPropertyType(
   /* $FlowFixMe[missing-local-annot] The type annotation(s) required by Flow's
    * LTI update could not be added via codemod */

--- a/packages/react-native-codegen/src/parsers/typescript/components/events.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/events.js
@@ -25,6 +25,7 @@ const {
   throwIfArgumentPropsAreNull,
 } = require('../../error-utils');
 const {getEventArgument} = require('../../parsers-commons');
+import {emitDoubleProp} from '../../parsers-primitives';
 function getPropertyType(
   /* $FlowFixMe[missing-local-annot] The type annotation(s) required by Flow's
    * LTI update could not be added via codemod */
@@ -69,13 +70,7 @@ function getPropertyType(
         },
       };
     case 'Double':
-      return {
-        name,
-        optional,
-        typeAnnotation: {
-          type: 'DoubleTypeAnnotation',
-        },
-      };
+      return emitDoubleProp(name, optional);
     case 'Float':
       return {
         name,


### PR DESCRIPTION
## Summary:

> Create a function emitDoubleProp(name: string, optional: boolean) in parser-primitives.js. Factor out the code from [Flow](https://github.com/facebook/react-native/blob/d8ced6f8953cd896471983714e722caf50783960/packages/react-native-codegen/src/parsers/flow/components/events.js#L61-L67) and [TypeScript](https://github.com/facebook/react-native/blob/d8ced6f8953cd896471983714e722caf50783960/packages/react-native-codegen/src/parsers/typescript/components/events.js#L71-L77) into that function. Use that function in the original call site.

## Changelog:

[INTERNAL][ADDED] - emitDoubleProp in parser primitves

## Test Plan:

yarn jest packages/react-native-codegen