### PR TITLE
Fix setRuntimeConfigProvider multiple times error

### DIFF
--- a/packages/react-native/Libraries/NativeComponent/NativeComponentRegistry.js
+++ b/packages/react-native/Libraries/NativeComponent/NativeComponentRegistry.js
@@ -38,11 +38,9 @@ export function setRuntimeConfigProvider(
     verify: boolean,
   },
 ): void {
-  invariant(
-    getRuntimeConfig == null,
-    'NativeComponentRegistry.setRuntimeConfigProvider() called more than once.',
-  );
-  getRuntimeConfig = runtimeConfigProvider;
+  if (getRuntimeConfig === undefined) {
+    getRuntimeConfig = runtimeConfigProvider;
+  }
 }
 
 /**


### PR DESCRIPTION
Summary:
Fix the following error:
 {F1038388240}

Calling ```setRuntimeConfigProvider``` multiple times is not always a wrong behaviour, the following could happen and before this diff App C will raise above error:
- App A has main bundle X
- App B has main bundle Y
- App C has main bundle X and bundle Y

To fix we guarantee ```setRuntimeConfigProvider``` only called once instead of raising an error.

Changelog:
[iOS][Changed] Fix setRuntimeConfigProvider called multiple times error

Reviewed By: dmytrorykun

Differential Revision: D47094267

