### PR TITLE
remove bindingsInstallFunc argument from bridgeless api

### DIFF
--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost+Internal.h
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost+Internal.h
@@ -7,11 +7,20 @@
 
 #import "RCTHost.h"
 
+#import <jsi/jsi.h>
+
 typedef NSURL * (^RCTHostBundleURLProvider)(void);
+
+@protocol RCTHostRuntimeDelegate <NSObject>
+
+- (void)hostDidInitializeRuntime:(facebook::jsi::Runtime &)runtime;
+
+@end
 
 @interface RCTHost (Internal)
 
 - (void)registerSegmentWithId:(NSNumber *)segmentId path:(NSString *)path;
 - (void)setBundleURLProvider:(RCTHostBundleURLProvider)bundleURLProvider;
+- (void)setRuntimeDelegate:(id<RCTHostRuntimeDelegate>)runtimeDelegate;
 
 @end

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.h
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.h
@@ -50,7 +50,6 @@ typedef std::shared_ptr<facebook::react::JSEngineInstance> (^RCTHostJSEngineProv
 - (instancetype)initWithBundleURL:(NSURL *)bundleURL
                      hostDelegate:(id<RCTHostDelegate>)hostDelegate
        turboModuleManagerDelegate:(id<RCTTurboModuleManagerDelegate>)turboModuleManagerDelegate
-              bindingsInstallFunc:(facebook::react::ReactInstance::BindingsInstallFunc)bindingsInstallFunc
                  jsEngineProvider:(RCTHostJSEngineProvider)jsEngineProvider NS_DESIGNATED_INITIALIZER FB_OBJC_DIRECT;
 
 /**

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.mm
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.mm
@@ -27,6 +27,7 @@ using namespace facebook::react;
   RCTInstance *_instance;
   __weak id<RCTHostDelegate> _hostDelegate;
   __weak id<RCTTurboModuleManagerDelegate> _turboModuleManagerDelegate;
+  __weak id<RCTHostRuntimeDelegate> _runtimeDelegate;
   NSURL *_oldDelegateBundleURL;
   NSURL *_bundleURL;
   RCTBundleManager *_bundleManager;
@@ -261,6 +262,11 @@ using namespace facebook::react;
                      isFatal:errorMap.getBool(JSErrorHandlerKey::kIsFatal)];
 }
 
+- (void)instance:(RCTInstance *)instance didInitializeRuntime:(facebook::jsi::Runtime &)runtime
+{
+  [_runtimeDelegate hostDidInitializeRuntime:runtime];
+}
+
 #pragma mark - Internal
 
 - (void)registerSegmentWithId:(NSNumber *)segmentId path:(NSString *)path
@@ -271,6 +277,11 @@ using namespace facebook::react;
 - (void)setBundleURLProvider:(RCTHostBundleURLProvider)bundleURLProvider
 {
   _bundleURLProvider = [bundleURLProvider copy];
+}
+
+- (void)setRuntimeDelegate:(id<RCTHostRuntimeDelegate>)runtimeDelegate
+{
+  _runtimeDelegate = runtimeDelegate;
 }
 
 #pragma mark - Private

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.mm
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.mm
@@ -32,7 +32,6 @@ using namespace facebook::react;
   NSURL *_bundleURL;
   RCTBundleManager *_bundleManager;
   RCTHostBundleURLProvider _bundleURLProvider;
-  facebook::react::ReactInstance::BindingsInstallFunc _bindingsInstallFunc;
   RCTHostJSEngineProvider _jsEngineProvider;
 
   // All the surfaces that need to be started after main bundle execution
@@ -57,7 +56,6 @@ using namespace facebook::react;
 - (instancetype)initWithBundleURL:(NSURL *)bundleURL
                      hostDelegate:(id<RCTHostDelegate>)hostDelegate
        turboModuleManagerDelegate:(id<RCTTurboModuleManagerDelegate>)turboModuleManagerDelegate
-              bindingsInstallFunc:(facebook::react::ReactInstance::BindingsInstallFunc)bindingsInstallFunc
                  jsEngineProvider:(RCTHostJSEngineProvider)jsEngineProvider
 {
   if (self = [super init]) {
@@ -65,7 +63,6 @@ using namespace facebook::react;
     _turboModuleManagerDelegate = turboModuleManagerDelegate;
     _surfaceStartBuffer = [NSMutableArray new];
     _bundleManager = [RCTBundleManager new];
-    _bindingsInstallFunc = bindingsInstallFunc;
     _moduleRegistry = [RCTModuleRegistry new];
     _jsEngineProvider = [jsEngineProvider copy];
 
@@ -149,7 +146,6 @@ using namespace facebook::react;
                                       bundleManager:_bundleManager
                          turboModuleManagerDelegate:_turboModuleManagerDelegate
                                 onInitialBundleLoad:_onInitialBundleLoad
-                                bindingsInstallFunc:_bindingsInstallFunc
                                      moduleRegistry:_moduleRegistry];
   [_hostDelegate hostDidStart:self];
 }
@@ -217,7 +213,6 @@ using namespace facebook::react;
                                       bundleManager:_bundleManager
                          turboModuleManagerDelegate:_turboModuleManagerDelegate
                                 onInitialBundleLoad:_onInitialBundleLoad
-                                bindingsInstallFunc:_bindingsInstallFunc
                                      moduleRegistry:_moduleRegistry];
   [_hostDelegate hostDidStart:self];
 

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHostCreationHelpers.mm
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHostCreationHelpers.mm
@@ -16,6 +16,5 @@ RCTHost *RCTHostCreateDefault(
   return [[RCTHost alloc] initWithBundleURL:bundleURL
                                hostDelegate:hostDelegate
                  turboModuleManagerDelegate:turboModuleManagerDelegate
-                        bindingsInstallFunc:nullptr
                            jsEngineProvider:jsEngineProvider];
 }

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.h
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.h
@@ -58,7 +58,6 @@ typedef void (^_Null_unspecified RCTInstanceInitialBundleLoadCompletionBlock)();
                    bundleManager:(RCTBundleManager *)bundleManager
       turboModuleManagerDelegate:(id<RCTTurboModuleManagerDelegate>)turboModuleManagerDelegate
              onInitialBundleLoad:(RCTInstanceInitialBundleLoadCompletionBlock)onInitialBundleLoad
-             bindingsInstallFunc:(facebook::react::ReactInstance::BindingsInstallFunc)bindingsInstallFunc
                   moduleRegistry:(RCTModuleRegistry *)moduleRegistry NS_DESIGNATED_INITIALIZER FB_OBJC_DIRECT;
 
 - (void)callFunctionOnJSModule:(NSString *)moduleName method:(NSString *)method args:(NSArray *)args;

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.h
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.h
@@ -40,6 +40,7 @@ FB_RUNTIME_PROTOCOL
 - (std::shared_ptr<facebook::react::ContextContainer>)createContextContainer;
 
 - (void)instance:(RCTInstance *)instance didReceiveErrorMap:(facebook::react::MapBuffer)errorMap;
+- (void)instance:(RCTInstance *)instance didInitializeRuntime:(facebook::jsi::Runtime &)runtime;
 
 @end
 

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.mm
@@ -293,6 +293,8 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
       strongSelf->_bindingsInstallFunc(runtime);
     }
 
+    [strongSelf->_delegate instance:strongSelf didInitializeRuntime:runtime];
+
     // Set up Display Link
     RCTModuleData *timingModuleData = [[RCTModuleData alloc] initWithModuleInstance:timing
                                                                              bridge:nil

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.mm
@@ -73,7 +73,6 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
   RCTPerformanceLogger *_performanceLogger;
   RCTDisplayLink *_displayLink;
   RCTInstanceInitialBundleLoadCompletionBlock _onInitialBundleLoad;
-  ReactInstance::BindingsInstallFunc _bindingsInstallFunc;
   RCTTurboModuleManager *_turboModuleManager;
   std::mutex _invalidationMutex;
   std::atomic<bool> _valid;
@@ -90,7 +89,6 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
                    bundleManager:(RCTBundleManager *)bundleManager
       turboModuleManagerDelegate:(id<RCTTurboModuleManagerDelegate>)tmmDelegate
              onInitialBundleLoad:(RCTInstanceInitialBundleLoadCompletionBlock)onInitialBundleLoad
-             bindingsInstallFunc:(ReactInstance::BindingsInstallFunc)bindingsInstallFunc
                   moduleRegistry:(RCTModuleRegistry *)moduleRegistry
 {
   if (self = [super init]) {
@@ -103,7 +101,6 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
     _appTMMDelegate = tmmDelegate;
     _jsThreadManager = [RCTJSThreadManager new];
     _onInitialBundleLoad = onInitialBundleLoad;
-    _bindingsInstallFunc = bindingsInstallFunc;
     _bridgeModuleDecorator = [[RCTBridgeModuleDecorator alloc] initWithViewRegistry:[RCTViewRegistry new]
                                                                      moduleRegistry:moduleRegistry
                                                                       bundleManager:bundleManager
@@ -287,10 +284,6 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
 
     if (RCTGetUseNativeViewConfigsInBridgelessMode()) {
       installNativeViewConfigProviderBinding(runtime);
-    }
-
-    if (strongSelf->_bindingsInstallFunc) {
-      strongSelf->_bindingsInstallFunc(runtime);
     }
 
     [strongSelf->_delegate instance:strongSelf didInitializeRuntime:runtime];


### PR DESCRIPTION
Summary: this isn't needed anymore, so we can delete it and remove it from our public api

Differential Revision: D46215054

