### PR TITLE
W3CPointerEvents: emit click events based on pointerDown/pointerUp

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
@@ -700,6 +700,16 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
     setPointerEventsFlag(view, PointerEventHelper.EVENT.MOVE_CAPTURE, value);
   }
 
+  @ReactProp(name = "onClick")
+  public void setClick(@NonNull T view, boolean value) {
+    setPointerEventsFlag(view, PointerEventHelper.EVENT.CLICK, value);
+  }
+
+  @ReactProp(name = "onClickCapture")
+  public void setClickCapture(@NonNull T view, boolean value) {
+    setPointerEventsFlag(view, PointerEventHelper.EVENT.CLICK_CAPTURE, value);
+  }
+
   /* Experimental W3C Pointer events end */
 
   @ReactProp(name = "onMoveShouldSetResponder")

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/PointerEventHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/PointerEventHelper.java
@@ -25,6 +25,8 @@ public class PointerEventHelper {
   public static enum EVENT {
     CANCEL,
     CANCEL_CAPTURE,
+    CLICK,
+    CLICK_CAPTURE,
     DOWN,
     DOWN_CAPTURE,
     ENTER,
@@ -49,6 +51,7 @@ public class PointerEventHelper {
   public static final String POINTER_UP = "topPointerUp";
   public static final String POINTER_OVER = "topPointerOver";
   public static final String POINTER_OUT = "topPointerOut";
+  public static final String CLICK = "topClick";
 
   // https://w3c.github.io/pointerevents/#the-buttons-property
   public static int getButtons(String eventName, String pointerType, int buttonState) {
@@ -117,6 +120,8 @@ public class PointerEventHelper {
       case UP_CAPTURE:
       case CANCEL:
       case CANCEL_CAPTURE:
+      case CLICK:
+      case CLICK_CAPTURE:
         return true;
     }
 


### PR DESCRIPTION
Summary:
This diff makes changes to emit bubbling click events (i.e. [these](https://www.w3.org/TR/uievents/#click)) based on the existing pointer-down/pointer-up events. As per the [pointer events spec](https://www.w3.org/TR/pointerevents3/#the-click-auxclick-and-contextmenu-events), click events are still dispatched as PointerEvents (i.e. conform to the PointerEvent interface).

Changelog: [Internal] [Added] - W3CPointerEvents: emit click events based on pointerDown/pointerUp

Reviewed By: NickGerleman

Differential Revision: D45666344

