### PR TITLE
fix: foreground ripple crash on api < 23

### DIFF
--- a/packages/react-native/Libraries/Components/Pressable/useAndroidRippleForView.js
+++ b/packages/react-native/Libraries/Components/Pressable/useAndroidRippleForView.js
@@ -71,7 +71,7 @@ export default function useAndroidRippleForView(
 
       return {
         viewProps:
-          foreground === true
+          foreground === true && Platform.Version >= 23
             ? {nativeForegroundAndroid: nativeRippleValue}
             : {nativeBackgroundAndroid: nativeRippleValue},
         onPressIn(event: PressEvent): void {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

The Pressable component supports the `foreground` option for ripple. However, using it on old android api levels (e.g. android 5) crashes with

```
Error while updating property
nativeForegroundAndroid' of a view managed by:
RCTView
null
No virtual method setForeground(Landroid/ graphics/drawable/Drawable;)V in class Lcom/ facebook/react/views/view/ReactViewGroup; or its super classes
```


TouchableNativeFeedback.js has a check to make sure this does not happen [as seen here](https://github.com/facebook/react-native/blob/b0485bed0945061becace5af924fa60b17ab295f/packages/react-native/Libraries/Components/Touchable/TouchableNativeFeedback.js#L158)

I also want to point out that this PR can be closed https://github.com/facebook/react-native/pull/30466 as it's already implemented


## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID] [FIXED] - foreground ripple crashed on api < 23

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

tested locally on [another project](https://github.com/react-navigation/react-navigation/pull/11386) because I wasn't able to get RN tester running
