### PR TITLE
Add CMakeLists to build C++ files in OSS

### DIFF
--- a/packages/react-native/ReactAndroid/build.gradle
+++ b/packages/react-native/ReactAndroid/build.gradle
@@ -336,6 +336,23 @@ task downloadGlog(dependsOn: createNativeDepsDirectories, type: Download) {
     dest(new File(downloadsDir, "glog-${GLOG_VERSION}.tar.gz"))
 }
 
+task downloadGtest(dependsOn: createNativeDepsDirectories, type: Download) {
+    src("https://github.com/google/googletest/archive/refs/tags/release-${GTEST_VERSION}.tar.gz")
+    onlyIfModified(true)
+    overwrite(false)
+    retries(5)
+    dest(new File(downloadsDir, "gtest.tar.gz"))
+}
+
+task prepareGtest(dependsOn: dependenciesPath ? [] : [downloadGtest], type: Copy) {
+    from(dependenciesPath ?: tarTree(downloadGtest.dest))
+    eachFile { fname -> {
+        fname.path = (fname.path - "googletest-release-${GTEST_VERSION}/")
+     }
+    }
+    into(new File(thirdPartyNdkDir,"googletest"))
+}
+
 // Prepare glog sources to be compiled, this task will perform steps that normally should've been
 // executed by automake. This way we can avoid dependencies on make/automake
 final def prepareGlog = tasks.register("prepareGlog", PrepareGlogTask) {
@@ -360,6 +377,7 @@ task downloadNdkBuildDependencies {
     dependsOn(downloadGlog)
     dependsOn(downloadFmt)
     dependsOn(downloadLibevent)
+    dependsOn(downloadGtest)
 }
 
 /**
@@ -485,6 +503,10 @@ android {
                 targets "jsijniprofiler",
                     "reactnativeblob",
                     "reactperfloggerjni",
+                    "bridgeless",
+                    "rninstance",
+                    "hermesinstancejni",
+                    "uimanagerjni",
                     // prefab targets
                     "reactnativejni",
                     "react_render_debug",
@@ -541,7 +563,7 @@ android {
         }
     }
 
-    preBuild.dependsOn(prepareJSC, prepareBoost, prepareDoubleConversion, prepareFmt, prepareFolly, prepareGlog, prepareLibevent)
+    preBuild.dependsOn(prepareJSC, prepareBoost, prepareDoubleConversion, prepareFmt, prepareFolly, prepareGlog, prepareLibevent, prepareGtest)
     preBuild.dependsOn("generateCodegenArtifactsFromSchema")
     preBuild.dependsOn(preparePrefab)
 

--- a/packages/react-native/ReactAndroid/gradle.properties
+++ b/packages/react-native/ReactAndroid/gradle.properties
@@ -29,6 +29,7 @@ FMT_VERSION=6.2.1
 FOLLY_VERSION=2021.07.22.00
 GLOG_VERSION=0.3.5
 LIBEVENT_VERSION=2.1.12
+GTEST_VERSION=1.12.1
 
 android.useAndroidX=true
 android.enableJetifier=true

--- a/packages/react-native/ReactAndroid/src/main/jni/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/CMakeLists.txt
@@ -48,6 +48,7 @@ add_react_third_party_ndk_subdir(fmt)
 add_react_third_party_ndk_subdir(libevent)
 add_react_third_party_ndk_subdir(folly)
 add_react_third_party_ndk_subdir(jsc)
+add_react_third_party_ndk_subdir(googletest)
 
 # Common targets
 add_react_common_subdir(yoga)
@@ -97,6 +98,9 @@ add_react_common_subdir(react/utils)
 add_react_common_subdir(react/bridging)
 add_react_common_subdir(react/renderer/mapbuffer)
 add_react_common_subdir(react/nativemodule/core)
+add_react_common_subdir(jserrorhandler)
+add_react_common_subdir(react/bridgeless)
+add_react_common_subdir(react/bridgeless/hermes)
 
 # ReactAndroid JNI targets
 add_react_build_subdir(generated/source/codegen/jni)
@@ -114,12 +118,8 @@ add_react_android_subdir(src/main/jni/react/fabric)
 add_react_android_subdir(src/main/jni/react/newarchdefaults)
 add_react_android_subdir(src/main/jni/react/hermes/reactexecutor)
 add_react_android_subdir(src/main/jni/react/hermes/instrumentation/)
-
-# GTest setup
-set(GOOGLETEST_ROOT ${ANDROID_NDK}/sources/third_party/googletest)
-add_library(gtest STATIC ${GOOGLETEST_ROOT}/src/gtest_main.cc ${GOOGLETEST_ROOT}/src/gtest-all.cc)
-target_include_directories(gtest PRIVATE ${GOOGLETEST_ROOT})
-target_include_directories(gtest PUBLIC ${GOOGLETEST_ROOT}/include)
+add_react_android_subdir(src/main/jni/react/bridgeless/jni)
+add_react_android_subdir(src/main/jni/react/bridgeless/hermes/jni)
 
 # GTest dependencies
 add_executable(reactnative_unittest
@@ -163,17 +163,17 @@ add_executable(reactnative_unittest
   ${REACT_COMMON_DIR}/react/renderer/templateprocessor/tests/UITemplateProcessorTest.cpp
   ${REACT_COMMON_DIR}/react/renderer/textlayoutmanager/tests/TextLayoutManagerTest.cpp
   ${REACT_COMMON_DIR}/react/renderer/uimanager/tests/FabricUIManagerTest.cpp
-  
+
   ########## (COMPILE BUT FAIL ON ASSERTS) ###########
   # ${REACT_COMMON_DIR}/react/renderer/animations/tests/LayoutAnimationTest.cpp
   # ${REACT_COMMON_DIR}/react/renderer/mounting/tests/MountingTest.cpp
   # ${REACT_COMMON_DIR}/react/renderer/mounting/tests/ShadowTreeLifeCycleTest.cpp
-  
+
   ########## (COMPILE BUT FAIL WITH RUNTIME EXCEPTIONS) ###########
   # ${REACT_COMMON_DIR}/hermes/inspector/chrome/tests/ConnectionDemuxTests.cpp
   # ${REACT_COMMON_DIR}/hermes/inspector/detail/tests/SerialExecutorTests.cpp
   # ${REACT_COMMON_DIR}/hermes/inspector/tests/InspectorTests.cpp
-  
+
   ########## (DO NOT COMPILE) ###########
   # ${REACT_COMMON_DIR}/react/renderer/core/tests/ShadowNodeTest.cpp
   # ${REACT_COMMON_DIR}/react/renderer/core/tests/ConcreteShadowNodeTest.cpp
@@ -192,9 +192,9 @@ add_executable(reactnative_unittest
   target_link_libraries(reactnative_unittest
   folly_runtime
   folly_futures
-  glog  
+  glog
   glog_init
-  gtest
+  gtest_main
   hermes-engine::libhermes
   hermes_inspector
   jsi

--- a/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/hermes/jni/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/hermes/jni/CMakeLists.txt
@@ -1,0 +1,29 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+cmake_minimum_required(VERSION 3.13)
+set(CMAKE_VERBOSE_MAKEFILE on)
+
+file(GLOB_RECURSE hermes_instance_jni_SRC CONFIGURE_DEPENDS *.cpp)
+
+add_library(hermesinstancejni
+        SHARED
+        ${hermes_instance_jni_SRC}
+)
+target_compile_options(
+        hermesinstancejni
+        PRIVATE
+        $<$<CONFIG:Debug>:-DHERMES_ENABLE_DEBUGGER=1>
+        -std=c++17
+        -fexceptions
+)
+target_include_directories(hermesinstancejni PRIVATE .)
+target_link_libraries(
+        hermesinstancejni
+        hermes-engine::libhermes
+        rninstance
+        fbjni
+        bridgelesshermes
+)

--- a/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/jni/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/jni/CMakeLists.txt
@@ -1,0 +1,31 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+cmake_minimum_required(VERSION 3.13)
+set(CMAKE_VERBOSE_MAKEFILE on)
+
+file(GLOB_RECURSE bridgeless_jni_SRC CONFIGURE_DEPENDS *.cpp)
+
+add_library(rninstance
+        SHARED
+        ${bridgeless_jni_SRC}
+)
+target_compile_options(
+        rninstance
+        PRIVATE
+        $<$<CONFIG:Debug>:-DHERMES_ENABLE_DEBUGGER=1>
+        -std=c++17
+        -fexceptions
+)
+target_include_directories(rninstance PUBLIC .)
+target_link_libraries(
+        rninstance
+        fabricjni
+        turbomodulejsijni
+        fb
+        jsi
+        fbjni
+        bridgeless
+)

--- a/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/jni/JJSTimerExecutor.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/bridgeless/jni/JJSTimerExecutor.cpp
@@ -14,7 +14,6 @@ namespace facebook::react {
 
 void JJSTimerExecutor::setTimerManager(
     std::weak_ptr<TimerManager> timerManager) {
-  assert(timerManager && "`timerManager` must not be `nullptr`.");
   timerManager_ = timerManager;
 }
 

--- a/packages/react-native/ReactCommon/jserrorhandler/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jserrorhandler/CMakeLists.txt
@@ -1,0 +1,22 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+cmake_minimum_required(VERSION 3.13)
+set(CMAKE_VERBOSE_MAKEFILE on)
+
+add_compile_options(-std=c++17)
+
+file(GLOB_RECURSE js_error_handler_SRC CONFIGURE_DEPENDS *.cpp)
+add_library(
+        jserrorhandler
+        SHARED
+        ${js_error_handler_SRC}
+)
+target_include_directories(jserrorhandler PUBLIC .)
+target_link_libraries(jserrorhandler
+        jsi
+        folly_runtime
+        mapbufferjni
+)

--- a/packages/react-native/ReactCommon/react/bridgeless/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/bridgeless/CMakeLists.txt
@@ -1,0 +1,37 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+cmake_minimum_required(VERSION 3.13)
+set(CMAKE_VERBOSE_MAKEFILE on)
+
+file(GLOB bridgeless_SRC "*.cpp")
+
+add_library(bridgeless
+        STATIC
+        ${bridgeless_SRC}
+)
+target_compile_options(
+        bridgeless
+        PRIVATE
+        $<$<CONFIG:Debug>:-DHERMES_ENABLE_DEBUGGER=1>
+        -std=c++17
+        -fexceptions
+)
+target_include_directories(bridgeless PUBLIC .)
+
+find_library(LIBHERMES NAMES hermes-engine::libhermes)
+if (LIBHERMES)
+    target_link_libraries(bridgeless hermes-engine::libhermes)
+endif ()
+
+target_link_libraries(
+        bridgeless
+        jserrorhandler
+        fabricjni
+        turbomodulejsijni
+        fb
+        jsi
+        jsireact
+)

--- a/packages/react-native/ReactCommon/react/bridgeless/hermes/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/bridgeless/hermes/CMakeLists.txt
@@ -1,0 +1,25 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+cmake_minimum_required(VERSION 3.13)
+set(CMAKE_VERBOSE_MAKEFILE on)
+
+add_compile_options(-std=c++17)
+
+file(GLOB_RECURSE bridgeless_hermes_SRC CONFIGURE_DEPENDS *.cpp)
+add_library(
+        bridgelesshermes
+        STATIC
+        ${bridgeless_hermes_SRC}
+)
+target_include_directories(bridgelesshermes PUBLIC .)
+
+target_link_libraries(bridgelesshermes
+        jsireact
+        hermes-engine::libhermes
+        hermes_inspector
+        jsi
+        hermes_executor_common
+)

--- a/packages/react-native/ReactCommon/react/bridgeless/hermes/HermesInstance.h
+++ b/packages/react-native/ReactCommon/react/bridgeless/hermes/HermesInstance.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <hermes/API/hermes/hermes.h>
+#include <hermes/hermes.h>
 #include <jsi/jsi.h>
 #include <react/config/ReactNativeConfig.h>
 

--- a/packages/react-native/ReactCommon/react/bridgeless/tests/cxx/ReactInstanceTest.cpp
+++ b/packages/react-native/ReactCommon/react/bridgeless/tests/cxx/ReactInstanceTest.cpp
@@ -12,7 +12,7 @@
 #include <gtest/gtest.h>
 
 #include <ReactCommon/RuntimeExecutor.h>
-#include <hermes/API/hermes/hermes.h>
+#include <hermes/hermes.h>
 #include <jsi/jsi.h>
 #include <react/bridgeless/ReactInstance.h>
 #include <react/renderer/mapbuffer/MapBuffer.h>

--- a/packages/react-native/ReactCommon/react/bridging/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/bridging/CMakeLists.txt
@@ -21,4 +21,4 @@ add_library(react_bridging STATIC ${react_bridging_SRC})
 
 target_include_directories(react_bridging PUBLIC ${REACT_COMMON_DIR})
 
-target_link_libraries(react_bridging jsi)
+target_link_libraries(react_bridging jsi callinvoker)

--- a/packages/react-native/ReactCommon/react/renderer/componentregistry/native/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/componentregistry/native/CMakeLists.txt
@@ -28,4 +28,5 @@ target_link_libraries(rrc_native
         react_render_core
         react_render_debug
         react_utils
+        callinvoker
 )


### PR DESCRIPTION
Summary:
Add CMakeLists to build Bridgeless C++ files in OSS

Changelog: [Internal]

Reviewed By: cortinico

Differential Revision: D46527523

