### PR TITLE
Create module to set up PerformanceObserver

### DIFF
--- a/packages/react-native/Libraries/Core/setUpPerformanceObserver.js
+++ b/packages/react-native/Libraries/Core/setUpPerformanceObserver.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import {polyfillGlobal} from '../Utilities/PolyfillFunctions';
+
+polyfillGlobal(
+  'PerformanceObserver',
+  () => require('../WebPerformance/PerformanceObserver').default,
+);


### PR DESCRIPTION
Summary:
We implemented `PerformanceObserver` but didn't create a `setUp*` module for it like we did for the rest of globals in RN.

This creates the module but doesn't enable it by default (until stable in OSS). We'll require this in a case by case basis for testing.

Changelog: [internal]

Differential Revision: D46597766

