### PR TITLE
Correct "does not exists" in Animated error messages

### DIFF
--- a/packages/react-native/Libraries/NativeAnimation/RCTNativeAnimatedNodesManager.m
+++ b/packages/react-native/Libraries/NativeAnimation/RCTNativeAnimatedNodesManager.m
@@ -346,7 +346,7 @@ static NSString *RCTNormalizeAnimatedEventName(NSString *eventName)
   RCTAnimatedNode *node = _animationNodes[nodeTag];
 
   if (!node) {
-    RCTLogError(@"Animated node with tag %@ does not exists", nodeTag);
+    RCTLogError(@"Animated node with tag %@ does not exist", nodeTag);
     return;
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/PropsAnimatedNode.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/PropsAnimatedNode.java
@@ -97,7 +97,7 @@ import java.util.Map;
     for (Map.Entry<String, Integer> entry : mPropNodeMapping.entrySet()) {
       @Nullable AnimatedNode node = mNativeAnimatedNodesManager.getNodeById(entry.getValue());
       if (node == null) {
-        throw new IllegalArgumentException("Mapped property node does not exists");
+        throw new IllegalArgumentException("Mapped property node does not exist");
       } else if (node instanceof StyleAnimatedNode) {
         ((StyleAnimatedNode) node).collectViewUpdates(mPropMap);
       } else if (node instanceof ValueAnimatedNode) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/StyleAnimatedNode.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/StyleAnimatedNode.java
@@ -38,7 +38,7 @@ import java.util.Map;
     for (Map.Entry<String, Integer> entry : mPropMapping.entrySet()) {
       @Nullable AnimatedNode node = mNativeAnimatedNodesManager.getNodeById(entry.getValue());
       if (node == null) {
-        throw new IllegalArgumentException("Mapped style node does not exists");
+        throw new IllegalArgumentException("Mapped style node does not exist");
       } else if (node instanceof TransformAnimatedNode) {
         ((TransformAnimatedNode) node).collectViewUpdates(propsMap);
       } else if (node instanceof ValueAnimatedNode) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/TransformAnimatedNode.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/TransformAnimatedNode.java
@@ -66,7 +66,7 @@ import java.util.List;
         int nodeTag = ((AnimatedTransformConfig) transformConfig).mNodeTag;
         AnimatedNode node = mNativeAnimatedNodesManager.getNodeById(nodeTag);
         if (node == null) {
-          throw new IllegalArgumentException("Mapped style node does not exists");
+          throw new IllegalArgumentException("Mapped style node does not exist");
         } else if (node instanceof ValueAnimatedNode) {
           value = ((ValueAnimatedNode) node).getValue();
         } else {


### PR DESCRIPTION
Summary:
# Changelog:
[Internal] -

Was looking at some [crash report](https://github.com/facebook/react-native/pull/37927) on Github and noticed that error message has a grammar error.

Searching the code revealed three more, all in Animated.

This calms down my OCD :)

Differential Revision: D46792795

