### PR TITLE
Refactor integration of BridgelessReactPackage into ReactHost

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/BridgelessReactPackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/BridgelessReactPackage.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react;
+
+import com.facebook.infer.annotation.Nullsafe;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.devsupport.LogBoxModule;
+import com.facebook.react.devsupport.interfaces.DevSupportManager;
+import com.facebook.react.module.annotations.ReactModule;
+import com.facebook.react.module.annotations.ReactModuleList;
+import com.facebook.react.module.model.ReactModuleInfo;
+import com.facebook.react.module.model.ReactModuleInfoProvider;
+import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
+import com.facebook.react.modules.core.DeviceEventManagerModule;
+import com.facebook.react.modules.debug.DevSettingsModule;
+import com.facebook.react.modules.debug.SourceCodeModule;
+import com.facebook.react.modules.deviceinfo.DeviceInfoModule;
+import com.facebook.react.modules.systeminfo.AndroidInfoModule;
+import com.facebook.react.turbomodule.core.interfaces.TurboModule;
+import java.util.HashMap;
+import java.util.Map;
+
+@Nullsafe(Nullsafe.Mode.LOCAL)
+@ReactModuleList(
+    nativeModules = {
+      AndroidInfoModule.class,
+      DeviceInfoModule.class,
+      DevSettingsModule.class,
+      SourceCodeModule.class,
+      LogBoxModule.class,
+      DeviceEventManagerModule.class,
+    })
+public class BridgelessReactPackage extends TurboReactPackage {
+
+  private DevSupportManager mDevSupportManager;
+  private DefaultHardwareBackBtnHandler mHardwareBackBtnHandler;
+
+  public BridgelessReactPackage(
+      DevSupportManager devSupportManager, DefaultHardwareBackBtnHandler hardwareBackBtnHandler) {
+    mDevSupportManager = devSupportManager;
+    mHardwareBackBtnHandler = hardwareBackBtnHandler;
+  }
+
+  @Override
+  public NativeModule getModule(String name, ReactApplicationContext reactContext) {
+    switch (name) {
+      case AndroidInfoModule.NAME:
+        return new AndroidInfoModule(reactContext);
+      case DeviceInfoModule.NAME:
+        return new DeviceInfoModule(reactContext);
+      case SourceCodeModule.NAME:
+        return new SourceCodeModule(reactContext);
+      case DevSettingsModule.NAME:
+        return new DevSettingsModule(reactContext, mDevSupportManager);
+      case DeviceEventManagerModule.NAME:
+        return new DeviceEventManagerModule(reactContext, mHardwareBackBtnHandler);
+      case LogBoxModule.NAME:
+        return new LogBoxModule(reactContext, mDevSupportManager);
+      default:
+        throw new IllegalArgumentException(
+            "In BridgelessReactPackage, could not find Native module for " + name);
+    }
+  }
+
+  @Override
+  public ReactModuleInfoProvider getReactModuleInfoProvider() {
+    try {
+      Class<?> reactModuleInfoProviderClass =
+          Class.forName("com.facebook.react.CoreModulesPackage$$ReactModuleInfoProvider");
+      return (ReactModuleInfoProvider) reactModuleInfoProviderClass.newInstance();
+    } catch (ClassNotFoundException e) {
+      // In OSS case, the annotation processor does not run. We fall back on creating this byhand
+      Class<? extends NativeModule>[] moduleList =
+          new Class[] {
+            AndroidInfoModule.class,
+            DeviceInfoModule.class,
+            SourceCodeModule.class,
+            DevSettingsModule.class,
+            DeviceEventManagerModule.class,
+            LogBoxModule.class,
+          };
+      final Map<String, ReactModuleInfo> reactModuleInfoMap = new HashMap<>();
+      for (Class<? extends NativeModule> moduleClass : moduleList) {
+        ReactModule reactModule = moduleClass.getAnnotation(ReactModule.class);
+        if (reactModule != null) {
+          reactModuleInfoMap.put(
+              reactModule.name(),
+              new ReactModuleInfo(
+                  reactModule.name(),
+                  moduleClass.getName(),
+                  reactModule.canOverrideExistingModule(),
+                  reactModule.needsEagerInit(),
+                  reactModule.hasConstants(),
+                  reactModule.isCxxModule(),
+                  TurboModule.class.isAssignableFrom(moduleClass)));
+        }
+      }
+      return new ReactModuleInfoProvider() {
+        @Override
+        public Map<String, ReactModuleInfo> getReactModuleInfos() {
+          return reactModuleInfoMap;
+        }
+      };
+    } catch (InstantiationException e) {
+      throw new RuntimeException(
+          "No ReactModuleInfoProvider for CoreModulesPackage$$ReactModuleInfoProvider", e);
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException(
+          "No ReactModuleInfoProvider for CoreModulesPackage$$ReactModuleInfoProvider", e);
+    }
+  }
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHostDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactHostDelegate.kt
@@ -9,12 +9,11 @@ package com.facebook.react.bridgeless
 
 import com.facebook.infer.annotation.ThreadSafe
 import com.facebook.react.ReactPackage
+import com.facebook.react.ReactPackageTurboModuleManagerDelegate
 import com.facebook.react.bridge.JSBundleLoader
-import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.fabric.ReactNativeConfig
 import com.facebook.react.turbomodule.core.TurboModuleManager
-import com.facebook.react.turbomodule.core.TurboModuleManagerDelegate
 
 /**
  * [ReactHostDelegate] is an interface that defines parameters required to initialize React Native.
@@ -49,7 +48,7 @@ interface ReactHostDelegate {
   val jSBundleLoader: JSBundleLoader
 
   /** TODO: combine getTurboModuleManagerDelegate inside [ReactPackage] */
-  fun getTurboModuleManagerDelegate(context: ReactApplicationContext): TurboModuleManagerDelegate
+  val turboModuleManagerDelegateBuilder: ReactPackageTurboModuleManagerDelegate.Builder
 
   /**
    * Callback that can be used by React Native host applications to react to exceptions thrown by
@@ -68,16 +67,13 @@ interface ReactHostDelegate {
       override val jSMainModulePath: String,
       override val jSBundleLoader: JSBundleLoader,
       override val jSEngineInstance: JSEngineInstance,
+      override val turboModuleManagerDelegateBuilder:
+          ReactPackageTurboModuleManagerDelegate.Builder,
       override val reactPackages: List<ReactPackage> = emptyList(),
       override val bindingsInstaller: BindingsInstaller? = null,
-      private val turboModuleManagerDelegate:
-          (context: ReactApplicationContext) -> TurboModuleManagerDelegate,
       private val reactNativeConfig: ReactNativeConfig = ReactNativeConfig.DEFAULT_CONFIG,
       private val exceptionHandler: (error: Exception) -> Unit = {}
   ) : ReactHostDelegate {
-
-    override fun getTurboModuleManagerDelegate(context: ReactApplicationContext) =
-        turboModuleManagerDelegate(context)
 
     override fun getReactNativeConfig(turboModuleManager: TurboModuleManager) = reactNativeConfig
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactHostDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactHostDelegate.kt
@@ -9,8 +9,8 @@ package com.facebook.react.defaults
 
 import com.facebook.jni.annotations.DoNotStrip
 import com.facebook.react.ReactPackage
+import com.facebook.react.ReactPackageTurboModuleManagerDelegate
 import com.facebook.react.bridge.JSBundleLoader
-import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridgeless.BindingsInstaller
 import com.facebook.react.bridgeless.JSEngineInstance
 import com.facebook.react.bridgeless.ReactHostDelegate
@@ -18,7 +18,6 @@ import com.facebook.react.bridgeless.hermes.HermesInstance
 import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.fabric.ReactNativeConfig
 import com.facebook.react.turbomodule.core.TurboModuleManager
-import com.facebook.react.turbomodule.core.TurboModuleManagerDelegate
 
 /**
  * A utility class that allows you to simplify the initialization of React Native by setting up a
@@ -46,14 +45,10 @@ class DefaultReactHostDelegate(
     override val reactPackages: List<ReactPackage> = emptyList(),
     override val jSEngineInstance: JSEngineInstance = HermesInstance(),
     override val bindingsInstaller: BindingsInstaller = DefaultBindingsInstaller(),
-    private val turboModuleManagerDelegate:
-        (context: ReactApplicationContext) -> TurboModuleManagerDelegate,
     private val reactNativeConfig: ReactNativeConfig = ReactNativeConfig.DEFAULT_CONFIG,
-    private val exceptionHandler: (Exception) -> Unit = {}
+    private val exceptionHandler: (Exception) -> Unit = {},
+    override val turboModuleManagerDelegateBuilder: ReactPackageTurboModuleManagerDelegate.Builder
 ) : ReactHostDelegate {
-
-  override fun getTurboModuleManagerDelegate(context: ReactApplicationContext) =
-      turboModuleManagerDelegate(context)
 
   override fun getReactNativeConfig(turboModuleManager: TurboModuleManager) = reactNativeConfig
 

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridgeless/ReactHostDelegateTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridgeless/ReactHostDelegateTest.kt
@@ -7,11 +7,11 @@
 
 package com.facebook.react.bridgeless
 
+import com.facebook.react.ReactPackageTurboModuleManagerDelegate
 import com.facebook.react.bridge.JSBundleLoader
 import com.facebook.react.bridgeless.hermes.HermesInstance
 import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.defaults.DefaultReactHostDelegate
-import com.facebook.react.turbomodule.core.TurboModuleManagerDelegate
 import com.facebook.testutils.shadows.ShadowSoLoader
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -32,8 +32,8 @@ class ReactHostDelegateTest {
   @Test
   fun testDefaultReactHostDelegateCreation() {
     val jsBundleLoader: JSBundleLoader = Mockito.mock(JSBundleLoader::class.java)
-    val turboModuleManagerDelegateMock: TurboModuleManagerDelegate =
-        Mockito.mock(TurboModuleManagerDelegate::class.java)
+    val turboModuleManagerDelegateBuilderMock: ReactPackageTurboModuleManagerDelegate.Builder =
+        Mockito.mock(ReactPackageTurboModuleManagerDelegate.Builder::class.java)
     val hermesInstance: JSEngineInstance = Mockito.mock(HermesInstance::class.java)
     val jsMainModulePathMocked = "mockedJSMainModulePath"
     val delegate =
@@ -41,7 +41,7 @@ class ReactHostDelegateTest {
             jSMainModulePath = jsMainModulePathMocked,
             jSBundleLoader = jsBundleLoader,
             jSEngineInstance = hermesInstance,
-            turboModuleManagerDelegate = { turboModuleManagerDelegateMock })
+            turboModuleManagerDelegateBuilder = turboModuleManagerDelegateBuilderMock)
 
     assertThat(delegate.jSMainModulePath).isEqualTo(jsMainModulePathMocked)
   }


### PR DESCRIPTION
Summary:
This diff refactors the integration of ReactPackages into ReactHost and ReactHostDelegate.

As part of this diff I'm also modifying ReactHostDelegate to depend on TurboModuleManagerDelegate.Builder instead of TurboModuleManagerDelegateBuilder. This is necessary to be able to create BridgelessReactPackage inside ReactInstance

bypass-github-export-checks

changelog: [internal] internal

Reviewed By: luluwu2032

Differential Revision: D46410795

