### PR TITLE
explicitly enable ATS in app template

### DIFF
--- a/packages/react-native/scripts/cocoapods/__tests__/test_utils/InstallerMock.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/test_utils/InstallerMock.rb
@@ -114,19 +114,30 @@ class UserProjectMock
     attr_reader :path
     attr_reader :build_configurations
     attr_reader :native_targets
+    attr_reader :files
 
     attr_reader :save_invocation_count
 
-
-    def initialize(path = "/test/path.xcproj", build_configurations = [], native_targets: [])
-        @path = Pathname.new(path)
+    def initialize(path = "/test/path.xcproj", build_configurations = [], parent = "/test", native_targets: [], files: [])
+        @path = Pathname.new(path, parent)
         @build_configurations = build_configurations
         @native_targets = native_targets
+        @files = files
         @save_invocation_count = 0
     end
 
     def save()
         @save_invocation_count += 1
+    end
+end
+
+class PBXFileRefMock
+    attr_reader :name
+    attr_reader :path
+
+    def initialize(name)
+        @name = name
+        @path = name
     end
 end
 

--- a/packages/react-native/scripts/cocoapods/__tests__/test_utils/PathnameMock.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/test_utils/PathnameMock.rb
@@ -9,8 +9,9 @@ class Pathname
 
     attr_reader :path
 
-    def initialize(path)
+    def initialize(path, parent = "")
         @path = path
+        @parent = parent
     end
 
     def realpath
@@ -19,6 +20,10 @@ class Pathname
 
     def relative_path_from(path)
         return @path
+    end
+
+    def parent
+        return @parent
     end
 
     def self.pwd!(pwd)

--- a/packages/react-native/scripts/cocoapods/__tests__/test_utils/XcodeprojMock.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/test_utils/XcodeprojMock.rb
@@ -1,0 +1,21 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+module Xcodeproj
+    class Plist
+        @@path_to_file_mapping = Hash.new
+        def self.read_from_path(path)
+            return @@path_to_file_mapping[path]
+        end
+
+        def self.write_to_path(hash, path)
+            @@path_to_file_mapping[path] = hash
+        end
+
+        def self.reset()
+            @@path_to_file_mapping.clear
+        end
+  end
+end

--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -396,6 +396,42 @@ class ReactNativePodsUtils
         ])
     end
 
+    def self.get_plist_paths_from(user_project)
+        info_plists = user_project
+          .files
+          .select { |p|
+            p.name&.end_with?('Info.plist')
+          }
+        return info_plists
+      end
+
+    def self.update_ats_in_plist(plistPaths, parent)
+        plistPaths.each do |plistPath|
+            fullPlistPath = File.join(parent, plistPath.path)
+            plist = Xcodeproj::Plist.read_from_path(fullPlistPath)
+            ats_configs = {
+                "NSAllowsArbitraryLoads" => false,
+                "NSAllowsLocalNetworking" => true,
+            }
+            if plist.nil?
+                plist = {
+                    "NSAppTransportSecurity" => ats_configs
+                }
+            else
+                plist["NSAppTransportSecurity"] = ats_configs
+            end
+            Xcodeproj::Plist.write_to_path(plist, fullPlistPath)
+        end
+    end
+
+    def self.apply_ats_config(installer)
+        user_project = installer.aggregate_targets
+                    .map{ |t| t.user_project }
+                    .first
+        plistPaths = self.get_plist_paths_from(user_project)
+        self.update_ats_in_plist(plistPaths, user_project.path.parent)
+    end
+
     def self.react_native_pods
         return [
             "DoubleConversion",

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -246,6 +246,7 @@ def react_native_post_install(
   ReactNativePodsUtils.set_node_modules_user_settings(installer, react_native_path)
   ReactNativePodsUtils.apply_flags_for_fabric(installer, fabric_enabled: fabric_enabled)
   ReactNativePodsUtils.apply_xcode_15_patch(installer)
+  ReactNativePodsUtils.apply_ats_config(installer)
 
   NewArchitectureHelper.set_clang_cxx_language_standard_if_needed(installer)
   is_new_arch_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == "1"

--- a/packages/react-native/template/ios/HelloWorld/Info.plist
+++ b/packages/react-native/template/ios/HelloWorld/Info.plist
@@ -26,14 +26,11 @@
 	<true/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
-		<key>NSExceptionDomains</key>
-		<dict>
-			<key>localhost</key>
-			<dict>
-				<key>NSExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-			</dict>
-		</dict>
+	  <!-- Do not change NSAllowsArbitraryLoads to true, or you will risk app rejection! -->
+		<key>NSAllowsArbitraryLoads</key>
+		<false/>
+		<key>NSAllowsLocalNetworking</key>
+		<true/>
 	</dict>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string></string>

--- a/packages/rn-tester/RNTester/Info.plist
+++ b/packages/rn-tester/RNTester/Info.plist
@@ -38,10 +38,14 @@
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>
+		<false/>
+		<key>NSAllowsLocalNetworking</key>
 		<true/>
 	</dict>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>You need to add NSLocationWhenInUseUsageDescription key in Info.plist to enable geolocation, otherwise it is going to *fail silently*!</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>You need to add NSPhotoLibraryUsageDescription key in Info.plist to enable photo library usage, otherwise it is going to *fail silently*!</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>
@@ -57,7 +61,5 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
-	<key>NSPhotoLibraryUsageDescription</key>
-	<string>You need to add NSPhotoLibraryUsageDescription key in Info.plist to enable photo library usage, otherwise it is going to *fail silently*!</string>
 </dict>
 </plist>


### PR DESCRIPTION
Summary:
Changelog: [Internal]

in this change, i'm looking to make sure our app template will not violate apple best practices and minimize probability of app rejection.

this change entails two guardrails:
- explicitly marking disabling ATS as disabled with a comment. even though this is already the case, this will make it more unlikely someone will override this
- replacing the localhost domain override with the apple provided NSAllowsLocalNetworking key, which is the recommendation

Reviewed By: RSNara

Differential Revision: D46707159

