### PR TITLE
add unit test for start method on RCTHost

### DIFF
--- a/packages/react-native/ReactCommon/react/bridgeless/iostests/RCTHostTests.mm
+++ b/packages/react-native/ReactCommon/react/bridgeless/iostests/RCTHostTests.mm
@@ -7,13 +7,72 @@
 
 #import <XCTest/XCTest.h>
 
+#import <RCTTestUtils/RCTSwizzleHelpers.h>
+#import <ReactCommon/RCTHermesInstance.h>
+#import <ReactCommon/RCTHost.h>
+#import <ReactCommon/RCTInstance.h>
+#import <ReactCommon/RCTTurboModuleManager.h>
+
+#import <OCMock/OCMock.h>
+
+@interface ShimRCTInstance : NSObject
+@end
+
 @interface RCTHostTests : XCTestCase
 @end
 
-@implementation RCTHostTests
+@implementation RCTHostTests {
+  RCTHost *_subject;
+  id<RCTHostDelegate> _mockHostDelegate;
+}
 
-- (void)testHost
+static ShimRCTInstance *shimmedRCTInstance;
+
+- (void)setUp
 {
+  [super setUp];
+
+  shimmedRCTInstance = [ShimRCTInstance new];
+
+  _mockHostDelegate = OCMProtocolMock(@protocol(RCTHostDelegate));
+  _subject = [[RCTHost alloc] initWithBundleURL:OCMClassMock([NSURL class])
+                                   hostDelegate:_mockHostDelegate
+                     turboModuleManagerDelegate:OCMProtocolMock(@protocol(RCTTurboModuleManagerDelegate))
+                               jsEngineProvider:^std::shared_ptr<facebook::react::JSEngineInstance>() {
+                                 return std::make_shared<facebook::react::RCTHermesInstance>();
+                               }];
+}
+
+- (void)testStart
+{
+  [_subject start];
+  OCMVerify(OCMTimes(1), [_mockHostDelegate hostDidStart:_subject]);
+}
+
+@end
+
+@implementation ShimRCTInstance
+
+- (instancetype)init
+{
+  if (self = [super init]) {
+    RCTSwizzleInstanceSelector(
+        [RCTInstance class],
+        [ShimRCTInstance class],
+        @selector(initWithDelegate:
+                  jsEngineInstance:bundleManager:turboModuleManagerDelegate:onInitialBundleLoad:moduleRegistry:));
+  }
+  return self;
+}
+
+- (instancetype)initWithDelegate:(id<RCTInstanceDelegate>)delegate
+                jsEngineInstance:(std::shared_ptr<facebook::react::JSEngineInstance>)jsEngineInstance
+                   bundleManager:(RCTBundleManager *)bundleManager
+      turboModuleManagerDelegate:(id<RCTTurboModuleManagerDelegate>)tmmDelegate
+             onInitialBundleLoad:(RCTInstanceInitialBundleLoadCompletionBlock)onInitialBundleLoad
+                  moduleRegistry:(RCTModuleRegistry *)moduleRegistry
+{
+  return self;
 }
 
 @end


### PR DESCRIPTION
Summary:
Changelog: [Internal]

in this diff, i add a test that runs `start` validates that the lifecycle `hostDidStart:` is called as a result.

notably, i created a custom shim for `RCTInstance` to completely stub out its behavior.

Reviewed By: cipolleschi

Differential Revision: D46508066

