### PR TITLE
W3CPointerEvents: add tests for click event

### DIFF
--- a/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventClickTouch.js
+++ b/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventClickTouch.js
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+import type {PlatformTestComponentBaseProps} from '../PlatformTest/RNTesterPlatformTestTypes';
+import type {PointerEvent} from 'react-native/Libraries/Types/CoreEventTypes';
+
+import {check_PointerEvent} from './PointerEventSupport';
+import RNTesterPlatformTest from '../PlatformTest/RNTesterPlatformTest';
+import * as React from 'react';
+import {useRef, useCallback} from 'react';
+import {StyleSheet, View} from 'react-native';
+import type {PlatformTestContext} from '../PlatformTest/RNTesterPlatformTestTypes';
+
+function checkClickEventProperties(
+  assert_equals: PlatformTestContext['assert_equals'],
+  event: PointerEvent,
+) {
+  assert_equals(event.nativeEvent.width, 1, 'default width is 1');
+  assert_equals(event.nativeEvent.height, 1, 'default height is 1');
+  assert_equals(event.nativeEvent.pressure, 0, 'default pressure is 0');
+  assert_equals(
+    event.nativeEvent.tangentialPressure,
+    0,
+    'default tangentialPressure is 0',
+  );
+  assert_equals(event.nativeEvent.tiltX, 0, 'default tiltX is 0');
+  assert_equals(event.nativeEvent.tiltY, 0, 'default tiltY is 0');
+  assert_equals(event.nativeEvent.twist, 0, 'default twist is 0');
+  assert_equals(
+    event.nativeEvent.isPrimary,
+    false,
+    'default isPrimary is false',
+  );
+}
+
+function PointerEventClickTouchTestCase(props: PlatformTestComponentBaseProps) {
+  const {harness} = props;
+
+  const hasSeenPointerDown = useRef<boolean>(false);
+  const hasSeenPointerUp = useRef<boolean>(false);
+  const hasSeenClick = useRef<boolean>(false);
+
+  const testPointerClick = harness.useAsyncTest('click event received');
+
+  const handleClick = useCallback(
+    (e: PointerEvent) => {
+      if (hasSeenClick.current) {
+        return;
+      }
+      hasSeenClick.current = true;
+      testPointerClick.step(({assert_equals}) => {
+        assert_equals(
+          hasSeenPointerDown.current,
+          true,
+          'pointerdown was received',
+        );
+        assert_equals(hasSeenPointerUp.current, true, 'pointerup was received');
+        checkClickEventProperties(assert_equals, e);
+      });
+
+      check_PointerEvent(harness, e, 'click', {});
+      testPointerClick.done();
+    },
+    [harness, testPointerClick],
+  );
+
+  const handlePointerDown = useCallback(
+    (e: PointerEvent) => {
+      if (hasSeenPointerDown.current) {
+        return;
+      }
+      hasSeenPointerDown.current = true;
+      testPointerClick.step(({assert_equals}) => {
+        assert_equals(
+          hasSeenPointerUp.current,
+          false,
+          'pointerup was not received',
+        );
+        assert_equals(hasSeenClick.current, false, 'click was not received');
+      });
+    },
+    [testPointerClick],
+  );
+
+  const handlePointerUp = useCallback(
+    (e: PointerEvent) => {
+      if (hasSeenPointerUp.current) {
+        return;
+      }
+      hasSeenPointerUp.current = true;
+      testPointerClick.step(({assert_equals}) => {
+        assert_equals(
+          hasSeenPointerDown.current,
+          true,
+          'pointerdown was received',
+        );
+        assert_equals(hasSeenClick.current, false, 'click was not received');
+      });
+    },
+    [testPointerClick],
+  );
+
+  return (
+    <View
+      onClick={handleClick}
+      onPointerDown={handlePointerDown}
+      onPointerUp={handlePointerUp}
+      style={styles.target}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  target: {
+    backgroundColor: 'black',
+    height: 64,
+    width: '100%',
+  },
+});
+
+type Props = $ReadOnly<{}>;
+export default function PointerEventClickTouch(
+  props: Props,
+): React.MixedElement {
+  return (
+    <RNTesterPlatformTest
+      component={PointerEventClickTouchTestCase}
+      description="This test checks if the click event triggers."
+      instructions={['Click or tap on the black rectangle.']}
+      title="Click test"
+    />
+  );
+}

