### PR TITLE
Fix Hermes-Xcode integration

### DIFF
--- a/packages/react-native/sdks/hermes-engine/utils/build-hermes-xcode.sh
+++ b/packages/react-native/sdks/hermes-engine/utils/build-hermes-xcode.sh
@@ -60,5 +60,5 @@ echo "Build Apple framework"
 echo "Copy Apple framework to destroot/Library/Frameworks"
 
 cp -pfR \
-  "${PODS_ROOT}/hermes-engine/build/API/hermes/hermes.framework" \
+  "${PODS_ROOT}/hermes-engine/build/${PLATFORM_NAME}/API/hermes/hermes.framework" \
   "${PODS_ROOT}/hermes-engine/destroot/Library/Frameworks/ios"


### PR DESCRIPTION
Summary:
Following D46097200, the integration between Hermes and Xcode got broken as Hermes is creating the framework in a different folder.

This is a patch to unblock people internally to build RNTester with Hermes and to run it on a simulator.
We should find a way to parametrize this, passing the target from Xcode to this script, after checking where Hermes is built

## Changelog:
[internal] - Fix RNTester-Hermes-Xcode integration for testing locally on simulators

Differential Revision: D46224915

