### PR TITLE
Add nullptr check to SharedFunction

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Image/RCTImageComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Image/RCTImageComponentView.mm
@@ -109,6 +109,9 @@ using namespace facebook::react;
       // This will only become issue if we decouple life cycle of a
       // ShadowNode from ComponentView, which is not something we do now.
       imageRequest.cancel();
+      imageRequest.cancel();
+      imageRequest.cancel();
+      imageRequest.cancel();
     }
   }
 

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageShadowNode.h
@@ -46,7 +46,7 @@ class ImageShadowNode final : public ConcreteViewShadowNode<
       ShadowNodeFamily::Shared const & /*family*/,
       ComponentDescriptor const &componentDescriptor) {
     auto imageSource = ImageSource{ImageSource::Type::Invalid};
-    return {imageSource, {imageSource, nullptr}, 0};
+    return {imageSource, {imageSource, nullptr, {}}, 0};
   }
 
 #pragma mark - LayoutableShadowNode

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageRequest.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageRequest.h
@@ -12,6 +12,7 @@
 #include <react/renderer/imagemanager/ImageResponseObserverCoordinator.h>
 #include <react/renderer/imagemanager/ImageTelemetry.h>
 #include <react/renderer/imagemanager/primitives.h>
+#include <react/utils/SharedFunction.h>
 
 namespace facebook::react {
 
@@ -29,7 +30,8 @@ class ImageRequest final {
    */
   ImageRequest(
       ImageSource imageSource,
-      std::shared_ptr<const ImageTelemetry> telemetry);
+      std::shared_ptr<const ImageTelemetry> telemetry,
+      SharedFunction<> cancelationFunction);
 
   /*
    * The move constructor.
@@ -40,11 +42,6 @@ class ImageRequest final {
    * `ImageRequest` does not support copying by design.
    */
   ImageRequest(const ImageRequest &other) = delete;
-
-  /**
-   * Set cancelation function.
-   */
-  void setCancelationFunction(std::function<void(void)> cancelationFunction);
 
   /*
    * Calls cancel function if one is defined. Should be when downloading
@@ -94,9 +91,9 @@ class ImageRequest final {
   std::shared_ptr<const ImageResponseObserverCoordinator> coordinator_{};
 
   /*
-   * Function we can call to cancel image request (see destructor).
+   * Function we can call to cancel image request.
    */
-  std::function<void(void)> cancelRequest_;
+  SharedFunction<> cancelRequest_;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/cxx/react/renderer/imagemanager/ImageManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/cxx/react/renderer/imagemanager/ImageManager.cpp
@@ -24,7 +24,7 @@ ImageRequest ImageManager::requestImage(
     const ImageSource &imageSource,
     SurfaceId /*surfaceId*/) const {
   // Not implemented.
-  return {imageSource, nullptr};
+  return {imageSource, nullptr, {}};
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/cxx/react/renderer/imagemanager/ImageRequest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/cxx/react/renderer/imagemanager/ImageRequest.cpp
@@ -13,8 +13,11 @@ namespace facebook::react {
 
 ImageRequest::ImageRequest(
     ImageSource imageSource,
-    std::shared_ptr<const ImageTelemetry> telemetry)
-    : imageSource_(std::move(imageSource)), telemetry_(std::move(telemetry)) {
+    std::shared_ptr<const ImageTelemetry> telemetry,
+    SharedFunction<> cancelationFunction)
+    : imageSource_(std::move(imageSource)),
+      telemetry_(std::move(telemetry)),
+      cancelRequest_(std::move(cancelationFunction)) {
   // Not implemented.
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/ImageRequest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/ImageRequest.cpp
@@ -11,20 +11,16 @@ namespace facebook::react {
 
 ImageRequest::ImageRequest(
     ImageSource imageSource,
-    std::shared_ptr<const ImageTelemetry> telemetry)
-    : imageSource_(std::move(imageSource)), telemetry_(std::move(telemetry)) {
+    std::shared_ptr<const ImageTelemetry> telemetry,
+    SharedFunction<> cancelationFunction)
+    : imageSource_(std::move(imageSource)),
+      telemetry_(std::move(telemetry)),
+      cancelRequest_(std::move(cancelationFunction)) {
   coordinator_ = std::make_shared<ImageResponseObserverCoordinator>();
 }
 
-void ImageRequest::setCancelationFunction(
-    std::function<void(void)> cancelationFunction) {
-  cancelRequest_ = cancelationFunction;
-}
-
 void ImageRequest::cancel() const {
-  if (cancelRequest_) {
-    cancelRequest_();
-  }
+  cancelRequest_();
 }
 
 const ImageSource &ImageRequest::getImageSource() const {

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/RCTImageManager.mm
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/RCTImageManager.mm
@@ -48,12 +48,10 @@ using namespace facebook::react;
     telemetry = nullptr;
   }
 
-  auto imageRequest = ImageRequest(imageSource, telemetry);
+  auto sharedCancelationFunction = SharedFunction<>();
+  auto imageRequest = ImageRequest(imageSource, telemetry, sharedCancelationFunction);
   auto weakObserverCoordinator =
       (std::weak_ptr<const ImageResponseObserverCoordinator>)imageRequest.getSharedObserverCoordinator();
-
-  auto sharedCancelationFunction = SharedFunction<>();
-  imageRequest.setCancelationFunction(sharedCancelationFunction);
 
   /*
    * Even if an image is being loaded asynchronously on some other background thread, some other preparation

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/RCTSyncImageManager.mm
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/RCTSyncImageManager.mm
@@ -37,12 +37,10 @@ using namespace facebook::react;
 - (ImageRequest)requestImage:(ImageSource)imageSource surfaceId:(SurfaceId)surfaceId
 {
   auto telemetry = std::make_shared<ImageTelemetry>(surfaceId);
-  auto imageRequest = ImageRequest(imageSource, telemetry);
+  auto sharedCancelationFunction = SharedFunction<>();
+  auto imageRequest = ImageRequest(imageSource, telemetry, sharedCancelationFunction);
   auto weakObserverCoordinator =
       (std::weak_ptr<const ImageResponseObserverCoordinator>)imageRequest.getSharedObserverCoordinator();
-
-  auto sharedCancelationFunction = SharedFunction<>();
-  imageRequest.setCancelationFunction(sharedCancelationFunction);
 
   dispatch_group_t imageWaitGroup = dispatch_group_create();
 

--- a/packages/react-native/ReactCommon/react/utils/SharedFunction.h
+++ b/packages/react-native/ReactCommon/react/utils/SharedFunction.h
@@ -21,9 +21,9 @@ namespace facebook::react {
  * - When captured by `std::function` arguments are not copyable;
  * - When we need to replace the content of the callable later on the go.
  */
-template <typename ReturnT = void, typename... ArgumentT>
+template <typename... ArgumentT>
 class SharedFunction {
-  using T = ReturnT(ArgumentT...);
+  using T = void(ArgumentT...);
 
   struct Pair {
     Pair(std::function<T> &&function) : function(std::move(function)) {}
@@ -46,9 +46,11 @@ class SharedFunction {
     pair_->function = function;
   }
 
-  ReturnT operator()(ArgumentT... args) const {
+  void operator()(ArgumentT... args) const {
     std::shared_lock lock(pair_->mutex);
-    return pair_->function(args...);
+    if (pair_->function) {
+      pair_->function(args...);
+    }
   }
 
  private:


### PR DESCRIPTION
Summary:
changelog: [internal]

`SharedFunction<>` is created with nullptr for its internal `std::function`. If called after created with default constructor, it crashes app. It also does not have API to check if its internal function is not nullptr.

With image cancelation, there is a race between when native component calls `imageRequest.cancel()` and when cancelation function is set in `RCTImageManager`.
To fix this, this diff adds a nullptr check inside SharedFunction. So it is always safe to call.

Differential Revision: D47022957

