### PR TITLE
Refactor reload() method to expose Future instead of Task

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/BoltsFutureTask.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/BoltsFutureTask.java
@@ -27,7 +27,7 @@ class BoltsFutureTask<T> implements Future<T> {
   private boolean isTaskCancelled = false;
   private final CancellationTokenSource mCancellationTokenSource;
 
-  private BoltsFutureTask(Task<T> task) {
+  BoltsFutureTask(Task<T> task) {
     this(task, new CancellationTokenSource());
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/BridgelessReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/BridgelessReactContext.java
@@ -40,8 +40,7 @@ import javax.annotation.Nullable;
  * com.facebook.react.bridge.CatalystInstance}, which doesn't exist in bridgeless mode.
  */
 @Nullsafe(Nullsafe.Mode.LOCAL)
-public class BridgelessReactContext extends ReactApplicationContext
-    implements EventDispatcherProvider {
+class BridgelessReactContext extends ReactApplicationContext implements EventDispatcherProvider {
 
   private final ReactHost mReactHost;
   private final AtomicReference<String> mSourceURL = new AtomicReference<>();
@@ -95,7 +94,7 @@ public class BridgelessReactContext extends ReactApplicationContext
     return mReactHost.isInstanceInitialized();
   }
 
-  public DevSupportManager getDevSupportManager() {
+  DevSupportManager getDevSupportManager() {
     return mReactHost.getDevSupportManager();
   }
 
@@ -154,7 +153,7 @@ public class BridgelessReactContext extends ReactApplicationContext
     mReactHost.handleHostException(e);
   }
 
-  public DefaultHardwareBackBtnHandler getDefaultHardwareBackBtnHandler() {
+  DefaultHardwareBackBtnHandler getDefaultHardwareBackBtnHandler() {
     return mReactHost.getDefaultBackButtonHandler();
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHost.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHost.java
@@ -268,17 +268,18 @@ public class ReactHost implements ReactHostInterface {
   }
 
   /** Initialize and run a React Native surface in a background without mounting real views. */
-  public Task<Void> prerenderSurface(final ReactSurface surface) {
+  public Future<Void> prerenderSurface(final ReactSurface surface) {
     final String method = "prerenderSurface(surfaceId = " + surface.getSurfaceID() + ")";
     log(method, "Schedule");
 
     attachSurface(surface);
-    return callAfterGetOrCreateReactInstance(
-        method,
-        reactInstance -> {
-          log(method, "Execute");
-          reactInstance.prerenderSurface(surface);
-        });
+    return new BoltsFutureTask<>(
+        callAfterGetOrCreateReactInstance(
+            method,
+            reactInstance -> {
+              log(method, "Execute");
+              reactInstance.prerenderSurface(surface);
+            }));
   }
 
   /**

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHost.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHost.java
@@ -64,6 +64,7 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -198,12 +199,12 @@ public class ReactHost implements ReactHostInterface {
    *     errors occur during initialization, and will be cancelled if ReactHost.destroy() is called
    *     before it completes.
    */
-  public Task<Void> start() {
+  public Future<Void> start() {
     if (ReactFeatureFlags.enableBridgelessArchitectureNewCreateReloadDestroy) {
-      return newStart();
+      return new BoltsFutureTask<>(newStart());
     }
 
-    return oldStart();
+    return new BoltsFutureTask<>(oldStart());
   }
 
   @ThreadConfined("ReactHost")

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHost.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHost.java
@@ -308,17 +308,18 @@ public class ReactHost implements ReactHostInterface {
    * @param surface The surface to stop
    * @return A Task that will complete when stopSurface has been called.
    */
-  public Task<Boolean> stopSurface(final ReactSurface surface) {
+  public Future<Boolean> stopSurface(final ReactSurface surface) {
     final String method = "stopSurface(surfaceId = " + surface.getSurfaceID() + ")";
     log(method, "Schedule");
 
     detachSurface(surface);
-    return callWithExistingReactInstance(
-        method,
-        reactInstance -> {
-          log(method, "Execute");
-          reactInstance.stopSurface(surface);
-        });
+    return new BoltsFutureTask<>(
+        callWithExistingReactInstance(
+            method,
+            reactInstance -> {
+              log(method, "Execute");
+              reactInstance.stopSurface(surface);
+            }));
   }
 
   /**

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHost.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHost.java
@@ -1038,27 +1038,28 @@ public class ReactHost implements ReactHostInterface {
    *     tap on reload button)
    * @return A task that completes when React Native reloads
    */
-  public Task<Void> reload(String reason) {
+  public Future<Void> reload(String reason) {
     final String method = "reload()";
     if (ReactFeatureFlags.enableBridgelessArchitectureNewCreateReloadDestroy) {
-      return Task.call(
-              () -> {
-                if (mDestroyTask != null) {
-                  log(
-                      method,
-                      "Destroying React Native. Waiting for destroy to finish, before reloading React Native.");
-                  return mDestroyTask
-                      .continueWithTask(task -> newGetOrCreateReloadTask(reason), mBGExecutor)
-                      .makeVoid();
-                }
+      return new BoltsFutureTask<>(
+          Task.call(
+                  () -> {
+                    if (mDestroyTask != null) {
+                      log(
+                          method,
+                          "Destroying React Native. Waiting for destroy to finish, before reloading React Native.");
+                      return mDestroyTask
+                          .continueWithTask(task -> newGetOrCreateReloadTask(reason), mBGExecutor)
+                          .makeVoid();
+                    }
 
-                return newGetOrCreateReloadTask(reason).makeVoid();
-              },
-              mBGExecutor)
-          .continueWithTask(Task::getResult);
+                    return newGetOrCreateReloadTask(reason).makeVoid();
+                  },
+                  mBGExecutor)
+              .continueWithTask(Task::getResult));
     }
 
-    return oldReload(reason);
+    return new BoltsFutureTask<>(oldReload(reason));
   }
 
   @ThreadConfined("ReactHost")

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHost.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHost.java
@@ -288,17 +288,18 @@ public class ReactHost implements ReactHostInterface {
    * @param surface The ReactSurface to render
    * @return A Task that will complete when startSurface has been called.
    */
-  public Task<Void> startSurface(final ReactSurface surface) {
+  public Future<Void> startSurface(final ReactSurface surface) {
     final String method = "startSurface(surfaceId = " + surface.getSurfaceID() + ")";
     log(method, "Schedule");
 
     attachSurface(surface);
-    return callAfterGetOrCreateReactInstance(
-        method,
-        reactInstance -> {
-          log(method, "Execute");
-          reactInstance.startSurface(surface);
-        });
+    return new BoltsFutureTask<>(
+        callAfterGetOrCreateReactInstance(
+            method,
+            reactInstance -> {
+              log(method, "Execute");
+              reactInstance.startSurface(surface);
+            }));
   }
 
   /**

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactSurface.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactSurface.java
@@ -19,7 +19,6 @@ import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.NativeMap;
 import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.bridge.WritableNativeMap;
-import com.facebook.react.bridgeless.internal.bolts.Task;
 import com.facebook.react.common.annotations.VisibleForTesting;
 import com.facebook.react.fabric.SurfaceHandler;
 import com.facebook.react.fabric.SurfaceHandlerBinding;
@@ -163,14 +162,14 @@ public class ReactSurface implements ReactSurfaceInterface {
     return host.startSurface(this);
   }
 
-  public Task<Void> stop() {
+  public Future<Boolean> stop() {
     ReactHost host = mReactHost.get();
     if (host == null) {
-      return Task.forError(
+      return new FailedFuture<>(
           new IllegalStateException(
               "Trying to call ReactSurface.stop(), but no ReactHost is attached."));
     }
-    return host.stopSurface(this).makeVoid();
+    return host.stopSurface(this);
   }
 
   public int getSurfaceID() {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactSurface.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactSurface.java
@@ -147,16 +147,16 @@ public class ReactSurface implements ReactSurfaceInterface {
     return host.prerenderSurface(this);
   }
 
-  public Task<Void> start() {
+  public Future<Void> start() {
     if (mSurfaceView.get() == null) {
-      return Task.forError(
+      return new FailedFuture<>(
           new IllegalStateException(
               "Trying to call ReactSurface.start(), but view is not created."));
     }
 
     ReactHost host = mReactHost.get();
     if (host == null) {
-      return Task.forError(
+      return new FailedFuture<>(
           new IllegalStateException(
               "Trying to call ReactSurface.start(), but no ReactHost is attached."));
     }

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridgeless/ReactHostTest.java
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridgeless/ReactHostTest.java
@@ -119,7 +119,7 @@ public class ReactHostTest {
 
     assertThat(mReactHost.isInstanceInitialized()).isFalse();
 
-    mReactHost.start().waitForCompletion();
+    mReactHost.start().get();
 
     assertThat(mReactHost.isInstanceInitialized()).isTrue();
     assertThat(mReactHost.getCurrentReactContext()).isNotNull();

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridgeless/ReactSurfaceTest.java
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridgeless/ReactSurfaceTest.java
@@ -100,8 +100,7 @@ public class ReactSurfaceTest {
 
     mReactSurface.start().get();
 
-    Task<Void> task = mReactSurface.stop();
-    task.waitForCompletion();
+    mReactSurface.stop().get();
 
     verify(mReactHost).stopSurface(mReactSurface);
   }
@@ -149,7 +148,7 @@ public class ReactSurfaceTest {
 
     assertThat(mReactSurface.isRunning()).isTrue();
 
-    mReactSurface.stop().waitForCompletion();
+    mReactSurface.stop().get();
 
     assertThat(mReactSurface.isRunning()).isFalse();
   }

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridgeless/ReactSurfaceTest.java
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridgeless/ReactSurfaceTest.java
@@ -85,24 +85,22 @@ public class ReactSurfaceTest {
   }
 
   @Test
-  public void testStart() throws InterruptedException {
+  public void testStart() throws InterruptedException, ExecutionException {
     mReactSurface.attach(mReactHost);
     assertThat(mReactHost.isSurfaceAttached(mReactSurface)).isFalse();
-    Task<Void> task = mReactSurface.start();
-    task.waitForCompletion();
+    mReactSurface.start().get();
 
     verify(mReactHost).startSurface(mReactSurface);
     assertThat(mSurfaceHandler.isRunning).isTrue();
   }
 
   @Test
-  public void testStop() throws InterruptedException {
+  public void testStop() throws InterruptedException, ExecutionException {
     mReactSurface.attach(mReactHost);
 
-    Task<Void> task = mReactSurface.start();
-    task.waitForCompletion();
+    mReactSurface.start().get();
 
-    task = mReactSurface.stop();
+    Task<Void> task = mReactSurface.stop();
     task.waitForCompletion();
 
     verify(mReactHost).stopSurface(mReactSurface);
@@ -142,12 +140,12 @@ public class ReactSurfaceTest {
   }
 
   @Test
-  public void testStartStopHandlerCalls() throws InterruptedException {
+  public void testStartStopHandlerCalls() throws InterruptedException, ExecutionException {
     mReactSurface.attach(mReactHost);
 
     assertThat(mReactSurface.isRunning()).isFalse();
 
-    mReactSurface.start().waitForCompletion();
+    mReactSurface.start().get();
 
     assertThat(mReactSurface.isRunning()).isTrue();
 

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridgeless/ReactSurfaceTest.java
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridgeless/ReactSurfaceTest.java
@@ -23,6 +23,7 @@ import com.facebook.react.bridgeless.internal.bolts.Task;
 import com.facebook.react.fabric.SurfaceHandler;
 import com.facebook.react.uimanager.events.EventDispatcher;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -75,10 +76,9 @@ public class ReactSurfaceTest {
   }
 
   @Test
-  public void testPrerender() throws InterruptedException {
+  public void testPrerender() throws InterruptedException, ExecutionException {
     mReactSurface.attach(mReactHost);
-    Task<Void> task = mReactSurface.prerender();
-    task.waitForCompletion();
+    mReactSurface.prerender().get();
 
     verify(mReactHost).prerenderSurface(mReactSurface);
     assertThat(mSurfaceHandler.isRunning).isTrue();


### PR DESCRIPTION
Summary:
Migrate ReactHost.reload() method to expose Future instead of Task
changelog: [internal] internal

Reviewed By: cortinico

Differential Revision: D46333942

