### PR TITLE
test-e2e-local dont launch emulator if device connected

### DIFF
--- a/scripts/test-e2e-local.js
+++ b/scripts/test-e2e-local.js
@@ -22,7 +22,7 @@ const yargs = require('yargs');
 const fs = require('fs');
 
 const {
-  launchAndroidEmulator,
+  maybeLaunchAndroidEmulator,
   isPackagerRunning,
   launchPackagerInSeparateWindow,
 } = require('./testing-utils');
@@ -107,7 +107,7 @@ if (argv.target === 'RNTester') {
   } else {
     // we do the android path here
 
-    launchAndroidEmulator();
+    maybeLaunchAndroidEmulator();
 
     console.info(
       `We're going to test the ${

--- a/scripts/testing-utils.js
+++ b/scripts/testing-utils.js
@@ -60,7 +60,20 @@ function tryLaunchEmulator() {
   };
 }
 
-function launchAndroidEmulator() {
+function hasConnectedDevice() {
+  const physicalDevices = exec('adb devices | grep -v emulator', {silent: true})
+    .stdout.trim()
+    .split('\n')
+    .slice(1);
+  return physicalDevices.length > 0;
+}
+
+function maybeLaunchAndroidEmulator() {
+  if (hasConnectedDevice) {
+    console.info('Already have a device connected. Skip launching emulator.');
+    return;
+  }
+
   const result = tryLaunchEmulator();
   if (result.success) {
     console.info('Successfully launched emulator.');
@@ -103,7 +116,7 @@ function launchPackagerInSeparateWindow(folderPath) {
 }
 
 module.exports = {
-  launchAndroidEmulator,
+  maybeLaunchAndroidEmulator,
   isPackagerRunning,
   launchPackagerInSeparateWindow,
 };


### PR DESCRIPTION
Summary: Changelog: [Internal] - Don't launch android emulator if you already have a device connected.

Reviewed By: cortinico

Differential Revision: D46688735

