### PR TITLE
Fixing line truncation issue when numberOfLines = {1}

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
@@ -577,7 +577,6 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
 
   public void setNumberOfLines(int numberOfLines) {
     mNumberOfLines = numberOfLines == 0 ? ViewDefaults.NUMBER_OF_LINES : numberOfLines;
-    setSingleLine(mNumberOfLines == 1);
     setMaxLines(mNumberOfLines);
   }
 


### PR DESCRIPTION
Summary:
Changelog:
[Android][Fixed] - Fixing line truncation issue in Text containing /n when numberOfLines = {1}

When the text has multiple lines (with new line characters \n to hard-break the lines), and the first line is short enough to fit, Text component with `numberOfLines = {1}` doesn't display "..." at the end and rather disrespects the /n character.

With `numberOfLines = {1}`, On iOS it translates to
`line 1`, on Android & Web it translates to `line 1 line 2...`

**Expected Behavior :**

`line 1...`

Reviewed By: NickGerleman

Differential Revision: D46175963

