### PR TITLE
Remove missing dependencies from React-Fabric

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -134,10 +134,11 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
   return YES;
 }
 
+#if RCT_NEW_ARCH_ENABLED
 #pragma mark - RCTCxxBridgeDelegate
 - (std::unique_ptr<facebook::react::JSExecutorFactory>)jsExecutorFactoryForBridge:(RCTBridge *)bridge
 {
-#if RCT_NEW_ARCH_ENABLED
+
   _runtimeScheduler = std::make_shared<facebook::react::RuntimeScheduler>(RCTRuntimeExecutorFromBridge(bridge));
   std::shared_ptr<facebook::react::CallInvoker> callInvoker =
       std::make_shared<facebook::react::RuntimeSchedulerCallInvoker>(_runtimeScheduler);
@@ -147,12 +148,6 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
   _contextContainer->erase("RuntimeScheduler");
   _contextContainer->insert("RuntimeScheduler", _runtimeScheduler);
   return RCTAppSetupDefaultJsExecutorFactory(bridge, turboModuleManager, _runtimeScheduler);
-#else
-  if (self.runtimeSchedulerEnabled) {
-    _runtimeScheduler = std::make_shared<facebook::react::RuntimeScheduler>(RCTRuntimeExecutorFromBridge(bridge));
-  }
-  return RCTAppSetupJsExecutorFactoryForOldArch(bridge, _runtimeScheduler);
-#endif
 }
 
 #pragma mark - RCTTurboModuleManagerDelegate

--- a/packages/react-native/Libraries/AppDelegate/RCTLegacyInteropComponents.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTLegacyInteropComponents.mm
@@ -12,7 +12,9 @@
 
 + (NSArray<NSString *> *)legacyInteropComponents
 {
-  return @[ @"RNTMyLegacyNativeView" ];
+  return @[
+			@"RNTMyLegacyNativeView"
+  ];
 }
 
 @end

--- a/packages/react-native/ReactCommon/React-Fabric.podspec
+++ b/packages/react-native/ReactCommon/React-Fabric.podspec
@@ -51,9 +51,9 @@ Pod::Spec.new do |s|
   s.dependency "glog"
   s.dependency "DoubleConversion"
   s.dependency "React-Core"
-  s.dependency "React-debug"
-  s.dependency "React-utils"
-  s.dependency "React-runtimescheduler"
+  # s.dependency "React-debug"
+  # s.dependency "React-utils"
+  # s.dependency "React-runtimescheduler"
   s.dependency "React-cxxreact"
 
   if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"

--- a/packages/rn-tester/RNTester/AppDelegate.mm
+++ b/packages/rn-tester/RNTester/AppDelegate.mm
@@ -9,68 +9,17 @@
 
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTLinkingManager.h>
-#import <React/RCTLocalAssetImageLoader.h>
-#import <React/RCTNetworking.h>
-#import <React/RCTRootView.h>
 #import <ReactCommon/RCTSampleTurboModule.h>
 #import <ReactCommon/SampleTurboCxxModule.h>
 
-#import <cxxreact/JSExecutor.h>
-
 #if !TARGET_OS_TV && !TARGET_OS_UIKITFORMAC
 #import <React/RCTPushNotificationManager.h>
-#endif
-
-#ifdef RN_FABRIC_ENABLED
-#import <React/RCTComponentViewFactory.h>
-#import <React/RCTFabricSurfaceHostingProxyRootView.h>
-#import <React/RCTSurfacePresenter.h>
-#import <React/RCTSurfacePresenterBridgeAdapter.h>
-
-#import <React/RCTLegacyViewManagerInteropComponentView.h>
-#import <react/config/ReactNativeConfig.h>
-#import <react/renderer/runtimescheduler/RuntimeScheduler.h>
-#import <react/renderer/runtimescheduler/RuntimeSchedulerBinding.h>
-#import <react/renderer/runtimescheduler/RuntimeSchedulerCallInvoker.h>
 #endif
 
 #if RCT_NEW_ARCH_ENABLED
 #import <NativeCxxModuleExample/NativeCxxModuleExample.h>
 #import <RNTMyNativeViewComponentView.h>
 #endif
