### PR TITLE
feat: allow custom assignment of rootView to rootViewController

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.h
@@ -36,6 +36,8 @@
  *   - (UIView *)createRootViewWithBridge:(RCTBridge *)bridge moduleName:(NSString*)moduleName initProps:(NSDictionary
  *)initProps;
  *   - (UIViewController *)createRootViewController;
+ *   - (UIViewController *)attachRootView:(UIViewController *) rootViewController
+ rootView:(UIView *)rootView;
  * New Architecture:
  *   - (BOOL)concurrentRootEnabled
  *   - (BOOL)turboModuleEnabled;
@@ -93,6 +95,16 @@
  * @return: an instance of `UIViewController`.
  */
 - (UIViewController *)createRootViewController;
+
+/**
+ * It assigns the rootView to the rootViewController
+ * By default, it assigns the rootView to the view property of the rootViewController
+ *
+ * @return: an instance of `UIViewController`
+ */
+- (UIViewController *)attachRootView:(UIViewController *) rootViewController
+                            rootView:(UIView *)rootView;
+
 
 /// This method controls whether the App will use RuntimeScheduler. Only applicable in the legacy architecture.
 ///

--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.h
@@ -36,8 +36,7 @@
  *   - (UIView *)createRootViewWithBridge:(RCTBridge *)bridge moduleName:(NSString*)moduleName initProps:(NSDictionary
  *)initProps;
  *   - (UIViewController *)createRootViewController;
- *   - (UIViewController *)attachRootView:(UIViewController *) rootViewController
- rootView:(UIView *)rootView;
+ *   - (void)setRootView:(UIView *)rootView toRootViewController:(UIViewController *)rootViewController;
  * New Architecture:
  *   - (BOOL)concurrentRootEnabled
  *   - (BOOL)turboModuleEnabled;
@@ -99,12 +98,12 @@
 /**
  * It assigns the rootView to the rootViewController
  * By default, it assigns the rootView to the view property of the rootViewController
+ * If you are not using a simple UIViewController, then there could be other methods to use to setup the rootView.
+ * For example: UISplitViewController requires `setViewController(_:for:)`
  *
- * @return: an instance of `UIViewController`
+ * @return: void
  */
-- (UIViewController *)attachRootView:(UIViewController *) rootViewController
-                            rootView:(UIView *)rootView;
-
+- (void)setRootView:(UIView *)rootView toRootViewController:(UIViewController *)rootViewController;
 
 /// This method controls whether the App will use RuntimeScheduler. Only applicable in the legacy architecture.
 ///

--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -77,7 +77,7 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
 
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
   UIViewController *rootViewController = [self createRootViewController];
-  rootViewController.view = rootView;
+  [self attachRootView:rootViewController rootView:rootView];
   self.window.rootViewController = rootViewController;
   [self.window makeKeyAndVisible];
 
@@ -127,6 +127,12 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
 - (UIViewController *)createRootViewController
 {
   return [UIViewController new];
+}
+
+- (UIViewController *)attachRootView:(UIViewController *) rootViewController
+                            rootView:(UIView *)rootView {
+    rootViewController.view = rootView;
+    return rootViewController;
 }
 
 - (BOOL)runtimeSchedulerEnabled

--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -77,7 +77,7 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
 
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
   UIViewController *rootViewController = [self createRootViewController];
-  [self attachRootView:rootViewController rootView:rootView];
+  [self setRootView:rootView toRootViewController:rootViewController];
   self.window.rootViewController = rootViewController;
   [self.window makeKeyAndVisible];
 
@@ -129,11 +129,10 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
   return [UIViewController new];
 }
 
-- (UIViewController *)attachRootView:(UIViewController *) rootViewController
-                            rootView:(UIView *)rootView {
+- (void)setRootView:(UIView *)rootView toRootViewController:(UIViewController *)rootViewController {
     rootViewController.view = rootView;
-    return rootViewController;
 }
+
 
 - (BOOL)runtimeSchedulerEnabled
 {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:
To use a native Drawer on iPad, I can override `createRootViewController` to create a `UISplitViewController` instead of a `UIViewController`, but I then need to assign the rootView with
```objective-c 
[splitViewController setViewController:mainVC forColumn:UISplitViewControllerColumnSecondary];
```
which I can currently only do by copy pasting the entire `didFinishLaunchingWithOptions` and only replacing the assignment 
```objective-c
    rootViewController.view = rootView;
```

In an attempt of making it easier for developers to use a native drawer in iOS, being able to override the assignment would make it easier.

## Changelog:
[iOS] [ADDED] - added override method with default implementation

## Test Plan
Tested on iPad iOS 16 simulator