### PR TITLE
[Codegen-139] Move verifyProprsNotAlreadyDefined Function To parsers-commons.js

### DIFF
--- a/packages/react-native-codegen/src/parsers/flow/components/componentsUtils.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/componentsUtils.js
@@ -11,9 +11,9 @@
 'use strict';
 
 const {getValueFromTypes} = require('../utils.js');
+const {verifyPropNotAlreadyDefined} = require('../../parsers-commons');
 import type {TypeDeclarationMap, PropAST, ASTNode} from '../../utils';
 import type {BuildSchemaFN, Parser} from '../../parser';
-import {verifyPropNotAlreadyDefined} from '../../parsers-commons';
 
 function getTypeAnnotationForArray<+T>(
   name: string,

--- a/packages/react-native-codegen/src/parsers/flow/components/componentsUtils.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/componentsUtils.js
@@ -13,6 +13,7 @@
 const {getValueFromTypes} = require('../utils.js');
 import type {TypeDeclarationMap, PropAST, ASTNode} from '../../utils';
 import type {BuildSchemaFN, Parser} from '../../parser';
+import {verifyPropNotAlreadyDefined} from "../../parsers-commons";
 
 function getTypeAnnotationForArray<+T>(
   name: string,
@@ -204,17 +205,6 @@ function flattenProperties(
       }
     }, [])
     .filter(Boolean);
-}
-
-function verifyPropNotAlreadyDefined(
-  props: $ReadOnlyArray<PropAST>,
-  needleProp: PropAST,
-) {
-  const propName = needleProp.key.name;
-  const foundProp = props.some(prop => prop.key.name === propName);
-  if (foundProp) {
-    throw new Error(`A prop was already defined with the name ${propName}`);
-  }
 }
 
 function getTypeAnnotation<+T>(

--- a/packages/react-native-codegen/src/parsers/flow/components/componentsUtils.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/componentsUtils.js
@@ -13,7 +13,7 @@
 const {getValueFromTypes} = require('../utils.js');
 import type {TypeDeclarationMap, PropAST, ASTNode} from '../../utils';
 import type {BuildSchemaFN, Parser} from '../../parser';
-import {verifyPropNotAlreadyDefined} from "../../parsers-commons";
+import {verifyPropNotAlreadyDefined} from '../../parsers-commons';
 
 function getTypeAnnotationForArray<+T>(
   name: string,

--- a/packages/react-native-codegen/src/parsers/parsers-commons.js
+++ b/packages/react-native-codegen/src/parsers/parsers-commons.js
@@ -1072,6 +1072,17 @@ function buildPropertiesForEvent(
   return getPropertyType(name, optional, typeAnnotation, parser);
 }
 
+function verifyPropNotAlreadyDefined(
+  props: $ReadOnlyArray<PropAST>,
+  needleProp: PropAST,
+) {
+  const propName = needleProp.key.name;
+  const foundProp = props.some(prop => prop.key.name === propName);
+  if (foundProp) {
+    throw new Error(`A prop was already defined with the name ${propName}`);
+  }
+}
+
 module.exports = {
   wrapModuleSchema,
   unwrapNullable,
@@ -1099,4 +1110,5 @@ module.exports = {
   handleGenericTypeAnnotation,
   getTypeResolutionStatus,
   buildPropertiesForEvent,
+  verifyPropNotAlreadyDefined,
 };

--- a/packages/react-native-codegen/src/parsers/typescript/components/componentsUtils.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/componentsUtils.js
@@ -15,7 +15,7 @@ const {
 } = require('../parseTopLevelType');
 import type {TypeDeclarationMap, PropAST, ASTNode} from '../../utils';
 import type {BuildSchemaFN, Parser} from '../../parser';
-import {verifyPropNotAlreadyDefined} from "../../parsers-commons";
+import {verifyPropNotAlreadyDefined} from '../../parsers-commons';
 
 function getUnionOfLiterals(
   name: string,

--- a/packages/react-native-codegen/src/parsers/typescript/components/componentsUtils.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/componentsUtils.js
@@ -15,6 +15,7 @@ const {
 } = require('../parseTopLevelType');
 import type {TypeDeclarationMap, PropAST, ASTNode} from '../../utils';
 import type {BuildSchemaFN, Parser} from '../../parser';
+import {verifyPropNotAlreadyDefined} from "../../parsers-commons";
 
 function getUnionOfLiterals(
   name: string,
@@ -451,17 +452,6 @@ function getSchemaInfo(
     defaultValue: topLevelType.defaultValue,
     withNullDefault: false, // Just to make `getTypeAnnotation` signature match with the one from Flow
   };
-}
-
-function verifyPropNotAlreadyDefined(
-  props: $ReadOnlyArray<PropAST>,
-  needleProp: PropAST,
-) {
-  const propName = needleProp.key.name;
-  const foundProp = props.some(prop => prop.key.name === propName);
-  if (foundProp) {
-    throw new Error(`A prop was already defined with the name ${propName}`);
-  }
 }
 
 function flattenProperties(

--- a/packages/react-native-codegen/src/parsers/typescript/components/componentsUtils.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/componentsUtils.js
@@ -13,9 +13,9 @@ const {
   parseTopLevelType,
   flattenIntersectionType,
 } = require('../parseTopLevelType');
+const {verifyPropNotAlreadyDefined} = require('../../parsers-commons');
 import type {TypeDeclarationMap, PropAST, ASTNode} from '../../utils';
 import type {BuildSchemaFN, Parser} from '../../parser';
-import {verifyPropNotAlreadyDefined} from '../../parsers-commons';
 
 function getUnionOfLiterals(
   name: string,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Move the `verifyProprsNotAlreadyDefined` functions [from Flow](https://github.com/facebook/react-native/blob/d8ced6f8953cd896471983714e722caf50783960/packages/react-native-codegen/src/parsers/flow/components/componentsUtils.js#L220-L229) and [from TypeScript](https://github.com/facebook/react-native/blob/d8ced6f8953cd896471983714e722caf50783960/packages/react-native-codegen/src/parsers/typescript/components/componentsUtils.js#LL486-L495) to the parsers-commons.js file. Use the new function in place of the others.

## Changelog:

[Internal] [Changed] - Moved `verifyProprsNotAlreadyDefined` to `parsers-commons.js`

## Test Plan
