### PR TITLE
Return final animation values to JS when animation completes

### DIFF
--- a/packages/react-native/Libraries/NativeAnimation/Drivers/RCTDecayAnimation.m
+++ b/packages/react-native/Libraries/NativeAnimation/Drivers/RCTDecayAnimation.m
@@ -70,10 +70,10 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
 
 - (void)stopAnimation
 {
-  _valueNode = nil;
   if (_callback) {
-    _callback(@[ @{@"finished" : @(_animationHasFinished)} ]);
+    _callback(@[ @{@"finished" : @(_animationHasFinished), @"value" : @(_valueNode.value)} ]);
   }
+  _valueNode = nil;
 }
 
 - (void)stepAnimationWithTime:(NSTimeInterval)currentTime

--- a/packages/react-native/Libraries/NativeAnimation/Drivers/RCTFrameAnimation.m
+++ b/packages/react-native/Libraries/NativeAnimation/Drivers/RCTFrameAnimation.m
@@ -76,10 +76,10 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
 
 - (void)stopAnimation
 {
-  _valueNode = nil;
   if (_callback) {
-    _callback(@[ @{@"finished" : @(_animationHasFinished)} ]);
+    _callback(@[ @{@"finished" : @(_animationHasFinished), @"value" : @(_valueNode.value)} ]);
   }
+  _valueNode = nil;
 }
 
 - (void)stepAnimationWithTime:(NSTimeInterval)currentTime

--- a/packages/react-native/Libraries/NativeAnimation/Drivers/RCTSpringAnimation.m
+++ b/packages/react-native/Libraries/NativeAnimation/Drivers/RCTSpringAnimation.m
@@ -96,10 +96,10 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
 
 - (void)stopAnimation
 {
-  _valueNode = nil;
   if (_callback) {
-    _callback(@[ @{@"finished" : @(_animationHasFinished)} ]);
+    _callback(@[ @{@"finished" : @(_animationHasFinished), @"value" : @(_valueNode.value)} ]);
   }
+  _valueNode = nil;
 }
 
 - (void)stepAnimationWithTime:(NSTimeInterval)currentTime

--- a/packages/rn-tester/RNTesterUnitTests/RCTNativeAnimatedNodesManagerTests.m
+++ b/packages/rn-tester/RNTesterUnitTests/RCTNativeAnimatedNodesManagerTests.m
@@ -486,7 +486,8 @@ static id RCTPropChecker(NSString *prop, NSNumber *value)
 
   RCTResponseSenderBlock endCallback = ^(NSArray *response) {
     endCallbackCalls++;
-    XCTAssertEqualObjects(response, @[ @{@"finished" : @YES} ]);
+    NSArray *expected = @[ @{@"finished" : @YES, @"value" : @1} ];
+    XCTAssertEqualObjects(response, expected);
   };
 
   [_nodesManager startAnimatingNode:@1
@@ -714,7 +715,8 @@ static id RCTPropChecker(NSString *prop, NSNumber *value)
 
   RCTResponseSenderBlock endCallback = ^(NSArray *response) {
     endCallbackCalled = YES;
-    XCTAssertEqualObjects(response, @[ @{@"finished" : @NO} ]);
+    XCTAssertEqual(response.count, 1);
+    XCTAssertEqualObjects(response[0][@"finished"], @NO);
   };
 
   [_nodesManager startAnimatingNode:@404


### PR DESCRIPTION
Summary:
When using the native driver for animations that involve layout changes (ie. translateY and other transforms, but not styles such as opacity), because it bypasses Fabric, the new coordinates are not updated so the Pressability responder region/tap target is incorrect

**This diff:**
- Returning the final values from the native side, at the same place it sets the "finished" flag. This gets sent to JS in `animated/animations/Animation.js`.

Changelog:
[iOS][Changed] - return animated values to JS for natively driven animations

Reviewed By: rshest

Differential Revision: D46709214

