### PR TITLE
[iOS] Inline the source map if we're using JSC

### DIFF
--- a/packages/react-native/React/Base/RCTBundleURLProvider.h
+++ b/packages/react-native/React/Base/RCTBundleURLProvider.h
@@ -101,6 +101,7 @@ RCT_EXTERN void RCTBundleURLProviderAllowPackagerServerAccess(BOOL allowed);
 
 @property (nonatomic, assign) BOOL enableMinification;
 @property (nonatomic, assign) BOOL enableDev;
+@property (nonatomic, assign) BOOL inlineSourceMap;
 
 /**
  * The scheme/protocol used of the packager, the default is the http protocol
@@ -133,7 +134,8 @@ RCT_EXTERN void RCTBundleURLProviderAllowPackagerServerAccess(BOOL allowed);
                           enableDev:(BOOL)enableDev
                  enableMinification:(BOOL)enableMinification
                         modulesOnly:(BOOL)modulesOnly
-                          runModule:(BOOL)runModule;
+                          runModule:(BOOL)runModule
+                   inlineSourceMap:(BOOL)inlineSourceMap;
 /**
  * Given a hostname for the packager and a resource path (including "/"), return the URL to the resource.
  * In general, please use the instance method to decide if the packager is running and fallback to the pre-packaged
@@ -142,6 +144,6 @@ RCT_EXTERN void RCTBundleURLProviderAllowPackagerServerAccess(BOOL allowed);
 + (NSURL *)resourceURLForResourcePath:(NSString *)path
                          packagerHost:(NSString *)packagerHost
                                scheme:(NSString *)scheme
-                                query:(NSString *)query;
+                           queryItems:(NSArray<NSURLQueryItem *> *)queryItems;
 
 @end

--- a/packages/rn-tester/RNTester/AppDelegate.mm
+++ b/packages/rn-tester/RNTester/AppDelegate.mm
@@ -47,6 +47,9 @@
 
 - (NSURL *)sourceURLForBridge:(RCTBridge *)bridge
 {
+#if !USE_HERMES
+  [[RCTBundleURLProvider sharedSettings] setInlineSourceMap:YES];
+#endif
   return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"js/RNTesterApp.ios"];
 }
 


### PR DESCRIPTION
## Summary:

See: http://blog.nparashuram.com/2019/10/debugging-react-native-ios-apps-with.html
When using direct debugging with JavaScriptCore, Safari Web Inspector doesn't pick up the source map. This leads to a very sub-par developer experience debugging the JSbundle directly. The solution is to tell metro to inline the source map.

I did this by modifying `RCTBundleURLProvider` to have a new query parameter for `inlineSourceMap`, and set to true by default for JSC.

## Changelog:

[IOS] [ADDED] - Added support to inline the source map via RCTBundleURLProvider

## Test Plan:

I can put a breakpoint in RNTester, via Safari Web Inspector, in human readable code :D 

<img width="1728" alt="Screenshot 2023-06-14 at 4 09 03 AM" src="https://github.com/facebook/react-native/assets/6722175/055277fa-d887-4566-9dc6-3ea07a1a60b0">

