### PR TITLE
fix KeyboardAvoidingView jumps when keyboard height changes

### DIFF
--- a/packages/react-native/Libraries/Components/Keyboard/KeyboardAvoidingView.js
+++ b/packages/react-native/Libraries/Components/Keyboard/KeyboardAvoidingView.js
@@ -142,16 +142,19 @@ class KeyboardAvoidingView extends React.Component<Props, State> {
       return;
     }
 
-    if (duration && easing) {
-      LayoutAnimation.configureNext({
-        // We have to pass the duration equal to minimal accepted duration defined here: RCTLayoutAnimation.m
+    // bottom is changing, animate
+    LayoutAnimation.configureNext({
+      // We have to pass the duration equal to minimal accepted duration defined here: RCTLayoutAnimation.m
+      duration: duration > 10 ? duration : 10,
+      update: {
         duration: duration > 10 ? duration : 10,
-        update: {
-          duration: duration > 10 ? duration : 10,
-          type: LayoutAnimation.Types[easing] || 'keyboard',
-        },
-      });
-    }
+        type:
+          Platform.OS === 'android'
+            ? 'linear'
+            : LayoutAnimation.Types[easing] || 'keyboard',
+      },
+    });
+
     this.setState({bottom: height});
   };
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

The `KeyboardAvoidingView` component currently does not animate when the keyboard's height changes in place, e.g. when switching between two input types. This is because of an if conditional that checks that the keyboard event itself was animated (by checking the presence of duration and easing type on the said keyboard event). Unfortunately, the keyboard doesn't animate when the type changes, e.g. when switching between an alpha-numeric type to a number type thereby changing the keyboard height, which causes a jarring jump in the `KeyboardAvoidingView`'s position.

This PR ensures the `KeyboardAvoidingView` always animates as long as it has to move.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:
[GENERAL] [FIXED] - remove duration and easing check on keyboard event before the animation
[GENERAL] [FIXED] - always animate `KeyboardAvoidingView` as long as `bottom` changes
<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

#### BEFORE
https://github.com/facebook/react-native/assets/26779819/fa53b309-d128-4c68-9979-8a7de8aae91b


#### AFTER
https://github.com/facebook/react-native/assets/26779819/ada83376-744e-49f1-98da-9e217c2ced04


