### PR TITLE
Don't use setState for disabled KeyboardAvoidingView to avoid re-renders

### DIFF
--- a/packages/react-native/Libraries/Components/Keyboard/KeyboardAvoidingView.js
+++ b/packages/react-native/Libraries/Components/Keyboard/KeyboardAvoidingView.js
@@ -132,9 +132,9 @@ class KeyboardAvoidingView extends React.Component<Props, State> {
 
   // Avoid unnecessary renders if the KeyboardAvoidingView is disabled.
   _setBottom = (value: number) => {
-    const {enabled = true} = this.props;
+    const enabled = this.props.enabled ?? true;
     this._bottom = value;
-    if (enabled === true) {
+    if (enabled) {
       this.setState({bottom: value});
     }
   };
@@ -154,8 +154,8 @@ class KeyboardAvoidingView extends React.Component<Props, State> {
 
     this._setBottom(height);
 
-    const {enabled = true} = this.props;
-    if (enabled === true && duration && easing) {
+    const enabled = this.props.enabled ?? true;
+    if (enabled && duration && easing) {
       LayoutAnimation.configureNext({
         // We have to pass the duration equal to minimal accepted duration defined here: RCTLayoutAnimation.m
         duration: duration > 10 ? duration : 10,
@@ -168,8 +168,8 @@ class KeyboardAvoidingView extends React.Component<Props, State> {
   };
 
   componentDidUpdate(_: Props, prevState: State): void {
-    const {enabled = true} = this.props;
-    if (enabled === true && this._bottom !== prevState.bottom) {
+    const enabled = this.props.enabled ?? true;
+    if (enabled && this._bottom !== prevState.bottom) {
       this.setState({bottom: this._bottom});
     }
   }

--- a/packages/react-native/Libraries/Components/Keyboard/KeyboardAvoidingView.js
+++ b/packages/react-native/Libraries/Components/Keyboard/KeyboardAvoidingView.js
@@ -134,7 +134,7 @@ class KeyboardAvoidingView extends React.Component<Props, State> {
   _setBottom = (value: number) => {
     const {enabled = true} = this.props;
     this._bottom = value;
-    if (enabled) {
+    if (enabled === true) {
       this.setState({bottom: value});
     }
   };
@@ -154,7 +154,8 @@ class KeyboardAvoidingView extends React.Component<Props, State> {
 
     this._setBottom(height);
 
-    if (enabled && duration && easing) {
+    const {enabled = true} = this.props;
+    if (enabled === true && duration && easing) {
       LayoutAnimation.configureNext({
         // We have to pass the duration equal to minimal accepted duration defined here: RCTLayoutAnimation.m
         duration: duration > 10 ? duration : 10,
@@ -168,7 +169,7 @@ class KeyboardAvoidingView extends React.Component<Props, State> {
 
   componentDidUpdate(_: Props, prevState: State): void {
     const {enabled = true} = this.props;
-    if (enabled && this._bottom !== prevState.bottom) {
+    if (enabled === true && this._bottom !== prevState.bottom) {
       this.setState({bottom: this._bottom});
     }
   }

--- a/packages/react-native/Libraries/Components/Keyboard/KeyboardAvoidingView.js
+++ b/packages/react-native/Libraries/Components/Keyboard/KeyboardAvoidingView.js
@@ -65,6 +65,7 @@ class KeyboardAvoidingView extends React.Component<Props, State> {
   _subscriptions: Array<EventSubscription> = [];
   viewRef: {current: React.ElementRef<typeof View> | null, ...};
   _initialFrameHeight: number = 0;
+  _bottom: number = 0;
 
   constructor(props: Props) {
     super(props);
@@ -129,20 +130,31 @@ class KeyboardAvoidingView extends React.Component<Props, State> {
     }
   };
 
+  // Avoid unnecessary renders if the KeyboardAvoidingView is disabled.
+  _setBottom = (value: number) => {
+    const {enabled = true} = this.props;
+    this._bottom = value;
+    if (enabled) {
+      this.setState({bottom: value});
+    }
+  };
+
   _updateBottomIfNecessary = async () => {
     if (this._keyboardEvent == null) {
-      this.setState({bottom: 0});
+      this._setBottom(0);
       return;
     }
 
     const {duration, easing, endCoordinates} = this._keyboardEvent;
     const height = await this._relativeKeyboardHeight(endCoordinates);
 
-    if (this.state.bottom === height) {
+    if (this._bottom === height) {
       return;
     }
 
-    if (duration && easing) {
+    this._setBottom(height);
+
+    if (enabled && duration && easing) {
       LayoutAnimation.configureNext({
         // We have to pass the duration equal to minimal accepted duration defined here: RCTLayoutAnimation.m
         duration: duration > 10 ? duration : 10,
@@ -152,8 +164,14 @@ class KeyboardAvoidingView extends React.Component<Props, State> {
         },
       });
     }
-    this.setState({bottom: height});
   };
+
+  componentDidUpdate(_: Props, prevState: State): void {
+    const {enabled = true} = this.props;
+    if (enabled && this._bottom !== prevState.bottom) {
+      this.setState({bottom: this._bottom});
+    }
+  }
 
   componentDidMount(): void {
     if (Platform.OS === 'ios') {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

There are two reasons to apply these changes:
- We don't need to re-render the `KeyboardAvoidingView` if it is disabled. It may be especially useful in combination with [react-navigation](https://reactnavigation.org/) where we could disable `KeyboardAvoidingView` for screens that are not focused 
- They fix the problem with the `KeyboardAvoidingView` wrapped inside the [react-freeze](https://github.com/software-mansion/react-freeze) component. Similarly, as above, it is useful when we want to freeze screens that are not visible for the user.

## Changelog:
[GENERAL] [CHANGED] Don't use setState for disabled KeyboardAvoidingView to avoid re-renders

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

- Check if the KeyboardAvoidingView works as expected. 

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
