### PR TITLE
Do not create RuntimeExecutor on non-JSI executors (#38125)

### DIFF
--- a/packages/react-native/ReactCommon/cxxreact/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/cxxreact/CMakeLists.txt
@@ -27,4 +27,5 @@ target_link_libraries(reactnative
         jsinspector
         logger
         reactperflogger
-        runtimeexecutor)
+        runtimeexecutor
+        react_debug)

--- a/packages/react-native/ReactCommon/cxxreact/React-cxxreact.podspec
+++ b/packages/react-native/ReactCommon/cxxreact/React-cxxreact.podspec
@@ -33,7 +33,7 @@ Pod::Spec.new do |s|
   s.source_files           = "*.{cpp,h}"
   s.exclude_files          = "SampleCxxModule.*"
   s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
-  s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/DoubleConversion\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-runtimeexecutor/React_runtimeexecutor.framework/Headers\"",
+  s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/DoubleConversion\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-runtimeexecutor/React_runtimeexecutor.framework/Headers\" \"$(PODS_CONFIGURATION_BUILD_DIR)/React-debug/React_debug.framework/Headers\"",
                                "CLANG_CXX_LANGUAGE_STANDARD" => "c++17" }
   s.header_dir             = "cxxreact"
 
@@ -47,6 +47,7 @@ Pod::Spec.new do |s|
   s.dependency "React-perflogger", version
   s.dependency "React-jsi", version
   s.dependency "React-logger", version
+  s.dependency "React-debug", version
 
   if ENV['USE_HERMES'] == nil || ENV['USE_HERMES'] == "1"
     s.dependency 'hermes-engine'


### PR DESCRIPTION
Cherry-pick of 0542da1aca5d411964e3a0833f4c48428ed90c91 to the 0.72 branch
Summary:
Pull Request resolved: https://github.com/facebook/react-native/pull/38125

On Android, when using the remote debugging feature (using legacy websockets), it's not safe to assume we can get a `jsi::Runtime` from `JSExecutor`.

Changelog: [General][Fixed] Android does't crash when using remote debugger

Reviewed By: NickGerleman

Differential Revision: D47124234

fbshipit-source-id: 0542da1aca5d411964e3a0833f4c48428ed90c91


