### PR TITLE
Enable mock-maker-inline for Android JVM tests

### DIFF
--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridgeless/ReactHostDelegateTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridgeless/ReactHostDelegateTest.kt
@@ -14,7 +14,6 @@ import com.facebook.react.defaults.DefaultReactHostDelegate
 import com.facebook.react.turbomodule.core.TurboModuleManagerDelegate
 import com.facebook.testutils.shadows.ShadowSoLoader
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito
@@ -31,7 +30,6 @@ class ReactHostDelegateTest {
    * API
    */
   @Test
-  @Ignore
   fun testDefaultReactHostDelegateCreation() {
     val jsBundleLoader: JSBundleLoader = Mockito.mock(JSBundleLoader::class.java)
     val turboModuleManagerDelegateMock: TurboModuleManagerDelegate =

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/deviceinfo/DeviceInfoModuleTest.java
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/deviceinfo/DeviceInfoModuleTest.java
@@ -126,7 +126,8 @@ public class DeviceInfoModuleTest extends TestCase {
   }
 
   private static void givenDisplayMetricsHolderContains(final WritableMap fakeDisplayMetrics) {
-    when(DisplayMetricsHolder.getDisplayMetricsWritableMap(1.0)).thenReturn(fakeDisplayMetrics);
+    when(DisplayMetricsHolder.getDisplayMetricsWritableMap(1.0))
+        .thenAnswer(invocation -> fakeDisplayMetrics);
   }
 
   private static void verifyUpdateDimensionsEventsEmitted(

--- a/packages/react-native/ReactAndroid/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/packages/react-native/ReactAndroid/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
Summary:
I'm re-enabling a test that got disabled due to us not using mock-maker-inline in OSS. I'm also adding `mock-maker-inline` for OSS so it will be easier to convert tests to Kotlin as classes in Kotlin are final by default.

Changelog:
[Internal] [Changed] - Enable mock-maker-inline for Android JVM tests

Differential Revision: D46222913

