### PR TITLE
[RN][iOS] Split hermes-engine podspec in Debug and Release to get rid of PRODUCTION flag

### DIFF
--- a/packages/react-native/Libraries/Blob/React-RCTBlob.podspec
+++ b/packages/react-native/Libraries/Blob/React-RCTBlob.podspec
@@ -54,12 +54,14 @@ Pod::Spec.new do |s|
   s.dependency "RCT-Folly", folly_version
   s.dependency "React-Codegen", version
   s.dependency "ReactCommon/turbomodule/core", version
-  s.dependency "React-jsi", version
+  s.dependency "React-jsi"
   s.dependency "React-Core/RCTBlobHeaders", version
   s.dependency "React-Core/RCTWebSocket", version
   s.dependency "React-RCTNetwork", version
 
   if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
     s.dependency "hermes-engine"
+    s.dependency "hermes-engine_debug", :configurations => ['Debug']
+    s.dependency "hermes-engine_release", :configurations => ['Release']
   end
 end

--- a/packages/react-native/React-Core.podspec
+++ b/packages/react-native/React-Core.podspec
@@ -134,10 +134,11 @@ Pod::Spec.new do |s|
   s.dependency "Yoga"
   s.dependency "glog"
 
-  if ENV['USE_HERMES'] == "0"
-    s.dependency 'React-jsc'
+  if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
+    s.dependency "hermes-engine"
+    s.dependency "hermes-engine_debug", :configurations => ['Debug']
+    s.dependency "hermes-engine_release", :configurations => ['Release']
   else
-    s.dependency 'React-hermes'
-    s.dependency 'hermes-engine'
+    s.dependency "React-jsc"
   end
 end

--- a/packages/react-native/React-Core.podspec
+++ b/packages/react-native/React-Core.podspec
@@ -135,6 +135,7 @@ Pod::Spec.new do |s|
   s.dependency "glog"
 
   if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
+    s.dependency "React-hermes"
     s.dependency "hermes-engine"
     s.dependency "hermes-engine_debug", :configurations => ['Debug']
     s.dependency "hermes-engine_release", :configurations => ['Release']

--- a/packages/react-native/React/React-RCTFabric.podspec
+++ b/packages/react-native/React/React-RCTFabric.podspec
@@ -84,6 +84,8 @@ Pod::Spec.new do |s|
 
   if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
     s.dependency "hermes-engine"
+    s.dependency "hermes-engine_debug", :configurations => ['Debug']
+    s.dependency "hermes-engine_release", :configurations => ['Release']
   else
     s.dependency "React-jsi"
   end

--- a/packages/react-native/ReactCommon/React-Fabric.podspec
+++ b/packages/react-native/ReactCommon/React-Fabric.podspec
@@ -58,8 +58,10 @@ Pod::Spec.new do |s|
 
   if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
     s.dependency "hermes-engine"
+    s.dependency "hermes-engine_debug", :configurations => ['Debug']
+    s.dependency "hermes-engine_release", :configurations => ['Release']
   else
-    s.dependency "React-jsi"
+    s.dependency "React-jsc"
   end
 
   s.subspec "animations" do |ss|

--- a/packages/react-native/ReactCommon/React-FabricImage.podspec
+++ b/packages/react-native/ReactCommon/React-FabricImage.podspec
@@ -81,7 +81,9 @@ Pod::Spec.new do |s|
 
   if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
     s.dependency "hermes-engine"
+    s.dependency "hermes-engine_debug", :configurations => ['Debug']
+    s.dependency "hermes-engine_release", :configurations => ['Release']
   else
-    s.dependency "React-jsi"
+    s.dependency "React-jsc"
   end
 end

--- a/packages/react-native/ReactCommon/ReactCommon.podspec
+++ b/packages/react-native/ReactCommon/ReactCommon.podspec
@@ -53,6 +53,8 @@ Pod::Spec.new do |s|
     ss.dependency "glog"
     if using_hermes
       ss.dependency "hermes-engine"
+      ss.dependency "hermes-engine_debug", :configurations => ['Debug']
+      ss.dependency "hermes-engine_release", :configurations => ['Release']
     end
 
     ss.subspec "bridging" do |sss|
@@ -63,6 +65,8 @@ Pod::Spec.new do |s|
       sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
       if using_hermes
         sss.dependency "hermes-engine"
+        sss.dependency "hermes-engine_debug", :configurations => ['Debug']
+        sss.dependency "hermes-engine_release", :configurations => ['Release']
       end
     end
 

--- a/packages/react-native/ReactCommon/cxxreact/React-cxxreact.podspec
+++ b/packages/react-native/ReactCommon/cxxreact/React-cxxreact.podspec
@@ -48,7 +48,11 @@ Pod::Spec.new do |s|
   s.dependency "React-jsi", version
   s.dependency "React-logger", version
 
