### PR TITLE
Use vals inside ReactApplication

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactApplication.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactApplication.kt
@@ -14,13 +14,12 @@ import com.facebook.react.interfaces.ReactHostInterface
 /** Interface that represents an instance of a React Native application */
 interface ReactApplication {
   /** Get the default [ReactNativeHost] for this app. */
-  fun getReactNativeHost(): ReactNativeHost
+  val reactNativeHost: ReactNativeHost
 
   /**
    * Get the default [ReactHostInterface] for this app. This method will be used by the new
    * architecture of react native
    */
-  fun getReactHostInterface(): ReactHostInterface? {
-    return null
-  }
+  val reactHostInterface: ReactHostInterface?
+    get() = null
 }

--- a/packages/react-native/template/android/app/src/main/java/com/helloworld/MainApplication.kt
+++ b/packages/react-native/template/android/app/src/main/java/com/helloworld/MainApplication.kt
@@ -11,7 +11,7 @@ import com.facebook.soloader.SoLoader
 
 class MainApplication : Application(), ReactApplication {
 
-  private val reactNativeHost: ReactNativeHost =
+  override val reactNativeHost: ReactNativeHost =
       object : DefaultReactNativeHost(this) {
         override fun getPackages(): List<ReactPackage> {
           // Packages that cannot be autolinked yet can be added manually here, for example:
@@ -26,8 +26,6 @@ class MainApplication : Application(), ReactApplication {
         override val isNewArchEnabled: Boolean = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED
         override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED
       }
-
-  override fun getReactNativeHost(): ReactNativeHost = reactNativeHost
 
   override fun onCreate() {
     super.onCreate()


### PR DESCRIPTION
Summary:
For better Kotlin interop we should be using `val` in this interface rather than just `fun`.
This is not a breaking change as Java users can still use `getReactNativeHost()` as before.

Changelog:
[Internal] [Changed] -  Use vals inside ReactApplication

Differential Revision: D47053030

