### PR TITLE
[Codegen 129]: add emitObjectProp in parser primitives

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-primitives-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-primitives-test.js
@@ -42,12 +42,14 @@ const {
   typeEnumResolution,
   Visitor,
   emitStringProp,
+  emitObjectProp,
 } = require('../parsers-primitives.js');
 const {MockedParser} = require('../parserMock');
 const {emitUnion} = require('../parsers-primitives');
 const {UnsupportedUnionTypeAnnotationParserError} = require('../errors');
 const {FlowParser} = require('../flow/parser');
 const {TypeScriptParser} = require('../typescript/parser');
+const {extractArrayElementType} = require('../flow/components/events');
 
 const parser = new MockedParser();
 const flowParser = new FlowParser();
@@ -1664,6 +1666,109 @@ describe('emitBoolProp', () => {
         optional: false,
         typeAnnotation: {
           type: 'BooleanTypeAnnotation',
+        },
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+});
+
+describe('emitObjectProp', () => {
+  const name = 'someProp';
+  describe('when property is optional', () => {
+    it('returns optional Object Prop', () => {
+      const typeAnnotation = {
+        type: 'GenericTypeAnnotation',
+        id: {
+          name: 'ObjectTypeAnnotation',
+        },
+        properties: [
+          {
+            key: {
+              name: 'someKey',
+            },
+            optional: true,
+            value: {
+              type: 'StringTypeAnnotation',
+              typeAnnotation: {
+                type: 'StringTypeAnnotation',
+              },
+            },
+          },
+        ],
+      };
+      const result = emitObjectProp(
+        name,
+        true,
+        flowParser,
+        typeAnnotation,
+        extractArrayElementType,
+      );
+      const expected = {
+        name: 'someProp',
+        optional: true,
+        typeAnnotation: {
+          properties: [
+            {
+              name: 'someKey',
+              optional: true,
+              typeAnnotation: {
+                type: 'StringTypeAnnotation',
+              },
+            },
+          ],
+          type: 'ObjectTypeAnnotation',
+        },
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when property is required', () => {
+    it('returns required Object Prop', () => {
+      const typeAnnotation = {
+        type: 'GenericTypeAnnotation',
+        id: {
+          name: 'ObjectTypeAnnotation',
+        },
+        properties: [
+          {
+            key: {
+              name: 'someKey',
+            },
+            optional: false,
+            value: {
+              type: 'StringTypeAnnotation',
+              typeAnnotation: {
+                type: 'StringTypeAnnotation',
+              },
+            },
+          },
+        ],
+      };
+      const result = emitObjectProp(
+        name,
+        false,
+        flowParser,
+        typeAnnotation,
+        extractArrayElementType,
+      );
+      const expected = {
+        name: 'someProp',
+        optional: false,
+        typeAnnotation: {
+          properties: [
+            {
+              name: 'someKey',
+              optional: false,
+              typeAnnotation: {
+                type: 'StringTypeAnnotation',
+              },
+            },
+          ],
+          type: 'ObjectTypeAnnotation',
         },
       };
 

--- a/packages/react-native-codegen/src/parsers/flow/components/events.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/events.js
@@ -33,6 +33,7 @@ const {
   emitMixedProp,
   emitStringProp,
   emitInt32Prop,
+  emitObjectProp,
 } = require('../../parsers-primitives');
 
 function getPropertyType(
@@ -64,18 +65,13 @@ function getPropertyType(
         parser,
       );
     case 'ObjectTypeAnnotation':
-      return {
+      return emitObjectProp(
         name,
         optional,
-        typeAnnotation: {
-          type: 'ObjectTypeAnnotation',
-          properties: parser
-            .getObjectProperties(typeAnnotation)
-            .map(member =>
-              buildPropertiesForEvent(member, parser, getPropertyType),
-            ),
-        },
-      };
+        parser,
+        typeAnnotation,
+        extractArrayElementType,
+      );
     case 'UnionTypeAnnotation':
       return {
         name,
@@ -315,4 +311,5 @@ function getEvents(
 
 module.exports = {
   getEvents,
+  extractArrayElementType,
 };

--- a/packages/react-native-codegen/src/parsers/parsers-primitives.js
+++ b/packages/react-native-codegen/src/parsers/parsers-primitives.js
@@ -657,6 +657,24 @@ function emitMixedProp(
   };
 }
 
+function emitObjectProp(
+  name: string,
+  optional: boolean,
+  parser: Parser,
+  typeAnnotation: $FlowFixMe,
+  extractArrayElementType: (
+    typeAnnotation: $FlowFixMe,
+    name: string,
+    parser: Parser,
+  ) => EventTypeAnnotation,
+): NamedShape<EventTypeAnnotation> {
+  return {
+    name,
+    optional,
+    typeAnnotation: extractArrayElementType(typeAnnotation, name, parser),
+  };
+}
+
 module.exports = {
   emitArrayType,
   emitBoolean,
@@ -687,4 +705,5 @@ module.exports = {
   typeEnumResolution,
   translateArrayTypeAnnotation,
   Visitor,
+  emitObjectProp,
 };

--- a/packages/react-native-codegen/src/parsers/typescript/components/events.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/events.js
@@ -35,6 +35,7 @@ const {
   emitMixedProp,
   emitStringProp,
   emitInt32Prop,
+  emitObjectProp,
 } = require('../../parsers-primitives');
 function getPropertyType(
   /* $FlowFixMe[missing-local-annot] The type annotation(s) required by Flow's
@@ -49,10 +50,7 @@ function getPropertyType(
   const topLevelType = parseTopLevelType(annotation);
   const typeAnnotation = topLevelType.type;
   const optional = optionalProperty || topLevelType.optional;
-  const type =
-    typeAnnotation.type === 'TSTypeReference'
-      ? typeAnnotation.typeName.name
-      : typeAnnotation.type;
+  const type = parser.extractTypeFromTypeAnnotation(typeAnnotation);
 
   switch (type) {
     case 'TSBooleanKeyword':
@@ -66,18 +64,13 @@ function getPropertyType(
     case 'Float':
       return emitFloatProp(name, optional);
     case 'TSTypeLiteral':
-      return {
+      return emitObjectProp(
         name,
         optional,
-        typeAnnotation: {
-          type: 'ObjectTypeAnnotation',
-          properties: parser
-            .getObjectProperties(typeAnnotation)
-            .map(member =>
-              buildPropertiesForEvent(member, parser, getPropertyType),
-            ),
-        },
-      };
+        parser,
+        typeAnnotation,
+        extractArrayElementType,
+      );
     case 'TSUnionType':
       return {
         name,
@@ -96,7 +89,6 @@ function getPropertyType(
         typeAnnotation: extractArrayElementType(typeAnnotation, name, parser),
       };
     default:
-      (type: empty);
       throw new Error(`Unable to determine event type for "${name}": ${type}`);
   }
 }
@@ -318,4 +310,5 @@ function getEvents(
 
 module.exports = {
   getEvents,
+  extractArrayElementType,
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Part of #34872 
> Create a function emitObjectProp(name: string, optional: boolean) in parser-primitives.js. Factor out the code from [Flow](https://github.com/facebook/react-native/blob/d8ced6f8953cd896471983714e722caf50783960/packages/react-native-codegen/src/parsers/flow/components/events.js#L84-L93) and [TypeScript](https://github.com/facebook/react-native/blob/d8ced6f8953cd896471983714e722caf50783960/packages/react-native-codegen/src/parsers/typescript/components/events.js#L87-L96) into that function. Use that function in the original call site.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[Internal][Changed]: Add emitObjectProp in parser primitives

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

```shell
yarn test react-native-codegen
``` 
