### PR TITLE
[Codegen 129] add emitObjectProp in parser primitives

### DIFF
--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-primitives-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-primitives-test.js
@@ -49,7 +49,7 @@ const {emitUnion} = require('../parsers-primitives');
 const {UnsupportedUnionTypeAnnotationParserError} = require('../errors');
 const {FlowParser} = require('../flow/parser');
 const {TypeScriptParser} = require('../typescript/parser');
-const {getPropertyType} = require('../flow/components/events');
+const {extractArrayElementType} = require('../flow/components/events');
 
 const parser = new MockedParser();
 const flowParser = new FlowParser();
@@ -1679,6 +1679,10 @@ describe('emitObjectProp', () => {
   describe('when property is optional', () => {
     it('returns optional Object Prop', () => {
       const typeAnnotation = {
+        type: 'GenericTypeAnnotation',
+        id: {
+          name: 'ObjectTypeAnnotation',
+        },
         properties: [
           {
             key: {
@@ -1699,7 +1703,7 @@ describe('emitObjectProp', () => {
         true,
         flowParser,
         typeAnnotation,
-        getPropertyType,
+        extractArrayElementType,
       );
       const expected = {
         name: 'someProp',
@@ -1725,6 +1729,10 @@ describe('emitObjectProp', () => {
   describe('when property is required', () => {
     it('returns required Object Prop', () => {
       const typeAnnotation = {
+        type: 'GenericTypeAnnotation',
+        id: {
+          name: 'ObjectTypeAnnotation',
+        },
         properties: [
           {
             key: {
@@ -1745,7 +1753,7 @@ describe('emitObjectProp', () => {
         false,
         flowParser,
         typeAnnotation,
-        getPropertyType,
+        extractArrayElementType,
       );
       const expected = {
         name: 'someProp',

--- a/packages/react-native-codegen/src/parsers/flow/components/events.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/events.js
@@ -70,7 +70,7 @@ function getPropertyType(
         optional,
         parser,
         typeAnnotation,
-        getPropertyType,
+        extractArrayElementType,
       );
     case 'UnionTypeAnnotation':
       return {
@@ -311,5 +311,5 @@ function getEvents(
 
 module.exports = {
   getEvents,
-  getPropertyType,
+  extractArrayElementType,
 };

--- a/packages/react-native-codegen/src/parsers/parsers-primitives.js
+++ b/packages/react-native-codegen/src/parsers/parsers-primitives.js
@@ -60,7 +60,6 @@ const {
   wrapNullable,
   unwrapNullable,
   translateFunctionTypeAnnotation,
-  buildPropertiesForEvent,
 } = require('./parsers-commons');
 
 const {isModuleRegistryCall} = require('./utils');
@@ -663,24 +662,16 @@ function emitObjectProp(
   optional: boolean,
   parser: Parser,
   typeAnnotation: $FlowFixMe,
-  getPropertyType: (
-    name: $FlowFixMe,
-    optional: boolean,
+  extractArrayElementType: (
     typeAnnotation: $FlowFixMe,
+    name: string,
     parser: Parser,
-  ) => NamedShape<EventTypeAnnotation>,
+  ) => EventTypeAnnotation,
 ): NamedShape<EventTypeAnnotation> {
   return {
     name,
     optional,
-    typeAnnotation: {
-      type: 'ObjectTypeAnnotation',
-      properties: parser
-        .getObjectProperties(typeAnnotation)
-        .map(member =>
-          buildPropertiesForEvent(member, parser, getPropertyType),
-        ),
-    },
+    typeAnnotation: extractArrayElementType(typeAnnotation, name, parser),
   };
 }
 

--- a/packages/react-native-codegen/src/parsers/typescript/components/events.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/events.js
@@ -50,10 +50,7 @@ function getPropertyType(
   const topLevelType = parseTopLevelType(annotation);
   const typeAnnotation = topLevelType.type;
   const optional = optionalProperty || topLevelType.optional;
-  const type =
-    typeAnnotation.type === 'TSTypeReference'
-      ? typeAnnotation.typeName.name
-      : typeAnnotation.type;
+  const type = parser.extractTypeFromTypeAnnotation(typeAnnotation);
 
   switch (type) {
     case 'TSBooleanKeyword':
@@ -72,7 +69,7 @@ function getPropertyType(
         optional,
         parser,
         typeAnnotation,
-        getPropertyType,
+        extractArrayElementType,
       );
     case 'TSUnionType':
       return {
@@ -92,7 +89,6 @@ function getPropertyType(
         typeAnnotation: extractArrayElementType(typeAnnotation, name, parser),
       };
     default:
-      (type: empty);
       throw new Error(`Unable to determine event type for "${name}": ${type}`);
   }
 }
@@ -314,4 +310,5 @@ function getEvents(
 
 module.exports = {
   getEvents,
+  extractArrayElementType,
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This is a follow up PR to #37872 as it was not merged correctly.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[Internal][Changed]: Add emitObjectProp in parser primitives

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
`yarn test react-native-codegen`
