### PR TITLE
Auto close issue if version is too old

### DIFF
--- a/.github/workflow-scripts/actOnLabel.js
+++ b/.github/workflow-scripts/actOnLabel.js
@@ -133,5 +133,16 @@ module.exports = async (github, context, labelWithContext) => {
       );
       await requestAuthorFeedback();
       return;
+    case 'Type: Too Old Version':
+      await addComment(
+        `| :warning: | Too Old Version of React Native |\n` +
+          `| --- | --- |\n` +
+          `| :information_source: | It looks like your issue or the example you provided uses a [**Too Old Version of React Native**](https://github.com/reactwg/react-native-releases/blob/main/README.md#releases-support-policy).\nDue to the number of issues we receive, we're currently only accepting new issues against one of the supported versions. Please [upgrade](https://reactnative.dev/docs/upgrading) to latest and verify if the issue persists (alternatively, create a new project and repro the issue in it). If you cannot upgrade, please open your issue on [StackOverflow](https://stackoverflow.com/questions/tagged/react-native) to get further community support. |`,
+      );
+      await closeIssue();
+      return;
+    default:
+      // No action needed
+      return;
   }
 };

--- a/.github/workflow-scripts/verifyVersion.js
+++ b/.github/workflow-scripts/verifyVersion.js
@@ -42,6 +42,11 @@ module.exports = async (github, context) => {
   ).data;
   const latestVersion = parseVersionFromString(latestRelease.name);
 
+  // We want to "insta-close" an issue if RN version provided is too old. And encourage users to upgrade.
+  if (isVersionTooOld(issueVersion, latestVersion)) {
+    return {label: 'Type: Too Old Version'};
+  }
+
   if (!isVersionSupported(issueVersion, latestVersion)) {
     return {label: 'Type: Unsupported Version'};
   }
@@ -59,11 +64,31 @@ module.exports = async (github, context) => {
   }
 };
 
-// We support N-2 minor versions, and the latest major.
+/**
+ * Check if the RN version provided in an issue is supported.
+ *
+ * "We support `N-2` minor versions, and the `latest` major".
+ */
 function isVersionSupported(actualVersion, latestVersion) {
   return (
     actualVersion.major >= latestVersion.major &&
     actualVersion.minor >= latestVersion.minor - 2
+  );
+}
+
+/**
+ * Check if the RN version provided in an issue is too old.
+ * "We support `N-2` minor versions, and the `latest` major".
+ *
+ * A RN version is *too old* if it's:
+ * - `1` or more *major* behind the *latest major*.
+ * - `5` or more *minor* behind the *latest minor* in the *same major*. Less aggressive.
+ *   (e.g. If `0.72.0` is the current latest then `0.67.0` and lower is too old for `0.72.0`)
+ */
+function isVersionTooOld(actualVersion, latestVersion) {
+  return (
+    latestVersion.major - actualVersion.major >= 1 ||
+    latestVersion.minor - actualVersion.minor >= 5
   );
 }
 


### PR DESCRIPTION
## Summary:

*Auto-close* an issue when the version of React Native specified is **TOO OLD**.
Applies `Type: Too Old Version` label and closes such issues using `actOnLabel` workflow.

## Changelog:

[GENERAL] [ADDED] - Auto close issue if version is too old.

## Test Plan:

- Should *auto-close* an issue with `Type: Too Old Version` label