### PR TITLE
Restore base config merge in metro-config

### DIFF
--- a/packages/metro-config/index.js
+++ b/packages/metro-config/index.js
@@ -8,9 +8,9 @@
  * @noformat
  */
 
-/*:: import type {MetroConfig} from 'metro-config'; */
+/*:: import type {ConfigT} from 'metro-config'; */
 
-const {mergeConfig} = require('metro-config');
+const {getDefaultConfig: getBaseConfig, mergeConfig} = require('metro-config');
 
 const INTERNAL_CALLSITES_REGEX = new RegExp(
   [
@@ -37,8 +37,8 @@ const INTERNAL_CALLSITES_REGEX = new RegExp(
  */
 function getDefaultConfig(
   projectRoot /*: string */
-) /*: MetroConfig */ {
-  return {
+) /*: ConfigT */ {
+  const config = {
     resolver: {
       resolverMainFields: ['react-native', 'browser', 'main'],
       platforms: ['android', 'ios'],
@@ -76,6 +76,11 @@ function getDefaultConfig(
     },
     watchFolders: [],
   };
+
+  return mergeConfig(
+    getBaseConfig.getDefaultValues(projectRoot),
+    config,
+  );
 }
 
 module.exports = {getDefaultConfig, mergeConfig};


### PR DESCRIPTION
## Summary

Reverts https://github.com/facebook/react-native/pull/36777.

This is motivated by reducing user friction when the widespread assumption is for `@react-native/metro-config` to export a complete Metro config, as with Expo/rnx-kit, and like previously understood uses of `metro-config`. See https://github.com/facebook/metro/issues/1010#issuecomment-1609215165 for further notes.

Fixes:
- https://github.com/facebook/metro/issues/1010
- https://github.com/facebook/react-native/issues/38069
- https://github.com/kristerkari/react-native-svg-transformer/issues/276

Note that we do not intend for `@react-native/metro-config` to directly export `assetExts` etc — these can be accessed on the `resolver` property from the full config object.

Changelog: [General][Changed] `@react-native/metro-config` now includes all base config values from `metro-config`

## Test Plan

**Steps**

- Using a new React Native 0.72 project.
	- Use `yarn link` to substitute `@react-native/metro-config` with local version.
	- Use `yarn link` to substitute `@react-native-community/cli-plugin-metro` with local fork.
	    - This is modified to log the final config to the terminal.
	- Expand `watchFolders` in Metro config.
	- `yarn start`

✅ **Produces functionally identical final config**

(Diff before and after changes)

✅ **App builds**

![image](https://github.com/facebook/react-native/assets/2547783/6266451e-f267-415d-995b-08ed753782bf)

Differential Revision: D47055973

