### PR TITLE
Add static platform check props

### DIFF
--- a/packages/react-native/Libraries/Utilities/Platform.android.js
+++ b/packages/react-native/Libraries/Utilities/Platform.android.js
@@ -20,6 +20,12 @@ export type PlatformSelectSpec<T> = {
 const Platform = {
   __constants: null,
   OS: 'android',
+  isAndroid: true,
+  isIOS: false,
+  isMacOS: false,
+  isNative: true,
+  isWeb: false,
+  isWindows: false,
   // $FlowFixMe[unsafe-getters-setters]
   get Version(): number {
     // $FlowFixMe[object-this-reference]

--- a/packages/react-native/Libraries/Utilities/Platform.d.ts
+++ b/packages/react-native/Libraries/Utilities/Platform.d.ts
@@ -27,6 +27,12 @@ type PlatformConstants = {
   };
 };
 interface PlatformStatic {
+  isAndroid: boolean;
+  isIOS: boolean;
+  isMacOS: boolean;
+  isNative: boolean;
+  isWeb: boolean;
+  isWindows: boolean;
   isTV: boolean;
   isTesting: boolean;
   Version: number | string;

--- a/packages/react-native/Libraries/Utilities/Platform.ios.js
+++ b/packages/react-native/Libraries/Utilities/Platform.ios.js
@@ -20,6 +20,12 @@ export type PlatformSelectSpec<T> = {
 const Platform = {
   __constants: null,
   OS: 'ios',
+  isAndroid: false,
+  isIOS: true,
+  isMacOS: false,
+  isNative: true,
+  isWeb: false,
+  isWindows: false,
   // $FlowFixMe[unsafe-getters-setters]
   get Version(): string {
     // $FlowFixMe[object-this-reference]


### PR DESCRIPTION
## Summary:

I've noticed that a lot of RN projects have something along the lines of the following in them:

```ts
export const isAndroid = Platform.OS === 'android'
export const isIOS = Platform.OS === 'ios'
```

This seems common enough that I think it makes sense to just export these from RN itself. Platform already has `isPad` and `isTV`. This would add another way to express platform checks with that API.

## Changelog:

[GENERAL] [ADDED] - Adds isAndroid, isIOS, isMacOS, isNative, isWeb, and isWindows static properties to Platform

## Test Plan:

I just patched these into a demo app. Here's a screenshot:

<img width="1070" alt="Screenshot 2023-06-13 at 7 39 06 PM" src="https://github.com/facebook/react-native/assets/1944151/b1ca64e8-36a9-4bc3-954d-dfdfaaaf6da2">
