### PR TITLE
Expose TextInput and ScrollView instance type for better Flow typing

### DIFF
--- a/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
@@ -167,7 +167,7 @@ export type DecelerationRateType = 'fast' | 'normal' | number;
 export type ScrollResponderType = ScrollViewImperativeMethods;
 
 type NativeScrollViewInstance = React.ElementRef<HostComponent<mixed>>;
-type PublicScrollViewInstance = $ReadOnly<{|
+export type PublicScrollViewInstance = $ReadOnly<{|
   ...$Exact<NativeScrollViewInstance>,
   ...ScrollViewImperativeMethods,
 |}>;

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
@@ -1043,11 +1043,13 @@ export type TextInputComponentStatics = $ReadOnly<{|
   |}>,
 |}>;
 
+export type PublicTextInputInstance = $ReadOnly<{
+  ...React.ElementRef<HostComponent<mixed>>,
+  ...ImperativeMethods,
+}>;
+
 export type TextInputType = React.AbstractComponent<
   React.ElementConfig<InternalTextInput>,
-  $ReadOnly<{|
-    ...React.ElementRef<HostComponent<mixed>>,
-    ...ImperativeMethods,
-  |}>,
+  PublicTextInputInstance,
 > &
   TextInputComponentStatics;

--- a/packages/rn-tester/js/examples/ScrollView/ScrollViewExample.js
+++ b/packages/rn-tester/js/examples/ScrollView/ScrollViewExample.js
@@ -9,6 +9,7 @@
  */
 
 import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+import type {PublicScrollViewInstance} from 'react-native/Libraries/Components/ScrollView/ScrollView';
 import type {ViewStyleProp} from 'react-native/Libraries/StyleSheet/StyleSheet';
 
 import ScrollViewPressableStickyHeaderExample from './ScrollViewPressableStickyHeaderExample';
@@ -511,7 +512,7 @@ const AndroidScrollBarOptions = () => {
 
 const HorizontalScrollView = (props: {direction: 'ltr' | 'rtl'}) => {
   const {direction} = props;
-  const scrollRef = React.useRef<?React.ElementRef<typeof ScrollView>>();
+  const scrollRef = React.useRef<?PublicScrollViewInstance>();
   const title = direction === 'ltr' ? 'LTR Layout' : 'RTL Layout';
   return (
     <View style={{direction}}>
@@ -943,7 +944,7 @@ const KeyboardExample = () => {
 
 const InvertStickyHeaders = () => {
   const [invertStickyHeaders, setInvertStickyHeaders] = useState(false);
-  const _scrollView = React.useRef<?React.ElementRef<typeof ScrollView>>(null);
+  const _scrollView = React.useRef<?PublicScrollViewInstance>(null);
   return (
     <View>
       <ScrollView
@@ -983,7 +984,7 @@ const InvertStickyHeaders = () => {
 };
 
 const MultipleStickyHeaders = () => {
-  const _scrollView = React.useRef<?React.ElementRef<typeof ScrollView>>(null);
+  const _scrollView = React.useRef<?PublicScrollViewInstance>(null);
   const stickyHeaderStyle = {backgroundColor: 'yellow'};
   return (
     <View>


### PR DESCRIPTION
The intersection of AbstractComponent and another statics object often leads to weird typing with React.ElementRef. In this diff, I exposed the instance ref type as `PublicTextInputInstance` and `PublicScrollViewInstance`, and make downstream code use these two types instead of `React.ElementRef<typeof TextInput>` or `React.ElementRef<typeof ScrollView>`. This change helps to fix most of new Flow errors in an future release where React typings are further strictified.

Differential Revision: D46882959

