### PR TITLE
fix: limit diagnostics width output by `hermesc`

### DIFF
--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/BundleHermesCTask.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/BundleHermesCTask.kt
@@ -174,6 +174,7 @@ abstract class BundleHermesCTask : DefaultTask() {
     return windowsAwareCommandLine(
         hermesCommand,
         "-emit-binary",
+        "-max-diagnostic-width=80",
         "-out",
         bytecodeFile.cliPath(rootFile),
         bundleFile.cliPath(rootFile),

--- a/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/BundleHermesCTaskTest.kt
+++ b/packages/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/BundleHermesCTaskTest.kt
@@ -341,11 +341,12 @@ class BundleHermesCTaskTest {
 
     assertEquals(customHermesc, hermesCommand[0])
     assertEquals("-emit-binary", hermesCommand[1])
-    assertEquals("-out", hermesCommand[2])
-    assertEquals(bytecodeFile.absolutePath, hermesCommand[3])
-    assertEquals(bundleFile.absolutePath, hermesCommand[4])
-    assertEquals("my-custom-hermes-flag", hermesCommand[5])
-    assertEquals(6, hermesCommand.size)
+    assertEquals("-max-diagnostic-width=80", hermesCommand[2])
+    assertEquals("-out", hermesCommand[3])
+    assertEquals(bytecodeFile.absolutePath, hermesCommand[4])
+    assertEquals(bundleFile.absolutePath, hermesCommand[5])
+    assertEquals("my-custom-hermes-flag", hermesCommand[6])
+    assertEquals(7, hermesCommand.size)
   }
 
   @Test
@@ -366,11 +367,12 @@ class BundleHermesCTaskTest {
     assertEquals("/c", hermesCommand[1])
     assertEquals(customHermesc, hermesCommand[2])
     assertEquals("-emit-binary", hermesCommand[3])
-    assertEquals("-out", hermesCommand[4])
-    assertEquals(bytecodeFile.relativeTo(tempFolder.root).path, hermesCommand[5])
-    assertEquals(bundleFile.relativeTo(tempFolder.root).path, hermesCommand[6])
-    assertEquals("my-custom-hermes-flag", hermesCommand[7])
-    assertEquals(8, hermesCommand.size)
+    assertEquals("-max-diagnostic-width=80", hermesCommand[4])
+    assertEquals("-out", hermesCommand[5])
+    assertEquals(bytecodeFile.relativeTo(tempFolder.root).path, hermesCommand[6])
+    assertEquals(bundleFile.relativeTo(tempFolder.root).path, hermesCommand[7])
+    assertEquals("my-custom-hermes-flag", hermesCommand[8])
+    assertEquals(9, hermesCommand.size)
   }
 
   @Test

--- a/packages/react-native/scripts/react-native-xcode.sh
+++ b/packages/react-native/scripts/react-native-xcode.sh
@@ -176,7 +176,7 @@ else
   if [[ $EMIT_SOURCEMAP == true ]]; then
     EXTRA_COMPILER_ARGS="$EXTRA_COMPILER_ARGS -output-source-map"
   fi
-  "$HERMES_CLI_PATH" -emit-binary $EXTRA_COMPILER_ARGS -out "$DEST/main.jsbundle" "$BUNDLE_FILE"
+  "$HERMES_CLI_PATH" -emit-binary -max-diagnostic-width=80 $EXTRA_COMPILER_ARGS -out "$DEST/main.jsbundle" "$BUNDLE_FILE"
   if [[ $EMIT_SOURCEMAP == true ]]; then
     HBC_SOURCEMAP_FILE="$DEST/main.jsbundle.map"
     "$NODE_BINARY" "$COMPOSE_SOURCEMAP_PATH" "$PACKAGER_SOURCEMAP_FILE" "$HBC_SOURCEMAP_FILE" -o "$SOURCEMAP_FILE"


### PR DESCRIPTION
## Summary:

Limit diagnostics width output by `hermesc` as they may cause slowdowns or even crashes in Gradle/Xcode when a minified bundle is used as input.

See issues filed:
- https://github.com/microsoft/rnx-kit/issues/2416
- https://github.com/microsoft/rnx-kit/issues/2419
- https://github.com/microsoft/rnx-kit/issues/2424

## Changelog:

[GENERAL] [FIXED] - Limit diagnostics width output by `hermesc`

## Test Plan:

See listed issues for repros.