### PR TITLE
Configure JDK Toolchain to 11 for all the 3rd party libraries.

### DIFF
--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
@@ -66,7 +66,6 @@ class ReactPlugin : Plugin<Project> {
       configureBuildConfigFields(project)
       configureDevPorts(project)
       configureBackwardCompatibilityReactMap(project)
-      configureJavaToolChains(project)
 
       project.extensions.getByType(AndroidComponentsExtension::class.java).apply {
         onVariants(selector().all()) { variant ->
@@ -80,6 +79,9 @@ class ReactPlugin : Plugin<Project> {
     project.pluginManager.withPlugin("com.android.library") {
       configureCodegen(project, extension, rootExtension, isLibrary = true)
     }
+
+    // Library and App Configurations
+    configureJavaToolChains(project)
   }
 
   private fun checkJvmVersion(project: Project) {

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/JdkConfiguratorUtils.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/JdkConfiguratorUtils.kt
@@ -8,26 +8,40 @@
 package com.facebook.react.utils
 
 import com.android.build.api.variant.AndroidComponentsExtension
+import com.facebook.react.utils.PropertyUtils.INTERNAL_DISABLE_JAVA_VERSION_ALIGNMENT
+import org.gradle.api.Action
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
+import org.gradle.api.plugins.AppliedPlugin
 import org.jetbrains.kotlin.gradle.dsl.KotlinTopLevelExtension
 
 internal object JdkConfiguratorUtils {
   /**
-   * Function that takes care of configuring the JDK toolchain for Application projects. As we do
-   * decide the JDK version based on the AGP version that RNGP brings over, here we can safely
+   * Function that takes care of configuring the JDK toolchain for all the projects projects. As we
+   * do decide the JDK version based on the AGP version that RNGP brings over, here we can safely
    * configure the toolchain to 11.
    */
-  fun configureJavaToolChains(project: Project) {
-    project.extensions.getByType(AndroidComponentsExtension::class.java).finalizeDsl { ext ->
-      ext.compileOptions.sourceCompatibility = JavaVersion.VERSION_11
-      ext.compileOptions.targetCompatibility = JavaVersion.VERSION_11
+  fun configureJavaToolChains(input: Project) {
+    if (input.hasProperty(INTERNAL_DISABLE_JAVA_VERSION_ALIGNMENT)) {
+      return
     }
-    project.pluginManager.withPlugin("org.jetbrains.kotlin.android") {
-      project.extensions.getByType(KotlinTopLevelExtension::class.java).jvmToolchain(11)
-    }
-    project.pluginManager.withPlugin("org.jetbrains.kotlin.jvm") {
-      project.extensions.getByType(KotlinTopLevelExtension::class.java).jvmToolchain(11)
+    input.rootProject.allprojects { project ->
+      val action =
+          Action<AppliedPlugin> {
+            project.extensions.getByType(AndroidComponentsExtension::class.java).finalizeDsl { ext
+              ->
+              ext.compileOptions.sourceCompatibility = JavaVersion.VERSION_11
+              ext.compileOptions.targetCompatibility = JavaVersion.VERSION_11
+            }
+          }
+      project.pluginManager.withPlugin("com.android.application", action)
+      project.pluginManager.withPlugin("com.android.library", action)
+      project.pluginManager.withPlugin("org.jetbrains.kotlin.android") {
+        project.extensions.getByType(KotlinTopLevelExtension::class.java).jvmToolchain(11)
+      }
+      project.pluginManager.withPlugin("org.jetbrains.kotlin.jvm") {
+        project.extensions.getByType(KotlinTopLevelExtension::class.java).jvmToolchain(11)
+      }
     }
   }
 }

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/PropertyUtils.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/PropertyUtils.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.utils
+
+/** Collection of all the Gradle Propreties that are accepted by React Native Gradle Plugin. */
+object PropertyUtils {
+
+  /**
+   * Internal Property that acts as a killswitch to configure the JDK version and align it for app
+   * and all the libraries.
+   */
+  const val INTERNAL_DISABLE_JAVA_VERSION_ALIGNMENT = "react.internal.disableJavaVersionAlignment"
+}


### PR DESCRIPTION
Summary:
This fixes the behavior reported in https://github.com/reactwg/react-native-releases/discussions/54#discussioncomment-5984629
by forcing all the libraries to compile with JDK 11.

This prevents build issues when on Gradle 8 and Kotlin 1.8

Changelog:
[Internal] [Changed] - Configure JDK Toolchain to 11 for all the 3rd party libraries

Differential Revision: D46190989

