### PR TITLE
Back out "When animating using native driver, trigger rerender on animation completion"

### DIFF
--- a/packages/react-native/Libraries/Animated/animations/Animation.js
+++ b/packages/react-native/Libraries/Animated/animations/Animation.js
@@ -11,11 +11,9 @@
 'use strict';
 
 import type {PlatformConfig} from '../AnimatedPlatformConfig';
-import type AnimatedNode from '../nodes/AnimatedNode';
 import type AnimatedValue from '../nodes/AnimatedValue';
 
 import NativeAnimatedHelper from '../NativeAnimatedHelper';
-import AnimatedProps from '../nodes/AnimatedProps';
 
 export type EndResult = {finished: boolean, value?: number, ...};
 export type EndCallback = (result: EndResult) => void;
@@ -67,21 +65,6 @@ export default class Animation {
     onEnd && onEnd(result);
   }
 
-  __findAnimatedPropsNode(node: AnimatedNode): ?AnimatedProps {
-    if (node instanceof AnimatedProps) {
-      return node;
-    }
-
-    for (const child of node.__getChildren()) {
-      const result = this.__findAnimatedPropsNode(child);
-      if (result) {
-        return result;
-      }
-    }
-
-    return null;
-  }
-
   __startNativeAnimation(animatedValue: AnimatedValue): void {
     const startNativeAnimationWaitId = `${startNativeAnimationNextId}:startAnimation`;
     startNativeAnimationNextId += 1;
@@ -106,10 +89,6 @@ export default class Animation {
           if (value != null) {
             animatedValue.__onAnimatedValueUpdateReceived(value);
           }
-
-          // Once the JS side node is synced with the updated values, trigger an
-          // update on the AnimatedProps node to call any registered callbacks.
-          this.__findAnimatedPropsNode(animatedValue)?.update();
         },
       );
     } catch (e) {

--- a/packages/react-native/Libraries/Animated/useAnimatedProps.js
+++ b/packages/react-native/Libraries/Animated/useAnimatedProps.js
@@ -66,9 +66,7 @@ export default function useAnimatedProps<TProps: {...}, TInstance>(
       // changes), but `setNativeView` already optimizes for that.
       node.setNativeView(instance);
 
-      // NOTE: When using the JS animation driver, this callback is called on
-      // every animation frame. When using the native driver, this callback is
-      // called when the animation completes.
+      // NOTE: This callback is only used by the JavaScript animation driver.
       onUpdateRef.current = () => {
         if (
           process.env.NODE_ENV === 'test' ||


### PR DESCRIPTION
Summary:
Original commit changeset: 185471b28f5f

Original Phabricator Diff: D46574511

The original diff may have broken several E2E tests:
- https://www.internalfb.com/intern/test/281475053258471/
- https://www.internalfb.com/intern/test/562950042062069/
- https://www.internalfb.com/intern/test/281475065342188/
- https://www.internalfb.com/intern/test/844425018778537/

Errors come from: https://www.internalfb.com/code/fbsource/[79ff1b109432c02b756d4fea6e7a66ff21e34be6]/xplat/js/react-native-github/packages/react-native/Libraries/Animated/useAnimatedProps.js?lines=89

Differential Revision: D46629553

