### PR TITLE
Type mock.contexts correctly in Jest

### DIFF
--- a/packages/react-native/flow/jest.js
+++ b/packages/react-native/flow/jest.js
@@ -39,6 +39,10 @@ type JestMockFn<TArguments: $ReadOnlyArray<any>, TReturn> = {
      */
     instances: Array<TReturn>,
     /**
+     * An array that contains the contexts for all calls of the mock function.
+     */
+    contexts: Array<mixed>,
+    /**
      * An array that contains all the object results that have been
      * returned by this mock function call
      */


### PR DESCRIPTION
Summary:
Jest supports accessing the contexts used to call mock functions (the `this` value) but we're not typing that correctly in the definitions in React Native. This changes that.

Changelog: [internal]

Differential Revision: D46684043

