### PR TITLE
Revert "fix: border width top/bottom not matching the border radius"

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewBackgroundDrawable.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewBackgroundDrawable.java
@@ -891,7 +891,7 @@ public class ReactViewBackgroundDrawable extends Drawable {
 
     /** Compute mInnerTopLeftCorner */
     mInnerTopLeftCorner.x = mInnerClipTempRectForBorderRadius.left;
-    mInnerTopLeftCorner.y = mInnerClipTempRectForBorderRadius.top * 2;
+    mInnerTopLeftCorner.y = mInnerClipTempRectForBorderRadius.top;
 
     getEllipseIntersectionWithLine(
         // Ellipse Bounds
@@ -917,10 +917,7 @@ public class ReactViewBackgroundDrawable extends Drawable {
     }
 
     mInnerBottomLeftCorner.x = mInnerClipTempRectForBorderRadius.left;
-    mInnerBottomLeftCorner.y =
-        borderWidth.bottom != 0
-            ? mInnerClipTempRectForBorderRadius.bottom * -2
-            : mInnerClipTempRectForBorderRadius.bottom;
+    mInnerBottomLeftCorner.y = mInnerClipTempRectForBorderRadius.bottom;
 
     getEllipseIntersectionWithLine(
         // Ellipse Bounds
@@ -946,7 +943,7 @@ public class ReactViewBackgroundDrawable extends Drawable {
     }
 
     mInnerTopRightCorner.x = mInnerClipTempRectForBorderRadius.right;
-    mInnerTopRightCorner.y = mInnerClipTempRectForBorderRadius.top * 2;
+    mInnerTopRightCorner.y = mInnerClipTempRectForBorderRadius.top;
 
     getEllipseIntersectionWithLine(
         // Ellipse Bounds
@@ -972,10 +969,7 @@ public class ReactViewBackgroundDrawable extends Drawable {
     }
 
     mInnerBottomRightCorner.x = mInnerClipTempRectForBorderRadius.right;
-    mInnerBottomRightCorner.y =
-        borderWidth.bottom != 0
-            ? mInnerClipTempRectForBorderRadius.bottom * -2
-            : mInnerClipTempRectForBorderRadius.bottom;
+    mInnerBottomRightCorner.y = mInnerClipTempRectForBorderRadius.bottom;
 
     getEllipseIntersectionWithLine(
         // Ellipse Bounds


### PR DESCRIPTION
## Summary:

In an effort to fix https://github.com/facebook/react-native/issues/37753, this PR reverts the changes introduced by https://github.com/facebook/react-native/commit/cd6a91343ee24af83c7437b3f2449b41e97760e9 and https://github.com/facebook/react-native/commit/1d5103227851ab92de889d5e7e910393b5d8743a so border-radius width calculations work as expected 

## Changelog:
 

[ANDROID] [FIXED] - Fix border-radius width calculations 

## Test Plan:

Test border colors along with border-radius through RNTester 
<img width="538" alt="image" src="https://github.com/facebook/react-native/assets/11707729/4b148d4b-35dc-4737-be00-c5ff156b0865">
