### PR TITLE
Enable @react-native/babel-plugin-codegen for RNTester

### DIFF
--- a/packages/rn-tester/babel.config.js
+++ b/packages/rn-tester/babel.config.js
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+ module.exports = {
+   presets: ['module:metro-react-native-babel-preset'],
+   plugins: ['@react-native/babel-plugin-codegen'],
+ };


### PR DESCRIPTION
Summary:
This diff adds `react-native/babel-plugin-codegen` as an extra Babel plugin for Metro in RNTester to enable static view configs support.
This diff does not provide full static view configs support for every React Native project. It only enables them for RNTester to unblock further bridgeless mode OSS rollout work.

Changelog: [Internal] - Static view configs support for RNTester.

Differential Revision: D46523066

