### PR TITLE
 use TripleEqual instead of doubleEqual when comparing two string

### DIFF
--- a/.github/workflows/verifyVersion.js
+++ b/.github/workflows/verifyVersion.js
@@ -11,7 +11,7 @@ module.exports = async (github, context) => {
   const issue = context.payload.issue;
 
   // Ignore issues using upgrade template (they use a special label)
-  if (issue.labels.find(label => label.name == 'Type: Upgrade Issue')) {
+  if (issue.labels.find(label => label.name === 'Type: Upgrade Issue')) {
     return;
   }
 


### PR DESCRIPTION
When comparing two strings , better use eqeqeq instead of eqeq 
