### PR TITLE
Add a separate HermesInstance for internal

### DIFF
--- a/packages/react-native/ReactCommon/react/bridgeless/ReactInstance.cpp
+++ b/packages/react-native/ReactCommon/react/bridgeless/ReactInstance.cpp
@@ -13,8 +13,6 @@
 #include <glog/logging.h>
 #include <jsi/instrumentation.h>
 #include <jsi/jsi/JSIDynamic.h>
-#include <jsireact/JSIExecutor.h>
-#include <jsireact/JSITracing.h>
 #include <react/renderer/runtimescheduler/RuntimeSchedulerBinding.h>
 
 #include <cxxreact/ReactMarker.h>
@@ -320,8 +318,6 @@ void defineReactInstanceFlags(
     jsi::Runtime &runtime,
     ReactInstance::JSRuntimeFlags options) noexcept {
   defineReadOnlyGlobal(runtime, "RN$Bridgeless", jsi::Value(true));
-
-  jsi::addNativeTracingHooks(runtime);
 
   if (options.isProfiling) {
     defineReadOnlyGlobal(runtime, "__RCTProfileIsProfiling", jsi::Value(true));

--- a/packages/react-native/ReactCommon/react/bridgeless/hermes/HermesInstance.cpp
+++ b/packages/react-native/ReactCommon/react/bridgeless/hermes/HermesInstance.cpp
@@ -7,6 +7,7 @@
 
 #include "HermesInstance.h"
 
+#include <JSITracing.h>
 #include <jsi/jsilib.h>
 
 #ifdef HERMES_ENABLE_DEBUGGER
@@ -114,6 +115,8 @@ std::unique_ptr<jsi::Runtime> HermesInstance::createJSRuntime(
       std::make_unique<DecoratedRuntime>(std::move(hermesRuntime));
   return decoratedRuntime;
 #endif
+
+  jsi::addNativeTracingHooks(*hermesRuntime);
 
   return hermesRuntime;
 }


### PR DESCRIPTION
Summary:
Currently we have 2 versions of JSITracing:
- [Internal](https://www.internalfb.com/code/fbsource/[06c0641fed51160887cdaec18d22dd39d11ee1c0]/xplat/ReactNative/react/jsi/JSITracing.h)
- [OSS](https://www.internalfb.com/code/fbsource/[06c0641fed51160887cdaec18d22dd39d11ee1c0]/xplat/js/react-native-github/packages/react-native/ReactCommon/hermes/executor/JSITracing.h)

After talking with rubennorte it's expected that the OSS version has empty implementation and we want to keep it this way for Bridgeless as well.

To include both OSS and internal JSITracing for Bridgeless, in this diff a duplicate internal HermesInstance is created, after this change:
- Internal HermesInstance will use existed internal JSITracing
- OSS HermesInstance will use existed OSS JSITracing

The newly created internal HermesInstance will be located in existed internal Hermes folder which was created for the Bridge.

**Is there a better way to solve this issue?**
- I thought about including both versions of JSITracing in ReactInstance.cpp but couldn't find a way to unify the including paths for JSITracing.h inside ReactInstance.cpp

Changelog: [Internal]

Reviewed By: cortinico

Differential Revision: D46527522

