### PR TITLE
Remove testID from TextStyle types

### DIFF
--- a/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.d.ts
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.d.ts
@@ -335,7 +335,6 @@ export interface TextStyle extends TextStyleIOS, TextStyleAndroid, ViewStyle {
   textShadowOffset?: {width: number; height: number} | undefined;
   textShadowRadius?: number | undefined;
   textTransform?: 'none' | 'capitalize' | 'uppercase' | 'lowercase' | undefined;
-  testID?: string | undefined;
 }
 
 /**


### PR DESCRIPTION
## Summary:

`testID` which is a valid prop for `<Text>` is also found in the types for `TextStyle`. This pull request removes said property from the styles.

## Changelog:

[General] [Fixed] - Remove testID from TextStyle types

## Test Plan:

```tsx
const styles = StyleSheet.create({
  view: {
    testID: 'should-error-in-typescript-but-does-not'
  }
})
```

`TextStyle` is used to type the `StyleSheet` along with `ViewStyle` and `ImageStyle` which do not contain `testID`.

```tsx
const MyText = <Text testID="already-typed-fine">Hello</Text>
```

`testID` is used to identify components with the mentioned prop. This works for `Text` and will continue to do so, `TextProps` has `testID` added specifically. When using `getByTestId` in jest adding testID to the style already has no effect.

When adding `testID` to a style a warning will already be shown in development: Warning: Failed prop type: Invalid props.style key `testID` supplied to `Text`.