### PR TITLE
Add dev mode check for direct events following naming convention

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModuleConstantsHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModuleConstantsHelper.java
@@ -11,7 +11,9 @@ import static com.facebook.systrace.Systrace.TRACE_TAG_REACT_JAVA_BRIDGE;
 
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
+import com.facebook.common.logging.FLog;
 import com.facebook.react.common.MapBuilder;
+import com.facebook.react.common.build.ReactBuildConfig;
 import com.facebook.react.config.ReactFeatureFlags;
 import com.facebook.systrace.SystraceMessage;
 import java.util.ArrayList;
@@ -26,7 +28,7 @@ import java.util.Set;
  * registered view managers.
  */
 /* package */ class UIManagerModuleConstantsHelper {
-
+  private static final String TAG = "UIManagerModuleConstantsHelper";
   private static final String BUBBLING_EVENTS_KEY = "bubblingEventTypes";
   private static final String DIRECT_EVENTS_KEY = "directEventTypes";
 
@@ -48,6 +50,31 @@ import java.util.Set;
     return MapBuilder.<String, Object>of(
         BUBBLING_EVENTS_KEY, UIManagerModuleConstants.getBubblingEventTypeConstants(),
         DIRECT_EVENTS_KEY, UIManagerModuleConstants.getDirectEventTypeConstants());
+  }
+
+  private static void validateDirectEventNames(
+      String viewManagerName, Map<String, Object> directEvents) {
+    if (!ReactBuildConfig.DEBUG || directEvents == null) {
+      return;
+    }
+
+    for (String key : directEvents.keySet()) {
+      Object value = directEvents.get(key);
+      if (value != null && (value instanceof Map)) {
+        String regName = (String) ((Map) value).get("registrationName");
+        if (regName != null
+            && key.startsWith("top")
+            && regName.startsWith("on")
+            && !key.substring(3).equals(regName.substring(2))) {
+          FLog.e(
+              TAG,
+              String.format(
+                  "Direct event name for '%s' doesn't correspond to the naming convention,"
+                      + " expected 'topEventName'->'onEventName', got '%s'->'%s'",
+                  viewManagerName, key, regName));
+        }
+      }
+    }
   }
 
   /**
@@ -133,6 +160,7 @@ import java.util.Set;
     }
 
     Map viewManagerDirectEvents = viewManager.getExportedCustomDirectEventTypeConstants();
+    validateDirectEventNames(viewManager.getName(), viewManagerDirectEvents);
     if (viewManagerDirectEvents != null) {
       recursiveMerge(cumulativeDirectEventTypes, viewManagerDirectEvents);
       recursiveMerge(viewManagerDirectEvents, defaultDirectEvents);


### PR DESCRIPTION
Summary:
# Changelist:
[Internal] -

This addresses potential problem with inconsistent naming of direct events on Android, as we've recently found out that there are several such occasions, which can be potentially a source of errors.

Differential Revision: D46801798

