### PR TITLE
Etx17/[Codegen 115] - Move the buildPropertiesForEvent in a function in parsers-commons.js...

### DIFF
--- a/packages/react-native-codegen/src/parsers/flow/components/events.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/events.js
@@ -24,7 +24,7 @@ const {
 } = require('../../error-utils');
 const {
   getEventArgument,
-  buildPropertiesForEvent,
+  buildPropertiesWrapper,
 } = require('../../parsers-commons');
 const {
   emitBoolProp,
@@ -70,7 +70,7 @@ function getPropertyType(
         typeAnnotation: {
           type: 'ObjectTypeAnnotation',
           properties: typeAnnotation.properties.map(member =>
-            buildPropertiesForEvent(member, parser, getPropertyType),
+            buildPropertiesWrapper(member, parser, getPropertyType),
           ),
         },
       };
@@ -129,7 +129,7 @@ function extractArrayElementType(
       return {
         type: 'ObjectTypeAnnotation',
         properties: typeAnnotation.properties.map(member =>
-          buildPropertiesForEvent(member, parser, getPropertyType),
+          buildPropertiesWrapper(member, parser, getPropertyType),
         ),
       };
     case 'ArrayTypeAnnotation':

--- a/packages/react-native-codegen/src/parsers/parsers-commons.js
+++ b/packages/react-native-codegen/src/parsers/parsers-commons.js
@@ -1072,6 +1072,14 @@ function buildPropertiesForEvent(
   return getPropertyType(name, optional, typeAnnotation, parser);
 }
 
+function buildPropertiesWrapper(
+  property: $FlowFixMe,
+  parser: Parser,
+  getPropertyType: Function
+): NamedShape<EventTypeAnnotation> {
+  return buildPropertiesForEvent(property, parser, getPropertyType);
+}
+
 module.exports = {
   wrapModuleSchema,
   unwrapNullable,
@@ -1098,5 +1106,5 @@ module.exports = {
   getCommandProperties,
   handleGenericTypeAnnotation,
   getTypeResolutionStatus,
-  buildPropertiesForEvent,
+  buildPropertiesWrapper,
 };

--- a/packages/react-native-codegen/src/parsers/typescript/components/events.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/events.js
@@ -26,7 +26,7 @@ const {
 } = require('../../error-utils');
 const {
   getEventArgument,
-  buildPropertiesForEvent,
+  buildPropertiesWrapper,
 } = require('../../parsers-commons');
 const {
   emitBoolProp,
@@ -72,7 +72,7 @@ function getPropertyType(
         typeAnnotation: {
           type: 'ObjectTypeAnnotation',
           properties: typeAnnotation.members.map(member =>
-            buildPropertiesForEvent(member, parser, getPropertyType),
+            buildPropertiesWrapper(member, parser, getPropertyType),
           ),
         },
       };
@@ -139,7 +139,7 @@ function extractArrayElementType(
       return {
         type: 'ObjectTypeAnnotation',
         properties: typeAnnotation.members.map(member =>
-          buildPropertiesForEvent(member, parser, getPropertyType),
+          buildPropertiesWrapper(member, parser, getPropertyType),
         ),
       };
     case 'TSArrayType':


### PR DESCRIPTION
## Summary:

Moved the buildPropertiesForEvent in a function in parsers-commons.js  and used that function in place of the other two (Flow, TypeScript)

## Changelog:
[INTERNAL] [ADDED] - Moved the buildPropertiesForEvent in a new buildPropertiesWrapper function (in common-parsers.js) and use it in Flow and Typescript parsers in place of the buildPropertiesForEvent.

## Test Plan:

 Run yarn jest react-native-codegen and ensure CI is green
 
![image](https://github.com/facebook/react-native/assets/90650411/b1e00f33-7320-4bb6-bec1-eb24995863cc)

