### PR TITLE
Fix for UIApplicationDidReceiveMemoryWarningNotification not being obeyed on iOS

### DIFF
--- a/packages/react-native/React/Base/RCTConstants.h
+++ b/packages/react-native/React/Base/RCTConstants.h
@@ -73,7 +73,7 @@ RCT_EXTERN void RCTSetValidateCanSendEventInRCTEventEmitter(BOOL value);
 /*
  * Memory Pressure Unloading Level
  */
-RCT_EXTERN BOOL RCTGetMemoryPressureUnloadLevel(void);
+RCT_EXTERN int RCTGetMemoryPressureUnloadLevel(void);
 RCT_EXTERN void RCTSetMemoryPressureUnloadLevel(int value);
 
 /*

--- a/packages/react-native/React/Base/RCTConstants.m
+++ b/packages/react-native/React/Base/RCTConstants.m
@@ -56,7 +56,7 @@ void RCTSetValidateCanSendEventInRCTEventEmitter(BOOL value)
  */
 static int RCTMemoryPressureUnloadLevel = 15;
 
-BOOL RCTGetMemoryPressureUnloadLevel(void)
+int RCTGetMemoryPressureUnloadLevel(void)
 {
   return RCTMemoryPressureUnloadLevel;
 }


### PR DESCRIPTION
## Summary:

Prior to 0.69, an RN app receiving the `UIApplicationDidReceiveMemoryWarningNotification` notification resulted in RN performing a GC on the JSC. Since 0.69 this has not worked, this PR fixes the issue.

Before 0.69 this was handled via a hardcoded memory pressure level: https://github.com/facebook/react-native/blob/c5c17985dae402725abb8a3a94ccedc515428711/React/CxxBridge/RCTCxxBridge.mm#L362

(It seems like the levels are an Android concept - see https://developer.android.com/reference/android/content/ComponentCallbacks2#constants_1)

In commit https://github.com/facebook/react-native/commit/0916df99511d6918ea905c2a9df45bccc1fd332a it was changed to run from a constant which could be reconfigured but a mistake (return type of `BOOL` rather than `int`) was resulting in the intended default memory pressure level of 15 (same as the old hardcoded value) being changed to 1 when it was passed on to `handleMemoryPressure`.

## Changelog:

[IOS] [FIXED] - UIApplicationDidReceiveMemoryWarningNotification has not been obeyed on iOS since RN 0.69

## Test Plan:

Tested manually via the Simulator using Debug -> Simulate Memory Warning and monitoring the console output of the app.

Before fix:

```
WARNING: Logging before InitGoogleLogging() is written to STDERR
W0620 11:21:42.824463 257294336 JSIExecutor.cpp:377] Memory warning (pressure level: 1) received by JS VM, unrecognized pressure level
```

With fix (and also the same output for the latest 0.68 tag in the repo):

```
WARNING: Logging before InitGoogleLogging() is written to STDERR
I0620 11:25:47.479444 79212544 JSIExecutor.cpp:370] Memory warning (pressure level: TRIM_MEMORY_RUNNING_CRITICAL) received by JS VM, running a GC
```
