### PR TITLE
Performance.measure: handle the case with a single startMark argument correctly

### DIFF
--- a/packages/react-native/Libraries/WebPerformance/PerformanceEntryReporter.h
+++ b/packages/react-native/Libraries/WebPerformance/PerformanceEntryReporter.h
@@ -147,6 +147,10 @@ class PerformanceEntryReporter : public EventLogger {
     return eventCounts_;
   }
 
+  void setTimeStampProvider(std::function<double()> provider) {
+    timeStampProvider_ = provider;
+  }
+
  private:
   std::optional<AsyncCallback<>> callback_;
 
@@ -171,6 +175,8 @@ class PerformanceEntryReporter : public EventLogger {
   std::unordered_map<EventTag, EventEntry> eventsInFlight_;
   std::mutex eventsInFlightMutex_;
 
+  std::function<double()> timeStampProvider_ = nullptr;
+
   static EventTag sCurrentEventTag_;
 
   PerformanceEntryReporter();
@@ -182,6 +188,8 @@ class PerformanceEntryReporter : public EventLogger {
       PerformanceEntryType entryType,
       const char *entryName,
       std::vector<RawPerformanceEntry> &res) const;
+
+  double getCurrentTimeStamp() const;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/Libraries/WebPerformance/__tests__/PerformanceEntryReporterTest.cpp
+++ b/packages/react-native/Libraries/WebPerformance/__tests__/PerformanceEntryReporterTest.cpp
@@ -146,8 +146,11 @@ TEST(PerformanceEntryReporter, PerformanceEntryReporterTestReportMeasures) {
   reporter.measure("measure3", 0.0, 0.0, 5.0, "mark1");
   reporter.measure("measure4", 1.5, 0.0, std::nullopt, std::nullopt, "mark2");
 
+  reporter.setTimeStampProvider([]() { return 3.5; });
+  reporter.measure("measure5", 0.0, 0.0, std::nullopt, "mark2");
+
   reporter.mark("mark3", 2.0);
-  reporter.measure("measure5", 2.0, 2.0);
+  reporter.measure("measure6", 2.0, 2.0);
   reporter.mark("mark4", 2.0);
 
   auto res = reporter.popPendingEntries();
@@ -226,10 +229,17 @@ TEST(PerformanceEntryReporter, PerformanceEntryReporterTestReportMeasures) {
        std::nullopt,
        std::nullopt,
        std::nullopt},
-      {"measure5",
+      {"measure6",
        static_cast<int>(PerformanceEntryType::MEASURE),
        2.0,
        0.0,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt},
+      {"measure5",
+       static_cast<int>(PerformanceEntryType::MEASURE),
+       2.0,
+       1.5,
        std::nullopt,
        std::nullopt,
        std::nullopt},


### PR DESCRIPTION
Summary:
# Changelist
[Internal] -

There was one particular permutation of input arguments to `Performance.measure` that wasn't handled correctly on the native side, namely when there is only the start mark argument present, but not the end time/mark, e.g.:
```
Performance.measure('myMeasure', 'someStartMark');
```

In this case, [according to the standard](https://developer.mozilla.org/en-US/docs/Web/API/Performance/measure), the end time should be taken as the current one:
> The end timestamp is one of:
> ...
>  -the value returned by Performance.now(), if no end mark is specified or can be determined from other values.

It was taken as 0 instead, making the total duration negative and consequently getting it filtered out by the default `durationThreshold` of 0.

I've added a corresponding missing clause in the native unit tests. This also required a slight extension to the `PerformanceObserver` API to allow for mocking the current timestamp provider.

Differential Revision: D46728261

