### PR TITLE
Re-enable ReactHostTest

### DIFF
--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridgeless/ReactHostTest.java
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridgeless/ReactHostTest.java
@@ -49,8 +49,8 @@ import org.robolectric.android.controller.ActivityController;
   "androidx.*",
   "javax.net.ssl.*"
 })
-@PrepareForTest({ReactHost.class, ComponentFactory.class})
 @Ignore("Ignore for now as these tests fail in OSS only")
+@PrepareForTest({ReactHost.class, ComponentFactory.class})
 public class ReactHostTest {
 
   private ReactHostDelegate mReactHostDelegate;
@@ -105,7 +105,7 @@ public class ReactHostTest {
     assertThat(uiManager).isNull();
   }
 
-  @Ignore("FIXME")
+  @Test
   public void testGetDevSupportManager() {
     assertThat(mReactHost.getDevSupportManager()).isEqualTo(mDevSupportManager);
   }


### PR DESCRIPTION
Summary:
ReactHostTest was disabled as part of D44729814, I'm re-enabling it as they pass locally

changelog: [internal] internal

Reviewed By: cortinico

Differential Revision: D46806278

