### PR TITLE
Provide jsi::Runtime directly to RCTTurboModuleManager

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.mm
@@ -135,9 +135,7 @@ std::unique_ptr<facebook::react::JSExecutorFactory> RCTAppSetupDefaultJsExecutor
             if (runtimeScheduler) {
               facebook::react::RuntimeSchedulerBinding::createAndInstallIfNeeded(runtime, runtimeScheduler);
             }
-            facebook::react::RuntimeExecutor syncRuntimeExecutor =
-                [&](std::function<void(facebook::jsi::Runtime & runtime_)> &&callback) { callback(runtime); };
-            [turboModuleManager installJSBindingWithRuntimeExecutor:syncRuntimeExecutor];
+            [turboModuleManager installJSBindings:runtime];
           }));
 }
 

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.mm
@@ -273,9 +273,7 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
       return;
     }
 
-    facebook::react::RuntimeExecutor syncRuntimeExecutor =
-        [&](std::function<void(facebook::jsi::Runtime & runtime_)> &&callback) { callback(runtime); };
-    [strongSelf->_turboModuleManager installJSBindingWithRuntimeExecutor:syncRuntimeExecutor];
+    [strongSelf->_turboModuleManager installJSBindings:runtime];
     facebook::react::bindNativeLogger(runtime, [](const std::string &message, unsigned int logLevel) {
       _RCTLogJavaScriptInternal(static_cast<RCTLogLevel>(logLevel), [NSString stringWithUTF8String:message.c_str()]);
     });

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.h
@@ -58,6 +58,11 @@ RCT_EXTERN void RCTTurboModuleSetBindingMode(facebook::react::TurboModuleBinding
                       delegate:(id<RCTTurboModuleManagerDelegate>)delegate
                      jsInvoker:(std::shared_ptr<facebook::react::CallInvoker>)jsInvoker;
 
+- (void)installJSBindings:(facebook::jsi::Runtime &)runtime;
+
+/**
+ * @deprecated: use installJSBindings instead
+ */
 - (void)installJSBindingWithRuntimeExecutor:(facebook::react::RuntimeExecutor &)runtimeExecutor;
 
 - (void)invalidate;


### PR DESCRIPTION
Summary:
We end up creating a stub RuntimeExecutor wherever we configure this, and might as well pass in the runtime directly, to match the other binding installer signatures.

Changelog: [iOS][Deprecated] Use -[RCTTurboModuleManager installJSBindings:] instead of -[RCTTurboModuleManager installJSBindingWithRuntimeExecutor:]

Differential Revision: D46390501

