### PR TITLE
Terminate instead of throwing if TurboModule callback double-called

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/core/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/CMakeLists.txt
@@ -32,6 +32,7 @@ target_include_directories(react_nativemodule_core
 target_link_libraries(react_nativemodule_core
         fbjni
         folly_runtime
+        glog
         jsi
         react_bridging
         react_debug

--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboCxxModule.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboCxxModule.cpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include <ReactCommon/TurboModuleUtils.h>
+#include <glog/logging.h>
 #include <jsi/JSIDynamic.h>
 
 using namespace facebook;
@@ -24,7 +25,7 @@ CxxModule::Callback makeTurboCxxModuleCallback(
   return [weakWrapper,
           wrapperWasCalled = false](std::vector<folly::dynamic> args) mutable {
     if (wrapperWasCalled) {
-      throw std::runtime_error("callback arg cannot be called more than once");
+      LOG(FATAL) << "callback arg cannot be called more than once";
     }
 
     auto strongWrapper = weakWrapper.lock();

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaTurboModule.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaTurboModule.cpp
@@ -10,6 +10,7 @@
 #include <string>
 
 #include <fbjni/fbjni.h>
+#include <glog/logging.h>
 #include <jsi/jsi.h>
 
 #include <ReactCommon/TurboModule.h>
@@ -83,8 +84,7 @@ jni::local_ref<JCxxCallbackImpl::JavaPart> createJavaCallbackFromJSIFunction(
        callbackWrapperOwner = std::move(callbackWrapperOwner),
        wrapperWasCalled = false](folly::dynamic responses) mutable {
         if (wrapperWasCalled) {
-          throw std::runtime_error(
-              "Callback arg cannot be called more than once");
+          LOG(FATAL) << "callback arg cannot be called more than once";
         }
 
         auto strongWrapper = weakWrapper.lock();

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/React-NativeModulesApple.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/React-NativeModulesApple.podspec
@@ -42,6 +42,7 @@ Pod::Spec.new do |s|
 
     s.source_files = "ReactCommon/**/*.{mm,cpp,h}"
 
+    s.dependency "glog"
     s.dependency "ReactCommon/turbomodule/core"
     s.dependency "ReactCommon/turbomodule/bridging"
     s.dependency "React-callinvoker"

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
@@ -8,6 +8,7 @@
 #import "RCTTurboModule.h"
 #import "RCTBlockGuard.h"
 
+#include <glog/logging.h>
 #import <objc/message.h>
 #import <objc/runtime.h>
 #import <atomic>
@@ -184,7 +185,7 @@ convertJSIFunctionToCallback(jsi::Runtime &runtime, const jsi::Function &value, 
   BOOL __block wrapperWasCalled = NO;
   RCTResponseSenderBlock callback = ^(NSArray *responses) {
     if (wrapperWasCalled) {
-      throw std::runtime_error("callback arg cannot be called more than once");
+      LOG(FATAL) << "callback arg cannot be called more than once";
     }
 
     auto strongWrapper = weakWrapper.lock();


### PR DESCRIPTION
Summary:
If a TM calls a completion callback, or resolves or rejects a promise multiple times, a C++ exception is thrown.

For an in the wild crash, we are getting this signal as:
1. `libdispatch` calls std::terminate while pumping a thread's message queue
2. The hooked FB app termination handler is called
3. Our termination handler introspects the currently thrown exception.
4. The handler introspecting the currently thrown exception sees this C++ exception being thrown, suggesting `libdispatch` termination may be due to unhandled C++ exception
4. We have lost the stack trace by this point of the code invoking the returned lambas

I think if we change the time of `abort()` to when the callback is called, we might be able to preserve the stack trace of module code calling the callback.

Differential Revision: D46175685

