### PR TITLE
Invalidate NSTextStorage on AttributedString change

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphShadowNode.h
@@ -9,7 +9,6 @@
 
 #include <react/renderer/components/text/BaseTextShadowNode.h>
 #include <react/renderer/components/text/ParagraphEventEmitter.h>
-#include <react/renderer/components/text/ParagraphLayoutManager.h>
 #include <react/renderer/components/text/ParagraphProps.h>
 #include <react/renderer/components/text/ParagraphState.h>
 #include <react/renderer/components/view/ConcreteViewShadowNode.h>


### PR DESCRIPTION
Summary:
changelog:
[iOS][fix]: Correctly invalidate NSTextStorage when non layout related props change

Fixes: https://github.com/facebook/react-native/issues/37944

Problem:
NSTextStorage was not invalidated if non-layout props were changed. So for example 'color' dynamically changed, it wouldn't get invalidated and font of incorrect color would be rendered on screen.

Reviewed By: javache

Differential Revision: D47019250

