### PR TITLE
introduce internal delegate callback for jsi runtime initialization

### DIFF
--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost+Internal.h
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost+Internal.h
@@ -7,11 +7,20 @@
 
 #import "RCTHost.h"
 
+#import <jsi/jsi.h>
+
 typedef NSURL * (^RCTHostBundleURLProvider)(void);
+
+@protocol RCTHostRuntimeDelegate <NSObject>
+
+- (void)hostDidInitializeRuntime:(facebook::jsi::Runtime &)runtime;
+
+@end
 
 @interface RCTHost (Internal)
 
 - (void)registerSegmentWithId:(NSNumber *)segmentId path:(NSString *)path;
 - (void)setBundleURLProvider:(RCTHostBundleURLProvider)bundleURLProvider;
+- (void)setRuntimeDelegate:(id<RCTHostRuntimeDelegate>)runtimeDelegate;
 
 @end

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.mm
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.mm
@@ -27,6 +27,7 @@ using namespace facebook::react;
   RCTInstance *_instance;
   __weak id<RCTHostDelegate> _hostDelegate;
   __weak id<RCTTurboModuleManagerDelegate> _turboModuleManagerDelegate;
+  __weak id<RCTHostRuntimeDelegate> _runtimeDelegate;
   NSURL *_oldDelegateBundleURL;
   NSURL *_bundleURL;
   RCTBundleManager *_bundleManager;
@@ -261,6 +262,11 @@ using namespace facebook::react;
                      isFatal:errorMap.getBool(JSErrorHandlerKey::kIsFatal)];
 }
 
+- (void)instance:(RCTInstance *)instance didInitializeRuntime:(facebook::jsi::Runtime &)runtime
+{
+  [_runtimeDelegate hostDidInitializeRuntime:runtime];
+}
+
 #pragma mark - Internal
 
 - (void)registerSegmentWithId:(NSNumber *)segmentId path:(NSString *)path
@@ -271,6 +277,11 @@ using namespace facebook::react;
 - (void)setBundleURLProvider:(RCTHostBundleURLProvider)bundleURLProvider
 {
   _bundleURLProvider = [bundleURLProvider copy];
+}
+
+- (void)setRuntimeDelegate:(id<RCTHostRuntimeDelegate>)runtimeDelegate
+{
+  _runtimeDelegate = runtimeDelegate;
 }
 
 #pragma mark - Private

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.h
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.h
@@ -40,6 +40,7 @@ FB_RUNTIME_PROTOCOL
 - (std::shared_ptr<facebook::react::ContextContainer>)createContextContainer;
 
 - (void)instance:(RCTInstance *)instance didReceiveErrorMap:(facebook::react::MapBuffer)errorMap;
+- (void)instance:(RCTInstance *)instance didInitializeRuntime:(facebook::jsi::Runtime &)runtime;
 
 @end
 

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.mm
@@ -293,6 +293,8 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
       strongSelf->_bindingsInstallFunc(runtime);
     }
 
+    [strongSelf->_delegate instance:strongSelf didInitializeRuntime:runtime];
+
     // Set up Display Link
     RCTModuleData *timingModuleData = [[RCTModuleData alloc] initWithModuleInstance:timing
                                                                              bridge:nil


### PR DESCRIPTION
Summary:
Changelog: [Internal]

in this stack, i remove the `bindingsInstallFunc` argument from `RCTHost`'s public API.

the bindingsInstallFunc is a lambda that provides a runtime parameter, which the consumer can "install bindings" to. we have our specific use case for this internally, but there's no need to expose this.

in this change, i introduce a delegate callback path that notifies an internal delegate that the react runtime has been created.

Differential Revision: D46215051

