### PR TITLE
Extract logic to CellMetricsAggregator

### DIFF
--- a/packages/virtualized-lists/Lists/FillRateHelper.js
+++ b/packages/virtualized-lists/Lists/FillRateHelper.js
@@ -10,7 +10,8 @@
 
 'use strict';
 
-import type {CellMetricProps} from './VirtualizedListProps';
+import type {CellMetricProps} from './ListMetricsAggregator';
+import ListMetricsAggregator from './ListMetricsAggregator';
 
 export type FillRateInfo = Info;
 
@@ -26,13 +27,6 @@ class Info {
   total_time_spent: number = 0;
   sample_count: number = 0;
 }
-
-type CellMetrics = {
-  inLayout?: boolean,
-  length: number,
-  offset: number,
-  ...
-};
 
 const DEBUG = false;
 
@@ -51,7 +45,7 @@ let _sampleRate = DEBUG ? 1 : null;
 class FillRateHelper {
   _anyBlankStartTime: ?number = null;
   _enabled = false;
-  _getCellMetrics: (index: number, props: CellMetricProps) => ?CellMetrics;
+  _listMetrics: ListMetricsAggregator;
   _info: Info = new Info();
   _mostlyBlankStartTime: ?number = null;
   _samplesStartTime: ?number = null;
@@ -79,10 +73,8 @@ class FillRateHelper {
     _minSampleCount = minSampleCount;
   }
 
-  constructor(
-    getCellMetrics: (index: number, props: CellMetricProps) => ?CellMetrics,
-  ) {
-    this._getCellMetrics = getCellMetrics;
+  constructor(listMetrics: ListMetricsAggregator) {
+    this._listMetrics = listMetrics;
     this._enabled = (_sampleRate || 0) > Math.random();
     this._resetData();
   }
@@ -186,12 +178,12 @@ class FillRateHelper {
 
     let blankTop = 0;
     let first = cellsAroundViewport.first;
-    let firstFrame = this._getCellMetrics(first, props);
+    let firstFrame = this._listMetrics.getCellMetrics(first, props);
     while (
       first <= cellsAroundViewport.last &&
-      (!firstFrame || !firstFrame.inLayout)
+      (!firstFrame || !firstFrame.isMounted)
     ) {
-      firstFrame = this._getCellMetrics(first, props);
+      firstFrame = this._listMetrics.getCellMetrics(first, props);
       first++;
     }
     // Only count blankTop if we aren't rendering the first item, otherwise we will count the header
@@ -204,12 +196,12 @@ class FillRateHelper {
     }
     let blankBottom = 0;
     let last = cellsAroundViewport.last;
-    let lastFrame = this._getCellMetrics(last, props);
+    let lastFrame = this._listMetrics.getCellMetrics(last, props);
     while (
       last >= cellsAroundViewport.first &&
-      (!lastFrame || !lastFrame.inLayout)
+      (!lastFrame || !lastFrame.isMounted)
     ) {
-      lastFrame = this._getCellMetrics(last, props);
+      lastFrame = this._listMetrics.getCellMetrics(last, props);
       last--;
     }
     // Only count blankBottom if we aren't rendering the last item, otherwise we will count the

--- a/packages/virtualized-lists/Lists/FillRateHelper.js
+++ b/packages/virtualized-lists/Lists/FillRateHelper.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-import type {FrameMetricProps} from './VirtualizedListProps';
+import type {CellMetricProps} from './VirtualizedListProps';
 
 export type FillRateInfo = Info;
 
@@ -27,7 +27,7 @@ class Info {
   sample_count: number = 0;
 }
 
-type FrameMetrics = {
+type CellMetrics = {
   inLayout?: boolean,
   length: number,
   offset: number,
@@ -51,7 +51,7 @@ let _sampleRate = DEBUG ? 1 : null;
 class FillRateHelper {
   _anyBlankStartTime: ?number = null;
   _enabled = false;
-  _getFrameMetrics: (index: number, props: FrameMetricProps) => ?FrameMetrics;
+  _getCellMetrics: (index: number, props: CellMetricProps) => ?CellMetrics;
   _info: Info = new Info();
   _mostlyBlankStartTime: ?number = null;
   _samplesStartTime: ?number = null;
@@ -80,9 +80,9 @@ class FillRateHelper {
   }
 
   constructor(
-    getFrameMetrics: (index: number, props: FrameMetricProps) => ?FrameMetrics,
+    getCellMetrics: (index: number, props: CellMetricProps) => ?CellMetrics,
   ) {
-    this._getFrameMetrics = getFrameMetrics;
+    this._getCellMetrics = getCellMetrics;
     this._enabled = (_sampleRate || 0) > Math.random();
     this._resetData();
   }
@@ -139,7 +139,7 @@ class FillRateHelper {
 
   computeBlankness(
     props: {
-      ...FrameMetricProps,
+      ...CellMetricProps,
       initialNumToRender?: ?number,
       ...
     },
@@ -186,12 +186,12 @@ class FillRateHelper {
 
     let blankTop = 0;
     let first = cellsAroundViewport.first;
-    let firstFrame = this._getFrameMetrics(first, props);
+    let firstFrame = this._getCellMetrics(first, props);
     while (
       first <= cellsAroundViewport.last &&
       (!firstFrame || !firstFrame.inLayout)
     ) {
-      firstFrame = this._getFrameMetrics(first, props);
+      firstFrame = this._getCellMetrics(first, props);
       first++;
     }
     // Only count blankTop if we aren't rendering the first item, otherwise we will count the header
@@ -204,12 +204,12 @@ class FillRateHelper {
     }
     let blankBottom = 0;
     let last = cellsAroundViewport.last;
-    let lastFrame = this._getFrameMetrics(last, props);
+    let lastFrame = this._getCellMetrics(last, props);
     while (
       last >= cellsAroundViewport.first &&
       (!lastFrame || !lastFrame.inLayout)
     ) {
-      lastFrame = this._getFrameMetrics(last, props);
+      lastFrame = this._getCellMetrics(last, props);
       last--;
     }
     // Only count blankBottom if we aren't rendering the last item, otherwise we will count the

--- a/packages/virtualized-lists/Lists/ListMetricsAggregator.js
+++ b/packages/virtualized-lists/Lists/ListMetricsAggregator.js
@@ -1,0 +1,179 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {Props as VirtualizedListProps} from './VirtualizedListProps';
+import {keyExtractor as defaultKeyExtractor} from './VirtualizeUtils';
+
+import invariant from 'invariant';
+
+export type CellMetrics = {
+  /**
+   * Index of the item in the list
+   */
+  index: number,
+  /**
+   * Length of the cell along the scrolling axis
+   */
+  length: number,
+  /**
+   * Offset to the cell along the scrolling axis
+   */
+  offset: number,
+  /**
+   * Whether the cell is last known to be mounted
+   */
+  isMounted: boolean,
+};
+
+/**
+ * Subset of VirtualizedList props needed to calculate cell metrics
+ */
+export type CellMetricProps = {
+  data: VirtualizedListProps['data'],
+  getItemCount: VirtualizedListProps['getItemCount'],
+  getItem: VirtualizedListProps['getItem'],
+  getItemLayout?: VirtualizedListProps['getItemLayout'],
+  keyExtractor?: VirtualizedListProps['keyExtractor'],
+  ...
+};
+
+/**
+ * Provides an interface to query information about the metrics of a list and its cells.
+ */
+export default class ListMetricsAggregator {
+  _averageCellLength = 0;
+  _frames: {[string]: CellMetrics} = {};
+  _highestMeasuredCellIndex = 0;
+  _totalCellLength = 0;
+  _totalCellsMeasured = 0;
+
+  /**
+   * Notify the ListMetricsAggregator that a cell has been laid out.
+   *
+   * @returns whether the cell layout has changed since last notification
+   */
+  notifyCellLayout(
+    cellKey: string,
+    index: number,
+    length: number,
+    offset: number,
+  ): boolean {
+    const next: CellMetrics = {
+      offset,
+      length,
+      index,
+      isMounted: true,
+    };
+    const curr = this._frames[cellKey];
+    if (
+      !curr ||
+      next.offset !== curr.offset ||
+      next.length !== curr.length ||
+      index !== curr.index
+    ) {
+      this._totalCellLength += next.length - (curr ? curr.length : 0);
+      this._totalCellsMeasured += curr ? 0 : 1;
+      this._averageCellLength =
+        this._totalCellLength / this._totalCellsMeasured;
+      this._frames[cellKey] = next;
+      this._highestMeasuredCellIndex = Math.max(
+        this._highestMeasuredCellIndex,
+        index,
+      );
+      return true;
+    } else {
+      this._frames[cellKey].isMounted = true;
+      return false;
+    }
+  }
+
+  /**
+   * Notify ListMetricsAggregator that a cell has been unmounted.
+   */
+  notifyCellUnmounted(cellKey: string): void {
+    const curr = this._frames[cellKey];
+    if (curr) {
+      this._frames[cellKey] = {...curr, isMounted: false};
+    }
+  }
+
+  /**
+   * Return the average length of the cells which have been measured
+   */
+  getAverageCellLength(): number {
+    return this._averageCellLength;
+  }
+
+  /**
+   * Return the highest measured cell index
+   */
+  getHighestMeasuredCellIndex(): number {
+    return this._highestMeasuredCellIndex;
+  }
+
+  /**
+   * Returns the exact metrics of a cell if it has already been laid out,
+   * otherwise an estimate based on the average length of previously measured
+   * cells
+   */
+  getCellMetricsApprox(index: number, props: CellMetricProps): CellMetrics {
+    const frame = this.getCellMetrics(index, props);
+    if (frame && frame.index === index) {
+      // check for invalid frames due to row re-ordering
+      return frame;
+    } else {
+      const {data, getItemCount} = props;
+      invariant(
+        index >= 0 && index < getItemCount(data),
+        'Tried to get frame for out of range index ' + index,
+      );
+      return {
+        length: this._averageCellLength,
+        offset: this._averageCellLength * index,
+        index,
+        isMounted: false,
+      };
+    }
+  }
+
+  /**
+   * Returns the exact metrics of a cell if it has already been laid out
+   */
+  getCellMetrics(index: number, props: CellMetricProps): ?CellMetrics {
+    const {data, getItem, getItemCount, getItemLayout} = props;
+    invariant(
+      index >= 0 && index < getItemCount(data),
+      'Tried to get frame for out of range index ' + index,
+    );
+    const keyExtractor = props.keyExtractor ?? defaultKeyExtractor;
+    const frame = this._frames[keyExtractor(getItem(data, index), index)];
+    if (!frame || frame.index !== index) {
+      if (getItemLayout) {
+        const {length, offset} = getItemLayout(data, index);
+        return {index, length, offset, isMounted: true};
+      }
+    }
+    return frame;
+  }
+
+  /**
+   * Gets an approximate offset to an item at a given index. Supports
+   * fractional indices.
+   */
+  getCellOffsetApprox(index: number, props: CellMetricProps): number {
+    if (Number.isInteger(index)) {
+      return this.getCellMetricsApprox(index, props).offset;
+    } else {
+      const frameMetrics = this.getCellMetricsApprox(Math.floor(index), props);
+      const remainder = index - Math.floor(index);
+      return frameMetrics.offset + remainder * frameMetrics.length;
+    }
+  }
+}

--- a/packages/virtualized-lists/Lists/ViewabilityHelper.js
+++ b/packages/virtualized-lists/Lists/ViewabilityHelper.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-import type {FrameMetricProps} from './VirtualizedListProps';
+import type {CellMetricProps} from './VirtualizedListProps';
 
 const invariant = require('invariant');
 
@@ -101,12 +101,12 @@ class ViewabilityHelper {
    * Determines which items are viewable based on the current metrics and config.
    */
   computeViewableItems(
-    props: FrameMetricProps,
+    props: CellMetricProps,
     scrollOffset: number,
     viewportHeight: number,
-    getFrameMetrics: (
+    getCellMetrics: (
       index: number,
-      props: FrameMetricProps,
+      props: CellMetricProps,
     ) => ?{
       length: number,
       offset: number,
@@ -146,7 +146,7 @@ class ViewabilityHelper {
       return [];
     }
     for (let idx = first; idx <= last; idx++) {
-      const metrics = getFrameMetrics(idx, props);
+      const metrics = getCellMetrics(idx, props);
       if (!metrics) {
         continue;
       }
@@ -178,12 +178,12 @@ class ViewabilityHelper {
    * `onViewableItemsChanged` as appropriate.
    */
   onUpdate(
-    props: FrameMetricProps,
+    props: CellMetricProps,
     scrollOffset: number,
     viewportHeight: number,
-    getFrameMetrics: (
+    getCellMetrics: (
       index: number,
-      props: FrameMetricProps,
+      props: CellMetricProps,
     ) => ?{
       length: number,
       offset: number,
@@ -192,7 +192,7 @@ class ViewabilityHelper {
     createViewToken: (
       index: number,
       isViewable: boolean,
-      props: FrameMetricProps,
+      props: CellMetricProps,
     ) => ViewToken,
     onViewableItemsChanged: ({
       viewableItems: Array<ViewToken>,
@@ -210,7 +210,7 @@ class ViewabilityHelper {
     if (
       (this._config.waitForInteraction && !this._hasInteracted) ||
       itemCount === 0 ||
-      !getFrameMetrics(0, props)
+      !getCellMetrics(0, props)
     ) {
       return;
     }
@@ -220,7 +220,7 @@ class ViewabilityHelper {
         props,
         scrollOffset,
         viewportHeight,
-        getFrameMetrics,
+        getCellMetrics,
         renderRange,
       );
     }
@@ -275,7 +275,7 @@ class ViewabilityHelper {
   }
 
   _onUpdateSync(
-    props: FrameMetricProps,
+    props: CellMetricProps,
     viewableIndicesToCheck: Array<number>,
     onViewableItemsChanged: ({
       changed: Array<ViewToken>,
@@ -285,7 +285,7 @@ class ViewabilityHelper {
     createViewToken: (
       index: number,
       isViewable: boolean,
-      props: FrameMetricProps,
+      props: CellMetricProps,
     ) => ViewToken,
   ) {
     // Filter out indices that have gone out of view since this call was scheduled.

--- a/packages/virtualized-lists/Lists/ViewabilityHelper.js
+++ b/packages/virtualized-lists/Lists/ViewabilityHelper.js
@@ -10,7 +10,8 @@
 
 'use strict';
 
-import type {CellMetricProps} from './VirtualizedListProps';
+import type {CellMetricProps} from './ListMetricsAggregator';
+import ListMetricsAggregator from './ListMetricsAggregator';
 
 const invariant = require('invariant');
 
@@ -104,14 +105,7 @@ class ViewabilityHelper {
     props: CellMetricProps,
     scrollOffset: number,
     viewportHeight: number,
-    getCellMetrics: (
-      index: number,
-      props: CellMetricProps,
-    ) => ?{
-      length: number,
-      offset: number,
-      ...
-    },
+    listMetrics: ListMetricsAggregator,
     // Optional optimization to reduce the scan size
     renderRange?: {
       first: number,
@@ -146,7 +140,7 @@ class ViewabilityHelper {
       return [];
     }
     for (let idx = first; idx <= last; idx++) {
-      const metrics = getCellMetrics(idx, props);
+      const metrics = listMetrics.getCellMetrics(idx, props);
       if (!metrics) {
         continue;
       }
@@ -181,14 +175,7 @@ class ViewabilityHelper {
     props: CellMetricProps,
     scrollOffset: number,
     viewportHeight: number,
-    getCellMetrics: (
-      index: number,
-      props: CellMetricProps,
-    ) => ?{
-      length: number,
-      offset: number,
-      ...
-    },
+    listMetrics: ListMetricsAggregator,
     createViewToken: (
       index: number,
       isViewable: boolean,
@@ -210,7 +197,7 @@ class ViewabilityHelper {
     if (
       (this._config.waitForInteraction && !this._hasInteracted) ||
       itemCount === 0 ||
-      !getCellMetrics(0, props)
+      !listMetrics.getCellMetrics(0, props)
     ) {
       return;
     }
@@ -220,7 +207,7 @@ class ViewabilityHelper {
         props,
         scrollOffset,
         viewportHeight,
-        getCellMetrics,
+        listMetrics,
         renderRange,
       );
     }

--- a/packages/virtualized-lists/Lists/VirtualizeUtils.js
+++ b/packages/virtualized-lists/Lists/VirtualizeUtils.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-import type {FrameMetricProps} from './VirtualizedListProps';
+import type {CellMetricProps} from './VirtualizedListProps';
 
 /**
  * Used to find the indices of the frames that overlap the given offsets. Useful for finding the
@@ -19,10 +19,10 @@ import type {FrameMetricProps} from './VirtualizedListProps';
  */
 export function elementsThatOverlapOffsets(
   offsets: Array<number>,
-  props: FrameMetricProps,
-  getFrameMetrics: (
+  props: CellMetricProps,
+  getCellMetrics: (
     index: number,
-    props: FrameMetricProps,
+    props: CellMetricProps,
   ) => {
     length: number,
     offset: number,
@@ -40,7 +40,7 @@ export function elementsThatOverlapOffsets(
     while (left <= right) {
       // eslint-disable-next-line no-bitwise
       const mid = left + ((right - left) >>> 1);
-      const frame = getFrameMetrics(mid, props);
+      const frame = getCellMetrics(mid, props);
       const scaledOffsetStart = frame.offset * zoomScale;
       const scaledOffsetEnd = (frame.offset + frame.length) * zoomScale;
 
@@ -99,16 +99,16 @@ export function newRangeCount(
  * biased in the direction of scroll.
  */
 export function computeWindowedRenderLimits(
-  props: FrameMetricProps,
+  props: CellMetricProps,
   maxToRenderPerBatch: number,
   windowSize: number,
   prev: {
     first: number,
     last: number,
   },
-  getFrameMetricsApprox: (
+  getCellMetricsApprox: (
     index: number,
-    props: FrameMetricProps,
+    props: CellMetricProps,
   ) => {
     length: number,
     offset: number,
@@ -152,7 +152,7 @@ export function computeWindowedRenderLimits(
   const overscanEnd = Math.max(0, visibleEnd + leadFactor * overscanLength);
 
   const lastItemOffset =
-    getFrameMetricsApprox(itemCount - 1, props).offset * zoomScale;
+    getCellMetricsApprox(itemCount - 1, props).offset * zoomScale;
   if (lastItemOffset < overscanBegin) {
     // Entire list is before our overscan window
     return {
@@ -165,7 +165,7 @@ export function computeWindowedRenderLimits(
   let [overscanFirst, first, last, overscanLast] = elementsThatOverlapOffsets(
     [overscanBegin, visibleBegin, visibleEnd, overscanEnd],
     props,
-    getFrameMetricsApprox,
+    getCellMetricsApprox,
     zoomScale,
   );
   overscanFirst = overscanFirst == null ? 0 : overscanFirst;

--- a/packages/virtualized-lists/Lists/VirtualizeUtils.js
+++ b/packages/virtualized-lists/Lists/VirtualizeUtils.js
@@ -10,7 +10,8 @@
 
 'use strict';
 
-import type {CellMetricProps} from './VirtualizedListProps';
+import type {CellMetricProps} from './ListMetricsAggregator';
+import ListMetricsAggregator from './ListMetricsAggregator';
 
 /**
  * Used to find the indices of the frames that overlap the given offsets. Useful for finding the
@@ -20,14 +21,7 @@ import type {CellMetricProps} from './VirtualizedListProps';
 export function elementsThatOverlapOffsets(
   offsets: Array<number>,
   props: CellMetricProps,
-  getCellMetrics: (
-    index: number,
-    props: CellMetricProps,
-  ) => {
-    length: number,
-    offset: number,
-    ...
-  },
+  listMetrics: ListMetricsAggregator,
   zoomScale: number = 1,
 ): Array<number> {
   const itemCount = props.getItemCount(props.data);
@@ -38,9 +32,8 @@ export function elementsThatOverlapOffsets(
     let right = itemCount - 1;
 
     while (left <= right) {
-      // eslint-disable-next-line no-bitwise
-      const mid = left + ((right - left) >>> 1);
-      const frame = getCellMetrics(mid, props);
+      const mid = left + Math.floor((right - left) / 2);
+      const frame = listMetrics.getCellMetricsApprox(mid, props);
       const scaledOffsetStart = frame.offset * zoomScale;
       const scaledOffsetEnd = (frame.offset + frame.length) * zoomScale;
 
@@ -106,14 +99,7 @@ export function computeWindowedRenderLimits(
     first: number,
     last: number,
   },
-  getCellMetricsApprox: (
-    index: number,
-    props: CellMetricProps,
-  ) => {
-    length: number,
-    offset: number,
-    ...
-  },
+  listMetrics: ListMetricsAggregator,
   scrollMetrics: {
     dt: number,
     offset: number,
@@ -152,7 +138,7 @@ export function computeWindowedRenderLimits(
   const overscanEnd = Math.max(0, visibleEnd + leadFactor * overscanLength);
 
   const lastItemOffset =
-    getCellMetricsApprox(itemCount - 1, props).offset * zoomScale;
+    listMetrics.getCellMetricsApprox(itemCount - 1, props).offset * zoomScale;
   if (lastItemOffset < overscanBegin) {
     // Entire list is before our overscan window
     return {
@@ -165,7 +151,7 @@ export function computeWindowedRenderLimits(
   let [overscanFirst, first, last, overscanLast] = elementsThatOverlapOffsets(
     [overscanBegin, visibleBegin, visibleEnd, overscanEnd],
     props,
-    getCellMetricsApprox,
+    listMetrics,
     zoomScale,
   );
   overscanFirst = overscanFirst == null ? 0 : overscanFirst;

--- a/packages/virtualized-lists/Lists/VirtualizedListProps.js
+++ b/packages/virtualized-lists/Lists/VirtualizedListProps.js
@@ -296,7 +296,7 @@ export type Props = {|
 /**
  * Subset of properties needed to calculate frame metrics
  */
-export type FrameMetricProps = {
+export type CellMetricProps = {
   data: RequiredProps['data'],
   getItemCount: RequiredProps['getItemCount'],
   getItem: RequiredProps['getItem'],

--- a/packages/virtualized-lists/Lists/VirtualizedListProps.js
+++ b/packages/virtualized-lists/Lists/VirtualizedListProps.js
@@ -292,15 +292,3 @@ export type Props = {|
   ...RequiredProps,
   ...OptionalProps,
 |};
-
-/**
- * Subset of properties needed to calculate frame metrics
- */
-export type CellMetricProps = {
-  data: RequiredProps['data'],
-  getItemCount: RequiredProps['getItemCount'],
-  getItem: RequiredProps['getItem'],
-  getItemLayout?: OptionalProps['getItemLayout'],
-  keyExtractor?: OptionalProps['keyExtractor'],
-  ...
-};

--- a/packages/virtualized-lists/Lists/VirtualizedSectionList.js
+++ b/packages/virtualized-lists/Lists/VirtualizedSectionList.js
@@ -138,11 +138,11 @@ class VirtualizedSectionList<
     if (this._listRef == null) {
       return;
     }
+    const listRef = this._listRef;
     if (params.itemIndex > 0 && this.props.stickySectionHeadersEnabled) {
-      const frame = this._listRef.__getCellMetricsApprox(
-        index - params.itemIndex,
-        this._listRef.props,
-      );
+      const frame = listRef
+        .__getListMetrics()
+        .getCellMetricsApprox(index - params.itemIndex, listRef.props);
       viewOffset += frame.length;
     }
     const toIndexParams = {

--- a/packages/virtualized-lists/Lists/VirtualizedSectionList.js
+++ b/packages/virtualized-lists/Lists/VirtualizedSectionList.js
@@ -139,7 +139,7 @@ class VirtualizedSectionList<
       return;
     }
     if (params.itemIndex > 0 && this.props.stickySectionHeadersEnabled) {
-      const frame = this._listRef.__getFrameMetricsApprox(
+      const frame = this._listRef.__getCellMetricsApprox(
         index - params.itemIndex,
         this._listRef.props,
       );

--- a/packages/virtualized-lists/Lists/__tests__/FillRateHelper-test.js
+++ b/packages/virtualized-lists/Lists/__tests__/FillRateHelper-test.js
@@ -23,7 +23,7 @@ const dataGlobal = [
 ];
 function getCellMetrics(index: number) {
   const frame = rowFramesGlobal[dataGlobal[index].key];
-  return {length: frame.height, offset: frame.y, inLayout: frame.inLayout};
+  return {length: frame.height, offset: frame.y, isMounted: frame.isMounted};
 }
 
 function computeResult({helper, props, state, scroll}): number {
@@ -47,11 +47,11 @@ describe('computeBlankness', function () {
   });
 
   it('computes correct blankness of viewport', function () {
-    const helper = new FillRateHelper(getCellMetrics);
+    const helper = new FillRateHelper({getCellMetrics});
     rowFramesGlobal = {
-      header: {y: 0, height: 0, inLayout: true},
-      a: {y: 0, height: 50, inLayout: true},
-      b: {y: 50, height: 50, inLayout: true},
+      header: {y: 0, height: 0, isMounted: true},
+      a: {y: 0, height: 50, isMounted: true},
+      b: {y: 50, height: 50, isMounted: true},
     };
     let blankness = computeResult({helper});
     expect(blankness).toBe(0);
@@ -66,32 +66,32 @@ describe('computeBlankness', function () {
   });
 
   it('skips frames that are not in layout', function () {
-    const helper = new FillRateHelper(getCellMetrics);
+    const helper = new FillRateHelper({getCellMetrics});
     rowFramesGlobal = {
-      header: {y: 0, height: 0, inLayout: false},
-      a: {y: 0, height: 10, inLayout: false},
-      b: {y: 10, height: 30, inLayout: true},
-      c: {y: 40, height: 40, inLayout: true},
-      d: {y: 80, height: 20, inLayout: false},
-      footer: {y: 100, height: 0, inLayout: false},
+      header: {y: 0, height: 0, isMounted: false},
+      a: {y: 0, height: 10, isMounted: false},
+      b: {y: 10, height: 30, isMounted: true},
+      c: {y: 40, height: 40, isMounted: true},
+      d: {y: 80, height: 20, isMounted: false},
+      footer: {y: 100, height: 0, isMounted: false},
     };
     const blankness = computeResult({helper, state: {last: 4}});
     expect(blankness).toBe(0.3);
   });
 
   it('sampling rate can disable', function () {
-    let helper = new FillRateHelper(getCellMetrics);
+    let helper = new FillRateHelper({getCellMetrics});
     rowFramesGlobal = {
-      header: {y: 0, height: 0, inLayout: true},
-      a: {y: 0, height: 40, inLayout: true},
-      b: {y: 40, height: 40, inLayout: true},
+      header: {y: 0, height: 0, isMounted: true},
+      a: {y: 0, height: 40, isMounted: true},
+      b: {y: 40, height: 40, isMounted: true},
     };
     let blankness = computeResult({helper});
     expect(blankness).toBe(0.2);
 
     FillRateHelper.setSampleRate(0);
 
-    helper = new FillRateHelper(getCellMetrics);
+    helper = new FillRateHelper({getCellMetrics});
     blankness = computeResult({helper});
     expect(blankness).toBe(0);
   });
@@ -102,11 +102,11 @@ describe('computeBlankness', function () {
       FillRateHelper.addListener(listener),
     );
     subscriptions[1].remove();
-    const helper = new FillRateHelper(getCellMetrics);
+    const helper = new FillRateHelper({getCellMetrics});
     rowFramesGlobal = {
-      header: {y: 0, height: 0, inLayout: true},
-      a: {y: 0, height: 40, inLayout: true},
-      b: {y: 40, height: 40, inLayout: true},
+      header: {y: 0, height: 0, isMounted: true},
+      a: {y: 0, height: 40, isMounted: true},
+      b: {y: 40, height: 40, isMounted: true},
     };
     const blankness = computeResult({helper});
     expect(blankness).toBe(0.2);

--- a/packages/virtualized-lists/Lists/__tests__/FillRateHelper-test.js
+++ b/packages/virtualized-lists/Lists/__tests__/FillRateHelper-test.js
@@ -21,7 +21,7 @@ const dataGlobal = [
   {key: 'd'},
   {key: 'footer'},
 ];
-function getFrameMetrics(index: number) {
+function getCellMetrics(index: number) {
   const frame = rowFramesGlobal[dataGlobal[index].key];
   return {length: frame.height, offset: frame.y, inLayout: frame.inLayout};
 }
@@ -47,7 +47,7 @@ describe('computeBlankness', function () {
   });
 
   it('computes correct blankness of viewport', function () {
-    const helper = new FillRateHelper(getFrameMetrics);
+    const helper = new FillRateHelper(getCellMetrics);
     rowFramesGlobal = {
       header: {y: 0, height: 0, inLayout: true},
       a: {y: 0, height: 50, inLayout: true},
@@ -66,7 +66,7 @@ describe('computeBlankness', function () {
   });
 
   it('skips frames that are not in layout', function () {
-    const helper = new FillRateHelper(getFrameMetrics);
+    const helper = new FillRateHelper(getCellMetrics);
     rowFramesGlobal = {
       header: {y: 0, height: 0, inLayout: false},
       a: {y: 0, height: 10, inLayout: false},
@@ -80,7 +80,7 @@ describe('computeBlankness', function () {
   });
 
   it('sampling rate can disable', function () {
-    let helper = new FillRateHelper(getFrameMetrics);
+    let helper = new FillRateHelper(getCellMetrics);
     rowFramesGlobal = {
       header: {y: 0, height: 0, inLayout: true},
       a: {y: 0, height: 40, inLayout: true},
@@ -91,7 +91,7 @@ describe('computeBlankness', function () {
 
     FillRateHelper.setSampleRate(0);
 
-    helper = new FillRateHelper(getFrameMetrics);
+    helper = new FillRateHelper(getCellMetrics);
     blankness = computeResult({helper});
     expect(blankness).toBe(0);
   });
@@ -102,7 +102,7 @@ describe('computeBlankness', function () {
       FillRateHelper.addListener(listener),
     );
     subscriptions[1].remove();
-    const helper = new FillRateHelper(getFrameMetrics);
+    const helper = new FillRateHelper(getCellMetrics);
     rowFramesGlobal = {
       header: {y: 0, height: 0, inLayout: true},
       a: {y: 0, height: 40, inLayout: true},

--- a/packages/virtualized-lists/Lists/__tests__/ViewabilityHelper-test.js
+++ b/packages/virtualized-lists/Lists/__tests__/ViewabilityHelper-test.js
@@ -38,9 +38,9 @@ describe('computeViewableItems', function () {
       d: {y: 150, height: 50},
     };
     data = [{key: 'a'}, {key: 'b'}, {key: 'c'}, {key: 'd'}];
-    expect(helper.computeViewableItems(props, 0, 200, getCellMetrics)).toEqual([
-      0, 1, 2, 3,
-    ]);
+    expect(
+      helper.computeViewableItems(props, 0, 200, {getCellMetrics}),
+    ).toEqual([0, 1, 2, 3]);
   });
 
   it('returns top 2 rows as viewable (1. entirely visible and 2. majority)', function () {
@@ -54,9 +54,9 @@ describe('computeViewableItems', function () {
       d: {y: 250, height: 50},
     };
     data = [{key: 'a'}, {key: 'b'}, {key: 'c'}, {key: 'd'}];
-    expect(helper.computeViewableItems(props, 0, 200, getCellMetrics)).toEqual([
-      0, 1,
-    ]);
+    expect(
+      helper.computeViewableItems(props, 0, 200, {getCellMetrics}),
+    ).toEqual([0, 1]);
   });
 
   it('returns only 2nd row as viewable (majority)', function () {
@@ -70,9 +70,9 @@ describe('computeViewableItems', function () {
       d: {y: 250, height: 50},
     };
     data = [{key: 'a'}, {key: 'b'}, {key: 'c'}, {key: 'd'}];
-    expect(helper.computeViewableItems(props, 25, 200, getCellMetrics)).toEqual(
-      [1],
-    );
+    expect(
+      helper.computeViewableItems(props, 25, 200, {getCellMetrics}),
+    ).toEqual([1]);
   });
 
   it('handles empty input', function () {
@@ -81,9 +81,9 @@ describe('computeViewableItems', function () {
     });
     rowFrames = {};
     data = [];
-    expect(helper.computeViewableItems(props, 0, 200, getCellMetrics)).toEqual(
-      [],
-    );
+    expect(
+      helper.computeViewableItems(props, 0, 200, {getCellMetrics}),
+    ).toEqual([]);
   });
 
   it('handles different view area coverage percent thresholds', function () {
@@ -96,40 +96,40 @@ describe('computeViewableItems', function () {
     data = [{key: 'a'}, {key: 'b'}, {key: 'c'}, {key: 'd'}];
 
     let helper = new ViewabilityHelper({viewAreaCoveragePercentThreshold: 0});
-    expect(helper.computeViewableItems(props, 0, 50, getCellMetrics)).toEqual([
-      0,
-    ]);
-    expect(helper.computeViewableItems(props, 1, 50, getCellMetrics)).toEqual([
-      0, 1,
-    ]);
-    expect(helper.computeViewableItems(props, 199, 50, getCellMetrics)).toEqual(
-      [1, 2],
+    expect(helper.computeViewableItems(props, 0, 50, {getCellMetrics})).toEqual(
+      [0],
     );
-    expect(helper.computeViewableItems(props, 250, 50, getCellMetrics)).toEqual(
-      [2],
+    expect(helper.computeViewableItems(props, 1, 50, {getCellMetrics})).toEqual(
+      [0, 1],
     );
+    expect(
+      helper.computeViewableItems(props, 199, 50, {getCellMetrics}),
+    ).toEqual([1, 2]);
+    expect(
+      helper.computeViewableItems(props, 250, 50, {getCellMetrics}),
+    ).toEqual([2]);
 
     helper = new ViewabilityHelper({viewAreaCoveragePercentThreshold: 100});
-    expect(helper.computeViewableItems(props, 0, 200, getCellMetrics)).toEqual([
-      0, 1,
-    ]);
-    expect(helper.computeViewableItems(props, 1, 200, getCellMetrics)).toEqual([
-      1,
-    ]);
     expect(
-      helper.computeViewableItems(props, 400, 200, getCellMetrics),
+      helper.computeViewableItems(props, 0, 200, {getCellMetrics}),
+    ).toEqual([0, 1]);
+    expect(
+      helper.computeViewableItems(props, 1, 200, {getCellMetrics}),
+    ).toEqual([1]);
+    expect(
+      helper.computeViewableItems(props, 400, 200, {getCellMetrics}),
     ).toEqual([2]);
     expect(
-      helper.computeViewableItems(props, 600, 200, getCellMetrics),
+      helper.computeViewableItems(props, 600, 200, {getCellMetrics}),
     ).toEqual([3]);
 
     helper = new ViewabilityHelper({viewAreaCoveragePercentThreshold: 10});
-    expect(helper.computeViewableItems(props, 30, 200, getCellMetrics)).toEqual(
-      [0, 1, 2],
-    );
-    expect(helper.computeViewableItems(props, 31, 200, getCellMetrics)).toEqual(
-      [1, 2],
-    );
+    expect(
+      helper.computeViewableItems(props, 30, 200, {getCellMetrics}),
+    ).toEqual([0, 1, 2]);
+    expect(
+      helper.computeViewableItems(props, 31, 200, {getCellMetrics}),
+    ).toEqual([1, 2]);
   });
 
   it('handles different item visible percent thresholds', function () {
@@ -141,31 +141,31 @@ describe('computeViewableItems', function () {
     };
     data = [{key: 'a'}, {key: 'b'}, {key: 'c'}, {key: 'd'}];
     let helper = new ViewabilityHelper({itemVisiblePercentThreshold: 0});
-    expect(helper.computeViewableItems(props, 0, 50, getCellMetrics)).toEqual([
-      0,
-    ]);
-    expect(helper.computeViewableItems(props, 1, 50, getCellMetrics)).toEqual([
-      0, 1,
-    ]);
+    expect(helper.computeViewableItems(props, 0, 50, {getCellMetrics})).toEqual(
+      [0],
+    );
+    expect(helper.computeViewableItems(props, 1, 50, {getCellMetrics})).toEqual(
+      [0, 1],
+    );
 
     helper = new ViewabilityHelper({itemVisiblePercentThreshold: 100});
-    expect(helper.computeViewableItems(props, 0, 250, getCellMetrics)).toEqual([
-      0, 1, 2,
-    ]);
-    expect(helper.computeViewableItems(props, 1, 250, getCellMetrics)).toEqual([
-      1, 2,
-    ]);
+    expect(
+      helper.computeViewableItems(props, 0, 250, {getCellMetrics}),
+    ).toEqual([0, 1, 2]);
+    expect(
+      helper.computeViewableItems(props, 1, 250, {getCellMetrics}),
+    ).toEqual([1, 2]);
 
     helper = new ViewabilityHelper({itemVisiblePercentThreshold: 10});
-    expect(helper.computeViewableItems(props, 184, 20, getCellMetrics)).toEqual(
-      [1],
-    );
-    expect(helper.computeViewableItems(props, 185, 20, getCellMetrics)).toEqual(
-      [1, 2],
-    );
-    expect(helper.computeViewableItems(props, 186, 20, getCellMetrics)).toEqual(
-      [2],
-    );
+    expect(
+      helper.computeViewableItems(props, 184, 20, {getCellMetrics}),
+    ).toEqual([1]);
+    expect(
+      helper.computeViewableItems(props, 185, 20, {getCellMetrics}),
+    ).toEqual([1, 2]);
+    expect(
+      helper.computeViewableItems(props, 186, 20, {getCellMetrics}),
+    ).toEqual([2]);
   });
 });
 
@@ -181,7 +181,7 @@ describe('onUpdate', function () {
       props,
       0,
       200,
-      getCellMetrics,
+      {getCellMetrics},
       createViewToken,
       onViewableItemsChanged,
     );
@@ -195,7 +195,7 @@ describe('onUpdate', function () {
       props,
       0,
       200,
-      getCellMetrics,
+      {getCellMetrics},
       createViewToken,
       onViewableItemsChanged,
     );
@@ -204,7 +204,7 @@ describe('onUpdate', function () {
       props,
       100,
       200,
-      getCellMetrics,
+      {getCellMetrics},
       createViewToken,
       onViewableItemsChanged,
     );
@@ -228,7 +228,7 @@ describe('onUpdate', function () {
       props,
       0,
       200,
-      getCellMetrics,
+      {getCellMetrics},
       createViewToken,
       onViewableItemsChanged,
     );
@@ -242,7 +242,7 @@ describe('onUpdate', function () {
       props,
       100,
       200,
-      getCellMetrics,
+      {getCellMetrics},
       createViewToken,
       onViewableItemsChanged,
     );
@@ -260,7 +260,7 @@ describe('onUpdate', function () {
       props,
       200,
       200,
-      getCellMetrics,
+      {getCellMetrics},
       createViewToken,
       onViewableItemsChanged,
     );
@@ -287,7 +287,7 @@ describe('onUpdate', function () {
       props,
       0,
       200,
-      getCellMetrics,
+      {getCellMetrics},
       createViewToken,
       onViewableItemsChanged,
     );
@@ -321,7 +321,7 @@ describe('onUpdate', function () {
       props,
       0,
       200,
-      getCellMetrics,
+      {getCellMetrics},
       createViewToken,
       onViewableItemsChanged,
     );
@@ -329,7 +329,7 @@ describe('onUpdate', function () {
       props,
       300, // scroll past item 'a'
       200,
-      getCellMetrics,
+      {getCellMetrics},
       createViewToken,
       onViewableItemsChanged,
     );
@@ -362,7 +362,7 @@ describe('onUpdate', function () {
       props,
       0,
       100,
-      getCellMetrics,
+      {getCellMetrics},
       createViewToken,
       onViewableItemsChanged,
     );
@@ -374,7 +374,7 @@ describe('onUpdate', function () {
       props,
       20,
       100,
-      getCellMetrics,
+      {getCellMetrics},
       createViewToken,
       onViewableItemsChanged,
     );
@@ -401,7 +401,7 @@ describe('onUpdate', function () {
       props,
       0,
       200,
-      getCellMetrics,
+      {getCellMetrics},
       createViewToken,
       onViewableItemsChanged,
     );
@@ -426,7 +426,7 @@ describe('onUpdate', function () {
       props,
       0,
       200,
-      getCellMetrics,
+      {getCellMetrics},
       createViewToken,
       onViewableItemsChanged,
     );

--- a/packages/virtualized-lists/Lists/__tests__/ViewabilityHelper-test.js
+++ b/packages/virtualized-lists/Lists/__tests__/ViewabilityHelper-test.js
@@ -18,7 +18,7 @@ const props = {
   data,
   getItemCount: () => data.length,
 };
-function getFrameMetrics(index: number) {
+function getCellMetrics(index: number) {
   const frame = rowFrames[data[index].key];
   return {length: frame.height, offset: frame.y};
 }
@@ -38,9 +38,9 @@ describe('computeViewableItems', function () {
       d: {y: 150, height: 50},
     };
     data = [{key: 'a'}, {key: 'b'}, {key: 'c'}, {key: 'd'}];
-    expect(helper.computeViewableItems(props, 0, 200, getFrameMetrics)).toEqual(
-      [0, 1, 2, 3],
-    );
+    expect(helper.computeViewableItems(props, 0, 200, getCellMetrics)).toEqual([
+      0, 1, 2, 3,
+    ]);
   });
 
   it('returns top 2 rows as viewable (1. entirely visible and 2. majority)', function () {
@@ -54,9 +54,9 @@ describe('computeViewableItems', function () {
       d: {y: 250, height: 50},
     };
     data = [{key: 'a'}, {key: 'b'}, {key: 'c'}, {key: 'd'}];
-    expect(helper.computeViewableItems(props, 0, 200, getFrameMetrics)).toEqual(
-      [0, 1],
-    );
+    expect(helper.computeViewableItems(props, 0, 200, getCellMetrics)).toEqual([
+      0, 1,
+    ]);
   });
 
   it('returns only 2nd row as viewable (majority)', function () {
@@ -70,9 +70,9 @@ describe('computeViewableItems', function () {
       d: {y: 250, height: 50},
     };
     data = [{key: 'a'}, {key: 'b'}, {key: 'c'}, {key: 'd'}];
-    expect(
-      helper.computeViewableItems(props, 25, 200, getFrameMetrics),
-    ).toEqual([1]);
+    expect(helper.computeViewableItems(props, 25, 200, getCellMetrics)).toEqual(
+      [1],
+    );
   });
 
   it('handles empty input', function () {
@@ -81,7 +81,7 @@ describe('computeViewableItems', function () {
     });
     rowFrames = {};
     data = [];
-    expect(helper.computeViewableItems(props, 0, 200, getFrameMetrics)).toEqual(
+    expect(helper.computeViewableItems(props, 0, 200, getCellMetrics)).toEqual(
       [],
     );
   });
@@ -96,40 +96,40 @@ describe('computeViewableItems', function () {
     data = [{key: 'a'}, {key: 'b'}, {key: 'c'}, {key: 'd'}];
 
     let helper = new ViewabilityHelper({viewAreaCoveragePercentThreshold: 0});
-    expect(helper.computeViewableItems(props, 0, 50, getFrameMetrics)).toEqual([
+    expect(helper.computeViewableItems(props, 0, 50, getCellMetrics)).toEqual([
       0,
     ]);
-    expect(helper.computeViewableItems(props, 1, 50, getFrameMetrics)).toEqual([
+    expect(helper.computeViewableItems(props, 1, 50, getCellMetrics)).toEqual([
       0, 1,
     ]);
-    expect(
-      helper.computeViewableItems(props, 199, 50, getFrameMetrics),
-    ).toEqual([1, 2]);
-    expect(
-      helper.computeViewableItems(props, 250, 50, getFrameMetrics),
-    ).toEqual([2]);
+    expect(helper.computeViewableItems(props, 199, 50, getCellMetrics)).toEqual(
+      [1, 2],
+    );
+    expect(helper.computeViewableItems(props, 250, 50, getCellMetrics)).toEqual(
+      [2],
+    );
 
     helper = new ViewabilityHelper({viewAreaCoveragePercentThreshold: 100});
-    expect(helper.computeViewableItems(props, 0, 200, getFrameMetrics)).toEqual(
-      [0, 1],
-    );
-    expect(helper.computeViewableItems(props, 1, 200, getFrameMetrics)).toEqual(
-      [1],
-    );
+    expect(helper.computeViewableItems(props, 0, 200, getCellMetrics)).toEqual([
+      0, 1,
+    ]);
+    expect(helper.computeViewableItems(props, 1, 200, getCellMetrics)).toEqual([
+      1,
+    ]);
     expect(
-      helper.computeViewableItems(props, 400, 200, getFrameMetrics),
+      helper.computeViewableItems(props, 400, 200, getCellMetrics),
     ).toEqual([2]);
     expect(
-      helper.computeViewableItems(props, 600, 200, getFrameMetrics),
+      helper.computeViewableItems(props, 600, 200, getCellMetrics),
     ).toEqual([3]);
 
     helper = new ViewabilityHelper({viewAreaCoveragePercentThreshold: 10});
-    expect(
-      helper.computeViewableItems(props, 30, 200, getFrameMetrics),
-    ).toEqual([0, 1, 2]);
-    expect(
-      helper.computeViewableItems(props, 31, 200, getFrameMetrics),
-    ).toEqual([1, 2]);
+    expect(helper.computeViewableItems(props, 30, 200, getCellMetrics)).toEqual(
+      [0, 1, 2],
+    );
+    expect(helper.computeViewableItems(props, 31, 200, getCellMetrics)).toEqual(
+      [1, 2],
+    );
   });
 
   it('handles different item visible percent thresholds', function () {
@@ -141,31 +141,31 @@ describe('computeViewableItems', function () {
     };
     data = [{key: 'a'}, {key: 'b'}, {key: 'c'}, {key: 'd'}];
     let helper = new ViewabilityHelper({itemVisiblePercentThreshold: 0});
-    expect(helper.computeViewableItems(props, 0, 50, getFrameMetrics)).toEqual([
+    expect(helper.computeViewableItems(props, 0, 50, getCellMetrics)).toEqual([
       0,
     ]);
-    expect(helper.computeViewableItems(props, 1, 50, getFrameMetrics)).toEqual([
+    expect(helper.computeViewableItems(props, 1, 50, getCellMetrics)).toEqual([
       0, 1,
     ]);
 
     helper = new ViewabilityHelper({itemVisiblePercentThreshold: 100});
-    expect(helper.computeViewableItems(props, 0, 250, getFrameMetrics)).toEqual(
-      [0, 1, 2],
-    );
-    expect(helper.computeViewableItems(props, 1, 250, getFrameMetrics)).toEqual(
-      [1, 2],
-    );
+    expect(helper.computeViewableItems(props, 0, 250, getCellMetrics)).toEqual([
+      0, 1, 2,
+    ]);
+    expect(helper.computeViewableItems(props, 1, 250, getCellMetrics)).toEqual([
+      1, 2,
+    ]);
 
     helper = new ViewabilityHelper({itemVisiblePercentThreshold: 10});
-    expect(
-      helper.computeViewableItems(props, 184, 20, getFrameMetrics),
-    ).toEqual([1]);
-    expect(
-      helper.computeViewableItems(props, 185, 20, getFrameMetrics),
-    ).toEqual([1, 2]);
-    expect(
-      helper.computeViewableItems(props, 186, 20, getFrameMetrics),
-    ).toEqual([2]);
+    expect(helper.computeViewableItems(props, 184, 20, getCellMetrics)).toEqual(
+      [1],
+    );
+    expect(helper.computeViewableItems(props, 185, 20, getCellMetrics)).toEqual(
+      [1, 2],
+    );
+    expect(helper.computeViewableItems(props, 186, 20, getCellMetrics)).toEqual(
+      [2],
+    );
   });
 });
 
@@ -181,7 +181,7 @@ describe('onUpdate', function () {
       props,
       0,
       200,
-      getFrameMetrics,
+      getCellMetrics,
       createViewToken,
       onViewableItemsChanged,
     );
@@ -195,7 +195,7 @@ describe('onUpdate', function () {
       props,
       0,
       200,
-      getFrameMetrics,
+      getCellMetrics,
       createViewToken,
       onViewableItemsChanged,
     );
@@ -204,7 +204,7 @@ describe('onUpdate', function () {
       props,
       100,
       200,
-      getFrameMetrics,
+      getCellMetrics,
       createViewToken,
       onViewableItemsChanged,
     );
@@ -228,7 +228,7 @@ describe('onUpdate', function () {
       props,
       0,
       200,
-      getFrameMetrics,
+      getCellMetrics,
       createViewToken,
       onViewableItemsChanged,
     );
@@ -242,7 +242,7 @@ describe('onUpdate', function () {
       props,
       100,
       200,
-      getFrameMetrics,
+      getCellMetrics,
       createViewToken,
       onViewableItemsChanged,
     );
@@ -260,7 +260,7 @@ describe('onUpdate', function () {
       props,
       200,
       200,
-      getFrameMetrics,
+      getCellMetrics,
       createViewToken,
       onViewableItemsChanged,
     );
@@ -287,7 +287,7 @@ describe('onUpdate', function () {
       props,
       0,
       200,
-      getFrameMetrics,
+      getCellMetrics,
       createViewToken,
       onViewableItemsChanged,
     );
@@ -321,7 +321,7 @@ describe('onUpdate', function () {
       props,
       0,
       200,
-      getFrameMetrics,
+      getCellMetrics,
       createViewToken,
       onViewableItemsChanged,
     );
@@ -329,7 +329,7 @@ describe('onUpdate', function () {
       props,
       300, // scroll past item 'a'
       200,
-      getFrameMetrics,
+      getCellMetrics,
       createViewToken,
       onViewableItemsChanged,
     );
@@ -362,7 +362,7 @@ describe('onUpdate', function () {
       props,
       0,
       100,
-      getFrameMetrics,
+      getCellMetrics,
       createViewToken,
       onViewableItemsChanged,
     );
@@ -374,7 +374,7 @@ describe('onUpdate', function () {
       props,
       20,
       100,
-      getFrameMetrics,
+      getCellMetrics,
       createViewToken,
       onViewableItemsChanged,
     );
@@ -401,7 +401,7 @@ describe('onUpdate', function () {
       props,
       0,
       200,
-      getFrameMetrics,
+      getCellMetrics,
       createViewToken,
       onViewableItemsChanged,
     );
@@ -426,7 +426,7 @@ describe('onUpdate', function () {
       props,
       0,
       200,
-      getFrameMetrics,
+      getCellMetrics,
       createViewToken,
       onViewableItemsChanged,
     );

--- a/packages/virtualized-lists/Lists/__tests__/VirtualizeUtils-test.js
+++ b/packages/virtualized-lists/Lists/__tests__/VirtualizeUtils-test.js
@@ -42,14 +42,19 @@ describe('newRangeCount', function () {
 describe('elementsThatOverlapOffsets', function () {
   it('handles fixed length', function () {
     const offsets = [0, 250, 350, 450];
-    function getCellMetrics(index: number) {
+    function getCellMetricsApprox(index: number) {
       return {
         length: 100,
         offset: 100 * index,
       };
     }
     expect(
-      elementsThatOverlapOffsets(offsets, fakeProps(100), getCellMetrics, 1),
+      elementsThatOverlapOffsets(
+        offsets,
+        fakeProps(100),
+        {getCellMetricsApprox},
+        1,
+      ),
     ).toEqual([0, 2, 3, 4]);
   });
   it('handles variable length', function () {
@@ -65,21 +70,26 @@ describe('elementsThatOverlapOffsets', function () {
       elementsThatOverlapOffsets(
         offsets,
         fakeProps(frames.length),
-        ii => frames[ii],
+        {getCellMetricsApprox: ii => frames[ii]},
         1,
       ),
     ).toEqual([1, 1, 3]);
   });
   it('handles frame boundaries', function () {
     const offsets = [0, 100, 200, 300];
-    function getCellMetrics(index: number) {
+    function getCellMetricsApprox(index: number) {
       return {
         length: 100,
         offset: 100 * index,
       };
     }
     expect(
-      elementsThatOverlapOffsets(offsets, fakeProps(100), getCellMetrics, 1),
+      elementsThatOverlapOffsets(
+        offsets,
+        fakeProps(100),
+        {getCellMetricsApprox},
+        1,
+      ),
     ).toEqual([0, 0, 1, 2]);
   });
   it('handles out of bounds', function () {
@@ -93,7 +103,7 @@ describe('elementsThatOverlapOffsets', function () {
       elementsThatOverlapOffsets(
         offsets,
         fakeProps(frames.length),
-        ii => frames[ii],
+        {getCellMetricsApprox: ii => frames[ii]},
         1,
       ),
     ).toEqual([undefined, 1]);

--- a/packages/virtualized-lists/Lists/__tests__/VirtualizeUtils-test.js
+++ b/packages/virtualized-lists/Lists/__tests__/VirtualizeUtils-test.js
@@ -42,14 +42,14 @@ describe('newRangeCount', function () {
 describe('elementsThatOverlapOffsets', function () {
   it('handles fixed length', function () {
     const offsets = [0, 250, 350, 450];
-    function getFrameMetrics(index: number) {
+    function getCellMetrics(index: number) {
       return {
         length: 100,
         offset: 100 * index,
       };
     }
     expect(
-      elementsThatOverlapOffsets(offsets, fakeProps(100), getFrameMetrics, 1),
+      elementsThatOverlapOffsets(offsets, fakeProps(100), getCellMetrics, 1),
     ).toEqual([0, 2, 3, 4]);
   });
   it('handles variable length', function () {
@@ -72,14 +72,14 @@ describe('elementsThatOverlapOffsets', function () {
   });
   it('handles frame boundaries', function () {
     const offsets = [0, 100, 200, 300];
-    function getFrameMetrics(index: number) {
+    function getCellMetrics(index: number) {
       return {
         length: 100,
         offset: 100 * index,
       };
     }
     expect(
-      elementsThatOverlapOffsets(offsets, fakeProps(100), getFrameMetrics, 1),
+      elementsThatOverlapOffsets(offsets, fakeProps(100), getCellMetrics, 1),
     ).toEqual([0, 0, 1, 2]);
   });
   it('handles out of bounds', function () {


### PR DESCRIPTION
Summary:
This extracts the state and logic VirtualizedList uses to query information related to cell metrics. We will need to modify this (and other places) when fixing up RTL support for horizontal FlatList.

Changelog: [Internal]

Reviewed By: javache

Differential Revision: D46427052

