### PR TITLE
Add Systrace instrumentation to RuntimeScheduler

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/CMakeLists.txt
@@ -25,4 +25,5 @@ target_link_libraries(react_render_runtimescheduler
         jsi
         react_debug
         react_render_core
+        react_render_debug
         runtimeexecutor)

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/React-runtimescheduler.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/React-runtimescheduler.podspec
@@ -55,6 +55,7 @@ Pod::Spec.new do |s|
   s.dependency "React-runtimeexecutor"
   s.dependency "React-callinvoker"
   s.dependency "React-debug"
+  s.dependency "React-rendererdebug"
   s.dependency "React-utils"
   s.dependency "glog"
   s.dependency "RCT-Folly", folly_version

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.h
@@ -133,6 +133,11 @@ class RuntimeScheduler final {
    */
   void scheduleWorkLoopIfNecessary() const;
 
+  void executeTask(
+      jsi::Runtime& runtime,
+      std::shared_ptr<Task> task,
+      bool didUserCallbackTimeout) const;
+
   /*
    * Returns a time point representing the current point in time. May be called
    * from multiple threads.


### PR DESCRIPTION
Summary:
This adds systrace sections for the most relevant parts of `RuntimeScheduler`. This helps us identify how things are scheduled, which in this case makes it obvious we're not dispatching events the most efficient way (as top-level callbacks in the runtime executor instead of as tasks in the scheduler).

Changelog: [internal]

Differential Revision: D46556399

