### PR TITLE
Fix onChangeText not firing when clearing the value of TextInput with multiline=true on iOS

### DIFF
--- a/packages/react-native/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.m
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.m
@@ -256,7 +256,7 @@ static void *TextFieldSelectionObservingContext = &TextFieldSelectionObservingCo
 
 - (void)textViewDidChange:(__unused UITextView *)textView
 {
-  if (_ignoreNextTextInputCall) {
+  if (_ignoreNextTextInputCall && [_lastStringStateWasUpdatedWith isEqual:_backedTextInputView.attributedText]) {
     _ignoreNextTextInputCall = NO;
     return;
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This fix fixes the TextInput issue in #37784 with onChangeText not working on iOS only.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[IOS] [FIXED] - Fix onChangeText not firing when clearing the value of TextInput with multiline=true on iOS

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

1. Run the repro code given in the issue (#37784).
2. Verified that onChangeText works after pressing the submit button.
3. Run the repro code from the issue (#36494) that caused this issue.
4. Verified that issue (#36494) is not reoccurring.