### PR TITLE
introduce RCTContextContainerHandling

### DIFF
--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTContextContainerHandling.h
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTContextContainerHandling.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import <react/utils/ContextContainer.h>
+
+@protocol RCTContextContainerHandling <NSObject>
+
+- (void)didCreateContextContainer:(std::shared_ptr<facebook::react::ContextContainer>)contextContainer;
+
+@end

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost+Internal.h
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost+Internal.h
@@ -7,11 +7,20 @@
 
 #import "RCTHost.h"
 
+#import <jsi/jsi.h>
+
 typedef NSURL * (^RCTHostBundleURLProvider)(void);
+
+@protocol RCTHostRuntimeDelegate <NSObject>
+
+- (void)hostDidInitializeRuntime:(facebook::jsi::Runtime &)runtime;
+
+@end
 
 @interface RCTHost (Internal)
 
 - (void)registerSegmentWithId:(NSNumber *)segmentId path:(NSString *)path;
 - (void)setBundleURLProvider:(RCTHostBundleURLProvider)bundleURLProvider;
+- (void)setRuntimeDelegate:(id<RCTHostRuntimeDelegate>)runtimeDelegate;
 
 @end

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost+Internal.h
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost+Internal.h
@@ -7,6 +7,7 @@
 
 #import "RCTHost.h"
 
+#import <ReactCommon/RCTContextContainerHandling.h>
 #import <jsi/jsi.h>
 
 typedef NSURL * (^RCTHostBundleURLProvider)(void);
@@ -22,5 +23,6 @@ typedef NSURL * (^RCTHostBundleURLProvider)(void);
 - (void)registerSegmentWithId:(NSNumber *)segmentId path:(NSString *)path;
 - (void)setBundleURLProvider:(RCTHostBundleURLProvider)bundleURLProvider;
 - (void)setRuntimeDelegate:(id<RCTHostRuntimeDelegate>)runtimeDelegate;
