### PR TITLE
Reduce visibility of BridgelessReactContext

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/BridgelessReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/BridgelessReactContext.java
@@ -40,8 +40,7 @@ import javax.annotation.Nullable;
  * com.facebook.react.bridge.CatalystInstance}, which doesn't exist in bridgeless mode.
  */
 @Nullsafe(Nullsafe.Mode.LOCAL)
-public class BridgelessReactContext extends ReactApplicationContext
-    implements EventDispatcherProvider {
+class BridgelessReactContext extends ReactApplicationContext implements EventDispatcherProvider {
 
   private final ReactHost mReactHost;
   private final AtomicReference<String> mSourceURL = new AtomicReference<>();
@@ -95,7 +94,7 @@ public class BridgelessReactContext extends ReactApplicationContext
     return mReactHost.isInstanceInitialized();
   }
 
-  public DevSupportManager getDevSupportManager() {
+  DevSupportManager getDevSupportManager() {
     return mReactHost.getDevSupportManager();
   }
 
@@ -154,7 +153,7 @@ public class BridgelessReactContext extends ReactApplicationContext
     mReactHost.handleHostException(e);
   }
 
-  public DefaultHardwareBackBtnHandler getDefaultHardwareBackBtnHandler() {
+  DefaultHardwareBackBtnHandler getDefaultHardwareBackBtnHandler() {
     return mReactHost.getDefaultBackButtonHandler();
   }
 }


### PR DESCRIPTION
Summary:
This diff reduces dependency of BridgelessReactContext to package only, this way we are removing BridgelessReactContext out of the Stable API, and app developers won't be able to access it directly.

changelog: [internal] internal

Reviewed By: cortinico

Differential Revision: D46410796

