### PR TITLE
[Native part] Add workaround for android API 33 ANR when inverting ScrollView

### DIFF
--- a/packages/react-native/Libraries/Components/ScrollView/ScrollViewNativeComponent.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollViewNativeComponent.js
@@ -86,7 +86,7 @@ export const __INTERNAL_VIEW_CONFIG: PartialViewConfig =
             process: require('../../StyleSheet/processColor').default,
           },
           pointerEvents: true,
-          internalAndroidApplyInvertedFix: true,
+          isInvertedVirtualizedList: true,
         },
       }
     : {

--- a/packages/react-native/Libraries/Components/ScrollView/ScrollViewNativeComponent.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollViewNativeComponent.js
@@ -86,6 +86,7 @@ export const __INTERNAL_VIEW_CONFIG: PartialViewConfig =
             process: require('../../StyleSheet/processColor').default,
           },
           pointerEvents: true,
+          internalAndroidApplyInvertedFix: true,
         },
       }
     : {

--- a/packages/react-native/Libraries/Components/ScrollView/ScrollViewNativeComponentType.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollViewNativeComponentType.js
@@ -41,7 +41,7 @@ export type ScrollViewNativeProps = $ReadOnly<{
   endFillColor?: ?ColorValue,
   fadingEdgeLength?: ?number,
   indicatorStyle?: ?('default' | 'black' | 'white'),
-  internalAndroidApplyInvertedFix?: ?boolean,
+  isInvertedVirtualizedList?: ?boolean,
   keyboardDismissMode?: ?('none' | 'on-drag' | 'interactive'),
   maintainVisibleContentPosition?: ?$ReadOnly<{
     minIndexForVisible: number,

--- a/packages/react-native/Libraries/Components/ScrollView/ScrollViewNativeComponentType.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollViewNativeComponentType.js
@@ -41,6 +41,7 @@ export type ScrollViewNativeProps = $ReadOnly<{
   endFillColor?: ?ColorValue,
   fadingEdgeLength?: ?number,
   indicatorStyle?: ?('default' | 'black' | 'white'),
+  internalAndroidApplyInvertedFix?: ?boolean,
   keyboardDismissMode?: ?('none' | 'on-drag' | 'interactive'),
   maintainVisibleContentPosition?: ?$ReadOnly<{
     minIndexForVisible: number,

--- a/packages/react-native/Libraries/Components/ScrollView/ScrollViewViewConfig.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollViewViewConfig.js
@@ -46,6 +46,7 @@ const ScrollViewViewConfig = {
     fadingEdgeLength: true,
     indicatorStyle: true,
     inverted: true,
+    isInvertedVirtualizedList: true,
     keyboardDismissMode: true,
     maintainVisibleContentPosition: true,
     maximumZoomScale: true,
@@ -78,7 +79,6 @@ const ScrollViewViewConfig = {
     snapToOffsets: true,
     snapToStart: true,
     zoomScale: true,
-    internalAndroidApplyInvertedFix: true,
   },
 };
 

--- a/packages/react-native/Libraries/Components/ScrollView/ScrollViewViewConfig.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollViewViewConfig.js
@@ -78,6 +78,7 @@ const ScrollViewViewConfig = {
     snapToOffsets: true,
     snapToStart: true,
     zoomScale: true,
+    internalAndroidApplyInvertedFix: true,
   },
 };
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.java
@@ -380,8 +380,8 @@ public class ReactScrollViewManager extends ViewGroupManager<ReactScrollView>
     view.setScrollEventThrottle(scrollEventThrottle);
   }
 
-  @ReactProp(name = "internalAndroidApplyInvertedFix")
-  public void setInternalAndroidApplyInvertedFix(ReactScrollView view, boolean applyFix) {
+  @ReactProp(name = "isInvertedVirtualizedList")
+  public void setIsInvertedVirtualizedList(ReactScrollView view, boolean applyFix) {
      // Usually when inverting the scroll view we are using scaleY: -1 on the list
      // and on the parent container. HOWEVER, starting from android API 33 there is
      // a bug that can cause an ANR due to that. Thus we are using different transform

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.java
@@ -379,4 +379,22 @@ public class ReactScrollViewManager extends ViewGroupManager<ReactScrollView>
   public void setScrollEventThrottle(ReactScrollView view, int scrollEventThrottle) {
     view.setScrollEventThrottle(scrollEventThrottle);
   }
+
+  @ReactProp(name = "internalAndroidApplyInvertedFix")
+  public void setInternalAndroidApplyInvertedFix(ReactScrollView view, boolean applyFix) {
+     // Usually when inverting the scroll view we are using scaleY: -1 on the list
+     // and on the parent container. HOWEVER, starting from android API 33 there is
+     // a bug that can cause an ANR due to that. Thus we are using different transform
+     // commands to circumvent the ANR. This however causes the vertical scrollbar to
+     // be on the wrong side. Thus we are moving it to the other side, when the list
+     // is inverted.
+     // See also:
+     //  - https://github.com/facebook/react-native/issues/35350
+     //  - https://issuetracker.google.com/issues/287304310
+     if (applyFix) {
+       view.setVerticalScrollbarPosition(View.SCROLLBAR_POSITION_LEFT);
+     } else {
+       view.setVerticalScrollbarPosition(View.SCROLLBAR_POSITION_DEFAULT);
+     }
+  }
 }

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewProps.cpp
@@ -319,6 +319,15 @@ ScrollViewProps::ScrollViewProps(
                     rawProps,
                     "scrollToOverflowEnabled",
                     sourceProps.scrollToOverflowEnabled,
+                    {})),
+      internalAndroidApplyInvertedFix(
+          CoreFeatures::enablePropIteratorSetter
+              ? sourceProps.internalAndroidApplyInvertedFix
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "internalAndroidApplyInvertedFix",
+                    sourceProps.internalAndroidApplyInvertedFix,
                     {})) {}
 
 void ScrollViewProps::setProp(
@@ -368,6 +377,7 @@ void ScrollViewProps::setProp(
     RAW_SET_PROP_SWITCH_CASE_BASIC(snapToEnd);
     RAW_SET_PROP_SWITCH_CASE_BASIC(contentInsetAdjustmentBehavior);
     RAW_SET_PROP_SWITCH_CASE_BASIC(scrollToOverflowEnabled);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(internalAndroidApplyInvertedFix);
   }
 }
 
@@ -492,7 +502,11 @@ SharedDebugStringConvertibleList ScrollViewProps::getDebugProps() const {
           debugStringConvertibleItem(
               "snapToStart", snapToStart, defaultScrollViewProps.snapToStart),
           debugStringConvertibleItem(
-              "snapToEnd", snapToEnd, defaultScrollViewProps.snapToEnd)};
+              "snapToEnd", snapToEnd, defaultScrollViewProps.snapToEnd),
+          debugStringConvertibleItem(
+              "internalAndroidApplyInvertedFix",
+              snapToEnd,
+              defaultScrollViewProps.internalAndroidApplyInvertedFix)};
 }
 #endif
 

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewProps.cpp
@@ -320,14 +320,14 @@ ScrollViewProps::ScrollViewProps(
                     "scrollToOverflowEnabled",
                     sourceProps.scrollToOverflowEnabled,
                     {})),
