### PR TITLE
Fix use_react_native to support absolute paths

### DIFF
--- a/packages/react-native/scripts/cocoapods/__tests__/codegen-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/codegen-test.rb
@@ -184,7 +184,7 @@ class CodegenTests < Test::Unit::TestCase
 
     def testCheckAndGenerateEmptyThirdPartyProvider_withAbsoluteReactNativePath_buildCodegen()
         # Arrange
-        rn_path = File.dirname(`node --print "require.resolve('react-native/package.json')"`)
+        rn_path = '/Users/distiller/react-native/packages/react-native'
         codegen_cli_path = rn_path + "/../@react-native/codegen"
         DirMock.mocked_existing_dirs([
             codegen_cli_path,

--- a/packages/react-native/scripts/cocoapods/__tests__/codegen-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/codegen-test.rb
@@ -182,6 +182,47 @@ class CodegenTests < Test::Unit::TestCase
         })
     end
 
+    def testCheckAndGenerateEmptyThirdPartyProvider_withAbsoluteReactNativePath_buildCodegen()
+        # Arrange
+        rn_path = File.dirname(`node --print "require.resolve('react-native/package.json')"`)
+        codegen_cli_path = rn_path + "/../@react-native/codegen"
+        DirMock.mocked_existing_dirs([
+            codegen_cli_path,
+        ])
+
+        # Act
+        checkAndGenerateEmptyThirdPartyProvider!(rn_path, false, dir_manager: DirMock, file_manager: FileMock)
+
+        # Assert
+        assert_equal(Pathname.pwd_invocation_count, 1)
+        assert_equal(Pod::Config.instance.installation_root.relative_path_from_invocation_count, 1)
+        assert_equal(FileMock.exist_invocation_params, [
+            rn_path + "/React/Fabric/" + @third_party_provider_header,
+            rn_path + "/React/Fabric/" + @tmp_schema_list_file
+        ])
+        assert_equal(DirMock.exist_invocation_params, [
+            rn_path + "/../react-native-codegen",
+            codegen_cli_path,
+            codegen_cli_path + "/lib",
+        ])
+        assert_equal(Pod::UI.collected_messages, [
+            "[Codegen] building #{codegen_cli_path}.",
+            "[Codegen] generating an empty RCTThirdPartyFabricComponentsProvider"
+        ])
+        assert_equal($collected_commands, [rn_path + "/../@react-native/codegen/scripts/oss/build.sh"])
+        assert_equal(FileMock.open_files[0].collected_write, ["[]"])
+        assert_equal(FileMock.open_files[0].fsync_invocation_count, 1)
+        assert_equal(Pod::Executable.executed_commands[0], {
+            "command" => "node",
+            "arguments" => [
+                rn_path + "/scripts/generate-provider-cli.js",
+                "--platform", 'ios',
+                "--schemaListPath", rn_path + "/React/Fabric/" + @tmp_schema_list_file,
+                "--outputDir", rn_path + "/React/Fabric"
+            ]
+        })
+    end
+
     # ================= #
     # Test - RunCodegen #
     # ================= #

--- a/packages/react-native/scripts/cocoapods/__tests__/codegen-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/codegen-test.rb
@@ -55,7 +55,7 @@ class CodegenTests < Test::Unit::TestCase
         checkAndGenerateEmptyThirdPartyProvider!(@prefix, false, dir_manager: DirMock, file_manager: FileMock)
 
         # Assert
