### PR TITLE
fix: int cast can cause endless loop if value < 1

### DIFF
--- a/packages/react-native/Libraries/Text/Text.d.ts
+++ b/packages/react-native/Libraries/Text/Text.d.ts
@@ -44,11 +44,6 @@ export interface TextPropsIOS {
     | undefined;
 
   /**
-   * Specifies smallest possible scale a font can reach when adjustsFontSizeToFit is enabled. (values 0.01-1.0).
-   */
-  minimumFontScale?: number | undefined;
-
-  /**
    * When `true`, no visual change is made when text is pressed down. By
    * default, a gray oval highlights the text on press down.
    */
@@ -209,6 +204,11 @@ export interface TextProps
    * - >= 1: sets the maxFontSizeMultiplier of this node to this value
    */
   maxFontSizeMultiplier?: number | null | undefined;
+
+  /**
+   * Specifies smallest possible scale a font can reach when adjustsFontSizeToFit is enabled. (values 0.01-1.0).
+   */
+  minimumFontScale?: number | undefined;
 }
 
 /**

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
@@ -87,7 +87,7 @@ public class ReactTextShadowNode extends ReactBaseTextShadowNode {
               // TODO: We could probably use a smarter algorithm here. This will require 0(n)
               // measurements
               // based on the number of points the font size needs to be reduced by.
-              currentFontSize = currentFontSize - (int) PixelUtil.toPixelFromDIP(1);
+              currentFontSize = currentFontSize - (int)Math.ceil(PixelUtil.toPixelFromDIP(1));
 
               float ratio = (float) currentFontSize / (float) initialFontSize;
               ReactAbsoluteSizeSpan[] sizeSpans =

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
@@ -87,7 +87,7 @@ public class ReactTextShadowNode extends ReactBaseTextShadowNode {
               // TODO: We could probably use a smarter algorithm here. This will require 0(n)
               // measurements
               // based on the number of points the font size needs to be reduced by.
-              currentFontSize = currentFontSize - (int)Math.ceil(PixelUtil.toPixelFromDIP(1));
+              currentFontSize -= Math.max(1, (int)PixelUtil.toPixelFromDIP(1));
 
               float ratio = (float) currentFontSize / (float) initialFontSize;
               ReactAbsoluteSizeSpan[] sizeSpans =


### PR DESCRIPTION
## Summary:

I faced an issue that on Android the whole UI would freeze when using minimumFontScale. This is caused by an int cast that turns the while loop into an endless loop.
Also the docs are not correct since they say it is an iOS only prop.
https://reactnative.dev/docs/text#minimumfontscale-ios

## Changelog:

[ANDROID] [FIXED] - UI freezing when using minimumFontScale

## Test Plan:

Run this sample app with and without this fix. https://github.com/g4rb4g3/androidMinimumFontScaleBug
Without the ui will freeze when hitting the + button, with the fix a Text component will be shown and no freeze will happen. 🙂 