### PR TITLE
Fix grouping of console logs

### DIFF
--- a/packages/react-native/ReactCommon/hermes/inspector/chrome/Connection.cpp
+++ b/packages/react-native/ReactCommon/hermes/inspector/chrome/Connection.cpp
@@ -421,6 +421,10 @@ void Connection::Impl::onMessageAdded(
     const ConsoleMessageInfo &info) {
   m::runtime::ConsoleAPICalledNotification apiCalledNote;
   apiCalledNote.type = info.level;
+  apiCalledNote.timestamp =
+      std::chrono::duration<double, std::ratio<1, 1000>>(
+          std::chrono::system_clock::now().time_since_epoch())
+          .count();
   // TODO(jpporto): fix test cases sending invalid context id.
   // apiCalledNote.executionContextId = kHermesExecutionContextId;
 


### PR DESCRIPTION
Summary:
Chrome Dev Tools doesn't correctly display grouped console logs (i.e. console output between a `console.group` and `console.groupEnd`) when timestamps are all zero.

Populate the timestamp field so grouping functions as expected.

Differential Revision: D46605659