--- a/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventClickTouchHierarchy.js
+++ b/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventClickTouchHierarchy.js
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+import type {PlatformTestComponentBaseProps} from '../PlatformTest/RNTesterPlatformTestTypes';
+
+import RNTesterPlatformTest from '../PlatformTest/RNTesterPlatformTest';
+import * as React from 'react';
+import {useRef} from 'react';
+import {StyleSheet, View} from 'react-native';
+import {EventTracker} from './PointerEventSupport';
+import type {EventOccurrence} from './PointerEventSupport';
+import {mkEvent} from './PointerEventSupport';
+
+const eventsToTrack = ['onClick', 'onPointerDown', 'onPointerUp'];
+
+function PointerEventClickTouchHierarchyTestCase(
+  props: PlatformTestComponentBaseProps,
+) {
+  const {harness} = props;
+
+  const eventsInOrder = useRef<Array<EventOccurrence>>([]);
+
+  const testPointerClick = harness.useAsyncTest(
+    'click event received in hierarchy',
+  );
+
+  const checkResults = () => {
+    testPointerClick.step(({assert_equals}) => {
+      const eventsReceived = eventsInOrder.current;
+      assert_equals(
+        eventsReceived.length,
+        14,
+        'received the expected number of events',
+      );
+      const childToParentEvents = eventsReceived.slice(0, 4);
+      const parentToChildEvents = eventsReceived.slice(4, 8);
+      const childOnlyEvents = eventsReceived.slice(8);
+      assert_equals(
+        JSON.stringify(childToParentEvents),
+        JSON.stringify([
+          mkEvent('child', 'onPointerDown'),
+          mkEvent('parent', 'onPointerDown'),
+          mkEvent('parent', 'onPointerUp'),
+          mkEvent('parent', 'onClick'),
+        ]),
+        'correct events when moving child -> parent',
+      );
+      assert_equals(
+        JSON.stringify(parentToChildEvents),
+        JSON.stringify([
+          mkEvent('parent', 'onPointerDown'),
+          mkEvent('child', 'onPointerUp'),
+          mkEvent('parent', 'onPointerUp'),
+          mkEvent('parent', 'onClick'),
+        ]),
+        'correct events when moving parent -> child',
+      );
+      assert_equals(
+        JSON.stringify(childOnlyEvents),
+        JSON.stringify([
+          mkEvent('child', 'onPointerDown'),
+          mkEvent('parent', 'onPointerDown'),
+          mkEvent('child', 'onPointerUp'),
+          mkEvent('parent', 'onPointerUp'),
+          mkEvent('child', 'onClick'),
+          mkEvent('parent', 'onClick'),
+        ]),
+        'correct events when clicking on child',
+      );
+    });
+    testPointerClick.done();
+  };
+
+  return (
+    <View>
+      <EventTracker
+        id="parent"
+        eventsRef={eventsInOrder}
+        eventsToTrack={eventsToTrack}
+        style={styles.targetParent}>
+        <EventTracker
+          id="child"
+          eventsRef={eventsInOrder}
+          eventsToTrack={eventsToTrack}
+          style={styles.target}
+        />
+      </EventTracker>
+      <View style={styles.checkResults} onClick={checkResults} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  targetParent: {
+    backgroundColor: 'black',
+    height: 64,
+    width: '100%',
+  },
+  target: {
+    backgroundColor: 'blue',
+    height: 64,
+    width: 64,
+  },
+  checkResults: {
+    backgroundColor: 'green',
+    height: 64,
+    width: 64,
+  },
+});
+
+type Props = $ReadOnly<{}>;
+export default function PointerEventClickTouchHierarchy(
+  props: Props,
+): React.MixedElement {
+  return (
+    <RNTesterPlatformTest
+      component={PointerEventClickTouchHierarchyTestCase}
+      description="This test checks if the click event triggers properly in a hierarchy."
+      instructions={[
+        'Start a touch on the blue rectangle',
+        'Move your finger over the black rectangle',
+        'Release the touch',
+        'Start a new touch on the black rectangle',
+        'Move your finger over the blue rectangle',
+        'Release the touch',
+        'Start a new touch on the blue rectangle',
+        'Release the touch (still on blue rectangle)',
+        'Tap the green rectangle to check results',
+      ]}
+      title="Click hierarchy test"
+    />
+  );
+}

