### PR TITLE
[Codegen] Add getObjectProperties function to Parser

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-test.js
@@ -383,6 +383,53 @@ describe('FlowParser', () => {
       );
     });
   });
+
+  describe('getObjectProperties', () => {
+    it('returns properties of an object represented by a type annotation', () => {
+      const properties = [
+        {
+          type: 'ObjectTypeProperty',
+          key: {
+            type: 'Identifier',
+            name: 'a',
+          },
+          value: {
+            type: 'StringTypeAnnotation',
+            range: [],
+          },
+        },
+        {
+          type: 'ObjectTypeProperty',
+          key: {
+            type: 'Identifier',
+            name: 'b',
+          },
+          optional: true,
+          value: {
+            type: 'BooleanTypeAnnotation',
+            range: [],
+          },
+        },
+      ];
+
+      const typeAnnotation = {
+        type: 'TypeAlias',
+        properties: properties,
+      };
+
+      const expected = properties;
+
+      expect(parser.getObjectProperties(typeAnnotation)).toEqual(expected);
+    });
+
+    it('returns undefined if typeAnnotation does not have properties', () => {
+      const declaration = {
+        type: 'TypeAlias',
+      };
+
+      expect(parser.getObjectProperties(declaration)).toEqual(undefined);
+    });
+  });
 });
 
 describe('TypeScriptParser', () => {
@@ -725,6 +772,53 @@ describe('TypeScriptParser', () => {
       expect(parser.extractTypeFromTypeAnnotation(typeAnnotation)).toEqual(
         'SomeOtherType',
       );
+    });
+  });
+
+  describe('getObjectProperties', () => {
+    it('returns members of an object represented by a type annotation', () => {
+      const members = [
+        {
+          type: 'ObjectTypeProperty',
+          key: {
+            type: 'Identifier',
+            name: 'a',
+          },
+          value: {
+            type: 'StringTypeAnnotation',
+            range: [],
+          },
+        },
+        {
+          type: 'ObjectTypeProperty',
+          key: {
+            type: 'Identifier',
+            name: 'b',
+          },
+          optional: true,
+          value: {
+            type: 'BooleanTypeAnnotation',
+            range: [],
+          },
+        },
+      ];
+
+      const typeAnnotation = {
+        type: 'TypeAlias',
+        members: members,
+      };
+
+      const expected = members;
+
+      expect(parser.getObjectProperties(typeAnnotation)).toEqual(expected);
+    });
+
+    it('returns undefined if typeAnnotation does not have members', () => {
+      const declaration = {
+        type: 'TypeAlias',
+      };
+
+      expect(parser.getObjectProperties(declaration)).toEqual(undefined);
     });
   });
 });

--- a/packages/react-native-codegen/src/parsers/flow/components/events.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/events.js
@@ -69,9 +69,11 @@ function getPropertyType(
         optional,
         typeAnnotation: {
           type: 'ObjectTypeAnnotation',
-          properties: typeAnnotation.properties.map(member =>
-            buildPropertiesForEvent(member, parser, getPropertyType),
-          ),
+          properties: parser
+            .getObjectProperties(typeAnnotation)
+            .map(member =>
+              buildPropertiesForEvent(member, parser, getPropertyType),
+            ),
         },
       };
     case 'UnionTypeAnnotation':
@@ -128,9 +130,11 @@ function extractArrayElementType(
     case 'ObjectTypeAnnotation':
       return {
         type: 'ObjectTypeAnnotation',
-        properties: typeAnnotation.properties.map(member =>
-          buildPropertiesForEvent(member, parser, getPropertyType),
-        ),
+        properties: parser
+          .getObjectProperties(typeAnnotation)
+          .map(member =>
+            buildPropertiesForEvent(member, parser, getPropertyType),
+          ),
       };
     case 'ArrayTypeAnnotation':
       return {

--- a/packages/react-native-codegen/src/parsers/flow/parser.js
+++ b/packages/react-native-codegen/src/parsers/flow/parser.js
@@ -539,6 +539,10 @@ class FlowParser implements Parser {
       ? typeAnnotation.id.name
       : typeAnnotation.type;
   }
+
+  getObjectProperties(typeAnnotation: $FlowFixMe): $FlowFixMe {
+    return typeAnnotation.properties;
+  }
 }
 
 module.exports = {

--- a/packages/react-native-codegen/src/parsers/parser.js
+++ b/packages/react-native-codegen/src/parsers/parser.js
@@ -407,4 +407,11 @@ export interface Parser {
    * @returns: the extracted type.
    */
   extractTypeFromTypeAnnotation(typeAnnotation: $FlowFixMe): string;
+
+  /**
+   * Given a typeAnnotation return the properties of an object.
+   * @parameter property
+   * @returns: the properties of an object represented by a type annotation.
+   */
+  getObjectProperties(typeAnnotation: $FlowFixMe): $FlowFixMe;
 }

--- a/packages/react-native-codegen/src/parsers/parserMock.js
+++ b/packages/react-native-codegen/src/parsers/parserMock.js
@@ -478,4 +478,8 @@ export class MockedParser implements Parser {
       ? typeAnnotation.id.name
       : typeAnnotation.type;
   }
+
+  getObjectProperties(typeAnnotation: $FlowFixMe): $FlowFixMe {
+    return typeAnnotation.properties;
+  }
 }

--- a/packages/react-native-codegen/src/parsers/typescript/components/events.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/events.js
@@ -71,9 +71,11 @@ function getPropertyType(
         optional,
         typeAnnotation: {
           type: 'ObjectTypeAnnotation',
-          properties: typeAnnotation.members.map(member =>
-            buildPropertiesForEvent(member, parser, getPropertyType),
-          ),
+          properties: parser
+            .getObjectProperties(typeAnnotation)
+            .map(member =>
+              buildPropertiesForEvent(member, parser, getPropertyType),
+            ),
         },
       };
     case 'TSUnionType':
@@ -138,9 +140,11 @@ function extractArrayElementType(
     case 'TSTypeLiteral':
       return {
         type: 'ObjectTypeAnnotation',
-        properties: typeAnnotation.members.map(member =>
-          buildPropertiesForEvent(member, parser, getPropertyType),
-        ),
+        properties: parser
+          .getObjectProperties(typeAnnotation)
+          .map(member =>
+            buildPropertiesForEvent(member, parser, getPropertyType),
+          ),
       };
     case 'TSArrayType':
       return {
@@ -183,7 +187,7 @@ function findEventArgumentsAndType(
 
   if (typeAnnotation.type === 'TSTypeLiteral') {
     return {
-      argumentProps: typeAnnotation.members,
+      argumentProps: parser.getObjectProperties(typeAnnotation),
       paperTopLevelNameDeprecated: paperName,
       bubblingType,
     };

--- a/packages/react-native-codegen/src/parsers/typescript/parser.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parser.js
@@ -553,6 +553,10 @@ class TypeScriptParser implements Parser {
       ? typeAnnotation.typeName.name
       : typeAnnotation.type;
   }
+
+  getObjectProperties(typeAnnotation: $FlowFixMe): $FlowFixMe {
+    return typeAnnotation.members;
+  }
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary:

[Codegen 128] This PR add a `getObjectProperties` function to the Parser interface, which returns the properties of an object represented by a type annotation as requested on https://github.com/facebook/react-native/issues/34872
 

## Changelog:
 

[INTERNAL] [ADDED] - Add getObjectProperties function to codegen Parser

 

## Test Plan:


Run `yarn jest react-native-codegen` and ensure CI is green

