### PR TITLE
Refactor to npm-utils

### DIFF
--- a/scripts/__tests__/npm-utils-test.js
+++ b/scripts/__tests__/npm-utils-test.js
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+const {getPackageVersionStrByTag, publishPackage} = require('../npm-utils');
+
+const execMock = jest.fn();
+jest.mock('shelljs', () => ({
+  exec: execMock,
+}));
+
+describe('npm-utils', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.resetAllMocks();
+  });
+
+  describe('getPackageVersionStrByTag', () => {
+    it('should return package version string', () => {
+      execMock.mockImplementationOnce(() => ({code: 0, stdout: '0.34.2 \n'}));
+      const versionStr = getPackageVersionStrByTag('my-package', 'next');
+      expect(versionStr).toBe('0.34.2');
+    });
+    it('should throw error when invalid result', () => {
+      execMock.mockImplementationOnce(() => ({
+        code: 1,
+        stderr: 'Some error message',
+      }));
+
+      expect(() => {
+        getPackageVersionStrByTag('my-package', 'next');
+      }).toThrow('Failed to get next version from npm\nSome error message');
+    });
+  });
+
+  describe('publishPackage', () => {
+    it('should run publish command', () => {
+      publishPackage(
+        'path/to/my-package',
+        {tag: 'latest', otp: 'otp'},
+        {silent: true, cwd: 'i/expect/this/to/be/overriden'},
+      );
+      expect(execMock).toHaveBeenCalledWith(
+        'npm publish --tag latest --otp otp',
+        {silent: true, cwd: 'path/to/my-package'},
+      );
+    });
+
+    it('should run publish command when no execOptions', () => {
+      publishPackage('path/to/my-package', {tag: 'latest', otp: 'otp'});
+      expect(execMock).toHaveBeenCalledWith(
+        'npm publish --tag latest --otp otp',
+        {cwd: 'path/to/my-package'},
+      );
+    });
+  });
+});

--- a/scripts/__tests__/publish-npm-test.js
+++ b/scripts/__tests__/publish-npm-test.js
@@ -88,7 +88,7 @@ describe('publish-npm', () => {
         true,
       );
       expect(execMock.mock.calls[0][0]).toBe(
-        `npm view react-native dist-tags.next`,
+        `npm view react-native@next version`,
       );
       expect(execMock.mock.calls[1][0]).toBe(
         `node scripts/set-rn-version.js --to-version ${expectedVersion} --build-type nightly`,
@@ -111,7 +111,7 @@ describe('publish-npm', () => {
 
       expect(publishAndroidArtifactsToMavenMock).not.toBeCalled();
       expect(execMock.mock.calls[0][0]).toBe(
-        `npm view react-native dist-tags.next`,
+        `npm view react-native@next version`,
       );
       expect(execMock.mock.calls[1][0]).toBe(
         `node scripts/set-rn-version.js --to-version ${expectedVersion} --build-type nightly`,

--- a/scripts/monorepo/find-and-publish-all-bumped-packages.js
+++ b/scripts/monorepo/find-and-publish-all-bumped-packages.js
@@ -101,19 +101,12 @@ const findAndPublishAllBumpedPackages = () => {
         );
       }
 
-      const npmOTPFlag = NPM_CONFIG_OTP ? `--otp ${NPM_CONFIG_OTP}` : '';
-
-      const {status, stderr} = spawnSync('npm', ['publish', `${npmOTPFlag}`], {
-        cwd: packageAbsolutePath,
-        shell: true,
-        stdio: 'pipe',
-        encoding: 'utf-8',
-      });
-      if (status !== 0) {
+      const result = publishPackage(packageAbsolutePath, {otp: NPM_CONFIG_OTP});
+      if (result.code !== 0) {
         console.log(
-          `\u274c Failed to publish version ${nextVersion} of ${packageManifest.name}. npm publish exited with code ${status}:`,
+          `\u274c Failed to publish version ${nextVersion} of ${packageManifest.name}. npm publish exited with code ${result.code}:`,
         );
-        console.log(stderr);
+        console.log(result.stderr);
 
         process.exit(1);
       } else {

--- a/scripts/npm-utils.js
+++ b/scripts/npm-utils.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+'use strict';
+
+const {exec} = require('shelljs');
+
+function getPackageVersionStrByTag(packageName, tag) {
+  const result = exec(`npm view ${packageName}@${tag} version`);
+
+  if (result.code) {
+    throw `Failed to get ${tag} version from npm\n${result.stderr}`;
+  }
+  return result.stdout.trim();
+}
+
+function publishPackage(packagePath, packageOptions, execOptions) {
+  const {tag, otp} = packageOptions;
+  const tagFlag = tag ? ` --tag ${tag}` : '';
+  const otpFlag = otp ? ` --otp ${otp}` : '';
+  const options = execOptions
+    ? {...execOptions, cwd: packagePath}
+    : {cwd: packagePath};
+
+  return exec(`npm publish${tagFlag}${otpFlag}`, options);
+}
+
+module.exports = {
+  getPackageVersionStrByTag,
+  publishPackage,
+};


### PR DESCRIPTION
Summary:
Changelog: [Internal] Refactor some npm commands and centralize in npm-utils.

For now, centralize `getPackageVersionStrByTag` and `publishPackage` and update:
1. `publish-npm` to use utilities. This is how we publish `react-native` for commitlies, releases, and nightlies
2. Update `find-and-publish-all-bumped-packages.js` where we publish our monorepo dependencies

Reviewed By: cortinico, hoxyq

Differential Revision: D46131120

