### PR TITLE
Fix broken test_android on main due to wrong import

### DIFF
--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/packagerconnection/JSPackagerClientTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/packagerconnection/JSPackagerClientTest.kt
@@ -10,7 +10,6 @@ package com.facebook.react.packagerconnection
 import com.facebook.react.packagerconnection.ReconnectingWebSocket.ConnectionCallback
 import java.io.IOException
 import okio.ByteString
-import okio.ByteString.encodeUtf8
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -147,4 +146,7 @@ class JSPackagerClientTest {
       action: String,
       handler: RequestHandler
   ): Map<String, RequestHandler> = mapOf(action to handler)
+
+  private fun encodeUtf8(input: String): ByteString =
+      ByteString.of(*input.toByteArray(Charsets.UTF_8))
 }


### PR DESCRIPTION
Summary:
`test_android` is currently broken on main due to a wrong import for the `encodeUtf8` function from OkIO

Changelog:
[Internal] [Changed] - Fix broken test_android on main due to wrong import

Differential Revision: D46555207

