### PR TITLE
Fix Android border clip check

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewBackgroundDrawable.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewBackgroundDrawable.java
@@ -564,19 +564,28 @@ public class ReactViewBackgroundDrawable extends Drawable {
     int colorRight = getBorderColor(Spacing.RIGHT);
     int colorBottom = getBorderColor(Spacing.BOTTOM);
     int borderColor = getBorderColor(Spacing.ALL);
+
     int colorBlock = getBorderColor(Spacing.BLOCK);
     int colorBlockStart = getBorderColor(Spacing.BLOCK_START);
     int colorBlockEnd = getBorderColor(Spacing.BLOCK_END);
+
+    if (isBorderColorDefined(Spacing.BLOCK)) {
+      colorBottom = colorBlock;
+      colorTop = colorBlock;
+    }
+    if (isBorderColorDefined(Spacing.BLOCK_END)) {
+      colorBottom = colorBlockEnd;
+    }
+    if (isBorderColorDefined(Spacing.BLOCK_START)) {
+      colorTop = colorBlockStart;
+    }
 
     // Clip border ONLY if its color is non transparent
     if (Color.alpha(colorLeft) != 0
         && Color.alpha(colorTop) != 0
         && Color.alpha(colorRight) != 0
         && Color.alpha(colorBottom) != 0
-        && Color.alpha(borderColor) != 0
-        && Color.alpha(colorBlock) != 0
-        && Color.alpha(colorBlockStart) != 0
-        && Color.alpha(colorBlockEnd) != 0) {
+        && Color.alpha(borderColor) != 0) {
 
       mInnerClipTempRectForBorderRadius.top += borderWidth.top;
       mInnerClipTempRectForBorderRadius.bottom -= borderWidth.bottom;


### PR DESCRIPTION
## Summary:

Instead of requiring all  types of border color values to be present we should only take into consideration the left, top, right, bottom, and allEdges values and inject block values into  colorBottom and colorTop.

This PR only addresses the first issue described here (https://github.com/facebook/react-native/issues/37753#issuecomment-1587196793) by @kelset 

## Changelog:
 
[ANDROID] [FIXED] - Fix border clip check 

## Test Plan:

Test through rn-tester if border color is being applied
  
<img width="482" alt="image" src="https://github.com/facebook/react-native/assets/11707729/c8c8772c-da8d-4393-bc3f-5868eca5df15">

