### PR TITLE
[TextInput][iOS] Default color should adapt to Dark Mode

### DIFF
--- a/packages/react-native/Libraries/Text/RCTTextAttributes.m
+++ b/packages/react-native/Libraries/Text/RCTTextAttributes.m
@@ -247,19 +247,19 @@ NSString *const RCTTextAttributesTagAttributeName = @"RCTTextAttributesTagAttrib
 
 - (UIColor *)effectiveForegroundColor
 {
-  UIColor *effectiveForegroundColor = _foregroundColor ?: [UIColor blackColor];
+  UIColor *effectiveForegroundColor = _foregroundColor;
 
-  if (!isnan(_opacity)) {
+  if (effectiveForegroundColor && !isnan(_opacity)) {
     effectiveForegroundColor =
         [effectiveForegroundColor colorWithAlphaComponent:CGColorGetAlpha(effectiveForegroundColor.CGColor) * _opacity];
   }
 
-  return effectiveForegroundColor;
+  return effectiveForegroundColor ?: [UIColor blackColor];
 }
 
 - (UIColor *)effectiveBackgroundColor
 {
-  UIColor *effectiveBackgroundColor = _backgroundColor; // ?: [[UIColor whiteColor] colorWithAlphaComponent:0];
+  UIColor *effectiveBackgroundColor = _backgroundColor;
 
   if (effectiveBackgroundColor && !isnan(_opacity)) {
     effectiveBackgroundColor =

--- a/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.m
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.m
@@ -67,12 +67,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
 - (void)enforceTextAttributesIfNeeded
 {
   id<RCTBackedTextInputViewProtocol> backedTextInputView = self.backedTextInputView;
-
   NSDictionary<NSAttributedStringKey, id> *textAttributes = [[_textAttributes effectiveTextAttributes] mutableCopy];
-  if ([textAttributes valueForKey:NSForegroundColorAttributeName] == nil) {
-    [textAttributes setValue:[UIColor blackColor] forKey:NSForegroundColorAttributeName];
-  }
-
   backedTextInputView.defaultTextAttributes = textAttributes;
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.mm
@@ -156,7 +156,7 @@ inline static UIFont *RCTEffectiveFontFromTextAttributes(const TextAttributes &t
 
 inline static UIColor *RCTEffectiveForegroundColorFromTextAttributes(const TextAttributes &textAttributes)
 {
-  UIColor *effectiveForegroundColor = RCTUIColorFromSharedColor(textAttributes.foregroundColor) ?: [UIColor blackColor];
+  UIColor *effectiveForegroundColor = RCTUIColorFromSharedColor(textAttributes.foregroundColor) ?: [UIColor labelColor];
 
   if (!isnan(textAttributes.opacity)) {
     effectiveForegroundColor = [effectiveForegroundColor


### PR DESCRIPTION


## Summary:

Currently, TextInputs on iOS explicitly default to having black as the text color. This seems wrong: ever since dark mode was introduced, defaults _should_ adapt to the OS (Be it Light/Dark/Increase Contrast / Dark Elevated, etc). That is the benefit of using UIKit system controls, they're tightly coupled to the OS. If the user wanted the TextInput to always be a specific color (because they hardcoded the background color), then they can specify that in the `style` prop. If their app doesn't support dark mode, then their app plist should reflect that.

I looked into the commit history, and it seems the change was introduced [here](https://github.com/facebook/react-native/pull/28708). It seems that when Dark Mode was introduced, the "default" text color changing  to depend on system theme was seen as an RN regression. This is simply not true, iOS Dark Mode was opt in, and intentionally changed the defaults and asked apps to adapt their style to match. The "breaking change" was not in RN, but in the OS itself. Had the app been purely native, there would still be a change. I don't think it's RN's job to enforce a default when the OS itself has changed it,  I think RN should follow the OS. 


## Changelog:

[IOS] [FIXED] - TextInput default color should adapt to Dark Mode

## Test Plan:

Tested the TextInput example page on RNTester in dark mode before and after my change.

Before:
<img width="529" alt="Screenshot 2023-06-21 at 11 09 26 PM" src="https://github.com/facebook/react-native/assets/6722175/5d9b747b-f376-4b4e-bea3-07757278fb30">
After:
<img width="529" alt="Screenshot 2023-06-21 at 11 21 08 PM" src="https://github.com/facebook/react-native/assets/6722175/4c5e92f2-daf1-4e67-896a-37b9557c04cb">



