### PR TITLE
Use the correct path to upload apk from android template jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -814,7 +814,7 @@ jobs:
             ./gradlew assemble<< parameters.flavor >> -PREACT_NATIVE_MAVEN_LOCAL_REPO=/root/react-native/maven-local
 
       - store_artifacts:
-          path: /tmp/$PROJECT_NAME/android/app/build/outputs/apk/
+          path: /tmp/AndroidTemplateProject/android/app/build/outputs/apk/
           destination: template-apk
 
   # -------------------------


### PR DESCRIPTION
## Summary:

Upload of apk artifacts from template jobs is currently failing (see https://app.circleci.com/pipelines/github/facebook/react-native/25867/workflows/daec954a-2de9-4573-877a-c9d4cfade6b0/jobs/739866/steps) due to wrong path.
This fixes it.

## Changelog:

[INTERNAL] - Use the correct path to upload apk from android template jobs

## Test Plan:

will wait for CI results