### PR TITLE
Breaking - Bump minimum Node version from 16 to 18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1139,7 +1139,7 @@ jobs:
           command: |
             apt update
             apt install -y wget git curl
-            curl -sL https://deb.nodesource.com/setup_16.x | bash -
+            curl -sL https://deb.nodesource.com/setup_18.x | bash -
             apt install -y nodejs
             npm install --global yarn
       - checkout

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -21,7 +21,7 @@
   ],
   "bugs": "https://github.com/facebook/react-native/issues",
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "bin": "./cli.js",
   "types": "types",

--- a/packages/react-native/template/package.json
+++ b/packages/react-native/template/package.json
@@ -31,6 +31,6 @@
     "typescript": "5.0.4"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   }
 }


### PR DESCRIPTION
Summary:
## Bump minimum Node JS version to 18 via `react-native/package.json#engines`

In https://github.com/facebook/react-native/pull/35443 we bumped up the node version from 16 to 18.

Node 16's EOL is 2023-09-11

https://nodejs.org/en/blog/announcements/nodejs16-eol/

This follows up by formally making Node 18 the minimum supported version.

Docs PR:
https://github.com/facebook/react-native-website/pull/3748

Changelog:
[General][Breaking] Bump minimum Node JS version to 18

Differential Revision: D46462639

