### PR TITLE
Upgrade hermes-* packages in xplat and arvr to version 0.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "eslint-plugin-redundant-undefined": "^0.4.0",
     "eslint-plugin-relay": "^1.8.3",
     "flow-bin": "^0.207.0",
-    "hermes-eslint": "0.8.0",
+    "hermes-eslint": "0.12.0",
     "inquirer": "^7.1.0",
     "jest": "^29.2.1",
     "jest-junit": "^10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6081,19 +6081,31 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
-hermes-eslint@0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/hermes-eslint/-/hermes-eslint-0.8.0.tgz#e0a892d3f63f25d0966aa558ed40e373e2d0a065"
-  integrity sha512-TXbTys9Ssx9kzB8W18TK8m23QTSG6RqI4dOVzG12DslDJGNBU3pJV8AWkiwz8aOyCU6uiWhbVE2855E7g3iXoA==
+hermes-eslint@0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/hermes-eslint/-/hermes-eslint-0.12.0.tgz#e0a0ff4c24679650789cee26d0f70fe7ca7915b7"
+  integrity sha512-I+CqRj8ciokZisoZkHK2xRB5kOnjq/42MWNlW7v1S9tLpi0iuZd1sXsb1TEDgkqk/xDpfNdOrIoesb+9c5MkSw==
   dependencies:
     esrecurse "^4.3.0"
-    hermes-estree "0.8.0"
-    hermes-parser "0.8.0"
+    hermes-estree "0.12.0"
+    hermes-parser "0.12.0"
+
+hermes-estree@0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/hermes-estree/-/hermes-estree-0.12.0.tgz#8a289f9aee854854422345e6995a48613bac2ca8"
+  integrity sha512-+e8xR6SCen0wyAKrMT3UD0ZCCLymKhRgjEB5sS28rKiFir/fXgLoeRilRUssFCILmGHb+OvHDUlhxs0+IEyvQw==
 
 hermes-estree@0.8.0:
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/hermes-estree/-/hermes-estree-0.8.0.tgz#530be27243ca49f008381c1f3e8b18fb26bf9ec0"
   integrity sha512-W6JDAOLZ5pMPMjEiQGLCXSSV7pIBEgRR5zGkxgmzGSXHOxqV5dC/M1Zevqpbm9TZDE5tu358qZf8Vkzmsc+u7Q==
+
+hermes-parser@0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/hermes-parser/-/hermes-parser-0.12.0.tgz#114dc26697cfb41a6302c215b859b74224383773"
+  integrity sha512-d4PHnwq6SnDLhYl3LHNHvOg7nQ6rcI7QVil418REYksv0Mh3cEkHDcuhGxNQ3vgnLSLl4QSvDrFCwQNYdpWlzw==
+  dependencies:
+    hermes-estree "0.12.0"
 
 hermes-parser@0.8.0:
   version "0.8.0"


### PR DESCRIPTION
Summary:
Upgrade hermes parser packages to the latest released versions.

Changelog is here: https://github.com/facebook/hermes/blob/main/tools/hermes-parser/js/CHANGELOG.md
Main differences are improved parser support for new Flow features.

Changelog: [Internal]

Differential Revision: D46303102

