### PR TITLE
Add foojay-resolver-convention to auto-download the right JDK

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -28,7 +28,10 @@ if (File("${rootDir}/packages").exists()) {
 
 rootProject.name = "react-native-github"
 
-plugins { id("com.gradle.enterprise").version("3.7.1") }
+plugins {
+  id("com.gradle.enterprise").version("3.7.1")
+  id("org.gradle.toolchains.foojay-resolver-convention").version("0.5.0")
+}
 
 // If you specify a file inside gradle/gradle-enterprise.gradle.kts
 // you can configure your custom Gradle Enterprise instance


### PR DESCRIPTION
Summary:
This adds https://github.com/gradle/foojay-toolchains to our build setup.
This will make sure that if the user doesn't have JDK 17 installed, it will be
autodownloaded once they try to build the first time.

Changelog:
[Internal] [Changed] - Add foojay-resolver-convention to auto-download the right JDK

Reviewed By: sammy-SC

Differential Revision: D47129944

