### PR TITLE
Attempt at fixing crash when blurring image on iOS

### DIFF
--- a/packages/react-native/Libraries/Image/RCTImageBlurUtils.m
+++ b/packages/react-native/Libraries/Image/RCTImageBlurUtils.m
@@ -54,7 +54,7 @@ UIImage *RCTBlurredImageWithRadius(UIImage *inputImage, CGFloat radius)
   // create temp buffer
   vImage_Error tempBufferSize = vImageBoxConvolve_ARGB8888(
       &buffer1, &buffer2, NULL, 0, 0, boxSize, boxSize, NULL, kvImageGetTempBufferSize | kvImageEdgeExtend);
-  if (tempBufferSize < 0) {
+  if (tempBufferSize <= 0) {
     free(buffer1.data);
     free(buffer2.data);
     return inputImage;


### PR DESCRIPTION
Summary:
changelog: [internal]

We do not control what `vImageBoxConvolve_ARGB8888` returns, it may return 0. If it does return 0, we will allocate memory chunk of size 0. Yes, malloc will let you do that. Well, it depends on the implementation, but according to the spec it is legal. The only requirement is to by able to call free on that without crash.

If `vImageBoxConvolve_ARGB8888` does return 0 and we allocate memory of size 0. Call to `vImageBoxConvolve_ARGB8888` with tempBuffer of size 0 will lead to a crash.

[The documentation](https://developer.apple.com/documentation/accelerate/1515945-vimageboxconvolve_argb8888#discussion) for `vImageBoxConvolve_ARGB8888` and tempBuffer states:
> To determine the minimum size for the temporary buffer, the first time you call this function pass the kvImageGetTempBufferSize flag. Pass the same values for all other parameters that you intend to use in for the second call. The function returns the required minimum size, which **should be a positive value**. (A negative returned value indicates an error.) The kvImageGetTempBufferSize flag prevents the function from performing any processing other than to determine the minimum buffer size.

I think the keyword word there is "should be a positive value". 0 is not a positive value.

Differential Revision: D46263204

