### PR TITLE
Handle null connections

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/Inspector.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/Inspector.java
@@ -34,7 +34,11 @@ public class Inspector {
 
   public static LocalConnection connect(int pageId, RemoteConnection remote) {
     try {
-      return instance().connectNative(pageId, remote);
+      final LocalConnection local = instance().connectNative(pageId, remote);
+      if (local == null) {
+        throw new IllegalStateException("Can't open failed connection");
+      }
+      return local;
     } catch (UnsatisfiedLinkError e) {
       FLog.e(ReactConstants.TAG, "Inspector doesn't work in open source yet", e);
       throw new RuntimeException(e);

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/JInspector.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/JInspector.cpp
@@ -95,7 +95,9 @@ jni::local_ref<JLocalConnection::javaobject> JInspector::connect(
     jni::alias_ref<JRemoteConnection::javaobject> remote) {
   auto localConnection = inspector_->connect(
       pageId, std::make_unique<RemoteConnection>(std::move(remote)));
-  return JLocalConnection::newObjectCxxArgs(std::move(localConnection));
+  return localConnection
+      ? JLocalConnection::newObjectCxxArgs(std::move(localConnection))
+      : nullptr;
 }
 
 void JInspector::registerNatives() {


### PR DESCRIPTION
Summary:
`inspector_->connect` can return `null` when the connection fails. Check for `null` and raise an exception (preventing a later crash when the `null` connection is used).

Changelog: [Internal]

Differential Revision: D46126080

