### PR TITLE
[Codegen 132] Add function `emitMixedProp` to parser-primitives

### DIFF
--- a/packages/react-native-codegen/src/parsers/flow/components/events.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/events.js
@@ -27,6 +27,7 @@ const {
   emitBoolProp,
   emitDoubleProp,
   emitFloatProp,
+  emitMixedProp,
   emitStringProp,
   emitInt32Prop,
 } = require('../../parsers-primitives');
@@ -80,13 +81,7 @@ function getPropertyType(
         },
       };
     case 'UnsafeMixed':
-      return {
-        name,
-        optional,
-        typeAnnotation: {
-          type: 'MixedTypeAnnotation',
-        },
-      };
+      return emitMixedProp(name, optional);
     case 'ArrayTypeAnnotation':
     case '$ReadOnlyArray':
       return {

--- a/packages/react-native-codegen/src/parsers/parsers-primitives.js
+++ b/packages/react-native-codegen/src/parsers/parsers-primitives.js
@@ -644,6 +644,19 @@ function emitBoolProp(
   };
 }
 
+function emitMixedProp(
+  name: string,
+  optional: boolean,
+): NamedShape<EventTypeAnnotation> {
+  return {
+    name,
+    optional,
+    typeAnnotation: {
+      type: 'MixedTypeAnnotation',
+    },
+  };
+}
+
 module.exports = {
   emitArrayType,
   emitBoolean,
@@ -655,6 +668,7 @@ module.exports = {
   emitFunction,
   emitInt32,
   emitInt32Prop,
+  emitMixedProp,
   emitNumber,
   emitGenericObject,
   emitDictionary,

--- a/packages/react-native-codegen/src/parsers/typescript/components/events.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/events.js
@@ -29,6 +29,7 @@ const {
   emitBoolProp,
   emitDoubleProp,
   emitFloatProp,
+  emitMixedProp,
   emitStringProp,
   emitInt32Prop,
 } = require('../../parsers-primitives');
@@ -82,13 +83,7 @@ function getPropertyType(
         },
       };
     case 'UnsafeMixed':
-      return {
-        name,
-        optional,
-        typeAnnotation: {
-          type: 'MixedTypeAnnotation',
-        },
-      };
+      return emitMixedProp(name, optional);
     case 'TSArrayType':
       return {
         name,


### PR DESCRIPTION

## Summary:

[Codegen 132] This PR introduces `emitMixedProp` to parser-primitives and abstracts the logic out of typescript and parser events as requested on https://github.com/facebook/react-native/issues/34872

## Changelog:

[Internal] [Changed] - Add emitMixedProp  to parser-primitives and update usages.

## Test Plan:

Run yarn jest react-native-codegen and ensure CI is green

## Screenshot of tests passing locally:

<img width="1182" alt="Screenshot 2023-05-28 at 12 46 49 PM" src="https://github.com/facebook/react-native/assets/64726664/dbea4daf-d954-4c7f-b121-c6aad1fb318e">
