### PR TITLE
Add global hook to assert that base Metro config is called

### DIFF
--- a/packages/metro-config/index.js
+++ b/packages/metro-config/index.js
@@ -77,6 +77,9 @@ function getDefaultConfig(
     watchFolders: [],
   };
 
+  // Set global hook so that the CLI can detect when this config has been loaded
+  global.__REACT_NATIVE_METRO_CONFIG_LOADED = true;
+
   return mergeConfig(
     getBaseConfig.getDefaultValues(projectRoot),
     config,


### PR DESCRIPTION
Summary:
Towards https://github.com/react-native-community/cli/issues/1987. Will be paired with a CLI PR targeting React Native 0.72.1.

A global hook is the more lenient of the options considered to handle this — notably it will allow the CLI `start` command to continue when we may have mismatched versions of `@react-native/metro-config`.

Changelog: None

Differential Revision: D47125080

