### PR TITLE
Fix SurfaceMountingManager leaking views from stopped surfaces

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
@@ -159,4 +159,7 @@ public class ReactFeatureFlags {
 
   /** Report mount operations from the host platform to notify mount hooks. */
   public static boolean enableMountHooks = false;
+
+  /** Fixes a leak in SurfaceMountingManager.mTagSetForStoppedSurface */
+  public static boolean fixStoppedSurfaceTagSetLeak = true;
 }


### PR DESCRIPTION
Summary:
When a Surface is stopped, we don't immediately destroy the SurfaceMountingManager but instead just tear down its internal state. This allows for better error handling (eg did this react tag ever exist, or is this non-existing tag).

The way we construct the set of tags post-deletion is flawed though: `mTagToViewState.keySet()` does not create a new Set with all the tags used, but instead uses the underlying HashMap to iterate over the keys as needed. This effectively keeps all the Views inside that deleted surface alive.

Changelog: [Android][Fixed] Surfaces in the new architecture no longer leak views once stopped

Differential Revision: D46840717