-  if ENV['USE_HERMES'] == nil || ENV['USE_HERMES'] == "1"
-    s.dependency 'hermes-engine'
+  if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
+    s.dependency "hermes-engine"
+    s.dependency "hermes-engine_debug", :configurations => ['Debug']
+    s.dependency "hermes-engine_release", :configurations => ['Release']
+  else
+    s.dependency "React-jsc"
   end
 end

--- a/packages/react-native/ReactCommon/hermes/React-hermes.podspec
+++ b/packages/react-native/ReactCommon/hermes/React-hermes.podspec
@@ -51,6 +51,9 @@ Pod::Spec.new do |s|
   s.dependency "DoubleConversion"
   s.dependency "glog"
   s.dependency "RCT-Folly/Futures", folly_version
-  s.dependency "hermes-engine"
   s.dependency "React-jsi"
+  s.dependency "hermes-engine"
+  s.dependency "hermes-engine_debug", :configurations => ['Debug']
+  s.dependency "hermes-engine_release", :configurations => ['Release']
+
 end

--- a/packages/react-native/ReactCommon/jsi/React-jsi.podspec
+++ b/packages/react-native/ReactCommon/jsi/React-jsi.podspec
@@ -56,5 +56,8 @@ Pod::Spec.new do |s|
     # Just need to provide JSIDynamic in this case.
     s.source_files = "jsi/JSIDynamic.{cpp,h}"
     s.dependency "hermes-engine"
+    s.dependency "hermes-engine_debug", :configurations => ['Debug']
+    s.dependency "hermes-engine_release", :configurations => ['Release']
+
   end
 end

--- a/packages/react-native/ReactCommon/jsiexecutor/React-jsiexecutor.podspec
+++ b/packages/react-native/ReactCommon/jsiexecutor/React-jsiexecutor.podspec
@@ -36,13 +36,15 @@ Pod::Spec.new do |s|
   s.header_dir             = "jsireact"
 
   s.dependency "React-cxxreact", version
-  s.dependency "React-jsi", version
+  s.dependency "React-jsi"
   s.dependency "React-perflogger", version
   s.dependency "RCT-Folly", folly_version
   s.dependency "DoubleConversion"
   s.dependency "glog"
 
-  if ENV['USE_HERMES'] == nil || ENV['USE_HERMES'] == "1"
-    s.dependency 'hermes-engine'
+  if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
+    s.dependency "hermes-engine"
+    s.dependency "hermes-engine_debug", :configurations => ['Debug']
+    s.dependency "hermes-engine_release", :configurations => ['Release']
   end
 end

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/React-NativeModulesApple.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/React-NativeModulesApple.podspec
@@ -53,5 +53,7 @@ Pod::Spec.new do |s|
 
     if using_hermes
       s.dependency "hermes-engine"
+      s.dependency "hermes-engine_debug", :configurations => ['Debug']
+      s.dependency "hermes-engine_release", :configurations => ['Release']
     end
 end

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/ReactCommon-Samples.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/ReactCommon-Samples.podspec
@@ -55,7 +55,9 @@ Pod::Spec.new do |s|
 
   if using_hermes
     s.dependency "hermes-engine"
+    s.dependency "hermes-engine_debug", :configurations => ['Debug']
+    s.dependency "hermes-engine_release", :configurations => ['Release']
   else
-    s.dependency "React-jsi"
+    s.dependency "React-jsc"
   end
 end

--- a/packages/react-native/ReactCommon/runtimeexecutor/React-runtimeexecutor.podspec
+++ b/packages/react-native/ReactCommon/runtimeexecutor/React-runtimeexecutor.podspec
@@ -32,5 +32,11 @@ Pod::Spec.new do |s|
   s.source_files           = "**/*.{cpp,h}"
   s.header_dir             = "ReactCommon"
 
-  s.dependency "React-jsi", version
+  s.dependency "React-jsi"
+
+  if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
+    s.dependency "hermes-engine"
+    s.dependency "hermes-engine_debug", :configurations => ['Debug']
+    s.dependency "hermes-engine_release", :configurations => ['Release']
+  end
 end

--- a/packages/react-native/scripts/cocoapods/__tests__/jsengine-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/jsengine-test.rb
@@ -101,13 +101,21 @@ class JSEngineTests < Test::Unit::TestCase
             "returned by",
             "prepare-hermes-for-build",
         ])
-        assert_equal($podInvocationCount, 4)
+        assert_equal($podInvocationCount, 6)
         assert_equal($podInvocation["React-jsi"][:path], "../../ReactCommon/jsi")
         assert_equal($podInvocation["React-hermes"][:path], "../../ReactCommon/hermes")
         assert_equal($podInvocation["libevent"][:version], "~> 2.1.12")
         hermes_engine_pod_invocation = $podInvocation["hermes-engine"]
         assert_equal(hermes_engine_pod_invocation[:podspec], "../../sdks/hermes-engine/hermes-engine.podspec")
         assert_equal(hermes_engine_pod_invocation[:tag], "")
