### PR TITLE
Replace $Call in react-native

### DIFF
--- a/packages/react-native/Libraries/Interaction/PanResponder.js
+++ b/packages/react-native/Libraries/Interaction/PanResponder.js
@@ -574,9 +574,6 @@ function clearInteractionHandle(
   }
 }
 
-export type PanResponderInstance = $Call<
-  $PropertyType<typeof PanResponder, 'create'>,
-  PanResponderConfig,
->;
+export type PanResponderInstance = ReturnType<(typeof PanResponder)['create']>;
 
 export default PanResponder;

--- a/packages/react-native/Libraries/Utilities/ReactNativeTestTools.js
+++ b/packages/react-native/Libraries/Utilities/ReactNativeTestTools.js
@@ -28,7 +28,6 @@ const ReactTestRenderer = require('react-test-renderer');
 const shallowRenderer = new ShallowRenderer();
 export type ReactTestInstance = $PropertyType<ReactTestRendererType, 'root'>;
 export type Predicate = (node: ReactTestInstance) => boolean;
-type $ReturnType<Fn> = $Call<<Ret, A>((...A) => Ret) => Ret, Fn>;
 /* $FlowFixMe[value-as-type] (>=0.125.1 site=react_native_fb) This comment
  * suppresses an error found when Flow v0.125.1 was deployed. To see the error,
  * delete this comment and run Flow. */
@@ -36,7 +35,7 @@ export type ReactTestRendererJSON =
   /* $FlowFixMe[prop-missing] (>=0.125.1 site=react_native_fb) This comment
    * suppresses an error found when Flow v0.125.1 was deployed. To see the error,
    * delete this comment and run Flow. */
-  $ReturnType<ReactTestRenderer.create.toJSON>;
+  ReturnType<ReactTestRenderer.create.toJSON>;
 
 function byClickable(): Predicate {
   return withMessage(

--- a/packages/react-native/Libraries/promiseRejectionTrackingOptions.js
+++ b/packages/react-native/Libraries/promiseRejectionTrackingOptions.js
@@ -10,9 +10,7 @@
 
 import typeof {enable} from 'promise/setimmediate/rejection-tracking';
 
-type ExtractOptionsType = <P>(((options?: ?P) => void)) => P;
-
-let rejectionTrackingOptions: $Call<ExtractOptionsType, enable> = {
+let rejectionTrackingOptions: $NonMaybeType<Parameters<enable>[0]> = {
   allRejections: true,
   onUnhandled: (id, rejection = {}) => {
     let message: string;

--- a/packages/rn-tester/js/examples/PlatformColor/PlatformColorExample.js
+++ b/packages/rn-tester/js/examples/PlatformColor/PlatformColorExample.js
@@ -15,7 +15,10 @@ const {DynamicColorIOS, PlatformColor, StyleSheet, Text, View} = ReactNative;
 
 function PlatformColorsExample() {
   function createTable() {
-    let colors: Array<{color: $Call<typeof PlatformColor>, label: string}> = [];
+    let colors: Array<{
+      color: ReturnType<typeof PlatformColor>,
+      label: string,
+    }> = [];
     if (Platform.OS === 'ios') {
       colors = [
         // https://developer.apple.com/documentation/uikit/uicolor/ui_element_colors


### PR DESCRIPTION
Summary:
With the introduction of [new utility types](https://flow.org/en/docs/types/utilities/#toc-return-type) in Flow, these $Call are no longer needed

Changelog: [Internal]

Differential Revision: D47078502

