### PR TITLE
Expose react_utils via prefab to fix broken test_android

### DIFF
--- a/packages/react-native/ReactAndroid/build.gradle
+++ b/packages/react-native/ReactAndroid/build.gradle
@@ -186,6 +186,10 @@ final def preparePrefab = tasks.register("preparePrefab", PreparePrefabHeadersTa
                 ]
             ),
             new PrefabPreprocessingEntry(
+                    "react_utils",
+                    new Pair("../ReactCommon/react/utils/", "react/utils/"),
+            ),
+            new PrefabPreprocessingEntry(
                 "react_render_imagemanager",
                 [
                     new Pair("../ReactCommon/react/renderer/imagemanager/", "react/renderer/imagemanager/"),
@@ -488,6 +492,7 @@ android {
                     "runtimeexecutor",
                     "react_codegen_rncore",
                     "react_debug",
+                    "react_utils",
                     "react_render_componentregistry",
                     "react_newarchdefaults",
                     "react_render_animations",
@@ -584,6 +589,9 @@ android {
         }
         react_debug {
             headers(new File(prefabHeadersDir, "react_debug").absolutePath)
+        }
+        react_utils {
+            headers(new File(prefabHeadersDir, "react_utils").absolutePath)
         }
         react_render_componentregistry {
             headers(new File(prefabHeadersDir, "react_render_componentregistry").absolutePath)

--- a/packages/react-native/ReactAndroid/cmake-utils/ReactNative-application.cmake
+++ b/packages/react-native/ReactAndroid/cmake-utils/ReactNative-application.cmake
@@ -68,6 +68,7 @@ add_library(turbomodulejsijni ALIAS ReactAndroid::turbomodulejsijni)
 add_library(runtimeexecutor ALIAS ReactAndroid::runtimeexecutor)
 add_library(react_codegen_rncore ALIAS ReactAndroid::react_codegen_rncore)
 add_library(react_debug ALIAS ReactAndroid::react_debug)
+add_library(react_utils ALIAS ReactAndroid::react_utils)
 add_library(react_render_componentregistry ALIAS ReactAndroid::react_render_componentregistry)
 add_library(react_newarchdefaults ALIAS ReactAndroid::react_newarchdefaults)
 add_library(react_render_core ALIAS ReactAndroid::react_render_core)
@@ -95,6 +96,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME}
         jsi                                 # prefab ready
         react_codegen_rncore                # prefab ready
         react_debug                         # prefab ready
+        react_utils                         # prefab ready
         react_nativemodule_core             # prefab ready
         react_newarchdefaults               # prefab ready
         react_render_componentregistry      # prefab ready


### PR DESCRIPTION
Summary:
test_android is currently failing as we're not shipping the implementation of one of the symbol inside `react_utils`
which is now accessed by the `ConcreteComponentDescriptor.h` file (used by the app project).

Either we expose `react_utils` as a static library (.a) or as a dynamic library (.so). I've decided to go for the latter
for the sake of saving space on user devices.

Changelog:
[Internal] [Changed] - Expose react_utils via prefab to fix broken test_android

Differential Revision: D46841689

