### PR TITLE
refactor: improve useColorScheme subscription efficiency

### DIFF
--- a/packages/react-native/Libraries/Utilities/useColorScheme.js
+++ b/packages/react-native/Libraries/Utilities/useColorScheme.js
@@ -16,9 +16,9 @@ import Appearance from './Appearance';
 import {useCallback, useSyncExternalStore} from 'react';
 
 export default function useColorScheme(): ?ColorSchemeName {
-  const subscribe = useCallback(callback => {
-    const appearanceSubscription = Appearance.addChangeListener(callback);
-    return appearanceSubscription.remove;
+  const subscribe = useCallback((onStoreChange: () => void) => {
+    const appearanceSubscription = Appearance.addChangeListener(onStoreChange);
+    return () => appearanceSubscription.remove();
   }, []);
 
   return useSyncExternalStore(subscribe, Appearance.getColorScheme);

--- a/packages/react-native/Libraries/Utilities/useColorScheme.js
+++ b/packages/react-native/Libraries/Utilities/useColorScheme.js
@@ -13,13 +13,12 @@
 import type {ColorSchemeName} from './NativeAppearance';
 
 import Appearance from './Appearance';
-import {useCallback, useSyncExternalStore} from 'react';
+import {useSyncExternalStore} from 'react';
+const subscribe = (onStoreChange: () => void) => {
+  const appearanceSubscription = Appearance.addChangeListener(onStoreChange);
+  return () => appearanceSubscription.remove();
+};
 
 export default function useColorScheme(): ?ColorSchemeName {
-  const subscribe = useCallback((onStoreChange: () => void) => {
-    const appearanceSubscription = Appearance.addChangeListener(onStoreChange);
-    return () => appearanceSubscription.remove();
-  }, []);
-
   return useSyncExternalStore(subscribe, Appearance.getColorScheme);
 }

--- a/packages/react-native/Libraries/Utilities/useColorScheme.js
+++ b/packages/react-native/Libraries/Utilities/useColorScheme.js
@@ -13,14 +13,13 @@
 import type {ColorSchemeName} from './NativeAppearance';
 
 import Appearance from './Appearance';
-import {useSyncExternalStore} from 'react';
+import {useCallback, useSyncExternalStore} from 'react';
 
 export default function useColorScheme(): ?ColorSchemeName {
-  return useSyncExternalStore(
-    callback => {
-      const appearanceSubscription = Appearance.addChangeListener(callback);
-      return () => appearanceSubscription.remove();
-    },
-    () => Appearance.getColorScheme(),
-  );
+  const subscribe = useCallback(callback => {
+    const appearanceSubscription = Appearance.addChangeListener(callback);
+    return appearanceSubscription.remove;
+  }, []);
+
+  return useSyncExternalStore(subscribe, Appearance.getColorScheme);
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

motivation: re-rendering `useColorScheme()` hook with what is on the main branch means there is a subscribe + unsubscribe dance happening.

related docs: https://react.dev/reference/react/useSyncExternalStore#my-subscribe-function-gets-called-after-every-re-render


## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[INTERNAL] [CHANGED] - improve useColorScheme subscription efficiency

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

tested locally in an app