### PR TITLE
Add -Wno-error=cpp on App's default Cmake file

### DIFF
--- a/packages/react-native/ReactAndroid/cmake-utils/ReactNative-application.cmake
+++ b/packages/react-native/ReactAndroid/cmake-utils/ReactNative-application.cmake
@@ -46,7 +46,20 @@ target_include_directories(${CMAKE_PROJECT_NAME}
                 ${CMAKE_CURRENT_SOURCE_DIR}
                 ${PROJECT_BUILD_DIR}/generated/rncli/src/main/jni)
 
-target_compile_options(${CMAKE_PROJECT_NAME} PRIVATE -Wall -Werror -fexceptions -frtti -std=c++17 -DWITH_INSPECTOR=1 -DLOG_TAG=\"ReactNative\")
+target_compile_options(${CMAKE_PROJECT_NAME}
+        PRIVATE
+                -Wall
+                -Werror
+                # We suppress cpp #error and #warning to don't fail the build
+                # due to use migrating away from
+                # #include <react/renderer/graphics/conversions.h>
+                # This can be removed for React Native 0.73
+                -Wno-error=cpp 
+                -fexceptions
+                -frtti
+                -std=c++17
+                -DWITH_INSPECTOR=1
+                -DLOG_TAG=\"ReactNative\")
 
 # Prefab packages from React Native
 find_package(ReactAndroid REQUIRED CONFIG)


### PR DESCRIPTION
Summary:
This will fail build failures from apps which are using libraries which imports
```
#include <react/renderer/graphics/conversions.h>
```
That's just a warning but our usage of `-Wall -Werror` is causing this to fail user builds.

More context on this issue here:
https://github.com/reactwg/react-native-releases/discussions/54#discussioncomment-5968545

We can revert this `-Wno-error` once we're on 0.73 as that specific #warning will be entirely
removed from the codebase.

Changelog:
[Internal] [Changed] - Add -Wno-error=cpp on App's default Cmake file

Differential Revision: D46071400

