### PR TITLE
rn-ci-e2e-test CircleCI using wrong parameters

### DIFF
--- a/scripts/run-ci-e2e-tests.js
+++ b/scripts/run-ci-e2e-tests.js
@@ -64,7 +64,11 @@ try {
   }
 
   describe('Create react-native package');
-  if (exec('node ./scripts/set-rn-version.js --to-version 1000.0.0').code) {
+  if (
+    exec(
+      'node ./scripts/set-rn-version.js --to-version 1000.0.0 --build-type dry-run',
+    ).code
+  ) {
     echo('Failed to set version and update package.json ready for release');
     exitCode = 1;
     throw Error(exitCode);

--- a/scripts/set-rn-version.js
+++ b/scripts/set-rn-version.js
@@ -49,6 +49,7 @@ if (require.main === module) {
     .option('b', {
       alias: 'build-type',
       type: 'string',
+      choices: ['dry-run', 'nightly', 'release'],
       required: true,
     }).argv;
 


### PR DESCRIPTION
Summary:
Changelog: [Internal] - rn-ci-e2e-test is running on CircleCI but has been passing in the wrong parameter with `--version` -- which didn't evaluate the script, it would early exit as `--version` is a reserved parameter in yargs.

You can see if you do `node scripts/set-rn-version.js --help`

When I fixed this [here](https://www.internalfb.com/diff/D46511840?dst_version_fbid=827076485041949&transaction_fbid=625055476222975), forgot to pass `build-type` parameter

This will fix the broken testjs e2e builds here: https://app.circleci.com/pipelines/github/facebook/react-native/25703/workflows/11a41ba1-c731-44e4-b515-a8b209ae0848/jobs/732035

Differential Revision: D46672741

