### PR TITLE
Delete bridge.loadAndExecuteSplitBundleURL

### DIFF
--- a/packages/react-native/React/Base/RCTBridge.h
+++ b/packages/react-native/React/Base/RCTBridge.h
@@ -227,11 +227,4 @@ RCT_EXTERN void RCTSetTurboModuleCleanupMode(RCTTurboModuleCleanupMode mode);
  */
 - (BOOL)isBatchActive;
 
-/**
- * Loads and executes additional bundles in the VM for development.
- */
-- (void)loadAndExecuteSplitBundleURL:(NSURL *)bundleURL
-                             onError:(RCTLoadAndExecuteErrorBlock)onError
-                          onComplete:(dispatch_block_t)onComplete;
-
 @end

--- a/packages/react-native/React/Base/RCTBridge.m
+++ b/packages/react-native/React/Base/RCTBridge.m
@@ -420,11 +420,4 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
   [self.batchedBridge registerSegmentWithId:segmentId path:path];
 }
 
-- (void)loadAndExecuteSplitBundleURL:(NSURL *)bundleURL
-                             onError:(RCTLoadAndExecuteErrorBlock)onError
-                          onComplete:(dispatch_block_t)onComplete
-{
-  [self.batchedBridge loadAndExecuteSplitBundleURL:bundleURL onError:onError onComplete:onComplete];
-}
-
 @end

--- a/packages/react-native/React/CxxBridge/RCTCxxBridge.mm
+++ b/packages/react-native/React/CxxBridge/RCTCxxBridge.mm
@@ -1089,42 +1089,6 @@ struct RCTInstanceCallback : public InstanceCallback {
   [self.devSettings setupHMRClientWithBundleURL:self.bundleURL];
 }
 
-#if RCT_DEV_MENU | RCT_PACKAGER_LOADING_FUNCTIONALITY
-- (void)loadAndExecuteSplitBundleURL:(NSURL *)bundleURL
-                             onError:(RCTLoadAndExecuteErrorBlock)onError
-                          onComplete:(dispatch_block_t)onComplete
-{
-  __weak __typeof(self) weakSelf = self;
-  [RCTJavaScriptLoader loadBundleAtURL:bundleURL
-      onProgress:^(RCTLoadingProgress *progressData) {
-#if (RCT_DEV_MENU | RCT_DEV_MENU) && __has_include(<React/RCTDevLoadingViewProtocol.h>)
-        id<RCTDevLoadingViewProtocol> loadingView = [weakSelf moduleForName:@"DevLoadingView"
-                                                      lazilyLoadIfNecessary:YES];
-        [loadingView updateProgress:progressData];
-#endif
-      }
-      onComplete:^(NSError *error, RCTSource *source) {
-        if (error) {
-          onError(error);
-          return;
-        }
-
-        [self enqueueApplicationScript:source.data
-                                   url:source.url
-                            onComplete:^{
-                              [self.devSettings setupHMRClientWithAdditionalBundleURL:source.url];
-                              onComplete();
-                            }];
-      }];
-}
-#else
-- (void)loadAndExecuteSplitBundleURL:(NSURL *)bundleURL
-                             onError:(RCTLoadAndExecuteErrorBlock)onError
-                          onComplete:(dispatch_block_t)onComplete
-{
-}
-#endif
-
 - (void)handleError:(NSError *)error
 {
   // This is generally called when the infrastructure throws an


### PR DESCRIPTION
Summary:
Changelog:
[iOS][Removed] - Delete bridge.loadAndExecuteSplitBundleURL

Reviewed By: cortinico

Differential Revision: D46166549

