### PR TITLE
[0.72 New Architecture] added missing text measure cache text attributes

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/TextMeasureCache.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/TextMeasureCache.h
@@ -89,6 +89,9 @@ inline bool areTextAttributesEquivalentLayoutWise(
   // attributes that affect only a decorative aspect of displayed text (like
   // colors).
   return std::tie(
+             lhs.foregroundColor,
+             lhs.backgroundColor,
+             lhs.opacity,
              lhs.fontFamily,
              lhs.fontWeight,
              lhs.fontStyle,
@@ -97,6 +100,9 @@ inline bool areTextAttributesEquivalentLayoutWise(
              lhs.dynamicTypeRamp,
              lhs.alignment) ==
       std::tie(
+             rhs.foregroundColor,
+             rhs.backgroundColor,
+             rhs.opacity,
              rhs.fontFamily,
              rhs.fontWeight,
              rhs.fontStyle,
@@ -116,6 +122,9 @@ inline size_t textAttributesHashLayoutWise(
   // `areTextAttributesEquivalentLayoutWise` mentions.
   return folly::hash::hash_combine(
       0,
+      textAttributes.foregroundColor,
+      textAttributes.backgroundColor,
+      textAttributes.opacity,
       textAttributes.fontFamily,
       textAttributes.fontSize,
       textAttributes.fontSizeMultiplier,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:
[Related issue](https://github.com/facebook/react-native/issues/37944)

## Changelog:
Added missing text measure cache text attributes

Pick one each for the category and type tags:

[IOS] [FIXED] - added missing text measure cache text attributes

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:
* init 0.72 with `npx react-native@latest init RN0720RC1 --version 0.72.0-rc.6`
* `cd RN0720RC1/ios`
* `RCT_NEW_ARCH_ENABLED=1 bundle exec pod install --verbose`
* test with iOS simulator with example code

```tsx
const [colorValue, setColorValue] = useState<string>('blue');

return (
          <View
            style={{ justifyContent: 'center', alignItems: 'center', flex: 1 }}>
            <Button
              title="Change Color"
              onPress={() => setColorValue('orange')}
            />
            <Text style={{ color: colorValue }}>Hello</Text>
          </View>
)
```
