### PR TITLE
Update Node.js to v18 in all RN packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1139,7 +1139,7 @@ jobs:
           command: |
             apt update
             apt install -y wget git curl
-            curl -sL https://deb.nodesource.com/setup_16.x | bash -
+            curl -sL https://deb.nodesource.com/setup_18.x | bash -
             apt install -y nodejs
             npm install --global yarn
       - checkout

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -12,6 +12,6 @@
   "keywords": ["assets", "registry", "react-native", "support"],
   "bugs": "https://github.com/facebook/react-native/issues",
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   }
 }

--- a/packages/babel-plugin-codegen/package.json
+++ b/packages/babel-plugin-codegen/package.json
@@ -12,7 +12,7 @@
   "keywords": ["babel", "plugin", "codegen", "react-native", "native-modules", "view-manager"],
   "bugs": "https://github.com/facebook/react-native/issues",
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "files": [
     "index.js"

--- a/packages/eslint-config-react-native/package.json
+++ b/packages/eslint-config-react-native/package.json
@@ -16,7 +16,7 @@
   ],
   "bugs": "https://github.com/facebook/react-native/issues",
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "main": "index.js",
   "dependencies": {

--- a/packages/eslint-plugin-react-native/package.json
+++ b/packages/eslint-plugin-react-native/package.json
@@ -12,7 +12,7 @@
   "keywords": ["eslint", "rules", "eslint-config", "react-native"],
   "bugs": "https://github.com/facebook/react-native/issues",
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "main": "index.js"
 }

--- a/packages/eslint-plugin-specs/package.json
+++ b/packages/eslint-plugin-specs/package.json
@@ -12,7 +12,7 @@
   "keywords": ["eslint", "rules", "react-native", "native-modules", "components", "specs"],
   "bugs": "https://github.com/facebook/react-native/issues",
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "main": "index.js",
   "scripts": {

--- a/packages/hermes-inspector-msggen/package.json
+++ b/packages/hermes-inspector-msggen/package.json
@@ -13,7 +13,7 @@
     "msggen": "./bin/index.js"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "scripts": {
     "flow": "flow",

--- a/packages/metro-config/package.json
+++ b/packages/metro-config/package.json
@@ -12,7 +12,7 @@
   "keywords": ["metro", "config", "react-native"],
   "bugs": "https://github.com/facebook/react-native/issues",
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "exports": "./index.js",
   "dependencies": {

--- a/packages/normalize-color/package.json
+++ b/packages/normalize-color/package.json
@@ -12,6 +12,6 @@
   "keywords": ["color", "normalization", "normalize-colors", "react-native"],
   "bugs": "https://github.com/facebook/react-native/issues",
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   }
 }

--- a/packages/polyfills/package.json
+++ b/packages/polyfills/package.json
@@ -12,6 +12,6 @@
   "keywords": ["polyfill", "polyfills", "js", "js-polyfills", "react-native"],
   "bugs": "https://github.com/facebook/react-native/issues",
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   }
 }

--- a/packages/react-native-bots/package.json
+++ b/packages/react-native-bots/package.json
@@ -11,7 +11,7 @@
   },
   "homepage": "https://github.com/facebook/react-native/tree/HEAD/packages/react-native-bots#readme",
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "devDependencies": {
     "@rnx-kit/rn-changelog-generator": "^0.4.0",

--- a/packages/react-native-codegen-typescript-test/package.json
+++ b/packages/react-native-codegen-typescript-test/package.json
@@ -10,7 +10,7 @@
   },
   "homepage": "https://github.com/facebook/react-native/tree/HEAD/packages/react-native-typescript-test",
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "scripts": {
     "build": "yarn clean && node scripts/build.js --verbose && tsc",

--- a/packages/react-native-codegen/package.json
+++ b/packages/react-native-codegen/package.json
@@ -18,7 +18,7 @@
   ],
   "bugs": "https://github.com/facebook/react-native/issues",
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "scripts": {
     "build": "yarn clean && node scripts/build.js --verbose",

--- a/packages/react-native-gradle-plugin/package.json
+++ b/packages/react-native-gradle-plugin/package.json
@@ -12,7 +12,7 @@
   "keywords": ["gradle", "plugin", "react-native"],
   "bugs": "https://github.com/facebook/react-native/issues",
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "scripts": {
     "build": "./gradlew build",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -21,7 +21,7 @@
   ],
   "bugs": "https://github.com/facebook/react-native/issues",
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "bin": "./cli.js",
   "types": "types",

--- a/packages/react-native/template/package.json
+++ b/packages/react-native/template/package.json
@@ -31,6 +31,6 @@
     "typescript": "5.0.4"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   }
 }

--- a/packages/rn-tester/package.json
+++ b/packages/rn-tester/package.json
@@ -10,7 +10,7 @@
     "directory": "packages/rn-tester"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "scripts": {
     "start": "react-native start",

--- a/packages/virtualized-lists/package.json
+++ b/packages/virtualized-lists/package.json
@@ -12,7 +12,7 @@
   "keywords": ["lists", "virtualized-lists", "section-lists", "react-native"],
   "bugs": "https://github.com/facebook/react-native/issues",
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "dependencies": {
     "invariant": "^2.2.4",


### PR DESCRIPTION
Summary:
## Bump minimum Node JS version to 18 via `react-native/package.json#engines`

In https://github.com/facebook/react-native/pull/35443 we bumped up the node version from 16 to 18.

Node 16 [ends maintenance releases on 2023-09-11](https://nodejs.org/en/blog/announcements/nodejs16-eol/), and bumping this minimum will allow other associated Node JS tools (CLI, Metro, Jest) to reduce their support burden.

This follows up by formally making Node 18 the minimum supported version.

**Docs PR:**
https://github.com/facebook/react-native-website/pull/3748

**Changelog:**
[General][Breaking] Bump minimum Node JS version to 18

Differential Revision: D46583997

