### PR TITLE
Disable nstextstorage_caching in OSS

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Image/RCTImageComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Image/RCTImageComponentView.mm
@@ -109,9 +109,6 @@ using namespace facebook::react;
       // This will only become issue if we decouple life cycle of a
       // ShadowNode from ComponentView, which is not something we do now.
       imageRequest.cancel();
-      imageRequest.cancel();
-      imageRequest.cancel();
-      imageRequest.cancel();
     }
   }
 

--- a/packages/react-native/ReactCommon/react/config/ReactNativeConfig.cpp
+++ b/packages/react-native/ReactCommon/react/config/ReactNativeConfig.cpp
@@ -23,9 +23,6 @@ bool EmptyReactNativeConfig::getBool(const std::string &param) const {
   if (param == "react_fabric:enabled_layout_animations_ios") {
     return true;
   }
-  if (param == "react_fabric:enable_nstextstorage_caching") {
-    return true;
-  }
   return false;
 }
 


### PR DESCRIPTION
Summary:
changelog: [iOS] Disable NSTextStorage caching in OSS

A [bug was reported](https://github.com/facebook/react-native/issues/37944) for NSTextStorage caching. Even thought I fixed the bug in D47019250, I want to disable the feature in OSS until the fix is verified in Facebook app.
My plan is to pick this commit for 0.72.1 and reenable NSTextStorage caching once the fix is validated.

Differential Revision: D47127912

