### PR TITLE
Fix test windows disabling npx envinfo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1067,9 +1067,9 @@ jobs:
           name: Enable Yarn with corepack
           command: corepack enable
 
-      - run:
-          name: Display Environment info
-          command: npx envinfo@latest
+      # - run:
+      #     name: Display Environment info
+      #     command: npx envinfo@latest
 
       - restore_cache:
           keys:


### PR DESCRIPTION
`test_windows` are failing in CI. This change should fix them for the time being while we investigate further
## Changelog:
[internal] - Fix test_windows removing `npx envinfo`

## Test Plan:

circleci should be green
