### PR TITLE
refactor(codegen): add throwIfTypeAliasIsNotInterface in error-utils

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
@@ -36,6 +36,7 @@ const {
   throwIfEventHasNoName,
   throwIfBubblingTypeIsNull,
   throwIfArgumentPropsAreNull,
+  throwIfTypeAliasIsNotInterface,
 } = require('../error-utils');
 const {
   UnsupportedModulePropertyParserError,
@@ -991,6 +992,47 @@ describe('throwIfArgumentPropsAreNull', () => {
 
     expect(() => {
       throwIfArgumentPropsAreNull(argumentProps, eventName);
+    }).not.toThrow();
+  });
+});
+
+describe('throwIfTypeAliasIsNotInterface', () => {
+  const flowParser = new FlowParser();
+  const typescriptParser = new TypeScriptParser();
+
+  it('throws an error if type argument for codegenNativeCommands is not an interface in Flow', () => {
+    const typeAlias = {};
+    expect(() => {
+      throwIfTypeAliasIsNotInterface(typeAlias, flowParser);
+    }).toThrowError(
+      `The type argument for codegenNativeCommands must be an interface, received ${typeAlias.type}`,
+    );
+  });
+
+  it('does not throw an error if type argument for codegenNativeCommands is an interface in Flow', () => {
+    const typeAlias = {
+      type: 'InterfaceDeclaration',
+    };
+    expect(() => {
+      throwIfTypeAliasIsNotInterface(typeAlias, flowParser);
+    }).not.toThrow();
+  });
+
+  it('throws an error if type argument for codegenNativeCommands is not an interface in Trypscript', () => {
+    const typeAlias = {};
+    expect(() => {
+      throwIfTypeAliasIsNotInterface(typeAlias, typescriptParser);
+    }).toThrowError(
+      `The type argument for codegenNativeCommands must be an interface, received ${typeAlias.type}`,
+    );
+  });
+
+  it('does not throw an error if type argument for codegenNativeCommands is an interface in Typescript', () => {
+    const typeAlias = {
+      type: 'TSInterfaceDeclaration',
+    };
+    expect(() => {
+      throwIfTypeAliasIsNotInterface(typeAlias, typescriptParser);
     }).not.toThrow();
   });
 });

--- a/packages/react-native-codegen/src/parsers/error-utils.js
+++ b/packages/react-native-codegen/src/parsers/error-utils.js
@@ -343,6 +343,14 @@ function throwIfArgumentPropsAreNull(
   return argumentProps;
 }
 
+function throwIfTypeAliasIsNotInterface(typeAlias: $FlowFixMe, parser: Parser) {
+  if (typeAlias.type !== parser.interfaceDeclaration) {
+    throw new Error(
+      `The type argument for codegenNativeCommands must be an interface, received ${typeAlias.type}`,
+    );
+  }
+}
+
 module.exports = {
   throwIfModuleInterfaceIsMisnamed,
   throwIfUnsupportedFunctionReturnTypeAnnotationParserError,
@@ -366,4 +374,5 @@ module.exports = {
   throwIfEventHasNoName,
   throwIfBubblingTypeIsNull,
   throwIfArgumentPropsAreNull,
+  throwIfTypeAliasIsNotInterface,
 };

--- a/packages/react-native-codegen/src/parsers/flow/components/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/index.js
@@ -16,7 +16,10 @@ const {getCommands} = require('./commands');
 const {getEvents} = require('./events');
 const {getProps} = require('./props');
 const {getProperties} = require('./componentsUtils.js');
-const {throwIfMoreThanOneCodegenNativecommands} = require('../../error-utils');
+const {
+  throwIfMoreThanOneCodegenNativecommands,
+  throwIfTypeAliasIsNotInterface,
+} = require('../../error-utils');
 const {
   createComponentConfig,
   findNativeComponentType,
@@ -73,11 +76,7 @@ function getCommandProperties(ast: $FlowFixMe, parser: Parser) {
 
   const typeAlias = types[commandTypeName];
 
-  if (typeAlias.type !== 'InterfaceDeclaration') {
-    throw new Error(
-      `The type argument for codegenNativeCommands must be an interface, received ${typeAlias.type}`,
-    );
-  }
+  throwIfTypeAliasIsNotInterface(typeAlias, parser);
 
   const properties = parser.bodyProperties(typeAlias);
   if (!properties) {

--- a/packages/react-native-codegen/src/parsers/typescript/components/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/index.js
@@ -17,7 +17,10 @@ const {getEvents} = require('./events');
 const {categorizeProps} = require('./extends');
 const {getProps} = require('./props');
 const {getProperties} = require('./componentsUtils.js');
-const {throwIfMoreThanOneCodegenNativecommands} = require('../../error-utils');
+const {
+  throwIfMoreThanOneCodegenNativecommands,
+  throwIfTypeAliasIsNotInterface,
+} = require('../../error-utils');
 const {
   createComponentConfig,
   findNativeComponentType,
@@ -73,11 +76,7 @@ function getCommandProperties(ast: $FlowFixMe, parser: Parser) {
   const types = parser.getTypes(ast);
   const typeAlias = types[commandTypeName];
 
-  if (typeAlias.type !== 'TSInterfaceDeclaration') {
-    throw new Error(
-      `The type argument for codegenNativeCommands must be an interface, received ${typeAlias.type}`,
-    );
-  }
+  throwIfTypeAliasIsNotInterface(typeAlias, parser);
 
   const properties = parser.bodyProperties(typeAlias);
   if (!properties) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
part of codegen issue https://github.com/facebook/react-native/issues/34872

> Extract the code that checks whether typeAlias.type is an InterfaceDeclaration ([Flow](https://github.com/facebook/react-native/blob/d8ced6f8953cd896471983714e722caf50783960/packages/react-native-codegen/src/parsers/flow/components/index.js#L76-L80), [TypeScript](https://github.com/facebook/react-native/blob/d8ced6f8953cd896471983714e722caf50783960/packages/react-native-codegen/src/parsers/typescript/components/index.js#L76-L80)) into a throwIfTypeAliasIsNotInteface error. Create this new function in the error-utils.js file.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[Internal][Added]: Add throwIfTypeAliasIsNotInterface in error-utils

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

yarn test react-native-codegen
