### PR TITLE
Fix instacrash on main for Release due to java.lang.NoSuchMethodError

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/events/EventEmitterWrapper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/events/EventEmitterWrapper.java
@@ -21,6 +21,7 @@ import com.facebook.react.uimanager.events.EventCategoryDef;
  * This class holds reference to the C++ EventEmitter object. Instances of this class are created in
  * FabricMountingManager.cpp, where the pointer to the C++ event emitter is set.
  */
+@DoNotStrip
 @SuppressLint("MissingNativeLoadLibrary")
 public class EventEmitterWrapper {
 
@@ -30,6 +31,7 @@ public class EventEmitterWrapper {
 
   @DoNotStrip private final HybridData mHybridData;
 
+  @DoNotStrip
   private EventEmitterWrapper(HybridData hybridData) {
     mHybridData = hybridData;
   }


### PR DESCRIPTION
Summary:
RN Tester is instacrashing on Android on main sadly since a while.
I've noticed it while working on another diff. The crash is a native crash with message:

```
Abort message: 'terminating with uncaught exception of type facebook::jni::JniException: java.lang.NoSuchMethodError: no non-static method "Lcom/facebook/react/fabric/events/EventEmitterWrapper;.<init>(Lcom/facebook/jni/HybridData;)V"'
```

which happens because this method is stripped by proguard. I'm fixing it here.

Changelog:
[Android] [Fixed] - Fix instacrash on main for Release due to java.lang.NoSuchMethodError

Reviewed By: cipolleschi

Differential Revision: D46145613

