### PR TITLE
Fix undefined symbols `_FBcoreLocalexxHash48` and `_RCTLocalizedStringFromKey` in OSS

### DIFF
--- a/packages/react-native/React/I18n/RCTLocalizedString.h
+++ b/packages/react-native/React/I18n/RCTLocalizedString.h
@@ -14,6 +14,10 @@
 
 #import <React/FBXXHashUtils.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 uint64_t FBcoreLocalexxHash48(const char *input, uint64_t length, uint64_t seed);
 NSString *RCTLocalizedStringFromKey(uint64_t key, NSString *defaultValue);
 
@@ -22,5 +26,9 @@ NSString *RCTLocalizedStringFromKey(uint64_t key, NSString *defaultValue);
 
 #define RCTLocalizedString(string, description) \
   RCTLocalizedStringFromKey(RCTLocalizedStringKey(string, description), @"" string)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/packages/react-native/React/I18n/RCTLocalizedString.mm
+++ b/packages/react-native/React/I18n/RCTLocalizedString.mm
@@ -9,6 +9,8 @@
 
 #if !defined(WITH_FBI18N) || !(WITH_FBI18N)
 
+extern "C" {
+
 static NSString *FBTStringByConvertingIntegerToBase64(uint64_t number)
 {
   const NSUInteger base = 64;
@@ -39,4 +41,6 @@ NSString *RCTLocalizedStringFromKey(uint64_t key, NSString *defaultValue)
     return [bundle localizedStringForKey:FBTStringByConvertingIntegerToBase64(key) value:defaultValue table:nil];
   }
 }
+}
+
 #endif


### PR DESCRIPTION
Summary:
We see a linker failure in the OSS build because our header exports C-style functions (not ObjC), that Objective C will assume are C ABI, but we build them as C++ functions.

Internally these are all marked as `extern "C"`, so to not deviate I did the same here to expose these always as plain C functions.

Changelog: [Internal]

Differential Revision: D46671506

