### PR TITLE
Create a Debug manifest inside React Native Android

### DIFF
--- a/packages/react-native/ReactAndroid/src/debug/AndroidManifest.xml
+++ b/packages/react-native/ReactAndroid/src/debug/AndroidManifest.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+  <!--
+    This manifest file is used only by Gradle to configure debug-only capabilities
+    for React Native Apps.
+   -->
+  <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+
+  <application>
+    <activity android:name="com.facebook.react.devsupport.DevSettingsActivity"
+              android:exported="false" />
+  </application>
+
+</manifest>

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/BridgeDevSupportManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/BridgeDevSupportManager.java
@@ -57,11 +57,6 @@ import java.util.concurrent.TimeoutException;
  * instance manager recreates it (through {@link #onNewReactContextCreated). Also, instance manager
  * is responsible for enabling/disabling dev support in case when app is backgrounded or when all
  * the views has been detached from the instance (through {@link #setDevSupportEnabled} method).
- *
- * IMPORTANT: In order for developer support to work correctly it is required that the
- * manifest of your application contain the following entries:
- * {@code <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" android:exported="false"/>}
- * {@code <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>}
  */
 public final class BridgeDevSupportManager extends DevSupportManagerBase {
   private boolean mIsSamplingProfilerEnabled = false;

--- a/packages/react-native/template/android/app/src/debug/AndroidManifest.xml
+++ b/packages/react-native/template/android/app/src/debug/AndroidManifest.xml
@@ -2,12 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
-
     <application
         android:usesCleartextTraffic="true"
         tools:targetApi="28"
-        tools:ignore="GoogleAppIndexingWarning">
-        <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" android:exported="false" />
-    </application>
+        tools:ignore="GoogleAppIndexingWarning"/>
 </manifest>

--- a/packages/rn-tester/android/app/src/main/AndroidManifest.xml
+++ b/packages/rn-tester/android/app/src/main/AndroidManifest.xml
@@ -60,7 +60,6 @@
         <data android:scheme="rntester" android:host="example" />
       </intent-filter>
     </activity>
-    <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" android:exported="false"/>
     <provider
       android:name="com.facebook.react.modules.blob.BlobProvider"
       android:authorities="@string/blob_provider_authority"


### PR DESCRIPTION
Summary:
While working on debugging tools, I noticed that we ask in every template app to
- Add a "com.facebook.react.devsupport.DevSettingsActivity" activity
- Add the <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>

This is error prone and can be cleanup as we now distribute React Native that is variant aware (debug/release).
So I'm creating a manifest inside `src/debug` that contains those directive so we don't need to ask users
to add them (I'm removing them from the template).

Changelog:
[Internal] [Changed] - Create a Debug manifest inside React Native Android

Reviewed By: cipolleschi

Differential Revision: D46556884

