### PR TITLE
W3CPointerEvents: add basic testbed for click event accessibility

### DIFF
--- a/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventAccessibility.js
+++ b/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventAccessibility.js
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+import * as React from 'react';
+import {useState} from 'react';
+import {StyleSheet, View, Pressable, ScrollView, Text} from 'react-native';
+import {EventTracker} from './PointerEventSupport';
+import type {EventOccurrence} from './PointerEventSupport';
+import type {PointerEvent} from 'react-native/Libraries/Types/CoreEventTypes';
+
+const eventsToTrack = ['onClick'];
+
+export default function PointerEventAccessibility(props: {}): React.MixedElement {
+  const [eventsSeen, setEventsSeen] = useState<Array<EventOccurrence>>([]);
+
+  const onAnyEvent = (occurrence: EventOccurrence, event: PointerEvent) =>
+    setEventsSeen(evs => evs.concat([occurrence]));
+
+  return (
+    <View style={styles.topLevel}>
+      <View style={styles.clickableContainer}>
+        <EventTracker
+          id="pointer-parent"
+          eventsToTrack={eventsToTrack}
+          style={styles.targetParent}
+          onAnyEvent={onAnyEvent}
+          focusable={true}>
+          <EventTracker
+            id="pointer-child"
+            eventsToTrack={eventsToTrack}
+            onAnyEvent={onAnyEvent}
+            style={styles.target}
+            focusable={true}
+          />
+        </EventTracker>
+        <Pressable
+          onPress={() =>
+            setEventsSeen(evs =>
+              evs.concat({eventName: 'onClick', id: 'pressable-parent'}),
+            )
+          }>
+          <View style={styles.targetParent}>
+            <Pressable
+              focusable={true}
+              onPress={() =>
+                setEventsSeen(evs =>
+                  evs.concat({eventName: 'onClick', id: 'pressable-child'}),
+                )
+              }>
+              <View style={styles.targetPressable} />
+            </Pressable>
+          </View>
+        </Pressable>
+      </View>
+      <Pressable onPress={() => setEventsSeen([])}>
+        <Text key={0} style={styles.reset}>
+          Reset events
+        </Text>
+      </Pressable>
+      <ScrollView style={styles.eventsLog}>
+        {eventsSeen.map((occurrence, ii) => (
+          <Text key={`${ii}-${occurrence.id}-${occurrence.eventName}`}>
+            {occurrence.id} {occurrence.eventName}
+          </Text>
+        ))}
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  topLevel: {
+    display: 'flex',
+  },
+  targetParent: {
+    backgroundColor: 'red',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: 128,
+    width: 128,
+  },
+  eventsLog: {
+    height: 300,
+  },
+  clickableContainer: {
+    display: 'flex',
+    flexDirection: 'row',
+    gap: 16,
+  },
+  target: {
+    backgroundColor: 'blue',
+    height: 64,
+    width: 64,
+  },
+  targetPressable: {
+    backgroundColor: 'yellow',
+    height: 64,
+    width: 64,
+  },
+  reset: {
+    margin: 10,
+    fontSize: 30,
+    borderColor: 'red',
+    borderWidth: 1,
+    textAlign: 'center',
+  },
+});

--- a/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventSupport.js
+++ b/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventSupport.js
@@ -245,7 +245,8 @@ export function mkEvent(id: string, eventName: EventName): EventOccurrence {
 }
 
 export type EventTrackerProps = $ReadOnly<{
-  eventsRef: {current: Array<EventOccurrence>},
+  eventsRef?: {current: Array<EventOccurrence>},
+  onAnyEvent?: (EventOccurrence, PointerEvent) => void,
   eventsToTrack: Array<EventName>,
   id: string,
   ...ViewProps,
@@ -254,7 +255,7 @@ export type EventTrackerProps = $ReadOnly<{
 type HandlerFunction = PointerEvent => void;
 
 export function EventTracker(props: EventTrackerProps): React.MixedElement {
-  const {eventsToTrack, eventsRef, id, style, ...viewProps} = props;
+  const {eventsToTrack, eventsRef, id, style, onAnyEvent, ...viewProps} = props;
   const handlerProps = useMemo(() => {
     const handlers: {
       onClick?: HandlerFunction,
@@ -263,11 +264,13 @@ export function EventTracker(props: EventTrackerProps): React.MixedElement {
     } = {};
     for (const eventName of eventsToTrack) {
       handlers[eventName] = (e: PointerEvent) => {
-        eventsRef.current.push({id: id, eventName: eventName});
+        const occurrence = {id, eventName};
+        eventsRef?.current.push(occurrence);
+        onAnyEvent?.(occurrence, e);
       };
     }
     return handlers;
-  }, [eventsToTrack, id, eventsRef]);
+  }, [eventsToTrack, id, eventsRef, onAnyEvent]);
 
   return (
     <View {...handlerProps} {...viewProps} style={props.style} id={props.id}>

--- a/packages/rn-tester/js/examples/Experimental/W3CPointerEventsExample.js
+++ b/packages/rn-tester/js/examples/Experimental/W3CPointerEventsExample.js
@@ -29,6 +29,7 @@ import PointerEventClickTouchHierarchy from './W3CPointerEventPlatformTests/Poin
 import EventfulView from './W3CPointerEventsEventfulView';
 import ManyPointersPropertiesExample from './Compatibility/ManyPointersPropertiesExample';
 import PointerEventClickTouchHierarchyPointerEvents from './W3CPointerEventPlatformTests/PointerEventClickTouchHierarchyPointerEvents';
+import PointerEventAccessibility from './W3CPointerEventPlatformTests/PointerEventAccessibility';
 
 function AbsoluteChildExample({log}: {log: string => void}) {
   return (
@@ -258,6 +259,13 @@ export default {
       title: 'Pointer Events: hierarchy click test with pointerEvents',
       render(): React.Node {
         return <PointerEventClickTouchHierarchyPointerEvents />;
+      },
+    },
+    {
+      name: 'pointerevent_click_touch_accessibility',
+      title: 'Pointer Events: accessibility click testbed',
+      render(): React.Node {
+        return <PointerEventAccessibility />;
       },
     },
     {


### PR DESCRIPTION
Summary:
Changelog: [Internal] [Added] - W3CPointerEvents: add basic testbed for click event accessibility

This change adds a test bed with some nested pressables/clickable views. We can use this to test behavior for accessibility clicks on nested pressables (a corner case), and this can be expanded for other a11y testing in the future.

Reviewed By: NickGerleman

Differential Revision: D46081730

