### PR TITLE
Add tests in CI not to break Hermes-Xcode integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -922,6 +922,26 @@ jobs:
   # -------------------------
   #    JOBS: Test iOS RNTester
   # -------------------------
+  test_ios_rntester_hermes_integration:
+     executor: reactnativeios
+     steps:
+      - checkout_code_with_cache
+      - run_yarn
+      - run:
+          name: Pod install
+          command: |
+            cd packages/rn-tester
+            rm -rf Pods Podfile.lock
+            bundle install
+            RCT_NEW_ARCH_ENABLED=1 bundle exec pod install
+      - run:
+          name: Build RNTester
+          command: |
+            xcodebuild build \
+              -workspace packages/rn-tester/RNTesterPods.xcworkspace \
+              -scheme RNTester \
+              -sdk iphonesimulator
+
   test_ios_rntester:
     executor: reactnativeios
     parameters:
@@ -1597,6 +1617,7 @@ workflows:
         - equal: [ false, << pipeline.parameters.run_nightly_workflow >> ]
     jobs:
       - prepare_hermes_workspace
+      - test_ios_rntester_hermes_integration
       - build_hermesc_linux:
           requires:
             - prepare_hermes_workspace

--- a/packages/react-native/sdks/hermes-engine/utils/build-hermes-xcode.sh
+++ b/packages/react-native/sdks/hermes-engine/utils/build-hermes-xcode.sh
@@ -60,5 +60,5 @@ echo "Build Apple framework"
 echo "Copy Apple framework to destroot/Library/Frameworks"
 
 cp -pfR \
-  "${PODS_ROOT}/hermes-engine/build/API/hermes/hermes.framework" \
+  "${PODS_ROOT}/hermes-engine/build/${PLATFORM_NAME}/API/hermes/hermes.framework" \
   "${PODS_ROOT}/hermes-engine/destroot/Library/Frameworks/ios"


### PR DESCRIPTION
Summary:
This change add a test in circleCI to make sure that we don't break the integration between RNTester Hermes and Xcode

## Changelog:
[Internal] - Add circleci test to track the integration between Xcode and Hermes

Differential Revision: D46225044

