### PR TITLE
Temp: Always report debug info on module not found error

### DIFF
--- a/packages/react-native/Libraries/TurboModule/TurboModuleRegistry.js
+++ b/packages/react-native/Libraries/TurboModule/TurboModuleRegistry.js
@@ -30,8 +30,9 @@ function isTurboModuleInteropEnabled() {
   return global.RN$TurboInterop === true;
 }
 
-function shouldReportLoadedModules() {
-  return isTurboModuleInteropEnabled();
+// TODO(154308585): Remove "module not found" debug info logging
+function shouldReportDebugInfo() {
+  return true;
 }
 
 // TODO(148943970): Consider reversing the lookup here:
@@ -41,7 +42,7 @@ function requireModule<T: TurboModule>(name: string): ?T {
     // Backward compatibility layer during migration.
     const legacyModule = NativeModules[name];
     if (legacyModule != null) {
-      if (shouldReportLoadedModules()) {
+      if (shouldReportDebugInfo()) {
         moduleLoadHistory.NativeModules.push(name);
       }
       return ((legacyModule: $FlowFixMe): T);
@@ -51,17 +52,16 @@ function requireModule<T: TurboModule>(name: string): ?T {
   if (turboModuleProxy != null) {
     const module: ?T = turboModuleProxy(name);
     if (module != null) {
-      if (shouldReportLoadedModules()) {
+      if (shouldReportDebugInfo()) {
         moduleLoadHistory.TurboModules.push(name);
       }
       return module;
     }
   }
 
-  if (shouldReportLoadedModules()) {
+  if (shouldReportDebugInfo()) {
     moduleLoadHistory.NotFound.push(name);
   }
-
   return null;
 }
 
@@ -75,7 +75,12 @@ export function getEnforcing<T: TurboModule>(name: string): T {
     `TurboModuleRegistry.getEnforcing(...): '${name}' could not be found. ` +
     'Verify that a module by this name is registered in the native binary.';
 
-  if (shouldReportLoadedModules()) {
+  if (shouldReportDebugInfo()) {
+    message += 'Bridgeless mode: ' + (isBridgeless() ? 'true' : 'false') + '. ';
+    message +=
+      'TurboModule interop: ' +
+      (isTurboModuleInteropEnabled() ? 'true' : 'false') +
+      '. ';
     message += 'Modules loaded: ' + JSON.stringify(moduleLoadHistory);
   }
 


### PR DESCRIPTION
Summary:
The TurboModule interop layer causes a surge in "module not found" exceptions: T154044825.

After D45102812, this exception **should** have included debug info. But, it didn't.

## Problems
So, there are two problems:
1. No debug logs are getting printed.
2. In the TurboModule interop test group, global.RN$TurboInterop is false **for some reason.** This is **very** strange.

## Changes
1. **Always** print the debug logs.
2. Add more flag-related debug information to the "module not found" debug logs. This will help us validate whether global.RN$TurboInterop is truely false.

## Concerns
> **Always** print the debug logs on Android.

**Question:** Won't this be really expensive?

This shouldn't be too expensive: There are about ~50 native module requires in Fb4a. So: (1) the exception message shouldn't grow to an unreasonable size, (2) we'll only use enough memory to store ~50 strings in the JS VM.

Changelog: [Internal]

Reviewed By: fkgozali

Differential Revision: D46195117

