### PR TITLE
[IOS][FIXED] Fix RCTImageBlurUtils.m Crash

### DIFF
--- a/packages/react-native/Libraries/Image/RCTImageBlurUtils.m
+++ b/packages/react-native/Libraries/Image/RCTImageBlurUtils.m
@@ -19,16 +19,13 @@ UIImage *RCTBlurredImageWithRadius(UIImage *inputImage, CGFloat radius)
   }
 
   // convert to ARGB if it isn't
-  if (CGImageGetBitsPerPixel(imageRef) != 32 ||
+  if (CGImageGetBitsPerPixel(imageRef) != 32 || CGImageGetBitsPerComponent(imageRef) != 8 ||
       !((CGImageGetBitmapInfo(imageRef) & kCGBitmapAlphaInfoMask))) {
-    UIGraphicsImageRendererFormat *const rendererFormat = [UIGraphicsImageRendererFormat defaultFormat];
-    rendererFormat.scale = inputImage.scale;
-    UIGraphicsImageRenderer *const renderer = [[UIGraphicsImageRenderer alloc] initWithSize:inputImage.size
-                                                                                     format:rendererFormat];
-
-    imageRef = [renderer imageWithActions:^(UIGraphicsImageRendererContext *_Nonnull context) {
-                 [inputImage drawAtPoint:CGPointZero];
-               }].CGImage;
+    UIGraphicsBeginImageContextWithOptions(inputImage.size, NO, inputImage.scale);
+    [inputImage drawAtPoint:CGPointZero];
+    inputImage = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+    imageRef = inputImage.CGImage;
   }
 
   vImage_Buffer buffer1, buffer2;

--- a/packages/react-native/Libraries/Image/RCTImageBlurUtils.m
+++ b/packages/react-native/Libraries/Image/RCTImageBlurUtils.m
@@ -19,7 +19,7 @@ UIImage *RCTBlurredImageWithRadius(UIImage *inputImage, CGFloat radius)
   }
 
   // convert to ARGB if it isn't
-  if (CGImageGetBitsPerPixel(imageRef) != 32 || CGImageGetBitsPerComponent(imageRef) != 8 ||
+  if (CGImageGetBitsPerPixel(imageRef) != 32 ||
       !((CGImageGetBitmapInfo(imageRef) & kCGBitmapAlphaInfoMask))) {
     UIGraphicsImageRendererFormat *const rendererFormat = [UIGraphicsImageRendererFormat defaultFormat];
     rendererFormat.scale = inputImage.scale;


### PR DESCRIPTION
## Summary:

RCTIMageBlurUtils.m is causing a crash for some specific images. More context in this PR:
https://github.com/facebook/react-native/pull/37508#issuecomment-1558964327

I was under the impression that the change in the previous PR actually resolved the issue, however some images were still crashing. It turns out that the issue actually lies within the new UIGraphicsImageRenderer not properly aligning the bitmap data.

For simplicity I opted to use the older UIGraphicsBeginImageContextWithOptions which now works reliably, however might be a bit slower as the API is older.

There could be a path to use the newer UIGraphicsImageRenderer, however as the new API does not provide a lot of customizability it would involve writing more code and dealing with additional complexity, particularly when dealing with memory management in order to manually ensure that the buffer is properly formatted and aligned.

## Changelog:
[IOS] [FIXED] - Fix RCTImageBlurUtils.m Image Blurring Crash


## Test Plan:

```
<ImageBackground
        blurRadius={18}
        source={{uri: 'https://i.scdn.co/image/ab67616d0000b2737663b2f75fe4d8fb2cac8c27'}}
/>

<ImageBackground
        blurRadius={5}
        source={{uri: 'https://i.scdn.co/image/ab67616d0000b273d5a219b270d74a266131df18'}}
/>
```
