### PR TITLE
[RCTUITextView] Remove some magic constants

### DIFF
--- a/packages/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.m
+++ b/packages/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.m
@@ -22,8 +22,7 @@
 
 static UIFont *defaultPlaceholderFont(void)
 {
-  UIFont *font = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
-    return font;
+  return [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
 }
 
 static UIColor *defaultPlaceholderColor(void)

--- a/packages/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.m
+++ b/packages/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.m
@@ -22,13 +22,14 @@
 
 static UIFont *defaultPlaceholderFont(void)
 {
-  return [UIFont systemFontOfSize:17];
+  UIFont *font = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
+    return font;
 }
 
 static UIColor *defaultPlaceholderColor(void)
 {
   // Default placeholder color from UITextField.
-  return [UIColor colorWithRed:0 green:0 blue:0.0980392 alpha:0.22];
+  return [UIColor placeholderTextColor];
 }
 
 - (instancetype)initWithFrame:(CGRect)frame


### PR DESCRIPTION
## Summary:

RCTUITextView has two instances where it references some magic constants for font size and color. We inherited these in React Native macOS, and now I want to remove that diff & implement these properly :D.

Looking at commit history, these constants were found by UI inspecting a UITextView several years ago. We don't need to do this.. Apple provides API's for accessing these constants through the system. This gives us slightly better support for things like Large Text support (where 17 needs to be scaled) and Dark Mode (where the old placeholderFontColor is just wrong). Granted, these constants are overwritten almost immediately, I still thought it worth using the proper OS APIs.

The other nice thing about this API is they have very nice macOS equivalents, making the diffs nicer :).

## Changelog:



Pick one each for the category and type tags:

[IOS] [FIXED] - Remove some magic constants from RCTUITextView

## Test Plan:

Verified that the default UIFont is still 17 after this change. 