--- a/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventClickTouchHierarchyPointerEvents.js
+++ b/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventClickTouchHierarchyPointerEvents.js
@@ -1,0 +1,194 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+import type {PlatformTestComponentBaseProps} from '../PlatformTest/RNTesterPlatformTestTypes';
+import type {EventOccurrence, EventTrackerProps} from './PointerEventSupport';
+import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
+
+import {EventTracker, mkEvent} from './PointerEventSupport';
+import RNTesterPlatformTest from '../PlatformTest/RNTesterPlatformTest';
+import * as React from 'react';
+import {useRef} from 'react';
+import {StyleSheet, View} from 'react-native';
+
+function PointerEventBoxParentChild(props: {
+  eventsToTrack: EventTrackerProps['eventsToTrack'],
+  eventsRef: EventTrackerProps['eventsRef'],
+  pointerEvents: $NonMaybeType<ViewProps['pointerEvents']>,
+  childStyle: ViewProps['style'],
+  parentStyleOverride?: ViewProps['style'],
+}) {
+  const parentId = `parent_${props.pointerEvents}`;
+  const childId = `child_${props.pointerEvents}`;
+  return (
+    <EventTracker
+      eventsRef={props.eventsRef}
+      eventsToTrack={props.eventsToTrack}
+      id={parentId}
+      style={StyleSheet.compose(styles.parent, props.parentStyleOverride)}
+      pointerEvents={props.pointerEvents}>
+      <EventTracker
+        eventsRef={props.eventsRef}
+        eventsToTrack={props.eventsToTrack}
+        id={childId}
+        style={props.childStyle}
+      />
+    </EventTracker>
+  );
+}
+
+const eventsToTrack = ['onClick'];
+
+function PointerEventClickTouchHierarchyPointerEventsTestCase(
+  props: PlatformTestComponentBaseProps,
+) {
+  const {harness} = props;
+
+  const eventsInOrder = useRef<Array<EventOccurrence>>([]);
+
+  const testPointerClick = harness.useAsyncTest(
+    'click event received in hierarchy with pointerEvents',
+  );
+
+  const checkResults = () => {
+    testPointerClick.step(({assert_equals}) => {
+      const eventsReceived = eventsInOrder.current;
+      assert_equals(
+        eventsReceived.length,
+        5,
+        'received the expected number of events',
+      );
+      const boxOnlyEvents = eventsReceived.slice(0, 1);
+      const boxNoneEvents = eventsReceived.slice(1, 3);
+      const autoEvents = eventsReceived.slice(3);
+      assert_equals(
+        JSON.stringify(boxOnlyEvents),
+        JSON.stringify([mkEvent('parent_box-only', 'onClick')]),
+        'correct events for box-only',
+      );
+      assert_equals(
+        JSON.stringify(boxNoneEvents),
+        JSON.stringify([
+          mkEvent('child_box-none', 'onClick'),
+          mkEvent('parent_box-none', 'onClick'),
+        ]),
+        'correct events for box-none',
+      );
+      assert_equals(
+        JSON.stringify(autoEvents),
+        JSON.stringify([
+          mkEvent('child_auto', 'onClick'),
+          mkEvent('parent_auto', 'onClick'),
+        ]),
+        'correct events for auto',
+      );
+    });
+    testPointerClick.done();
+  };
+
+  return (
+    <View>
+      <View style={styles.parentContainer}>
+        <PointerEventBoxParentChild
+          eventsToTrack={eventsToTrack}
+          childStyle={styles.targetBoxOnly}
+          pointerEvents="box-only"
+          eventsRef={eventsInOrder}
+        />
+        <PointerEventBoxParentChild
+          eventsToTrack={eventsToTrack}
+          childStyle={styles.targetBoxNone}
+          pointerEvents="box-none"
+          eventsRef={eventsInOrder}
+          parentStyleOverride={{
+            backgroundColor: 'maroon',
+            height: 100,
+            justifyContent: 'flex-start',
+          }}
+        />
+        <PointerEventBoxParentChild
+          eventsToTrack={eventsToTrack}
+          childStyle={styles.targetAuto}
+          pointerEvents="auto"
+          eventsRef={eventsInOrder}
+        />
+        <PointerEventBoxParentChild
+          eventsToTrack={eventsToTrack}
+          childStyle={styles.targetNone}
+          pointerEvents="none"
+          eventsRef={eventsInOrder}
+        />
+      </View>
+      <View style={styles.checkResults} onClick={checkResults} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  parentContainer: {
+    display: 'flex',
+    flexDirection: 'row',
+    gap: 10,
+  },
+  parent: {
+    display: 'flex',
+    backgroundColor: 'black',
+    height: 80,
+    width: '20%',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  targetBoxOnly: {
+    backgroundColor: 'blue',
+    height: 50,
+    width: 50,
+  },
+  targetBoxNone: {
+    backgroundColor: 'red',
+    height: 50,
+    width: 50,
+  },
+  targetAuto: {
+    backgroundColor: 'yellow',
+    height: 50,
+    width: 50,
+  },
+  targetNone: {
+    backgroundColor: 'purple',
+    height: 50,
+    width: 50,
+  },
+  checkResults: {
+    backgroundColor: 'green',
+    height: 50,
+    width: '80%',
+  },
+});
+
+type Props = $ReadOnly<{}>;
+export default function PointerEventClickTouchHierarchyPointerEvents(
+  props: Props,
+): React.MixedElement {
+  return (
+    <RNTesterPlatformTest
+      component={PointerEventClickTouchHierarchyPointerEventsTestCase}
+      description="This test checks if the click event triggers properly in a hierarchy when the `pointerEvents` property is used."
+      instructions={[
+        'Click (tap/release) the blue square',
+        'Click (tap/release) the dark red rectangle (outer)',
+        'Click (tap/release) the red square (inner)',
+        'Click (tap/release) the yellow square',
+        'Click (tap/release) the purple square',
+        'Tap the green rectangle to check results',
+      ]}
+      title="Click hierarchy test (pointerEvents)"
+    />
+  );
+}

--- a/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventSupport.js
+++ b/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventSupport.js
@@ -12,6 +12,9 @@ import type {PlatformTestHarness} from '../PlatformTest/RNTesterPlatformTestType
 import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
 import type {PointerEvent} from 'react-native/Libraries/Types/CoreEventTypes';
 
+import {View} from 'react-native';
+import * as React from 'react';
+
 import {useMemo} from 'react';
 
 // These props are not in the specification but are present in the WPT so we keep them
@@ -225,4 +228,50 @@ export function useTestEventHandler(
     return props;
   }, [eventNames, handler]);
   return eventProps;
