### PR TITLE
Use `fileExists` in replace_hermes script

### DIFF
--- a/packages/react-native/sdks/hermes-engine/utils/replace_hermes_version.js
+++ b/packages/react-native/sdks/hermes-engine/utils/replace_hermes_version.js
@@ -34,15 +34,17 @@ function shouldReplaceHermesConfiguration(configuration) {
     console.log(`Found ${LAST_BUILD_FILENAME} file`);
     const oldConfiguration = fs.readFileSync(LAST_BUILD_FILENAME).toString();
     if (oldConfiguration === configuration) {
-      console.log('No need to download a new build of Hermes!');
+      console.log(
+        'Same config of the previous build. No need to replace Hermes engine',
+      );
       return false;
     }
   }
 
   // Assumption: if there is no stored last build, we assume that it was build for debug.
-  if (!fs.existsSync && configuration === 'Debug') {
+  if (!fileExists && configuration === 'Debug') {
     console.log(
-      'File does not exists, but Debug configuration. No need to download a new build of Hermes!',
+      'No previous build detected, but Debug Configuration. No need to replace Hermes engine',
     );
     return false;
   }


### PR DESCRIPTION
Summary:
Thanks to [adrianha](https://github.com/adrianha) for spotting a bug in the script that replace the Hermes engine.
I miscopied the variable to check when there is no previous build file.

This change uses the right variable and improves also the messages printed to the user.

## Changelog:
[Internal] - Fix replace_hermes_version script using the right `fileExists` variable

Differential Revision: D46762041

