### PR TITLE
Unblock test_android by using a non-internal method of OkHTTP

### DIFF
--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/network/ReactCookieJarContainerTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/network/ReactCookieJarContainerTest.kt
@@ -25,7 +25,7 @@ import org.robolectric.RobolectricTestRunner
 @PrepareForTest(ReactCookieJarContainer::class)
 @PowerMockIgnore("org.mockito.*", "org.robolectric.*", "androidx.*", "android.*")
 class ReactCookieJarContainerTest {
-  private val httpUrl: HttpUrl = HttpUrl.parse("http://example.com")
+  private val httpUrl: HttpUrl = HttpUrl.Builder().host("example.com").scheme("http").build()
 
   @Test
   fun testMissingJar() {


### PR DESCRIPTION
Summary:
test_android is currently broken due to us using `toHttpUrl` which is `Deprecated` with
.ERROR severity level in OkHTTP 4. This fixes it by using the HttpUrl.Builder class
which is always accessible in OkHTTP.

Changelog:
[Internal] [Changed] - Unblock test_android by using a non-internal method of OkHTTP

Reviewed By: sammy-SC

Differential Revision: D46799515

