### PR TITLE
Add Pointer Capture APIs through intercepting events in UIManagerBinding

### DIFF
--- a/packages/react-native/Libraries/DOM/Nodes/ReadOnlyElement.js
+++ b/packages/react-native/Libraries/DOM/Nodes/ReadOnlyElement.js
@@ -170,6 +170,35 @@ export default class ReadOnlyElement extends ReadOnlyNode {
   getClientRects(): DOMRectList {
     throw new TypeError('Unimplemented');
   }
+
+  /**
+   * Pointer Capture APIs
+   */
+
+  hasPointerCapture(pointerId: number): boolean {
+    const node = getShadowNode(this);
+    if (node != null) {
+      return nullthrows(getFabricUIManager()).hasPointerCapture(
+        node,
+        pointerId,
+      );
+    }
+    return false;
+  }
+
+  setPointerCapture(pointerId: number): void {
+    const node = getShadowNode(this);
+    if (node != null) {
+      nullthrows(getFabricUIManager()).setPointerCapture(node, pointerId);
+    }
+  }
+
+  releasePointerCapture(pointerId: number): void {
+    const node = getShadowNode(this);
+    if (node != null) {
+      nullthrows(getFabricUIManager()).releasePointerCapture(node, pointerId);
+    }
+  }
 }
 
 function getChildElements(node: ReadOnlyNode): $ReadOnlyArray<ReadOnlyElement> {

--- a/packages/react-native/Libraries/ReactNative/FabricUIManager.js
+++ b/packages/react-native/Libraries/ReactNative/FabricUIManager.js
@@ -91,6 +91,13 @@ export interface Spec {
   +getScrollPosition: (
     node: Node,
   ) => ?[/* scrollLeft: */ number, /* scrollTop: */ number];
+
+  /**
+   * Support methods for the Pointer Capture APIs.
+   */
+  +hasPointerCapture: (node: Node, pointerId: number) => boolean;
+  +setPointerCapture: (node: Node, pointerId: number) => void;
+  +releasePointerCapture: (node: Node, pointerId: number) => void;
 }
 
 let nativeFabricUIManagerProxy: ?Spec;

--- a/packages/react-native/Libraries/ReactNative/__mocks__/FabricUIManager.js
+++ b/packages/react-native/Libraries/ReactNative/__mocks__/FabricUIManager.js
@@ -281,6 +281,9 @@ const FabricUIManagerMock: IFabricUIManagerMock = {
       return [x, y, width, height];
     },
   ),
+  hasPointerCapture: jest.fn((node: Node, pointerId: number): boolean => false),
+  setPointerCapture: jest.fn((node: Node, pointerId: number): void => {}),
+  releasePointerCapture: jest.fn((node: Node, pointerId: number): void => {}),
   setNativeProps: jest.fn((node: Node, newProps: NodeProps): void => {}),
   dispatchCommand: jest.fn(
     (node: Node, commandName: string, args: Array<mixed>): void => {},

--- a/packages/react-native/ReactCommon/react/renderer/core/EventEmitter.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventEmitter.cpp
@@ -130,4 +130,8 @@ void EventEmitter::setEnabled(bool enabled) const {
   }
 }
 
