### PR TITLE
Do not use setNativeState in RuntimeScheduler::Task

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.h
@@ -94,6 +94,11 @@
  */
 - (UIViewController *)createRootViewController;
 
+/// This method controls whether the App will use RuntimeScheduler. Only applicable in the legacy architecture.
+///
+/// @return: `YES` to use RuntimeScheduler, `NO` to use JavaScript scheduler. The default value is `YES`.
+- (BOOL)runtimeSchedulerEnabled;
+
 #if RCT_NEW_ARCH_ENABLED
 @property (nonatomic, strong) RCTSurfacePresenterBridgeAdapter *bridgeAdapter;
 

--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -132,11 +132,16 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
   return [UIViewController new];
 }
 
+- (BOOL)runtimeSchedulerEnabled
+{
+  return YES;
+}
+
 #pragma mark - RCTCxxBridgeDelegate
 - (std::unique_ptr<facebook::react::JSExecutorFactory>)jsExecutorFactoryForBridge:(RCTBridge *)bridge
 {
-  _runtimeScheduler = std::make_shared<facebook::react::RuntimeScheduler>(RCTRuntimeExecutorFromBridge(bridge));
 #if RCT_NEW_ARCH_ENABLED
+  _runtimeScheduler = std::make_shared<facebook::react::RuntimeScheduler>(RCTRuntimeExecutorFromBridge(bridge));
   std::shared_ptr<facebook::react::CallInvoker> callInvoker =
       std::make_shared<facebook::react::RuntimeSchedulerCallInvoker>(_runtimeScheduler);
   RCTTurboModuleManager *turboModuleManager = [[RCTTurboModuleManager alloc] initWithBridge:bridge
@@ -146,6 +151,9 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
   _contextContainer->insert("RuntimeScheduler", _runtimeScheduler);
   return RCTAppSetupDefaultJsExecutorFactory(bridge, turboModuleManager, _runtimeScheduler);
 #else
+  if (self.runtimeSchedulerEnabled) {
+    _runtimeScheduler = std::make_shared<facebook::react::RuntimeScheduler>(RCTRuntimeExecutorFromBridge(bridge));
+  }
   return RCTAppSetupJsExecutorFactoryForOldArch(bridge, _runtimeScheduler);
 #endif
 }

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/primitives.h
@@ -12,12 +12,17 @@
 
 namespace facebook::react {
 
+struct TaskWrapper : public jsi::HostObject {
+  TaskWrapper(std::shared_ptr<Task> const &task) : task(task) {}
+
+  std::shared_ptr<Task> task;
+};
+
 inline static jsi::Value valueFromTask(
     jsi::Runtime &runtime,
     std::shared_ptr<Task> task) {
-  jsi::Object obj(runtime);
-  obj.setNativeState(runtime, std::move(task));
-  return obj;
+  return jsi::Object::createFromHostObject(
+      runtime, std::make_shared<TaskWrapper>(task));
 }
 
 inline static std::shared_ptr<Task> taskFromValue(
@@ -27,7 +32,7 @@ inline static std::shared_ptr<Task> taskFromValue(
     return nullptr;
   }
 
-  return value.getObject(runtime).getNativeState<Task>(runtime);
+  return value.getObject(runtime).getHostObject<TaskWrapper>(runtime)->task;
 }
 
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
changelog: [internal]

`setNativeState` is not implemented in JSC. Let's stick to host objects for now.

Reviewed By: cipolleschi

Differential Revision: D46193786

