### PR TITLE
Remove upcasting test in BridgingTest.cpp

### DIFF
--- a/packages/react-native/ReactCommon/react/bridging/tests/BridgingTest.cpp
+++ b/packages/react-native/ReactCommon/react/bridging/tests/BridgingTest.cpp
@@ -475,11 +475,9 @@ TEST_F(BridgingTest, supportTest) {
   EXPECT_FALSE((bridging::supportsFromJs<std::vector<int>, jsi::String>));
   EXPECT_FALSE((bridging::supportsFromJs<std::vector<int>, jsi::String &>));
 
-  // Ensure copying and up/down casting JSI values is also supported.
+  // Ensure copying and down casting JSI values is also supported.
   EXPECT_TRUE((bridging::supportsFromJs<jsi::Value>));
   EXPECT_TRUE((bridging::supportsFromJs<jsi::Value, jsi::Value &>));
-  EXPECT_TRUE((bridging::supportsFromJs<jsi::Value, jsi::Object>));
-  EXPECT_TRUE((bridging::supportsFromJs<jsi::Value, jsi::Object &>));
   EXPECT_TRUE((bridging::supportsFromJs<jsi::String>));
   EXPECT_TRUE((bridging::supportsFromJs<jsi::String, jsi::String>));
   EXPECT_TRUE((bridging::supportsFromJs<jsi::String, jsi::String &>));


### PR DESCRIPTION
Summary:
While these tests currently happen to pass, actually trying to
instantiate `fromJs` fails to compile. I suspect this is attributable
to some difference in how `fromJs` is instantiated in evaluated and
unevaluated contexts. That is since `supportsFromJs` only instantiates
it in an unevaluated context (in a decltype), the rules are presumably
different.

It is also worth noting that the operator of up-casting JSI types to
`jsi::Value` is explicitly deleted in `Converter`, which suggests
that the conversion this test is checking for may be intentionally
unsupported.

For now, since `fromJs` cannot actually be used with the given
parameters, delete the test.
This unblocks a later diff which changes the constructor of
`jsi::Value` such that
`std::is_convertible<jsi::Object &, jsi::Value>` is no longer true (the
conversion is never allowed, but is currently enforced by
`static_assert` ). With that change
`supportsFromJs<jsi::Value, jsi::Object>` also becomes false.

Reviewed By: javache, cortinico

Differential Revision: D46059603

