### PR TITLE
Extract task execution to a separate method in RuntimeScheduler

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.h
@@ -133,6 +133,11 @@ class RuntimeScheduler final {
    */
   void scheduleWorkLoopIfNecessary() const;
 
+  void executeTask(
+      jsi::Runtime& runtime,
+      std::shared_ptr<Task> task,
+      bool didUserCallbackTimeout) const;
+
   /*
    * Returns a time point representing the current point in time. May be called
    * from multiple threads.


### PR DESCRIPTION
Summary:
Small refactor in preparation to add systrace markers for several methods in RuntimeScheduler.

Extracts the logic to execute a task to a private method and removes incorrect `const` modifier from some methods.

Changelog: [internal]

Differential Revision: D46556398

