### PR TITLE
Fix ReactHostTest.testPreload()

### DIFF
--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridgeless/ReactHostTest.java
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridgeless/ReactHostTest.java
@@ -49,8 +49,8 @@ import org.robolectric.android.controller.ActivityController;
   "androidx.*",
   "javax.net.ssl.*"
 })
-@PrepareForTest({ReactHost.class, ComponentFactory.class})
 @Ignore("Ignore for now as these tests fail in OSS only")
+@PrepareForTest({ReactHost.class, ComponentFactory.class})
 public class ReactHostTest {
 
   private ReactHostDelegate mReactHostDelegate;
@@ -105,7 +105,7 @@ public class ReactHostTest {
     assertThat(uiManager).isNull();
   }
 
-  @Ignore("FIXME")
+  @Test
   public void testGetDevSupportManager() {
     assertThat(mReactHost.getDevSupportManager()).isEqualTo(mDevSupportManager);
   }


### PR DESCRIPTION
Summary:
In this diff I'm fixing the ReactHostTest.testPreload test that was broken due to concurrency issues between a task submited in bolts that interacted with the UIThread and RobolectricTestRunner blocking on the UI Thread.

I created an utility method to wait for completion of the task

see: https://robolectric.org/blog/2019/06/04/paused-looper/

changelog: [internal] internal

Reviewed By: fkgozali

Differential Revision: D46812085

