### PR TITLE
Fix Runnables used with enableEarlyScheduledMountItemExecution being unguarded

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/GuardedResultAsyncTask.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/GuardedResultAsyncTask.java
@@ -17,7 +17,6 @@ public abstract class GuardedResultAsyncTask<Result> extends AsyncTask<Void, Voi
 
   private final JSExceptionHandler mExceptionHandler;
 
-  @Deprecated
   protected GuardedResultAsyncTask(ReactContext reactContext) {
     this(reactContext.getExceptionHandler());
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/GuardedRunnable.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/GuardedRunnable.java
@@ -15,7 +15,6 @@ public abstract class GuardedRunnable implements Runnable {
 
   private final JSExceptionHandler mExceptionHandler;
 
-  @Deprecated
   public GuardedRunnable(ReactContext reactContext) {
     this(reactContext.getExceptionHandler());
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -37,6 +37,7 @@ import com.facebook.debug.tags.ReactDebugOverlayTags;
 import com.facebook.infer.annotation.ThreadConfined;
 import com.facebook.proguard.annotations.DoNotStripAny;
 import com.facebook.react.bridge.ColorPropConverter;
+import com.facebook.react.bridge.GuardedRunnable;
 import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.NativeArray;
 import com.facebook.react.bridge.NativeMap;
@@ -785,9 +786,9 @@ public class FabricUIManager implements UIManager, LifecycleEventListener {
     if (shouldSchedule) {
       mMountItemDispatcher.addMountItem(mountItem);
       Runnable runnable =
-          new Runnable() {
+          new GuardedRunnable(mReactApplicationContext) {
             @Override
-            public void run() {
+            public void runGuarded() {
               mMountItemDispatcher.tryDispatchMountItems();
             }
           };

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/GuardedFrameCallback.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/GuardedFrameCallback.java
@@ -16,7 +16,6 @@ public abstract class GuardedFrameCallback extends ChoreographerCompat.FrameCall
 
   @NonNull private final JSExceptionHandler mExceptionHandler;
 
-  @Deprecated
   protected GuardedFrameCallback(@NonNull ReactContext reactContext) {
     this(reactContext.getExceptionHandler());
   }


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Also un-deprecating the constructors of other Guarded runnables, as an extension of D46685374

Differential Revision: D46971220

