### PR TITLE
[Codegen 120] Refactor: Extract `findComponentConfig(...)` to `parsers-commons.js`

### DIFF
--- a/packages/react-native-codegen/src/parsers/flow/components/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/index.js
@@ -16,49 +16,12 @@ const {getCommands} = require('./commands');
 const {getEvents} = require('./events');
 const {getProps} = require('./props');
 const {getProperties} = require('./componentsUtils.js');
-const {throwIfMoreThanOneCodegenNativecommands} = require('../../error-utils');
 const {
-  createComponentConfig,
-  findNativeComponentType,
   propertyNames,
   getCommandOptions,
   getOptions,
-  getCommandTypeNameAndOptionsExpression,
+  findComponentConfig,
 } = require('../../parsers-commons');
-const {
-  throwIfConfigNotfound,
-  throwIfMoreThanOneConfig,
-} = require('../../error-utils');
-
-// $FlowFixMe[signature-verification-failure] there's no flowtype for AST
-function findComponentConfig(ast: $FlowFixMe, parser: Parser) {
-  const foundConfigs: Array<{[string]: string}> = [];
-
-  const defaultExports = ast.body.filter(
-    node => node.type === 'ExportDefaultDeclaration',
-  );
-
-  defaultExports.forEach(statement => {
-    findNativeComponentType(statement, foundConfigs, parser);
-  });
-
-  throwIfConfigNotfound(foundConfigs);
-  throwIfMoreThanOneConfig(foundConfigs);
-
-  const foundConfig = foundConfigs[0];
-
-  const namedExports = ast.body.filter(
-    node => node.type === 'ExportNamedDeclaration',
-  );
-
-  const commandsTypeNames = namedExports
-    .map(statement => getCommandTypeNameAndOptionsExpression(statement, parser))
-    .filter(Boolean);
-
-  throwIfMoreThanOneCodegenNativecommands(commandsTypeNames);
-
-  return createComponentConfig(foundConfig, commandsTypeNames);
-}
 
 function getCommandProperties(ast: $FlowFixMe, parser: Parser) {
   const {commandTypeName, commandOptionsExpression} = findComponentConfig(

--- a/packages/react-native-codegen/src/parsers/typescript/components/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/index.js
@@ -17,49 +17,12 @@ const {getEvents} = require('./events');
 const {categorizeProps} = require('./extends');
 const {getProps} = require('./props');
 const {getProperties} = require('./componentsUtils.js');
-const {throwIfMoreThanOneCodegenNativecommands} = require('../../error-utils');
 const {
-  createComponentConfig,
-  findNativeComponentType,
   propertyNames,
   getCommandOptions,
   getOptions,
-  getCommandTypeNameAndOptionsExpression,
+  findComponentConfig,
 } = require('../../parsers-commons');
-const {
-  throwIfConfigNotfound,
-  throwIfMoreThanOneConfig,
-} = require('../../error-utils');
-
-// $FlowFixMe[signature-verification-failure] TODO(T108222691): Use flow-types for @babel/parser
-function findComponentConfig(ast: $FlowFixMe, parser: Parser) {
-  const foundConfigs: Array<{[string]: string}> = [];
-
-  const defaultExports = ast.body.filter(
-    node => node.type === 'ExportDefaultDeclaration',
-  );
-
-  defaultExports.forEach(statement =>
-    findNativeComponentType(statement, foundConfigs, parser),
-  );
-
-  throwIfConfigNotfound(foundConfigs);
-  throwIfMoreThanOneConfig(foundConfigs);
-
-  const foundConfig = foundConfigs[0];
-
-  const namedExports = ast.body.filter(
-    node => node.type === 'ExportNamedDeclaration',
-  );
-
-  const commandsTypeNames = namedExports
-    .map(statement => getCommandTypeNameAndOptionsExpression(statement, parser))
-    .filter(Boolean);
-
-  throwIfMoreThanOneCodegenNativecommands(commandsTypeNames);
-
-  return createComponentConfig(foundConfig, commandsTypeNames);
-}
 
 function getCommandProperties(ast: $FlowFixMe, parser: Parser) {
   const {commandTypeName, commandOptionsExpression} = findComponentConfig(


### PR DESCRIPTION
## Summary:

This PR extracts the `findComponentConfig(...)` Flow and TS from the `index.js`'s files to the `parser-commons.js` file.

## Changelog:

[INTERNAL][CHANGED] - Refactor: Extract `findComponentConfig(...)` from Flow & TS to `parsers-commons.js`

## Test Plan:

- `yarn flow && yarn test packages/react-native-codegen`  → should be green.
