### PR TITLE
Extend expected Flow type of the global.performance object to match Performance API

### DIFF
--- a/packages/react-native/Libraries/Core/setUpPerformance.js
+++ b/packages/react-native/Libraries/Core/setUpPerformance.js
@@ -19,18 +19,11 @@ if (NativePerformance) {
 } else {
   if (!global.performance) {
     // $FlowExpectedError[cannot-write]
-    global.performance = ({}: {now?: () => number});
-  }
-
-  /**
-   * Returns a double, measured in milliseconds.
-   * https://developer.mozilla.org/en-US/docs/Web/API/Performance/now
-   */
-  if (typeof global.performance.now !== 'function') {
-    // $FlowExpectedError[cannot-write]
-    global.performance.now = function () {
-      const performanceNow = global.nativePerformanceNow || Date.now;
-      return performanceNow();
-    };
+    global.performance = ({
+      now: function () {
+        const performanceNow = global.nativePerformanceNow || Date.now;
+        return performanceNow();
+      },
+    }: {now?: () => number});
   }
 }

--- a/packages/react-native/Libraries/Utilities/createPerformanceLogger.js
+++ b/packages/react-native/Libraries/Utilities/createPerformanceLogger.js
@@ -27,7 +27,7 @@ const PRINT_TO_CONSOLE: false = false; // Type as false to prevent accidentally 
 const WEB_PERFORMANCE_PREFIX = 'global_perf_';
 
 export const getCurrentTimestamp: () => number =
-  global.nativeQPLTimestamp ?? global.performance.now.bind(global.performance);
+  global.nativeQPLTimestamp ?? (() => global.performance.now());
 
 class PerformanceLogger implements IPerformanceLogger {
   _timespans: {[key: string]: ?Timespan} = {};

--- a/packages/react-native/flow/global.js
+++ b/packages/react-native/flow/global.js
@@ -27,9 +27,7 @@ declare var global: {
   },
 
   // setUpPerformance
-  +performance: {
-    +now: () => number,
-  },
+  +performance: Performance,
 
   // setUpXHR
   +XMLHttpRequest: typeof XMLHttpRequest,


### PR DESCRIPTION
Summary:
# Changelog:
[Internal] -

The `global.performance` object now has all of the API defined according to the `Performance` API, so we can modify the local RN's flow definition override correspondingly.

Differential Revision: D46762326

