### PR TITLE
Interop: Create gating for the Bridge proxy

### DIFF
--- a/packages/react-native/React/Base/RCTBridge.h
+++ b/packages/react-native/React/Base/RCTBridge.h
@@ -227,11 +227,4 @@ RCT_EXTERN void RCTSetTurboModuleCleanupMode(RCTTurboModuleCleanupMode mode);
  */
 - (BOOL)isBatchActive;
 
-/**
- * Loads and executes additional bundles in the VM for development.
- */
-- (void)loadAndExecuteSplitBundleURL:(NSURL *)bundleURL
-                             onError:(RCTLoadAndExecuteErrorBlock)onError
-                          onComplete:(dispatch_block_t)onComplete;
-
 @end

--- a/packages/react-native/React/Base/RCTBridge.h
+++ b/packages/react-native/React/Base/RCTBridge.h
@@ -60,6 +60,10 @@ RCT_EXTERN void RCTDisableTurboModuleManagerDelegateLocking(BOOL enabled);
 RCT_EXTERN BOOL RCTTurboModuleInteropEnabled(void);
 RCT_EXTERN void RCTEnableTurboModuleInterop(BOOL enabled);
 
+// Turn on TurboModule interop's Bridge proxy
+RCT_EXTERN BOOL RCTTurboModuleInteropBridgeProxyEnabled(void);
+RCT_EXTERN void RCTEnableTurboModuleInteropBridgeProxy(BOOL enabled);
+
 // Route all TurboModules through TurboModule interop
 RCT_EXTERN BOOL RCTTurboModuleInteropForAllTurboModulesEnabled(void);
 RCT_EXTERN void RCTEnableTurboModuleInteropForAllTurboModules(BOOL enabled);

--- a/packages/react-native/React/Base/RCTBridge.m
+++ b/packages/react-native/React/Base/RCTBridge.m
@@ -420,11 +420,4 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
   [self.batchedBridge registerSegmentWithId:segmentId path:path];
 }
 
-- (void)loadAndExecuteSplitBundleURL:(NSURL *)bundleURL
-                             onError:(RCTLoadAndExecuteErrorBlock)onError
-                          onComplete:(dispatch_block_t)onComplete
-{
-  [self.batchedBridge loadAndExecuteSplitBundleURL:bundleURL onError:onError onComplete:onComplete];
-}
-
 @end

--- a/packages/react-native/React/Base/RCTBridge.m
+++ b/packages/react-native/React/Base/RCTBridge.m
@@ -130,6 +130,17 @@ void RCTEnableTurboModuleInterop(BOOL enabled)
   turboModuleInteropEnabled = enabled;
 }
 
+static BOOL turboModuleInteropBridgeProxyEnabled = NO;
+BOOL RCTTurboModuleInteropBridgeProxyEnabled(void)
+{
+  return turboModuleInteropBridgeProxyEnabled;
+}
+
+void RCTEnableTurboModuleInteropBridgeProxy(BOOL enabled)
+{
+  turboModuleInteropBridgeProxyEnabled = enabled;
+}
+
 static BOOL useTurboModuleInteropForAllTurboModules = NO;
 BOOL RCTTurboModuleInteropForAllTurboModulesEnabled(void)
 {

--- a/packages/react-native/React/Base/RCTBridgeModule.h
+++ b/packages/react-native/React/Base/RCTBridgeModule.h
@@ -390,6 +390,7 @@ RCT_EXTERN_C_END
 
 - (id)moduleForName:(const char *)moduleName;
 - (id)moduleForName:(const char *)moduleName lazilyLoadIfNecessary:(BOOL)lazilyLoad;
+- (BOOL)moduleIsInitialized:(Class)moduleClass;
 @end
 
 typedef UIView * (^RCTBridgelessComponentViewProvider)(NSNumber *);

--- a/packages/react-native/React/Base/RCTModuleRegistry.m
+++ b/packages/react-native/React/Base/RCTModuleRegistry.m
@@ -47,4 +47,21 @@
   return module;
 }
 
+- (BOOL)moduleIsInitialized:(Class)moduleClass
+{
+  RCTBridge *bridge = _bridge;
+
+  if (bridge) {
+    return [bridge moduleIsInitialized:moduleClass];
+  }
+
+  id<RCTTurboModuleRegistry> turboModuleRegistry = _turboModuleRegistry;
+  if (turboModuleRegistry) {
+    NSString *moduleName = RCTBridgeModuleNameForClass(moduleClass);
+    return [turboModuleRegistry moduleIsInitialized:[moduleName UTF8String]];
+  }
+
+  return NO;
+}
+
 @end

--- a/packages/react-native/React/CxxBridge/RCTCxxBridge.mm
+++ b/packages/react-native/React/CxxBridge/RCTCxxBridge.mm
@@ -1089,42 +1089,6 @@ struct RCTInstanceCallback : public InstanceCallback {
   [self.devSettings setupHMRClientWithBundleURL:self.bundleURL];
 }
 
-#if RCT_DEV_MENU | RCT_PACKAGER_LOADING_FUNCTIONALITY
-- (void)loadAndExecuteSplitBundleURL:(NSURL *)bundleURL
-                             onError:(RCTLoadAndExecuteErrorBlock)onError
-                          onComplete:(dispatch_block_t)onComplete
-{
-  __weak __typeof(self) weakSelf = self;
-  [RCTJavaScriptLoader loadBundleAtURL:bundleURL
-      onProgress:^(RCTLoadingProgress *progressData) {
-#if (RCT_DEV_MENU | RCT_DEV_MENU) && __has_include(<React/RCTDevLoadingViewProtocol.h>)
-        id<RCTDevLoadingViewProtocol> loadingView = [weakSelf moduleForName:@"DevLoadingView"
-                                                      lazilyLoadIfNecessary:YES];
-        [loadingView updateProgress:progressData];
-#endif
-      }
-      onComplete:^(NSError *error, RCTSource *source) {
-        if (error) {
-          onError(error);
-          return;
-        }
-
-        [self enqueueApplicationScript:source.data
-                                   url:source.url
-                            onComplete:^{
-                              [self.devSettings setupHMRClientWithAdditionalBundleURL:source.url];
-                              onComplete();
-                            }];
-      }];
-}
-#else
-- (void)loadAndExecuteSplitBundleURL:(NSURL *)bundleURL
-                             onError:(RCTLoadAndExecuteErrorBlock)onError
-                          onComplete:(dispatch_block_t)onComplete
-{
-}
-#endif
-
 - (void)handleError:(NSError *)error
 {
   // This is generally called when the infrastructure throws an


### PR DESCRIPTION
Summary:
The TurboModule interop layer on iOS will ship with a Bridge proxy.

The Bridge proxy is an object (see D46084318) that will try to simulate the Bridge's APIs, whenever possible, by delegating to Bridgeless abstractions.

## Changes
**Fact:** All FBiOS modules work with/without the bridge.

So, let's break down the Interop layer test group (i.e: interop on) into two groups:
- interop on, bridge proxy off
- interop on, bridge proxy on

## Benefits
This will speed up the production test, by allowing us to:
1. Isolate Interop issues to the bridge proxy faster.
2. Stabilize the TurboModule interop layer faster.

NOTE: This flag is temporary, and should be removed long-term: The TurboModule interop layer should ship with the bridge proxy enabled by default.

Changelog: [Internal]

Reviewed By: philIip

Differential Revision: D46088752