+- (void)setContextContainerHandler:(id<RCTContextContainerHandling>)contextContainerHandler;
 
 @end

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.h
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.h
@@ -50,7 +50,6 @@ typedef std::shared_ptr<facebook::react::JSEngineInstance> (^RCTHostJSEngineProv
 - (instancetype)initWithBundleURL:(NSURL *)bundleURL
                      hostDelegate:(id<RCTHostDelegate>)hostDelegate
        turboModuleManagerDelegate:(id<RCTTurboModuleManagerDelegate>)turboModuleManagerDelegate
-              bindingsInstallFunc:(facebook::react::ReactInstance::BindingsInstallFunc)bindingsInstallFunc
                  jsEngineProvider:(RCTHostJSEngineProvider)jsEngineProvider NS_DESIGNATED_INITIALIZER FB_OBJC_DIRECT;
 
 /**

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.h
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.h
@@ -29,8 +29,6 @@ typedef std::shared_ptr<facebook::react::JSEngineInstance> (^RCTHostJSEngineProv
 
 @protocol RCTHostDelegate <NSObject>
 
-- (std::shared_ptr<facebook::react::ContextContainer>)createContextContainer;
-
 - (void)host:(RCTHost *)host
     didReceiveJSErrorStack:(NSArray<NSDictionary<NSString *, id> *> *)stack
                    message:(NSString *)message

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.mm
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.mm
@@ -27,6 +27,7 @@ using namespace facebook::react;
   RCTInstance *_instance;
   __weak id<RCTHostDelegate> _hostDelegate;
   __weak id<RCTTurboModuleManagerDelegate> _turboModuleManagerDelegate;
+  __weak id<RCTHostRuntimeDelegate> _runtimeDelegate;
   NSURL *_oldDelegateBundleURL;
   NSURL *_bundleURL;
   RCTBundleManager *_bundleManager;
@@ -261,6 +262,11 @@ using namespace facebook::react;
                      isFatal:errorMap.getBool(JSErrorHandlerKey::kIsFatal)];
 }
 
+- (void)instance:(RCTInstance *)instance didInitializeRuntime:(facebook::jsi::Runtime &)runtime
+{
+  [_runtimeDelegate hostDidInitializeRuntime:runtime];
+}
+
 #pragma mark - Internal
 
 - (void)registerSegmentWithId:(NSNumber *)segmentId path:(NSString *)path
@@ -271,6 +277,11 @@ using namespace facebook::react;
 - (void)setBundleURLProvider:(RCTHostBundleURLProvider)bundleURLProvider
 {
   _bundleURLProvider = [bundleURLProvider copy];
+}
+
+- (void)setRuntimeDelegate:(id<RCTHostRuntimeDelegate>)runtimeDelegate
+{
+  _runtimeDelegate = runtimeDelegate;
 }
 
 #pragma mark - Private

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.mm
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.mm
@@ -25,9 +25,12 @@ using namespace facebook::react;
 
 @implementation RCTHost {
   RCTInstance *_instance;
+
   __weak id<RCTHostDelegate> _hostDelegate;
   __weak id<RCTTurboModuleManagerDelegate> _turboModuleManagerDelegate;
   __weak id<RCTHostRuntimeDelegate> _runtimeDelegate;
+  __weak id<RCTContextContainerHandling> _contextContainerHandler;
+
   NSURL *_oldDelegateBundleURL;
   NSURL *_bundleURL;
   RCTBundleManager *_bundleManager;
@@ -228,11 +231,6 @@ using namespace facebook::react;
 
 #pragma mark - RCTInstanceDelegate
 
-- (std::shared_ptr<facebook::react::ContextContainer>)createContextContainer
-{
-  return [_hostDelegate createContextContainer];
-}
-
 - (void)instance:(RCTInstance *)instance didReceiveErrorMap:(facebook::react::MapBuffer)errorMap
 {
   NSString *message = [NSString stringWithCString:errorMap.getString(JSErrorHandlerKey::kErrorMessage).c_str()
@@ -262,6 +260,13 @@ using namespace facebook::react;
   [_runtimeDelegate hostDidInitializeRuntime:runtime];
 }
 
+#pragma mark - RCTContextContainerHandling
+
+- (void)didCreateContextContainer:(std::shared_ptr<facebook::react::ContextContainer>)contextContainer
+{
+  [_contextContainerHandler didCreateContextContainer:contextContainer];
+}
+
 #pragma mark - Internal
 
 - (void)registerSegmentWithId:(NSNumber *)segmentId path:(NSString *)path
@@ -277,6 +282,11 @@ using namespace facebook::react;
 - (void)setRuntimeDelegate:(id<RCTHostRuntimeDelegate>)runtimeDelegate
 {
   _runtimeDelegate = runtimeDelegate;
+}
+
+- (void)setContextContainerHandler:(id<RCTContextContainerHandling>)contextContainerHandler
+{
+  _contextContainerHandler = contextContainerHandler;
 }
 
 #pragma mark - Private

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.mm
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHost.mm
@@ -32,7 +32,6 @@ using namespace facebook::react;
   NSURL *_bundleURL;
   RCTBundleManager *_bundleManager;
   RCTHostBundleURLProvider _bundleURLProvider;
-  facebook::react::ReactInstance::BindingsInstallFunc _bindingsInstallFunc;
   RCTHostJSEngineProvider _jsEngineProvider;
 
   // All the surfaces that need to be started after main bundle execution
@@ -57,7 +56,6 @@ using namespace facebook::react;
 - (instancetype)initWithBundleURL:(NSURL *)bundleURL
                      hostDelegate:(id<RCTHostDelegate>)hostDelegate
        turboModuleManagerDelegate:(id<RCTTurboModuleManagerDelegate>)turboModuleManagerDelegate
-              bindingsInstallFunc:(facebook::react::ReactInstance::BindingsInstallFunc)bindingsInstallFunc
                  jsEngineProvider:(RCTHostJSEngineProvider)jsEngineProvider
 {
   if (self = [super init]) {
@@ -65,7 +63,6 @@ using namespace facebook::react;
     _turboModuleManagerDelegate = turboModuleManagerDelegate;
     _surfaceStartBuffer = [NSMutableArray new];
     _bundleManager = [RCTBundleManager new];
-    _bindingsInstallFunc = bindingsInstallFunc;
     _moduleRegistry = [RCTModuleRegistry new];
     _jsEngineProvider = [jsEngineProvider copy];
 
@@ -149,7 +146,6 @@ using namespace facebook::react;
                                       bundleManager:_bundleManager
                          turboModuleManagerDelegate:_turboModuleManagerDelegate
                                 onInitialBundleLoad:_onInitialBundleLoad
-                                bindingsInstallFunc:_bindingsInstallFunc
                                      moduleRegistry:_moduleRegistry];
   [_hostDelegate hostDidStart:self];
 }
@@ -217,7 +213,6 @@ using namespace facebook::react;
                                       bundleManager:_bundleManager
                          turboModuleManagerDelegate:_turboModuleManagerDelegate
                                 onInitialBundleLoad:_onInitialBundleLoad
-                                bindingsInstallFunc:_bindingsInstallFunc
                                      moduleRegistry:_moduleRegistry];
   [_hostDelegate hostDidStart:self];
 

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHostCreationHelpers.mm
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTHostCreationHelpers.mm
@@ -16,6 +16,5 @@ RCTHost *RCTHostCreateDefault(
   return [[RCTHost alloc] initWithBundleURL:bundleURL
                                hostDelegate:hostDelegate
                  turboModuleManagerDelegate:turboModuleManagerDelegate
-                        bindingsInstallFunc:nullptr
                            jsEngineProvider:jsEngineProvider];
 }

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.h
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.h
@@ -12,7 +12,8 @@
 #import <react/bridgeless/JSEngineInstance.h>
 #import <react/bridgeless/ReactInstance.h>
 #import <react/renderer/mapbuffer/MapBuffer.h>
-#import <react/utils/ContextContainer.h>
+
+#import "RCTContextContainerHandling.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -35,9 +36,7 @@ RCT_EXTERN void RCTInstanceSetRuntimeDiagnosticFlags(NSString *_Nullable flags);
 FB_RUNTIME_PROTOCOL
 @protocol RCTTurboModuleManagerDelegate;
 
-@protocol RCTInstanceDelegate <NSObject>
-
-- (std::shared_ptr<facebook::react::ContextContainer>)createContextContainer;
+@protocol RCTInstanceDelegate <RCTContextContainerHandling>
 
 - (void)instance:(RCTInstance *)instance didReceiveErrorMap:(facebook::react::MapBuffer)errorMap;
 - (void)instance:(RCTInstance *)instance didInitializeRuntime:(facebook::jsi::Runtime &)runtime;

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.h
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.h
@@ -58,7 +58,6 @@ typedef void (^_Null_unspecified RCTInstanceInitialBundleLoadCompletionBlock)();
                    bundleManager:(RCTBundleManager *)bundleManager
       turboModuleManagerDelegate:(id<RCTTurboModuleManagerDelegate>)turboModuleManagerDelegate
              onInitialBundleLoad:(RCTInstanceInitialBundleLoadCompletionBlock)onInitialBundleLoad
-             bindingsInstallFunc:(facebook::react::ReactInstance::BindingsInstallFunc)bindingsInstallFunc
                   moduleRegistry:(RCTModuleRegistry *)moduleRegistry NS_DESIGNATED_INITIALIZER FB_OBJC_DIRECT;
 
 - (void)callFunctionOnJSModule:(NSString *)moduleName method:(NSString *)method args:(NSArray *)args;

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.h
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.h
@@ -40,6 +40,7 @@ FB_RUNTIME_PROTOCOL
 - (std::shared_ptr<facebook::react::ContextContainer>)createContextContainer;
 
 - (void)instance:(RCTInstance *)instance didReceiveErrorMap:(facebook::react::MapBuffer)errorMap;
+- (void)instance:(RCTInstance *)instance didInitializeRuntime:(facebook::jsi::Runtime &)runtime;
 
 @end
 

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.mm
@@ -293,6 +293,8 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
       strongSelf->_bindingsInstallFunc(runtime);
     }
 
+    [strongSelf->_delegate instance:strongSelf didInitializeRuntime:runtime];
+
     // Set up Display Link
     RCTModuleData *timingModuleData = [[RCTModuleData alloc] initWithModuleInstance:timing
                                                                              bridge:nil

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.mm
@@ -73,7 +73,6 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
   RCTPerformanceLogger *_performanceLogger;
   RCTDisplayLink *_displayLink;
   RCTInstanceInitialBundleLoadCompletionBlock _onInitialBundleLoad;
-  ReactInstance::BindingsInstallFunc _bindingsInstallFunc;
   RCTTurboModuleManager *_turboModuleManager;
   std::mutex _invalidationMutex;
   std::atomic<bool> _valid;
@@ -90,7 +89,6 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
                    bundleManager:(RCTBundleManager *)bundleManager
       turboModuleManagerDelegate:(id<RCTTurboModuleManagerDelegate>)tmmDelegate
              onInitialBundleLoad:(RCTInstanceInitialBundleLoadCompletionBlock)onInitialBundleLoad
-             bindingsInstallFunc:(ReactInstance::BindingsInstallFunc)bindingsInstallFunc
                   moduleRegistry:(RCTModuleRegistry *)moduleRegistry
 {
   if (self = [super init]) {
@@ -103,7 +101,6 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
     _appTMMDelegate = tmmDelegate;
     _jsThreadManager = [RCTJSThreadManager new];
     _onInitialBundleLoad = onInitialBundleLoad;
-    _bindingsInstallFunc = bindingsInstallFunc;
     _bridgeModuleDecorator = [[RCTBridgeModuleDecorator alloc] initWithViewRegistry:[RCTViewRegistry new]
                                                                      moduleRegistry:moduleRegistry
                                                                       bundleManager:bundleManager
@@ -287,10 +284,6 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
 
     if (RCTGetUseNativeViewConfigsInBridgelessMode()) {
       installNativeViewConfigProviderBinding(runtime);
-    }
-
-    if (strongSelf->_bindingsInstallFunc) {
-      strongSelf->_bindingsInstallFunc(runtime);
     }
 
     [strongSelf->_delegate instance:strongSelf didInitializeRuntime:runtime];

--- a/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/bridgeless/platform/ios/Core/RCTInstance.mm
@@ -235,10 +235,9 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
   RCTLogSetBridgelessModuleRegistry(_bridgeModuleDecorator.moduleRegistry);
   RCTLogSetBridgelessCallableJSModules(_bridgeModuleDecorator.callableJSModules);
 
-  auto contextContainer = [_delegate createContextContainer];
-  if (!contextContainer) {
-    contextContainer = std::make_shared<ContextContainer>();
-  }
+  auto contextContainer = std::make_shared<ContextContainer>();
+  [_delegate didCreateContextContainer:contextContainer];
+
   contextContainer->insert(
       "RCTImageLoader", facebook::react::wrapManagedObject([_turboModuleManager moduleForName:"RCTImageLoader"]));
   contextContainer->insert(


### PR DESCRIPTION
Summary:
Changelog: [Internal]

the context container is a DI object in our internal infra. the delegate method `createContextContainer` is used to pass down internal implementations that may be used in our infra, notably the `ReactNativeConfig`. this API used to be required for the app delegate to implement.

in this change, i introduce a protocol, `RCTContextContainerHandling`, where we shift the burden of creating the DI container to our internal infra where userland can now optionally add dependencies to this.

this also removes more C++ boilerplate for the bridgeless setup.

Reviewed By: sammy-SC

Differential Revision: D46245433

