### PR TITLE
Add plumbing/boilerplate for an iOS implementation of the `gotpointercapture` and `lostpointercapture` events

### DIFF
--- a/packages/react-native/Libraries/Components/View/ViewPropTypes.js
+++ b/packages/react-native/Libraries/Components/View/ViewPropTypes.js
@@ -105,6 +105,8 @@ type PointerEventProps = $ReadOnly<{|
   onPointerOverCapture?: ?(e: PointerEvent) => void,
   onPointerOut?: ?(e: PointerEvent) => void,
   onPointerOutCapture?: ?(e: PointerEvent) => void,
+  onGotPointerCapture?: ?(e: PointerEvent) => void,
+  onLostPointerCapture?: ?(e: PointerEvent) => void,
 |}>;
 
 type FocusEventProps = $ReadOnly<{|

--- a/packages/react-native/Libraries/NativeComponent/BaseViewConfig.ios.js
+++ b/packages/react-native/Libraries/NativeComponent/BaseViewConfig.ios.js
@@ -144,6 +144,18 @@ const bubblingEventTypes = {
       bubbled: 'onPointerOut',
     },
   },
+  topGotPointerCapture: {
+    phasedRegistrationNames: {
+      captured: 'onGotPointerCaptureCapture',
+      bubbled: 'onGotPointerCapture',
+    },
+  },
+  topLostPointerCapture: {
+    phasedRegistrationNames: {
+      captured: 'onLostPointerCaptureCapture',
+      bubbled: 'onLostPointerCapture',
+    },
+  },
 };
 
 const directEventTypes = {
@@ -366,6 +378,8 @@ const validAttributesForEventProps = ConditionallyIgnoredEventHandlers({
   onPointerLeave: true,
   onPointerOver: true,
   onPointerOut: true,
+  onGotPointerCapture: true,
+  onLostPointerCapture: true,
 });
 
 /**

--- a/packages/react-native/React/Views/RCTView.h
+++ b/packages/react-native/React/Views/RCTView.h
@@ -132,5 +132,7 @@ extern const UIAccessibilityTraits SwitchAccessibilityTrait;
 @property (nonatomic, assign) RCTCapturingEventBlock onPointerLeave;
 @property (nonatomic, assign) RCTBubblingEventBlock onPointerOver;
 @property (nonatomic, assign) RCTBubblingEventBlock onPointerOut;
+@property (nonatomic, assign) RCTBubblingEventBlock onGotPointerCapture;
+@property (nonatomic, assign) RCTBubblingEventBlock onLostPointerCapture;
 
 @end

--- a/packages/react-native/React/Views/RCTViewManager.m
+++ b/packages/react-native/React/Views/RCTViewManager.m
@@ -549,5 +549,7 @@ RCT_EXPORT_VIEW_PROPERTY(onPointerEnter, RCTCapturingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onPointerLeave, RCTCapturingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onPointerOver, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onPointerOut, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onGotPointerCapture, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onLostPointerCapture, RCTBubblingEventBlock)
 
 @end

--- a/packages/react-native/ReactCommon/react/renderer/components/view/TouchEventEmitter.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/TouchEventEmitter.cpp
@@ -223,4 +223,20 @@ void TouchEventEmitter::onPointerOut(const PointerEvent &event) const {
       RawEvent::Category::ContinuousStart);
 }
 
+void TouchEventEmitter::onGotPointerCapture(const PointerEvent &event) const {
+  dispatchPointerEvent(
+      "gotPointerCapture",
+      event,
+      EventPriority::AsynchronousBatched,
+      RawEvent::Category::ContinuousStart);
+}
+
+void TouchEventEmitter::onLostPointerCapture(const PointerEvent &event) const {
+  dispatchPointerEvent(
+      "lostPointerCapture",
+      event,
+      EventPriority::AsynchronousBatched,
+      RawEvent::Category::ContinuousEnd);
+}
+
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/TouchEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/TouchEventEmitter.h
@@ -38,6 +38,8 @@ class TouchEventEmitter : public EventEmitter {
   void onPointerLeave(PointerEvent const &event) const;
   void onPointerOver(PointerEvent const &event) const;
   void onPointerOut(PointerEvent const &event) const;
+  void onGotPointerCapture(PointerEvent const &event) const;
+  void onLostPointerCapture(PointerEvent const &event) const;
 
  private:
   void dispatchTouchEvent(

--- a/packages/react-native/ReactCommon/react/renderer/components/view/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/primitives.h
@@ -60,6 +60,10 @@ struct ViewEvents {
     PointerOutCapture = 29,
     Click = 30,
     ClickCapture = 31,
+    GotPointerCapture = 32,
+    GotPointerCaptureCapture = 33,
+    LostPointerCapture = 34,
+    LostPointerCaptureCapture = 35,
   };
 
   constexpr bool operator[](const Offset offset) const {

--- a/packages/react-native/ReactCommon/react/renderer/components/view/propsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/propsConversions.h
@@ -616,6 +616,30 @@ static inline ViewEvents convertRawProp(
       "onClickCapture",
       sourceValue[Offset::ClickCapture],
       defaultValue[Offset::ClickCapture]);
+  result[Offset::GotPointerCapture] = convertRawProp(
+      context,
+      rawProps,
+      "onGotPointerCapture",
+      sourceValue[Offset::GotPointerCapture],
+      defaultValue[Offset::GotPointerCapture]);
+  result[Offset::GotPointerCaptureCapture] = convertRawProp(
+      context,
+      rawProps,
+      "onGotPointerCaptureCapture",
+      sourceValue[Offset::GotPointerCaptureCapture],
+      defaultValue[Offset::GotPointerCaptureCapture]);
+  result[Offset::LostPointerCapture] = convertRawProp(
+      context,
+      rawProps,
+      "onLostPointerCapture",
+      sourceValue[Offset::LostPointerCapture],
+      defaultValue[Offset::LostPointerCapture]);
+  result[Offset::LostPointerCaptureCapture] = convertRawProp(
+      context,
+      rawProps,
+      "onLostPointerCaptureCapture",
+      sourceValue[Offset::LostPointerCaptureCapture],
+      defaultValue[Offset::LostPointerCaptureCapture]);
 
   // PanResponder callbacks
   result[Offset::MoveShouldSetResponder] = convertRawProp(


### PR DESCRIPTION
Summary:
Changelog: [Internal] - Add plumbing/boilerplate for an iOS implementation of the `gotpointercapture` and `lostpointercapture` events

This diff simply adds the boilerplate necessary to hook up the `gotpointercapture` and `lostpointercapture` events to the fabric iOS touch handler. This diff does not contain any actual implementation of their behavior as that will occur in future diffs.

Reviewed By: yungsters

Differential Revision: D44977499

