### PR TITLE
Fix 'out-of-line definition of constexpr' build error for XCode 15 for React Native

### DIFF
--- a/packages/react-native/ReactCommon/cxxreact/RAMBundleRegistry.cpp
+++ b/packages/react-native/ReactCommon/cxxreact/RAMBundleRegistry.cpp
@@ -13,7 +13,10 @@
 
 namespace facebook::react {
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
 constexpr uint32_t RAMBundleRegistry::MAIN_BUNDLE_ID;
+#pragma clang diagnostic pop
 
 std::unique_ptr<RAMBundleRegistry> RAMBundleRegistry::singleBundleRegistry(
     std::unique_ptr<JSModulesUnbundle> mainBundle) {


### PR DESCRIPTION
Summary:
This diff fixes the
```
out-of-line definition of constexpr static data member is redundant in C++17 and is deprecated [-Werror,-Wdeprecated]
```
error in `RAMBundleRegistry`

## Changelog:
[internal] - Fix Xcode 15 namespace build errors in `RAMBundleRegistry`.

Differential Revision: D46988689

