### PR TITLE
fix(ios): fix `pod install --project-directory=ios` failing

### DIFF
--- a/packages/react-native/scripts/cocoapods/__tests__/codegen_utils-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/codegen_utils-test.rb
@@ -382,7 +382,7 @@ class CodegenUtilsTests < Test::Unit::TestCase
         assert_equal(codegen_utils_mock.get_react_codegen_spec_params,  [{
             :fabric_enabled => false,
             :folly_version=>"2021.07.22.00",
-            :package_json_file => "#{app_path}../node_modules/react-native/package.json",
+            :package_json_file => "#{app_path}/ios/../node_modules/react-native/package.json",
             :script_phases => "echo TestScript"
         }])
         assert_equal(codegen_utils_mock.generate_react_codegen_spec_params,  [{

--- a/packages/react-native/scripts/cocoapods/__tests__/codegen_utils-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/codegen_utils-test.rb
@@ -373,7 +373,7 @@ class CodegenUtilsTests < Test::Unit::TestCase
             '[Codegen] warn: using experimental new codegen integration'
         ])
         assert_equal(codegen_utils_mock.get_react_codegen_script_phases_params,  [{
-            :app_path => "~/app",
+            :app_path => app_path,
             :config_file_dir => "",
             :config_key => "codegenConfig",
             :fabric_enabled => false,
@@ -382,7 +382,7 @@ class CodegenUtilsTests < Test::Unit::TestCase
         assert_equal(codegen_utils_mock.get_react_codegen_spec_params,  [{
             :fabric_enabled => false,
             :folly_version=>"2021.07.22.00",
-            :package_json_file => "../node_modules/react-native/package.json",
+            :package_json_file => "#{app_path}../node_modules/react-native/package.json",
             :script_phases => "echo TestScript"
         }])
         assert_equal(codegen_utils_mock.generate_react_codegen_spec_params,  [{

--- a/packages/react-native/scripts/cocoapods/codegen_utils.rb
+++ b/packages/react-native/scripts/cocoapods/codegen_utils.rb
@@ -132,7 +132,7 @@ class CodegenUtils
             "React-jsi": [],
             "ReactCommon/turbomodule/bridging": [],
             "ReactCommon/turbomodule/core": [],
-            "React-NativeModulesApple": [], 
+            "React-NativeModulesApple": [],
             "glog": [],
             "DoubleConversion": [],
           }
@@ -316,7 +316,7 @@ class CodegenUtils
         :config_key => config_key
       )
       react_codegen_spec = codegen_utils.get_react_codegen_spec(
-        file_manager.join(react_native_path, "package.json"),
+        file_manager.join(relative_installation_root, react_native_path, "package.json"),
         :folly_version => folly_version,
         :fabric_enabled => fabric_enabled,
         :hermes_enabled => hermes_enabled,


### PR DESCRIPTION
## Summary:

![image](https://user-images.githubusercontent.com/4123478/217618490-4f99e408-1a07-4acf-a05c-e8837562a931.png)

`pod install --project-directory=ios` currently fails when new arch is enabled: https://github.com/react-native-async-storage/async-storage/pull/910

- Patch for 0.71: https://github.com/facebook/react-native/pull/37993
- Patch for 0.72: https://github.com/facebook/react-native/pull/37994

## Changelog:

[IOS] [FIXED] - Fix `pod install --project-directory=...` when New Arch is enabled

## Test Plan:

```
git clone https://github.com/react-native-async-storage/async-storage.git
cd async-storage
gh pr checkout 910
yarn
RCT_NEW_ARCH_ENABLED=1 pod install --project-directory=example/ios
```