### PR TITLE
(codegen 133) - Parser extractTypeFromTypeAnnotation

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-test.js
@@ -358,6 +358,31 @@ describe('FlowParser', () => {
       expect(parser.interfaceDeclaration).toEqual('InterfaceDeclaration');
     });
   });
+
+  describe('extractTypeFromTypeAnnotation', () => {
+    it('should return the name if typeAnnotation is GenericTypeAnnotation', () => {
+      const typeAnnotation = {
+        type: 'GenericTypeAnnotation',
+        id: {
+          name: 'SomeType',
+        },
+      };
+
+      expect(parser.extractTypeFromTypeAnnotation(typeAnnotation)).toEqual(
+        'SomeType',
+      );
+    });
+
+    it('should return the type if typeAnnotation is not GenericTypeAnnotation', () => {
+      const typeAnnotation = {
+        type: 'SomeOtherType',
+      };
+
+      expect(parser.extractTypeFromTypeAnnotation(typeAnnotation)).toEqual(
+        'SomeOtherType',
+      );
+    });
+  });
 });
 
 describe('TypeScriptParser', () => {

--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-test.js
@@ -702,4 +702,29 @@ describe('TypeScriptParser', () => {
       expect(parser.interfaceDeclaration).toEqual('TSInterfaceDeclaration');
     });
   });
+
+  describe('extractTypeFromTypeAnnotation', () => {
+    it('should return the name if typeAnnotation is TSTypeReference', () => {
+      const typeAnnotation = {
+        type: 'TSTypeReference',
+        typeName: {
+          name: 'SomeType',
+        },
+      };
+
+      expect(parser.extractTypeFromTypeAnnotation(typeAnnotation)).toEqual(
+        'SomeType',
+      );
+    });
+
+    it('should return the type if typeAnnotation is not TSTypeReference', () => {
+      const typeAnnotation = {
+        type: 'SomeOtherType',
+      };
+
+      expect(parser.extractTypeFromTypeAnnotation(typeAnnotation)).toEqual(
+        'SomeOtherType',
+      );
+    });
+  });
 });

