### PR TITLE
[New architecture] Fix loading view not being visible on iOS

### DIFF
--- a/packages/react-native/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingProxyRootView.mm
+++ b/packages/react-native/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingProxyRootView.mm
@@ -180,6 +180,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)aDecoder)
   {
     return loadingView;
   };
+  super.isActivityIndicatorViewVisible = loadingView != nil;
 }
 
 #pragma mark RCTSurfaceDelegate proxying

--- a/packages/react-native/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingView.h
+++ b/packages/react-native/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingView.h
@@ -73,6 +73,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, copy, nullable) RCTSurfaceHostingViewActivityIndicatorViewFactory activityIndicatorViewFactory;
 
+@property (nonatomic, assign) BOOL isActivityIndicatorViewVisible;
+@property (nonatomic, assign) BOOL isSurfaceViewVisible;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/react-native/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingView.mm
+++ b/packages/react-native/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingView.mm
@@ -13,13 +13,6 @@
 #import "RCTSurfaceView.h"
 #import "RCTUtils.h"
 
-@interface RCTSurfaceHostingView ()
-
-@property (nonatomic, assign) BOOL isActivityIndicatorViewVisible;
-@property (nonatomic, assign) BOOL isSurfaceViewVisible;
-
-@end
-
 @implementation RCTSurfaceHostingView {
   UIView *_Nullable _activityIndicatorView;
   UIView *_Nullable _surfaceView;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

It seems like the `loadingView` property on `RCTSurfaceHostingProxyRootView` was not being used, as there was no way to set`isActivityIndicatorViewVisible` on `RCTSurfaceHostingView`. This PR makes it so that after setting the loading view, `isActivityIndicatorViewVisible` is automatically set depending on whether the view is `nil` or not.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:


For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
[IOS] [FIXED] - Fixed loading screen not being visible when set

## Test Plan:

Before:

https://github.com/facebook/react-native/assets/21055725/d2db3065-2bcc-47b7-9859-40798afe5274

After:

https://github.com/facebook/react-native/assets/21055725/ace53fae-2572-4002-9821-200569ab7c44

