### PR TITLE
Default to ignoring cached Metro bundle when offline

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -185,7 +185,7 @@ public class ReactInstanceManager {
   private final @Nullable JSIModulePackage mJSIModulePackage;
   private final @Nullable ReactPackageTurboModuleManagerDelegate.Builder mTMMDelegateBuilder;
   private List<ViewManager> mViewManagers;
-  private boolean mUseFallbackBundle = false;
+  private boolean mUseFallbackBundle = true;
 
   private class ReactContextInitParams {
     private final JavaScriptExecutorFactory mJsExecutorFactory;


### PR DESCRIPTION
Summary:
Changelog: [Android][Breaking] Default to ignoring cached Metro bundle when offline

Currently, on Android, if we can't find a Metro server at startup, we try to run the last cached Metro bundle instead of the prebuilt bundle asset in the APK. This is inconsistent with the iOS behaviour, and breaks bundle features that rely on a runtime Metro connection to work correctly - such as HTTP asset loading and lazy bundling (which is the default as of D43600054).

Here we change the default for `ReactInstanceManager`'s `useFallbackBundle` property to `true`, which has the effect of ignoring the cached Metro bundle.

This is a **breaking change** because some developers' workflows might depend on performing a build while connected to a Metro instance, then using the app standalone without access to Metro. This may be exacerbated by the fact that the RN Gradle plugin [skips including a prebuilt bundle in debug builds](https://github.com/facebook/react-native/blob/eaafc260c14674bfbf7ce3a647404c70d546854f/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/TaskConfiguration.kt#L54). This means that, out of the box, debug builds of Android RN apps will only start if connected to Metro. (Contrast with iOS where a "fallback" bundle *is* included out of the box.)

We recommend that developers always connect to a Metro server in development, and perform a release build for standalone use. Alternatively, developers can use `ReactInstanceManager.setUseFallbackBundle(false)` to restore the old behaviour.

Differential Revision: D47021957

