### PR TITLE
Update prettier to v2.8.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "metro-react-native-babel-transformer": "0.76.2",
     "mkdirp": "^0.5.1",
     "mock-fs": "^5.1.4",
-    "prettier": "^2.4.1",
+    "prettier": "2.8.8",
     "react": "18.2.0",
     "react-test-renderer": "18.2.0",
     "shelljs": "^0.8.5",

--- a/packages/eslint-config-react-native/package.json
+++ b/packages/eslint-config-react-native/package.json
@@ -9,7 +9,11 @@
     "directory": "packages/eslint-config-react-native"
   },
   "homepage": "https://github.com/facebook/react-native/tree/HEAD/packages/eslint-config-react-native#readme",
-  "keywords": ["eslint", "config", "react-native"],
+  "keywords": [
+    "eslint",
+    "config",
+    "react-native"
+  ],
   "bugs": "https://github.com/facebook/react-native/issues",
   "engines": {
     "node": ">=16"
@@ -36,6 +40,6 @@
   },
   "devDependencies": {
     "eslint": "^8.19.0",
-    "prettier": "^2.4.1"
+    "prettier": "2.8.8"
   }
 }

--- a/packages/react-native-codegen/package.json
+++ b/packages/react-native-codegen/package.json
@@ -9,7 +9,13 @@
     "directory": "packages/react-native-codegen"
   },
   "homepage": "https://github.com/facebook/react-native/tree/HEAD/packages/react-native-codegen#readme",
-  "keywords": ["code", "generation", "codegen", "tools", "react-native"],
+  "keywords": [
+    "code",
+    "generation",
+    "codegen",
+    "tools",
+    "react-native"
+  ],
   "bugs": "https://github.com/facebook/react-native/issues",
   "engines": {
     "node": ">=16"
@@ -44,7 +50,7 @@
     "invariant": "^2.2.4",
     "micromatch": "^4.0.4",
     "mkdirp": "^0.5.1",
-    "prettier": "^2.4.1",
+    "prettier": "2.8.8",
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {

--- a/packages/react-native/template/package.json
+++ b/packages/react-native/template/package.json
@@ -26,7 +26,7 @@
     "eslint": "^8.19.0",
     "jest": "^29.2.1",
     "metro-react-native-babel-preset": "0.76.2",
-    "prettier": "^2.4.1",
+    "prettier": "2.8.8",
     "react-test-renderer": "18.2.0",
     "typescript": "5.0.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9155,10 +9155,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.4.1.tgz#671e11c89c14a4cfc876ce564106c4a6726c9f5c"
-  integrity sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==
+prettier@2.8.8:
+  version "2.8.8"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
+  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
 
 pretty-format@^24.9.0:
   version "24.9.0"


### PR DESCRIPTION
Summary: Upgrade Prettier to the latest stable version, 2.8.8.

Reviewed By: SamChou19815

Differential Revision: D46403769

