### PR TITLE
Fix loading NODE_BINARY inside Generate Legacy Components Interop

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
+++ b/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
@@ -97,7 +97,8 @@ Pod::Spec.new do |s|
     s.script_phases = {
       :name => "Generate Legacy Components Interop",
       :script => "
-. ${PODS_ROOT}/../.xcode.env
+WITH_ENVIRONMENT=\"$REACT_NATIVE_PATH/scripts/xcode/with-environment.sh\"
+source $WITH_ENVIRONMENT
 ${NODE_BINARY} ${REACT_NATIVE_PATH}/scripts/codegen/generate-legacy-interop-components.js -p #{ENV['APP_PATH']} -o ${REACT_NATIVE_PATH}/Libraries/AppDelegate
       ",
       :execution_position => :before_compile,


### PR DESCRIPTION
## Summary:

When trying to build an app using 0.72.0-RC.5 inside a project that uses `.xcode.env.local` the  `[CP-User] Generate Legacy Components Interop` Phase script fails to run due to a `Permission denied` error. That's because `.xcode.env.local` is not being loaded, resulting in `NODE_BINARY=" "` and then the `React-RCTAppDelegate` script tries to run `generate-legacy-interop-components.js` directly. 

E.g

![image](https://github.com/facebook/react-native/assets/11707729/ce72d7d1-69ab-4477-a754-10cd52bb21a2)


In order to fix this we should run the `with-environment.sh` script instead of directly loading `.${PODS_ROOT}/../.xcode.env`

## Changelog:

[IOS] [FIXED] - Fix loading `NODE_BINARY` inside Generate Legacy Components Interop
 

## Test Plan:

Make sure you don't have a `.xcode.env` file and run locally a project that uses React-RCTAppDelegate 
