### PR TITLE
Fix hermes-engine in Nightlies

### DIFF
--- a/packages/react-native/sdks/hermes-engine/hermes-utils.rb
+++ b/packages/react-native/sdks/hermes-engine/hermes-utils.rb
@@ -131,7 +131,7 @@ end
 # Returns: the path to the downloaded Hermes tarball
 def download_nightly_hermes(react_native_path, version)
     tarball_url = nightly_tarball_url(version)
-    return download_stable_hermes(react_native_path, tarball_url, version, nil)
+    return download_hermes_tarball(react_native_path, tarball_url, version, nil)
 end
 
 def nightly_tarball_url(version)


### PR DESCRIPTION
Summary:
With commit [332be0f](https://github.com/facebook/react-native/commit/332be0f0c84c48e0b0edd373636b0b5538fa3b2b) nightlies were broken due to a wrong update with the method we need to use to download hermes.

This change fixes that issue

## Changelog:
[Internal] - Fix hermes-engine download in Nightlies

Reviewed By: cortinico

Differential Revision: D46800717

