### PR TITLE
Fix pod install for swift libs using new arch

### DIFF
--- a/packages/react-native/scripts/cocoapods/__tests__/fabric-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/fabric-test.rb
@@ -48,9 +48,9 @@ class FabricTest < Test::Unit::TestCase
     def check_installed_pods(prefix)
         assert_equal(6, $podInvocationCount)
 
-        check_pod("React-Fabric", :path => "#{prefix}/ReactCommon")
+        check_pod("React-Fabric", :path => "#{prefix}/ReactCommon", :modular_headers => true)
         check_pod("React-FabricImage", :path => "#{prefix}/ReactCommon")
-        check_pod("React-graphics", :path => "#{prefix}/ReactCommon/react/renderer/graphics")
+        check_pod("React-graphics", :path => "#{prefix}/ReactCommon/react/renderer/graphics", :modular_headers => true)
         check_pod("React-RCTFabric", :path => "#{prefix}/React", :modular_headers => true)
         check_pod("RCT-Folly/Fabric", :podspec => "#{prefix}/third-party-podspecs/RCT-Folly.podspec")
         check_pod("React-ImageManager", :path => "#{prefix}/ReactCommon/react/renderer/imagemanager/platform/ios")

--- a/packages/react-native/scripts/cocoapods/fabric.rb
+++ b/packages/react-native/scripts/cocoapods/fabric.rb
@@ -8,8 +8,8 @@
 #
 # @parameter react_native_path: relative path to react-native
 def setup_fabric!(react_native_path: "../node_modules/react-native", new_arch_enabled: false)
-    pod 'React-Fabric', :path => "#{react_native_path}/ReactCommon"
-    pod 'React-graphics', :path => "#{react_native_path}/ReactCommon/react/renderer/graphics"
+    pod 'React-Fabric', :path => "#{react_native_path}/ReactCommon", :modular_headers => true
+    pod 'React-graphics', :path => "#{react_native_path}/ReactCommon/react/renderer/graphics", :modular_headers => true
     pod 'React-RCTFabric', :path => "#{react_native_path}/React", :modular_headers => true
     pod 'React-ImageManager', :path => "#{react_native_path}/ReactCommon/react/renderer/imagemanager/platform/ios"
     pod 'RCT-Folly/Fabric', :podspec => "#{react_native_path}/third-party-podspecs/RCT-Folly.podspec"

--- a/packages/react-native/scripts/cocoapods/jsengine.rb
+++ b/packages/react-native/scripts/cocoapods/jsengine.rb
@@ -10,7 +10,7 @@ require_relative './utils.rb'
 # @parameter react_native_path: relative path to react-native
 # @parameter fabric_enabled: whether Fabirc is enabled
 def setup_jsc!(react_native_path: "../node_modules/react-native", fabric_enabled: false)
