### PR TITLE
refactor(codegen): extract getCommandProperties to parsers-common

### DIFF
--- a/packages/react-native-codegen/src/parsers/flow/components/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/index.js
@@ -15,61 +15,11 @@ import type {ComponentSchemaBuilderConfig} from '../../schema.js';
 const {getCommands} = require('./commands');
 const {getEvents} = require('./events');
 const {getProperties} = require('./componentsUtils.js');
-const {throwIfTypeAliasIsNotInterface} = require('../../error-utils');
 const {
-  propertyNames,
-  getCommandOptions,
   getOptions,
   findComponentConfig,
+  getCommandProperties,
 } = require('../../parsers-commons');
-
-function getCommandProperties(ast: $FlowFixMe, parser: Parser) {
-  const {commandTypeName, commandOptionsExpression} = findComponentConfig(
-    ast,
-    parser,
-  );
-
-  if (commandTypeName == null) {
-    return [];
-  }
-  const types = parser.getTypes(ast);
-
-  const typeAlias = types[commandTypeName];
-
-  throwIfTypeAliasIsNotInterface(typeAlias, parser);
-
-  const properties = parser.bodyProperties(typeAlias);
-  if (!properties) {
-    throw new Error(
-      `Failed to find type definition for "${commandTypeName}", please check that you have a valid codegen flow file`,
-    );
-  }
-
-  const flowPropertyNames = propertyNames(properties);
-
-  const commandOptions = getCommandOptions(commandOptionsExpression);
-
-  if (commandOptions == null || commandOptions.supportedCommands == null) {
-    throw new Error(
-      'codegenNativeCommands must be given an options object with supportedCommands array',
-    );
-  }
-
-  if (
-    commandOptions.supportedCommands.length !== flowPropertyNames.length ||
-    !commandOptions.supportedCommands.every(supportedCommand =>
-      flowPropertyNames.includes(supportedCommand),
-    )
-  ) {
-    throw new Error(
-      `codegenNativeCommands expected the same supportedCommands specified in the ${commandTypeName} interface: ${flowPropertyNames.join(
-        ', ',
-      )}`,
-    );
-  }
-
-  return properties;
-}
 
 // $FlowFixMe[signature-verification-failure] there's no flowtype for AST
 function buildComponentSchema(

--- a/packages/react-native-codegen/src/parsers/typescript/components/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/index.js
@@ -16,60 +16,11 @@ const {getCommands} = require('./commands');
 const {getEvents} = require('./events');
 const {categorizeProps} = require('./extends');
 const {getProperties} = require('./componentsUtils.js');
-const {throwIfTypeAliasIsNotInterface} = require('../../error-utils');
 const {
-  propertyNames,
-  getCommandOptions,
   getOptions,
   findComponentConfig,
+  getCommandProperties,
 } = require('../../parsers-commons');
-
-function getCommandProperties(ast: $FlowFixMe, parser: Parser) {
-  const {commandTypeName, commandOptionsExpression} = findComponentConfig(
-    ast,
-    parser,
-  );
-  if (commandTypeName == null) {
-    return [];
-  }
-
-  const types = parser.getTypes(ast);
-  const typeAlias = types[commandTypeName];
-
-  throwIfTypeAliasIsNotInterface(typeAlias, parser);
-
-  const properties = parser.bodyProperties(typeAlias);
-  if (!properties) {
-    throw new Error(
-      `Failed to find type definition for "${commandTypeName}", please check that you have a valid codegen typescript file`,
-    );
-  }
-
-  const typeScriptPropertyNames = propertyNames(properties);
-
-  const commandOptions = getCommandOptions(commandOptionsExpression);
-  if (commandOptions == null || commandOptions.supportedCommands == null) {
-    throw new Error(
-      'codegenNativeCommands must be given an options object with supportedCommands array',
-    );
-  }
-
-  if (
-    commandOptions.supportedCommands.length !==
-      typeScriptPropertyNames.length ||
-    !commandOptions.supportedCommands.every(supportedCommand =>
-      typeScriptPropertyNames.includes(supportedCommand),
-    )
-  ) {
-    throw new Error(
-      `codegenNativeCommands expected the same supportedCommands specified in the ${commandTypeName} interface: ${typeScriptPropertyNames.join(
-        ', ',
-      )}`,
-    );
-  }
-
-  return properties;
-}
 
 // $FlowFixMe[unclear-type] TODO(T108222691): Use flow-types for @babel/parser
 type PropsAST = Object;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

part of codegen issue https://github.com/facebook/react-native/issues/34872

> Extract the buildCommandProperties function ([Flow](https://github.com/facebook/react-native/blob/d8ced6f8953cd896471983714e722caf50783960/packages/react-native-codegen/src/parsers/flow/components/index.js#L76-L80), [TypeScript](https://github.com/facebook/react-native/blob/d8ced6f8953cd896471983714e722caf50783960/packages/react-native-codegen/src/parsers/typescript/components/index.js#L64-L113)) from the index.js's files to the parsers-commons.js file.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[Internal][Added]: Extract getCommandProperties to parsers-common

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

yarn test react-native-codegen
