### PR TITLE
[Codegen 138] Add `getProperties` to Parsers and update usages

### DIFF
--- a/packages/react-native-codegen/src/parsers/flow/components/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/index.js
@@ -14,7 +14,6 @@ import type {ComponentSchemaBuilderConfig} from '../../schema.js';
 
 const {getCommands} = require('./commands');
 const {getEvents} = require('./events');
-const {getProperties} = require('./componentsUtils.js');
 const {throwIfTypeAliasIsNotInterface} = require('../../error-utils');
 const {
   propertyNames,
@@ -83,7 +82,7 @@ function buildComponentSchema(
 
   const types = parser.getTypes(ast);
 
-  const propProperties = getProperties(propsTypeName, types);
+  const propProperties = parser.getProperties(propsTypeName, types);
   const commandProperties = getCommandProperties(ast, parser);
   const {extendsProps, props} = parser.getProps(propProperties, types);
 

--- a/packages/react-native-codegen/src/parsers/flow/parser.js
+++ b/packages/react-native-codegen/src/parsers/flow/parser.js
@@ -511,7 +511,7 @@ class FlowParser implements Parser {
     extendsProps: $ReadOnlyArray<ExtendsPropsShape>,
   } {
     const nonExtendsProps = this.removeKnownExtends(typeDefinition, types);
-    const props = flattenProperties(nonExtendsProps, types)
+    const props = flattenProperties(nonExtendsProps, types, this)
       .map(property => buildPropSchema(property, types, this))
       .filter(Boolean);
 
@@ -519,6 +519,17 @@ class FlowParser implements Parser {
       props,
       extendsProps: this.getExtendsProps(typeDefinition, types),
     };
+  }
+
+  getProperties(typeName: string, types: TypeDeclarationMap): $FlowFixMe {
+    const typeAlias = types[typeName];
+    try {
+      return typeAlias.right.typeParameters.params[0].properties;
+    } catch (e) {
+      throw new Error(
+        `Failed to find type definition for "${typeName}", please check that you have a valid codegen flow file`,
+      );
+    }
   }
 }
 

--- a/packages/react-native-codegen/src/parsers/parser.js
+++ b/packages/react-native-codegen/src/parsers/parser.js
@@ -376,4 +376,6 @@ export interface Parser {
     props: $ReadOnlyArray<NamedShape<PropTypeAnnotation>>,
     extendsProps: $ReadOnlyArray<ExtendsPropsShape>,
   };
+
+  getProperties(typeName: string, types: TypeDeclarationMap): $FlowFixMe;
 }

--- a/packages/react-native-codegen/src/parsers/parserMock.js
+++ b/packages/react-native-codegen/src/parsers/parserMock.js
@@ -436,7 +436,7 @@ export class MockedParser implements Parser {
     extendsProps: $ReadOnlyArray<ExtendsPropsShape>,
   } {
     const nonExtendsProps = this.removeKnownExtends(typeDefinition, types);
-    const props = flattenProperties(nonExtendsProps, types)
+    const props = flattenProperties(nonExtendsProps, types, this)
       .map(property => buildPropSchema(property, types, this))
       .filter(Boolean);
 
@@ -444,5 +444,16 @@ export class MockedParser implements Parser {
       props,
       extendsProps: this.getExtendsProps(typeDefinition, types),
     };
+  }
+
+  getProperties(typeName: string, types: TypeDeclarationMap): $FlowFixMe {
+    const typeAlias = types[typeName];
+    try {
+      return typeAlias.right.typeParameters.params[0].properties;
+    } catch (e) {
+      throw new Error(
+        `Failed to find type definition for "${typeName}", please check that you have a valid codegen flow file`,
+      );
+    }
   }
 }

