### PR TITLE
Re-enable direct debugging with JSC on iOS 16.4+

### DIFF
--- a/packages/react-native/ReactCommon/jsc/JSCRuntime.cpp
+++ b/packages/react-native/ReactCommon/jsc/JSCRuntime.cpp
@@ -399,9 +399,9 @@ JSCRuntime::JSCRuntime(JSGlobalContextRef ctx)
 #endif
 {
 #ifndef NDEBUG
-    if (__builtin_available(macOS 13.3, iOS 16.4, tvOS 16.4, *)) {
-        JSGlobalContextSetInspectable(ctx_, true);
-    }
+  if (__builtin_available(macOS 13.3, iOS 16.4, tvOS 16.4, *)) {
+    JSGlobalContextSetInspectable(ctx_, true);
+  }
 #endif
 }
 

--- a/packages/react-native/ReactCommon/jsc/JSCRuntime.cpp
+++ b/packages/react-native/ReactCommon/jsc/JSCRuntime.cpp
@@ -398,6 +398,11 @@ JSCRuntime::JSCRuntime(JSGlobalContextRef ctx)
       stringCounter_(0)
 #endif
 {
+#ifndef NDEBUG
+    if (__builtin_available(macOS 13.3, iOS 16.4, tvOS 16.4, *)) {
+        JSGlobalContextSetInspectable(ctx_, true);
+    }
+#endif
 }
 
 JSCRuntime::~JSCRuntime() {


### PR DESCRIPTION
## Summary:

See: https://webkit.org/blog/13936/enabling-the-inspection-of-web-content-in-apps

As of iOS 16.4 and above, JSContexts are no longer inspectable by default. Without this, we cannot attach Safari Web Inspector to the JSContext, AKA, we can no longer direct debug. This is a simple change to re-enable that. I decided to extend the `@availability` check to macOS and tvOS as I'm certain both out of tree platform forks will want this fix as well.

## Changelog:

[IOS] [FIXED] - Re-enable direct debugging with JSC on iOS 16.4+

## Test Plan:

I launched RNTester in an iOS 15, and iOS 16.4 simulator. I then verified that we can attach Safari Web inspector to both simulators' JSContexts.