### PR TITLE
Revert changes on ReactHostDelegate

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHostDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHostDelegate.kt
@@ -11,9 +11,9 @@ import com.facebook.infer.annotation.ThreadSafe
 import com.facebook.react.ReactPackage
 import com.facebook.react.bridge.JSBundleLoader
 import com.facebook.react.bridge.ReactApplicationContext
-import com.facebook.react.bridge.ReactContext
 import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.fabric.ReactNativeConfig
+import com.facebook.react.turbomodule.core.TurboModuleManager
 import com.facebook.react.turbomodule.core.TurboModuleManagerDelegate
 
 /**
@@ -61,7 +61,7 @@ interface ReactHostDelegate {
    * ReactNative Configuration that allows to customize the behavior of key/value pairs used by the
    * framework to enable/disable experimental capabilities
    */
-  fun getReactNativeConfig(context: ReactContext): ReactNativeConfig
+  fun getReactNativeConfig(turboModuleManager: TurboModuleManager): ReactNativeConfig
 
   @UnstableReactNativeAPI
   class ReactHostDelegateBase(
@@ -79,7 +79,7 @@ interface ReactHostDelegate {
     override fun getTurboModuleManagerDelegate(context: ReactApplicationContext) =
         turboModuleManagerDelegate(context)
 
-    override fun getReactNativeConfig(context: ReactContext) = reactNativeConfig
+    override fun getReactNativeConfig(turboModuleManager: TurboModuleManager) = reactNativeConfig
 
     override fun handleInstanceException(error: Exception) = exceptionHandler(error)
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactInstance.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactInstance.java
@@ -225,7 +225,7 @@ final class ReactInstance {
     mFabricUIManager =
         new FabricUIManager(mBridgelessReactContext, viewManagerRegistry, eventBeatManager);
 
-    ReactNativeConfig config = mDelegate.getReactNativeConfig(mBridgelessReactContext);
+    ReactNativeConfig config = mDelegate.getReactNativeConfig(mTurboModuleManager);
 
     // Misc initialization that needs to be done before Fabric init
     DisplayMetricsHolder.initDisplayMetricsIfNotInitialized(mBridgelessReactContext);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactHostDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactHostDelegate.kt
@@ -11,13 +11,13 @@ import com.facebook.jni.annotations.DoNotStrip
 import com.facebook.react.ReactPackage
 import com.facebook.react.bridge.JSBundleLoader
 import com.facebook.react.bridge.ReactApplicationContext
-import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridgeless.BindingsInstaller
 import com.facebook.react.bridgeless.JSEngineInstance
 import com.facebook.react.bridgeless.ReactHostDelegate
 import com.facebook.react.bridgeless.hermes.HermesInstance
 import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.fabric.ReactNativeConfig
+import com.facebook.react.turbomodule.core.TurboModuleManager
 import com.facebook.react.turbomodule.core.TurboModuleManagerDelegate
 
 /**
@@ -55,7 +55,7 @@ class DefaultReactHostDelegate(
   override fun getTurboModuleManagerDelegate(context: ReactApplicationContext) =
       turboModuleManagerDelegate(context)
 
-  override fun getReactNativeConfig(context: ReactContext) = reactNativeConfig
+  override fun getReactNativeConfig(turboModuleManager: TurboModuleManager) = reactNativeConfig
 
   override fun handleInstanceException(error: Exception) = exceptionHandler(error)
 }


### PR DESCRIPTION
Summary:
This diff is reverting a change on ReactHostDelegate (D45662329) that caused MobileConfig to not being properly initialize in fb4a.

changelog: [internal] internal

Reviewed By: NickGerleman

Differential Revision: D46468413

