### PR TITLE
Add license header to SetSpanOperation.java

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/SetSpanOperation.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/SetSpanOperation.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 package com.facebook.react.views.text;
 
 import android.text.Spannable;


### PR DESCRIPTION
Summary:
SetSpanOperation.java doesn't have the required licence header, causing a compliance failure for OSS repo checkup. This diff adds the header.

Changelog: [Internal]

Reviewed By: cortinico

Differential Revision: D46505914