-        assert_equal(Pathname.pwd_invocation_count, 1)
+        assert_equal(Pathname.pwd_invocation_count, 0)
         assert_equal(Pod::Config.instance.installation_root.relative_path_from_invocation_count, 1)
         assert_equal(FileMock.exist_invocation_params, [
             @prefix + "/React/Fabric/" + @third_party_provider_header,
@@ -81,7 +81,7 @@ class CodegenTests < Test::Unit::TestCase
         }
 
         # Assert
-        assert_equal(Pathname.pwd_invocation_count, 1)
+        assert_equal(Pathname.pwd_invocation_count, 0)
         assert_equal(Pod::Config.instance.installation_root.relative_path_from_invocation_count, 1)
         assert_equal(FileMock.exist_invocation_params, [
             @prefix + "/React/Fabric/" + @third_party_provider_header
@@ -113,7 +113,7 @@ class CodegenTests < Test::Unit::TestCase
         checkAndGenerateEmptyThirdPartyProvider!(@prefix, false, dir_manager: DirMock, file_manager: FileMock)
 
         # Assert
-        assert_equal(Pathname.pwd_invocation_count, 1)
+        assert_equal(Pathname.pwd_invocation_count, 0)
         assert_equal(Pod::Config.instance.installation_root.relative_path_from_invocation_count, 1)
         assert_equal(FileMock.exist_invocation_params, [
             @prefix + "/React/Fabric/" + @third_party_provider_header,
@@ -153,7 +153,7 @@ class CodegenTests < Test::Unit::TestCase
         checkAndGenerateEmptyThirdPartyProvider!(@prefix, false, dir_manager: DirMock, file_manager: FileMock)
 
         # Assert
-        assert_equal(Pathname.pwd_invocation_count, 1)
+        assert_equal(Pathname.pwd_invocation_count, 0)
         assert_equal(Pod::Config.instance.installation_root.relative_path_from_invocation_count, 1)
         assert_equal(FileMock.exist_invocation_params, [
             @prefix + "/React/Fabric/" + @third_party_provider_header,
@@ -194,7 +194,7 @@ class CodegenTests < Test::Unit::TestCase
         checkAndGenerateEmptyThirdPartyProvider!(rn_path, false, dir_manager: DirMock, file_manager: FileMock)
 
         # Assert
-        assert_equal(Pathname.pwd_invocation_count, 1)
+        assert_equal(Pathname.pwd_invocation_count, 0)
         assert_equal(Pod::Config.instance.installation_root.relative_path_from_invocation_count, 1)
         assert_equal(FileMock.exist_invocation_params, [
             rn_path + "/React/Fabric/" + @third_party_provider_header,

--- a/packages/react-native/scripts/cocoapods/__tests__/codegen_utils-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/codegen_utils-test.rb
@@ -75,7 +75,7 @@ class CodegenUtilsTests < Test::Unit::TestCase
         CodegenUtils.new().generate_react_codegen_podspec!(spec, codegen_output_dir, file_manager: FileMock)
 
         # Assert
-        assert_equal(Pathname.pwd_invocation_count, 1)
+        assert_equal(Pathname.pwd_invocation_count, 0)
         assert_equal(Pod::Config.instance.installation_root.relative_path_from_invocation_count, 1)
         assert_equal(Pod::Executable.executed_commands, [{ "command" => 'mkdir', "arguments" => ["-p", "~/app/ios/build"]}])
         assert_equal(Pod::UI.collected_messages, ["[Codegen] Generating ~/app/ios/build/React-Codegen.podspec.json"])

--- a/packages/react-native/scripts/cocoapods/codegen.rb
+++ b/packages/react-native/scripts/cocoapods/codegen.rb
@@ -11,9 +11,8 @@
 # - dir_manager: a class that implements the `Dir` interface. Defaults to `Dir`, the Dependency can be injected for testing purposes.
 # @throws an error if it could not find the codegen folder.
 def build_codegen!(react_native_path, relative_installation_root, dir_manager: Dir)
-    is_react_native_path_absolute = react_native_path.start_with?("/")
-    codegen_repo_path = "#{is_react_native_path_absolute ? '' : relative_installation_root.to_s + '/'}#{react_native_path}/../react-native-codegen";
-    codegen_npm_path = "#{is_react_native_path_absolute ? '' : relative_installation_root.to_s + '/'}#{react_native_path}/../@react-native/codegen";
+    codegen_repo_path = "#{basePath(react_native_path, relative_installation_root)}/../react-native-codegen";
+    codegen_npm_path = "#{basePath(react_native_path, relative_installation_root)}/../@react-native/codegen";
     codegen_cli_path = ""
 
     if dir_manager.exist?(codegen_repo_path)
@@ -41,7 +40,6 @@ def checkAndGenerateEmptyThirdPartyProvider!(react_native_path, new_arch_enabled
     return if new_arch_enabled
 
     relative_installation_root = Pod::Config.instance.installation_root.relative_path_from(Pathname.pwd)
-    is_react_native_path_absolute = react_native_path.start_with?("/")
 
     output_dir = "#{react_native_path}/React/Fabric"
 
@@ -63,7 +61,7 @@ def checkAndGenerateEmptyThirdPartyProvider!(react_native_path, new_arch_enabled
         Pod::Executable.execute_command(
         'node',
         [
-            "#{is_react_native_path_absolute ? '' : relative_installation_root.to_s + '/'}#{react_native_path}/scripts/generate-provider-cli.js",
+            "#{basePath(react_native_path, relative_installation_root)}/scripts/generate-provider-cli.js",
             "--platform", 'ios',
             "--schemaListPath", temp_schema_list_path,
             "--outputDir", "#{output_dir}"
@@ -108,5 +106,13 @@ def run_codegen!(
       :hermes_enabled => hermes_enabled
     )
     codegen_utils.generate_react_codegen_podspec!(react_codegen_spec, codegen_output_dir)
+  end
+end
+
+def basePath(react_native_path, relative_installation_root)
+  if react_native_path.start_with?("/")
+    react_native_path
+  else
+    "#{relative_installation_root.to_s}/#{react_native_path}"
   end
 end

--- a/packages/react-native/scripts/cocoapods/codegen.rb
+++ b/packages/react-native/scripts/cocoapods/codegen.rb
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+require 'pathname'
+
 # It builds the codegen CLI if it is not present
 #
 # Parameters:
@@ -11,8 +13,8 @@
 # - dir_manager: a class that implements the `Dir` interface. Defaults to `Dir`, the Dependency can be injected for testing purposes.
 # @throws an error if it could not find the codegen folder.
 def build_codegen!(react_native_path, relative_installation_root, dir_manager: Dir)
-    codegen_repo_path = "#{basePath(react_native_path, relative_installation_root)}/../react-native-codegen";
-    codegen_npm_path = "#{basePath(react_native_path, relative_installation_root)}/../@react-native/codegen";
+    codegen_repo_path = File.join(basePath(react_native_path, relative_installation_root), "..", "react-native-codegen")
+    codegen_npm_path = File.join(basePath(react_native_path, relative_installation_root), "..", "@react-native/codegen")
     codegen_cli_path = ""
 
     if dir_manager.exist?(codegen_repo_path)
@@ -110,9 +112,9 @@ def run_codegen!(
 end
 
 def basePath(react_native_path, relative_installation_root)
-  if react_native_path.start_with?("/")
+  if Pathname.new(react_native_path).absolute
     react_native_path
   else
-    "#{relative_installation_root.to_s}/#{react_native_path}"
+    File.join(relative_installation_root.to_s, react_native_path)
   end
 end

--- a/packages/react-native/scripts/cocoapods/codegen.rb
+++ b/packages/react-native/scripts/cocoapods/codegen.rb
@@ -11,8 +11,9 @@
 # - dir_manager: a class that implements the `Dir` interface. Defaults to `Dir`, the Dependency can be injected for testing purposes.
 # @throws an error if it could not find the codegen folder.
 def build_codegen!(react_native_path, relative_installation_root, dir_manager: Dir)
-    codegen_repo_path = "#{relative_installation_root}/#{react_native_path}/../react-native-codegen";
-    codegen_npm_path = "#{relative_installation_root}/#{react_native_path}/../@react-native/codegen";
+    is_react_native_path_absolute = react_native_path.start_with?("/")
+    codegen_repo_path = "#{is_react_native_path_absolute ? '' : relative_installation_root.to_s + '/'}#{react_native_path}/../react-native-codegen";
+    codegen_npm_path = "#{is_react_native_path_absolute ? '' : relative_installation_root.to_s + '/'}#{react_native_path}/../@react-native/codegen";
     codegen_cli_path = ""
 
     if dir_manager.exist?(codegen_repo_path)
@@ -40,6 +41,7 @@ def checkAndGenerateEmptyThirdPartyProvider!(react_native_path, new_arch_enabled
     return if new_arch_enabled
 
     relative_installation_root = Pod::Config.instance.installation_root.relative_path_from(Pathname.pwd)
+    is_react_native_path_absolute = react_native_path.start_with?("/")
 
     output_dir = "#{react_native_path}/React/Fabric"
 
@@ -61,7 +63,7 @@ def checkAndGenerateEmptyThirdPartyProvider!(react_native_path, new_arch_enabled
         Pod::Executable.execute_command(
         'node',
         [
-            "#{relative_installation_root}/#{react_native_path}/scripts/generate-provider-cli.js",
+            "#{is_react_native_path_absolute ? '' : relative_installation_root.to_s + '/'}#{react_native_path}/scripts/generate-provider-cli.js",
             "--platform", 'ios',
             "--schemaListPath", temp_schema_list_path,
             "--outputDir", "#{output_dir}"


### PR DESCRIPTION
## Summary:

While setting up a monorepo that required a custom react-native path location (react-native-macos in my case) I was getting the following error when running `pod install`

![image](https://github.com/facebook/react-native/assets/11707729/29bacfbb-78d9-49db-9c75-3e75674d87e9)

That's because `build_codegen` and `checkAndGenerateEmptyThirdPartyProvider` functions don't check if the given `react_native_path` is absolute or relative. 

This PR fixes this problem by checking if `react_native_path` starts with `/`

## Changelog:

[IOS] [FIXED] - Fix `use_react_native` to support custom react native absolute paths

## Test Plan:

Modify [rn-tester/Podfile](https://github.com/facebook/react-native/tree/main/packages/rn-tester/Podfile) to use an absolute path when calling `use_react_native` 

E.g.

```rb
rn_path = File.dirname(`node --print "require.resolve('react-native/package.json')"`) 

use_react_native!(
  path: rn_path, 
  ...
)
```
 
then run `pod install`
