### PR TITLE
Move BridgelessReactPackage to com.facebook.react package

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/BridgelessReactPackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/BridgelessReactPackage.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react;
+
+import com.facebook.infer.annotation.Nullsafe;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.devsupport.LogBoxModule;
+import com.facebook.react.devsupport.interfaces.DevSupportManager;
+import com.facebook.react.module.annotations.ReactModuleList;
+import com.facebook.react.module.model.ReactModuleInfoProvider;
+import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
+import com.facebook.react.modules.core.DeviceEventManagerModule;
+import com.facebook.react.modules.debug.DevSettingsModule;
+import com.facebook.react.modules.debug.SourceCodeModule;
+import com.facebook.react.modules.deviceinfo.DeviceInfoModule;
+import com.facebook.react.modules.systeminfo.AndroidInfoModule;
+
+@Nullsafe(Nullsafe.Mode.LOCAL)
+@ReactModuleList(
+    nativeModules = {
+      AndroidInfoModule.class,
+      DeviceInfoModule.class,
+      DevSettingsModule.class,
+      SourceCodeModule.class,
+      LogBoxModule.class,
+      DeviceEventManagerModule.class,
+    })
+public class BridgelessReactPackage extends TurboReactPackage {
+
+  private DevSupportManager mDevSupportManager;
+  private DefaultHardwareBackBtnHandler mHardwareBackBtnHandler;
+
+  public BridgelessReactPackage(
+      DevSupportManager devSupportManager, DefaultHardwareBackBtnHandler hardwareBackBtnHandler) {
+    mDevSupportManager = devSupportManager;
+    mHardwareBackBtnHandler = hardwareBackBtnHandler;
+  }
+
+  @Override
+  public NativeModule getModule(String name, ReactApplicationContext reactContext) {
+    switch (name) {
+      case AndroidInfoModule.NAME:
+        return new AndroidInfoModule(reactContext);
+      case DeviceInfoModule.NAME:
+        return new DeviceInfoModule(reactContext);
+      case SourceCodeModule.NAME:
+        return new SourceCodeModule(reactContext);
+      case DevSettingsModule.NAME:
+        return new DevSettingsModule(reactContext, mDevSupportManager);
+      case DeviceEventManagerModule.NAME:
+        return new DeviceEventManagerModule(reactContext, mHardwareBackBtnHandler);
+      case LogBoxModule.NAME:
+        return new LogBoxModule(reactContext, mDevSupportManager);
+      default:
+        throw new IllegalArgumentException(
+            "In BridgelessReactPackage, could not find Native module for " + name);
+    }
+  }
+
+  @Override
+  public ReactModuleInfoProvider getReactModuleInfoProvider() {
+    return new BridgelessReactPackage$$ReactModuleInfoProvider();
+  }
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/queue/MessageQueueThreadSpec.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/queue/MessageQueueThreadSpec.java
@@ -16,7 +16,7 @@ public class MessageQueueThreadSpec {
   // The Thread constructor interprets zero the same as not specifying a stack size
   public static final long DEFAULT_STACK_SIZE_BYTES = 0;
 
-  protected static enum ThreadType {
+  protected enum ThreadType {
     MAIN_UI,
     NEW_BACKGROUND,
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/BoltsFutureTask.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/BoltsFutureTask.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.bridgeless;
+
+import com.facebook.react.bridgeless.internal.bolts.CancellationTokenSource;
+import com.facebook.react.bridgeless.internal.bolts.Task;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * This class is a {@link Future} that holds an instance of {@link Task}. The implementation of this
+ * class delegates its behavior on the held task, following the {@link Future} interface defined in
+ * {@link "https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/Future.html"}
+ *
+ * @param <T> The type of the result of the task.
+ */
+class BoltsFutureTask<T> implements Future<T> {
+  private final Task<T> mTask;
+  private boolean isTaskCancelled = false;
+  private final CancellationTokenSource mCancellationTokenSource;
+
+  private BoltsFutureTask(Task<T> task) {
+    this(task, new CancellationTokenSource());
+  }
+
+  /**
+   * Creates a new instance of {@link BoltsFutureTask} for a task that handles cancellation. For
+   * more details about bolts cancellation refer to {@link
+   * "https://github.com/BoltsFramework/Bolts-Android#cancelling-tasks"}
+   *
+   * @param task {@link Task} to be held by BoltsFutureTask
+   * @param cancellationTokenSource {@link CancellationTokenSource} object that is used by the task
+   *     received by parameter to handle cancellation.
+   */
+  private BoltsFutureTask(Task<T> task, CancellationTokenSource cancellationTokenSource) {
+    mTask = task;
+    mCancellationTokenSource = cancellationTokenSource;
+  }
+
+  @Override
+  public boolean cancel(boolean mayInterruptIfRunning) {
+    try {
+      if (!isDone()) {
+        mCancellationTokenSource.cancel();
+      }
+      return true;
+    } finally {
+      isTaskCancelled = true;
+    }
+  }
+
+  @Override
+  public boolean isCancelled() {
+    return isTaskCancelled || mTask.isCancelled();
+  }
+
+  @Override
+  public boolean isDone() {
+    return isTaskCancelled || mTask.isCancelled() || mTask.isFaulted() || mTask.isCompleted();
+  }
+
+  @Override
+  public T get() throws ExecutionException, InterruptedException {
+    mTask.waitForCompletion();
+    return getResult(mTask);
+  }
+
+  @Override
+  public T get(long timeout, TimeUnit unit)
+      throws ExecutionException, InterruptedException, TimeoutException {
+    if (mTask.waitForCompletion(timeout, unit)) {
+      return getResult(mTask);
+    }
+    throw new TimeoutException();
+  }
+
+  private T getResult(Task<T> task) throws ExecutionException {
+    if (task.isFaulted()) {
+      throw new ExecutionException("", new Throwable());
+    } else if (task.isCancelled()) {
+      throw new CancellationException("");
+    }
+    return task.getResult();
+  }
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/BridgelessReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/BridgelessReactContext.java
@@ -115,7 +115,7 @@ public class BridgelessReactContext extends ReactApplicationContext
     }
 
     @Override
-    public @Nullable Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+    public @Nullable Object invoke(Object proxy, Method method, @Nullable Object[] args) {
       NativeArray jsArgs = args != null ? Arguments.fromJavaArgs(args) : new WritableNativeArray();
       mReactHost.callFunctionOnModule(
           JavaScriptModuleRegistry.getJSModuleName(mJSModuleInterface), method.getName(), jsArgs);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHost.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHost.java
@@ -1209,12 +1209,12 @@ public class ReactHost {
    * Entrypoint to destroy the ReactInstance. If the ReactInstance is reloading, will wait until
    * reload is finished, before destroying.
    *
+   * @param reason {@link String} describing why ReactHost is being destroyed (e.g. memmory
+   *     pressure)
+   * @param ex {@link Exception} exception that caused the trigger to destroy ReactHost (or null)
+   *     This exception will be used to log properly the cause of destroy operation.
    * @return A task that completes when React Native gets destroyed.
    */
-  public Task<Void> destroy(String reason) {
-    return destroy(reason, null);
-  }
-
   public Task<Void> destroy(String reason, @Nullable Exception ex) {
     final String method = "destroy()";
     if (ReactFeatureFlags.enableBridgelessArchitectureNewCreateReloadDestroy) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHost.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHost.java
@@ -452,7 +452,7 @@ public class ReactHost {
     return reactInstance.getUIManager();
   }
 
-  public <T extends NativeModule> boolean hasNativeModule(Class<T> nativeModuleInterface) {
+  /* package */ <T extends NativeModule> boolean hasNativeModule(Class<T> nativeModuleInterface) {
     final ReactInstance reactInstance = mReactInstanceTaskRef.get().getResult();
     if (reactInstance != null) {
       return reactInstance.hasNativeModule(nativeModuleInterface);
@@ -460,7 +460,7 @@ public class ReactHost {
     return false;
   }
 
-  public Collection<NativeModule> getNativeModules() {
+  /* package */ Collection<NativeModule> getNativeModules() {
     final ReactInstance reactInstance = mReactInstanceTaskRef.get().getResult();
     if (reactInstance != null) {
       return reactInstance.getNativeModules();
@@ -468,7 +468,8 @@ public class ReactHost {
     return new ArrayList<>();
   }
 
-  public @Nullable <T extends NativeModule> T getNativeModule(Class<T> nativeModuleInterface) {
+  /* package */ @Nullable
+  <T extends NativeModule> T getNativeModule(Class<T> nativeModuleInterface) {
     if (nativeModuleInterface == UIManagerModule.class) {
       ReactSoftExceptionLogger.logSoftExceptionVerbose(
           TAG,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHost.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHost.java
@@ -1017,6 +1017,8 @@ public class ReactHost {
    * Entrypoint to reload the ReactInstance. If the ReactInstance is destroying, will wait until
    * destroy is finished, before reloading.
    *
+   * @param reason {@link String} describing why ReactHost is being reloaded (e.g. js error, user
+   *     tap on reload button)
    * @return A task that completes when React Native reloads
    */
   public Task<Void> reload(String reason) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/InspectorPackagerConnection.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/InspectorPackagerConnection.java
@@ -333,6 +333,6 @@ public class InspectorPackagerConnection {
   }
 
   public interface BundleStatusProvider {
-    public BundleStatus getBundleStatus();
+    BundleStatus getBundleStatus();
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DevSupportManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DevSupportManager.java
@@ -111,7 +111,7 @@ public interface DevSupportManager extends JSExceptionHandler {
    * determined right before loading the packager. Your customizer must call |callback|, as loading
    * will be blocked waiting for it to resolve.
    */
-  public interface PackagerLocationCustomizer {
+  interface PackagerLocationCustomizer {
     void run(Runnable callback);
   }
 

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridgeless/ReactHostTest.java
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridgeless/ReactHostTest.java
@@ -119,7 +119,7 @@ public class ReactHostTest {
 
     assertThat(mReactHost.isInstanceInitialized()).isFalse();
 
-    mReactHost.preload().waitForCompletion();
+    mReactHost.start().waitForCompletion();
 
     assertThat(mReactHost.isInstanceInitialized()).isTrue();
     assertThat(mReactHost.getCurrentReactContext()).isNotNull();


### PR DESCRIPTION
Summary:
Move BridgelessReactPackage to com.facebook.react package.
This is necessary because BridgelessReactPackage is a core package that needs to be part of RN (and should not be re-defined by all apps)

I will revisit naming in a later diff

changelog: [internal] internal

Reviewed By: cortinico

Differential Revision: D46408934