-      internalAndroidApplyInvertedFix(
+      isInvertedVirtualizedList(
           CoreFeatures::enablePropIteratorSetter
-              ? sourceProps.internalAndroidApplyInvertedFix
+              ? sourceProps.isInvertedVirtualizedList
               : convertRawProp(
                     context,
                     rawProps,
-                    "internalAndroidApplyInvertedFix",
-                    sourceProps.internalAndroidApplyInvertedFix,
+                    "isInvertedVirtualizedList",
+                    sourceProps.isInvertedVirtualizedList,
                     {})) {}
 
 void ScrollViewProps::setProp(
@@ -377,7 +377,7 @@ void ScrollViewProps::setProp(
     RAW_SET_PROP_SWITCH_CASE_BASIC(snapToEnd);
     RAW_SET_PROP_SWITCH_CASE_BASIC(contentInsetAdjustmentBehavior);
     RAW_SET_PROP_SWITCH_CASE_BASIC(scrollToOverflowEnabled);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(internalAndroidApplyInvertedFix);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(isInvertedVirtualizedList);
   }
 }
 
@@ -504,9 +504,9 @@ SharedDebugStringConvertibleList ScrollViewProps::getDebugProps() const {
           debugStringConvertibleItem(
               "snapToEnd", snapToEnd, defaultScrollViewProps.snapToEnd),
           debugStringConvertibleItem(
-              "internalAndroidApplyInvertedFix",
+              "isInvertedVirtualizedList",
               snapToEnd,
-              defaultScrollViewProps.internalAndroidApplyInvertedFix)};
+              defaultScrollViewProps.isInvertedVirtualizedList)};
 }
 #endif
 

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewProps.h
@@ -68,6 +68,7 @@ class ScrollViewProps final : public ViewProps {
   ContentInsetAdjustmentBehavior contentInsetAdjustmentBehavior{
       ContentInsetAdjustmentBehavior::Never};
   bool scrollToOverflowEnabled{false};
+  bool internalAndroidApplyInvertedFix{false};
 
 #pragma mark - DebugStringConvertible
 

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewProps.h
@@ -68,7 +68,7 @@ class ScrollViewProps final : public ViewProps {
   ContentInsetAdjustmentBehavior contentInsetAdjustmentBehavior{
       ContentInsetAdjustmentBehavior::Never};
   bool scrollToOverflowEnabled{false};
-  bool internalAndroidApplyInvertedFix{false};
+  bool isInvertedVirtualizedList{false};
 
 #pragma mark - DebugStringConvertible
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This PR is a result of this PR, which got merged but then reverted: 

- https://github.com/facebook/react-native/pull/37913

We are trying to implement a workaround for #35350, so react-native users on android API 33+ can use `<FlatList inverted={true} />` without running into ANRs.

This is the native part, where we add a new internal prop named `isInvertedVirtualizedList`, which can in a follow up change be used to achieve the final fix as proposed in https://github.com/facebook/react-native/pull/37913

However as @NickGerleman pointed out, its important that we first ship the native change.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[ANDROID] [ADDED] - Native part of fixing ANR when having an inverted FlatList on android API 33+

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

- Check the RN tester app and see that scrollview is still working as expected
- Add the `isInvertedVirtualizedList` prop as test to a scrollview and see how the scrollbar will change position.