-    pod 'React-jsi', :path => "#{react_native_path}/ReactCommon/jsi"
+    pod 'React-jsi', :path => "#{react_native_path}/ReactCommon/jsi", :modular_headers => true
     pod 'React-jsc', :path => "#{react_native_path}/ReactCommon/jsc"
     if fabric_enabled
         pod 'React-jsc/Fabric', :path => "#{react_native_path}/ReactCommon/jsc"

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -117,8 +117,8 @@ def use_react_native! (
   pod 'React-Core/RCTWebSocket', :path => "#{prefix}/"
   pod 'React-rncore', :path => "#{prefix}/ReactCommon"
   pod 'React-cxxreact', :path => "#{prefix}/ReactCommon/cxxreact"
-  pod 'React-debug', :path => "#{prefix}/ReactCommon/react/debug"
-  pod 'React-utils', :path => "#{prefix}/ReactCommon/react/utils"
+  pod 'React-debug', :path => "#{prefix}/ReactCommon/react/debug", :modular_headers => true
+  pod 'React-utils', :path => "#{prefix}/ReactCommon/react/utils", :modular_headers => true
 
   if hermes_enabled
     setup_hermes!(:react_native_path => prefix, :fabric_enabled => fabric_enabled)
@@ -131,7 +131,7 @@ def use_react_native! (
 
   pod 'React-callinvoker', :path => "#{prefix}/ReactCommon/callinvoker"
   pod 'React-runtimeexecutor', :path => "#{prefix}/ReactCommon/runtimeexecutor"
-  pod 'React-rendererdebug', :path => "#{prefix}/ReactCommon/react/renderer/debug"
+  pod 'React-rendererdebug', :path => "#{prefix}/ReactCommon/react/renderer/debug", :modular_headers => true
   pod 'React-perflogger', :path => "#{prefix}/ReactCommon/reactperflogger"
   pod 'React-logger', :path => "#{prefix}/ReactCommon/logger"
   pod 'ReactCommon/turbomodule/core', :path => "#{prefix}/ReactCommon", :modular_headers => true
@@ -139,7 +139,7 @@ def use_react_native! (
   pod 'Yoga', :path => "#{prefix}/ReactCommon/yoga", :modular_headers => true
 
   pod 'DoubleConversion', :podspec => "#{prefix}/third-party-podspecs/DoubleConversion.podspec"
-  pod 'glog', :podspec => "#{prefix}/third-party-podspecs/glog.podspec"
+  pod 'glog', :podspec => "#{prefix}/third-party-podspecs/glog.podspec", :modular_headers => true
   pod 'boost', :podspec => "#{prefix}/third-party-podspecs/boost.podspec"
   pod 'RCT-Folly', :podspec => "#{prefix}/third-party-podspecs/RCT-Folly.podspec", :modular_headers => true
 


### PR DESCRIPTION
## Summary:

This fixes a bug that started with React Native 0.72.0 when using the new architecture and installing a native lib that has Swift code (in my case, `@datadog/mobile-react-native`).

Running `pod install` errors with the following output (`DatadogSDKReactNative` is the pod containing the Swift code):

```
[...]
Analyzing dependencies
Downloading dependencies
Installing DatadogSDKReactNative 1.8.0-rc0
[!] The following Swift pods cannot yet be integrated as static libraries:

The Swift pod `DatadogSDKReactNative` depends upon `React-Fabric`, `React-graphics`, `React-utils`, and `React-debug`, which do not define modules. To opt into those targets generating module maps (which is necessary to import them from Swift when building as static libraries), you may set `use_modular_headers!` globally in your Podfile, or specify `:modular_headers => true` for particular dependencies.
```

Indeed, this pods were added as dependencies in `packages/react-native/scripts/cocoapods/new_architecture.rb` but do not define modules contrary to the other pods in the list.

I've added `:modular_headers => true` for all these pods and this fixes the issue.

EDIT: after testing it, I added a few modular headers to a few more pods that have been added to the list of dependencies.

This PR is solving a problem that already occured in the past and was solved here: https://github.com/facebook/react-native/pull/33743

## Changelog:
[IOS] [FIXED] - Fix pod install for libraries using Swift code when the new architecture is enabled

## Test Plan:

1. Clone [this](https://github.com/louiszawadzki/react-native) repo
2. From `main`, add a Swift file to the `MyNativeView` native module in the RN tester app (see inspiration from [this commit](https://github.com/fortmarek/react-native/commit/26958fccf4b4ac90d0bf9bb3699f12760a6b2b58)) 
3. Try to run `RCT_NEW_ARCH_ENABLED=1 USE_HERMES=0 bundle exec pod install` inside the `packages/rn-tester`
4. Observe errors
5. Apply [the commit](https://github.com/facebook/react-native/commit/7b7c3ff530cae07daccc5b5ea6b72d239f913be0) from this PR
6. Both pod install and the subsequent build should succeed.
7. Revert the changes and repeat steps 2 to 6 with `RCT_NEW_ARCH_ENABLED=1 USE_HERMES=1 bundle exec pod install`