### PR TITLE
[Actions] Bump `autorebase.yml` to `v1.8`

### DIFF
--- a/.github/workflows/autorebase.yml
+++ b/.github/workflows/autorebase.yml
@@ -1,4 +1,7 @@
 name: Automatic Rebase
+# This workflow is used to automatically rebase a PR when a comment is made
+# containing the text "/rebase". It uses the cirrus-actions/rebase action.
+# See https://github.com/cirrus-actions/rebase
 on:
   issue_comment:
     types: [created]
@@ -6,19 +9,19 @@ permissions:
   contents: read
 jobs:
   rebase:
-    permissions:
-      contents: write  # for cirrus-actions/rebase to push code to rebase
-      pull-requests: read  # for cirrus-actions/rebase to get info about PR
     name: Rebase
-    if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/rebase')
+    permissions:
+      contents: write # for cirrus-actions/rebase to push code to rebase
+      pull-requests: read # for cirrus-actions/rebase to get info about PR
     runs-on: ubuntu-latest
+    if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/rebase')
     steps:
       - name: Checkout the latest code
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }} # TODO: consider using a PAT with required permissions
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
       - name: Automatic Rebase
-        uses: cirrus-actions/rebase@1.7
+        uses: cirrus-actions/rebase@1.8
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # TODO: consider using a PAT with required permissions

--- a/.github/workflows/autorebase.yml
+++ b/.github/workflows/autorebase.yml
@@ -19,9 +19,9 @@ jobs:
       - name: Checkout the latest code
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }} # TODO: consider using a PAT with required permissions
+          token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
       - name: Automatic Rebase
         uses: cirrus-actions/rebase@1.8
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # TODO: consider using a PAT with required permissions
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary:

`cirrus-actions/rebase` `v.1.8` fixes number of bugs.
`v1.8` Changelog: https://github.com/cirrus-actions/rebase/releases/tag/1.8
See: https://github.com/cirrus-actions/rebase


## Changelog:

[GENERAL] [SECURITY] - [Actions] Bump `autorebase.yml` to `v1.8`

## Test Plan:

- `/rebase` comment should rebase the PR as usual.