### PR TITLE
Rename FrameMetrics to CellMetrics

### DIFF
--- a/packages/virtualized-lists/Lists/FillRateHelper.js
+++ b/packages/virtualized-lists/Lists/FillRateHelper.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-import type {FrameMetricProps} from './VirtualizedListProps';
+import type {CellMetricProps} from './VirtualizedListProps';
 
 export type FillRateInfo = Info;
 
@@ -27,7 +27,7 @@ class Info {
   sample_count: number = 0;
 }
 
-type FrameMetrics = {
+type CellMetrics = {
   inLayout?: boolean,
   length: number,
   offset: number,
@@ -51,7 +51,7 @@ let _sampleRate = DEBUG ? 1 : null;
 class FillRateHelper {
   _anyBlankStartTime: ?number = null;
   _enabled = false;
-  _getFrameMetrics: (index: number, props: FrameMetricProps) => ?FrameMetrics;
+  _getCellMetrics: (index: number, props: CellMetricProps) => ?CellMetrics;
   _info: Info = new Info();
   _mostlyBlankStartTime: ?number = null;
   _samplesStartTime: ?number = null;
@@ -80,9 +80,9 @@ class FillRateHelper {
   }
 
   constructor(
-    getFrameMetrics: (index: number, props: FrameMetricProps) => ?FrameMetrics,
+    getCellMetrics: (index: number, props: CellMetricProps) => ?CellMetrics,
   ) {
-    this._getFrameMetrics = getFrameMetrics;
+    this._getCellMetrics = getCellMetrics;
     this._enabled = (_sampleRate || 0) > Math.random();
     this._resetData();
   }
@@ -139,7 +139,7 @@ class FillRateHelper {
 
   computeBlankness(
     props: {
-      ...FrameMetricProps,
+      ...CellMetricProps,
       initialNumToRender?: ?number,
       ...
     },
@@ -186,12 +186,12 @@ class FillRateHelper {
 
     let blankTop = 0;
     let first = cellsAroundViewport.first;
-    let firstFrame = this._getFrameMetrics(first, props);
+    let firstFrame = this._getCellMetrics(first, props);
     while (
       first <= cellsAroundViewport.last &&
       (!firstFrame || !firstFrame.inLayout)
     ) {
-      firstFrame = this._getFrameMetrics(first, props);
+      firstFrame = this._getCellMetrics(first, props);
       first++;
     }
     // Only count blankTop if we aren't rendering the first item, otherwise we will count the header
@@ -204,12 +204,12 @@ class FillRateHelper {
     }
     let blankBottom = 0;
     let last = cellsAroundViewport.last;
-    let lastFrame = this._getFrameMetrics(last, props);
+    let lastFrame = this._getCellMetrics(last, props);
     while (
       last >= cellsAroundViewport.first &&
       (!lastFrame || !lastFrame.inLayout)
     ) {
-      lastFrame = this._getFrameMetrics(last, props);
+      lastFrame = this._getCellMetrics(last, props);
       last--;
     }
     // Only count blankBottom if we aren't rendering the last item, otherwise we will count the

--- a/packages/virtualized-lists/Lists/ViewabilityHelper.js
+++ b/packages/virtualized-lists/Lists/ViewabilityHelper.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-import type {FrameMetricProps} from './VirtualizedListProps';
+import type {CellMetricProps} from './VirtualizedListProps';
 
 const invariant = require('invariant');
 
@@ -101,12 +101,12 @@ class ViewabilityHelper {
    * Determines which items are viewable based on the current metrics and config.
    */
   computeViewableItems(
-    props: FrameMetricProps,
+    props: CellMetricProps,
     scrollOffset: number,
     viewportHeight: number,
-    getFrameMetrics: (
+    getCellMetrics: (
       index: number,
-      props: FrameMetricProps,
+      props: CellMetricProps,
     ) => ?{
       length: number,
       offset: number,
@@ -146,7 +146,7 @@ class ViewabilityHelper {
       return [];
     }
     for (let idx = first; idx <= last; idx++) {
-      const metrics = getFrameMetrics(idx, props);
+      const metrics = getCellMetrics(idx, props);
       if (!metrics) {
         continue;
       }
@@ -178,12 +178,12 @@ class ViewabilityHelper {
    * `onViewableItemsChanged` as appropriate.
    */
   onUpdate(
-    props: FrameMetricProps,
+    props: CellMetricProps,
     scrollOffset: number,
     viewportHeight: number,
-    getFrameMetrics: (
+    getCellMetrics: (
       index: number,
-      props: FrameMetricProps,
+      props: CellMetricProps,
     ) => ?{
       length: number,
       offset: number,
@@ -192,7 +192,7 @@ class ViewabilityHelper {
     createViewToken: (
       index: number,
       isViewable: boolean,
-      props: FrameMetricProps,
+      props: CellMetricProps,
     ) => ViewToken,
     onViewableItemsChanged: ({
       viewableItems: Array<ViewToken>,
@@ -210,7 +210,7 @@ class ViewabilityHelper {
     if (
       (this._config.waitForInteraction && !this._hasInteracted) ||
       itemCount === 0 ||
-      !getFrameMetrics(0, props)
+      !getCellMetrics(0, props)
     ) {
       return;
     }
@@ -220,7 +220,7 @@ class ViewabilityHelper {
         props,
         scrollOffset,
         viewportHeight,
-        getFrameMetrics,
+        getCellMetrics,
         renderRange,
       );
     }
@@ -275,7 +275,7 @@ class ViewabilityHelper {
   }
 
   _onUpdateSync(
-    props: FrameMetricProps,
+    props: CellMetricProps,
     viewableIndicesToCheck: Array<number>,
     onViewableItemsChanged: ({
       changed: Array<ViewToken>,
@@ -285,7 +285,7 @@ class ViewabilityHelper {
     createViewToken: (
       index: number,
       isViewable: boolean,
-      props: FrameMetricProps,
+      props: CellMetricProps,
     ) => ViewToken,
   ) {
     // Filter out indices that have gone out of view since this call was scheduled.

--- a/packages/virtualized-lists/Lists/VirtualizeUtils.js
+++ b/packages/virtualized-lists/Lists/VirtualizeUtils.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-import type {FrameMetricProps} from './VirtualizedListProps';
+import type {CellMetricProps} from './VirtualizedListProps';
 
 /**
  * Used to find the indices of the frames that overlap the given offsets. Useful for finding the
@@ -19,10 +19,10 @@ import type {FrameMetricProps} from './VirtualizedListProps';
  */
 export function elementsThatOverlapOffsets(
   offsets: Array<number>,
-  props: FrameMetricProps,
-  getFrameMetrics: (
+  props: CellMetricProps,
+  getCellMetrics: (
     index: number,
-    props: FrameMetricProps,
+    props: CellMetricProps,
   ) => {
     length: number,
     offset: number,
@@ -40,7 +40,7 @@ export function elementsThatOverlapOffsets(
     while (left <= right) {
       // eslint-disable-next-line no-bitwise
       const mid = left + ((right - left) >>> 1);
-      const frame = getFrameMetrics(mid, props);
+      const frame = getCellMetrics(mid, props);
       const scaledOffsetStart = frame.offset * zoomScale;
       const scaledOffsetEnd = (frame.offset + frame.length) * zoomScale;
 
@@ -99,16 +99,16 @@ export function newRangeCount(
  * biased in the direction of scroll.
  */
 export function computeWindowedRenderLimits(
-  props: FrameMetricProps,
+  props: CellMetricProps,
   maxToRenderPerBatch: number,
   windowSize: number,
   prev: {
     first: number,
     last: number,
   },
-  getFrameMetricsApprox: (
+  getCellMetricsApprox: (
     index: number,
-    props: FrameMetricProps,
+    props: CellMetricProps,
   ) => {
     length: number,
     offset: number,
@@ -152,7 +152,7 @@ export function computeWindowedRenderLimits(
   const overscanEnd = Math.max(0, visibleEnd + leadFactor * overscanLength);
 
   const lastItemOffset =
-    getFrameMetricsApprox(itemCount - 1, props).offset * zoomScale;
+    getCellMetricsApprox(itemCount - 1, props).offset * zoomScale;
   if (lastItemOffset < overscanBegin) {
     // Entire list is before our overscan window
     return {
@@ -165,7 +165,7 @@ export function computeWindowedRenderLimits(
   let [overscanFirst, first, last, overscanLast] = elementsThatOverlapOffsets(
     [overscanBegin, visibleBegin, visibleEnd, overscanEnd],
     props,
-    getFrameMetricsApprox,
+    getCellMetricsApprox,
     zoomScale,
   );
   overscanFirst = overscanFirst == null ? 0 : overscanFirst;

--- a/packages/virtualized-lists/Lists/VirtualizedListProps.js
+++ b/packages/virtualized-lists/Lists/VirtualizedListProps.js
@@ -296,7 +296,7 @@ export type Props = {|
 /**
  * Subset of properties needed to calculate frame metrics
  */
-export type FrameMetricProps = {
+export type CellMetricProps = {
   data: RequiredProps['data'],
   getItemCount: RequiredProps['getItemCount'],
   getItem: RequiredProps['getItem'],

--- a/packages/virtualized-lists/Lists/VirtualizedSectionList.js
+++ b/packages/virtualized-lists/Lists/VirtualizedSectionList.js
@@ -139,7 +139,7 @@ class VirtualizedSectionList<
       return;
     }
     if (params.itemIndex > 0 && this.props.stickySectionHeadersEnabled) {
-      const frame = this._listRef.__getFrameMetricsApprox(
+      const frame = this._listRef.__getCellMetricsApprox(
         index - params.itemIndex,
         this._listRef.props,
       );

--- a/packages/virtualized-lists/Lists/__tests__/FillRateHelper-test.js
+++ b/packages/virtualized-lists/Lists/__tests__/FillRateHelper-test.js
@@ -21,7 +21,7 @@ const dataGlobal = [
   {key: 'd'},
   {key: 'footer'},
 ];
-function getFrameMetrics(index: number) {
+function getCellMetrics(index: number) {
   const frame = rowFramesGlobal[dataGlobal[index].key];
   return {length: frame.height, offset: frame.y, inLayout: frame.inLayout};
 }
@@ -47,7 +47,7 @@ describe('computeBlankness', function () {
   });
 
   it('computes correct blankness of viewport', function () {
-    const helper = new FillRateHelper(getFrameMetrics);
+    const helper = new FillRateHelper(getCellMetrics);
     rowFramesGlobal = {
       header: {y: 0, height: 0, inLayout: true},
       a: {y: 0, height: 50, inLayout: true},
@@ -66,7 +66,7 @@ describe('computeBlankness', function () {
   });
 
   it('skips frames that are not in layout', function () {
-    const helper = new FillRateHelper(getFrameMetrics);
+    const helper = new FillRateHelper(getCellMetrics);
     rowFramesGlobal = {
       header: {y: 0, height: 0, inLayout: false},
       a: {y: 0, height: 10, inLayout: false},
@@ -80,7 +80,7 @@ describe('computeBlankness', function () {
   });
 
   it('sampling rate can disable', function () {
-    let helper = new FillRateHelper(getFrameMetrics);
+    let helper = new FillRateHelper(getCellMetrics);
     rowFramesGlobal = {
       header: {y: 0, height: 0, inLayout: true},
       a: {y: 0, height: 40, inLayout: true},
@@ -91,7 +91,7 @@ describe('computeBlankness', function () {
 
     FillRateHelper.setSampleRate(0);
 
-    helper = new FillRateHelper(getFrameMetrics);
+    helper = new FillRateHelper(getCellMetrics);
     blankness = computeResult({helper});
     expect(blankness).toBe(0);
   });
@@ -102,7 +102,7 @@ describe('computeBlankness', function () {
       FillRateHelper.addListener(listener),
     );
     subscriptions[1].remove();
-    const helper = new FillRateHelper(getFrameMetrics);
+    const helper = new FillRateHelper(getCellMetrics);
     rowFramesGlobal = {
       header: {y: 0, height: 0, inLayout: true},
       a: {y: 0, height: 40, inLayout: true},

--- a/packages/virtualized-lists/Lists/__tests__/ViewabilityHelper-test.js
+++ b/packages/virtualized-lists/Lists/__tests__/ViewabilityHelper-test.js
@@ -18,7 +18,7 @@ const props = {
   data,
   getItemCount: () => data.length,
 };
-function getFrameMetrics(index: number) {
+function getCellMetrics(index: number) {
   const frame = rowFrames[data[index].key];
   return {length: frame.height, offset: frame.y};
 }
@@ -38,9 +38,9 @@ describe('computeViewableItems', function () {
       d: {y: 150, height: 50},
     };
     data = [{key: 'a'}, {key: 'b'}, {key: 'c'}, {key: 'd'}];
-    expect(helper.computeViewableItems(props, 0, 200, getFrameMetrics)).toEqual(
-      [0, 1, 2, 3],
-    );
+    expect(helper.computeViewableItems(props, 0, 200, getCellMetrics)).toEqual([
+      0, 1, 2, 3,
+    ]);
   });
 
   it('returns top 2 rows as viewable (1. entirely visible and 2. majority)', function () {
@@ -54,9 +54,9 @@ describe('computeViewableItems', function () {
       d: {y: 250, height: 50},
     };
     data = [{key: 'a'}, {key: 'b'}, {key: 'c'}, {key: 'd'}];
-    expect(helper.computeViewableItems(props, 0, 200, getFrameMetrics)).toEqual(
-      [0, 1],
-    );
+    expect(helper.computeViewableItems(props, 0, 200, getCellMetrics)).toEqual([
+      0, 1,
+    ]);
   });
 
   it('returns only 2nd row as viewable (majority)', function () {
@@ -70,9 +70,9 @@ describe('computeViewableItems', function () {
       d: {y: 250, height: 50},
     };
     data = [{key: 'a'}, {key: 'b'}, {key: 'c'}, {key: 'd'}];
-    expect(
-      helper.computeViewableItems(props, 25, 200, getFrameMetrics),
-    ).toEqual([1]);
+    expect(helper.computeViewableItems(props, 25, 200, getCellMetrics)).toEqual(
+      [1],
+    );
   });
 
   it('handles empty input', function () {
@@ -81,7 +81,7 @@ describe('computeViewableItems', function () {
     });
     rowFrames = {};
     data = [];
-    expect(helper.computeViewableItems(props, 0, 200, getFrameMetrics)).toEqual(
+    expect(helper.computeViewableItems(props, 0, 200, getCellMetrics)).toEqual(
       [],
     );
   });
@@ -96,40 +96,40 @@ describe('computeViewableItems', function () {
     data = [{key: 'a'}, {key: 'b'}, {key: 'c'}, {key: 'd'}];
 
     let helper = new ViewabilityHelper({viewAreaCoveragePercentThreshold: 0});
-    expect(helper.computeViewableItems(props, 0, 50, getFrameMetrics)).toEqual([
+    expect(helper.computeViewableItems(props, 0, 50, getCellMetrics)).toEqual([
       0,
     ]);
-    expect(helper.computeViewableItems(props, 1, 50, getFrameMetrics)).toEqual([
+    expect(helper.computeViewableItems(props, 1, 50, getCellMetrics)).toEqual([
       0, 1,
     ]);
-    expect(
-      helper.computeViewableItems(props, 199, 50, getFrameMetrics),
-    ).toEqual([1, 2]);
-    expect(
-      helper.computeViewableItems(props, 250, 50, getFrameMetrics),
-    ).toEqual([2]);
+    expect(helper.computeViewableItems(props, 199, 50, getCellMetrics)).toEqual(
+      [1, 2],
+    );
+    expect(helper.computeViewableItems(props, 250, 50, getCellMetrics)).toEqual(
+      [2],
+    );
 
     helper = new ViewabilityHelper({viewAreaCoveragePercentThreshold: 100});
-    expect(helper.computeViewableItems(props, 0, 200, getFrameMetrics)).toEqual(
-      [0, 1],
-    );
-    expect(helper.computeViewableItems(props, 1, 200, getFrameMetrics)).toEqual(
-      [1],
-    );
+    expect(helper.computeViewableItems(props, 0, 200, getCellMetrics)).toEqual([
+      0, 1,
+    ]);
+    expect(helper.computeViewableItems(props, 1, 200, getCellMetrics)).toEqual([
+      1,
+    ]);
     expect(
-      helper.computeViewableItems(props, 400, 200, getFrameMetrics),
+      helper.computeViewableItems(props, 400, 200, getCellMetrics),
     ).toEqual([2]);
     expect(
-      helper.computeViewableItems(props, 600, 200, getFrameMetrics),
+      helper.computeViewableItems(props, 600, 200, getCellMetrics),
     ).toEqual([3]);
 
     helper = new ViewabilityHelper({viewAreaCoveragePercentThreshold: 10});
-    expect(
-      helper.computeViewableItems(props, 30, 200, getFrameMetrics),
-    ).toEqual([0, 1, 2]);
-    expect(
-      helper.computeViewableItems(props, 31, 200, getFrameMetrics),
-    ).toEqual([1, 2]);
+    expect(helper.computeViewableItems(props, 30, 200, getCellMetrics)).toEqual(
+      [0, 1, 2],
+    );
+    expect(helper.computeViewableItems(props, 31, 200, getCellMetrics)).toEqual(
+      [1, 2],
+    );
   });
 
   it('handles different item visible percent thresholds', function () {
@@ -141,31 +141,31 @@ describe('computeViewableItems', function () {
     };
     data = [{key: 'a'}, {key: 'b'}, {key: 'c'}, {key: 'd'}];
     let helper = new ViewabilityHelper({itemVisiblePercentThreshold: 0});
-    expect(helper.computeViewableItems(props, 0, 50, getFrameMetrics)).toEqual([
+    expect(helper.computeViewableItems(props, 0, 50, getCellMetrics)).toEqual([
       0,
     ]);
-    expect(helper.computeViewableItems(props, 1, 50, getFrameMetrics)).toEqual([
+    expect(helper.computeViewableItems(props, 1, 50, getCellMetrics)).toEqual([
       0, 1,
     ]);
 
     helper = new ViewabilityHelper({itemVisiblePercentThreshold: 100});
-    expect(helper.computeViewableItems(props, 0, 250, getFrameMetrics)).toEqual(
-      [0, 1, 2],
-    );
-    expect(helper.computeViewableItems(props, 1, 250, getFrameMetrics)).toEqual(
-      [1, 2],
-    );
+    expect(helper.computeViewableItems(props, 0, 250, getCellMetrics)).toEqual([
+      0, 1, 2,
+    ]);
+    expect(helper.computeViewableItems(props, 1, 250, getCellMetrics)).toEqual([
+      1, 2,
+    ]);
 
     helper = new ViewabilityHelper({itemVisiblePercentThreshold: 10});
-    expect(
-      helper.computeViewableItems(props, 184, 20, getFrameMetrics),
-    ).toEqual([1]);
-    expect(
-      helper.computeViewableItems(props, 185, 20, getFrameMetrics),
-    ).toEqual([1, 2]);
-    expect(
-      helper.computeViewableItems(props, 186, 20, getFrameMetrics),
-    ).toEqual([2]);
+    expect(helper.computeViewableItems(props, 184, 20, getCellMetrics)).toEqual(
+      [1],
+    );
+    expect(helper.computeViewableItems(props, 185, 20, getCellMetrics)).toEqual(
+      [1, 2],
+    );
+    expect(helper.computeViewableItems(props, 186, 20, getCellMetrics)).toEqual(
+      [2],
+    );
   });
 });
 
@@ -181,7 +181,7 @@ describe('onUpdate', function () {
       props,
       0,
       200,
-      getFrameMetrics,
+      getCellMetrics,
       createViewToken,
       onViewableItemsChanged,
     );
@@ -195,7 +195,7 @@ describe('onUpdate', function () {
       props,
       0,
       200,
-      getFrameMetrics,
+      getCellMetrics,
       createViewToken,
       onViewableItemsChanged,
     );
@@ -204,7 +204,7 @@ describe('onUpdate', function () {
       props,
       100,
       200,
-      getFrameMetrics,
+      getCellMetrics,
       createViewToken,
       onViewableItemsChanged,
     );
@@ -228,7 +228,7 @@ describe('onUpdate', function () {
       props,
       0,
       200,
-      getFrameMetrics,
+      getCellMetrics,
       createViewToken,
       onViewableItemsChanged,
     );
@@ -242,7 +242,7 @@ describe('onUpdate', function () {
       props,
       100,
       200,
-      getFrameMetrics,
+      getCellMetrics,
       createViewToken,
       onViewableItemsChanged,
     );
@@ -260,7 +260,7 @@ describe('onUpdate', function () {
       props,
       200,
       200,
-      getFrameMetrics,
+      getCellMetrics,
       createViewToken,
       onViewableItemsChanged,
     );
@@ -287,7 +287,7 @@ describe('onUpdate', function () {
       props,
       0,
       200,
-      getFrameMetrics,
+      getCellMetrics,
       createViewToken,
       onViewableItemsChanged,
     );
@@ -321,7 +321,7 @@ describe('onUpdate', function () {
       props,
       0,
       200,
-      getFrameMetrics,
+      getCellMetrics,
       createViewToken,
       onViewableItemsChanged,
     );
@@ -329,7 +329,7 @@ describe('onUpdate', function () {
       props,
       300, // scroll past item 'a'
       200,
-      getFrameMetrics,
+      getCellMetrics,
       createViewToken,
       onViewableItemsChanged,
     );
@@ -362,7 +362,7 @@ describe('onUpdate', function () {
       props,
       0,
       100,
-      getFrameMetrics,
+      getCellMetrics,
       createViewToken,
       onViewableItemsChanged,
     );
@@ -374,7 +374,7 @@ describe('onUpdate', function () {
       props,
       20,
       100,
-      getFrameMetrics,
+      getCellMetrics,
       createViewToken,
       onViewableItemsChanged,
     );
@@ -401,7 +401,7 @@ describe('onUpdate', function () {
       props,
       0,
       200,
-      getFrameMetrics,
+      getCellMetrics,
       createViewToken,
       onViewableItemsChanged,
     );
@@ -426,7 +426,7 @@ describe('onUpdate', function () {
       props,
       0,
       200,
-      getFrameMetrics,
+      getCellMetrics,
       createViewToken,
       onViewableItemsChanged,
     );

--- a/packages/virtualized-lists/Lists/__tests__/VirtualizeUtils-test.js
+++ b/packages/virtualized-lists/Lists/__tests__/VirtualizeUtils-test.js
@@ -42,14 +42,14 @@ describe('newRangeCount', function () {
 describe('elementsThatOverlapOffsets', function () {
   it('handles fixed length', function () {
     const offsets = [0, 250, 350, 450];
-    function getFrameMetrics(index: number) {
+    function getCellMetrics(index: number) {
       return {
         length: 100,
         offset: 100 * index,
       };
     }
     expect(
-      elementsThatOverlapOffsets(offsets, fakeProps(100), getFrameMetrics, 1),
+      elementsThatOverlapOffsets(offsets, fakeProps(100), getCellMetrics, 1),
     ).toEqual([0, 2, 3, 4]);
   });
   it('handles variable length', function () {
@@ -72,14 +72,14 @@ describe('elementsThatOverlapOffsets', function () {
   });
   it('handles frame boundaries', function () {
     const offsets = [0, 100, 200, 300];
-    function getFrameMetrics(index: number) {
+    function getCellMetrics(index: number) {
       return {
         length: 100,
         offset: 100 * index,
       };
     }
     expect(
-      elementsThatOverlapOffsets(offsets, fakeProps(100), getFrameMetrics, 1),
+      elementsThatOverlapOffsets(offsets, fakeProps(100), getCellMetrics, 1),
     ).toEqual([0, 0, 1, 2]);
   });
   it('handles out of bounds', function () {


### PR DESCRIPTION
Summary:
These functions describe how to get the metrics of a specific cell. "Frame" here seems non-descriptive and redundant to the "Metrics" part. Renaming this before a larger refactor.

Changelog: [Internal]

Reviewed By: philIip

Differential Revision: D46427058

