### PR TITLE
Remove unused mapException methods

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/CMakeLists.txt
@@ -10,7 +10,6 @@ file(GLOB reactnativejni_SRC CONFIGURE_DEPENDS *.cpp)
 
 add_compile_options(
         -fexceptions
-        -frtti
         -Wno-unused-lambda-capture
         -std=c++17
         -DWITH_INSPECTOR=1)

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/ReadableNativeArray.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/ReadableNativeArray.cpp
@@ -13,14 +13,6 @@ using namespace facebook::jni;
 
 namespace facebook::react {
 
-// TODO T112842309: Remove after fbjni upgraded in OSS
-void ReadableNativeArray::mapException(const std::exception &ex) {
-  if (dynamic_cast<const folly::TypeError *>(&ex) != nullptr) {
-    throwNewJavaException(
-        exceptions::gUnexpectedNativeTypeExceptionClass, ex.what());
-  }
-}
-
 void ReadableNativeArray::mapException(std::exception_ptr ex) {
   try {
     std::rethrow_exception(ex);

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/ReadableNativeArray.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/ReadableNativeArray.h
@@ -32,7 +32,6 @@ class ReadableNativeArray
   static constexpr const char *kJavaDescriptor =
       "Lcom/facebook/react/bridge/ReadableNativeArray;";
 
-  static void mapException(const std::exception &ex);
   static void mapException(std::exception_ptr ex);
   static void registerNatives();
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/ReadableNativeMap.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/ReadableNativeMap.cpp
@@ -11,14 +11,6 @@ using namespace facebook::jni;
 
 namespace facebook::react {
 
-// TODO T112842309: Remove after fbjni upgraded in OSS
-void ReadableNativeMap::mapException(const std::exception &ex) {
-  if (dynamic_cast<const folly::TypeError *>(&ex) != nullptr) {
-    throwNewJavaException(
-        exceptions::gUnexpectedNativeTypeExceptionClass, ex.what());
-  }
-}
-
 void ReadableNativeMap::mapException(std::exception_ptr ex) {
   try {
     std::rethrow_exception(ex);

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/ReadableNativeMap.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/ReadableNativeMap.h
@@ -40,7 +40,6 @@ struct ReadableNativeMap : jni::HybridClass<ReadableNativeMap, NativeMap> {
   std::optional<folly::dynamic> keys_;
   static jni::local_ref<jhybridobject> createWithContents(folly::dynamic &&map);
 
-  static void mapException(const std::exception &ex);
   static void mapException(std::exception_ptr ex);
   static void registerNatives();
 


### PR DESCRIPTION
Summary:
Follow-up cleanup from D34379950, now that fbjni has been upgraded. Also synced the internal and external build flags.

Changelog: [Internal]

Differential Revision: D46975010

