### PR TITLE
Support Android Transitions during Fragment navigation

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.java
@@ -152,6 +152,7 @@ public class ReactImageView extends GenericDraweeView {
     mDraweeControllerBuilder = draweeControllerBuilder;
     mGlobalImageLoadListener = globalImageLoadListener;
     mCallerContext = callerContext;
+    setLegacyVisibilityHandlingEnabled(true);
   }
 
   public void setShouldNotifyLoadEvents(boolean shouldNotify) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.java
@@ -152,6 +152,8 @@ public class ReactImageView extends GenericDraweeView {
     mDraweeControllerBuilder = draweeControllerBuilder;
     mGlobalImageLoadListener = globalImageLoadListener;
     mCallerContext = callerContext;
+    // Workaround Android bug where ImageView visibility is not propagated to the Drawable, so you
+    // have to manually update visibility. Will be resolved once we move to VitoView.
     setLegacyVisibilityHandlingEnabled(true);
   }
 


### PR DESCRIPTION
## Summary:

Adds support for Android Transitions during Fragment navigation.

React Native navigation libraries (like [the Navigation router](https://github.com/grahammendick/navigation/blob/e9deae985a1962db17d6b1fbf90628d20c29810c/NavigationReactNative/src/android/src/main/java/com/navigation/reactnative/NavigationStackView.java#L139) and [React Native Screens](https://github.com/software-mansion/react-native-screens/blob/ea240b46866d66398904d0c2d0fe5fabdc2f269b/android/src/main/java/com/swmansion/rnscreens/ScreenContainer.kt#L98)) use Fragments to manage the stack of screens. But they can’t use Transitions to animate these Fragments because React Native images disappear during the Transition (see the videos in the Test Plan section below).

Navigation libraries are forced to [setCustomAnimations](https://developer.android.com/reference/androidx/fragment/app/FragmentTransaction.html#setCustomAnimations(int,int)) instead of [enter and exit Transitions](https://developer.android.com/reference/android/app/Fragment#setEnterTransition(android.transition.Transition)). But animations have limitations compared to Transitions

- Animations have to be resx files so can’t be defined declaratively in React
- Android’s Material Transforms are built around Transitions
- Native shared elements only support Transitions

Images disappearing during Transitions is [a known Fresco bug](https://github.com/facebook/fresco/issues/2512). This PR applies [the fix suggested by the Fresco repo](https://github.com/facebook/fresco/issues/1445#issuecomment-315763953). 

## Changelog:

[ANDROID] [FIXED] - Support Android Transitions during Fragment navigation

## Test Plan:

I’ve created a [minimal reproduction that demonstrates the bug](https://github.com/grahammendick/image-disappears-during-transition-bug). The first video below shows the example from that repo. You can see that the image disappears when changing the painting. It should fade out and in like the text does.

The second video shows the same example after the fix is applied. You can see that the painting fades out and in just like the text.

https://github.com/facebook/react-native/assets/1761227/6739f029-eda0-44d2-b328-a73b075bd82a


https://github.com/facebook/react-native/assets/1761227/9c73cdf0-303b-4a82-8df5-5f6a5846a58e



