### PR TITLE
[RN][Windows] Restore envinfo for test_windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1067,9 +1067,15 @@ jobs:
           name: Enable Yarn with corepack
           command: corepack enable
 
-      # - run:
-      #     name: Display Environment info
-      #     command: npx envinfo@latest
+      # it looks like that, last week, envinfo released version 7.9.0 which does not works
+      # with Windows. I have opened an issue here: https://github.com/tabrindle/envinfo/issues/238
+      # TODO: T156811874 - Revert this to npx envinfo@latest when the issue is addressed
+      - run:
+          name: Display Environment info
+          command: |
+            npm install -g envinfo
+            envinfo -v
+            envinfo
 
       - restore_cache:
           keys:


### PR DESCRIPTION
## Summary:

We had to disable the envinfo command on test_windows to get the CI back to green.

The reason why it started failing is because they released 7.9.0 which does not seem to have the executable on Windows, so `npx` fails to find what to run.

This fix restore the command in a way that it should display the envinfo using an older version of the package. I also added a task to come back to this periodically.

## Changelog:

[Internal] - Restore envinfo on windows

## Test Plan:

- CircleCI: test_windows stays green
