### PR TITLE
Allow string `transform` style in TypeScript

### DIFF
--- a/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.d.ts
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.d.ts
@@ -190,6 +190,7 @@ export interface TransformsStyle {
         | SkewYTransform
         | MatrixTransform
       )[]
+    | string
     | undefined;
   /**
    * @deprecated Use matrix in transform prop instead.


### PR DESCRIPTION
Summary:
Fixes https://github.com/facebook/react-native/issues/37543

Missed as part of D39423409 (or maybe we didn't have TS types inline yet?)

Changelog:
[General][Fixed] - Allow string `transform` style in TypeScript

Differential Revision: D46161450

