### PR TITLE
Backport Hermes release fix on `main`

### DIFF
--- a/packages/react-native/ReactAndroid/hermes-engine/build.gradle
+++ b/packages/react-native/ReactAndroid/hermes-engine/build.gradle
@@ -181,6 +181,9 @@ android {
                     // This has the (unlucky) side effect of letting AGP call the build
                     // tasks `configureCMakeRelease` while is actually building the debug flavor.
                     arguments "-DCMAKE_BUILD_TYPE=Release"
+                    // Adding -O3 to handle the issue here: https://github.com/android/ndk/issues/1740#issuecomment-1198438260
+                    // The old NDK toolchain is not passing -O3 correctly for release CMake builds. This is fixed in NDK 25 and can be removed once we're there.
+                    cppFlags "-O3"
                 }
             }
         }


### PR DESCRIPTION
Summary:
I'm backporting this comming `60a452b4853dc5651c465867344904dd6fc86703`
from the release branch of 0.72-stable to main which fixes this issue
in the Android NDK:
https://github.com/android/ndk/issues/1740#issuecomment-1198438260

Changelog:
[Internal] [Changed] - Backport Hermes release fix on `main`

Reviewed By: mdvacca

Differential Revision: D46398346

