### PR TITLE
Revert changes to getters in Binding

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.h
@@ -42,7 +42,7 @@ class Binding : public jni::HybridClass<Binding>,
 
   static void registerNatives();
 
-  const std::shared_ptr<Scheduler> &getScheduler();
+  std::shared_ptr<Scheduler> getScheduler();
 
  private:
   void setConstraints(
@@ -124,10 +124,11 @@ class Binding : public jni::HybridClass<Binding>,
 
   // Private member variables
   std::shared_mutex installMutex_;
-  std::unique_ptr<FabricMountingManager> mountingManager_;
+  std::shared_ptr<FabricMountingManager> mountingManager_;
   std::shared_ptr<Scheduler> scheduler_;
 
-  FabricMountingManager *getMountingManager(const char *locationHint);
+  std::shared_ptr<FabricMountingManager> getMountingManager(
+      const char *locationHint);
 
   // LayoutAnimations
   void onAnimationStarted() override;


### PR DESCRIPTION
Summary:
In D44221018, I changed this to return a ref to the smart pointer, and even made it a raw pointer in D45948987, but this is not thread-safe: the uninstallFabricUIManager happens on a different thread from the accesses to these pointers on the JS thread, so we actually need to use the shared pointer here to be safe.

Changelog: [Internal]

Differential Revision: D46221511

