### PR TITLE
Enable Bridgeless

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
@@ -19,6 +19,8 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.bridge.Callback;
+import com.facebook.react.config.ReactFeatureFlags;
+import com.facebook.react.interfaces.ReactHostInterface;
 import com.facebook.react.modules.core.PermissionListener;
 
 /**
@@ -86,6 +88,10 @@ public class ReactActivityDelegate {
     return ((ReactApplication) getPlainActivity().getApplication()).getReactNativeHost();
   }
 
+  public ReactHostInterface getReactHost() {
+    return ((ReactApplication) getPlainActivity().getApplication()).getReactHostInterface();
+  }
+
   public ReactInstanceManager getReactInstanceManager() {
     return mReactDelegate.getReactInstanceManager();
   }
@@ -97,14 +103,19 @@ public class ReactActivityDelegate {
   protected void onCreate(Bundle savedInstanceState) {
     String mainComponentName = getMainComponentName();
     final Bundle launchOptions = composeLaunchOptions();
-    mReactDelegate =
-        new ReactDelegate(
-            getPlainActivity(), getReactNativeHost(), mainComponentName, launchOptions) {
-          @Override
-          protected ReactRootView createRootView() {
-            return ReactActivityDelegate.this.createRootView(launchOptions);
-          }
-        };
+    if (ReactFeatureFlags.enableBridgelessArchitecture) {
+      mReactDelegate =
+          new ReactDelegate(getPlainActivity(), getReactHost(), mainComponentName, launchOptions);
+    } else {
+      mReactDelegate =
+          new ReactDelegate(
+              getPlainActivity(), getReactNativeHost(), mainComponentName, launchOptions) {
+            @Override
+            protected ReactRootView createRootView() {
+              return ReactActivityDelegate.this.createRootView(launchOptions);
+            }
+          };
+    }
     if (mainComponentName != null) {
       loadApp(mainComponentName);
     }
@@ -137,11 +148,13 @@ public class ReactActivityDelegate {
   }
 
   public boolean onKeyDown(int keyCode, KeyEvent event) {
-    if (getReactNativeHost().hasInstance()
-        && getReactNativeHost().getUseDeveloperSupport()
-        && keyCode == KeyEvent.KEYCODE_MEDIA_FAST_FORWARD) {
-      event.startTracking();
-      return true;
+    if (!ReactFeatureFlags.enableBridgelessArchitecture) {
+      if (getReactNativeHost().hasInstance()
+          && getReactNativeHost().getUseDeveloperSupport()
+          && keyCode == KeyEvent.KEYCODE_MEDIA_FAST_FORWARD) {
+        event.startTracking();
+        return true;
+      }
     }
     return false;
   }
@@ -151,11 +164,13 @@ public class ReactActivityDelegate {
   }
 
   public boolean onKeyLongPress(int keyCode, KeyEvent event) {
-    if (getReactNativeHost().hasInstance()
-        && getReactNativeHost().getUseDeveloperSupport()
-        && keyCode == KeyEvent.KEYCODE_MEDIA_FAST_FORWARD) {
-      getReactNativeHost().getReactInstanceManager().showDevOptionsDialog();
-      return true;
+    if (!ReactFeatureFlags.enableBridgelessArchitecture) {
+      if (getReactNativeHost().hasInstance()
+          && getReactNativeHost().getUseDeveloperSupport()
+          && keyCode == KeyEvent.KEYCODE_MEDIA_FAST_FORWARD) {
+        getReactNativeHost().getReactInstanceManager().showDevOptionsDialog();
+        return true;
+      }
     }
     return false;
   }
@@ -165,22 +180,28 @@ public class ReactActivityDelegate {
   }
 
   public boolean onNewIntent(Intent intent) {
-    if (getReactNativeHost().hasInstance()) {
-      getReactNativeHost().getReactInstanceManager().onNewIntent(intent);
-      return true;
+    if (!ReactFeatureFlags.enableBridgelessArchitecture) {
+      if (getReactNativeHost().hasInstance()) {
+        getReactNativeHost().getReactInstanceManager().onNewIntent(intent);
+        return true;
+      }
     }
     return false;
   }
 
   public void onWindowFocusChanged(boolean hasFocus) {
-    if (getReactNativeHost().hasInstance()) {
-      getReactNativeHost().getReactInstanceManager().onWindowFocusChange(hasFocus);
+    if (!ReactFeatureFlags.enableBridgelessArchitecture) {
+      if (getReactNativeHost().hasInstance()) {
+        getReactNativeHost().getReactInstanceManager().onWindowFocusChange(hasFocus);
+      }
     }
   }
 
   public void onConfigurationChanged(Configuration newConfig) {
-    if (getReactNativeHost().hasInstance()) {
-      getReactInstanceManager().onConfigurationChanged(getContext(), newConfig);
+    if (!ReactFeatureFlags.enableBridgelessArchitecture) {
+      if (getReactNativeHost().hasInstance()) {
+        getReactInstanceManager().onConfigurationChanged(getContext(), newConfig);
+      }
     }
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
@@ -14,7 +14,10 @@ import android.view.KeyEvent;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.facebook.infer.annotation.Assertions;
+import com.facebook.react.config.ReactFeatureFlags;
 import com.facebook.react.devsupport.DoubleTapReloadRecognizer;
+import com.facebook.react.interfaces.ReactHostInterface;
+import com.facebook.react.interfaces.ReactSurfaceInterface;
 import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
 
 /**
@@ -32,7 +35,9 @@ public class ReactDelegate {
 
   @Nullable private DoubleTapReloadRecognizer mDoubleTapReloadRecognizer;
 
-  private ReactNativeHost mReactNativeHost;
+  @Nullable private ReactNativeHost mReactNativeHost;
+  @Nullable private ReactHostInterface mReactHost;
+  @Nullable private ReactSurfaceInterface mReactSurface;
 
   private boolean mFabricEnabled = false;
 
@@ -50,6 +55,18 @@ public class ReactDelegate {
 
   public ReactDelegate(
       Activity activity,
+      ReactHostInterface reactHost,
+      @Nullable String appKey,
+      @Nullable Bundle launchOptions) {
+    mActivity = activity;
+    mMainComponentName = appKey;
+    mLaunchOptions = launchOptions;
+    mDoubleTapReloadRecognizer = new DoubleTapReloadRecognizer();
+    mReactHost = reactHost;
+  }
+
+  public ReactDelegate(
+      Activity activity,
       ReactNativeHost reactNativeHost,
       @Nullable String appKey,
       @Nullable Bundle launchOptions,
@@ -63,48 +80,72 @@ public class ReactDelegate {
   }
 
   public void onHostResume() {
-    if (getReactNativeHost().hasInstance()) {
+    if (ReactFeatureFlags.enableBridgelessArchitecture) {
       if (mActivity instanceof DefaultHardwareBackBtnHandler) {
-        getReactNativeHost()
-            .getReactInstanceManager()
-            .onHostResume(mActivity, (DefaultHardwareBackBtnHandler) mActivity);
-      } else {
-        throw new ClassCastException(
-            "Host Activity does not implement DefaultHardwareBackBtnHandler");
+        mReactHost.onHostResume(mActivity, (DefaultHardwareBackBtnHandler) mActivity);
+      }
+    } else {
+      if (getReactNativeHost().hasInstance()) {
+        if (mActivity instanceof DefaultHardwareBackBtnHandler) {
+          getReactNativeHost()
+              .getReactInstanceManager()
+              .onHostResume(mActivity, (DefaultHardwareBackBtnHandler) mActivity);
+        } else {
+          throw new ClassCastException(
+              "Host Activity does not implement DefaultHardwareBackBtnHandler");
+        }
       }
     }
   }
 
   public void onHostPause() {
-    if (getReactNativeHost().hasInstance()) {
-      getReactNativeHost().getReactInstanceManager().onHostPause(mActivity);
+    if (ReactFeatureFlags.enableBridgelessArchitecture) {
+      mReactHost.onHostPause(mActivity);
+    } else {
+      if (getReactNativeHost().hasInstance()) {
+        getReactNativeHost().getReactInstanceManager().onHostPause(mActivity);
+      }
     }
   }
 
   public void onHostDestroy() {
-    if (mReactRootView != null) {
-      mReactRootView.unmountReactApplication();
-      mReactRootView = null;
-    }
-    if (getReactNativeHost().hasInstance()) {
-      getReactNativeHost().getReactInstanceManager().onHostDestroy(mActivity);
+    if (ReactFeatureFlags.enableBridgelessArchitecture) {
+      mReactHost.onHostDestroy(mActivity);
+    } else {
+      if (mReactRootView != null) {
+        mReactRootView.unmountReactApplication();
+        mReactRootView = null;
+      }
+      if (getReactNativeHost().hasInstance()) {
+        getReactNativeHost().getReactInstanceManager().onHostDestroy(mActivity);
+      }
     }
   }
 
   public boolean onBackPressed() {
-    if (getReactNativeHost().hasInstance()) {
-      getReactNativeHost().getReactInstanceManager().onBackPressed();
+    if (ReactFeatureFlags.enableBridgelessArchitecture) {
+      mReactHost.onBackPressed();
       return true;
+    } else {
+      if (getReactNativeHost().hasInstance()) {
+        getReactNativeHost().getReactInstanceManager().onBackPressed();
+        return true;
+      }
     }
     return false;
   }
 
   public void onActivityResult(
       int requestCode, int resultCode, Intent data, boolean shouldForwardToReactInstance) {
-    if (getReactNativeHost().hasInstance() && shouldForwardToReactInstance) {
-      getReactNativeHost()
-          .getReactInstanceManager()
-          .onActivityResult(mActivity, requestCode, resultCode, data);
+    if (ReactFeatureFlags.enableBridgelessArchitecture) {
+      // TODO T156475655: Implement onActivityResult for Bridgeless
+      return;
+    } else {
+      if (getReactNativeHost().hasInstance() && shouldForwardToReactInstance) {
+        getReactNativeHost()
+            .getReactInstanceManager()
+            .onActivityResult(mActivity, requestCode, resultCode, data);
+      }
     }
   }
 
@@ -113,16 +154,31 @@ public class ReactDelegate {
   }
 
   public void loadApp(String appKey) {
-    if (mReactRootView != null) {
-      throw new IllegalStateException("Cannot loadApp while app is already running.");
+    // With Bridgeless enabled, create and start the surface
+    if (ReactFeatureFlags.enableBridgelessArchitecture) {
+      if (mReactSurface == null) {
+        // Create a ReactSurface
+        mReactSurface = mReactHost.createSurface(mActivity, appKey, mLaunchOptions);
+        // Set main Activity's content view
+        mActivity.setContentView(mReactSurface.getView());
+      }
+      mReactSurface.start();
+    } else {
+      if (mReactRootView != null) {
+        throw new IllegalStateException("Cannot loadApp while app is already running.");
+      }
+      mReactRootView = createRootView();
+      mReactRootView.startReactApplication(
+          getReactNativeHost().getReactInstanceManager(), appKey, mLaunchOptions);
     }
-    mReactRootView = createRootView();
-    mReactRootView.startReactApplication(
-        getReactNativeHost().getReactInstanceManager(), appKey, mLaunchOptions);
   }
 
   public ReactRootView getReactRootView() {
-    return mReactRootView;
+    if (ReactFeatureFlags.enableBridgelessArchitecture) {
+      return (ReactRootView) mReactSurface.getView();
+    } else {
+      return mReactRootView;
+    }
   }
 
   protected ReactRootView createRootView() {
@@ -139,7 +195,11 @@ public class ReactDelegate {
    *     application.
    */
   public boolean shouldShowDevMenuOrReload(int keyCode, KeyEvent event) {
-    if (getReactNativeHost().hasInstance() && getReactNativeHost().getUseDeveloperSupport()) {
+    if (ReactFeatureFlags.enableBridgelessArchitecture) {
+      // TODO T156475655: Implement shouldShowDevMenuOrReload for Bridgeless
+      return false;
+    } else if (getReactNativeHost().hasInstance()
+        && getReactNativeHost().getUseDeveloperSupport()) {
       if (keyCode == KeyEvent.KEYCODE_MENU) {
         getReactNativeHost().getReactInstanceManager().showDevOptionsDialog();
         return true;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactSurface.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactSurface.java
@@ -12,6 +12,7 @@ import android.os.Bundle;
 import android.util.DisplayMetrics;
 import android.view.View;
 import android.view.View.MeasureSpec;
+import android.view.ViewGroup;
 import androidx.annotation.UiThread;
 import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.infer.annotation.ThreadSafe;
@@ -24,6 +25,7 @@ import com.facebook.react.common.annotations.VisibleForTesting;
 import com.facebook.react.fabric.SurfaceHandler;
 import com.facebook.react.fabric.SurfaceHandlerBinding;
 import com.facebook.react.interfaces.ReactSurfaceInterface;
+import com.facebook.react.interfaces.TaskInterface;
 import com.facebook.react.modules.i18nmanager.I18nUtil;
 import com.facebook.react.uimanager.events.EventDispatcher;
 import java.util.concurrent.atomic.AtomicReference;
@@ -130,7 +132,8 @@ public class ReactSurface implements ReactSurfaceInterface {
     return mSurfaceHandler;
   }
 
-  public @Nullable ReactSurfaceView getView() {
+  @Override
+  public @Nullable ViewGroup getView() {
     return mSurfaceView.get();
   }
 
@@ -144,7 +147,8 @@ public class ReactSurface implements ReactSurfaceInterface {
     return host.prerenderSurface(this);
   }
 
-  public Task<Void> start() {
+  @Override
+  public TaskInterface start() {
     if (mSurfaceView.get() == null) {
       return Task.forError(
           new IllegalStateException(
@@ -181,7 +185,7 @@ public class ReactSurface implements ReactSurfaceInterface {
   public void clear() {
     UiThreadUtil.runOnUiThread(
         () -> {
-          ReactSurfaceView view = getView();
+          ReactSurfaceView view = (ReactSurfaceView) getView();
           if (view != null) {
             view.removeAllViews();
             view.setId(View.NO_ID);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/internal/bolts/Task.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/internal/bolts/Task.java
@@ -7,6 +7,7 @@
 
 package com.facebook.react.bridgeless.internal.bolts;
 
+import com.facebook.react.interfaces.TaskInterface;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -26,7 +27,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  *
  * @param <TResult> The type of the result of the task.
  */
-public class Task<TResult> {
+public class Task<TResult> implements TaskInterface {
   /** An {@link java.util.concurrent.Executor} that executes tasks in parallel. */
   public static final ExecutorService BACKGROUND_EXECUTOR = BoltsExecutors.background();
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
@@ -27,15 +27,18 @@ object DefaultNewArchitectureEntryPoint {
   fun load(
       turboModulesEnabled: Boolean = true,
       fabricEnabled: Boolean = true,
+      bridgelessEnaled: Boolean = false,
       dynamicLibraryName: String = "appmodules",
   ) {
     ReactFeatureFlags.useTurboModules = turboModulesEnabled
     ReactFeatureFlags.enableFabricRenderer = fabricEnabled
     ReactFeatureFlags.unstable_useFabricInterop = fabricEnabled
+    ReactFeatureFlags.enableBridgelessArchitecture = bridgelessEnaled
 
     this.privateFabricEnabled = fabricEnabled
     this.privateTurboModulesEnabled = turboModulesEnabled
     this.privateConcurrentReactEnabled = fabricEnabled
+    this.privateBridgelessEnabled = bridgelessEnaled
 
     SoLoader.loadLibrary("react_newarchdefaults")
     SoLoader.loadLibrary(dynamicLibraryName)
@@ -49,10 +52,11 @@ object DefaultNewArchitectureEntryPoint {
   fun load(
       turboModulesEnabled: Boolean = true,
       fabricEnabled: Boolean = true,
+      bridgelessEnaled: Boolean = false,
       @Suppress("UNUSED_PARAMETER") concurrentReactEnabled: Boolean = true,
       dynamicLibraryName: String = "appmodules",
   ) {
-    load(turboModulesEnabled, fabricEnabled, dynamicLibraryName)
+    load(turboModulesEnabled, fabricEnabled, bridgelessEnaled, dynamicLibraryName)
   }
 
   private var privateFabricEnabled: Boolean = false
@@ -69,4 +73,9 @@ object DefaultNewArchitectureEntryPoint {
   @JvmStatic
   val concurrentReactEnabled: Boolean
     get() = privateConcurrentReactEnabled
+
+  private var privateBridgelessEnabled: Boolean = false
+  @JvmStatic
+  val bridgelessEnaled: Boolean
+    get() = privateBridgelessEnabled
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultTurboModuleManagerDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultTurboModuleManagerDelegate.kt
@@ -27,7 +27,7 @@ private constructor(context: ReactApplicationContext, packages: List<ReactPackag
   @DoNotStrip external override fun initHybrid(): HybridData?
 
   class Builder : ReactPackageTurboModuleManagerDelegate.Builder() {
-    override fun build(context: ReactApplicationContext, packages: List<ReactPackage>) =
+    public override fun build(context: ReactApplicationContext, packages: List<ReactPackage>) =
         DefaultTurboModuleManagerDelegate(context, packages)
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
@@ -687,7 +687,7 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
     return mCurrentContext;
   }
 
-  protected @Nullable String getJSAppBundleName() {
+  public @Nullable String getJSAppBundleName() {
     return mJSAppBundleName;
   }
 
@@ -695,7 +695,7 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
     return mApplicationContext;
   }
 
-  protected DevServerHelper getDevServerHelper() {
+  public DevServerHelper getDevServerHelper() {
     return mDevServerHelper;
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/interfaces/ReactHostInterface.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/interfaces/ReactHostInterface.kt
@@ -8,6 +8,8 @@
 package com.facebook.react.interfaces
 
 import android.app.Activity
+import android.content.Context
+import android.os.Bundle
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.queue.ReactQueueConfiguration
 import com.facebook.react.common.LifecycleState
@@ -63,4 +65,11 @@ interface ReactHostInterface {
 
   /** To be called when the host activity is destroyed. */
   fun onHostDestroy(activity: Activity?)
+
+  /** To be called to create and setup an ReactSurface. */
+  fun createSurface(
+      context: Context,
+      moduleName: String,
+      initialProps: Bundle?
+  ): ReactSurfaceInterface?
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/interfaces/ReactSurfaceInterface.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/interfaces/ReactSurfaceInterface.kt
@@ -7,8 +7,16 @@
 
 package com.facebook.react.interfaces
 
+import android.view.ViewGroup
+
 /** Represents a Surface in React Native. */
 interface ReactSurfaceInterface {
   // the API of this interface will be completed as we analyze and refactor API of ReactSurface,
   // ReactRootView, etc.
+
+  // Start running this surface
+  fun start(): TaskInterface
+
+  // Get React root view of this surface
+  fun getView(): ViewGroup?
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/interfaces/TaskInterface.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/interfaces/TaskInterface.kt
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.interfaces
+
+/**
+ * This is the public interface for Task which represents the result of an asynchronous computation.
+ */
+interface TaskInterface {}

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridgeless/ReactSurfaceTest.java
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridgeless/ReactSurfaceTest.java
@@ -88,7 +88,7 @@ public class ReactSurfaceTest {
   public void testStart() throws InterruptedException {
     mReactSurface.attach(mReactHost);
     assertThat(mReactHost.isSurfaceAttached(mReactSurface)).isFalse();
-    Task<Void> task = mReactSurface.start();
+    Task<Void> task = (Task<Void>) mReactSurface.start();
     task.waitForCompletion();
 
     verify(mReactHost).startSurface(mReactSurface);
@@ -99,7 +99,7 @@ public class ReactSurfaceTest {
   public void testStop() throws InterruptedException {
     mReactSurface.attach(mReactHost);
 
-    Task<Void> task = mReactSurface.start();
+    Task<Void> task = (Task<Void>) mReactSurface.start();
     task.waitForCompletion();
 
     task = mReactSurface.stop();
@@ -147,7 +147,8 @@ public class ReactSurfaceTest {
 
     assertThat(mReactSurface.isRunning()).isFalse();
 
-    mReactSurface.start().waitForCompletion();
+    Task<Void> task = (Task<Void>) mReactSurface.start();
+    task.waitForCompletion();
 
     assertThat(mReactSurface.isRunning()).isTrue();
 


### PR DESCRIPTION
Summary:
Enable Bridgeless in RNTester Android by adding the initialization logic

Changelog: [Internal]

Differential Revision: D46375362

