### PR TITLE
[LOCAL] Set kotlin.jvm.target.validation.mode=warning on user projects

### DIFF
--- a/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/JdkConfiguratorUtils.kt
+++ b/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/JdkConfiguratorUtils.kt
@@ -36,5 +36,11 @@ internal object JdkConfiguratorUtils {
       project.pluginManager.withPlugin("com.android.application", action)
       project.pluginManager.withPlugin("com.android.library", action)
     }
+    // We set kotlin.jvm.target.validation.mode=warning on the root projects, as for projects
+    // on Gradle 8+ and Kotlin 1.8+ this value is set to `error`. This will cause the build to
+    // fail if the JDK version between compileKotlin and compileJava and jvmTarget are not
+    // aligned. This won't be necessary anymore from React Native 0.73. More on this:
+    // https://kotlinlang.org/docs/whatsnew18.html#obligatory-check-for-jvm-targets-of-related-kotlin-and-java-compile-tasks
+    input.rootProject.extensions.extraProperties.set("kotlin.jvm.target.validation.mode", "warning")
   }
 }


### PR DESCRIPTION
## Summary:

This is a fix for https://github.com/reactwg/react-native-releases/discussions/54#discussioncomment-5984629
It sets `kotlin.jvm.target.validation.mode=warning` so that projects won't break if they're using Kotlin 1.8+ and have JDK versions misaligned due to external libraries.

This doens't need to be backported to `main` as on main we set `jvmToolchain(11)` for all the libraries so this flag is unnecessary.

Also this is not a `.0` blocker and can land in `.1`

Also this requires a bump of RNGP

## Changelog:

[INTERNAL] - Set kotlin.jvm.target.validation.mode=warning on user projects

## Test Plan:

Tested locally with `./gradlew build`.