### PR TITLE
 use TripleEqual instead of doubleEqual when comparing two string

### DIFF
--- a/.github/workflow-scripts/verifyVersion.js
+++ b/.github/workflow-scripts/verifyVersion.js
@@ -11,7 +11,7 @@ module.exports = async (github, context) => {
   const issue = context.payload.issue;
 
   // Ignore issues using upgrade template (they use a special label)
-  if (issue.labels.find(label => label.name == 'Type: Upgrade Issue')) {
+  if (issue.labels.find(label => label.name === 'Type: Upgrade Issue')) {
     return;
   }
 


### PR DESCRIPTION
## Summary

It is generally recommended to use "===" instead of "==" when comparing two strings

## Test plan

## Changelog:
[Internal] [Changed] - use TripleEqual instead of doubleEqual when comparing two string