-
-#if DEBUG
-#ifdef FB_SONARKIT_ENABLED
-#import <FlipperKit/FlipperClient.h>
-#import <FlipperKitLayoutPlugin/FlipperKitLayoutPlugin.h>
-#import <FlipperKitLayoutPlugin/SKDescriptorMapper.h>
-#import <FlipperKitNetworkPlugin/FlipperKitNetworkPlugin.h>
-#import <FlipperKitReactPlugin/FlipperKitReactPlugin.h>
-#import <FlipperKitUserDefaultsPlugin/FKUserDefaultsPlugin.h>
-#import <SKIOSNetworkPlugin/SKIOSNetworkAdapter.h>
-#endif
-#endif
-
-#import <ReactCommon/RCTTurboModuleManager.h>
-#import "RNTesterTurboModuleProvider.h"
-
-@interface AppDelegate () <RCTCxxBridgeDelegate, RCTTurboModuleManagerDelegate> {
-#ifdef RN_FABRIC_ENABLED
-  RCTSurfacePresenterBridgeAdapter *_bridgeAdapter;
-  std::shared_ptr<const facebook::react::ReactNativeConfig> _reactNativeConfig;
-  facebook::react::ContextContainer::Shared _contextContainer;
-  std::shared_ptr<facebook::react::RuntimeScheduler> _runtimeScheduler;
-#endif
-}
-@end
-
-#if RCT_NEW_ARCH_ENABLED
-/// Declare conformance to `RCTComponentViewFactoryComponentProvider`
-@interface AppDelegate () <RCTComponentViewFactoryComponentProvider>
-@end
-#endif
-
-static NSString *const kRNConcurrentRoot = @"concurrentRoot";
 
 @implementation AppDelegate
 
@@ -113,67 +62,6 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
                  onComplete:(RCTSourceLoadBlock)loadCallback
 {
   [RCTJavaScriptLoader loadBundleAtURL:[self sourceURLForBridge:bridge] onProgress:onProgress onComplete:loadCallback];
-}
-
-#pragma mark - RCTCxxBridgeDelegate
-
-// This function is called during
-// `[[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];`
-- (std::unique_ptr<facebook::react::JSExecutorFactory>)jsExecutorFactoryForBridge:(RCTBridge *)bridge
-{
-  std::shared_ptr<facebook::react::CallInvoker> callInvoker = bridge.jsCallInvoker;
-
-#ifdef RN_FABRIC_ENABLED
-  _runtimeScheduler = std::make_shared<facebook::react::RuntimeScheduler>(RCTRuntimeExecutorFromBridge(bridge));
-  _contextContainer->erase("RuntimeScheduler");
-  _contextContainer->insert("RuntimeScheduler", _runtimeScheduler);
-  callInvoker = std::make_shared<facebook::react::RuntimeSchedulerCallInvoker>(_runtimeScheduler);
-#endif
-
-  RCTTurboModuleManager *turboModuleManager = [[RCTTurboModuleManager alloc] initWithBridge:bridge
-                                                                                   delegate:self
-                                                                                  jsInvoker:callInvoker];
-  [bridge setRCTTurboModuleRegistry:turboModuleManager];
-
-#if RCT_DEV
-  /**
-   * Eagerly initialize RCTDevMenu so CMD + d, CMD + i, and CMD + r work.
-   * This is a stop gap until we have a system to eagerly init Turbo Modules.
-   */
-  [turboModuleManager moduleForName:"RCTDevMenu"];
-#endif
-
-  __weak __typeof(self) weakSelf = self;
-
-#if RCT_USE_HERMES
-  return std::make_unique<facebook::react::HermesExecutorFactory>(
-#else
-  return std::make_unique<facebook::react::JSCExecutorFactory>(
-#endif
-      facebook::react::RCTJSIExecutorRuntimeInstaller([weakSelf, bridge, turboModuleManager](
-                                                          facebook::jsi::Runtime &runtime) {
-        if (!bridge) {
-          return;
-        }
-
-#if RN_FABRIC_ENABLED
-        __typeof(self) strongSelf = weakSelf;
-        if (strongSelf && strongSelf->_runtimeScheduler) {
-          facebook::react::RuntimeSchedulerBinding::createAndInstallIfNeeded(runtime, strongSelf->_runtimeScheduler);
-        }
-#endif
-
-        facebook::react::RuntimeExecutor syncRuntimeExecutor =
-            [&](std::function<void(facebook::jsi::Runtime & runtime_)> &&callback) { callback(runtime); };
-        [turboModuleManager installJSBindingWithRuntimeExecutor:syncRuntimeExecutor];
-      }));
-}
-
-#pragma mark - RCTTurboModuleManagerDelegate
-
-- (Class)getModuleClassFromName:(const char *)name
-{
-  return facebook::react::RNTesterTurboModuleClassProvider(name);
 }
 
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const std::string &)name


### PR DESCRIPTION
## Summary:
When reverting the runtimescheduler fix, we forgot to remove some lines from the React-Fabric dependencies. This broke pod install and we have a red ci since then.

## Changelog:

[iOS][Fixed] - fix React-Fabric dependencies

## Test Plan:

CircleCI is green