--- a/packages/react-native-codegen/src/parsers/typescript/components/events.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/events.js
@@ -188,7 +188,7 @@ function findEventArgumentsAndType(
 } {
   if (typeAnnotation.type === 'TSInterfaceDeclaration') {
     return {
-      argumentProps: flattenProperties([typeAnnotation], types),
+      argumentProps: flattenProperties([typeAnnotation], types, parser),
       paperTopLevelNameDeprecated: paperName,
       bubblingType,
     };

--- a/packages/react-native-codegen/src/parsers/typescript/components/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/index.js
@@ -15,7 +15,6 @@ import type {ComponentSchemaBuilderConfig} from '../../schema.js';
 const {getCommands} = require('./commands');
 const {getEvents} = require('./events');
 const {categorizeProps} = require('./extends');
-const {getProperties} = require('./componentsUtils.js');
 const {throwIfTypeAliasIsNotInterface} = require('../../error-utils');
 const {
   propertyNames,
@@ -86,7 +85,7 @@ function buildComponentSchema(
 
   const types = parser.getTypes(ast);
 
-  const propProperties = getProperties(propsTypeName, types);
+  const propProperties = parser.getProperties(propsTypeName, types);
 
   const commandProperties = getCommandProperties(ast, parser);
 

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -270,7 +270,7 @@ function translateTypeAnnotation(
       return translateObjectTypeAnnotation(
         hasteModuleName,
         nullable,
-        flattenProperties([typeAnnotation], types),
+        flattenProperties([typeAnnotation], types, parser),
         typeResolutionStatus,
         baseTypes,
         types,
@@ -288,6 +288,7 @@ function translateTypeAnnotation(
         flattenProperties(
           flattenIntersectionType(typeAnnotation, types),
           types,
+          parser,
         ),
         typeResolutionStatus,
         [],

--- a/packages/react-native-codegen/src/parsers/typescript/parser.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parser.js
@@ -510,7 +510,7 @@ class TypeScriptParser implements Parser {
     }
 
     // find events and props
-    for (const prop of flattenProperties(remaining, types)) {
+    for (const prop of flattenProperties(remaining, types, this)) {
       const topLevelType = parseTopLevelType(
         prop.typeAnnotation.typeAnnotation,
         types,
@@ -531,6 +531,33 @@ class TypeScriptParser implements Parser {
         .filter(Boolean),
       extendsProps,
     };
+  }
+
+  getProperties(typeName: string, types: TypeDeclarationMap): $FlowFixMe {
+    const alias = types[typeName];
+    if (!alias) {
+      throw new Error(
+        `Failed to find definition for "${typeName}", please check that you have a valid codegen typescript file`,
+      );
+    }
+    const aliasKind =
+      alias.type === 'TSInterfaceDeclaration' ? 'interface' : 'type';
+
+    try {
+      if (aliasKind === 'interface') {
+        return [...(alias.extends ?? []), ...alias.body.body];
+      }
+
+      return (
+        alias.typeAnnotation.members ||
+        alias.typeAnnotation.typeParameters.params[0].members ||
+        alias.typeAnnotation.typeParameters.params
+      );
+    } catch (e) {
+      throw new Error(
+        `Failed to find ${aliasKind} definition for "${typeName}", please check that you have a valid codegen typescript file`,
+      );
+    }
   }
 }
 


### PR DESCRIPTION
## Summary:

[Codegen 138] This PR introduces `getProperties` to Parser base class and implements the function in Typescript and Flow Parsers.
This PR also gets rid of `getProperties` from :
- `packages/react-native-codegen/src/parsers/typescript/components/componentsUtils.js`
- `packages/react-native-codegen/src/parsers/flow/components/componentsUtils.js`
and updates the usages with `getProperties` from the respective parser objects as requested on https://github.com/facebook/react-native/issues/34872

## Changelog:

[Internal] [Changed] - Add getProperties  to Parsers base class and update usages.

## Test Plan:

Run yarn jest react-native-codegen and ensure CI is green

## Screenshot of tests passing locally:

![Screenshot 2023-05-31 at 4 38 41 PM](https://github.com/facebook/react-native/assets/64726664/dd660369-eabd-4c2e-a440-a41ed6f9d47a)

