### PR TITLE
[iOS] Fix Fabric issue with React-Core pod when Xcode project has multiple targets

### DIFF
--- a/packages/react-native/scripts/cocoapods/new_architecture.rb
+++ b/packages/react-native/scripts/cocoapods/new_architecture.rb
@@ -16,7 +16,8 @@ class NewArchitectureHelper
         language_standard = nil
 
         installer.pods_project.targets.each do |target|
-            if target.name == 'React-Core'
+            # The React-Core pod may have a suffix added by Cocoapods, so we test whether 'React-Core' is a substring, and do not require exact match
+            if target.name.include? 'React-Core'
                 language_standard = target.resolved_build_setting("CLANG_CXX_LANGUAGE_STANDARD", resolve_against_xcconfig: true).values[0]
             end
         end
@@ -61,7 +62,8 @@ class NewArchitectureHelper
 
         # Add RCT_NEW_ARCH_ENABLED to generated pod target projects
         installer.target_installation_results.pod_target_installation_results.each do |pod_name, target_installation_result|
-            if pod_name == 'React-Core'
+            # The React-Core pod may have a suffix added by Cocoapods, so we test whether 'React-Core' is a substring, and do not require exact match
+            if pod_name.include? 'React-Core'
                 target_installation_result.native_target.build_configurations.each do |config|
                     config.build_settings['OTHER_CPLUSPLUSFLAGS'] = @@new_arch_cpp_flags
                 end


### PR DESCRIPTION
## Summary:

In Xcode projects with multiple targets, and in particular when targets are for different platforms (e.g. iOS and macOS), Cocoapods may add a suffix to a Pod name like `React-Core`.

When this happens, the code in `new_architecture.rb` (which was looking for a pod with exact name `React-Core`) would not add the preprocessor definitions for Fabric as expected.

This change fixes this issue. Fixes #37102 .

## Changelog:

[iPhone][Fixed] - Fix Fabric issue with React-Core pod when Xcode project has multiple targets

## Test Plan:

Tested that this change fixes this issue which occurs 100% of the time in React Native TV projects.