### PR TITLE
Exclude trailing whitespace from newline character on measuring text line width

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/FontMetricsUtil.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/FontMetricsUtil.java
@@ -47,7 +47,7 @@ public class FontMetricsUtil {
       WritableMap line = Arguments.createMap();
       line.putDouble("x", layout.getLineLeft(i) / dm.density);
       line.putDouble("y", bounds.top / dm.density);
-      line.putDouble("width", layout.getLineWidth(i) / dm.density);
+      line.putDouble("width", layout.getLineMax(i) / dm.density);
       line.putDouble("height", bounds.height() / dm.density);
       line.putDouble("descender", layout.getLineDescent(i) / dm.density);
       line.putDouble("ascender", -layout.getLineAscent(i) / dm.density);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/FontMetricsUtil.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/FontMetricsUtil.java
@@ -42,7 +42,7 @@ public class FontMetricsUtil {
         X_HEIGHT_MEASUREMENT_TEXT, 0, X_HEIGHT_MEASUREMENT_TEXT.length(), xHeightBounds);
     double xHeight = xHeightBounds.height() / AMPLIFICATION_FACTOR / dm.density;
     for (int i = 0; i < layout.getLineCount(); i++) {
-      boolean endsWithNewLine = text.charAt(layout.getLineEnd(i) - 1) == '\n';
+      boolean endsWithNewLine = text.length() > 0 && text.charAt(layout.getLineEnd(i) - 1) == '\n';
       float lineWidth = endsWithNewLine ? layout.getLineMax(i) : layout.getLineWidth(i);
       Rect bounds = new Rect();
       layout.getLineBounds(i, bounds);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/FontMetricsUtil.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/FontMetricsUtil.java
@@ -42,12 +42,14 @@ public class FontMetricsUtil {
         X_HEIGHT_MEASUREMENT_TEXT, 0, X_HEIGHT_MEASUREMENT_TEXT.length(), xHeightBounds);
     double xHeight = xHeightBounds.height() / AMPLIFICATION_FACTOR / dm.density;
     for (int i = 0; i < layout.getLineCount(); i++) {
+      boolean endsWithNewLine = text.charAt(layout.getLineEnd(i) - 1) == '\n';
+      float lineWidth = endsWithNewLine ? layout.getLineMax(i) : layout.getLineWidth(i);
       Rect bounds = new Rect();
       layout.getLineBounds(i, bounds);
       WritableMap line = Arguments.createMap();
       line.putDouble("x", layout.getLineLeft(i) / dm.density);
       line.putDouble("y", bounds.top / dm.density);
-      line.putDouble("width", layout.getLineMax(i) / dm.density);
+      line.putDouble("width", lineWidth / dm.density);
       line.putDouble("height", bounds.height() / dm.density);
       line.putDouble("descender", layout.getLineDescent(i) / dm.density);
       line.putDouble("ascender", -layout.getLineAscent(i) / dm.density);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
@@ -135,7 +135,8 @@ public class ReactTextShadowNode extends ReactBaseTextShadowNode {
             layoutWidth = width;
           } else {
             for (int lineIndex = 0; lineIndex < lineCount; lineIndex++) {
-              boolean endsWithNewLine = text.charAt(layout.getLineEnd(lineIndex) - 1) == '\n';
+              boolean endsWithNewLine = text.length() > 0
+                  && text.charAt(layout.getLineEnd(lineIndex) - 1) == '\n';
               float lineWidth =
                   endsWithNewLine
                       ? layout.getLineMax(lineIndex)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
@@ -135,7 +135,7 @@ public class ReactTextShadowNode extends ReactBaseTextShadowNode {
             layoutWidth = width;
           } else {
             for (int lineIndex = 0; lineIndex < lineCount; lineIndex++) {
-              float lineWidth = layout.getLineWidth(lineIndex);
+              float lineWidth = layout.getLineMax(lineIndex);
               if (lineWidth > layoutWidth) {
                 layoutWidth = lineWidth;
               }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
@@ -135,7 +135,11 @@ public class ReactTextShadowNode extends ReactBaseTextShadowNode {
             layoutWidth = width;
           } else {
             for (int lineIndex = 0; lineIndex < lineCount; lineIndex++) {
-              float lineWidth = layout.getLineMax(lineIndex);
+              boolean endsWithNewLine = text.charAt(layout.getLineEnd(lineIndex) - 1) == '\n';
+              float lineWidth =
+                  endsWithNewLine
+                      ? layout.getLineMax(lineIndex)
+                      : layout.getLineWidth(lineIndex);
               if (lineWidth > layoutWidth) {
                 layoutWidth = lineWidth;
               }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
@@ -271,7 +271,7 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
               isRtlParagraph
                   // Equivalent to `layout.getLineLeft(line)` but `getLineLeft` returns incorrect
                   // values when the paragraph is RTL and `setSingleLine(true)`.
-                  ? textViewWidth - (int) layout.getLineWidth(line)
+                  ? textViewWidth - (int) layout.getLineMax(line)
                   : (int) layout.getLineRight(line) - width;
         } else {
           // The direction of the paragraph may not be exactly the direction the string is heading

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
@@ -267,11 +267,13 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
         // the last offset in the layout will result in an endless loop. Work around
         // this bug by avoiding getPrimaryHorizontal in that case.
         if (start == text.length() - 1) {
+          boolean endsWithNewLine = text.charAt(layout.getLineEnd(line) - 1) == '\n';
+          float lineWidth = endsWithNewLine ? layout.getLineMax(line) : layout.getLineWidth(line);
           placeholderHorizontalPosition =
               isRtlParagraph
                   // Equivalent to `layout.getLineLeft(line)` but `getLineLeft` returns incorrect
                   // values when the paragraph is RTL and `setSingleLine(true)`.
-                  ? textViewWidth - (int) layout.getLineMax(line)
+                  ? textViewWidth - (int) lineWidth
                   : (int) layout.getLineRight(line) - width;
         } else {
           // The direction of the paragraph may not be exactly the direction the string is heading

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
@@ -267,7 +267,8 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
         // the last offset in the layout will result in an endless loop. Work around
         // this bug by avoiding getPrimaryHorizontal in that case.
         if (start == text.length() - 1) {
-          boolean endsWithNewLine = text.charAt(layout.getLineEnd(line) - 1) == '\n';
+          boolean endsWithNewLine = text.length() > 0
+              && text.charAt(layout.getLineEnd(line) - 1) == '\n';
           float lineWidth = endsWithNewLine ? layout.getLineMax(line) : layout.getLineWidth(line);
           placeholderHorizontalPosition =
               isRtlParagraph

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
@@ -407,7 +407,8 @@ public class TextLayoutManager {
       calculatedWidth = width;
     } else {
       for (int lineIndex = 0; lineIndex < calculatedLineCount; lineIndex++) {
-        boolean endsWithNewLine = text.charAt(layout.getLineEnd(lineIndex) - 1) == '\n';
+        boolean endsWithNewLine = text.length() > 0
+            && text.charAt(layout.getLineEnd(lineIndex) - 1) == '\n';
         float lineWidth =
             endsWithNewLine
                 ? layout.getLineMax(lineIndex)
@@ -466,7 +467,8 @@ public class TextLayoutManager {
           // the last offset in the layout will result in an endless loop. Work around
           // this bug by avoiding getPrimaryHorizontal in that case.
           if (start == text.length() - 1) {
-            boolean endsWithNewLine = text.charAt(layout.getLineEnd(line) - 1) == '\n';
+            boolean endsWithNewLine = text.length() > 0 
+                && text.charAt(layout.getLineEnd(line) - 1) == '\n';
             float lineWidth = endsWithNewLine ? layout.getLineMax(line) : layout.getLineWidth(line);
             placeholderLeftPosition =
                 isRtlParagraph

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
@@ -407,7 +407,7 @@ public class TextLayoutManager {
       calculatedWidth = width;
     } else {
       for (int lineIndex = 0; lineIndex < calculatedLineCount; lineIndex++) {
-        float lineWidth = layout.getLineWidth(lineIndex);
+        float lineWidth = layout.getLineMax(lineIndex);
         if (lineWidth > calculatedWidth) {
           calculatedWidth = lineWidth;
         }
@@ -466,7 +466,7 @@ public class TextLayoutManager {
                 isRtlParagraph
                     // Equivalent to `layout.getLineLeft(line)` but `getLineLeft` returns incorrect
                     // values when the paragraph is RTL and `setSingleLine(true)`.
-                    ? calculatedWidth - layout.getLineWidth(line)
+                    ? calculatedWidth - layout.getLineMax(line)
                     : layout.getLineRight(line) - placeholderWidth;
           } else {
             // The direction of the paragraph may not be exactly the direction the string is heading

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
@@ -407,7 +407,11 @@ public class TextLayoutManager {
       calculatedWidth = width;
     } else {
       for (int lineIndex = 0; lineIndex < calculatedLineCount; lineIndex++) {
-        float lineWidth = layout.getLineMax(lineIndex);
+        boolean endsWithNewLine = text.charAt(layout.getLineEnd(lineIndex) - 1) == '\n';
+        float lineWidth =
+            endsWithNewLine
+                ? layout.getLineMax(lineIndex)
+                : layout.getLineWidth(lineIndex);
         if (lineWidth > calculatedWidth) {
           calculatedWidth = lineWidth;
         }
@@ -462,11 +466,13 @@ public class TextLayoutManager {
           // the last offset in the layout will result in an endless loop. Work around
           // this bug by avoiding getPrimaryHorizontal in that case.
           if (start == text.length() - 1) {
+            boolean endsWithNewLine = text.charAt(layout.getLineEnd(line) - 1) == '\n';
+            float lineWidth = endsWithNewLine ? layout.getLineMax(line) : layout.getLineWidth(line);
             placeholderLeftPosition =
                 isRtlParagraph
                     // Equivalent to `layout.getLineLeft(line)` but `getLineLeft` returns incorrect
                     // values when the paragraph is RTL and `setSingleLine(true)`.
-                    ? calculatedWidth - layout.getLineMax(line)
+                    ? calculatedWidth - lineWidth
                     : layout.getLineRight(line) - placeholderWidth;
           } else {
             // The direction of the paragraph may not be exactly the direction the string is heading

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
@@ -467,7 +467,7 @@ public class TextLayoutManager {
           // the last offset in the layout will result in an endless loop. Work around
           // this bug by avoiding getPrimaryHorizontal in that case.
           if (start == text.length() - 1) {
-            boolean endsWithNewLine = text.length() > 0 
+            boolean endsWithNewLine = text.length() > 0
                 && text.charAt(layout.getLineEnd(line) - 1) == '\n';
             float lineWidth = endsWithNewLine ? layout.getLineMax(line) : layout.getLineWidth(line);
             placeholderLeftPosition =

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManagerMapBuffer.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManagerMapBuffer.java
@@ -429,7 +429,7 @@ public class TextLayoutManagerMapBuffer {
       calculatedWidth = width;
     } else {
       for (int lineIndex = 0; lineIndex < calculatedLineCount; lineIndex++) {
-        float lineWidth = layout.getLineWidth(lineIndex);
+        float lineWidth = layout.getLineMax(lineIndex);
         if (lineWidth > calculatedWidth) {
           calculatedWidth = lineWidth;
         }
@@ -489,7 +489,7 @@ public class TextLayoutManagerMapBuffer {
                     // Equivalent to `layout.getLineLeft(line)` but `getLineLeft` returns
                     // incorrect
                     // values when the paragraph is RTL and `setSingleLine(true)`.
-                    ? calculatedWidth - layout.getLineWidth(line)
+                    ? calculatedWidth - layout.getLineMax(line)
                     : layout.getLineRight(line) - placeholderWidth;
           } else {
             // The direction of the paragraph may not be exactly the direction the string is

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManagerMapBuffer.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManagerMapBuffer.java
@@ -429,7 +429,8 @@ public class TextLayoutManagerMapBuffer {
       calculatedWidth = width;
     } else {
       for (int lineIndex = 0; lineIndex < calculatedLineCount; lineIndex++) {
-        boolean endsWithNewLine = text.charAt(layout.getLineEnd(lineIndex) - 1) == '\n';
+        boolean endsWithNewLine = text.length() > 0
+            && text.charAt(layout.getLineEnd(lineIndex) - 1) == '\n';
         float lineWidth =
             endsWithNewLine
                 ? layout.getLineMax(lineIndex)
@@ -488,7 +489,8 @@ public class TextLayoutManagerMapBuffer {
           // the last offset in the layout will result in an endless loop. Work around
           // this bug by avoiding getPrimaryHorizontal in that case.
           if (start == text.length() - 1) {
-            boolean endsWithNewLine = text.charAt(layout.getLineEnd(line) - 1) == '\n';
+            boolean endsWithNewLine = text.length() > 0
+                && text.charAt(layout.getLineEnd(line) - 1) == '\n';
             float lineWidth = endsWithNewLine ? layout.getLineMax(line) : layout.getLineWidth(line);
             placeholderLeftPosition =
                 isRtlParagraph

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManagerMapBuffer.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManagerMapBuffer.java
@@ -429,7 +429,11 @@ public class TextLayoutManagerMapBuffer {
       calculatedWidth = width;
     } else {
       for (int lineIndex = 0; lineIndex < calculatedLineCount; lineIndex++) {
-        float lineWidth = layout.getLineMax(lineIndex);
+        boolean endsWithNewLine = text.charAt(layout.getLineEnd(lineIndex) - 1) == '\n';
+        float lineWidth =
+            endsWithNewLine
+                ? layout.getLineMax(lineIndex)
+                : layout.getLineWidth(lineIndex);
         if (lineWidth > calculatedWidth) {
           calculatedWidth = lineWidth;
         }
@@ -484,12 +488,14 @@ public class TextLayoutManagerMapBuffer {
           // the last offset in the layout will result in an endless loop. Work around
           // this bug by avoiding getPrimaryHorizontal in that case.
           if (start == text.length() - 1) {
+            boolean endsWithNewLine = text.charAt(layout.getLineEnd(line) - 1) == '\n';
+            float lineWidth = endsWithNewLine ? layout.getLineMax(line) : layout.getLineWidth(line);
             placeholderLeftPosition =
                 isRtlParagraph
                     // Equivalent to `layout.getLineLeft(line)` but `getLineLeft` returns
                     // incorrect
                     // values when the paragraph is RTL and `setSingleLine(true)`.
-                    ? calculatedWidth - layout.getLineMax(line)
+                    ? calculatedWidth - lineWidth
                     : layout.getLineRight(line) - placeholderWidth;
           } else {
             // The direction of the paragraph may not be exactly the direction the string is


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Multiline text in Android shows some extra space. It's easily noticeable when you set the text `alignSelf` to `flex-start`. This is because we are using `layout.getLineWidth` which will include trailing whitespace.
<img width="300" alt="image" src="https://github.com/facebook/react-native/assets/50919443/8939092b-caef-4ad8-9b34-2ccef5d20968">

Based on Android doc, `getLineMax` exclude trailing whitespace.
<img width="625" alt="image" src="https://github.com/facebook/react-native/assets/50919443/0b32e842-5fab-4fc7-8fd9-299877b9c553">

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID] [FIXED] - Exclude trailing whitespace from newline character on measuring text line width

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[ANDROID] [FIXED] - Exclude trailing whitespace from newline character on measuring text line width

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

After applying the changes:
<img width="300" alt="image" src="https://github.com/facebook/react-native/assets/50919443/bfbf52b0-7e7d-4c89-8958-6af38d8bc1c7">

Code snippet:
```
<Text style={{backgroundColor: 'red', alignSelf: 'flex-start', color: 'white'}}>
    1{'\n'}
</Text>
```