### PR TITLE
Build React Native Shared Objects with Stack Smash Protection

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/CMakeLists.txt
@@ -17,7 +17,7 @@ endif(CCACHE_FOUND)
 
 # Make sure every shared lib includes a .note.gnu.build-id header
 add_link_options(-Wl,--build-id)
-add_compile_options(-Wall -Werror -std=c++17)
+add_compile_options(-Wall -Werror -std=c++17 -fstack-protector-all)
 
 function(add_react_android_subdir relative_path)
   add_subdirectory(${REACT_ANDROID_DIR}/${relative_path} ReactAndroid/${relative_path})

--- a/packages/react-native/ReactAndroid/src/main/jni/react/newarchdefaults/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/newarchdefaults/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-fexceptions -frtti -std=c++17 -Wall -DLOG_TAG=\"ReactNative\")
+add_compile_options(-fexceptions -frtti -std=c++17 -Wall -fstack-protector-all -DLOG_TAG=\"ReactNative\")
 
 file(GLOB react_newarchdefaults_SRC CONFIGURE_DEPENDS *.cpp)
 

--- a/packages/react-native/ReactCommon/butter/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/butter/CMakeLists.txt
@@ -13,6 +13,7 @@ add_compile_options(
         -std=c++17
         -Wall
         -Wpedantic
+        -fstack-protector-all
         -Wno-gnu-zero-variadic-macro-arguments)
 
 add_library(butter INTERFACE)

--- a/packages/react-native/ReactCommon/callinvoker/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/callinvoker/CMakeLists.txt
@@ -12,6 +12,7 @@ add_compile_options(
         -std=c++17
         -Wall
         -Wpedantic
+        -fstack-protector-all
         -Wno-gnu-zero-variadic-macro-arguments)
 
 add_library(callinvoker INTERFACE)

--- a/packages/react-native/ReactCommon/cxxreact/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/cxxreact/CMakeLists.txt
@@ -11,6 +11,7 @@ add_compile_options(
         -frtti
         -std=c++17
         -Wno-unused-lambda-capture
+        -fstack-protector-all
         -DLOG_TAG=\"ReactNative\")
 
 file(GLOB reactnative_SRC CONFIGURE_DEPENDS *.cpp)

--- a/packages/react-native/ReactCommon/hermes/executor/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/hermes/executor/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-std=c++17)
+add_compile_options(-std=c++17 -fstack-protector-all)
 
 file(GLOB_RECURSE hermes_executor_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(

--- a/packages/react-native/ReactCommon/hermes/inspector/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/hermes/inspector/CMakeLists.txt
@@ -17,6 +17,7 @@ target_compile_options(
         PRIVATE
         -DHERMES_INSPECTOR_FOLLY_KLUDGE=1
         -std=c++17
+        -fstack-protector-all
         -fexceptions
 )
 

--- a/packages/react-native/ReactCommon/jsc/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jsc/CMakeLists.txt
@@ -15,6 +15,7 @@ add_compile_options(
         -frtti
         -O3
         -Wno-unused-lambda-capture
+        -fstack-protector-all
         -DLOG_TAG=\"ReactNative\")
 
 add_library(jscruntime

--- a/packages/react-native/ReactCommon/jserrorhandler/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jserrorhandler/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-std=c++17)
+add_compile_options(-std=c++17 -fstack-protector-all)
 
 file(GLOB_RECURSE js_error_handler_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(

--- a/packages/react-native/ReactCommon/jsi/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jsi/CMakeLists.txt
@@ -15,6 +15,7 @@ add_compile_options(
         -frtti
         -O3
         -Wno-unused-lambda-capture
+        -fstack-protector-all
         -DLOG_TAG=\"ReactNative\")
 
 file(GLOB jsi_SRC CONFIGURE_DEPENDS jsi/*.cpp)

--- a/packages/react-native/ReactCommon/jsiexecutor/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jsiexecutor/CMakeLists.txt
@@ -10,6 +10,7 @@ add_compile_options(
         -fexceptions
         -frtti
         -std=c++17
+        -fstack-protector-all
         -O3)
 
 add_library(jsireact

--- a/packages/react-native/ReactCommon/jsinspector/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jsinspector/CMakeLists.txt
@@ -8,6 +8,7 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 add_compile_options(
         -fexceptions
+        -fstack-protector-all
         -std=c++17)
 
 file(GLOB jsinspector_SRC CONFIGURE_DEPENDS *.cpp)

--- a/packages/react-native/ReactCommon/logger/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/logger/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-fexceptions)
+add_compile_options(-fexceptions -fstack-protector-all)
 
 file(GLOB logger_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(logger SHARED ${logger_SRC})

--- a/packages/react-native/ReactCommon/react/bridgeless/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/bridgeless/CMakeLists.txt
@@ -17,6 +17,7 @@ target_compile_options(
         PRIVATE
         $<$<CONFIG:Debug>:-DHERMES_ENABLE_DEBUGGER=1>
         -std=c++17
+        -fstack-protector-all
         -fexceptions
 )
 target_include_directories(bridgeless PUBLIC .)

--- a/packages/react-native/ReactCommon/react/bridging/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/bridging/CMakeLists.txt
@@ -13,6 +13,7 @@ add_compile_options(
         -Wall
         -Wpedantic
         -Wno-gnu-zero-variadic-macro-arguments
+        -fstack-protector-all
         -DLOG_TAG=\"ReactNative\")
 
 file(GLOB react_bridging_SRC CONFIGURE_DEPENDS *.cpp)

--- a/packages/react-native/ReactCommon/react/config/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/config/CMakeLists.txt
@@ -13,6 +13,7 @@ add_compile_options(
         -Wall
         -Wpedantic
         -Wno-gnu-zero-variadic-macro-arguments
+        -fstack-protector-all
         -DLOG_TAG=\"Fabric\")
 
 file(GLOB react_config_SRC CONFIGURE_DEPENDS *.cpp)

--- a/packages/react-native/ReactCommon/react/debug/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/debug/CMakeLists.txt
@@ -13,6 +13,7 @@ add_compile_options(
         -Wall
         -Wpedantic
         -Wno-gnu-zero-variadic-macro-arguments
+        -fstack-protector-all
         -DLOG_TAG=\"Fabric\")
 
 

--- a/packages/react-native/ReactCommon/react/nativemodule/core/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/CMakeLists.txt
@@ -12,6 +12,7 @@ add_compile_options(
         -std=c++17
         -Wall
         -Wpedantic
+        -fstack-protector-all
         -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"ReactNative\")
 

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/CMakeLists.txt
@@ -13,6 +13,7 @@ add_compile_options(
         -Wall
         -Wpedantic
         -Wno-gnu-zero-variadic-macro-arguments
+        -fstack-protector-all
         -DFOLLY_NO_CONFIG=1
         -DLOG_TAG=\"ReactNative\")
 

--- a/packages/react-native/ReactCommon/react/renderer/animations/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/animations/CMakeLists.txt
@@ -12,6 +12,7 @@ add_compile_options(
         -std=c++17
         -Wall
         -Wpedantic
+        -fstack-protector-all
         -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/CMakeLists.txt
@@ -12,6 +12,7 @@ add_compile_options(
         -std=c++17
         -Wall
         -Wpedantic
+        -fstack-protector-all
         -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 

--- a/packages/react-native/ReactCommon/react/renderer/componentregistry/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/componentregistry/CMakeLists.txt
@@ -12,6 +12,7 @@ add_compile_options(
         -std=c++17
         -Wall
         -Wpedantic
+        -fstack-protector-all
         -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 

--- a/packages/react-native/ReactCommon/react/renderer/components/image/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/CMakeLists.txt
@@ -12,6 +12,7 @@ add_compile_options(
         -std=c++17
         -Wall
         -Wpedantic
+        -fstack-protector-all
         -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/CMakeLists.txt
@@ -12,6 +12,7 @@ add_compile_options(
         -std=c++17
         -Wall
         -Wpedantic
+        -fstack-protector-all
         -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 

--- a/packages/react-native/ReactCommon/react/renderer/components/modal/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/modal/CMakeLists.txt
@@ -12,6 +12,7 @@ add_compile_options(
         -std=c++17
         -Wall
         -Wpedantic
+        -fstack-protector-all
         -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 

--- a/packages/react-native/ReactCommon/react/renderer/components/progressbar/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/progressbar/CMakeLists.txt
@@ -12,6 +12,7 @@ add_compile_options(
         -std=c++17
         -Wall
         -Wpedantic
+        -fstack-protector-all
         -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 

--- a/packages/react-native/ReactCommon/react/renderer/components/root/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/root/CMakeLists.txt
@@ -12,6 +12,7 @@ add_compile_options(
         -std=c++17
         -Wall
         -Wpedantic
+        -fstack-protector-all
         -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/CMakeLists.txt
@@ -12,6 +12,7 @@ add_compile_options(
         -std=c++17
         -Wall
         -Wpedantic
+        -fstack-protector-all
         -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 

--- a/packages/react-native/ReactCommon/react/renderer/components/text/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/CMakeLists.txt
@@ -12,6 +12,7 @@ add_compile_options(
         -std=c++17
         -Wall
         -Wpedantic
+        -fstack-protector-all
         -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/CMakeLists.txt
@@ -12,6 +12,7 @@ add_compile_options(
         -std=c++17
         -Wall
         -Wpedantic
+        -fstack-protector-all
         -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 

--- a/packages/react-native/ReactCommon/react/renderer/components/unimplementedview/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/unimplementedview/CMakeLists.txt
@@ -12,6 +12,7 @@ add_compile_options(
         -std=c++17
         -Wall
         -Wpedantic
+        -fstack-protector-all
         -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/CMakeLists.txt
@@ -12,6 +12,7 @@ add_compile_options(
         -std=c++17
         -Wall
         -Wpedantic
+        -fstack-protector-all
         -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 

--- a/packages/react-native/ReactCommon/react/renderer/core/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/core/CMakeLists.txt
@@ -12,6 +12,7 @@ add_compile_options(
         -std=c++17
         -Wall
         -Wpedantic
+        -fstack-protector-all
         -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 

--- a/packages/react-native/ReactCommon/react/renderer/debug/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/debug/CMakeLists.txt
@@ -12,6 +12,7 @@ add_compile_options(
         -std=c++17
         -Wall
         -Wpedantic
+        -fstack-protector-all
         -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 

--- a/packages/react-native/ReactCommon/react/renderer/element/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/element/CMakeLists.txt
@@ -12,6 +12,7 @@ add_compile_options(
         -std=c++17
         -Wall
         -Wpedantic
+        -fstack-protector-all
         -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 

--- a/packages/react-native/ReactCommon/react/renderer/graphics/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/CMakeLists.txt
@@ -12,6 +12,7 @@ add_compile_options(
         -std=c++17
         -Wall
         -Wpedantic
+        -fstack-protector-all
         -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/CMakeLists.txt
@@ -12,6 +12,7 @@ add_compile_options(
         -std=c++17
         -Wall
         -Wpedantic
+        -fstack-protector-all
         -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 

--- a/packages/react-native/ReactCommon/react/renderer/leakchecker/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/leakchecker/CMakeLists.txt
@@ -12,6 +12,7 @@ add_compile_options(
         -std=c++17
         -Wall
         -Wpedantic
+        -fstack-protector-all
         -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 

--- a/packages/react-native/ReactCommon/react/renderer/mapbuffer/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/mapbuffer/CMakeLists.txt
@@ -12,6 +12,7 @@ add_compile_options(
         -std=c++17
         -Wall
         -Wpedantic
+        -fstack-protector-all
         -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 

--- a/packages/react-native/ReactCommon/react/renderer/mounting/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/CMakeLists.txt
@@ -12,6 +12,7 @@ add_compile_options(
         -std=c++17
         -Wall
         -Wpedantic
+        -fstack-protector-all
         -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/CMakeLists.txt
@@ -12,6 +12,7 @@ add_compile_options(
         -std=c++17
         -Wall
         -Wpedantic
+        -fstack-protector-all
         -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/CMakeLists.txt
@@ -12,6 +12,7 @@ add_compile_options(
         -std=c++17
         -Wall
         -Wpedantic
+        -fstack-protector-all
         -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 

--- a/packages/react-native/ReactCommon/react/renderer/telemetry/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/telemetry/CMakeLists.txt
@@ -12,6 +12,7 @@ add_compile_options(
         -std=c++17
         -Wall
         -Wpedantic
+        -fstack-protector-all
         -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 

--- a/packages/react-native/ReactCommon/react/renderer/templateprocessor/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/templateprocessor/CMakeLists.txt
@@ -12,6 +12,7 @@ add_compile_options(
         -std=c++17
         -Wall
         -Wpedantic
+        -fstack-protector-all
         -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/CMakeLists.txt
@@ -12,6 +12,7 @@ add_compile_options(
         -std=c++17
         -Wall
         -Wpedantic
+        -fstack-protector-all
         -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/CMakeLists.txt
@@ -12,6 +12,7 @@ add_compile_options(
         -std=c++17
         -Wall
         -Wpedantic
+        -fstack-protector-all
         -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 

--- a/packages/react-native/ReactCommon/react/utils/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/utils/CMakeLists.txt
@@ -12,6 +12,7 @@ add_compile_options(
         -std=c++17
         -Wall
         -Wpedantic
+        -fstack-protector-all
         -Wno-gnu-zero-variadic-macro-arguments
         -DLOG_TAG=\"Fabric\")
 

--- a/packages/react-native/ReactCommon/reactperflogger/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/reactperflogger/CMakeLists.txt
@@ -12,6 +12,7 @@ add_compile_options(
         -std=c++17
         -Wall
         -Wpedantic
+        -fstack-protector-all
         -Wno-gnu-zero-variadic-macro-arguments)
 
 file(GLOB reactperflogger_SRC CONFIGURE_DEPENDS reactperflogger/*.cpp)

--- a/packages/react-native/ReactCommon/runtimeexecutor/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/runtimeexecutor/CMakeLists.txt
@@ -12,6 +12,7 @@ add_compile_options(
         -std=c++17
         -Wall
         -Wpedantic
+        -fstack-protector-all
         -Wno-gnu-zero-variadic-macro-arguments)
 
 file(GLOB_RECURSE runtimeexecutor_SRC CONFIGURE_DEPENDS *.cpp *.h)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Some of the .so files in React Native does not seem to be stack protected. We figure that out by checking for "__stack_chk_fail" string inside the binary files.

This was probably happening because we were not using the "-fstack-protector" flag.

The fix I have imagined involves adding a "-fstack-protector-all" flag in the compile options in the CMake files.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[ANDROID][ADDED]  - Added `-fstack-protector-all` flag in CMakeLists.txt for `ReactAndroid` and `ReactCommon`.

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

One of the ways to test this would be to generate the rn-tester app from this branch and following these steps:
https://github.com/facebook/react-native/issues/36870#issuecomment-1592796732