### PR TITLE
[Codegen 137] extract buildPropertiesForEvent to parsers-commons

### DIFF
--- a/packages/react-native-codegen/src/parsers/flow/components/events.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/events.js
@@ -22,7 +22,10 @@ const {
   throwIfBubblingTypeIsNull,
   throwIfArgumentPropsAreNull,
 } = require('../../error-utils');
-const {getEventArgument} = require('../../parsers-commons');
+const {
+  getEventArgument,
+  buildPropertiesForEvent,
+} = require('../../parsers-commons');
 const {
   emitBoolProp,
   emitDoubleProp,
@@ -67,7 +70,7 @@ function getPropertyType(
         typeAnnotation: {
           type: 'ObjectTypeAnnotation',
           properties: typeAnnotation.properties.map(member =>
-            buildPropertiesForEvent(member, parser),
+            buildPropertiesForEvent(member, parser, getPropertyType),
           ),
         },
       };
@@ -126,7 +129,7 @@ function extractArrayElementType(
       return {
         type: 'ObjectTypeAnnotation',
         properties: typeAnnotation.properties.map(member =>
-          buildPropertiesForEvent(member, parser),
+          buildPropertiesForEvent(member, parser, getPropertyType),
         ),
       };
     case 'ArrayTypeAnnotation':
@@ -229,19 +232,6 @@ function findEventArgumentsAndType(
   }
 }
 
-function buildPropertiesForEvent(
-  /* $FlowFixMe[missing-local-annot] The type annotation(s) required by Flow's
-   * LTI update could not be added via codemod */
-  property,
-  parser: Parser,
-): NamedShape<EventTypeAnnotation> {
-  const name = property.key.name;
-  const optional = parser.isOptionalProperty(property);
-  const typeAnnotation = parser.getTypeAnnotationFromProperty(property);
-
-  return getPropertyType(name, optional, typeAnnotation, parser);
-}
-
 function buildEventSchema(
   types: TypeMap,
   property: EventTypeAST,
@@ -283,8 +273,8 @@ function buildEventSchema(
         type: 'EventTypeAnnotation',
         argument: getEventArgument(
           nonNullableArgumentProps,
-          buildPropertiesForEvent,
           parser,
+          getPropertyType,
         ),
       },
     };
@@ -298,8 +288,8 @@ function buildEventSchema(
       type: 'EventTypeAnnotation',
       argument: getEventArgument(
         nonNullableArgumentProps,
-        buildPropertiesForEvent,
         parser,
+        getPropertyType,
       ),
     },
   };

--- a/packages/react-native-codegen/src/parsers/parsers-commons.js
+++ b/packages/react-native-codegen/src/parsers/parsers-commons.js
@@ -894,16 +894,18 @@ function buildPropSchema(
  * LTI update could not be added via codemod */
 function getEventArgument(
   argumentProps: PropAST,
-  buildPropertiesForEvent: (
-    property: PropAST,
+  parser: Parser,
+  getPropertyType: (
+    name: $FlowFixMe,
+    optional: boolean,
+    typeAnnotation: $FlowFixMe,
     parser: Parser,
   ) => NamedShape<EventTypeAnnotation>,
-  parser: Parser,
 ): ObjectTypeAnnotation<EventTypeAnnotation> {
   return {
     type: 'ObjectTypeAnnotation',
     properties: argumentProps.map(member =>
-      buildPropertiesForEvent(member, parser),
+      buildPropertiesForEvent(member, parser, getPropertyType),
     ),
   };
 }
@@ -1053,6 +1055,23 @@ function handleGenericTypeAnnotation(
   };
 }
 
+function buildPropertiesForEvent(
+  property: $FlowFixMe,
+  parser: Parser,
+  getPropertyType: (
+    name: $FlowFixMe,
+    optional: boolean,
+    typeAnnotation: $FlowFixMe,
+    parser: Parser,
+  ) => NamedShape<EventTypeAnnotation>,
+): NamedShape<EventTypeAnnotation> {
+  const name = property.key.name;
+  const optional = parser.isOptionalProperty(property);
+  const typeAnnotation = parser.getTypeAnnotationFromProperty(property);
+
+  return getPropertyType(name, optional, typeAnnotation, parser);
+}
+
 module.exports = {
   wrapModuleSchema,
   unwrapNullable,
@@ -1079,4 +1098,5 @@ module.exports = {
   getCommandProperties,
   handleGenericTypeAnnotation,
   getTypeResolutionStatus,
+  buildPropertiesForEvent,
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

Part of #34872

> Extract buildPropertiesForEvent into parsers-commons.js file. Use the code from either [Flow](https://github.com/facebook/react-native/blob/d8ced6f8953cd896471983714e722caf50783960/packages/react-native-codegen/src/parsers/flow/components/events.js#L258-L272) or [TypeScript](https://github.com/facebook/react-native/blob/d8ced6f8953cd896471983714e722caf50783960/packages/react-native-codegen/src/parsers/typescript/components/events.js#L277-L288) which now should be equal. Delete the original ones and use the newly created method instead of those.

[Internal][Changed]: Extract buildPropertiesForEvent and update callsites

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
`yarn test`
