### PR TITLE
[LOCAL] Make sure Java Toolchain and source/target level is applied to all projects

### DIFF
--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
@@ -19,6 +19,7 @@ import com.facebook.react.utils.BackwardCompatUtils.configureBackwardCompatibili
 import com.facebook.react.utils.DependencyUtils.configureDependencies
 import com.facebook.react.utils.DependencyUtils.configureRepositories
 import com.facebook.react.utils.DependencyUtils.readVersionAndGroupStrings
+import com.facebook.react.utils.JdkConfiguratorUtils.configureJavaToolChains
 import com.facebook.react.utils.JsonUtils
 import com.facebook.react.utils.NdkConfiguratorUtils.configureReactNativeNdk
 import com.facebook.react.utils.ProjectUtils.needsCodegenFromPackageJson
@@ -78,6 +79,9 @@ class ReactPlugin : Plugin<Project> {
     project.pluginManager.withPlugin("com.android.library") {
       configureCodegen(project, extension, rootExtension, isLibrary = true)
     }
+
+    // App and Library Configurations
+    configureJavaToolChains(project)
   }
 
   private fun checkJvmVersion(project: Project) {

--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/JdkConfiguratorUtils.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/JdkConfiguratorUtils.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.utils
+
+import com.android.build.api.variant.AndroidComponentsExtension
+import org.gradle.api.Action
+import org.gradle.api.JavaVersion
+import org.gradle.api.Project
+import org.gradle.api.plugins.AppliedPlugin
+
+internal object JdkConfiguratorUtils {
+  /**
+   * Function that takes care of configuring the JDK toolchain for all the projects projects. As we
+   * do decide the JDK version based on the AGP version that RNGP brings over, here we can safely
+   * configure the toolchain to 11.
+   */
+  fun configureJavaToolChains(input: Project) {
+    input.rootProject.allprojects { project ->
+      val action =
+          Action<AppliedPlugin> {
+            project.extensions.getByType(AndroidComponentsExtension::class.java).finalizeDsl {
+                ext ->
+              ext.compileOptions.sourceCompatibility = JavaVersion.VERSION_11
+              ext.compileOptions.targetCompatibility = JavaVersion.VERSION_11
+            }
+          }
+      project.pluginManager.withPlugin("com.android.application", action)
+      project.pluginManager.withPlugin("com.android.library", action)
+    }
+  }
+}


### PR DESCRIPTION
## Summary:

This should fix https://github.com/reactwg/react-native-releases/discussions/54#discussioncomment-5984629 by making sure we set JDK source/target level to 11 for all the modules.

## Changelog:

[INTERNAL] - Make sure Java Toolchain and source/target level is applied to all projects

## Test Plan:

cc @Kudo 