### PR TITLE
Add @react-native/babel-plugin-codegen to babel.config.js

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -99,6 +99,7 @@
     "@react-native-community/cli-platform-android": "12.0.0-alpha.3",
     "@react-native-community/cli-platform-ios": "12.0.0-alpha.3",
     "@react-native/assets-registry": "^0.73.0",
+    "@react-native/babel-plugin-codegen": "^0.73.0",
     "@react-native/codegen": "^0.73.0",
     "@react-native/gradle-plugin": "^0.73.0",
     "@react-native/js-polyfills": "^0.73.0",

--- a/packages/react-native/template/babel.config.js
+++ b/packages/react-native/template/babel.config.js
@@ -1,3 +1,4 @@
 module.exports = {
   presets: ['module:metro-react-native-babel-preset'],
+  plugins: ['@react-native/babel-plugin-codegen'],
 };

--- a/packages/rn-tester/babel.config.js
+++ b/packages/rn-tester/babel.config.js
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+ module.exports = {
+   presets: ['module:metro-react-native-babel-preset'],
+   plugins: ['@react-native/babel-plugin-codegen'],
+ };


### PR DESCRIPTION
Summary:
Add `react-native/babel-plugin-codegen` to `babel.config.js` in both `template` and `rn-tester`. This will enable Static View Configs for bridgeless mode compatibility.

Changelog:
[Internal] - Add react-native/babel-plugin-codegen to babel.config.js

Reviewed By: cipolleschi

Differential Revision: D41556316

