### PR TITLE
Introduce DefaultReactHostDelegate

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/BindingsInstaller.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/BindingsInstaller.kt
@@ -13,7 +13,7 @@ import com.facebook.proguard.annotations.DoNotStripAny
 import com.facebook.soloader.SoLoader
 
 @DoNotStripAny
-abstract class BindingsInstaller(@field:DoNotStrip private val mHybridData: HybridData) {
+abstract class BindingsInstaller(@field:DoNotStrip private val mHybridData: HybridData?) {
   companion object {
     init {
       SoLoader.loadLibrary("rninstance")

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHost.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHost.java
@@ -945,7 +945,7 @@ public class ReactHost {
                   // Since metro is running, fetch the JS bundle from the server
                   return loadJSBundleFromMetro();
                 }
-                return Task.forResult(mReactHostDelegate.getJSBundleLoader(mContext));
+                return Task.forResult(mReactHostDelegate.getJSBundleLoader());
               },
               mBGExecutor);
     } else {
@@ -960,7 +960,7 @@ public class ReactHost {
        * throws an exception, the task will fault, and we'll go through the ReactHost error
        * reporting pipeline.
        */
-      return Task.call(() -> mReactHostDelegate.getJSBundleLoader(mContext));
+      return Task.call(() -> mReactHostDelegate.getJSBundleLoader());
     }
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHostDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHostDelegate.kt
@@ -35,6 +35,7 @@ interface ReactHostDelegate {
 
   fun handleInstanceException(e: Exception)
 
+  // TODO: remove TurboModuleManager as a parameter
   fun getReactNativeConfig(turboModuleManager: TurboModuleManager): ReactNativeConfig
 
   @UnstableReactNativeAPI
@@ -45,7 +46,7 @@ interface ReactHostDelegate {
       private val jsBundleLoader: JSBundleLoader,
       private val turboModuleManagerDelegate: TurboModuleManagerDelegate,
       private val jsEngineInstance: JSEngineInstance,
-      private val reactNativeConfig: ReactNativeConfig,
+      private val reactNativeConfig: ReactNativeConfig = ReactNativeConfig.DEFAULT_CONFIG,
       private val exceptionHandler: (Exception) -> Unit = {}
   ) : ReactHostDelegate {
     override fun getJSBundleLoader(context: Context) = jsBundleLoader

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHostDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHostDelegate.kt
@@ -32,7 +32,7 @@ interface ReactHostDelegate {
 
   fun getTurboModuleManagerDelegate(context: ReactApplicationContext): TurboModuleManagerDelegate
 
-  fun handleInstanceException(e: Exception)
+  fun handleInstanceException(error: Exception)
 
   fun getReactNativeConfig(context: ReactContext): ReactNativeConfig
 
@@ -46,7 +46,7 @@ interface ReactHostDelegate {
       private val turboModuleManagerDelegate:
           (context: ReactApplicationContext) -> TurboModuleManagerDelegate,
       private val reactNativeConfig: ReactNativeConfig = ReactNativeConfig.DEFAULT_CONFIG,
-      private val exceptionHandler: (Exception) -> Unit = {}
+      private val exceptionHandler: (error: Exception) -> Unit = {}
   ) : ReactHostDelegate {
 
     override fun getTurboModuleManagerDelegate(context: ReactApplicationContext) =
@@ -54,6 +54,6 @@ interface ReactHostDelegate {
 
     override fun getReactNativeConfig(context: ReactContext) = reactNativeConfig
 
-    override fun handleInstanceException(e: Exception) = exceptionHandler(e)
+    override fun handleInstanceException(error: Exception) = exceptionHandler(error)
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHostDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHostDelegate.kt
@@ -23,7 +23,7 @@ import com.facebook.react.turbomodule.core.TurboModuleManagerDelegate
 interface ReactHostDelegate {
   val jSMainModulePath: String
 
-  val bindingsInstaller: BindingsInstaller
+  val bindingsInstaller: BindingsInstaller?
 
   val reactPackages: List<ReactPackage>
 
@@ -40,7 +40,7 @@ interface ReactHostDelegate {
   @UnstableReactNativeAPI
   class ReactHostDelegateBase(
       override val jSMainModulePath: String,
-      override val bindingsInstaller: BindingsInstaller,
+      override val bindingsInstaller: BindingsInstaller? = null,
       override val reactPackages: List<ReactPackage>,
       private val jsBundleLoader: JSBundleLoader,
       private val turboModuleManagerDelegate: TurboModuleManagerDelegate,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHostDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHostDelegate.kt
@@ -7,14 +7,13 @@
 
 package com.facebook.react.bridgeless
 
-import android.content.Context
 import com.facebook.infer.annotation.ThreadSafe
 import com.facebook.react.ReactPackage
 import com.facebook.react.bridge.JSBundleLoader
 import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContext
 import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.fabric.ReactNativeConfig
-import com.facebook.react.turbomodule.core.TurboModuleManager
 import com.facebook.react.turbomodule.core.TurboModuleManagerDelegate
 
 /** TODO: add javadoc for class and methods */
@@ -27,36 +26,33 @@ interface ReactHostDelegate {
 
   val reactPackages: List<ReactPackage>
 
-  fun getJSBundleLoader(context: Context): JSBundleLoader
+  val jSEngineInstance: JSEngineInstance
+
+  val jSBundleLoader: JSBundleLoader
 
   fun getTurboModuleManagerDelegate(context: ReactApplicationContext): TurboModuleManagerDelegate
 
-  fun getJSEngineInstance(context: ReactApplicationContext): JSEngineInstance
-
   fun handleInstanceException(e: Exception)
 
-  // TODO: remove TurboModuleManager as a parameter
-  fun getReactNativeConfig(turboModuleManager: TurboModuleManager): ReactNativeConfig
+  fun getReactNativeConfig(context: ReactContext): ReactNativeConfig
 
   @UnstableReactNativeAPI
   class ReactHostDelegateBase(
       override val jSMainModulePath: String,
+      override val jSBundleLoader: JSBundleLoader,
+      override val jSEngineInstance: JSEngineInstance,
+      override val reactPackages: List<ReactPackage> = emptyList(),
       override val bindingsInstaller: BindingsInstaller? = null,
-      override val reactPackages: List<ReactPackage>,
-      private val jsBundleLoader: JSBundleLoader,
-      private val turboModuleManagerDelegate: TurboModuleManagerDelegate,
-      private val jsEngineInstance: JSEngineInstance,
+      private val turboModuleManagerDelegate:
+          (context: ReactApplicationContext) -> TurboModuleManagerDelegate,
       private val reactNativeConfig: ReactNativeConfig = ReactNativeConfig.DEFAULT_CONFIG,
       private val exceptionHandler: (Exception) -> Unit = {}
   ) : ReactHostDelegate {
-    override fun getJSBundleLoader(context: Context) = jsBundleLoader
 
     override fun getTurboModuleManagerDelegate(context: ReactApplicationContext) =
-        turboModuleManagerDelegate
+        turboModuleManagerDelegate(context)
 
-    override fun getJSEngineInstance(context: ReactApplicationContext) = jsEngineInstance
-
-    override fun getReactNativeConfig(turboModuleManager: TurboModuleManager) = reactNativeConfig
+    override fun getReactNativeConfig(context: ReactContext) = reactNativeConfig
 
     override fun handleInstanceException(e: Exception) = exceptionHandler(e)
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactInstance.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactInstance.java
@@ -150,7 +150,7 @@ final class ReactInstance {
           }
         });
 
-    JSEngineInstance jsEngineInstance = mDelegate.getJSEngineInstance(mBridgelessReactContext);
+    JSEngineInstance jsEngineInstance = mDelegate.getJSEngineInstance();
     BindingsInstaller bindingsInstaller = mDelegate.getBindingsInstaller();
     // Notify JS if profiling is enabled
     boolean isProfiling =
@@ -225,7 +225,7 @@ final class ReactInstance {
     mFabricUIManager =
         new FabricUIManager(mBridgelessReactContext, viewManagerRegistry, eventBeatManager);
 
-    ReactNativeConfig config = mDelegate.getReactNativeConfig(mTurboModuleManager);
+    ReactNativeConfig config = mDelegate.getReactNativeConfig(mBridgelessReactContext);
 
     // Misc initialization that needs to be done before Fabric init
     DisplayMetricsHolder.initDisplayMetricsIfNotInitialized(mBridgelessReactContext);
@@ -383,7 +383,7 @@ final class ReactInstance {
       JavaTimerManager timerManager,
       JSTimerExecutor jsTimerExecutor,
       ReactJsExceptionHandler jReactExceptionsManager,
-      BindingsInstaller jBindingsInstaller,
+      @Nullable BindingsInstaller jBindingsInstaller,
       boolean isProfiling);
 
   @DoNotStrip

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/hermes/HermesInstance.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/hermes/HermesInstance.kt
@@ -12,7 +12,7 @@ import com.facebook.jni.annotations.DoNotStrip
 import com.facebook.react.bridgeless.JSEngineInstance
 import com.facebook.soloader.SoLoader
 
-class HermesInstance() : JSEngineInstance(initHybrid()!!) {
+class HermesInstance : JSEngineInstance(initHybrid()!!) {
 
   companion object {
     @JvmStatic @DoNotStrip protected external fun initHybrid(): HybridData?

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/hermes/HermesInstance.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/hermes/HermesInstance.kt
@@ -11,7 +11,6 @@ import com.facebook.jni.HybridData
 import com.facebook.jni.annotations.DoNotStrip
 import com.facebook.react.bridgeless.JSEngineInstance
 import com.facebook.soloader.SoLoader
-import kotlin.jvm.JvmStatic
 
 class HermesInstance() : JSEngineInstance(initHybrid()!!) {
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultBindingsInstaller.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultBindingsInstaller.kt
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.defaults
+
+import com.facebook.react.bridgeless.BindingsInstaller
+import com.facebook.react.common.annotations.UnstableReactNativeAPI
+
+@UnstableReactNativeAPI class DefaultBindingsInstaller : BindingsInstaller(null) {}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactHostDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactHostDelegate.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.defaults
+
+import com.facebook.react.ReactPackage
+import com.facebook.react.bridge.JSBundleLoader
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContext
+import com.facebook.react.bridgeless.BindingsInstaller
+import com.facebook.react.bridgeless.JSEngineInstance
+import com.facebook.react.bridgeless.ReactHostDelegate
+import com.facebook.react.bridgeless.hermes.HermesInstance
+import com.facebook.react.common.annotations.UnstableReactNativeAPI
+import com.facebook.react.fabric.ReactNativeConfig
+import com.facebook.react.turbomodule.core.TurboModuleManagerDelegate
+
+@UnstableReactNativeAPI
+class DefaultReactHostDelegate(
+    override val jSMainModulePath: String,
+    override val jSBundleLoader: JSBundleLoader,
+    override val reactPackages: List<ReactPackage> = emptyList(),
+    override val jSEngineInstance: JSEngineInstance = HermesInstance(),
+    override val bindingsInstaller: BindingsInstaller = DefaultBindingsInstaller(),
+    private val turboModuleManagerDelegate:
+        (context: ReactApplicationContext) -> TurboModuleManagerDelegate,
+    private val reactNativeConfig: ReactNativeConfig = ReactNativeConfig.DEFAULT_CONFIG,
+    private val exceptionHandler: (Exception) -> Unit = {}
+) : ReactHostDelegate {
+
+  override fun getTurboModuleManagerDelegate(context: ReactApplicationContext) =
+      turboModuleManagerDelegate(context)
+
+  override fun getReactNativeConfig(context: ReactContext) = reactNativeConfig
+
+  override fun handleInstanceException(error: Exception) = exceptionHandler(error)
+}

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridgeless/ReactHostDelegateTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridgeless/ReactHostDelegateTest.kt
@@ -40,12 +40,12 @@ class ReactHostDelegateTest {
     val delegate =
         ReactHostDelegate.ReactHostDelegateBase(
             jsMainModulePathMocked,
-            jsBundleLoader = jsBundleLoader,
+            jSBundleLoader = jsBundleLoader,
             reactPackages = reactPackages,
             bindingsInstaller = bindingsInstallerMock,
-            jsEngineInstance = jsEngineInstanceMock,
+            jSEngineInstance = jsEngineInstanceMock,
             reactNativeConfig = reactNativeConfigMock,
-            turboModuleManagerDelegate = turboModuleManagerDelegateMock,
+            turboModuleManagerDelegate = { turboModuleManagerDelegateMock },
             exceptionHandler = {})
 
     assertThat(delegate.jSMainModulePath).isEqualTo(jsMainModulePathMocked)

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridgeless/ReactHostDelegateTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridgeless/ReactHostDelegateTest.kt
@@ -7,10 +7,10 @@
 
 package com.facebook.react.bridgeless
 
-import com.facebook.react.ReactPackage
 import com.facebook.react.bridge.JSBundleLoader
+import com.facebook.react.bridgeless.hermes.HermesInstance
 import com.facebook.react.common.annotations.UnstableReactNativeAPI
-import com.facebook.react.fabric.ReactNativeConfig
+import com.facebook.react.defaults.DefaultReactHostDelegate
 import com.facebook.react.turbomodule.core.TurboModuleManagerDelegate
 import com.facebook.testutils.shadows.ShadowSoLoader
 import org.assertj.core.api.Assertions.assertThat
@@ -25,28 +25,23 @@ import org.robolectric.annotation.Config
 @Config(shadows = [ShadowSoLoader::class])
 class ReactHostDelegateTest {
 
-  /** Mock test for ReactInstanceDelegate, used to setup the process to create a stable API */
+  /**
+   * Mock test for {@link DefaultReactHostDelegate}, used to setup the process to create a stable
+   * API
+   */
   @Test
-  fun testReactInstanceDelegateCreation() {
+  fun testDefaultReactHostDelegateCreation() {
     val jsBundleLoader: JSBundleLoader = Mockito.mock(JSBundleLoader::class.java)
-    val reactPackage: ReactPackage = Mockito.mock(ReactPackage::class.java)
-    val bindingsInstallerMock: BindingsInstaller = Mockito.mock(BindingsInstaller::class.java)
     val turboModuleManagerDelegateMock: TurboModuleManagerDelegate =
         Mockito.mock(TurboModuleManagerDelegate::class.java)
-    val jsEngineInstanceMock: JSEngineInstance = Mockito.mock(JSEngineInstance::class.java)
-    val reactNativeConfigMock: ReactNativeConfig = Mockito.mock(ReactNativeConfig::class.java)
-    val reactPackages = listOf(reactPackage)
+    val hermesInstance: JSEngineInstance = Mockito.mock(HermesInstance::class.java)
     val jsMainModulePathMocked = "mockedJSMainModulePath"
     val delegate =
-        ReactHostDelegate.ReactHostDelegateBase(
-            jsMainModulePathMocked,
+        DefaultReactHostDelegate(
+            jSMainModulePath = jsMainModulePathMocked,
             jSBundleLoader = jsBundleLoader,
-            reactPackages = reactPackages,
-            bindingsInstaller = bindingsInstallerMock,
-            jSEngineInstance = jsEngineInstanceMock,
-            reactNativeConfig = reactNativeConfigMock,
-            turboModuleManagerDelegate = { turboModuleManagerDelegateMock },
-            exceptionHandler = {})
+            jSEngineInstance = hermesInstance,
+            turboModuleManagerDelegate = { turboModuleManagerDelegateMock })
 
     assertThat(delegate.jSMainModulePath).isEqualTo(jsMainModulePathMocked)
   }

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridgeless/ReactHostTest.java
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridgeless/ReactHostTest.java
@@ -20,7 +20,6 @@ import android.app.Activity;
 import com.facebook.react.MemoryPressureRouter;
 import com.facebook.react.bridge.JSBundleLoader;
 import com.facebook.react.bridge.MemoryPressureListener;
-import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.UIManager;
 import com.facebook.react.bridgeless.internal.bolts.TaskCompletionSource;
 import com.facebook.react.devsupport.interfaces.PackagerStatusCallback;
@@ -32,7 +31,6 @@ import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentMatchers;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
@@ -83,9 +81,7 @@ public class ReactHostTest {
     whenNew(MemoryPressureRouter.class).withAnyArguments().thenReturn(mMemoryPressureRouter);
     whenNew(BridgelessDevSupportManager.class).withAnyArguments().thenReturn(mDevSupportManager);
 
-    doReturn(mJSBundleLoader)
-        .when(mReactHostDelegate)
-        .getJSBundleLoader(ArgumentMatchers.<ReactApplicationContext>any());
+    doReturn(mJSBundleLoader).when(mReactHostDelegate).getJSBundleLoader();
 
     mReactHost =
         new ReactHost(


### PR DESCRIPTION
Summary:
Introduce DefaultReactHostDelegate class that will be used to simplify creation of ReactHostDelegate in React Native Android

changelog: [internal] internal

Reviewed By: cortinico, philIip

Differential Revision: D45665528

