### PR TITLE
W3CPointerEvents: change click event from direct to bubbling

### DIFF
--- a/packages/react-native/Libraries/NativeComponent/BaseViewConfig.android.js
+++ b/packages/react-native/Libraries/NativeComponent/BaseViewConfig.android.js
@@ -103,6 +103,12 @@ const bubblingEventTypes = {
       bubbled: 'onPointerOver',
     },
   },
+  topClick: {
+    phasedRegistrationNames: {
+      captured: 'onClickCapture',
+      bubbled: 'onClick',
+    },
+  },
 };
 
 const directEventTypes = {
@@ -134,9 +140,6 @@ const directEventTypes = {
   },
   topMomentumScrollEnd: {
     registrationName: 'onMomentumScrollEnd',
-  },
-  topClick: {
-    registrationName: 'onClick',
   },
   topLoadingStart: {
     registrationName: 'onLoadingStart',

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
@@ -588,6 +588,11 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
                 MapBuilder.of(
                     "phasedRegistrationNames",
                     MapBuilder.of("bubbled", "onPointerOver", "captured", "onPointerOverCapture")))
+            .put(
+                "topClick",
+                MapBuilder.of(
+                    "phasedRegistrationNames",
+                    MapBuilder.of("bubbled", "onClick", "captured", "onClickCapture")))
             .build());
     return eventTypeConstants;
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModuleConstants.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModuleConstants.java
@@ -64,7 +64,6 @@ import java.util.Map;
         .put("topLoadingStart", MapBuilder.of(rn, "onLoadingStart"))
         .put("topSelectionChange", MapBuilder.of(rn, "onSelectionChange"))
         .put("topMessage", MapBuilder.of(rn, "onMessage"))
-        .put("topClick", MapBuilder.of(rn, "onClick"))
         // Scroll events are added as per task T22348735.
         // Subject for further improvement.
         .put("topScrollBeginDrag", MapBuilder.of(rn, "onScrollBeginDrag"))


### PR DESCRIPTION
Summary:
AFAICT this was added in https://github.com/facebook/react-native/pull/24359 to support accessibility, however per [the spec](https://www.w3.org/TR/uievents/#event-type-click) the click event is supposed to bubble up.

This change updates the necessary configs so that `click` is treated as a bubbling event and not as a direct-dispatch event.

Changelog: [Android] [Breaking] - W3CPointerEvents: change click event from direct to bubbling

Reviewed By: yungsters

Differential Revision: D45745906