+        hermes_engine_pod_invocation = $podInvocation["hermes-engine_release"]
+        assert_equal(hermes_engine_pod_invocation[:podspec], "../../sdks/hermes-engine/hermes-engine.release.podspec")
+        assert_equal(hermes_engine_pod_invocation[:tag], "")
+        assert_equal(hermes_engine_pod_invocation[:configurations], ["Release"])
+        hermes_engine_pod_invocation = $podInvocation["hermes-engine_debug"]
+        assert_equal(hermes_engine_pod_invocation[:podspec], "../../sdks/hermes-engine/hermes-engine.debug.podspec")
+        assert_equal(hermes_engine_pod_invocation[:tag], "")
+        assert_equal(hermes_engine_pod_invocation[:configurations], ["Debug"])
     end
 
     def test_setupHermes_installsPods_installsFabricSubspecWhenFabricEnabled
@@ -118,13 +126,21 @@ class JSEngineTests < Test::Unit::TestCase
         setup_hermes!(:react_native_path => @react_native_path, :fabric_enabled => fabric_enabled)
 
         # Assert
-        assert_equal($podInvocationCount, 4)
+        assert_equal($podInvocationCount, 6)
         assert_equal($podInvocation["React-jsi"][:path], "../../ReactCommon/jsi")
         hermes_engine_pod_invocation = $podInvocation["hermes-engine"]
         assert_equal(hermes_engine_pod_invocation[:podspec], "../../sdks/hermes-engine/hermes-engine.podspec")
         assert_equal(hermes_engine_pod_invocation[:tag], "")
         assert_equal($podInvocation["React-hermes"][:path], "../../ReactCommon/hermes")
         assert_equal($podInvocation["libevent"][:version], "~> 2.1.12")
+        hermes_engine_pod_invocation = $podInvocation["hermes-engine_release"]
+        assert_equal(hermes_engine_pod_invocation[:podspec], "../../sdks/hermes-engine/hermes-engine.release.podspec")
+        assert_equal(hermes_engine_pod_invocation[:tag], "")
+        assert_equal(hermes_engine_pod_invocation[:configurations], ["Release"])
+        hermes_engine_pod_invocation = $podInvocation["hermes-engine_debug"]
+        assert_equal(hermes_engine_pod_invocation[:podspec], "../../sdks/hermes-engine/hermes-engine.debug.podspec")
+        assert_equal(hermes_engine_pod_invocation[:tag], "")
+        assert_equal(hermes_engine_pod_invocation[:configurations], ["Debug"])
     end
 
 end

