### PR TITLE
fix: TextInput line height issue in Android

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -1067,6 +1067,11 @@ public class ReactEditText extends AppCompatEditText
     applyTextAttributes();
   }
 
+  public void setLineHeight(float lineHeight) {
+    mTextAttributes.setLineHeight(lineHeight);
+    applyTextAttributes();
+  }
+
   public void setMaxFontSizeMultiplier(float maxFontSizeMultiplier) {
     if (maxFontSizeMultiplier != mTextAttributes.getMaxFontSizeMultiplier()) {
       mTextAttributes.setMaxFontSizeMultiplier(maxFontSizeMultiplier);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -501,7 +501,6 @@ public class ReactEditText extends AppCompatEditText
   public void setPlaceholder(@Nullable String placeholder) {
     if (!Objects.equals(placeholder, mPlaceholder)) {
       mPlaceholder = placeholder;
-      setHint(placeholder);
     }
   }
 
@@ -627,10 +626,33 @@ public class ReactEditText extends AppCompatEditText
     // to prevent an (asynchronous) infinite loop.
     mDisableTextDiffing = true;
 
+    // Apply font size and line height to placeholder
+    if (reactTextUpdate.getText().length() == 0 && getText().length() == 0 && mPlaceholder != null) {
+      SpannableStringBuilder hintSpannable = new SpannableStringBuilder(mPlaceholder);
+
+      int spanFlags = Spannable.SPAN_INCLUSIVE_INCLUSIVE;
+      spanFlags |= Spannable.SPAN_PRIORITY;
+
+      float fontSize = mTextAttributes.getEffectiveFontSize();
+      if (!Float.isNaN(fontSize)) {
+        hintSpannable.setSpan(new ReactAbsoluteSizeSpan((int) fontSize), 0, hintSpannable.length(), spanFlags);
+      }
+
+      float lineHeight = mTextAttributes.getEffectiveLineHeight();
+      if (!Float.isNaN(lineHeight)) {
+        hintSpannable.setSpan(new CustomLineHeightSpan(lineHeight), 0, hintSpannable.length(), spanFlags);
+      }
+
+      setHint(hintSpannable);
+    }
+
     // On some devices, when the text is cleared, buggy keyboards will not clear the composing
     // text so, we have to set text to null, which will clear the currently composing text.
     if (reactTextUpdate.getText().length() == 0) {
       setText(null);
+
+      // Puts and empty string to avoid flickering on first character
+      getText().replace(0, length(), spannableStringBuilder);
     } else {
       // When we update text, we trigger onChangeText code that will
       // try to update state if the wrapper is available. Temporarily disable
@@ -691,11 +713,6 @@ public class ReactEditText extends AppCompatEditText
    * the presence of spans https://github.com/facebook/react-native/issues/35936 (S318090)
    */
   private void stripStyleEquivalentSpans(SpannableStringBuilder sb) {
-    stripSpansOfKind(
-        sb,
-        ReactAbsoluteSizeSpan.class,
-        (span) -> span.getSize() == mTextAttributes.getEffectiveFontSize());
-
     stripSpansOfKind(
         sb,
         ReactBackgroundColorSpan.class,
@@ -1087,9 +1104,23 @@ public class ReactEditText extends AppCompatEditText
     // In general, the `getEffective*` functions return `Float.NaN` if the
     // property hasn't been set.
 
-    // `getEffectiveFontSize` always returns a value so don't need to check for anything like
-    // `Float.NaN`.
-    setTextSize(TypedValue.COMPLEX_UNIT_PX, mTextAttributes.getEffectiveFontSize());
+    // `getEffectiveFontSize` always returns a value so don't need
+    // to check for anything like `Float.NaN`
+    float fontSize = mTextAttributes.getEffectiveFontSize();
+    setTextSize(TypedValue.COMPLEX_UNIT_PX, fontSize);
+
+    // Applies the line height as the font size so that the cursor height
+    // matches the text height when the input is empty
+    float lineHeight = mTextAttributes.getEffectiveLineHeight();
+    if (!Float.isNaN(lineHeight)) {
+      // Due to the fact that the cursor size is slightly bigger when the
+      // input is empty than when there is text, the font metrics are used
+      // to discover the relation in the font "height" and using that difference,
+      // adapt the line height applied to the text
+      Paint.FontMetrics fm = getPaint().getFontMetrics();
+      final float diff = Math.abs((fm.bottom / fm.top));
+      setTextSize(TypedValue.COMPLEX_UNIT_PX, lineHeight * (1 - diff));
+    }
 
     float effectiveLetterSpacing = mTextAttributes.getEffectiveLetterSpacing();
     if (!Float.isNaN(effectiveLetterSpacing)) {
@@ -1204,6 +1235,14 @@ public class ReactEditText extends AppCompatEditText
       if (DEBUG_MODE) {
         FLog.e(
             TAG, "onTextChanged[" + getId() + "]: " + s + " " + start + " " + before + " " + count);
+      }
+
+      // Necessary to apply the text attribute to the spannable for Fabric to avoid
+      // flicker of wrong style on the first character before `maybeSetText` is called
+      if (mFabricViewStateManager != null && mFabricViewStateManager.hasStateWrapper()) {
+        if (mTextAttributes != null) {
+          addSpansFromStyleAttributes((SpannableStringBuilder) s);
+        }
       }
 
       if (!mIsSettingTextFromJS && mListeners != null) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -387,6 +387,11 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
     }
   }
 
+  @ReactProp(name = "lineHeight")
+  public void setLineHeight(ReactEditText view, @Nullable float lineHeight) {
+    view.setLineHeight(lineHeight);
+  }
+
   @ReactProp(name = ViewProps.FONT_SIZE, defaultFloat = ViewDefaults.FONT_SIZE_SP)
   public void setFontSize(ReactEditText view, float fontSize) {
     view.setFontSize(fontSize);

--- a/packages/rn-tester/js/examples/TextInput/TextInputExample.android.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputExample.android.js
@@ -81,10 +81,15 @@ class LineHeightExample extends React.Component<
         />
         <TextInput
           multiline
-          textAlignVertical="top"
           style={[
             styles.singleLine,
-            {lineHeight: 40, height: 200, borderColor: 'black', borderWidth: 1},
+            {
+              lineHeight: 40,
+              height: 200,
+              borderColor: 'black',
+              borderWidth: 1,
+              textAlignVertical: 'top',
+            },
           ]}
           value={this.state.valueMultiline}
           onChangeText={value => this.setState({valueMultiline: value})}

--- a/packages/rn-tester/js/examples/TextInput/TextInputExample.android.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputExample.android.js
@@ -41,6 +41,71 @@ class ToggleDefaultPaddingExample extends React.Component<
   }
 }
 
+class LineHeightExample extends React.Component<
+  $FlowFixMeProps,
+  $FlowFixMeState,
+> {
+  /* $FlowFixMe[missing-local-annot] The type annotation(s) required by Flow's
+   * LTI update could not be added via codemod */
+  constructor(props) {
+    super(props);
+    this.state = {value: '', valueMultiline: ''};
+
+    this.setValue = this.setValue.bind(this);
+    this.setValueMultiline = this.setValueMultiline.bind(this);
+  }
+
+  setValue(value: string) {
+    this.setState({value});
+  }
+
+  setValueMultiline(value: string) {
+    this.setState({valueMultiline: value});
+  }
+
+  render(): React.Node {
+    return (
+      <View>
+        <TextInput
+          style={[styles.singleLine, {lineHeight: 10}]}
+          value={this.state.value}
+          onChangeText={this.setValue}
+          placeholder="lineHeight = 10"
+        />
+        <TextInput
+          style={[styles.singleLine, {lineHeight: 20}]}
+          value={this.state.value}
+          onChangeText={this.setValue}
+          placeholder="lineHeight = 20"
+        />
+        <TextInput
+          style={[styles.singleLine, {lineHeight: 40}]}
+          value={this.state.value}
+          onChangeText={this.setValue}
+          placeholder="lineHeight = 40"
+        />
+        <TextInput
+          style={[styles.singleLine, {lineHeight: 60}]}
+          value={this.state.value}
+          onChangeText={this.setValue}
+          placeholder="lineHeight = 60"
+        />
+        <TextInput
+          multiline
+          textAlignVertical="top"
+          style={[
+            styles.singleLine,
+            {lineHeight: 40, height: 200, borderColor: 'black', borderWidth: 1},
+          ]}
+          value={this.state.valueMultiline}
+          onChangeText={this.setValueMultiline}
+          placeholder="lineHeight = 40 + multiline"
+        />
+      </View>
+    );
+  }
+}
+
 class AutogrowingTextInputExample extends React.Component<{...}> {
   /* $FlowFixMe[missing-local-annot] The type annotation(s) required by Flow's
    * LTI update could not be added via codemod */
@@ -273,6 +338,12 @@ exports.examples = ([
           />
         </View>
       );
+    },
+  },
+  {
+    title: 'lineHeight',
+    render: function (): React.Node {
+      return <LineHeightExample />;
     },
   },
   {

--- a/packages/rn-tester/js/examples/TextInput/TextInputExample.android.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputExample.android.js
@@ -50,17 +50,6 @@ class LineHeightExample extends React.Component<
   constructor(props) {
     super(props);
     this.state = {value: '', valueMultiline: ''};
-
-    this.setValue = this.setValue.bind(this);
-    this.setValueMultiline = this.setValueMultiline.bind(this);
-  }
-
-  setValue(value: string) {
-    this.setState({value});
-  }
-
-  setValueMultiline(value: string) {
-    this.setState({valueMultiline: value});
   }
 
   render(): React.Node {
@@ -69,25 +58,25 @@ class LineHeightExample extends React.Component<
         <TextInput
           style={[styles.singleLine, {lineHeight: 10}]}
           value={this.state.value}
-          onChangeText={this.setValue}
+          onChangeText={value => this.setState({value})}
           placeholder="lineHeight = 10"
         />
         <TextInput
           style={[styles.singleLine, {lineHeight: 20}]}
           value={this.state.value}
-          onChangeText={this.setValue}
+          onChangeText={value => this.setState({value})}
           placeholder="lineHeight = 20"
         />
         <TextInput
           style={[styles.singleLine, {lineHeight: 40}]}
           value={this.state.value}
-          onChangeText={this.setValue}
+          onChangeText={value => this.setState({value})}
           placeholder="lineHeight = 40"
         />
         <TextInput
           style={[styles.singleLine, {lineHeight: 60}]}
           value={this.state.value}
-          onChangeText={this.setValue}
+          onChangeText={value => this.setState({value})}
           placeholder="lineHeight = 60"
         />
         <TextInput
@@ -98,7 +87,7 @@ class LineHeightExample extends React.Component<
             {lineHeight: 40, height: 200, borderColor: 'black', borderWidth: 1},
           ]}
           value={this.state.valueMultiline}
-          onChangeText={this.setValueMultiline}
+          onChangeText={value => this.setState({valueMultiline: value})}
           placeholder="lineHeight = 40 + multiline"
         />
       </View>


### PR DESCRIPTION
## Summary:

There are two issues related to line height in Android: 
1. the height of the input changes when typing, since it seems the line height is not taken into consideration in the measurements
2. the cursor height of an empty input is smaller than when the input has text

See extensive discussion of these problems in [Expensify issue](https://github.com/Expensify/App/issues/14799).

<details>
<summary>Videos of the problematic behaviour</summary>

1st problem:

| Old Arch                                                                                                              | New Arch                                                                                                        |
| ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
| <video src="https://user-images.githubusercontent.com/25725586/233036342-2fbd0087-c924-4fd6-96a3-24d9056ce26f.mov"> | <video src="https://user-images.githubusercontent.com/25725586/233036840-351579cb-bbfb-496c-8a1a-c58efeeb953c.mov"> | <video src="https://user-images.githubusercontent.com/25725586/233036909-956a4434-1983-45b9-a490-fa3a8c6f8094.mov"> |

2nd problem:

https://github.com/facebook/react-native/assets/25725586/d7c67548-d409-4c77-91a4-df5c02a412ca

</details>

### Reasoning for the fix

**1st Problem**

- Old Arch

One interesting thing that `updateCachedSpannable` does in New Arch is 'fake' text content if there is none, so that there is something to measure. This is not done for the Old Arch, which in itself is the root of the problem. The fix was modifying the `ReactTextInputShadowNode.java->measure` method to fake some text on the text input if lineHeight is set so that it can be used to measure correctly.

- New Arch

Although for New Arch it's taking into consideration the faking of the text, the lineHeight is not being passed down to the `TextAttributes`, so it was necessary to add a setter `setLineHeight` to both `ReactTextInputManager.java` and `ReactEditText.java`, which set the line height value in it's `textAttributes` instance. With this, the line height is correctly applied to the spans when updating the spannables.

**2nd Problem**

Since the cursor size seems to be tied to the `textSize` of the `EditText` when empty, the solution taken was setting the `textSize` to be equal to the line height (taking into consideration that it's not 1-1 and the cursor will be smaller, so there's a coeficient that is used based on the font metrics).

With this change, the font size of the spannables must not be stripped, and the font size and line height must be applied to the placeholder.

<details>
<summary>Videos after the fix</summary>

https://github.com/facebook/react-native/assets/25725586/780b50fd-6f2b-4140-a1f6-d8a8aca4082a

![Screenshot 2023-06-21 at 14 57 56](https://github.com/facebook/react-native/assets/25725586/86cf41d5-6481-4dde-8767-f4f687037dea)

</details>

## Changelog:

[ANDROID] [FIXED] - Cursor and text input adapt to line height when empty

## Test Plan:

Run `rn-tester` in Android and check the `Text Input` -> `Line Height` example and other TextInput examples to see that no behaviour changed.
