### PR TITLE
Re-enable direct debugging with JSC on iOS 16.4+

### DIFF
--- a/packages/react-native/ReactCommon/jsc/JSCRuntime.cpp
+++ b/packages/react-native/ReactCommon/jsc/JSCRuntime.cpp
@@ -398,6 +398,13 @@ JSCRuntime::JSCRuntime(JSGlobalContextRef ctx)
       stringCounter_(0)
 #endif
 {
+#ifndef NDEBUG
+#ifdef TARGET_OS_MAC
+  if (__builtin_available(macOS 13.3, iOS 16.4, tvOS 16.4, *)) {
+    JSGlobalContextSetInspectable(ctx_, true);
+  }
+#endif
+#endif
 }
 
 JSCRuntime::~JSCRuntime() {


### PR DESCRIPTION
Summary:
Restores https://github.com/facebook/react-native/pull/37874 (reverted earlier today), with fix for `JSCRuntime.cpp` build on Android.

Changelog: None

Differential Revision: D46762984

