### PR TITLE
feat: added getInspectorDataForInstance

### DIFF
--- a/packages/react-native/Libraries/Inspector/findRenderers.js
+++ b/packages/react-native/Libraries/Inspector/findRenderers.js
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+import type {
+  HostComponent,
+  InspectorData,
+} from '../Renderer/shims/ReactNativeTypes';
+
+import invariant from 'invariant';
+import * as React from 'react';
+
+const hook = window.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+
+export type HostRef = React.ElementRef<HostComponent<mixed>>;
+export type ReactRenderer = {
+  // Types for HostInstance and Fiber are private and defined in React
+  findFiberByHostInstance: (hostInstance: mixed) => ?mixed,
+  rendererConfig: {
+    getInspectorDataForInstance: (fiber: ?mixed) => InspectorData,
+    getInspectorDataForViewAtPoint: (
+      inspectedView: ?HostRef,
+      locationX: number,
+      locationY: number,
+      callback: Function,
+    ) => void,
+    ...
+  },
+};
+
+function findRenderers(): $ReadOnlyArray<ReactRenderer> {
+  const allRenderers = Array.from(hook.renderers.values());
+
+  invariant(
+    allRenderers.length >= 1,
+    'Expected to find at least one React Native renderer on DevTools hook.',
+  );
+
+  return allRenderers;
+}
+
+module.exports = findRenderers;

--- a/packages/react-native/Libraries/Inspector/getInspectorDataForInstance.js
+++ b/packages/react-native/Libraries/Inspector/getInspectorDataForInstance.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+import type {InspectorData} from '../Renderer/shims/ReactNativeTypes';
+
+const findRenderers = require('./findRenderers');
+
+const renderers = findRenderers();
+
+module.exports = function getInspectorDataForInstance(
+  hostInstance: Object,
+): InspectorData {
+  for (const renderer of renderers) {
+    if (renderer?.rendererConfig?.getInspectorDataForInstance != null) {
+      const fiber = renderer.findFiberByHostInstance(hostInstance);
+
+      const inspectorData =
+        renderer.rendererConfig.getInspectorDataForInstance(fiber);
+      const inspectoDataHierarchy = inspectorData?.hierarchy;
+
+      if (inspectoDataHierarchy != null && inspectoDataHierarchy.length > 0) {
+        return inspectorData;
+      }
+    }
+  }
+
+  return {
+    hierarchy: [],
+    props: {},
+    selectedIndex: null,
+    source: null,
+  };
+};

--- a/packages/react-native/Libraries/Inspector/getInspectorDataForViewAtPoint.js
+++ b/packages/react-native/Libraries/Inspector/getInspectorDataForViewAtPoint.js
@@ -8,39 +8,14 @@
  * @flow
  */
 
-import type {
-  HostComponent,
-  TouchedViewDataAtPoint,
-} from '../Renderer/shims/ReactNativeTypes';
+import type {TouchedViewDataAtPoint} from '../Renderer/shims/ReactNativeTypes';
+import type {HostRef} from './findRenderers';
 
-const invariant = require('invariant');
-const React = require('react');
+const findRenderers = require('./findRenderers');
 
-export type HostRef = React.ElementRef<HostComponent<mixed>>;
-export type ReactRenderer = {
-  rendererConfig: {
-    getInspectorDataForViewAtPoint: (
-      inspectedView: ?HostRef,
-      locationX: number,
-      locationY: number,
-      callback: Function,
-    ) => void,
-    ...
-  },
-};
-
-const hook = window.__REACT_DEVTOOLS_GLOBAL_HOOK__;
 const renderers = findRenderers();
 
-function findRenderers(): $ReadOnlyArray<ReactRenderer> {
-  const allRenderers = Array.from(hook.renderers.values());
-  invariant(
-    allRenderers.length >= 1,
-    'Expected to find at least one React Native renderer on DevTools hook.',
-  );
-  return allRenderers;
-}
-
+export type {HostRef};
 module.exports = function getInspectorDataForViewAtPoint(
   inspectedView: ?HostRef,
   locationX: number,


### PR DESCRIPTION
Summary:
Changelog:
[Internal] [Added] - added `getInspectorDataForInstance` method

This will be used to get inspector data (specifically props, to get style) by having host instance, which is sent from React DevTools when hovering over some element

Differential Revision: D46677221

