### PR TITLE
Remove dependency from PRODUCTION flag from React-hermes

### DIFF
--- a/packages/react-native/ReactCommon/hermes/React-hermes.podspec
+++ b/packages/react-native/ReactCommon/hermes/React-hermes.podspec
@@ -6,7 +6,6 @@
 require "json"
 
 # Whether Hermes is built for Release or Debug is determined by the PRODUCTION envvar.
-build_type = ENV['PRODUCTION'] == "1" ? :release : :debug
 
 # package.json
 package = JSON.parse(File.read(File.join(__dir__, "..", "..", "package.json")))
@@ -42,7 +41,7 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig    = {
                                "HEADER_SEARCH_PATHS" => "\"${PODS_ROOT}/hermes-engine/destroot/include\" \"$(PODS_TARGET_SRCROOT)/..\" \"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/libevent/include\"",
                                "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
-                             }.merge!(build_type == :debug ? { "GCC_PREPROCESSOR_DEFINITIONS" => "HERMES_ENABLE_DEBUGGER=1" } : {})
+                             }
   s.header_dir             = "reacthermes"
   s.dependency "React-cxxreact", version
   s.dependency "React-jsiexecutor", version

--- a/packages/react-native/scripts/cocoapods/__tests__/utils-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/utils-test.rb
@@ -174,6 +174,40 @@ class UtilsTests < Test::Unit::TestCase
         assert_equal(result, true)
     end
 
+    # ======================================================== #
+    # Test -  Set GCC Preprocessor Definition for React-hermes #
+    # ======================================================== #
+
+    def test_SetGCCPreprocessorDefinitionForReactHermes_itSetsThePreprocessorForDebug
+        # Arrange
+        react_hermes_name = "React-hermes"
+        react_core_name = "React-Core"
+       react_hermes_debug_config = BuildConfigurationMock.new("Debug")
+       react_hermes_release_config = BuildConfigurationMock.new("Release")
+       react_core_debug_config = BuildConfigurationMock.new("Debug")
+       react_core_release_config = BuildConfigurationMock.new("Release")
+       react_hermes_target = TargetMock.new(react_hermes_name, [react_hermes_debug_config, react_hermes_release_config])
+       react_core_target = TargetMock.new(react_core_name, [react_core_debug_config, react_core_release_config])
+
+        installer = InstallerMock.new(
+          :pod_target_installation_results => {
+            react_hermes_name => TargetInstallationResultMock.new(react_hermes_target, react_hermes_target),
+            react_core_name => TargetInstallationResultMock.new(react_core_target, react_core_target),
+          }
+        )
+
+        # Act
+        ReactNativePodsUtils.set_gcc_preprocessor_definition_for_React_hermes(installer)
+
+        # Assert
+        build_setting = "GCC_PREPROCESSOR_DEFINITIONS"
+        expected_value = "HERMES_ENABLE_DEBUGGER=1"
+        assert_equal(expected_value, react_hermes_debug_config.build_settings[build_setting])
+        assert_nil(react_hermes_release_config.build_settings[build_setting])
+        assert_nil(react_core_debug_config.build_settings[build_setting])
+        assert_nil(react_core_release_config.build_settings[build_setting])
+    end
+
     # ============================ #
     # Test - Exclude Architectures #
     # ============================ #

--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -39,6 +39,10 @@ class ReactNativePodsUtils
         installer.pods_project.pod_group(name) != nil
     end
 
+    def self.set_gcc_preprocessor_definition_for_React_hermes(installer)
+        self.add_build_settings_to_pod(installer, "GCC_PREPROCESSOR_DEFINITIONS", "HERMES_ENABLE_DEBUGGER=1", "React-hermes", "Debug")
+    end
+
     def self.turn_off_resource_bundle_react_core(installer)
         # this is needed for Xcode 14, see more details here https://github.com/facebook/react-native/issues/34673
         # we should be able to remove this once CocoaPods catches up to it, see more details here https://github.com/CocoaPods/CocoaPods/issues/11402
@@ -143,6 +147,18 @@ class ReactNativePodsUtils
     end
 
     private
+
+    def self.add_build_settings_to_pod(installer, settings_name, settings_value, target_pod_name, configuration)
+        installer.target_installation_results.pod_target_installation_results.each do |pod_name, target_installation_result|
+            if pod_name.to_s == target_pod_name
+                target_installation_result.native_target.build_configurations.each do |config|
+                        if configuration == nil || (configuration != nil && configuration == config.name)
+                            config.build_settings[settings_name] = settings_value
+                        end
+                    end
+                end
+            end
+    end
 
     def self.fix_library_search_path(config)
         lib_search_paths = config.build_settings["LIBRARY_SEARCH_PATHS"]

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -237,6 +237,10 @@ def react_native_post_install(
 
   fabric_enabled = ReactNativePodsUtils.has_pod(installer, 'React-Fabric')
 
+  if ReactNativePodsUtils.has_pod(installer, "React-hermes")
+    ReactNativePodsUtils.set_gcc_preprocessor_definition_for_React_hermes(installer)
+  end
+
   ReactNativePodsUtils.exclude_i386_architecture_while_using_hermes(installer)
   ReactNativePodsUtils.fix_library_search_paths(installer)
   ReactNativePodsUtils.update_search_paths(installer)


### PR DESCRIPTION
Summary:
React-hermes pod sets the `GCC_PREPROCESSOR_DEFINITIONS` flag for Debug config only, by leveraging the `PRODUCTION=1` flag.

This flag is not standard for iOS, therefore we want to remove it from the condebase to simplify the build APIs.

This change moves the setting of the `GCC_PREPROCESSOR_DEFINITIONS` flag from the podspec xcconfig (which can't distinguish between Debug and Release configurations) to a post install hook (which can).

## Changelog:
[internal] - Remove dependency on PRODUCTION=1 from React-hermes podspec

Differential Revision: D46316662

