### PR TITLE
Trigger rerender on animation complete

### DIFF
--- a/packages/react-native/Libraries/Animated/__tests__/AnimatedNative-test.js
+++ b/packages/react-native/Libraries/Animated/__tests__/AnimatedNative-test.js
@@ -1027,21 +1027,17 @@ describe('Native Animated', () => {
       }).start();
       jest.runAllTimers();
 
-      Animated.timing(opacity, {
-        toValue: 4,
-        duration: 500,
-        useNativeDriver: false,
-      }).start();
-      try {
-        process.env.NODE_ENV = 'development';
-        expect(jest.runAllTimers).toThrow(
-          'Attempting to run JS driven animation on animated node that has ' +
-            'been moved to "native" earlier by starting an animation with ' +
-            '`useNativeDriver: true`',
-        );
-      } finally {
-        process.env.NODE_ENV = 'test';
-      }
+      expect(
+        Animated.timing(opacity, {
+          toValue: 4,
+          duration: 500,
+          useNativeDriver: false,
+        }).start,
+      ).toThrow(
+        'Attempting to run JS driven animation on animated node that has ' +
+          'been moved to "native" earlier by starting an animation with ' +
+          '`useNativeDriver: true`',
+      );
     });
 
     it('fails for unsupported styles', () => {

--- a/packages/react-native/Libraries/Animated/animations/DecayAnimation.js
+++ b/packages/react-native/Libraries/Animated/animations/DecayAnimation.js
@@ -85,6 +85,15 @@ export default class DecayAnimation extends Animation {
     this._onUpdate = onUpdate;
     this.__onEnd = onEnd;
     this._startTime = Date.now();
+
+    if (!this._useNativeDriver && animatedValue.__isNative === true) {
+      throw new Error(
+        'Attempting to run JS driven animation on animated node ' +
+          'that has been moved to "native" earlier by starting an ' +
+          'animation with `useNativeDriver: true`',
+      );
+    }
+
     if (this._useNativeDriver) {
       this.__startNativeAnimation(animatedValue);
     } else {

--- a/packages/react-native/Libraries/Animated/animations/SpringAnimation.js
+++ b/packages/react-native/Libraries/Animated/animations/SpringAnimation.js
@@ -221,6 +221,14 @@ export default class SpringAnimation extends Animation {
     }
 
     const start = () => {
+      if (!this._useNativeDriver && animatedValue.__isNative === true) {
+        throw new Error(
+          'Attempting to run JS driven animation on animated node ' +
+            'that has been moved to "native" earlier by starting an ' +
+            'animation with `useNativeDriver: true`',
+        );
+      }
+
       if (this._useNativeDriver) {
         this.__startNativeAnimation(animatedValue);
       } else {

--- a/packages/react-native/Libraries/Animated/animations/TimingAnimation.js
+++ b/packages/react-native/Libraries/Animated/animations/TimingAnimation.js
@@ -112,6 +112,14 @@ export default class TimingAnimation extends Animation {
     this.__onEnd = onEnd;
 
     const start = () => {
+      if (!this._useNativeDriver && animatedValue.__isNative === true) {
+        throw new Error(
+          'Attempting to run JS driven animation on animated node ' +
+            'that has been moved to "native" earlier by starting an ' +
+            'animation with `useNativeDriver: true`',
+        );
+      }
+
       // Animations that sometimes have 0 duration and sometimes do not
       // still need to use the native driver when duration is 0 so as to
       // not cause intermixed JS and native animations.

--- a/packages/react-native/Libraries/Animated/useAnimatedProps.js
+++ b/packages/react-native/Libraries/Animated/useAnimatedProps.js
@@ -66,7 +66,9 @@ export default function useAnimatedProps<TProps: {...}, TInstance>(
       // changes), but `setNativeView` already optimizes for that.
       node.setNativeView(instance);
 
-      // NOTE: This callback is only used by the JavaScript animation driver.
+      // NOTE: When using the JS animation driver, this callback is called on
+      // every animation frame. When using the native driver, this callback is
+      // called when the animation completes.
       onUpdateRef.current = () => {
         if (
           process.env.NODE_ENV === 'test' ||
@@ -82,12 +84,6 @@ export default function useAnimatedProps<TProps: {...}, TInstance>(
           // $FlowIgnore[not-a-function] - Assume it's still a function.
           // $FlowFixMe[incompatible-use]
           instance.setNativeProps(node.__getAnimatedValue());
-        } else {
-          throw new Error(
-            'Attempting to run JS driven animation on animated node ' +
-              'that has been moved to "native" earlier by starting an ' +
-              'animation with `useNativeDriver: true`',
-          );
         }
       };
 


### PR DESCRIPTION
Summary:
When using the native driver for animations that involve layout changes (ie. translateY and other transforms, but not styles such as opacity), because it bypasses Fabric, the new coordinates are not updated so the Pressability responder region/tap target is incorrect.

Prior diffs ensure that upon completion of natively driven animations, the final values are synced to the JS side AnimatedValue nodes. In this diff, on completion of a natively driven animation, AnimatedProps.update() is called, which in turn calls the value update callback on AnimatedProps, which [triggers a rerender (via setState)](https://www.internalfb.com/code/fbsource/[566daad5db45807260a8af1f85385ca86aebf894]/xplat/js/react-native-github/packages/react-native/Libraries/Animated/useAnimatedProps.js?lines=80) which has the effect of pushing the latest animated values to Fabric.

Alternative considered was using setNativeProps, but that approach was dropped as setNativeProps was only introduced to make migration easier and should not be used for new code, as per sammy-SC.

Changelog:
[General][Fixed] - When animating using native driver, trigger rerender on animation completion in order to update Pressability responder regions

Differential Revision: D46655246

