### PR TITLE
Remove CallInvoker parameter from toJs method in Codegen

### DIFF
--- a/packages/react-native-codegen/e2e/__tests__/modules/__snapshots__/GenerateModuleH-test.js.snap
+++ b/packages/react-native-codegen/e2e/__tests__/modules/__snapshots__/GenerateModuleH-test.js.snap
@@ -206,7 +206,7 @@ struct Bridging<NativeEnumTurboModuleStatusRegularEnum> {
     }
   }
 
-  static jsi::String toJs(jsi::Runtime &rt, NativeEnumTurboModuleStatusRegularEnum value, const std::shared_ptr<CallInvoker> &jsInvoker) {
+  static jsi::String toJs(jsi::Runtime &rt, NativeEnumTurboModuleStatusRegularEnum value) {
     if (value == NativeEnumTurboModuleStatusRegularEnum::Active) {
       return bridging::toJs(rt, \\"Active\\");
     } else if (value == NativeEnumTurboModuleStatusRegularEnum::Paused) {
@@ -238,7 +238,7 @@ struct Bridging<NativeEnumTurboModuleStatusStrEnum> {
     }
   }
 
-  static jsi::String toJs(jsi::Runtime &rt, NativeEnumTurboModuleStatusStrEnum value, const std::shared_ptr<CallInvoker> &jsInvoker) {
+  static jsi::String toJs(jsi::Runtime &rt, NativeEnumTurboModuleStatusStrEnum value) {
     if (value == NativeEnumTurboModuleStatusStrEnum::Active) {
       return bridging::toJs(rt, \\"active\\");
     } else if (value == NativeEnumTurboModuleStatusStrEnum::Paused) {
@@ -270,7 +270,7 @@ struct Bridging<NativeEnumTurboModuleStatusNumEnum> {
     }
   }
 
-  static jsi::Value toJs(jsi::Runtime &rt, NativeEnumTurboModuleStatusNumEnum value, const std::shared_ptr<CallInvoker> &jsInvoker) {
+  static jsi::Value toJs(jsi::Runtime &rt, NativeEnumTurboModuleStatusNumEnum value) {
     if (value == NativeEnumTurboModuleStatusNumEnum::Active) {
       return bridging::toJs(rt, 2);
     } else if (value == NativeEnumTurboModuleStatusNumEnum::Paused) {
@@ -302,7 +302,7 @@ struct Bridging<NativeEnumTurboModuleStatusFractionEnum> {
     }
   }
 
-  static jsi::Value toJs(jsi::Runtime &rt, NativeEnumTurboModuleStatusFractionEnum value, const std::shared_ptr<CallInvoker> &jsInvoker) {
+  static jsi::Value toJs(jsi::Runtime &rt, NativeEnumTurboModuleStatusFractionEnum value) {
     if (value == NativeEnumTurboModuleStatusFractionEnum::Active) {
       return bridging::toJs(rt, 0.2f);
     } else if (value == NativeEnumTurboModuleStatusFractionEnum::Paused) {
@@ -2149,7 +2149,7 @@ struct Bridging<NativeEnumTurboModuleStatusRegularEnum> {
     }
   }
 
-  static jsi::String toJs(jsi::Runtime &rt, NativeEnumTurboModuleStatusRegularEnum value, const std::shared_ptr<CallInvoker> &jsInvoker) {
+  static jsi::String toJs(jsi::Runtime &rt, NativeEnumTurboModuleStatusRegularEnum value) {
     if (value == NativeEnumTurboModuleStatusRegularEnum::Active) {
       return bridging::toJs(rt, \\"Active\\");
     } else if (value == NativeEnumTurboModuleStatusRegularEnum::Paused) {
@@ -2181,7 +2181,7 @@ struct Bridging<NativeEnumTurboModuleStatusStrEnum> {
     }
   }
 
-  static jsi::String toJs(jsi::Runtime &rt, NativeEnumTurboModuleStatusStrEnum value, const std::shared_ptr<CallInvoker> &jsInvoker) {
+  static jsi::String toJs(jsi::Runtime &rt, NativeEnumTurboModuleStatusStrEnum value) {
     if (value == NativeEnumTurboModuleStatusStrEnum::Active) {
       return bridging::toJs(rt, \\"active\\");
     } else if (value == NativeEnumTurboModuleStatusStrEnum::Paused) {
@@ -2213,7 +2213,7 @@ struct Bridging<NativeEnumTurboModuleStatusNumEnum> {
     }
   }
 
-  static jsi::Value toJs(jsi::Runtime &rt, NativeEnumTurboModuleStatusNumEnum value, const std::shared_ptr<CallInvoker> &jsInvoker) {
+  static jsi::Value toJs(jsi::Runtime &rt, NativeEnumTurboModuleStatusNumEnum value) {
     if (value == NativeEnumTurboModuleStatusNumEnum::Active) {
       return bridging::toJs(rt, 2);
     } else if (value == NativeEnumTurboModuleStatusNumEnum::Paused) {
@@ -2245,7 +2245,7 @@ struct Bridging<NativeEnumTurboModuleStatusFractionEnum> {
     }
   }
 
-  static jsi::Value toJs(jsi::Runtime &rt, NativeEnumTurboModuleStatusFractionEnum value, const std::shared_ptr<CallInvoker> &jsInvoker) {
+  static jsi::Value toJs(jsi::Runtime &rt, NativeEnumTurboModuleStatusFractionEnum value) {
     if (value == NativeEnumTurboModuleStatusFractionEnum::Active) {
       return bridging::toJs(rt, 0.2f);
     } else if (value == NativeEnumTurboModuleStatusFractionEnum::Paused) {

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleH.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleH.js
@@ -343,7 +343,7 @@ struct Bridging<${enumName}> {
     ${fromCases}
   }
 
-  static ${toValue} toJs(jsi::Runtime &rt, ${enumName} value, const std::shared_ptr<CallInvoker> &jsInvoker) {
+  static ${toValue} toJs(jsi::Runtime &rt, ${enumName} value) {
     ${toCases}
   }
 };`;

--- a/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleH-test.js.snap
+++ b/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleH-test.js.snap
@@ -222,7 +222,7 @@ struct Bridging<SampleTurboModuleCxxNumEnum> {
     }
   }
 
-  static jsi::Value toJs(jsi::Runtime &rt, SampleTurboModuleCxxNumEnum value, const std::shared_ptr<CallInvoker> &jsInvoker) {
+  static jsi::Value toJs(jsi::Runtime &rt, SampleTurboModuleCxxNumEnum value) {
     if (value == SampleTurboModuleCxxNumEnum::ONE) {
       return bridging::toJs(rt, 1);
     } else if (value == SampleTurboModuleCxxNumEnum::TWO) {
@@ -252,7 +252,7 @@ struct Bridging<SampleTurboModuleCxxFloatEnum> {
     }
   }
 
-  static jsi::Value toJs(jsi::Runtime &rt, SampleTurboModuleCxxFloatEnum value, const std::shared_ptr<CallInvoker> &jsInvoker) {
+  static jsi::Value toJs(jsi::Runtime &rt, SampleTurboModuleCxxFloatEnum value) {
     if (value == SampleTurboModuleCxxFloatEnum::POINT_ZERO) {
       return bridging::toJs(rt, 0.0f);
     } else if (value == SampleTurboModuleCxxFloatEnum::POINT_ONE) {
@@ -282,7 +282,7 @@ struct Bridging<SampleTurboModuleCxxStringEnum> {
     }
   }
 
-  static jsi::String toJs(jsi::Runtime &rt, SampleTurboModuleCxxStringEnum value, const std::shared_ptr<CallInvoker> &jsInvoker) {
+  static jsi::String toJs(jsi::Runtime &rt, SampleTurboModuleCxxStringEnum value) {
     if (value == SampleTurboModuleCxxStringEnum::HELLO) {
       return bridging::toJs(rt, \\"hello\\");
     } else if (value == SampleTurboModuleCxxStringEnum::GoodBye) {
@@ -1220,7 +1220,7 @@ struct Bridging<SampleTurboModuleNumEnum> {
     }
   }
 
-  static jsi::Value toJs(jsi::Runtime &rt, SampleTurboModuleNumEnum value, const std::shared_ptr<CallInvoker> &jsInvoker) {
+  static jsi::Value toJs(jsi::Runtime &rt, SampleTurboModuleNumEnum value) {
     if (value == SampleTurboModuleNumEnum::ONE) {
       return bridging::toJs(rt, 1);
     } else if (value == SampleTurboModuleNumEnum::TWO) {
@@ -1250,7 +1250,7 @@ struct Bridging<SampleTurboModuleFloatEnum> {
     }
   }
 
-  static jsi::Value toJs(jsi::Runtime &rt, SampleTurboModuleFloatEnum value, const std::shared_ptr<CallInvoker> &jsInvoker) {
+  static jsi::Value toJs(jsi::Runtime &rt, SampleTurboModuleFloatEnum value) {
     if (value == SampleTurboModuleFloatEnum::POINT_ZERO) {
       return bridging::toJs(rt, 0.0f);
     } else if (value == SampleTurboModuleFloatEnum::POINT_ONE) {
@@ -1280,7 +1280,7 @@ struct Bridging<SampleTurboModuleStringEnum> {
     }
   }
 
-  static jsi::String toJs(jsi::Runtime &rt, SampleTurboModuleStringEnum value, const std::shared_ptr<CallInvoker> &jsInvoker) {
+  static jsi::String toJs(jsi::Runtime &rt, SampleTurboModuleStringEnum value) {
     if (value == SampleTurboModuleStringEnum::HELLO) {
       return bridging::toJs(rt, \\"hello\\");
     } else if (value == SampleTurboModuleStringEnum::GoodBye) {


### PR DESCRIPTION
Summary:
This parameter is currently unused and is causing Android builds to fail
as they compile with `-Wall`

This is a follow-up to https://github.com/facebook/react-native/pull/37454/ as that PR updated only the `fromJs` and not the `toJs` method as well.

Changelog:
[Internal] [Changed] - Remove CallInvoker parameter from toJs method in Codegen

Differential Revision: D46647110

