### PR TITLE
Initialize "rninstance" at ReactInstance class loading time

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactInstance.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactInstance.java
@@ -88,6 +88,10 @@ final class ReactInstance {
 
   @DoNotStrip @Nullable private ComponentNameResolverManager mComponentNameResolverManager;
 
+  static {
+    loadLibraryIfNeeded();
+  }
+
   private static volatile boolean sIsLibraryLoaded;
 
   /* package */ ReactInstance(
@@ -100,7 +104,6 @@ final class ReactInstance {
       boolean useDevSupport) {
     mBridgelessReactContext = bridgelessReactContext;
     mDelegate = delegate;
-    loadLibraryIfNeeded();
 
     Systrace.beginSection(Systrace.TRACE_TAG_REACT_JAVA_BRIDGE, "ReactInstance.initialize");
 


### PR DESCRIPTION
Summary:
In this diff I'm moving the initialization of "rninstance" so as soon as the class is loaded

The goal is to ensure so is loaded earlier and prevent issues like T156403678

changelong: [internal] internal

Reviewed By: luluwu2032

Differential Revision: D46945464

