### PR TITLE
Create test that verifies ReactHost.destroy() works as expected

### DIFF
--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridgeless/ReactHostTest.java
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridgeless/ReactHostTest.java
@@ -49,8 +49,8 @@ import org.robolectric.android.controller.ActivityController;
   "androidx.*",
   "javax.net.ssl.*"
 })
-@PrepareForTest({ReactHost.class, ComponentFactory.class})
 @Ignore("Ignore for now as these tests fail in OSS only")
+@PrepareForTest({ReactHost.class, ComponentFactory.class})
 public class ReactHostTest {
 
   private ReactHostDelegate mReactHostDelegate;
@@ -105,7 +105,7 @@ public class ReactHostTest {
     assertThat(uiManager).isNull();
   }
 
-  @Ignore("FIXME")
+  @Test
   public void testGetDevSupportManager() {
     assertThat(mReactHost.getDevSupportManager()).isEqualTo(mDevSupportManager);
   }

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridgeless/ReactHostTest.java
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridgeless/ReactHostTest.java
@@ -123,7 +123,7 @@ public class ReactHostTest {
   }
 
   @Test
-  public void testPreload() throws Exception {
+  public void testStart() throws Exception {
     TaskCompletionSource<Boolean> taskCompletionSource = new TaskCompletionSource<>();
     taskCompletionSource.setResult(true);
     whenNew(TaskCompletionSource.class).withAnyArguments().thenReturn(taskCompletionSource);

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridgeless/ReactHostTest.java
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridgeless/ReactHostTest.java
@@ -124,6 +124,10 @@ public class ReactHostTest {
 
   @Test
   public void testStart() throws Exception {
+    statAndTestReactHost();
+  }
+
+  private void statAndTestReactHost() throws Exception {
     TaskCompletionSource<Boolean> taskCompletionSource = new TaskCompletionSource<>();
     taskCompletionSource.setResult(true);
     whenNew(TaskCompletionSource.class).withAnyArguments().thenReturn(taskCompletionSource);
@@ -135,6 +139,15 @@ public class ReactHostTest {
     assertThat(mReactHost.isInstanceInitialized()).isTrue();
     assertThat(mReactHost.getCurrentReactContext()).isNotNull();
     verify(mMemoryPressureRouter).addMemoryPressureListener((MemoryPressureListener) any());
+  }
+
+  @Test
+  public void testDestroy() throws Exception {
+    statAndTestReactHost();
+
+    waitForTaskUIThread(mReactHost.destroy("Destroying from testing infra", null));
+    assertThat(mReactHost.isInstanceInitialized()).isFalse();
+    assertThat(mReactHost.getCurrentReactContext()).isNull();
   }
 
   private static <T> void waitForTaskUIThread(Task<T> task) throws InterruptedException {


### PR DESCRIPTION
Summary:
Create test ReactHostTest.testDestroy() that verifies ReactHost.destroy() works as expected

changelog: [internal] internal

Reviewed By: cortinico

Differential Revision: D46813611