+const SharedEventTarget &EventEmitter::getEventTarget() const {
+  return eventTarget_;
+}
+
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/EventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventEmitter.h
@@ -54,6 +54,8 @@ class EventEmitter {
    */
   void setEnabled(bool enabled) const;
 
+  SharedEventTarget const &getEventTarget() const;
+
  protected:
 #ifdef ANDROID
   // We need this temporarily due to lack of Java-counterparts for particular

--- a/packages/react-native/ReactCommon/react/renderer/core/EventTargetWrapper.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventTargetWrapper.cpp
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "EventTargetWrapper.h"
+
+namespace facebook::react {
+
+EventTargetWrapper::EventTargetWrapper(
+    SharedEventTarget eventTarget,
+    jsi::Runtime &runtime)
+    : eventTarget_(std::move(eventTarget)), runtime_(runtime) {
+  eventTarget_->retain(runtime_);
+}
+
+EventTargetWrapper::~EventTargetWrapper() {
+  eventTarget_->release(runtime_);
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/EventTargetWrapper.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventTargetWrapper.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <jsi/jsi.h>
+
+#include <react/renderer/core/EventTarget.h>
+
+namespace facebook::react {
+
+/**
+ * RAII wrapper around `SharedEventTarget` which manages the retain/release of
+ * the underlying `EventTarget`.
+ */
+class EventTargetWrapper final {
+ public:
+  EventTargetWrapper(SharedEventTarget eventTarget, jsi::Runtime &runtime);
+  ~EventTargetWrapper();
+  EventTargetWrapper(const EventTargetWrapper &) = delete;
+  EventTargetWrapper &operator=(const EventTargetWrapper &) = delete;
+  EventTargetWrapper(EventTargetWrapper &&) = delete;
+  EventTargetWrapper &operator=(EventTargetWrapper &&) = delete;
+
+ private:
+  SharedEventTarget eventTarget_;
+  jsi::Runtime &runtime_;
+};
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/PointerEventsProcessor.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/PointerEventsProcessor.cpp
@@ -1,0 +1,243 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "PointerEventsProcessor.h"
+
+namespace facebook::react {
+
+bool PointerEventsProcessor::isPointerEvent(std::string const &type) {
+  return pointerEventNames().find(type) != pointerEventNames().end();
+}
+
+PointerEvent PointerEventsProcessor::pointerEventFromValue(
+    jsi::Runtime &runtime,
+    jsi::Value const &value) {
+  auto object = value.asObject(runtime);
+
+  PointerEvent event = {};
+  event.pointerId =
+      static_cast<int>(object.getProperty(runtime, "pointerId").asNumber());
+  event.pressure =
+      static_cast<float>(object.getProperty(runtime, "pressure").asNumber());
+  event.pointerType = object.getProperty(runtime, "pointerType")
+                          .asString(runtime)
+                          .utf8(runtime);
+  event.clientPoint = {
+      static_cast<float>(object.getProperty(runtime, "clientX").asNumber()),
+      static_cast<float>(object.getProperty(runtime, "clientY").asNumber())};
+  event.screenPoint = {
+      static_cast<float>(object.getProperty(runtime, "screenX").asNumber()),
+      static_cast<float>(object.getProperty(runtime, "screenY").asNumber())};
+  event.offsetPoint = {
+      static_cast<float>(object.getProperty(runtime, "offsetX").asNumber()),
+      static_cast<float>(object.getProperty(runtime, "offsetY").asNumber())};
+  event.width =
+      static_cast<float>(object.getProperty(runtime, "width").asNumber());
+  event.height =
+      static_cast<float>(object.getProperty(runtime, "height").asNumber());
+  event.tiltX =
+      static_cast<int>(object.getProperty(runtime, "tiltX").asNumber());
+  event.tiltY =
+      static_cast<int>(object.getProperty(runtime, "tiltY").asNumber());
+  event.detail =
+      static_cast<int>(object.getProperty(runtime, "detail").asNumber());
+  event.buttons =
+      static_cast<int>(object.getProperty(runtime, "buttons").asNumber());
+  event.tangentialPressure = static_cast<float>(
+      object.getProperty(runtime, "tangentialPressure").asNumber());
+  event.twist =
+      static_cast<int>(object.getProperty(runtime, "twist").asNumber());
+  event.ctrlKey = object.getProperty(runtime, "ctrlKey").asBool();
+  event.shiftKey = object.getProperty(runtime, "shiftKey").asBool();
+  event.metaKey = object.getProperty(runtime, "metaKey").asBool();
+  event.isPrimary = object.getProperty(runtime, "isPrimary").asBool();
+  event.button =
+      static_cast<int>(object.getProperty(runtime, "button").asNumber());
+
+  return event;
+}
+
+jsi::Value PointerEventsProcessor::valueFromPointerEvent(
+    jsi::Runtime &runtime,
+    PointerEvent const &event) {
+  auto object = jsi::Object(runtime);
+  object.setProperty(runtime, "pointerId", event.pointerId);
+  object.setProperty(runtime, "pressure", event.pressure);
+  object.setProperty(runtime, "pointerType", event.pointerType);
+  object.setProperty(runtime, "clientX", event.clientPoint.x);
+  object.setProperty(runtime, "clientY", event.clientPoint.y);
+  object.setProperty(runtime, "x", event.clientPoint.x);
+  object.setProperty(runtime, "y", event.clientPoint.y);
+  object.setProperty(runtime, "pageX", event.clientPoint.x);
+  object.setProperty(runtime, "pageY", event.clientPoint.y);
+  object.setProperty(runtime, "screenX", event.screenPoint.x);
+  object.setProperty(runtime, "screenY", event.screenPoint.y);
+  object.setProperty(runtime, "offsetX", event.offsetPoint.x);
+  object.setProperty(runtime, "offsetY", event.offsetPoint.y);
+  object.setProperty(runtime, "width", event.width);
+  object.setProperty(runtime, "height", event.height);
+  object.setProperty(runtime, "tiltX", event.tiltX);
+  object.setProperty(runtime, "tiltY", event.tiltY);
+  object.setProperty(runtime, "detail", event.detail);
+  object.setProperty(runtime, "buttons", event.buttons);
+  object.setProperty(runtime, "tangentialPressure", event.tangentialPressure);
+  object.setProperty(runtime, "twist", event.twist);
+  object.setProperty(runtime, "ctrlKey", event.ctrlKey);
+  object.setProperty(runtime, "shiftKey", event.shiftKey);
+  object.setProperty(runtime, "altKey", event.altKey);
+  object.setProperty(runtime, "metaKey", event.metaKey);
+  object.setProperty(runtime, "isPrimary", event.isPrimary);
+  object.setProperty(runtime, "button", event.button);
+  return object;
+}
+
+PointerEventsProcessor::PointerEventsProcessor(
+    std::shared_ptr<UIManager> uiManager)
+    : uiManager_(std::move(uiManager)) {}
+
+void PointerEventsProcessor::interceptPointerEvent(
+    jsi::Runtime &runtime,
+    EventTarget const *eventTarget,
+    std::string const &type,
+    ReactEventPriority priority,
+    jsi::Value &payload,
+    DispatchEvent const &eventDispatcher) {
+  PointerEvent event = pointerEventFromValue(runtime, payload);
+
+  // Process all pending pointer capture assignments
+  processPendingPointerCapture(event, runtime, eventDispatcher);
+
+  // Check if event needs retargeting
+  auto overrideIter =
+      pendingPointerCaptureTargetOverrides_.find(event.pointerId);
+  bool hasPendingOverride =
+      overrideIter != pendingPointerCaptureTargetOverrides_.end();
+  if (hasPendingOverride &&
+      overrideIter->second->getTag() != eventTarget->getTag()) {
+    // Retarget event
+    auto nodeToTarget =
+        uiManager_->getNewestCloneOfShadowNode(*overrideIter->second);
+
+    // Update offsetPoint to account for change in target
+    auto layoutMetrics = uiManager_->getRelativeLayoutMetrics(
+        *nodeToTarget, nullptr, {/* .includeTransform = */ true});
+    event.offsetPoint = {
+        event.clientPoint.x - layoutMetrics.frame.origin.x,
+        event.clientPoint.y - layoutMetrics.frame.origin.y};
+
+    // Retrieve the event target of the retargeted node
+    auto retargetedEventTarget =
+        nodeToTarget->getEventEmitter()->getEventTarget();
+
+    // Regenerate an updated jsi value from the updated PointerEvent
+    auto retargetedPayload = valueFromPointerEvent(runtime, event);
+
+    EventTargetWrapper wrapper(retargetedEventTarget, runtime);
+    eventDispatcher(
+        runtime,
+        retargetedEventTarget.get(),
+        type,
+        priority,
+        retargetedPayload);
+  } else {
+    // Pass through event
+    eventDispatcher(runtime, eventTarget, type, priority, payload);
+  }
+
+  // Implicit release of pointer capture
+  if (hasPendingOverride &&
+      (type == "topPointerUp" || type == "topPointerCancel")) {
+    releasePointerCapture(event.pointerId, overrideIter->second.get());
+    processPendingPointerCapture(event, runtime, eventDispatcher);
+  }
+}
+
+void PointerEventsProcessor::setPointerCapture(
+    PointerIdentifier pointerId,
+    ShadowNode::Shared const &shadowNode) {
+  pendingPointerCaptureTargetOverrides_[pointerId] = shadowNode;
+}
+
+void PointerEventsProcessor::releasePointerCapture(
+    PointerIdentifier pointerId,
+    ShadowNode const * /*shadowNode*/) {
+  pendingPointerCaptureTargetOverrides_.erase(pointerId);
+}
+
+bool PointerEventsProcessor::hasPointerCapture(
+    PointerIdentifier pointerId,
+    ShadowNode const *shadowNode) {
+  auto pendingPointerItr =
+      pendingPointerCaptureTargetOverrides_.find(pointerId);
+  if (pendingPointerItr == pendingPointerCaptureTargetOverrides_.end()) {
+    return false;
+  }
+  return pendingPointerItr->second->getTag() == shadowNode->getTag();
+}
+
+void PointerEventsProcessor::processPendingPointerCapture(
+    const PointerEvent &event,
+    jsi::Runtime &runtime,
+    DispatchEvent const &eventDispatcher) {
+  auto activeOverrideIter =
+      activePointerCaptureTargetOverrides_.find(event.pointerId);
+  bool hasActiveOverride =
+      activeOverrideIter != activePointerCaptureTargetOverrides_.end();
+
+  auto pendingOverrideIter =
+      pendingPointerCaptureTargetOverrides_.find(event.pointerId);
+  bool hasPendingOverride =
+      pendingOverrideIter != pendingPointerCaptureTargetOverrides_.end();
+
+  if (!hasPendingOverride && !hasActiveOverride) {
+    return;
+  }
+
+  auto activeOverrideTag =
+      (hasActiveOverride) ? activeOverrideIter->second->getTag() : -1;
+  auto pendingOverrideTag =
+      (hasPendingOverride) ? pendingOverrideIter->second->getTag() : -1;
+
+  if (hasActiveOverride && activeOverrideTag != pendingOverrideTag) {
+    auto shadowNodeToEmitTo =
+        uiManager_->getNewestCloneOfShadowNode(*activeOverrideIter->second);
+    auto eventTarget = shadowNodeToEmitTo->getEventEmitter()->getEventTarget();
+    auto payload = valueFromPointerEvent(runtime, event);
+
+    EventTargetWrapper wrapper(eventTarget, runtime);
+    eventDispatcher(
+        runtime,
+        eventTarget.get(),
+        "topLostPointerCapture",
+        ReactEventPriority::Discrete,
+        payload);
+  }
+
+  if (hasPendingOverride && activeOverrideTag != pendingOverrideTag) {
+    auto shadowNodeToEmitTo =
+        uiManager_->getNewestCloneOfShadowNode(*pendingOverrideIter->second);
+    auto eventTarget = shadowNodeToEmitTo->getEventEmitter()->getEventTarget();
+    auto payload = valueFromPointerEvent(runtime, event);
+
+    EventTargetWrapper wrapper(eventTarget, runtime);
+    eventDispatcher(
+        runtime,
+        eventTarget.get(),
+        "topGotPointerCapture",
+        ReactEventPriority::Discrete,
+        payload);
+  }
+
+  if (!hasPendingOverride) {
+    activePointerCaptureTargetOverrides_.erase(event.pointerId);
+  } else {
+    activePointerCaptureTargetOverrides_[event.pointerId] =
+        pendingOverrideIter->second;
+  }
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/PointerEventsProcessor.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/PointerEventsProcessor.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <functional>
+
+#include <jsi/jsi.h>
+#include <react/renderer/core/EventTargetWrapper.h>
+#include <react/renderer/uimanager/UIManager.h>
+#include <react/renderer/uimanager/primitives.h>
+
+namespace facebook::react {
+
+using DispatchEvent = std::function<void(
+    jsi::Runtime &runtime,
+    EventTarget const *eventTarget,
+    std::string const &type,
+    ReactEventPriority priority,
+    jsi::Value &event)>;
+
+using PointerIdentifier = int;
+
+class PointerEventsProcessor final {
+ public:
+  explicit PointerEventsProcessor(std::shared_ptr<UIManager> uiManager);
+
+  static bool isPointerEvent(std::string const &type);
+
+  void interceptPointerEvent(
+      jsi::Runtime &runtime,
+      EventTarget const *eventTarget,
+      std::string const &type,
+      ReactEventPriority priority,
+      jsi::Value &payload,
+      DispatchEvent const &eventDispatcher);
+
+  void setPointerCapture(
+      PointerIdentifier pointerId,
+      ShadowNode::Shared const &shadowNode);
+  void releasePointerCapture(
+      PointerIdentifier pointerId,
+      ShadowNode const *shadowNode);
+  bool hasPointerCapture(
+      PointerIdentifier pointerId,
+      ShadowNode const *shadowNode);
+
+ private:
+  void processPendingPointerCapture(
+      PointerEvent const &event,
+      jsi::Runtime &runtime,
+      DispatchEvent const &eventDispatcher);
+
+  static std::unordered_set<std::string> pointerEventNames() {
+    static const std::unordered_set<std::string> n = {
+        "topPointerDown",
+        "topPointerMove",
+        "topPointerUp",
+        "topPointerCancel",
+        "topPointerEnter",
+        "topPointerLeave",
+        "topPointerOver",
+        "topPointerOut"};
+    return n;
+  }
+  static PointerEvent pointerEventFromValue(
+      jsi::Runtime &runtime,
+      jsi::Value const &value);
+  static jsi::Value valueFromPointerEvent(
+      jsi::Runtime &runtime,
+      PointerEvent const &event);
+
+  std::shared_ptr<UIManager> uiManager_;
+  std::unordered_map<int, ShadowNode::Shared>
+      pendingPointerCaptureTargetOverrides_;
+  std::unordered_map<int, ShadowNode::Shared>
+      activePointerCaptureTargetOverrides_;
+};
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.h
@@ -10,6 +10,7 @@
 #include <folly/dynamic.h>
 #include <jsi/jsi.h>
 #include <react/renderer/core/RawValue.h>
+#include <react/renderer/uimanager/PointerEventsProcessor.h>
 #include <react/renderer/uimanager/UIManager.h>
 #include <react/renderer/uimanager/primitives.h>
 
@@ -73,6 +74,7 @@ class UIManagerBinding : public jsi::HostObject {
  private:
   std::shared_ptr<UIManager> uiManager_;
   std::unique_ptr<EventHandler const> eventHandler_;
+  std::unique_ptr<PointerEventsProcessor> pointerEventsProcessor_;
   mutable ReactEventPriority currentEventPriority_;
 };
 


### PR DESCRIPTION
Summary:
Changelog: [Internal] - Add Pointer Capture APIs through intercepting events in UIManagerBinding

This implements the basics of pointer capture in a novel way by intercepting events created by the host platform in UIManagerBinding and modifying/emitting additional events sent to JS. Because it lives in the C++ land we can synchronously call the `setPointerCapture`/`releasePointerCapture`/ect. methods from JS without having to risk any deadlocks or thread spinning. Following up on this I'd like to extend this idea further and move more of the functionality we've implemented in ObjC & Java so far to this shared layer to make each of the platform's implementations easier to maintain.

Differential Revision: D46071147

