### PR TITLE
Set iOS AppState to inactive when app is launching

### DIFF
--- a/packages/react-native/Libraries/AppState/AppState.d.ts
+++ b/packages/react-native/Libraries/AppState/AppState.d.ts
@@ -24,7 +24,7 @@ import {NativeEventSubscription} from '../EventEmitter/RCTNativeAppEventEmitter'
  * App States
  *      active - The app is running in the foreground
  *      background - The app is running in the background. The user is either in another app or on the home screen
- *      inactive [iOS] - This is a transition state that currently never happens for typical React Native apps.
+ *      inactive [iOS] - This is a transition state that happens when the app launches, is asking for permissions or when a call or SMS message is received.
  *      unknown [iOS] - Initial value until the current app state is determined
  *      extension [iOS] - The app is running as an app extension
  *

--- a/packages/react-native/React/CoreModules/RCTAppState.mm
+++ b/packages/react-native/React/CoreModules/RCTAppState.mm
@@ -20,7 +20,7 @@ static NSString *RCTCurrentAppState()
   static NSDictionary *states;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
-    states = @{@(UIApplicationStateActive) : @"active", @(UIApplicationStateBackground) : @"background"};
+    states = @{@(UIApplicationStateActive) : @"active", @(UIApplicationStateBackground) : @"background", @(UIApplicationStateInactive) : @"inactive"};
   });
 
   if (RCTRunningInAppExtension()) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

When an iOS app launches, the current `AppStateStatus` that is returned is `"unknown"`. 
However, `RCTSharedApplication().applicationState` returns `UIApplicationStateInactive` - which makes sense since the app is still showing its launch screen.
I suggest to return `"inactive"` instead of `"unknown"`, since it makes more sense and `"unknown"` is not mentioned in the [official documentation](https://reactnative.dev/docs/appstate).

I also edited the annotation for the `"inactive"` status type to make it more accurate.

## Changelog:

[IOS] [CHANGED] - Set initial AppState status to "inactive" instead of "unknown"

## Test Plan:

I played a bit with the `rn-tester` app to display the `AppStateExample` [component](https://github.com/facebook/react-native/blob/main/packages/rn-tester/js/examples/AppState/AppStateExample.js). I did not manage to display its content, but I managed to render it and log from [its render function](https://github.com/facebook/react-native/blob/main/packages/rn-tester/js/examples/AppState/AppStateExample.js#L84).
This is what I log in the `render` function:
![image](https://github.com/facebook/react-native/assets/8973379/76212f48-6d2e-4b14-b2a4-72c58e39bf3d)

Here is the log I saw before the change:
![image](https://github.com/facebook/react-native/assets/8973379/f3c56047-dfca-4bad-b676-0fc79b990dd9)

and after the change:
![image](https://github.com/facebook/react-native/assets/8973379/8de84b31-69a7-4547-b251-483ddde68e25)

