### PR TITLE
Handle double SurfaceHandler#stop call

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceHandler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceHandler.cpp
@@ -108,7 +108,9 @@ void SurfaceHandler::stop() const noexcept {
   // mounted views, so we need to commit an empty tree to trigger all
   // side-effects (including destroying and removing mounted views).
   react_native_assert(shadowTree && "`shadowTree` must not be null.");
-  shadowTree->commitEmptyTree();
+  if (shadowTree) {
+    shadowTree->commitEmptyTree();
+  }
 }
 
 void SurfaceHandler::setDisplayMode(DisplayMode displayMode) const noexcept {


### PR DESCRIPTION
Summary:
We call `surfaceHandler.stop` both from `SurfaceHandlerBinding` as well as `Binding`. Since we don't check asserts in production, the second one should generally be a no-op, but may be causing a crash due to incorrectly de-referencing a unique_ptr.

Changelog: [Internal]

Reviewed By: mdvacca

Differential Revision: D46441620

