### PR TITLE
Prevent DEBUG React Native builds idling out

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.mm
@@ -55,6 +55,12 @@ void RCTAppSetupPrepareApp(UIApplication *application, BOOL turboModuleEnabled)
 #if RCT_NEW_ARCH_ENABLED
   RCTEnableTurboModule(turboModuleEnabled);
 #endif
+
+#if DEBUG
+  // Disable idle timer in dev builds to avoid putting application in background and complicating
+  // Metro reconnection logic. Users only need this when running the application using our CLI tooling.
+  application.idleTimerDisabled = YES;
+#endif
 }
 
 UIView *


### PR DESCRIPTION
Summary:
User who run their applications using `npx react-native ios` have the application going into the
background if there is inactivity on the device. This is common for users developing on device (why touch
the device if you're tweaking background colours, etc...).

If the application is build with Xcode directly, this is already managed.  This change prevents the idle
timer from running in DEBUG builds.

Differential Revision: D46427401

Closes #37574

