### PR TITLE
introduce a private API for RCTHost to refresh its bundle url

### DIFF
--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost+Internal.h
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost+Internal.h
@@ -7,8 +7,11 @@
 
 #import "RCTHost.h"
 
+typedef NSURL * (^RCTHostBundleURLProvider)(void);
+
 @interface RCTHost (Internal)
 
 - (void)registerSegmentWithId:(NSNumber *)segmentId path:(NSString *)path;
+- (void)setBundleURLProvider:(RCTHostBundleURLProvider)bundleURLProvider;
 
 @end

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.h
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.h
@@ -29,7 +29,6 @@ typedef std::shared_ptr<facebook::react::JSEngineInstance> (^RCTHostJSEngineProv
 
 @protocol RCTHostDelegate <NSObject>
 
-- (NSURL *)getBundleURL;
 - (std::shared_ptr<facebook::react::ContextContainer>)createContextContainer;
 
 - (void)host:(RCTHost *)host

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.h
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.h
@@ -48,10 +48,11 @@ typedef std::shared_ptr<facebook::react::JSEngineInstance> (^RCTHostJSEngineProv
  */
 @interface RCTHost : NSObject
 
-- (instancetype)initWithHostDelegate:(id<RCTHostDelegate>)hostDelegate
-          turboModuleManagerDelegate:(id<RCTTurboModuleManagerDelegate>)turboModuleManagerDelegate
-                 bindingsInstallFunc:(facebook::react::ReactInstance::BindingsInstallFunc)bindingsInstallFunc
-                    jsEngineProvider:(RCTHostJSEngineProvider)jsEngineProvider NS_DESIGNATED_INITIALIZER FB_OBJC_DIRECT;
+- (instancetype)initWithBundleURL:(NSURL *)bundleURL
+                     hostDelegate:(id<RCTHostDelegate>)hostDelegate
+       turboModuleManagerDelegate:(id<RCTTurboModuleManagerDelegate>)turboModuleManagerDelegate
+              bindingsInstallFunc:(facebook::react::ReactInstance::BindingsInstallFunc)bindingsInstallFunc
+                 jsEngineProvider:(RCTHostJSEngineProvider)jsEngineProvider NS_DESIGNATED_INITIALIZER FB_OBJC_DIRECT;
 
 /**
  * This function initializes an RCTInstance if one does not yet exist.  This function is currently only called on the

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.mm
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.mm
@@ -52,10 +52,11 @@ using namespace facebook::react;
  Host initialization should not be resource intensive. A host may be created before any intention of using React Native
  has been expressed.
  */
-- (instancetype)initWithHostDelegate:(id<RCTHostDelegate>)hostDelegate
-          turboModuleManagerDelegate:(id<RCTTurboModuleManagerDelegate>)turboModuleManagerDelegate
-                 bindingsInstallFunc:(facebook::react::ReactInstance::BindingsInstallFunc)bindingsInstallFunc
-                    jsEngineProvider:(RCTHostJSEngineProvider)jsEngineProvider
+- (instancetype)initWithBundleURL:(NSURL *)bundleURL
+                     hostDelegate:(id<RCTHostDelegate>)hostDelegate
+       turboModuleManagerDelegate:(id<RCTTurboModuleManagerDelegate>)turboModuleManagerDelegate
+              bindingsInstallFunc:(facebook::react::ReactInstance::BindingsInstallFunc)bindingsInstallFunc
+                 jsEngineProvider:(RCTHostJSEngineProvider)jsEngineProvider
 {
   if (self = [super init]) {
     _hostDelegate = hostDelegate;
@@ -78,7 +79,7 @@ using namespace facebook::react;
       return strongSelf->_bundleURL;
     };
 
-    auto bundleURLSetter = ^(NSURL *bundleURL) {
+    auto bundleURLSetter = ^(NSURL *bundleURL_) {
       [weakSelf _setBundleURL:bundleURL];
     };
 
@@ -92,6 +93,7 @@ using namespace facebook::react;
       return [strongSelf->_hostDelegate getBundleURL];
     };
 
+    [self _setBundleURL:bundleURL];
     [_bundleManager setBridgelessBundleURLGetter:bundleURLGetter
                                        andSetter:bundleURLSetter
                                 andDefaultGetter:defaultBundleURLGetter];
@@ -140,7 +142,6 @@ using namespace facebook::react;
         @"RCTHost should not be creating a new instance if one already exists. This implies there is a bug with how/when this method is being called.");
     [_instance invalidate];
   }
-  [self _setBundleURL:[_hostDelegate getBundleURL]];
   _instance = [[RCTInstance alloc] initWithDelegate:self
                                    jsEngineInstance:[self _provideJSEngine]
                                       bundleManager:_bundleManager

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHostCreationHelpers.h
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHostCreationHelpers.h
@@ -20,6 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 RCT_EXTERN_C_BEGIN
 
 RCTHost *RCTHostCreateDefault(
+    NSURL *bundleURL,
     id<RCTHostDelegate> hostDelegate,
     id<RCTTurboModuleManagerDelegate> turboModuleManagerDelegate,
     RCTHostJSEngineProvider jsEngineProvider);

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHostCreationHelpers.mm
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHostCreationHelpers.mm
@@ -8,12 +8,14 @@
 #import "RCTHostCreationHelpers.h"
 
 RCTHost *RCTHostCreateDefault(
+    NSURL *bundleURL,
     id<RCTHostDelegate> hostDelegate,
     id<RCTTurboModuleManagerDelegate> turboModuleManagerDelegate,
     RCTHostJSEngineProvider jsEngineProvider)
 {
-  return [[RCTHost alloc] initWithHostDelegate:hostDelegate
-                    turboModuleManagerDelegate:turboModuleManagerDelegate
-                           bindingsInstallFunc:nullptr
-                              jsEngineProvider:jsEngineProvider];
+  return [[RCTHost alloc] initWithBundleURL:bundleURL
+                               hostDelegate:hostDelegate
+                 turboModuleManagerDelegate:turboModuleManagerDelegate
+                        bindingsInstallFunc:nullptr
+                           jsEngineProvider:jsEngineProvider];
 }


### PR DESCRIPTION
Summary:
Changelog: [Internal]

in the situation where we want to refresh the bundle url due to developer mode, we add a private API that allows the host to refresh its bundle URL if needed. this private API will be called on cmd + R, which is the only case that supports the changing bundle URL in the middle of the app session.

Reviewed By: cipolleschi

Differential Revision: D45937856

