### PR TITLE
Refactor ReactSurface to use TaskInterface

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactSurface.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridgeless/ReactSurface.java
@@ -137,7 +137,8 @@ public class ReactSurface implements ReactSurfaceInterface {
     return mSurfaceView.get();
   }
 
-  public Task<Void> prerender() {
+  @Override
+  public TaskInterface prerender() {
     ReactHost host = mReactHost.get();
     if (host == null) {
       return Task.forError(
@@ -164,7 +165,8 @@ public class ReactSurface implements ReactSurfaceInterface {
     return host.startSurface(this);
   }
 
-  public Task<Void> stop() {
+  @Override
+  public TaskInterface stop() {
     ReactHost host = mReactHost.get();
     if (host == null) {
       return Task.forError(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/interfaces/ReactSurfaceInterface.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/interfaces/ReactSurfaceInterface.kt
@@ -14,8 +14,14 @@ interface ReactSurfaceInterface {
   // the API of this interface will be completed as we analyze and refactor API of ReactSurface,
   // ReactRootView, etc.
 
+  // Prerender this surface
+  fun prerender(): TaskInterface
+
   // Start running this surface
   fun start(): TaskInterface
+
+  // Stop running this surface
+  fun stop(): TaskInterface
 
   // Get React root view of this surface
   fun getView(): ViewGroup?

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridgeless/ReactSurfaceTest.java
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridgeless/ReactSurfaceTest.java
@@ -77,7 +77,7 @@ public class ReactSurfaceTest {
   @Test
   public void testPrerender() throws InterruptedException {
     mReactSurface.attach(mReactHost);
-    Task<Void> task = mReactSurface.prerender();
+    Task<Void> task = (Task<Void>) mReactSurface.prerender();
     task.waitForCompletion();
 
     verify(mReactHost).prerenderSurface(mReactSurface);
@@ -102,7 +102,7 @@ public class ReactSurfaceTest {
     Task<Void> task = (Task<Void>) mReactSurface.start();
     task.waitForCompletion();
 
-    task = mReactSurface.stop();
+    task = (Task<Void>) mReactSurface.stop();
     task.waitForCompletion();
 
     verify(mReactHost).stopSurface(mReactSurface);
@@ -152,7 +152,8 @@ public class ReactSurfaceTest {
 
     assertThat(mReactSurface.isRunning()).isTrue();
 
-    mReactSurface.stop().waitForCompletion();
+    task = (Task<Void>) mReactSurface.stop();
+    task.waitForCompletion();
 
     assertThat(mReactSurface.isRunning()).isFalse();
   }


### PR DESCRIPTION
Summary:
Changelog: [Internal]

As part of refactoring ReactSurface, ensuring the methods expose interfaces instead of internal classes, e.g. use TaskInterface instead of Task,

Differential Revision: D47026648

