### PR TITLE
Add ReactNativeConfig.DEFAULT_CONFIG as default parameter for ReactNativeConfig

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHostDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHostDelegate.kt
@@ -35,6 +35,7 @@ interface ReactHostDelegate {
 
   fun handleInstanceException(e: Exception)
 
+  // TODO: remove TurboModuleManager as a parameter
   fun getReactNativeConfig(turboModuleManager: TurboModuleManager): ReactNativeConfig
 
   @UnstableReactNativeAPI
@@ -45,7 +46,7 @@ interface ReactHostDelegate {
       private val jsBundleLoader: JSBundleLoader,
       private val turboModuleManagerDelegate: TurboModuleManagerDelegate,
       private val jsEngineInstance: JSEngineInstance,
-      private val reactNativeConfig: ReactNativeConfig,
+      private val reactNativeConfig: ReactNativeConfig = ReactNativeConfig.DEFAULT_CONFIG,
       private val exceptionHandler: (Exception) -> Unit = {}
   ) : ReactHostDelegate {
     override fun getJSBundleLoader(context: Context) = jsBundleLoader

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHostDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHostDelegate.kt
@@ -23,7 +23,7 @@ import com.facebook.react.turbomodule.core.TurboModuleManagerDelegate
 interface ReactHostDelegate {
   val jSMainModulePath: String
 
-  val bindingsInstaller: BindingsInstaller
+  val bindingsInstaller: BindingsInstaller?
 
   val reactPackages: List<ReactPackage>
 
@@ -40,7 +40,7 @@ interface ReactHostDelegate {
   @UnstableReactNativeAPI
   class ReactHostDelegateBase(
       override val jSMainModulePath: String,
-      override val bindingsInstaller: BindingsInstaller,
+      override val bindingsInstaller: BindingsInstaller? = null,
       override val reactPackages: List<ReactPackage>,
       private val jsBundleLoader: JSBundleLoader,
       private val turboModuleManagerDelegate: TurboModuleManagerDelegate,


### PR DESCRIPTION
Summary:
Add ReactNativeConfig.DEFAULT_CONFIG as default parameter for ReactNativeConfig

changelog: [internal] internal

Reviewed By: cortinico, philIip

Differential Revision: D45662330

