### PR TITLE
Specify float value in ParagraphLayoutManager

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphLayoutManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphLayoutManager.cpp
@@ -58,7 +58,7 @@ bool ParagraphLayoutManager::shoudMeasureString(
 
   bool hasMaximumSizeChanged =
       layoutConstraints.maximumSize.width != lastAvailableWidth_;
-  Float threshold = 0.01;
+  Float threshold = 0.01f;
   bool doesMaximumSizeMatchLastMeasurement =
       std::abs(
           layoutConstraints.maximumSize.width -


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

React-Native-Windows had to override this file because we treat certain warning as errors. This fix adds in the "f suffix" to remove the unspecified float error. 

## Changelog:
[GENERAL] [FIXED] - Specify float value in ParagraphLayoutManager

## Test Plan:

Tested with RNW tests
