### PR TITLE
Migrate ReactHost.start method to expose Future instead of Task

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
@@ -36,7 +36,7 @@ import java.util.concurrent.CopyOnWriteArraySet;
  */
 public class ReactContext extends ContextWrapper {
   @DoNotStrip
-  public interface RCTDeviceEventEmitter extends JavaScriptModule {
+  private interface RCTDeviceEventEmitter extends JavaScriptModule {
     void emit(@NonNull String eventName, @Nullable Object data);
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/queue/MessageQueueThreadSpec.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/queue/MessageQueueThreadSpec.java
@@ -16,7 +16,7 @@ public class MessageQueueThreadSpec {
   // The Thread constructor interprets zero the same as not specifying a stack size
   public static final long DEFAULT_STACK_SIZE_BYTES = 0;
 
-  protected static enum ThreadType {
+  protected enum ThreadType {
     MAIN_UI,
     NEW_BACKGROUND,
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHost.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHost.java
@@ -1215,12 +1215,12 @@ public class ReactHost {
    * Entrypoint to destroy the ReactInstance. If the ReactInstance is reloading, will wait until
    * reload is finished, before destroying.
    *
+   * @param reason {@link String} describing why ReactHost is being destroyed (e.g. memmory
+   *     pressure)
+   * @param ex {@link Exception} exception that caused the trigger to destroy ReactHost (or null)
+   *     This exception will be used to log properly the cause of destroy operation.
    * @return A task that completes when React Native gets destroyed.
    */
-  public Future<Void> destroy(String reason) {
-    return destroy(reason, null);
-  }
-
   public Future<Void> destroy(String reason, @Nullable Exception ex) {
     CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
     final String method = "destroy()";

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHost.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHost.java
@@ -458,7 +458,7 @@ public class ReactHost {
     return reactInstance.getUIManager();
   }
 
-  public <T extends NativeModule> boolean hasNativeModule(Class<T> nativeModuleInterface) {
+  /* package */ <T extends NativeModule> boolean hasNativeModule(Class<T> nativeModuleInterface) {
     final ReactInstance reactInstance = mReactInstanceTaskRef.get().getResult();
     if (reactInstance != null) {
       return reactInstance.hasNativeModule(nativeModuleInterface);
@@ -466,7 +466,7 @@ public class ReactHost {
     return false;
   }
 
-  public Collection<NativeModule> getNativeModules() {
+  /* package */ Collection<NativeModule> getNativeModules() {
     final ReactInstance reactInstance = mReactInstanceTaskRef.get().getResult();
     if (reactInstance != null) {
       return reactInstance.getNativeModules();
@@ -474,7 +474,8 @@ public class ReactHost {
     return new ArrayList<>();
   }
 
-  public @Nullable <T extends NativeModule> T getNativeModule(Class<T> nativeModuleInterface) {
+  /* package */ @Nullable
+  <T extends NativeModule> T getNativeModule(Class<T> nativeModuleInterface) {
     if (nativeModuleInterface == UIManagerModule.class) {
       ReactSoftExceptionLogger.logSoftExceptionVerbose(
           TAG,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHost.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHost.java
@@ -202,24 +202,24 @@ public class ReactHost {
    *     errors occur during initialization, and will be cancelled if ReactHost.destroy() is called
    *     before it completes.
    */
-  public Task<Void> preload() {
+  public Task<Void> start() {
     if (ReactFeatureFlags.enableBridgelessArchitectureNewCreateReloadDestroy) {
-      return new_preload();
+      return newStart();
     }
 
-    return old_preload();
+    return oldStart();
   }
 
   @ThreadConfined("ReactHost")
-  private @Nullable Task<Void> mPreloadTask = null;
+  private @Nullable Task<Void> mStartTask = null;
 
-  private Task<Void> old_preload() {
+  private Task<Void> oldStart() {
     final String method = "old_preload()";
     return Task.call(
             () -> {
-              if (mPreloadTask == null) {
+              if (mStartTask == null) {
                 log(method, "Schedule");
-                mPreloadTask =
+                mStartTask =
                     getOrCreateReactInstanceTask()
                         .continueWithTask(
                             task -> {
@@ -235,26 +235,26 @@ public class ReactHost {
                             mBGExecutor)
                         .makeVoid();
               }
-              return mPreloadTask;
+              return mStartTask;
             },
             mBGExecutor)
         .continueWithTask(Task::getResult);
   }
 
-  private Task<Void> new_preload() {
+  private Task<Void> newStart() {
     final String method = "new_preload()";
     return Task.call(
             () -> {
-              if (mPreloadTask == null) {
+              if (mStartTask == null) {
                 log(method, "Schedule");
-                mPreloadTask =
-                    waitThen_new_getOrCreateReactInstanceTask()
+                mStartTask =
+                    waitThenCallNewGetOrCreateReactInstanceTask()
                         .continueWithTask(
                             (task) -> {
                               if (task.isFaulted()) {
                                 mReactHostDelegate.handleInstanceException(task.getError());
                                 // Wait for destroy to finish
-                                return new_getOrCreateDestroyTask(
+                                return newGetOrCreateDestroyTask(
                                         "new_preload() failure: " + task.getError().getMessage(),
                                         task.getError())
                                     .continueWithTask(destroyTask -> Task.forError(task.getError()))
@@ -264,7 +264,7 @@ public class ReactHost {
                             },
                             mBGExecutor);
               }
-              return mPreloadTask;
+              return mStartTask;
             },
             mBGExecutor)
         .continueWithTask(Task::getResult);
@@ -720,20 +720,20 @@ public class ReactHost {
    */
   private Task<ReactInstance> getOrCreateReactInstanceTask() {
     if (ReactFeatureFlags.enableBridgelessArchitectureNewCreateReloadDestroy) {
-      return Task.call(this::waitThen_new_getOrCreateReactInstanceTask, mBGExecutor)
+      return Task.call(this::waitThenCallNewGetOrCreateReactInstanceTask, mBGExecutor)
           .continueWithTask(Task::getResult);
     }
 
-    return old_getOrCreateReactInstanceTask();
+    return oldGetOrCreateReactInstanceTask();
   }
 
   @ThreadConfined("ReactHost")
-  private Task<ReactInstance> waitThen_new_getOrCreateReactInstanceTask() {
-    return waitThen_new_getOrCreateReactInstanceTaskWithRetries(0, 4);
+  private Task<ReactInstance> waitThenCallNewGetOrCreateReactInstanceTask() {
+    return waitThenCallNewGetOrCreateReactInstanceTaskWithRetries(0, 4);
   }
 
   @ThreadConfined("ReactHost")
-  private Task<ReactInstance> waitThen_new_getOrCreateReactInstanceTaskWithRetries(
+  private Task<ReactInstance> waitThenCallNewGetOrCreateReactInstanceTaskWithRetries(
       int tryNum, int maxTries) {
     final String method = "waitThen_new_getOrCreateReactInstanceTaskWithRetries";
     if (mReloadTask != null) {
@@ -751,7 +751,7 @@ public class ReactHost {
                 + tryNum
                 + ").");
         return mDestroyTask.onSuccessTask(
-            (task) -> waitThen_new_getOrCreateReactInstanceTaskWithRetries(tryNum + 1, maxTries),
+            (task) -> waitThenCallNewGetOrCreateReactInstanceTaskWithRetries(tryNum + 1, maxTries),
             mBGExecutor);
       }
 
@@ -760,11 +760,11 @@ public class ReactHost {
           "React Native is tearing down. Not wait for teardown to finish: reached max retries.");
     }
 
-    return new_getOrCreateReactInstanceTask();
+    return newGetOrCreateReactInstanceTask();
   }
 
   @ThreadConfined("ReactHost")
-  private Task<ReactInstance> new_getOrCreateReactInstanceTask() {
+  private Task<ReactInstance> newGetOrCreateReactInstanceTask() {
     final String method = "new_getOrCreateReactInstanceTask()";
     log(method);
 
@@ -858,7 +858,7 @@ public class ReactHost {
         });
   }
 
-  private Task<ReactInstance> old_getOrCreateReactInstanceTask() {
+  private Task<ReactInstance> oldGetOrCreateReactInstanceTask() {
     final String method = "old_getOrCreateReactInstanceTask()";
     log(method);
 
@@ -1037,17 +1037,17 @@ public class ReactHost {
                       method,
                       "Destroying React Native. Waiting for destroy to finish, before reloading React Native.");
                   return mDestroyTask
-                      .continueWithTask(task -> new_getOrCreateReloadTask(reason), mBGExecutor)
+                      .continueWithTask(task -> newGetOrCreateReloadTask(reason), mBGExecutor)
                       .makeVoid();
                 }
 
-                return new_getOrCreateReloadTask(reason).makeVoid();
+                return newGetOrCreateReloadTask(reason).makeVoid();
               },
               mBGExecutor)
           .continueWithTask(Task::getResult);
     }
 
-    return old_reload(reason);
+    return oldReload(reason);
   }
 
   @ThreadConfined("ReactHost")
@@ -1062,7 +1062,7 @@ public class ReactHost {
    * ReactInstance task work throws an exception.
    */
   @ThreadConfined("ReactHost")
-  private Task<ReactInstance> new_getOrCreateReloadTask(String reason) {
+  private Task<ReactInstance> newGetOrCreateReloadTask(String reason) {
     final String method = "new_getOrCreateReloadTask()";
     log(method);
 
@@ -1165,10 +1165,10 @@ public class ReactHost {
                     mReactInstanceTaskRef.reset();
 
                     log(method, "Resetting preload task ref");
-                    mPreloadTask = null;
+                    mStartTask = null;
 
                     // Kickstart a new ReactInstance create
-                    return new_getOrCreateReactInstanceTask();
+                    return newGetOrCreateReactInstanceTask();
                   },
                   mBGExecutor)
               .onSuccess(
@@ -1235,11 +1235,11 @@ public class ReactHost {
                           method,
                           "Reloading React Native. Waiting for reload to finish before destroying React Native.");
                       return mReloadTask.continueWithTask(
-                          task -> new_getOrCreateDestroyTask(reason, ex),
+                          task -> newGetOrCreateDestroyTask(reason, ex),
                           mBGExecutor,
                           cancellationTokenSource.getToken());
                     }
-                    return new_getOrCreateDestroyTask(reason, ex);
+                    return newGetOrCreateDestroyTask(reason, ex);
                   },
                   mBGExecutor,
                   cancellationTokenSource.getToken())
@@ -1247,7 +1247,7 @@ public class ReactHost {
           cancellationTokenSource);
     }
 
-    old_destroy(reason, ex);
+    oldDestroy(reason, ex);
     return new BoltsFutureTask<>(Task.forResult(nullsafeFIXME(null, "Empty Destroy Task")));
   }
 
@@ -1263,7 +1263,7 @@ public class ReactHost {
    * ReactInstance task work throws an exception.
    */
   @ThreadConfined("ReactHost")
-  private Task<Void> new_getOrCreateDestroyTask(final String reason, @Nullable Exception ex) {
+  private Task<Void> newGetOrCreateDestroyTask(final String reason, @Nullable Exception ex) {
     final String method = "new_getOrCreateDestroyTask()";
     log(method);
 
@@ -1347,7 +1347,7 @@ public class ReactHost {
                     mReactInstanceTaskRef.reset();
 
                     log(method, "Resetting Preload task ref");
-                    mPreloadTask = null;
+                    mStartTask = null;
 
                     log(method, "Resetting destroy task ref");
                     mDestroyTask = null;
@@ -1360,7 +1360,7 @@ public class ReactHost {
   }
 
   /** Destroy and recreate the ReactInstance and context. */
-  private Task<Void> old_reload(String reason) {
+  private Task<Void> oldReload(String reason) {
     final String method = "old_reload()";
     log(method);
 
@@ -1370,7 +1370,7 @@ public class ReactHost {
 
     synchronized (mReactInstanceTaskRef) {
       mMemoryPressureRouter.removeMemoryPressureListener(mMemoryPressureListener);
-      old_destroyReactInstanceAndContext(method, reason);
+      oldDestroyReactInstanceAndContext(method, reason);
 
       return callAfterGetOrCreateReactInstance(
           method,
@@ -1387,7 +1387,7 @@ public class ReactHost {
   }
 
   /** Destroy the specified instance and context. */
-  private void old_destroy(String reason, @Nullable Exception ex) {
+  private void oldDestroy(String reason, @Nullable Exception ex) {
     final String method = "old_destroy()";
     log(method);
 
@@ -1403,7 +1403,7 @@ public class ReactHost {
         mMemoryPressureRouter.destroy(reactContext);
       }
 
-      old_destroyReactInstanceAndContext(method, reason);
+      oldDestroyReactInstanceAndContext(method, reason);
 
       // Remove all attached surfaces
       log(method, "Clearing attached surfaces");
@@ -1421,7 +1421,7 @@ public class ReactHost {
     }
   }
 
-  private void old_destroyReactInstanceAndContext(final String callingMethod, final String reason) {
+  private void oldDestroyReactInstanceAndContext(final String callingMethod, final String reason) {
     final String method = "old_destroyReactInstanceAndContext(" + callingMethod + ")";
     log(method);
 
@@ -1466,7 +1466,7 @@ public class ReactHost {
 
               // Re-enable preloads
               log(method, "Resetting Preload task ref");
-              mPreloadTask = null;
+              mStartTask = null;
             });
       } else {
         raiseSoftException(
@@ -1481,7 +1481,7 @@ public class ReactHost {
         mBGExecutor.execute(
             () -> {
               log(method, "Resetting Preload task ref");
-              mPreloadTask = null;
+              mStartTask = null;
             });
       }
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHost.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHost.java
@@ -202,12 +202,12 @@ public class ReactHost {
    *     errors occur during initialization, and will be cancelled if ReactHost.destroy() is called
    *     before it completes.
    */
-  public Task<Void> start() {
+  public Future<Void> start() {
     if (ReactFeatureFlags.enableBridgelessArchitectureNewCreateReloadDestroy) {
-      return newStart();
+      return new BoltsFutureTask<>(newStart());
     }
 
-    return oldStart();
+    return new BoltsFutureTask<>(oldStart());
   }
 
   @ThreadConfined("ReactHost")

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHost.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHost.java
@@ -1023,6 +1023,8 @@ public class ReactHost {
    * Entrypoint to reload the ReactInstance. If the ReactInstance is destroying, will wait until
    * destroy is finished, before reloading.
    *
+   * @param reason {@link String} describing why ReactHost is being reloaded (e.g. js error, user
+   *     tap on reload button)
    * @return A task that completes when React Native reloads
    */
   public Task<Void> reload(String reason) {

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridgeless/ReactHostTest.java
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridgeless/ReactHostTest.java
@@ -119,7 +119,7 @@ public class ReactHostTest {
 
     assertThat(mReactHost.isInstanceInitialized()).isFalse();
 
-    mReactHost.preload().waitForCompletion();
+    mReactHost.start().waitForCompletion();
 
     assertThat(mReactHost.isInstanceInitialized()).isTrue();
     assertThat(mReactHost.getCurrentReactContext()).isNotNull();

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridgeless/ReactHostTest.java
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridgeless/ReactHostTest.java
@@ -119,7 +119,7 @@ public class ReactHostTest {
 
     assertThat(mReactHost.isInstanceInitialized()).isFalse();
 
-    mReactHost.start().waitForCompletion();
+    mReactHost.start().get();
 
     assertThat(mReactHost.isInstanceInitialized()).isTrue();
     assertThat(mReactHost.getCurrentReactContext()).isNotNull();


### PR DESCRIPTION
Summary:
Migrate ReactHost.start method to expose Future instead of Task

changelog: [internal] internal

Reviewed By: cortinico

Differential Revision: D46323801

