### PR TITLE
Export moduleIsInitialized from RCTModuleRegistry

### DIFF
--- a/packages/react-native/React/Base/RCTBridge.h
+++ b/packages/react-native/React/Base/RCTBridge.h
@@ -227,11 +227,4 @@ RCT_EXTERN void RCTSetTurboModuleCleanupMode(RCTTurboModuleCleanupMode mode);
  */
 - (BOOL)isBatchActive;
 
-/**
- * Loads and executes additional bundles in the VM for development.
- */
-- (void)loadAndExecuteSplitBundleURL:(NSURL *)bundleURL
-                             onError:(RCTLoadAndExecuteErrorBlock)onError
-                          onComplete:(dispatch_block_t)onComplete;
-
 @end

--- a/packages/react-native/React/Base/RCTBridge.m
+++ b/packages/react-native/React/Base/RCTBridge.m
@@ -420,11 +420,4 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
   [self.batchedBridge registerSegmentWithId:segmentId path:path];
 }
 
-- (void)loadAndExecuteSplitBundleURL:(NSURL *)bundleURL
-                             onError:(RCTLoadAndExecuteErrorBlock)onError
-                          onComplete:(dispatch_block_t)onComplete
-{
-  [self.batchedBridge loadAndExecuteSplitBundleURL:bundleURL onError:onError onComplete:onComplete];
-}
-
 @end

--- a/packages/react-native/React/Base/RCTBridgeModule.h
+++ b/packages/react-native/React/Base/RCTBridgeModule.h
@@ -390,6 +390,7 @@ RCT_EXTERN_C_END
 
 - (id)moduleForName:(const char *)moduleName;
 - (id)moduleForName:(const char *)moduleName lazilyLoadIfNecessary:(BOOL)lazilyLoad;
+- (BOOL)moduleIsInitialized:(Class)moduleClass;
 @end
 
 typedef UIView * (^RCTBridgelessComponentViewProvider)(NSNumber *);

--- a/packages/react-native/React/Base/RCTModuleRegistry.m
+++ b/packages/react-native/React/Base/RCTModuleRegistry.m
@@ -47,4 +47,21 @@
   return module;
 }
 
+- (BOOL)moduleIsInitialized:(Class)moduleClass
+{
+  RCTBridge *bridge = _bridge;
+
+  if (bridge) {
+    return [bridge moduleIsInitialized:moduleClass];
+  }
+
+  id<RCTTurboModuleRegistry> turboModuleRegistry = _turboModuleRegistry;
+  if (turboModuleRegistry) {
+    NSString *moduleName = RCTBridgeModuleNameForClass(moduleClass);
+    return [turboModuleRegistry moduleIsInitialized:[moduleName UTF8String]];
+  }
+
+  return NO;
+}
+
 @end

--- a/packages/react-native/React/CxxBridge/RCTCxxBridge.mm
+++ b/packages/react-native/React/CxxBridge/RCTCxxBridge.mm
@@ -1089,42 +1089,6 @@ struct RCTInstanceCallback : public InstanceCallback {
   [self.devSettings setupHMRClientWithBundleURL:self.bundleURL];
 }
 
-#if RCT_DEV_MENU | RCT_PACKAGER_LOADING_FUNCTIONALITY
-- (void)loadAndExecuteSplitBundleURL:(NSURL *)bundleURL
-                             onError:(RCTLoadAndExecuteErrorBlock)onError
-                          onComplete:(dispatch_block_t)onComplete
-{
-  __weak __typeof(self) weakSelf = self;
-  [RCTJavaScriptLoader loadBundleAtURL:bundleURL
-      onProgress:^(RCTLoadingProgress *progressData) {
-#if (RCT_DEV_MENU | RCT_DEV_MENU) && __has_include(<React/RCTDevLoadingViewProtocol.h>)
-        id<RCTDevLoadingViewProtocol> loadingView = [weakSelf moduleForName:@"DevLoadingView"
-                                                      lazilyLoadIfNecessary:YES];
-        [loadingView updateProgress:progressData];
-#endif
-      }
-      onComplete:^(NSError *error, RCTSource *source) {
-        if (error) {
-          onError(error);
-          return;
-        }
-
-        [self enqueueApplicationScript:source.data
-                                   url:source.url
-                            onComplete:^{
-                              [self.devSettings setupHMRClientWithAdditionalBundleURL:source.url];
-                              onComplete();
-                            }];
-      }];
-}
-#else
-- (void)loadAndExecuteSplitBundleURL:(NSURL *)bundleURL
-                             onError:(RCTLoadAndExecuteErrorBlock)onError
-                          onComplete:(dispatch_block_t)onComplete
-{
-}
-#endif
-
 - (void)handleError:(NSError *)error
 {
   // This is generally called when the infrastructure throws an


### PR DESCRIPTION
Summary:
## Context
Product code can query the Bridge, or the TurboModuleManager, to see whether a native module has been initialized or not. But, this API doesn't exist in RCTModuleRegistry.

## Changes
This diff exports moduleIsInitialized: from RCTModuleRegistry. That way, RCTBridgeProxy (introduce in D46088752) can more easily implement the moduleIsInitialized: API.

Changelog:
[iOS][Added] - Introduce RCTModuleRegistry moduleIsInitialized:

Reviewed By: cortinico

Differential Revision: D46166548