+}
+
+type EventName = 'onClick' | 'onPointerDown' | 'onPointerUp';
+
+export type EventOccurrence = {
+  id: string,
+  eventName: EventName,
+};
+
+export function mkEvent(id: string, eventName: EventName): EventOccurrence {
+  return {
+    id,
+    eventName,
+  };
+}
+
+export type EventTrackerProps = $ReadOnly<{
+  eventsRef: {current: Array<EventOccurrence>},
+  eventsToTrack: Array<EventName>,
+  id: string,
+  ...ViewProps,
+}>;
+
+type HandlerFunction = PointerEvent => void;
+
+export function EventTracker(props: EventTrackerProps): React.MixedElement {
+  const {eventsToTrack, eventsRef, id, style, ...viewProps} = props;
+  const handlerProps = useMemo(() => {
+    const handlers: {
+      onClick?: HandlerFunction,
+      onPointerDown?: HandlerFunction,
+      onPointerUp?: HandlerFunction,
+    } = {};
+    for (const eventName of eventsToTrack) {
+      handlers[eventName] = (e: PointerEvent) => {
+        eventsRef.current.push({id: id, eventName: eventName});
+      };
+    }
+    return handlers;
+  }, [eventsToTrack, id, eventsRef]);
+
+  return (
+    <View {...handlerProps} {...viewProps} style={props.style} id={props.id}>
+      {props.children}
+    </View>
+  );
 }

