### PR TITLE
Set WebSocket.binaryType default value to 'blob'

### DIFF
--- a/packages/react-native/Libraries/WebSocket/WebSocket.js
+++ b/packages/react-native/Libraries/WebSocket/WebSocket.js
@@ -82,7 +82,7 @@ class WebSocket extends (EventTarget(...WEBSOCKET_EVENTS): any) {
   _socketId: number;
   _eventEmitter: NativeEventEmitter<WebSocketEventDefinitions>;
   _subscriptions: Array<EventSubscription>;
-  _binaryType: ?BinaryType = 'blob';
+  _binaryType: ?BinaryType;
 
   onclose: ?Function;
   onerror: ?Function;
@@ -146,6 +146,10 @@ class WebSocket extends (EventTarget(...WEBSOCKET_EVENTS): any) {
     this._socketId = nextWebSocketId++;
     this._registerEvents();
     NativeWebSocketModule.connect(url, protocols, {headers}, this._socketId);
+
+    if (BlobManager.isAvailable) {
+      this.binaryType = 'blob';
+    }
   }
 
   get binaryType(): ?BinaryType {

--- a/packages/react-native/Libraries/WebSocket/WebSocket.js
+++ b/packages/react-native/Libraries/WebSocket/WebSocket.js
@@ -82,7 +82,7 @@ class WebSocket extends (EventTarget(...WEBSOCKET_EVENTS): any) {
   _socketId: number;
   _eventEmitter: NativeEventEmitter<WebSocketEventDefinitions>;
   _subscriptions: Array<EventSubscription>;
-  _binaryType: ?BinaryType;
+  _binaryType: ?BinaryType = 'blob';
 
   onclose: ?Function;
   onerror: ?Function;

--- a/packages/react-native/Libraries/WebSocket/__tests__/WebSocket-test.js
+++ b/packages/react-native/Libraries/WebSocket/__tests__/WebSocket-test.js
@@ -28,4 +28,10 @@ describe('WebSocket', function () {
   it('should have connection lifecycle constants defined on the instance', () => {
     expect(new WebSocket('wss://echo.websocket.org').CONNECTING).toEqual(0);
   });
+
+  it('should have binaryType of blob by default on the instance', () => {
+    expect(new WebSocket('wss://echo.websocket.org').binaryType).toEqual(
+      'blob',
+    );
+  });
 });

--- a/packages/react-native/Libraries/WebSocket/__tests__/WebSocket-test.js
+++ b/packages/react-native/Libraries/WebSocket/__tests__/WebSocket-test.js
@@ -29,9 +29,24 @@ describe('WebSocket', function () {
     expect(new WebSocket('wss://echo.websocket.org').CONNECTING).toEqual(0);
   });
 
-  it('should have binaryType of blob by default on the instance', () => {
+  it('should have binaryType of undefined when BlobManager is not available', () => {
     expect(new WebSocket('wss://echo.websocket.org').binaryType).toEqual(
-      'blob',
+      undefined,
     );
   });
+
+  // it('should have binaryType of blob when BlobManager is available', () => {
+  //   jest.setMock('../../BatchedBridge/NativeModules', {
+  //     WebSocketModule: {
+  //       connect: () => {},
+  //     },
+  //     PlatformConstants: {},
+  //     BlobModule: require('../../Blob/__mocks__/BlobModule'),
+  //   });
+  //   const BlobManager = require('../../Blob/BlobManager')
+  //   expect(BlobManager.isAvailable).toEqual(true);
+  //   expect(new WebSocket('wss://echo.websocket.org').binaryType).toEqual(
+  //     'blob',
+  //   );
+  // });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Per WHATWG spec,

> Each [WebSocket](https://websockets.spec.whatwg.org/#websocket) object has an associated binary type, which is a [BinaryType](https://websockets.spec.whatwg.org/#enumdef-binarytype). Initially it must be "[blob](https://websockets.spec.whatwg.org/#dom-binarytype-blob)".

Fixes https://github.com/facebook/react-native/issues/37524

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[General][Changed] - Change the default value of `WebSocket.binaryType` from `undefined` to `blob` to align with WHATWG spec.

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

- Add a test to verify the default value of `WebSocket.binaryType` equals `'blob'`.