### PR TITLE
Undeprecated GuardedAsyncTask constructor

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/GuardedAsyncTask.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/GuardedAsyncTask.java
@@ -20,7 +20,6 @@ public abstract class GuardedAsyncTask<Params, Progress> extends AsyncTask<Param
 
   private final JSExceptionHandler mExceptionHandler;
 
-  @Deprecated
   protected GuardedAsyncTask(ReactContext reactContext) {
     this(reactContext.getExceptionHandler());
   }


### PR DESCRIPTION
Summary:
This was deprecated as part of bridgeless development, but since we now have `BridgelessReactContext`, which is also a `ReactContext`, this deprecation is no longer necessary.

Changelog: [Internal]

Differential Revision: D46685374

