### PR TITLE
Remove duplication in rn-tester react-native.config.js file

### DIFF
--- a/packages/react-native/react-native.config.js
+++ b/packages/react-native/react-native.config.js
@@ -24,16 +24,4 @@ module.exports = {
       dependencyConfig: android.dependencyConfig,
     },
   },
-  /**
-   * Used when running RNTester (with React Native from source)
-   */
-  reactNativePath: '.',
-  project: {
-    ios: {
-      sourceDir: '../packages/rn-tester',
-    },
-    android: {
-      sourceDir: '../packages/rn-tester',
-    },
-  },
 };

--- a/packages/rn-tester/react-native.config.js
+++ b/packages/rn-tester/react-native.config.js
@@ -9,21 +9,12 @@
 
 'use strict';
 
-const ios = require('@react-native-community/cli-platform-ios');
-const android = require('@react-native-community/cli-platform-android');
+// Inside the React Native monorepo, we need to explicitly extend the base
+// CLI config as the adjacent package will not be conventionally discovered.
+const config = require('../react-native/react-native.config.js');
 
 module.exports = {
-  commands: [...ios.commands, ...android.commands],
-  platforms: {
-    ios: {
-      projectConfig: ios.projectConfig,
-      dependencyConfig: ios.dependencyConfig,
-    },
-    android: {
-      projectConfig: android.projectConfig,
-      dependencyConfig: android.dependencyConfig,
-    },
-  },
+  ...config,
   reactNativePath: '../react-native',
   project: {
     ios: {


### PR DESCRIPTION
Summary:
Tweaks `react-native.config.js` files to remove duplication. `rn-tester` now references framework-included config from `react-native` (ahead of making config additions to this entry point).

As far as I can tell (from historic diff context), the presence of `packages/rn-tester/react-native.config.js` is a special case, due to the CLI's config discovery algorithm, and this file needs to remain a complete config.

Changelog: [Internal]

Reviewed By: hoxyq

Differential Revision: D46859698