--- a/packages/rn-tester/js/examples/Experimental/W3CPointerEventsExample.js
+++ b/packages/rn-tester/js/examples/Experimental/W3CPointerEventsExample.js
@@ -24,8 +24,11 @@ import PointerEventPointerMoveBetween from './W3CPointerEventPlatformTests/Point
 import PointerEventPointerOverOut from './W3CPointerEventPlatformTests/PointerEventPointerOverOut';
 import PointerEventLayoutChangeShouldFirePointerOver from './W3CPointerEventPlatformTests/PointerEventLayoutChangeShouldFirePointerOver';
 import PointerEventPointerCancelTouch from './W3CPointerEventPlatformTests/PointerEventPointerCancelTouch';
+import PointerEventClickTouch from './W3CPointerEventPlatformTests/PointerEventClickTouch';
+import PointerEventClickTouchHierarchy from './W3CPointerEventPlatformTests/PointerEventClickTouchHierarchy';
 import EventfulView from './W3CPointerEventsEventfulView';
 import ManyPointersPropertiesExample from './Compatibility/ManyPointersPropertiesExample';
+import PointerEventClickTouchHierarchyPointerEvents from './W3CPointerEventPlatformTests/PointerEventClickTouchHierarchyPointerEvents';
 
 function AbsoluteChildExample({log}: {log: string => void}) {
   return (
@@ -234,6 +237,27 @@ export default {
       title: 'WPT 11: Pointer Events pointercancel Tests',
       render(): React.Node {
         return <PointerEventPointerCancelTouch />;
+      },
+    },
+    {
+      name: 'pointerevent_click_touch',
+      title: 'Pointer Events: basic click test',
+      render(): React.Node {
+        return <PointerEventClickTouch />;
+      },
+    },
+    {
+      name: 'pointerevent_click_touch_hierarchy',
+      title: 'Pointer Events: hierarchy click test',
+      render(): React.Node {
+        return <PointerEventClickTouchHierarchy />;
+      },
+    },
+    {
+      name: 'pointerevent_click_touch_hierarchy_pointerEvents',
+      title: 'Pointer Events: hierarchy click test with pointerEvents',
+      render(): React.Node {
+        return <PointerEventClickTouchHierarchyPointerEvents />;
       },
     },
     {


### PR DESCRIPTION
Summary:
Changelog: [Internal] - W3CPointerEvents: add tests for click event

We don't have any existing tests which exercise the new (PointerEvent-based) click events. This change adds 3 tests:

1. PointerEventClickTouch: checks that the click event fires on an element when it is touched and released, and verifies that the event properties have the expected values
2. PointerEventClickTouchHierarchy: checks that the click event fires appropriately in a hierarchy of elements when the initial target of the touch is not the same as the final target (i.e. where the touch is released)
3. PointerEventClickTouchHierarchyPointerEvents: checks that the click event respects the setting of `pointerEvents` property in a hierarchy of elements

Note: these tests currently fail (at least on Android); future changes will bring the functionality in line with test expectations.

Reviewed By: vincentriemer

Differential Revision: D45121367

