### PR TITLE
Restore installing DevSupport to all the config

### DIFF
--- a/packages/react-native/scripts/cocoapods/__tests__/flipper-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/flipper-test.rb
@@ -22,8 +22,7 @@ class FlipperTests < Test::Unit::TestCase
 
         # Assert
         assert_equal($podInvocationCount, 1)
-        assert_equal($podInvocation['React-Core/DevSupport'][:path], "../../" )
-        assert_equal($podInvocation['React-Core/DevSupport'][:configurations], ["Debug"] )
+        assert_equal($podInvocation['React-Core/DevSupport'][:path], "../../")
     end
 
     # ======================= #

--- a/packages/react-native/scripts/cocoapods/flipper.rb
+++ b/packages/react-native/scripts/cocoapods/flipper.rb
@@ -20,8 +20,8 @@ $flipper_default_versions = {
 # when the dependencies are installed for a non production app.
 #
 # @parameter pathToReactNative: the path to the React Native installation
-def install_flipper_dependencies(pathToReactNative, configurations: ["Debug"])
-    pod 'React-Core/DevSupport', :path => "#{pathToReactNative}/", :configurations => configurations
+def install_flipper_dependencies(pathToReactNative)
+    pod 'React-Core/DevSupport', :path => "#{pathToReactNative}/"
 end
 
 

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -166,7 +166,7 @@ def use_react_native! (
 
   # Flipper now build in Release mode but it is not linked to the Release binary (as specified by the Configuration option)
   if flipper_configuration.flipper_enabled
-    install_flipper_dependencies(prefix, :configurations => flipper_configuration.configurations)
+    install_flipper_dependencies(prefix)
     use_flipper_pods(flipper_configuration.versions, :configurations => flipper_configuration.configurations)
   end
 


### PR DESCRIPTION
Summary:
CircleCI was broken because we changed how the `React-Core/DevSupport` pod is installed.

## Changelog:
[Internal] - Restore the installation of React-Core/DevSupport

Differential Revision: D46734714

