### PR TITLE
convert ProjectMock path type from string to Pathname

### DIFF
--- a/packages/react-native/scripts/cocoapods/__tests__/test_utils/InstallerMock.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/test_utils/InstallerMock.rb
@@ -119,7 +119,7 @@ class UserProjectMock
 
 
     def initialize(path = "/test/path.xcproj", build_configurations = [], native_targets: [])
-        @path = path
+        @path = Pathname.new(path)
         @build_configurations = build_configurations
         @native_targets = native_targets
         @save_invocation_count = 0

--- a/packages/react-native/scripts/cocoapods/__tests__/test_utils/PathnameMock.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/test_utils/PathnameMock.rb
@@ -34,6 +34,9 @@ class Pathname
         return @@pwd_invocation_count
     end
 
+    def to_s
+        return @path
+    end
 
     def self.reset()
         @@pwd = ""

--- a/packages/react-native/scripts/cocoapods/__tests__/utils-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/utils-test.rb
@@ -324,7 +324,7 @@ class UtilsTests < Test::Unit::TestCase
         first_target = prepare_target("FirstTarget")
         second_target = prepare_target("SecondTarget")
         third_target = prepare_target("ThirdTarget")
-        user_project_mock = UserProjectMock.new("a/path", [
+        user_project_mock = UserProjectMock.new("/a/path", [
                 prepare_config("Debug"),
                 prepare_config("Release"),
             ],
@@ -434,7 +434,7 @@ class UtilsTests < Test::Unit::TestCase
         first_target = prepare_target("FirstTarget")
         second_target = prepare_target("SecondTarget")
         third_target = prepare_target("ThirdTarget", "com.apple.product-type.bundle")
-        user_project_mock = UserProjectMock.new("a/path", [
+        user_project_mock = UserProjectMock.new("/a/path", [
                 prepare_config("Debug"),
                 prepare_config("Release"),
             ],
@@ -492,7 +492,7 @@ class UtilsTests < Test::Unit::TestCase
             }),
         ], nil)
 
-        user_project_mock = UserProjectMock.new("a/path", [
+        user_project_mock = UserProjectMock.new("/a/path", [
                 prepare_config("Debug"),
                 prepare_config("Release"),
             ],
@@ -644,7 +644,7 @@ class UtilsTests < Test::Unit::TestCase
             DependencyMock.new("React-ImageManager"),
         ])
         third_target = prepare_target("ThirdTarget", "com.apple.product-type.bundle")
-        user_project_mock = UserProjectMock.new("a/path", [
+        user_project_mock = UserProjectMock.new("/a/path", [
                 prepare_config("Debug"),
                 prepare_config("Release"),
             ],
@@ -688,7 +688,7 @@ class UtilsTests < Test::Unit::TestCase
         first_target = prepare_target("FirstTarget")
         second_target = prepare_target("SecondTarget")
         third_target = prepare_target("ThirdTarget", "com.apple.product-type.bundle")
-        user_project_mock = UserProjectMock.new("a/path", [
+        user_project_mock = UserProjectMock.new("/a/path", [
                 prepare_config("Debug"),
                 prepare_config("Release"),
             ],
@@ -750,7 +750,7 @@ class UtilsTests < Test::Unit::TestCase
         first_target = prepare_target("FirstTarget")
         second_target = prepare_target("SecondTarget")
         third_target = prepare_target("ThirdTarget", "com.apple.product-type.bundle")
-        user_project_mock = UserProjectMock.new("a/path", [
+        user_project_mock = UserProjectMock.new("/a/path", [
                 prepare_config("Debug"),
                 prepare_config("Release"),
             ],
@@ -779,7 +779,7 @@ end
 # ===== #
 
 def prepare_empty_user_project_mock
-    return UserProjectMock.new("a/path", [
+    return UserProjectMock.new("/a/path", [
         BuildConfigurationMock.new("Debug"),
         BuildConfigurationMock.new("Release"),
     ])


### PR DESCRIPTION
Summary:
Changelog: [Internal]

the path instance attribute on `Project` is not actually supposed to be `String`, but `Pathname`: https://www.rubydoc.info/github/CocoaPods/Xcodeproj/Xcodeproj/Project#path-instance_method

i need this actually to be a pathname, so doing the refactor in this diff

Differential Revision: D47041355

