### PR TITLE
W3CPointerEvents: fix NPE due to null targetView

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/JSPointerDispatcher.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/JSPointerDispatcher.java
@@ -615,7 +615,7 @@ public class JSPointerDispatcher {
     int activePointerId = eventState.getActivePointerId();
     List<ViewTarget> activeHitPath = eventState.getHitPathByPointerId().get(activePointerId);
 
-    if (!activeHitPath.isEmpty()) {
+    if (!activeHitPath.isEmpty() && targetView != null) {
       boolean listeningForCancel =
           isAnyoneListeningForBubblingEvent(activeHitPath, EVENT.CANCEL, EVENT.CANCEL_CAPTURE);
       if (listeningForCancel) {


### PR DESCRIPTION
Summary:
Changelog: [Android] [Fixed] - W3CPointerEvents: fix NPE due to null targetView

For reasons not entirely understood, we sometimes end up with a null `targetView` in this code path during the dispatch of an `ACTION_CANCEL`. This results in an NPE during the call to `getChildOffsetRelativeToRoot`. This change adds a null check before the call to avoid the crash.

Differential Revision: D46562263