--- a/packages/react-native-codegen/src/parsers/flow/components/events.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/events.js
@@ -40,7 +40,7 @@ function getPropertyType(
   typeAnnotation: $FlowFixMe,
   parser: Parser,
 ): NamedShape<EventTypeAnnotation> {
-  const type = extractTypeFromTypeAnnotation(typeAnnotation);
+  const type = parser.extractTypeFromTypeAnnotation(typeAnnotation);
 
   switch (type) {
     case 'BooleanTypeAnnotation':
@@ -99,7 +99,7 @@ function extractArrayElementType(
   name: string,
   parser: Parser,
 ): EventTypeAnnotation {
-  const type = extractTypeFromTypeAnnotation(typeAnnotation);
+  const type = parser.extractTypeFromTypeAnnotation(typeAnnotation);
 
   switch (type) {
     case 'BooleanTypeAnnotation':
@@ -162,12 +162,6 @@ function extractArrayElementType(
 
 function prettify(jsonObject: $FlowFixMe): string {
   return JSON.stringify(jsonObject, null, 2);
-}
-
-function extractTypeFromTypeAnnotation(typeAnnotation: $FlowFixMe): string {
-  return typeAnnotation.type === 'GenericTypeAnnotation'
-    ? typeAnnotation.id.name
-    : typeAnnotation.type;
 }
 
 function findEventArgumentsAndType(

--- a/packages/react-native-codegen/src/parsers/flow/parser.js
+++ b/packages/react-native-codegen/src/parsers/flow/parser.js
@@ -533,6 +533,12 @@ class FlowParser implements Parser {
   genericTypeAnnotationErrorMessage(typeAnnotation: $FlowFixMe): string {
     return `A non GenericTypeAnnotation must be a type declaration ('${this.typeAlias}') or enum ('${this.enumDeclaration}'). Instead, got the unsupported ${typeAnnotation.type}.`;
   }
+
+  extractTypeFromTypeAnnotation(typeAnnotation: $FlowFixMe): string {
+    return typeAnnotation.type === 'GenericTypeAnnotation'
+      ? typeAnnotation.id.name
+      : typeAnnotation.type;
+  }
 }
 
 module.exports = {

--- a/packages/react-native-codegen/src/parsers/parser.js
+++ b/packages/react-native-codegen/src/parsers/parser.js
@@ -400,4 +400,11 @@ export interface Parser {
    * Given a unsupported typeAnnotation, returns an error message.
    */
   genericTypeAnnotationErrorMessage(typeAnnotation: $FlowFixMe): string;
+
+  /**
+   * Given a type annotation, it extracts the type.
+   * @parameter typeAnnotation: the annotation for a type in the AST.
+   * @returns: the extracted type.
+   */
+  extractTypeFromTypeAnnotation(typeAnnotation: $FlowFixMe): string;
 }

--- a/packages/react-native-codegen/src/parsers/parserMock.js
+++ b/packages/react-native-codegen/src/parsers/parserMock.js
@@ -472,4 +472,10 @@ export class MockedParser implements Parser {
   genericTypeAnnotationErrorMessage(typeAnnotation: $FlowFixMe): string {
     return `A non GenericTypeAnnotation must be a type declaration ('${this.typeAlias}') or enum ('${this.enumDeclaration}'). Instead, got the unsupported ${typeAnnotation.type}.`;
   }
+
+  extractTypeFromTypeAnnotation(typeAnnotation: $FlowFixMe): string {
+    return typeAnnotation.type === 'GenericTypeAnnotation'
+      ? typeAnnotation.id.name
+      : typeAnnotation.type;
+  }
 }

--- a/packages/react-native-codegen/src/parsers/typescript/components/events.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/events.js
@@ -101,7 +101,7 @@ function extractArrayElementType(
   name: string,
   parser: Parser,
 ): EventTypeAnnotation {
-  const type = extractTypeFromTypeAnnotation(typeAnnotation);
+  const type = parser.extractTypeFromTypeAnnotation(typeAnnotation);
 
   switch (type) {
     case 'TSParenthesizedType':
@@ -157,12 +157,6 @@ function extractArrayElementType(
         )}`,
       );
   }
-}
-
-function extractTypeFromTypeAnnotation(typeAnnotation: $FlowFixMe): string {
-  return typeAnnotation.type === 'TSTypeReference'
-    ? typeAnnotation.typeName.name
-    : typeAnnotation.type;
 }
 
 function findEventArgumentsAndType(

--- a/packages/react-native-codegen/src/parsers/typescript/parser.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parser.js
@@ -547,6 +547,12 @@ class TypeScriptParser implements Parser {
   genericTypeAnnotationErrorMessage(typeAnnotation: $FlowFixMe): string {
     return `A non GenericTypeAnnotation must be a type declaration ('${this.typeAlias}'), an interface ('${this.interfaceDeclaration}'), or enum ('${this.enumDeclaration}'). Instead, got the unsupported ${typeAnnotation.type}.`;
   }
+
+  extractTypeFromTypeAnnotation(typeAnnotation: $FlowFixMe): string {
+    return typeAnnotation.type === 'TSTypeReference'
+      ? typeAnnotation.typeName.name
+      : typeAnnotation.type;
+  }
 }
 
 module.exports = {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

> [Codegen 133 - Assigned to @Randall71] Create an extractTypeFromTypeAnnotation(typeAnnotation) function in the Parser base class. Implement it using [this code for Flow](https://github.com/facebook/react-native/blob/d8ced6f8953cd896471983714e722caf50783960/packages/react-native-codegen/src/parsers/flow/components/events.js#L193-L197) and [this code for TypeScript](https://github.com/facebook/react-native/blob/d8ced6f8953cd896471983714e722caf50783960/packages/react-native-codegen/src/parsers/typescript/components/events.js#L189-L193). Replace the invocation of that function with the one from the parser

This is part of #34872 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

[INTERNAL] [ADDED] - extractTypeFromTypeAnnotation(typeAnnotation) in parser

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

yarn jest packages/react-native-codegen > new tests written, as well as coverage from existing tests

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
