### PR TITLE
Remove CFBundleSignature from Info.plist files

### DIFF
--- a/packages/react-native/template/ios/HelloWorld/Info.plist
+++ b/packages/react-native/template/ios/HelloWorld/Info.plist
@@ -18,8 +18,6 @@
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
-	<key>CFBundleSignature</key>
-	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/packages/react-native/template/ios/HelloWorldTests/Info.plist
+++ b/packages/react-native/template/ios/HelloWorldTests/Info.plist
@@ -16,8 +16,6 @@
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
-	<key>CFBundleSignature</key>
-	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/packages/rn-tester/RNTester/Info.plist
+++ b/packages/rn-tester/RNTester/Info.plist
@@ -16,8 +16,6 @@
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
-	<key>CFBundleSignature</key>
-	<string>????</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/packages/rn-tester/RNTester/RNTesterBundle/Info.plist
+++ b/packages/rn-tester/RNTester/RNTesterBundle/Info.plist
@@ -16,8 +16,6 @@
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
-	<key>CFBundleSignature</key>
-	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>NSHumanReadableCopyright</key>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Several `Info.plist` files, including those found in the popularly-used Hello World template, specify a `CFBundleSignature` property set to `????`. As best as I can tell, this is [a very old legacy feature](https://stackoverflow.com/a/1898662) and plays a similar role to `CFBundleIdentifier`. That is, many applications are currently running around identifying themselves as `????` specifically only to legacy systems that don't yet support CFBundleIdentifier.

This key is [no longer current](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/TP40009249-101685-TPXREF107) and is likely something that can be safely removed. I believe it _should_ thus be removed.

Of the six `Info.plist` files already found in this project, two already do not include it:

- `packages/rn-tester/RNTesterUnitTests/Info.plist`
- `packages/rn-tester/RNTesterIntegrationTests/Info.plist`

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

- [IOS] [REMOVED] CFBundleSignature dropped from `packages/react-native/template/ios/HelloWorld/Info.plist`.
- [IOS] [REMOVED] CFBundleSignature dropped from `packages/react-native/template/ios/HelloWorldTests/Info.plist`.
- [IOS] [REMOVED] CFBundleSignature dropped from `packages/rn-tester/RNTester/Info.plist`.
- [IOS] [REMOVED] CFBundleSignature dropped from `packages/rn-tester/RNTester/RNTesterBundle/Info.plist`.

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

⚠️  I don't personally yet have the system knowledge to fully test that this will cause no problems at all.