### PR TITLE
Add PointerEventCaptureMouse WPT test

### DIFF
--- a/packages/react-native/Libraries/Components/View/ViewPropTypes.js
+++ b/packages/react-native/Libraries/Components/View/ViewPropTypes.js
@@ -105,6 +105,8 @@ type PointerEventProps = $ReadOnly<{|
   onPointerOverCapture?: ?(e: PointerEvent) => void,
   onPointerOut?: ?(e: PointerEvent) => void,
   onPointerOutCapture?: ?(e: PointerEvent) => void,
+  onGotPointerCapture?: ?(e: PointerEvent) => void,
+  onLostPointerCapture?: ?(e: PointerEvent) => void,
 |}>;
 
 type FocusEventProps = $ReadOnly<{|

--- a/packages/react-native/Libraries/NativeComponent/BaseViewConfig.ios.js
+++ b/packages/react-native/Libraries/NativeComponent/BaseViewConfig.ios.js
@@ -144,6 +144,18 @@ const bubblingEventTypes = {
       bubbled: 'onPointerOut',
     },
   },
+  topGotPointerCapture: {
+    phasedRegistrationNames: {
+      captured: 'onGotPointerCaptureCapture',
+      bubbled: 'onGotPointerCapture',
+    },
+  },
+  topLostPointerCapture: {
+    phasedRegistrationNames: {
+      captured: 'onLostPointerCaptureCapture',
+      bubbled: 'onLostPointerCapture',
+    },
+  },
 };
 
 const directEventTypes = {
@@ -366,6 +378,8 @@ const validAttributesForEventProps = ConditionallyIgnoredEventHandlers({
   onPointerLeave: true,
   onPointerOver: true,
   onPointerOut: true,
+  onGotPointerCapture: true,
+  onLostPointerCapture: true,
 });
 
 /**

--- a/packages/react-native/React/Views/RCTView.h
+++ b/packages/react-native/React/Views/RCTView.h
@@ -132,5 +132,7 @@ extern const UIAccessibilityTraits SwitchAccessibilityTrait;
 @property (nonatomic, assign) RCTCapturingEventBlock onPointerLeave;
 @property (nonatomic, assign) RCTBubblingEventBlock onPointerOver;
 @property (nonatomic, assign) RCTBubblingEventBlock onPointerOut;
+@property (nonatomic, assign) RCTBubblingEventBlock onGotPointerCapture;
+@property (nonatomic, assign) RCTBubblingEventBlock onLostPointerCapture;
 
 @end

--- a/packages/react-native/React/Views/RCTViewManager.m
+++ b/packages/react-native/React/Views/RCTViewManager.m
@@ -549,5 +549,7 @@ RCT_EXPORT_VIEW_PROPERTY(onPointerEnter, RCTCapturingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onPointerLeave, RCTCapturingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onPointerOver, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onPointerOut, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onGotPointerCapture, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onLostPointerCapture, RCTBubblingEventBlock)
 
 @end

--- a/packages/react-native/ReactCommon/react/renderer/components/view/TouchEventEmitter.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/TouchEventEmitter.cpp
@@ -223,4 +223,20 @@ void TouchEventEmitter::onPointerOut(const PointerEvent &event) const {
       RawEvent::Category::ContinuousStart);
 }
 
+void TouchEventEmitter::onGotPointerCapture(const PointerEvent &event) const {
+  dispatchPointerEvent(
+      "gotPointerCapture",
+      event,
+      EventPriority::AsynchronousBatched,
+      RawEvent::Category::ContinuousStart);
+}
+
+void TouchEventEmitter::onLostPointerCapture(const PointerEvent &event) const {
+  dispatchPointerEvent(
+      "lostPointerCapture",
+      event,
+      EventPriority::AsynchronousBatched,
+      RawEvent::Category::ContinuousEnd);
+}
+
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/TouchEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/TouchEventEmitter.h
@@ -38,6 +38,8 @@ class TouchEventEmitter : public EventEmitter {
   void onPointerLeave(PointerEvent const &event) const;
   void onPointerOver(PointerEvent const &event) const;
   void onPointerOut(PointerEvent const &event) const;
+  void onGotPointerCapture(PointerEvent const &event) const;
+  void onLostPointerCapture(PointerEvent const &event) const;
 
  private:
   void dispatchTouchEvent(

--- a/packages/react-native/ReactCommon/react/renderer/components/view/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/primitives.h
@@ -60,6 +60,10 @@ struct ViewEvents {
     PointerOutCapture = 29,
     Click = 30,
     ClickCapture = 31,
+    GotPointerCapture = 32,
+    GotPointerCaptureCapture = 33,
+    LostPointerCapture = 34,
+    LostPointerCaptureCapture = 35,
   };
 
   constexpr bool operator[](const Offset offset) const {

--- a/packages/react-native/ReactCommon/react/renderer/components/view/propsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/propsConversions.h
@@ -616,6 +616,30 @@ static inline ViewEvents convertRawProp(
       "onClickCapture",
       sourceValue[Offset::ClickCapture],
       defaultValue[Offset::ClickCapture]);
+  result[Offset::GotPointerCapture] = convertRawProp(
+      context,
+      rawProps,
+      "onGotPointerCapture",
+      sourceValue[Offset::GotPointerCapture],
+      defaultValue[Offset::GotPointerCapture]);
+  result[Offset::GotPointerCaptureCapture] = convertRawProp(
+      context,
+      rawProps,
+      "onGotPointerCaptureCapture",
+      sourceValue[Offset::GotPointerCaptureCapture],
+      defaultValue[Offset::GotPointerCaptureCapture]);
+  result[Offset::LostPointerCapture] = convertRawProp(
+      context,
+      rawProps,
+      "onLostPointerCapture",
+      sourceValue[Offset::LostPointerCapture],
+      defaultValue[Offset::LostPointerCapture]);
+  result[Offset::LostPointerCaptureCapture] = convertRawProp(
+      context,
+      rawProps,
+      "onLostPointerCaptureCapture",
+      sourceValue[Offset::LostPointerCaptureCapture],
+      defaultValue[Offset::LostPointerCaptureCapture]);
 
   // PanResponder callbacks
   result[Offset::MoveShouldSetResponder] = convertRawProp(

--- a/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventCaptureMouse.js
+++ b/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventCaptureMouse.js
@@ -1,0 +1,213 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+import type {PlatformTestComponentBaseProps} from '../PlatformTest/RNTesterPlatformTestTypes';
+import type {PointerEvent} from 'react-native/Libraries/Types/CoreEventTypes';
+
+import * as React from 'react';
+import {useCallback, useRef} from 'react';
+import {StyleSheet, View, Text} from 'react-native';
+import RNTesterPlatformTest from '../PlatformTest/RNTesterPlatformTest';
+import type {ElementRef} from 'react';
+
+// adapted from https://github.com/web-platform-tests/wpt/blob/master/pointerevents/pointerevent_capture_mouse.html
+function PointerEventCaptureMouseTestCase(
+  props: PlatformTestComponentBaseProps,
+) {
+  const {harness} = props;
+
+  const target0Ref = useRef<ElementRef<typeof View> | null>(null);
+  const target1Ref = useRef<ElementRef<typeof View> | null>(null);
+
+  const isPointerCaptureRef = useRef(false);
+  const pointermoveNoCaptureGot0Ref = useRef(false);
+  const pointermoveCaptureGot0Ref = useRef(false);
+  const pointermoveNoCaptureGot1Ref = useRef(false);
+  const ownEventForTheCapturedTargetGotRef = useRef(false);
+
+  const testGotPointerCapture = harness.useAsyncTest(
+    'gotpointercapture event received"',
+  );
+  const testLostPointerCapture = harness.useAsyncTest(
+    'lostpointercapture event received"',
+  );
+
+  const handleCaptureButtonDown = useCallback((evt: PointerEvent) => {
+    const target0 = target0Ref.current;
+    if (target0 != null && isPointerCaptureRef.current === false) {
+      isPointerCaptureRef.current = true;
+      try {
+        // $FlowFixMe[prop-missing]
+        target0.setPointerCapture(evt.nativeEvent.pointerId);
+      } catch (e) {}
+    }
+  }, []);
+
+  const handleTarget0GotPointerCapture = useCallback(
+    (evt: PointerEvent) => {
+      testGotPointerCapture.done();
+    },
+    [testGotPointerCapture],
+  );
+
+  const handleTarget0LostPointerCapture = useCallback(
+    (evt: PointerEvent) => {
+      testLostPointerCapture.done();
+      isPointerCaptureRef.current = false;
+    },
+    [testLostPointerCapture],
+  );
+
+  const testPointerMove0 = harness.useAsyncTest(
+    'pointerover event for black rectangle received',
+  );
+  const testPointerMove1 = harness.useAsyncTest(
+    'pointerover event for purple rectangle received',
+  );
+
+  const handleTarget0PointerMove = useCallback(
+    (evt: PointerEvent) => {
+      const target0 = target0Ref.current;
+      if (!pointermoveNoCaptureGot0Ref.current) {
+        testPointerMove0.done();
+        pointermoveNoCaptureGot0Ref.current = true;
+      }
+      if (isPointerCaptureRef.current && target0 != null) {
+        const {clientX, clientY} = evt.nativeEvent;
+        const {left, right, top, bottom} =
+          // $FlowFixMe[prop-missing]
+          target0.getBoundingClientRect();
+
+        if (!pointermoveCaptureGot0Ref.current) {
+          harness.test(
+            ({assert_equals}) => {
+              assert_equals(
+                evt.nativeEvent.relatedTarget,
+                null,
+                'relatedTarget is null when the capture is set',
+              );
+            },
+            'relatedTarget is null when the capture is set.',
+            {skip: true},
+          );
+          harness.test(({assert_true}) => {
+            assert_true(
+              clientX < left ||
+                clientX > right ||
+                clientY < top ||
+                clientY > bottom,
+              'pointermove received for captured element while out of it',
+            );
+          }, 'pointermove received for captured element while out of it');
+          pointermoveCaptureGot0Ref.current = true;
+        }
+        if (
+          clientX > left &&
+          clientX < right &&
+          clientY > top &&
+          clientY < bottom &&
+          !ownEventForTheCapturedTargetGotRef.current
+        ) {
+          harness.test(({assert_true}) => {
+            assert_true(
+              true,
+              'pointermove received for captured element while inside of it',
+            );
+          }, 'pointermove received for captured element while inside of it');
+          ownEventForTheCapturedTargetGotRef.current = true;
+        }
+      }
+    },
+    [harness, testPointerMove0],
+  );
+
+  const handleTarget1PointerMove = useCallback(
+    (evt: PointerEvent) => {
+      harness.test(({assert_equals}) => {
+        assert_equals(
+          isPointerCaptureRef.current,
+          false,
+          "pointermove shouldn't trigger for this target when capture is enabled",
+        );
+      }, "pointermove shouldn't trigger for the purple rectangle while the black rectangle has capture");
+
+      if (!pointermoveNoCaptureGot1Ref.current) {
+        testPointerMove1.done();
+        pointermoveNoCaptureGot1Ref.current = true;
+      }
+    },
+    [harness, testPointerMove1],
+  );
+
+  return (
+    <View style={styles.container}>
+      <View
+        ref={target0Ref}
+        onGotPointerCapture={handleTarget0GotPointerCapture}
+        onLostPointerCapture={handleTarget0LostPointerCapture}
+        onPointerMove={handleTarget0PointerMove}
+        style={styles.target0}
+      />
+      <View
+        ref={target1Ref}
+        style={styles.target1}
+        onPointerMove={handleTarget1PointerMove}
+      />
+      <View
+        onPointerDown={handleCaptureButtonDown}
+        style={styles.captureButton}>
+        <Text>Set Capture</Text>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  captureButton: {
+    alignSelf: 'flex-start',
+    backgroundColor: 'lightblue',
+    paddingHorizontal: 32,
+    paddingVertical: 16,
+    borderRadius: 8,
+  },
+  container: {},
+  target0: {
+    backgroundColor: 'black',
+    padding: 32,
+    marginBottom: 16,
+  },
+  target1: {
+    backgroundColor: 'purple',
+    padding: 32,
+    marginBottom: 16,
+  },
+});
+
+type Props = $ReadOnly<{}>;
+export default function PointerEventCaptureMouse(
+  props: Props,
+): React.MixedElement {
+  return (
+    <RNTesterPlatformTest
+      component={PointerEventCaptureMouseTestCase}
+      description="This test checks if setCapture/releaseCapture functions works properly."
+      instructions={[
+        'Move your mouse over the black rectangle. pointermove event should be logged in the black rectangle',
+        'Move your mouse over the purple rectangle. pointerover event should be logged in the purple rectangle',
+        'Press and hold left mouse button over "Set Capture" button. "gotpointercapture" should be logged in the black rectangle',
+        'Move your mouse anywhere. pointermove should be logged in the black rectangle',
+        'Move your mouse over the purple rectangle. Nothig should happen',
+        'Move your mouse over the black rectangle. pointermove should be logged in the black rectangle',
+        'Release left mouse button. "lostpointercapture" should be logged in the black rectangle',
+      ]}
+      title="Pointer Events capture test"
+    />
+  );
+}

--- a/packages/rn-tester/js/examples/Experimental/W3CPointerEventsExample.js
+++ b/packages/rn-tester/js/examples/Experimental/W3CPointerEventsExample.js
@@ -26,6 +26,7 @@ import PointerEventLayoutChangeShouldFirePointerOver from './W3CPointerEventPlat
 import PointerEventPointerCancelTouch from './W3CPointerEventPlatformTests/PointerEventPointerCancelTouch';
 import PointerEventClickTouch from './W3CPointerEventPlatformTests/PointerEventClickTouch';
 import PointerEventClickTouchHierarchy from './W3CPointerEventPlatformTests/PointerEventClickTouchHierarchy';
+import PointerEventCaptureMouse from './W3CPointerEventPlatformTests/PointerEventCaptureMouse';
 import EventfulView from './W3CPointerEventsEventfulView';
 import ManyPointersPropertiesExample from './Compatibility/ManyPointersPropertiesExample';
 import PointerEventClickTouchHierarchyPointerEvents from './W3CPointerEventPlatformTests/PointerEventClickTouchHierarchyPointerEvents';
@@ -238,6 +239,13 @@ export default {
       title: 'WPT 11: Pointer Events pointercancel Tests',
       render(): React.Node {
         return <PointerEventPointerCancelTouch />;
+      },
+    },
+    {
+      name: 'pointerevent_caapture_mouse',
+      title: 'WPT 12: Pointer Events capture test',
+      render(): React.Node {
+        return <PointerEventCaptureMouse />;
       },
     },
     {


### PR DESCRIPTION
Summary:
Changelog: [Internal] - Add PointerEventCaptureMouse WPT test

This diff introduces a port of the wpt test "pointerevent_capture_mouse" (https://github.com/web-platform-tests/wpt/blob/master/pointerevents/pointerevent_capture_mouse.html) in preparation of validating our pointer capture implementation.

Differential Revision: D46230497

