### PR TITLE
Handle offsetParent for children of the root node correctly

### DIFF
--- a/packages/react-native/Libraries/DOM/Nodes/ReactNativeElement.js
+++ b/packages/react-native/Libraries/DOM/Nodes/ReactNativeElement.js
@@ -79,7 +79,10 @@ export default class ReactNativeElement
 
     if (node != null) {
       const offset = nullthrows(getFabricUIManager()).getOffset(node);
-      if (offset != null) {
+      // For children of the root node we currently return offset data
+      // but a `null` parent because the root node is not accessible
+      // in JavaScript yet.
+      if (offset != null && offset[0] != null) {
         const offsetParentInstanceHandle = offset[0];
         const offsetParent = getPublicInstanceFromInternalInstanceHandle(
           offsetParentInstanceHandle,


### PR DESCRIPTION
Summary:
We currently throw an exception when trying to access `node.offsetParent` in direct children of the root node in Fabric. This fixes that with an additional check.

Changelog: [internal]

Differential Revision: D46485786

