### PR TITLE
Remove unnecessary @JvmDefault

### DIFF
--- a/packages/react-native/ReactAndroid/build.gradle
+++ b/packages/react-native/ReactAndroid/build.gradle
@@ -472,7 +472,7 @@ android {
     }
 
     kotlinOptions {
-        // Using '-Xjvm-default=all' to support usage of @JvmDefault in kotlin files
+        // Using '-Xjvm-default=all' to generate default java methods for interfaces
         freeCompilerArgs = ['-Xjvm-default=all']
     }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
@@ -89,7 +89,7 @@ public class ReactActivityDelegate {
   }
 
   public ReactHostInterface getReactHost() {
-    return ((ReactApplication) getPlainActivity().getApplication()).reactHostInterface();
+    return ((ReactApplication) getPlainActivity().getApplication()).getReactHostInterface();
   }
 
   public ReactInstanceManager getReactInstanceManager() {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactApplication.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactApplication.kt
@@ -19,8 +19,8 @@ interface ReactApplication {
   /**
    * Get the default [ReactHostInterface] for this app. This method will be used by the new
    * architecture of react native
-   *
-   * TODO: refactor to 'val reactHostInterface'
    */
-  @JvmDefault fun reactHostInterface(): ReactHostInterface? = null
+  fun getReactHostInterface(): ReactHostInterface? {
+    return null
+  }
 }

--- a/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.java
+++ b/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.java
@@ -154,7 +154,7 @@ public class RNTesterApplication extends Application implements ReactApplication
 
   @Override
   @UnstableReactNativeAPI
-  public ReactHostInterface reactHostInterface() {
+  public ReactHostInterface getReactHostInterface() {
     if (mReactHost == null) {
       // Create an instance of ReactHost to manager the instance of ReactInstance,
       // which is similar to how we use ReactNativeHost to manager instance of ReactInstanceManager


### PR DESCRIPTION
Summary:
I'm cleaning up the ReactApplication code a bit to use a property with custom setter
Moreover I'm also removing the JvmDefault annotation as that is unnecessary as we use
the `-Xjvm-default=all`, plus is deprecated and will be removed soon by Kotlin.

Changelog:
[Internal] [Changed] - Remove unnecessary JvmDefault

Differential Revision: D47016727

