### PR TITLE
Implement multiple manager lookup for the interop layer

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropComponentDescriptor.mm
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropComponentDescriptor.mm
@@ -18,7 +18,7 @@
 
 namespace facebook::react {
 
-static std::string moduleNameFromComponentName(const std::string &componentName)
+static std::string moduleNameFromComponentNameNoRCTPrefix(const std::string &componentName)
 {
   // TODO: remove FB specific code (T56174424)
   if (componentName == "StickerInputView") {
@@ -45,22 +45,41 @@ static std::string moduleNameFromComponentName(const std::string &componentName)
     return componentName + "Manager";
   }
 
-  return "RCT" + componentName + "Manager";
+  return componentName + "Manager";
 }
 
 inline NSString *RCTNSStringFromString(const std::string &string)
 {
-  return [NSString stringWithCString:string.c_str() encoding:NSUTF8StringEncoding];
+  return [NSString stringWithUTF8String:string.c_str()];
+}
+
+static Class getViewManagerFromComponentName(const std::string &componentName)
+{
+  auto viewManagerName = moduleNameFromComponentNameNoRCTPrefix(componentName);
+
+  // 1. Try to get the manager with the RCT prefix.
+  auto rctViewManagerName = "RCT" + viewManagerName;
+  Class viewManagerClass = NSClassFromString(RCTNSStringFromString(rctViewManagerName));
+  if (viewManagerClass) {
+    return viewManagerClass;
+  }
+
+  // 2. Try to get the manager without the prefix.
+  viewManagerClass = NSClassFromString(RCTNSStringFromString(viewManagerName));
+  if (viewManagerClass) {
+    return viewManagerClass;
+  }
+
+  return nil;
 }
 
 static std::shared_ptr<void> const constructCoordinator(
     ContextContainer::Shared const &contextContainer,
     ComponentDescriptor::Flavor const &flavor)
 {
-  auto &componentName = *static_cast<std::string const *>(flavor.get());
-  auto moduleName = moduleNameFromComponentName(componentName);
-  Class module = NSClassFromString(RCTNSStringFromString(moduleName));
-  assert(module);
+  auto componentName = *std::static_pointer_cast<std::string const>(flavor);
+  Class viewManagerClass = getViewManagerFromComponentName(componentName);
+  assert(viewManagerClass);
   auto optionalBridge = contextContainer->find<std::shared_ptr<void>>("Bridge");
   RCTBridge *bridge;
   if (optionalBridge) {
@@ -79,7 +98,7 @@ static std::shared_ptr<void> const constructCoordinator(
     bridgeModuleDecorator = unwrapManagedObject(optionalModuleDecorator.value());
   }
 
-  RCTComponentData *componentData = [[RCTComponentData alloc] initWithManagerClass:module
+  RCTComponentData *componentData = [[RCTComponentData alloc] initWithManagerClass:viewManagerClass
                                                                             bridge:bridge
                                                                    eventDispatcher:eventDispatcher];
   return wrapManagedObject([[RCTLegacyViewManagerInteropCoordinator alloc]


### PR DESCRIPTION
Summary:
In [this issue](https://github.com/facebook/react-native/issues/37905), the community detected a strict assumption in the interop layer for which, given a component `XXXView`, its ViewManager must be called `RCTXXXViewManager`.

That's not the case for some components, for example, `BVLinearGradient`, which View manager is `BVLinearGradientManager` and not `RCTBVLinearGradientManager`.

This diff adds a secondary lookup logic:
1. We look for the `RCTXXXViewManager`.
2. If not found, we look for `XXXViewManager`.

We will assess whether to generalize this logic once and for all or to expand other lookup cases on an example/failure basis as it's not a goal to have a 100% accurate interop layer. The Goal is to cover most use cases.

## Changelog:
[iOS][Added] - Allow to lookup for ViewManager without the RCT prefix in the Interop Layer

Differential Revision: D47055969

