### PR TITLE
W3CPointerEvents: add missing attributes to pointer events

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/PointerEvent.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/PointerEvent.java
@@ -222,6 +222,8 @@ public class PointerEvent extends Event<PointerEvent> {
     pointerEvent.putDouble("tiltX", 0);
     pointerEvent.putDouble("tiltY", 0);
 
+    pointerEvent.putInt("twist", 0);
+
     if (pointerType.equals(PointerEventHelper.POINTER_TYPE_MOUSE)) {
       pointerEvent.putDouble("width", 1);
       pointerEvent.putDouble("height", 1);
@@ -241,6 +243,7 @@ public class PointerEvent extends Event<PointerEvent> {
 
     pointerEvent.putDouble(
         "pressure", PointerEventHelper.getPressure(pointerEvent.getInt("buttons"), mEventName));
+    pointerEvent.putDouble("tangentialPressure", 0.0);
 
     return pointerEvent;
   }


### PR DESCRIPTION
Summary:
Changelog: [Internal] [Changed] - W3CPointerEvents: add missing attributes to pointer events

The [PointerEvent interface](https://www.w3.org/TR/pointerevents/#pointerevent-interface) includes some additional properties which we weren't including in the events we dispatched.

This diff adds them (set to default values):
- twist
- tangentialPressure

In the future, we can try to set reasonable values for these properties based on the underlying native events.

Reviewed By: NickGerleman

Differential Revision: D45747033

