### PR TITLE
Add enterKeyHint in TextInput type declaration

### DIFF
--- a/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
@@ -70,6 +70,15 @@ export type ReturnKeyTypeOptions =
   | ReturnKeyTypeAndroid
   | ReturnKeyTypeIOS;
 
+export type EnterKeyHintTypeAndroid = 'previous';
+export type EnterKeyHintTypeIOS = 'enter';
+export type EnterKeyHintType = 'done' | 'go' | 'next' | 'search' | 'send';
+
+export type EnterKeyHintTypeOptions =
+  | EnterKeyHintType
+  | EnterKeyHintTypeAndroid
+  | EnterKeyHintTypeIOS;
+
 type DataDetectorTypes =
   | 'phoneNumber'
   | 'link'
@@ -778,6 +787,12 @@ export interface TextInputProps
    * Determines how the return key should look.
    */
   returnKeyType?: ReturnKeyTypeOptions | undefined;
+
+  /**
+   * Determines what text should be shown to the return key on virtual keyboards.
+   * Has precedence over the returnKeyType prop.
+   */
+  enterKeyHint?: EnterKeyHintTypeOptions | undefined;
 
   /**
    * If true, the text input obscures the text entered so that sensitive text like passwords stay secure.

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -223,13 +223,16 @@ export type TextContentType =
   | 'oneTimeCode';
 
 export type enterKeyHintType =
-  | 'enter'
+  // Cross Platform
   | 'done'
   | 'go'
   | 'next'
-  | 'previous'
   | 'search'
-  | 'send';
+  | 'send'
+  // Android-only
+  | 'previous'
+  // iOS-only
+  | 'enter';
 
 type PasswordRules = string;
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Resolves: #37622 

Related:
https://github.com/facebook/react-native/pull/34482
https://reactnative.dev/docs/textinput#enterkeyhint


## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message



For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
[Internal][Added]: Add enterKeyHint in TextInput type declaration

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
