### PR TITLE
[Codegen 114] Extract getTypeAnnotationFromProperty from buildPropertiesForEvent into specific parsers

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-test.js
@@ -306,6 +306,41 @@ describe('FlowParser', () => {
     });
   });
 
+  describe('getTypeAnnotationFromProperty', () => {
+    describe('when property value type is NullableTypeAnnotation', () => {
+      it('returns typeAnnotation of the value', () => {
+        const typeAnnotation = {
+          type: 'StringTypeAnnotation',
+        };
+
+        const property = {
+          value: {
+            type: 'NullableTypeAnnotation',
+            typeAnnotation: typeAnnotation,
+          },
+        };
+
+        expect(parser.getTypeAnnotationFromProperty(property)).toEqual(
+          typeAnnotation,
+        );
+      });
+    });
+
+    describe('when property value type is not NullableTypeAnnotation', () => {
+      it('returns the value', () => {
+        const value = {
+          type: 'StringTypeAnnotation',
+        };
+
+        const property = {
+          value: value,
+        };
+
+        expect(parser.getTypeAnnotationFromProperty(property)).toEqual(value);
+      });
+    });
+  });
+
   describe('typeAlias', () => {
     it('returns typeAlias Property', () => {
       expect(parser.typeAlias).toEqual('TypeAlias');
@@ -598,6 +633,30 @@ describe('TypeScriptParser', () => {
         optional: false,
       };
       expect(parser.isOptionalProperty(property)).toEqual(false);
+    });
+  });
+
+  describe('getTypeAnnotationFromProperty', () => {
+    it('returns the type annotation', () => {
+      const typeAnnotation = {
+        type: 'TSStringKeyword',
+        key: {
+          type: 'Identifier',
+          name: 'b',
+        },
+        members: [],
+      };
+
+      const property = {
+        typeAnnotation: {
+          type: 'TSTypeAnnotation',
+          typeAnnotation: typeAnnotation,
+        },
+      };
+
+      expect(parser.getTypeAnnotationFromProperty(property)).toEqual(
+        typeAnnotation,
+      );
     });
   });
 

--- a/packages/react-native-codegen/src/parsers/flow/components/componentsUtils.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/componentsUtils.js
@@ -10,7 +10,6 @@
 
 'use strict';
 
-import type {NamedShape} from '../../../CodegenSchema.js';
 const {getValueFromTypes} = require('../utils.js');
 import type {TypeDeclarationMap, PropAST, ASTNode} from '../../utils';
 import type {BuildSchemaFN, Parser} from '../../parser';

--- a/packages/react-native-codegen/src/parsers/flow/components/events.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/events.js
@@ -264,7 +264,7 @@ function buildPropertiesForEvent(
 ): NamedShape<EventTypeAnnotation> {
   const name = property.key.name;
   const optional = parser.isOptionalProperty(property);
-  let typeAnnotation =
+  const typeAnnotation =
     property.value.type === 'NullableTypeAnnotation'
       ? property.value.typeAnnotation
       : property.value;

--- a/packages/react-native-codegen/src/parsers/flow/components/events.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/events.js
@@ -264,10 +264,7 @@ function buildPropertiesForEvent(
 ): NamedShape<EventTypeAnnotation> {
   const name = property.key.name;
   const optional = parser.isOptionalProperty(property);
-  const typeAnnotation =
-    property.value.type === 'NullableTypeAnnotation'
-      ? property.value.typeAnnotation
-      : property.value;
+  const typeAnnotation = parser.getTypeAnnotationFromProperty(property);
 
   return getPropertyType(name, optional, typeAnnotation, parser);
 }

--- a/packages/react-native-codegen/src/parsers/flow/parser.js
+++ b/packages/react-native-codegen/src/parsers/flow/parser.js
@@ -367,6 +367,12 @@ class FlowParser implements Parser {
     return getSchemaInfo;
   }
 
+  getTypeAnnotationFromProperty(property: PropAST): $FlowFixMe {
+    return property.value.type === 'NullableTypeAnnotation'
+      ? property.value.typeAnnotation
+      : property.value;
+  }
+
   getGetTypeAnnotationFN(): GetTypeAnnotationFN {
     return getTypeAnnotation;
   }

--- a/packages/react-native-codegen/src/parsers/parser.js
+++ b/packages/react-native-codegen/src/parsers/parser.js
@@ -350,6 +350,13 @@ export interface Parser {
 
   getGetSchemaInfoFN(): GetSchemaInfoFN;
 
+  /**
+   * Given a property return the type annotation.
+   * @parameter property
+   * @returns: the annotation for a type in the AST.
+   */
+  getTypeAnnotationFromProperty(property: PropAST): $FlowFixMe;
+
   getResolvedTypeAnnotation(
     typeAnnotation: $FlowFixMe,
     types: TypeDeclarationMap,

--- a/packages/react-native-codegen/src/parsers/parserMock.js
+++ b/packages/react-native-codegen/src/parsers/parserMock.js
@@ -272,6 +272,10 @@ export class MockedParser implements Parser {
     return property.optional || false;
   }
 
+  getTypeAnnotationFromProperty(property: PropAST): $FlowFixMe {
+    return property.typeAnnotation.typeAnnotation;
+  }
+
   getGetTypeAnnotationFN(): GetTypeAnnotationFN {
     return () => {
       return {};

--- a/packages/react-native-codegen/src/parsers/typescript/components/events.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/events.js
@@ -283,7 +283,7 @@ function buildPropertiesForEvent(
 ): NamedShape<EventTypeAnnotation> {
   const name = property.key.name;
   const optional = parser.isOptionalProperty(property);
-  let typeAnnotation = property.typeAnnotation.typeAnnotation;
+  const typeAnnotation = property.typeAnnotation.typeAnnotation;
 
   return getPropertyType(name, optional, typeAnnotation, parser);
 }

--- a/packages/react-native-codegen/src/parsers/typescript/components/events.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/events.js
@@ -283,7 +283,7 @@ function buildPropertiesForEvent(
 ): NamedShape<EventTypeAnnotation> {
   const name = property.key.name;
   const optional = parser.isOptionalProperty(property);
-  const typeAnnotation = property.typeAnnotation.typeAnnotation;
+  const typeAnnotation = parser.getTypeAnnotationFromProperty(property);
 
   return getPropertyType(name, optional, typeAnnotation, parser);
 }

--- a/packages/react-native-codegen/src/parsers/typescript/parser.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parser.js
@@ -363,6 +363,10 @@ class TypeScriptParser implements Parser {
     return getSchemaInfo;
   }
 
+  getTypeAnnotationFromProperty(property: PropAST): $FlowFixMe {
+    return property.typeAnnotation.typeAnnotation;
+  }
+
   getGetTypeAnnotationFN(): GetTypeAnnotationFN {
     return getTypeAnnotation;
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

This PR aims to remove the duplicated logic in [flow|typescript]/components/events.js files to move it in specific parsers. It is a task of https://github.com/facebook/react-native/issues/34872:
> [Codegen 114 - Assigned to @MaeIg] Add a function getTypeAnnotationFromProperty(property) in the Parser object and implement it in FlowParser and TypeScriptParser, using the implementation you can find in the [parsers/flow/components/events.js](https://github.com/facebook/react-native/blob/e133100721939108b0f28dfa9f60ac627c804018/packages/react-native-codegen/src/parsers/flow/components/events.js#L174-L177) and parsers/typescript/components/events.js. Use the parsers in the buildPropertiesForEvent.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

[Internal] [Changed] - Extract getTypeAnnotationFromProperty from buildPropertiesForEvent into specific parsers

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

Flow:
<img width="600" alt="image" src="https://github.com/facebook/react-native/assets/40902940/554bb82d-b492-4550-9a84-254fc4f78285">

Eslint:
<img width="498" alt="image" src="https://github.com/facebook/react-native/assets/40902940/53a302b7-c2aa-4008-9583-2e3b4cddc14c">

Jest:
<img width="395" alt="image" src="https://github.com/facebook/react-native/assets/40902940/c7ff53f1-2be1-4099-b2e6-081128cf5333">


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
