### PR TITLE
Descriptive CocoaPods error if CMake is not installed

### DIFF
--- a/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
+++ b/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
@@ -90,7 +90,7 @@ Pod::Spec.new do |spec|
 
     spec.prepare_command = ". #{react_native_path}/sdks/hermes-engine/utils/create-dummy-hermes-xcframework.sh"
 
-    CMAKE_BINARY = %x(command -v cmake | tr -d '\n')
+    CMAKE_BINARY = Pod::Executable::which!('cmake')
     # NOTE: Script phases are sorted alphabetically inside Xcode project
     spec.script_phases = [
       {


### PR DESCRIPTION
Summary:
The CocoaPods build assumes that a `cmake` command is present during `pod install`. It acts gracefully if it is not, leading to a confusing error during the build, and requiring a `pod deintegrate` after reinstalling because of when the binary is set.

This replaces the usage with `Pod::Executable::which!`, the built-in CocoaPods method of finding an executable from `PATH` which errors out the build if not found. This will cause a failure during `pod install`, when we are looking for the command, and specify that `cmake` is the missing executable.

This branch is only taken for source builds, so this will not show up in the cases where we do not need CocoaPods.

Changelog:
[iOS][Fixed] - Descriptive Cocoapods Error if CMake is not installed

Differential Revision: D46670007

