### PR TITLE
fix(virtualized-lists): `react-test-renderer` is not a runtime dependency

### DIFF
--- a/packages/virtualized-lists/package.json
+++ b/packages/virtualized-lists/package.json
@@ -22,7 +22,6 @@
     "react-test-renderer": "18.2.0"
   },
   "peerDependencies": {
-    "react-native": "*",
-    "react-test-renderer": "18.2.0"
+    "react-native": "*"
   }
 }


### PR DESCRIPTION
## Summary:

Installing `react-native` 0.72.x causes a warning about `react-test-renderer` because `@react-native/virtualized-lists` has declared a peer dependency on it. As far as I know, it is not used for anything but tests.

```
➤ YN0002: │ react-native@npm:0.72.0-rc.6 [292eb] doesn't provide react-test-renderer (p5a2fb), requested by @react-native/virtualized-lists
```

Note that while many package managers default to warnings in this case, there are still a number of users out there for which this is an error.

## Changelog:

[GENERAL] [FIXED] - `@react-native/virtualized-lists` does not need `react-test-renderer` at runtime

## Test Plan:

n/a