### PR TITLE
Add debugging docs link to NewAppScreen

### DIFF
--- a/packages/react-native/Libraries/NewAppScreen/components/DebugInstructions.js
+++ b/packages/react-native/Libraries/NewAppScreen/components/DebugInstructions.js
@@ -25,15 +25,15 @@ const DebugInstructions: () => Node = Platform.select({
   ios: () => (
     <Text>
       Press <Text style={styles.highlight}>Cmd + D</Text> in the simulator or{' '}
-      <Text style={styles.highlight}>Shake</Text> your device to open the React
-      Native debug menu.
+      <Text style={styles.highlight}>Shake</Text> your device to open the Dev
+      Menu.
     </Text>
   ),
   default: () => (
     <Text>
       Press <Text style={styles.highlight}>Cmd or Ctrl + M</Text> or{' '}
-      <Text style={styles.highlight}>Shake</Text> your device to open the React
-      Native debug menu.
+      <Text style={styles.highlight}>Shake</Text> your device to open the Dev
+      Menu.
     </Text>
   ),
 });

--- a/packages/react-native/Libraries/NewAppScreen/components/LearnMoreLinks.js
+++ b/packages/react-native/Libraries/NewAppScreen/components/LearnMoreLinks.js
@@ -60,13 +60,20 @@ const links = [
   },
   {
     id: 7,
+    title: 'Debugging',
+    link: 'https://facebook.github.io/react-native/docs/debugging',
+    description:
+      'Learn about the tools available to debug and inspect your app.',
+  },
+  {
+    id: 8,
     title: 'Help',
-    link: 'https://reactnative.dev/help',
+    link: 'https://facebook.github.io/react-native/help',
     description:
       'Need more help? There are many other React Native developers who may have the answer.',
   },
   {
-    id: 8,
+    id: 9,
     title: 'Follow us on Twitter',
     link: 'https://twitter.com/reactnative',
     description:


### PR DESCRIPTION
Summary:
- Add debugging docs link to `NewAppScreen`.
- Align "React Native debug menu" term in `DebugInstructions` to "Dev Menu".

Changelog:
[General][Changed] Add debugging docs link to new app screen

Differential Revision: D46149252