--- a/packages/react-native/scripts/cocoapods/jsengine.rb
+++ b/packages/react-native/scripts/cocoapods/jsengine.rb
@@ -34,7 +34,11 @@ def setup_hermes!(react_native_path: "../node_modules/react-native", fabric_enab
     # We have custom logic to compute the source for hermes-engine. See sdks/hermes-engine/*
     hermestag_file = File.join(react_native_path, "sdks", ".hermesversion")
     hermestag = File.exist?(hermestag_file) ? File.read(hermestag_file).strip : ''
+
     pod 'hermes-engine', :podspec => "#{react_native_path}/sdks/hermes-engine/hermes-engine.podspec", :tag => hermestag
+    pod 'hermes-engine_debug', :podspec => "#{react_native_path}/sdks/hermes-engine/hermes-engine.debug.podspec", :tag => hermestag, :configurations => ["Debug"]
+    pod 'hermes-engine_release', :podspec => "#{react_native_path}/sdks/hermes-engine/hermes-engine.release.podspec", :tag => hermestag, :configurations => ["Release"]
+
     pod 'React-hermes', :path => "#{react_native_path}/ReactCommon/hermes"
     pod 'libevent', '~> 2.1.12'
 end

--- a/packages/react-native/scripts/hermes/__tests__/hermes-utils-test.js
+++ b/packages/react-native/scripts/hermes/__tests__/hermes-utils-test.js
@@ -112,6 +112,14 @@ function populateMockFilesystemWithHermesBuildScripts() {
     'Dummy file',
   );
   fs.writeFileSync(
+    path.join(SDKS_DIR, 'hermes-engine/hermes-engine.debug.podspec'),
+    'Dummy file',
+  );
+  fs.writeFileSync(
+    path.join(SDKS_DIR, 'hermes-engine/hermes-engine.release.podspec'),
+    'Dummy file',
+  );
+  fs.writeFileSync(
     path.join(SDKS_DIR, 'hermes-engine/hermes-utils.rb'),
     'Dummy file',
   );

--- a/packages/react-native/scripts/hermes/hermes-utils.js
+++ b/packages/react-native/scripts/hermes/hermes-utils.js
@@ -168,15 +168,17 @@ function copyPodSpec() {
   if (!fs.existsSync(HERMES_DIR)) {
     fs.mkdirSync(HERMES_DIR, {recursive: true});
   }
-  const podspec = 'hermes-engine.podspec';
+
+  copyFromSDKToHermes('hermes-engine.debug.podspec');
+  copyFromSDKToHermes('hermes-engine.release.podspec');
+  copyFromSDKToHermes('hermes-engine.podspec');
+  copyFromSDKToHermes('hermes-utils.rb');
+}
+
+function copyFromSDKToHermes(filename) {
   fs.copyFileSync(
-    path.join(SDKS_DIR, 'hermes-engine', podspec),
-    path.join(HERMES_DIR, podspec),
-  );
-  const utils = 'hermes-utils.rb';
-  fs.copyFileSync(
-    path.join(SDKS_DIR, 'hermes-engine', utils),
-    path.join(HERMES_DIR, utils),
+    path.join(SDKS_DIR, 'hermes-engine', filename),
+    path.join(HERMES_DIR, filename),
   );
 }
 

--- a/packages/react-native/scripts/react-native-xcode.sh
+++ b/packages/react-native/scripts/react-native-xcode.sh
@@ -88,7 +88,7 @@ if [[ -z "$HERMES_ENABLED" ]]; then
   USE_HERMES=false
 fi
 
-HERMES_ENGINE_PATH="$PODS_ROOT/hermes-engine"
+HERMES_ENGINE_PATH="$PODS_ROOT/hermes-engine_$CONFIGURATION"
 [ -z "$HERMES_CLI_PATH" ] && HERMES_CLI_PATH="$HERMES_ENGINE_PATH/destroot/bin/hermesc"
 
 # Hermes is enabled in new projects by default, so we cannot assume that USE_HERMES=1 is set as an envvar.

--- a/packages/react-native/sdks/hermes-engine/hermes-engine.debug.podspec
+++ b/packages/react-native/sdks/hermes-engine/hermes-engine.debug.podspec
@@ -1,0 +1,114 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+require "json"
+require_relative "./hermes-utils.rb"
+
+react_native_path = File.join(__dir__, "..", "..")
+
+# Whether Hermes is built for Release or Debug is determined by the PRODUCTION envvar.
+build_type = :debug
+
+# package.json
+package = JSON.parse(File.read(File.join(react_native_path, "package.json")))
+version = package['version']
+
+# sdks/.hermesversion
+hermestag_file = File.join(react_native_path, "sdks", ".hermesversion")
+build_from_source = ENV['BUILD_FROM_SOURCE'] === 'true'
+
+git = "https://github.com/facebook/hermes.git"
+
+abort_if_invalid_tarball_provided!
+
+source = compute_hermes_source(build_from_source, hermestag_file, git, version, build_type, react_native_path)
+
+Pod::Spec.new do |spec|
+  spec.name        = "hermes-engine_debug"
+  spec.version     = version
+  spec.summary     = "Hermes is a small and lightweight JavaScript engine optimized for running React Native."
+  spec.description = "Hermes is a JavaScript engine optimized for fast start-up of React Native apps. It features ahead-of-time static optimization and compact bytecode."
+  spec.homepage    = "https://hermesengine.dev"
+  spec.license     = package['license']
+  spec.author      = "Facebook"
+  spec.source      = source
+  spec.platforms   = { :osx => "10.13", :ios => "12.4" }
+
+  spec.preserve_paths      = '**/*.*'
+  spec.source_files        = ''
+
+  spec.pod_target_xcconfig = {
+                    "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",
+                    "CLANG_CXX_LIBRARY" => "compiler-default"
+                  }.merge!(build_type == :debug ? { "GCC_PREPROCESSOR_DEFINITIONS" => "HERMES_ENABLE_DEBUGGER=1" } : {})
+
+  spec.ios.vendored_frameworks = "destroot/Library/Frameworks/ios/hermes.framework"
+  spec.osx.vendored_frameworks = "destroot/Library/Frameworks/macosx/hermes.framework"
+
+  if source[:http] then
+
+    spec.subspec 'Pre-built' do |ss|
+      ss.preserve_paths = ["destroot/bin/*"].concat(build_type == :debug ? ["**/*.{h,c,cpp}"] : [])
+      ss.source_files = "destroot/include/**/*.h"
+      ss.exclude_files = ["destroot/include/jsi/jsi/JSIDynamic.{h,cpp}", "destroot/include/jsi/jsi/jsilib-*.{h,cpp}"]
+      ss.header_mappings_dir = "destroot/include"
+      ss.ios.vendored_frameworks = "destroot/Library/Frameworks/universal/hermes.xcframework"
+      ss.osx.vendored_frameworks = "destroot/Library/Frameworks/macosx/hermes.framework"
+    end
+
+  elsif source[:git] then
+
+    spec.subspec 'Hermes' do |ss|
+      ss.source_files = ''
+      ss.public_header_files = 'API/hermes/*.h'
+      ss.header_dir = 'hermes'
+    end
+
+    spec.subspec 'JSI' do |ss|
+      ss.source_files = ''
+      ss.public_header_files = 'API/jsi/jsi/*.h'
+      ss.header_dir = 'jsi'
+    end
+
+    spec.subspec 'Public' do |ss|
+      ss.source_files = ''
+      ss.public_header_files = 'public/hermes/Public/*.h'
+      ss.header_dir = 'hermes/Public'
+    end
+
+    hermesc_path = "${PODS_ROOT}/hermes-engine/build_host_hermesc"
+
+    if ENV.has_key?('HERMES_OVERRIDE_HERMESC_PATH') && File.exist?(ENV['HERMES_OVERRIDE_HERMESC_PATH']) then
+      hermesc_path = ENV['HERMES_OVERRIDE_HERMESC_PATH']
+    end
+
+    spec.user_target_xcconfig = {
+      'HERMES_CLI_PATH' => "#{hermesc_path}/bin/hermesc"
+    }
+
+    spec.prepare_command = ". #{react_native_path}/sdks/hermes-engine/utils/create-dummy-hermes-xcframework.sh"
+
+    CMAKE_BINARY = %x(command -v cmake | tr -d '\n')
+    # NOTE: Script phases are sorted alphabetically inside Xcode project
+    spec.script_phases = [
+      {
+        :name => '[RN] [1] Build Hermesc',
+        :script => <<-EOS
+        . ${PODS_ROOT}/../.xcode.env
+        export CMAKE_BINARY=${CMAKE_BINARY:-#{CMAKE_BINARY}}
+        . ${REACT_NATIVE_PATH}/sdks/hermes-engine/utils/build-hermesc-xcode.sh #{hermesc_path}
+        EOS
+      },
+      {
+        :name => '[RN] [2] Build Hermes',
+        :script => <<-EOS
+        . ${PODS_ROOT}/../.xcode.env
+        export CMAKE_BINARY=${CMAKE_BINARY:-#{CMAKE_BINARY}}
+        . ${REACT_NATIVE_PATH}/sdks/hermes-engine/utils/build-hermes-xcode.sh #{version} #{hermesc_path}/ImportHermesc.cmake
+        EOS
+      }
+    ]
+  end
+end

--- a/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
+++ b/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
@@ -8,9 +8,6 @@ require_relative "./hermes-utils.rb"
 
 react_native_path = File.join(__dir__, "..", "..")
 
-# Whether Hermes is built for Release or Debug is determined by the PRODUCTION envvar.
-build_type = ENV['PRODUCTION'] == "1" ? :release : :debug
-
 # package.json
 package = JSON.parse(File.read(File.join(react_native_path, "package.json")))
 version = package['version']
@@ -23,7 +20,7 @@ git = "https://github.com/facebook/hermes.git"
 
 abort_if_invalid_tarball_provided!
 
-source = compute_hermes_source(build_from_source, hermestag_file, git, version, build_type, react_native_path)
+source = compute_hermes_source(build_from_source, hermestag_file, git, version, :release, react_native_path)
 
 Pod::Spec.new do |spec|
   spec.name        = "hermes-engine"
@@ -34,81 +31,15 @@ Pod::Spec.new do |spec|
   spec.license     = package['license']
   spec.author      = "Facebook"
   spec.source      = source
-  spec.platforms   = { :osx => "10.13", :ios => min_ios_version_supported }
+  spec.platforms   = { :osx => "10.13", :ios => "12.4" }
 
-  spec.preserve_paths      = '**/*.*'
-  spec.source_files        = ''
+  spec.preserve_paths      = ["destroot/bin/*"]
 
   spec.pod_target_xcconfig = {
-                    "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",
-                    "CLANG_CXX_LIBRARY" => "compiler-default"
-                  }.merge!(build_type == :debug ? { "GCC_PREPROCESSOR_DEFINITIONS" => "HERMES_ENABLE_DEBUGGER=1" } : {})
+    "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",
+    "CLANG_CXX_LIBRARY" => "compiler-default"
+  }
 
-  spec.ios.vendored_frameworks = "destroot/Library/Frameworks/ios/hermes.framework"
-  spec.osx.vendored_frameworks = "destroot/Library/Frameworks/macosx/hermes.framework"
-
-  if source[:http] then
-
-    spec.subspec 'Pre-built' do |ss|
-      ss.preserve_paths = ["destroot/bin/*"].concat(build_type == :debug ? ["**/*.{h,c,cpp}"] : [])
-      ss.source_files = "destroot/include/**/*.h"
-      ss.exclude_files = ["destroot/include/jsi/jsi/JSIDynamic.{h,cpp}", "destroot/include/jsi/jsi/jsilib-*.{h,cpp}"]
-      ss.header_mappings_dir = "destroot/include"
-      ss.ios.vendored_frameworks = "destroot/Library/Frameworks/universal/hermes.xcframework"
-      ss.osx.vendored_frameworks = "destroot/Library/Frameworks/macosx/hermes.framework"
-    end
-
-  elsif source[:git] then
-
-    spec.subspec 'Hermes' do |ss|
-      ss.source_files = ''
-      ss.public_header_files = 'API/hermes/*.h'
-      ss.header_dir = 'hermes'
-    end
-
-    spec.subspec 'JSI' do |ss|
-      ss.source_files = ''
-      ss.public_header_files = 'API/jsi/jsi/*.h'
-      ss.header_dir = 'jsi'
-    end
-
-    spec.subspec 'Public' do |ss|
-      ss.source_files = ''
-      ss.public_header_files = 'public/hermes/Public/*.h'
-      ss.header_dir = 'hermes/Public'
-    end
-
-    hermesc_path = "${PODS_ROOT}/hermes-engine/build_host_hermesc"
-
-    if ENV.has_key?('HERMES_OVERRIDE_HERMESC_PATH') && File.exist?(ENV['HERMES_OVERRIDE_HERMESC_PATH']) then
-      hermesc_path = ENV['HERMES_OVERRIDE_HERMESC_PATH']
-    end
-
-    spec.user_target_xcconfig = {
-      'HERMES_CLI_PATH' => "#{hermesc_path}/bin/hermesc"
-    }
-
-    spec.prepare_command = ". #{react_native_path}/sdks/hermes-engine/utils/create-dummy-hermes-xcframework.sh"
-
-    CMAKE_BINARY = %x(command -v cmake | tr -d '\n')
-    # NOTE: Script phases are sorted alphabetically inside Xcode project
-    spec.script_phases = [
-      {
-        :name => '[RN] [1] Build Hermesc',
-        :script => <<-EOS
-        . ${PODS_ROOT}/../.xcode.env
-        export CMAKE_BINARY=${CMAKE_BINARY:-#{CMAKE_BINARY}}
-        . ${REACT_NATIVE_PATH}/sdks/hermes-engine/utils/build-hermesc-xcode.sh #{hermesc_path}
-        EOS
-      },
-      {
-        :name => '[RN] [2] Build Hermes',
-        :script => <<-EOS
-        . ${PODS_ROOT}/../.xcode.env
-        export CMAKE_BINARY=${CMAKE_BINARY:-#{CMAKE_BINARY}}
-        . ${REACT_NATIVE_PATH}/sdks/hermes-engine/utils/build-hermes-xcode.sh #{version} #{hermesc_path}/ImportHermesc.cmake
-        EOS
-      }
-    ]
-  end
+  spec.dependency "hermes-engine_debug", :configurations => ['Debug']
+  spec.dependency "hermes-engine_release", :configurations => ['Release']
 end

--- a/packages/react-native/sdks/hermes-engine/hermes-engine.release.podspec
+++ b/packages/react-native/sdks/hermes-engine/hermes-engine.release.podspec
@@ -1,0 +1,114 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+require "json"
+require_relative "./hermes-utils.rb"
+
+react_native_path = File.join(__dir__, "..", "..")
+
+# Whether Hermes is built for Release or Debug is determined by the PRODUCTION envvar.
+build_type = :release
+
+# package.json
+package = JSON.parse(File.read(File.join(react_native_path, "package.json")))
+version = package['version']
+
+# sdks/.hermesversion
+hermestag_file = File.join(react_native_path, "sdks", ".hermesversion")
+build_from_source = ENV['BUILD_FROM_SOURCE'] === 'true'
+
+git = "https://github.com/facebook/hermes.git"
+
+abort_if_invalid_tarball_provided!
+
+source = compute_hermes_source(build_from_source, hermestag_file, git, version, build_type, react_native_path)
+
+Pod::Spec.new do |spec|
+  spec.name        = "hermes-engine_release"
+  spec.version     = version
+  spec.summary     = "Hermes is a small and lightweight JavaScript engine optimized for running React Native."
+  spec.description = "Hermes is a JavaScript engine optimized for fast start-up of React Native apps. It features ahead-of-time static optimization and compact bytecode."
+  spec.homepage    = "https://hermesengine.dev"
+  spec.license     = package['license']
+  spec.author      = "Facebook"
+  spec.source      = source
+  spec.platforms   = { :osx => "10.13", :ios => "12.4" }
+
+  spec.preserve_paths      = '**/*.*'
+  spec.source_files        = ''
+
+  spec.pod_target_xcconfig = {
+                    "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",
+                    "CLANG_CXX_LIBRARY" => "compiler-default"
+                  }.merge!(build_type == :debug ? { "GCC_PREPROCESSOR_DEFINITIONS" => "HERMES_ENABLE_DEBUGGER=1" } : {})
+
+  spec.ios.vendored_frameworks = "destroot/Library/Frameworks/ios/hermes.framework"
+  spec.osx.vendored_frameworks = "destroot/Library/Frameworks/macosx/hermes.framework"
+
+  if source[:http] then
+
+    spec.subspec 'Pre-built' do |ss|
+      ss.preserve_paths = ["destroot/bin/*"].concat(build_type == :debug ? ["**/*.{h,c,cpp}"] : [])
+      ss.source_files = "destroot/include/**/*.h"
+      ss.exclude_files = ["destroot/include/jsi/jsi/JSIDynamic.{h,cpp}", "destroot/include/jsi/jsi/jsilib-*.{h,cpp}"]
+      ss.header_mappings_dir = "destroot/include"
+      ss.ios.vendored_frameworks = "destroot/Library/Frameworks/universal/hermes.xcframework"
+      ss.osx.vendored_frameworks = "destroot/Library/Frameworks/macosx/hermes.framework"
+    end
+
+  elsif source[:git] then
+
+    # spec.subspec 'Hermes' do |ss|
+    #   ss.source_files = ''
+    #   ss.public_header_files = 'API/hermes/*.h'
+    #   ss.header_dir = 'hermes'
+    # end
+
+    # spec.subspec 'JSI' do |ss|
+    #   ss.source_files = ''
+    #   ss.public_header_files = 'API/jsi/jsi/*.h'
+    #   ss.header_dir = 'jsi'
+    # end
+
+    # spec.subspec 'Public' do |ss|
+    #   ss.source_files = ''
+    #   ss.public_header_files = 'public/hermes/Public/*.h'
+    #   ss.header_dir = 'hermes/Public'
+    # end
+
+    # hermesc_path = "${PODS_ROOT}/hermes-engine/build_host_hermesc"
+
+    # if ENV.has_key?('HERMES_OVERRIDE_HERMESC_PATH') && File.exist?(ENV['HERMES_OVERRIDE_HERMESC_PATH']) then
+    #   hermesc_path = ENV['HERMES_OVERRIDE_HERMESC_PATH']
+    # end
+
+    # spec.user_target_xcconfig = {
+    #   'HERMES_CLI_PATH' => "#{hermesc_path}/bin/hermesc"
+    # }
+
+    # spec.prepare_command = ". #{react_native_path}/sdks/hermes-engine/utils/create-dummy-hermes-xcframework.sh"
+
+    # CMAKE_BINARY = %x(command -v cmake | tr -d '\n')
+    # # NOTE: Script phases are sorted alphabetically inside Xcode project
+    # spec.script_phases = [
+    #   {
+    #     :name => '[RN] [1] Build Hermesc',
+    #     :script => <<-EOS
+    #     . ${PODS_ROOT}/../.xcode.env
+    #     export CMAKE_BINARY=${CMAKE_BINARY:-#{CMAKE_BINARY}}
+    #     . ${REACT_NATIVE_PATH}/sdks/hermes-engine/utils/build-hermesc-xcode.sh #{hermesc_path}
+    #     EOS
+    #   },
+    #   {
+    #     :name => '[RN] [2] Build Hermes',
+    #     :script => <<-EOS
+    #     . ${PODS_ROOT}/../.xcode.env
+    #     export CMAKE_BINARY=${CMAKE_BINARY:-#{CMAKE_BINARY}}
+    #     . ${REACT_NATIVE_PATH}/sdks/hermes-engine/utils/build-hermes-xcode.sh #{version} #{hermesc_path}/ImportHermesc.cmake
+    #     EOS
+    #   }
+    # ]
+  end
+end

--- a/packages/react-native/sdks/hermes-engine/hermes-engine.release.podspec
+++ b/packages/react-native/sdks/hermes-engine/hermes-engine.release.podspec
@@ -60,55 +60,55 @@ Pod::Spec.new do |spec|
 
   elsif source[:git] then
 
-    # spec.subspec 'Hermes' do |ss|
-    #   ss.source_files = ''
-    #   ss.public_header_files = 'API/hermes/*.h'
-    #   ss.header_dir = 'hermes'
-    # end
+    spec.subspec 'Hermes' do |ss|
+      ss.source_files = ''
+      ss.public_header_files = 'API/hermes/*.h'
+      ss.header_dir = 'hermes'
+    end
 
-    # spec.subspec 'JSI' do |ss|
-    #   ss.source_files = ''
-    #   ss.public_header_files = 'API/jsi/jsi/*.h'
-    #   ss.header_dir = 'jsi'
-    # end
+    spec.subspec 'JSI' do |ss|
+      ss.source_files = ''
+      ss.public_header_files = 'API/jsi/jsi/*.h'
+      ss.header_dir = 'jsi'
+    end
 
-    # spec.subspec 'Public' do |ss|
-    #   ss.source_files = ''
-    #   ss.public_header_files = 'public/hermes/Public/*.h'
-    #   ss.header_dir = 'hermes/Public'
-    # end
+    spec.subspec 'Public' do |ss|
+      ss.source_files = ''
+      ss.public_header_files = 'public/hermes/Public/*.h'
+      ss.header_dir = 'hermes/Public'
+    end
 
-    # hermesc_path = "${PODS_ROOT}/hermes-engine/build_host_hermesc"
+    hermesc_path = "${PODS_ROOT}/hermes-engine/build_host_hermesc"
 
-    # if ENV.has_key?('HERMES_OVERRIDE_HERMESC_PATH') && File.exist?(ENV['HERMES_OVERRIDE_HERMESC_PATH']) then
-    #   hermesc_path = ENV['HERMES_OVERRIDE_HERMESC_PATH']
-    # end
+    if ENV.has_key?('HERMES_OVERRIDE_HERMESC_PATH') && File.exist?(ENV['HERMES_OVERRIDE_HERMESC_PATH']) then
+      hermesc_path = ENV['HERMES_OVERRIDE_HERMESC_PATH']
+    end
 
-    # spec.user_target_xcconfig = {
-    #   'HERMES_CLI_PATH' => "#{hermesc_path}/bin/hermesc"
-    # }
+    spec.user_target_xcconfig = {
+      'HERMES_CLI_PATH' => "#{hermesc_path}/bin/hermesc"
+    }
 
-    # spec.prepare_command = ". #{react_native_path}/sdks/hermes-engine/utils/create-dummy-hermes-xcframework.sh"
+    spec.prepare_command = ". #{react_native_path}/sdks/hermes-engine/utils/create-dummy-hermes-xcframework.sh"
 
-    # CMAKE_BINARY = %x(command -v cmake | tr -d '\n')
-    # # NOTE: Script phases are sorted alphabetically inside Xcode project
-    # spec.script_phases = [
-    #   {
-    #     :name => '[RN] [1] Build Hermesc',
-    #     :script => <<-EOS
-    #     . ${PODS_ROOT}/../.xcode.env
-    #     export CMAKE_BINARY=${CMAKE_BINARY:-#{CMAKE_BINARY}}
-    #     . ${REACT_NATIVE_PATH}/sdks/hermes-engine/utils/build-hermesc-xcode.sh #{hermesc_path}
-    #     EOS
-    #   },
-    #   {
-    #     :name => '[RN] [2] Build Hermes',
-    #     :script => <<-EOS
-    #     . ${PODS_ROOT}/../.xcode.env
-    #     export CMAKE_BINARY=${CMAKE_BINARY:-#{CMAKE_BINARY}}
-    #     . ${REACT_NATIVE_PATH}/sdks/hermes-engine/utils/build-hermes-xcode.sh #{version} #{hermesc_path}/ImportHermesc.cmake
-    #     EOS
-    #   }
-    # ]
+    CMAKE_BINARY = %x(command -v cmake | tr -d '\n')
+    # NOTE: Script phases are sorted alphabetically inside Xcode project
+    spec.script_phases = [
+      {
+        :name => '[RN] [1] Build Hermesc',
+        :script => <<-EOS
+        . ${PODS_ROOT}/../.xcode.env
+        export CMAKE_BINARY=${CMAKE_BINARY:-#{CMAKE_BINARY}}
+        . ${REACT_NATIVE_PATH}/sdks/hermes-engine/utils/build-hermesc-xcode.sh #{hermesc_path}
+        EOS
+      },
+      {
+        :name => '[RN] [2] Build Hermes',
+        :script => <<-EOS
+        . ${PODS_ROOT}/../.xcode.env
+        export CMAKE_BINARY=${CMAKE_BINARY:-#{CMAKE_BINARY}}
+        . ${REACT_NATIVE_PATH}/sdks/hermes-engine/utils/build-hermes-xcode.sh #{version} #{hermesc_path}/ImportHermesc.cmake
+        EOS
+      }
+    ]
   end
 end


### PR DESCRIPTION
## Summary:

In iOS in OSS, we used to use the PRODUCTION flag to install pods with a Release configuration. This is a non-standard flow which we would like to remove.
The standard flow would only use Xcode Debug/Release configurations and would save the reinstall pods step to every developer.

The last blocker for the removal of this flag was the `hermes-engine` pod which not only has to use different configurations depending on whether it is build for debug or release, but it has 
also to provide different prebuilts for the two setups.

The adopted solution is to split the podspec in three: an high level podspec that depends on the flavour-aware podspecs.
You can look [here](https://github.com/CocoaPods/CocoaPods/issues/2847) for the description of the issue and the adopted solution.

## Changelog:


[IOS] [CHANGED] - Split Hermes-engine in three subspecs to remove the PRODUCTION flag 

## Test Plan:

Tested locally in an app created from the template
Tested locally with RNTester
CircleCI
